### PR TITLE
chore(mnqm): Implement repository-backed read/list/stat semantics for the memory filesystem

### DIFF
--- a/server/src/memory_fs.rs
+++ b/server/src/memory_fs.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use djinn_core::models::NoteCompact;
+use djinn_core::models::Note;
 use djinn_db::{
     NoteRepository, folder_for_type, normalize_virtual_note_path, permalink_from_virtual_note_path,
     render_note_markdown, virtual_note_path_for_permalink,
@@ -58,7 +58,7 @@ pub type Result<T> = std::result::Result<T, MemoryFsError>;
 #[derive(Debug, Default)]
 struct MemoryTree {
     directories: BTreeSet<String>,
-    files: BTreeMap<String, NoteCompact>,
+    files: BTreeMap<String, Note>,
 }
 
 impl MemoryTree {
@@ -88,7 +88,7 @@ impl MemoryTree {
         }
     }
 
-    fn insert_note(&mut self, note: NoteCompact) {
+    fn insert_note(&mut self, note: Note) {
         let file_path = virtual_note_path_for_permalink(&note.permalink);
         let parent = Self::parent_dir(&file_path);
         self.insert_dir_hierarchy(&parent);
@@ -218,7 +218,7 @@ impl MemoryFilesystemCore {
 
         self.repo.touch_accessed(&note.id).await?;
 
-        let content = render_note_markdown(&note.title, &note.note_type, &note.tags, &note.content);
+        let content = self.render_note_content(&note);
         let metadata = MemoryEntryMetadata {
             path: resolved.logical_path.clone(),
             kind: MemoryEntryKind::File,
@@ -234,7 +234,7 @@ impl MemoryFilesystemCore {
     }
 
     async fn build_tree(&self, project_id: &str) -> Result<MemoryTree> {
-        let notes = self.repo.list_compact(project_id, None, None, 0).await?;
+        let notes = self.repo.list(project_id, None).await?;
         let mut tree = MemoryTree::default();
         tree.directories.insert(String::new());
 
@@ -249,13 +249,18 @@ impl MemoryFilesystemCore {
         Ok(tree)
     }
 
-    fn file_metadata(&self, note: &NoteCompact) -> MemoryEntryMetadata {
+    fn file_metadata(&self, note: &Note) -> MemoryEntryMetadata {
         let path = virtual_note_path_for_permalink(&note.permalink);
+        let size = self.render_note_content(note).len() as u64;
         MemoryEntryMetadata {
             path,
             kind: MemoryEntryKind::File,
-            size: 0,
+            size,
         }
+    }
+
+    fn render_note_content(&self, note: &Note) -> String {
+        render_note_markdown(&note.title, &note.note_type, &note.tags, &note.content)
     }
 }
 
@@ -338,6 +343,12 @@ mod tests {
             .unwrap();
         assert_eq!(resolved.permalink, "patterns/reusable-flow");
 
+        let before = repo
+            .get_by_permalink(&project_id, "patterns/reusable-flow")
+            .await
+            .unwrap()
+            .unwrap();
+
         let file = core
             .read_file(&project_id, "patterns/reusable-flow.md")
             .await
@@ -345,13 +356,15 @@ mod tests {
         assert_eq!(file.metadata.kind, MemoryEntryKind::File);
         assert!(file.content.contains("title: Reusable Flow"));
         assert!(file.content.contains("Body text"));
+        assert_eq!(file.metadata.size, file.content.len() as u64);
 
         let touched = repo
             .get_by_permalink(&project_id, "patterns/reusable-flow")
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(touched.access_count, 1);
+        assert_eq!(touched.access_count, before.access_count + 1);
+        assert!(touched.last_accessed >= before.last_accessed);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -388,6 +401,19 @@ mod tests {
         let root_entries = core.list_dir(&project_id, "").await.unwrap();
         assert!(root_entries.iter().any(|entry| entry.name == "brief.md"));
         assert!(root_entries.iter().any(|entry| entry.name == "design"));
+
+        let brief_stat = core.stat(&project_id, "brief.md").await.unwrap();
+        assert_eq!(brief_stat.kind, MemoryEntryKind::File);
+        assert!(brief_stat.size > 0);
+        assert_eq!(
+            root_entries
+                .iter()
+                .find(|entry| entry.name == "brief.md")
+                .unwrap()
+                .metadata
+                .size,
+            brief_stat.size
+        );
 
         let design_entries = core.list_dir(&project_id, "design").await.unwrap();
         assert!(design_entries.iter().any(|entry| entry.name == "specs"));


### PR DESCRIPTION
## Summary
Build out read-side filesystem behavior on top of the new core so notes can be exposed as directory listings and file contents with metadata parity. Preserve the current memory-read access tracking expectations.

## Acceptance Criteria
- [x] The filesystem core can list note directories and read note file contents from repository-backed data using canonical `.md` paths.
- [x] Filesystem file reads update note access tracking with parity to existing `memory_read` behavior.
- [x] Tests cover directory listing, file content reads, and access-count/last-accessed updates triggered by read operations.

---
Djinn task: mnqm