### PR TITLE
feat(7vbo): Repair canonical/current-note wikilinks using legacy ADR and singleton aliases

### DIFF
--- a/.djinn/decisions/adr-051-planner-as-patrol-and-architect-as-consultant.md
+++ b/.djinn/decisions/adr-051-planner-as-patrol-and-architect-as-consultant.md
@@ -12,9 +12,9 @@ tags: ["adr","architecture","agents","roles","planner","architect","patrol","aut
 
 Date: 2026-04-08
 
-Supersedes (partially): [[ADR-034 Agent Role Hierarchy — Architect Patrol, Task Types, and Escalation]]
-Extends: [["ADR-050: Architect/Chat Code-Graph Consolidation, Canonical SCIP Indexing, and Graph Query Extensions"]], [[ADR-046 Chat-Driven Planning]]
-Related: [[ADR-025 Backlog Grooming and Autonomous Dispatch Triggers]], [[ADR-023 Cognitive Memory Architecture]], [[ADR-043 Repository Map — SCIP-Powered Structural Context]], [[ADR-047 Repo-Graph Query Seam]]
+Supersedes (partially): [[decisions/adr-034-agent-role-hierarchy-architect-patrol-scrum-master-rules-and-task-types|ADR-034 Agent Role Hierarchy — Architect Patrol, Task Types, and Escalation]]
+Extends: [[decisions/adr-050-architect-chat-code-graph-consolidation|ADR-050: Architect/Chat Code-Graph Consolidation, Canonical SCIP Indexing, and Graph Query Extensions]], [[decisions/adr-046-chat-driven-planning-drafting-epics-research-agent-deliverables-and-memory-write-access|ADR-046 Chat-Driven Planning]]
+Related: [[decisions/adr-025-backlog-grooming-and-autonomous-dispatch-triggers|ADR-025 Backlog Grooming and Autonomous Dispatch Triggers]], [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning|ADR-023 Cognitive Memory Architecture]], [[decisions/adr-043-repository-map-scip-powered-structural-context-for-agent-sessions|ADR-043 Repository Map — SCIP-Powered Structural Context]], [[decisions/adr-047-repo-graph-query-seam-for-code-graph-tool|ADR-047 Repo-Graph Query Seam]]
 
 ## Implementation Status (2026-04-08 — handoff to next session)
 
@@ -414,10 +414,10 @@ Prerequisites (1, 2) gate everything. Role redistribution (3–6) and reentrance
 
 ## Relations
 
-- [[ADR-034 Agent Role Hierarchy — Architect Patrol, Task Types, and Escalation]] — partially superseded. The patrol role, escalation ceiling, and architect dispatch triggers move. Wave-based decomposition, self-task creation, task types, and coordinator rules 1–2 (excluding the auto-dispatch guard changes) are preserved.
-- [["ADR-050: Architect/Chat Code-Graph Consolidation, Canonical SCIP Indexing, and Graph Query Extensions"]] — extended. This ADR consumes ADR-050's tool surface and formalizes Architect as the sole producer of code-reasoning findings. The parity contract between Architect and Chat is preserved unchanged.
+- [[decisions/adr-034-agent-role-hierarchy-architect-patrol-scrum-master-rules-and-task-types|ADR-034 Agent Role Hierarchy — Architect Patrol, Task Types, and Escalation]] — partially superseded. The patrol role, escalation ceiling, and architect dispatch triggers move. Wave-based decomposition, self-task creation, task types, and coordinator rules 1–2 (excluding the auto-dispatch guard changes) are preserved.
+- [[decisions/adr-050-architect-chat-code-graph-consolidation|ADR-050: Architect/Chat Code-Graph Consolidation, Canonical SCIP Indexing, and Graph Query Extensions]] — extended. This ADR consumes ADR-050's tool surface and formalizes Architect as the sole producer of code-reasoning findings. The parity contract between Architect and Chat is preserved unchanged.
 - [[ADR-046 Chat-Driven Planning — Drafting Epics, Research Agent Deliverables, and Memory Write Access]] — extended. Chat is the interactive form of Architect (per ADR-050); this ADR makes the symmetric consultant contract explicit.
