### PR TITLE
chore(pd8e): Repair ADR-054-related design and roadmap broken links with canonical targets

### DIFF
--- a/.djinn/design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy.md
+++ b/.djinn/design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy.md
@@ -64,5 +64,9 @@ Create focused worker tasks for:
 
 ## Relations
 - [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]
-- [[decisions/adr-053-semantic-memory-search-—-candle-embeddings-with-sqlite-vec]]
+- [[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]
 - [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
+
+## Link cleanup note
+- Repaired the stale ADR-053 permalink alias above to the canonical target `[[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]`.
+- Residual legacy title-alias debt in adjacent design notes was left to the narrower current-note cleanup pass unless a canonical target was unambiguous.

--- a/.djinn/design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy.md
+++ b/.djinn/design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy.md
@@ -63,14 +63,9 @@ Create focused worker tasks for:
 
 ## Relations
 - [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]
-<<<<<<< HEAD
 - [[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]
 - [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
 
 ## Link cleanup note
 - Repaired the stale ADR-053 permalink alias above to the canonical target `[[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]`.
 - Residual legacy title-alias debt in adjacent design notes was left to the narrower current-note cleanup pass unless a canonical target was unambiguous.
-=======
-- [[decisions/adr-053-semantic-memory-search-—-candle-embeddings-with-sqlite-vec]]
-- [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
->>>>>>> origin/main

--- a/.djinn/design/adr-056-roadmap-planner-driven-codebase-learning-and-memory-hygiene.md
+++ b/.djinn/design/adr-056-roadmap-planner-driven-codebase-learning-and-memory-hygiene.md
@@ -41,6 +41,6 @@ Satisfied. Planner patrol has first-class visibility into memory health and code
 
 ## Relations
 - [[decisions/adr-056-proposal-planner-driven-codebase-learning-and-memory-hygiene]]
-- [[ADR-051: Planner as Patrol and Architect as Consultant]]
-- [[ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy]]
-- [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]]
+- [[decisions/adr-051-planner-as-patrol-and-architect-as-consultant]]
+- [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]
+- [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]

--- a/.djinn/design/adr-057-roadmap-fuse-mounted-memory.md
+++ b/.djinn/design/adr-057-roadmap-fuse-mounted-memory.md
@@ -58,5 +58,9 @@ Goal: connect the filesystem view to task/session context and begin shrinking CR
 ## Relations
 - [[decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface]]
 - [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
-- [[decisions/adr-054-proposal-memory-extraction-quality-gates-and-note-taxonomy]]
+- [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]
 - [[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]
+
+## Link cleanup note
+- Normalized the stale ADR-054 roadmap/dependency alias to the canonical ADR permalink `[[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]`.
+- Remaining alias-debt cleanup outside confidently canonical current targets is intentionally left for broader memory-health follow-up work.

--- a/.djinn/design/epic-task-mcp-split-design.md
+++ b/.djinn/design/epic-task-mcp-split-design.md
@@ -463,4 +463,4 @@ These tools require no signature changes but gain input validation:
 
 ## Relations
 - [[decisions/adr-003-split-epic-and-task-mcp-tools-with-input-validation|ADR-003: Split Epic and Task MCP Tools with Input Validation]] — decision record
-- [[V1 Requirements]] — KANBAN and ROAD views consume these tools
+- [[requirements/v1-requirements]] — KANBAN and ROAD views consume these tools

--- a/.djinn/design/implement-adr-052-pulse-proposal-inbox-ask-architect-trigger-proposed-epic-lane-roadmap.md
+++ b/.djinn/design/implement-adr-052-pulse-proposal-inbox-ask-architect-trigger-proposed-epic-lane-roadmap.md
@@ -7,7 +7,7 @@ tags: ["adr-052","pulse","proposal-inbox","roadmap"]
 # Implement ADR-052: Pulse proposal inbox, ask-architect trigger, proposed epic lane — Roadmap
 
 ## Status
-Wave 1 implementation landed on main: Pulse now exposes the ask-architect entrypoint, proposal inbox/detail surface, accept/reject review actions, and sidebar badge/toast notification path. The plumbing dependency epic [[design/fix-proposal-pipeline-plumbing-defects-adr-052-defects-uncovered-roadmap]] is closed.
+Wave 1 implementation landed on main: Pulse now exposes the ask-architect entrypoint, proposal inbox/detail surface, accept/reject review actions, and sidebar badge/toast notification path. The plumbing dependency epic for proposal-pipeline defects uncovered during ADR-052 planning is closed.
 
 ## Planner decision: proposed epic lane
 For v1, use **Option C (hybrid projection)** from ADR-052.
@@ -49,7 +49,10 @@ Close the epic once:
 ## Relations
 - [[decisions/adr-052-pulse-proposal-inbox-ask-architect-trigger-and-virtual-proposed-epic-lane]]
 - [[decisions/adr-051-planner-as-patrol-and-architect-as-consultant]]
-- [[design/fix-proposal-pipeline-plumbing-defects-adr-052-defects-uncovered-roadmap]]
+
+## Link cleanup note
+- Removed the stale non-resolving `design/fix-proposal-pipeline-plumbing-defects-adr-052-defects-uncovered-roadmap` wikilink because no canonical design note with that permalink exists in the current knowledge base.
+- Left broader historical alias cleanup out of scope for this note; this pass only kept links with confidently canonical current targets.
 
 
 


### PR DESCRIPTION
## Summary
Repair the roadmap/design broken links surfaced during ADR-054 planning and memory-health review so the epic closes with consistent planning artifacts. Current `design/` broken links include a roadmap link and an ADR-title link; fix only the confidently canonical targets and document any residual alias debt left for broader cleanup work.

## Acceptance Criteria
- [x] Broken roadmap/design wikilinks identified during the ADR-054 planning sweep are repaired to canonical targets or removed if no canonical target exists
- [x] The touched design/roadmap notes remain internally consistent with current epic/ADR state after link cleanup
- [x] The task documents which broken links were fixed and any unresolved alias debt intentionally left out of scope

---
Djinn task: pd8e