### PR TITLE
chore(1wdl): Port schema and migrations toward Dolt/MySQL compatibility for ADR-055

### DIFF
--- a/server/crates/djinn-db/build.rs
+++ b/server/crates/djinn-db/build.rs
@@ -15,4 +15,7 @@
 //! decided nothing in `djinn-db` had changed.
 fn main() {
     println!("cargo:rerun-if-changed=migrations");
+    println!("cargo:rerun-if-changed=schema.sql");
+    println!("cargo:rerun-if-changed=sql/mysql_schema.sql");
+    println!("cargo:rerun-if-changed=sql/mysql_notes_fulltext_prototype.sql");
 }

--- a/server/crates/djinn-db/docs/adr-055-schema-migration-plan.md
+++ b/server/crates/djinn-db/docs/adr-055-schema-migration-plan.md
@@ -1,0 +1,63 @@
+# ADR-055 schema migration plan for Dolt/MySQL
+
+Originated from task `019d891d-dc2c-7421-8763-395380c02029`.
+
+## Goal
+
+Provide a concrete, inspectable migration target for the note/task/session relational state needed
+by ADR-055 without breaking the current SQLite runtime.
+
+## Current selectable backend
+
+- **SQLite remains the active runtime**.
+- `server/src/db/runtime.rs` still defaults to `sqlite` and preserves SQLite-specific bootstrap
+  behavior such as local pragmas and embedded refinery migrations.
+- Selecting `mysql` or `dolt` is already explicit through `DJINN_DB_BACKEND`, but repository
+  execution remains staged until the cutover lands.
+
+## Staged MySQL/Dolt artifacts
+
+Two concrete artifacts now define the migration target:
+
+1. `server/crates/djinn-db/sql/mysql_schema.sql`
+   - full relational schema snapshot for the ADR-055 note/task/session state
+   - includes `projects`, `tasks`, `notes`, `sessions`, `session_messages`,
+     `task_memory_refs`, and related note-link / provenance tables needed by current workflows
+2. `server/crates/djinn-db/sql/mysql_notes_fulltext_prototype.sql`
+   - reference search SQL using `MATCH ... AGAINST` over `notes`
+
+## SQLite-only elements now isolated
+
+The SQLite path continues to own these features in `schema.sql` and refinery migrations:
+
+- `notes_fts` FTS5 virtual table
+- trigger-based synchronization into `notes_fts`
+- pragma-driven connection setup
+- optional `sqlite-vec` runtime initialization
+
+The MySQL/Dolt schema snapshot intentionally omits those features and replaces them with:
+
+- a native `FULLTEXT` index on `notes(title, content, tags)`
+- ordinary relational embedding tables (`note_embeddings`, `note_embedding_meta`)
+- no trigger-maintained shadow tables
+
+## Verification hooks
+
+`server/crates/djinn-db/src/migrations.rs` now exposes both schema snapshots and contains tests
+asserting that:
+
+- the SQLite snapshot still includes FTS5 + trigger sync
+- the MySQL snapshot uses `FULLTEXT` and excludes FTS5 / trigger / `vec0` structures
+- the MySQL schema and prototype together cover `tasks`, `notes`, and `sessions`
+
+## Intended cutover sequence
+
+1. Keep SQLite refinery migrations as-is for the current runtime.
+2. Use `sql/mysql_schema.sql` as the authoritative relational target while MySQL repository support
+   is implemented.
+3. Switch lexical note search to the existing backend-aware planning seam plus the
+   `mysql_notes_fulltext_prototype.sql` query shape.
+4. Introduce backend-specific migrators once repository execution can run on MySQL/Dolt.
+
+This keeps the SQLite path selectable today while making the Dolt/MySQL schema path concrete and
+unambiguous.

--- a/server/crates/djinn-db/docs/mysql-fulltext-notes-search-prototype.md
+++ b/server/crates/djinn-db/docs/mysql-fulltext-notes-search-prototype.md
@@ -68,7 +68,7 @@ When the MySQL backend lands, the repository cutover should:
    - contradiction still returns top 3 before `TypeRisk` filtering
    - context discovery still returns lexical candidates only
 
