### PR TITLE
feat(sync): forced and project-scoped task sync import

### DIFF
--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -213,8 +213,12 @@ impl bridge::SyncOps for AgentSyncOps {
         vec![]
     }
 
-    async fn import_all(&self) -> Vec<bridge::SyncResult> {
+    async fn import_all(&self, _: bool) -> Vec<bridge::SyncResult> {
         vec![]
+    }
+
+    async fn import_project(&self, _: &str, _: bool) -> Result<bridge::SyncResult, String> {
+        Err("sync not available in djinn-agent task-mutation bridge".into())
     }
 
     async fn status(&self) -> Vec<bridge::ChannelStatus> {

--- a/server/crates/djinn-mcp/src/bridge.rs
+++ b/server/crates/djinn-mcp/src/bridge.rs
@@ -127,7 +127,8 @@ pub trait SyncOps: Send + Sync {
     async fn disable_project(&self, project_id: &str) -> Result<(), String>;
     async fn delete_remote_branch(&self, channel: &str, project_path: &Path) -> Result<(), String>;
     async fn export_all(&self, user_id: Option<&str>) -> Vec<SyncResult>;
-    async fn import_all(&self) -> Vec<SyncResult>;
+    async fn import_all(&self, force: bool) -> Vec<SyncResult>;
+    async fn import_project(&self, project_id: &str, force: bool) -> Result<SyncResult, String>;
     async fn status(&self) -> Vec<ChannelStatus>;
 }
 

--- a/server/crates/djinn-mcp/src/state.rs
+++ b/server/crates/djinn-mcp/src/state.rs
@@ -243,8 +243,11 @@ pub(crate) mod stubs {
         async fn export_all(&self, _: Option<&str>) -> Vec<SyncResult> {
             vec![]
         }
-        async fn import_all(&self) -> Vec<SyncResult> {
+        async fn import_all(&self, _: bool) -> Vec<SyncResult> {
             vec![]
+        }
+        async fn import_project(&self, _: &str, _: bool) -> Result<SyncResult, String> {
+            Err("sync not enabled".into())
         }
         async fn status(&self) -> Vec<ChannelStatus> {
             vec![ChannelStatus {

--- a/server/crates/djinn-mcp/src/tools/sync_tools.rs
+++ b/server/crates/djinn-mcp/src/tools/sync_tools.rs
@@ -31,8 +31,10 @@ pub struct TaskSyncExportParams {
 
 #[derive(Deserialize, schemars::JsonSchema)]
 pub struct TaskSyncImportParams {
-    /// Project path (accepted for API compatibility, currently unused).
+    /// Optional project path. When provided, import only that project.
     pub project: Option<String>,
+    /// Force import even if the remote branch SHA matches the last imported SHA.
+    pub force: Option<bool>,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -287,17 +289,38 @@ impl DjinnMcpServer {
         &self,
         Parameters(p): Parameters<TaskSyncImportParams>,
     ) -> Json<TaskSyncRunResponse> {
-        if let Some(path) = p.project.as_ref()
-            && self.project_id_for_path(path).await.is_none()
-        {
-            return Json(TaskSyncRunResponse {
-                ok: None,
-                channels: None,
-                error: Some(format!("project not found: {path}")),
-            });
-        }
         let mgr = self.state.sync_manager();
-        let results = mgr.import_all().await;
+        let force = p.force.unwrap_or(false);
+
+        let results: Vec<SyncChannelResult> = if let Some(path) = p.project.as_ref() {
+            let project_id = match self.project_id_for_path(path).await {
+                Some(id) => id,
+                None => {
+                    return Json(TaskSyncRunResponse {
+                        ok: None,
+                        channels: None,
+                        error: Some(format!("project not found: {}", path)),
+                    });
+                }
+            };
+
+            match mgr.import_project(&project_id, force).await {
+                Ok(result) => vec![result.into()],
+                Err(error) => {
+                    return Json(TaskSyncRunResponse {
+                        ok: None,
+                        channels: None,
+                        error: Some(error),
+                    });
+                }
+            }
+        } else {
+            mgr.import_all(force)
+                .await
+                .into_iter()
+                .map(Into::into)
+                .collect()
+        };
 
         if results.is_empty() {
             return Json(TaskSyncRunResponse {
@@ -307,10 +330,11 @@ impl DjinnMcpServer {
             });
         }
 
-        let all_ok = results.iter().all(|r| r.ok);
+        let ok = results.iter().all(|r| r.ok);
+
         Json(TaskSyncRunResponse {
-            ok: Some(all_ok),
-            channels: Some(results.into_iter().map(SyncChannelResult::from).collect()),
+            ok: Some(ok),
+            channels: Some(results),
             error: None,
         })
     }

--- a/server/src/mcp_bridge.rs
+++ b/server/src/mcp_bridge.rs
@@ -243,9 +243,9 @@ impl SyncOps for SyncBridge {
             .collect()
     }
 
-    async fn import_all(&self) -> Vec<SyncResult> {
+    async fn import_all(&self, force: bool) -> Vec<SyncResult> {
         self.0
-            .import_all()
+            .import_all(force)
             .await
             .into_iter()
             .map(|r| SyncResult {
@@ -255,6 +255,16 @@ impl SyncOps for SyncBridge {
                 error: r.error,
             })
             .collect()
+    }
+
+    async fn import_project(&self, project_id: &str, force: bool) -> Result<SyncResult, String> {
+        let r = self.0.import_project(project_id, force).await;
+        Ok(SyncResult {
+            channel: r.channel,
+            ok: r.ok,
+            count: r.count,
+            error: r.error,
+        })
     }
 
     async fn status(&self) -> Vec<ChannelStatus> {

--- a/server/src/sync/manager.rs
+++ b/server/src/sync/manager.rs
@@ -106,7 +106,7 @@ impl SyncManager {
                         // Auto-import using two-phase pull (SYNC-09).
                         // Two-phase pull (SYNC-08) makes idle cycles ~50ms.
                         // Events emitted with from_sync=true won't trigger re-export (SYNC-06).
-                        mgr.import_all().await;
+                        mgr.import_all(false).await;
                     }
                     _ = cancel.cancelled() => break,
                 }
@@ -298,7 +298,7 @@ impl SyncManager {
     ///
     /// Each channel is independent — a failure in one doesn't stop others (SYNC-05).
     /// Within a channel, each project is imported independently.
-    pub async fn import_all(&self) -> Vec<SyncResult> {
+    pub async fn import_all(&self, force: bool) -> Vec<SyncResult> {
         let mut results = Vec::new();
 
         let sync_projects = self.list_sync_enabled_projects().await;
@@ -317,6 +317,7 @@ impl SyncManager {
                             &project.id,
                             &self.inner.db,
                             &self.inner.events_tx,
+                            force,
                         )
                         .await
                     }
@@ -382,6 +383,97 @@ impl SyncManager {
         }
 
         results
+    }
+
+    pub async fn import_project(&self, project_id: &str, force: bool) -> SyncResult {
+        let project_repo = project_repo(&self.inner);
+
+        let project = match project_repo.get(project_id).await {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                return SyncResult {
+                    channel: "tasks".to_string(),
+                    ok: false,
+                    count: None,
+                    error: Some(format!("project not found: {project_id}")),
+                };
+            }
+            Err(e) => {
+                return SyncResult {
+                    channel: "tasks".to_string(),
+                    ok: false,
+                    count: None,
+                    error: Some(e.to_string()),
+                };
+            }
+        };
+
+        let project_path = PathBuf::from(&project.path);
+
+        match tasks_channel::import(
+            &project_path,
+            &project.id,
+            &self.inner.db,
+            &self.inner.events_tx,
+            force,
+        )
+        .await
+        {
+            Ok(count) => {
+                {
+                    let mut states = self.inner.states.lock().await;
+                    if let Some(st) = states.get_mut("tasks") {
+                        st.backoff.record_success();
+                        st.last_synced_at = Some(now_utc());
+                        st.last_error = None;
+                    }
+                }
+                let _ = self
+                    .inner
+                    .events_tx
+                    .send(DjinnEventEnvelope::sync_completed(
+                        "tasks", "import", count, None,
+                    ));
+                SyncResult {
+                    channel: "tasks".to_string(),
+                    ok: true,
+                    count: Some(count),
+                    error: None,
+                }
+            }
+            Err(e) => {
+                let err = e.to_string();
+
+                let delay = {
+                    let mut states = self.inner.states.lock().await;
+                    states
+                        .get_mut("tasks")
+                        .map(|s| {
+                            s.backoff.record_failure();
+                            s.last_error = Some(err.clone());
+                            s.backoff.delay_secs()
+                        })
+                        .unwrap_or(0)
+                };
+
+                let _ = self
+                    .inner
+                    .events_tx
+                    .send(DjinnEventEnvelope::sync_completed(
+                        "tasks",
+                        "import",
+                        0,
+                        Some(&err),
+                    ));
+
+                SyncResult {
+                    channel: "tasks".to_string(),
+                    ok: false,
+                    count: None,
+                    error: Some(format!("{} (retry in {}s)", err, delay)),
+                }
+            }
+        }
     }
 
     /// Query sync-enabled projects from the DB (SYNC-07).

--- a/server/src/sync/tasks_channel.rs
+++ b/server/src/sync/tasks_channel.rs
@@ -269,21 +269,27 @@ pub async fn import(
     project_id: &str,
     db: &Database,
     events: &broadcast::Sender<DjinnEventEnvelope>,
+    force: bool,
 ) -> Result<usize> {
     // Two-phase pull (SYNC-08): cheap SHA check before expensive fetch.
     let settings =
         djinn_db::SettingsRepository::new(db.clone(), crate::events::event_bus_for(events));
     let sha_key = sha_settings_key(project_id);
     let remote_sha = ls_remote_sha(project).await;
-    if let Some(ref sha) = remote_sha {
-        let stored = settings.get(&sha_key).await.ok().flatten();
-        if stored.as_ref().map(|s| &s.value) == Some(sha) {
-            tracing::trace!(
-                sha,
-                project_id,
-                "two-phase pull: SHA unchanged, skipping import"
-            );
-            return Ok(0);
+    if force {
+        tracing::info!(project_id = %project_id, "forcing task sync import; bypassing SHA checkpoint");
+    }
+    if !force {
+        if let Some(ref sha) = remote_sha {
+            let stored = settings.get(&sha_key).await.ok().flatten();
+            if stored.as_ref().map(|s| &s.value) == Some(sha) {
+                tracing::debug!(
+                    project_id = %project_id,
+                    remote_sha = %sha,
+                    "task sync import skipped; remote SHA already imported"
+                );
+                return Ok(0);
+            }
         }
     }
 

--- a/server/src/sync/tests.rs
+++ b/server/src/sync/tests.rs
@@ -183,7 +183,7 @@ async fn import_all_skips_when_disabled() {
     let db = crate::test_helpers::create_test_db();
     let (tx, _rx) = broadcast::channel(16);
     let mgr = SyncManager::new(db, tx);
-    let results = mgr.import_all().await;
+    let results = mgr.import_all(false).await;
     assert!(results.is_empty());
 }
 


### PR DESCRIPTION
## Summary
Add forced and project-scoped task sync import.

## What changed
- Added `force` to `task_sync_import`
- Made `task_sync_import(project=...)` import only the requested project
- Added `import_project(project_id, force)` through the sync bridge/manager
- Updated task sync import to bypass the `last_imported_sha` short-circuit when `force=true`
- Kept background/normal imports unchanged (`force=false`)

## Why
This fixes recovery scenarios where `djinn/tasks` is the source of truth but local task state is missing or stale. Previously, import could silently no-op if the remote branch SHA matched the stored `last_imported_sha`, and the `project` parameter was accepted but not actually used to scope the import.

## Result
You can now force a rebuild-style import for a single project, while preserving the existing SHA-skip optimization for normal sync flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)