### PR TITLE
chore(98vz): Land mounted-memory view selection health payload after integration drift

### DIFF
--- a/server/src/memory_mount.rs
+++ b/server/src/memory_mount.rs
@@ -317,6 +317,8 @@ pub async fn start_memory_mount(
                 resolved.project_id.clone(),
             ),
         ));
+        let project_id = resolved.project_id.clone();
+        let project_path = resolved.project_path.clone();
         let fs = LinuxMemoryFilesystem::new(
             repo,
             resolved.project_id,
@@ -342,7 +344,7 @@ pub async fn start_memory_mount(
         Ok(Some(MountedMemoryFilesystem::from_session(
             session,
             runtime_status,
-            (state, resolved.project_id, resolved.project_path),
+            (state, project_id, project_path),
         )))
     }
 

--- a/server/src/memory_mount.rs
+++ b/server/src/memory_mount.rs
@@ -72,9 +72,9 @@ impl MemoryMountConfig {
     }
 }
 
-#[derive(Debug)]
 pub struct MountedMemoryFilesystem {
     runtime_status: std::sync::Arc<tokio::sync::Mutex<MemoryMountRuntimeStatus>>,
+    view_context: Option<(crate::server::AppState, String, PathBuf)>,
     #[cfg(all(target_os = "linux", feature = "memory-mount"))]
     session: Option<fuser::BackgroundSession>,
 }
@@ -85,6 +85,7 @@ impl MountedMemoryFilesystem {
             runtime_status: std::sync::Arc::new(tokio::sync::Mutex::new(
                 MemoryMountRuntimeStatus::disabled(),
             )),
+            view_context: None,
             #[cfg(all(target_os = "linux", feature = "memory-mount"))]
             session: None,
         }
