### PR TITLE
chore(nwg2): Normalize broken wikilinks in current canonical memory notes

### DIFF
--- a/.djinn/decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface.md
+++ b/.djinn/decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface.md
@@ -14,7 +14,7 @@ Proposed
 
 Date: 2026-04-13
 
-Related: [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]], [[ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy]], [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]], [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
+Related: [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]], [[ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy]], [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]], [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning]]
 
 ## Context
 
@@ -113,9 +113,9 @@ Option A is cleaner (agents don't need to know about branches), but Option B is 
 
 ### 4. Wikilink resolution
 
-Notes use `[[wikilinks]]` to reference each other. The FUSE layer resolves these for rendering:
+Notes use wikilinks to reference each other. The FUSE layer resolves them for rendering:
 
-- `[[Note Title]]` → resolves to the file path of the matching note
+- `Note Title` wikilinks → resolve to the file path of the matching note
 - Broken links are visible as files in a virtual `.broken-links/` directory
 - Creating a file that matches a broken link title automatically repairs the link
 
@@ -283,5 +283,5 @@ Half-measure. The power of this approach is that agents can write notes by creat
 - [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]]
 - [[ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy]]
 - [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]]
-- [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
+- [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning]]
 - [[ADR-053: Semantic Memory Search — Candle Embeddings with sqlite-vec]]

--- a/.djinn/decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface.md
+++ b/.djinn/decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface.md
@@ -14,7 +14,7 @@ Proposed
 
 Date: 2026-04-13
 
-Related: [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]], [[ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy]], [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]], [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning]]
+Related: [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]], [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]], [[decisions/adr-056-proposal-planner-driven-codebase-learning-and-memory-hygiene]], [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning]]
 
 ## Context
 
