### PR TITLE
fix(provider): parse SSE data: lines without a leading space (Kimi for Coding empty-stream)

### DIFF
--- a/server/crates/djinn-provider/src/provider/client.rs
+++ b/server/crates/djinn-provider/src/provider/client.rs
@@ -45,6 +45,25 @@ fn body_model_id(body: &serde_json::Value) -> &str {
     body.get("model").and_then(|m| m.as_str()).unwrap_or("")
 }
 
+/// Parse one SSE line, returning the trimmed `data:` payload to yield, or `None`
+/// for non-data lines (`event:`, `id:`, comments, blanks) and the empty/`[DONE]`
+/// sentinels.
+///
+/// Per the SSE spec the single space after `data:` is OPTIONAL. Anthropic and
+/// OpenAI emit `data: {...}` (with space), but some Anthropic-compatible vendors
+/// — notably the Kimi for Coding endpoint (`api.kimi.com/coding`) — emit
+/// `data:{...}` with NO space. We strip only the `data:` field name and let
+/// `trim()` drop the optional leading space so both forms parse. Matching the
+/// literal `"data: "` (with space) silently dropped every Kimi event, which
+/// surfaced as a "stream ended without events" empty turn.
+fn parse_sse_data_line(line: &str) -> Option<&str> {
+    let data = line.strip_prefix("data:")?.trim();
+    if data.is_empty() || data == "[DONE]" {
+        return None;
+    }
+    Some(data)
+}
+
 /// Render the request headers (auth + extras) into a single redacted string for
 /// the debug log. Auth header VALUES are always redacted; any other header that
 /// looks credential-bearing is scrubbed via [`redact_secrets`] using the same
@@ -281,15 +300,11 @@ impl ApiClient {
             loop {
                 match tokio::time::timeout(STREAM_CHUNK_TIMEOUT, lines.next_line()).await {
                     Ok(Ok(Some(line))) => {
-                        // SSE lines starting with "data: "
-                        if let Some(data) = line.strip_prefix("data: ") {
-                            let data = data.trim();
-                            if data.is_empty() || data == "[DONE]" {
-                                continue;
-                            }
+                        // Yield payloads from SSE `data:` lines; skip event:, id:,
+                        // comment, blank lines and the `[DONE]` sentinel.
+                        if let Some(data) = parse_sse_data_line(&line) {
                             yield Ok(data.to_string());
                         }
-                        // Skip event:, id:, comment lines, and blank lines
                     }
                     Ok(Ok(None)) => break, // end of stream
                     Ok(Err(e)) => {
@@ -474,6 +489,35 @@ mod tests {
     #[test]
     fn request_timeout_is_10_minutes() {
         assert_eq!(REQUEST_TIMEOUT, Duration::from_secs(600));
+    }
+
+    #[test]
+    fn parse_sse_data_line_handles_space_and_no_space() {
+        // Anthropic/OpenAI form (space after colon).
+        assert_eq!(
+            parse_sse_data_line("data: {\"type\":\"message_start\"}"),
+            Some("{\"type\":\"message_start\"}")
+        );
+        // Kimi for Coding form (NO space after colon) — the regression.
+        assert_eq!(
+            parse_sse_data_line("data:{\"type\":\"message_start\"}"),
+            Some("{\"type\":\"message_start\"}")
+        );
+    }
+
+    #[test]
+    fn parse_sse_data_line_skips_non_data_and_sentinels() {
+        // Non-data SSE fields and comments are ignored.
+        assert_eq!(parse_sse_data_line("event:message_start"), None);
+        assert_eq!(parse_sse_data_line("event: message_start"), None);
+        assert_eq!(parse_sse_data_line("id: 42"), None);
+        assert_eq!(parse_sse_data_line(": keep-alive comment"), None);
+        assert_eq!(parse_sse_data_line(""), None);
+        // Empty payloads and the [DONE] sentinel (either spacing) are dropped.
+        assert_eq!(parse_sse_data_line("data:"), None);
+        assert_eq!(parse_sse_data_line("data: "), None);
+        assert_eq!(parse_sse_data_line("data: [DONE]"), None);
+        assert_eq!(parse_sse_data_line("data:[DONE]"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`kimi-for-coding/k2p7` consistently produced **turn-1 empty turns** ("provider stream ended without events") and got auto-disabled by the health breaker — while every other provider worked. The Kimi for Coding plan was effectively unusable on djinn.

## Root cause

Captured djinn's literal outbound request (via the `DJINN_DEBUG_PROVIDER_REQUEST` logger from #755) and replayed it with `curl`. The **request was fine** — the same body/headers returned a full 90-event SSE stream from `api.kimi.com/coding/v1/messages`.

The difference is in **how djinn parses the response**. The shared SSE reader in `djinn-provider/src/provider/client.rs` matched the literal prefix `"data: "` (with a trailing space):

```rust
if let Some(data) = line.strip_prefix("data: ") { ... }
```

Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) the single space after the field colon is **optional**. Anthropic and OpenAI emit `data: {...}` (with space); Kimi for Coding emits `data:{...}` with **no space**. So every Kimi event failed the prefix match and was silently dropped → the stream yielded zero events → empty turn → breaker trip.

Confirmed via controlled `curl` bisection that ruled out body, content-type, max_tokens (64000 is accepted), cache_control, tool schemas, pod network egress, User-Agent, and gzip — only the `data:` spacing differs.

## Fix

Strip only the `data:` field name and let the existing `trim()` drop the optional leading space, so both `data: {...}` and `data:{...}` parse. Extracted the line parsing into a pure `parse_sse_data_line()` helper with regression tests covering both spacings, non-data fields (`event:`/`id:`/comments), and the `[DONE]`/empty sentinels.

This is provider-agnostic and safe for all existing providers (they send the space; `trim()` handles it).

## Test

```
cargo test -p djinn-provider --lib provider::client::tests::parse_sse   # 2 passed
cargo fmt -p djinn-provider --check                                     # clean
cargo clippy -p djinn-provider --all-features -- -D warnings            # clean
```