### PR TITLE
chore(h3p6): Introduce a browser-compatible frontend runtime boundary

### DIFF
--- a/desktop/src/api/agents.ts
+++ b/desktop/src/api/agents.ts
@@ -1,8 +1,7 @@
-import { getServerPort } from "@/electron/commands";
+import { getServerUrl } from "@/electron/commands";
 
 async function getBaseUrl(): Promise<string> {
-  const port = await getServerPort();
-  return `http://127.0.0.1:${port}`;
+  return getServerUrl();
 }
 
 export type BaseRole = "worker" | "reviewer" | "lead" | "planner";

--- a/desktop/src/api/chat.ts
+++ b/desktop/src/api/chat.ts
@@ -1,9 +1,8 @@
-import { getServerPort } from "@/electron/commands";
+import { getServerUrl } from "@/electron/commands";
 import type { ChatMessage } from "@/stores/chatStore";
 
 async function getBaseUrl(): Promise<string> {
-  const port = await getServerPort();
-  return `http://127.0.0.1:${port}`;
+  return getServerUrl();
 }
 
 type ContentBlock =

--- a/desktop/src/api/mcpClient.ts
+++ b/desktop/src/api/mcpClient.ts
@@ -1,7 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { McpToolInput, McpToolName, McpToolOutput } from "@/api/generated/mcp-tools.gen";
-import { getServerPort } from "@/electron/commands";
+import { getServerUrl } from "@/electron/commands";
 
 type ToolCallResult = {
   content?: Array<{ type?: string; text?: string }>;
@@ -51,8 +51,8 @@ function extractToolPayload<T>(result: ToolCallResult): T {
 }
 
 async function getMcpUrl(): Promise<string> {
-  const port = await getServerPort();
-  return `http://127.0.0.1:${port}/mcp`;
+  const baseUrl = await getServerUrl();
+  return `${baseUrl}/mcp`;
 }
 
 async function connectClient(forceReconnect = false): Promise<Client> {

--- a/desktop/src/api/projectTools.ts
+++ b/desktop/src/api/projectTools.ts
@@ -1,8 +1,7 @@
-import { getServerPort } from "@/electron/commands";
+import { getServerUrl } from "@/electron/commands";
 
 async function getBaseUrl(): Promise<string> {
-  const port = await getServerPort();
-  return `http://127.0.0.1:${port}`;
+  return getServerUrl();
 }
 
 // ── MCP Servers ──────────────────────────────────────────────────────────────

--- a/desktop/src/api/server.ts
+++ b/desktop/src/api/server.ts
@@ -1,6 +1,6 @@
 import { callMcpTool } from "@/api/mcpClient";
 import type { McpToolOutput, ProjectListOutputSchema } from "@/api/generated/mcp-tools.gen";
-import { getServerPort } from "@/electron/commands";
+import { getServerUrl } from "@/electron/commands";
 import type { Epic, Task } from "@/api/types";
 import { projectStore } from "@/stores/projectStore";
 
@@ -18,8 +18,7 @@ export async function setUserIdentity(email: string, userId: string): Promise<vo
 }
 
 async function getBaseUrl(): Promise<string> {
-  const port = await getServerPort();
-  return `http://127.0.0.1:${port}`;
+  return getServerUrl();
 }
 
 function providerDescription(provider: ProviderCatalogItem): string {
@@ -193,7 +192,7 @@ export type Project = ProjectListOutputSchema.ProjectInfo & {
 export async function fetchProjects(): Promise<Project[]> {
   const data = await callMcpTool("project_list");
   const projects: Project[] = await Promise.all(
-    data.projects.map(async (p) => {
+    data.projects.map(async (p: Project) => {
       try {
         const config = await callMcpTool("project_config_get", { project: p.path });
         return { ...p, branch: config.target_branch, auto_merge: config.auto_merge };
@@ -430,7 +429,7 @@ export async function fetchKanbanSnapshot(
   }
 
   // Stamp each task with the project it belongs to (needed for all-projects view)
-  const projectId = projectStore.getState().projects.find((p) => p.path === resolvedProjectPath)?.id ?? null;
+  const projectId = projectStore.getState().projects.find((p: Project) => p.path === resolvedProjectPath)?.id ?? null;
   const tasks = allTasks.map((t) => ({ ...t, project_id: projectId }));
 
   return {

--- a/desktop/src/components/AuthGate.tsx
+++ b/desktop/src/components/AuthGate.tsx
@@ -24,10 +24,19 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
     // Attempt silent auth now that the server is connected.
     // This replaces the backend-driven approach that was removed from lib.rs.
-    attemptSilentAuth().catch(() => {
-      // If silent auth fails, fall through to show login screen
-      useAuthStore.setState({ isLoading: false, isAuthenticated: false });
-    });
+    attemptSilentAuth()
+      .then((authenticated) => {
+        if (authenticated) {
+          return fetchState();
+        }
+
+        useAuthStore.setState({ isLoading: false, isAuthenticated: false });
+        return undefined;
+      })
+      .catch(() => {
+        // If silent auth fails, fall through to show login screen
+        useAuthStore.setState({ isLoading: false, isAuthenticated: false });
+      });
 
     listen<{ isAuthenticated: boolean; user: AuthUser | null }>("auth:state-changed", (event) => {
       const state = event.payload;

--- a/desktop/src/components/AuthGate.tsx
+++ b/desktop/src/components/AuthGate.tsx
@@ -30,7 +30,10 @@ export function AuthGate({ children }: { children: ReactNode }) {
           return fetchState();
         }
 
-        useAuthStore.setState({ isLoading: false, isAuthenticated: false });
+        const { isAuthenticated: alreadyAuthenticated } = useAuthStore.getState();
+        if (!alreadyAuthenticated) {
+          useAuthStore.setState({ isLoading: false, isAuthenticated: false });
+        }
         return undefined;
       })
       .catch(() => {

--- a/desktop/src/electron/commands.browser.test.ts
+++ b/desktop/src/electron/commands.browser.test.ts
@@ -5,7 +5,11 @@ describe("electron commands browser runtime", () => {
     vi.resetModules();
     vi.unstubAllGlobals();
     window.localStorage.clear();
-    Reflect.deleteProperty(window, "electronAPI");
+    Object.defineProperty(window, "electronAPI", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
   });
 
   afterEach(() => {

--- a/desktop/src/electron/commands.browser.test.ts
+++ b/desktop/src/electron/commands.browser.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("electron commands browser runtime", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+    Reflect.deleteProperty(window, "electronAPI");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it("boots against an HTTP server without window.electronAPI", async () => {
+    window.localStorage.setItem("djinn.serverBaseUrl", "http://browser.test:4123/");
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "ok", version: "1.2.3" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const commands = await import("./commands");
+
+    await expect(commands.getServerUrl()).resolves.toBe("http://browser.test:4123");
+    await expect(commands.getServerPort()).resolves.toBe(4123);
+    await expect(commands.getConnectionMode()).resolves.toEqual({
+      type: "remote",
+      url: "http://browser.test:4123",
+    });
+
+    await expect(commands.getServerStatus()).resolves.toEqual({
+      base_url: "http://browser.test:4123",
+      port: 4123,
+      is_healthy: true,
+      has_error: false,
+      error_message: null,
+      server_version: "1.2.3",
+      update_available: false,
+    });
+
+    await expect(commands.retryServerConnection()).resolves.toBe("http://browser.test:4123");
+
+    expect(fetchMock).toHaveBeenCalledWith("http://browser.test:4123/health");
+    expect(commands.isElectronRuntime()).toBe(false);
+  });
+
+  it("stores browser remote URLs through the shared runtime boundary", async () => {
+    const commands = await import("./commands");
+
+    await commands.setConnectionMode({ type: "remote", url: "http://configured.test:9000/" });
+
+    await expect(commands.getServerUrl()).resolves.toBe("http://configured.test:9000");
+    expect(window.localStorage.getItem("djinn.serverBaseUrl")).toBe("http://configured.test:9000");
+  });
+});

--- a/desktop/src/electron/commands.ts
+++ b/desktop/src/electron/commands.ts
@@ -7,6 +7,128 @@
 
 import { invoke } from "./shims/invoke";
 
+const BROWSER_SERVER_URL_STORAGE_KEY = "djinn.serverBaseUrl";
+const BROWSER_DEFAULT_SERVER_URL = "http://127.0.0.1:3000";
+
+export interface ServerStatus {
+  base_url: string | null;
+  port: number | null;
+  is_healthy: boolean;
+  has_error: boolean;
+  error_message: string | null;
+  server_version: string | null;
+  update_available: boolean;
+}
+
+function hasElectronApi(): boolean {
+  return typeof window !== "undefined" && typeof window.electronAPI?.invoke === "function";
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function getBrowserStoredServerUrl(): string | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage.getItem(BROWSER_SERVER_URL_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setBrowserStoredServerUrl(url: string | null): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    if (url) {
+      window.localStorage.setItem(BROWSER_SERVER_URL_STORAGE_KEY, url);
+    } else {
+      window.localStorage.removeItem(BROWSER_SERVER_URL_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore localStorage failures in restricted browser environments.
+  }
+}
+
+function getBrowserServerUrl(): string {
+  const configuredUrl = import.meta.env.VITE_DJINN_SERVER_URL?.trim();
+  if (configuredUrl) {
+    return trimTrailingSlash(configuredUrl);
+  }
+
+  const storedUrl = getBrowserStoredServerUrl()?.trim();
+  if (storedUrl) {
+    return trimTrailingSlash(storedUrl);
+  }
+
+  if (typeof window !== "undefined" && /^https?:$/.test(window.location.protocol)) {
+    return trimTrailingSlash(window.location.origin);
+  }
+
+  return BROWSER_DEFAULT_SERVER_URL;
+}
+
+function portFromUrl(baseUrl: string): number | null {
+  try {
+    const url = new URL(baseUrl);
+    if (url.port) return Number(url.port);
+    if (url.protocol === "https:") return 443;
+    if (url.protocol === "http:") return 80;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function getBrowserServerStatus(): Promise<ServerStatus> {
+  const baseUrl = getBrowserServerUrl();
+
+  try {
+    const response = await fetch(`${baseUrl}/health`);
+    if (!response.ok) {
+      return {
+        base_url: baseUrl,
+        port: portFromUrl(baseUrl),
+        is_healthy: false,
+        has_error: true,
+        error_message: `Health check failed: ${response.status}`,
+        server_version: null,
+        update_available: false,
+      };
+    }
+
+    let serverVersion: string | null = null;
+    try {
+      const payload = (await response.json()) as { version?: string };
+      serverVersion = typeof payload.version === "string" ? payload.version : null;
+    } catch {
+      serverVersion = null;
+    }
+
+    return {
+      base_url: baseUrl,
+      port: portFromUrl(baseUrl),
+      is_healthy: true,
+      has_error: false,
+      error_message: null,
+      server_version: serverVersion,
+      update_available: false,
+    };
+  } catch (error) {
+    return {
+      base_url: baseUrl,
+      port: portFromUrl(baseUrl),
+      is_healthy: false,
+      has_error: true,
+      error_message: error instanceof Error ? error.message : "Failed to reach server",
+      server_version: null,
+      update_available: false,
+    };
+  }
+}
+
 export interface AuthUser {
   sub: string;
   name?: string;
@@ -38,6 +160,9 @@ export async function startGithubLogin(): Promise<DeviceCodeInfo> {
  * @returns The port number the backend server is running on
  */
 export async function getServerPort(): Promise<number> {
+  if (!hasElectronApi()) {
+    return portFromUrl(getBrowserServerUrl()) ?? 80;
+  }
   return invoke("get_server_port");
 }
 
@@ -45,6 +170,9 @@ export async function getServerPort(): Promise<number> {
  * Get the full server base URL from the Electron backend.
  */
 export async function getServerUrl(): Promise<string> {
+  if (!hasElectronApi()) {
+    return getBrowserServerUrl();
+  }
   return invoke("get_server_url");
 }
 
@@ -52,15 +180,10 @@ export async function getServerUrl(): Promise<string> {
  * Get the server status from the Electron backend.
  * @returns The current server status including health and error state
  */
-export async function getServerStatus(): Promise<{
-  base_url: string | null;
-  port: number | null;
-  is_healthy: boolean;
-  has_error: boolean;
-  error_message: string | null;
-  server_version: string | null;
-  update_available: boolean;
-}> {
+export async function getServerStatus(): Promise<ServerStatus> {
+  if (!hasElectronApi()) {
+    return getBrowserServerStatus();
+  }
   return invoke("get_server_status");
 }
 
@@ -70,10 +193,20 @@ export async function getServerStatus(): Promise<{
  * @returns The base URL the server is reachable at
  */
 export async function retryServerConnection(): Promise<string> {
+  if (!hasElectronApi()) {
+    const status = await getBrowserServerStatus();
+    if (!status.is_healthy || !status.base_url) {
+      throw new Error(status.error_message ?? "Failed to connect to server");
+    }
+    return status.base_url;
+  }
   return invoke("retry_server_connection");
 }
 
 export async function retryServerDiscovery(): Promise<number> {
+  if (!hasElectronApi()) {
+    return getServerPort();
+  }
   return invoke("retry_server_discovery");
 }
 
@@ -84,10 +217,26 @@ export type ConnectionMode =
   | { type: "wsl" };
 
 export async function getConnectionMode(): Promise<ConnectionMode> {
+  if (!hasElectronApi()) {
+    return { type: "remote", url: getBrowserServerUrl() };
+  }
   return invoke("get_connection_mode");
 }
 
 export async function setConnectionMode(mode: ConnectionMode): Promise<void> {
+  if (!hasElectronApi()) {
+    if (mode.type === "remote") {
+      setBrowserStoredServerUrl(trimTrailingSlash(mode.url));
+      return;
+    }
+
+    if (mode.type === "daemon") {
+      setBrowserStoredServerUrl(null);
+      return;
+    }
+
+    throw new Error(`Connection mode '${mode.type}' is not supported in browser mode`);
+  }
   return invoke("set_connection_mode", { mode });
 }
 
@@ -97,6 +246,10 @@ export async function setConnectionMode(mode: ConnectionMode): Promise<void> {
  * @returns The selected directory path or null if cancelled
  */
 export async function selectDirectory(title?: string): Promise<string | null> {
+  if (!hasElectronApi()) {
+    void title;
+    throw new Error("Directory selection is only available in Electron mode");
+  }
   const result = await invoke<string | null>("select_directory", { title });
   return result;
 }
@@ -108,6 +261,10 @@ export async function selectDirectory(title?: string): Promise<string | null> {
  * @returns Array of branch names
  */
 export async function listGitBranches(projectPath: string): Promise<string[]> {
+  if (!hasElectronApi()) {
+    void projectPath;
+    return [];
+  }
   return invoke<string[]>("list_git_branches", { projectPath });
 }
 
@@ -117,6 +274,10 @@ export async function listGitBranches(projectPath: string): Promise<string[]> {
  * @returns The remote URL if configured, null otherwise
  */
 export async function checkGitRemote(projectPath: string): Promise<string | null> {
+  if (!hasElectronApi()) {
+    void projectPath;
+    throw new Error("Git remote checks are only available in Electron mode");
+  }
   return invoke<string | null>("check_git_remote", { projectPath });
 }
 
@@ -127,6 +288,11 @@ export async function checkGitRemote(projectPath: string): Promise<string | null
  * @returns Success message
  */
 export async function setupGitRemote(projectPath: string, remoteUrl: string): Promise<string> {
+  if (!hasElectronApi()) {
+    void projectPath;
+    void remoteUrl;
+    throw new Error("Git remote setup is only available in Electron mode");
+  }
   return invoke<string>("setup_git_remote", { projectPath, remoteUrl });
 }
 
@@ -136,6 +302,9 @@ export async function setupGitRemote(projectPath: string, remoteUrl: string): Pr
  * @returns true if tokens were synced, false if no local tokens available
  */
 export async function syncGithubTokens(): Promise<boolean> {
+  if (!hasElectronApi()) {
+    return false;
+  }
   return invoke<boolean>("sync_github_tokens");
 }
 
@@ -143,6 +312,9 @@ export async function syncGithubTokens(): Promise<boolean> {
  * Get current authentication state.
  */
 export async function authGetState(): Promise<AuthState> {
+  if (!hasElectronApi()) {
+    return { isAuthenticated: true, user: null };
+  }
   return invoke<AuthState>("auth_get_state");
 }
 
@@ -150,6 +322,9 @@ export async function authGetState(): Promise<AuthState> {
  * Start OAuth login flow (backwards-compatible wrapper for authStore).
  */
 export async function authLogin(): Promise<void> {
+  if (!hasElectronApi()) {
+    return;
+  }
   await invoke("auth_login");
 }
 
@@ -157,6 +332,9 @@ export async function authLogin(): Promise<void> {
  * Logout current authenticated user.
  */
 export async function authLogout(): Promise<void> {
+  if (!hasElectronApi()) {
+    return;
+  }
   await invoke("auth_logout");
 }
 
@@ -187,6 +365,9 @@ export type TunnelStatus =
  * Get saved SSH hosts from the backend.
  */
 export async function getSshHosts(): Promise<SshHost[]> {
+  if (!hasElectronApi()) {
+    return [];
+  }
   return invoke<SshHost[]>("get_ssh_hosts");
 }
 
@@ -194,6 +375,10 @@ export async function getSshHosts(): Promise<SshHost[]> {
  * Save (create or update) an SSH host configuration.
  */
 export async function saveSshHost(host: SshHost): Promise<void> {
+  if (!hasElectronApi()) {
+    void host;
+    throw new Error("SSH host management is only available in Electron mode");
+  }
   return invoke<void>("save_ssh_host", { host });
 }
 
@@ -201,6 +386,10 @@ export async function saveSshHost(host: SshHost): Promise<void> {
  * Remove an SSH host configuration by ID.
  */
 export async function removeSshHost(id: string): Promise<void> {
+  if (!hasElectronApi()) {
+    void id;
+    throw new Error("SSH host management is only available in Electron mode");
+  }
   return invoke<void>("remove_ssh_host", { id });
 }
 
@@ -209,6 +398,10 @@ export async function removeSshHost(id: string): Promise<void> {
  * @returns A success message or throws on failure.
  */
 export async function testSshConnection(hostId: string): Promise<string> {
+  if (!hasElectronApi()) {
+    void hostId;
+    throw new Error("SSH connection testing is only available in Electron mode");
+  }
   return invoke<string>("test_ssh_connection", { hostId });
 }
 
@@ -216,6 +409,9 @@ export async function testSshConnection(hostId: string): Promise<string> {
  * Get the current SSH tunnel status.
  */
 export async function getTunnelStatus(): Promise<TunnelStatus> {
+  if (!hasElectronApi()) {
+    return { status: "disconnected" };
+  }
   return invoke<TunnelStatus>("get_tunnel_status");
 }
 
@@ -224,6 +420,10 @@ export async function getTunnelStatus(): Promise<TunnelStatus> {
  * @returns A status message.
  */
 export async function deployServerToHost(hostId: string): Promise<string> {
+  if (!hasElectronApi()) {
+    void hostId;
+    throw new Error("Server deployment is only available in Electron mode");
+  }
   return invoke<string>("deploy_server_to_host", { hostId });
 }
 
@@ -231,6 +431,9 @@ export async function deployServerToHost(hostId: string): Promise<string> {
  * Check if WSL is available on this machine.
  */
 export async function checkWslAvailable(): Promise<boolean> {
+  if (!hasElectronApi()) {
+    return false;
+  }
   return invoke<boolean>("check_wsl_available");
 }
 
@@ -240,6 +443,10 @@ export async function checkWslAvailable(): Promise<boolean> {
  * @returns The selected file path or null if cancelled
  */
 export async function selectFile(title?: string): Promise<string | null> {
+  if (!hasElectronApi()) {
+    void title;
+    throw new Error("File selection is only available in Electron mode");
+  }
   return invoke<string | null>("select_file", { title });
 }
 
@@ -248,6 +455,9 @@ export async function selectFile(title?: string): Promise<string | null> {
  * @returns The path to the downloaded binary
  */
 export async function downloadServerBinary(): Promise<string> {
+  if (!hasElectronApi()) {
+    throw new Error("Server binary downloads are only available in Electron mode");
+  }
   return invoke<string>("download_server_binary");
 }
 
@@ -255,6 +465,9 @@ export async function downloadServerBinary(): Promise<string> {
  * Check if a saved connection mode exists (first-launch detection).
  */
 export async function hasSavedConnectionMode(): Promise<boolean> {
+  if (!hasElectronApi()) {
+    return true;
+  }
   return invoke<boolean>("has_saved_connection_mode");
 }
 
@@ -264,5 +477,12 @@ export async function hasSavedConnectionMode(): Promise<boolean> {
  * @returns true if authentication succeeded
  */
 export async function attemptSilentAuth(): Promise<boolean> {
+  if (!hasElectronApi()) {
+    return true;
+  }
   return invoke<boolean>("attempt_silent_auth");
+}
+
+export function isElectronRuntime(): boolean {
+  return hasElectronApi();
 }

--- a/desktop/src/electron/shims/event.ts
+++ b/desktop/src/electron/shims/event.ts
@@ -4,6 +4,11 @@ export async function listen<T>(
   event: string,
   handler: (event: { payload: T }) => void
 ): Promise<UnlistenFn> {
+  if (typeof window === "undefined" || typeof window.electronAPI?.on !== "function") {
+    void event;
+    void handler;
+    return () => undefined;
+  }
   return window.electronAPI.on(event, (payload: unknown) =>
     handler({ payload: payload as T })
   );

--- a/desktop/src/electron/shims/global.d.ts
+++ b/desktop/src/electron/shims/global.d.ts
@@ -10,5 +10,5 @@ interface ElectronAPI {
 }
 
 interface Window {
-  electronAPI: ElectronAPI;
+  electronAPI?: ElectronAPI;
 }

--- a/desktop/src/electron/shims/invoke.ts
+++ b/desktop/src/electron/shims/invoke.ts
@@ -1,4 +1,7 @@
 export async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  if (typeof window === "undefined" || typeof window.electronAPI?.invoke !== "function") {
+    throw new Error(`Electron invoke '${cmd}' is unavailable in browser mode`);
+  }
   if (args !== undefined) {
     return window.electronAPI.invoke(cmd, args) as Promise<T>;
   }

--- a/desktop/src/electron/shims/opener.ts
+++ b/desktop/src/electron/shims/opener.ts
@@ -1,3 +1,9 @@
 export async function openUrl(url: string): Promise<void> {
-  return window.electronAPI.invoke('shell:open-external', { url }) as Promise<void>;
+  if (typeof window === "undefined") return;
+
+  if (typeof window.electronAPI?.invoke === "function") {
+    return window.electronAPI.invoke('shell:open-external', { url }) as Promise<void>;
+  }
+
+  window.open(url, "_blank", "noopener,noreferrer");
 }

--- a/desktop/src/electron/shims/window.ts
+++ b/desktop/src/electron/shims/window.ts
@@ -1,3 +1,11 @@
 export function getCurrentWindow() {
+  if (typeof window === "undefined" || typeof window.electronAPI?.getWindow !== "function") {
+    return {
+      minimize: async () => undefined,
+      toggleMaximize: async () => undefined,
+      close: async () => undefined,
+      startDragging: () => undefined,
+    };
+  }
   return window.electronAPI.getWindow();
 }

--- a/desktop/src/hooks/useEventSource.ts
+++ b/desktop/src/hooks/useEventSource.ts
@@ -12,11 +12,13 @@
 
 import { useEffect, useRef } from "react";
 import { sseStore, type SSEEvent, type SSEEventType } from "../stores/sseStore";
-import { getServerPort, retryServerConnection } from "@/electron/commands";
+import { getServerUrl, retryServerConnection } from "@/electron/commands";
 import { initSSEEventHandlers } from "../stores/sseEventHandlers";
 import { fetchKanbanSnapshot } from "@/api/server";
 import { useSelectedProject } from "@/stores/useProjectStore";
 import { projectStore, ALL_PROJECTS } from "@/stores/projectStore";
+import type { ProjectState } from "@/stores/projectStore";
+import type { Project } from "@/api/types";
 import { taskStore } from "@/stores/taskStore";
 import { epicStore } from "@/stores/epicStore";
 import { resetMcpClient } from "@/api/mcpClient";
@@ -78,7 +80,7 @@ export function useEventSource(projectId?: string | null) {
     const hydrateSnapshot = async (projectPath: string | null) => {
       try {
         const allPaths = isAll
-          ? projectStore.getState().projects.map((p) => p.path).filter(Boolean) as string[]
+          ? projectStore.getState().projects.map((p: Project) => p.path).filter(Boolean) as string[]
           : undefined;
         const snapshot = await fetchKanbanSnapshot(projectPath, allPaths);
         if (!isActive) return;
@@ -98,11 +100,11 @@ export function useEventSource(projectId?: string | null) {
     // this effect.
     let unsubProjectPath: (() => void) | undefined;
     if (!selectedProjectPath && projectId) {
-      unsubProjectPath = projectStore.subscribe((state) => {
+      unsubProjectPath = projectStore.subscribe((state: ProjectState) => {
         if (!isActive) return;
         if (isAll) {
           // ALL_PROJECTS mode: wait for projects to load, then hydrate all
-          const paths = state.projects.map((p) => p.path).filter(Boolean) as string[];
+          const paths = state.projects.map((p: Project) => p.path).filter(Boolean) as string[];
           if (paths.length > 0) {
             unsubProjectPath?.();
             unsubProjectPath = undefined;
@@ -123,10 +125,10 @@ export function useEventSource(projectId?: string | null) {
       try {
         await hydrateSnapshot(selectedProjectPath);
 
-        const port = await getServerPort();
+        const baseUrl = await getServerUrl();
         
         // Build URL with Last-Event-ID if available
-        let url = `http://127.0.0.1:${port}/events`;
+        let url = `${baseUrl}/events`;
         if (projectId && !isAll) {
           url += `?project_id=${encodeURIComponent(projectId)}`;
         }

--- a/desktop/src/hooks/useServerHealth.test.ts
+++ b/desktop/src/hooks/useServerHealth.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const commandMocks = vi.hoisted(() => ({
   getServerStatus: vi.fn(),
-  retryServerDiscovery: vi.fn(),
+  retryServerConnection: vi.fn(),
 }));
 
 const eventMocks = vi.hoisted(() => ({
@@ -12,7 +12,7 @@ const eventMocks = vi.hoisted(() => ({
 
 vi.mock('@/electron/commands', () => ({
   getServerStatus: commandMocks.getServerStatus,
-  retryServerDiscovery: commandMocks.retryServerDiscovery,
+  retryServerConnection: commandMocks.retryServerConnection,
 }));
 vi.mock('@/electron/shims/event', () => ({ listen: eventMocks.listen }));
 

--- a/desktop/src/test/setup.ts
+++ b/desktop/src/test/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest"
+import { vi } from "vitest"
 
 // jsdom doesn't provide Web Streams API — polyfill so eventsource-parser (and anything
 // else using TransformStream/ReadableStream/WritableStream) can load without crashing.
@@ -38,6 +39,7 @@ Object.defineProperty(window, 'electronAPI', {
     })),
   },
   writable: true,
+  configurable: true,
 });
 
 // Test utility: emit events to registered listeners

--- a/desktop/src/vite-env.d.ts
+++ b/desktop/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_DJINN_SERVER_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
Refactor the React frontend so core data fetching and navigation can run in a normal browser session without Electron preload APIs. Focus on the runtime boundary currently centered on `desktop/src/electron/commands.ts`, `desktop/src/electron/shims/*`, and the API modules/hooks that import them.

## Acceptance Criteria
- [x] Frontend modules that currently hard-depend on Electron for basic server communication have a browser-compatible path that runs without `window.electronAPI`
- [x] Browser/runtime adapter seams are introduced in a small number of shared modules instead of scattering environment checks throughout components
- [x] Tests cover the new non-Electron runtime path for at least one representative fetch/bootstrapping flow

---
Djinn task: h3p6