-- [[ADR-025 Backlog Grooming and Autonomous Dispatch Triggers]] — extended. Auto-dispatch rules gain reentrance guards.
-- [[ADR-023 Cognitive Memory Architecture]] — complementary. Proposals are memory writes with an acceptance lifecycle; confidence scoring applies to adopted ADRs once they leave the `proposed/` lane.
+- [[decisions/adr-025-backlog-grooming-and-autonomous-dispatch-triggers|ADR-025 Backlog Grooming and Autonomous Dispatch Triggers]] — extended. Auto-dispatch rules gain reentrance guards.
+- [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning|ADR-023 Cognitive Memory Architecture]] — complementary. Proposals are memory writes with an acceptance lifecycle; confidence scoring applies to adopted ADRs once they leave the `proposed/` lane.
 - [[ADR-047 Repo-Graph Query Seam for code_graph tool]] — related. The bridge surface being fixed in Migration step 1 is the seam defined by this ADR.
 - [[ADR-043 Repository Map — SCIP-Powered Structural Context for Agent Sessions]] — related. The canonical graph lifecycle is the infrastructure ADR-050 built on, which this ADR formalizes as "not an agent task."

--- a/.djinn/decisions/adr-052-pulse-proposal-inbox-ask-architect-trigger-and-virtual-proposed-epic-lane.md
+++ b/.djinn/decisions/adr-052-pulse-proposal-inbox-ask-architect-trigger-and-virtual-proposed-epic-lane.md
@@ -13,9 +13,9 @@ Date: 2026-04-08
 
 Originating spike: `ih6u` — *"Finish ADR-051 Epic C: Pulse surfaces + proposed epic lane"*
 
-Extends: [["ADR-051: Planner-as-Patrol, Architect-as-Consultant, ADR-to-Epic Pipeline, and Auto-Dispatch Reentrance Guards"]]
+Extends: [[decisions/adr-051-planner-as-patrol-and-architect-as-consultant|ADR-051: Planner-as-Patrol, Architect-as-Consultant, ADR-to-Epic Pipeline, and Auto-Dispatch Reentrance Guards]]
 
-Related: [[ADR-050: Architect/Chat Code-Graph Consolidation]], [[ADR-046: Chat-Driven Planning]]
+Related: [[decisions/adr-050-architect-chat-code-graph-consolidation|ADR-050: Architect/Chat Code-Graph Consolidation]], [[decisions/adr-046-chat-driven-planning-drafting-epics-research-agent-deliverables-and-memory-write-access|ADR-046: Chat-Driven Planning]]
 
 ## ⚠️ Reconstruction notice
 

--- a/.djinn/decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec.md
+++ b/.djinn/decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec.md
@@ -11,7 +11,7 @@ tags: ["adr","memory","embeddings","candle","sqlite-vec","nomic","semantic-searc
 
 Date: 2026-04-13
 
-Related: [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]], [[ADR-042: DB-Only Knowledge Extraction, Consolidation, and Task-Routing Fixes]]
+Related: [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning|ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]], [[decisions/adr-042-db-only-knowledge-extraction-consolidation-and-task-routing-fixes|ADR-042: DB-Only Knowledge Extraction, Consolidation, and Task-Routing Fixes]]
 
 ## Context
 

