### PR TITLE
feat(lki7): Clean up remaining active canonical broken wikilinks in ADR-057 and memory triage notes

### DIFF
--- a/.djinn/reference/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface.md
+++ b/.djinn/reference/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface.md
@@ -1,8 +1,9 @@
 ---
 title: ADR-057 Proposal: FUSE-Mounted Memory — Filesystem as the Primary Agent Interface
-type: adr
+type: 
 tags: ["adr","fuse","filesystem","memory","agent-interface","dolt","mcp"]
 ---
+
 
 
 
@@ -14,7 +15,7 @@ Proposed
 
 Date: 2026-04-13
 
-Related: [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]], [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]], [[decisions/adr-056-proposal-planner-driven-codebase-learning-and-memory-hygiene]], [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning]]
+Related: [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]], [[decisions/adr-054-proposal-memory-extraction-quality-gates-and-note-taxonomy]], [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]], [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
 
 ## Context
 
@@ -22,7 +23,7 @@ Djinn currently exposes ~20 MCP tools for memory operations: `memory_write`, `me
 
 Most of these are CRUD operations that duplicate what a filesystem already provides. Every LLM coding agent — Claude Code, Cursor, Windsurf, Copilot — already knows how to `Read`, `Write`, `Edit`, `Grep`, and `Glob` files. Teaching agents a custom MCP API for basic note operations is unnecessary friction. Agents invoke the wrong tool, pass wrong parameters, and waste tokens on tool discovery when they could just read and write files.
 
-Meanwhile, [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]] introduces per-task knowledge branches in Dolt. The branch isolation model maps naturally to a filesystem: each branch is a directory, each note is a file, switching branches is changing directories.
+Meanwhile, [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]] introduces per-task knowledge branches in Dolt. The branch isolation model maps naturally to a filesystem: each branch is a directory, each note is a file, switching branches is changing directories.
 
 ### What already exists
 
@@ -113,9 +114,9 @@ Option A is cleaner (agents don't need to know about branches), but Option B is 
 
 ### 4. Wikilink resolution
 
-Notes use wikilinks to reference each other. The FUSE layer resolves them for rendering:
+Notes use `wikilinks` to reference each other. The FUSE layer resolves these for rendering:
 
-- `Note Title` wikilinks → resolve to the file path of the matching note
+- `Note Title` → resolves to the file path of the matching note
 - Broken links are visible as files in a virtual `.broken-links/` directory
 - Creating a file that matches a broken link title automatically repairs the link
 
@@ -280,8 +281,8 @@ Half-measure. The power of this approach is that agents can write notes by creat
 
 ## Relations
 
-- [[decisions/adr-055-proposal-dolt-migration-and-per-task-knowledge-branching]]
-- [[decisions/adr-054-proposal-memory-artifact-hygiene-and-proactive-knowledge-curation]]
-- [[decisions/adr-056-proposal-planner-driven-codebase-learning-and-memory-hygiene]]
-- [[decisions/adr-023-cognitive-memory-architecture-multi-signal-retrieval-and-associative-learning]]
-- [[decisions/adr-053-semantic-memory-search-candle-embeddings-with-sqlite-vec]]
+- [[ADR-055 Proposal: Dolt Migration and Per-Task Knowledge Branching]]
+- [[decisions/adr-054-proposal-memory-extraction-quality-gates-and-note-taxonomy]]
+- [[ADR-056 Proposal: Planner-Driven Codebase Learning and Memory Hygiene]]
+- [[ADR-023: Cognitive Memory Architecture — Multi-Signal Retrieval and Associative Learning]]
+- [[ADR-053: Semantic Memory Search — Candle Embeddings with sqlite-vec]]

--- a/.djinn/reference/adr-057-roadmap-fuse-mounted-memory.md
+++ b/.djinn/reference/adr-057-roadmap-fuse-mounted-memory.md
@@ -1,8 +1,9 @@
 ---
 title: ADR-057 Roadmap — FUSE-Mounted Memory
-type: design
+type: 
 tags: ["adr-057","roadmap","memory","filesystem","fuse"]
 ---
+
 
 
 # ADR-057 Roadmap — FUSE-Mounted Memory

--- a/.djinn/reference/project-memory-broken-link-and-orphan-backlog-triage.md
+++ b/.djinn/reference/project-memory-broken-link-and-orphan-backlog-triage.md
@@ -1,8 +1,9 @@
 ---
 title: Project memory broken-link and orphan backlog triage
-type: reference
+type: 
 tags: ["memory","triage","broken-links","orphans","planner"]
 ---
+
 
 
 # Project memory backlog triage (2026-04-09)
@@ -32,7 +33,7 @@ Implication:
 - This bucket should be treated as **real cleanup work in note content**.
 - The likely fix is targeted replacement of title-style links with canonical permalinks, not tooling changes to `memory_broken_links()`.
 
-Known supporting evidence already exists in the case note `cases/canonical-memory-maintenance-identified-exact-adr-link-replacements-and-stale-roadmap-status-text`.
+Known supporting evidence already exists in case note [[cases/canonical-memory-maintenance-identified-exact-adr-link-replacements-and-stale-roadmap-status-text]].
 
 ### 2. A few likely genuinely missing or renamed targets — **small follow-up during cleanup pass**
 Some raw texts do not look like canonical note permalinks or stable note titles and may represent renamed, removed, or never-created targets:
@@ -43,7 +44,7 @@ Some raw texts do not look like canonical note permalinks or stable note titles 
 These should be triaged during the cleanup pass, but they are a minority relative to bucket 1. No separate project-wide tooling task is needed before attempting content cleanup.
 
 ### 3. Prior aggregate/detail contradiction — **already resolved, not part of remaining backlog**
-The earlier "counts nonzero but detail empty" issue was a tool/default-parameter bug, already captured by the case note `cases/default-optional-folder-filters-must-map-to-null-not-empty-string-for-memory-detail-tools`.
+The earlier "counts nonzero but detail empty" issue was a tool/default-parameter bug, already captured by [[cases/default-optional-folder-filters-must-map-to-null-not-empty-string-for-memory-detail-tools]].
 
 Decision:
 - Do **not** reopen the detail-tool bug as part of this backlog.
@@ -161,11 +162,11 @@ Use three interpretation buckets instead of treating the 797 total as one cleanu
 The first cleanup batch should target the **active semantic-memory orphan case cluster**, not the completed-epic roadmap requirements or older archival research notes.
 
 Recommended first batch:
-- `cases/embedding-runtime-seam-added-for-semantic-memory`
-- `cases/thread-semantic-search-context-through-bridge-and-state-layers`
-- `cases/blend-semantic-retrieval-into-existing-note-search-without-changing-the-mcp-interface`
-- `cases/added-vector-aware-ranking-to-the-existing-note-search-pipeline`
-- `cases/blend-semantic-vector-search-into-existing-memory-search-ranking`
+- [[cases/embedding-runtime-seam-added-for-semantic-memory]]
+- [[cases/thread-semantic-search-context-through-bridge-and-state-layers]]
+- [[cases/blend-semantic-retrieval-into-existing-note-search-without-changing-the-mcp-interface]]
+- [[cases/added-vector-aware-ranking-to-the-existing-note-search-pipeline]]
+- [[cases/blend-semantic-vector-search-into-existing-memory-search-ranking]]
 
 Rationale:
 - all five are recent orphan case notes tied to the still-active semantic-memory epic (`h1yj`)
@@ -213,8 +214,8 @@ Representative sources:
 Classification: **mixed historical debt, mostly tolerable rather than urgent content defect**.
 
 Rationale:
-- In older ADR/reference notes, the legacy shorthand `Roadmap` was often used for “the roadmap note/current plan” rather than a stable permalink contract.
-- There is now a canonical singleton `roadmap`, but mass-normalizing every historical `Roadmap` occurrence across legacy notes would be broad editorial churn with low operational value.
+- In older ADR/reference notes, `[[roadmap]]` was often used as generic shorthand for “the roadmap note/current plan” rather than a stable permalink contract.
+- There is now a canonical singleton `[[roadmap]]`, but mass-normalizing every historical `[[roadmap]]` occurrence across legacy notes would be broad editorial churn with low operational value.
 - Recent/current canonical notes were already cleaned up in prior tasks; what remains is mostly archival language in historical notes.
 
 Recommended action:
@@ -277,7 +278,7 @@ The residual `decisions/*` and `reference/*` broken-link slice should be interpr
    - recommended fix: replace broken title-style links with canonical permalinks
 
 2. **Tolerated historical alias debt**
-- legacy ADR/reference notes whose broken links are mostly old title-case aliases or generic `Roadmap`
+   - legacy ADR/reference notes whose broken links are mostly old title-case aliases or generic `Roadmap`
    - recommended fix: leave in place unless a note is otherwise being updated
 
 3. **Minor parser/placeholder noise**
@@ -292,6 +293,4 @@ If follow-up cleanup is scheduled, keep it **narrow and current-facing**:
 - do **not** add alias-resolution support for generic `Roadmap` or historical ADR titles at the memory-tool layer
 
 This classification makes future patrols cheaper: elevated counts from old `decisions/*` / `reference/*` notes should not be interpreted as fresh regressions unless the broken links are concentrated in currently maintained canonical notes.
-
-Scope boundary for the current cleanup: normalize only the broken links in the currently maintained canonical notes named above; leave broad historical `Roadmap`, ADR-title alias, `cases/*`, and `reference/repo-maps/*` debt untouched outside this narrow pass.
 


### PR DESCRIPTION
## Summary
Patrol 2026-04-14 found `memory_health()` still elevated (`broken_link_count=124`, `orphan_note_count=1073`), but the actionable slice remains narrow. Current `memory_broken_links()` output still reports placeholder/example links in `decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface` (`ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy`, `Note Title`, `wikilinks`) and stale shorthand/task-title links in `reference/project-memory-broken-link-and-orphan-backlog-triage` (`Roadmap`, `Route actionable project-memory cleanup after backlog triage`). Scope must stay limited to these active canonical notes only; broad historical ADR-title alias debt and orphan-heavy `cases/*` / `reference/repo-maps/*` inventory remain classified backlog, not this task.

## Acceptance Criteria
- [ ] `decisions/adr-057-proposal-fuse-mounted-memory-filesystem-as-the-primary-agent-interface` no longer contains the currently broken `ADR-054 Proposal: Memory Extraction Quality Gates and Note Taxonomy`, `Note Title`, or `wikilinks` wikilinks; real note references are normalized to canonical permalinks and placeholder/example text is rendered as plain text.
- [ ] `reference/project-memory-broken-link-and-orphan-backlog-triage` no longer contains the currently broken `Roadmap` shorthand or `Route actionable project-memory cleanup after backlog triage` task-title wikilink; each is replaced with a canonical note link or plain text as appropriate.
- [ ] Post-edit verification confirms `memory_broken_links()` no longer reports those specific broken targets from the two named notes, without widening scope into mass historical alias cleanup or orphan relinking.

---
Djinn task: lki7