### PR TITLE
feat(ck9v): Plan next wave: Docker-Based Deployment, Web UI, and OpenViking Memory Backend

### DIFF
--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -1,62 +1,67 @@
 ---
-title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 type: design
-tags: ["epic-roadmap","adr-053","docker","web-ui","openviking"]
+tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
 ---
 
 # Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
 
 ## Status
-Epic [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is **not complete**. No implementation tasks have landed yet; the board only contains this planning task. The codebase still ships an Electron shell, relies on Electron IPC for key UI flows, serves only API/MCP routes from `server/src/server/mod.rs`, and still uses the legacy `NoteRepository`/memory MCP surface in `server/` and `server/crates/djinn-mcp/`.
+Epic `7izs` remains **open**. The architectural direction in [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is accepted, but the codebase still contains substantial Electron-specific UI/runtime behavior and the legacy `NoteRepository`-based memory system.
 
-## Current repo facts
-- Desktop packaging is still Electron-based (`desktop/package.json`, `desktop/electron/main.ts`, `desktop/electron/ipc-handlers.ts`).
-- Frontend code still imports Electron wrappers broadly (`desktop/src/electron/commands.ts`, `desktop/src/electron/shims/*`).
-- The Rust server currently exposes health/events/MCP/project-management routes, but no SPA static-file serving or browser-oriented replacement endpoints for native pickers/window APIs (`server/src/server/mod.rs`, `server/src/server/project_tools.rs`).
-- Memory operations still center on `djinn_db::NoteRepository`, `memory_build_context`, `memory_health`, `memory_broken_links`, `memory_orphans`, task confidence, and the KB watcher (`server/crates/djinn-mcp/src/tools/memory_tools/*`, `server/src/task_confidence.rs`, `server/src/watchers/kb.rs`).
-- No Dockerfile or compose stack exists in the repo root or `server/`.
+## Current Board State
 
-## Decomposition strategy
-Sequence this epic as three waves so workers can land vertical slices without trampling each other.
+### Active / recently active wave
+- `rpgb` — serve the React web app from `djinn-server`
+- `h3p6` — introduce a browser-compatible frontend runtime boundary
+- `2744` — replace native project/file pickers with server-backed filesystem browsing
+- `4a4t` — create the OpenViking memory backend seam and bootstrap client
+- `aijd` — package `djinn-server` and OpenViking with Docker Compose
 
-### Wave 1 — Foundation and seams
-1. Add server static-asset hosting so the Rust server can serve the built web app alongside existing HTTP/MCP APIs.
-2. Extract the frontend runtime boundary away from Electron-only shims so the React app can run in a normal browser against the Rust server.
-3. Add server-side filesystem browsing/import APIs to replace the native directory/file pickers used by project onboarding and connection settings.
-4. Introduce a memory backend seam plus an OpenViking client/configuration slice without changing user-visible memory behavior yet.
-5. Add Docker packaging and a compose stack wiring Djinn + OpenViking, using the new server/web build outputs.
+### What this wave establishes
+1. Browser delivery of the SPA from the Rust server.
+2. A shared frontend runtime seam so the app can run without `window.electronAPI` for core transport/bootstrap flows.
+3. The first browser-native filesystem picker flow.
+4. An initial OpenViking integration seam so later phases can migrate incrementally instead of as a big-bang swap.
+5. Container packaging once the server/static-hosting and memory-backend seams exist.
 
-### Wave 2 — Web-only UX completion
-- Remove remaining Electron-only flows (window chrome, auth/token/local integration, SSH/remote helpers that must move server-side or be dropped).
-- Switch the shipped app/docs to browser-first usage.
-- Reduce or eliminate Electron build/package scripts once the browser path is production-ready.
+## Why the epic is not complete
+Code search confirms the repo still contains:
+- Electron main/preload/IPC shell code under `desktop/electron/*`
+- Electron-only commands still used by frontend flows such as `selectDirectory`, `selectFile`, and SSH connection management
+- Legacy memory systems including `NoteRepository`, `task_confidence`, `watchers/kb.rs`, and MCP schemas/tests for tools ADR-053 plans to retire
+- No completed transition of `memory_refs` to `viking://` URIs yet
 
-### Wave 3 — Memory migration
-- Implement dual-read shadowing against OpenViking.
-- Migrate writes and `memory_refs` URI handling to `viking://`.
-- Remove confidence-scoring and legacy knowledge-base maintenance features deprecated by ADR-053.
-- Delete legacy `NoteRepository`-specific codepaths, watchers, and surplus MCP tools.
+So the epic is in active migration, not closure.
 
-## Wave 1 tasks
-This wave creates five concrete worker tasks:
-1. Server SPA/static hosting scaffold.
-2. Frontend browser-runtime adapter replacing Electron-only transport assumptions.
-3. Filesystem browsing/import HTTP APIs plus web picker integration.
-4. Memory backend seam + OpenViking client bootstrap.
-5. Dockerfile/compose packaging for Djinn + OpenViking.
+## Sequencing
+- `2744` should stay sequenced behind `h3p6` because the browser picker depends on the shared non-Electron runtime boundary.
+- `aijd` should stay sequenced behind `rpgb` and `4a4t` because the Compose stack must package the browser-served server and the OpenViking sidecar contract it depends on.
 
-## Exit criteria for this wave
-- The server can serve a built frontend bundle.
-- The frontend has a browser-compatible runtime path for basic server communication.
-- At least one onboarding/project-selection flow works without native file dialogs.
-- OpenViking integration is represented by a real backend seam and client bootstrap instead of being only an ADR.
-- A local operator can start Djinn + OpenViking with Docker Compose.
+## Next Wave After Current Foundations
 
-## Follow-up notes
-- Keep tasks narrow and file-seamed to avoid simultaneous edits to the same Electron/server bootstrap files.
-- Do **not** attempt full memory switchover in the same wave as seam extraction; land the integration seam first, then migrate behavior in later waves.
-- Preserve MCP compatibility during the migration period; browser delivery and backend swap should not break the planner/worker toolchain mid-epic.
+### Wave 2A — Browser deployment parity
+1. **Move SSH/deployment flows to server-owned APIs**
+   - Replace Electron-managed SSH host/tunnel/deploy orchestration with server-side HTTP APIs and browser-compatible UI flows.
+   - This covers the remaining major web-migration gap after the runtime boundary and picker work.
+
+### Wave 2B — OpenViking phased migration
+2. **Dual-read shadow for read/search/list/build-context flows**
+   - Route read-oriented memory operations through the new backend seam with parity checks while preserving the legacy implementation.
+3. **Write-path migration and data switchover tooling**
+   - Add migration/bootstrap tooling, dual-write or cutover semantics, and operational docs for moving persisted memory into OpenViking.
+4. **`memory_refs` URI transition**
+   - Introduce `viking://` URI handling for tasks/epics while keeping legacy permalink resolution during migration.
+5. **Legacy memory cleanup**
+   - Remove obsolete confidence scoring, watcher/housekeeping, and MCP tools that ADR-053 explicitly replaces once the cutover is complete.
+
+## Exit Criteria for Epic Closure
+The epic can close only when all three are true:
+1. Djinn is runnable as a browser-served Docker/Compose deployment without Electron-required user flows.
+2. OpenViking is the effective memory backend for supported memory operations, with migration/compatibility handled.
+3. Legacy Electron-only packaging and legacy memory subsystems called out by ADR-053 are removed or intentionally retired.
 
 ## Relations
 - [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
-- [[brief]]
+- [[roadmap]]
+- [[reference/adr-043-roadmap-active-decomposition-status]]

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -4,6 +4,12 @@ type: design
 tags: ["adr-053","docker","web-ui","openviking","roadmap"]
 ---
 
+---
+title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+type: design
+tags: ["adr-053","docker","web-ui","openviking","roadmap"]
+---
+
 # Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
 
 ## Status
@@ -17,6 +23,7 @@ Epic `7izs` remains open. The architectural direction from [[decisions/adr-053-d
 - `2744` — replace native project/file pickers with server-backed filesystem browsing. Worker implementation is in progress and currently blocked in verification by unrelated `djinn-agent` snapshot drift rather than picker-specific failures.
 - `4a4t` — create the OpenViking memory backend seam and bootstrap client.
 - `wpe0` — repair unrelated `djinn-db` baseline test failures so epic tasks can verify against a green server baseline.
+- `3ok1` — diagnose the `djinn-agent` prompt snapshot drift that is causing unrelated ADR-053 verification churn across multiple tasks.
 
 ## Next-wave sequencing
 
@@ -35,21 +42,25 @@ Epic `7izs` remains open. The architectural direction from [[decisions/adr-053-d
 
 ## Active task map
 - Browser/runtime foundation: `h3p6` ✅
-- Static frontend hosting: `rpgb`
+- Static frontend hosting: `rpgb` (blocked by `wpe0`)
 - Browser filesystem picker: `2744`
 - Browser SSH/deploy flows: `24v4`
-- Docker packaging: `aijd`
+- Docker packaging: `aijd` (blocked by `rpgb`, `4a4t`)
 - OpenViking backend seam: `4a4t`
-- Dual-read shadow: `vce4`
-- Write/bootstrap migration: `d4qf`
-- `memory_refs` URI transition: `ow2x`
-- Legacy memory cleanup: `ow2c`
+- Dual-read shadow: `vce4` (blocked by `4a4t`)
+- Write/bootstrap migration: `d4qf` (blocked by `vce4`)
+- `memory_refs` URI transition: `ow2x` (blocked by `d4qf`)
+- Legacy memory cleanup: `ow2c` (blocked by `ow2x`)
 - Verification-baseline repair: `wpe0`
+- Prompt-snapshot diagnosis spike: `3ok1`
 
 ## Planning notes
 - Do not create additional broad ADR-053 worker tasks until the current queue shrinks; the epic already has enough decomposed work for the next execution wave.
 - Prefer blocker relationships over new decomposition rows where work is already represented.
-- If `djinn-agent` prompt snapshot churn continues to block unrelated verification after `wpe0`, split that into a focused baseline-remediation task rather than broadening feature tasks.
+- `wpe0` is the immediate verification-baseline gate for server-hosting work such as `rpgb`.
+- `aijd` should wait on both server-side frontend hosting (`rpgb`) and the OpenViking seam/bootstrap (`4a4t`) so Docker packaging is wired against the real runtime shape instead of placeholder assumptions.
+- The OpenViking migration sequence is now explicitly chained: `4a4t` → `vce4` → `d4qf` → `ow2x` → `ow2c`.
+- Keep `3ok1` focused on diagnosing prompt snapshot churn; if the outcome is “expected snapshots changed”, future feature tasks should update snapshots rather than absorbing unrelated verification noise.
 
 ## Relations
 - [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -1,0 +1,62 @@
+---
+title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+type: design
+tags: ["epic-roadmap","adr-053","docker","web-ui","openviking"]
+---
+
+# Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+
+## Status
+Epic [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is **not complete**. No implementation tasks have landed yet; the board only contains this planning task. The codebase still ships an Electron shell, relies on Electron IPC for key UI flows, serves only API/MCP routes from `server/src/server/mod.rs`, and still uses the legacy `NoteRepository`/memory MCP surface in `server/` and `server/crates/djinn-mcp/`.
+
+## Current repo facts
+- Desktop packaging is still Electron-based (`desktop/package.json`, `desktop/electron/main.ts`, `desktop/electron/ipc-handlers.ts`).
+- Frontend code still imports Electron wrappers broadly (`desktop/src/electron/commands.ts`, `desktop/src/electron/shims/*`).
+- The Rust server currently exposes health/events/MCP/project-management routes, but no SPA static-file serving or browser-oriented replacement endpoints for native pickers/window APIs (`server/src/server/mod.rs`, `server/src/server/project_tools.rs`).
+- Memory operations still center on `djinn_db::NoteRepository`, `memory_build_context`, `memory_health`, `memory_broken_links`, `memory_orphans`, task confidence, and the KB watcher (`server/crates/djinn-mcp/src/tools/memory_tools/*`, `server/src/task_confidence.rs`, `server/src/watchers/kb.rs`).
+- No Dockerfile or compose stack exists in the repo root or `server/`.
+
+## Decomposition strategy
+Sequence this epic as three waves so workers can land vertical slices without trampling each other.
+
+### Wave 1 — Foundation and seams
+1. Add server static-asset hosting so the Rust server can serve the built web app alongside existing HTTP/MCP APIs.
+2. Extract the frontend runtime boundary away from Electron-only shims so the React app can run in a normal browser against the Rust server.
+3. Add server-side filesystem browsing/import APIs to replace the native directory/file pickers used by project onboarding and connection settings.
+4. Introduce a memory backend seam plus an OpenViking client/configuration slice without changing user-visible memory behavior yet.
+5. Add Docker packaging and a compose stack wiring Djinn + OpenViking, using the new server/web build outputs.
+
+### Wave 2 — Web-only UX completion
+- Remove remaining Electron-only flows (window chrome, auth/token/local integration, SSH/remote helpers that must move server-side or be dropped).
+- Switch the shipped app/docs to browser-first usage.
+- Reduce or eliminate Electron build/package scripts once the browser path is production-ready.
+
+### Wave 3 — Memory migration
+- Implement dual-read shadowing against OpenViking.
+- Migrate writes and `memory_refs` URI handling to `viking://`.
+- Remove confidence-scoring and legacy knowledge-base maintenance features deprecated by ADR-053.
+- Delete legacy `NoteRepository`-specific codepaths, watchers, and surplus MCP tools.
+
+## Wave 1 tasks
+This wave creates five concrete worker tasks:
+1. Server SPA/static hosting scaffold.
+2. Frontend browser-runtime adapter replacing Electron-only transport assumptions.
+3. Filesystem browsing/import HTTP APIs plus web picker integration.
+4. Memory backend seam + OpenViking client bootstrap.
+5. Dockerfile/compose packaging for Djinn + OpenViking.
+
+## Exit criteria for this wave
+- The server can serve a built frontend bundle.
+- The frontend has a browser-compatible runtime path for basic server communication.
+- At least one onboarding/project-selection flow works without native file dialogs.
+- OpenViking integration is represented by a real backend seam and client bootstrap instead of being only an ADR.
+- A local operator can start Djinn + OpenViking with Docker Compose.
+
+## Follow-up notes
+- Keep tasks narrow and file-seamed to avoid simultaneous edits to the same Electron/server bootstrap files.
+- Do **not** attempt full memory switchover in the same wave as seam extraction; land the integration seam first, then migrate behavior in later waves.
+- Preserve MCP compatibility during the migration period; browser delivery and backend swap should not break the planner/worker toolchain mid-epic.
+
+## Relations
+- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
+- [[brief]]

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -1,71 +1,54 @@
 ---
 title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 type: design
-tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
+tags: ["adr-053","docker","web-ui","openviking","roadmap"]
 ---
 
-# Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+# Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 
 ## Status
-Epic `7izs` remains open. The goal is **not** yet complete: core foundation work is still in progress and the OpenViking migration has only reached the seam/bootstrap stage.
+In progress. Epic `7izs` is not complete. Foundational work is underway, but the Docker deployment, browser-only replacement flows, and OpenViking migration are only partially landed.
 
-## Architectural source
+## Architectural anchor
 - [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
-- [[reference/adr-043-roadmap-active-decomposition-status]]
-- [[cases/recreated-missing-canonical-roadmap-note-for-docker-openviking-epic-memory]]
-- [[cases/singleton-note-writes-from-planner-worktree-target-duplicates-instead-of-canonical-project-root-files]]
+- Canonical active-wave reference remains [[roadmap]] for board-wide decomposition context.
 
 ## Completed work
-- `h3p6` closed: browser-compatible frontend runtime boundary landed, giving the web UI a shared non-Electron transport/runtime seam.
-- `sgs2` closed: restored the missing canonical roadmap memory reference and repaired epic/task metadata drift.
+- `h3p6` closed: browser-compatible frontend runtime boundary landed.
+- `sgs2` closed: repaired missing canonical roadmap reference and epic/task memory refs.
+- `rpgb` and `4a4t` both have substantial in-flight implementations submitted and reopened only on unrelated verification drift (`djinn-provider` clippy / snapshot drift), not because the core approach was invalid.
 
-## Active foundation work
-- `rpgb` — serve the React app from `djinn-server`
+## Current active wave
+### In progress
+- `rpgb` — serve the React web app from `djinn-server`
 - `2744` — replace native pickers with server-backed filesystem browsing
 - `4a4t` — create the OpenViking memory backend seam and bootstrap client
 
-These are the critical enablement tasks. The epic cannot close until the browser-hosted shell and OpenViking migration path both exist end-to-end.
+### Ready/open behind current foundations
+- `aijd` — package `djinn-server` and OpenViking with Docker Compose
+- `24v4` — move SSH connection and deployment flows behind server-owned browser APIs
+- `vce4` — add OpenViking dual-read shadow for memory reads and context retrieval
+- `d4qf` — migrate memory writes and bootstrap data into OpenViking
+- `ow2x` — transition task and epic `memory_refs` to `viking://` URIs with legacy compatibility
+- `ow2c` — retire legacy memory confidence, watcher, and obsolete MCP tool surfaces after OpenViking cutover
 
-## Current wave plan
-This wave focuses on sequencing the next implementation batch behind the active foundation work rather than opening more parallel work than the codebase can safely absorb.
+## Wave assessment
+The epic should remain open. None of the three ADR-053 workstreams is done end-to-end yet:
+1. **Docker deployment** has a task defined but not yet landed.
+2. **Web UI migration** has runtime-boundary groundwork done, but static serving, picker replacement, and SSH/deploy browser APIs are still in progress/open.
+3. **OpenViking migration** has a seam/bootstrap task in flight, while shadow reads, write cutover, URI transition, and legacy cleanup remain open.
 
-### Web deployment track
-1. `rpgb` must land before Docker packaging is considered complete, because the server image/compose stack must package and serve the built SPA.
-2. `aijd` depends on `rpgb`.
-3. `2744` continues independently once the browser runtime boundary is available.
-4. `24v4` follows as the remaining Electron-to-server migration for SSH/deploy flows.
+## Sequencing guidance
+Use the already-created tasks as the active decomposition wave; do **not** add more worker tasks until this wave drains.
 
-### OpenViking migration track
-1. `4a4t` establishes the backend seam and client bootstrap.
-2. `vce4` depends on `4a4t` for shadow reads and parity logging.
-3. `d4qf` depends on `4a4t` and `vce4` for write cutover and bootstrap import.
-4. `ow2x` depends on `d4qf` because URI emission should switch only after OpenViking-backed read/write paths exist.
-5. `ow2c` depends on `d4qf` and `ow2x` because cleanup belongs after authoritative cutover and mixed-format compatibility are in place.
+Recommended dependency/order:
+1. `rpgb` and `2744` can proceed in parallel on the web stack.
+2. `aijd` should consume the frontend-serving outcome from `rpgb` and the OpenViking bootstrap assumptions from `4a4t`.
+3. `vce4` should follow `4a4t`.
+4. `d4qf` should follow `vce4`.
+5. `ow2x` should follow `d4qf`.
+6. `ow2c` should follow `ow2x`.
+7. `24v4` can proceed independently of the memory migration, but should align with the browser-only deployment model established by `rpgb`.
 
-## Wave task set
-Existing open tasks already define the next wave and remain the correct implementation slices; this planning pass primarily tightened sequencing and memory-linking rather than adding more parallel work:
-- `aijd` — Docker Compose packaging after SPA serving
-- `24v4` — browser/server-owned SSH and deployment APIs
-- `vce4` — OpenViking dual-read shadow
-- `d4qf` — OpenViking write/bootstrap migration
-- `ow2x` — `viking://` memory_refs transition
-- `ow2c` — legacy memory cleanup after cutover
-
-## 2026-04-13 planning wave refresh
-- Reassessed epic `7izs`: still open because SPA serving (`rpgb`), filesystem picker migration (`2744`), and OpenViking seam/bootstrap (`4a4t`) are still in progress, and the downstream Docker/OpenViking cutover tasks have not landed.
-- Confirmed the next implementation wave is already represented on the board by existing worker tasks rather than needing additional decomposition.
-- Tightened sequencing on the board: `aijd` blocked by `rpgb`; `vce4` blocked by `4a4t`; `d4qf` blocked by `4a4t` + `vce4`; `ow2x` blocked by `d4qf`; `ow2c` blocked by `d4qf` + `ow2x`.
-- Normalized active task memory refs so the in-flight foundation tasks and cleanup task point at this roadmap note.
-
-## Planner notes
-- Prefer this design note over the singleton `[[roadmap]]` for epic `7izs` planning, because the singleton roadmap is currently used by other epics and has known drift risk.
-- Do not schedule cleanup (`ow2c`) before the OpenViking path is authoritative.
-- Do not treat Docker packaging as complete until the runtime serves the frontend bundle from the server image.
-
-## Exit criteria for epic closure
-Epic `7izs` can close only when:
-- the web UI is served by `djinn-server` in Docker,
-- file-picker and SSH/deploy browser flows no longer require Electron,
-- OpenViking is authoritative for memory read/write flows,
-- task/epic `memory_refs` can operate on `viking://` URIs with compatibility during migration,
-- legacy memory-only systems targeted by ADR-053 are retired.
+## Planner note for this session
+This planning pass found that the epic already has a full active wave of worker tasks (more than the 3–5 target) created by the previous decomposition session. The correct action in this session is to restore the missing dedicated design roadmap note and capture the current sequencing/completion assessment rather than creating duplicate tasks.

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -7,61 +7,59 @@ tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
 # Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
 
 ## Status
-Epic `7izs` remains **open**. The architectural direction in [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is accepted, but the codebase still contains substantial Electron-specific UI/runtime behavior and the legacy `NoteRepository`-based memory system.
+Epic `7izs` remains open. The goal is **not** yet complete: core foundation work is still in progress and the OpenViking migration has only reached the seam/bootstrap stage.
 
-## Current Board State
-
-### Active / recently active wave
-- `rpgb` — serve the React web app from `djinn-server`
-- `h3p6` — introduce a browser-compatible frontend runtime boundary
-- `2744` — replace native project/file pickers with server-backed filesystem browsing
-- `4a4t` — create the OpenViking memory backend seam and bootstrap client
-- `aijd` — package `djinn-server` and OpenViking with Docker Compose
-
-### What this wave establishes
-1. Browser delivery of the SPA from the Rust server.
-2. A shared frontend runtime seam so the app can run without `window.electronAPI` for core transport/bootstrap flows.
-3. The first browser-native filesystem picker flow.
-4. An initial OpenViking integration seam so later phases can migrate incrementally instead of as a big-bang swap.
-5. Container packaging once the server/static-hosting and memory-backend seams exist.
-
-## Why the epic is not complete
-Code search confirms the repo still contains:
-- Electron main/preload/IPC shell code under `desktop/electron/*`
-- Electron-only commands still used by frontend flows such as `selectDirectory`, `selectFile`, and SSH connection management
-- Legacy memory systems including `NoteRepository`, `task_confidence`, `watchers/kb.rs`, and MCP schemas/tests for tools ADR-053 plans to retire
-- No completed transition of `memory_refs` to `viking://` URIs yet
-
-So the epic is in active migration, not closure.
-
-## Sequencing
-- `2744` should stay sequenced behind `h3p6` because the browser picker depends on the shared non-Electron runtime boundary.
-- `aijd` should stay sequenced behind `rpgb` and `4a4t` because the Compose stack must package the browser-served server and the OpenViking sidecar contract it depends on.
-
-## Next Wave After Current Foundations
-
-### Wave 2A — Browser deployment parity
-1. **Move SSH/deployment flows to server-owned APIs**
-   - Replace Electron-managed SSH host/tunnel/deploy orchestration with server-side HTTP APIs and browser-compatible UI flows.
-   - This covers the remaining major web-migration gap after the runtime boundary and picker work.
-
-### Wave 2B — OpenViking phased migration
-2. **Dual-read shadow for read/search/list/build-context flows**
-   - Route read-oriented memory operations through the new backend seam with parity checks while preserving the legacy implementation.
-3. **Write-path migration and data switchover tooling**
-   - Add migration/bootstrap tooling, dual-write or cutover semantics, and operational docs for moving persisted memory into OpenViking.
-4. **`memory_refs` URI transition**
-   - Introduce `viking://` URI handling for tasks/epics while keeping legacy permalink resolution during migration.
-5. **Legacy memory cleanup**
-   - Remove obsolete confidence scoring, watcher/housekeeping, and MCP tools that ADR-053 explicitly replaces once the cutover is complete.
-
-## Exit Criteria for Epic Closure
-The epic can close only when all three are true:
-1. Djinn is runnable as a browser-served Docker/Compose deployment without Electron-required user flows.
-2. OpenViking is the effective memory backend for supported memory operations, with migration/compatibility handled.
-3. Legacy Electron-only packaging and legacy memory subsystems called out by ADR-053 are removed or intentionally retired.
-
-## Relations
+## Architectural source
 - [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
-- [[roadmap]]
 - [[reference/adr-043-roadmap-active-decomposition-status]]
+- [[cases/recreated-missing-canonical-roadmap-note-for-docker-openviking-epic-memory]]
+- [[cases/singleton-note-writes-from-planner-worktree-target-duplicates-instead-of-canonical-project-root-files]]
+
+## Completed work
+- `h3p6` closed: browser-compatible frontend runtime boundary landed, giving the web UI a shared non-Electron transport/runtime seam.
+- `sgs2` closed: restored the missing canonical roadmap memory reference and repaired epic/task metadata drift.
+
+## Active foundation work
+- `rpgb` — serve the React app from `djinn-server`
+- `2744` — replace native pickers with server-backed filesystem browsing
+- `4a4t` — create the OpenViking memory backend seam and bootstrap client
+
+These are the critical enablement tasks. The epic cannot close until the browser-hosted shell and OpenViking migration path both exist end-to-end.
+
+## Current wave plan
+This wave focuses on sequencing the next implementation batch behind the active foundation work rather than opening more parallel work than the codebase can safely absorb.
+
+### Web deployment track
+1. `rpgb` must land before Docker packaging is considered complete, because the server image/compose stack must package and serve the built SPA.
+2. `aijd` depends on `rpgb`.
+3. `2744` continues independently once the browser runtime boundary is available.
+4. `24v4` follows as the remaining Electron-to-server migration for SSH/deploy flows.
+
+### OpenViking migration track
+1. `4a4t` establishes the backend seam and client bootstrap.
+2. `vce4` depends on `4a4t` for shadow reads and parity logging.
+3. `d4qf` depends on `4a4t` and `vce4` for write cutover and bootstrap import.
+4. `ow2x` depends on `d4qf` because URI emission should switch only after OpenViking-backed read/write paths exist.
+5. `ow2c` depends on `d4qf` and `ow2x` because cleanup belongs after authoritative cutover and mixed-format compatibility are in place.
+
+## Wave task set
+Existing open tasks already define the next wave and remain the correct 3–5+ implementation slices; this planning pass primarily tightened sequencing:
+- `aijd` — Docker Compose packaging after SPA serving
+- `24v4` — browser/server-owned SSH and deployment APIs
+- `vce4` — OpenViking dual-read shadow
+- `d4qf` — OpenViking write/bootstrap migration
+- `ow2x` — `viking://` memory_refs transition
+- `ow2c` — legacy memory cleanup after cutover
+
+## Planner notes
+- Prefer this design note over the singleton `[[roadmap]]` for epic `7izs` planning, because the singleton roadmap is currently used by other epics and has known drift risk.
+- Do not schedule cleanup (`ow2c`) before the OpenViking path is authoritative.
+- Do not treat Docker packaging as complete until the runtime serves the frontend bundle from the server image.
+
+## Exit criteria for epic closure
+Epic `7izs` can close only when:
+- the web UI is served by `djinn-server` in Docker,
+- file-picker and SSH/deploy browser flows no longer require Electron,
+- OpenViking is authoritative for memory read/write flows,
+- task/epic `memory_refs` can operate on `viking://` URIs with compatibility during migration,
+- legacy memory-only systems targeted by ADR-053 are retired.

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -1,54 +1,73 @@
 ---
 title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 type: design
-tags: ["adr-053","docker","web-ui","openviking","roadmap"]
+tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
 ---
 
-# Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
+# Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
 
 ## Status
-In progress. Epic `7izs` is not complete. Foundational work is underway, but the Docker deployment, browser-only replacement flows, and OpenViking migration are only partially landed.
+In progress. Epic `7izs` is **not complete**.
 
-## Architectural anchor
-- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
-- Canonical active-wave reference remains [[roadmap]] for board-wide decomposition context.
+## Goal
+Migrate Djinn from an Electron desktop shell plus custom memory system to:
+- Docker Compose deployment
+- browser-served web UI from `djinn-server`
+- OpenViking-backed memory services and `viking://` memory references
+
+This roadmap is the canonical wave-planning note for epic `7izs` and should be preferred over the singleton [[roadmap]] note for this epic's active work.
+
+## Architectural guardrails
+- Follow [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]].
+- Keep `djinn-server` as the single runtime entrypoint that serves both API routes and the SPA bundle.
+- Replace Electron-only capabilities with server-owned HTTP APIs and browser-compatible UI flows.
+- Migrate memory in phases: seam/bootstrap → shadow reads → write/import cutover → `viking://` refs → legacy cleanup.
+- Do not remove legacy memory systems until OpenViking is authoritative for read and write paths.
 
 ## Completed work
 - `h3p6` closed: browser-compatible frontend runtime boundary landed.
-- `sgs2` closed: repaired missing canonical roadmap reference and epic/task memory refs.
-- `rpgb` and `4a4t` both have substantial in-flight implementations submitted and reopened only on unrelated verification drift (`djinn-provider` clippy / snapshot drift), not because the core approach was invalid.
+- `sgs2` closed: canonical roadmap/memory-ref repair completed so active work points at a real roadmap artifact.
 
-## Current active wave
-### In progress
+## Active wave
+### In progress / verifying
 - `rpgb` — serve the React web app from `djinn-server`
-- `2744` — replace native pickers with server-backed filesystem browsing
+- `2744` — replace native project/file pickers with server-backed filesystem browsing
 - `4a4t` — create the OpenViking memory backend seam and bootstrap client
 
-### Ready/open behind current foundations
-- `aijd` — package `djinn-server` and OpenViking with Docker Compose
-- `24v4` — move SSH connection and deployment flows behind server-owned browser APIs
-- `vce4` — add OpenViking dual-read shadow for memory reads and context retrieval
-- `d4qf` — migrate memory writes and bootstrap data into OpenViking
-- `ow2x` — transition task and epic `memory_refs` to `viking://` URIs with legacy compatibility
-- `ow2c` — retire legacy memory confidence, watcher, and obsolete MCP tool surfaces after OpenViking cutover
+### Ready next once active items land
+1. `aijd` — package `djinn-server` and OpenViking with Docker Compose
+2. `24v4` — move SSH connection and deployment flows behind server-owned browser APIs
+3. `vce4` — add OpenViking dual-read shadow for memory reads and context retrieval
+4. `d4qf` — migrate memory writes and bootstrap data into OpenViking
+5. `ow2x` — transition task and epic `memory_refs` to `viking://` URIs with legacy compatibility
+6. `ow2c` — retire legacy memory confidence, watcher, and obsolete MCP tool surfaces after OpenViking cutover
 
-## Wave assessment
-The epic should remain open. None of the three ADR-053 workstreams is done end-to-end yet:
-1. **Docker deployment** has a task defined but not yet landed.
-2. **Web UI migration** has runtime-boundary groundwork done, but static serving, picker replacement, and SSH/deploy browser APIs are still in progress/open.
-3. **OpenViking migration** has a seam/bootstrap task in flight, while shadow reads, write cutover, URI transition, and legacy cleanup remain open.
+## Sequencing
+1. **Web delivery foundation**
+   - `rpgb` provides SPA/static hosting from the Rust server.
+   - `2744` removes the most visible Electron-only picker dependency.
+2. **Memory backend foundation**
+   - `4a4t` establishes the backend seam and OpenViking bootstrap/config.
+3. **Deployment + remaining Electron removal**
+   - `aijd` can package the stack once SPA hosting shape and OpenViking boot wiring are real.
+   - `24v4` removes SSH/deploy flows from Electron ownership.
+4. **OpenViking migration**
+   - `vce4` depends on `4a4t`.
+   - `d4qf` depends on `vce4` or at minimum the seam from `4a4t`, but should follow shadow-read validation.
+   - `ow2x` follows readable/writable OpenViking-backed note flows.
+   - `ow2c` is final cleanup after OpenViking becomes authoritative.
 
-## Sequencing guidance
-Use the already-created tasks as the active decomposition wave; do **not** add more worker tasks until this wave drains.
+## Completion gate
+Epic `7izs` is complete only when all three workstreams are done:
+- `djinn-server` serves the browser UI and the Docker Compose stack runs Djinn + OpenViking cleanly.
+- Electron-owned picker and SSH/deploy flows are replaced by browser/server flows.
+- OpenViking is authoritative for reads and writes, `memory_refs` support `viking://`, and legacy memory subsystems are retired.
 
-Recommended dependency/order:
-1. `rpgb` and `2744` can proceed in parallel on the web stack.
-2. `aijd` should consume the frontend-serving outcome from `rpgb` and the OpenViking bootstrap assumptions from `4a4t`.
-3. `vce4` should follow `4a4t`.
-4. `d4qf` should follow `vce4`.
-5. `ow2x` should follow `d4qf`.
-6. `ow2c` should follow `ow2x`.
-7. `24v4` can proceed independently of the memory migration, but should align with the browser-only deployment model established by `rpgb`.
+## Notes for future planning waves
+- Do not treat the singleton [[roadmap]] note as authoritative for this epic; it currently tracks ADR-043 work and can diverge from epic `7izs` board state.
+- If `rpgb`, `2744`, and `4a4t` all land successfully, the next planning wave should focus on blocker cleanup and ensuring dependency order across `aijd`, `24v4`, `vce4`, `d4qf`, `ow2x`, and `ow2c` rather than creating duplicate tasks.
 
-## Planner note for this session
-This planning pass found that the epic already has a full active wave of worker tasks (more than the 3–5 target) created by the previous decomposition session. The correct action in this session is to restore the missing dedicated design roadmap note and capture the current sequencing/completion assessment rather than creating duplicate tasks.
+## Relations
+- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
+- [[cases/recreated-missing-canonical-roadmap-note-for-docker-openviking-epic-memory]]
+- [[reference/adr-043-roadmap-active-decomposition-status]]

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -1,52 +1,57 @@
 ---
-title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
+title: Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
 type: design
-tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
+tags: ["adr-053","docker","web-ui","openviking","roadmap"]
 ---
 
 # Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
 
 ## Status
-Epic `7izs` remains open. The goal is not yet complete: only the browser-runtime boundary (`h3p6`) and roadmap/memory-ref repair (`sgs2`) are closed, while the core deployment, browser parity, and OpenViking migration slices are still in progress or queued.
-
-## Architectural anchor
-- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is the governing decision.
-- `memory_refs` should continue to include this note plus `[[roadmap]]` only as a temporary cross-link; this note is the epic-specific plan.
+Epic `7izs` remains open. The architectural direction from [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is still valid, but the implementation is only partially landed.
 
 ## Completed work
-- `h3p6` — browser-compatible frontend runtime boundary landed, giving web-mode transport/runtime seams to build on.
-- `sgs2` — restored canonical roadmap memory references for this epic.
-- `rpgb` implementation work is substantially present, but final verification is blocked on the repo-green follow-up task `wpe0`.
+- Browser-compatible frontend runtime boundary landed via task `h3p6`, giving the web app a non-Electron transport/bootstrap seam.
+- Canonical roadmap/memory-ref repair landed via task `sgs2`, restoring `design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap` as the intended epic roadmap permalink.
 
-## Active wave
+## In-flight work
+- `2744` — replace native project/file pickers with server-backed filesystem browsing. Worker implementation is in progress and currently blocked in verification by unrelated `djinn-agent` snapshot drift rather than picker-specific failures.
+- `4a4t` — create the OpenViking memory backend seam and bootstrap client.
+- `wpe0` — repair unrelated `djinn-db` baseline test failures so epic tasks can verify against a green server baseline.
 
-### 1. Web UI parity and server hosting
-- `rpgb` — serve the built React bundle from `djinn-server` with SPA fallback while preserving API/MCP routes. This is now blocked on `wpe0` so it can verify against a green base instead of absorbing unrelated db-fix scope.
-- `2744` — replace Electron file/directory pickers with server-backed filesystem browsing for one concrete onboarding/project flow.
-- `24v4` — move remaining SSH/deploy flows behind server-owned browser APIs after picker/browser-path foundations stabilize.
+## Next-wave sequencing
 
-### 2. OpenViking migration
-- `4a4t` — create the backend seam and OpenViking bootstrap/client wiring. This is the prerequisite for all later migration phases.
-- `vce4` — add dual-read shadowing for read/list/search/build-context after `4a4t`.
-- `d4qf` — migrate write/bootstrap flows after seam + read shadowing.
-- `ow2x` — switch `memory_refs` to mixed-format `viking://` compatibility after write-path migration exists.
-- `ow2c` — remove legacy confidence/watcher/obsolete memory MCP surfaces only after OpenViking is authoritative and URI compatibility is in place.
+### Wave A — Make the browser-hosted deployment viable
+1. `wpe0` must land first to restore a trustworthy verification baseline for server-side work.
+2. `rpgb` can then land the Rust static asset / SPA hosting path in `djinn-server`.
+3. `2744` and `24v4` complete the remaining browser-only UX seams by replacing native pickers and Electron-owned SSH/deploy flows.
+4. `aijd` packages the server + frontend + OpenViking stack in Docker Compose once server hosting and core runtime seams are present.
 
-### 3. Packaging/deployment
-- `aijd` — package the server and OpenViking with Docker Compose once the server-hosted SPA path (`rpgb`) and OpenViking bootstrap seam (`4a4t`) are both landed.
+### Wave B — OpenViking migration
+1. `4a4t` establishes the memory backend seam and client bootstrap.
+2. `vce4` adds OpenViking dual-read shadowing for read/context paths.
+3. `d4qf` migrates writes and bootstrap/import behavior.
+4. `ow2x` switches task/epic `memory_refs` toward `viking://` URIs with compatibility.
+5. `ow2c` removes legacy confidence, watcher, and obsolete MCP memory surfaces after cutover.
 
-## Sequencing
-- `wpe0` -> `rpgb`
-- `2744` -> `24v4`
-- `4a4t` -> `vce4` -> `d4qf` -> `ow2x` -> `ow2c`
-- `rpgb` + `4a4t` -> `aijd`
+## Active task map
+- Browser/runtime foundation: `h3p6` ✅
+- Static frontend hosting: `rpgb`
+- Browser filesystem picker: `2744`
+- Browser SSH/deploy flows: `24v4`
+- Docker packaging: `aijd`
+- OpenViking backend seam: `4a4t`
+- Dual-read shadow: `vce4`
+- Write/bootstrap migration: `d4qf`
+- `memory_refs` URI transition: `ow2x`
+- Legacy memory cleanup: `ow2c`
+- Verification-baseline repair: `wpe0`
 
-## Current board judgment
-No new wave of decomposition is needed right now because this planning session already produced the next 3–5 worker tasks for the epic and the board still has active in-progress work (`2744`, `4a4t`, `wpe0`) plus queued follow-ons (`24v4`, `vce4`, `d4qf`, `ow2x`, `ow2c`, `aijd`). The correct action is to preserve sequencing and keep the epic open until the verification blocker and core seams land.
+## Planning notes
+- Do not create additional broad ADR-053 worker tasks until the current queue shrinks; the epic already has enough decomposed work for the next execution wave.
+- Prefer blocker relationships over new decomposition rows where work is already represented.
+- If `djinn-agent` prompt snapshot churn continues to block unrelated verification after `wpe0`, split that into a focused baseline-remediation task rather than broadening feature tasks.
 
-## Exit conditions for epic closure
-Close epic `7izs` only after:
-1. djinn-server serves the browser UI and browser-only flows no longer depend on Electron,
-2. Docker Compose deployment exists and is documented,
-3. OpenViking is the authoritative memory backend with legacy memory-only surfaces retired,
-4. task/epic memory refs work with `viking://` URIs during/after cutover.
+## Relations
+- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
+- [[reference/adr-043-roadmap-active-decomposition-status]]
+- [[roadmap]]

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -4,70 +4,61 @@ type: design
 tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
 ---
 
-# Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
+# Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 
 ## Status
-In progress. Epic `7izs` is **not complete**.
+In progress. Epic `7izs` is not complete: foundational browser-runtime work has landed (`h3p6`), roadmap-reference repair landed (`sgs2`), and the next execution wave is already represented by active worker tasks. No epic closure is warranted.
 
-## Goal
-Migrate Djinn from an Electron desktop shell plus custom memory system to:
-- Docker Compose deployment
-- browser-served web UI from `djinn-server`
-- OpenViking-backed memory services and `viking://` memory references
-
-This roadmap is the canonical wave-planning note for epic `7izs` and should be preferred over the singleton [[roadmap]] note for this epic's active work.
-
-## Architectural guardrails
-- Follow [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]].
-- Keep `djinn-server` as the single runtime entrypoint that serves both API routes and the SPA bundle.
-- Replace Electron-only capabilities with server-owned HTTP APIs and browser-compatible UI flows.
-- Migrate memory in phases: seam/bootstrap → shadow reads → write/import cutover → `viking://` refs → legacy cleanup.
-- Do not remove legacy memory systems until OpenViking is authoritative for read and write paths.
+## Architecture anchor
+- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] defines the target shape: Docker Compose deployment, browser-delivered UI, and phased OpenViking migration.
+- `memory_refs` must keep working during migration; use compatibility layers rather than big-bang replacement.
 
 ## Completed work
-- `h3p6` closed: browser-compatible frontend runtime boundary landed.
-- `sgs2` closed: canonical roadmap/memory-ref repair completed so active work points at a real roadmap artifact.
+1. **Browser runtime boundary landed** — `h3p6`
+   - Frontend can now run without mandatory `window.electronAPI`.
+   - Shared transport/runtime seams exist for browser mode.
+2. **Roadmap reference repair landed** — `sgs2`
+   - Epic/task references were normalized after the missing-note incident.
 
 ## Active wave
-### In progress / verifying
-- `rpgb` — serve the React web app from `djinn-server`
-- `2744` — replace native project/file pickers with server-backed filesystem browsing
-- `4a4t` — create the OpenViking memory backend seam and bootstrap client
+### Web / deployment track
+- `rpgb` — Serve the React web app from `djinn-server`
+- `2744` — Replace native project/file pickers with server-backed filesystem browsing
+- `24v4` — Move SSH connection and deployment flows behind server-owned browser APIs
+- `aijd` — Package `djinn-server` and OpenViking with Docker Compose
 
-### Ready next once active items land
-1. `aijd` — package `djinn-server` and OpenViking with Docker Compose
-2. `24v4` — move SSH connection and deployment flows behind server-owned browser APIs
-3. `vce4` — add OpenViking dual-read shadow for memory reads and context retrieval
-4. `d4qf` — migrate memory writes and bootstrap data into OpenViking
-5. `ow2x` — transition task and epic `memory_refs` to `viking://` URIs with legacy compatibility
-6. `ow2c` — retire legacy memory confidence, watcher, and obsolete MCP tool surfaces after OpenViking cutover
+### Memory migration track
+- `4a4t` — Create the OpenViking memory backend seam and bootstrap client
+- `vce4` — Add OpenViking dual-read shadow for memory reads and context retrieval
+- `d4qf` — Migrate memory writes and bootstrap data into OpenViking
+- `ow2x` — Transition task and epic `memory_refs` to `viking://` URIs with legacy compatibility
+- `ow2c` — Retire legacy memory confidence, watcher, and obsolete MCP tool surfaces after OpenViking cutover
 
-## Sequencing
-1. **Web delivery foundation**
-   - `rpgb` provides SPA/static hosting from the Rust server.
-   - `2744` removes the most visible Electron-only picker dependency.
-2. **Memory backend foundation**
-   - `4a4t` establishes the backend seam and OpenViking bootstrap/config.
-3. **Deployment + remaining Electron removal**
-   - `aijd` can package the stack once SPA hosting shape and OpenViking boot wiring are real.
-   - `24v4` removes SSH/deploy flows from Electron ownership.
-4. **OpenViking migration**
-   - `vce4` depends on `4a4t`.
-   - `d4qf` depends on `vce4` or at minimum the seam from `4a4t`, but should follow shadow-read validation.
-   - `ow2x` follows readable/writable OpenViking-backed note flows.
-   - `ow2c` is final cleanup after OpenViking becomes authoritative.
+## Required sequencing
+### Web / deployment ordering
+1. `rpgb` should land before `aijd` so container packaging targets the real static-asset serving path.
+2. `24v4` depends on the browser runtime boundary already landed in `h3p6`, but can proceed independently of `2744` as long as it stays focused on SSH/deploy APIs.
+3. `2744` can proceed in parallel with `rpgb`, but must target the shared browser runtime seam rather than reintroducing Electron-specific code.
 
-## Completion gate
-Epic `7izs` is complete only when all three workstreams are done:
-- `djinn-server` serves the browser UI and the Docker Compose stack runs Djinn + OpenViking cleanly.
-- Electron-owned picker and SSH/deploy flows are replaced by browser/server flows.
-- OpenViking is authoritative for reads and writes, `memory_refs` support `viking://`, and legacy memory subsystems are retired.
+### Memory migration ordering
+1. `4a4t` is the prerequisite seam for all OpenViking follow-ons.
+2. `vce4` depends on `4a4t`.
+3. `d4qf` depends on `vce4` so write cutover follows shadow-read parity work.
+4. `ow2x` depends on `d4qf` because `viking://` references only make sense once OpenViking-backed content is authoritative enough for mixed-format resolution.
+5. `ow2c` depends on `ow2x` and final cutover completion.
 
-## Notes for future planning waves
-- Do not treat the singleton [[roadmap]] note as authoritative for this epic; it currently tracks ADR-043 work and can diverge from epic `7izs` board state.
-- If `rpgb`, `2744`, and `4a4t` all land successfully, the next planning wave should focus on blocker cleanup and ensuring dependency order across `aijd`, `24v4`, `vce4`, `d4qf`, `ow2x`, and `ow2c` rather than creating duplicate tasks.
+## Planner assessment for this wave
+The epic already has a full active wave on the board, so this planning pass should **tighten roadmap/sequencing rather than add duplicate tasks**. The priority is to keep the existing tasks ordered correctly and avoid board churn while `rpgb`, `2744`, and `4a4t` are still in flight.
+
+## Exit criteria for epic closure
+Do not close epic `7izs` until all of the following are true:
+- `djinn-server` serves the SPA in production and Docker packaging is documented and working.
+- Browser UI no longer depends on Electron-only pickers or SSH/deploy IPC.
+- OpenViking is authoritative for memory reads/writes.
+- `memory_refs` support `viking://` with legacy compatibility during migration.
+- Legacy memory confidence/watcher/obsolete MCP surfaces are removed or disabled.
 
 ## Relations
 - [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
-- [[cases/recreated-missing-canonical-roadmap-note-for-docker-openviking-epic-memory]]
+- [[roadmap]]
 - [[reference/adr-043-roadmap-active-decomposition-status]]

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -4,63 +4,49 @@ type: design
 tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
 ---
 
-# Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
+# Docker-Based Deployment, Web UI, and OpenViking Memory Backend — Roadmap
 
 ## Status
-In progress. Epic `7izs` is not complete: foundational browser-runtime work has landed (`h3p6`), roadmap-reference repair landed (`sgs2`), static frontend serving (`rpgb`) is implemented but waiting on repo-green remediation (`wpe0`), and the OpenViking seam/bootstrap work (`4a4t`) plus filesystem picker migration (`2744`) remain in flight. No epic closure is warranted.
+Epic `7izs` remains open. The goal is not yet complete: only the browser-runtime boundary (`h3p6`) and roadmap/memory-ref repair (`sgs2`) are closed, while the core deployment, browser parity, and OpenViking migration slices are still in progress or queued.
 
-## Architecture anchor
-- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] defines the target shape: Docker Compose deployment, browser-delivered UI, and phased OpenViking migration.
-- `memory_refs` must keep working during migration; use compatibility layers rather than big-bang replacement.
+## Architectural anchor
+- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] is the governing decision.
+- `memory_refs` should continue to include this note plus `[[roadmap]]` only as a temporary cross-link; this note is the epic-specific plan.
 
 ## Completed work
-1. **Browser runtime boundary landed** — `h3p6`
-   - Frontend can now run without mandatory `window.electronAPI`.
-   - Shared transport/runtime seams exist for browser mode.
-2. **Roadmap reference repair landed** — `sgs2`
-   - Epic/task references were normalized after the missing-note incident.
+- `h3p6` — browser-compatible frontend runtime boundary landed, giving web-mode transport/runtime seams to build on.
+- `sgs2` — restored canonical roadmap memory references for this epic.
+- `rpgb` implementation work is substantially present, but final verification is blocked on the repo-green follow-up task `wpe0`.
 
 ## Active wave
-### Web / deployment track
-- `rpgb` — Serve the React web app from `djinn-server` (implemented; blocked on `wpe0` repo-green verification fix before closure)
-- `wpe0` — Fix unrelated `djinn-db` test failures blocking epic verification
-- `2744` — Replace native project/file pickers with server-backed filesystem browsing
-- `24v4` — Move SSH connection and deployment flows behind server-owned browser APIs
-- `aijd` — Package `djinn-server` and OpenViking with Docker Compose
 
-### Memory migration track
-- `4a4t` — Create the OpenViking memory backend seam and bootstrap client
-- `vce4` — Add OpenViking dual-read shadow for memory reads and context retrieval
-- `d4qf` — Migrate memory writes and bootstrap data into OpenViking
-- `ow2x` — Transition task and epic `memory_refs` to `viking://` URIs with legacy compatibility
-- `ow2c` — Retire legacy memory confidence, watcher, and obsolete MCP tool surfaces after OpenViking cutover
+### 1. Web UI parity and server hosting
+- `rpgb` — serve the built React bundle from `djinn-server` with SPA fallback while preserving API/MCP routes. This is now blocked on `wpe0` so it can verify against a green base instead of absorbing unrelated db-fix scope.
+- `2744` — replace Electron file/directory pickers with server-backed filesystem browsing for one concrete onboarding/project flow.
+- `24v4` — move remaining SSH/deploy flows behind server-owned browser APIs after picker/browser-path foundations stabilize.
 
-## Required sequencing
-### Web / deployment ordering
-1. `wpe0` must land before `rpgb` can close, because the remaining failing verification is now isolated to unrelated `djinn-db` tests on the current base branch.
-2. `rpgb` should land before `aijd` so container packaging targets the real static-asset serving path.
-3. `24v4` depends on the browser runtime boundary already landed in `h3p6`, but can proceed independently of `2744` as long as it stays focused on SSH/deploy APIs.
-4. `2744` can proceed in parallel with `rpgb`, but must target the shared browser runtime seam rather than reintroducing Electron-specific code.
+### 2. OpenViking migration
+- `4a4t` — create the backend seam and OpenViking bootstrap/client wiring. This is the prerequisite for all later migration phases.
+- `vce4` — add dual-read shadowing for read/list/search/build-context after `4a4t`.
+- `d4qf` — migrate write/bootstrap flows after seam + read shadowing.
+- `ow2x` — switch `memory_refs` to mixed-format `viking://` compatibility after write-path migration exists.
+- `ow2c` — remove legacy confidence/watcher/obsolete memory MCP surfaces only after OpenViking is authoritative and URI compatibility is in place.
 
-### Memory migration ordering
-1. `4a4t` is the prerequisite seam for all OpenViking follow-ons.
-2. `vce4` depends on `4a4t`.
-3. `d4qf` depends on `vce4` so write cutover follows shadow-read parity work.
-4. `ow2x` depends on `d4qf` because `viking://` references only make sense once OpenViking-backed content is authoritative enough for mixed-format resolution.
-5. `ow2c` depends on `ow2x` and final cutover completion.
+### 3. Packaging/deployment
+- `aijd` — package the server and OpenViking with Docker Compose once the server-hosted SPA path (`rpgb`) and OpenViking bootstrap seam (`4a4t`) are both landed.
 
-## Planner assessment for this wave
-The epic already has a full active wave on the board, so this planning pass should **tighten roadmap/sequencing rather than add duplicate tasks**. The priority is to keep the existing tasks ordered correctly, isolate repo-green verification fixes (`wpe0`) from feature slices, and avoid board churn while `rpgb`, `2744`, and `4a4t` are still in flight.
+## Sequencing
+- `wpe0` -> `rpgb`
+- `2744` -> `24v4`
+- `4a4t` -> `vce4` -> `d4qf` -> `ow2x` -> `ow2c`
+- `rpgb` + `4a4t` -> `aijd`
 
-## Exit criteria for epic closure
-Do not close epic `7izs` until all of the following are true:
-- `djinn-server` serves the SPA in production and Docker packaging is documented and working.
-- Browser UI no longer depends on Electron-only pickers or SSH/deploy IPC.
-- OpenViking is authoritative for memory reads/writes.
-- `memory_refs` support `viking://` with legacy compatibility during migration.
-- Legacy memory confidence/watcher/obsolete MCP surfaces are removed or disabled.
+## Current board judgment
+No new wave of decomposition is needed right now because this planning session already produced the next 3–5 worker tasks for the epic and the board still has active in-progress work (`2744`, `4a4t`, `wpe0`) plus queued follow-ons (`24v4`, `vce4`, `d4qf`, `ow2x`, `ow2c`, `aijd`). The correct action is to preserve sequencing and keep the epic open until the verification blocker and core seams land.
 
-## Relations
-- [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]]
-- [[roadmap]]
-- [[reference/adr-043-roadmap-active-decomposition-status]]
+## Exit conditions for epic closure
+Close epic `7izs` only after:
+1. djinn-server serves the browser UI and browser-only flows no longer depend on Electron,
+2. Docker Compose deployment exists and is documented,
+3. OpenViking is the authoritative memory backend with legacy memory-only surfaces retired,
+4. task/epic memory refs work with `viking://` URIs during/after cutover.

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -7,7 +7,7 @@ tags: ["docker","web-ui","openviking","roadmap","epic-7izs"]
 # Docker-Based Deployment, Web UI, and OpenViking Memory Backend Roadmap
 
 ## Status
-In progress. Epic `7izs` is not complete: foundational browser-runtime work has landed (`h3p6`), roadmap-reference repair landed (`sgs2`), and the next execution wave is already represented by active worker tasks. No epic closure is warranted.
+In progress. Epic `7izs` is not complete: foundational browser-runtime work has landed (`h3p6`), roadmap-reference repair landed (`sgs2`), static frontend serving (`rpgb`) is implemented but waiting on repo-green remediation (`wpe0`), and the OpenViking seam/bootstrap work (`4a4t`) plus filesystem picker migration (`2744`) remain in flight. No epic closure is warranted.
 
 ## Architecture anchor
 - [[decisions/adr-053-docker-based-deployment-web-ui-and-openviking-memory-backend]] defines the target shape: Docker Compose deployment, browser-delivered UI, and phased OpenViking migration.
@@ -22,7 +22,8 @@ In progress. Epic `7izs` is not complete: foundational browser-runtime work has 
 
 ## Active wave
 ### Web / deployment track
-- `rpgb` — Serve the React web app from `djinn-server`
+- `rpgb` — Serve the React web app from `djinn-server` (implemented; blocked on `wpe0` repo-green verification fix before closure)
+- `wpe0` — Fix unrelated `djinn-db` test failures blocking epic verification
 - `2744` — Replace native project/file pickers with server-backed filesystem browsing
 - `24v4` — Move SSH connection and deployment flows behind server-owned browser APIs
 - `aijd` — Package `djinn-server` and OpenViking with Docker Compose
@@ -36,9 +37,10 @@ In progress. Epic `7izs` is not complete: foundational browser-runtime work has 
 
 ## Required sequencing
 ### Web / deployment ordering
-1. `rpgb` should land before `aijd` so container packaging targets the real static-asset serving path.
-2. `24v4` depends on the browser runtime boundary already landed in `h3p6`, but can proceed independently of `2744` as long as it stays focused on SSH/deploy APIs.
-3. `2744` can proceed in parallel with `rpgb`, but must target the shared browser runtime seam rather than reintroducing Electron-specific code.
+1. `wpe0` must land before `rpgb` can close, because the remaining failing verification is now isolated to unrelated `djinn-db` tests on the current base branch.
+2. `rpgb` should land before `aijd` so container packaging targets the real static-asset serving path.
+3. `24v4` depends on the browser runtime boundary already landed in `h3p6`, but can proceed independently of `2744` as long as it stays focused on SSH/deploy APIs.
+4. `2744` can proceed in parallel with `rpgb`, but must target the shared browser runtime seam rather than reintroducing Electron-specific code.
 
 ### Memory migration ordering
 1. `4a4t` is the prerequisite seam for all OpenViking follow-ons.
@@ -48,7 +50,7 @@ In progress. Epic `7izs` is not complete: foundational browser-runtime work has 
 5. `ow2c` depends on `ow2x` and final cutover completion.
 
 ## Planner assessment for this wave
-The epic already has a full active wave on the board, so this planning pass should **tighten roadmap/sequencing rather than add duplicate tasks**. The priority is to keep the existing tasks ordered correctly and avoid board churn while `rpgb`, `2744`, and `4a4t` are still in flight.
+The epic already has a full active wave on the board, so this planning pass should **tighten roadmap/sequencing rather than add duplicate tasks**. The priority is to keep the existing tasks ordered correctly, isolate repo-green verification fixes (`wpe0`) from feature slices, and avoid board churn while `rpgb`, `2744`, and `4a4t` are still in flight.
 
 ## Exit criteria for epic closure
 Do not close epic `7izs` until all of the following are true:

--- a/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
+++ b/.djinn/design/docker-based-deployment-web-ui-and-openviking-memory-backend-roadmap.md
@@ -43,13 +43,19 @@ This wave focuses on sequencing the next implementation batch behind the active 
 5. `ow2c` depends on `d4qf` and `ow2x` because cleanup belongs after authoritative cutover and mixed-format compatibility are in place.
 
 ## Wave task set
-Existing open tasks already define the next wave and remain the correct 3–5+ implementation slices; this planning pass primarily tightened sequencing:
+Existing open tasks already define the next wave and remain the correct implementation slices; this planning pass primarily tightened sequencing and memory-linking rather than adding more parallel work:
 - `aijd` — Docker Compose packaging after SPA serving
 - `24v4` — browser/server-owned SSH and deployment APIs
 - `vce4` — OpenViking dual-read shadow
 - `d4qf` — OpenViking write/bootstrap migration
 - `ow2x` — `viking://` memory_refs transition
 - `ow2c` — legacy memory cleanup after cutover
+
+## 2026-04-13 planning wave refresh
+- Reassessed epic `7izs`: still open because SPA serving (`rpgb`), filesystem picker migration (`2744`), and OpenViking seam/bootstrap (`4a4t`) are still in progress, and the downstream Docker/OpenViking cutover tasks have not landed.
+- Confirmed the next implementation wave is already represented on the board by existing worker tasks rather than needing additional decomposition.
+- Tightened sequencing on the board: `aijd` blocked by `rpgb`; `vce4` blocked by `4a4t`; `d4qf` blocked by `4a4t` + `vce4`; `ow2x` blocked by `d4qf`; `ow2c` blocked by `d4qf` + `ow2x`.
+- Normalized active task memory refs so the in-flight foundation tasks and cleanup task point at this roadmap note.
 
 ## Planner notes
 - Prefer this design note over the singleton `[[roadmap]]` for epic `7izs` planning, because the singleton roadmap is currently used by other epics and has known drift risk.


### PR DESCRIPTION
## Summary
Planning task for epic 'Docker-Based Deployment, Web UI, and OpenViking Memory Backend' (7izs). The Planner should:
1. Read the epic's memory_refs for context and prior roadmap notes.
2. Review any previous wave results (closed tasks, session reflections).
3. Decide: is the epic's goal fully met? If YES → call `epic_close(7izs)`, then `submit_grooming`. Do NOT create new tasks.
4. If NO → write or update the epic roadmap design note, create 3–5 worker tasks (or a spike if uncertainty is high).
5. Call `submit_grooming` when done.

## Acceptance Criteria
- [ ] Epic state assessed: either closed via epic_close (if goal fully met) or roadmap updated with next-wave plan
- [ ] If epic remains open: 3–5 worker tasks (or a spike) created with acceptance criteria
- [ ] submit_grooming called to finalize the wave

---
Djinn task: ck9v