### PR TITLE
chore(gl52): Enforce ADR-054 structured templates for extracted pattern, pitfall, and case notes

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/llm_extraction.rs
+++ b/server/crates/djinn-agent/src/actors/slot/llm_extraction.rs
@@ -44,6 +44,36 @@ const NOVELTY_SYSTEM_PROMPT: &str = "You are a semantic novelty judge for extrac
 
 const MIN_DURABLE_WORDS: usize = 16;
 
+const PATTERN_REQUIRED_SECTIONS: &[&str] = &[
+    "## Context",
+    "## Problem shape",
+    "## Recommended approach",
+    "## Why it works",
+    "## Tradeoffs / limits",
+    "## When to use",
+    "## When not to use",
+    "## Related",
+];
+
+const PITFALL_REQUIRED_SECTIONS: &[&str] = &[
+    "## Trigger / smell",
+    "## Failure mode",
+    "## Observable symptoms",
+    "## Prevention",
+    "## Recovery",
+    "## Related",
+];
+
+const CASE_REQUIRED_SECTIONS: &[&str] = &[
+    "## Situation",
+    "## Constraint",
+    "## Approach taken",
+    "## Result",
+    "## Why it worked / failed",
+    "## Reusable lesson",
+    "## Related",
+];
+
 // ── JSON response shape ───────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize, Default)]
@@ -100,6 +130,7 @@ struct QualityAssessment {
     durability: bool,
     novelty: NoveltyAssessment,
     type_fit: bool,
+    required_structure: bool,
     outcome: ExtractionOutcome,
     reasons: Vec<&'static str>,
 }
@@ -360,10 +391,18 @@ async fn run_llm_extraction_inner(
          Include a \"scope_paths\" array per note with relevant path prefixes from the list above.\n\n\
          Extract knowledge from this session. Return JSON:\n\
          {{\n\
-           \"cases\": [{{\"title\": \"...\", \"content\": \"Brief problem and solution description\", \"scope_paths\": [\"...\"]}}],\n\
-           \"patterns\": [{{\"title\": \"...\", \"content\": \"Reusable process or method discovered\", \"scope_paths\": [\"...\"]}}],\n\
-           \"pitfalls\": [{{\"title\": \"...\", \"content\": \"Error encountered and how it was resolved\", \"scope_paths\": [\"...\"]}}]\n\
+           \"cases\": [{{\"title\": \"...\", \"content\": \"Markdown note using the exact required case headings\", \"scope_paths\": [\"...\"]}}],\n\
+           \"patterns\": [{{\"title\": \"...\", \"content\": \"Markdown note using the exact required pattern headings\", \"scope_paths\": [\"...\"]}}],\n\
+           \"pitfalls\": [{{\"title\": \"...\", \"content\": \"Markdown note using the exact required pitfall headings\", \"scope_paths\": [\"...\"]}}]\n\
          }}\n\
+         Required durable templates:\n\
+         Pattern content must contain exactly these markdown headings in order:\n\
+         ## Context\n## Problem shape\n## Recommended approach\n## Why it works\n## Tradeoffs / limits\n## When to use\n## When not to use\n## Related\n\
+         Pitfall content must contain exactly these markdown headings in order:\n\
+         ## Trigger / smell\n## Failure mode\n## Observable symptoms\n## Prevention\n## Recovery\n## Related\n\
+         Case content must contain exactly these markdown headings in order:\n\
+         ## Situation\n## Constraint\n## Approach taken\n## Result\n## Why it worked / failed\n## Reusable lesson\n## Related\n\
+         If you cannot fill every required section for a note type, omit that note instead of returning a shorter paragraph.\n\
          Return empty arrays if nothing significant was learned. \
          Maximum 3 cases, 3 patterns, 2 pitfalls.\n\
          Only extract if there is clear signal (high errors+files_changed suggests pitfalls; \
@@ -540,6 +579,7 @@ async fn process_extracted_note(
         durability = assessment.durability,
         novelty = ?assessment.novelty,
         type_fit = assessment.type_fit,
+        required_structure = assessment.required_structure,
         reasons = ?assessment.reasons,
         "llm_extraction: evaluated extraction quality gate"
     );