--- a/.djinn/decisions/database-layer-—-rusqlite-over-libsql-turso.md
+++ b/.djinn/decisions/database-layer-—-rusqlite-over-libsql-turso.md
@@ -149,7 +149,7 @@ Use `sqlite-vec` extension (asg017/sqlite-vec) loaded at runtime via `Connection
 - Stack Research section on Turso patterns — those API examples are now irrelevant
 
 ## Relations
-- [[Project Brief]] — updates database constraint
+- [[brief]] — updates database constraint
 - [[Embedded Database Survey]] — superseded by this ADR
 - [[Stack Research]] — libsql patterns replaced by rusqlite
 - [[Architecture Research]] — sqld sidecar architecture no longer needed

--- a/.djinn/decisions/language-selection-—-compiler-as-ai-code-reviewer.md
+++ b/.djinn/decisions/language-selection-—-compiler-as-ai-code-reviewer.md
@@ -164,6 +164,6 @@ The rewrite cost is real but bounded. AI bears most of it. The long-term payoff 
 - [Security Weaknesses of Copilot-Generated Code](https://arxiv.org/html/2310.02059v3)
 
 ## Relations
-- [[Project Brief]] — project context driving this decision
+- [[brief]] — project context driving this decision
 - [[Embedded Database Survey]] — database choice depends on language decision
 - [[Rust Agentic Ecosystem Survey]] — ecosystem viability for Rust

--- a/.djinn/decisions/server-lifecycle-—-desktop-managed-daemon-with-graceful-restart.md
+++ b/.djinn/decisions/server-lifecycle-—-desktop-managed-daemon-with-graceful-restart.md
@@ -104,6 +104,6 @@ The desktop is the supervisor:
 - Should the desktop pre-extract the new binary before signaling shutdown to minimize downtime?
 
 ## Relations
-- [[Project Brief]] — server lifecycle not previously specified
+- [[brief]] — server lifecycle not previously specified
 - [[V1 Requirements]] — adds LIFE-* requirements
 - [[Database Layer — rusqlite over libsql/Turso]] — ADR-002, state survival via DB

--- a/.djinn/design/epic-task-mcp-split-design.md
+++ b/.djinn/design/epic-task-mcp-split-design.md
@@ -10,7 +10,7 @@ type: design
 ---
 # Epic-Task MCP Split Design
 
-Full method signatures, validation rules, and return types for the epic/task MCP tool split defined in [[ADR-003: Split Epic and Task MCP Tools with Input Validation]].
+Full method signatures, validation rules, and return types for the epic/task MCP tool split defined in [[decisions/adr-003-split-epic-and-task-mcp-tools-with-input-validation|ADR-003: Split Epic and Task MCP Tools with Input Validation]].
 
 ---
 
@@ -462,5 +462,5 @@ These tools require no signature changes but gain input validation:
 | **Net new MCP methods** | **+7** |
 
 ## Relations
-- [[ADR-003: Split Epic and Task MCP Tools with Input Validation]] — decision record
+- [[decisions/adr-003-split-epic-and-task-mcp-tools-with-input-validation|ADR-003: Split Epic and Task MCP Tools with Input Validation]] — decision record
 - [[V1 Requirements]] — KANBAN and ROAD views consume these tools

--- a/.djinn/reference/cognitive-memory-scope.md
+++ b/.djinn/reference/cognitive-memory-scope.md
@@ -103,7 +103,7 @@
 - All LLM calls use the cheapest adequate model (haiku-class for L0/L1/dedup/contradiction, not opus-class)
 
 ## Relations
-- [[Roadmap]]
-- [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
+- [[roadmap]]
+- [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning|ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
 - [[Cognitive Memory Systems Research]]
-- [[V1 Requirements]]
+- [[requirements/v1-requirements|V1 Requirements]]

--- a/.djinn/reference/git-workflow-diagrams.md
+++ b/.djinn/reference/git-workflow-diagrams.md
@@ -1,8 +1,9 @@
 ---
 title: Git Workflow Diagrams
-type: reference
+type: 
 tags: ["git","workflow","diagrams","worktree","merge","architecture"]
 ---
+
 
 # Git Workflow Diagrams
 
@@ -268,6 +269,6 @@ A remote `origin` is required because the squash-merge flow pushes directly to i
 
 ## Relations
 
-- [[ADR-007 djinn Namespace Git Sync]]
+- [[decisions/djinn-namespace-git-sync|ADR-007 djinn Namespace Git Sync]]
 - [[decisions/adr-009-simplified-execution-—-no-phases,-direct-task-dispatch|ADR-009 Simplified Execution]]
-- [[ADR-015 Session Continuity and Resume]]
+- [[decisions/adr-015-session-continuity-resume|ADR-015 Session Continuity and Resume]]

--- a/.djinn/reference/memory-sync-and-worktree-aware-knowledge-base.md
+++ b/.djinn/reference/memory-sync-and-worktree-aware-knowledge-base.md
@@ -1,8 +1,9 @@
 ---
 title: Memory Sync and Worktree-Aware Knowledge Base
-type: adr
+type: 
 tags: ["sync","memory","cognitive","worktree"]
 ---
+
 
 # Memory Sync and Worktree-Aware Knowledge Base
 
@@ -11,7 +12,7 @@ Proposed
 
 ## Context
 
-[[ADR-023 Cognitive Memory Architecture Multi-Signal Retrieval and Associative Learning]] introduces per-note cognitive metadata: `access_count`, `last_accessed`, `confidence`, and `note_associations` (Hebbian co-access weights). Today this data lives exclusively in `~/.djinn/djinn.db` and is lost when:
+[[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning|ADR-023 Cognitive Memory Architecture Multi-Signal Retrieval and Associative Learning]] introduces per-note cognitive metadata: `access_count`, `last_accessed`, `confidence`, and `note_associations` (Hebbian co-access weights). Today this data lives exclusively in `~/.djinn/djinn.db` and is lost when:
 
 - A colleague clones a project that uses Djinn
 - The DB is rebuilt or re-registered
@@ -23,7 +24,7 @@ Additionally, memory tools (`memory_write`, `memory_edit`, `memory_delete`) curr
 - Note changes aren't reviewable on the task branch PR
 - Notes can't be discarded with a failed task
 
-[[Djinn Namespace Git Sync]] (ADR-007) already reserves the `djinn/memory` branch but has no implementation.
+[[decisions/djinn-namespace-git-sync|Djinn Namespace Git Sync]] (ADR-007) already reserves the `djinn/memory` branch but has no implementation.
 
 ## Decision
 
@@ -94,4 +95,4 @@ A fresh clone bootstraps meaningful signals by importing all users' metric files
 
 - [[ADR-023 Cognitive Memory Architecture Multi-Signal Retrieval and Associative Learning]]
 - [[Djinn Namespace Git Sync]]
-- [[Project .djinn Directory — Notes Only, Git-Tracked]]
+- [[decisions/project-.djinn-directory-—-notes-only,-git-tracked|Project .djinn Directory — Notes Only, Git-Tracked]]

--- a/.djinn/reference/milestone-2-scope.md
+++ b/.djinn/reference/milestone-2-scope.md
@@ -41,8 +41,8 @@ tags: []
 - Clerk configuration: `clerk.djinnai.io` domain, register both `djinn://auth/callback` and `http://localhost:19876/auth/callback` as redirect URIs
 
 ## Relations
