### PR TITLE
chore(flkb): Implement ADR-056 code-graph diff and knowledge-gap patrol summary

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/helpers.rs
+++ b/server/crates/djinn-agent/src/actors/slot/helpers.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::actors::coordinator::pr_poller::PR_REVIEW_FEEDBACK_EVENT;
 use crate::context::AgentContext;
 use djinn_core::models::Task;
+use djinn_core::models::parse_json_array;
 use djinn_core::models::{SessionRecord, SessionStatus, TransitionAction};
 use djinn_db::ActivityQuery;
 use djinn_db::ProjectRepository;
@@ -963,4 +964,416 @@ pub(crate) fn format_knowledge_notes(
     }
 
     lines.join("\n")
+}
+
+fn graph_diff_module_paths(diff: &djinn_mcp::bridge::GraphDiff) -> (Vec<String>, Vec<String>) {
+    let mut added = std::collections::BTreeSet::new();
+    let mut removed = std::collections::BTreeSet::new();
+
+    for node in &diff.added_nodes {
+        if node.kind == "file"
+            && let Some(path) = node.key.strip_prefix("file:")
+        {
+            added.insert(path.to_string());
+        }
+    }
+    for node in &diff.removed_nodes {
+        if node.kind == "file"
+            && let Some(path) = node.key.strip_prefix("file:")
+        {
+            removed.insert(path.to_string());
+        }
+    }
+
+    (added.into_iter().collect(), removed.into_iter().collect())
+}
+
+fn note_scope_covers_path(note_scope_paths: &[String], path: &str) -> bool {
+    note_scope_paths.iter().any(|scope| {
+        path == scope
+            || path.starts_with(&format!("{scope}/"))
+            || scope.starts_with(&format!("{path}/"))
+    })
+}
+
+pub(crate) async fn build_planner_patrol_context(
+    task: &Task,
+    app_state: &AgentContext,
+    project_path: &str,
+) -> Option<String> {
+    if task.issue_type != "review" || !task.title.to_ascii_lowercase().contains("patrol") {
+        return None;
+    }
+
+    let graph_ops = app_state.repo_graph_ops.clone()?;
+    let diff = graph_ops
+        .diff(project_path, Some("previous"))
+        .await
+        .ok()
+        .flatten();
+    let ranked = graph_ops
+        .ranked(project_path, Some("file"), Some("pagerank"), 20)
+        .await
+        .ok()
+        .unwrap_or_default();
+
+    let project_repo = ProjectRepository::new(app_state.db.clone(), app_state.event_bus.clone());
+    let project_id = project_repo
+        .resolve_id_by_path_fuzzy(project_path)
+        .await
+        .ok()
+        .flatten()?;
+    let note_repo =
+        djinn_db::NoteRepository::new(app_state.db.clone(), app_state.event_bus.clone());
+    let notes = note_repo
+        .list(&project_id, None)
+        .await
+        .ok()
+        .unwrap_or_default();
+
+    let mut documented_paths = Vec::new();
+    for note in &notes {
+        let scopes = parse_json_array(&note.scope_paths);
+        if !scopes.is_empty() {
+            documented_paths.extend(scopes);
+        }
+    }
+
+    let mut lines = Vec::new();
+    lines.push("### Code Graph Diff Summary".to_string());
+
+    if let Some(diff) = diff {
+        let (new_modules, removed_modules) = graph_diff_module_paths(&diff);
+        let new_modules_display = if new_modules.is_empty() {
+            "none".to_string()
+        } else {
+            new_modules
+                .iter()
+                .take(8)
+                .map(|m| format!("`{m}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let removed_modules_display = if removed_modules.is_empty() {
+            "none".to_string()
+        } else {
+            removed_modules
+                .iter()
+                .take(8)
+                .map(|m| format!("`{m}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        lines.push(format!(
+            "- Commits: {} → {}",
+            diff.base_commit.as_deref().unwrap_or("unknown"),
+            diff.head_commit.as_deref().unwrap_or("unknown")
+        ));
+        lines.push(format!("- New modules: {new_modules_display}"));
+        lines.push(format!("- Removed modules: {removed_modules_display}"));
+        lines.push(format!(
+            "- Structural delta: {} added nodes, {} removed nodes, {} added edges, {} removed edges",
+            diff.added_nodes.len(),
+            diff.removed_nodes.len(),
+            diff.added_edges.len(),
+            diff.removed_edges.len()
+        ));
+    } else {
+        lines.push("- No previous canonical graph diff is available yet.".to_string());
+    }
+
+    let mut undocumented_hotspots = Vec::new();
+    let mut weakly_documented_hotspots = Vec::new();
+    for node in ranked.into_iter().take(12) {
+        let Some(path) = node.key.strip_prefix("file:") else {
+            continue;
+        };
+        let coverage_count = documented_paths
+            .iter()
+            .filter(|scope| note_scope_covers_path(std::slice::from_ref(scope), path))
+            .count();
+        let item = format!(
+            "`{path}` (score {:.3}, coverage {coverage_count})",
+            node.page_rank
+        );
+        if coverage_count == 0 {
+            undocumented_hotspots.push(item);
+        } else if coverage_count <= 1 {
+            weakly_documented_hotspots.push(item);
+        }
+    }
+
+    lines.push("\n### Knowledge Coverage Gaps".to_string());
+    lines.push(format!(
+        "- Undocumented hotspots: {}",
+        if undocumented_hotspots.is_empty() {
+            "none".to_string()
+        } else {
+            undocumented_hotspots
+                .iter()
+                .take(6)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    ));
+    lines.push(format!(
+        "- Weakly documented hotspots: {}",
+        if weakly_documented_hotspots.is_empty() {
+            "none".to_string()
+        } else {
+            weakly_documented_hotspots
+                .iter()
+                .take(6)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    ));
+
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use djinn_core::events::EventBus;
+    use djinn_core::models::Project;
+    use djinn_db::{Database, NoteRepository, ProjectRepository};
+    use djinn_mcp::bridge::{
+        CycleGroup, EdgeEntry, GraphDiff, GraphDiffEdge, GraphDiffNode, GraphStatus, ImpactResult,
+        NeighborsResult, OrphanEntry, PathResult, RankedNode, RepoGraphOps, SearchHit,
+        SymbolDescription,
+    };
+    use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
+
+    #[derive(Clone)]
+    struct FakeRepoGraphOps {
+        diff: Option<GraphDiff>,
+        ranked: Vec<RankedNode>,
+    }
+
+    #[async_trait]
+    impl RepoGraphOps for FakeRepoGraphOps {
+        async fn neighbors(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) -> Result<NeighborsResult, String> {
+            Err("unused in test".into())
+        }
+
+        async fn ranked(
+            &self,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+            _: usize,
+        ) -> Result<Vec<RankedNode>, String> {
+            Ok(self.ranked.clone())
+        }
+
+        async fn implementations(&self, _: &str, _: &str) -> Result<Vec<String>, String> {
+            Err("unused in test".into())
+        }
+
+        async fn impact(
+            &self,
+            _: &str,
+            _: &str,
+            _: usize,
+            _: Option<&str>,
+        ) -> Result<ImpactResult, String> {
+            Err("unused in test".into())
+        }
+
+        async fn search(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+            _: usize,
+        ) -> Result<Vec<SearchHit>, String> {
+            Err("unused in test".into())
+        }
+
+        async fn cycles(
+            &self,
+            _: &str,
+            _: Option<&str>,
+            _: usize,
+        ) -> Result<Vec<CycleGroup>, String> {
+            Err("unused in test".into())
+        }
+
+        async fn orphans(
+            &self,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+            _: usize,
+        ) -> Result<Vec<OrphanEntry>, String> {
+            Err("unused in test".into())
+        }
+
+        async fn path(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: Option<usize>,
+        ) -> Result<Option<PathResult>, String> {
+            Err("unused in test".into())
+        }
+
+        async fn edges(
+            &self,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+            _: usize,
+        ) -> Result<Vec<EdgeEntry>, String> {
+            Err("unused in test".into())
+        }
+
+        async fn diff(&self, _: &str, _: Option<&str>) -> Result<Option<GraphDiff>, String> {
+            Ok(self.diff.clone())
+        }
+
+        async fn describe(&self, _: &str, _: &str) -> Result<Option<SymbolDescription>, String> {
+            Err("unused in test".into())
+        }
+
+        async fn status(&self, _: &str) -> Result<GraphStatus, String> {
+            Err("unused in test".into())
+        }
+    }
+
+    async fn setup_project() -> (Database, AgentContext, Project, tempfile::TempDir) {
+        let db = Database::open_in_memory().expect("db");
+        db.ensure_initialized().await.expect("init db");
+        let tmp = crate::test_helpers::test_tempdir("planner-patrol-context-");
+        let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+        let project = project_repo
+            .create("test-project", tmp.path().to_str().expect("tmp path"))
+            .await
+            .expect("create project");
+        let ctx = crate::test_helpers::agent_context_from_db(db.clone(), CancellationToken::new());
+        (db, ctx, project, tmp)
+    }
+
+    fn patrol_task(project_id: &str) -> Task {
+        Task {
+            id: uuid::Uuid::now_v7().to_string(),
+            project_id: project_id.to_string(),
+            short_id: "ptst".to_string(),
+            epic_id: None,
+            title: "Planner patrol: board health review".to_string(),
+            description: String::new(),
+            design: String::new(),
+            issue_type: "review".to_string(),
+            status: "open".to_string(),
+            priority: 1,
+            owner: "planner".to_string(),
+            labels: "[]".to_string(),
+            acceptance_criteria: "[]".to_string(),
+            reopen_count: 0,
+            continuation_count: 0,
+            verification_failure_count: 0,
+            total_reopen_count: 0,
+            total_verification_failure_count: 0,
+            intervention_count: 0,
+            last_intervention_at: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            closed_at: None,
+            close_reason: None,
+            merge_commit_sha: None,
+            pr_url: None,
+            merge_conflict_metadata: None,
+            memory_refs: "[]".to_string(),
+            agent_type: None,
+            unresolved_blocker_count: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn planner_patrol_context_reports_diff_and_coverage_gaps() {
+        let (db, mut ctx, project, tmp) = setup_project().await;
+        let note_repo = NoteRepository::new(db.clone(), EventBus::noop());
+        note_repo
+            .create_with_scope(
+                &project.id,
+                tmp.path(),
+                "Server subsystem overview",
+                "documents server source",
+                "reference",
+                None,
+                "[]",
+                r#"["server/src/existing.rs"]"#,
+            )
+            .await
+            .expect("create scoped note");
+
+        ctx.repo_graph_ops = Some(Arc::new(FakeRepoGraphOps {
+            diff: Some(GraphDiff {
+                base_commit: Some("abc123".to_string()),
+                head_commit: Some("def456".to_string()),
+                added_nodes: vec![GraphDiffNode {
+                    key: "file:server/src/new_area.rs".to_string(),
+                    kind: "file".to_string(),
+                    display_name: "server/src/new_area.rs".to_string(),
+                }],
+                removed_nodes: vec![GraphDiffNode {
+                    key: "file:server/src/old_area.rs".to_string(),
+                    kind: "file".to_string(),
+                    display_name: "server/src/old_area.rs".to_string(),
+                }],
+                added_edges: vec![GraphDiffEdge {
+                    from: "file:server/src/new_area.rs".to_string(),
+                    to: "file:server/src/lib.rs".to_string(),
+                    edge_kind: "FileReference".to_string(),
+                }],
+                removed_edges: vec![],
+            }),
+            ranked: vec![
+                RankedNode {
+                    key: "file:server/src/new_area.rs".to_string(),
+                    kind: "file".to_string(),
+                    display_name: "server/src/new_area.rs".to_string(),
+                    score: 10.0,
+                    page_rank: 0.91,
+                    structural_weight: 1.0,
+                    inbound_edge_weight: 1.0,
+                    outbound_edge_weight: 1.0,
+                },
+                RankedNode {
+                    key: "file:server/src/existing.rs".to_string(),
+                    kind: "file".to_string(),
+                    display_name: "server/src/existing.rs".to_string(),
+                    score: 9.0,
+                    page_rank: 0.75,
+                    structural_weight: 1.0,
+                    inbound_edge_weight: 1.0,
+                    outbound_edge_weight: 1.0,
+                },
+            ],
+        }));
+
+        let summary = build_planner_patrol_context(&patrol_task(&project.id), &ctx, &project.path)
+            .await
+            .expect("planner patrol context");
+
+        assert!(summary.contains("Code Graph Diff Summary"));
+        assert!(summary.contains("`server/src/new_area.rs`"));
+        assert!(summary.contains("`server/src/old_area.rs`"));
+        assert!(summary.contains("Undocumented hotspots: `server/src/new_area.rs`"));
+        assert!(summary.contains("Weakly documented hotspots: `server/src/existing.rs`"));
+    }
 }

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle.rs
@@ -1039,6 +1039,9 @@ pub(crate) async fn run_task_lifecycle(params: TaskLifecycleParams) -> anyhow::R
         }
     };
 
+    let planner_patrol_context =
+        super::helpers::build_planner_patrol_context(&task, &app_state, &project_path).await;
+
     let base_system_prompt = runtime_role.render_prompt(
         &task,
         &TaskContext {
@@ -1061,6 +1064,7 @@ pub(crate) async fn run_task_lifecycle(params: TaskLifecycleParams) -> anyhow::R
             verification_failure,
             epic_context,
             knowledge_context,
+            planner_patrol_context,
         },
     );
     // Apply role-level prompt extensions from DB (system_prompt_extensions + learned_prompt).

--- a/server/crates/djinn-agent/src/prompts.rs
+++ b/server/crates/djinn-agent/src/prompts.rs
@@ -85,6 +85,10 @@ pub struct TaskContext {
     // ── Knowledge context ────────────────────────────────────────────────
     /// Path-scoped knowledge notes relevant to this task's code areas.
     pub knowledge_context: Option<String>,
+
+    // ── Planner patrol context ───────────────────────────────────────────
+    /// Planner-patrol-only summary of code-graph diffs and undocumented hotspots.
+    pub planner_patrol_context: Option<String>,
 }
 
 // ─── Renderer ─────────────────────────────────────────────────────────────────
@@ -186,6 +190,15 @@ pub(crate) fn render_prompt_for_role(
         _ => String::new(),
     };
     out = out.replace("{{knowledge_context_section}}", &knowledge_context_section);
+
+    let planner_patrol_context_section = match &ctx.planner_patrol_context {
+        Some(text) if !text.trim().is_empty() => format!("## Planner Patrol Context\n\n{text}\n"),
+        _ => String::new(),
+    };
+    out = out.replace(
+        "{{planner_patrol_context_section}}",
+        &planner_patrol_context_section,
+    );
 
     let activity_section = match &ctx.activity {
         Some(log) if !log.trim().is_empty() => format!(
@@ -443,6 +456,7 @@ mod tests {
             verification_failure: None,
             epic_context: None,
             knowledge_context: None,
+            planner_patrol_context: None,
         }
     }
 
@@ -738,6 +752,22 @@ mod tests {
             prompt.contains("planning task to deprecate the outdated note"),
             "planner prompt should prescribe planning-task routing for contradiction resolution"
         );
+    }
+
+    #[test]
+    fn planner_prompt_includes_patrol_context_section_when_present() {
+        let task = make_task();
+        let ctx = TaskContext {
+            planner_patrol_context: Some(
+                "### Code Graph Diff Summary\n\nNew modules: `server/src/new_area.rs`".into(),
+            ),
+            ..make_ctx()
+        };
+        let prompt = render_prompt(AgentType::Planner, &task, &ctx);
+
+        assert!(prompt.contains("Planner Patrol Context"));
+        assert!(prompt.contains("Code Graph Diff Summary"));
+        assert!(prompt.contains("New modules:"));
     }
 
     /// Architect spike notes must still carry task traceability (per ADR-051

--- a/server/crates/djinn-agent/src/prompts/base.md
+++ b/server/crates/djinn-agent/src/prompts/base.md
@@ -31,6 +31,8 @@ You are an autonomous agent in the Djinn task execution system. **There is no hu
 
 {{knowledge_context_section}}
 
+{{planner_patrol_context_section}}
+
 {{activity_section}}
 
 ## Environment

--- a/server/crates/djinn-agent/src/prompts/planner.md
+++ b/server/crates/djinn-agent/src/prompts/planner.md
@@ -51,6 +51,13 @@ For spikes or tasks with non-trivial design decisions:
 - If `orphan_note_count > 0`: call `memory_orphans()` to list unlinked notes. Orphans in `decisions/` or `patterns/` are often fine (standalone reference). Orphans in `pitfalls/` or `scratch/` older than 14 days may be stale — flag them for cleanup.
 - If any folder shows high stale-note counts: note it in your `submit_grooming` summary as a maintenance signal.
 
+### A5b. Code Structure Change and Coverage Review
+- Read the **Planner Patrol Context** section injected into this prompt. It summarizes canonical graph diffs, new/removed modules, and undocumented or weakly documented hotspots derived from existing code-graph plus note-scope data.
+- Treat **new modules**, **removed modules**, and large added/removed edge counts as structural-change signals. If a major subsystem moved or appeared without documentation coverage, create a `spike` task for the Architect.
+- Treat **undocumented hotspots** as candidates for architect spikes when they are both structurally central and lack scoped note coverage.
+- Treat **weakly documented hotspots** as lower-severity follow-ups: prefer planning tasks when scoped notes exist but coverage is thin or stale.
+- Include the most important graph-side signals in your `submit_grooming` summary so patrol output captures both memory health and code-structure drift.
+
 ### A6. Contradiction and Low-Confidence Review
 - Search for contradicted or low-confidence notes: `memory_search(q="contradicts supersedes stale")`.
 - Review any notes that appear to conflict with each other or with recent ADRs.


### PR DESCRIPTION
## Summary
Expose code-structure changes and knowledge gaps to Planner patrol so it can identify when architect spikes should be created for undocumented subsystems or major structural changes.

## Acceptance Criteria
- [x] Planner-facing patrol context includes canonical graph diff summary, new/removed modules or equivalent structural changes, and a list of undocumented or weakly documented hotspots derived from existing code-graph data.
- [x] Tests cover the new code-graph summary plumbing and validate output for representative refresh/diff scenarios.

---
Djinn task: flkb