### PR TITLE
chore(u5qe): Expose mounted-memory view selection and fallback state in runtime status surfaces

### DIFF
--- a/server/src/memory_mount.rs
+++ b/server/src/memory_mount.rs
@@ -9,7 +9,9 @@
 //! The mount is disabled by default. When enabled on Linux with the cargo feature present, Djinn
 //! mounts the single registered project's memory note tree at `memory_mount_path` using FUSE.
 //! Runtime note operations resolve through the active task/session branch context when one can be
-//! determined. Otherwise the mount falls back to the canonical `main` view.
+//! determined. Otherwise the mount falls back to the canonical `main` view. Runtime status and
+//! health surfaces expose that selection explicitly so operators can see whether agents are using
+//! the canonical view or a task-scoped worktree view, plus any fallback reason.
 //!
 //! Operational safety for this wave:
 //! - startup rejects invalid configuration before the HTTP server begins serving
@@ -40,10 +42,9 @@ use djinn_db::NoteRepository;
 use djinn_db::ProjectRepository;
 
 use crate::events::EventBus;
+use crate::memory_fs::MemoryViewSelection;
 #[cfg(all(target_os = "linux", feature = "memory-mount"))]
-use crate::memory_fs::{
-    MemoryEntryKind, MemoryEntryMetadata, MemoryFilesystemCore, MemoryViewSelection,
-};
+use crate::memory_fs::{MemoryEntryKind, MemoryEntryMetadata, MemoryFilesystemCore};
 
 #[cfg(all(target_os = "linux", feature = "memory-mount"))]
 const WRITE_DEBOUNCE_WINDOW: Duration = Duration::from_millis(500);
@@ -125,6 +126,18 @@ pub(crate) struct MemoryMountRuntimeStatus {
     pub(crate) detail: Option<String>,
     pub(crate) pending_writes: usize,
     pub(crate) last_error: Option<String>,
+    pub(crate) view_selection: Option<MemoryViewSelection>,
+    pub(crate) view_fallback: Option<MemoryMountViewFallbackReason>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MemoryMountViewFallbackReason {
+    AmbiguousActiveTaskContext,
+    ActiveTaskNotFound,
+    ActiveTaskForDifferentProject,
+    NoRunningSessionForActiveTask,
+    ActiveSessionMissingWorktreePath,
+    ActiveSessionOnCanonicalProjectRoot,
 }
 
 #[cfg_attr(
@@ -141,6 +154,8 @@ impl MemoryMountRuntimeStatus {
             detail: None,
             pending_writes: 0,
             last_error: None,
+            view_selection: None,
+            view_fallback: None,
         }
     }
 
@@ -153,6 +168,8 @@ impl MemoryMountRuntimeStatus {
             detail: Some("mount validated but not yet attached".to_string()),
             pending_writes: 0,
             last_error: None,
+            view_selection: Some(MemoryViewSelection::Canonical),
+            view_fallback: Some(MemoryMountViewFallbackReason::AmbiguousActiveTaskContext),
         }
     }
 
@@ -170,6 +187,15 @@ impl MemoryMountRuntimeStatus {
 
     fn set_pending_writes(&mut self, pending_writes: usize) {
         self.pending_writes = pending_writes;
+    }
+
+    fn set_view_selection(
+        &mut self,
+        selection: MemoryViewSelection,
+        fallback: Option<MemoryMountViewFallbackReason>,
+    ) {
+        self.view_selection = Some(selection);
+        self.view_fallback = fallback;
     }
 }
 