-## Included reference artifact
+## Included reference artifacts
 
 `sql/mysql_notes_fulltext_prototype.sql` contains executable reference SQL for:
 
@@ -77,5 +77,25 @@ When the MySQL backend lands, the repository cutover should:
 - contradiction candidates
 - build-context lexical discovery
 
-This is intentionally stored outside refinery migrations so the current SQLite test/runtime path
-remains unaffected while the Dolt/MySQL backend is still in progress.
+`sql/mysql_schema.sql` now accompanies that prototype with a concrete MySQL/Dolt schema snapshot for
+the ADR-055 note/task/session tables. The schema explicitly:
+
+- keeps `tasks`, `notes`, `sessions`, `task_memory_refs`, and adjacent relational tables in a
+  MySQL-compatible layout
+- replaces SQLite FTS5 shadow tables and triggers with `ALTER TABLE notes ADD FULLTEXT KEY`
+- keeps embedding bytes in ordinary relational tables instead of depending on `sqlite-vec`
+
+Both artifacts are intentionally stored outside refinery migrations so the current SQLite
+test/runtime path remains unaffected while the Dolt/MySQL backend is still in progress.
+
+## Backend selection and migration path
+
+The repository now exposes both schema snapshots in Rust via `djinn_db::sqlite_schema_snapshot()`
+and `djinn_db::mysql_schema_snapshot()`. Tests in `src/migrations.rs` verify the split:
+
+- the SQLite snapshot still contains `notes_fts` and trigger-driven sync
+- the MySQL snapshot contains `FULLTEXT` indexing and omits SQLite-only virtual tables/triggers
+
+This matches the runtime seam introduced in `server/src/db/runtime.rs`: SQLite remains the default
+selectable backend today, while `mysql`/`dolt` selection is explicit and can be paired with the
+staged MySQL schema artifact without ambiguity.

