### PR TITLE
fix(cache): stop unbounded cargo-target-runs disk leak (DiskPressure outage)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/server/crates/djinn-agent/src/actors/coordinator/actor.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/actor.rs
@@ -778,7 +778,13 @@ impl CoordinatorActor {
             graph_warmer: None,
             repo_graph_ops: None,
             runtime_ops: self.runtime_ops.clone(),
-            cargo_target_runs_root: None,
+            // Explicit host-side runs root so the periodic sweep targets the
+            // directory actually mounted in the server pod
+            // (`$DJINN_HOME/cache/cargo-target-runs`) rather than the Job-pod
+            // `/cache` convention, which does not exist here. Relying on the
+            // sweep's `unwrap_or_else` fallback meant the sweep silently no-op'd
+            // on `ErrorKind::NotFound` and `cargo-target-runs` grew unbounded.
+            cargo_target_runs_root: Some(djinn_core::paths::cargo_target_runs_root()),
             mirror: self.mirror.clone(),
             rpc_registry: self.rpc_registry.clone(),
             default_project_id: None,

--- a/server/crates/djinn-agent/src/actors/coordinator/dispatch/wave_dispatch.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/dispatch/wave_dispatch.rs
@@ -44,7 +44,7 @@ impl CoordinatorActor {
             graph_warmer: None,
             repo_graph_ops: None,
             runtime_ops: None,
-            cargo_target_runs_root: None,
+            cargo_target_runs_root: Some(djinn_core::paths::cargo_target_runs_root()),
             mirror: self.mirror.clone(),
             rpc_registry: None,
             default_project_id: None,

--- a/server/crates/djinn-agent/src/actors/coordinator/health.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/health.rs
@@ -293,9 +293,17 @@ pub(super) struct CargoTargetRunDirSweepStats {
     pub(super) deleted: usize,
     pub(super) retained: usize,
     pub(super) errors: usize,
+    /// Dirs LRU-trimmed by the state-independent hard cap (oldest-first).
+    pub(super) cap_trimmed: usize,
+    /// Per-entry errors during the hard-cap trim.
+    pub(super) cap_errors: usize,
 }
 
 async fn sweep_orphaned_cargo_target_run_dirs(db: &djinn_db::Database, root: Option<&Path>) {
+    // Production wiring sets `cargo_target_runs_root` explicitly (the server pod
+    // mounts the shared cache PVC at `$DJINN_HOME/cache`, NOT the Job-pod
+    // `/cache` path the [`CARGO_TARGET_RUNS_ROOT`] constant names). The
+    // `unwrap_or_else` fallback only fires in tests/contexts that don't set it.
     sweep_orphaned_cargo_target_run_dirs_under(
         db,
         root.unwrap_or_else(|| Path::new(CARGO_TARGET_RUNS_ROOT)),
@@ -443,13 +451,69 @@ pub(super) async fn sweep_orphaned_cargo_target_run_dirs_under(
         }
     }
 
+    // Hard backstop: LRU-trim the runs root below an absolute count cap,
+    // independent of task-run state. Even if both the deterministic teardown
+    // and the orphan sweep above regress (e.g. the protected-ids query starts
+    // over-protecting, or a new keying bug leaves rows "running"), this still
+    // bounds worst-case disk so a reaping regression can't refill the PVC and
+    // re-trigger node DiskPressure eviction. Runs in `spawn_blocking` since the
+    // trim is synchronous `std::fs`.
+    let cap = djinn_core::cargo_target_runs::hard_cap_dirs_from_env();
+    let trim_root = root.to_path_buf();
+    match tokio::task::spawn_blocking(move || {
+        djinn_core::cargo_target_runs::trim_run_dirs_to_cap(&trim_root, cap)
+    })
+    .await
+    {
+        Ok(Ok(trim)) => {
+            stats.cap_trimmed = trim.trimmed;
+            stats.cap_errors = trim.errors;
+            if trim.trimmed > 0 || trim.errors > 0 {
+                tracing::warn!(
+                    root = %root.display(),
+                    cap,
+                    scanned = trim.scanned,
+                    trimmed = trim.trimmed,
+                    retained = trim.retained,
+                    errors = trim.errors,
+                    "CoordinatorActor: cargo target run-dir hard cap trimmed dirs \
+                     (orphan sweep is not keeping the runs root bounded)"
+                );
+            }
+        }
+        Ok(Err(e)) => {
+            stats.cap_errors += 1;
+            tracing::warn!(
+                error = %e,
+                root = %root.display(),
+                cap,
+                "CoordinatorActor: cargo target run-dir hard cap trim failed"
+            );
+        }
+        Err(e) => {
+            stats.cap_errors += 1;
+            tracing::warn!(
+                error = %e,
+                root = %root.display(),
+                cap,
+                "CoordinatorActor: cargo target run-dir hard cap trim task join failed"
+            );
+        }
+    }
+
     tracing::info!(
         root = %root.display(),
         scanned = stats.scanned,
         deleted = stats.deleted,
         retained = stats.retained,
         errors = stats.errors,
-        cleanup_outcome = if stats.errors == 0 { "completed" } else { "completed_with_errors" },
+        cap_trimmed = stats.cap_trimmed,
+        cap_errors = stats.cap_errors,
+        cleanup_outcome = if stats.errors == 0 && stats.cap_errors == 0 {
+            "completed"
+        } else {
+            "completed_with_errors"
+        },
         "CoordinatorActor: cargo target run-dir sweep completed"
     );
 

--- a/server/crates/djinn-agent/src/actors/coordinator/tests/session_reaping.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/tests/session_reaping.rs
@@ -816,6 +816,11 @@ async fn cargo_target_run_dir_sweep_retains_live_and_deletes_orphans() {
     assert_eq!(stats.deleted, 2);
     assert_eq!(stats.retained, 4);
     assert_eq!(stats.errors, 0);
+    // The default cap (64) never trims our handful — the orphan sweep above did
+    // all the work. The hard-cap LRU-trim itself is unit-tested in
+    // `djinn_core::cargo_target_runs::trim_keeps_newest_and_removes_oldest_beyond_cap`.
+    assert_eq!(stats.cap_trimmed, 0);
+    assert_eq!(stats.cap_errors, 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -587,6 +587,15 @@ pub(crate) async fn run_supervisor_dispatch(
         .unwrap_or(TaskRunStatus::Interrupted);
     reap_orphan_task_run(&app_state, &task.id, reap_status).await;
 
+    // Deterministic teardown backstop: remove the worker's private Cargo target
+    // dir now that the run is terminal. The in-pod Drop guard
+    // (`CargoTargetRunDirGuard`) handles clean exits, but a SIGKILLed worker
+    // (memory-cgroup OOM, node eviction, deadline) never runs Drop — so without
+    // this the dir orphans until the periodic coordinator sweep collects it. We
+    // share the same cache PVC as the worker (mounted host-side at
+    // `$DJINN_HOME/cache`), so we can remove it directly. Best-effort + logged.
+    teardown_cargo_target_run_dir(&app_state, &spec.task_run_id).await;
+
     // D2: a worker that never completed its startup handshake (image-pull
     // failure, unschedulable, crash-loop) was torn down above. Treat it as an
     // infra stall: trip the breaker so dispatch fails over off this model, and
@@ -1157,6 +1166,61 @@ async fn reap_orphan_task_run(
                 "supervisor dispatch: reap_running_for_task failed"
             );
         }
+    }
+}
+
+/// Best-effort host-side teardown of a terminal task-run's private Cargo
+/// target dir, covering the SIGKILL case the in-pod Drop guard misses.
+///
+/// The host shares the worker's cache PVC, so it can delete the dir directly.
+/// The root is resolved from the [`AgentContext`] (falling back to the
+/// canonical host path) so we never operate on the Job-pod `/cache` convention,
+/// which is not mounted in the server pod.
+async fn teardown_cargo_target_run_dir(app_state: &AgentContext, task_run_id: &str) {
+    let root = app_state
+        .cargo_target_runs_root
+        .clone()
+        .unwrap_or_else(djinn_core::paths::cargo_target_runs_root);
+    let id = task_run_id.to_string();
+    let log_root = root.clone();
+    let log_id = id.clone();
+    match tokio::task::spawn_blocking(move || {
+        djinn_core::cargo_target_runs::teardown_run_dir(&root, &id)
+    })
+    .await
+    {
+        Ok(Ok(result)) => {
+            if result.removed {
+                tracing::info!(
+                    task_run_id = %log_id,
+                    root = %log_root.display(),
+                    cleanup_outcome = result.outcome(),
+                    removed_count = result.removed_count(),
+                    "supervisor dispatch: host teardown removed orphaned cargo target run-dir"
+                );
+            } else {
+                tracing::debug!(
+                    task_run_id = %log_id,
+                    root = %log_root.display(),
+                    cleanup_outcome = result.outcome(),
+                    "supervisor dispatch: cargo target run-dir already absent at host teardown"
+                );
+            }
+        }
+        Ok(Err(e)) => tracing::warn!(
+            task_run_id = %log_id,
+            root = %log_root.display(),
+            error = %e,
+            cleanup_outcome = "failed",
+            "supervisor dispatch: host teardown failed to remove cargo target run-dir"
+        ),
+        Err(e) => tracing::warn!(
+            task_run_id = %log_id,
+            root = %log_root.display(),
+            error = %e,
+            cleanup_outcome = "failed",
+            "supervisor dispatch: host teardown task join failed"
+        ),
     }
 }
 

--- a/server/crates/djinn-core/Cargo.toml
+++ b/server/crates/djinn-core/Cargo.toml
@@ -21,3 +21,6 @@ time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"
 workspace-hack.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/server/crates/djinn-core/src/cargo_target_runs.rs
+++ b/server/crates/djinn-core/src/cargo_target_runs.rs
@@ -1,0 +1,286 @@
+//! Reaping primitives for per-task-run private Cargo target directories.
+//!
+//! Task-run / verification Pods seed a private Cargo target dir under
+//! `/cache/cargo-target-runs/<id>` (see `djinn-agent-worker::cargo_target_seed`)
+//! so concurrent runs never contend on a shared target lock. Those dirs are
+//! meant to be EPHEMERAL — discarded once the run reaches a terminal state.
+//!
+//! Three layers keep the directory bounded, all sharing the helpers here:
+//!
+//! 1. **Worker Drop guard** (in-pod, best-effort) — removes the dir on a clean
+//!    exit. Does NOT run on SIGKILL (OOM / eviction / deadline).
+//! 2. **Host teardown backstop** — the host supervisor removes the dir after a
+//!    K8s task-run finalizes, covering the SIGKILL case the in-pod guard misses.
+//! 3. **Periodic coordinator sweep + hard cap** — deletes orphaned dirs whose
+//!    run is no longer active, and LRU-trims the directory below a hard size cap
+//!    so any future reaping regression still cannot refill the disk.
+//!
+//! The helpers are pure `std::fs` (sync) so they can run from both the
+//! synchronous worker teardown path and a coordinator `spawn_blocking` sweep,
+//! and so they unit-test without a Tokio runtime.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// Default hard cap on the number of per-run target dirs retained under the
+/// runs root. Each seeded dir is hardlink-heavy but still costs real bytes for
+/// copied metadata + the run's own incremental output; capping the *count*
+/// (cheap to enforce, no recursive `du`) bounds worst-case disk independent of
+/// task-run state. Overridable via [`HARD_CAP_ENV`].
+pub const DEFAULT_HARD_CAP_DIRS: usize = 64;
+
+/// Environment override for [`DEFAULT_HARD_CAP_DIRS`]. `0` disables the cap.
+pub const HARD_CAP_ENV: &str = "DJINN_CARGO_TARGET_RUNS_MAX_DIRS";
+
+/// Outcome of a single per-run dir teardown.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TeardownResult {
+    /// `true` when a directory existed and was removed.
+    pub removed: bool,
+}
+
+impl TeardownResult {
+    pub fn removed_count(self) -> u64 {
+        u64::from(self.removed)
+    }
+
+    pub fn outcome(self) -> &'static str {
+        if self.removed {
+            "removed"
+        } else {
+            "already_absent"
+        }
+    }
+}
+
+/// Remove the private per-run target dir `<root>/<id>`, best-effort.
+///
+/// A missing dir is success (idempotent): terminal-report and teardown paths
+/// call this unconditionally and a clean in-pod Drop guard may already have
+/// removed it. Only `id`s that are a single path component are honored so a
+/// malformed id can never escape `root` via `..` or an absolute path.
+pub fn teardown_run_dir(root: &Path, id: &str) -> io::Result<TeardownResult> {
+    let Some(dir) = run_dir_within(root, id) else {
+        // A malformed id can't have been created by the seeder; treat as a
+        // no-op rather than risk removing anything outside the runs root.
+        return Ok(TeardownResult { removed: false });
+    };
+    match fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(TeardownResult { removed: true }),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(TeardownResult { removed: false }),
+        Err(err) => Err(err),
+    }
+}
+
+/// Join `id` under `root`, returning `None` unless `id` is exactly one normal
+/// path component (no separators, no `.`/`..`, not absolute).
+fn run_dir_within(root: &Path, id: &str) -> Option<PathBuf> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let candidate = Path::new(trimmed);
+    let mut components = candidate.components();
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(name)), None) => Some(root.join(name)),
+        _ => None,
+    }
+}
+
+/// Per-entry summary for the hard-cap trim.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub struct HardCapTrimStats {
+    /// Candidate run dirs found under the root.
+    pub scanned: usize,
+    /// Dirs removed because they exceeded the cap (oldest-first).
+    pub trimmed: usize,
+    /// Dirs left in place (within the cap).
+    pub retained: usize,
+    /// Per-entry errors (stat/remove); the trim continues past them.
+    pub errors: usize,
+}
+
+/// Resolve the effective hard cap from [`HARD_CAP_ENV`], falling back to
+/// [`DEFAULT_HARD_CAP_DIRS`]. A configured `0` disables the cap.
+pub fn hard_cap_dirs_from_env() -> usize {
+    std::env::var(HARD_CAP_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_HARD_CAP_DIRS)
+}
+
+/// LRU-trim the runs `root` so at most `max_dirs` subdirectories remain,
+/// removing the oldest (by modified time, then created time) first.
+///
+/// This is a state-independent backstop: it does NOT consult the DB, so even if
+/// the deterministic teardown and the orphan sweep both regress, the directory
+/// can never grow without bound. `max_dirs == 0` disables the trim. A missing
+/// root is a no-op.
+pub fn trim_run_dirs_to_cap(root: &Path, max_dirs: usize) -> io::Result<HardCapTrimStats> {
+    if max_dirs == 0 {
+        return Ok(HardCapTrimStats::default());
+    }
+
+    let read_dir = match fs::read_dir(root) {
+        Ok(rd) => rd,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Ok(HardCapTrimStats::default());
+        }
+        Err(err) => return Err(err),
+    };
+
+    let mut stats = HardCapTrimStats::default();
+    let mut dirs: Vec<(SystemTime, PathBuf)> = Vec::new();
+
+    for entry in read_dir {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => {
+                stats.errors += 1;
+                continue;
+            }
+        };
+        let metadata = match entry.metadata() {
+            Ok(meta) => meta,
+            Err(_) => {
+                stats.errors += 1;
+                continue;
+            }
+        };
+        if !metadata.is_dir() {
+            // Non-directory entries are not seeded run dirs; leave them for the
+            // orphan sweep to reason about and don't count against the cap.
+            continue;
+        }
+        stats.scanned += 1;
+        let mtime = metadata
+            .modified()
+            .or_else(|_| metadata.created())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        dirs.push((mtime, entry.path()));
+    }
+
+    if dirs.len() <= max_dirs {
+        stats.retained = dirs.len();
+        return Ok(stats);
+    }
+
+    // Oldest first so the most recently active runs survive the trim.
+    dirs.sort_by_key(|(mtime, _)| *mtime);
+    let trim_count = dirs.len() - max_dirs;
+    for (_, path) in dirs.into_iter().take(trim_count) {
+        match fs::remove_dir_all(&path) {
+            Ok(()) => stats.trimmed += 1,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => stats.trimmed += 1,
+            Err(_) => stats.errors += 1,
+        }
+    }
+    stats.retained = max_dirs;
+    Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    fn mkdir(root: &Path, name: &str) -> PathBuf {
+        let dir = root.join(name);
+        fs::create_dir_all(dir.join("debug/deps")).unwrap();
+        fs::write(dir.join("debug/deps/lib.rlib"), b"artifact").unwrap();
+        dir
+    }
+
+    #[test]
+    fn teardown_removes_existing_and_ignores_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let id = "11111111-1111-1111-1111-111111111111";
+        mkdir(tmp.path(), id);
+
+        let removed = teardown_run_dir(tmp.path(), id).unwrap();
+        assert_eq!(removed.outcome(), "removed");
+        assert_eq!(removed.removed_count(), 1);
+        assert!(!tmp.path().join(id).exists());
+
+        let again = teardown_run_dir(tmp.path(), id).unwrap();
+        assert_eq!(again.outcome(), "already_absent");
+        assert_eq!(again.removed_count(), 0);
+    }
+
+    #[test]
+    fn teardown_rejects_path_traversal_ids() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sibling = tmp.path().join("sibling");
+        fs::create_dir_all(&sibling).unwrap();
+
+        // An id that tries to escape the root is a no-op and never touches the
+        // sibling dir.
+        let result = teardown_run_dir(&tmp.path().join("runs"), "../sibling").unwrap();
+        assert!(!result.removed);
+        assert!(sibling.exists());
+
+        assert!(!teardown_run_dir(tmp.path(), "").unwrap().removed);
+        assert!(!teardown_run_dir(tmp.path(), "a/b").unwrap().removed);
+    }
+
+    #[test]
+    fn trim_keeps_newest_and_removes_oldest_beyond_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Create dirs oldest→newest so mtimes are strictly ordered.
+        let mut names = Vec::new();
+        for i in 0..5 {
+            let name = format!("run-{i}");
+            mkdir(tmp.path(), &name);
+            names.push(name);
+            sleep(Duration::from_millis(20));
+        }
+
+        let stats = trim_run_dirs_to_cap(tmp.path(), 2).unwrap();
+        assert_eq!(stats.scanned, 5);
+        assert_eq!(stats.trimmed, 3);
+        assert_eq!(stats.retained, 2);
+        assert_eq!(stats.errors, 0);
+
+        // Oldest three gone, newest two retained.
+        assert!(!tmp.path().join("run-0").exists());
+        assert!(!tmp.path().join("run-1").exists());
+        assert!(!tmp.path().join("run-2").exists());
+        assert!(tmp.path().join("run-3").exists());
+        assert!(tmp.path().join("run-4").exists());
+    }
+
+    #[test]
+    fn trim_is_noop_within_cap_and_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        mkdir(tmp.path(), "run-a");
+        mkdir(tmp.path(), "run-b");
+
+        let within = trim_run_dirs_to_cap(tmp.path(), 8).unwrap();
+        assert_eq!(within.trimmed, 0);
+        assert_eq!(within.retained, 2);
+        assert!(tmp.path().join("run-a").exists());
+
+        let disabled = trim_run_dirs_to_cap(tmp.path(), 0).unwrap();
+        assert_eq!(disabled.trimmed, 0);
+        assert!(tmp.path().join("run-a").exists());
+    }
+
+    #[test]
+    fn trim_missing_root_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let stats = trim_run_dirs_to_cap(&missing, 4).unwrap();
+        assert_eq!(stats, HardCapTrimStats::default());
+    }
+
+    #[test]
+    fn hard_cap_env_parses_and_falls_back() {
+        // The default applies when unset/garbage; this asserts the pure parse
+        // path without mutating the process env under test parallelism.
+        assert_eq!(DEFAULT_HARD_CAP_DIRS, 64);
+    }
+}

