### PR TITLE
chore(7941): Wire task-session lifecycle to branch-aware knowledge storage seams

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/llm_extraction.rs
+++ b/server/crates/djinn-agent/src/actors/slot/llm_extraction.rs
@@ -25,7 +25,7 @@ use djinn_provider::{CompletionRequest, complete, resolve_memory_provider};
 use serde::Deserialize;
 
 use super::session_extraction::SessionTaxonomy;
-use crate::context::AgentContext;
+use crate::context::{AgentContext, KnowledgeBranchTarget};
 
 // ── Prompt constants ──────────────────────────────────────────────────────────
 
@@ -82,6 +82,45 @@ struct ExtractedNote {
     content: String,
     #[serde(default)]
     scope_paths: Vec<String>,
+}
+
+impl ExtractionContext<'_> {
+    async fn create_extracted_note(
+        &self,
+        title: &str,
+        content: &str,
+        note_type: &str,
+        scope_paths_json: &str,
+    ) -> djinn_db::Result<djinn_core::models::Note> {
+        match self.knowledge_branch_target {
+            KnowledgeBranchTarget::Main => {
+                self.note_repo
+                    .create_db_note_with_scope(
+                        self.project_id,
+                        title,
+                        content,
+                        note_type,
+                        "[]",
+                        scope_paths_json,
+                    )
+                    .await
+            }
+            KnowledgeBranchTarget::TaskScoped { .. } => {
+                self.note_repo
+                    .create_with_scope(
+                        self.project_id,
+                        Path::new(self.project_path),
+                        title,
+                        content,
+                        note_type,
+                        None,
+                        "[]",
+                        scope_paths_json,
+                    )
+                    .await
+            }
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -149,6 +188,7 @@ struct ExtractionContext<'a> {
     provider: &'a dyn LlmProvider,
     project_id: &'a str,
     project_path: &'a str,
+    knowledge_branch_target: &'a KnowledgeBranchTarget,
     session_id: &'a str,
     task_short_id: &'a str,
     task_title: &'a str,
@@ -469,7 +509,20 @@ async fn run_llm_extraction_inner(
     );
 
     // ── Write notes ────────────────────────────────────────────────────────
-    let note_repo = NoteRepository::new(app_state.db.clone(), app_state.event_bus.clone());
+    let knowledge_branch_target = app_state
+        .knowledge_branch_target_for(Path::new(project_path), session.worktree_path.as_deref());
+    tracing::debug!(
+        session_id = %session_id,
+        knowledge_branch_target = %knowledge_branch_target.intent_label(),
+        worktree_root = ?knowledge_branch_target.worktree_root(),
+        "llm_extraction: resolved knowledge write target"
+    );
+    let note_repo = NoteRepository::new(app_state.db.clone(), app_state.event_bus.clone())
+        .with_worktree_root(
+            knowledge_branch_target
+                .worktree_root()
+                .map(Path::to_path_buf),
+        );
     let provenance = format!(
         "\n\n---\n*Extracted from session {session_id}. Confidence: 0.5 (session-extracted).*"
     );
@@ -486,6 +539,7 @@ async fn run_llm_extraction_inner(
         provider: provider.as_ref(),
         project_id: &project.id,
         project_path: &project.path,
+        knowledge_branch_target: &knowledge_branch_target,
         session_id: &session_id,
         task_short_id: &task.short_id,
         task_title: &task.title,
@@ -634,13 +688,10 @@ async fn process_extracted_note(
     };
     let scope_paths_json = serde_json::to_string(&scope_paths).unwrap_or_else(|_| "[]".to_string());
     match extraction_context
-        .note_repo
-        .create_db_note_with_scope(
-            extraction_context.project_id,
+        .create_extracted_note(
             &note.title,
             &content_with_provenance,
             note_type,
-            "[]",
             &scope_paths_json,
         )
         .await

--- a/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/llm_extraction_tests.rs
@@ -34,6 +34,76 @@ fn make_tmpdir() -> TempDir {
     crate::test_helpers::test_tempdir("djinn-llm-extraction-")
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn llm_extraction_routes_durable_writes_into_task_worktree_when_session_has_one() {
+    let fixture = make_fixture().await;
+    let worktree_root = fixture
+        .tmpdir
+        .path()
+        .join(".djinn")
+        .join("worktrees")
+        .join("7941");
+    std::fs::create_dir_all(&worktree_root).expect("create worktree root");
+    set_session_worktree_path(&fixture, &worktree_root).await;
+
+    let ctx = agent_context_from_db(fixture.db.clone(), fixture.cancel.clone());
+    let taxonomy = SessionTaxonomy {
+        files_changed: 3,
+        errors: 2,
+        tools_used: 6,
+        notes_read: 1,
+        notes_written: 2,
+        tasks_transitioned: 1,
+        ..SessionTaxonomy::default()
+    };
+
+    let provider = fake_extraction_provider();
+    run_llm_extraction_with_provider(fixture.session_id.clone(), taxonomy, ctx, provider).await;
+
+    let note_repo = NoteRepository::new(fixture.db.clone(), djinn_core::events::EventBus::noop())
+        .with_worktree_root(Some(worktree_root.clone()));
+    let all_notes = note_repo
+        .list(&fixture.project.id, None)
+        .await
+        .expect("list notes");
+
+    let case_note = all_notes
+        .iter()
+        .find(|note| note.note_type == "case")
+        .expect("case note created");
+    assert_eq!(case_note.storage, "file");
+    assert!(
+        case_note
+            .file_path
+            .ends_with(".djinn/cases/test-case-note.md")
+    );
+
+    assert!(
+        worktree_root
+            .join(".djinn/cases/test-case-note.md")
+            .exists()
+    );
+    assert!(
+        worktree_root
+            .join(".djinn/patterns/test-pattern-note.md")
+            .exists()
+    );
+    assert!(
+        worktree_root
+            .join(".djinn/pitfalls/test-pitfall-note.md")
+            .exists()
+    );
+}
+
+async fn set_session_worktree_path(fixture: &TestFixture, worktree_path: &std::path::Path) {
+    sqlx::query("UPDATE sessions SET worktree_path = ?1 WHERE id = ?2")
+        .bind(worktree_path.to_string_lossy().to_string())
+        .bind(&fixture.session_id)
+        .execute(fixture.db.pool())
+        .await
+        .expect("update session worktree_path");
+}
+
 static SEMANTIC_DUPLICATE_CANDIDATE_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
 fn semantic_duplicate_candidate_lookup(

--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -121,6 +121,28 @@ pub struct AgentContext {
     pub repo_graph_ops: Option<Arc<dyn RepoGraphOps>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KnowledgeBranchTarget {
+    Main,
+    TaskScoped { worktree_root: PathBuf },
+}
+
+impl KnowledgeBranchTarget {
+    pub fn worktree_root(&self) -> Option<&Path> {
+        match self {
+            Self::Main => None,
+            Self::TaskScoped { worktree_root } => Some(worktree_root.as_path()),
+        }
+    }
+
+    pub fn intent_label(&self) -> &'static str {
+        match self {
+            Self::Main => "main",
+            Self::TaskScoped { .. } => "task",
+        }
+    }
+}
+
 impl AgentContext {
     /// Returns the working root for code-reading tool dispatch (read, shell,
     /// lsp, code_graph).  When `working_root` is `Some` it takes precedence
@@ -130,6 +152,44 @@ impl AgentContext {
             Some(p) => p.to_path_buf(),
             None => fallback.to_path_buf(),
         }
+    }
+
+    /// Resolve the knowledge-write target for a session.
+    ///
+    /// Task sessions with a preserved worktree route note writes into that
+    /// task-scoped tree so extracted notes participate in the same promotion /
+    /// discard lifecycle as agent-authored memory mutations. Sessions without a
+    /// usable worktree fall back to canonical-main writes, preserving the
+    /// default SQLite-backed behavior for contexts that do not opt into
+    /// task-branch routing.
+    pub fn knowledge_branch_target_for(
+        &self,
+        project_root: &Path,
+        session_worktree_path: Option<&str>,
+    ) -> KnowledgeBranchTarget {
+        let Some(worktree_path) = session_worktree_path
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        else {
+            return KnowledgeBranchTarget::Main;
+        };
+
+        let worktree_root = PathBuf::from(worktree_path);
+        if worktree_root == project_root {
+            KnowledgeBranchTarget::Main
+        } else {
+            KnowledgeBranchTarget::TaskScoped { worktree_root }
+        }
+    }
+
+    pub fn knowledge_worktree_root_for(
+        &self,
+        project_root: &Path,
+        session_worktree_path: Option<&str>,
+    ) -> Option<PathBuf> {
+        self.knowledge_branch_target_for(project_root, session_worktree_path)
+            .worktree_root()
+            .map(Path::to_path_buf)
     }
 }
 


### PR DESCRIPTION
## Summary
Implement the runtime seam for per-task knowledge branches after the design contract exists. Most lifecycle hooks are already in place; the remaining work is to finish the session-scoped extraction/write routing so extracted-note persistence uses the same branch-target abstraction as agent-driven memory mutations without cutting over SQLite behavior.

## Acceptance Criteria
- [x] Coordinator/session code creates or prepares a task-specific Dolt branch lifecycle seam for dispatch, session startup, and task close/abandon paths, using concrete hook points verified in the current codebase.
- [x] Session-scoped note writes/extraction are routed through an abstraction that can target `main` vs `task_{id}` semantics without breaking current SQLite-backed behavior.
- [x] The implementation or scaffold clearly documents how branch creation, checkout/selection, and cleanup interact with existing worktree/session lifecycle code.

---
Djinn task: 7941