### PR TITLE
chore(tbkc): Fix memory note edit routing for canonical brief and requirements notes

### DIFF
--- a/.djinn/brief.md
+++ b/.djinn/brief.md
@@ -131,7 +131,7 @@ The current Go server has accumulated significant complexity:
 - [[decisions/language-selection-—-compiler-as-ai-code-reviewer]] — ADR driving language choice
 - [[research/embedded-database-survey]] — ADR driving database choice
 - [[research/rust-agentic-ecosystem-survey]] — stack ecosystem research
-- [[v1-requirements]] — detailed requirement breakdown
+- [[requirements/v1-requirements]] — detailed requirement breakdown
 - [[roadmap]] — phased delivery plan
 - [[research/stack-research]] — Rust server stack deep dive
 - [[research/features-research]] — feature analysis for task orchestration systems

--- a/server/crates/djinn-agent/src/extension/tests/memory_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/memory_dispatch_tests.rs
@@ -602,6 +602,98 @@ async fn call_tool_dispatches_registered_mcp_tool_success() {
 }
 
 #[tokio::test]
+async fn call_tool_memory_current_requirement_targets_canonical_project_root_from_worktree() {
+    let db = create_test_db();
+    let project = create_test_project(&db).await;
+    std::fs::create_dir_all(&project.path).expect("create project dir");
+    let worktree =
+        Path::new(&project.path).join(".djinn/worktrees/test-current-requirement-worktree");
+    std::fs::create_dir_all(worktree.join(".git")).expect("create worktree dir");
+
+    let note_repo = NoteRepository::new(db.clone(), EventBus::noop());
+    note_repo
+        .create(
+            &project.id,
+            Path::new(&project.path),
+            "V1 Requirements",
+            "tracks [[Cognitive Memory Scope]]",
+            "requirement",
+            "[]",
+        )
+        .await
+        .expect("seed requirements note");
+
+    let state = agent_context_from_db(db.clone(), CancellationToken::new());
+
+    let edited = call_tool(
+        &state,
+        "memory_edit",
+        Some(
+            serde_json::json!({
+                "project": worktree.display().to_string(),
+                "identifier": "requirements/v1-requirements",
+                "operation": "find_replace",
+                "find_text": "[[Cognitive Memory Scope]]",
+                "content": "[[reference/cognitive-memory-scope]]"
+            })
+            .as_object()
+            .expect("memory_edit args object")
+            .clone(),
+        ),
+        &worktree,
+        None,
+        Some("planner"),
+        None,
+    )
+    .await
+    .expect("memory_edit dispatch should succeed");
+
+    assert!(
+        edited
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .contains("[[reference/cognitive-memory-scope]]")
+    );
+
+    let note = note_repo
+        .get_by_permalink(&project.id, "requirements/v1-requirements")
+        .await
+        .expect("load requirements")
+        .expect("requirements note exists");
+
+    assert_eq!(note.note_type, "requirement");
+    assert_eq!(note.permalink, "requirements/v1-requirements");
+    assert_eq!(
+        Path::new(&note.file_path),
+        Path::new(&project.path).join(".djinn/requirements/v1-requirements.md")
+    );
+
+    let canonical_contents = std::fs::read_to_string(
+        Path::new(&project.path).join(".djinn/requirements/v1-requirements.md"),
+    )
+    .expect("read canonical requirements");
+    let worktree_contents =
+        std::fs::read_to_string(worktree.join(".djinn/requirements/v1-requirements.md"))
+            .expect("read worktree requirements");
+    assert!(canonical_contents.contains("[[reference/cognitive-memory-scope]]"));
+    assert_eq!(canonical_contents, worktree_contents);
+
+    assert!(
+        note_repo
+            .get_by_permalink(&project.id, "reference/v1-requirements")
+            .await
+            .expect("check duplicate requirements note")
+            .is_none()
+    );
+    assert!(
+        !Path::new(&project.path)
+            .join(".djinn/reference/v1-requirements.md")
+            .exists()
+    );
+}
+
+#[tokio::test]
 async fn call_tool_dispatches_registered_mcp_tool_error() {
     let db = create_test_db();
     let project = create_test_project(&db).await;

--- a/server/crates/djinn-db/src/repositories/note/crud.rs
+++ b/server/crates/djinn-db/src/repositories/note/crud.rs
@@ -466,6 +466,11 @@ impl NoteRepository {
         }
     }
 
