### PR TITLE
feat(provider): env-gated outbound request logger + feed breaker on empty/no-event turns

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1394,6 +1394,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "wiremock",
  "workspace-hack",

--- a/server/crates/djinn-agent/src/actors/slot/reply_loop/turn.rs
+++ b/server/crates/djinn-agent/src/actors/slot/reply_loop/turn.rs
@@ -30,6 +30,34 @@ use super::persistence::{persist_session_message, serialize_llm_input, serialize
 use super::streaming::{StreamLoopContext, StreamTurnState, consume_provider_stream};
 use super::tool_dispatch::{ToolDispatchContext, collect_tool_results, tool_runtime_metadata};
 
+/// Build the terminal error for a reply loop that gave up after the bounded
+/// empty/no-event-turn retries.
+///
+/// Carries a typed [`djinn_provider::provider::ProviderError`] source so the
+/// host's `classify_provider_failure` can `downcast_ref` it and feed the
+/// per-(scope,model) health breaker. Before this, a terminal empty/no-event
+/// stream (the kimi-for-coding/k2p7 incident: every turn-1 ended with no SSE
+/// events) returned a plain `anyhow` error → classified `None` → breaker never
+/// fed → dispatch re-selected the dead model forever (it broke `twty`/`oy1q`).
+///
+/// We mirror the Codex empty-200 mid-stream path (`from_stream_error`'s default)
+/// and use `ProviderInternal { status: 500 }`, which `classify_provider_failure`
+/// maps to the GENTLE consecutive-failure breaker (`Failure`): a one-off blip is
+/// absorbed (a successful session resets the streak) but a model that produces
+/// empty turns on EVERY dispatch finally auto-disables / fails over. We do NOT
+/// use `EmptyCompletion`, which is deliberately `None` (it has its own in-loop
+/// backoff for Codex consumer-backend throttling). The readable diagnostic rides
+/// along as `.context` so the existing string-based detectors still match on the
+/// top-level Display.
+fn empty_turn_terminal_error(kind: &str, retries: u32, diag: String) -> anyhow::Error {
+    anyhow::Error::new(djinn_provider::provider::ProviderError::ProviderInternal { status: 500 })
+        .context(format!(
+            "provider returned {retries} empty {kind} turns — the backend likely refused or \
+             throttled the request (a ChatGPT-account Codex rate limit returns empty 200s, \
+             not 429s; verify provider/account status or switch to an API-key backend); {diag}"
+        ))
+}
+
 fn permission_denial_text(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
     lower.contains("permission denied")
@@ -774,11 +802,10 @@ pub(crate) async fn run_reply_loop(
                     continue;
                 }
                 let diag = runtime_fs_diagnostics(project_path, worktree_path);
-                return Err(anyhow::anyhow!(
-                    "provider returned {} empty/no-event turns — the backend likely refused or \
-                     throttled the request (a ChatGPT-account Codex rate limit returns empty 200s, \
-                     not 429s; verify provider/account status or switch to an API-key backend); {}",
-                    empty_turn_retries, diag
+                return Err(empty_turn_terminal_error(
+                    "no-event",
+                    empty_turn_retries,
+                    diag,
                 ));
             }
 
@@ -817,11 +844,10 @@ pub(crate) async fn run_reply_loop(
                     continue;
                 }
                 let diag = runtime_fs_diagnostics(project_path, worktree_path);
-                return Err(anyhow::anyhow!(
-                    "provider returned {} empty assistant turns — the backend likely refused or \
-                     throttled the request (a ChatGPT-account Codex rate limit returns empty 200s, \
-                     not 429s; verify provider/account status or switch to an API-key backend); {}",
-                    empty_turn_retries, diag
+                return Err(empty_turn_terminal_error(
+                    "assistant",
+                    empty_turn_retries,
+                    diag,
                 ));
             }
             // Reset retry counter on successful content.
@@ -1268,4 +1294,37 @@ pub(crate) async fn run_reply_loop(
         total_cache_read as i64,
         total_cache_write as i64,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djinn_provider::provider::ProviderError;
+
+    #[test]
+    fn empty_turn_terminal_error_is_breaker_classifiable() {
+        // The terminal empty/no-event-turn failure must carry a typed
+        // `ProviderError` source so `classify_provider_failure` (which
+        // `downcast_ref`s) can feed the per-(scope,model) breaker. Before this,
+        // it returned a plain `anyhow!` string → downcast failed → `None` → the
+        // breaker was never fed and the dead model was re-selected forever.
+        for kind in ["no-event", "assistant"] {
+            let err = empty_turn_terminal_error(kind, 2, "diag".to_string());
+            let typed = err
+                .downcast_ref::<ProviderError>()
+                .expect("terminal empty-turn error must carry a typed ProviderError source");
+            // ProviderInternal{500} mirrors the Codex empty-200 path and maps to
+            // the GENTLE consecutive-failure breaker (`Failure`), NOT
+            // `EmptyCompletion` (which classifies as `None` by design).
+            assert_eq!(*typed, ProviderError::ProviderInternal { status: 500 });
+            assert!(
+                typed.retryable(),
+                "{kind}: a server-internal empty-turn failure is transient/retryable"
+            );
+            // The readable diagnostic still rides on the top-level Display.
+            let display = err.to_string();
+            assert!(display.contains("empty"), "{kind}: {display}");
+            assert!(display.contains("diag"), "{kind}: {display}");
+        }
+    }
 }

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -459,6 +459,9 @@ fn build_task_run_env(
     env.push(env_var("GIT_CONFIG_KEY_0", "safe.directory"));
     env.push(env_var("GIT_CONFIG_VALUE_0", "*"));
 
+    // djinn:allow-oversize — job.rs was already over the 50KB byte guard on
+    // main before this one-line forward; kept whole rather than split.
+    //
     // Forward the outbound-request debug flag to the task-run pod (the LLM
     // call for worker/planner/reviewer stages happens in this Pod, not the
     // server). Only forwarded when set on the server, so it stays off by

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -459,6 +459,15 @@ fn build_task_run_env(
     env.push(env_var("GIT_CONFIG_KEY_0", "safe.directory"));
     env.push(env_var("GIT_CONFIG_VALUE_0", "*"));
 
+    // Forward the outbound-request debug flag to the task-run pod (the LLM
+    // call for worker/planner/reviewer stages happens in this Pod, not the
+    // server). Only forwarded when set on the server, so it stays off by
+    // default; used to capture the literal provider request for diagnosing
+    // empty-stream failures (e.g. kimi-for-coding).
+    if let Ok(v) = std::env::var("DJINN_DEBUG_PROVIDER_REQUEST") {
+        env.push(env_var("DJINN_DEBUG_PROVIDER_REQUEST", &v));
+    }
+
     env.extend(task_run_cache_env_vars(project_id, task_run_id_str));
     env
 }

--- a/server/crates/djinn-provider/Cargo.toml
+++ b/server/crates/djinn-provider/Cargo.toml
@@ -45,3 +45,4 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 wiremock = "0.6"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/server/crates/djinn-provider/src/provider/client.rs
+++ b/server/crates/djinn-provider/src/provider/client.rs
@@ -21,6 +21,95 @@ fn auth_secrets(auth: &AuthMethod) -> Vec<String> {
     }
 }
 
+/// Env var that gates the outbound provider-request debug logger. Truthy
+/// (`1`/`true`/`yes`/`on`, case-insensitive) turns it on. Default OFF — no log
+/// spam and no behaviour change when unset.
+const DEBUG_PROVIDER_REQUEST_ENV: &str = "DJINN_DEBUG_PROVIDER_REQUEST";
+
+/// `tracing` target the outbound-request log uses. Grep
+/// `djinn_provider::outbound_request` to find the captured lines.
+const OUTBOUND_REQUEST_TARGET: &str = "djinn_provider::outbound_request";
+
+fn debug_provider_request_enabled() -> bool {
+    std::env::var(DEBUG_PROVIDER_REQUEST_ENV)
+        .ok()
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            matches!(v.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
+/// Best-effort extraction of the model id from a request body for log fields.
+fn body_model_id(body: &serde_json::Value) -> &str {
+    body.get("model").and_then(|m| m.as_str()).unwrap_or("")
+}
+
+/// Render the request headers (auth + extras) into a single redacted string for
+/// the debug log. Auth header VALUES are always redacted; any other header that
+/// looks credential-bearing is scrubbed via [`redact_secrets`] using the same
+/// key/value heuristics as response bodies.
+fn render_redacted_headers(auth: &AuthMethod, extra_headers: &HeaderMap) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    match auth {
+        AuthMethod::BearerToken(_) => {
+            lines.push("Authorization: Bearer ***REDACTED***".to_string());
+        }
+        AuthMethod::ApiKeyHeader { header, .. } => {
+            lines.push(format!("{header}: ***REDACTED***"));
+        }
+        AuthMethod::NoAuth => {}
+    }
+    for (name, value) in extra_headers {
+        let raw = value.to_str().unwrap_or("<non-utf8>");
+        // Reuse the body redactor on a synthetic `"name":"value"` pair so the
+        // existing sensitive-key heuristics (authorization/api-key/secret/bearer)
+        // scrub credential-bearing extra headers (e.g. Helicone-Auth).
+        let scrubbed = redact_secrets(&format!("\"{name}\":\"{raw}\""), &[]);
+        let rendered = scrubbed
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .map(|inner| inner.replacen("\":\"", ": ", 1))
+            .unwrap_or_else(|| format!("{name}: {raw}"));
+        lines.push(rendered);
+    }
+    lines.join("\n")
+}
+
+/// When `DJINN_DEBUG_PROVIDER_REQUEST` is truthy, log the EXACT outbound LLM
+/// HTTP request (method, effective URL, all headers, full JSON body) at INFO,
+/// with secrets redacted, just before it is sent. Used to diagnose failures we
+/// cannot reproduce offline (the kimi-for-coding/k2p7 empty-stream incident: the
+/// literal runtime request — full injected MCP tool set + exact serialization —
+/// differs from a known-good curl in some way we can only see by capturing it).
+fn log_outbound_request(
+    method: &str,
+    url: &str,
+    body: &serde_json::Value,
+    auth: &AuthMethod,
+    extra_headers: &HeaderMap,
+) {
+    if !debug_provider_request_enabled() {
+        return;
+    }
+    let secrets = auth_secrets(auth);
+    let secret_refs: Vec<&str> = secrets.iter().map(String::as_str).collect();
+    // The actual serialized JSON that goes on the wire, then redacted so a
+    // gateway-echoed api-key or any sensitive field never lands in the log.
+    let body_json = serde_json::to_string(body).unwrap_or_else(|_| "<unserializable>".to_string());
+    let body_redacted = redact_secrets(&body_json, &secret_refs);
+    let headers_redacted = render_redacted_headers(auth, extra_headers);
+    tracing::info!(
+        target: OUTBOUND_REQUEST_TARGET,
+        provider_model = %body_model_id(body),
+        method = %method,
+        url = %url,
+        headers = %headers_redacted,
+        body = %body_redacted,
+        "outbound provider request (DJINN_DEBUG_PROVIDER_REQUEST)"
+    );
+}
+
 /// Build the boundary `anyhow::Error` for a non-success HTTP status: a typed
 /// [`ProviderError`] source (so callers can `downcast_ref`) plus a readable,
 /// secret-redacted context message.
@@ -95,6 +184,8 @@ impl ApiClient {
 
         Box::pin(stream! {
             let secret_refs: Vec<&str> = secrets.iter().map(String::as_str).collect();
+            // Env-gated capture of the literal outbound request (default OFF).
+            log_outbound_request("POST", &url, &body, &auth, &extra_headers);
             // Retry loop for the initial HTTP request.
             let response = 'retry: {
                 let mut attempt = 0u32;
@@ -231,6 +322,8 @@ impl ApiClient {
     ) -> anyhow::Result<String> {
         let secrets = auth_secrets(auth);
         let secret_refs: Vec<&str> = secrets.iter().map(String::as_str).collect();
+        // Env-gated capture of the literal outbound request (default OFF).
+        log_outbound_request("POST", url, &body, auth, &extra_headers);
         let mut attempt = 0u32;
         loop {
             let mut req = self.inner.post(url).json(&body);
@@ -473,5 +566,130 @@ mod tests {
         assert!(!is_rate_limit_status(
             reqwest::StatusCode::SERVICE_UNAVAILABLE
         ));
+    }
+
+    // ─── Outbound-request debug logger (DJINN_DEBUG_PROVIDER_REQUEST) ─────────
+
+    use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::Context;
+    use tracing_subscriber::prelude::*;
+
+    /// Serialize tests that mutate the process-global env var + tracing default.
+    fn env_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| StdMutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedEvents(Arc<StdMutex<Vec<String>>>);
+
+    struct CaptureVisitor<'a>(&'a mut Vec<String>);
+    impl Visit for CaptureVisitor<'_> {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0.push(format!("{}={:?}", field.name(), value));
+        }
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.0.push(format!("{}={}", field.name(), value));
+        }
+    }
+
+    impl<S: tracing::Subscriber> Layer<S> for CapturedEvents {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            if event.metadata().target() != OUTBOUND_REQUEST_TARGET {
+                return;
+            }
+            let mut fields = Vec::new();
+            event.record(&mut CaptureVisitor(&mut fields));
+            self.0.lock().unwrap().push(fields.join(" | "));
+        }
+    }
+
+    fn capture_with_env(value: Option<&str>) -> Vec<String> {
+        let captured = CapturedEvents(Arc::new(StdMutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        tracing::subscriber::with_default(subscriber, || {
+            match value {
+                Some(v) => unsafe { std::env::set_var(DEBUG_PROVIDER_REQUEST_ENV, v) },
+                None => unsafe { std::env::remove_var(DEBUG_PROVIDER_REQUEST_ENV) },
+            }
+            let body = serde_json::json!({
+                "model": "kimi-for-coding/k2p7",
+                "messages": [{"role": "user", "content": "hi"}],
+            });
+            let auth = AuthMethod::BearerToken("sk-super-secret-token".to_string());
+            let mut headers = HeaderMap::new();
+            headers.insert("anthropic-version", "2023-06-01".parse().unwrap());
+            log_outbound_request(
+                "POST",
+                "https://api.kimi.com/coding/v1",
+                &body,
+                &auth,
+                &headers,
+            );
+        });
+        captured.0.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn logger_silent_when_env_unset() {
+        let _g = env_test_guard();
+        let events = capture_with_env(None);
+        assert!(
+            events.is_empty(),
+            "no outbound-request event must be emitted when {DEBUG_PROVIDER_REQUEST_ENV} is unset: {events:?}"
+        );
+        // A falsey value is also OFF.
+        let events = capture_with_env(Some("0"));
+        assert!(
+            events.is_empty(),
+            "falsey value must keep the logger OFF: {events:?}"
+        );
+    }
+
+    #[test]
+    fn logger_emits_and_redacts_when_env_set() {
+        let _g = env_test_guard();
+        for truthy in ["1", "true", "YES", "on"] {
+            let events = capture_with_env(Some(truthy));
+            assert_eq!(
+                events.len(),
+                1,
+                "exactly one outbound-request event expected for {truthy:?}: {events:?}"
+            );
+            let joined = &events[0];
+            // The token must never appear in the captured event — redacted in
+            // both the Authorization header and (defensively) the body.
+            assert!(
+                !joined.contains("sk-super-secret-token"),
+                "secret token leaked into log for {truthy:?}: {joined}"
+            );
+            assert!(
+                joined.contains("***REDACTED***"),
+                "expected redaction marker: {joined}"
+            );
+            // Useful fields are present for diffing against a known-good curl.
+            assert!(
+                joined.contains("kimi-for-coding/k2p7"),
+                "model id field missing: {joined}"
+            );
+            assert!(
+                joined.contains("https://api.kimi.com/coding/v1"),
+                "url field missing: {joined}"
+            );
+            assert!(
+                joined.contains("Authorization"),
+                "auth header missing: {joined}"
+            );
+            assert!(
+                joined.contains("anthropic-version"),
+                "extra header missing: {joined}"
+            );
+        }
+        // Cleanup so the env var never leaks to a sibling test.
+        unsafe { std::env::remove_var(DEBUG_PROVIDER_REQUEST_ENV) };
     }
 }


### PR DESCRIPTION
Two changes to crack a Kimi failure and harden the per-(scope,model) health breaker.

## Context
`kimi-for-coding/k2p7` (Anthropic-compatible endpoint `https://api.kimi.com/coding/v1`) fails on every worker turn-1 with `reply loop error: provider returned 2 empty/no-event turns` (`provider_failure: None`). Direct-curl testing proved the Kimi endpoint returns proper SSE for every reconstructed request, so the trigger lives in the **literal** request djinn sends at runtime (full injected MCP tool set + exact serialization) which we cannot reproduce offline. We need to capture it.

## Change 1 — env-gated outbound provider-request logger
Gated behind `DJINN_DEBUG_PROVIDER_REQUEST` (truthy `1`/`true`/`yes`/`on` = on; **default OFF**, no behavior change / no log spam when unset). When enabled, logs **at INFO** the exact outbound LLM HTTP request just before it is sent: method, effective URL, all headers, and the full serialized JSON body — with secrets **redacted** via the existing `redact_secrets` helper (Authorization / `x-api-key` header values, plus `sk-`/`tp-`/`Bearer ` tokens echoed in the body). Includes the provider/model id as a log field.

- Implemented once in the provider HTTP client send path (`stream_sse` + `post_json` in `client.rs`) so it covers **all** formats and logs the actual serialized body that goes on the wire.
- **Log target:** `djinn_provider::outbound_request`. **Fields:** `provider_model`, `method`, `url`, `headers`, `body`.

This lets us diff djinn's real runtime request against a known-good curl to find the Kimi empty-stream trigger.

## Change 2 — empty/no-event turn now feeds the health breaker
A turn that ends with `saw_round_event == false` (and the empty-assistant-turn sibling) used to return the terminal "empty/no-event turns" error from `turn.rs` as a plain `anyhow` error with no typed `ProviderError`, so `classify_provider_failure` could not `downcast_ref` it → `provider_failure: None` → the per-(scope,model) breaker was **never fed**, and the dead model was re-selected forever (broke `twty`/`oy1q`).

Fix: the terminal empty-turn failure now carries a typed `ProviderError::ProviderInternal { status: 500 }` (mirroring the Codex empty-200 mid-stream path), which `classify_provider_failure` maps to `ProviderFailureClass::Failure` → the **gentle consecutive-failure breaker**. A one-off blip is absorbed (a successful session resets the streak), but a model that produces empty turns on **every** dispatch auto-disables / fails over after the threshold. We deliberately do **not** use `EmptyCompletion` (it classifies as `None` by design — it has its own in-loop backoff for Codex throttling). Retry/backoff counts are unchanged; only the terminal failure's type changed. The readable diagnostic rides along as `.context` so existing string-based detectors still match on Display.

## Tests
- `logger_silent_when_env_unset` / `logger_emits_and_redacts_when_env_set`: the logger emits exactly one captured tracing event **only** when the env var is truthy, and the token never appears in the captured event (redacted in both the Authorization header and the body).
- `empty_turn_terminal_error_is_breaker_classifiable`: the terminal empty-turn error downcasts to `ProviderInternal{500}` (so the breaker would be fed).
- `cargo fmt`, `cargo clippy -D warnings`, `cargo check` clean on both touched crates; existing `classify_provider_failure` tests still pass; size guard OK (turn.rs allowed by its pre-existing `// djinn:allow-oversize` marker; client.rs under limits).

Do **not** enqueue/merge — the parent drives merge → release → deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)