### PR TITLE
fix(anthropic): surface 200 SSE error events as typed ProviderError

### DIFF
--- a/server/crates/djinn-provider/src/provider/format/anthropic/mod.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/mod.rs
@@ -17,5 +17,5 @@ use request::AnthropicSystemBlock;
 #[cfg(test)]
 pub(crate) use serde_json::{Value, json};
 #[allow(unused_imports)]
-pub(crate) use streaming::{ToolAcc, parse_anthropic_event};
+pub(crate) use streaming::{ToolAcc, classify_anthropic_error_event, parse_anthropic_event};
 pub(crate) use tools::convert_tool;

--- a/server/crates/djinn-provider/src/provider/format/anthropic/streaming.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/streaming.rs
@@ -6,7 +6,9 @@ use std::pin::Pin;
 use crate::message::{ContentBlock, Conversation};
 #[allow(unused_imports)]
 use crate::provider::client::ApiClient;
-use crate::provider::{LlmProvider, ProviderConfig, StreamEvent, TokenUsage, ToolChoice};
+use crate::provider::{
+    LlmProvider, ProviderConfig, ProviderError, StreamEvent, TokenUsage, ToolChoice,
+};
 
 use super::request::AnthropicProvider;
 
@@ -183,10 +185,70 @@ pub(crate) fn parse_anthropic_event(
             events.push(StreamEvent::Done);
         }
 
-        _ => {} // ping, error, etc.
+        // `error` is handled out-of-band in the stream loop (it must surface as
+        // a typed `Err(ProviderError)`, not a `StreamEvent`); see
+        // `classify_anthropic_error_event`. `ping` and any unknown event types
+        // carry no usable completion content and are dropped.
+        _ => {}
     }
 
     events
