### PR TITLE
chore(9f1v): Harden exact-permalink memory_read and design-folder listing semantics

### DIFF
--- a/server/crates/djinn-db/src/repositories/note/crud.rs
+++ b/server/crates/djinn-db/src/repositories/note/crud.rs
@@ -905,8 +905,21 @@ impl NoteRepository {
     /// human-supplied identifier that could be either a permalink slug or a
     /// (partial) title.
     pub async fn resolve(&self, project_id: &str, identifier: &str) -> Result<Option<Note>> {
-        if let Some(n) = self.get_by_permalink(project_id, identifier).await? {
-            return Ok(Some(n));
+        let trimmed = identifier.trim();
+        if !trimmed.is_empty() {
+            let without_scheme = trimmed.strip_prefix("memory://").unwrap_or(trimmed);
+            let normalized = normalize_virtual_note_path(without_scheme);
+            if !normalized.is_empty() {
+                if let Some(n) = self.get_by_permalink(project_id, &normalized).await? {
+                    return Ok(Some(n));
+                }
+                if let Some(permalink) = permalink_from_virtual_note_path(&normalized)
+                    && permalink != normalized
+                    && let Some(n) = self.get_by_permalink(project_id, &permalink).await?
+                {
+                    return Ok(Some(n));
+                }
+            }
         }
         let results = self
             .search(NoteSearchParams {

--- a/server/crates/djinn-db/src/repositories/note/tests/search_ranking.rs
+++ b/server/crates/djinn-db/src/repositories/note/tests/search_ranking.rs
@@ -291,6 +291,53 @@ async fn fts5_search_prefers_tags_over_content() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resolve_prefers_exact_permalink_before_title_search_fallback() {
+    let tmp = crate::database::test_tempdir().unwrap();
+    let db = Database::open_in_memory().unwrap();
+    let (tx, _rx) = broadcast::channel(256);
+    let project = make_project(&db, tmp.path()).await;
+    let repo = NoteRepository::new(db, event_bus_for(&tx));
+
+    let design = repo
+        .create_db_note_with_permalink(
+            &project.id,
+            "design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy",
+            "ADR-054 Roadmap Memory Extraction Quality Gates and Note Taxonomy",
+            "Canonical design note wins exact permalink resolution.",
+            "design",
+            "[]",
+        )
+        .await
+        .unwrap();
+
+    repo.create(
+        &project.id,
+        tmp.path(),
+        "ADR-054 Roadmap Memory Extraction Quality Gates and Note Taxonomy",
+        "Archived case note that would otherwise rank via title/content fallback.",
+        "case",
+        "[]",
+    )
+    .await
+    .unwrap();
+
+    let resolved = repo
+        .resolve(
+            &project.id,
+            "memory://design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy.md",
+        )
+        .await
+        .unwrap()
+        .expect("exact permalink should resolve");
+
+    assert_eq!(resolved.id, design.id);
+    assert_eq!(
+        resolved.permalink,
+        "design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dedup_candidates_returns_empty_for_empty_project() {
     let tmp = crate::database::test_tempdir().unwrap();
     let db = Database::open_in_memory().unwrap();

--- a/server/crates/djinn-mcp/src/tools/memory_tools/ops.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/ops.rs
@@ -1,5 +1,8 @@
 use djinn_db::NoteSearchParams;
-use djinn_db::{NoteRepository, ProjectRepository};
+use djinn_db::{
+    NoteRepository, ProjectRepository, normalize_virtual_note_path,
+    permalink_from_virtual_note_path,
+};
 
 use crate::server::DjinnMcpServer;
 
@@ -12,7 +15,33 @@ use super::{
 };
 
 fn normalize_folder_filter(folder: Option<String>) -> Option<String> {
-    folder.filter(|value| !value.is_empty())
+    folder.and_then(|value| {
+        let trimmed = value.trim();
+        let without_scheme = trimmed.strip_prefix("memory://").unwrap_or(trimmed);
+        let normalized = normalize_virtual_note_path(without_scheme);
+        (!normalized.is_empty()).then_some(normalized)
+    })
+}
+
+fn permalink_candidates(identifier: &str) -> Vec<String> {
+    let trimmed = identifier.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    let without_scheme = trimmed.strip_prefix("memory://").unwrap_or(trimmed);
+    let normalized = normalize_virtual_note_path(without_scheme);
+    if normalized.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = vec![normalized.clone()];
+    if let Some(permalink) = permalink_from_virtual_note_path(&normalized)
+        && permalink != normalized
+    {
+        candidates.push(permalink);
+    }
+    candidates
 }
 
 async fn record_retrieved_notes(
@@ -89,9 +118,19 @@ pub async fn memory_read(server: &DjinnMcpServer, p: ReadParams) -> MemoryNoteRe
 
     let repo = NoteRepository::new(server.state.db().clone(), server.state.event_bus())
         .with_vector_store(server.state.vector_store());
-    let note = match repo.get_by_permalink(&project_id, &p.identifier).await {
-        Ok(Some(note)) => note,
-        _ => match repo
+    let note = if let Some(note) = {
+        let mut exact = None;
+        for candidate in permalink_candidates(&p.identifier) {
+            if let Ok(Some(note)) = repo.get_by_permalink(&project_id, &candidate).await {
+                exact = Some(note);
+                break;
+            }
+        }
+        exact
+    } {
+        note
+    } else {
+        match repo
             .search(NoteSearchParams {
                 project_id: &project_id,
                 query: &p.identifier,
@@ -115,7 +154,7 @@ pub async fn memory_read(server: &DjinnMcpServer, p: ReadParams) -> MemoryNoteRe
                 }
             }
             _ => return MemoryNoteResponse::error(format!("note not found: {}", p.identifier)),
-        },
+        }
     };
 
     let _ = repo.touch_accessed(&note.id).await;
@@ -214,10 +253,11 @@ pub async fn memory_list(server: &DjinnMcpServer, p: ListParams) -> MemoryListRe
     let repo = NoteRepository::new(server.state.db().clone(), server.state.event_bus())
         .with_vector_store(server.state.vector_store());
     let depth = p.depth.unwrap_or(1);
+    let folder = normalize_folder_filter(p.folder);
     let notes = repo
         .list_compact(
             &project_id,
-            p.folder.as_deref(),
+            folder.as_deref(),
             p.note_type.as_deref(),
             depth,
         )

--- a/server/crates/djinn-mcp/src/tools/memory_tools/ops_tests.rs
+++ b/server/crates/djinn-mcp/src/tools/memory_tools/ops_tests.rs
@@ -287,6 +287,118 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_read_ops_prefers_exact_design_permalink_over_competing_case_search_match() {
+        let setup = setup_server().await;
+        let project_id = ProjectRepository::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+        )
+        .resolve(&setup.project)
+        .await
+        .unwrap()
+        .expect("project id");
+        let repo = NoteRepository::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+        );
+
+        let design_permalink =
+            "design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy";
+        let design = repo
+            .create_db_note_with_permalink(
+                &project_id,
+                design_permalink,
+                "ADR-054 Roadmap Memory Extraction Quality Gates and Note Taxonomy",
+                "Canonical design note for ADR-054 closure reconciliation.",
+                "design",
+                "[]",
+            )
+            .await
+            .unwrap();
+        let stale_case = repo
+            .create(
+                &project_id,
+                setup._tmp.path(),
+                "ADR-054 roadmap memory extraction quality gates and note taxonomy",
+                "Superseded case note mentioning ADR-054 roadmap extraction quality gates taxonomy.",
+                "case",
+                "[]",
+            )
+            .await
+            .unwrap();
+
+        let response = ops::memory_read(
+            &setup.server,
+            ReadParams {
+                project: setup.project.clone(),
+                identifier: format!("memory://{design_permalink}.md"),
+            },
+        )
+        .await;
+
+        assert!(
+            response.error.is_none(),
+            "unexpected error: {:?}",
+            response.error
+        );
+        assert_eq!(response.id.as_deref(), Some(design.id.as_str()));
+        assert_eq!(response.permalink.as_deref(), Some(design_permalink));
+        assert_ne!(response.id.as_deref(), Some(stale_case.id.as_str()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn memory_list_ops_normalizes_design_folder_filter_before_listing() {
+        let setup = setup_server().await;
+        let project_id = ProjectRepository::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+        )
+        .resolve(&setup.project)
+        .await
+        .unwrap()
+        .expect("project id");
+        let repo = NoteRepository::new(
+            setup.server.state.db().clone(),
+            setup.server.state.event_bus(),
+        );
+
+        let design = repo
+            .create_db_note_with_permalink(
+                &project_id,
+                "design/adr-054-roadmap-memory-extraction-quality-gates-and-note-taxonomy",
+                "ADR-054 Roadmap Memory Extraction Quality Gates and Note Taxonomy",
+                "Canonical design note visible to folder listing.",
+                "design",
+                "[]",
+            )
+            .await
+            .unwrap();
+
+        let listed = ops::memory_list(
+            &setup.server,
+            ListParams {
+                project: setup.project.clone(),
+                folder: Some("memory://design/".to_string()),
+                note_type: Some("design".to_string()),
+                depth: Some(1),
+            },
+        )
+        .await;
+
+        assert!(
+            listed.error.is_none(),
+            "unexpected error: {:?}",
+            listed.error
+        );
+        assert!(
+            listed
+                .notes
+                .iter()
+                .any(|note| note.id == design.id && note.permalink == design.permalink)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn memory_search_ops_applies_task_fallback_and_success_shape() {
         let setup = setup_server().await;
 


### PR DESCRIPTION
## Summary
After the write/index defect is fixed, harden memory read/list behavior so canonical exact-permalink resolution wins deterministically and folder listing reflects newly created notes. This wave should eliminate the ADR-054 failure mode where intended design permalinks fell through to older case-note matches or disappeared from `memory_list(folder="design")`.

## Acceptance Criteria
- [x] `memory_read` returns an exact-permalink match before any title/full-text fallback when the target note exists canonically.
- [x] `memory_list(folder="design")` surfaces newly created canonical design notes after the write-path fix, including the ADR-054 roadmap-style case.
- [x] Regression tests cover the failure mode where an exact design permalink previously fell through to a stale superseded case-note search result.

---
Djinn task: 9f1v