-- [[Roadmap]] — Phase 2 (Auth & Onboarding)
+- [[roadmap]] — Phase 2 (Auth & Onboarding)
 - [[V1 Requirements]] — AUTH and ONBOARD requirements
 - [['ADR-001: Desktop-Only Clerk Authentication via System Browser PKCE']] — auth architecture
-- [[ADR-002: Feature Licensing Deferred — Metabase-Style Open Core]] — licensing out of scope
+- [[decisions/feature-licensing-—-metabase-style-open-core|ADR-002: Feature Licensing Deferred — Metabase-Style Open Core]] — licensing out of scope
 - [[Architecture Research]] — original auth design (superseded by ADR-001)

--- a/.djinn/reference/pr-pipeline-statuses-scope.md
+++ b/.djinn/reference/pr-pipeline-statuses-scope.md
@@ -66,6 +66,6 @@ tags: ["scope","reference","pr-workflow"]
 - Log all status transitions with reasons for debugging
 
 ## Relations
-- [[ADR-040: Granular Post-Review PR Pipeline Statuses]]
-- [[ADR-037: GitHub App PR Workflow and CI-Based Verification]]
-- [[Roadmap]]
+- [[decisions/adr-040-granular-post-review-pr-pipeline-statuses|ADR-040: Granular Post-Review PR Pipeline Statuses]]
+- [[decisions/adr-037-github-app-pr-workflow-and-ci-verification|ADR-037: GitHub App PR Workflow and CI-Based Verification]]
+- [[roadmap]]