@@ -22,7 +22,7 @@ Djinn currently exposes ~20 MCP tools for memory operations: `memory_write`, `me
 
 Most of these are CRUD operations that duplicate what a filesystem already provides. Every LLM coding agent — Claude Code, Cursor, Windsurf, Copilot — already knows how to `Read`, `Write`, `Edit`, `Grep`, and `Glob` files. Teaching agents a custom MCP API for basic note operations is unnecessary friction. Agents invoke the wrong tool, pass wrong parameters, and waste tokens on tool discovery when they could just read and write files.
 
-Meanwhile, [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]] introduces per-task knowledge branches in Dolt. The branch isolation model maps naturally to a filesystem: each branch is a directory, each note is a file, switching branches is changing directories.
+Meanwhile, [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]] introduces per-task knowledge branches in Dolt. The branch isolation model maps naturally to a filesystem: each branch is a directory, each note is a file, switching branches is changing directories.
 
 ### What already exists
 
@@ -280,8 +280,8 @@ Half-measure. The power of this approach is that agents can write notes by creat
 
 ## Relations
 
-- [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]]
-- [[ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy]]
-- [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]]
+- [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
+- [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]
+- [[decisions/adr-056-proposal-planner-driven-codebase-learning-and-memory-hygiene]]
 - [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning]]
-- [[ADR-053: Semantic Memory Search — Candle Embeddings with sqlite-vec]]
+- [[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]

--- a/.djinn/reference/project-memory-broken-link-and-orphan-backlog-triage.md
+++ b/.djinn/reference/project-memory-broken-link-and-orphan-backlog-triage.md
@@ -32,7 +32,7 @@ Implication:
 - This bucket should be treated as **real cleanup work in note content**.
 - The likely fix is targeted replacement of title-style links with canonical permalinks, not tooling changes to `memory_broken_links()`.
 
-Known supporting evidence already exists in case note [[cases/canonical-memory-maintenance-identified-exact-adr-link-replacements-and-stale-roadmap-status-text]].
+Known supporting evidence already exists in the case note `cases/canonical-memory-maintenance-identified-exact-adr-link-replacements-and-stale-roadmap-status-text`.
 
 ### 2. A few likely genuinely missing or renamed targets — **small follow-up during cleanup pass**
 Some raw texts do not look like canonical note permalinks or stable note titles and may represent renamed, removed, or never-created targets:
@@ -43,7 +43,7 @@ Some raw texts do not look like canonical note permalinks or stable note titles 
 These should be triaged during the cleanup pass, but they are a minority relative to bucket 1. No separate project-wide tooling task is needed before attempting content cleanup.
 
 ### 3. Prior aggregate/detail contradiction — **already resolved, not part of remaining backlog**
-The earlier "counts nonzero but detail empty" issue was a tool/default-parameter bug, already captured by [[cases/default-optional-folder-filters-must-map-to-null-not-empty-string-for-memory-detail-tools]].
+The earlier "counts nonzero but detail empty" issue was a tool/default-parameter bug, already captured by the case note `cases/default-optional-folder-filters-must-map-to-null-not-empty-string-for-memory-detail-tools`.
 
 Decision:
 - Do **not** reopen the detail-tool bug as part of this backlog.
@@ -96,7 +96,7 @@ When patrol sees high memory-health counts:
 
 ## Routed next action
 
-Created follow-up planning task [[Route actionable project-memory cleanup after backlog triage]] to own the narrow actionable cleanup without reopening project-wide triage.
+Created follow-up planning task "Route actionable project-memory cleanup after backlog triage" to own the narrow actionable cleanup without reopening project-wide triage.
 
 
 ## Follow-up decision: orphan-heavy folders reporting policy (2026-04-09)
@@ -161,11 +161,11 @@ Use three interpretation buckets instead of treating the 797 total as one cleanu
 The first cleanup batch should target the **active semantic-memory orphan case cluster**, not the completed-epic roadmap requirements or older archival research notes.
 
 Recommended first batch:
-- [[cases/embedding-runtime-seam-added-for-semantic-memory]]
-- [[cases/thread-semantic-search-context-through-bridge-and-state-layers]]
-- [[cases/blend-semantic-retrieval-into-existing-note-search-without-changing-the-mcp-interface]]
-- [[cases/added-vector-aware-ranking-to-the-existing-note-search-pipeline]]
-- [[cases/blend-semantic-vector-search-into-existing-memory-search-ranking]]
+- `cases/embedding-runtime-seam-added-for-semantic-memory`
+- `cases/thread-semantic-search-context-through-bridge-and-state-layers`
+- `cases/blend-semantic-retrieval-into-existing-note-search-without-changing-the-mcp-interface`
+- `cases/added-vector-aware-ranking-to-the-existing-note-search-pipeline`
+- `cases/blend-semantic-vector-search-into-existing-memory-search-ranking`
 
 Rationale:
 - all five are recent orphan case notes tied to the still-active semantic-memory epic (`h1yj`)
@@ -213,8 +213,8 @@ Representative sources:
 Classification: **mixed historical debt, mostly tolerable rather than urgent content defect**.
 
 Rationale:
-- In older ADR/reference notes, `[[Roadmap]]` was often used as generic shorthand for “the roadmap note/current plan” rather than a stable permalink contract.
-- There is now a canonical singleton `[[roadmap]]`, but mass-normalizing every historical `[[Roadmap]]` occurrence across legacy notes would be broad editorial churn with low operational value.
+- In older ADR/reference notes, the legacy shorthand `Roadmap` was often used for “the roadmap note/current plan” rather than a stable permalink contract.
+- There is now a canonical singleton `roadmap`, but mass-normalizing every historical `Roadmap` occurrence across legacy notes would be broad editorial churn with low operational value.
 - Recent/current canonical notes were already cleaned up in prior tasks; what remains is mostly archival language in historical notes.
 
 Recommended action:
@@ -277,7 +277,7 @@ The residual `decisions/*` and `reference/*` broken-link slice should be interpr
    - recommended fix: replace broken title-style links with canonical permalinks
 
 2. **Tolerated historical alias debt**
-   - legacy ADR/reference notes whose broken links are mostly old title-case aliases or generic `Roadmap`
+- legacy ADR/reference notes whose broken links are mostly old title-case aliases or generic `Roadmap`
    - recommended fix: leave in place unless a note is otherwise being updated
 
 3. **Minor parser/placeholder noise**
@@ -292,4 +292,6 @@ If follow-up cleanup is scheduled, keep it **narrow and current-facing**:
 - do **not** add alias-resolution support for generic `Roadmap` or historical ADR titles at the memory-tool layer
 
 This classification makes future patrols cheaper: elevated counts from old `decisions/*` / `reference/*` notes should not be interpreted as fresh regressions unless the broken links are concentrated in currently maintained canonical notes.
+
+Scope boundary for the current cleanup: normalize only the broken links in the currently maintained canonical notes named above; leave broad historical `Roadmap`, ADR-title alias, `cases/*`, and `reference/repo-maps/*` debt untouched outside this narrow pass.
 

--- a/.djinn/reference/project-memory-broken-link-and-orphan-backlog-triage.md
+++ b/.djinn/reference/project-memory-broken-link-and-orphan-backlog-triage.md
@@ -1,6 +1,6 @@
 ---
 title: Project memory broken-link and orphan backlog triage
-type: 
+type: reference
 tags: ["memory","triage","broken-links","orphans","planner"]
 ---
 

--- a/.djinn/reference/repository-understanding-and-memory-freshness-upgrade-path.md
+++ b/.djinn/reference/repository-understanding-and-memory-freshness-upgrade-path.md
@@ -1,6 +1,6 @@
 ---
 title: Repository Understanding and Memory Freshness Upgrade Path
-type: 
+type: reference
 tags: ["adr","memory","code-graph","scip","state-of-the-art","proposal"]
 ---
 


### PR DESCRIPTION
## Summary
Execute the narrow current-note memory hygiene follow-up documented in `reference/narrow-current-note-memory-hygiene-follow-up`. Limit the work to the four current canonical notes named there and normalize only their broken title-style or placeholder wikilinks. Do not reopen broad historical alias cleanup, mass `cases/*` linking, or `reference/repo-maps/*` orphan work.

## Acceptance Criteria
- [x] The four named current canonical notes (`decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface`, `decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec`, `reference/repository-understanding-and-memory-freshness-upgrade-path`, and `reference/project-memory-broken-link-and-orphan-backlog-triage`) are updated so their identified broken title-style or placeholder wikilinks resolve to canonical note permalinks or plain text.
- [x] The cleanup explicitly leaves broad historical `Roadmap` and ADR-title alias debt untouched outside those four notes, and records that scope boundary in task output/comments or note updates.
- [x] Post-cleanup verification confirms `memory_broken_links()` no longer reports the specific broken targets from those four notes, without expanding into mass historical alias cleanup or orphan relinking.

---
Djinn task: nwg2