### PR TITLE
chore(mved): Catalog SQLite-specific migration seams for ADR-055

### DIFF
--- a/.djinn/decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching.md
+++ b/.djinn/decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching.md
@@ -4,6 +4,8 @@ type: adr
 tags: ["adr","dolt","database","branching","migration","qdrant","knowledge-management"]
 ---
 
+
+
 # ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching
 
 ## Status
@@ -294,15 +296,10 @@ DoltLite (announced 2026-03-25) is a SQLite fork with Prolly Trees and Dolt-styl
 - Configure Dolt GC thresholds
 - Monitor commit graph growth
 
-### Phase 5 — History features
-- Knowledge blame in memory tools
-- Time-travel queries in `memory_build_context`
-- Knowledge diff in Planner patrol context
-- Rollback capability in MCP tools
-
 ## Relations
 
 - [[ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy]]
 - [[ADR-053: Semantic Memory Search — Candle Embeddings with sqlite-vec]]
 - [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
 - [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]]
+- [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]] — concrete SQLite/Dolt/Qdrant seam inventory for Wave 1 migration tasks

--- a/.djinn/design/adr-055-roadmap-dolt-migration-and-per-task-knowledge-branching.md
+++ b/.djinn/design/adr-055-roadmap-dolt-migration-and-per-task-knowledge-branching.md
@@ -6,14 +6,17 @@ tags: ["adr-055","roadmap","dolt","mysql","qdrant","branching"]
 
 # ADR-055 roadmap — Dolt migration and per-task knowledge branching
 
-<<<<<<< HEAD
 Originated from epic `5izw` and task `019d8915-2695-7593-83a9-4226231a6675` (`mved`).
 
 ## Status
 
-Proposed.
+Epic remains open. Wave 1 backend-seam work is active and not yet complete, so the epic is not ready for closure.
 
 This roadmap tracks Wave 1 decomposition for [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]].
+
+## Architectural goal
+
+Implement [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]] by replacing SQLite-specific note storage/search seams with Dolt + MySQL-compatible relational storage, Qdrant-backed vector retrieval, and a per-task knowledge-branch lifecycle that isolates speculative extraction until promotion.
 
 ## Wave 1 goals
 
@@ -51,55 +54,46 @@ This roadmap tracks Wave 1 decomposition for [[decisions/adr-055-proposal-dolt-m
 - `4hkv` — design task-branch knowledge promotion flow for ADR-055.
 - Should assume branch checkout and branch-aware reads/writes live below repositories in the backend/session layer, per [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]].
 
-## Initial sequencing
+## What Wave 1 must answer
 
-1. Land seam inventory.
-2. Extract vector-store and backend bootstrap seams.
-3. Prototype FULLTEXT lexical replacement behind a lexical backend boundary.
-4. Define branch lifecycle contract once backend/session ownership is explicit.
-=======
-## Status
-Epic remains open. Wave 1 backend-seam work is active and not yet complete, so the epic is not ready for closure.
-
-## Architectural goal
-Implement [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]] by replacing SQLite-specific note storage/search seams with Dolt + MySQL-compatible relational storage, Qdrant-backed vector retrieval, and a per-task knowledge-branch lifecycle that isolates speculative extraction until promotion.
-
-## Current wave (Wave 1) — foundation and uncertainty reduction
-
-### In flight / planned
-- `mved` — catalog SQLite-specific migration seams for Dolt/MySQL + Qdrant
-- `6iiz` — introduce vector-store abstraction and Qdrant scaffold for note embeddings
-- `y70d` — refactor database bootstrap for selectable SQLite vs Dolt/MySQL backends
-- `keit` — prototype Dolt/MySQL FULLTEXT notes search to replace FTS5
-- `4hkv` — design task-branch knowledge promotion flow for ADR-055
-
-### What Wave 1 must answer
-1. Where SQLite-specific assumptions currently live (`database.rs`, note search, embeddings, migration/bootstrap, worktree note sync).
+1. Where SQLite-specific assumptions currently live across `database.rs`, note search, embeddings, migration/bootstrap, and note sync.
 2. What backend seams are required so SQLite remains functional while Dolt/Qdrant scaffolding lands.
 3. How task dispatch, session extraction, branch-scoped note IO, promotion review, and cleanup should interact under Dolt task branches.
 
