### PR TITLE
perf(ci): drop unused apt linker step, prebuilt hakari, PR-only lints, shard server tests

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -93,29 +93,6 @@ jobs:
       - run: rustup toolchain install
         working-directory: server
 
-      - name: Install Rust linker toolchain
-        timeout-minutes: 10
-        run: |
-          # GitHub-hosted runners intermittently draw a stalling apt mirror.
-          # Without a per-command timeout a hung apt wedges the whole job (and,
-          # in the merge queue, every PR queued behind it for up to the 60-min
-          # check-response timeout). Bound each attempt with `timeout` and retry
-          # so a stalled mirror recovers within the step instead of hanging.
-          for attempt in 1 2 3 4; do
-            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
-               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
-              break
-            fi
-            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
-            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
-            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
-            sudo dpkg --configure -a 2>/dev/null || true
-            sleep $((attempt * 15))
-          done
-          clang --version
-          mold --version
-          ld.mold --version
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
@@ -157,29 +134,6 @@ jobs:
 
       - run: rustup toolchain install
         working-directory: server
-
-      - name: Install Rust linker toolchain
-        timeout-minutes: 10
-        run: |
-          # GitHub-hosted runners intermittently draw a stalling apt mirror.
-          # Without a per-command timeout a hung apt wedges the whole job (and,
-          # in the merge queue, every PR queued behind it for up to the 60-min
-          # check-response timeout). Bound each attempt with `timeout` and retry
-          # so a stalled mirror recovers within the step instead of hanging.
-          for attempt in 1 2 3 4; do
-            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
-               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
-              break
-            fi
-            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
-            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
-            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
-            sudo dpkg --configure -a 2>/dev/null || true
-            sleep $((attempt * 15))
-          done
-          clang --version
-          mold --version
-          ld.mold --version
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -228,29 +182,6 @@ jobs:
       - run: rustup toolchain install
         working-directory: server
 
-      - name: Install Rust linker toolchain
-        timeout-minutes: 10
-        run: |
-          # GitHub-hosted runners intermittently draw a stalling apt mirror.
-          # Without a per-command timeout a hung apt wedges the whole job (and,
-          # in the merge queue, every PR queued behind it for up to the 60-min
-          # check-response timeout). Bound each attempt with `timeout` and retry
-          # so a stalled mirror recovers within the step instead of hanging.
-          for attempt in 1 2 3 4; do
-            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
-               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
-              break
-            fi
-            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
-            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
-            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
-            sudo dpkg --configure -a 2>/dev/null || true
-            sleep $((attempt * 15))
-          done
-          clang --version
-          mold --version
-          ld.mold --version
-
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
@@ -259,19 +190,20 @@ jobs:
           cache-all-crates: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - uses: taiki-e/install-action@v2
+        if: github.event_name != 'merge_group'
+        with:
+          tool: cargo-hakari
       - name: Verify workspace-hack (hakari)
+        if: github.event_name != 'merge_group'
         run: |
-          # rust-cache restores Cargo's install metadata separately from the
-          # actual binary. If that cache is inconsistent, `cargo install`
-          # without --force can decide cargo-hakari is already installed while
-          # leaving `cargo hakari` unavailable on PATH.
-          cargo install cargo-hakari --locked --force
           cargo hakari verify || {
             echo "::error::workspace-hack is out of date. Run 'cargo hakari generate && cargo hakari manage-deps' locally."
             exit 1
           }
 
       - name: Verify skills manifest is up to date
+        if: github.event_name != 'merge_group'
         run: cargo run -p djinn-agent --bin djinn-skills-manifest -- check --root ..
 
       - name: Clippy
@@ -345,6 +277,10 @@ jobs:
     needs: [changes, server-clippy]
     if: needs.changes.outputs.server == 'true' && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     defaults:
       run:
         working-directory: server
@@ -369,29 +305,6 @@ jobs:
 
       - run: rustup toolchain install
         working-directory: server