@@ -94,6 +95,7 @@ impl MountedMemoryFilesystem {
     pub(crate) fn with_status(status: MemoryMountRuntimeStatus) -> Self {
         Self {
             runtime_status: std::sync::Arc::new(tokio::sync::Mutex::new(status)),
+            view_context: None,
             #[cfg(all(target_os = "linux", feature = "memory-mount"))]
             session: None,
         }
@@ -103,14 +105,22 @@ impl MountedMemoryFilesystem {
     fn from_session(
         session: fuser::BackgroundSession,
         runtime_status: std::sync::Arc<tokio::sync::Mutex<MemoryMountRuntimeStatus>>,
+        view_context: (crate::server::AppState, String, PathBuf),
     ) -> Self {
         Self {
             runtime_status,
+            view_context: Some(view_context),
             session: Some(session),
         }
     }
 
     pub(crate) async fn status_snapshot(&self) -> MemoryMountRuntimeStatus {
+        if let Some((state, project_id, project_path)) = &self.view_context {
+            let resolution = state
+                .resolve_memory_mount_view_resolution(project_id, project_path)
+                .await;
+            self.runtime_status.lock().await.view = resolution.health;
+        }
         self.runtime_status.lock().await.clone()
     }
 
@@ -132,6 +142,7 @@ pub(crate) struct MemoryMountRuntimeStatus {
     pub(crate) mount_path: Option<PathBuf>,
     pub(crate) project_id: Option<String>,
     pub(crate) detail: Option<String>,
+    pub(crate) view: crate::server::MemoryMountViewHealth,
     pub(crate) pending_writes: usize,
     pub(crate) last_error: Option<String>,
 }
@@ -148,6 +159,12 @@ impl MemoryMountRuntimeStatus {
             mount_path: None,
             project_id: None,
             detail: None,
+            view: crate::server::MemoryMountViewHealth {
+                kind: crate::server::MemoryMountViewKind::Canonical,
+                task_short_id: None,
+                worktree_root: None,
+                fallback: None,
+            },
             pending_writes: 0,
             last_error: None,
         }
@@ -160,6 +177,12 @@ impl MemoryMountRuntimeStatus {
             mount_path: Some(mount_path),
             project_id: Some(project_id),
             detail: Some("mount validated but not yet attached".to_string()),
+            view: crate::server::MemoryMountViewHealth {
+                kind: crate::server::MemoryMountViewKind::Canonical,
+                task_short_id: None,
+                worktree_root: None,
+                fallback: None,
+            },
             pending_writes: 0,
             last_error: None,
         }
@@ -319,6 +342,7 @@ pub async fn start_memory_mount(
         Ok(Some(MountedMemoryFilesystem::from_session(
             session,
             runtime_status,
+            (state, resolved.project_id, resolved.project_path),
         )))
     }
 
@@ -441,10 +465,18 @@ impl LinuxMemoryFilesystem {
     }
 
     fn current_view_selection(&self) -> MemoryViewSelection {
-        self.runtime.block_on(
+        self.current_view_resolution().selection
+    }
+
+    fn current_view_resolution(&self) -> crate::server::MemoryMountViewResolution {
+        let resolution = self.runtime.block_on(
             self.state
-                .resolve_memory_mount_view_selection(&self.project_id, &self.project_path),
-        )
+                .resolve_memory_mount_view_resolution(&self.project_id, &self.project_path),
+        );
+        self.runtime.block_on(async {
+            self.runtime_status.lock().await.view = resolution.health.clone();
+        });
+        resolution
     }
 
     fn next_fh(&self, path: &str) -> u64 {
@@ -1510,10 +1542,27 @@ mod tests {
         assert_eq!(
             selection,
             MemoryViewSelection::Task {
-                task_short_id: Some(task.short_id),
+                task_short_id: Some(task.short_id.clone()),
                 worktree_root: Some(worktree_dir.path().to_path_buf()),
             }
         );
+
+        let resolution = state
+            .resolve_memory_mount_view_resolution(&project.id, Path::new(&project.path))
+            .await;
+        assert_eq!(
+            resolution.health.kind,
+            crate::server::MemoryMountViewKind::TaskScoped
+        );
+        assert_eq!(
+            resolution.health.task_short_id.as_deref(),
+            Some(task.short_id.as_str())
+        );
+        assert_eq!(
+            resolution.health.worktree_root.as_deref(),
+            Some(worktree_dir.path().to_string_lossy().as_ref())
+        );
+        assert!(resolution.health.fallback.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1531,6 +1580,26 @@ mod tests {
             .await;
 
         assert_eq!(selection, MemoryViewSelection::Canonical);
+
+        let resolution = state
+            .resolve_memory_mount_view_resolution(&project.id, Path::new(&project.path))
+            .await;
+        assert_eq!(
+            resolution.health.kind,
+            crate::server::MemoryMountViewKind::Canonical
+        );
+        let fallback = resolution
+            .health
+            .fallback
+            .expect("fallback should be reported");
+        assert_eq!(
+            fallback.reason,
+            crate::server::MemoryMountViewFallbackReason::NoActiveSession
+        );
+        assert_eq!(
+            fallback.task_short_id.as_deref(),
+            Some(task.short_id.as_str())
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1551,5 +1620,18 @@ mod tests {
             .await;
 
         assert_eq!(selection, MemoryViewSelection::Canonical);
+
+        let resolution = state
+            .resolve_memory_mount_view_resolution(&project.id, Path::new(&project.path))
+            .await;
+        let fallback = resolution
+            .health
+            .fallback
+            .expect("fallback should be reported");
+        assert_eq!(
+            fallback.reason,
+            crate::server::MemoryMountViewFallbackReason::AmbiguousActiveTasks
+        );
+        assert_eq!(fallback.active_task_count, Some(2));
     }
 }

--- a/server/src/server/mod.rs
+++ b/server/src/server/mod.rs
@@ -46,6 +46,56 @@ pub(crate) enum MemoryMountLifecycleState {
     Degraded,
 }
 
+/// Describes which mounted-memory view ADR-057 is currently serving.
+///
+/// Operators should read this alongside `fallback`: a `canonical` view with no
+/// fallback means the mount is intentionally serving the canonical repository
+/// view, while a populated fallback explains why task-scoped resolution could
+/// not be used for the current filesystem-first session.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryMountViewKind {
+    Canonical,
+    TaskScoped,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryMountViewFallbackReason {
+    AmbiguousActiveTasks,
+    ActiveTaskNotFound,
+    TaskProjectMismatch,
+    NoActiveSession,
+    MissingSessionWorktree,
+    CanonicalProjectRoot,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct MemoryMountViewFallback {
+    pub(crate) reason: MemoryMountViewFallbackReason,
+    pub(crate) detail: Option<String>,
+    pub(crate) active_task_count: Option<usize>,
+    pub(crate) task_id: Option<String>,
+    pub(crate) task_short_id: Option<String>,
+    pub(crate) task_project_id: Option<String>,
+    pub(crate) mount_project_id: Option<String>,
+    pub(crate) session_worktree_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct MemoryMountViewHealth {
+    pub(crate) kind: MemoryMountViewKind,
+    pub(crate) task_short_id: Option<String>,
+    pub(crate) worktree_root: Option<String>,
+    pub(crate) fallback: Option<MemoryMountViewFallback>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemoryMountViewResolution {
+    pub(crate) selection: crate::memory_fs::MemoryViewSelection,
+    pub(crate) health: MemoryMountViewHealth,
+}
+
 #[derive(Serialize)]
 pub(crate) struct MemoryMountHealth {
     enabled: bool,
@@ -55,6 +105,7 @@ pub(crate) struct MemoryMountHealth {
     mount_path: Option<String>,
     project_id: Option<String>,
     detail: Option<String>,
+    view: MemoryMountViewHealth,
     pending_writes: usize,
     last_error: Option<String>,
 }

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -34,6 +34,37 @@ const EVENT_CHANNEL_CAPACITY: usize = 1024;
 const SETTINGS_RAW_KEY: &str = "settings.raw";
 const MODEL_HEALTH_STATE_KEY: &str = "model_health.state";
 
+fn canonical_view_resolution(
+    active_task_count: usize,
+    fallback: Option<crate::server::MemoryMountViewFallback>,
+) -> crate::server::MemoryMountViewResolution {
+    let fallback = fallback.or_else(|| {
+        (active_task_count > 1).then(|| crate::server::MemoryMountViewFallback {
+            reason: crate::server::MemoryMountViewFallbackReason::AmbiguousActiveTasks,
+            detail: Some(
+                "mounted memory requires exactly one active task before task-scoped selection can be used"
+                    .to_string(),
+            ),
+            active_task_count: Some(active_task_count),
+            task_id: None,
+            task_short_id: None,
+            task_project_id: None,
+            mount_project_id: None,
+            session_worktree_path: None,
+        })
+    });
+
+    crate::server::MemoryMountViewResolution {
+        selection: MemoryViewSelection::Canonical,
+        health: crate::server::MemoryMountViewHealth {
+            kind: crate::server::MemoryMountViewKind::Canonical,
+            task_short_id: None,
+            worktree_root: None,
+            fallback,
+        },
+    }
+}
+
 /// Shared application state, cheaply cloneable via `Arc`.
 #[derive(Clone)]
 pub struct AppState {
@@ -235,6 +266,12 @@ impl AppState {
                 mount_path: None,
                 project_id: None,
                 detail: None,
+                view: crate::server::MemoryMountViewHealth {
+                    kind: crate::server::MemoryMountViewKind::Canonical,
+                    task_short_id: None,
+                    worktree_root: None,
+                    fallback: None,
+                },
                 pending_writes: 0,
                 last_error: None,
             };
@@ -249,6 +286,7 @@ impl AppState {
             mount_path: status.mount_path.map(|path| path.display().to_string()),
             project_id: status.project_id,
             detail: status.detail,
+            view: status.view,
             pending_writes: status.pending_writes,
             last_error: status.last_error,
         }
@@ -271,6 +309,20 @@ impl AppState {
         project_id: &str,
         project_path: &Path,
     ) -> MemoryViewSelection {
+        self.resolve_memory_mount_view_resolution(project_id, project_path)
+            .await
+            .selection
+    }
+
+    #[cfg_attr(
+        not(any(test, all(target_os = "linux", feature = "memory-mount"))),
+        allow(dead_code)
+    )]
+    pub(crate) async fn resolve_memory_mount_view_resolution(
+        &self,
+        project_id: &str,
+        project_path: &Path,
+    ) -> crate::server::MemoryMountViewResolution {
         let active_task_ids: Vec<String> = self
             .inner
             .active_tasks
@@ -281,7 +333,7 @@ impl AppState {
             .collect();
 
         let [task_id] = active_task_ids.as_slice() else {
-            return MemoryViewSelection::Canonical;
+            return canonical_view_resolution(active_task_ids.len(), None);
         };
 
         let task_repo = djinn_db::TaskRepository::new(self.db().clone(), self.event_bus());
@@ -290,7 +342,19 @@ impl AppState {
                 task_id,
                 "memory mount falling back to main: active task not found"
             );
-            return MemoryViewSelection::Canonical;
+            return canonical_view_resolution(
+                1,
+                Some(crate::server::MemoryMountViewFallback {
+                    reason: crate::server::MemoryMountViewFallbackReason::ActiveTaskNotFound,
+                    detail: Some("active task no longer exists in the database".to_string()),
+                    active_task_count: Some(1),
+                    task_id: Some(task_id.to_string()),
+                    task_short_id: None,
+                    task_project_id: None,
+                    mount_project_id: Some(project_id.to_string()),
+                    session_worktree_path: None,
+                }),
+            );
         };
 
         if task.project_id != project_id {
@@ -300,7 +364,19 @@ impl AppState {
                 mount_project_id = %project_id,
                 "memory mount falling back to main: active task belongs to another project"
             );
-            return MemoryViewSelection::Canonical;
+            return canonical_view_resolution(
+                1,
+                Some(crate::server::MemoryMountViewFallback {
+                    reason: crate::server::MemoryMountViewFallbackReason::TaskProjectMismatch,
+                    detail: Some("active task belongs to another registered project".to_string()),
+                    active_task_count: Some(1),
+                    task_id: Some(task.id),
+                    task_short_id: Some(task.short_id),
+                    task_project_id: Some(task.project_id),
+                    mount_project_id: Some(project_id.to_string()),
+                    session_worktree_path: None,
+                }),
+            );
         }
 
         let session_repo = djinn_db::SessionRepository::new(self.db().clone(), self.event_bus());
@@ -310,7 +386,19 @@ impl AppState {
                 short_id = %task.short_id,
                 "memory mount falling back to main: no running session for active task"
             );
-            return MemoryViewSelection::Canonical;
+            return canonical_view_resolution(
+                1,
+                Some(crate::server::MemoryMountViewFallback {
+                    reason: crate::server::MemoryMountViewFallbackReason::NoActiveSession,
+                    detail: Some("no running session is attached to the active task".to_string()),
+                    active_task_count: Some(1),
+                    task_id: Some(task.id),
+                    task_short_id: Some(task.short_id),
+                    task_project_id: Some(project_id.to_string()),
+                    mount_project_id: Some(project_id.to_string()),
+                    session_worktree_path: None,
+                }),
+            );
         };
 
         let Some(worktree_path) = session
@@ -324,7 +412,19 @@ impl AppState {
                 short_id = %task.short_id,
                 "memory mount falling back to main: active session has no worktree path"
             );
-            return MemoryViewSelection::Canonical;
+            return canonical_view_resolution(
+                1,
+                Some(crate::server::MemoryMountViewFallback {
+                    reason: crate::server::MemoryMountViewFallbackReason::MissingSessionWorktree,
+                    detail: Some("active session did not publish a worktree path".to_string()),
+                    active_task_count: Some(1),
+                    task_id: Some(task.id),
+                    task_short_id: Some(task.short_id),
+                    task_project_id: Some(project_id.to_string()),
+                    mount_project_id: Some(project_id.to_string()),
+                    session_worktree_path: None,
+                }),
+            );
         };
 
         let worktree_root = PathBuf::from(worktree_path);
@@ -334,12 +434,35 @@ impl AppState {
                 short_id = %task.short_id,
                 "memory mount falling back to main: active session is on canonical project root"
             );
-            return MemoryViewSelection::Canonical;
+            return canonical_view_resolution(
+                1,
+                Some(crate::server::MemoryMountViewFallback {
+                    reason: crate::server::MemoryMountViewFallbackReason::CanonicalProjectRoot,
+                    detail: Some(
+                        "active session worktree resolves to the canonical project root"
+                            .to_string(),
+                    ),
+                    active_task_count: Some(1),
+                    task_id: Some(task.id),
+                    task_short_id: Some(task.short_id),
+                    task_project_id: Some(project_id.to_string()),
+                    mount_project_id: Some(project_id.to_string()),
+                    session_worktree_path: Some(worktree_root.display().to_string()),
+                }),
+            );
         }
 
-        MemoryViewSelection::Task {
-            task_short_id: Some(task.short_id),
-            worktree_root: Some(worktree_root),
+        crate::server::MemoryMountViewResolution {
+            selection: MemoryViewSelection::Task {
+                task_short_id: Some(task.short_id.clone()),
+                worktree_root: Some(worktree_root.clone()),
+            },
+            health: crate::server::MemoryMountViewHealth {
+                kind: crate::server::MemoryMountViewKind::TaskScoped,
+                task_short_id: Some(task.short_id),
+                worktree_root: Some(worktree_root.display().to_string()),
+                fallback: None,
+            },
         }
     }
 

--- a/server/src/server/tests/router.rs
+++ b/server/src/server/tests/router.rs
@@ -30,6 +30,10 @@ async fn health_returns_ok() {
     assert_eq!(json["memory_mount"]["active"], false);
     assert_eq!(json["memory_mount"]["lifecycle"], "disabled");
     assert_eq!(json["memory_mount"]["configured"], false);
+    assert_eq!(json["memory_mount"]["view"]["kind"], "canonical");
+    assert!(json["memory_mount"]["view"]["task_short_id"].is_null());
+    assert!(json["memory_mount"]["view"]["worktree_root"].is_null());
+    assert!(json["memory_mount"]["view"]["fallback"].is_null());
     assert_eq!(json["memory_mount"]["pending_writes"], 0);
     assert!(json["memory_mount"]["mount_path"].is_null());
     assert!(json["memory_mount"]["project_id"].is_null());
@@ -50,6 +54,23 @@ async fn health_reports_memory_mount_runtime_status_details() {
                 detail: Some(
                     "failed to flush pending write for research/note.md: boom".to_string(),
                 ),
+                view: crate::server::MemoryMountViewHealth {
+                    kind: crate::server::MemoryMountViewKind::Canonical,
+                    task_short_id: None,
+                    worktree_root: None,
+                    fallback: Some(crate::server::MemoryMountViewFallback {
+                        reason: crate::server::MemoryMountViewFallbackReason::NoActiveSession,
+                        detail: Some(
+                            "no running session is attached to the active task".to_string(),
+                        ),
+                        active_task_count: Some(1),
+                        task_id: Some("task-123".to_string()),
+                        task_short_id: Some("u5qe".to_string()),
+                        task_project_id: Some("project-123".to_string()),
+                        mount_project_id: Some("project-123".to_string()),
+                        session_worktree_path: None,
+                    }),
+                },
                 pending_writes: 0,
                 last_error: Some(
                     "failed to flush pending write for research/note.md: boom".to_string(),
@@ -79,11 +100,66 @@ async fn health_reports_memory_mount_runtime_status_details() {
         json["memory_mount"]["detail"],
         "failed to flush pending write for research/note.md: boom"
     );
+    assert_eq!(json["memory_mount"]["view"]["kind"], "canonical");
+    assert!(json["memory_mount"]["view"]["worktree_root"].is_null());
+    assert_eq!(
+        json["memory_mount"]["view"]["fallback"]["reason"],
+        "no_active_session"
+    );
+    assert_eq!(
+        json["memory_mount"]["view"]["fallback"]["task_short_id"],
+        "u5qe"
+    );
     assert_eq!(json["memory_mount"]["pending_writes"], 0);
     assert_eq!(
         json["memory_mount"]["last_error"],
         "failed to flush pending write for research/note.md: boom"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn health_reports_task_scoped_memory_mount_view() {
+    let state = AppState::new(test_helpers::create_test_db(), CancellationToken::new());
+    state
+        .set_memory_mount_for_tests(Some(MountedMemoryFilesystem::with_status(
+            MemoryMountRuntimeStatus {
+                lifecycle: crate::server::MemoryMountLifecycleState::Mounted,
+                configured: true,
+                mount_path: Some(std::path::PathBuf::from("/mnt/djinn-memory")),
+                project_id: Some("project-123".to_string()),
+                detail: None,
+                view: crate::server::MemoryMountViewHealth {
+                    kind: crate::server::MemoryMountViewKind::TaskScoped,
+                    task_short_id: Some("98vz".to_string()),
+                    worktree_root: Some("/worktrees/task-98vz".to_string()),
+                    fallback: None,
+                },
+                pending_writes: 2,
+                last_error: None,
+            },
+        )))
+        .await;
+    let app = server::router(state);
+
+    let req = axum::http::Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["memory_mount"]["lifecycle"], "mounted");
+    assert_eq!(json["memory_mount"]["view"]["kind"], "task_scoped");
+    assert_eq!(json["memory_mount"]["view"]["task_short_id"], "98vz");
+    assert_eq!(
+        json["memory_mount"]["view"]["worktree_root"],
+        "/worktrees/task-98vz"
+    );
+    assert!(json["memory_mount"]["view"]["fallback"].is_null());
+    assert_eq!(json["memory_mount"]["pending_writes"], 2);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
Re-land the ADR-057 mounted-memory view reporting slice on a fresh branch after `u5qe` accumulated post-approval CI and merge-conflict churn. Focus only on the code that is still missing on current main: structured `/health` memory-mount view reporting that distinguishes canonical vs task-scoped selection, includes fallback reason/context, keeps runtime status snapshots in sync, and restores the related router/runtime tests and inline docs without reopening broader mount/runtime scope.

## Acceptance Criteria
- [x] `/health` exposes a structured mounted-memory view payload that reports canonical vs task-scoped selection plus fallback reason/context when task view resolution cannot be used.
- [x] `server/src/memory_mount.rs`, `server/src/server/state/mod.rs`, and `server/src/server/tests/router.rs` are updated so runtime status snapshots and tests cover both task-scoped reporting and canonical fallback without non-feature dead-code or merge-conflict regressions.
- [x] Inline docs or module comments explain how operators interpret the mounted-memory view state in filesystem-first ADR-057 flows, and `cargo test -p djinn-server` plus `cargo clippy -p djinn-server --all-targets -- -D warnings` pass for the landing branch.

---
Djinn task: 98vz