-### Concrete code seams confirmed during planning
+## Concrete code seams confirmed during planning
+
 - `server/crates/djinn-db/src/database.rs` is tightly coupled to SQLite pool types, pragma setup, and sqlite-vec initialization.
 - `server/crates/djinn-db/src/repositories/note/search.rs` depends on FTS5 tables and BM25-specific SQL query shape.
 - `server/crates/djinn-db/src/repositories/note/embeddings.rs` assumes sqlite-vec availability and local embedding persistence semantics.
 - `server/crates/djinn-db/src/repositories/note/crud.rs` already contains worktree `.djinn/` note parsing and file-backed note sync behavior that must be reconciled with branch-aware canonical storage.
 - `server/crates/djinn-agent/src/actors/coordinator/dispatch.rs`, `server/crates/djinn-agent/src/actors/slot/session_extraction.rs`, and `server/crates/djinn-agent/src/actors/slot/llm_extraction.rs` are the key lifecycle seams for branch creation, branch-scoped extraction writes, and cleanup/promotion triggers.
 
+## Initial sequencing
+
+1. Land seam inventory.
+2. Extract vector-store and backend bootstrap seams.
+3. Prototype FULLTEXT lexical replacement behind a lexical backend boundary.
+4. Define branch lifecycle contract once backend/session ownership is explicit.
+5. Start Wave 2 implementation only after Wave 1 seam outputs are merged.
+
 ## Next wave (Wave 2) — implementation after Wave 1 lands
-Wave 2 should not start until the seam inventory, backend bootstrap seam, lexical-search prototype, vector-store seam, and branch-flow contract exist. The tasks below are pre-created and blocked on Wave 1 outputs so they are ready once the foundation is merged.
+
+Wave 2 should not start until the seam inventory, backend bootstrap seam, lexical-search prototype, vector-store seam, and branch-flow contract exist. The pre-created follow-on tasks are blocked on Wave 1 outputs so they are ready once the foundation is merged.
 
 ### Wave 2 tasks
+
 1. MySQL/Dolt schema and migration port for note/task storage.
 2. Branch-aware session database routing plus task-branch lifecycle hooks.
 3. Promotion-review execution flow that diffs task branches, applies quality gates, and cleans up branch/Qdrant residue.
 4. Branch-aware embedding sync and retrieval filtering across `main` + task branches.
 
 ## Closure check
+
 Do not close this epic until:
+
 - Wave 1 tasks are reviewed and merged.
 - Wave 2 migration tasks are complete.
 - The codebase has an end-to-end task-branch knowledge flow, not just scaffolding.
->>>>>>> origin/main
 
 ## Relations
 

--- a/.djinn/design/adr-055-roadmap-dolt-migration-and-per-task-knowledge-branching.md
+++ b/.djinn/design/adr-055-roadmap-dolt-migration-and-per-task-knowledge-branching.md
@@ -1,62 +1,63 @@
 ---
-title: ADR-055 Roadmap — Dolt Migration and Per-Task Knowledge Branching
+title: ADR-055 roadmap — Dolt migration and per-task knowledge branching
 type: design
-tags: ["adr-055","roadmap","dolt","qdrant","knowledge-branching"]
+tags: ["adr-055","roadmap","dolt","mysql","qdrant","branching"]
 ---
 
-# ADR-055 Roadmap — Dolt Migration and Per-Task Knowledge Branching
+# ADR-055 roadmap — Dolt migration and per-task knowledge branching
 
-## Goal
-Migrate Djinn from SQLite + sqlite-vec to Dolt + Qdrant, then use Dolt branches to isolate per-task knowledge and selectively promote reviewed notes into canonical `main`.
+Originated from epic `5izw` and task `019d8915-2695-7593-83a9-4226231a6675` (`mved`).
 
-## Current State
-The codebase is still SQLite-first:
-- `server/crates/djinn-db/src/database.rs` opens `SqlitePool`, applies SQLite pragmas, and initializes `sqlite-vec`.
-- `server/crates/djinn-db/schema.sql` defines `notes_fts` as an FTS5 virtual table plus sync triggers.
-- `server/crates/djinn-db/src/repositories/note/search.rs` hardcodes FTS5/BM25 queries.
-- `server/crates/djinn-db/src/repositories/note/embeddings.rs` stores vectors in SQLite tables plus `note_embeddings_vec`.
-- `server/crates/djinn-db/src/repositories/note/crud.rs` already has a useful precursor seam: worktree-scoped note files can be synced into canonical storage, which is conceptually adjacent to future task-branch promotion.
+## Status
 
-No Dolt, MySQL, or Qdrant implementation seams are present yet.
+Proposed.
 
