### PR TITLE
chore(y70d): Refactor database bootstrap for selectable SQLite vs Dolt/MySQL backends

### DIFF
--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -5,6 +5,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use rusqlite::ffi::sqlite3_auto_extension;
+use serde::{Deserialize, Serialize};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Executor, SqlitePool};
 use tokio::sync::OnceCell;
@@ -14,6 +15,92 @@ use crate::error::{DbError, DbResult};
 use crate::migrations;
 
 const NOTE_EMBEDDING_DIMENSIONS: usize = 768;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabaseBackendKind {
+    Sqlite,
+    Mysql,
+}
+
+impl DatabaseBackendKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            Self::Mysql => "mysql",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MysqlBackendFlavor {
+    Mysql,
+    Dolt,
+}
+
+impl MysqlBackendFlavor {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mysql => "mysql",
+            Self::Dolt => "dolt",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "backend", rename_all = "snake_case")]
+pub enum DatabaseConnectConfig {
+    Sqlite(SqliteDatabaseConfig),
+    Mysql(MysqlDatabaseConfig),
+}
+
+impl DatabaseConnectConfig {
+    pub fn backend_kind(&self) -> DatabaseBackendKind {
+        match self {
+            Self::Sqlite(_) => DatabaseBackendKind::Sqlite,
+            Self::Mysql(_) => DatabaseBackendKind::Mysql,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SqliteDatabaseConfig {
+    pub path: PathBuf,
+    #[serde(default)]
+    pub readonly: bool,
+    #[serde(default = "default_true")]
+    pub create_if_missing: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MysqlDatabaseConfig {
+    pub url: String,
+    #[serde(default = "default_mysql_flavor")]
+    pub flavor: MysqlBackendFlavor,
+}
+
+impl MysqlDatabaseConfig {
+    pub fn display_backend(&self) -> &'static str {
+        self.flavor.as_str()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatabaseBootstrapInfo {
+    pub backend_kind: DatabaseBackendKind,
+    pub backend_label: String,
+    pub target: String,
+    pub readonly: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_mysql_flavor() -> MysqlBackendFlavor {
+    MysqlBackendFlavor::Mysql
+}
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SqliteVecStatus {
@@ -25,11 +112,12 @@ pub struct SqliteVecStatus {
 static SQLITE_VEC_REGISTRATION: OnceLock<Result<(), String>> = OnceLock::new();
 static SQLITE_VEC_DISABLED: AtomicBool = AtomicBool::new(false);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Database {
     pool: SqlitePool,
     db_path: std::path::PathBuf,
     readonly: bool,
+    bootstrap: DatabaseBootstrapInfo,
     initialized: Arc<OnceCell<()>>,
     sqlite_vec_status: Arc<OnceCell<SqliteVecStatus>>,
 }
@@ -37,54 +125,20 @@ pub struct Database {
 impl Database {
     /// Open (or create) the database at `path`, auto-creating parent dirs.
     pub fn open(path: &Path) -> DbResult<Self> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| DbError::InvalidData(e.to_string()))?;
-        }
-
-        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))?
-            .create_if_missing(true)
-            .foreign_keys(true);
-        let pool = SqlitePoolOptions::new()
-            .max_connections(8)
-            .after_connect(|conn, _meta| {
-                Box::pin(async move {
-                    apply_pragmas(conn).await?;
-                    Ok(())
-                })
-            })
-            .connect_lazy_with(opts);
-
-        Ok(Self {
-            pool,
-            db_path: path.to_path_buf(),
+        Self::open_with_config(DatabaseConnectConfig::Sqlite(SqliteDatabaseConfig {
+            path: path.to_path_buf(),
             readonly: false,
-            initialized: Arc::new(OnceCell::new()),
-            sqlite_vec_status: Arc::new(OnceCell::new()),
-        })
+            create_if_missing: true,
+        }))
     }
 
     /// Open the database at `path` in read-only mode.
     pub fn open_readonly(path: &Path) -> DbResult<Self> {
-        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}?mode=ro", path.display()))?
-            .read_only(true)
-            .foreign_keys(true);
-        let pool = SqlitePoolOptions::new()
-            .max_connections(8)
-            .after_connect(|conn, _meta| {
-                Box::pin(async move {
-                    apply_pragmas_readonly(conn).await?;
-                    Ok(())
-                })
-            })
-            .connect_lazy_with(opts);
-
-        Ok(Self {
-            pool,
-            db_path: path.to_path_buf(),
+        Self::open_with_config(DatabaseConnectConfig::Sqlite(SqliteDatabaseConfig {
+            path: path.to_path_buf(),
             readonly: true,
-            initialized: Arc::new(OnceCell::new()),
-            sqlite_vec_status: Arc::new(OnceCell::new()),
-        })
+            create_if_missing: false,
+        }))
     }
 
     /// Open a temporary database for tests.
@@ -94,15 +148,73 @@ impl Database {
     pub fn open_in_memory() -> DbResult<Self> {
         let base = workspace_test_tmp_dir()?;
         let tmp = base.join(format!("djinn-test-{}.db", uuid::Uuid::now_v7()));
-        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", tmp.display()))?
-            .create_if_missing(true)
+        Self::open_sqlite(
+            &SqliteDatabaseConfig {
+                path: tmp,
+                readonly: false,
+                create_if_missing: true,
+            },
+            1,
+        )
+    }
+
+    /// Open a database using an explicit backend selection seam.
+    pub fn open_with_config(config: DatabaseConnectConfig) -> DbResult<Self> {
+        match config {
+            DatabaseConnectConfig::Sqlite(sqlite) => Self::open_sqlite(&sqlite, 8),
+            DatabaseConnectConfig::Mysql(mysql) => Err(DbError::InvalidData(format!(
+                "database backend `{}` is configured but djinn-db repositories still require SQLite during the staged Dolt/MySQL migration",
+                mysql.display_backend()
+            ))),
+        }
+    }
+
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    pub fn bootstrap_info(&self) -> &DatabaseBootstrapInfo {
+        &self.bootstrap
+    }
+
+    pub fn backend_kind(&self) -> DatabaseBackendKind {
+        self.bootstrap.backend_kind
+    }
+
+    fn open_sqlite(config: &SqliteDatabaseConfig, max_connections: u32) -> DbResult<Self> {
+        if !config.readonly
+            && config.create_if_missing
+            && let Some(parent) = config.path.parent()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| DbError::InvalidData(e.to_string()))?;
+        }
+
+        let dsn = if config.readonly {
+            format!("sqlite://{}?mode=ro", config.path.display())
+        } else {
+            format!("sqlite://{}", config.path.display())
+        };
+
+        let mut opts = SqliteConnectOptions::from_str(&dsn)?
+            .read_only(config.readonly)
             .foreign_keys(true);
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .acquire_timeout(std::time::Duration::from_secs(300))
-            .after_connect(|conn, _meta| {
+        if !config.readonly {
+            opts = opts.create_if_missing(config.create_if_missing);
+        }
+
+        let mut pool_opts = SqlitePoolOptions::new().max_connections(max_connections);
+        if max_connections == 1 {
+            pool_opts = pool_opts.acquire_timeout(std::time::Duration::from_secs(300));
+        }
+        let readonly = config.readonly;
+        let pool = pool_opts
+            .after_connect(move |conn, _meta| {
                 Box::pin(async move {
-                    apply_pragmas(conn).await?;
+                    if readonly {
+                        apply_pragmas_readonly(conn).await?;
+                    } else {
+                        apply_pragmas(conn).await?;
+                    }
                     Ok(())
                 })
             })
@@ -110,15 +222,17 @@ impl Database {
 
         Ok(Self {
             pool,
-            db_path: tmp,
-            readonly: false,
+            db_path: config.path.clone(),
+            readonly: config.readonly,
+            bootstrap: DatabaseBootstrapInfo {
+                backend_kind: DatabaseBackendKind::Sqlite,
+                backend_label: "sqlite".to_owned(),
+                target: config.path.display().to_string(),
+                readonly: config.readonly,
+            },
             initialized: Arc::new(OnceCell::new()),
             sqlite_vec_status: Arc::new(OnceCell::new()),
         })
-    }
-
-    pub fn pool(&self) -> &SqlitePool {
-        &self.pool
     }
 
     pub async fn ensure_initialized(&self) -> DbResult<()> {
@@ -618,5 +732,35 @@ mod tests {
         assert_eq!(count, 0);
 
         set_sqlite_vec_disabled_for_tests(false);
+    }
+
+    #[test]
+    fn mysql_backend_selection_returns_explicit_staging_error() {
+        let error = Database::open_with_config(DatabaseConnectConfig::Mysql(MysqlDatabaseConfig {
+            url: "mysql://root@127.0.0.1:3306/djinn".to_owned(),
+            flavor: MysqlBackendFlavor::Dolt,
+        }))
+        .expect_err("mysql/dolt backend should not silently fall back to sqlite");
+
+        assert!(error.to_string().contains("still require SQLite"));
+        assert!(error.to_string().contains("dolt"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sqlite_backend_selection_preserves_bootstrap_metadata() {
+        let dir = crate::database::test_tempdir().unwrap();
+        let db_path = dir.path().join("selected.db");
+
+        let db = Database::open_with_config(DatabaseConnectConfig::Sqlite(SqliteDatabaseConfig {
+            path: db_path.clone(),
+            readonly: false,
+            create_if_missing: true,
+        }))
+        .unwrap();
+
+        assert_eq!(db.backend_kind(), DatabaseBackendKind::Sqlite);
+        assert_eq!(db.bootstrap_info().backend_label, "sqlite");
+        assert_eq!(db.bootstrap_info().target, db_path.display().to_string());
+        assert!(!db.bootstrap_info().readonly);
     }
 }

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -12,7 +12,11 @@ pub mod test_support {
     };
 }
 
-pub use database::{Database, SqliteVecStatus, default_db_path};
+pub use database::{
+    Database, DatabaseBackendKind, DatabaseBootstrapInfo, DatabaseConnectConfig,
+    MysqlBackendFlavor, MysqlDatabaseConfig, SqliteDatabaseConfig, SqliteVecStatus,
+    default_db_path,
+};
 pub use error::{DbError as Error, DbResult as Result};
 pub use repositories::{
     agent::{

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod checkpoint;
+pub mod runtime;
 
 #[cfg(test)]
 mod task_tests;

--- a/server/src/db/runtime.rs
+++ b/server/src/db/runtime.rs
@@ -1,0 +1,258 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use djinn_db::{
+    Database, DatabaseBackendKind, DatabaseBootstrapInfo, DatabaseConnectConfig,
+    MysqlBackendFlavor, MysqlDatabaseConfig, SqliteDatabaseConfig,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DatabaseRuntimeConfig {
+    pub connect: DatabaseConnectConfig,
+}
+
+impl DatabaseRuntimeConfig {
+    pub fn sqlite(path: PathBuf) -> Self {
+        Self {
+            connect: DatabaseConnectConfig::Sqlite(SqliteDatabaseConfig {
+                path,
+                readonly: false,
+                create_if_missing: true,
+            }),
+        }
+    }
+
+    pub fn from_cli_and_env(
+        db_path: Option<PathBuf>,
+        backend: Option<String>,
+        mysql_url: Option<String>,
+        mysql_flavor: Option<String>,
+    ) -> Result<Self, DatabaseRuntimeError> {
+        let backend = backend
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("sqlite")
+            .to_ascii_lowercase();
+
+        match backend.as_str() {
+            "sqlite" => Ok(Self::sqlite(
+                db_path.unwrap_or_else(djinn_db::default_db_path),
+            )),
+            "mysql" | "dolt" => {
+                let url = mysql_url.ok_or_else(|| DatabaseRuntimeError::MissingMysqlUrl {
+                    backend: backend.clone(),
+                })?;
+                let flavor = match mysql_flavor
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(backend.as_str())
+                    .to_ascii_lowercase()
+                    .as_str()
+                {
+                    "mysql" => MysqlBackendFlavor::Mysql,
+                    "dolt" => MysqlBackendFlavor::Dolt,
+                    other => {
+                        return Err(DatabaseRuntimeError::InvalidMysqlFlavor(other.to_owned()));
+                    }
+                };
+
+                Ok(Self {
+                    connect: DatabaseConnectConfig::Mysql(MysqlDatabaseConfig { url, flavor }),
+                })
+            }
+            other => Err(DatabaseRuntimeError::UnknownBackend(other.to_owned())),
+        }
+    }
+
+    pub fn backend_kind(&self) -> DatabaseBackendKind {
+        self.connect.backend_kind()
+    }
+}
+
+#[derive(Clone)]
+pub struct DatabaseRuntimeManager {
+    config: Arc<DatabaseRuntimeConfig>,
+}
+
+impl DatabaseRuntimeManager {
+    pub fn new(config: DatabaseRuntimeConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+
+    pub fn config(&self) -> &DatabaseRuntimeConfig {
+        &self.config
+    }
+
+    pub fn bootstrap(&self) -> Result<Database, DatabaseRuntimeError> {
+        Database::open_with_config(self.config.connect.clone()).map_err(DatabaseRuntimeError::Open)
+    }
+
+    pub fn startup_mode(&self) -> DatabaseRuntimeMode {
+        match &self.config.connect {
+            DatabaseConnectConfig::Sqlite(config) => DatabaseRuntimeMode {
+                backend_kind: DatabaseBackendKind::Sqlite,
+                backend_label: "sqlite".to_owned(),
+                target: config.path.display().to_string(),
+                managed_process: false,
+            },
+            DatabaseConnectConfig::Mysql(config) => DatabaseRuntimeMode {
+                backend_kind: DatabaseBackendKind::Mysql,
+                backend_label: config.display_backend().to_owned(),
+                target: redact_mysql_target(&config.url),
+                managed_process: matches!(config.flavor, MysqlBackendFlavor::Dolt),
+            },
+        }
+    }
+
+    pub fn health_snapshot(&self, db: &Database) -> DatabaseRuntimeHealth {
+        let bootstrap = db.bootstrap_info().clone();
+        let detail = runtime_detail_for_bootstrap(&bootstrap);
+        let DatabaseBootstrapInfo {
+            backend_kind,
+            backend_label,
+            target,
+            ..
+        } = bootstrap;
+        DatabaseRuntimeHealth {
+            backend_kind,
+            backend_label,
+            target,
+            runtime_status: DatabaseRuntimeStatus::Ready,
+            detail,
+        }
+    }
+
+    pub fn planned_health_snapshot(&self) -> DatabaseRuntimeHealth {
+        let mode = self.startup_mode();
+        let detail = match mode.backend_kind {
+            DatabaseBackendKind::Sqlite => {
+                "sqlite backend selected; no external SQL server process required".to_owned()
+            }
+            DatabaseBackendKind::Mysql => {
+                if mode.managed_process {
+                    "dolt sql-server lifecycle hook reserved here; bootstrap is staged until repository cutover completes"
+                        .to_owned()
+                } else {
+                    "mysql backend configuration parsed; runtime health checks will attach here once repository support lands"
+                        .to_owned()
+                }
+            }
+        };
+
+        DatabaseRuntimeHealth {
+            backend_kind: mode.backend_kind,
+            backend_label: mode.backend_label,
+            target: mode.target,
+            runtime_status: DatabaseRuntimeStatus::Pending,
+            detail,
+        }
+    }
+
+    pub fn should_spawn_sqlite_checkpoint(&self) -> bool {
+        matches!(self.config.backend_kind(), DatabaseBackendKind::Sqlite)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabaseRuntimeStatus {
+    Pending,
+    Ready,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct DatabaseRuntimeHealth {
+    pub backend_kind: DatabaseBackendKind,
+    pub backend_label: String,
+    pub target: String,
+    pub runtime_status: DatabaseRuntimeStatus,
+    pub detail: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DatabaseRuntimeMode {
+    pub backend_kind: DatabaseBackendKind,
+    pub backend_label: String,
+    pub target: String,
+    pub managed_process: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DatabaseRuntimeError {
+    #[error("unknown database backend `{0}`; expected sqlite, mysql, or dolt")]
+    UnknownBackend(String),
+    #[error("database backend `{backend}` requires DJINN_MYSQL_URL to be set")]
+    MissingMysqlUrl { backend: String },
+    #[error("unknown mysql/dolt flavor `{0}`; expected mysql or dolt")]
+    InvalidMysqlFlavor(String),
+    #[error("database bootstrap failed: {0}")]
+    Open(#[from] djinn_db::Error),
+}
+
+fn redact_mysql_target(url: &str) -> String {
+    match url.rsplit('@').next() {
+        Some(host_part) if host_part != url => format!("mysql://<redacted>@{host_part}"),
+        _ => "mysql://<configured>".to_owned(),
+    }
+}
+
+fn runtime_detail_for_bootstrap(bootstrap: &DatabaseBootstrapInfo) -> String {
+    match bootstrap.backend_kind {
+        DatabaseBackendKind::Sqlite => {
+            if bootstrap.readonly {
+                "sqlite backend ready in read-only mode".to_owned()
+            } else {
+                "sqlite backend ready; SQLite-specific pragmas and migrations applied locally"
+                    .to_owned()
+            }
+        }
+        DatabaseBackendKind::Mysql => "mysql-compatible backend selected".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_is_default_backend_selection() {
+        let config = DatabaseRuntimeConfig::from_cli_and_env(None, None, None, None).unwrap();
+        assert_eq!(config.backend_kind(), DatabaseBackendKind::Sqlite);
+    }
+
+    #[test]
+    fn dolt_requires_mysql_url() {
+        let error =
+            DatabaseRuntimeConfig::from_cli_and_env(None, Some("dolt".to_owned()), None, None)
+                .expect_err("dolt selection without url should fail");
+        assert!(error.to_string().contains("DJINN_MYSQL_URL"));
+    }
+
+    #[test]
+    fn mysql_target_is_redacted_for_health_output() {
+        let target = redact_mysql_target("mysql://user:secret@127.0.0.1:3306/djinn");
+        assert_eq!(target, "mysql://<redacted>@127.0.0.1:3306/djinn");
+    }
+
+    #[test]
+    fn sqlite_checkpoint_loop_only_runs_for_sqlite() {
+        let sqlite = DatabaseRuntimeManager::new(DatabaseRuntimeConfig::sqlite(
+            std::path::Path::new("/tmp/test.db").to_path_buf(),
+        ));
+        assert!(sqlite.should_spawn_sqlite_checkpoint());
+
+        let mysql = DatabaseRuntimeManager::new(DatabaseRuntimeConfig {
+            connect: DatabaseConnectConfig::Mysql(MysqlDatabaseConfig {
+                url: "mysql://root@127.0.0.1:3306/djinn".to_owned(),
+                flavor: MysqlBackendFlavor::Dolt,
+            }),
+        });
+        assert!(!mysql.should_spawn_sqlite_checkpoint());
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -22,9 +22,9 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-use djinn_db::{Database, default_db_path};
 use djinn_server::daemon;
 use djinn_server::db::checkpoint;
+use djinn_server::db::runtime::{DatabaseRuntimeConfig, DatabaseRuntimeManager};
 use djinn_server::logging;
 use djinn_server::server::{self, AppState};
 
@@ -52,6 +52,18 @@ struct Cli {
     /// Database path (default: ~/.djinn/djinn.db)
     #[arg(long, env = "DJINN_DB_PATH")]
     db_path: Option<PathBuf>,
+
+    /// Database backend selection seam for staged SQLite -> Dolt/MySQL migration.
+    #[arg(long, env = "DJINN_DB_BACKEND")]
+    db_backend: Option<String>,
+
+    /// MySQL-compatible DSN for future Dolt/MySQL runtime bootstrap.
+    #[arg(long, env = "DJINN_MYSQL_URL")]
+    mysql_url: Option<String>,
+
+    /// Flavor of the MySQL-compatible backend: mysql or dolt.
+    #[arg(long, env = "DJINN_MYSQL_FLAVOR")]
+    mysql_flavor: Option<String>,
 }
 
 fn main() {
@@ -96,12 +108,34 @@ async fn async_main() {
         shutdown_cancel.cancel();
     });
 
-    let db_path = cli.db_path.unwrap_or_else(default_db_path);
-    tracing::info!(path = %db_path.display(), "opening database");
-    let db = Database::open(&db_path).expect("failed to open database");
-    checkpoint::spawn(db.clone(), cancel.clone());
+    let db_runtime = DatabaseRuntimeManager::new(
+        DatabaseRuntimeConfig::from_cli_and_env(
+            cli.db_path.clone(),
+            cli.db_backend.clone(),
+            cli.mysql_url.clone(),
+            cli.mysql_flavor.clone(),
+        )
+        .unwrap_or_else(|e| {
+            tracing::error!(error = %e, "invalid database runtime configuration");
+            std::process::exit(1);
+        }),
+    );
+    let startup_mode = db_runtime.startup_mode();
+    tracing::info!(
+        backend = %startup_mode.backend_label,
+        target = %startup_mode.target,
+        managed_process = startup_mode.managed_process,
+        "opening database runtime"
+    );
+    let db = db_runtime.bootstrap().unwrap_or_else(|e| {
+        tracing::error!(error = %e, "failed to open database runtime");
+        std::process::exit(1);
+    });
+    if db_runtime.should_spawn_sqlite_checkpoint() {
+        checkpoint::spawn(db.clone(), cancel.clone());
+    }
 
-    let state = AppState::new(db, cancel.clone());
+    let state = AppState::new_with_runtime(db, db_runtime, cancel.clone());
     djinn_server::housekeeping::spawn(state.clone());
     state.initialize().await;
     state.initialize_agents().await;

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -1,4 +1,5 @@
 use axum::Router;
+use axum::extract::State;
 use axum::routing::{get, post};
 
 use serde::Serialize;
@@ -32,12 +33,14 @@ pub fn router(state: AppState) -> Router {
 struct HealthResponse {
     status: &'static str,
     version: &'static str,
+    database: crate::db::runtime::DatabaseRuntimeHealth,
 }
 
-async fn health() -> axum::Json<HealthResponse> {
+async fn health(State(state): State<AppState>) -> axum::Json<HealthResponse> {
     axum::Json(HealthResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
+        database: state.database_health(),
     })
 }
 

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast};
 use tokio_util::sync::CancellationToken;
 
+use crate::db::runtime::{DatabaseRuntimeHealth, DatabaseRuntimeManager};
 use crate::events::DjinnEventEnvelope;
 use crate::semantic_memory::{EmbeddingService, default_embedding_cache_dir};
 use crate::sync::SyncManager;
@@ -36,6 +37,7 @@ pub struct AppState {
 
 struct Inner {
     pub db: Database,
+    pub db_runtime: DatabaseRuntimeManager,
     pub cancel: CancellationToken,
     pub events: broadcast::Sender<DjinnEventEnvelope>,
     pub git_actors: Arc<Mutex<HashMap<PathBuf, GitActorHandle>>>,
@@ -90,10 +92,26 @@ struct Inner {
 
 impl AppState {
     pub fn new(db: Database, cancel: CancellationToken) -> Self {
-        Self::new_inner(db, cancel)
+        let runtime =
+            DatabaseRuntimeManager::new(crate::db::runtime::DatabaseRuntimeConfig::sqlite(
+                db.bootstrap_info().target.clone().into(),
+            ));
+        Self::new_with_runtime(db, runtime, cancel)
     }
 
-    fn new_inner(db: Database, cancel: CancellationToken) -> Self {
+    pub fn new_with_runtime(
+        db: Database,
+        db_runtime: DatabaseRuntimeManager,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self::new_inner(db, db_runtime, cancel)
+    }
+
+    fn new_inner(
+        db: Database,
+        db_runtime: DatabaseRuntimeManager,
+        cancel: CancellationToken,
+    ) -> Self {
         let (events, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         let sync = SyncManager::new(db.clone(), events.clone());
         let sync_user_id = resolve_sync_user_id();
@@ -101,6 +119,7 @@ impl AppState {
         Self {
             inner: Arc::new(Inner {
                 db,
+                db_runtime,
                 cancel,
                 events,
                 git_actors: Arc::new(Mutex::new(HashMap::new())),
@@ -188,6 +207,14 @@ impl AppState {
 
     pub fn db(&self) -> &Database {
         &self.inner.db
+    }
+
+    pub fn db_runtime(&self) -> &DatabaseRuntimeManager {
+        &self.inner.db_runtime
+    }
+
+    pub fn database_health(&self) -> DatabaseRuntimeHealth {
+        self.inner.db_runtime.health_snapshot(self.db())
     }
 
     pub fn cancel(&self) -> &CancellationToken {

--- a/server/src/server/tests/router.rs
+++ b/server/src/server/tests/router.rs
@@ -22,6 +22,24 @@ async fn health_returns_ok() {
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "ok");
+    assert_eq!(json["database"]["backend_label"], "sqlite");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn db_info_reports_selected_backend() {
+    let app = test_helpers::create_test_app();
+
+    let req = axum::http::Request::builder()
+        .uri("/db-info")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["backend"], "sqlite");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/src/sse.rs
+++ b/server/src/sse.rs
@@ -10,7 +10,6 @@ use tokio::sync::broadcast;
 
 use crate::events::DjinnEventEnvelope;
 use crate::server::AppState;
-use djinn_db::default_db_path;
 
 const FLUSH_INTERVAL: Duration = Duration::from_millis(100);
 const SESSION_MESSAGE_MIN_INTERVAL: Duration = Duration::from_millis(50);
@@ -250,12 +249,14 @@ pub async fn events_handler(
 #[derive(Serialize)]
 pub struct DbInfo {
     path: String,
+    backend: String,
     wsl: bool,
     direct_access_likely: bool,
 }
 
-pub async fn db_info_handler() -> axum::Json<DbInfo> {
-    let path = default_db_path();
+pub async fn db_info_handler(State(state): State<AppState>) -> axum::Json<DbInfo> {
+    let health = state.database_health();
+    let path = std::path::PathBuf::from(&health.target);
     let wsl = is_wsl();
     let direct_access_likely = !path
         .components()
@@ -264,6 +265,7 @@ pub async fn db_info_handler() -> axum::Json<DbInfo> {
 
     axum::Json(DbInfo {
         path: path.to_string_lossy().into_owned(),
+        backend: health.backend_label,
         wsl,
         direct_access_likely,
     })


### PR DESCRIPTION
## Summary
Prepare runtime/server scaffolding for Dolt without performing the full repository cutover yet. The task should isolate SQLite-specific bootstrap behavior and add a place for Dolt SQL server lifecycle management, health checks, and configuration.

## Acceptance Criteria
- [x] A Dolt/MySQL runtime management seam is added for server startup/health checks, with configuration and error handling paths documented or implemented.
- [x] Database bootstrap code is refactored so SQLite-specific connection setup is isolated from future MySQL/Dolt setup.
- [x] Tests or compile-checked scaffolding confirm the server can select the existing SQLite path today while accommodating a Dolt/MySQL path next.

---
Djinn task: y70d