-
-      - name: Install Rust linker toolchain
-        timeout-minutes: 10
-        run: |
-          # GitHub-hosted runners intermittently draw a stalling apt mirror.
-          # Without a per-command timeout a hung apt wedges the whole job (and,
-          # in the merge queue, every PR queued behind it for up to the 60-min
-          # check-response timeout). Bound each attempt with `timeout` and retry
-          # so a stalled mirror recovers within the step instead of hanging.
-          for attempt in 1 2 3 4; do
-            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
-               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
-              break
-            fi
-            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
-            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
-            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
-            sudo dpkg --configure -a 2>/dev/null || true
-            sleep $((attempt * 15))
-          done
-          clang --version
-          mold --version
-          ld.mold --version
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -452,7 +365,7 @@ jobs:
       # coverage needs a slower profile, wire that explicit profile into this
       # job instead of filtering the regressions out of CI.
       - name: Tests
-        run: cargo nextest run --workspace --all-targets --all-features --profile ci
+        run: cargo nextest run --workspace --all-targets --all-features --profile ci --partition count:${{ matrix.shard }}/4
 
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  sqlx offline-cache freshness gate (merge queue only)            ║
@@ -498,29 +411,6 @@ jobs:
 
       - run: rustup toolchain install
         working-directory: server
-
-      - name: Install Rust linker toolchain
-        timeout-minutes: 10
-        run: |
-          # GitHub-hosted runners intermittently draw a stalling apt mirror;
-          # bound each attempt with `timeout` and retry so a hung mirror can't
-          # wedge the job. server/.cargo/config.toml drives Linux builds through
-          # clang with -fuse-ld=mold; install both before cargo-sqlx shells out.
-          for attempt in 1 2 3 4; do
-            if timeout 150 sudo apt-get -o Acquire::Retries=3 update \
-               && timeout 200 sudo apt-get -o Acquire::Retries=3 install -y clang mold; then
-              break
-            fi
-            echo "::warning::apt toolchain install attempt ${attempt} stalled/failed; killing apt and retrying"
-            sudo pkill -9 -f 'apt-get|dpkg' 2>/dev/null || true
-            sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* 2>/dev/null || true
-            sudo dpkg --configure -a 2>/dev/null || true
-            sleep $((attempt * 15))
-          done
-          clang --version
-          mold --version
-          ld.mold --version
-          printf 'int main(void) { return 0; }\n' | clang -x c -fuse-ld=mold - -o /var/tmp/mold-smoke
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## What

Four CI optimizations to `quality-gate.yml`, all narrowly scoped to that one workflow file.

1. **Remove the "Install Rust linker toolchain" step from all 5 jobs.** `clang`/`mold` were installed by this step but never actually wired as the linker — `.cargo/config.toml` and `RUSTFLAGS` (`-D warnings`) do not use mold. The step was dead weight, and its `apt-get update/install` drew a stalling apt mirror today, wedging the merge queue (the documented cause of today's outage).
2. **Prebuilt `cargo-hakari`.** Replace the from-source `cargo install cargo-hakari --locked --force` with the `taiki-e/install-action` prebuilt binary, and gate the hakari verify step to PR-only (`if: github.event_name != 'merge_group'`).
3. **PR-only skills-manifest check** (`if: github.event_name != 'merge_group'`).
4. **Shard "Server Test" 4-way** via a `strategy.matrix.shard: [1,2,3,4]` and `cargo nextest ... --partition count:${{ matrix.shard }}/4`.

## Expected effect

- Removes the apt-mirror dependency that caused today's merge-queue outage.
- Making hakari + skills-manifest lints PR-only trims ~3 min of pre-Clippy work off merge-queue runs (they already ran on the PR).
- Sharding parallelizes the heavy DB-backed test suite ~4×, cutting wall-clock for the merge-queue test stage.

## Safety

Only **"Quality Gate"** is a required status check. It is an aggregator that reads `needs.<job>.result` (the matrix rolls up automatically) and treats `skipped` as success, so reshaping/sharding the individual jobs and gating lints to PR-only is safe. The Quality Gate job itself is unchanged.