-## Planning Decision
-The epic is **not complete**. This wave should establish the first migration seams rather than attempt end-to-end cutover in one step.
+This roadmap tracks Wave 1 decomposition for [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]].
 
-## Delivery Strategy
+## Wave 1 goals
 
-### Wave 1 — Prepare backend seams and independent sidecar work
-1. Extract/document the SQLite-specific database/search/vector surfaces that must become backend-aware.
-2. Introduce a vector-store abstraction and land a Qdrant-backed implementation behind config while preserving current behavior.
-3. Add Dolt/MySQL runtime bootstrap and health-management scaffolding without cutting over the default backend.
-4. Prototype/port notes schema and lexical search to a MySQL-compatible path, including FULLTEXT-backed retrieval semantics.
-5. Define the task-branch knowledge lifecycle contract so dispatch, extraction, merge, and cleanup hooks can be wired in a later wave without re-planning the data model.
+1. Catalog SQLite-specific seams so follow-on work can land behind explicit boundaries.
+2. Introduce a vector-store abstraction and Qdrant scaffold.
+3. Refactor database bootstrap so SQLite and Dolt/MySQL backends can coexist during migration.
+4. Prototype MySQL/Dolt lexical search to replace FTS5.
+5. Define the task-branch knowledge lifecycle contract.
 
-### Wave 2 — Dual-path backend implementation
-- Port schema/migrations for operational tables.
-- Add repository support for MySQL/Dolt note/task/session storage.
-- Wire Qdrant into semantic retrieval and backfill flows.
-- Validate search/retrieval parity against current SQLite behavior.
+## Active work buckets
 
-### Wave 3 — Per-task knowledge branching
-- Create Dolt branches at dispatch time.
-- Bind task/session knowledge writes to the task branch.
-- Implement diff, quality-gated promotion, and branch cleanup.
-- Add branch-aware Qdrant payload filtering.
+### 1. Seam inventory and migration map
 
-### Wave 4 — Operational lifecycle and history features
-- Compaction/flatten maintenance flows.
-- History/diff/blame tooling surfaces.
-- Rollback/admin support and monitoring.
+- `mved` — catalog SQLite-specific migration seams for ADR-055.
+- Output note: [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]].
+- This note is now the canonical inventory of SQLite-coupled bootstrap, migration, FTS5, sqlite-vec, pragma, and SQL-dialect seams.
 
-## Wave 1 Task Shape
-This wave intentionally favors seam extraction and backend scaffolding over full cutover. The main risk is mixing backend abstraction, schema migration, and branching semantics into one oversized task. Tasks should stay narrowly scoped and use blockers where they touch the same repositories.
+### 2. Vector-store extraction
 
-## Open Risks
-- MySQL FULLTEXT quality may not match current FTS5 scoring closely enough without additional tuning.
-- Dolt SQL procedure semantics may require transactional patterns different from current `sqlx` repository assumptions.
-- Branch-aware semantic retrieval needs payload/filter design in Qdrant before cutover.
+- `6iiz` — introduce vector-store abstraction and Qdrant scaffold for note embeddings.
+- Should follow the `VectorStore` and embedding-metadata split recommended in [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]].
+
+### 3. Relational backend/bootstrap extraction
+
+- `y70d` — refactor database bootstrap for selectable SQLite vs Dolt/MySQL backends.
+- Should use the `DatabaseBackend` / `SchemaMigrator` seam identified in [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]].
+
+### 4. Lexical search replacement
+
+- `keit` — prototype Dolt/MySQL FULLTEXT notes search to replace FTS5.
+- Should keep RRF fusion but replace the lexical candidate backend described in [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]].
+
+### 5. Task-branch knowledge promotion flow
+
+- `4hkv` — design task-branch knowledge promotion flow for ADR-055.
+- Should assume branch checkout and branch-aware reads/writes live below repositories in the backend/session layer, per [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]].
+
+## Initial sequencing
+
+1. Land seam inventory.
+2. Extract vector-store and backend bootstrap seams.
+3. Prototype FULLTEXT lexical replacement behind a lexical backend boundary.
+4. Define branch lifecycle contract once backend/session ownership is explicit.
 
 ## Relations
