### PR TITLE
feat(k8s,chart): configurable nodeSelector + tolerations for task-run + warm Pods

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -163,6 +163,20 @@ spec:
                         (include "djinn.fullname" .)
                         (include "djinn.namespace" .)
                         (.Values.service.rpcPort | int) | quote }}
+            # Pod scheduling for task-run + warm Jobs. JSON-encoded so the
+            # controller can deserialize directly into k8s_openapi types
+            # without bringing a YAML parser into the dispatch path. The
+            # `with` blocks omit the env var entirely when the values are
+            # empty defaults, leaving the controller on its built-in fallback
+            # (no scheduling hints — matches pre-feature behavior).
+            {{- with .Values.resources.taskrun.nodeSelector }}
+            - name: DJINN_K8S_NODE_SELECTOR
+              value: {{ toJson . | quote }}
+            {{- end }}
+            {{- with .Values.resources.taskrun.tolerations }}
+            - name: DJINN_K8S_TOLERATIONS
+              value: {{ toJson . | quote }}
+            {{- end }}
             - name: DJINN_VAULT_KEY_PATH
               value: /var/run/secrets/djinn/vault.key
             - name: GITHUB_APP_PRIVATE_KEY_PATH

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -85,6 +85,26 @@ resources:
     limits:
       cpu: "2"
       memory: "4Gi"
+    # Pod scheduling for both task-run and warm Jobs. Warm Pods pre-warm the
+    # graph cache that task-runs later adopt, so they MUST land on the same
+    # NodePool — that's why one set of hints covers both.
+    #
+    # Typical use case: a dedicated Karpenter NodePool tainted
+    # `workload-type=djinn:NoSchedule` and labelled `workload-type=djinn`.
+    # Set nodeSelector to target it and add the matching toleration:
+    #
+    #   nodeSelector:
+    #     workload-type: djinn
+    #   tolerations:
+    #     - key: workload-type
+    #       operator: Equal
+    #       value: djinn
+    #       effect: NoSchedule
+    #
+    # Empty defaults leave the fields unset — any node that the Pod's other
+    # constraints allow is eligible (preserves the pre-feature behavior).
+    nodeSelector: {}
+    tolerations: []
 
 # -----------------------------------------------------------------------------
 # Storage

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -1,5 +1,8 @@
 //! Runtime configuration shared by every `djinn-k8s` helper.
 
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::Toleration;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for `KubernetesRuntime`.
@@ -80,6 +83,19 @@ pub struct KubernetesConfig {
     /// Memory limit on the warm Pod container. Hard ceiling so a runaway
     /// indexer can't OOM the node. Default `4Gi`.
     pub warm_memory_limit: String,
+    /// `spec.nodeSelector` applied to both task-run and warm Pods. Empty map
+    /// leaves the field unset (any node tolerating the Pod's other constraints
+    /// is eligible). Operators typically use this together with `tolerations`
+    /// to pin builds onto a dedicated NodePool — e.g. nodeSelector
+    /// `workload-type: djinn` plus a matching toleration for a
+    /// `workload-type=djinn:NoSchedule` taint. Surfaced in the chart as
+    /// `resources.taskrun.nodeSelector`.
+    pub node_selector: BTreeMap<String, String>,
+    /// `spec.tolerations` applied to both task-run and warm Pods. Empty vec
+    /// leaves the field unset. Same NodePool-pinning use case as
+    /// `node_selector` above. Surfaced in the chart as
+    /// `resources.taskrun.tolerations`.
+    pub tolerations: Vec<Toleration>,
 }
 
 impl KubernetesConfig {
@@ -108,6 +124,8 @@ impl KubernetesConfig {
             warm_cpu_limit: "2".into(),
             warm_memory_request: "2Gi".into(),
             warm_memory_limit: "4Gi".into(),
+            node_selector: BTreeMap::new(),
+            tolerations: Vec::new(),
         }
     }
 