--- a/server/crates/djinn-db/sql/mysql_schema.sql
+++ b/server/crates/djinn-db/sql/mysql_schema.sql
@@ -1,0 +1,263 @@
+-- ADR-055 Dolt/MySQL schema snapshot for note/task/session state.
+--
+-- This snapshot intentionally covers the relational tables needed by the
+-- staged MySQL/Dolt backend cutover while preserving the existing SQLite
+-- runtime path. It removes SQLite-only FTS5 shadow tables, trigger-based sync,
+-- and sqlite-vec virtual tables in favor of native MySQL/Dolt structures.
+
+CREATE TABLE projects (
+    id              VARCHAR(36) NOT NULL PRIMARY KEY,
+    name            VARCHAR(255) NOT NULL,
+    path            TEXT NOT NULL,
+    created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    target_branch   VARCHAR(255) NOT NULL DEFAULT 'main',
+    auto_merge      BOOLEAN NOT NULL DEFAULT FALSE,
+    sync_enabled    BOOLEAN NOT NULL DEFAULT TRUE,
+    sync_remote     TEXT NULL,
+    UNIQUE KEY uq_projects_name (name),
+    UNIQUE KEY uq_projects_path (path(191))
+);
+
+CREATE TABLE tasks (
+    id                         VARCHAR(36) NOT NULL PRIMARY KEY,
+    project_id                 VARCHAR(36) NOT NULL,
+    title                      TEXT NOT NULL,
+    description                LONGTEXT NOT NULL,
+    status                     VARCHAR(64) NOT NULL DEFAULT 'todo',
+    issue_type                 VARCHAR(64) NOT NULL DEFAULT 'task',
+    parent_task_id             VARCHAR(36) NULL,
+    priority                   INT NULL,
+    labels                     LONGTEXT NOT NULL,
+    assignee                   VARCHAR(255) NULL,
+    batch_id                   VARCHAR(36) NULL,
+    source_branch              VARCHAR(255) NULL,
+    merge_commit_sha           VARCHAR(64) NULL,
+    archived_at                DATETIME(3) NULL,
+    blocked_reason             LONGTEXT NULL,
+    blocked_at                 DATETIME(3) NULL,
+    pm_override                BOOLEAN NOT NULL DEFAULT FALSE,
+    pm_override_reason         LONGTEXT NULL,
+    verification_failure_count INT NOT NULL DEFAULT 0,
+    created_at                 DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at                 DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    CONSTRAINT fk_tasks_project FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    CONSTRAINT fk_tasks_parent FOREIGN KEY (parent_task_id) REFERENCES tasks(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_tasks_project_id ON tasks(project_id);
+CREATE INDEX idx_tasks_project_status ON tasks(project_id, status);
+CREATE INDEX idx_tasks_project_priority ON tasks(project_id, priority);
+CREATE INDEX idx_tasks_project_parent ON tasks(project_id, parent_task_id);
+CREATE INDEX idx_tasks_project_issue_type ON tasks(project_id, issue_type);
+CREATE INDEX idx_tasks_project_archived ON tasks(project_id, archived_at);
+
+CREATE TABLE task_blockers (
+    task_id          VARCHAR(36) NOT NULL,
+    blocker_task_id  VARCHAR(36) NOT NULL,
+    created_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (task_id, blocker_task_id),
+    CONSTRAINT fk_task_blockers_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_task_blockers_blocker FOREIGN KEY (blocker_task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_task_blockers_blocker ON task_blockers(blocker_task_id);
+
+CREATE TABLE task_activity_log (
+    id          VARCHAR(36) NOT NULL PRIMARY KEY,
+    project_id  VARCHAR(36) NOT NULL,
+    task_id      VARCHAR(36) NOT NULL,
+    actor_role  VARCHAR(64) NOT NULL,
+    actor_id    VARCHAR(255) NULL,
+    event_type  VARCHAR(128) NOT NULL,
+    payload     LONGTEXT NOT NULL,
+    created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    archived_at DATETIME(3) NULL,
+    CONSTRAINT fk_task_activity_project FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    CONSTRAINT fk_task_activity_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_task_activity_project_task_created
+    ON task_activity_log(project_id, task_id, created_at DESC);
+CREATE INDEX idx_task_activity_project_created
+    ON task_activity_log(project_id, created_at DESC);
+CREATE INDEX idx_task_activity_archived ON task_activity_log(archived_at);
+
+CREATE TABLE notes (
+    id            VARCHAR(36) NOT NULL PRIMARY KEY,
+    project_id     VARCHAR(36) NOT NULL,
+    permalink     VARCHAR(255) NOT NULL,
+    title         TEXT NOT NULL,
+    file_path     TEXT NOT NULL,
+    storage       VARCHAR(32) NOT NULL DEFAULT 'file',
+    note_type     VARCHAR(64) NOT NULL,
+    folder        VARCHAR(255) NOT NULL,
+    tags          TEXT NOT NULL,
+    content       LONGTEXT NOT NULL,
+    created_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    updated_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    last_accessed DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    access_count  BIGINT NOT NULL DEFAULT 0,
+    confidence    DOUBLE NOT NULL DEFAULT 1.0,
+    abstract      TEXT NULL,
+    overview      TEXT NULL,
+    scope_paths   LONGTEXT NULL,
+    content_hash  CHAR(64) NULL,
+    CONSTRAINT fk_notes_project FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    UNIQUE KEY uq_notes_project_permalink (project_id, permalink),
+    UNIQUE KEY uq_notes_project_file_path (project_id, file_path(191))
+);
+
+CREATE INDEX idx_notes_project_folder ON notes(project_id, folder);
+CREATE INDEX idx_notes_project_updated ON notes(project_id, updated_at DESC);
+CREATE INDEX idx_notes_project_last_accessed ON notes(project_id, last_accessed DESC);
+CREATE INDEX idx_notes_project_content_hash ON notes(project_id, content_hash);
+CREATE INDEX idx_notes_project_folder_title ON notes(project_id, folder, title(191));
+
+-- MySQL/Dolt replacement for SQLite FTS5 shadow table + triggers.
+ALTER TABLE notes ADD FULLTEXT KEY notes_ft (title, content, tags);
+
+CREATE TABLE note_embeddings (
+    note_id        VARCHAR(36) NOT NULL PRIMARY KEY,
+    embedding      LONGBLOB NOT NULL,
+    embedding_dim  INT NOT NULL,
+    updated_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    CONSTRAINT fk_note_embeddings_note FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE
+);
+
+CREATE TABLE note_embedding_meta (
+    note_id         VARCHAR(36) NOT NULL PRIMARY KEY,
+    content_hash    CHAR(64) NOT NULL,
+    embedded_at     DATETIME(3) NOT NULL,
+    model_version   VARCHAR(255) NOT NULL,
+    embedding_dim   INT NOT NULL,
+    extension_state VARCHAR(64) NOT NULL DEFAULT 'pending',
+    CONSTRAINT fk_note_embedding_meta_note FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_note_embedding_meta_model_version
+    ON note_embedding_meta(model_version);
+CREATE INDEX idx_note_embedding_meta_embedded_at
+    ON note_embedding_meta(embedded_at DESC);
+
+CREATE TABLE note_links (
+    source_note_id       VARCHAR(36) NOT NULL,
+    target_permalink_raw VARCHAR(255) NOT NULL,
+    target_note_id       VARCHAR(36) NULL,
+    raw_text             TEXT NOT NULL,
+    occurrence_index     INT NOT NULL,
+    created_at           DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (source_note_id, occurrence_index),
+    CONSTRAINT fk_note_links_source FOREIGN KEY (source_note_id) REFERENCES notes(id) ON DELETE CASCADE,
+    CONSTRAINT fk_note_links_target FOREIGN KEY (target_note_id) REFERENCES notes(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_note_links_source ON note_links(source_note_id);
+CREATE INDEX idx_note_links_target ON note_links(target_note_id);
+CREATE INDEX idx_note_links_target_raw ON note_links(target_permalink_raw);
+
+CREATE TABLE sessions (
+    id         VARCHAR(36) NOT NULL PRIMARY KEY,
+    project_id VARCHAR(36) NOT NULL,
+    task_id    VARCHAR(36) NULL,
+    branch     VARCHAR(255) NOT NULL,
+    status     VARCHAR(64) NOT NULL,
+    started_at DATETIME(3) NOT NULL,
+    ended_at   DATETIME(3) NULL,
+    worker_id  VARCHAR(255) NULL,
+    metadata   LONGTEXT NULL,
+    title      TEXT NULL,
+    summary    LONGTEXT NULL,
+    prompt     LONGTEXT NULL,
+    response   LONGTEXT NULL,
+    paused     BOOLEAN NOT NULL DEFAULT FALSE,
+    compacted  BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT fk_sessions_project FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sessions_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_sessions_project_id ON sessions(project_id);
+CREATE INDEX idx_sessions_task_id ON sessions(task_id);
+CREATE INDEX idx_sessions_status ON sessions(status);
+
+CREATE TABLE task_memory_refs (
+    task_id     VARCHAR(36) NOT NULL,
+    note_id     VARCHAR(36) NOT NULL,
+    relation    VARCHAR(64) NOT NULL DEFAULT 'context',
+    created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (task_id, note_id),
+    CONSTRAINT fk_task_memory_refs_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_task_memory_refs_note FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_task_memory_refs_note_id ON task_memory_refs(note_id);
+
+CREATE TABLE epic_memory_refs (
+    task_id     VARCHAR(36) NOT NULL,
+    note_id     VARCHAR(36) NOT NULL,
+    relation    VARCHAR(64) NOT NULL DEFAULT 'context',
+    created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (task_id, note_id),
+    CONSTRAINT fk_epic_memory_refs_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_epic_memory_refs_note FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_epic_memory_refs_note_id ON epic_memory_refs(note_id);
+
+CREATE TABLE session_messages (
+    id         VARCHAR(36) NOT NULL PRIMARY KEY,
+    session_id VARCHAR(36) NOT NULL,
+    role       VARCHAR(64) NOT NULL,
+    content    LONGTEXT NOT NULL,
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    CONSTRAINT fk_session_messages_session FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_session_messages_session_id_created_at
+    ON session_messages(session_id, created_at);
+
+CREATE TABLE note_associations (
+    note_a_id       VARCHAR(36) NOT NULL,
+    note_b_id       VARCHAR(36) NOT NULL,
+    weight          DOUBLE NOT NULL DEFAULT 0.01,
+    co_access_count BIGINT NOT NULL DEFAULT 1,
+    last_co_access  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (note_a_id, note_b_id),
+    CONSTRAINT fk_note_associations_a FOREIGN KEY (note_a_id) REFERENCES notes(id) ON DELETE CASCADE,
+    CONSTRAINT fk_note_associations_b FOREIGN KEY (note_b_id) REFERENCES notes(id) ON DELETE CASCADE,
+    CONSTRAINT chk_note_association_order CHECK (note_a_id < note_b_id)
+);
+
+CREATE INDEX idx_note_associations_a ON note_associations(note_a_id);
+CREATE INDEX idx_note_associations_b ON note_associations(note_b_id);
+CREATE INDEX idx_note_associations_weight ON note_associations(weight);
+
+CREATE TABLE consolidated_note_provenance (
+    note_id    VARCHAR(36) NOT NULL,
+    session_id VARCHAR(36) NOT NULL,
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (note_id, session_id),
+    CONSTRAINT fk_consolidated_note_provenance_note FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE,
+    CONSTRAINT fk_consolidated_note_provenance_session FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_consolidated_note_provenance_session_id
+    ON consolidated_note_provenance(session_id);
+
+CREATE TABLE consolidation_run_metrics (
+    id                         VARCHAR(36) NOT NULL PRIMARY KEY,
+    project_id                 VARCHAR(36) NOT NULL,
+    note_type                  VARCHAR(64) NOT NULL,
+    status                     VARCHAR(64) NOT NULL,
+    scanned_note_count         INT NOT NULL,
+    candidate_cluster_count    INT NOT NULL,
+    consolidated_cluster_count INT NOT NULL,
+    consolidated_note_count    INT NOT NULL,
+    source_note_count          INT NOT NULL,
+    started_at                 DATETIME(3) NOT NULL,
+    completed_at               DATETIME(3) NULL,
+    error_message              LONGTEXT NULL,
+    CONSTRAINT fk_consolidation_metrics_project FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_consolidation_run_metrics_project_note_type_started_at
+    ON consolidation_run_metrics(project_id, note_type, started_at DESC);

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -18,6 +18,9 @@ pub use database::{
     default_db_path,
 };
 pub use error::{DbError as Error, DbResult as Result};
+pub use migrations::{
+    mysql_notes_fulltext_prototype, mysql_schema_snapshot, sqlite_schema_snapshot,
+};
 pub use repositories::{
     agent::{
         AgentCreateInput, AgentListQuery, AgentListResult, AgentMetrics, AgentRepository,

--- a/server/crates/djinn-db/src/migrations.rs
+++ b/server/crates/djinn-db/src/migrations.rs
@@ -6,6 +6,11 @@ mod embedded {
     embed_migrations!("migrations");
 }
 
+const SQLITE_SCHEMA_SNAPSHOT: &str = include_str!("../schema.sql");
+const MYSQL_SCHEMA_SNAPSHOT: &str = include_str!("../sql/mysql_schema.sql");
+const MYSQL_NOTES_FULLTEXT_PROTOTYPE: &str =
+    include_str!("../sql/mysql_notes_fulltext_prototype.sql");
+
 /// Run migrations using refinery's built-in rusqlite runner.
 ///
 /// Refinery handles checksum validation (rejects modified migrations) and
@@ -14,6 +19,24 @@ pub fn run(path: &Path) -> Result<(), Box<dyn std::error::Error + Send + Sync>> 
     let mut conn = rusqlite::Connection::open(path)?;
     embedded::migrations::runner().run(&mut conn)?;
     Ok(())
+}
+
+/// Return the canonical SQLite schema snapshot used by the current runtime.
+pub fn sqlite_schema_snapshot() -> &'static str {
+    SQLITE_SCHEMA_SNAPSHOT
+}
+
+/// Return the staged Dolt/MySQL schema snapshot for ADR-055 note/task/session state.
+///
+/// This artifact is intentionally separate from the embedded SQLite refinery migrations so the
+/// existing SQLite runtime remains selectable while the MySQL/Dolt migration path is explicit.
+pub fn mysql_schema_snapshot() -> &'static str {
+    MYSQL_SCHEMA_SNAPSHOT
+}
+
+/// Return the reference MySQL FULLTEXT query prototype paired with the staged schema snapshot.
+pub fn mysql_notes_fulltext_prototype() -> &'static str {
+    MYSQL_NOTES_FULLTEXT_PROTOTYPE
 }
 
 /// Return the embedded migration list (version, name, checksum) for testing.
@@ -49,4 +72,36 @@ pub(crate) fn run_until(
         .set_target(refinery::Target::Version(stop_version))
         .run(&mut conn)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mysql_notes_fulltext_prototype, mysql_schema_snapshot, sqlite_schema_snapshot};
+
+    #[test]
+    fn sqlite_snapshot_retains_sqlite_specific_search_structures() {
+        let schema = sqlite_schema_snapshot();
+        assert!(schema.contains("CREATE VIRTUAL TABLE notes_fts USING fts5"));
+        assert!(schema.contains("CREATE TRIGGER notes_ai AFTER INSERT ON notes BEGIN"));
+    }
+
+    #[test]
+    fn mysql_snapshot_replaces_fts_shadow_table_with_fulltext_index() {
+        let schema = mysql_schema_snapshot();
+        assert!(schema.contains("ALTER TABLE notes ADD FULLTEXT KEY notes_ft"));
+        assert!(!schema.contains("CREATE VIRTUAL TABLE notes_fts USING fts5"));
+        assert!(!schema.contains("CREATE TRIGGER notes_ai AFTER INSERT ON notes BEGIN"));
+        assert!(!schema.contains("vec0("));
+    }
+
+    #[test]
+    fn mysql_artifacts_document_clear_parallel_cutover_path() {
+        let schema = mysql_schema_snapshot();
+        let prototype = mysql_notes_fulltext_prototype();
+
+        assert!(schema.contains("CREATE TABLE tasks"));
+        assert!(schema.contains("CREATE TABLE notes"));
+        assert!(schema.contains("CREATE TABLE sessions"));
+        assert!(prototype.contains("MATCH(n.title, n.content, n.tags) AGAINST"));
+    }
 }


### PR DESCRIPTION
## Summary
Port the relational schema and migration strategy from SQLite-specific DDL toward a Dolt/MySQL-compatible layout once the seam inventory, bootstrap seam, and FULLTEXT prototype have landed. Focus on the concrete tables and migrations needed for note/task/session state under ADR-055.

## Acceptance Criteria
- [x] A Dolt/MySQL-compatible schema and migration plan is implemented or scaffolded for the note/task tables needed by ADR-055, with concrete DDL or migration files in the server workspace.
- [x] SQLite-specific schema elements (FTS5 virtual tables, sqlite-vec tables, pragma-dependent assumptions, trigger-based sync) are either isolated behind backend-specific migrations or replaced with MySQL/Dolt-compatible equivalents.
- [x] Documentation or tests show how the existing SQLite path remains selectable while the Dolt/MySQL migration path can be exercised without ambiguity.

---
Djinn task: 1wdl