@@ -865,6 +905,7 @@ fn assess_quality_gate(
     let generality = has_generality(note);
     let durability = has_durability(note);
     let type_fit = matches_type_semantics(note_type, note);
+    let required_structure = has_required_structure(note_type, note);
     let novelty_assessment = novelty.assessment;
 
     let mut reasons = Vec::new();
@@ -880,12 +921,17 @@ fn assess_quality_gate(
     if !type_fit {
         reasons.push("type_fit_mismatch");
     }
+    if !required_structure {
+        reasons.push("missing_required_adr_054_sections");
+    }
     if novelty_assessment == NoveltyAssessment::Duplicate {
         reasons.push("semantic_duplicate_of_existing_note");
     }
 
     let outcome = if novelty_assessment == NoveltyAssessment::Duplicate {
         ExtractionOutcome::MergeIntoExisting
+    } else if !required_structure {
+        ExtractionOutcome::DowngradeToWorkingSpec
     } else if !specificity || !type_fit {
         ExtractionOutcome::Discard
     } else if !generality || !durability {
@@ -900,9 +946,36 @@ fn assess_quality_gate(
         durability,
         novelty: novelty_assessment,
         type_fit,
+        required_structure,
         outcome,
         reasons,
     }
+}
+
+fn has_required_structure(note_type: &str, note: &ExtractedNote) -> bool {
+    required_sections(note_type)
+        .map(|sections| note_contains_sections_in_order(&note.content, sections))
+        .unwrap_or(false)
+}
+
+fn required_sections(note_type: &str) -> Option<&'static [&'static str]> {
+    match note_type {
+        "pattern" => Some(PATTERN_REQUIRED_SECTIONS),
+        "pitfall" => Some(PITFALL_REQUIRED_SECTIONS),
+        "case" => Some(CASE_REQUIRED_SECTIONS),
+        _ => None,
+    }
+}
+
+fn note_contains_sections_in_order(content: &str, sections: &[&str]) -> bool {
+    let mut cursor = 0;
+    for section in sections {
+        let Some(found_at) = content[cursor..].find(section) else {
+            return false;
+        };
+        cursor += found_at + section.len();
+    }
+    true
 }
 
 fn has_specificity(note: &ExtractedNote) -> bool {

--- a/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
@@ -136,12 +136,22 @@ async fn make_fixture() -> TestFixture {
 
 /// Build a FakeProvider that returns a valid extraction JSON with one of each note type.
 fn fake_extraction_provider() -> Arc<FakeProvider> {
-    let json = r#"{
-  "cases": [{"title": "Test Case Note", "content": "Situation: a flaky extraction pipeline had to compare candidate summaries under a deterministic constraint. Approach taken: inject a stable candidate seam and record why the fix worked. Result: future tasks can reuse the lesson when similar novelty checks fail."}],
-  "patterns": [{"title": "Test Pattern Note", "content": "Recommended approach: use a reusable seam when a workflow needs deterministic comparisons across multiple future tasks. Why it works: the approach isolates unstable dependencies and clarifies when to use the pattern and its tradeoffs."}],
-  "pitfalls": [{"title": "Test Pitfall Note", "content": "Trigger / smell: semantic duplicate checks become flaky when summaries change between runs. Failure mode: extraction creates noisy sibling notes. Prevention and recovery: inject stable summaries, compare them consistently, and avoid repeating the error in future tasks."}]
-}"#;
-    Arc::new(FakeProvider::text(json))
+    let json = serde_json::json!({
+        "cases": [{
+            "title": "Test Case Note",
+            "content": "## Situation\nA flaky extraction pipeline had to compare candidate summaries under a deterministic constraint.\n## Constraint\nNovelty checks needed stable inputs across repeated runs and future tasks.\n## Approach taken\nInject a stable candidate seam and keep the comparison summary explicit in the extraction flow.\n## Result\nThe extraction remained deterministic and avoided duplicate durable notes.\n## Why it worked / failed\nThe seam removed unstable inputs that were previously changing across runs.\n## Reusable lesson\nUse an explicit deterministic seam when extraction quality depends on comparing generated summaries reliably.\n## Related\n- novelty detection\n- extraction quality gates"
+        }],
+        "patterns": [{
+            "title": "Test Pattern Note",
+            "content": "## Context\nA workflow needs deterministic comparisons while still preserving reusable extraction behavior.\n## Problem shape\nUnstable provider responses can create noisy differences that look novel even when the underlying knowledge is the same.\n## Recommended approach\nIntroduce a reusable seam for the comparison inputs and keep the durable evaluation steps explicit.\n## Why it works\nThe seam isolates unstable dependencies and preserves a repeatable decision path.\n## Tradeoffs / limits\nIt adds test scaffolding and only helps when the comparison boundary is well understood.\n## When to use\nUse this when future tasks must compare summaries or candidates deterministically across repeated runs.\n## When not to use\nDo not use it when the workflow is intentionally exploratory or the comparison boundary is still changing.\n## Related\n- novelty detection\n- deterministic tests"
+        }],
+        "pitfalls": [{
+            "title": "Test Pitfall Note",
+            "content": "## Trigger / smell\nSemantic duplicate checks become flaky when summaries change between runs.\n## Failure mode\nExtraction creates noisy sibling notes instead of recognizing the same durable knowledge.\n## Observable symptoms\nRepeated runs alternate between merging and writing new notes with nearly identical content.\n## Prevention\nInject stable summaries and keep the comparison contract narrow and explicit.\n## Recovery\nReplace unstable inputs with deterministic fixtures and rerun the novelty gate.\n## Related\n- duplicate notes\n- extraction quality gates"
+        }]
+    })
+    .to_string();
+    Arc::new(FakeProvider::text(&json))
 }
 
 fn novelty_candidate(existing_id: &str) -> NoteDedupCandidate {
@@ -457,8 +467,16 @@ async fn llm_extracted_notes_contain_session_id_provenance() {
     let ctx = agent_context_from_db(fixture.db.clone(), fixture.cancel.clone());
 
     let taxonomy = SessionTaxonomy::default();
-    let json = r#"{"cases":[{"title":"Provenance Test","content":"Situation: extraction provenance must remain visible after a durable note is written. Constraint: future tasks need to know which session produced the case. Approach taken: append a provenance footer and keep the reusable lesson in the note result. Result: the stored case stays traceable. Lesson: future tasks can trust the durable note provenance."}],"patterns":[],"pitfalls":[]}"#;
-    let provider = Arc::new(FakeProvider::text(json));
+    let json = serde_json::json!({
+        "cases": [{
+            "title": "Provenance Test",
+            "content": "## Situation\nExtraction provenance must remain visible after a durable note is written.\n## Constraint\nFuture tasks need to know which session produced the case while keeping the note reusable.\n## Approach taken\nAppend a provenance footer and preserve the worked example in the durable case body.\n## Result\nThe stored case stays traceable without losing its reusable content.\n## Why it worked / failed\nThe footer keeps session origin explicit while leaving the durable lesson intact.\n## Reusable lesson\nKeep provenance appended separately so future tasks can trust the origin of extracted durable notes.\n## Related\n- provenance\n- durable extraction"
+        }],
+        "patterns": [],
+        "pitfalls": []
+    })
+    .to_string();
+    let provider = Arc::new(FakeProvider::text(&json));
 
     run_llm_extraction_with_provider(session_id.clone(), taxonomy, ctx, provider).await;
 
@@ -645,7 +663,15 @@ async fn llm_extraction_novelty_check_failure_falls_back_to_create() {
     let provider = Arc::new(FakeProvider::script(vec![
         vec![
             djinn_provider::provider::StreamEvent::Delta(ContentBlock::Text {
-                text: r#"{"cases":[{"title":"Fallback Novel Note","content":"Situation: a novelty response returned invalid JSON during extraction. Constraint: the durable lesson still matters across future tasks. Approach taken: continue with the durable case because the fallback preserved useful knowledge. Result: extraction still captured the note. Lesson: future tasks can reuse the fallback when novelty checks fail."}],"patterns":[],"pitfalls":[]}"#.to_string(),
+                text: serde_json::json!({
+                    "cases": [{
+                        "title": "Fallback Novel Note",
+                        "content": "## Situation\nA novelty response returned invalid JSON during extraction.\n## Constraint\nThe durable lesson still matters across future tasks even when the novelty call fails.\n## Approach taken\nContinue with the structured durable case after the novelty parser falls back to unknown.\n## Result\nExtraction still captured the note instead of losing the reusable precedent.\n## Why it worked / failed\nThe fallback preserved durable note creation when novelty infrastructure was temporarily unreliable.\n## Reusable lesson\nKeep the durable write path resilient when auxiliary novelty checks fail.\n## Related\n- novelty fallback\n- durable extraction"
+                    }],
+                    "patterns": [],
+                    "pitfalls": []
+                })
+                .to_string(),
             }),
             djinn_provider::provider::StreamEvent::Done,
         ],
@@ -746,13 +772,13 @@ async fn llm_extraction_downgrades_non_durable_note_to_working_spec_path() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn llm_extraction_discards_note_with_type_mismatch() {
+async fn llm_extraction_downgrades_note_missing_required_adr_054_sections() {
     let fixture = make_fixture().await;
     let ctx = agent_context_from_db(fixture.db.clone(), fixture.cancel.clone());
 
     let taxonomy = SessionTaxonomy {
         files_changed: 1,
-        errors: 0,
+        errors: 1,
         tools_used: 2,
         notes_read: 0,
         notes_written: 1,
@@ -761,7 +787,7 @@ async fn llm_extraction_discards_note_with_type_mismatch() {
     };
 
     let provider = Arc::new(FakeProvider::text(
-        r#"{"cases":[],"patterns":[{"title":"Vague Pattern Claim","content":"This worked."}],"pitfalls":[]}"#,
+        r#"{"cases":[],"patterns":[{"title":"Unstructured Pattern Note","content":"Reusable approach: keep extraction deterministic across future tasks by isolating unstable inputs and documenting why the pattern helps."}],"pitfalls":[]}"#,
     ));
 
     run_llm_extraction_with_provider(fixture.session_id.clone(), taxonomy, ctx, provider).await;
@@ -771,18 +797,21 @@ async fn llm_extraction_discards_note_with_type_mismatch() {
         .list(&fixture.project.id, None)
         .await
         .expect("list notes");
-    assert!(notes.is_empty(), "discarded notes should not be persisted");
+    assert!(
+        notes.is_empty(),
+        "notes missing ADR-054 sections should be routed away from durable writes"
+    );
 
     let stored_json: Option<String> =
         sqlx::query_scalar("SELECT event_taxonomy FROM sessions WHERE id = ?1")
             .bind(&fixture.session_id)
             .fetch_one(fixture.db.pool())
             .await
-            .expect("query session event_taxonomy after discard");
+            .expect("query session event_taxonomy after template downgrade");
     let stored_taxonomy: SessionTaxonomy = serde_json::from_str(stored_json.as_deref().unwrap())
-        .expect("deserialize stored taxonomy after discard");
+        .expect("deserialize stored taxonomy after template downgrade");
     assert_eq!(stored_taxonomy.extraction_quality.extracted, 1);
-    assert_eq!(stored_taxonomy.extraction_quality.discarded, 1);
+    assert_eq!(stored_taxonomy.extraction_quality.downgraded, 1);
     assert_eq!(stored_taxonomy.extraction_quality.written, 0);
 }
 

--- a/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
@@ -797,9 +797,38 @@ async fn llm_extraction_downgrades_note_missing_required_adr_054_sections() {
         .list(&fixture.project.id, None)
         .await
         .expect("list notes");
+    assert_eq!(
+        notes.len(),
+        1,
+        "notes missing ADR-054 sections should be routed into the working-spec fallback"
+    );
+
+    let working_spec = &notes[0];
+    assert_eq!(working_spec.note_type, "design");
+    assert_eq!(
+        working_spec.title,
+        format!("Working Spec {}", fixture.task.short_id)
+    );
+    assert!(working_spec.content.contains("## Active objective"));
+    assert!(working_spec.content.contains("## Relevant scope"));
+    assert!(working_spec.content.contains("## Constraints"));
+    assert!(working_spec.content.contains("## Current hypotheses"));
+    assert!(working_spec.content.contains("## Open questions"));
+    assert!(working_spec.content.contains("Unstructured Pattern Note"));
     assert!(
-        notes.is_empty(),
-        "notes missing ADR-054 sections should be routed away from durable writes"
+        working_spec
+            .content
+            .contains("missing_required_adr_054_sections")
+    );
+    assert!(working_spec.content.contains(&fixture.session_id));
+
+    let durable_notes: Vec<_> = notes
+        .iter()
+        .filter(|note| matches!(note.note_type.as_str(), "case" | "pattern" | "pitfall"))
+        .collect();
+    assert!(
+        durable_notes.is_empty(),
+        "notes missing ADR-054 sections should not become durable extracted notes"
     );
 
     let stored_json: Option<String> =


### PR DESCRIPTION
## Summary
Add type-specific structure enforcement to extracted durable notes so generic one-paragraph notes no longer enter the durable KB. Update the extraction prompt/response handling and validation rules so each durable note type must include the required ADR-054 sections.

## Acceptance Criteria
- [x] Extraction prompting and/or response schema requires the ADR-054 section structure for pattern, pitfall, and case notes
- [x] Durable notes missing required sections are rejected from durable creation and routed through the quality-gate fallback path
- [x] Tests verify one valid structured note per type and at least one invalid note that is prevented from becoming a durable write

---
Djinn task: gl52