### PR TITLE
feat(sgs2): Restore missing roadmap note and canonical memory refs for Docker/OpenViking epic

### DIFF
--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -1,62 +1,71 @@
 ---
-title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 type: design
-tags: ["epic-roadmap","adr-053","docker","web-ui","openviking"]
+tags: ["roadmap","design","docker","web-ui","openviking","epic-7izs"]
 ---
 
-# Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+# Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 
-## Status
-Epic [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is **not complete**. No implementation tasks have landed yet; the board only contains this planning task. The codebase still ships an Electron shell, relies on Electron IPC for key UI flows, serves only API/MCP routes from `server/src/server/mod.rs`, and still uses the legacy `NoteRepository`/memory MCP surface in `server/` and `server/crates/djinn-mcp/`.
+Related ADR: [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
+Epic: `7izs` — Docker-Based Deployment, Web UI, and OpenViking Memory Backend
+Canonical permalink: `design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap`
 
-## Current repo facts
-- Desktop packaging is still Electron-based (`desktop/package.json`, `desktop/electron/main.ts`, `desktop/electron/ipc-handlers.ts`).
-- Frontend code still imports Electron wrappers broadly (`desktop/src/electron/commands.ts`, `desktop/src/electron/shims/*`).
-- The Rust server currently exposes health/events/MCP/project-management routes, but no SPA static-file serving or browser-oriented replacement endpoints for native pickers/window APIs (`server/src/server/mod.rs`, `server/src/server/project_tools.rs`).
-- Memory operations still center on `djinn_db::NoteRepository`, `memory_build_context`, `memory_health`, `memory_broken_links`, `memory_orphans`, task confidence, and the KB watcher (`server/crates/djinn-mcp/src/tools/memory_tools/*`, `server/src/task_confidence.rs`, `server/src/watchers/kb.rs`).
-- No Dockerfile or compose stack exists in the repo root or `server/`.
+## Objective
 
-## Decomposition strategy
-Sequence this epic as three waves so workers can land vertical slices without trampling each other.
+Deliver the ADR-053 migration from the current Electron desktop + custom memory stack to:
+- a Docker Compose deployment model,
+- a browser-served web UI hosted by `djinn-server`, and
+- an OpenViking-backed memory architecture introduced in phases.
 
-### Wave 1 — Foundation and seams
-1. Add server static-asset hosting so the Rust server can serve the built web app alongside existing HTTP/MCP APIs.
-2. Extract the frontend runtime boundary away from Electron-only shims so the React app can run in a normal browser against the Rust server.
-3. Add server-side filesystem browsing/import APIs to replace the native directory/file pickers used by project onboarding and connection settings.
-4. Introduce a memory backend seam plus an OpenViking client/configuration slice without changing user-visible memory behavior yet.
-5. Add Docker packaging and a compose stack wiring Djinn + OpenViking, using the new server/web build outputs.
+This note is the canonical roadmap artifact referenced by epic `7izs` and its child tasks.
 
-### Wave 2 — Web-only UX completion
-- Remove remaining Electron-only flows (window chrome, auth/token/local integration, SSH/remote helpers that must move server-side or be dropped).
-- Switch the shipped app/docs to browser-first usage.
-- Reduce or eliminate Electron build/package scripts once the browser path is production-ready.
+## Current active wave
 
-### Wave 3 — Memory migration
-- Implement dual-read shadowing against OpenViking.
-- Migrate writes and `memory_refs` URI handling to `viking://`.
-- Remove confidence-scoring and legacy knowledge-base maintenance features deprecated by ADR-053.
-- Delete legacy `NoteRepository`-specific codepaths, watchers, and surplus MCP tools.
+The active wave is establishing the foundational seams needed for the migration:
 
-## Wave 1 tasks
-This wave creates five concrete worker tasks:
-1. Server SPA/static hosting scaffold.
-2. Frontend browser-runtime adapter replacing Electron-only transport assumptions.
-3. Filesystem browsing/import HTTP APIs plus web picker integration.
-4. Memory backend seam + OpenViking client bootstrap.
-5. Dockerfile/compose packaging for Djinn + OpenViking.
+1. **Serve the React app from `djinn-server`**
+   - Active task: `rpgb`
+   - Goal: add static asset hosting and SPA fallback without breaking existing API/MCP routes.
 
-## Exit criteria for this wave
-- The server can serve a built frontend bundle.
-- The frontend has a browser-compatible runtime path for basic server communication.
-- At least one onboarding/project-selection flow works without native file dialogs.
-- OpenViking integration is represented by a real backend seam and client bootstrap instead of being only an ADR.
-- A local operator can start Djinn + OpenViking with Docker Compose.
+2. **Introduce a browser-compatible frontend runtime boundary**
+   - Active task: `h3p6`
+   - Goal: remove hard dependencies on `window.electronAPI` from foundational frontend runtime flows.
 
-## Follow-up notes
-- Keep tasks narrow and file-seamed to avoid simultaneous edits to the same Electron/server bootstrap files.
-- Do **not** attempt full memory switchover in the same wave as seam extraction; land the integration seam first, then migrate behavior in later waves.
-- Preserve MCP compatibility during the migration period; browser delivery and backend swap should not break the planner/worker toolchain mid-epic.
+3. **Create the OpenViking memory backend seam and bootstrap client**
+   - Active task: `4a4t`
+   - Goal: add a backend abstraction and initial OpenViking bootstrap/config wiring while preserving the legacy implementation.
 
-## Relations
-- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
-- [[brief]]
+4. **Replace native project/file pickers with server-backed filesystem browsing**
+   - Active task: `2744`
+   - Goal: provide safe server-side listing endpoints and migrate at least one picker flow to a browser-native UX.
+
+5. **Package djinn-server and OpenViking with Docker Compose**
+   - Open task: `aijd`
+   - Goal: add a Dockerfile and compose stack that run Djinn with OpenViking, persistent volumes, and documented setup steps.
+
+## Wave sequencing
+
+### Wave 1 — foundational seams
+- Static frontend serving in `djinn-server`
+- Browser runtime boundary for the frontend
+- Initial OpenViking backend seam/bootstrap
+- First server-backed picker flow
+- Docker Compose packaging
+
+### Wave 2 — Electron replacement completion
+- Remove remaining Electron-only integrations
+- Move any residual shell/server-side behaviors behind HTTP/server APIs
+- Tighten browser-first startup/configuration flows
+
+### Wave 3 — OpenViking migration phases
+- dual-read/shadow integration
+- migration tooling and write switchover
+- `memory_refs` URI transition support
+- retirement of confidence-scoring and legacy memory subsystems
+- final cleanup of superseded tools/watchers/storage paths
+
+## Planner notes
+
+- Use this permalink for epic/task `memory_refs`: `design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap`
+- If future waves need to replace this note, update epic `7izs` and all open/in-progress child tasks in the same planning pass.
+- Current child-task references are intended to keep pointing here; the repair for the missing note is to restore this canonical permalink rather than mint a new one.

--- a/.djinn/reference/adr-043-roadmap-active-decomposition-status.md
+++ b/.djinn/reference/adr-043-roadmap-active-decomposition-status.md
@@ -1,8 +1,9 @@
 ---
 title: ADR-043 Roadmap — Active Decomposition Status
-type: roadmap
+type: 
 tags: ["adr-043","repo-map","scip","worktree"]
 ---
+
 
 # ADR-043: Monorepo-aware SCIP indexing, project-add trigger, and worktree reuse
 
@@ -47,3 +48,18 @@ Epic remains open. Core repo-map behavior exists, but the decomposition goal is 
 ## Relations
 - [[decisions/adr-043-repository-map-scip-powered-structural-context-for-agent-sessions]]
 - [[brief]]
+
+
+
+## Epic 7izs — Docker-Based Deployment, Web UI, and OpenViking Memory Backend
+
+Canonical roadmap reference for the current active wave: use [[roadmap]] until a dedicated design note is promoted into project memory.
+
+Wave status:
+- `rpgb`: serve the React app from `djinn-server`
+- `h3p6`: introduce a browser-compatible frontend runtime boundary
+- `4a4t`: create the OpenViking memory backend seam and bootstrap client
+- `2744`: replace native project/file pickers with server-backed filesystem browsing
+- `aijd`: package `djinn-server` and OpenViking with Docker Compose
+
+Planner note (2026-04-13): the prior `design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap` reference was missing from project memory, so epic/task `memory_refs` are being normalized to the existing canonical `roadmap` note for now.


### PR DESCRIPTION
## Summary
Patrol found that epic `7izs` and all active child tasks reference `design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap`, but that note does not currently exist in project memory. Recreate or replace the roadmap note with the intended canonical permalink, then repair epic/task memory_refs so active work points at an existing roadmap artifact.

## Acceptance Criteria
- [ ] A roadmap/design note exists for epic `7izs` at a real canonical permalink and reflects the current active wave
- [ ] Epic `7izs` and its active child tasks no longer reference a nonexistent roadmap note permalink
- [ ] Any replacement permalink chosen is documented on the epic/task board so future waves use the canonical roadmap reference

---
Djinn task: sgs2