+}
+
+/// Classify an Anthropic **in-stream** `error` SSE event into a typed
+/// [`ProviderError`] plus a human-readable message.
+///
+/// Anthropic signals rate-limit / overload / refusal as an HTTP `200` SSE
+/// stream carrying `event: error\ndata: {"type":"error","error":{"type":
+/// "rate_limit_error","message":"..."}}` rather than a 4xx/5xx status. Dropping
+/// it (the previous `_ => {}` behaviour) yielded zero `StreamEvent`s, so the
+/// turn looked like an "empty/no-event turn" and the real failure never reached
+/// `classify_provider_failure` / the per-(scope,model) health breaker.
+///
+/// We reuse [`ProviderError::from_stream_error`] — the same mapping the OpenAI
+/// Responses streaming path uses for its mid-stream `error`/`response.failed`
+/// events — passing Anthropic's `error.type` as the `code`. The substring
+/// classifier covers the Anthropic vocabulary directly:
+/// `rate_limit_error` → `RateLimit` (retryable), `overloaded_error`/`api_error`
+/// → `ProviderInternal{500}` (retryable, server-side), `authentication_error`/
+/// `permission_error` → `Authentication` (terminal), `invalid_request_error` →
+/// `InvalidRequest` (terminal). A `retry-after` (ms) is folded in when present.
+pub(crate) fn classify_anthropic_error_event(data: &str) -> (ProviderError, String) {
+    let v: Value = serde_json::from_str(data).unwrap_or(Value::Null);
+    let error = v.get("error");
+    let err_type = error
+        .and_then(|e| e.get("type"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let message = error
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("provider returned an error event")
+        .to_string();
+
+    let class = ProviderError::from_stream_error(err_type.as_deref(), &message);
+
+    // Anthropic may include `error.retry_after` (seconds) on rate-limit events;
+    // carry it through to the typed RateLimit so backoff can honour it.
+    let class = match class {
+        ProviderError::RateLimit { .. } => {
+            let retry_after_ms = error
+                .and_then(|e| e.get("retry_after"))
+                .and_then(Value::as_f64)
+                .map(|secs| (secs * 1000.0) as u64);
+            class.with_retry_after(retry_after_ms)
+        }
+        other => other,
+    };
+
+    // Human-readable message rides along as anyhow context; prefix the
+    // Anthropic error type when we have one (mirrors OpenAI's `code: message`).
+    let display = match err_type {
+        Some(t) => format!("{t}: {message}"),
+        None => message,
+    };
+
+    (class, display)
 }
 
 impl LlmProvider for AnthropicProvider {
@@ -244,6 +306,22 @@ impl LlmProvider for AnthropicProvider {
                                 // Anthropic data lines contain the event type in the JSON
                                 if let Ok(v) = serde_json::from_str::<Value>(&line) {
                                     let event_type = v["type"].as_str().unwrap_or("").to_string();
+                                    if event_type == "error" {
+                                        // Anthropic signals rate-limit/overload/refusal as a
+                                        // 200 SSE `error` event (not a 4xx/5xx status). Surface
+                                        // it as a TYPED `ProviderError` so the reply loop reports
+                                        // the real reason and the health breaker gets fed —
+                                        // dropping it (old `_ => {}`) made the turn look "empty".
+                                        // Preserve the typed error as the anyhow *source* (via
+                                        // `.context`) so `consume_provider_stream`'s
+                                        // `Err(e) => Err(e.context(..))` keeps it downcastable;
+                                        // do NOT stringify it (that erases the type the breaker
+                                        // classifies on).
+                                        let (class, msg) = classify_anthropic_error_event(&line);
+                                        tracing::error!(target: "djinn_provider::request", error = %msg, ?class, "anthropic stream error event");
+                                        yield Err(anyhow::Error::new(class).context(msg));
+                                        return;
+                                    }
                                     for event in parse_anthropic_event(&event_type, &line, &mut tool_acc, &mut input_tokens, &mut cache_read, &mut cache_write) {
                                         yield Ok(event);
                                     }

--- a/server/crates/djinn-provider/src/provider/format/anthropic/tests/streaming.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/tests/streaming.rs
@@ -18,15 +18,18 @@
 //!   `test_build_request_preserves_separate_system_blocks_with_cache_control`)
 //! - 1 `content_block_delta` parser test
 //!   (`test_content_block_delta_input_json_without_active_tool_is_ignored`)
-//! - 2 tokio stream integration tests
-//!   (`test_stream_uses_payload_type_over_sse_event_name`,
-//!   `test_streamed_error_event_is_ignored_but_http_error_shape_surfaces`)
+//! - tokio stream integration tests
+//!   (`test_stream_uses_payload_type_over_sse_event_name`, plus the SSE
+//!   `error`-event tests below that assert a 200 SSE `error` event surfaces as
+//!   a typed `Err(ProviderError)` — overloaded/rate-limit/auth — rather than
+//!   being dropped as an empty turn, and the classifier unit tests)
 //! - 1 `test_build_request_sets_required_tool_choice_when_tools_present`
 //!   that closes out the streaming-SSE concern just before the L437 break.
 
 use super::*;
 use super::{spawn_sse_server, test_anthropic_config, test_provider};
 use crate::message::{Conversation, Message};
+use crate::provider::ProviderError;
 use futures::TryStreamExt;
 
 #[test]
@@ -354,8 +357,13 @@ async fn test_stream_uses_payload_type_over_sse_event_name() {
 }
 
 #[tokio::test]
-async fn test_streamed_error_event_is_ignored_but_http_error_shape_surfaces() {
+async fn test_streamed_overloaded_error_event_surfaces_typed_provider_error() {
+    // Anthropic signals overload as a 200 SSE `error` event. It must surface as
+    // a typed retryable `ProviderError::ProviderInternal` (server-side), NOT be
+    // dropped to an "empty turn".
     let body = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":7}}}\n\n",
         "event: error\n",
         "data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"try again later\"}}\n\n",
         "event: message_stop\n",
@@ -367,16 +375,116 @@ async fn test_streamed_error_event_is_ignored_but_http_error_shape_surfaces() {
     let mut conv = Conversation::new();
     conv.push(Message::user("Hello"));
 
-    let events = provider
+    let err = provider
         .stream(&conv, &[], None)
         .await
         .expect("stream")
         .try_collect::<Vec<_>>()
         .await
-        .expect("collect events");
-    assert_eq!(events.len(), 1);
-    assert!(matches!(events[0], StreamEvent::Done));
+        .expect_err("overloaded_error event must surface as Err, not an empty turn");
 
+    // The typed ProviderError must be preserved as the anyhow source so the
+    // host breaker can downcast it (the whole point of the fix).
+    let pe = err
+        .downcast_ref::<ProviderError>()
+        .expect("typed ProviderError must be downcastable from the stream error");
+    assert_eq!(*pe, ProviderError::ProviderInternal { status: 500 });
+    assert!(pe.retryable(), "overloaded_error must be retryable");
+    // Human-readable detail rides along as anyhow context.
+    let text = err.to_string();
+    assert!(
+        text.contains("overloaded_error") && text.contains("try again later"),
+        "error message must carry the Anthropic detail: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_streamed_rate_limit_error_event_surfaces_typed_rate_limit() {
+    // The Kimi-Code signature: sustained worker volume → 200 SSE rate-limit
+    // error. Must surface as the retryable RateLimit variant (feeds backoff +
+    // breaker), not a swallowed empty turn.
+    let body = concat!(
+        "event: error\n",
+        "data: {\"type\":\"error\",\"error\":{\"type\":\"rate_limit_error\",\"message\":\"rate limited\"}}\n\n"
+    );
+    let mut config = test_anthropic_config();
+    config.base_url = spawn_sse_server(200, body);
+    let provider = AnthropicProvider::new(config);
+    let mut conv = Conversation::new();
+    conv.push(Message::user("Hello"));
+
+    let err = provider
+        .stream(&conv, &[], None)
+        .await
+        .expect("stream")
+        .try_collect::<Vec<_>>()
+        .await
+        .expect_err("rate_limit_error event must surface as Err");
+
+    let pe = err
+        .downcast_ref::<ProviderError>()
+        .expect("typed ProviderError must be downcastable");
+    assert!(
+        matches!(pe, ProviderError::RateLimit { .. }),
+        "rate_limit_error must map to RateLimit, got {pe:?}"
+    );
+    assert!(pe.retryable());
+    assert!(err.to_string().contains("rate limited"));
+}
+
+#[test]
+fn test_classify_anthropic_error_event_rate_limit_carries_retry_after() {
+    // Direct unit test of the classifier: rate_limit_error → RateLimit, and a
+    // numeric `error.retry_after` (seconds) is folded into retry_after_ms.
+    let data = r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down","retry_after":2}}"#;
+    let (class, msg) = classify_anthropic_error_event(data);
+    assert_eq!(
+        class,
+        ProviderError::RateLimit {
+            retry_after_ms: Some(2000)
+        }
+    );
+    assert_eq!(msg, "rate_limit_error: slow down");
+}
+
+#[test]
+fn test_classify_anthropic_error_event_overloaded_maps_to_internal() {
+    let data = r#"{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}"#;
+    let (class, _msg) = classify_anthropic_error_event(data);
+    assert_eq!(class, ProviderError::ProviderInternal { status: 500 });
+    assert!(class.retryable());
+}
+
+#[tokio::test]
+async fn test_streamed_auth_error_event_surfaces_typed_authentication() {
+    let mut conv = Conversation::new();
+    conv.push(Message::user("Hello"));
+
+    // A 200 SSE `authentication_error` event → typed Authentication (terminal,
+    // non-retryable) so the breaker disables rather than retries.
+    let body = concat!(
+        "event: error\n",
+        "data: {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key\"}}\n\n"
+    );
+    let mut sse_config = test_anthropic_config();
+    sse_config.base_url = spawn_sse_server(200, body);
+    let provider = AnthropicProvider::new(sse_config);
+    let err = provider
+        .stream(&conv, &[], None)
+        .await
+        .expect("stream")
+        .try_collect::<Vec<_>>()
+        .await
+        .expect_err("authentication_error event must surface as Err");
+    let pe = err
+        .downcast_ref::<ProviderError>()
+        .expect("typed ProviderError must be downcastable");
+    assert_eq!(*pe, ProviderError::Authentication);
+    assert!(!pe.retryable(), "auth failures are terminal");
+    assert!(err.to_string().contains("invalid x-api-key"));
+
+    // Regression guard: a genuine HTTP-401 (not a 200 SSE event) still surfaces
+    // the client's status-shaped error verbatim — the SSE path didn't disturb it.
     let error_body =
         r#"{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}"#;
     let mut error_config = test_anthropic_config();


### PR DESCRIPTION
## Problem
djinn's Anthropic SSE parser silently dropped HTTP-200 `error` events (`streaming.rs` `_ => {} // ping, error, etc.`). When an Anthropic-compatible provider signals rate-limit / overload / refusal via a **200 response carrying an SSE `error` event** (rather than a 4xx), djinn yielded **zero** `StreamEvent`s → the reply loop's `saw_round_event` stayed false → the turn failed as *"provider returned N empty/no-event turns"*, blind-retried, and — critically — the real error was swallowed (`provider_failure: None`), so the per-(scope,model) health breaker was **never fed** (no backoff, no failover, no auto-disable). Tasks cycled until the planner escalated.

Observed live with `kimi-for-coding/k2p7`: every worker dies on turn 1 (~3–4s) with empty/no-event turns, `provider_failure: None`, and re-dispatches into a loop. (Direct curl probes proved Kimi's endpoint is healthy across non-stream/stream/thinking/tools/cache_control/large-request, so the failure is this dropped-event path — see closed task `vry9`.)

This is provider-agnostic: any Anthropic-compatible endpoint that emits a 200+`error` event hit it.

## Fix
`error` SSE events are now classified into a typed `ProviderError` (via the canonical `ProviderError::from_stream_error`, the same mapping the OpenAI-Responses path uses) and yielded as `Err(..)` on the stream, preserving the type as the anyhow **source** so `classify_provider_failure`'s `downcast_ref::<ProviderError>()` succeeds and the breaker is fed:
- `rate_limit_error` → `RateLimit` (retryable; folds in `retry_after`)
- `overloaded_error` / `api_error` → retryable server (`ProviderInternal{500}`)
- `authentication_error` / `permission_error` → `Authentication` (terminal)
- `invalid_request_error` → `InvalidRequest` (terminal)
- `ping` / unknown → still ignored

## Tests
New stream tests for overloaded / rate-limit / auth error events (assert the typed `ProviderError` is downcastable from the stream `Err`), a regression guard that genuine HTTP-401 still surfaces, and two direct classifier unit tests. `cargo test -p djinn-provider anthropic` → 56 passed. clippy/fmt/check clean (`-D warnings`).

## Note
This makes Kimi's real failure **visible** (it'll now surface the actual `error` reason + feed the breaker instead of an opaque empty-turn loop). If Kimi's failing turn is a typed error event, this also gets it proper failover/disable; if it turns out to be a truly-empty 200, the surfaced diagnostics will say so and narrow it to djinn's HTTP send path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)