### PR TITLE
fix(pr-poller): treat 'manual' merge-queue dequeue reason as benign (no spurious rework)

### DIFF
--- a/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_commands.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/pr_poller/pr_commands.rs
@@ -623,7 +623,9 @@ pub(crate) fn record_auto_merge_decision_metrics(decision: &AutoMergeTickDecisio
 ///
 /// Reasons that are NOT failures: `"BRANCH_INVALIDATED"` (head moved —
 /// queue will pick up the new SHA), `"QUEUE_CLEARED"` (admin reset),
-/// `"DEQUEUED"` (manual intervention by a human).
+/// `"DEQUEUED"`/`"MANUAL"` (manual intervention by a human — `manual` is the
+/// `RemovedFromMergeQueueEvent` timeline-surface word, `DEQUEUED` the
+/// GraphQL-enum surface for the same operator queue-removal).
 ///
 /// All other reasons (CHECKS_FAILED, MERGE_CONFLICT, NO_RESPONSE,
 /// NOT_QUEUEABLE, ROLL_BACK, UNKNOWN_REMOVAL_REASON, anything new GitHub
@@ -633,17 +635,21 @@ pub(in crate::actors::coordinator) fn dequeue_reason_is_failure(reason: Option<&
     match reason {
         None => false,
         // GitHub emits two vocabularies for this reason depending on surface:
-        // SCREAMING_CASE GraphQL-enum style (`CHECKS_FAILED`) and lowercase
-        // snake_case on `RemovedFromMergeQueueEvent` timeline nodes
-        // (`failed_checks`, `merged`) — compare case-insensitively or the
-        // safe-list never matches real events and EVERY dequeue (including a
-        // successful merge) reopens the task for rework. `MERGED` is the
-        // queue's success exit; the next poll tick sees `pr.merged` and closes
-        // the task. Unknown reasons stay conservative-failure so a new GitHub
-        // vocabulary never silently swallows a real eviction.
+        // SCREAMING_CASE GraphQL-enum style (`CHECKS_FAILED`, `DEQUEUED`) and
+        // lowercase snake_case on `RemovedFromMergeQueueEvent` timeline nodes
+        // (`failed_checks`, `merged`, `manual`) — compare case-insensitively
+        // or the safe-list never matches real events and EVERY dequeue
+        // (including a successful merge) reopens the task for rework. The two
+        // surfaces don't share spellings for an operator queue-removal:
+        // `manual` is the timeline word, `DEQUEUED` the GraphQL-enum word for
+        // the same human dequeue — both are benign and must be safe-listed.
+        // `MERGED` is the queue's success exit; the next poll tick sees
+        // `pr.merged` and closes the task. Unknown reasons stay
+        // conservative-failure so a new GitHub vocabulary never silently
+        // swallows a real eviction.
         Some(r) => !matches!(
             r.to_ascii_uppercase().as_str(),
-            "MERGED" | "BRANCH_INVALIDATED" | "QUEUE_CLEARED" | "DEQUEUED"
+            "MERGED" | "BRANCH_INVALIDATED" | "QUEUE_CLEARED" | "DEQUEUED" | "MANUAL"
         ),
     }
 }

--- a/server/crates/djinn-agent/src/actors/coordinator/pr_poller/tests.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/pr_poller/tests.rs
@@ -749,6 +749,12 @@ fn dequeue_reasons_classified_correctly() {
     assert!(!dequeue_reason_is_failure(Some("branch_invalidated")));
     assert!(!dequeue_reason_is_failure(Some("QUEUE_CLEARED")));
     assert!(!dequeue_reason_is_failure(Some("DEQUEUED")));
+    // Operator queue-removal surfaces as `manual` on the timeline event and
+    // `DEQUEUED` on the GraphQL enum — both spellings are benign and must
+    // not reopen the task for rework (regression: a manual dequeue
+    // spuriously reopened a task in prod, 2026-06-18).
+    assert!(!dequeue_reason_is_failure(Some("manual")));
+    assert!(!dequeue_reason_is_failure(Some("MANUAL")));
     assert!(!dequeue_reason_is_failure(None));
 }
 
@@ -816,6 +822,15 @@ fn dequeue_requires_rework_ignores_non_failure_and_absent_events() {
     assert!(!dequeue_requires_rework(
         Some(&merged),
         Some("2026-06-12T14:12:31Z"),
+        None
+    ));
+    // An operator manually removing the PR from the queue surfaces as
+    // `manual` on the timeline event — benign, must not reopen for rework
+    // (regression: a manual dequeue spuriously reopened a task, 2026-06-18).
+    let manual = dequeue_event("manual", Some("2026-06-18T10:00:00Z"));
+    assert!(!dequeue_requires_rework(
+        Some(&manual),
+        Some("2026-06-18T09:00:00Z"),
         None
     ));
     assert!(!dequeue_requires_rework(


### PR DESCRIPTION
## Problem

`dequeue_reason_is_failure` in the PR poller decides whether a merge-queue dequeue means a real CI failure (→ reopen task for rework) or a benign removal (→ leave the task alone). Its safe-list of benign reasons was:

```rust
"MERGED" | "BRANCH_INVALIDATED" | "QUEUE_CLEARED" | "DEQUEUED"
```

GitHub's `RemovedFromMergeQueueEvent.reason` timeline node emits the lowercase string **`manual`** when an operator manually removes a PR from the merge queue — `DEQUEUED` is the GraphQL-enum surface for the same human dequeue, but the timeline surface spells it `manual`. Because `MANUAL` was not in the safe-list, a manual queue removal was misclassified as a CI failure and **spuriously reopened the task for rework**. This actually happened in production today.

## Fix

- Add `"MANUAL"` to the `matches!` safe-list (case-insensitive compare already in place).
- Update the doc comment and the inline "two vocabularies" comment to note that `manual` is the timeline-surface word for a human dequeue, paired with the GraphQL-enum `DEQUEUED`.
- Extend the existing unit tests proving `dequeue_reason_is_failure(Some("manual"))` / `Some("MANUAL")` are `false`, and that `dequeue_requires_rework` with a `manual` `DequeueEvent` returns `false`.

## Verify

`SQLX_OFFLINE=true cargo test -p djinn-agent dequeue_` — 6 passed, 0 failed. `cargo clippy -p djinn-agent --all-targets --all-features -- -D warnings` clean.