--- a/.djinn/reference/structured-session-finalization-scope.md
+++ b/.djinn/reference/structured-session-finalization-scope.md
@@ -67,7 +67,7 @@ tags: ["scope","reference","adr-036"]
 
 ## Relations
 
-- [[ADR-036: Structured Session Finalization — Finalize Tools and Forced Tool Choice]]
-- [[ADR-022: Outcome-Based Session Validation & Agent Role Redesign]] — superseded
-- [[ADR-027: Own the Agent Loop — Replace Goose with Direct LLM Integration]] — provider abstraction extended
-- [[Roadmap]]
+- [[decisions/adr-036-structured-session-finalization-finalize-tools-and-forced-tool-choice|ADR-036: Structured Session Finalization — Finalize Tools and Forced Tool Choice]]
+- [[decisions/adr-022-outcome-based-session-validation-agent-role-redesign|ADR-022: Outcome-Based Session Validation & Agent Role Redesign]] — superseded
+- [[decisions/adr-027-own-the-agent-loop-replace-goose-with-direct-llm-integration|ADR-027: Own the Agent Loop — Replace Goose with Direct LLM Integration]] — provider abstraction extended
+- [[roadmap]]

--- a/.djinn/reference/sync-improvements-implementation-plan.md
+++ b/.djinn/reference/sync-improvements-implementation-plan.md
@@ -1,9 +1,9 @@
 ---
 title: "Sync Improvements Implementation Plan"
-type: design
+type: 
 tags: ["sync", "git", "multi-device", "multi-project", "testing"]
-related: ["ADR-008 (desktop)", "ADR-026"]
 ---
+
 
 # Sync Improvements — Implementation Plan
 
@@ -395,5 +395,5 @@ These test the full sync system working together after all items are implemented
 ## Relations
 
 - [[ADR-008 (desktop)]] — source design document
-- [[ADR-026]] — test strategy this plan follows
-- [[ADR-019]] — MCP contract (sync tools are part of the contract)
+- [[decisions/adr-026-automated-testing-strategy-three-phase-full-stack-coverage|ADR-026]] — test strategy this plan follows
+- [[decisions/adr-019-mcp-as-single-api-and-typed-tool-schemas|ADR-019]] — MCP contract (sync tools are part of the contract)

--- a/.djinn/reference/v1-requirements.md
+++ b/.djinn/reference/v1-requirements.md
@@ -1,8 +1,9 @@
 ---
 title: V1 Requirements
-type: requirement
+type: 
 tags: []
 ---
+
 
 
 # V1 Requirements — Djinn Server Rust Rewrite
@@ -253,6 +254,6 @@ Requirements derived from [[brief]], [[research/research-summary]], and the four
 | CMEM-15 | Vector/semantic search via sqlite-vec: embedding-based similarity as additional RRF signal for paraphrase-robust retrieval | v2 | ADR-023 future signal, DB-08 |
 
 ## Relations (CMEM)
-- [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
+- [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning|ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
 - [[Cognitive Memory Systems Research]]
 - [[Cognitive Memory Scope]]


### PR DESCRIPTION
## Summary
Focused follow-up from broken-link/orphan triage. Repair the highest-value remaining memory-health defect by updating canonical/current notes that still use legacy ADR title/shorthand wikilinks and singleton alias links like `[[Roadmap]]` and `[[Project Brief]]`. Keep scope narrow: fix canonical/current-note surfaces first, and while doing so verify the small renamed-target subset (`Autoresearch Reference`, `Djinn Namespace Git Sync`, `Cognitive Memory Scope`, similar) only when encountered. Do not mass-edit the full historical backlog or orphan-heavy inventory folders.

## Acceptance Criteria
- [ ] Canonical/current notes identified by the triage note no longer use legacy ADR title/shorthand wikilinks or singleton alias links where a canonical permalink already exists.
- [ ] Any renamed/missing-target examples encountered in this focused slice are either relinked to an existing canonical note or recorded explicitly as unresolved concrete defects without broad mass-edit expansion.
- [ ] Task outcome distinguishes what was repaired in canonical/current-note surfaces from the intentionally deferred historical broken-link backlog and does not treat the `pitfalls/*` orphan inventory as a tooling bug.

---
Djinn task: 7vbo