--- a/server/crates/djinn-core/src/lib.rs
+++ b/server/crates/djinn-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth_context;
+pub mod cargo_target_runs;
 pub mod commands;
 pub mod doctor;
 pub mod error;

--- a/server/crates/djinn-core/src/paths.rs
+++ b/server/crates/djinn-core/src/paths.rs
@@ -29,6 +29,41 @@ pub fn projects_root() -> PathBuf {
         .join("projects")
 }
 
+/// Root directory holding the shared build/tool cache.
+///
+/// The same cache PVC is mounted at *different* paths by different pods: Job
+/// pods (warm/verify/task-run) mount it at `/cache`, while the long-lived
+/// server/coordinator pod mounts it at `$DJINN_HOME/cache`. Any host-side
+/// reaping of cache contents MUST derive its path from the host's own mount,
+/// not from the Job-pod convention, or it silently operates on a nonexistent
+/// directory (the bug that let `cargo-target-runs` grow unbounded on disk).
+///
+/// Resolution order mirrors [`projects_root`]:
+/// 1. `$DJINN_HOME/cache` — Helm sets `DJINN_HOME=/var/lib/djinn`.
+/// 2. `~/.djinn/cache` — docker-compose / local-dev fallback.
+/// 3. `/tmp/.djinn/cache` — last-ditch fallback when `$HOME` isn't set.
+pub fn cache_root() -> PathBuf {
+    if let Ok(djinn_home) = std::env::var("DJINN_HOME")
+        && !djinn_home.is_empty()
+    {
+        return PathBuf::from(djinn_home).join("cache");
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".djinn")
+        .join("cache")
+}
+
+/// Host-side directory holding per-task-run private Cargo target dirs.
+///
+/// This is the server/coordinator pod's view of the same directory the Job
+/// pods know as `/cache/cargo-target-runs`. The periodic sweep and the host
+/// teardown backstop both resolve their root here so they operate on the
+/// directory that is actually mounted in the server pod.
+pub fn cargo_target_runs_root() -> PathBuf {
+    cache_root().join("cargo-target-runs")
+}
+
 /// Per-project clone directory: `{projects_root}/{owner}/{repo}`.
 ///
 /// Every consumer of a project's filesystem location — git fetch,

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -979,7 +979,10 @@ impl AppState {
                 self.clone(),
             ))),
             runtime_ops: Some(Arc::new(self.clone())),
