### PR TITLE
fix: task-run work durability + stage-aware resume (deadline-kill rework loop)

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -66,6 +66,8 @@ use std::sync::Arc;
 mod lifecycle;
 mod worker_services;
 
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use djinn_agent::context::AgentContext;
@@ -77,12 +79,31 @@ use djinn_db::{Database, DatabaseConnectConfig, PostgresDatabaseConfig};
 use djinn_provider::catalog::{CatalogService, HealthTracker};
 use djinn_runtime::{ResolvedCredentials, RoleKind, TaskRunSpec, WorkerEvent};
 use djinn_supervisor::{RpcServices, SupervisorServices, TaskRunSupervisor};
-use djinn_workspace::{MirrorManager, Workspace};
+use djinn_workspace::{GitIdentity, MirrorManager, Workspace};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
+
+/// Wall-clock margin subtracted from the Job's `activeDeadlineSeconds` to set
+/// the in-pod soft deadline. The supervisor winds itself down (cancel +
+/// checkpoint commit/push) this far ahead of the kubelet's hard kill so a
+/// slow model never loses work to the deadline. ~10 min covers a checkpoint
+/// commit/push plus the terminal RPC flush with comfortable slack.
+const SOFT_DEADLINE_MARGIN: Duration = Duration::from_secs(600);
+
+/// Floor for the armed soft-deadline interval. For small configured deadlines
+/// (tests, tuned-down installs) `deadline - margin` can underflow or land
+/// implausibly early; clamp so the timer never fires immediately at startup.
+const SOFT_DEADLINE_MIN: Duration = Duration::from_secs(60);
+
+/// Upper bound on the checkpoint commit+push. The Pod's
+/// `terminationGracePeriodSeconds` (default 60s) is the hard window between
+/// SIGTERM and SIGKILL; bound the checkpoint well inside it so a wedged git
+/// operation (locked index, mid-merge) can't eat the whole grace period and
+/// starve the terminal RPC flush.
+const CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(20);
 
 use worker_services::WorkerSupervisorServices;
 
@@ -380,6 +401,20 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     //    that same TCP connection.
     let cancel = CancellationToken::new();
 
+    // Identity used by the SIGTERM / soft-deadline checkpoint, mirroring the
+    // supervisor's post-stage auto-commit: attribute to the task creator,
+    // falling back to the bot for system/patrol tasks (or host/worker skew).
+    let checkpoint_identity = CheckpointIdentity {
+        name: spec
+            .commit_author_name
+            .clone()
+            .unwrap_or_else(|| "djinn-bot".to_string()),
+        email: spec
+            .commit_author_email
+            .clone()
+            .unwrap_or_else(|| "bot@djinn.local".to_string()),
+    };
+
     // Wire SIGTERM / SIGINT into the supervisor's cancel token so the existing
     // `finalize_interrupted` path runs and flushes a terminal
     // `update_task_run_status(Interrupted)` RPC back to the host before the
@@ -387,9 +422,34 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     // graceful-drain SIGTERM kills the runtime mid-flight and the host's
     // task_runs row stays `running` forever.
     //
-    // The K8s Job sets `terminationGracePeriodSeconds=60`, which is the
-    // window we have to drain the RPC before SIGKILL hits.
-    install_termination_handlers(cancel.clone(), args.task_run_id.clone());
+    // Each signal ALSO triggers a best-effort checkpoint (commit + push of
+    // task_branch) so a mid-stage kill doesn't strand the worker's in-flight
+    // commits in the ephemeral clone — the supervisor's own post-stage push
+    // only runs at a stage boundary, which a cancelled mid-stage run never
+    // reaches. The K8s Job sets `terminationGracePeriodSeconds=60`, the window
+    // we have to checkpoint + drain the RPC before SIGKILL hits.
+    install_termination_handlers(
+        cancel.clone(),
+        args.task_run_id.clone(),
+        args.workspace_path.clone(),
+        spec.task_branch.clone(),
+        checkpoint_identity.clone(),
+    );
+
+    // Arm the in-pod soft deadline. The kubelet's `activeDeadlineSeconds` is a
+    // hard backstop that SIGKILLs the Pod with no chance to save work; the soft
+    // deadline fires `margin` ahead of it and drives the SAME graceful path as
+    // SIGTERM (cancel + checkpoint), so the healthy slow-model case winds itself
+    // down rather than being hard-killed. `DJINN_TASK_RUN_DEADLINE_SECONDS` is
+    // set by `build_task_run_job` from the same config value the Job carries;
+    // absent/unparseable → no soft deadline (the kubelet backstop still applies).
+    install_soft_deadline(
+        cancel.clone(),
+        args.task_run_id.clone(),
+        args.workspace_path.clone(),
+        spec.task_branch.clone(),
+        checkpoint_identity,
+    );
 
     let server_addr = args.server_addr.clone();
     let (rpc, background) = RpcServices::connect_tcp(
@@ -491,14 +551,123 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     Ok(())
 }
 
