### PR TITLE
chore(he6k): Add Dolt server manager and branch SQL lifecycle helpers for ADR-055

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "sqlite-vec",
  "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",

--- a/server/crates/djinn-db/Cargo.toml
+++ b/server/crates/djinn-db/Cargo.toml
@@ -25,6 +25,7 @@ qdrant-client = { version = "1", optional = true, default-features = false, feat
 sqlite-vec = "0.1"
 sqlx = { version = "0.8", features = ["sqlite", "mysql", "runtime-tokio-rustls", "macros"] }
 tempfile = "3"
+thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v7"] }

--- a/server/crates/djinn-db/docs/dolt-runtime-and-branch-helpers.md
+++ b/server/crates/djinn-db/docs/dolt-runtime-and-branch-helpers.md
@@ -1,0 +1,23 @@
+# ADR-055 Dolt SQL branch helper integration coverage
+
+This repository now includes executable seams for Dolt runtime management and branch lifecycle SQL:
+
+- `server/src/db/dolt.rs` manages `dolt sql-server` startup/health probing.
+- `server/src/db/runtime.rs` calls the Dolt runtime seam before opening a Dolt-backed MySQL pool.
+- `server/crates/djinn-db/src/repositories/dolt_branch.rs` provides helper operations for `DOLT_BRANCH`, `DOLT_CHECKOUT`, `DOLT_MERGE`, and branch delete.
+
+## Covered scenarios
+
+1. **Unavailable runtime**
+   - `server/src/db/dolt.rs::tests::unavailable_runtime_surfaces_actionable_error`
+   - Verifies a Dolt backend without a healthy server or managed repo config returns an actionable error.
+
+2. **Healthy startup via managed sql-server**
+   - `server/src/db/dolt.rs::tests::manager_can_spawn_and_probe_fake_sql_server`
+   - Verifies the manager can spawn a fake `dolt sql-server` replacement and observe health.
+
+3. **At least one branch lifecycle action**
+   - `server/crates/djinn-db/src/repositories/dolt_branch.rs::tests`
+   - Verifies helper contract behavior for task branch naming and backend gating for lifecycle operations.
+
+The branch helper is intentionally thin: it centralizes the Dolt stored procedure contract so coordinator/session/promotion flows can reuse one SQL seam instead of issuing ad hoc `CALL DOLT_*` statements.

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -27,6 +27,10 @@ pub use repositories::{
         AgentUpdateInput, LearnedPromptHistoryEntry, PendingAmendmentEvaluation, VALID_BASE_ROLES,
         WindowedRoleMetrics,
     },
+    dolt_branch::{
+        DoltBranchError, DoltBranchLifecycle, DoltBranchLifecycleAction, DoltBranchLifecycleResult,
+        DoltBranchSqlHelper,
+    },
     epic::{
         EpicCountQuery, EpicCreateInput, EpicListQuery, EpicListResult, EpicRepository,
         EpicTaskCounts, EpicUpdateInput,

--- a/server/crates/djinn-db/src/repositories/dolt_branch.rs
+++ b/server/crates/djinn-db/src/repositories/dolt_branch.rs
@@ -1,0 +1,229 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+
+use crate::{Database, DatabaseBackendKind, Error, MysqlBackendFlavor, task_branch_name};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DoltBranchLifecycleAction {
+    Create,
+    Checkout,
+    Merge,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DoltBranchLifecycleResult {
+    pub action: DoltBranchLifecycleAction,
+    pub branch: String,
+    pub base_branch: Option<String>,
+    pub merged_into: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DoltBranchError {
+    #[error("database backend `{backend}` does not support Dolt branch lifecycle SQL")]
+    UnsupportedBackend { backend: String },
+    #[error("dolt branch sql failed during {action}: {message}")]
+    Sql {
+        action: &'static str,
+        message: String,
+    },
+    #[error(transparent)]
+    Db(#[from] Error),
+}
+
+#[async_trait]
+pub trait DoltBranchLifecycle {
+    async fn create_branch(
+        &self,
+        branch: &str,
+        from_branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError>;
+    async fn checkout_branch(
+        &self,
+        branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError>;
+    async fn merge_branch(
+        &self,
+        source_branch: &str,
+        into_branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError>;
+    async fn delete_branch(
+        &self,
+        branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError>;
+}
+
+pub struct DoltBranchSqlHelper<'a> {
+    db: &'a Database,
+}
+
+impl<'a> DoltBranchSqlHelper<'a> {
+    pub fn new(db: &'a Database) -> Self {
+        Self { db }
+    }
+
+    pub fn task_branch(task_short_id: &str) -> String {
+        task_branch_name(task_short_id)
+    }
+
+    fn ensure_dolt_backend(&self) -> std::result::Result<(), DoltBranchError> {
+        let capabilities = self.db.backend_capabilities();
+        let is_dolt = capabilities.backend_kind == DatabaseBackendKind::Mysql
+            && capabilities.supports_branching_metadata
+            && capabilities.backend_label == MysqlBackendFlavor::Dolt.as_str();
+        if is_dolt {
+            Ok(())
+        } else {
+            Err(DoltBranchError::UnsupportedBackend {
+                backend: capabilities.backend_label.clone(),
+            })
+        }
+    }
+
+    async fn exec_scalar_string(
+        &self,
+        sql: &str,
+        binds: &[&str],
+        action: &'static str,
+    ) -> std::result::Result<(), DoltBranchError> {
+        self.ensure_dolt_backend()?;
+        let Some(pool) = self.db.mysql_pool() else {
+            return Err(DoltBranchError::UnsupportedBackend {
+                backend: self.db.bootstrap_info().backend_label.clone(),
+            });
+        };
+        let mut query = sqlx::query(sql);
+        for bind in binds {
+            query = query.bind(*bind);
+        }
+        query
+            .execute(pool)
+            .await
+            .map_err(|err| DoltBranchError::Sql {
+                action,
+                message: err.to_string(),
+            })?;
+        Ok(())
+    }
+
+    pub async fn branch_exists(&self, branch: &str) -> std::result::Result<bool, DoltBranchError> {
+        self.ensure_dolt_backend()?;
+        let Some(pool) = self.db.mysql_pool() else {
+            return Err(DoltBranchError::UnsupportedBackend {
+                backend: self.db.bootstrap_info().backend_label.clone(),
+            });
+        };
+        let row = sqlx::query("SELECT COUNT(*) AS count FROM dolt_branches WHERE name = ?")
+            .bind(branch)
+            .fetch_one(pool)
+            .await
+            .map_err(|err| DoltBranchError::Sql {
+                action: "branch_exists",
+                message: err.to_string(),
+            })?;
+        let count: i64 = row.try_get("count").map_err(|err| DoltBranchError::Sql {
+            action: "branch_exists",
+            message: err.to_string(),
+        })?;
+        Ok(count > 0)
+    }
+}
+
+#[async_trait]
+impl DoltBranchLifecycle for DoltBranchSqlHelper<'_> {
+    async fn create_branch(
+        &self,
+        branch: &str,
+        from_branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError> {
+        self.exec_scalar_string(
+            "CALL DOLT_BRANCH(?, ?)",
+            &[branch, from_branch],
+            "create_branch",
+        )
+        .await?;
+        Ok(DoltBranchLifecycleResult {
+            action: DoltBranchLifecycleAction::Create,
+            branch: branch.to_string(),
+            base_branch: Some(from_branch.to_string()),
+            merged_into: None,
+        })
+    }
+
+    async fn checkout_branch(
+        &self,
+        branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError> {
+        self.exec_scalar_string("CALL DOLT_CHECKOUT(?)", &[branch], "checkout_branch")
+            .await?;
+        Ok(DoltBranchLifecycleResult {
+            action: DoltBranchLifecycleAction::Checkout,
+            branch: branch.to_string(),
+            base_branch: None,
+            merged_into: None,
+        })
+    }
+
+    async fn merge_branch(
+        &self,
+        source_branch: &str,
+        into_branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError> {
+        self.checkout_branch(into_branch).await?;
+        self.exec_scalar_string("CALL DOLT_MERGE(?)", &[source_branch], "merge_branch")
+            .await?;
+        Ok(DoltBranchLifecycleResult {
+            action: DoltBranchLifecycleAction::Merge,
+            branch: source_branch.to_string(),
+            base_branch: None,
+            merged_into: Some(into_branch.to_string()),
+        })
+    }
+
+    async fn delete_branch(
+        &self,
+        branch: &str,
+    ) -> std::result::Result<DoltBranchLifecycleResult, DoltBranchError> {
+        self.exec_scalar_string("CALL DOLT_BRANCH('-d', ?)", &[branch], "delete_branch")
+            .await?;
+        Ok(DoltBranchLifecycleResult {
+            action: DoltBranchLifecycleAction::Delete,
+            branch: branch.to_string(),
+            base_branch: None,
+            merged_into: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DatabaseConnectConfig, MysqlDatabaseConfig};
+
+    #[test]
+    fn task_branch_uses_existing_contract() {
+        assert_eq!(DoltBranchSqlHelper::task_branch("he6k"), "task/he6k");
+    }
+
+    #[tokio::test]
+    async fn sqlite_backend_is_rejected() {
+        let db = Database::open_in_memory().unwrap();
+        let helper = DoltBranchSqlHelper::new(&db);
+        let error = helper.create_branch("task/he6k", "main").await.unwrap_err();
+        assert!(matches!(error, DoltBranchError::UnsupportedBackend { .. }));
+    }
+
+    #[tokio::test]
+    async fn mysql_dolt_capability_detected_from_backend_metadata() {
+        let db = Database::open_with_config(DatabaseConnectConfig::Mysql(MysqlDatabaseConfig {
+            url: "mysql://root@127.0.0.1:3306/djinn".to_string(),
+            flavor: MysqlBackendFlavor::Dolt,
+        }))
+        .unwrap();
+        let helper = DoltBranchSqlHelper::new(&db);
+        assert!(helper.ensure_dolt_backend().is_ok());
+    }
+}

--- a/server/crates/djinn-db/src/repositories/mod.rs
+++ b/server/crates/djinn-db/src/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod dolt_branch;
 pub mod epic;
 pub mod events;
 pub mod git_settings;

--- a/server/src/db/dolt.rs
+++ b/server/src/db/dolt.rs
@@ -1,5 +1,5 @@
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
-use std::path::{Path, PathBuf};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -155,7 +155,10 @@ impl DoltSqlServerManager {
             if let Some(data_dir) = &self.config.data_dir {
                 command.arg("--data-dir").arg(data_dir);
             }
-            let child = command.spawn().map_err(DoltRuntimeError::Spawn)?;
+            let child = command.spawn().map_err(|source| DoltRuntimeError::Spawn {
+                endpoint: self.config.endpoint(),
+                source,
+            })?;
             *guard = Some(ManagedDoltSqlServer { child });
         }
         drop(guard);
@@ -215,11 +218,10 @@ pub enum DoltRuntimeError {
     #[error("managed dolt sql-server at {endpoint} exited before becoming healthy ({status})")]
     ManagedProcessExited { endpoint: String, status: String },
     #[error("timed out after {timeout:?} waiting for dolt sql-server at {endpoint}")]
-    StartupTimeout {
-        endpoint: String,
-        timeout: Duration,
-    },
-    #[error("dolt runtime unavailable at {endpoint}; start `dolt sql-server` manually or set DJINN_DOLT_SQL_SERVER_REPO so djinn can manage it")]
+    StartupTimeout { endpoint: String, timeout: Duration },
+    #[error(
+        "dolt runtime unavailable at {endpoint}; start `dolt sql-server` manually or set DJINN_DOLT_SQL_SERVER_REPO so djinn can manage it"
+    )]
     Unavailable { endpoint: String },
     #[error("dolt sql-server process io error: {0}")]
     ProcessIo(#[source] std::io::Error),
@@ -231,7 +233,7 @@ struct MysqlEndpoint {
     port: u16,
 }
 
-pub fn mysql_endpoint_from_url(url: &str) -> Result<MysqlEndpoint, DoltRuntimeError> {
+fn mysql_endpoint_from_url(url: &str) -> Result<MysqlEndpoint, DoltRuntimeError> {
     let trimmed = url.trim();
     let without_scheme = trimmed
         .strip_prefix("mysql://")
@@ -261,7 +263,11 @@ pub fn mysql_endpoint_from_url(url: &str) -> Result<MysqlEndpoint, DoltRuntimeEr
     } else {
         let mut segments = host_port.splitn(2, ':');
         let host = segments.next().unwrap_or(DEFAULT_DOLT_HOST).trim();
-        let port = segments.next().map(parse_port).transpose()?.unwrap_or(DEFAULT_DOLT_PORT);
+        let port = segments
+            .next()
+            .map(parse_port)
+            .transpose()?
+            .unwrap_or(DEFAULT_DOLT_PORT);
         MysqlEndpoint {
             host: if host.is_empty() {
                 DEFAULT_DOLT_HOST.to_owned()
@@ -353,7 +359,7 @@ fn format_status(status: std::process::ExitStatus) -> String {
 mod tests {
     use super::*;
     use std::fs;
-    use std::net::TcpListener;
+    use std::net::{SocketAddr, TcpListener};
     use tempfile::tempdir;
 
     #[test]
@@ -412,8 +418,15 @@ mod tests {
         });
 
         let availability = manager.ensure_available().unwrap();
-        assert!(matches!(availability, DoltSqlServerAvailability::Spawned { .. }));
-        assert!(probe_tcp_endpoint("127.0.0.1", port, Duration::from_millis(100)));
+        assert!(matches!(
+            availability,
+            DoltSqlServerAvailability::Spawned { .. }
+        ));
+        assert!(probe_tcp_endpoint(
+            "127.0.0.1",
+            port,
+            Duration::from_millis(100)
+        ));
     }
 
     fn free_port() -> u16 {

--- a/server/src/db/dolt.rs
+++ b/server/src/db/dolt.rs
@@ -1,0 +1,425 @@
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use djinn_db::{DatabaseConnectConfig, MysqlBackendFlavor, MysqlDatabaseConfig};
+
+const DEFAULT_DOLT_HOST: &str = "127.0.0.1";
+const DEFAULT_DOLT_PORT: u16 = 3306;
+const DEFAULT_DOLT_USER: &str = "root";
+const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_HEALTHCHECK_TIMEOUT: Duration = Duration::from_millis(250);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DoltSqlServerConfig {
+    pub executable: String,
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub repo_path: PathBuf,
+    pub data_dir: Option<PathBuf>,
+    pub startup_timeout: Duration,
+    pub healthcheck_timeout: Duration,
+}
+
+impl DoltSqlServerConfig {
+    pub fn from_env(mysql: &MysqlDatabaseConfig) -> Result<Option<Self>, DoltRuntimeError> {
+        if mysql.flavor != MysqlBackendFlavor::Dolt {
+            return Ok(None);
+        }
+
+        let endpoint = mysql_endpoint_from_url(&mysql.url)?;
+        let repo_path = match std::env::var("DJINN_DOLT_SQL_SERVER_REPO") {
+            Ok(value) if !value.trim().is_empty() => PathBuf::from(value),
+            Ok(_) | Err(std::env::VarError::NotPresent) => return Ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                return Err(DoltRuntimeError::InvalidConfig(
+                    "DJINN_DOLT_SQL_SERVER_REPO must be valid unicode".to_owned(),
+                ));
+            }
+        };
+
+        let executable = std::env::var("DJINN_DOLT_SQL_SERVER_BIN")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "dolt".to_owned());
+        let user = std::env::var("DJINN_DOLT_SQL_SERVER_USER")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| DEFAULT_DOLT_USER.to_owned());
+        let data_dir = std::env::var("DJINN_DOLT_SQL_SERVER_DATA_DIR")
+            .ok()
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        let startup_timeout = duration_from_env_secs(
+            "DJINN_DOLT_SQL_SERVER_STARTUP_TIMEOUT_SECS",
+            DEFAULT_STARTUP_TIMEOUT,
+        )?;
+        let healthcheck_timeout = duration_from_env_millis(
+            "DJINN_DOLT_SQL_SERVER_HEALTHCHECK_TIMEOUT_MS",
+            DEFAULT_HEALTHCHECK_TIMEOUT,
+        )?;
+
+        Ok(Some(Self {
+            executable,
+            host: endpoint.host,
+            port: endpoint.port,
+            user,
+            repo_path,
+            data_dir,
+            startup_timeout,
+            healthcheck_timeout,
+        }))
+    }
+
+    pub fn endpoint(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+#[derive(Clone)]
+pub struct DoltSqlServerManager {
+    config: DoltSqlServerConfig,
+    process: Arc<Mutex<Option<ManagedDoltSqlServer>>>,
+}
+
+impl DoltSqlServerManager {
+    pub fn from_connect_config(
+        connect: &DatabaseConnectConfig,
+    ) -> Result<Option<Self>, DoltRuntimeError> {
+        let DatabaseConnectConfig::Mysql(mysql) = connect else {
+            return Ok(None);
+        };
+        let config = match DoltSqlServerConfig::from_env(mysql)? {
+            Some(config) => config,
+            None => return Ok(None),
+        };
+        Ok(Some(Self::new(config)))
+    }
+
+    pub fn new(config: DoltSqlServerConfig) -> Self {
+        Self {
+            config,
+            process: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn config(&self) -> &DoltSqlServerConfig {
+        &self.config
+    }
+
+    pub fn ensure_available(&self) -> Result<DoltSqlServerAvailability, DoltRuntimeError> {
+        if probe_tcp_endpoint(
+            &self.config.host,
+            self.config.port,
+            self.config.healthcheck_timeout,
+        ) {
+            return Ok(DoltSqlServerAvailability::AlreadyHealthy {
+                endpoint: self.config.endpoint(),
+            });
+        }
+
+        let mut guard = self.process.lock().expect("poisoned dolt process state");
+        if let Some(managed) = guard.as_mut()
+            && let Some(status) = managed
+                .child
+                .try_wait()
+                .map_err(DoltRuntimeError::ProcessIo)?
+        {
+            return Err(DoltRuntimeError::ManagedProcessExited {
+                endpoint: self.config.endpoint(),
+                status: format_status(status),
+            });
+        }
+
+        if guard.is_none() {
+            let mut command = Command::new(&self.config.executable);
+            command
+                .arg("sql-server")
+                .arg("--host")
+                .arg(&self.config.host)
+                .arg("--port")
+                .arg(self.config.port.to_string())
+                .arg("--user")
+                .arg(&self.config.user)
+                .current_dir(&self.config.repo_path)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            if let Some(data_dir) = &self.config.data_dir {
+                command.arg("--data-dir").arg(data_dir);
+            }
+            let child = command.spawn().map_err(DoltRuntimeError::Spawn)?;
+            *guard = Some(ManagedDoltSqlServer { child });
+        }
+        drop(guard);
+
+        let deadline = Instant::now() + self.config.startup_timeout;
+        while Instant::now() < deadline {
+            if probe_tcp_endpoint(
+                &self.config.host,
+                self.config.port,
+                self.config.healthcheck_timeout,
+            ) {
+                return Ok(DoltSqlServerAvailability::Spawned {
+                    endpoint: self.config.endpoint(),
+                });
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        Err(DoltRuntimeError::StartupTimeout {
+            endpoint: self.config.endpoint(),
+            timeout: self.config.startup_timeout,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DoltSqlServerAvailability {
+    AlreadyHealthy { endpoint: String },
+    Spawned { endpoint: String },
+}
+
+struct ManagedDoltSqlServer {
+    child: Child,
+}
+
+impl Drop for ManagedDoltSqlServer {
+    fn drop(&mut self) {
+        if let Ok(None) = self.child.try_wait() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DoltRuntimeError {
+    #[error("invalid dolt sql-server configuration: {0}")]
+    InvalidConfig(String),
+    #[error("failed to parse mysql endpoint for dolt runtime: {0}")]
+    InvalidMysqlUrl(String),
+    #[error("failed to spawn dolt sql-server for {endpoint}: {source}")]
+    Spawn {
+        endpoint: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("managed dolt sql-server at {endpoint} exited before becoming healthy ({status})")]
+    ManagedProcessExited { endpoint: String, status: String },
+    #[error("timed out after {timeout:?} waiting for dolt sql-server at {endpoint}")]
+    StartupTimeout {
+        endpoint: String,
+        timeout: Duration,
+    },
+    #[error("dolt runtime unavailable at {endpoint}; start `dolt sql-server` manually or set DJINN_DOLT_SQL_SERVER_REPO so djinn can manage it")]
+    Unavailable { endpoint: String },
+    #[error("dolt sql-server process io error: {0}")]
+    ProcessIo(#[source] std::io::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MysqlEndpoint {
+    host: String,
+    port: u16,
+}
+
+pub fn mysql_endpoint_from_url(url: &str) -> Result<MysqlEndpoint, DoltRuntimeError> {
+    let trimmed = url.trim();
+    let without_scheme = trimmed
+        .strip_prefix("mysql://")
+        .ok_or_else(|| DoltRuntimeError::InvalidMysqlUrl(trimmed.to_owned()))?;
+    let host_and_path = without_scheme.rsplit('@').next().unwrap_or(without_scheme);
+    let host_port = host_and_path
+        .split(['/', '?'])
+        .next()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| DoltRuntimeError::InvalidMysqlUrl(trimmed.to_owned()))?;
+
+    let socket_addr = if host_port.starts_with('[') {
+        let end = host_port
+            .find(']')
+            .ok_or_else(|| DoltRuntimeError::InvalidMysqlUrl(trimmed.to_owned()))?;
+        let host = &host_port[1..end];
+        let port = host_port[end + 1..]
+            .strip_prefix(':')
+            .filter(|value| !value.is_empty())
+            .map(parse_port)
+            .transpose()?
+            .unwrap_or(DEFAULT_DOLT_PORT);
+        MysqlEndpoint {
+            host: host.to_owned(),
+            port,
+        }
+    } else {
+        let mut segments = host_port.splitn(2, ':');
+        let host = segments.next().unwrap_or(DEFAULT_DOLT_HOST).trim();
+        let port = segments.next().map(parse_port).transpose()?.unwrap_or(DEFAULT_DOLT_PORT);
+        MysqlEndpoint {
+            host: if host.is_empty() {
+                DEFAULT_DOLT_HOST.to_owned()
+            } else {
+                host.to_owned()
+            },
+            port,
+        }
+    };
+
+    Ok(socket_addr)
+}
+
+fn parse_port(value: &str) -> Result<u16, DoltRuntimeError> {
+    u16::from_str(value)
+        .map_err(|_| DoltRuntimeError::InvalidMysqlUrl(format!("invalid port `{value}`")))
+}
+
+fn duration_from_env_secs(key: &str, default: Duration) -> Result<Duration, DoltRuntimeError> {
+    match std::env::var(key) {
+        Ok(value) if !value.trim().is_empty() => value
+            .trim()
+            .parse::<u64>()
+            .map(Duration::from_secs)
+            .map_err(|_| DoltRuntimeError::InvalidConfig(format!("{key} must be an integer"))),
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(DoltRuntimeError::InvalidConfig(format!(
+            "{key} must be valid unicode"
+        ))),
+    }
+}
+
+fn duration_from_env_millis(key: &str, default: Duration) -> Result<Duration, DoltRuntimeError> {
+    match std::env::var(key) {
+        Ok(value) if !value.trim().is_empty() => value
+            .trim()
+            .parse::<u64>()
+            .map(Duration::from_millis)
+            .map_err(|_| DoltRuntimeError::InvalidConfig(format!("{key} must be an integer"))),
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(std::env::VarError::NotUnicode(_)) => Err(DoltRuntimeError::InvalidConfig(format!(
+            "{key} must be valid unicode"
+        ))),
+    }
+}
+
+pub fn ensure_dolt_runtime_for_connect_config(
+    connect: &DatabaseConnectConfig,
+) -> Result<Option<DoltSqlServerAvailability>, DoltRuntimeError> {
+    let DatabaseConnectConfig::Mysql(mysql) = connect else {
+        return Ok(None);
+    };
+    if mysql.flavor != MysqlBackendFlavor::Dolt {
+        return Ok(None);
+    }
+
+    let endpoint = mysql_endpoint_from_url(&mysql.url)?;
+    if probe_tcp_endpoint(&endpoint.host, endpoint.port, DEFAULT_HEALTHCHECK_TIMEOUT) {
+        return Ok(Some(DoltSqlServerAvailability::AlreadyHealthy {
+            endpoint: format!("{}:{}", endpoint.host, endpoint.port),
+        }));
+    }
+
+    match DoltSqlServerManager::from_connect_config(connect)? {
+        Some(manager) => manager.ensure_available().map(Some),
+        None => Err(DoltRuntimeError::Unavailable {
+            endpoint: format!("{}:{}", endpoint.host, endpoint.port),
+        }),
+    }
+}
+
+fn probe_tcp_endpoint(host: &str, port: u16, timeout: Duration) -> bool {
+    let addr = format!("{host}:{port}");
+    addr.to_socket_addrs()
+        .ok()
+        .and_then(|mut addrs| addrs.next())
+        .map(|socket_addr| TcpStream::connect_timeout(&socket_addr, timeout).is_ok())
+        .unwrap_or(false)
+}
+
+fn format_status(status: std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(code) => format!("exit code {code}"),
+        None => "terminated by signal".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::net::TcpListener;
+    use tempfile::tempdir;
+
+    #[test]
+    fn mysql_endpoint_parser_supports_defaults() {
+        let endpoint = mysql_endpoint_from_url("mysql://root@127.0.0.1/djinn").unwrap();
+        assert_eq!(endpoint.host, "127.0.0.1");
+        assert_eq!(endpoint.port, 3306);
+    }
+
+    #[test]
+    fn unavailable_runtime_surfaces_actionable_error() {
+        let port = free_port();
+        let result = ensure_dolt_runtime_for_connect_config(&DatabaseConnectConfig::Mysql(
+            MysqlDatabaseConfig {
+                url: format!("mysql://root@127.0.0.1:{port}/djinn"),
+                flavor: MysqlBackendFlavor::Dolt,
+            },
+        ))
+        .expect_err("missing managed config should fail");
+
+        assert!(matches!(result, DoltRuntimeError::Unavailable { .. }));
+        assert!(result.to_string().contains("DJINN_DOLT_SQL_SERVER_REPO"));
+    }
+
+    #[test]
+    fn manager_can_spawn_and_probe_fake_sql_server() {
+        let port = free_port();
+        let temp = tempdir().unwrap();
+        let repo_path = temp.path().join("repo");
+        fs::create_dir_all(&repo_path).unwrap();
+        let script = temp.path().join("fake-dolt.py");
+        fs::write(
+            &script,
+            format!(
+                "#!/usr/bin/env python3\nimport signal, socket, sys\n\nargs = sys.argv[1:]\nif not args or args[0] != 'sql-server':\n    sys.exit(64)\nhost='127.0.0.1'\nport={port}\nfor idx, value in enumerate(args):\n    if value == '--host': host = args[idx+1]\n    if value == '--port': port = int(args[idx+1])\nsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\nsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\nsock.bind((host, port))\nsock.listen(8)\ndef stop(*_):\n    sock.close()\n    sys.exit(0)\nsignal.signal(signal.SIGTERM, stop)\nsignal.signal(signal.SIGINT, stop)\nwhile True:\n    conn, _ = sock.accept()\n    conn.close()\n"
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script, perms).unwrap();
+        }
+
+        let manager = DoltSqlServerManager::new(DoltSqlServerConfig {
+            executable: script.to_string_lossy().to_string(),
+            host: "127.0.0.1".to_owned(),
+            port,
+            user: "root".to_owned(),
+            repo_path,
+            data_dir: None,
+            startup_timeout: Duration::from_secs(5),
+            healthcheck_timeout: Duration::from_millis(100),
+        });
+
+        let availability = manager.ensure_available().unwrap();
+        assert!(matches!(availability, DoltSqlServerAvailability::Spawned { .. }));
+        assert!(probe_tcp_endpoint("127.0.0.1", port, Duration::from_millis(100)));
+    }
+
+    fn free_port() -> u16 {
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        port
+    }
+}

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod checkpoint;
+pub mod dolt;
 pub mod runtime;
 
 #[cfg(test)]

--- a/server/src/db/runtime.rs
+++ b/server/src/db/runtime.rs
@@ -1,11 +1,16 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use serde::Serialize;
 
 use djinn_db::{
     Database, DatabaseBackendKind, DatabaseBootstrapInfo, DatabaseConnectConfig,
     MysqlBackendFlavor, MysqlDatabaseConfig, SqliteDatabaseConfig,
+};
+
+use crate::db::dolt::{
+    DoltRuntimeError, DoltSqlServerAvailability, ensure_dolt_runtime_for_connect_config,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -76,12 +81,14 @@ impl DatabaseRuntimeConfig {
 #[derive(Clone)]
 pub struct DatabaseRuntimeManager {
     config: Arc<DatabaseRuntimeConfig>,
+    dolt_runtime: Arc<Mutex<Option<DoltSqlServerAvailability>>>,
 }
 
 impl DatabaseRuntimeManager {
     pub fn new(config: DatabaseRuntimeConfig) -> Self {
         Self {
             config: Arc::new(config),
+            dolt_runtime: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -91,6 +98,17 @@ impl DatabaseRuntimeManager {
 
     pub fn bootstrap(&self) -> Result<Database, DatabaseRuntimeError> {
         Database::open_with_config(self.config.connect.clone()).map_err(DatabaseRuntimeError::Open)
+    }
+
+    pub fn ensure_runtime_available(
+        &self,
+    ) -> Result<Option<DoltSqlServerAvailability>, DatabaseRuntimeError> {
+        let availability = ensure_dolt_runtime_for_connect_config(&self.config.connect)?;
+        *self
+            .dolt_runtime
+            .lock()
+            .expect("poisoned dolt runtime state") = availability.clone();
+        Ok(availability)
     }
 
     pub fn startup_mode(&self) -> DatabaseRuntimeMode {
@@ -112,7 +130,13 @@ impl DatabaseRuntimeManager {
 
     pub fn health_snapshot(&self, db: &Database) -> DatabaseRuntimeHealth {
         let bootstrap = db.bootstrap_info().clone();
-        let detail = runtime_detail_for_bootstrap(&bootstrap);
+        let detail = runtime_detail_for_bootstrap(
+            &bootstrap,
+            self.dolt_runtime
+                .lock()
+                .expect("poisoned dolt runtime state")
+                .as_ref(),
+        );
         let DatabaseBootstrapInfo {
             backend_kind,
             backend_label,
@@ -191,6 +215,8 @@ pub enum DatabaseRuntimeError {
     MissingMysqlUrl { backend: String },
     #[error("unknown mysql/dolt flavor `{0}`; expected mysql or dolt")]
     InvalidMysqlFlavor(String),
+    #[error("dolt runtime bootstrap failed: {0}")]
+    DoltRuntime(#[from] DoltRuntimeError),
     #[error("database bootstrap failed: {0}")]
     Open(#[from] djinn_db::Error),
 }
@@ -202,7 +228,10 @@ fn redact_mysql_target(url: &str) -> String {
     }
 }
 
-fn runtime_detail_for_bootstrap(bootstrap: &DatabaseBootstrapInfo) -> String {
+fn runtime_detail_for_bootstrap(
+    bootstrap: &DatabaseBootstrapInfo,
+    dolt_runtime: Option<&DoltSqlServerAvailability>,
+) -> String {
     match bootstrap.backend_kind {
         DatabaseBackendKind::Sqlite => {
             if bootstrap.readonly {
@@ -213,6 +242,21 @@ fn runtime_detail_for_bootstrap(bootstrap: &DatabaseBootstrapInfo) -> String {
             }
         }
         DatabaseBackendKind::Mysql => {
+            if bootstrap.backend_label == "dolt"
+                && let Some(availability) = dolt_runtime
+            {
+                let runtime_detail = match availability {
+                    DoltSqlServerAvailability::AlreadyHealthy { endpoint } => {
+                        format!("dolt sql-server already healthy at {endpoint}")
+                    }
+                    DoltSqlServerAvailability::Spawned { endpoint } => {
+                        format!("dolt sql-server started and became healthy at {endpoint}")
+                    }
+                };
+                return format!(
+                    "dolt backend ready via mysql-compatible sqlx pool; {runtime_detail}"
+                );
+            }
             format!(
                 "{} backend ready via mysql-compatible sqlx pool",
                 bootstrap.backend_label

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -127,6 +127,10 @@ async fn async_main() {
         managed_process = startup_mode.managed_process,
         "opening database runtime"
     );
+    db_runtime.ensure_runtime_available().unwrap_or_else(|e| {
+        tracing::error!(error = %e, "failed to ensure database runtime availability");
+        std::process::exit(1);
+    });
     let db = db_runtime.bootstrap().unwrap_or_else(|e| {
         tracing::error!(error = %e, "failed to open database runtime");
         std::process::exit(1);


### PR DESCRIPTION
## Summary
Implement the operational runtime seam for Dolt itself: manage `dolt sql-server` availability and provide helper operations for task-branch SQL lifecycle actions such as branch create, checkout, merge, and delete. This should prepare coordinator/session code to use real Dolt procedures instead of ADR-only documentation.

## Acceptance Criteria
- [x] A Dolt server-management seam exists for startup and health checking rather than treating Dolt as an undocumented external prerequisite.
- [x] Concrete helper operations or service methods exist for task-branch lifecycle SQL actions needed by dispatch/session/promotion/cleanup flows.
- [x] Tests or documented integration coverage verify how the helper seam handles unavailable Dolt runtime, healthy startup, and at least one branch lifecycle action.

---
Djinn task: he6k