@@ -142,6 +160,8 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_WARM_CPU_LIMIT` | `warm_cpu_limit` | `2` |
     /// | `DJINN_K8S_WARM_MEMORY_REQUEST` | `warm_memory_request` | `2Gi` |
     /// | `DJINN_K8S_WARM_MEMORY_LIMIT` | `warm_memory_limit` | `4Gi` |
+    /// | `DJINN_K8S_NODE_SELECTOR` | `node_selector` | `{}` (parsed as a JSON object of string→string) |
+    /// | `DJINN_K8S_TOLERATIONS` | `tolerations` | `[]` (parsed as a JSON array of k8s `Toleration` objects) |
     ///
     /// `DJINN_DATABASE_URL` is read from djinn-server's own environment (the
     /// Helm chart projects it via `envFrom: configMap djinn-config`) and
@@ -253,6 +273,30 @@ impl KubernetesConfig {
         if let Ok(v) = std::env::var("DJINN_K8S_WARM_MEMORY_LIMIT") {
             cfg.warm_memory_limit = v;
         }
+        if let Ok(v) = std::env::var("DJINN_K8S_NODE_SELECTOR") {
+            if !v.is_empty() {
+                match serde_json::from_str::<BTreeMap<String, String>>(&v) {
+                    Ok(map) => cfg.node_selector = map,
+                    Err(e) => tracing::warn!(
+                        value = %v,
+                        error = %e,
+                        "DJINN_K8S_NODE_SELECTOR not valid JSON (expected object of string→string) — keeping default"
+                    ),
+                }
+            }
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_TOLERATIONS") {
+            if !v.is_empty() {
+                match serde_json::from_str::<Vec<Toleration>>(&v) {
+                    Ok(t) => cfg.tolerations = t,
+                    Err(e) => tracing::warn!(
+                        value = %v,
+                        error = %e,
+                        "DJINN_K8S_TOLERATIONS not valid JSON (expected array of Toleration objects) — keeping default"
+                    ),
+                }
+            }
+        }
         cfg
     }
 }
@@ -306,6 +350,47 @@ mod tests {
             std::env::remove_var("DJINN_K8S_SERVER_ADDR");
             std::env::remove_var("DJINN_K8S_TTL_SECONDS");
             std::env::remove_var("DJINN_DATABASE_URL");
+        }
+    }
+
+    /// `from_env()` parses the JSON-encoded scheduling env vars (operators
+    /// set these to pin task-run + warm Pods to a dedicated NodePool).
+    #[test]
+    fn from_env_parses_pod_scheduling_json() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved_ns = std::env::var("DJINN_K8S_NODE_SELECTOR").ok();
+        let saved_tol = std::env::var("DJINN_K8S_TOLERATIONS").ok();
+        // SAFETY: serialized against sibling tests via ENV_LOCK.
+        unsafe {
+            std::env::set_var(
+                "DJINN_K8S_NODE_SELECTOR",
+                r#"{"workload-type":"djinn"}"#,
+            );
+            std::env::set_var(
+                "DJINN_K8S_TOLERATIONS",
+                r#"[{"key":"workload-type","operator":"Equal","value":"djinn","effect":"NoSchedule"}]"#,
+            );
+        }
+        let cfg = KubernetesConfig::from_env();
+        assert_eq!(
+            cfg.node_selector.get("workload-type").map(String::as_str),
+            Some("djinn"),
+        );
+        assert_eq!(cfg.tolerations.len(), 1);
+        let t = &cfg.tolerations[0];
+        assert_eq!(t.key.as_deref(), Some("workload-type"));
+        assert_eq!(t.operator.as_deref(), Some("Equal"));
+        assert_eq!(t.value.as_deref(), Some("djinn"));
+        assert_eq!(t.effect.as_deref(), Some("NoSchedule"));
+        unsafe {
+            match saved_ns {
+                Some(prev) => std::env::set_var("DJINN_K8S_NODE_SELECTOR", prev),
+                None => std::env::remove_var("DJINN_K8S_NODE_SELECTOR"),
+            }
+            match saved_tol {
+                Some(prev) => std::env::set_var("DJINN_K8S_TOLERATIONS", prev),
+                None => std::env::remove_var("DJINN_K8S_TOLERATIONS"),
+            }
         }
     }
 

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -12,7 +12,7 @@ use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     Container, EmptyDirVolumeSource, EnvVar, KeyToPath, PersistentVolumeClaimVolumeSource, PodSpec,
     PodTemplateSpec, ProjectedVolumeSource, ResourceRequirements, SecretVolumeSource,
-    ServiceAccountTokenProjection, Volume, VolumeMount, VolumeProjection,
+    ServiceAccountTokenProjection, Toleration, Volume, VolumeMount, VolumeProjection,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -226,11 +226,21 @@ pub fn build_task_run_job(
         crate::env_config::env_config_volume(project_id),
     ];
 
+    // Pin Pods to a dedicated NodePool when the operator has configured one.
+    // Both fields stay `None` if the corresponding config entry is empty so
+    // the rendered manifest is identical to the pre-feature shape.
+    let node_selector = (!config.node_selector.is_empty())
+        .then(|| config.node_selector.clone());
+    let tolerations: Option<Vec<Toleration>> = (!config.tolerations.is_empty())
+        .then(|| config.tolerations.clone());
+
     let pod_spec = PodSpec {
         service_account_name: Some(config.service_account.clone()),
         restart_policy: Some("Never".to_string()),
         containers: vec![container],
         volumes: Some(volumes),
+        node_selector,
+        tolerations,
         // Give the worker enough time after SIGTERM to flush its final
         // RPC frame (TerminalReport) before SIGKILL — K8s default 30s is
         // tight when the supervisor is mid-stream over a slow link.

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -460,6 +460,13 @@ mod tests {
         );
         assert_eq!(pod.termination_grace_period_seconds, Some(60));
 
+        // Default config carries no scheduling hints — the PodSpec fields
+        // must stay `None` so the manifest is byte-identical to the
+        // pre-feature shape. Anything else would mean existing installs
+        // started seeing nodeSelector/tolerations they didn't ask for.
+        assert!(pod.node_selector.is_none(), "default config must not set nodeSelector");
+        assert!(pod.tolerations.is_none(), "default config must not set tolerations");
+
         // Exactly one container named "worker".
         assert_eq!(pod.containers.len(), 1);
         let container = &pod.containers[0];
@@ -683,5 +690,46 @@ mod tests {
             envs.get("DJINN_DATABASE_URL").copied(),
             Some("postgres://djinn@djinn-postgres.djinn.svc:5432/djinn")
         );
+    }
+
+    /// When the operator has configured nodeSelector + tolerations (typical
+    /// case: a dedicated NodePool tainted/labelled for djinn builds), the
+    /// task-run PodSpec must carry both so the scheduler picks the right
+    /// pool *and* the kubelet doesn't reject the Pod at admission.
+    #[test]
+    fn task_run_pod_scheduling_propagates_from_config() {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.node_selector.insert("workload-type".into(), "djinn".into());
+        cfg.tolerations.push(Toleration {
+            key: Some("workload-type".into()),
+            operator: Some("Equal".into()),
+            value: Some("djinn".into()),
+            effect: Some("NoSchedule".into()),
+            ..Toleration::default()
+        });
+
+        let job = build_task_run_job(
+            &cfg,
+            &Uuid::now_v7(),
+            "proj-xyz",
+            "djinn-taskrun-test",
+            "registry.example:5000/djinn-project-p:abc123def456",
+        );
+
+        let pod = job
+            .spec
+            .as_ref()
+            .and_then(|s| s.template.spec.as_ref())
+            .expect("pod spec set");
+
+        let ns = pod.node_selector.as_ref().expect("nodeSelector set");
+        assert_eq!(ns.get("workload-type").map(String::as_str), Some("djinn"));
+
+        let tols = pod.tolerations.as_ref().expect("tolerations set");
+        assert_eq!(tols.len(), 1);
+        assert_eq!(tols[0].key.as_deref(), Some("workload-type"));
+        assert_eq!(tols[0].operator.as_deref(), Some("Equal"));
+        assert_eq!(tols[0].value.as_deref(), Some("djinn"));
+        assert_eq!(tols[0].effect.as_deref(), Some("NoSchedule"));
     }
 }

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -304,6 +304,12 @@ mod tests {
         assert_eq!(pod.service_account_name.as_deref(), Some(cfg.service_account.as_str()));
         assert_eq!(pod.containers.len(), 1);
 
+        // Default config carries no scheduling hints — manifest must be
+        // byte-identical to the pre-feature shape. Mirrors the equivalent
+        // assertion in job.rs.
+        assert!(pod.node_selector.is_none(), "default config must not set nodeSelector");
+        assert!(pod.tolerations.is_none(), "default config must not set tolerations");
+
         let container = &pod.containers[0];
         assert_eq!(container.name, "warmer");
         // Warm Pod runs on the per-project devcontainer image — that's
@@ -428,5 +434,39 @@ mod tests {
     #[test]
     fn sanitize_id_lowercases_and_maps_disallowed_chars() {
         assert_eq!(sanitize_id("Proj_ABC/xyz"), "proj-abc-xyz");
+    }
+
+    /// Warm Pods must inherit the same scheduling hints as task-runs —
+    /// otherwise they'd land on a different pool and the canonical-graph
+    /// cache they pre-populate wouldn't be reused by the task-run that
+    /// adopts it. The config struct carries one shared set of hints for
+    /// exactly this reason; this test guards the wiring through to the
+    /// warm-Job PodSpec.
+    #[test]
+    fn warm_pod_scheduling_propagates_from_config() {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.node_selector.insert("workload-type".into(), "djinn".into());
+        cfg.tolerations.push(Toleration {
+            key: Some("workload-type".into()),
+            operator: Some("Equal".into()),
+            value: Some("djinn".into()),
+            effect: Some("NoSchedule".into()),
+            ..Toleration::default()
+        });
+
+        let job = build_warm_job(&cfg, "proj-xyz", "reg.example:5000/djinn-project-p:abc123");
+        let pod = job
+            .spec
+            .as_ref()
+            .and_then(|s| s.template.spec.as_ref())
+            .expect("pod spec set");
+
+        let ns = pod.node_selector.as_ref().expect("nodeSelector set");
+        assert_eq!(ns.get("workload-type").map(String::as_str), Some("djinn"));
+
+        let tols = pod.tolerations.as_ref().expect("tolerations set");
+        assert_eq!(tols.len(), 1);
+        assert_eq!(tols[0].key.as_deref(), Some("workload-type"));
+        assert_eq!(tols[0].effect.as_deref(), Some("NoSchedule"));
     }
 }

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeMap;
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     Container, EmptyDirVolumeSource, EnvVar, PersistentVolumeClaimVolumeSource, PodSpec,
-    PodTemplateSpec, ResourceRequirements, Volume, VolumeMount,
+    PodTemplateSpec, ResourceRequirements, Toleration, Volume, VolumeMount,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -189,11 +189,22 @@ exec {bin} warm-graph "{project_id}"
         crate::env_config::env_config_volume(project_id),
     ];
 
+    // Warm Pods must land on the same NodePool as the task-runs they pre-warm
+    // — otherwise the warmup is wasted. Both fields are `None` when no
+    // operator scheduling hints are configured, keeping the manifest shape
+    // unchanged for existing installs.
+    let node_selector = (!config.node_selector.is_empty())
+        .then(|| config.node_selector.clone());
+    let tolerations: Option<Vec<Toleration>> = (!config.tolerations.is_empty())
+        .then(|| config.tolerations.clone());
+
     let pod_spec = PodSpec {
         service_account_name: Some(config.service_account.clone()),
         restart_policy: Some("Never".to_string()),
         containers: vec![container],
         volumes: Some(volumes),
+        node_selector,
+        tolerations,
         ..PodSpec::default()
     };
 


### PR DESCRIPTION
## Motivation

The djinn-k8s controller builds Job PodSpecs for task-run and warm workloads but doesn't expose any scheduling hints. On multi-NodePool clusters, those Pods fall through to whatever default pool can take them — even when the operator has provisioned a dedicated NodePool (e.g. a Karpenter pool labelled/tainted `workload-type=djinn`) specifically for djinn builds.

Today the only way for a Pod to land on such a pool is for it to:
- carry a matching `nodeSelector` so the scheduler picks it, *and*
- tolerate the pool's `NoSchedule` taint so it isn't rejected at admission.

Neither is configurable without a code patch.

## Changes

Two new fields on `KubernetesConfig`, **shared between task-run and warm Pods**:

```rust
pub node_selector: BTreeMap<String, String>,
pub tolerations: Vec<k8s_openapi::api::core::v1::Toleration>,
```

Warm Pods pre-warm the canonical-graph cache that task-runs later adopt, so they have to land on the same pool — otherwise the warmup is wasted. A single set of scheduling hints covers both.

Surfaced two ways, matching the existing chart pattern:

- **Env vars on the controller** (JSON-encoded): `DJINN_K8S_NODE_SELECTOR`, `DJINN_K8S_TOLERATIONS`. Parsed by `KubernetesConfig::from_env()`; malformed JSON falls back to the default with a `tracing::warn` (same pattern as the existing `DJINN_K8S_TTL_SECONDS` parser).
- **Helm chart values**: `resources.taskrun.nodeSelector` and `resources.taskrun.tolerations`. Both default to empty (`{}` / `[]`) so the rendered manifest is byte-identical to the pre-feature shape for any existing install.

Example values:

\`\`\`yaml
resources:
  taskrun:
    nodeSelector:
      workload-type: djinn
    tolerations:
      - key: workload-type
        operator: Equal
        value: djinn
        effect: NoSchedule
\`\`\`

## Files

| File | Change |
|---|---|
| `server/crates/djinn-k8s/src/config.rs` | Add fields, defaults, env parsing, doc-table entry, happy-path unit test |
| `server/crates/djinn-k8s/src/job.rs` | Import `Toleration`; set `node_selector` + `tolerations` on the task-run PodSpec (both `None` when unset → same shape as before) |
| `server/crates/djinn-k8s/src/warm_job.rs` | Same wiring on the warm-Job PodSpec |
| `deploy/helm/djinn/values.yaml` | New `nodeSelector` / `tolerations` keys under `resources.taskrun`, with a comment block explaining the use case |
| `deploy/helm/djinn/templates/deployment-server.yaml` | Render the two new env vars on the controller, guarded by `{{- with }}` so empty defaults emit nothing |

## Verification

- `helm lint` passes.
- `helm template` with the keys set renders the env vars with correct JSON.
- `helm template` with defaults emits no `DJINN_K8S_NODE_SELECTOR` / `DJINN_K8S_TOLERATIONS` lines — backward-compatible.
- New unit test (`from_env_parses_pod_scheduling_json`) covers happy-path JSON deserialization for both env vars, following the existing `ENV_LOCK`/save-restore pattern.
- `cargo check` / `cargo test` not run locally in this PR — relying on CI for compile + test verification.

## Scope deliberately punted

- **`affinity`**: not included. nodeSelector + tolerations covers the common NodePool-pinning case; affinity has a much larger surface (preferred vs required, multiple terms, complex matchers) and deserves its own design discussion.
- **Separate scheduling for warm vs task-run**: rejected because warm Pods exist to pre-warm caches the task-run adopts. Diverging their pools defeats the purpose. If a future use case needs them split, this can grow into `resources.warm.nodeSelector` later without a breaking API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)