-/// Spawn background listeners for SIGTERM and SIGINT that flip `cancel` when
-/// the kubelet (or operator) signals shutdown. The supervisor body checks
-/// `cancel` between stages, exits its for-loop with `Interrupted`, and runs
-/// `finalize_interrupted` — which calls `update_task_run_status(Interrupted)`
-/// over the still-live RPC channel. The Pod's
-/// `terminationGracePeriodSeconds=60` gives that RPC time to land before
-/// SIGKILL.
-fn install_termination_handlers(cancel: CancellationToken, task_run_id: String) {
+/// Commit author/committer identity for the wind-down checkpoint. Owned
+/// `String`s (not the borrowed [`GitIdentity`]) so it can be cloned into the
+/// detached signal / deadline tasks.
+#[derive(Clone)]
+struct CheckpointIdentity {
+    name: String,
+    email: String,
+}
+
+/// Best-effort "save work before we die" checkpoint: stage + commit any
+/// uncommitted changes on the attached workspace and push `task_branch` to the
+/// mirror, all bounded by [`CHECKPOINT_TIMEOUT`].
+///
+/// Called from the SIGTERM handler and the soft-deadline timer. It races the
+/// supervisor's own (cancelled) shutdown, so it may arrive mid-git-operation —
+/// a locked index, a half-applied merge. Every failure is logged and
+/// swallowed; this function never panics and never blocks past its timeout,
+/// because it runs inside the kubelet's short `terminationGracePeriodSeconds`
+/// window and must leave room for the terminal RPC flush.
+///
+/// Idempotent against the supervisor's pushes: the commit is a no-op on a clean
+/// tree and the push refspec (`task_branch:task_branch`) is a no-op when the
+/// mirror is already current.
+async fn checkpoint_workspace(
+    workspace_path: &Path,
+    task_branch: &str,
+    identity: &CheckpointIdentity,
+    task_run_id: &str,
+) {
+    let ws = match Workspace::attach_existing(workspace_path, task_branch.to_string()) {
+        Ok(ws) => ws,
+        Err(e) => {
+            warn!(
+                task_run_id,
+                branch = task_branch,
+                path = %workspace_path.display(),
+                error = %e,
+                "checkpoint: failed to attach workspace; cannot save in-flight work"
+            );
+            return;
+        }
+    };
+
+    let git_identity = GitIdentity {
+        name: &identity.name,
+        email: &identity.email,
+    };
+    let message = format!("checkpoint: interrupted task-run {task_run_id}");
+
+    let result = tokio::time::timeout(CHECKPOINT_TIMEOUT, async {
+        // Commit is best-effort: a clean tree (worker already committed via
+        // shell) returns Ok(false) and we still push. A failure (locked index
+        // mid-merge) is logged but must not block the push of whatever IS
+        // already committed in the clone.
+        match ws.commit(&message, git_identity).await {
+            Ok(true) => info!(
+                task_run_id,
+                branch = task_branch,
+                "checkpoint: committed uncommitted changes"
+            ),
+            Ok(false) => info!(
+                task_run_id,
+                branch = task_branch,
+                "checkpoint: tree already clean; nothing to commit"
+            ),
+            Err(e) => warn!(
+                task_run_id,
+                branch = task_branch,
+                error = %e,
+                "checkpoint: commit failed (continuing to push already-committed work)"
+            ),
+        }
+        match ws.push_to_origin(task_branch).await {
+            Ok(()) => info!(
+                task_run_id,
+                branch = task_branch,
+                "checkpoint: pushed task_branch to mirror — in-flight work is durable"
+            ),
+            Err(e) => error!(
+                task_run_id,
+                branch = task_branch,
+                error = %e,
+                "checkpoint: push_to_origin failed — in-flight work may be LOST on Pod kill"
+            ),
+        }
+    })
+    .await;
+
+    if result.is_err() {
+        error!(
+            task_run_id,
+            branch = task_branch,
+            timeout_secs = CHECKPOINT_TIMEOUT.as_secs(),
+            "checkpoint: timed out (wedged git operation?); in-flight work may be LOST"
+        );
+    }
+}
+
+/// Spawn background listeners for SIGTERM and SIGINT that flip `cancel` AND run
+/// the wind-down checkpoint when the kubelet (or operator) signals shutdown.
+///
+/// The supervisor body checks `cancel` between stages, exits its for-loop with
+/// `Interrupted`, and runs `finalize_interrupted` — which calls
+/// `update_task_run_status(Interrupted)` over the still-live RPC channel. The
+/// checkpoint (commit + push of `task_branch`) runs alongside that so a
+/// mid-stage kill doesn't strand the worker's commits in the ephemeral clone;
+/// the supervisor's own post-stage push only fires at a stage boundary, which a
+/// cancelled mid-stage run never reaches. The Pod's
+/// `terminationGracePeriodSeconds=60` gives both the checkpoint and the RPC
+/// flush time to land before SIGKILL.
+fn install_termination_handlers(
+    cancel: CancellationToken,
+    task_run_id: String,
+    workspace_path: PathBuf,
+    task_branch: String,
+    identity: CheckpointIdentity,
+) {
     for (kind, label) in [
         (SignalKind::terminate(), "SIGTERM"),
         (SignalKind::interrupt(), "SIGINT"),
@@ -516,17 +685,97 @@ fn install_termination_handlers(cancel: CancellationToken, task_run_id: String) 
         };
         let cancel = cancel.clone();
         let task_run_id = task_run_id.clone();
+        let workspace_path = workspace_path.clone();
+        let task_branch = task_branch.clone();
+        let identity = identity.clone();
         tokio::spawn(async move {
             if stream.recv().await.is_some() {
                 info!(
                     signal = label,
                     task_run_id = %task_run_id,
-                    "received termination signal; cancelling supervisor so the terminal RPC flushes"
+                    "received termination signal; cancelling supervisor + checkpointing work"
                 );
+                // Cancel first so the supervisor stops streaming and starts its
+                // own graceful exit; then checkpoint to save in-flight work.
                 cancel.cancel();
+                checkpoint_workspace(&workspace_path, &task_branch, &identity, &task_run_id).await;
             }
         });
     }
+}
+
+/// Compute when the soft deadline should fire from the configured Job
+/// `activeDeadlineSeconds`: `deadline - margin`, clamped to at least
+/// [`SOFT_DEADLINE_MIN`] so a small configured deadline (tests, tuned-down
+/// installs) doesn't underflow to zero and fire immediately at startup.
+fn soft_deadline_interval(deadline_secs: u64) -> Duration {
+    Duration::from_secs(deadline_secs)
+        .saturating_sub(SOFT_DEADLINE_MARGIN)
+        .max(SOFT_DEADLINE_MIN)
+}
+
+/// Arm an in-pod soft deadline at `configured_deadline - margin`. When it
+/// fires it drives the same graceful wind-down as SIGTERM (cancel + checkpoint)
+/// so a healthy-but-slow run saves its work and exits `Interrupted` BEFORE the
+/// kubelet's hard `activeDeadlineSeconds` SIGKILLs the Pod. An interrupted run
+/// is NOT fed to the host's model circuit-breaker (it is not a model failure),
+/// so a slow model isn't penalised for hitting the wall.
+///
+/// Reads `DJINN_TASK_RUN_DEADLINE_SECONDS` (set by `build_task_run_job` from
+/// the same config the Job's `activeDeadlineSeconds` carries). Absent or
+/// unparseable → no soft deadline; the kubelet backstop still applies. The
+/// armed interval is clamped to at least [`SOFT_DEADLINE_MIN`] so small
+/// configured deadlines (tests) don't fire immediately at startup.
+fn install_soft_deadline(
+    cancel: CancellationToken,
+    task_run_id: String,
+    workspace_path: PathBuf,
+    task_branch: String,
+    identity: CheckpointIdentity,
+) {
+    let deadline_secs = match std::env::var("DJINN_TASK_RUN_DEADLINE_SECONDS") {
+        Ok(v) => match v.parse::<u64>() {
+            Ok(n) => n,
+            Err(e) => {
+                warn!(
+                    value = %v,
+                    error = %e,
+                    "DJINN_TASK_RUN_DEADLINE_SECONDS not a valid u64; soft deadline disabled"
+                );
+                return;
+            }
+        },
+        Err(_) => {
+            // No deadline plumbed (out-of-cluster test, older host). The
+            // kubelet's activeDeadlineSeconds (if any) is the only backstop.
+            return;
+        }
+    };
+
+    let fire_after = soft_deadline_interval(deadline_secs);
+
+    info!(
+        task_run_id = %task_run_id,
+        deadline_secs,
+        soft_deadline_secs = fire_after.as_secs(),
+        "armed in-pod soft deadline"
+    );
+
+    tokio::spawn(async move {
+        tokio::select! {
+            // Already winding down via SIGTERM / normal completion — stand down.
+            _ = cancel.cancelled() => {}
+            _ = tokio::time::sleep(fire_after) => {
+                warn!(
+                    task_run_id = %task_run_id,
+                    soft_deadline_secs = fire_after.as_secs(),
+                    "soft deadline reached; winding down (cancel + checkpoint) before the kubelet hard-kills the Pod"
+                );
+                cancel.cancel();
+                checkpoint_workspace(&workspace_path, &task_branch, &identity, &task_run_id).await;
+            }
+        }
+    });
 }
 
 /// Build the in-Pod `AgentContext` the per-stage executor threads through