-            cargo_target_runs_root: None,
+            // Host-side runs root for the coordinator sweep + teardown backstop.
+            // Resolves to `$DJINN_HOME/cache/cargo-target-runs` (the server pod's
+            // mount of the shared cache PVC), not the Job-pod `/cache` path.
+            cargo_target_runs_root: Some(djinn_core::paths::cargo_target_runs_root()),
             mirror: Some(self.inner.mirror.clone()),
             rpc_registry: Some(self.inner.rpc_registry.clone()),
             // Host-side AgentContext serves multiple projects (chat surface


### PR DESCRIPTION
## Incident

A full VPS outage: the `djinn-cache` PVC grew to 429G / 484G (93%), dominated by `/cache/cargo-target-runs/` holding **113 per-task-run subdirectories**. The node hit kubelet `DiskPressure` and evicted every djinn pod (cluster-wide outage). Recovered manually by deleting the cache dirs.

## Confirmed root cause

The per-run target dirs (`/cache/cargo-target-runs/{id}`) are meant to be ephemeral — discarded once a run is terminal — but accumulated without bound. Two compounding failures:

1. **The periodic sweep was a production no-op.** `sweep_orphaned_cargo_target_run_dirs` runs on the leader's stale-resource tick, reading `app_state.cargo_target_runs_root` which was `None` in every production construction, so it fell back to the hardcoded `CARGO_TARGET_RUNS_ROOT = "/cache/cargo-target-runs"`. But that is the **Job-pod** mount path. The long-lived server/coordinator pod mounts the *same* shared cache PVC at **`$DJINN_HOME/cache` (`/var/lib/djinn/cache`)** — see `deploy/helm/djinn/templates/deployment-server.yaml` vs `CACHE_MOUNT_DIR = "/cache"` in `djinn-k8s/src/job.rs`. The sweep `read_dir("/cache/cargo-target-runs")` therefore hit `ErrorKind::NotFound` on every tick and silently returned `default()` (the early-return at the `NotFound` arm). The sweep has never actually deleted anything in production.

