### PR TITLE
chore(l8q4): Add verification coverage for semantic memory search and fallback behavior

### DIFF
--- a/server/crates/djinn-db/src/repositories/note/tests/embeddings.rs
+++ b/server/crates/djinn-db/src/repositories/note/tests/embeddings.rs
@@ -1,4 +1,31 @@
+use std::sync::Arc;
+
 use super::*;
+use crate::EmbeddedNote;
+
+struct StubEmbeddingProvider {
+    value: f32,
+    model_version: &'static str,
+    fail: bool,
+}
+
+#[async_trait::async_trait]
+impl NoteEmbeddingProvider for StubEmbeddingProvider {
+    async fn embed_note(&self, _text: &str) -> std::result::Result<EmbeddedNote, String> {
+        if self.fail {
+            Err("model unavailable".to_string())
+        } else {
+            Ok(EmbeddedNote {
+                values: embedding_with_value(self.value),
+                model_version: self.model_version.to_string(),
+            })
+        }
+    }
+
+    fn model_version(&self) -> String {
+        self.model_version.to_string()
+    }
+}
 
 fn embedding_with_value(value: f32) -> Vec<f32> {
     vec![value; 768]
@@ -79,4 +106,177 @@ async fn embedding_query_gracefully_returns_empty_when_vec_disabled() {
     }
 
     crate::database::set_sqlite_vec_disabled_for_tests(false);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn embedding_lifecycle_tracks_create_update_delete_with_provider() {
+    crate::database::set_sqlite_vec_disabled_for_tests(false);
+
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db, event_bus_for(&tx)).with_embedding_provider(Some(Arc::new(
+        StubEmbeddingProvider {
+            value: 0.2,
+            model_version: "model-v1",
+            fail: false,
+        },
+    )));
+
+    let note = repo
+        .create(
+            &project.id,
+            tmp.path(),
+            "Lifecycle Note",
+            "original body",
+            "reference",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+    let created = repo
+        .get_embedding(&note.id)
+        .await
+        .unwrap()
+        .expect("created embedding");
+    assert_eq!(created.model_version, "model-v1");
+    assert_eq!(
+        created.content_hash,
+        crate::note_hash::note_content_hash(
+            "title: Lifecycle Note\ntype: reference\ntags: []\n\noriginal body"
+        )
+    );
+
+    let updated = repo
+        .update(&note.id, "Lifecycle Note", "updated body", "[]")
+        .await
+        .unwrap();
+    let updated_embedding = repo
+        .get_embedding(&updated.id)
+        .await
+        .unwrap()
+        .expect("updated embedding");
+    assert_eq!(updated_embedding.model_version, "model-v1");
+    assert_eq!(
+        updated_embedding.content_hash,
+        crate::note_hash::note_content_hash(
+            "title: Lifecycle Note\ntype: reference\ntags: []\n\nupdated body"
+        )
+    );
+    assert_ne!(created.content_hash, updated_embedding.content_hash);
+
+    repo.delete(&updated.id).await.unwrap();
+    assert!(repo.get_embedding(&updated.id).await.unwrap().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reindex_repairs_missing_and_stale_embeddings_with_provider() {
+    crate::database::set_sqlite_vec_disabled_for_tests(false);
+
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db.clone(), event_bus_for(&tx)).with_embedding_provider(Some(
+        Arc::new(StubEmbeddingProvider {
+            value: 0.3,
+            model_version: "model-v2",
+            fail: false,
+        }),
+    ));
+
+    let file_note = repo
+        .create(
+            &project.id,
+            tmp.path(),
+            "Indexed File Note",
+            "body on disk",
+            "reference",
+            "[]",
+        )
+        .await
+        .unwrap();
+    let db_note = repo
+        .create_db_note(&project.id, "Indexed Db Note", "db body", "pattern", "[]")
+        .await
+        .unwrap();
+
+    repo.delete_embedding(&file_note.id).await.unwrap();
+    repo.upsert_embedding(UpsertNoteEmbedding {
+        note_id: &db_note.id,
+        content_hash: "stale-hash",
+        model_version: "old-model",
+        embedding: &embedding_with_value(0.9),
+    })
+    .await
+    .unwrap();
+
+    let summary = repo
+        .reindex_from_disk(&project.id, tmp.path())
+        .await
+        .unwrap();
+    assert_eq!(summary.unchanged + summary.updated, 1);
+    assert_eq!(summary.created, 0);
+    assert_eq!(summary.deleted, 0);
+
+    let repaired_file = repo
+        .get_embedding(&file_note.id)
+        .await
+        .unwrap()
+        .expect("missing file embedding repaired");
+    let repaired_db = repo
+        .get_embedding(&db_note.id)
+        .await
+        .unwrap()
+        .expect("stale db embedding repaired");
+
+    assert_eq!(repaired_file.model_version, "model-v2");
+    assert_eq!(repaired_db.model_version, "model-v2");
+    assert_ne!(repaired_db.content_hash, "stale-hash");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn embedding_provider_failure_degrades_without_persisting_embeddings() {
+    crate::database::set_sqlite_vec_disabled_for_tests(false);
+
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db, event_bus_for(&tx)).with_embedding_provider(Some(Arc::new(
+        StubEmbeddingProvider {
+            value: 0.0,
+            model_version: "broken-model",
+            fail: true,
+        },
+    )));
+
+    let note = repo
+        .create_db_note(
+            &project.id,
+            "Fallback Only Note",
+            "lexical-only body",
+            "reference",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+    assert!(repo.get_embedding(&note.id).await.unwrap().is_none());
+
+    let updated = repo
+        .update(
+            &note.id,
+            "Fallback Only Note",
+            "lexical-only body updated",
+            "[]",
+        )
+        .await
+        .unwrap();
+    assert!(repo.get_embedding(&updated.id).await.unwrap().is_none());
 }

--- a/server/crates/djinn-mcp/src/tools/memory_tools/ops_tests.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/ops_tests.rs
@@ -24,6 +24,8 @@ mod tests {
         embedding: Vec<f32>,
     }
 
+    struct FailingSemanticRuntimeOps;
+
     #[async_trait::async_trait]
     impl RuntimeOps for SemanticRuntimeOps {
         async fn apply_settings(
@@ -40,6 +42,27 @@ mod tests {
             Ok(Some(SemanticQueryEmbedding {
                 values: self.embedding.clone(),
             }))
+        }
+
+        async fn reset_runtime_settings(&self) {}
+        async fn persist_model_health_state(&self) {}
+        async fn purge_worktrees(&self) {}
+    }
+
+    #[async_trait::async_trait]
+    impl RuntimeOps for FailingSemanticRuntimeOps {
+        async fn apply_settings(
+            &self,
+            _: &djinn_core::models::DjinnSettings,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn embed_memory_query(
+            &self,
+            _: &str,
+        ) -> Result<Option<SemanticQueryEmbedding>, String> {
+            Err("embedding model unavailable".to_string())
         }
 
         async fn reset_runtime_settings(&self) {}
@@ -378,12 +401,68 @@ mod tests {
 
         if semantic_candidates.iter().any(|(id, _)| id == &semantic.id) {
             assert!(ids.contains(&semantic.id.as_str()));
+            assert_eq!(
+                ids.iter().filter(|&&id| id == semantic.id.as_str()).count(),
+                1,
+                "merged semantic+lexical results should be deduplicated"
+            );
         } else {
             assert!(
                 !ids.contains(&semantic.id.as_str()),
                 "semantic-only match should be absent when semantic candidate retrieval returns no match"
             );
         }
+
+        assert_eq!(
+            ids.iter().filter(|&&id| id == lexical.id.as_str()).count(),
+            1,
+            "lexical matches should also remain deduplicated"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_search_ops_falls_back_to_fts_when_query_embedding_fails() {
+        let setup = setup_server().await;
+        let failing_server = DjinnMcpServer::new(McpState::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+            djinn_provider::catalog::CatalogService::new(),
+            djinn_provider::catalog::HealthTracker::new(),
+            "test-user".into(),
+            Some(Arc::new(StubCoordinatorOps)),
+            Some(Arc::new(StubSlotPoolOps)),
+            None,
+            Arc::new(StubLspOps),
+            Arc::new(StubSyncOps),
+            Arc::new(FailingSemanticRuntimeOps),
+            Arc::new(StubGitOps),
+            Arc::new(StubRepoGraphOps),
+        ));
+
+        let response = ops::memory_search(
+            &failing_server,
+            SearchParams {
+                project: setup.project,
+                query: "architecture".to_string(),
+                folder: None,
+                note_type: None,
+                limit: Some(10),
+            },
+            None,
+        )
+        .await;
+
+        assert!(response.error.is_none(), "{:?}", response.error);
+        assert!(
+            !response.results.is_empty(),
+            "fts fallback should still return lexical matches"
+        );
+        assert!(
+            response
+                .results
+                .iter()
+                .any(|result| result.title == "Seed Note" || result.title == "Related Note")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
Harden the semantic memory search work with focused tests for initialization, indexing lifecycle, retrieval merge behavior, and degraded fallback. This task should consolidate verification after the main implementation seams land.

## Acceptance Criteria
- [x] Automated tests cover migration/init behavior, including graceful behavior when sqlite-vec or the embedding model is unavailable.
- [x] Repository or integration tests cover embedding lifecycle behavior for note write/update/delete or reindex flows.
- [x] Search-focused tests prove merged FTS+semantic behavior and confirm FTS-only fallback remains functional.

---
Djinn task: l8q4