@@ -794,4 +1043,135 @@ const _CONTRACT_TOKEN_PATH: &str = "/var/run/secrets/tokens/djinn";
 #[allow(dead_code)]
 fn _assert_contract_workspace_path() -> &'static Path {
     Path::new(_CONTRACT_WORKSPACE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn soft_deadline_subtracts_margin_for_large_deadlines() {
+        // 3h deadline → fires 10 min early (2h50m).
+        let fire = soft_deadline_interval(10_800);
+        assert_eq!(fire, Duration::from_secs(10_800 - 600));
+        assert_eq!(fire, Duration::from_secs(10_200));
+    }
+
+    #[test]
+    fn soft_deadline_clamps_small_deadlines_to_min() {
+        // A deadline at/below the margin would underflow to 0 and fire at
+        // startup; the clamp keeps it at the floor instead.
+        assert_eq!(soft_deadline_interval(0), SOFT_DEADLINE_MIN);
+        assert_eq!(soft_deadline_interval(600), SOFT_DEADLINE_MIN);
+        // Just above margin but still under margin+min → clamped.
+        assert_eq!(soft_deadline_interval(650), SOFT_DEADLINE_MIN);
+    }
+
+    #[test]
+    fn soft_deadline_uses_computed_value_once_above_floor() {
+        // margin + min = 660s; anything above yields deadline - margin.
+        let fire = soft_deadline_interval(700);
+        assert_eq!(fire, Duration::from_secs(100));
+        assert!(fire >= SOFT_DEADLINE_MIN);
+    }
+
+    fn git(dir: &Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    /// The wind-down checkpoint commits an uncommitted edit and pushes it to
+    /// the mirror — the durability seam that lets work survive a Pod kill.
+    #[tokio::test]
+    async fn checkpoint_commits_and_pushes_uncommitted_work() {
+        let origin = tempfile::TempDir::new().expect("origin");
+        let op = origin.path();
+        git(op, &["init", "--bare", "-b", "main"]);
+
+        // Seed main + a `task` branch via a working clone we'll treat as the Pod
+        // workspace.
+        let clone = tempfile::TempDir::new().expect("clone");
+        let cp = clone.path();
+        git(cp, &["clone", op.to_str().unwrap(), "."]);
+        std::fs::write(cp.join("base.txt"), "base\n").unwrap();
+        git(cp, &["add", "-A"]);
+        git(cp, &["commit", "-m", "base"]);
+        git(cp, &["push", "origin", "main"]);
+        git(cp, &["checkout", "-b", "task"]);
+
+        // Worker leaves an UNCOMMITTED edit (the lossy case the checkpoint saves).
+        std::fs::write(cp.join("work.txt"), "in-flight\n").unwrap();
+
+        let identity = CheckpointIdentity {
+            name: "djinn-bot".into(),
+            email: "bot@djinn.local".into(),
+        };
+        checkpoint_workspace(cp, "task", &identity, "run-xyz").await;
+
+        // The edit is committed locally...
+        let status = git(cp, &["status", "--porcelain"]);
+        assert!(
+            status.trim().is_empty(),
+            "checkpoint must commit the dirty tree: {status:?}"
+        );
+        // ...and pushed to the mirror under `task`.
+        let remote = git(op, &["rev-parse", "task"]);
+        let local = git(cp, &["rev-parse", "task"]);
+        assert_eq!(
+            remote.trim(),
+            local.trim(),
+            "checkpoint must push task to the mirror"
+        );
+    }
+
+    /// Checkpoint on an already-clean tree is a no-op commit but still pushes
+    /// committed-but-unpushed work (the common case: workers commit via shell).
+    #[tokio::test]
+    async fn checkpoint_pushes_committed_but_unpushed_work() {
+        let origin = tempfile::TempDir::new().expect("origin");
+        let op = origin.path();
+        git(op, &["init", "--bare", "-b", "main"]);
+
+        let clone = tempfile::TempDir::new().expect("clone");
+        let cp = clone.path();
+        git(cp, &["clone", op.to_str().unwrap(), "."]);
+        std::fs::write(cp.join("base.txt"), "base\n").unwrap();
+        git(cp, &["add", "-A"]);
+        git(cp, &["commit", "-m", "base"]);
+        git(cp, &["push", "origin", "main"]);
+        git(cp, &["checkout", "-b", "task"]);
+        // Worker COMMITTED its own work via shell (clean tree), but never pushed.
+        std::fs::write(cp.join("work.txt"), "done\n").unwrap();
+        git(cp, &["add", "-A"]);
+        git(cp, &["commit", "-m", "worker self-commit"]);
+        let local = git(cp, &["rev-parse", "task"]);
+
+        let identity = CheckpointIdentity {
+            name: "djinn-bot".into(),
+            email: "bot@djinn.local".into(),
+        };
+        checkpoint_workspace(cp, "task", &identity, "run-xyz").await;
+
+        let remote = git(op, &["rev-parse", "task"]);
+        assert_eq!(
+            remote.trim(),
+            local.trim(),
+            "checkpoint must push the worker's own commit even on a clean tree"
+        );
+    }
 }

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -401,6 +401,15 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     //    that same TCP connection.
     let cancel = CancellationToken::new();
 
+    // The live ephemeral stage clone's path, populated by
+    // `WorkerSupervisorServices::execute_stage` on its first call and read
+    // lazily by the SIGTERM / soft-deadline checkpoint. Created here so the
+    // checkpoint handlers (wired below, BEFORE the RPC connect / services
+    // construction so cancel-on-SIGTERM is armed as early as possible) and the
+    // services impl (constructed after the RPC connect) share the same slot.
+    let captured_workspace_path: Arc<std::sync::Mutex<Option<PathBuf>>> =
+        Arc::new(std::sync::Mutex::new(None));
+
     // Identity used by the SIGTERM / soft-deadline checkpoint, mirroring the
     // supervisor's post-stage auto-commit: attribute to the task creator,
     // falling back to the bot for system/patrol tasks (or host/worker skew).
@@ -431,7 +440,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     install_termination_handlers(
         cancel.clone(),
         args.task_run_id.clone(),
-        args.workspace_path.clone(),
+        captured_workspace_path.clone(),
         spec.task_branch.clone(),
         checkpoint_identity.clone(),
     );
@@ -446,7 +455,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     install_soft_deadline(
         cancel.clone(),
         args.task_run_id.clone(),
-        args.workspace_path.clone(),
+        captured_workspace_path.clone(),
         spec.task_branch.clone(),
         checkpoint_identity,
     );
@@ -488,6 +497,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
         credentials,
         cancel.clone(),
         agent_context,
+        captured_workspace_path,
     ));
 
     // 6. Construct the in-Pod `MirrorManager`. `clone_ephemeral` resolves
@@ -561,8 +571,16 @@ struct CheckpointIdentity {
 }
 
 /// Best-effort "save work before we die" checkpoint: stage + commit any
-/// uncommitted changes on the attached workspace and push `task_branch` to the
-/// mirror, all bounded by [`CHECKPOINT_TIMEOUT`].
+/// uncommitted changes on the LIVE ephemeral stage clone and push `task_branch`
+/// to the mirror, all bounded by [`CHECKPOINT_TIMEOUT`].
+///
+/// The path is read lazily, at fire time, from the `captured_workspace_path`
+/// slot that [`WorkerSupervisorServices`] populates on its first
+/// `execute_stage` call. That is the supervisor's own ephemeral `TempDir`
+/// clone (`MirrorManager::clone_ephemeral`), where every worker commit lands —
+/// NOT the host-materialised `/workspace` bind mount, which the in-pod
+/// supervisor never writes to. If no stage has started yet the slot is `None`
+/// and there is no in-flight work to save, so the checkpoint is a clean no-op.
 ///
 /// Called from the SIGTERM handler and the soft-deadline timer. It races the
 /// supervisor's own (cancelled) shutdown, so it may arrive mid-git-operation —
