### PR TITLE
feat(dvk4): Restore missing semantic memory search roadmap note and repair dangling references

### DIFF
--- a/.djinn/design/semantic-memory-search-candle-embeddings-with-sqlite-vec-roadmap.md
+++ b/.djinn/design/semantic-memory-search-candle-embeddings-with-sqlite-vec-roadmap.md
@@ -58,6 +58,9 @@ The epic can close only when all of the following are true:
 - systems without a working model or sqlite-vec extension degrade cleanly to FTS-only
 - tests cover the new initialization, indexing, and retrieval behavior
 
+## Maintenance Note
+This roadmap note was re-written through `memory_write` after patrol found artifact drift: the markdown file already existed under `design/semantic-memory-search-candle-embeddings-with-sqlite-vec-roadmap`, but `memory_read` could not resolve it. The canonical permalink remains `design/semantic-memory-search-candle-embeddings-with-sqlite-vec-roadmap`; references should keep using this permalink rather than creating a duplicate note.
+
 ## Relations
-- [[decisions/proposed/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]
+- [[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]
 - [[brief]]


### PR DESCRIPTION
## Summary
The epic and all four active implementation tasks reference `design/semantic-memory-search-candle-embeddings-with-sqlite-vec-roadmap`, but `memory_read` confirms the note does not exist. Recreate the canonical roadmap note (or replace the references with the correct canonical permalink), then update the epic/task memory_refs and inline wikilinks so active work stops pointing at a nonexistent planning artifact.

## Acceptance Criteria
- [ ] A canonical roadmap note for the semantic memory search epic exists and can be read successfully via memory tools, or an existing canonical replacement note is identified and used instead.
- [ ] The epic and all active semantic-memory tasks no longer reference a nonexistent roadmap permalink in memory_refs or task/epic planning text.
- [ ] A brief comment or note update records whether the roadmap was recreated or relinked so future patrols can distinguish resolved artifact drift from a transient read failure.

---
Djinn task: dvk4