### PR TITLE
chore(gter): Audit existing extracted notes against ADR-054 taxonomy and template rules

### DIFF
--- a/server/crates/djinn-agent/src/extension/handlers.rs
+++ b/server/crates/djinn-agent/src/extension/handlers.rs
@@ -20,6 +20,7 @@ use djinn_mcp::tools::epic_ops::{EpicShowRequest, EpicTasksRequest, EpicUpdateDe
 use djinn_mcp::tools::memory_tools::{
     BrokenLinksParams as SharedMemoryBrokenLinksParams,
     BuildContextParams as SharedMemoryBuildContextParams, EditParams as SharedMemoryEditParams,
+    ExtractedAuditParams as SharedMemoryExtractedAuditParams,
     HealthParams as SharedMemoryHealthParams, ListParams as SharedMemoryListParams,
     OrphansParams as SharedMemoryOrphansParams, ReadParams as SharedMemoryReadParams,
     SearchParams as SharedMemorySearchParams, WriteParams as SharedMemoryWriteParams,
@@ -52,8 +53,9 @@ pub(crate) use code_intel::{
 };
 use memory_agent::{
     call_agent_amend_prompt, call_agent_create, call_agent_metrics, call_memory_broken_links,
-    call_memory_build_context, call_memory_edit, call_memory_health, call_memory_list,
-    call_memory_move, call_memory_orphans, call_memory_read, call_memory_search, call_memory_write,
+    call_memory_build_context, call_memory_edit, call_memory_extracted_audit, call_memory_health,
+    call_memory_list, call_memory_move, call_memory_orphans, call_memory_read, call_memory_search,
+    call_memory_write,
 };
 use task_admin::{
     call_task_archive_activity, call_task_blocked_list, call_task_delete_branch,
@@ -174,6 +176,9 @@ where
         "memory_move" => call_memory_move(state, &call.arguments, &canonical_project_path).await,
         "memory_health" => {
             call_memory_health(state, &call.arguments, &canonical_project_path).await
+        }
+        "memory_extracted_audit" => {
+            call_memory_extracted_audit(state, &call.arguments, &canonical_project_path).await
         }
         "memory_broken_links" => {
             call_memory_broken_links(state, &call.arguments, &canonical_project_path).await

--- a/server/crates/djinn-agent/src/extension/handlers/memory_agent.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/memory_agent.rs
@@ -126,6 +126,26 @@ pub(super) async fn call_memory_health(
     ))
 }
 
+pub(super) async fn call_memory_extracted_audit(
+    state: &AgentContext,
+    _arguments: &Option<serde_json::Map<String, serde_json::Value>>,
+    project_path: &str,
+) -> Result<serde_json::Value, String> {
+    let server = djinn_mcp::server::DjinnMcpServer::new(state.to_mcp_state());
+    Ok(serde_json::to_value(
+        djinn_mcp::tools::memory_tools::ops::memory_extracted_audit(
+            &server,
+            SharedMemoryExtractedAuditParams {
+                project: project_path.to_owned(),
+            },
+        )
+        .await,
+    )
+    .unwrap_or_else(
+        |_| serde_json::json!({ "error": "failed to serialize memory_extracted_audit response" }),
+    ))
+}
+
 pub(super) async fn call_memory_write(
     state: &AgentContext,
     arguments: &Option<serde_json::Map<String, serde_json::Value>>,

--- a/server/crates/djinn-agent/src/extension/shared_schemas.rs
+++ b/server/crates/djinn-agent/src/extension/shared_schemas.rs
@@ -315,6 +315,17 @@ pub(crate) fn tool_memory_health() -> RmcpTool {
     )
 }
 
+pub(crate) fn tool_memory_extracted_audit() -> RmcpTool {
+    RmcpTool::new(
+        "memory_extracted_audit".to_string(),
+        "Audit existing extracted case/pattern/pitfall notes against ADR-054 taxonomy and required structure. Returns grouped cleanup backlogs for merge candidates, underspecified notes, demotion-to-working-spec candidates, and archive candidates, plus rerun guidance.".to_string(),
+        object!({
+            "type": "object",
+            "properties": {}
+        }),
+    )
+}
+
 pub(crate) fn tool_memory_broken_links() -> RmcpTool {
     RmcpTool::new(
         "memory_broken_links".to_string(),

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__architect_tool_names.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__architect_tool_names.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/djinn-agent/src/extension/tests/schema_snapshot_tests.rs
+assertion_line: 240
 expression: names
 ---
 [
@@ -30,6 +31,7 @@ expression: names
   "task_comment_add",
   "memory_build_context",
   "memory_health",
+  "memory_extracted_audit",
   "memory_broken_links",
   "memory_orphans",
   "agent_metrics",

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__architect_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__architect_tool_schemas.snap
@@ -899,6 +899,15 @@ expression: tool_schemas_architect()
   },
   {
     "concurrent_safe": true,
+    "description": "Audit existing extracted case/pattern/pitfall notes against ADR-054 taxonomy and required structure. Returns grouped cleanup backlogs for merge candidates, underspecified notes, demotion-to-working-spec candidates, and archive candidates, plus rerun guidance.",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "memory_extracted_audit"
+  },
+  {
+    "concurrent_safe": true,
     "description": "Lists all broken wikilinks with source context (permalink, title, raw text, target permalink).",
     "inputSchema": {
       "properties": {

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_names.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_names.snap
@@ -31,6 +31,7 @@ expression: names
   "memory_edit",
   "memory_build_context",
   "memory_health",
+  "memory_extracted_audit",
   "memory_broken_links",
   "memory_orphans",
   "agent_metrics",

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_schemas.snap
@@ -808,6 +808,15 @@ expression: tool_schemas_planner()
   },
   {
     "concurrent_safe": true,
+    "description": "Audit existing extracted case/pattern/pitfall notes against ADR-054 taxonomy and required structure. Returns grouped cleanup backlogs for merge candidates, underspecified notes, demotion-to-working-spec candidates, and archive candidates, plus rerun guidance.",
+    "inputSchema": {
+      "properties": {},
+      "type": "object"
+    },
+    "name": "memory_extracted_audit"
+  },
+  {
+    "concurrent_safe": true,
     "description": "Lists all broken wikilinks with source context (permalink, title, raw text, target permalink).",
     "inputSchema": {
       "properties": {

--- a/server/crates/djinn-agent/src/extension/tool_defs.rs
+++ b/server/crates/djinn-agent/src/extension/tool_defs.rs
@@ -607,6 +607,10 @@ pub(crate) fn tool_schemas_planner() -> Vec<serde_json::Value> {
     ));
     tool_values.push(serialize_tool(shared_schemas::tool_memory_health(), true));
     tool_values.push(serialize_tool(
+        shared_schemas::tool_memory_extracted_audit(),
+        true,
+    ));
+    tool_values.push(serialize_tool(
         shared_schemas::tool_memory_broken_links(),
         true,
     ));
@@ -660,6 +664,10 @@ pub(crate) fn tool_schemas_architect() -> Vec<serde_json::Value> {
         true,
     ));
     tool_values.push(serialize_tool(shared_schemas::tool_memory_health(), true));
+    tool_values.push(serialize_tool(
+        shared_schemas::tool_memory_extracted_audit(),
+        true,
+    ));
     tool_values.push(serialize_tool(
         shared_schemas::tool_memory_broken_links(),
         true,

--- a/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__architect_tools_section_snapshot.snap
+++ b/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__architect_tools_section_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/djinn-agent/src/prompts.rs
+assertion_line: 853
 expression: section
 ---
 - `task_show(id)` — Show details of a work item including recent activity and blockers.
@@ -29,6 +30,7 @@ expression: section
 - `task_comment_add(body, id)` — Add a comment or strategic observation to a task's activity log.
 - `memory_build_context(limit?, min_confidence?, query?, task_id?)` — Build a curated memory context pack for a task or query by combining note retrieval and ranking. Use this before deep analysis to gather relevant project history and decisions.
 - `memory_health()` — Returns aggregate health report: total notes, broken link count, orphan note count, duplicate cluster count, low-confidence note count, stale note count, stale notes by folder.
+- `memory_extracted_audit()` — Audit existing extracted case/pattern/pitfall notes against ADR-054 taxonomy and required structure. Returns grouped cleanup backlogs for merge candidates, underspecified notes, demotion-to-working-spec candidates, and archive candidates, plus rerun guidance.
 - `memory_broken_links(folder?)` — Lists all broken wikilinks with source context (permalink, title, raw text, target permalink).
 - `memory_orphans(folder?)` — Lists notes with zero inbound links. Excludes catalogs and singletons (brief, roadmap).
 - `agent_metrics(role)` — Show execution quality metrics for a role to support prompt tuning and intervention decisions.

--- a/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__planner_tools_section_snapshot.snap
+++ b/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__planner_tools_section_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/djinn-agent/src/prompts.rs
-assertion_line: 804
+assertion_line: 846
 expression: section
 ---
 - `task_show(id)` — Show details of a work item including recent activity and blockers.
@@ -30,6 +30,7 @@ expression: section
 - `memory_edit(content, identifier, operation, find_text?, section?, type?)` — Edit an existing note. Operations: "append" (add to end), "prepend" (add after frontmatter), "find_replace" (exact text replacement, requires find_text), "replace_section" (replace content under a markdown heading, requires section).
 - `memory_build_context(limit?, min_confidence?, query?, task_id?)` — Build a curated memory context pack for a task or query by combining note retrieval and ranking. Use this before deep analysis to gather relevant project history and decisions.
 - `memory_health()` — Returns aggregate health report: total notes, broken link count, orphan note count, duplicate cluster count, low-confidence note count, stale note count, stale notes by folder.
+- `memory_extracted_audit()` — Audit existing extracted case/pattern/pitfall notes against ADR-054 taxonomy and required structure. Returns grouped cleanup backlogs for merge candidates, underspecified notes, demotion-to-working-spec candidates, and archive candidates, plus rerun guidance.
 - `memory_broken_links(folder?)` — Lists all broken wikilinks with source context (permalink, title, raw text, target permalink).
 - `memory_orphans(folder?)` — Lists notes with zero inbound links. Excludes catalogs and singletons (brief, roadmap).
 - `agent_metrics(role)` — Show execution quality metrics for a role to support prompt tuning and intervention decisions.

--- a/server/crates/djinn-core/src/models/mod.rs
+++ b/server/crates/djinn-core/src/models/mod.rs
@@ -22,7 +22,8 @@ pub use credential::Credential;
 pub use epic::Epic;
 pub use git_settings::GitSettings;
 pub use note::{
-    BrokenLink, BrokenLinkRepair, BuildContextResponse, ContradictionCandidate, GitLogEntry,
+    BrokenLink, BrokenLinkRepair, BuildContextResponse, ContradictionCandidate,
+    ExtractedNoteAuditCategory, ExtractedNoteAuditFinding, ExtractedNoteAuditReport, GitLogEntry,
     GraphEdge, GraphNode, GraphResponse, HealthReport, Note, NoteAbstract, NoteCompact,
     NoteDedupCandidate, NoteOverview, NoteSearchResult, OrphanNote, ReindexSummary, StaleFolder,
     TypeRisk,

--- a/server/crates/djinn-core/src/models/note.rs
+++ b/server/crates/djinn-core/src/models/note.rs
@@ -182,6 +182,40 @@ pub struct HealthReport {
     pub stale_notes_by_folder: Vec<StaleFolder>,
 }
 
+/// Classification assigned during ADR-054 extracted-note corpus audits.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtractedNoteAuditCategory {
+    MergeCandidate,
+    Underspecified,
+    DemoteToWorkingSpec,
+    ArchiveCandidate,
+}
+
+/// A single extracted note flagged by the ADR-054 audit.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct ExtractedNoteAuditFinding {
+    pub note_id: String,
+    pub permalink: String,
+    pub title: String,
+    pub note_type: String,
+    pub folder: String,
+    pub category: ExtractedNoteAuditCategory,
+    pub reasons: Vec<String>,
+    pub related_note_ids: Vec<String>,
+}
+
+/// Aggregate ADR-054 audit report for existing extracted notes.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct ExtractedNoteAuditReport {
+    pub scanned_note_count: i64,
+    pub merge_candidates: Vec<ExtractedNoteAuditFinding>,
+    pub underspecified: Vec<ExtractedNoteAuditFinding>,
+    pub demote_to_working_spec: Vec<ExtractedNoteAuditFinding>,
+    pub archive_candidates: Vec<ExtractedNoteAuditFinding>,
+    pub rerun_hint: String,
+}
+
 /// Stale-note count for one folder.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct StaleFolder {

--- a/server/crates/djinn-db/src/repositories/note/graph.rs
+++ b/server/crates/djinn-db/src/repositories/note/graph.rs
@@ -1,3 +1,7 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use djinn_core::models::{ExtractedNoteAuditCategory, ExtractedNoteAuditFinding};
+
 use super::*;
 use crate::repositories::note::{NoteConsolidationRepository, STALE_CITATION};
 
@@ -213,6 +217,204 @@ impl NoteRepository {
             stale_notes_by_folder,
         })
     }
+
+    /// ADR-054 corpus audit for existing extracted case/pattern/pitfall notes.
+    pub async fn extracted_note_audit(&self, project_id: &str) -> Result<ExtractedNoteAuditReport> {
+        self.db.ensure_initialized().await?;
+
+        let notes = sqlx::query_as::<_, Note>(
+            "SELECT id, project_id, permalink, title, file_path,
+                    storage, note_type, folder, tags, content,
+                    created_at, updated_at, last_accessed,
+                    access_count, confidence, abstract as abstract_, overview,
+                    scope_paths
+             FROM notes
+             WHERE project_id = ?1
+               AND note_type IN ('case', 'pattern', 'pitfall')
+             ORDER BY note_type, permalink",
+        )
+        .bind(project_id)
+        .fetch_all(self.db.pool())
+        .await?;
+
+        let mut merge_candidates = Vec::new();
+        let mut underspecified = Vec::new();
+        let mut demote_to_working_spec = Vec::new();
+        let mut archive_candidates = Vec::new();
+        let mut seen = BTreeSet::new();
+
+        let consolidation_repo = NoteConsolidationRepository::new(self.db.clone());
+        let mut cluster_by_note_id = BTreeMap::new();
+        for note_type in ["case", "pattern", "pitfall"] {
+            for cluster in consolidation_repo
+                .likely_duplicate_clusters(project_id, note_type)
+                .await?
+            {
+                let related = cluster
+                    .notes
+                    .iter()
+                    .map(|note| note.id.clone())
+                    .collect::<Vec<_>>();
+                for note in &cluster.notes {
+                    cluster_by_note_id.insert(note.id.clone(), related.clone());
+                }
+            }
+        }
+
+        for note in &notes {
+            if let Some(related_ids) = cluster_by_note_id.get(&note.id)
+                && seen.insert((note.id.clone(), "merge"))
+            {
+                merge_candidates.push(ExtractedNoteAuditFinding {
+                    note_id: note.id.clone(),
+                    permalink: note.permalink.clone(),
+                    title: note.title.clone(),
+                    note_type: note.note_type.clone(),
+                    folder: note.folder.clone(),
+                    category: ExtractedNoteAuditCategory::MergeCandidate,
+                    reasons: vec![format!(
+                        "Likely duplicate cluster with {} related notes; consolidate into a canonical {} note",
+                        related_ids.len().saturating_sub(1),
+                        note.note_type
+                    )],
+                    related_note_ids: related_ids
+                        .iter()
+                        .filter(|id| *id != &note.id)
+                        .cloned()
+                        .collect(),
+                });
+            }
+
+            let required_sections = required_sections(&note.note_type);
+            let missing_sections = missing_required_sections(&note.content, &required_sections);
+            let paragraph_count = note
+                .content
+                .split("\n\n")
+                .filter(|block| !block.trim().is_empty())
+                .count();
+            let content_len = note.content.trim().chars().count();
+            let has_footer_only_shape = note.content.contains("*Extracted from session ")
+                && paragraph_count <= 2
+                && missing_sections.len() == required_sections.len();
+            let looks_task_local = looks_task_local(&note.title, &note.content);
+            let is_orphan = !sqlx::query_scalar::<_, i64>(
+                "SELECT EXISTS(SELECT 1 FROM note_links WHERE target_id = ?1)",
+            )
+            .bind(&note.id)
+            .fetch_one(self.db.pool())
+            .await?
+                > 0;
+
+            if (!missing_sections.is_empty() || content_len < 220 || paragraph_count < 3)
+                && seen.insert((note.id.clone(), "underspecified"))
+            {
+                let mut reasons = Vec::new();
+                if !missing_sections.is_empty() {
+                    reasons.push(format!(
+                        "Missing ADR-054 required sections: {}",
+                        missing_sections.join(", ")
+                    ));
+                }
+                if content_len < 220 {
+                    reasons.push(format!(
+                        "Body is too short for durable memory ({content_len} chars)"
+                    ));
+                }
+                if paragraph_count < 3 {
+                    reasons.push(format!(
+                        "Body has only {paragraph_count} paragraph(s); strengthen with explicit context, rationale, and transfer lesson"
+                    ));
+                }
+                underspecified.push(ExtractedNoteAuditFinding {
+                    note_id: note.id.clone(),
+                    permalink: note.permalink.clone(),
+                    title: note.title.clone(),
+                    note_type: note.note_type.clone(),
+                    folder: note.folder.clone(),
+                    category: ExtractedNoteAuditCategory::Underspecified,
+                    reasons,
+                    related_note_ids: cluster_by_note_id
+                        .get(&note.id)
+                        .into_iter()
+                        .flatten()
+                        .filter(|id| *id != &note.id)
+                        .cloned()
+                        .collect(),
+                });
+            }
+
+            if looks_task_local && seen.insert((note.id.clone(), "demote")) {
+                demote_to_working_spec.push(ExtractedNoteAuditFinding {
+                    note_id: note.id.clone(),
+                    permalink: note.permalink.clone(),
+                    title: note.title.clone(),
+                    note_type: note.note_type.clone(),
+                    folder: note.folder.clone(),
+                    category: ExtractedNoteAuditCategory::DemoteToWorkingSpec,
+                    reasons: vec![
+                        "Content reads as task/session-local working context rather than durable reusable knowledge"
+                            .to_string(),
+                        "Promote only if rewritten to explain the reusable lesson beyond the originating task"
+                            .to_string(),
+                    ],
+                    related_note_ids: cluster_by_note_id
+                        .get(&note.id)
+                        .into_iter()
+                        .flatten()
+                        .filter(|id| *id != &note.id)
+                        .cloned()
+                        .collect(),
+                });
+            }
+
+            if (has_footer_only_shape || (is_orphan && note.confidence <= STALE_CITATION))
+                && seen.insert((note.id.clone(), "archive"))
+            {
+                let mut reasons = Vec::new();
+                if has_footer_only_shape {
+                    reasons.push(
+                        "Note is essentially a single extracted paragraph plus provenance footer; archive unless strengthened or merged"
+                            .to_string(),
+                    );
+                }
+                if is_orphan {
+                    reasons.push("No inbound wikilinks; currently disconnected from the durable knowledge graph".to_string());
+                }
+                if note.confidence <= STALE_CITATION {
+                    reasons.push(format!(
+                        "Low confidence ({:.2}) suggests stale or weak durable value",
+                        note.confidence
+                    ));
+                }
+                archive_candidates.push(ExtractedNoteAuditFinding {
+                    note_id: note.id.clone(),
+                    permalink: note.permalink.clone(),
+                    title: note.title.clone(),
+                    note_type: note.note_type.clone(),
+                    folder: note.folder.clone(),
+                    category: ExtractedNoteAuditCategory::ArchiveCandidate,
+                    reasons,
+                    related_note_ids: cluster_by_note_id
+                        .get(&note.id)
+                        .into_iter()
+                        .flatten()
+                        .filter(|id| *id != &note.id)
+                        .cloned()
+                        .collect(),
+                });
+            }
+        }
+
+        Ok(ExtractedNoteAuditReport {
+            scanned_note_count: notes.len() as i64,
+            merge_candidates,
+            underspecified,
+            demote_to_working_spec,
+            archive_candidates,
+            rerun_hint: "Rerun `memory_extracted_audit()` after cleanup and compare category counts to measure the remaining ADR-054 migration backlog.".to_string(),
+        })
+    }
+
     async fn note_id_by_permalink(
         &self,
         project_id: &str,
@@ -377,4 +579,62 @@ impl NoteRepository {
 
         Ok(ranked)
     }
+}
+
+fn required_sections(note_type: &str) -> Vec<&'static str> {
+    match note_type {
+        "pattern" => vec![
+            "Context",
+            "Problem shape",
+            "Recommended approach",
+            "Why it works",
+            "Tradeoffs / limits",
+            "When to use",
+            "When not to use",
+            "Related",
+        ],
+        "pitfall" => vec![
+            "Trigger / smell",
+            "Failure mode",
+            "Observable symptoms",
+            "Prevention",
+            "Recovery",
+            "Related",
+        ],
+        "case" => vec![
+            "Situation",
+            "Constraint",
+            "Approach taken",
+            "Result",
+            "Why it worked / failed",
+            "Reusable lesson",
+            "Related",
+        ],
+        _ => vec![],
+    }
+}
+
+fn missing_required_sections(content: &str, required_sections: &[&str]) -> Vec<String> {
+    required_sections
+        .iter()
+        .filter(|section| !content.contains(&format!("## {section}")))
+        .map(|section| section.to_string())
+        .collect()
+}
+
+fn looks_task_local(title: &str, content: &str) -> bool {
+    let haystack = format!("{}\n{}", title.to_lowercase(), content.to_lowercase());
+    [
+        "this session",
+        "current task",
+        "working note",
+        "working spec",
+        "follow-up work",
+        "could not be updated from this session",
+        "drafted locally",
+        "active follow-up work",
+        "next session",
+    ]
+    .iter()
+    .any(|needle| haystack.contains(needle))
 }

--- a/server/crates/djinn-db/src/repositories/note/mod.rs
+++ b/server/crates/djinn-db/src/repositories/note/mod.rs
@@ -5,8 +5,8 @@ use sqlx::Sqlite;
 
 use djinn_core::events::{DjinnEventEnvelope, EventBus};
 use djinn_core::models::{
-    BrokenLink, GraphEdge, GraphNode, GraphResponse, HealthReport, Note, NoteCompact,
-    NoteSearchResult, OrphanNote, ReindexSummary, StaleFolder,
+    BrokenLink, ExtractedNoteAuditReport, GraphEdge, GraphNode, GraphResponse, HealthReport, Note,
+    NoteCompact, NoteSearchResult, OrphanNote, ReindexSummary, StaleFolder,
 };
 use std::sync::Arc;
 

--- a/server/crates/djinn-db/src/repositories/note/tests/wikilink_graph.rs
+++ b/server/crates/djinn-db/src/repositories/note/tests/wikilink_graph.rs
@@ -220,6 +220,110 @@ async fn orphan_detection_excludes_singletons_and_catalog_from_listing_and_healt
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extracted_note_audit_groups_merge_strengthen_demote_and_archive_backlogs() {
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db.clone(), event_bus_for(&tx));
+
+    let merge_a = repo
+        .create_db_note(
+            &project.id,
+            "Schema seam prerequisite check",
+            "Verify the prerequisite seam exists before wiring the schema seam. prerequisite seam schema seam check duplication clustering deterministic query api stable ordering repeated tokens cross note match alpha beta gamma",
+            "pattern",
+            "[]",
+        )
+        .await
+        .unwrap();
+    let merge_b = repo
+        .create_db_note(
+            &project.id,
+            "Verify prerequisite seam before schema wiring",
+            "Always verify the prerequisite seam exists before wiring the schema seam. prerequisite seam schema seam check duplication clustering deterministic query api stable ordering repeated tokens cross note match alpha beta gamma",
+            "pattern",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+    for note in [&merge_a, &merge_b] {
+        let abstract_text = format!(
+            "{} prerequisite seam schema seam check duplication clustering deterministic query api stable ordering repeated tokens cross note match alpha beta gamma",
+            note.title
+        );
+        sqlx::query(
+            "UPDATE notes
+             SET abstract = ?2,
+                 overview = ?3
+             WHERE id = ?1",
+        )
+        .bind(&note.id)
+        .bind(&abstract_text)
+        .bind(&abstract_text)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    }
+
+    let underspecified = repo
+        .create_db_note(
+            &project.id,
+            "Underspecified pattern note",
+            "A short note with no template sections.",
+            "pattern",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+    let demote = repo
+        .create_db_note(
+            &project.id,
+            "Current task roadmap note",
+            "This session captured the current task status and drafted locally what to do next session if follow-up work remains.",
+            "case",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+    let archive = repo
+        .create_db_note(
+            &project.id,
+            "Footer-only extracted note",
+            "Single paragraph extracted note.\n\n---\n*Extracted from session 123. Confidence: 0.2 (session-extracted).*",
+            "pitfall",
+            "[]",
+        )
+        .await
+        .unwrap();
+    repo.set_confidence(&archive.id, 0.2).await.unwrap();
+
+    let report = repo.extracted_note_audit(&project.id).await.unwrap();
+
+    assert_eq!(report.scanned_note_count, 5);
+    assert!(report.rerun_hint.contains("Rerun `memory_extracted_audit()`"));
+    assert!(report
+        .merge_candidates
+        .iter()
+        .any(|finding| finding.note_id == merge_a.id && finding.related_note_ids.contains(&merge_b.id)));
+    assert!(report
+        .underspecified
+        .iter()
+        .any(|finding| finding.note_id == underspecified.id));
+    assert!(report
+        .demote_to_working_spec
+        .iter()
+        .any(|finding| finding.note_id == demote.id));
+    assert!(report
+        .archive_candidates
+        .iter()
+        .any(|finding| finding.note_id == archive.id));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn resolve_previously_broken_links_on_create() {
     let tmp = crate::database::test_tempdir().unwrap();
     let db = Database::open_in_memory().unwrap();

--- a/server/crates/djinn-mcp/src/dispatch.rs
+++ b/server/crates/djinn-mcp/src/dispatch.rs
@@ -19,9 +19,9 @@ use crate::tools::github_tools::{GithubFetchFileParams, GithubSearchParams};
 use crate::tools::graph_tools::CodeGraphParams;
 use crate::tools::memory_tools::{
     AssociationsParams, BrokenLinksParams, BuildContextParams, CatalogParams, DeleteParams,
-    DiffParams, EditParams, GraphParams, HealthParams, HistoryParams, ListParams,
-    MemoryConfirmParams, MoveParams, OrphansParams, ReadParams, RecentParams, ReindexParams,
-    SearchParams, TaskRefsParams, WriteParams,
+    DiffParams, EditParams, ExtractedAuditParams, GraphParams, HealthParams, HistoryParams,
+    ListParams, MemoryConfirmParams, MoveParams, OrphansParams, ReadParams, RecentParams,
+    ReindexParams, SearchParams, TaskRefsParams, WriteParams,
 };
 use crate::tools::project_tools::{
     ProjectAddParams, ProjectConfigGetParams, ProjectConfigSetParams, ProjectRemoveParams,
@@ -394,6 +394,13 @@ impl DjinnMcpServer {
                 name,
                 self.memory_health(Parameters(decode_args::<HealthParams>(name, args)?))
                     .await,
+            ),
+            "memory_extracted_audit" => map_json(
+                name,
+                self.memory_extracted_audit(Parameters(decode_args::<ExtractedAuditParams>(
+                    name, args,
+                )?))
+                .await,
             ),
             "memory_recent" => map_json(
                 name,

--- a/server/crates/djinn-mcp/src/tools/memory_tools/ops.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/ops.rs
@@ -4,14 +4,58 @@ use djinn_db::{NoteRepository, ProjectRepository};
 use crate::server::DjinnMcpServer;
 
 use super::{
-    BrokenLinksParams, BuildContextParams, HealthParams, ListParams, MemoryBrokenLinksResponse,
-    MemoryBuildContextResponse, MemoryHealthResponse, MemoryListResponse, MemoryNoteResponse,
-    MemoryOrphansResponse, MemorySearchResponse, MemorySearchResultItem, OrphansParams, ReadParams,
-    SearchParams, note_to_view,
+    BrokenLinksParams, BuildContextParams, ExtractedAuditParams, HealthParams, ListParams,
+    MemoryBrokenLinksResponse, MemoryBuildContextResponse, MemoryExtractedAuditResponse,
+    MemoryHealthResponse, MemoryListResponse, MemoryNoteResponse, MemoryOrphansResponse,
+    MemorySearchResponse, MemorySearchResultItem, OrphansParams, ReadParams, SearchParams,
+    note_to_view,
 };
 
 fn normalize_folder_filter(folder: Option<String>) -> Option<String> {
     folder.filter(|value| !value.is_empty())
+}
+
+pub async fn memory_extracted_audit(
+    server: &DjinnMcpServer,
+    p: ExtractedAuditParams,
+) -> MemoryExtractedAuditResponse {
+    let project_id = match resolve_project_id(server, &p.project).await {
+        Ok(id) => id,
+        Err(error) => {
+            return MemoryExtractedAuditResponse {
+                scanned_note_count: None,
+                merge_candidates: None,
+                underspecified: None,
+                demote_to_working_spec: None,
+                archive_candidates: None,
+                rerun_hint: None,
+                error: Some(error),
+            };
+        }
+    };
+
+    let repo = NoteRepository::new(server.state.db().clone(), server.state.event_bus())
+        .with_vector_store(server.state.vector_store());
+    match repo.extracted_note_audit(&project_id).await {
+        Ok(report) => MemoryExtractedAuditResponse {
+            scanned_note_count: Some(report.scanned_note_count),
+            merge_candidates: Some(report.merge_candidates),
+            underspecified: Some(report.underspecified),
+            demote_to_working_spec: Some(report.demote_to_working_spec),
+            archive_candidates: Some(report.archive_candidates),
+            rerun_hint: Some(report.rerun_hint),
+            error: None,
+        },
+        Err(error) => MemoryExtractedAuditResponse {
+            scanned_note_count: None,
+            merge_candidates: None,
+            underspecified: None,
+            demote_to_working_spec: None,
+            archive_candidates: None,
+            rerun_hint: None,
+            error: Some(error.to_string()),
+        },
+    }
 }
 
 pub async fn resolve_project_id(server: &DjinnMcpServer, project: &str) -> Result<String, String> {

--- a/server/crates/djinn-mcp/src/tools/memory_tools/reads.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/reads.rs
@@ -112,6 +112,19 @@ impl DjinnMcpServer {
         }
     }
 
+    /// Audit existing extracted case/pattern/pitfall notes against ADR-054
+    /// taxonomy and template expectations. Output is grouped into merge,
+    /// strengthening, demotion, and archive backlogs so cleanup can be rerun.
+    #[tool(
+        description = "Audit existing extracted case/pattern/pitfall notes against ADR-054 taxonomy and template expectations. Returns grouped cleanup backlogs for merge candidates, underspecified notes, demotion-to-working-spec candidates, and archive candidates, plus rerun guidance."
+    )]
+    pub async fn memory_extracted_audit(
+        &self,
+        Parameters(params): Parameters<ExtractedAuditParams>,
+    ) -> Json<MemoryExtractedAuditResponse> {
+        Json(ops::memory_extracted_audit(self, params).await)
+    }
+
     /// List recently updated notes by timeframe (e.g., '7d', '24h', 'today').
     /// Returns compact summaries.
     #[tool(

--- a/server/crates/djinn-mcp/src/tools/memory_tools/types.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/types.rs
@@ -109,6 +109,11 @@ pub struct HealthParams {
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
+pub struct ExtractedAuditParams {
+    pub project: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
 pub struct CatalogParams {
     pub project: String,
 }
@@ -208,6 +213,17 @@ pub struct MemoryAssociationEntry {
 #[derive(Serialize, schemars::JsonSchema)]
 pub struct MemoryAssociationsResponse {
     pub associations: Vec<MemoryAssociationEntry>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub struct MemoryExtractedAuditResponse {
+    pub scanned_note_count: Option<i64>,
+    pub merge_candidates: Option<Vec<djinn_core::models::ExtractedNoteAuditFinding>>,
+    pub underspecified: Option<Vec<djinn_core::models::ExtractedNoteAuditFinding>>,
+    pub demote_to_working_spec: Option<Vec<djinn_core::models::ExtractedNoteAuditFinding>>,
+    pub archive_candidates: Option<Vec<djinn_core::models::ExtractedNoteAuditFinding>>,
+    pub rerun_hint: Option<String>,
     pub error: Option<String>,
 }
 

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -3045,6 +3045,128 @@ expression: signatures
       "required": [
         "project"
       ],
+      "title": "ExtractedAuditParams",
+      "type": "object"
+    },
+    "name": "memory_extracted_audit",
+    "output_schema": {
+      "$defs": {
+        "ExtractedNoteAuditCategory": {
+          "description": "Classification assigned during ADR-054 extracted-note corpus audits.",
+          "enum": [
+            "merge_candidate",
+            "underspecified",
+            "demote_to_working_spec",
+            "archive_candidate"
+          ],
+          "type": "string"
+        },
+        "ExtractedNoteAuditFinding": {
+          "description": "A single extracted note flagged by the ADR-054 audit.",
+          "properties": {
+            "category": {
+              "$ref": "#/$defs/ExtractedNoteAuditCategory"
+            },
+            "folder": {
+              "type": "string"
+            },
+            "note_id": {
+              "type": "string"
+            },
+            "note_type": {
+              "type": "string"
+            },
+            "permalink": {
+              "type": "string"
+            },
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "related_note_ids": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "note_id",
+            "permalink",
+            "title",
+            "note_type",
+            "folder",
+            "category",
+            "reasons",
+            "related_note_ids"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "archive_candidates": {
+          "items": {
+            "$ref": "#/$defs/ExtractedNoteAuditFinding"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "demote_to_working_spec": {
+          "items": {
+            "$ref": "#/$defs/ExtractedNoteAuditFinding"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "error": {
+          "nullable": true,
+          "type": "string"
+        },
+        "merge_candidates": {
+          "items": {
+            "$ref": "#/$defs/ExtractedNoteAuditFinding"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "rerun_hint": {
+          "nullable": true,
+          "type": "string"
+        },
+        "scanned_note_count": {
+          "format": "int64",
+          "nullable": true,
+          "type": "integer"
+        },
+        "underspecified": {
+          "items": {
+            "$ref": "#/$defs/ExtractedNoteAuditFinding"
+          },
+          "nullable": true,
+          "type": "array"
+        }
+      },
+      "title": "MemoryExtractedAuditResponse",
+      "type": "object"
+    }
+  },
+  {
+    "input_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "project": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "project"
+      ],
       "title": "GraphParams",
       "type": "object"
     },


### PR DESCRIPTION
## Summary
After the new extraction policy is implemented, audit the current pattern/pitfall/case corpus for notes that violate the stricter taxonomy or template expectations. Produce a concrete migration/cleanup pass that identifies which notes should be merged, strengthened, demoted, or archived.

## Acceptance Criteria
- [x] The repository gains a repeatable audit path that identifies existing pattern/pitfall/case notes violating ADR-054 taxonomy or required structure
- [x] The audit output distinguishes likely merge candidates, underspecified notes, and notes that should be demoted or archived
- [x] The task documents or encodes how the audit can be rerun after cleanup to measure remaining backlog

---
Djinn task: gter