@@ -575,12 +593,27 @@ struct CheckpointIdentity {
 /// tree and the push refspec (`task_branch:task_branch`) is a no-op when the
 /// mirror is already current.
 async fn checkpoint_workspace(
-    workspace_path: &Path,
+    captured_workspace_path: &std::sync::Mutex<Option<PathBuf>>,
     task_branch: &str,
     identity: &CheckpointIdentity,
     task_run_id: &str,
 ) {
-    let ws = match Workspace::attach_existing(workspace_path, task_branch.to_string()) {
+    let workspace_path = {
+        captured_workspace_path
+            .lock()
+            .expect("captured_workspace_path mutex poisoned")
+            .clone()
+    };
+    let Some(workspace_path) = workspace_path else {
+        info!(
+            task_run_id,
+            branch = task_branch,
+            "checkpoint: no stage has started (no captured workspace); nothing to save"
+        );
+        return;
+    };
+
+    let ws = match Workspace::attach_existing(&workspace_path, task_branch.to_string()) {
         Ok(ws) => ws,
         Err(e) => {
             warn!(
@@ -661,10 +694,16 @@ async fn checkpoint_workspace(
 /// cancelled mid-stage run never reaches. The Pod's
 /// `terminationGracePeriodSeconds=60` gives both the checkpoint and the RPC
 /// flush time to land before SIGKILL.
+///
+/// `captured_workspace_path` is the slot [`WorkerSupervisorServices`] shares;
+/// it is read lazily inside [`checkpoint_workspace`] at signal time, so the
+/// cancel wiring can stay early (before the RPC connect / services
+/// construction) while the checkpoint still sees the live ephemeral stage clone
+/// the supervisor records once stages begin.
 fn install_termination_handlers(
     cancel: CancellationToken,
     task_run_id: String,
-    workspace_path: PathBuf,
+    captured_workspace_path: Arc<std::sync::Mutex<Option<PathBuf>>>,
     task_branch: String,
     identity: CheckpointIdentity,
 ) {
@@ -685,7 +724,7 @@ fn install_termination_handlers(
         };
         let cancel = cancel.clone();
         let task_run_id = task_run_id.clone();
-        let workspace_path = workspace_path.clone();
+        let captured_workspace_path = captured_workspace_path.clone();
         let task_branch = task_branch.clone();
         let identity = identity.clone();
         tokio::spawn(async move {
@@ -698,7 +737,13 @@ fn install_termination_handlers(
                 // Cancel first so the supervisor stops streaming and starts its
                 // own graceful exit; then checkpoint to save in-flight work.
                 cancel.cancel();
-                checkpoint_workspace(&workspace_path, &task_branch, &identity, &task_run_id).await;
+                checkpoint_workspace(
+                    &captured_workspace_path,
+                    &task_branch,
+                    &identity,
+                    &task_run_id,
+                )
+                .await;
             }
         });
     }
@@ -729,7 +774,7 @@ fn soft_deadline_interval(deadline_secs: u64) -> Duration {
 fn install_soft_deadline(
     cancel: CancellationToken,
     task_run_id: String,
-    workspace_path: PathBuf,
+    captured_workspace_path: Arc<std::sync::Mutex<Option<PathBuf>>>,
     task_branch: String,
     identity: CheckpointIdentity,
 ) {
@@ -772,7 +817,13 @@ fn install_soft_deadline(
                     "soft deadline reached; winding down (cancel + checkpoint) before the kubelet hard-kills the Pod"
                 );
                 cancel.cancel();
-                checkpoint_workspace(&workspace_path, &task_branch, &identity, &task_run_id).await;
+                checkpoint_workspace(
+                    &captured_workspace_path,
+                    &task_branch,
+                    &identity,
+                    &task_run_id,
+                )
+                .await;
             }
         }
     });
@@ -1121,7 +1172,8 @@ mod tests {
             name: "djinn-bot".into(),
             email: "bot@djinn.local".into(),
         };
-        checkpoint_workspace(cp, "task", &identity, "run-xyz").await;
+        let captured = std::sync::Mutex::new(Some(cp.to_path_buf()));
+        checkpoint_workspace(&captured, "task", &identity, "run-xyz").await;
 
         // The edit is committed locally...
         let status = git(cp, &["status", "--porcelain"]);
@@ -1165,13 +1217,34 @@ mod tests {
             name: "djinn-bot".into(),
             email: "bot@djinn.local".into(),
         };
-        checkpoint_workspace(cp, "task", &identity, "run-xyz").await;
+        let captured = std::sync::Mutex::new(Some(cp.to_path_buf()));
+        checkpoint_workspace(&captured, "task", &identity, "run-xyz").await;
 
         let remote = git(op, &["rev-parse", "task"]);
         assert_eq!(
             remote.trim(),
             local.trim(),
             "checkpoint must push the worker's own commit even on a clean tree"
+        );
+    }
+
+    /// When no stage has started the captured path is `None` — there is no live
+    /// ephemeral clone and no in-flight work to save, so the checkpoint is a
+    /// clean no-op (no attach, no commit, no push, no panic).
+    #[tokio::test]
+    async fn checkpoint_with_no_captured_path_is_noop() {
+        let identity = CheckpointIdentity {
+            name: "djinn-bot".into(),
+            email: "bot@djinn.local".into(),
+        };
+        // Empty slot: execute_stage never ran, so nothing was captured.
+        let captured: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+        // Must return cleanly without touching the filesystem or panicking.
+        checkpoint_workspace(&captured, "task", &identity, "run-xyz").await;
+        // The slot is unchanged — the no-op path doesn't mutate it.
+        assert!(
+            captured.lock().unwrap().is_none(),
+            "no-op checkpoint must leave the empty captured-path slot untouched"
         );
     }
 }

--- a/server/crates/djinn-agent-worker/src/worker_services.rs
+++ b/server/crates/djinn-agent-worker/src/worker_services.rs
@@ -75,7 +75,12 @@ pub struct WorkerSupervisorServices {
     /// `Mutex<Option<_>>` rather than `OnceLock` because the value is owned
     /// behind `&self` from inside an `async_trait` method and the mutex
     /// guard is dropped before any `.await`.
-    captured_workspace_path: Mutex<Option<PathBuf>>,
+    ///
+    /// Shared via `Arc` with the SIGTERM / soft-deadline checkpoint handlers in
+    /// `main.rs`: the wind-down checkpoint must commit + push the SAME live
+    /// ephemeral clone (the supervisor's `TempDir` clone, not `/workspace`), so
+    /// the handlers read this slot lazily at fire time.
+    captured_workspace_path: Arc<Mutex<Option<PathBuf>>>,
 }
 
 impl WorkerSupervisorServices {
@@ -83,18 +88,24 @@ impl WorkerSupervisorServices {
     /// resolved credentials bundle, supervisor cancel token, and the panic-
     /// stub-ish `AgentContext` the in-Pod supervisor threads through the
     /// per-stage executor.
+    ///
+    /// `captured_workspace_path` is created in `main.rs::run_task_run` and
+    /// shared with the SIGTERM / soft-deadline checkpoint handlers so the
+    /// wind-down checkpoint targets the live ephemeral stage clone this impl
+    /// records on its first `execute_stage` call.
     pub fn new(
         rpc: Arc<RpcServices>,
         credentials: ResolvedCredentials,
         cancel: CancellationToken,
         agent_context: AgentContext,
+        captured_workspace_path: Arc<Mutex<Option<PathBuf>>>,
     ) -> Self {
         Self {
             rpc,
             credentials,
             cancel,
             agent_context,
-            captured_workspace_path: Mutex::new(None),
+            captured_workspace_path,
         }
     }
 }

--- a/server/crates/djinn-agent/src/actors/coordinator/health.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/health.rs
@@ -2,10 +2,12 @@ use super::*;
 
 /// How long a `task_run` may stay in `running` without an `ended_at` before
 /// the periodic sweep flips it to `interrupted`. Must comfortably exceed the
-/// K8s Job `activeDeadlineSeconds` (3600s) + `terminationGracePeriodSeconds`
+/// K8s Job `activeDeadlineSeconds` (10800s) + `terminationGracePeriodSeconds`
 /// (60s) + `ttlSecondsAfterFinished` (300s) so we never reap a still-live run
-/// whose pod is mid-termination.
-const STALE_TASK_RUN_THRESHOLD_SECS: i64 = 2 * 60 * 60;
+/// whose pod is mid-termination. Bumped to 4h alongside the deadline raise
+/// (3600→10800): a 3h-budget run that legitimately uses most of its window
+/// must not be reaped out from under itself.
+const STALE_TASK_RUN_THRESHOLD_SECS: i64 = 4 * 60 * 60;
 
 /// Startup-only threshold. Any `task_run` whose `started_at` is older than
 /// this at process boot is from a previous host instance — the worker Pod

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -141,21 +141,64 @@ pub(crate) async fn run_supervisor_dispatch(
     let has_review_response =
         matches!(task.status.as_str(), "needs_task_review" | "in_task_review");
 
+    // ── Resolve branches from project config ──────────────────────────────
+    let base_branch = default_target_branch(&task.project_id, &app_state).await;
+    let task_branch = task_branch_name(&task.short_id);
+
     // ── Pick the supervisor flow ──────────────────────────────────────────
-    let flow = crate::roles::flow_for_task_dispatch(&task, has_conflict, has_review_response);
+    let base_flow = crate::roles::flow_for_task_dispatch(&task, has_conflict, has_review_response);
+
+    // ── Stage-aware resume: skip the worker redo when its output is durable ──
+    //
+    // A task that lands back at `needs_task_review` routes to `ReviewResponse`
+    // (worker → reviewer). But the ONLY way a task reaches that status is the
+    // worker having already submitted (`submit_task_review`), so re-running the
+    // worker redoes identical work — the failure mode behind a reviewer-stage
+    // pod kill (Job deadline) redispatching as a fresh ~55-min worker run.
+    //
+    // When the worker's commits are durable on the mirror task_branch (it
+    // exists and is ahead of base — the sibling eager-push makes this hold
+    // after the worker stage), upgrade to the reviewer-only `ReviewResume`
+    // flow so the redispatch reviews the existing diff instead of redoing the
+    // work. This is driven by what DURABLY happened (branch present), not by an
+    // outcome emitted after cancellation — so a cancelled reviewer run never
+    // tricks us into skipping real work (cf. the kw7s cancel-gate precedent).
+    //
+    // The guard is conservative: a missing/empty task_branch (worker never
+    // pushed, first cycle) keeps `ReviewResponse` and the full worker redo.
+    // Provider-failure and genuine reviewer-rejection paths are unaffected —
+    // a rejection moves the task to `open` (→ NewTask worker flow), never to
+    // `needs_task_review`, so it never reaches this branch.
+    let worker_output_durable = matches!(base_flow, SupervisorFlow::ReviewResponse)
+        && match app_state.mirror.as_ref() {
+            Some(mirror) => {
+                mirror
+                    .branch_ahead_of_base(&task.project_id, &task_branch, &base_branch)
+                    .await
+            }
+            None => false,
+        };
+    let flow = resume_flow(base_flow, worker_output_durable);
+    if matches!(flow, SupervisorFlow::ReviewResume) {
+        tracing::info!(
+            task_id = %task.short_id,
+            branch = %task_branch,
+            "supervisor dispatch: worker output durable on task_branch; \
+             resuming at reviewer stage (skipping worker redo)"
+        );
+    }
 
     // ── Map flow → trigger ────────────────────────────────────────────────
     let trigger = if has_conflict {
         TaskRunTrigger::ConflictRetry
-    } else if matches!(flow, SupervisorFlow::ReviewResponse) {
+    } else if matches!(
+        flow,
+        SupervisorFlow::ReviewResponse | SupervisorFlow::ReviewResume
+    ) {
         TaskRunTrigger::ReviewResponse
     } else {
         TaskRunTrigger::NewTask
     };
-
-    // ── Resolve branches from project config ──────────────────────────────
-    let base_branch = default_target_branch(&task.project_id, &app_state).await;
-    let task_branch = task_branch_name(&task.short_id);
 
     // ── Resolve per-role model ids ────────────────────────────────────────
     let mut model_id_per_role: HashMap<RoleKind, String> = HashMap::new();
@@ -643,6 +686,26 @@ pub(crate) async fn run_supervisor_dispatch(
     }
 }
 
+/// Stage-aware-resume decision seam: given the flow the coordinator routed to
+/// and whether the worker's output is durably present on the mirror task_branch,
+/// pick the flow the run actually executes.
+///
+/// Only `ReviewResponse` (the worker→reviewer re-entry, reached exclusively from
+/// `needs_task_review`/`in_task_review` where the worker already submitted) is a
+/// candidate for the reviewer-only `ReviewResume` upgrade, and only when the
+/// worker output is durable. Every other flow — and `ReviewResponse` without
+/// durable output — passes through unchanged so an absent/empty task_branch
+/// falls back to the full worker redo. Kept as a pure free function so the
+/// "resume at reviewer vs redo worker" choice is unit-testable without a DB or
+/// mirror.
+fn resume_flow(base_flow: SupervisorFlow, worker_output_durable: bool) -> SupervisorFlow {
+    if matches!(base_flow, SupervisorFlow::ReviewResponse) && worker_output_durable {
+        SupervisorFlow::ReviewResume
+    } else {
+        base_flow
+    }
+}
+
 fn report_to_terminal_status(report: &TaskRunReport) -> TaskRunStatus {
     match &report.outcome {
         TaskRunOutcome::PrOpened { .. }
@@ -795,6 +858,52 @@ mod tests {
         let chosen = select_terminal_report(None, teardown_stub);
         assert_eq!(chosen.task_run_id, "id-A-transport");
         assert!(chosen.stages_completed.is_empty());
+    }
+
+    // ── Stage-aware resume decision ───────────────────────────────────────────
+
+    #[test]
+    fn resume_flow_upgrades_review_response_to_reviewer_only_when_durable() {
+        // The regression target: a reviewer-stage pod kill leaves the task at
+        // needs_task_review (worker already submitted), which routes to
+        // ReviewResponse (worker→reviewer). With the worker's commits durable on
+        // the mirror task_branch we must resume at the reviewer, NOT redo the
+        // worker.
+        assert_eq!(
+            resume_flow(SupervisorFlow::ReviewResponse, true),
+            SupervisorFlow::ReviewResume
+        );
+        assert_eq!(
+            SupervisorFlow::ReviewResume.role_sequence(),
+            &[djinn_runtime::RoleKind::Reviewer],
+            "ReviewResume must skip the worker stage"
+        );
+    }
+
+    #[test]
+    fn resume_flow_keeps_review_response_when_output_not_durable() {
+        // No durable worker output (task_branch missing / not ahead of base, or
+        // no mirror) → fall back to the full worker redo. Safety guard.
+        assert_eq!(
+            resume_flow(SupervisorFlow::ReviewResponse, false),
+            SupervisorFlow::ReviewResponse
+        );
+    }
+
+    #[test]
+    fn resume_flow_leaves_non_review_response_flows_untouched() {
+        // Only ReviewResponse is a resume candidate. Durability is irrelevant for
+        // every other flow — they must pass through unchanged regardless.
+        for flow in [
+            SupervisorFlow::NewTask,
+            SupervisorFlow::ConflictRetry,
+            SupervisorFlow::Spike,
+            SupervisorFlow::Planning,
+            SupervisorFlow::Lead,
+        ] {
+            assert_eq!(resume_flow(flow, true), flow);
+            assert_eq!(resume_flow(flow, false), flow);
+        }
     }
 
     #[tokio::test]

--- a/server/crates/djinn-agent/src/roles/mod.rs
+++ b/server/crates/djinn-agent/src/roles/mod.rs
@@ -181,7 +181,11 @@ pub(crate) fn role_for_task_dispatch(
 ///   through worker/reviewer/verifier).
 /// - `status=needs_task_review` / `in_task_review` → [`SupervisorFlow::ReviewResponse`]
 ///   (worker → reviewer → verifier; the planner stage is skipped because the
-///   planner already decided `execute` on a prior run).
+///   planner already decided `execute` on a prior run). The host
+///   (`supervisor_runner::resume_flow`) may further upgrade this to the
+///   reviewer-only [`SupervisorFlow::ReviewResume`] when the worker's commits
+///   are already durable on the mirror task_branch — stage-aware resume after a
+///   reviewer-stage pod kill, skipping the redundant worker redo.
 /// - Any conflict context (merge-conflict or post-review merge-validation) →
 ///   [`SupervisorFlow::ConflictRetry`] (worker → reviewer → verifier; conflict
 ///   fixups bypass the planner).

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -61,12 +61,20 @@ pub struct KubernetesConfig {
     /// this, a stuck RPC connection or runaway LLM stream can keep the Pod
     /// alive indefinitely — the Job's `ttl_seconds_after_finished` only
     /// fires after the Pod exits, so a hung worker leaks compute forever.
-    /// Default 3600s (1 hour) is generous for normal task runs.
+    /// Default 10800s (3 hours): this is an infra BACKSTOP, not a run
+    /// scheduler. The in-pod supervisor arms its own soft deadline at
+    /// `this - margin` and winds itself down gracefully (cancel + checkpoint
+    /// commit/push) well before the kubelet hard-kills the Pod, so a slow
+    /// model never loses work to the deadline in the healthy case. A 1-hour
+    /// default starved slow providers — a 50-60 min worker stage left no room
+    /// for the reviewer stage and the Pod was deadline-killed mid-review,
+    /// losing every commit — so the backstop is set generously.
     pub task_run_active_deadline_seconds: u64,
     /// `terminationGracePeriodSeconds` on the task-run Pod. K8s default 30s
-    /// is tight when the worker still has a `TerminalReport` frame to
-    /// flush over RPC before SIGTERM is escalated to SIGKILL; truncated
-    /// reports make post-mortem debugging hard. Default 60s.
+    /// is tight: when SIGTERM fires (deadline / eviction / drain) the worker
+    /// must both flush its terminal `TerminalReport` RPC AND run a checkpoint
+    /// commit/push so in-flight work survives the kill. Default 60s gives both
+    /// room before SIGTERM is escalated to SIGKILL.
     pub task_run_termination_grace_period_seconds: i64,
     /// CPU request on the warm Pod container. The canonical-graph pipeline
     /// spawns SCIP indexer subprocesses (rust-analyzer, scip-go, etc.) that
@@ -118,7 +126,7 @@ impl KubernetesConfig {
             warm_job_ttl_seconds: 300,
             warm_job_timeout_seconds: 1800,
             database_url: None,
-            task_run_active_deadline_seconds: 3600,
+            task_run_active_deadline_seconds: 10800,
             task_run_termination_grace_period_seconds: 60,
             warm_cpu_request: "1".into(),
             warm_cpu_limit: "2".into(),
@@ -154,7 +162,7 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_WARM_JOB_TTL_SECONDS` | `warm_job_ttl_seconds` | `300` (parsed as `i32`) |
     /// | `DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS` | `warm_job_timeout_seconds` | `1800` (parsed as `i64`) |
     /// | `DJINN_DATABASE_URL` | `database_url` | _(unset → warm Pod has no fallback; helm chart projects this via the `djinn-server` ConfigMap)_ |
-    /// | `DJINN_K8S_TASK_RUN_ACTIVE_DEADLINE_SECONDS` | `task_run_active_deadline_seconds` | `3600` (parsed as `u64`) |
+    /// | `DJINN_K8S_TASK_RUN_ACTIVE_DEADLINE_SECONDS` | `task_run_active_deadline_seconds` | `10800` (parsed as `u64`) |
     /// | `DJINN_K8S_TASK_RUN_TERMINATION_GRACE_PERIOD_SECONDS` | `task_run_termination_grace_period_seconds` | `60` (parsed as `i64`) |
     /// | `DJINN_K8S_WARM_CPU_REQUEST` | `warm_cpu_request` | `1` |
     /// | `DJINN_K8S_WARM_CPU_LIMIT` | `warm_cpu_limit` | `2` |

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -350,6 +350,16 @@ fn build_task_run_env(
         // DJINN_MIRROR_ROOT is read by the in-Pod MirrorManager so the
         // worker clones from /mirror without a hard-coded path.
         env_var("DJINN_MIRROR_ROOT", MIRROR_MOUNT_DIR),
+        // Forward the Job's activeDeadlineSeconds so the in-pod supervisor
+        // can arm its OWN soft deadline at `deadline - margin` and wind
+        // itself down gracefully (cancel + checkpoint commit/push) before
+        // the kubelet hard-kills the Pod at the deadline. Without this the
+        // worker is blind to its wall-clock budget and loses in-flight work
+        // to the SIGTERM/SIGKILL. Same i64→string value the Job carries.
+        env_var(
+            "DJINN_TASK_RUN_DEADLINE_SECONDS",
+            &config.task_run_active_deadline_seconds.to_string(),
+        ),
     ];
     // Forward the server's DB configuration so the worker's
     // `bootstrap_warm_database()` opens the same Postgres instance the
@@ -496,7 +506,7 @@ mod tests {
             spec.active_deadline_seconds,
             Some(cfg.task_run_active_deadline_seconds as i64),
         );
-        assert_eq!(spec.active_deadline_seconds, Some(3600));
+        assert_eq!(spec.active_deadline_seconds, Some(10800));
 
         // Pod template mirrors labels.
         let template_labels = spec
@@ -597,6 +607,13 @@ mod tests {
         assert_eq!(
             envs.get("DJINN_MIRROR_ROOT").copied(),
             Some(MIRROR_MOUNT_DIR)
+        );
+        // The in-pod soft-deadline timer reads this; it must equal the Job's
+        // activeDeadlineSeconds so the supervisor's wind-down fires BEFORE the
+        // kubelet hard-kills the Pod.
+        assert_eq!(
+            envs.get("DJINN_TASK_RUN_DEADLINE_SECONDS").copied(),
+            Some(cfg.task_run_active_deadline_seconds.to_string().as_str())
         );
         // DB env vars are gated on the corresponding config fields being
         // `Some`. `for_testing()` leaves them `None`, so they should be

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -93,8 +93,11 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(600);
 // The supervisor calls teardown immediately after `attach_stdio` for K8s and then
 // polls the Job for terminal state; if this fires before the worker exits, the
 // task-run is declared a failure and the planner is re-dispatched on a fresh
-// workspace, losing in-progress code changes.
-const TEARDOWN_POLL_TIMEOUT: Duration = Duration::from_secs(3600);
+// workspace, losing in-progress code changes. Must exceed the Job's
+// `activeDeadlineSeconds` (default 10800s) plus the termination grace window so
+// the host keeps polling until the kubelet's own deadline resolves the Pod — a
+// 3h-budget run must not be declared failed by the host an hour in.
+const TEARDOWN_POLL_TIMEOUT: Duration = Duration::from_secs(11_400);
 /// Poll interval used inside [`poll_job_terminal_state`].
 const TEARDOWN_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -871,12 +874,17 @@ mod tests {
     }
 
     /// The teardown poll must cover a full dev session: too short and the
-    /// supervisor reaps in-flight worker pods (bug #18 regression). Allow up
-    /// to 2h so future tuning has headroom.
+    /// supervisor reaps in-flight worker pods (bug #18 regression). It must
+    /// exceed the Job's `activeDeadlineSeconds` (default 10800s) plus the
+    /// termination grace window so the host keeps polling until the kubelet's
+    /// own deadline resolves a long-running Pod; allow up to ~3.5h headroom.
     #[test]
     fn teardown_timeout_is_bounded() {
         assert!(TEARDOWN_POLL_TIMEOUT >= Duration::from_secs(600));
-        assert!(TEARDOWN_POLL_TIMEOUT <= Duration::from_secs(7200));
+        // Must outlast the 3h deadline backstop (+ grace) so a 3h-budget run
+        // is not declared failed by the host while still legitimately running.
+        assert!(TEARDOWN_POLL_TIMEOUT >= Duration::from_secs(10_800));
+        assert!(TEARDOWN_POLL_TIMEOUT <= Duration::from_secs(12_600));
         assert!(TEARDOWN_POLL_INTERVAL < TEARDOWN_POLL_TIMEOUT);
     }
 

--- a/server/crates/djinn-runtime/src/spec.rs
+++ b/server/crates/djinn-runtime/src/spec.rs
@@ -60,6 +60,18 @@ pub enum SupervisorFlow {
     ConflictRetry,
     Spike,
     Planning,
+    /// Reviewer-only resume: a prior run's worker stage already completed and
+    /// its commits are durable on the mirror task_branch, but the run died in
+    /// (or before) the reviewer stage — typically a Job-deadline / pod kill of
+    /// the reviewer session. The host resolves this from `ReviewResponse` ONLY
+    /// when a cheap durability check confirms the worker output is present
+    /// (task_branch exists + is ahead of base), so re-running the worker would
+    /// redo identical work. The sequence is `[Reviewer]`; workspace setup still
+    /// clones task_branch first (so the reviewer sees the worker's diff), and
+    /// the reviewer's `task_review_start` pre-stage transition is valid because
+    /// the task is `needs_task_review` on the resume. When the worker output is
+    /// NOT durable the host keeps `ReviewResponse` (full worker redo).
+    ReviewResume,
     /// Lead intervention: a single-stage flow that runs the Lead agent on a
     /// task parked in `needs_lead_intervention`. The Lead inspects the stuck
     /// task and ends with `submit_decision`, which the supervisor maps to the
@@ -82,6 +94,7 @@ impl SupervisorFlow {
             SupervisorFlow::ConflictRetry => "conflict_retry",
             SupervisorFlow::Spike => "spike",
             SupervisorFlow::Planning => "planning",
+            SupervisorFlow::ReviewResume => "review_resume",
             SupervisorFlow::Lead => "lead",
         }
     }
@@ -104,6 +117,11 @@ pub fn role_sequence(flow: SupervisorFlow) -> &'static [RoleKind] {
             // Verifier currently stubbed; matches NewTask shape.
             &[Worker, Reviewer]
         }
+        // Reviewer-only resume: the worker stage already ran on a prior run and
+        // its commits are durable on the mirror task_branch (the host verified
+        // this before choosing the flow). Skip straight to the reviewer, which
+        // reviews the diff cloned from task_branch.
+        SupervisorFlow::ReviewResume => &[Reviewer],
         SupervisorFlow::Spike => &[Architect],
         SupervisorFlow::Planning => &[Planner],
         // Single-stage: the Lead is the only actor. Its `submit_decision`

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -658,48 +658,13 @@ impl TaskRunSupervisor {
                                     role = %role_kind.as_str(),
                                     "supervisor: committed worker/architect changes"
                                 );
-                                // Push the new commit to the mirror IMMEDIATELY
-                                // — before the subsequent stage (reviewer) runs
-                                // and before the post-stage transitions fire.
-                                // Without this, the worker's commits live only
-                                // in the ephemeral workspace until open_pr's
-                                // own push_to_origin runs at the very end. If
-                                // anything cancels between now and open_pr
-                                // (server restart, planner kill, cancel-token
-                                // race), the commits are LOST and the host's
-                                // coordinator-tick supervisor_pr_open sees
-                                // the stale mirror task_branch — pushing the
-                                // OLD commit to the PR. Observed on avoy:
-                                // worker fixed CI failure in cycle 2, but PR
-                                // #502 stayed pinned to cycle 1's commit
-                                // because the supervisor body never reached
-                                // its terminal open_pr.
-                                //
-                                // Eager push makes the commit durable to
-                                // the mirror right after the stage that
-                                // produced it. Idempotent (refspec
-                                // task_branch:task_branch). Best-effort —
-                                // a push failure here only means we'll
-                                // re-try at open_pr time; the run keeps
-                                // going.
-                                if let Err(e) = workspace.push_to_origin(&spec.task_branch).await {
-                                    tracing::warn!(
-                                        task_id = %task.short_id,
-                                        task_run_id = %run_id,
-                                        role = %role_kind.as_str(),
-                                        branch = %spec.task_branch,
-                                        error = %e,
-                                        "supervisor: eager push_to_origin failed (open_pr will retry)"
-                                    );
-                                } else {
-                                    tracing::debug!(
-                                        task_id = %task.short_id,
-                                        task_run_id = %run_id,
-                                        role = %role_kind.as_str(),
-                                        branch = %spec.task_branch,
-                                        "supervisor: pushed worker commit to mirror eagerly"
-                                    );
-                                }
+                                // The push that makes this commit durable in the
+                                // mirror happens UNCONDITIONALLY just below the
+                                // match — see the comment there. We no longer
+                                // push inside this arm: workers commonly commit
+                                // their own edits via shell, leaving the tree
+                                // clean and this arm un-taken, yet their work
+                                // still needs pushing. One push site covers both.
                             }
                             Ok(false) => {
                                 tracing::debug!(
@@ -718,6 +683,42 @@ impl TaskRunSupervisor {
                                     "supervisor: workspace.commit failed (continuing to next stage)"
                                 );
                             }
+                        }
+                        // Push task_branch to the mirror UNCONDITIONALLY after
+                        // the stage — not just when the auto-commit above
+                        // produced a new commit. Workers frequently commit their
+                        // own edits via shell during the session, so the tree is
+                        // already clean by the time we get here and
+                        // `workspace.commit` returns Ok(false): the eager push
+                        // inside the Ok(true) arm above is then skipped and the
+                        // worker's commits live only in the ephemeral TempDir,
+                        // lost if the Pod is deadline-killed / evicted before
+                        // open_pr (the only other push). The mirror is a mounted
+                        // PVC so the refspec `task_branch:task_branch` is cheap
+                        // and idempotent when there's nothing new to push.
+                        //
+                        // Loud on failure (error!, not warn!) — a push failure
+                        // here is the durability seam: the worker's progress is
+                        // at risk of loss on kill. Still best-effort: the run
+                        // keeps going (open_pr retries the push), it's just
+                        // visible now.
+                        if let Err(e) = workspace.push_to_origin(&spec.task_branch).await {
+                            tracing::error!(
+                                task_id = %task.short_id,
+                                task_run_id = %run_id,
+                                role = %role_kind.as_str(),
+                                branch = %spec.task_branch,
+                                error = %e,
+                                "supervisor: post-stage push_to_origin failed — worker progress not yet durable in mirror (open_pr will retry)"
+                            );
+                        } else {
+                            tracing::debug!(
+                                task_id = %task.short_id,
+                                task_run_id = %run_id,
+                                role = %role_kind.as_str(),
+                                branch = %spec.task_branch,
+                                "supervisor: pushed task_branch to mirror after stage (durable)"
+                            );
                         }
                         // Worker finished cleanly → submit_task_review
                         // (in_progress → needs_task_review). Architect has no

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -1148,6 +1148,7 @@ impl TaskRunSupervisor {
                         // path as a reviewer approval.
                         SupervisorFlow::NewTask
                         | SupervisorFlow::ReviewResponse
+                        | SupervisorFlow::ReviewResume
                         | SupervisorFlow::ConflictRetry
                         | SupervisorFlow::Lead => {
                             info!(

--- a/server/crates/djinn-workspace/src/mirror.rs
+++ b/server/crates/djinn-workspace/src/mirror.rs
@@ -390,6 +390,76 @@ impl MirrorManager {
 
         Ok(Workspace::new(dir, branch.to_string()))
     }
+
+    /// Cheap host-side check that `branch`'s commits are durably present in the
+    /// mirror AND carry work not already on `base` — i.e. `base` is NOT an
+    /// ancestor-or-equal of `branch`.
+    ///
+    /// Used by the stage-aware-resume decision (`supervisor_runner`): a
+    /// reviewer-stage run that died after the worker already pushed its commits
+    /// to `task_branch` can be resumed at the reviewer instead of redoing the
+    /// worker — but ONLY if that output is actually durable. A missing branch
+    /// (first cycle, or the worker never pushed) or a branch with nothing ahead
+    /// of base means there is no worker diff to review, so the caller must fall
+    /// back to the full worker redo.
+    ///
+    /// Reads the bare mirror directly (no clone): resolves both refs and runs
+    /// `git merge-base --is-ancestor base branch`. `branch` is durably ahead
+    /// when `base` is an ancestor of `branch` but the two are not equal. Any
+    /// resolution failure (mirror missing, branch absent) yields `false` — the
+    /// safe answer is "not durable, redo the worker".
+    pub async fn branch_ahead_of_base(&self, project_id: &str, branch: &str, base: &str) -> bool {
+        let mirror = self.mirror_path(project_id);
+        if !mirror.exists() {
+            return false;
+        }
+        let rev_parse = |refname: String| {
+            let mirror = mirror.clone();
+            async move {
+                run_git_command(
+                    mirror,
+                    vec![
+                        "rev-parse".into(),
+                        "--verify".into(),
+                        "--quiet".into(),
+                        refname,
+                    ],
+                )
+                .await
+                .ok()
+                .map(|o| o.stdout.trim().to_string())
+                .filter(|s| !s.is_empty())
+            }
+        };
+        let (Some(branch_sha), Some(base_sha)) = (
+            rev_parse(format!("refs/heads/{branch}")).await,
+            rev_parse(format!("refs/heads/{base}")).await,
+        ) else {
+            return false;
+        };
+        // Equal heads = no worker diff to review.
+        if branch_sha == base_sha {
+            return false;
+        }
+        // `merge-base --is-ancestor base branch` exits 0 (→ `Ok`) when base is
+        // an ancestor of branch — given the non-equal check above, branch is
+        // then strictly ahead with the worker's commits on top — and exits 1
+        // (→ `Err(CommandFailed { code: 1 })`) when it is not (branch diverged
+        // from / does not contain base). For the resume decision we require the
+        // ancestor relationship: a durable, fast-forwardable worker output the
+        // reviewer can review against base.
+        run_git_command(
+            mirror,
+            vec![
+                "merge-base".into(),
+                "--is-ancestor".into(),
+                base_sha,
+                branch_sha,
+            ],
+        )
+        .await
+        .is_ok()
+    }
 }
 
 /// Is `key` set in the repo config at `mirror`? `git config --get`
@@ -501,5 +571,116 @@ mod gc_tests {
         let mgr = MirrorManager::new(root.path().to_path_buf());
         let err = mgr.gc("does-not-exist").await.unwrap_err();
         assert!(matches!(err, MirrorError::Missing(_)));
+    }
+}
+
+#[cfg(test)]
+mod ahead_of_base_tests {
+    use super::*;
+
+    async fn git(repo: &Path, args: &[&str]) {
+        run_git_command(
+            repo.to_path_buf(),
+            args.iter().map(|s| s.to_string()).collect(),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    }
+
+    /// Build a bare mirror under `{root}/{project_id}.git` seeded with `main`
+    /// and (optionally) a `task` branch one commit ahead. Returns the
+    /// `MirrorManager`.
+    async fn seed_mirror(root: &Path, project_id: &str, with_ahead_task: bool) -> MirrorManager {
+        let mirror = root.join(format!("{project_id}.git"));
+        git(
+            root,
+            &["init", "--bare", "--quiet", mirror.to_str().unwrap()],
+        )
+        .await;
+
+        // Working clone to author commits, then push refs into the bare mirror.
+        let work = TempDir::new().unwrap();
+        git(
+            root,
+            &[
+                "clone",
+                "--quiet",
+                mirror.to_str().unwrap(),
+                work.path().to_str().unwrap(),
+            ],
+        )
+        .await;
+        let wp = work.path();
+        git(wp, &["config", "user.email", "t@t"]).await;
+        git(wp, &["config", "user.name", "t"]).await;
+        git(wp, &["checkout", "-q", "-b", "main"]).await;
+        git(wp, &["commit", "--allow-empty", "-qm", "base"]).await;
+        git(wp, &["push", "-q", "origin", "main"]).await;
+
+        if with_ahead_task {
+            git(wp, &["checkout", "-q", "-b", "task"]).await;
+            git(wp, &["commit", "--allow-empty", "-qm", "worker work"]).await;
+            git(wp, &["push", "-q", "origin", "task"]).await;
+        }
+
+        MirrorManager::new(root.to_path_buf())
+    }
+
+    #[tokio::test]
+    async fn true_when_task_branch_is_ahead_of_base() {
+        let root = TempDir::new().unwrap();
+        let mgr = seed_mirror(root.path(), "p1", true).await;
+        assert!(
+            mgr.branch_ahead_of_base("p1", "task", "main").await,
+            "task branch one commit ahead of main must read as durable"
+        );
+    }
+
+    #[tokio::test]
+    async fn false_when_task_branch_absent() {
+        // First-cycle / worker-never-pushed: no task branch → not durable.
+        let root = TempDir::new().unwrap();
+        let mgr = seed_mirror(root.path(), "p2", false).await;
+        assert!(!mgr.branch_ahead_of_base("p2", "task", "main").await);
+    }
+
+    #[tokio::test]
+    async fn false_when_task_branch_equals_base() {
+        // Worker pushed nothing new (branch == base HEAD) → no diff to review.
+        let root = TempDir::new().unwrap();
+        let mirror = root.path().join("p3.git");
+        git(
+            root.path(),
+            &["init", "--bare", "--quiet", mirror.to_str().unwrap()],
+        )
+        .await;
+        let work = TempDir::new().unwrap();
+        git(
+            root.path(),
+            &[
+                "clone",
+                "--quiet",
+                mirror.to_str().unwrap(),
+                work.path().to_str().unwrap(),
+            ],
+        )
+        .await;
+        let wp = work.path();
+        git(wp, &["config", "user.email", "t@t"]).await;
+        git(wp, &["config", "user.name", "t"]).await;
+        git(wp, &["checkout", "-q", "-b", "main"]).await;
+        git(wp, &["commit", "--allow-empty", "-qm", "base"]).await;
+        git(wp, &["branch", "task"]).await;
+        git(wp, &["push", "-q", "origin", "main", "task"]).await;
+
+        let mgr = MirrorManager::new(root.path().to_path_buf());
+        assert!(!mgr.branch_ahead_of_base("p3", "task", "main").await);
+    }
+
+    #[tokio::test]
+    async fn false_when_mirror_missing() {
+        let root = TempDir::new().unwrap();
+        let mgr = MirrorManager::new(root.path().to_path_buf());
+        assert!(!mgr.branch_ahead_of_base("absent", "task", "main").await);
     }
 }


### PR DESCRIPTION
## Incident

Overnight 2026-06-10 on the VPS, MiniMax-M3 task-runs hit the k8s Job `activeDeadlineSeconds=3600` mid-review: the worker finished (~55 min) and submitted, the reviewer started, and the kubelet killed the pod minutes later. The submitted work was discarded and the task redispatched as a fresh worker run — task 9g2q redid identical work 3 full times, which burned the MiniMax coding-plan 5-hour quota (9.69M tokens) and stalled all dispatch behind 429s from 08:21–10:00 UTC.

Root cause of the work loss: the eager post-worker push to the mirror only ran when the supervisor's auto-commit created a commit (`workspace.commit()` → `Ok(true)`). Workers commonly commit their own edits via shell, leaving the tree clean → push silently skipped → commits lived only in the pod's ephemeral TempDir clone → gone on kill. The only other push is at `open_pr`, which a killed run never reaches.

## Fixes

1. **Always push `task_branch` after the worker/architect stage** (`djinn-supervisor`): unconditional, idempotent push to the mirror; failures now log at `error!` instead of `warn!`.
2. **SIGTERM checkpoint** (`djinn-agent-worker`): on SIGTERM/SIGINT the pod cancels the supervisor AND best-effort commits + pushes the live ephemeral stage clone (shared `captured_workspace_path` slot, read lazily at fire time), bounded at 20s inside the 60s grace period.
3. **In-pod soft deadline** (`djinn-k8s` + `djinn-agent-worker`): the Job deadline is plumbed into the pod via `DJINN_TASK_RUN_DEADLINE_SECONDS`; a timer at `deadline − 600s` drives the same graceful wind-down (cancel + checkpoint) so a healthy slow run exits `Interrupted` (never feeds the model breaker) before the kubelet hard-kills it. Default `task_run_active_deadline_seconds` raised 3600 → 10800: it is an infra backstop, not a run scheduler. Coupled: host teardown poll timeout 3600 → 11400s, stale-run sweep 2h → 4h.
4. **Stage-aware resume** (`djinn-agent` + `djinn-runtime` + `djinn-workspace`): a task back at `needs_task_review` (only reachable when the worker already submitted) that routes to `ReviewResponse` is upgraded to a new reviewer-only `ReviewResume` flow when a cheap mirror check (`branch_ahead_of_base`) confirms the worker's commits are durable. Missing/empty branch → conservative fallback to the full worker redo. Reviewer rejections are unaffected (all three reject transitions land at `open` → NewTask flow), and the decision keys on durable state, not post-cancellation outcomes (kw7s precedent respected).

With 1–3, a deadline kill costs minutes instead of an hour; with 4, a reviewer-stage death resumes at review instead of redoing the worker.

## Verification

- `SQLX_OFFLINE=true cargo clippy --all-features` clean on all touched crates (CI parity).
- `cargo nextest`: 148/148 in `djinn-supervisor`/`djinn-workspace`/`djinn-k8s`/`djinn-runtime`/`djinn-agent-worker` (incl. `in_pod_drive` and `cancel_path` end-to-end against the test Postgres) and 839/839 in `djinn-agent`.
- New tests: checkpoint commit/push + no-op cases, soft-deadline interval clamping, job-spec deadline/env assertions, `branch_ahead_of_base` against real bare mirrors, `resume_flow` decision seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)