+
 - [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
-- [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]
-- [[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]
+- [[reference/adr-055-sqlite-seam-inventory-for-dolt-migration]]

--- a/.djinn/reference/adr-055-sqlite-seam-inventory-for-dolt-migration.md
+++ b/.djinn/reference/adr-055-sqlite-seam-inventory-for-dolt-migration.md
@@ -1,0 +1,465 @@
+---
+title: ADR-055 SQLite seam inventory for Dolt migration
+type: reference
+tags: ["adr-055","sqlite","dolt","mysql","qdrant","migration","seams"]
+---
+
+# ADR-055 SQLite seam inventory for Dolt/MySQL + Qdrant
+
+Originated from task `019d8915-2695-7593-83a9-4226231a6675` (`mved`).
+
+## Purpose
+
+This note inventories the concrete SQLite-coupled seams in the current `djinn-db` stack so follow-on ADR-055 work can replace them with explicit backend boundaries instead of broad ad hoc edits.
+
+Primary evidence reviewed:
+
+- `server/crates/djinn-db/src/database.rs`
+- `server/crates/djinn-db/src/migrations.rs`
+- `server/crates/djinn-db/schema.sql`
+- `server/crates/djinn-db/src/repositories/note/search.rs`
+- `server/crates/djinn-db/src/repositories/note/embeddings.rs`
+- targeted grep across `server/crates/djinn-db/src/**` and `server/crates/djinn-db/migrations/**`
+- [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
+
+## Executive summary
+
+SQLite is not isolated to one bootstrap module. The current coupling spans five layers:
+
+1. **Database runtime/bootstrap**: `Database` is hard-coded around `sqlx::SqlitePool`, `SqliteConnectOptions`, SQLite URIs, pragmas, and `rusqlite` migration execution.
+2. **DDL and migration strategy**: canonical schema and many migrations depend on SQLite-only DDL, timestamp functions, virtual tables, triggers, and table-rebuild patterns guarded by `PRAGMA foreign_keys` toggles.
+3. **Lexical search**: note search is directly built around FTS5 syntax, `MATCH`, `bm25(...)`, and `rowid` joins to the `notes_fts` virtual table.
+4. **Semantic vector storage**: embedding persistence assumes local blob storage plus `sqlite-vec` `vec0` virtual table initialization, availability checks, and nearest-neighbor query syntax.
+5. **Repository query semantics**: many repositories assume SQLite date/time functions, JSON table functions, and SQL dialect details that will need a SQL-dialect seam even when the high-level repository API stays the same.
+
+The main migration risk is not just changing connection strings. It is that the current repositories expose behavior that already bakes in SQLite-specific ranking, vector availability, temporal math, and JSON filtering.
+
+## Seam inventory
+
+### 1. Bootstrap and connection-management seam
+
+#### Concrete SQLite couplings
+
+**`server/crates/djinn-db/src/database.rs`**
+
+- `Database` owns a `pool: SqlitePool` and exposes `pub fn pool(&self) -> &SqlitePool`.
+- Constructors use `SqliteConnectOptions::from_str("sqlite://...")` in:
+  - `Database::open`
+  - `Database::open_readonly`
+  - `Database::open_in_memory`
+- `.foreign_keys(true)` is set directly on SQLite connect options.
+- connection initialization uses SQLite-only hooks:
+  - `apply_pragmas`
+  - `apply_pragmas_readonly`
+- `apply_pragmas` issues:
+  - `PRAGMA journal_mode = WAL`
+  - `PRAGMA busy_timeout = 30000`
+  - `PRAGMA synchronous = NORMAL`
+  - `PRAGMA foreign_keys = ON`
+  - `PRAGMA cache_size = -64000`
+- tests assert SQLite runtime state via `PRAGMA journal_mode`, `PRAGMA busy_timeout`, `PRAGMA synchronous`, and `PRAGMA foreign_keys`.
+- `default_db_path()` assumes a single local file database at `~/.djinn/djinn.db`.
+
+#### Why this is a migration seam
+
+Dolt/MySQL will need networked or daemon-backed connection setup, different pool/session initialization, no pragma concept, and likely per-session branch checkout. Qdrant should not be represented as a SQLite extension health bit attached to the relational pool.
+
+#### Initial abstraction boundary
+
+Create a **database backend/runtime seam** with responsibilities split into:
+
+- `RelationalBackend` / `DatabaseBackend` for pool creation and initialization
+- `SessionConfigurator` for backend-specific session defaults (`PRAGMA ...` vs `SET ...` / Dolt checkout)
+- `DatabaseLocator` for local SQLite path vs Dolt DSN configuration
+
+`Database` should stop exposing `&SqlitePool`; callers should depend on backend-neutral repository capabilities or an internal executor wrapper.
+
+---
+
+### 2. Migration-runner seam
+
+#### Concrete SQLite couplings
+
+**`server/crates/djinn-db/src/migrations.rs`**
+
+- `run(path: &Path)` opens the DB with `rusqlite::Connection::open(path)`.
+- refinery migrations are executed through the **rusqlite runner**.
+- `run_until(...)` test helper also depends on `rusqlite` and refinery version targeting.
+
+**`server/crates/djinn-db/src/database.rs`**
+
+- `ensure_initialized()` calls `tokio::task::spawn_blocking(move || migrations::run(&db_path))`.
+- initialization sequencing assumes a file path that a blocking `rusqlite` migration runner can open separately from `sqlx`.
+- test fixture helpers (`create_legacy_note_fixture_db`) create partially migrated SQLite files through `rusqlite`.
+
+#### Why this is a migration seam
+
+Dolt/MySQL migrations cannot reuse a local-file `rusqlite` runner. The current API also assumes initialization = “run migrations against a file path before async use.” Dolt likely needs DSN-based migrations, possibly different migration tooling, and branch-aware bootstrap rules.
+
+#### Initial abstraction boundary
+
+Create a **schema migrator seam**:
+
+- `SchemaMigrator::migrate(target)`
+- `SchemaBootstrapTarget` should be DSN/backend oriented, not `Path`
+- test helpers should move behind a backend fixture trait
+
+This seam should absorb:
+
+- migration transport (`rusqlite` vs MySQL driver)
+- migration source format
+- backend bootstrap ordering
+
+---
+
+### 3. Canonical schema / DDL seam
+
+#### Concrete SQLite couplings
+
+**`server/crates/djinn-db/schema.sql`**
+
+SQLite-specific DDL appears in several categories:
+
+1. **timestamp defaults and time functions**
+   - widespread `DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`
+   - examples across `settings`, `projects`, `tasks`, `notes`, `note_embeddings`, `note_links`, `sessions`, `verification_cache`, `note_associations`, `consolidated_note_provenance`, etc.
+2. **FTS5 virtual table**
+   - `CREATE VIRTUAL TABLE notes_fts USING fts5(...)`
+3. **trigger-based FTS synchronization**
+   - `notes_ai`, `notes_ad`, `notes_au`
+   - all rely on `rowid`
+4. **SQLite row identity assumptions**
+   - FTS table sync stores `rowid` and joins through `notes.rowid`
+5. **SQLite type/storage conventions**
+   - JSON-like columns stored as `TEXT` (`labels`, `tags`, `scope_paths`, payloads)
+   - booleans represented as `INTEGER NOT NULL DEFAULT 0/1`
+   - `BLOB` embedding storage in `note_embeddings.embedding`
+6. **CHECK / rebuild compatibility expectations**
+   - current schema and migrations often tolerate SQLite’s table rebuild style more than MySQL-style `ALTER TABLE`
+
+#### Why this is a migration seam
+
+ADR-055 replaces:
+
+- `notes_fts` with MySQL/Dolt `FULLTEXT`
+- `note_embeddings_vec` with Qdrant
+- SQLite timestamps/functions with MySQL-compatible defaults or app-side timestamps
+- trigger-maintained denormalized FTS state with either generated/indexed columns or app-driven indexing
+
+#### Initial abstraction boundary
+
+Split schema concerns into three explicit seams:
+
+- **relational canonical schema** (portable tables only)
+- **lexical index schema adapter** (`FTS5` vs `FULLTEXT`)
+- **vector index schema adapter** (SQLite local table vs external Qdrant collection metadata)
+
+Do not keep search/vector DDL embedded in the same “canonical schema snapshot” abstraction.
+
+---
+
+### 4. Lexical search seam (FTS5)
+
+#### Concrete SQLite couplings
+
+**`server/crates/djinn-db/src/repositories/note/search.rs`**
+
+- `sanitize_fts5_query(raw: &str)` explicitly targets **FTS5 syntax**.
+- Query building assumes `MATCH` against the `notes_fts` virtual table.
+- Ranking assumes SQLite `bm25(notes_fts, 3.0, 1.0, 2.0)` weights.
+- `dedup_candidates(...)`:
+  - selects from `notes_fts`
+  - joins `notes n ON notes_fts.rowid = n.rowid`
+  - filters with `WHERE notes_fts MATCH ?1`
+  - thresholds on negated BM25 score
+- `detect_contradiction_candidates(...)` repeats the same coupling.
+- `search(...)` uses FTS5 as the lexical candidate generator before RRF fusion.
+- `server/crates/djinn-db/src/repositories/note/consolidation.rs` also uses `sanitize_fts5_query`, `notes_fts`, and `bm25(...)`.
+- tests in `server/crates/djinn-db/src/repositories/note/tests/search_ranking.rs` are named for FTS5 behavior and encode title/content/tag weighting assumptions.
+
+#### Why this is a migration seam
+
+MySQL `FULLTEXT ... AGAINST` is not syntax-compatible with FTS5. There is no direct `bm25(notes_fts, title_weight, content_weight, tag_weight)` equivalent and there is no `rowid` join through an auxiliary virtual table.
+
+#### Initial abstraction boundary
+
+Introduce a **lexical search backend seam** at the repository layer:
+
+- `LexicalNoteSearchBackend`
+  - `candidate_scores(project_id, query, filters, limit)`
+  - `dedup_candidates(...)`
+  - `contradiction_candidates(...)`
+- `QuerySanitizer` should become backend-specific (`sanitize_fts5_query` cannot be reused for boolean-mode MySQL FULLTEXT).
+- Keep **RRF fusion** in shared repository code, but treat lexical retrieval as one pluggable signal source.
+
+This boundary allows the sibling task for MySQL FULLTEXT to replace only candidate generation while preserving downstream ranking fusion.
+
+---
+
+### 5. Semantic vector seam (`sqlite-vec` + local metadata)
+
+#### Concrete SQLite couplings
+
+**`server/crates/djinn-db/src/database.rs`**
+
+- `SqliteVecStatus` is a database-level concept.
+- auto-extension registration depends on:
+  - `rusqlite::ffi::sqlite3_auto_extension`
+  - `sqlite_vec::sqlite3_vec_init`
+- `initialize_sqlite_vec(...)` executes `SELECT vec_version()`.
+- it creates `note_embeddings_vec` with:
+  - `CREATE VIRTUAL TABLE IF NOT EXISTS note_embeddings_vec USING vec0(...)`
+- extension availability is cached on the `Database` instance.
+
+**`server/crates/djinn-db/src/repositories/note/embeddings.rs`**
+
+- `sync_note_embedding(...)` skips embedding generation entirely unless `sqlite_vec_status().available` is true.
+- `upsert_embedding(...)` writes to both:
+  - `note_embeddings` BLOB storage
+  - `note_embedding_meta`
+  - `note_embeddings_vec` virtual table when vec0 is available
+- `delete_embedding(...)` conditionally deletes from `note_embeddings_vec`.
+- `query_similar_embeddings(...)` issues sqlite-vec syntax:
+  - `SELECT note_id, distance FROM note_embeddings_vec WHERE embedding MATCH ?1 AND k = ?2`
+- `semantic_candidate_scores(...)` assumes the raw vector backend returns note IDs that must then be filtered in SQL.
+- tests in `server/crates/djinn-db/src/repositories/note/tests/embeddings.rs` explicitly toggle `set_sqlite_vec_disabled_for_tests` and assert `sqlite_vec_status` behavior.
+
+#### Why this is a migration seam
+
+ADR-055 moves nearest-neighbor search out of SQLite entirely and into Qdrant. Availability, collection setup, filtering, and delete/upsert behavior all need to move out of the relational DB runtime.
+
+There is also a hidden product seam here: current code conflates three responsibilities:
+
+1. embedding generation
+2. relational metadata persistence
+3. vector index persistence/querying
+
+#### Initial abstraction boundary
+
+Introduce a **vector store seam** with a narrow API:
+
+- `VectorStore`
+  - `upsert_note_embedding(note_id, vector, payload)`
+  - `delete_note_embedding(note_id)`
+  - `query_similar(vector, filters, limit)`
+  - `health()`
+
+Keep relational metadata in a separate `NoteEmbeddingMetadataRepository` (or repository submodule) so Qdrant migration does not have to preserve local `BLOB` storage semantics.
+
+Also split `SqliteVecStatus` into a backend-neutral **semantic index health** concept.
+
+---
+
+### 6. Repository SQL-dialect seam beyond search/vector features
+
+The task asked for places where repository APIs currently assume SQLite semantics. The following are the highest-leverage non-search seams.
+
+#### 6a. Time arithmetic and timestamp formatting
+
+Concrete references from grep across `server/crates/djinn-db/src/**`:
+
+- `verification_result.rs`, `verification_cache.rs`, `settings.rs`, `git_settings.rs`, `session.rs`, `task/status.rs`, `task/writes.rs`, `note/crud.rs`, `note/graph.rs`, `note/housekeeping.rs`, `agent.rs`, and others use:
+  - `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`
+  - `datetime('now', '-N days')`
+  - `datetime('now', '-N hours')`
+- `search.rs` uses `updated_at >= datetime('now', '-{hours} hours')`.
+- tests in `note/tests/graph_scoring.rs` and `repositories/test_support.rs` mutate timestamps with `datetime('now', ...)`.
+
+Why it matters:
+
+- MySQL/Dolt date arithmetic syntax differs.
+- app-visible ISO timestamp formatting is currently delegated to SQLite.
+
+Recommended boundary:
+
+- move toward an **app-side clock/timestamp formatter seam** for writes
+- centralize date-window predicates in a **dialect helper** or query builder rather than embedding raw `strftime/datetime` strings in repositories
+
+#### 6b. JSON table functions over TEXT columns
+
+Concrete references:
+
+- `search.rs` scope overlap uses `json_each(n.scope_paths)`.
+- `task/queries.rs` label filtering uses `EXISTS (SELECT 1 FROM json_each(...))`.
+- comments already note virtual table scan behavior in `task/reads.rs`.
+
+Why it matters:
+
+- current APIs assume JSON arrays are stored as SQLite `TEXT` blobs and queried with SQLite’s JSON1 table-valued functions.
+- MySQL JSON filtering syntax and indexing strategy differ materially.
+
+Recommended boundary:
+
+- introduce repository-local helpers for **array membership / overlap predicates**
+- consider whether some current JSON-text columns should become join tables or native JSON columns during Dolt migration
+
+#### 6c. SQLite-specific table rebuild migrations
+
+Concrete references in migrations:
+
+- many migrations toggle `PRAGMA foreign_keys = OFF/ON` while rebuilding tables, including:
+  - `V20260322000001__task_status_pr_states.sql`
+  - `V20260320000005__rename_pm_to_lead_statuses.sql`
+  - `V20260320000002__add_pr_ready_status.sql`
+  - `V20260320000001__remove_issue_type_check_constraint.sql`
+  - `V20260319000010__task_issue_type_drop_check.sql`
+  - `V20260319000002__remove_backlog_status.sql`
+  - `V20260313000001__epic_remove_in_review_status.sql`
+  - `V20260312000001__rebuild_tasks_add_backlog_status.sql`
+  - `V20260408000001__epic_proposed_and_breakdown_fields.sql`
+- these are tailored to SQLite’s limited `ALTER TABLE` capabilities.
+
+Why it matters:
+
+- Dolt/MySQL migration work should not attempt one-for-one translation of every historical SQLite rebuild migration.
+- there needs to be a decision whether Dolt bootstrap is from a fresh canonical schema, a new migration chain, or a one-time import path.
+
+Recommended boundary:
+
+- separate **historical SQLite migration preservation** from **new backend bootstrap**
+- treat Dolt bootstrap as a new migration lineage rather than forcing refinery/rusqlite history to remain authoritative
+
+---
+
+## Implementation work buckets
+
+### Bucket A — backend bootstrap and migrator extraction
+
+Scope:
+
+- `src/database.rs`
+- `src/migrations.rs`
+- tests and fixture helpers that assume local SQLite files
+
+Deliverables:
+
+- backend-neutral database bootstrap API
+- backend-specific session initialization hooks
+- migrator abstraction that no longer takes only `Path`
+
+Feeds sibling task:
+
+- `y70d` — refactor database bootstrap for selectable SQLite vs Dolt/MySQL backends
+
+### Bucket B — lexical search backend split
+
+Scope:
+
+- `src/repositories/note/search.rs`
+- `src/repositories/note/consolidation.rs`
+- FTS-oriented tests in `src/repositories/note/tests/search_ranking.rs`
+- `schema.sql` FTS table and triggers
+
+Deliverables:
+
+- lexical candidate provider seam
+- backend-specific query sanitizer
+- preserved shared RRF fusion and note hydration path
+
+Feeds sibling task:
+
+- `keit` — prototype Dolt/MySQL FULLTEXT notes search to replace FTS5
+
+### Bucket C — vector store extraction
+
+Scope:
+
+- `src/database.rs` sqlite-vec registration/status
+- `src/repositories/note/embeddings.rs`
+- `migrations/V20260413000001__add_note_embeddings.sql`
+- embedding tests built around sqlite-vec enable/disable state
+
+Deliverables:
+
+- vector-store trait and health model
+- separation of embedding metadata from vector index storage
+- Qdrant scaffold path
+
+Feeds sibling task:
+
+- `6iiz` — introduce vector-store abstraction and Qdrant scaffold for note embeddings
+
+### Bucket D — SQL dialect and portability helpers
+
+Scope:
+
+- repository SQL using `strftime`, `datetime`, `json_each`, and SQLite-specific boolean/timestamp conventions
+- representative files include `task/queries.rs`, `task/status.rs`, `note/search.rs`, `note/crud.rs`, `note/graph.rs`, `note/housekeeping.rs`, `agent.rs`, `verification_cache.rs`, `verification_result.rs`
+
+Deliverables:
+
+- dialect helper layer or query helpers for:
+  - current timestamp
+  - time-window filters
+  - JSON array membership / overlap predicates
+- decision on which current TEXT/JSON columns should remain JSON vs become normalized tables in Dolt
+
+This is broader than the first migration wave, but identifying it now prevents later surprises once search/vector work lands.
+
+### Bucket E — schema/bootstrap strategy for Dolt branch-aware runtime
+
+Scope:
+
+- canonical schema design for Dolt/MySQL
+- replacing trigger-maintained FTS and local vector tables
+- planning for per-task branch checkout during connection/session setup
+
+Deliverables:
+
+- split relational schema from search/vector indexing schema
+- choose app-side vs DB-side timestamp ownership
+- ensure branch checkout is owned by backend/session layer, not individual repositories
+
+Feeds sibling task:
+
+- `4hkv` indirectly, because branch-aware reads/writes must sit below repository call sites
+
+## Recommended first abstraction cuts
+
+### 1. `DatabaseBackend`
+
+A backend object should own:
+
+- pool creation
+- session initialization
+- health reporting
+- branch/session checkout behavior
+- backend-specific initialization side effects
+
+This is the first seam because current `Database` shape leaks SQLite throughout the repository layer.
+
+### 2. `SchemaMigrator`
+
+Do not keep migrations as a `rusqlite` implementation detail hidden behind `Database::ensure_initialized()`. Make migration/bootstrap an explicit backend concern.
+
+### 3. `LexicalNoteSearchBackend`
+
+This isolates FTS5/MySQL FULLTEXT differences while preserving repository-visible search behavior and RRF fusion.
+
+### 4. `VectorStore`
+
+This should become the only owner of nearest-neighbor persistence and query semantics. Repositories should not know about `vec0`, `MATCH ? AND k = ?`, or Qdrant request shapes.
+
+### 5. `SqlDialect` / query helper module
+
+A light abstraction for time and JSON predicates will pay off quickly because SQLite date and JSON functions are scattered across many repositories.
+
+## Suggested migration order
+
+1. **Extract bootstrap/migrator seam first** so follow-on tasks do not deepen `SqlitePool` exposure.
+2. **Extract vector store next** because sqlite-vec is the cleanest service boundary and already has a clear ADR-055 replacement (Qdrant).
+3. **Split lexical search backend** while keeping RRF unchanged.
+4. **Centralize dialect helpers** for timestamps/JSON predicates before broad Dolt query conversion.
+5. **Port canonical schema** after search/vector seams are no longer embedded in a single SQLite-first schema snapshot.
+
+## Non-goals for the first follow-on tasks
+
+- Do not generalize every repository to a fully generic SQL engine immediately.
+- Do not preserve one-for-one compatibility with every historical SQLite migration.
+- Do not let Qdrant concerns leak into note CRUD APIs; keep them behind `VectorStore`.
+- Do not tie lexical ranking fusion logic to a specific backend’s raw scoring semantics.
+
+## Relations
+
+- [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
+- [[roadmap]]


### PR DESCRIPTION
## Summary
Inventory the concrete SQLite-coupled surfaces in the current server/database stack so the migration can proceed via explicit seams rather than ad hoc edits. Cover database bootstrap, migrations, lexical search, semantic vector storage, and any places where current repository APIs assume SQLite semantics.

## Acceptance Criteria
- [x] A design/reference note catalogs the SQLite-specific database, FTS5, sqlite-vec, pragma, and migration seams that must change for Dolt/MySQL + Qdrant, with concrete file/module references.
- [x] The note groups seams into implementation work buckets and names the initial abstraction boundaries needed for follow-on tasks.
- [x] Relevant epic/task memory refs are updated to point at the new seam inventory note.

---
Djinn task: mved