@@ -432,10 +458,20 @@ impl LinuxMemoryFilesystem {
     }
 
     fn current_view_selection(&self) -> MemoryViewSelection {
-        self.runtime.block_on(
-            self.state
-                .resolve_memory_mount_view_selection(&self.project_id, &self.project_path),
-        )
+        self.runtime.block_on(async {
+            let resolution = self
+                .state
+                .resolve_memory_mount_view_selection_with_fallback(
+                    &self.project_id,
+                    &self.project_path,
+                )
+                .await;
+            self.runtime_status
+                .lock()
+                .await
+                .set_view_selection(resolution.selection.clone(), resolution.fallback.clone());
+            resolution.selection
+        })
     }
 
     fn next_fh(&self, path: &str) -> u64 {
@@ -595,9 +631,10 @@ impl LinuxMemoryFilesystem {
                 return;
             };
 
-            let selection = state
-                .resolve_memory_mount_view_selection(&project_id, &project_path)
+            let resolution = state
+                .resolve_memory_mount_view_selection_with_fallback(&project_id, &project_path)
                 .await;
+            let selection = resolution.selection.clone();
             let flush_result = core
                 .write_file_in_view(
                     &project_id,
@@ -615,6 +652,7 @@ impl LinuxMemoryFilesystem {
 
             let mut status = runtime_status.lock().await;
             status.set_pending_writes(pending_count);
+            status.set_view_selection(resolution.selection, resolution.fallback);
             match flush_result {
                 Ok(_) => {
                     if matches!(
@@ -1517,11 +1555,18 @@ mod tests {
 
         state.agent_context().register_activity(&task.id);
 
-        let selection = state
-            .resolve_memory_mount_view_selection(&project.id, Path::new(&project.path))
+        let resolution = state
+            .resolve_memory_mount_view_selection_with_fallback(
+                &project.id,
+                Path::new(&project.path),
+            )
             .await;
 
-        assert_eq!(selection, MemoryViewSelection::Canonical);
+        assert_eq!(resolution.selection, MemoryViewSelection::Canonical);
+        assert_eq!(
+            resolution.fallback,
+            Some(MemoryMountViewFallbackReason::NoRunningSessionForActiveTask)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1537,10 +1582,17 @@ mod tests {
         agent.register_activity(&first.id);
         agent.register_activity(&second.id);
 
-        let selection = state
-            .resolve_memory_mount_view_selection(&project.id, Path::new(&project.path))
+        let resolution = state
+            .resolve_memory_mount_view_selection_with_fallback(
+                &project.id,
+                Path::new(&project.path),
+            )
             .await;
 
-        assert_eq!(selection, MemoryViewSelection::Canonical);
+        assert_eq!(resolution.selection, MemoryViewSelection::Canonical);
+        assert_eq!(
+            resolution.fallback,
+            Some(MemoryMountViewFallbackReason::AmbiguousActiveTaskContext)
+        );
     }
 }

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -46,6 +46,44 @@ pub(crate) enum MemoryMountLifecycleState {
     Degraded,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryMountViewKind {
+    Canonical,
+    TaskScoped,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryMountFallbackReason {
+    AmbiguousActiveTaskContext,
+    ActiveTaskNotFound,
+    ActiveTaskForDifferentProject,
+    NoRunningSessionForActiveTask,
+    ActiveSessionMissingWorktreePath,
+    ActiveSessionOnCanonicalProjectRoot,
+}
+
+/// Structured view-selection state for the mounted memory surface.
+///
+/// ADR-057's filesystem-first flow means agents primarily interact with memory through the mounted
+/// filesystem instead of CRUD-oriented MCP tools. Operators can use this payload to tell whether
+/// the mount is currently serving the canonical `main` knowledge view or a task-scoped worktree
+/// view, plus why the runtime fell back to canonical when it could not safely select a task view.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct MemoryMountViewHealth {
+    kind: MemoryMountViewKind,
+    branch: String,
+    task_short_id: Option<String>,
+    worktree_root: Option<String>,
+    fallback_reason: Option<MemoryMountFallbackReason>,
+}
+
+/// Health snapshot for the ADR-057 mounted-memory runtime.
+///
+/// The `view` field makes the filesystem-first exposure contract explicit: it reports which memory
+/// view mounted agents are actually reading and writing right now, rather than forcing operators to
+/// infer canonical-vs-task-scoped behavior from debug logs.
 #[derive(Serialize)]
 pub(crate) struct MemoryMountHealth {
     enabled: bool,
@@ -57,6 +95,7 @@ pub(crate) struct MemoryMountHealth {
     detail: Option<String>,
     pending_writes: usize,
     last_error: Option<String>,
+    view: Option<MemoryMountViewHealth>,
 }
 
 async fn health(State(state): State<AppState>) -> axum::Json<HealthResponse> {

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -16,7 +16,7 @@ use djinn_agent::lsp::LspManager;
 use djinn_agent::roles::RoleRegistry;
 use djinn_db::{
     Database, NoopNoteVectorStore, NoteRepository, NoteVectorStore, ProjectRepository,
-    QdrantNoteVectorStore, SettingsRepository, SqliteVecNoteVectorStore,
+    QdrantNoteVectorStore, SettingsRepository, SqliteVecNoteVectorStore, task_branch_name,
 };
 use djinn_git::{GitActorHandle, GitError};
 use djinn_provider::catalog::{CatalogService, HealthTracker};
@@ -33,6 +33,12 @@ use canonical_graph_refresh_planner::{
 const EVENT_CHANNEL_CAPACITY: usize = 1024;
 const SETTINGS_RAW_KEY: &str = "settings.raw";
 const MODEL_HEALTH_STATE_KEY: &str = "model_health.state";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemoryMountViewResolution {
+    pub(crate) selection: MemoryViewSelection,
+    pub(crate) fallback: Option<crate::memory_mount::MemoryMountViewFallbackReason>,
+}
 
 /// Shared application state, cheaply cloneable via `Arc`.
 #[derive(Clone)]
@@ -237,10 +243,65 @@ impl AppState {
                 detail: None,
                 pending_writes: 0,
                 last_error: None,
+                view: None,
             };
         };
         let active = mount.is_active();
         let status = mount.status_snapshot().await;
+        let view = status.view_selection.as_ref().map(|selection| {
+            let kind = match selection {
+                MemoryViewSelection::Canonical => crate::server::MemoryMountViewKind::Canonical,
+                MemoryViewSelection::Branch { .. }
+                | MemoryViewSelection::Worktree { .. }
+                | MemoryViewSelection::Task { .. } => crate::server::MemoryMountViewKind::TaskScoped,
+            };
+            let branch = match selection {
+                MemoryViewSelection::Canonical => "main".to_string(),
+                MemoryViewSelection::Branch { branch } => branch.clone(),
+                MemoryViewSelection::Worktree { .. } => "main".to_string(),
+                MemoryViewSelection::Task { task_short_id, .. } => task_short_id
+                    .as_deref()
+                    .map(task_branch_name)
+                    .unwrap_or_else(|| "main".to_string()),
+            };
+            let (task_short_id, worktree_root) = match selection {
+                MemoryViewSelection::Task {
+                    task_short_id,
+                    worktree_root,
+                } => (
+                    task_short_id.clone(),
+                    worktree_root.as_ref().map(|root| root.display().to_string()),
+                ),
+                MemoryViewSelection::Worktree { root } => (None, Some(root.display().to_string())),
+                _ => (None, None),
+            };
+            crate::server::MemoryMountViewHealth {
+                kind,
+                branch,
+                task_short_id,
+                worktree_root,
+                fallback_reason: status.view_fallback.as_ref().map(|fallback| match fallback {
+                    crate::memory_mount::MemoryMountViewFallbackReason::AmbiguousActiveTaskContext => {
+                        crate::server::MemoryMountFallbackReason::AmbiguousActiveTaskContext
+                    }
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveTaskNotFound => {
+                        crate::server::MemoryMountFallbackReason::ActiveTaskNotFound
+                    }
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveTaskForDifferentProject => {
+                        crate::server::MemoryMountFallbackReason::ActiveTaskForDifferentProject
+                    }
+                    crate::memory_mount::MemoryMountViewFallbackReason::NoRunningSessionForActiveTask => {
+                        crate::server::MemoryMountFallbackReason::NoRunningSessionForActiveTask
+                    }
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveSessionMissingWorktreePath => {
+                        crate::server::MemoryMountFallbackReason::ActiveSessionMissingWorktreePath
+                    }
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveSessionOnCanonicalProjectRoot => {
+                        crate::server::MemoryMountFallbackReason::ActiveSessionOnCanonicalProjectRoot
+                    }
+                }),
+            }
+        });
         crate::server::MemoryMountHealth {
             enabled: status.configured,
             active,
@@ -251,6 +312,7 @@ impl AppState {
             detail: status.detail,
             pending_writes: status.pending_writes,
             last_error: status.last_error,
+            view,
         }
     }
 
@@ -271,6 +333,16 @@ impl AppState {
         project_id: &str,
         project_path: &Path,
     ) -> MemoryViewSelection {
+        self.resolve_memory_mount_view_selection_with_fallback(project_id, project_path)
+            .await
+            .selection
+    }
+
+    pub(crate) async fn resolve_memory_mount_view_selection_with_fallback(
+        &self,
+        project_id: &str,
+        project_path: &Path,
+    ) -> MemoryMountViewResolution {
         let active_task_ids: Vec<String> = self
             .inner
             .active_tasks
@@ -281,7 +353,12 @@ impl AppState {
             .collect();
 
         let [task_id] = active_task_ids.as_slice() else {
-            return MemoryViewSelection::Canonical;
+            return MemoryMountViewResolution {
+                selection: MemoryViewSelection::Canonical,
+                fallback: Some(
+                    crate::memory_mount::MemoryMountViewFallbackReason::AmbiguousActiveTaskContext,
+                ),
+            };
         };
 
         let task_repo = djinn_db::TaskRepository::new(self.db().clone(), self.event_bus());
@@ -290,7 +367,12 @@ impl AppState {
                 task_id,
                 "memory mount falling back to main: active task not found"
             );
-            return MemoryViewSelection::Canonical;
+            return MemoryMountViewResolution {
+                selection: MemoryViewSelection::Canonical,
+                fallback: Some(
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveTaskNotFound,
+                ),
+            };
         };
 
         if task.project_id != project_id {
@@ -300,7 +382,12 @@ impl AppState {
                 mount_project_id = %project_id,
                 "memory mount falling back to main: active task belongs to another project"
             );
-            return MemoryViewSelection::Canonical;
+            return MemoryMountViewResolution {
+                selection: MemoryViewSelection::Canonical,
+                fallback: Some(
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveTaskForDifferentProject,
+                ),
+            };
         }
 
         let session_repo = djinn_db::SessionRepository::new(self.db().clone(), self.event_bus());
@@ -310,7 +397,12 @@ impl AppState {
                 short_id = %task.short_id,
                 "memory mount falling back to main: no running session for active task"
             );
-            return MemoryViewSelection::Canonical;
+            return MemoryMountViewResolution {
+                selection: MemoryViewSelection::Canonical,
+                fallback: Some(
+                    crate::memory_mount::MemoryMountViewFallbackReason::NoRunningSessionForActiveTask,
+                ),
+            };
         };
 
         let Some(worktree_path) = session
@@ -324,7 +416,12 @@ impl AppState {
                 short_id = %task.short_id,
                 "memory mount falling back to main: active session has no worktree path"
             );
-            return MemoryViewSelection::Canonical;
+            return MemoryMountViewResolution {
+                selection: MemoryViewSelection::Canonical,
+                fallback: Some(
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveSessionMissingWorktreePath,
+                ),
+            };
         };
 
         let worktree_root = PathBuf::from(worktree_path);
@@ -334,12 +431,20 @@ impl AppState {
                 short_id = %task.short_id,
                 "memory mount falling back to main: active session is on canonical project root"
             );
-            return MemoryViewSelection::Canonical;
+            return MemoryMountViewResolution {
+                selection: MemoryViewSelection::Canonical,
+                fallback: Some(
+                    crate::memory_mount::MemoryMountViewFallbackReason::ActiveSessionOnCanonicalProjectRoot,
+                ),
+            };
         }
 
-        MemoryViewSelection::Task {
-            task_short_id: Some(task.short_id),
-            worktree_root: Some(worktree_root),
+        MemoryMountViewResolution {
+            selection: MemoryViewSelection::Task {
+                task_short_id: Some(task.short_id),
+                worktree_root: Some(worktree_root),
+            },
+            fallback: None,
         }
     }
 

--- a/server/src/server/tests/router.rs
+++ b/server/src/server/tests/router.rs
@@ -3,7 +3,9 @@ use axum::http::header::{ACCEPT, CONTENT_TYPE};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
-use crate::memory_mount::{MemoryMountRuntimeStatus, MountedMemoryFilesystem};
+use crate::memory_mount::{
+    MemoryMountRuntimeStatus, MemoryMountViewFallbackReason, MountedMemoryFilesystem,
+};
 use crate::server::{self, AppState};
 use crate::test_helpers;
 use tokio_util::sync::CancellationToken;
@@ -35,6 +37,7 @@ async fn health_returns_ok() {
     assert!(json["memory_mount"]["project_id"].is_null());
     assert!(json["memory_mount"]["detail"].is_null());
     assert!(json["memory_mount"]["last_error"].is_null());
+    assert!(json["memory_mount"]["view"].is_null());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -54,6 +57,8 @@ async fn health_reports_memory_mount_runtime_status_details() {
                 last_error: Some(
                     "failed to flush pending write for research/note.md: boom".to_string(),
                 ),
+                view_selection: Some(crate::memory_fs::MemoryViewSelection::Canonical),
+                view_fallback: Some(MemoryMountViewFallbackReason::NoRunningSessionForActiveTask),
             },
         )))
         .await;
@@ -84,6 +89,59 @@ async fn health_reports_memory_mount_runtime_status_details() {
         json["memory_mount"]["last_error"],
         "failed to flush pending write for research/note.md: boom"
     );
+    assert_eq!(json["memory_mount"]["view"]["kind"], "canonical");
+    assert_eq!(json["memory_mount"]["view"]["branch"], "main");
+    assert!(json["memory_mount"]["view"]["task_short_id"].is_null());
+    assert!(json["memory_mount"]["view"]["worktree_root"].is_null());
+    assert_eq!(
+        json["memory_mount"]["view"]["fallback_reason"],
+        "no_running_session_for_active_task"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn health_reports_task_scoped_memory_mount_view_details() {
+    let state = AppState::new(test_helpers::create_test_db(), CancellationToken::new());
+    state
+        .set_memory_mount_for_tests(Some(MountedMemoryFilesystem::with_status(
+            MemoryMountRuntimeStatus {
+                lifecycle: crate::server::MemoryMountLifecycleState::Mounted,
+                configured: true,
+                mount_path: Some(std::path::PathBuf::from("/mnt/djinn-memory")),
+                project_id: Some("project-123".to_string()),
+                detail: None,
+                pending_writes: 1,
+                last_error: None,
+                view_selection: Some(crate::memory_fs::MemoryViewSelection::Task {
+                    task_short_id: Some("u5qe".to_string()),
+                    worktree_root: Some(std::path::PathBuf::from(
+                        "/worktrees/project/.djinn/worktrees/u5qe",
+                    )),
+                }),
+                view_fallback: None,
+            },
+        )))
+        .await;
+    let app = server::router(state);
+
+    let req = axum::http::Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["memory_mount"]["view"]["kind"], "task_scoped");
+    assert_eq!(json["memory_mount"]["view"]["branch"], "task/u5qe");
+    assert_eq!(json["memory_mount"]["view"]["task_short_id"], "u5qe");
+    assert_eq!(
+        json["memory_mount"]["view"]["worktree_root"],
+        "/worktrees/project/.djinn/worktrees/u5qe"
+    );
+    assert!(json["memory_mount"]["view"]["fallback_reason"].is_null());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
Make the mounted memory surface explicit about which view agents are actually using once CRUD-oriented MCP exposure contracts. Build on the existing runtime status and session-aware branch selection so operators and agents can see whether mounted memory is serving the canonical view or a task-scoped worktree view, and why any fallback occurred.

## Acceptance Criteria
- [x] Mounted-memory runtime/status surfaces report whether the active view is canonical or task-scoped, including any branch/worktree fallback reason when the runtime cannot select a task view.
- [x] Health/runtime tests cover the new view-reporting fields and at least one fallback scenario derived from the existing resolve_memory_mount_view_selection behavior.
- [x] Documentation or inline module docs explain how operators/agents interpret the reported memory-mount view state when filesystem-first workflows are enabled.

---
Djinn task: u5qe