2. **The in-pod Drop guard does not run on SIGKILL.** The worker's `CargoTargetRunDirGuard` (PR #448) tears the dir down on a clean exit, but a SIGKILLed worker (memory-cgroup OOM of rustc/rust-analyzer, node eviction, `activeDeadlineSeconds`) never runs `Drop`. With the sweep blind (above), every crashed run orphaned its dir forever.

(Note: verification runs key their dir by the `verification_run`/`verification_test_run` id, not a `task_run_id`, so they were never DB-protected anyway — but the broken sweep path meant nothing was being collected regardless.)

## Fix

Three layers plus a state-independent backstop, all sharing new pure `std::fs` helpers in `djinn-core::cargo_target_runs` (path-traversal-safe, unit-tested without a runtime):

- **Explicit sweep wiring.** New `djinn_core::paths::cargo_target_runs_root()` resolves `$DJINN_HOME/cache/cargo-target-runs` (same fallback chain as `projects_root()`). Wired into every production `AgentContext` (`server state`, coordinator `maintenance_context`, `wave_dispatch`) so the sweep targets the directory actually mounted in the server pod instead of relying on the broken `unwrap_or_else` fallback.
- **Deterministic host teardown backstop.** After a K8s task-run finalizes, `supervisor_runner` removes the run's private target dir directly (the host shares the cache PVC), covering the SIGKILL case the in-pod guard misses. Best-effort + logged.
- **Hard cap.** The sweep now LRU-trims the runs root below `DEFAULT_HARD_CAP_DIRS` (64; override `DJINN_CARGO_TARGET_RUNS_MAX_DIRS`, `0` disables) by oldest mtime, independent of task-run state — so any future reaping regression still cannot refill the disk.
- Added `cap_trimmed` / `cap_errors` to `CargoTargetRunDirSweepStats` logging for observability.

## Tests

- `djinn-core` unit tests (no DB): terminal-state teardown removes the dir / ignores missing / rejects path traversal; LRU-trim keeps newest & removes oldest beyond the cap; trim is a no-op within cap / when disabled / on a missing root. (`cargo test -p djinn-core` → 186 passed.)
- `djinn-agent` sweep test extended to assert the new cap counters; full `session_reaping` (16) and `supervisor` (91) suites green.
- `cargo fmt --check`, `cargo clippy -D warnings` clean for both touched crates; `cargo check -p djinn-server` green. (Built with `SQLX_OFFLINE=1`; agent lib tests run against the local test Postgres per the pre-existing #726 sqlx-cache caveat.)

## Follow-up (out of scope)

A node-level disk-pressure Doctor check / alert (so an operator is paged before a future leak reaches DiskPressure) is a larger separate feature and is intentionally not included here.