### PR TITLE
fix(board): populate merge_commit_sha so merged tasks show again

### DIFF
--- a/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_review_handlers.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_review_handlers.rs
@@ -327,6 +327,38 @@ impl CoordinatorActor {
         }
     }
 
+    /// Close a task whose PR has merged, recording the landed merge-commit SHA.
+    ///
+    /// The SHA is persisted *before* the `PrMerge` transition so the
+    /// `task_updated` event the transition emits already carries it — that is
+    /// what lets the board place the card in the Merged column and the
+    /// coordinator record a throughput event (both gate on
+    /// `merge_commit_sha IS NOT NULL`). An empty/absent SHA degrades to a plain
+    /// `PrMerge` (task still closes; it just won't show as merged) rather than
+    /// blocking the close.
+    pub(in crate::actors::coordinator) async fn apply_pr_merge(
+        &self,
+        task_id: &str,
+        merge_commit_sha: Option<&str>,
+    ) {
+        if let Some(sha) = merge_commit_sha.filter(|s| !s.is_empty()) {
+            if let Err(e) = self.task_repo().set_merge_commit_sha(task_id, sha).await {
+                tracing::warn!(
+                    task_id,
+                    error = %e,
+                    "PR poller: failed to persist merge_commit_sha (task will still close)"
+                );
+            }
+        } else {
+            tracing::warn!(
+                task_id,
+                "PR poller: PR merged without a known merge_commit_sha — task closes but won't show as merged"
+            );
+        }
+        self.apply_pr_transition(task_id, TransitionAction::PrMerge, None)
+            .await;
+    }
+
     pub(in crate::actors::coordinator) async fn apply_pr_transition(
         &self,
         task_id: &str,

--- a/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_review_watcher.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_review_watcher.rs
@@ -78,7 +78,7 @@ impl CoordinatorActor {
                     pr = pull_number,
                     "PR poller: PR merged → closing task"
                 );
-                self.apply_pr_transition(&task.id, TransitionAction::PrMerge, None)
+                self.apply_pr_merge(&task.id, pr.merge_commit_sha.as_deref())
                     .await;
                 self.pr_status_cache.remove(&task.id);
                 self.merge_fail_count.remove(&task.id);
@@ -610,13 +610,21 @@ impl CoordinatorActor {
                 .merge_pull_request(&owner, &repo, pull_number, MergeMethod::Squash, &pr.title)
                 .await
             {
-                Ok(_) => {
+                Ok(merge_response) => {
+                    // The PUT /merge response carries the landed squash-commit
+                    // SHA (`{"sha": ..., "merged": true}`); record it so the
+                    // task lands in the board's Merged column.
+                    let merge_commit_sha = merge_response
+                        .get("sha")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_owned);
                     tracing::info!(
                         task_id = %task.short_id,
                         pr = pull_number,
+                        sha = merge_commit_sha.as_deref().unwrap_or("<unknown>"),
                         "PR poller: squash merge succeeded → closing task"
                     );
-                    self.apply_pr_transition(&task.id, TransitionAction::PrMerge, None)
+                    self.apply_pr_merge(&task.id, merge_commit_sha.as_deref())
                         .await;
                     self.pr_status_cache.remove(&task.id);
                     self.merge_fail_count.remove(&task.id);

--- a/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_watcher.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_watcher.rs
@@ -104,7 +104,7 @@ impl CoordinatorActor {
                     pr = pull_number,
                     "PR poller: PR merged → closing task"
                 );
-                self.apply_pr_transition(&task.id, TransitionAction::PrMerge, None)
+                self.apply_pr_merge(&task.id, pr.merge_commit_sha.as_deref())
                     .await;
                 self.pr_status_cache.remove(&task.id);
                 self.pr_draft_first_seen.remove(&task.id);

--- a/server/crates/djinn-provider/src/github_api/tests/pull_requests.rs
+++ b/server/crates/djinn-provider/src/github_api/tests/pull_requests.rs
@@ -329,6 +329,57 @@ async fn get_pull_request_success() {
     assert_eq!(checks.check_runs[0].conclusion.as_deref(), Some("success"));
 }
 
+/// A merged PR exposes the landed `merge_commit_sha` so the PR poller can
+/// persist it on the task (the board's Merged column gates on it). Regression
+/// for the field silently never being read — closed tasks then never showed as
+/// merged.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_pull_request_exposes_merge_commit_sha_when_merged() {
+    let server = MockServer::start().await;
+    let install_id = seed_installation_token();
+
+    Mock::given(method("GET"))
+        .and(path("/repos/djinnos/server/pulls/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "number": 42,
+            "title": "feat: add feature",
+            "state": "closed",
+            "merged": true,
+            "merge_commit_sha": "0123456789abcdef0123456789abcdef01234567",
+            "html_url": "https://github.com/djinnos/server/pull/42",
+            "head": { "ref": "feature-branch", "sha": "abc123" },
+            "base": { "ref": "main", "sha": "def456" },
+            "auto_merge": null,
+            "node_id": "PR_abc123"
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"/repos/djinnos/server/commits/abc123/check-runs",
+        ))
+        .and(query_param("per_page", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 0,
+            "check_runs": []
+        })))
+        .mount(&server)
+        .await;
+
+    let client = GitHubApiClient::for_installation_with_base_url(install_id, server.uri());
+    let (pr, _checks): (_, CheckRunsResponse) = client
+        .get_pull_request("djinnos", "server", 42)
+        .await
+        .unwrap();
+
+    assert_eq!(pr.merged, Some(true));
+    assert_eq!(
+        pr.merge_commit_sha.as_deref(),
+        Some("0123456789abcdef0123456789abcdef01234567")
+    );
+}
+
 /// A PR with more than one page of check runs must be fully aggregated:
 /// the client requests `per_page=100` and pages through `page=1`, `page=2`,
 /// ... until a short page signals the end — instead of silently dropping

--- a/server/crates/djinn-provider/src/github_api/types.rs
+++ b/server/crates/djinn-provider/src/github_api/types.rs
@@ -125,6 +125,12 @@ pub struct PullRequest {
     pub title: String,
     pub state: PrState,
     pub merged: Option<bool>,
+    /// The SHA of the merge commit on the base branch once the PR is merged.
+    /// GitHub populates this with the real landed commit when `merged == true`
+    /// (and with a speculative test-merge SHA while the PR is still open, which
+    /// we only ever read on the `merged` path). `None` when GitHub omits it.
+    #[serde(default)]
+    pub merge_commit_sha: Option<String>,
     pub html_url: String,
     pub head: PrRef,
     pub base: PrRef,

--- a/ui/src/components/KanbanBoard.test.tsx
+++ b/ui/src/components/KanbanBoard.test.tsx
@@ -235,6 +235,41 @@ describe("KanbanBoard", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("treats legacy PR-completed tasks (no merge SHA) as merged, but not force-closed ones", () => {
+    const tasks: Task[] = [
+      makeTask({
+        id: "t-legacy-merged",
+        title: "Legacy merged task",
+        status: "closed",
+        issue_type: "task",
+        epic_id: epicA.id,
+        pr_url: "https://github.com/example/repo/pull/7",
+        close_reason: "completed",
+        // No merge_commit_sha — closed before the SHA was persisted.
+      }),
+      makeTask({
+        id: "t-force-closed",
+        title: "Force closed unmerged task",
+        status: "closed",
+        issue_type: "task",
+        epic_id: epicA.id,
+        pr_url: "https://github.com/example/repo/pull/8",
+        close_reason: "force_closed",
+      }),
+    ];
+
+    render(
+      <KanbanBoard tasks={tasks} epics={new Map([[epicA.id, epicA]])} />,
+    );
+
+    const doneCol = screen.getByText("Merged").closest(".flex.flex-col");
+    expect(doneCol).toHaveTextContent("1");
+    expect(screen.getByText("Legacy merged task")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Force closed unmerged task"),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows empty board state when no tasks", () => {
     render(<KanbanBoard tasks={[]} epics={new Map()} />);
 

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -70,7 +70,16 @@ const STATUS_COLUMNS: Array<{
 
 function taskToColumnKey(task: Task): ColumnKey | null {
   if (task.status === "closed") {
-    return task.merge_commit_sha != null ? "done" : null;
+    // A task lands in "Merged" when we have the landed merge-commit SHA. Tasks
+    // closed before the SHA was persisted (legacy rows) won't have one, so fall
+    // back to the PR-flow completion signal: a task that opened a PR (`pr_url`)
+    // and closed as `completed` genuinely merged. This deliberately excludes
+    // force-closed-without-merge (`close_reason` = "force_closed") and the
+    // review/decomposition/planning/spike tasks that never open a PR.
+    const merged =
+      task.merge_commit_sha != null ||
+      (task.pr_url != null && task.close_reason === "completed");
+    return merged ? "done" : null;
   }
   if (
     task.status === "approved" ||


### PR DESCRIPTION
## Problem

The board's **Merged** column was gated on `task.merge_commit_sha != null` (#572), and the field was threaded through the list/SSE payload contracts (#574) — but **nothing ever populated it** on the actual PR-merge path. `set_merge_commit_sha` was only ever called from a proposal tool and a test. So every closed task had a `NULL` SHA and the board hid **all** merged tasks. The same field gates `record_merge_event`, so throughput metrics were silently broken too.

## Fix

**Backend — persist the landed SHA on every merge-close path**
- Add `merge_commit_sha` to the `PullRequest` GitHub API type (it was being dropped on deserialization).
- New `apply_pr_merge(task_id, sha)` helper persists the SHA **before** the `PrMerge` transition, so the `task_updated` event the transition emits already carries it (board placement + throughput in one consistent state).
- Wire the three production merge-close sites through it: both `pr.merged == true` detections (`pr_watcher` / `pr_review_watcher`) use `pr.merge_commit_sha`; the squash-merge success uses the `sha` from the `PUT /merge` response (previously discarded as `Ok(_)`). Merge-queue success closes via the same `pr.merged` path.

**Frontend — backward-compat for rows closed before the SHA was persisted**
- A closed task counts as Merged when it has a SHA, **or** (legacy) it opened a PR (`pr_url`) and closed as `completed`. This excludes force-closed-unmerged (`force_closed`) and the review/decomposition/planning/spike tasks that never open a PR.

## Tests
- Provider: a merged PR deserializes `merge_commit_sha`.
- Board: legacy PR-completed task shows as Merged; force-closed task stays hidden.

All affected crates compile; provider + board tests green (`tsc` clean).