### PR TITLE
fix(ci): bound apt linker-toolchain install with timeout + retry

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -94,9 +94,24 @@ jobs:
         working-directory: server
 
       - name: Install Rust linker toolchain
+        timeout-minutes: 10
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get -o Acquire::Retries=3 install -y clang mold
+          # GitHub-hosted runners intermittently draw a stalling apt mirror.
+          # Without a per-command timeout a hung apt wedges the whole job (and,
+          # in the merge queue, every PR queued behind it for up to the 60-min
+          # check-response timeout). Bound each attempt with `timeout` and retry
+          # so a stalled mirror recovers within the step instead of hanging.
+          for attempt in 1 2 3 4; do
+            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
+               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
+              break
+            fi
+            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
+            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
+            sudo dpkg --configure -a 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
           clang --version
           mold --version
           ld.mold --version
@@ -144,9 +159,24 @@ jobs:
         working-directory: server
 
       - name: Install Rust linker toolchain
+        timeout-minutes: 10
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get -o Acquire::Retries=3 install -y clang mold
+          # GitHub-hosted runners intermittently draw a stalling apt mirror.
+          # Without a per-command timeout a hung apt wedges the whole job (and,
+          # in the merge queue, every PR queued behind it for up to the 60-min
+          # check-response timeout). Bound each attempt with `timeout` and retry
+          # so a stalled mirror recovers within the step instead of hanging.
+          for attempt in 1 2 3 4; do
+            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
+               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
+              break
+            fi
+            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
+            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
+            sudo dpkg --configure -a 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
           clang --version
           mold --version
           ld.mold --version
@@ -199,9 +229,24 @@ jobs:
         working-directory: server
 
       - name: Install Rust linker toolchain
+        timeout-minutes: 10
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get -o Acquire::Retries=3 install -y clang mold
+          # GitHub-hosted runners intermittently draw a stalling apt mirror.
+          # Without a per-command timeout a hung apt wedges the whole job (and,
+          # in the merge queue, every PR queued behind it for up to the 60-min
+          # check-response timeout). Bound each attempt with `timeout` and retry
+          # so a stalled mirror recovers within the step instead of hanging.
+          for attempt in 1 2 3 4; do
+            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
+               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
+              break
+            fi
+            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
+            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
+            sudo dpkg --configure -a 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
           clang --version
           mold --version
           ld.mold --version
@@ -326,9 +371,24 @@ jobs:
         working-directory: server
 
       - name: Install Rust linker toolchain
+        timeout-minutes: 10
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get -o Acquire::Retries=3 install -y clang mold
+          # GitHub-hosted runners intermittently draw a stalling apt mirror.
+          # Without a per-command timeout a hung apt wedges the whole job (and,
+          # in the merge queue, every PR queued behind it for up to the 60-min
+          # check-response timeout). Bound each attempt with `timeout` and retry
+          # so a stalled mirror recovers within the step instead of hanging.
+          for attempt in 1 2 3 4; do
+            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
+               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
+              break
+            fi
+            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
+            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
+            sudo dpkg --configure -a 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
           clang --version
           mold --version
           ld.mold --version
@@ -440,11 +500,23 @@ jobs:
         working-directory: server
 
       - name: Install Rust linker toolchain
+        timeout-minutes: 10
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          # server/.cargo/config.toml drives Linux builds through clang with
-          # -fuse-ld=mold; install both before cargo-sqlx shells out to cargo.
-          sudo apt-get -o Acquire::Retries=3 install -y clang mold
+          # GitHub-hosted runners intermittently draw a stalling apt mirror;
+          # bound each attempt with `timeout` and retry so a hung mirror can't
+          # wedge the job. server/.cargo/config.toml drives Linux builds through
+          # clang with -fuse-ld=mold; install both before cargo-sqlx shells out.
+          for attempt in 1 2 3 4; do
+            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
+               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
+              break
+            fi
+            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
+            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
+            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
+            sudo dpkg --configure -a 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
           clang --version
           mold --version
           ld.mold --version


### PR DESCRIPTION
## Problem

GitHub-hosted runners are intermittently drawing a stalling apt mirror right now. The `Install Rust linker toolchain` step runs `apt-get install clang mold` with **no timeout**, so a hung apt wedges the whole job. In the merge queue (speculative-parallel, `max_entries_to_build: 5`), a wedged run blocks **every PR queued behind it** — observed today on #753 (80+ min) and #757. At the queue's `check_response_timeout_minutes: 60` GitHub then evicts the entry **as a failure**, which makes the PR poller reopen the task for spurious rework.

## Fix

Wrap each apt attempt in `timeout` and retry 4× with backoff (killing a hung apt + clearing dpkg locks between tries) so a stalled mirror recovers within the step, plus `timeout-minutes: 10` as a hard backstop so the step can never wedge the queue again. Applied to all 5 linker-toolchain install steps.

Merging via admin bypass because the merge queue itself is currently wedged by the bug this fixes.