### PR TITLE
chore(xp8p): Implement ADR-054 extraction quality-gate decisions in llm_extraction.rs

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/llm_extraction.rs
+++ b/server/crates/djinn-agent/src/actors/slot/llm_extraction.rs
@@ -40,6 +40,8 @@ const DUPLICATE_CONFIDENCE_SIGNAL: f64 = 0.65;
 const EXTRACTION_SYSTEM_PROMPT: &str = SYSTEM_PROMPT;
 const NOVELTY_SYSTEM_PROMPT: &str = "You are a semantic novelty judge for extracted knowledge notes. Compare a proposed note summary against an existing note summary. Respond with valid JSON only.";
 
+const MIN_DURABLE_WORDS: usize = 16;
+
 // ── JSON response shape ───────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, Default)]
@@ -70,6 +72,39 @@ enum NoveltyDecisionKind {
 #[derive(Debug, Deserialize)]
 struct NoveltyDecision {
     decision: NoveltyDecisionKind,
+    existing_note_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+enum ExtractionOutcome {
+    DurableWrite,
+    MergeIntoExisting,
+    DowngradeToWorkingSpec,
+    Discard,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NoveltyAssessment {
+    Novel,
+    Duplicate,
+    Unknown,
+}
+
+#[derive(Debug, Clone)]
+struct QualityAssessment {
+    specificity: bool,
+    generality: bool,
+    durability: bool,
+    novelty: NoveltyAssessment,
+    type_fit: bool,
+    outcome: ExtractionOutcome,
+    reasons: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone)]
+struct NoveltyCheckResult {
+    assessment: NoveltyAssessment,
     existing_note_id: Option<String>,
 }
 
@@ -466,41 +501,78 @@ async fn process_extracted_note(
     note: &ExtractedNote,
     extraction_quality: &mut super::session_extraction::ExtractionQuality,
 ) {
-    match novelty_decision(extraction_context, note_type, note).await {
-        Ok(Some(candidate_id)) => {
-            match extraction_context
-                .note_repo
-                .update_confidence(&candidate_id, DUPLICATE_CONFIDENCE_SIGNAL)
-                .await
-            {
-                Ok(updated_confidence) => tracing::debug!(
-                    session_id = %extraction_context.session_id,
-                    note_type = %note_type,
-                    title = %note.title,
-                    existing_note_id = %candidate_id,
-                    updated_confidence,
-                    "llm_extraction: semantic duplicate detected; boosted existing note confidence"
-                ),
-                Err(e) => tracing::warn!(
-                    session_id = %extraction_context.session_id,
-                    note_type = %note_type,
-                    title = %note.title,
-                    existing_note_id = %candidate_id,
-                    error = %e,
-                    "llm_extraction: semantic duplicate detected but failed to update existing confidence"
-                ),
+    let novelty = match novelty_decision(extraction_context, note_type, note).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::debug!(
+                session_id = %extraction_context.session_id,
+                note_type = %note_type,
+                title = %note.title,
+                error = %e,
+                "llm_extraction: novelty check failed; evaluating with unknown novelty"
+            );
+            NoveltyCheckResult {
+                assessment: NoveltyAssessment::Unknown,
+                existing_note_id: None,
             }
-            extraction_quality.novelty_skipped += 1;
+        }
+    };
+
+    let assessment = assess_quality_gate(note_type, note, &novelty);
+
+    tracing::debug!(
+        session_id = %extraction_context.session_id,
+        note_type = %note_type,
+        title = %note.title,
+        outcome = ?assessment.outcome,
+        specificity = assessment.specificity,
+        generality = assessment.generality,
+        durability = assessment.durability,
+        novelty = ?assessment.novelty,
+        type_fit = assessment.type_fit,
+        reasons = ?assessment.reasons,
+        "llm_extraction: evaluated extraction quality gate"
+    );
+
+    match assessment.outcome {
+        ExtractionOutcome::MergeIntoExisting => {
+            if let Some(candidate_id) = novelty.existing_note_id.as_deref() {
+                match extraction_context
+                    .note_repo
+                    .update_confidence(candidate_id, DUPLICATE_CONFIDENCE_SIGNAL)
+                    .await
+                {
+                    Ok(updated_confidence) => tracing::debug!(
+                        session_id = %extraction_context.session_id,
+                        note_type = %note_type,
+                        title = %note.title,
+                        existing_note_id = %candidate_id,
+                        updated_confidence,
+                        "llm_extraction: merged extraction into existing note via confidence boost"
+                    ),
+                    Err(e) => tracing::warn!(
+                        session_id = %extraction_context.session_id,
+                        note_type = %note_type,
+                        title = %note.title,
+                        existing_note_id = %candidate_id,
+                        error = %e,
+                        "llm_extraction: merge outcome failed to update existing confidence"
+                    ),
+                }
+                extraction_quality.novelty_skipped += 1;
+                extraction_quality.merged += 1;
+            }
             return;
         }
-        Ok(None) => {}
-        Err(e) => tracing::debug!(
-            session_id = %extraction_context.session_id,
-            note_type = %note_type,
-            title = %note.title,
-            error = %e,
-            "llm_extraction: novelty check failed; falling back to create"
-        ),
+        ExtractionOutcome::DowngradeToWorkingSpec => {
+            extraction_quality.downgraded += 1;
+            return;
+        }
+        ExtractionOutcome::Discard => {
+            extraction_quality.discarded += 1;
+            return;
+        }
+        ExtractionOutcome::DurableWrite => {}
     }
 
     let content_with_provenance = format!("{}{}", note.content, extraction_context.provenance);
@@ -560,7 +632,7 @@ async fn novelty_decision(
     extraction_context: &ExtractionContext<'_>,
     note_type: &str,
     note: &ExtractedNote,
-) -> Result<Option<String>, String> {
+) -> Result<NoveltyCheckResult, String> {
     let candidate_abstract = summarize_candidate_note(note);
     let folder = folder_for_type(note_type);
     let candidates = lookup_candidates(extraction_context, folder, note_type, &candidate_abstract)
@@ -568,7 +640,10 @@ async fn novelty_decision(
         .map_err(|e| format!("candidate lookup failed: {e}"))?;
 
     if candidates.is_empty() {
-        return Ok(None);
+        return Ok(NoveltyCheckResult {
+            assessment: NoveltyAssessment::Novel,
+            existing_note_id: None,
+        });
     }
 
     let response = complete(
@@ -586,7 +661,10 @@ async fn novelty_decision(
         .map_err(|e| format!("invalid novelty decision json: {e}"))?;
 
     match decision.decision {
-        NoveltyDecisionKind::Novel => Ok(None),
+        NoveltyDecisionKind::Novel => Ok(NoveltyCheckResult {
+            assessment: NoveltyAssessment::Novel,
+            existing_note_id: None,
+        }),
         NoveltyDecisionKind::AlreadyKnown => {
             let existing_note_id = decision
                 .existing_note_id
@@ -601,9 +679,182 @@ async fn novelty_decision(
                 existing_note_id = %existing_note_id,
                 "llm_extraction: semantic duplicate decision returned already_known"
             );
-            Ok(Some(existing_note_id))
+            Ok(NoveltyCheckResult {
+                assessment: NoveltyAssessment::Duplicate,
+                existing_note_id: Some(existing_note_id),
+            })
         }
     }
+}
+
+fn assess_quality_gate(
+    note_type: &str,
+    note: &ExtractedNote,
+    novelty: &NoveltyCheckResult,
+) -> QualityAssessment {
+    let specificity = has_specificity(note);
+    let generality = has_generality(note);
+    let durability = has_durability(note);
+    let type_fit = matches_type_semantics(note_type, note);
+    let novelty_assessment = novelty.assessment;
+
+    let mut reasons = Vec::new();
+    if !specificity {
+        reasons.push("insufficient_specificity");
+    }
+    if !generality {
+        reasons.push("task_local_or_overly_narrow");
+    }
+    if !durability {
+        reasons.push("not_durable_beyond_current_task");
+    }
+    if !type_fit {
+        reasons.push("type_fit_mismatch");
+    }
+    if novelty_assessment == NoveltyAssessment::Duplicate {
+        reasons.push("semantic_duplicate_of_existing_note");
+    }
+
+    let outcome = if novelty_assessment == NoveltyAssessment::Duplicate {
+        ExtractionOutcome::MergeIntoExisting
+    } else if !specificity || !type_fit {
+        ExtractionOutcome::Discard
+    } else if !generality || !durability {
+        ExtractionOutcome::DowngradeToWorkingSpec
+    } else {
+        ExtractionOutcome::DurableWrite
+    };
+
+    QualityAssessment {
+        specificity,
+        generality,
+        durability,
+        novelty: novelty_assessment,
+        type_fit,
+        outcome,
+        reasons,
+    }
+}
+
+fn has_specificity(note: &ExtractedNote) -> bool {
+    let text = normalized_text(note);
+    if text.split_whitespace().count() < 8 {
+        return false;
+    }
+    let signals = [
+        text.contains("situation"),
+        text.contains("constraint"),
+        text.contains("result"),
+        text.contains("lesson"),
+        text.contains("approach"),
+        text.contains("recommended"),
+        text.contains("why it works"),
+        text.contains("prevention"),
+        text.contains("recovery"),
+        text.contains('/'),
+        text.contains("`"),
+        !note.scope_paths.is_empty(),
+    ];
+    signals.into_iter().filter(|flag| *flag).count() >= 2
+}
+
+fn has_generality(note: &ExtractedNote) -> bool {
+    let text = normalized_text(note);
+    let positive = [
+        "reusable", "future", "across", "multiple", "general", "whenever", "teams", "tasks",
+        "pattern", "lesson", "prevent",
+    ];
+    let negative = [
+        "this task",
+        "current task",
+        "temporary",
+        "for now",
+        "wip",
+        "working spec",
+        "session-only",
+        "local experiment",
+    ];
+    positive.iter().any(|token| text.contains(token))
+        && !negative.iter().any(|token| text.contains(token))
+}
+
+fn has_durability(note: &ExtractedNote) -> bool {
+    let text = normalized_text(note);
+    if text.split_whitespace().count() < MIN_DURABLE_WORDS {
+        return false;
+    }
+    let durable_markers = [
+        "guideline",
+        "recommend",
+        "use when",
+        "avoid",
+        "prevention",
+        "tradeoff",
+        "lesson",
+        "result",
+        "constraint",
+    ];
+    let transient_markers = [
+        "todo",
+        "next step",
+        "open question",
+        "hypothesis",
+        "investigate",
+        "maybe",
+        "might",
+        "could",
+    ];
+    durable_markers.iter().any(|token| text.contains(token))
+        && !transient_markers.iter().any(|token| text.contains(token))
+}
+
+fn matches_type_semantics(note_type: &str, note: &ExtractedNote) -> bool {
+    let text = normalized_text(note);
+    match note_type {
+        "pattern" => {
+            contains_any(
+                &text,
+                &[
+                    "reusable",
+                    "recommended",
+                    "approach",
+                    "use when",
+                    "when to use",
+                ],
+            ) && contains_any(&text, &["because", "why", "tradeoff", "works"])
+        }
+        "pitfall" => {
+            contains_any(
+                &text,
+                &["pitfall", "failure", "error", "smell", "trigger", "symptom"],
+            ) && contains_any(&text, &["prevent", "recovery", "resolve", "avoid"])
+        }
+        "case" => {
+            contains_any(
+                &text,
+                &[
+                    "situation",
+                    "constraint",
+                    "result",
+                    "lesson",
+                    "worked",
+                    "failed",
+                ],
+            ) && contains_any(
+                &text,
+                &["approach", "did", "implemented", "fixed", "resolved"],
+            )
+        }
+        _ => false,
+    }
+}
+
+fn contains_any(text: &str, tokens: &[&str]) -> bool {
+    tokens.iter().any(|token| text.contains(token))
+}
+
+fn normalized_text(note: &ExtractedNote) -> String {
+    format!("{}\n{}", note.title, note.content).to_lowercase()
 }
 
 async fn lookup_candidates(

--- a/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
@@ -137,9 +137,9 @@ async fn make_fixture() -> TestFixture {
 /// Build a FakeProvider that returns a valid extraction JSON with one of each note type.
 fn fake_extraction_provider() -> Arc<FakeProvider> {
     let json = r#"{
-  "cases": [{"title": "Test Case Note", "content": "A test case: problem and solution described here."}],
-  "patterns": [{"title": "Test Pattern Note", "content": "A reusable pattern discovered in this session."}],
-  "pitfalls": [{"title": "Test Pitfall Note", "content": "A pitfall encountered and how it was resolved."}]
+  "cases": [{"title": "Test Case Note", "content": "Situation: a flaky extraction pipeline had to compare candidate summaries under a deterministic constraint. Approach taken: inject a stable candidate seam and record why the fix worked. Result: future tasks can reuse the lesson when similar novelty checks fail."}],
+  "patterns": [{"title": "Test Pattern Note", "content": "Recommended approach: use a reusable seam when a workflow needs deterministic comparisons across multiple future tasks. Why it works: the approach isolates unstable dependencies and clarifies when to use the pattern and its tradeoffs."}],
+  "pitfalls": [{"title": "Test Pitfall Note", "content": "Trigger / smell: semantic duplicate checks become flaky when summaries change between runs. Failure mode: extraction creates noisy sibling notes. Prevention and recovery: inject stable summaries, compare them consistently, and avoid repeating the error in future tasks."}]
 }"#;
     Arc::new(FakeProvider::text(json))
 }
@@ -445,6 +445,9 @@ async fn llm_extracted_notes_have_confidence_0_5() {
     assert_eq!(stored_taxonomy.extraction_quality.dedup_skipped, 0);
     assert_eq!(stored_taxonomy.extraction_quality.novelty_skipped, 0);
     assert_eq!(stored_taxonomy.extraction_quality.written, 3);
+    assert_eq!(stored_taxonomy.extraction_quality.merged, 0);
+    assert_eq!(stored_taxonomy.extraction_quality.downgraded, 0);
+    assert_eq!(stored_taxonomy.extraction_quality.discarded, 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -454,7 +457,7 @@ async fn llm_extracted_notes_contain_session_id_provenance() {
     let ctx = agent_context_from_db(fixture.db.clone(), fixture.cancel.clone());
 
     let taxonomy = SessionTaxonomy::default();
-    let json = r#"{"cases":[{"title":"Provenance Test","content":"This content should have provenance."}],"patterns":[],"pitfalls":[]}"#;
+    let json = r#"{"cases":[{"title":"Provenance Test","content":"Situation: extraction provenance must remain visible after a durable note is written. Constraint: future tasks need to know which session produced the case. Approach taken: append a provenance footer and keep the reusable lesson in the note result. Result: the stored case stays traceable. Lesson: future tasks can trust the durable note provenance."}],"patterns":[],"pitfalls":[]}"#;
     let provider = Arc::new(FakeProvider::text(json));
 
     run_llm_extraction_with_provider(session_id.clone(), taxonomy, ctx, provider).await;
@@ -610,6 +613,18 @@ async fn llm_extraction_semantic_duplicate_skips_create_and_boosts_existing_conf
         .expect("get existing after run")
         .expect("existing note after run");
     assert!(updated_existing.confidence > starting_confidence);
+
+    let stored_json: Option<String> =
+        sqlx::query_scalar("SELECT event_taxonomy FROM sessions WHERE id = ?1")
+            .bind(&fixture.session_id)
+            .fetch_one(fixture.db.pool())
+            .await
+            .expect("query session event_taxonomy after merge outcome");
+    let stored_taxonomy: SessionTaxonomy = serde_json::from_str(stored_json.as_deref().unwrap())
+        .expect("deserialize stored taxonomy after merge outcome");
+    assert_eq!(stored_taxonomy.extraction_quality.merged, 1);
+    assert_eq!(stored_taxonomy.extraction_quality.novelty_skipped, 1);
+    assert_eq!(stored_taxonomy.extraction_quality.written, 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -630,7 +645,7 @@ async fn llm_extraction_novelty_check_failure_falls_back_to_create() {
     let provider = Arc::new(FakeProvider::script(vec![
         vec![
             djinn_provider::provider::StreamEvent::Delta(ContentBlock::Text {
-                text: r#"{"cases":[{"title":"Fallback Novel Note","content":"Should still be written when novelty check output is invalid."}],"patterns":[],"pitfalls":[]}"#.to_string(),
+                text: r#"{"cases":[{"title":"Fallback Novel Note","content":"Situation: a novelty response returned invalid JSON during extraction. Constraint: the durable lesson still matters across future tasks. Approach taken: continue with the durable case because the fallback preserved useful knowledge. Result: extraction still captured the note. Lesson: future tasks can reuse the fallback when novelty checks fail."}],"patterns":[],"pitfalls":[]}"#.to_string(),
             }),
             djinn_provider::provider::StreamEvent::Done,
         ],
@@ -659,6 +674,91 @@ async fn llm_extraction_novelty_check_failure_falls_back_to_create() {
 
     assert_eq!(notes.len(), 1);
     assert_eq!(notes[0].title, "Fallback Novel Note");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn llm_extraction_downgrades_non_durable_note_to_working_spec_path() {
+    let fixture = make_fixture().await;
+    let ctx = agent_context_from_db(fixture.db.clone(), fixture.cancel.clone());
+
+    let taxonomy = SessionTaxonomy {
+        files_changed: 1,
+        errors: 0,
+        tools_used: 2,
+        notes_read: 0,
+        notes_written: 1,
+        tasks_transitioned: 1,
+        ..SessionTaxonomy::default()
+    };
+
+    let provider = Arc::new(FakeProvider::text(
+        r#"{"cases":[],"patterns":[{"title":"Temporary Working Spec Note","content":"Recommended approach for this task: keep a temporary hypothesis about the current migration and maybe investigate the next step later so the team can continue the session. Why it works: it preserves context during the current task, but it is still temporary and should not become durable memory."}],"pitfalls":[]}"#,
+    ));
+
+    run_llm_extraction_with_provider(fixture.session_id.clone(), taxonomy, ctx, provider).await;
+
+    let note_repo = NoteRepository::new(fixture.db.clone(), djinn_core::events::EventBus::noop());
+    let notes = note_repo
+        .list(&fixture.project.id, None)
+        .await
+        .expect("list notes");
+    assert!(
+        notes.is_empty(),
+        "downgraded notes should not become durable writes"
+    );
+
+    let stored_json: Option<String> =
+        sqlx::query_scalar("SELECT event_taxonomy FROM sessions WHERE id = ?1")
+            .bind(&fixture.session_id)
+            .fetch_one(fixture.db.pool())
+            .await
+            .expect("query session event_taxonomy after downgrade");
+    let stored_taxonomy: SessionTaxonomy = serde_json::from_str(stored_json.as_deref().unwrap())
+        .expect("deserialize stored taxonomy after downgrade");
+    assert_eq!(stored_taxonomy.extraction_quality.extracted, 1);
+    assert_eq!(stored_taxonomy.extraction_quality.downgraded, 1);
+    assert_eq!(stored_taxonomy.extraction_quality.written, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn llm_extraction_discards_note_with_type_mismatch() {
+    let fixture = make_fixture().await;
+    let ctx = agent_context_from_db(fixture.db.clone(), fixture.cancel.clone());
+
+    let taxonomy = SessionTaxonomy {
+        files_changed: 1,
+        errors: 0,
+        tools_used: 2,
+        notes_read: 0,
+        notes_written: 1,
+        tasks_transitioned: 1,
+        ..SessionTaxonomy::default()
+    };
+
+    let provider = Arc::new(FakeProvider::text(
+        r#"{"cases":[],"patterns":[{"title":"Vague Pattern Claim","content":"This worked."}],"pitfalls":[]}"#,
+    ));
+
+    run_llm_extraction_with_provider(fixture.session_id.clone(), taxonomy, ctx, provider).await;
+
+    let note_repo = NoteRepository::new(fixture.db.clone(), djinn_core::events::EventBus::noop());
+    let notes = note_repo
+        .list(&fixture.project.id, None)
+        .await
+        .expect("list notes");
+    assert!(notes.is_empty(), "discarded notes should not be persisted");
+
+    let stored_json: Option<String> =
+        sqlx::query_scalar("SELECT event_taxonomy FROM sessions WHERE id = ?1")
+            .bind(&fixture.session_id)
+            .fetch_one(fixture.db.pool())
+            .await
+            .expect("query session event_taxonomy after discard");
+    let stored_taxonomy: SessionTaxonomy = serde_json::from_str(stored_json.as_deref().unwrap())
+        .expect("deserialize stored taxonomy after discard");
+    assert_eq!(stored_taxonomy.extraction_quality.extracted, 1);
+    assert_eq!(stored_taxonomy.extraction_quality.discarded, 1);
+    assert_eq!(stored_taxonomy.extraction_quality.written, 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-agent/src/actors/slot/session_extraction.rs
+++ b/server/crates/djinn-agent/src/actors/slot/session_extraction.rs
@@ -50,6 +50,12 @@ pub struct ExtractionQuality {
     pub dedup_skipped: u32,
     pub novelty_skipped: u32,
     pub written: u32,
+    #[serde(default)]
+    pub merged: u32,
+    #[serde(default)]
+    pub downgraded: u32,
+    #[serde(default)]
+    pub discarded: u32,
 }
 
 // ── Tool name classification ──────────────────────────────────────────────────
@@ -865,6 +871,9 @@ mod tests {
                 dedup_skipped: 1,
                 novelty_skipped: 0,
                 written: 1,
+                merged: 0,
+                downgraded: 0,
+                discarded: 0,
             },
         };
         let json = serde_json::to_string(&tax).unwrap();

--- a/server/crates/djinn-db/src/repositories/agent.rs
+++ b/server/crates/djinn-db/src/repositories/agent.rs
@@ -71,6 +71,9 @@ pub struct ExtractionQualityMetrics {
     pub dedup_skipped: i64,
     pub novelty_skipped: i64,
     pub written: i64,
+    pub merged: i64,
+    pub downgraded: i64,
+    pub discarded: i64,
 }
 
 /// A pending amendment in `learned_prompt_history` that has not yet been
@@ -449,7 +452,7 @@ impl AgentRepository {
         .unwrap_or((0.0, 0.0, 0.0, 0));
 
         // Session-level metrics: completed sessions within the lookback window.
-        let session_row: (f64, f64, f64, f64, i64, i64, i64, i64) = sqlx::query_as(
+        let session_row: (f64, f64, f64, f64, i64, i64, i64, i64, i64, i64, i64) = sqlx::query_as(
             "SELECT
                 COALESCE(AVG(CAST(s.tokens_in + s.tokens_out AS REAL)), 0.0),
                 COALESCE(AVG(CAST(s.tokens_in AS REAL)), 0.0),
@@ -462,7 +465,10 @@ impl AgentRepository {
                 COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.extracted') AS INTEGER)), 0),
                 COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.dedup_skipped') AS INTEGER)), 0),
                 COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.novelty_skipped') AS INTEGER)), 0),
-                COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.written') AS INTEGER)), 0)
+                COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.written') AS INTEGER)), 0),
+                COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.merged') AS INTEGER)), 0),
+                COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.downgraded') AS INTEGER)), 0),
+                COALESCE(SUM(CAST(json_extract(s.event_taxonomy, '$.extraction_quality.discarded') AS INTEGER)), 0)
              FROM sessions s
              JOIN tasks t ON t.id = s.task_id
              WHERE t.project_id = ?1
@@ -475,7 +481,7 @@ impl AgentRepository {
         .bind(window_days)
         .fetch_one(self.db.pool())
         .await
-        .unwrap_or((0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0));
+        .unwrap_or((0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, 0, 0, 0));
 
         Ok(AgentMetrics {
             success_rate: task_row.0,
@@ -491,6 +497,9 @@ impl AgentRepository {
                 dedup_skipped: session_row.5,
                 novelty_skipped: session_row.6,
                 written: session_row.7,
+                merged: session_row.8,
+                downgraded: session_row.9,
+                discarded: session_row.10,
             },
         })
     }


### PR DESCRIPTION
## Summary
Upgrade the session-extraction pipeline so durable note creation is controlled by the richer ADR-054 gate instead of the current mostly create-vs-duplicate flow. Reuse the existing semantic novelty path, but add explicit evaluation for specificity, generality, durability, novelty, and type fit, and support the full decision surface required by the ADR.

## Acceptance Criteria
- [x] `llm_extraction.rs` evaluates extracted notes against ADR-054 quality dimensions: specificity, generality, durability, novelty, and type fit
- [x] The extraction pipeline supports explicit outcomes for durable write, merge-into-existing, downgrade-to-working-spec, and discard
- [x] Unit tests cover at least one downgrade/discard path and at least one merge-or-reuse path without regressing existing duplicate handling

---
Djinn task: xp8p