### PR TITLE
feat(yuxd): Continue canonical broken-link cleanup for remaining ADR shorthand and legacy label variants

### DIFF
--- a/.djinn/reference/git-workflow-diagrams.md
+++ b/.djinn/reference/git-workflow-diagrams.md
@@ -269,5 +269,5 @@ A remote `origin` is required because the squash-merge flow pushes directly to i
 ## Relations
 
 - [[ADR-007 djinn Namespace Git Sync]]
-- [[ADR-009 Simplified Execution]]
+- [[decisions/adr-009-simplified-execution-—-no-phases,-direct-task-dispatch|ADR-009 Simplified Execution]]
 - [[ADR-015 Session Continuity and Resume]]

--- a/.djinn/reference/session-resume-and-compaction-flow.md
+++ b/.djinn/reference/session-resume-and-compaction-flow.md
@@ -123,5 +123,5 @@ flowchart LR
 ## Relations
 - [[Task Dispatch and Slot Pool Flow]]
 - [[Task Lifecycle and Session Flow]]
-- [[Reply Loop Nudge and Marker System]]
+- [[decisions/adr-036-structured-session-finalization-finalize-tools-and-forced-tool-choice|ADR-036: Structured Session Finalization — Finalize Tools and Forced Tool Choice]]
 - [[ADR-015: Session Continuity and Resume]]

--- a/.djinn/reference/setup-verification-and-merge-conflict-flow.md
+++ b/.djinn/reference/setup-verification-and-merge-conflict-flow.md
@@ -193,7 +193,7 @@ sequenceDiagram
 
 ## Relations
 - [[Task Lifecycle and Session Flow]]
-- [[Reply Loop Nudge and Marker System]]
+- [[decisions/adr-036-structured-session-finalization-finalize-tools-and-forced-tool-choice|ADR-036: Structured Session Finalization — Finalize Tools and Forced Tool Choice]]
 - [[Task Dispatch and Slot Pool Flow]]
-- [[ADR-012: Epic Review Batches and Structured Output Nudging]]
+- [[decisions/adr-024-agent-role-redesign-pm-architect-and-approval-pipeline|ADR-024: Agent Role Redesign — PM, Architect, and Approval Pipeline]]
 - [[ADR-014: Project Setup and Verification Commands]]

--- a/.djinn/reference/task-lifecycle-and-session-flow.md
+++ b/.djinn/reference/task-lifecycle-and-session-flow.md
@@ -137,5 +137,5 @@ sequenceDiagram
 ## Relations
 - [[Task Dispatch and Slot Pool Flow]]
 - [[Session Resume and Compaction Flow]]
-- [[Reply Loop Nudge and Marker System]]
+- [[decisions/adr-036-structured-session-finalization-finalize-tools-and-forced-tool-choice|ADR-036: Structured Session Finalization — Finalize Tools and Forced Tool Choice]]
 - [[Setup Verification and Merge Conflict Flow]]


### PR DESCRIPTION
## Summary
Follow the canonical broken-link cleanup after `ah6c`'s permalink-normalization slice. Focus only on remaining canonical/current-note defects reported by `memory_broken_links()` that were not covered by direct singleton/title replacements: shorthand ADR variants (`ADR-026`, `ADR-019`, `ADR-009 Simplified Execution`, etc.), legacy label-style references (`ADR-012 Epic Review Batches and Structured Output Nudging`, `ADR-043: Repository Map — SCIP-Powered Structural Context for Agent Sessions`), and any concrete canonical-note misses such as `Reply Loop Nudge and Marker System` where a real target can be identified. Do not mass-edit `cases/*` or `reference/repo-maps/*`; tolerated orphan-heavy inventory remains out of scope unless a concrete canonical-note defect is found.

## Acceptance Criteria
- [ ] Read the updated canonical cleanup context from `ah6c`/triage notes and reduce the remaining broken-link backlog in canonical ADR/design/reference/research notes by fixing a focused subset of shorthand ADR and legacy label variants.
- [ ] Any unresolved labels with no confirmed canonical target are explicitly documented as true follow-up questions rather than treated as a reopened tooling bug or broad mass-linking task.
- [ ] Task ends with a non-ambiguous next state: either the next focused cleanup slice lands or any still-large remainder is decomposed again without touching tolerated `cases` or `reference/repo-maps` inventory.

---
Djinn task: yuxd