+    fn should_write_canonical_with_mirror(&self, current: &Note) -> bool {
+        self.worktree_root.is_some()
+            && (is_singleton(&current.note_type) || Path::new(&current.file_path).exists())
+    }
+
     fn write_note_files(
         &self,
         primary_file_path: &Path,
@@ -860,7 +865,7 @@ impl NoteRepository {
                 self.existing_note_file_path(&current)
             };
             let (primary_file_path, mirror_file_path) =
-                if is_singleton(&current.note_type) && self.worktree_root.is_some() {
+                if self.should_write_canonical_with_mirror(&current) {
                     (
                         canonical_file_path.as_path(),
                         Some(worktree_file_path.as_path()),
@@ -994,7 +999,7 @@ impl NoteRepository {
             let canonical_file_path = PathBuf::from(&current.file_path);
             let worktree_file_path = self.existing_note_file_path(&current);
             let (primary_file_path, mirror_file_path) =
-                if is_singleton(&current.note_type) && self.worktree_root.is_some() {
+                if self.should_write_canonical_with_mirror(&current) {
                     (
                         canonical_file_path.as_path(),
                         Some(worktree_file_path.as_path()),

--- a/server/crates/djinn-mcp/src/tools/memory_tools/writes_tests.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/writes_tests.rs
@@ -627,6 +627,70 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn current_requirement_edit_from_worktree_updates_canonical_path() {
+        let project_tmp = workspace_tempdir();
+        let worktree_tmp = project_tmp
+            .path()
+            .join(".djinn/worktrees/test-current-requirement");
+        std::fs::create_dir_all(worktree_tmp.join(".git")).unwrap();
+        let db = Database::open_in_memory().unwrap();
+        let state = test_mcp_state(db.clone());
+        let project = create_project(&db, project_tmp.path()).await;
+        let server = DjinnMcpServer::new(state);
+        let repo = NoteRepository::new(db.clone(), EventBus::noop());
+
+        repo.create(
+            &project.id,
+            project_tmp.path(),
+            "V1 Requirements",
+            "References [[Cognitive Memory Scope]].",
+            "requirement",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+        let Json(edited) = server
+            .memory_edit_with_worktree(
+                Parameters(EditParams {
+                    project: worktree_tmp.to_string_lossy().to_string(),
+                    identifier: "requirements/v1-requirements".to_string(),
+                    operation: "find_replace".to_string(),
+                    content: "[[reference/cognitive-memory-scope]]".to_string(),
+                    find_text: Some("[[Cognitive Memory Scope]]".to_string()),
+                    section: None,
+                    note_type: None,
+                }),
+                Some(PathBuf::from(&worktree_tmp)),
+            )
+            .await;
+        assert!(edited.error.is_none(), "{:?}", edited.error);
+
+        let canonical_path = project_tmp
+            .path()
+            .join(".djinn/requirements/v1-requirements.md");
+        let worktree_path = worktree_tmp.join(".djinn/requirements/v1-requirements.md");
+        assert!(canonical_path.exists());
+        assert!(worktree_path.exists());
+        let canonical_contents = std::fs::read_to_string(&canonical_path).unwrap();
+        let worktree_contents = std::fs::read_to_string(&worktree_path).unwrap();
+        assert!(canonical_contents.contains("[[reference/cognitive-memory-scope]]"));
+        assert_eq!(canonical_contents, worktree_contents);
+        assert!(
+            repo.get_by_permalink(&project.id, "reference/v1-requirements")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            !project_tmp
+                .path()
+                .join(".djinn/reference/v1-requirements.md")
+                .exists()
+        );
+    }
+
     // ── scope_paths routing regression tests ────────────────────────────────
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/src/mcp_contract_tests/memory_tools/contract_tests.rs
+++ b/server/src/mcp_contract_tests/memory_tools/contract_tests.rs
@@ -574,6 +574,90 @@ async fn mcp_singleton_memory_writes_use_canonical_project_root_and_mirror_workt
 }
 
 #[tokio::test]
+async fn mcp_current_requirement_edits_use_canonical_project_root_and_mirror_worktree() {
+    let db = create_test_db();
+    let (proj, _dir) = create_test_project_with_dir(&db).await;
+    let project = &proj.path;
+    let worktree = workspace_tempdir("mcp-current-requirement-worktree-");
+    std::fs::create_dir_all(worktree.path().join(".git")).expect("create synthetic .git dir");
+    let app = create_test_app_with_db(db.clone());
+    let worktree_header = worktree.path().to_string_lossy().to_string();
+    let session_id = initialize_mcp_session_with_headers(
+        &app,
+        &[("x-djinn-worktree-root", &worktree_header)],
+    )
+    .await;
+
+    let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+    let project_id: String = project_repo.resolve_or_create(project).await.unwrap();
+    let note_repo = NoteRepository::new(db.clone(), EventBus::noop());
+    note_repo
+        .create(
+            &project_id,
+            Path::new(project),
+            "V1 Requirements",
+            "alpha [[Cognitive Memory Scope]]",
+            "requirement",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+    let edited = mcp_call_tool_with_headers(
+        &app,
+        &session_id,
+        "memory_edit",
+        json!({
+            "project": project,
+            "identifier": "requirements/v1-requirements",
+            "operation": "find_replace",
+            "find_text": "[[Cognitive Memory Scope]]",
+            "content": "[[reference/cognitive-memory-scope]]"
+        }),
+        &[("x-djinn-worktree-root", &worktree_header)],
+    )
+    .await;
+    assert!(edited["content"].as_str().unwrap().contains("[[reference/cognitive-memory-scope]]"));
+
+    let note = note_repo
+        .get_by_permalink(&project_id, "requirements/v1-requirements")
+        .await
+        .unwrap()
+        .unwrap();
+
+    let canonical_path = Path::new(&note.file_path).to_path_buf();
+    let worktree_path = worktree.path().join(".djinn/requirements/v1-requirements.md");
+    assert_eq!(
+        canonical_path,
+        Path::new(project).join(".djinn/requirements/v1-requirements.md")
+    );
+    assert!(canonical_path.exists(), "current-note canonical file should exist");
+    assert!(worktree_path.exists(), "current-note worktree mirror should exist");
+
+    let canonical_contents =
+        std::fs::read_to_string(&canonical_path).expect("read canonical requirements");
+    let worktree_contents =
+        std::fs::read_to_string(&worktree_path).expect("read worktree requirements");
+    assert!(canonical_contents.contains("[[reference/cognitive-memory-scope]]"));
+    assert_eq!(canonical_contents, worktree_contents);
+
+    assert!(
+        note_repo
+            .get_by_permalink(&project_id, "reference/v1-requirements")
+            .await
+            .unwrap()
+            .is_none(),
+        "current-note edit should not retarget to reference note"
+    );
+    assert!(
+        !Path::new(project)
+            .join(".djinn/reference/v1-requirements.md")
+            .exists(),
+        "current-note edit should not create duplicate typed note"
+    );
+}
+
+#[tokio::test]
 async fn mcp_memory_list_all_and_filters_by_folder_and_type() {
     let db = create_test_db();
     let (proj, _dir) = create_test_project_with_dir(&db).await;


### PR DESCRIPTION
## Summary
Targeted follow-up from task 5m19. The attempted wikilink repair proved the remaining broken current-note links are not simple content drift: planner-path `memory_edit` rewrote worktree-local duplicates (`.djinn/reference/project-brief.md`, `.djinn/reference/v1-requirements.md`) while the canonical project-root notes `.djinn/brief.md` and `.djinn/requirements/v1-requirements.md` remained unchanged. Repair note-routing so edits to singleton/current canonical notes mutate the canonical project-root files and preserve canonical permalinks.

## Acceptance Criteria
- [x] Editing `brief` from the planner path updates canonical project-root `.djinn/brief.md` rather than creating or mutating worktree duplicate reference files, and the brief now links to `[[requirements/v1-requirements]]`.
- [x] Editing `requirements/v1-requirements` from the planner path updates canonical project-root `.djinn/requirements/v1-requirements.md` rather than a duplicate reference file, and the requirements note now links to `[[reference/cognitive-memory-scope]]`.
- [x] Verification demonstrates the current-note defect is resolved while the broader historical broken-link backlog remains explicitly deferred.

---
Djinn task: tbkc