### PR TITLE
chore(wue6): Complete ADR-054 access-tracking coverage for MCP memory search/retrieval flows

### DIFF
--- a/server/crates/djinn-db/src/repositories/note/tests/wikilink_graph.rs
+++ b/server/crates/djinn-db/src/repositories/note/tests/wikilink_graph.rs
@@ -304,23 +304,36 @@ async fn extracted_note_audit_groups_merge_strengthen_demote_and_archive_backlog
     let report = repo.extracted_note_audit(&project.id).await.unwrap();
 
     assert_eq!(report.scanned_note_count, 5);
-    assert!(report.rerun_hint.contains("Rerun `memory_extracted_audit()`"));
-    assert!(report
-        .merge_candidates
-        .iter()
-        .any(|finding| finding.note_id == merge_a.id && finding.related_note_ids.contains(&merge_b.id)));
-    assert!(report
-        .underspecified
-        .iter()
-        .any(|finding| finding.note_id == underspecified.id));
-    assert!(report
-        .demote_to_working_spec
-        .iter()
-        .any(|finding| finding.note_id == demote.id));
-    assert!(report
-        .archive_candidates
-        .iter()
-        .any(|finding| finding.note_id == archive.id));
+    assert!(
+        report
+            .rerun_hint
+            .contains("Rerun `memory_extracted_audit()`")
+    );
+    assert!(
+        report
+            .merge_candidates
+            .iter()
+            .any(|finding| finding.note_id == merge_a.id
+                && finding.related_note_ids.contains(&merge_b.id))
+    );
+    assert!(
+        report
+            .underspecified
+            .iter()
+            .any(|finding| finding.note_id == underspecified.id)
+    );
+    assert!(
+        report
+            .demote_to_working_spec
+            .iter()
+            .any(|finding| finding.note_id == demote.id)
+    );
+    assert!(
+        report
+            .archive_candidates
+            .iter()
+            .any(|finding| finding.note_id == archive.id)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-mcp/src/tools/memory_tools/ops.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/ops.rs
@@ -15,6 +15,21 @@ fn normalize_folder_filter(folder: Option<String>) -> Option<String> {
     folder.filter(|value| !value.is_empty())
 }
 
+async fn record_retrieved_notes(
+    server: &DjinnMcpServer,
+    repo: &NoteRepository,
+    note_ids: &[String],
+) {
+    // ADR-054 retrieval boundary: notes returned to the MCP client count as accessed,
+    // even if the client does not issue a follow-up `memory_read`. This keeps search
+    // result retrieval flows visible to temporal/co-access scoring without touching
+    // notes that were only considered internally during ranking.
+    for note_id in note_ids {
+        let _ = repo.touch_accessed(note_id).await;
+        server.record_memory_read(note_id).await;
+    }
+}
+
 pub async fn memory_extracted_audit(
     server: &DjinnMcpServer,
     p: ExtractedAuditParams,
@@ -156,21 +171,27 @@ pub async fn memory_search(
         })
         .await
     {
-        Ok(results) => MemorySearchResponse {
-            results: results
-                .into_iter()
-                .map(|r| MemorySearchResultItem {
-                    id: r.id,
-                    permalink: r.permalink,
-                    title: r.title,
-                    folder: r.folder,
-                    note_type: r.note_type,
-                    snippet: r.snippet,
-                    score: r.score,
-                })
-                .collect(),
-            error: None,
-        },
+        Ok(results) => {
+            let retrieved_note_ids: Vec<String> =
+                results.iter().map(|result| result.id.clone()).collect();
+            record_retrieved_notes(server, &repo, &retrieved_note_ids).await;
+
+            MemorySearchResponse {
+                results: results
+                    .into_iter()
+                    .map(|r| MemorySearchResultItem {
+                        id: r.id,
+                        permalink: r.permalink,
+                        title: r.title,
+                        folder: r.folder,
+                        note_type: r.note_type,
+                        snippet: r.snippet,
+                        score: r.score,
+                    })
+                    .collect(),
+                error: None,
+            }
+        }
         Err(e) => MemorySearchResponse {
             results: vec![],
             error: Some(format!("search failed: {e}")),

--- a/server/crates/djinn-mcp/src/tools/memory_tools/ops_tests.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/ops_tests.rs
@@ -309,6 +309,99 @@ mod tests {
             response.error
         );
         assert!(!response.results.is_empty());
+
+        for result in &response.results {
+            let access_count =
+                access_count_for(&setup.server, &setup.project, &result.permalink).await;
+            assert_eq!(
+                access_count, 1,
+                "returned search results should count as accessed retrievals"
+            );
+        }
+
+        let recorded = setup.server.recorded_note_ids().await;
+        let returned_ids: Vec<String> = response
+            .results
+            .iter()
+            .map(|result| result.id.clone())
+            .collect();
+        assert_eq!(recorded, returned_ids);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_search_ops_flushes_co_access_for_returned_results_only() {
+        let setup = setup_server().await;
+        let project_id = ProjectRepository::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+        )
+        .resolve(&setup.project)
+        .await
+        .unwrap()
+        .expect("project id");
+        let repo = NoteRepository::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+        );
+        let hidden = repo
+            .create(
+                &project_id,
+                setup._tmp.path(),
+                "Hidden Note",
+                "completely unrelated content",
+                "reference",
+                "[]",
+            )
+            .await
+            .unwrap();
+
+        let response = ops::memory_search(
+            &setup.server,
+            SearchParams {
+                project: setup.project.clone(),
+                query: "architecture".to_string(),
+                folder: None,
+                note_type: None,
+                limit: Some(10),
+            },
+            None,
+        )
+        .await;
+
+        assert!(response.error.is_none(), "{:?}", response.error);
+        assert!(
+            response.results.len() >= 2,
+            "seed setup should return multiple results"
+        );
+
+        setup.server.flush_co_access_batch().await;
+
+        let associations = repo
+            .get_associations_for_note(&response.results[0].id)
+            .await
+            .unwrap();
+        assert!(
+            associations.iter().any(|association| {
+                let pair = [
+                    association.note_a_id.as_str(),
+                    association.note_b_id.as_str(),
+                ];
+                pair.contains(&response.results[0].id.as_str())
+                    && pair.contains(&response.results[1].id.as_str())
+            }),
+            "returned search results should become co-access associated"
+        );
+
+        assert_eq!(
+            access_count_for(&setup.server, &setup.project, &hidden.permalink).await,
+            0,
+            "notes not returned from search should not be touched"
+        );
+        let hidden_associations = repo.get_associations_for_note(&hidden.id).await.unwrap();
+        assert!(
+            hidden_associations.is_empty(),
+            "notes excluded from search results should not be co-access associated"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
Finish ADR-054 rollout for access signals by extending MCP memory retrieval flows beyond `memory_read`. The current code already touches and records reads in `memory_read`, but `memory_search` returns results without any corresponding access/co-access update. Define the intended semantics for search-result touches, implement them in the appropriate MCP memory tool path(s), and cover the behavior with tests.

## Acceptance Criteria
- [x] `server/crates/djinn-mcp/src/tools/memory_tools/ops.rs` updates access metadata and co-access tracking for the intended search/retrieval result flow(s) implicated by ADR-054
- [x] Tests cover the new access-tracking behavior without regressing existing memory read/search semantics
- [x] Implementation documents or encodes whether search touches only opened notes, returned top hits, or another explicitly chosen retrieval boundary

---
Djinn task: wue6