### PR TITLE
docs(prompts): reviewer prompt — drop stale Dolt wording, add backing-service sidecar awareness

### DIFF
--- a/server/crates/djinn-agent/src/prompts/task-reviewer.md
+++ b/server/crates/djinn-agent/src/prompts/task-reviewer.md
@@ -12,7 +12,7 @@ Use `shell` to read the relevant files in the workspace. Focus on files related 
 
 **Batch independent reads into one turn.** Every assistant turn is a metered request that re-reads your whole context, so don't read files one-per-turn. When you need to inspect several changed files (or run several independent `grep`/`lsp` lookups), emit all of those tool calls in a single turn — they dispatch in parallel. Use `offset`/`limit` to read enough of a large file in one pass. Only serialize a call that genuinely needs a previous result.
 
-For memory-note changes, inspect notes via the registered memory MCP tools (`memory_read`, `memory_search`, `memory_list`, `memory_build_context`) — memory lives in Dolt, not on the filesystem.
+For memory-note changes, inspect notes via the registered memory MCP tools (`memory_read`, `memory_search`, `memory_list`, `memory_build_context`) — memory is not stored in the workspace filesystem, so don't try to read note files from disk.
 
 ### Step 2: Check Each Criterion
 
@@ -75,6 +75,10 @@ If any junk files are present, reject with a comment listing them. The worker mu
 ## Sandbox Write Paths (when running shell)
 
 If you need shell scratch space during review, the sandbox allows writes to your task worktree, `/cache/` (the persistent cross-run build-cache volume — shared caches such as `CARGO_HOME=/cache/cargo` and `GOMODCACHE` are pre-pointed here; task-run `CARGO_TARGET_DIR` is a private `/cache/cargo-target-runs/<task_run_id>` directory seeded from the warm base when available; leave them as set), `$HOME/.cache/djinn/` (ephemeral scratch), and `/var/tmp/`. `/tmp` is not writable and will return `Permission denied`.
+
+## Backing Services (for task-specific inspection)
+
+If the project's image declares backing services (Postgres/Redis/RabbitMQ), each runs as a sidecar in your Pod, reachable on `127.0.0.1:<port>`, with its connection string pre-exported as an env var (e.g. `TEST_POSTGRES_URL`, `REDIS_URL`, `AMQP_URL`). Run `env | grep -E 'POSTGRES|REDIS|AMQP'` to see what's available — you do **not** start these yourself, and if the env var is absent the image simply has no service declared. When an acceptance criterion requires checking data or schema (e.g. a migration applied, a row shape, a key written), you may connect to the sidecar via its env var as part of task-specific *inspection*. This is for inspection only — do not use it to re-run build/lint/test suites (see Step 2).
 
 ## Anti-Loop Reminder
 


### PR DESCRIPTION
## What

Two focused edits to `server/crates/djinn-agent/src/prompts/task-reviewer.md`:

1. **Drop stale Dolt reference.** The memory-note inspection guidance said memory "lives in Dolt, not on the filesystem." Dolt is gone (backend is Postgres only). Reworded to keep the actual point — memory notes are not files in the workspace, so inspect them via the memory MCP tools (`memory_read`, `memory_search`, `memory_list`, `memory_build_context`) rather than reading files from disk.

2. **Add backing-services / Postgres-sidecar awareness**, adapted to the reviewer's inspection role. If the project's image declares backing services, each runs as a sidecar on `127.0.0.1:<port>` with its connection string pre-exported as an env var (`TEST_POSTGRES_URL`, `REDIS_URL`, `AMQP_URL`). The note frames the sidecar as available for *task-specific inspection* (e.g. checking data/schema for an acceptance criterion) — consistent with the existing shell-inspection guidance — and explicitly NOT for re-running build/lint/test suites.

## Out of scope

The verification-assumption wording ("suites have already been run and passed… do NOT re-run them") is intentionally left untouched — that rework is owned by the separate verification-removal effort. The new sidecar note is framed to not contradict it (inspection only).

## Verification

`SQLX_OFFLINE=true cargo test -p djinn-agent prompts` — 62 passed, 0 failed. No prompt snapshot/content test asserted on the changed wording, so no test expectations needed updating.