### PR TITLE
ci(release): build both release binaries in one job sharing target dir + cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,9 +152,16 @@ jobs:
           cache-from: type=gha,scope=djinn-agent-runtime-base
           cache-to: type=gha,scope=djinn-agent-runtime-base,mode=max
 
-  # ── Rust binary jobs (produce artifacts the image jobs COPY in) ───────
-  server-binary:
-    name: djinn-server binary (+ UI embed)
+  # ── Rust binary job (produces artifacts the image jobs COPY in) ───────
+  # Both release binaries build in ONE job sharing a single `server/target`
+  # dir + one Swatinem cache, so the common dependency graph (tokio, sqlx,
+  # axum, …) compiles ONCE instead of twice. Two SEQUENTIAL cargo builds —
+  # NOT a unified `-p A -p B` — keep each binary's exact feature resolution
+  # (a unified build would feature-unify qdrant onto worker deps). Worker
+  # first (default features, no qdrant), then server (adds qdrant on top),
+  # reusing the on-disk artifacts of the shared non-qdrant deps.
+  binaries:
+    name: djinn-server + djinn-agent-worker binaries (+ UI embed)
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -190,54 +197,30 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
-          shared-key: release-server
+          shared-key: release-bins
           cache-on-failure: true
           cache-all-crates: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Cargo build
+      # Worker FIRST so its deps resolve WITHOUT qdrant (default features);
+      # the server build then layers only the qdrant-extra deps on top,
+      # reusing every shared non-qdrant artifact already on disk.
+      - name: Cargo build worker
+        run: cargo build --release --locked -p djinn-agent-worker
+      - name: Cargo build server
         run: cargo build --release --locked --features qdrant -p djinn-server
-      - name: Stage + strip binary
+      - name: Stage + strip binaries
         run: |
           mkdir -p ../stage
           cp target/release/djinn-server ../stage/djinn-server
           strip ../stage/djinn-server
+          cp target/release/djinn-agent-worker ../stage/djinn-agent-worker
+          strip ../stage/djinn-agent-worker
       - uses: actions/upload-artifact@v4
         with:
           name: djinn-server-bin
           path: stage/djinn-server
           retention-days: 1
           if-no-files-found: error
-
-  worker-binary:
-    name: djinn-agent-worker binary
-    runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: server
-    env:
-      SQLX_OFFLINE: "true"
-      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-    steps:
-      - uses: actions/checkout@v4
-      - run: rustup toolchain install
-      - name: Install mold
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: server
-          shared-key: release-worker
-          cache-on-failure: true
-          cache-all-crates: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Cargo build
-        run: cargo build --release --locked -p djinn-agent-worker
-      - name: Stage + strip binary
-        run: |
-          mkdir -p ../stage
-          cp target/release/djinn-agent-worker ../stage/djinn-agent-worker
-          strip ../stage/djinn-agent-worker
       - uses: actions/upload-artifact@v4
         with:
           name: djinn-agent-worker-bin
@@ -248,7 +231,7 @@ jobs:
   # ── Image jobs that consume a binary ──────────────────────────────────
   server:
     name: djinn-server
-    needs: server-binary
+    needs: binaries
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -289,7 +272,7 @@ jobs:
     # Needs the pre-built worker binary and the base image at the same
     # commit's sha tag (FROM arg below) — without both, the runtime image
     # would either be missing the binary or built on a stale base.
-    needs: [runtime-base, worker-binary]
+    needs: [runtime-base, binaries]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`release.yml` built the two release binaries in two SEPARATE jobs (`server-binary`, `worker-binary`), each with its own Swatinem cache and its own `server/target` dir. As a result, each job independently compiled the entire shared release-profile Rust dependency graph (tokio, sqlx, axum, …) — the heavy common deps were compiled **twice** per release, making releases slow.

## Change

Merge both into ONE job, `binaries`, that shares a single `server/target` dir and a single Swatinem cache (`shared-key: release-bins`), so the common dependency graph compiles once.

Crucially this uses **two sequential `cargo build` invocations** against the same target dir — **not** a unified `cargo build -p A -p B`. A unified invocation would trigger Cargo feature unification and enable qdrant-driven features on shared deps for the worker too, subtly changing the worker binary. Two separate builds each preserve their exact current feature resolution:

- `cargo build --release --locked -p djinn-agent-worker` (default features, no qdrant) — built FIRST so shared deps resolve without qdrant
- `cargo build --release --locked --features qdrant -p djinn-server` — then layers only the qdrant-extra deps on top, reusing the on-disk artifacts of the shared non-qdrant deps the worker build already compiled

The UI is still built (pnpm) before the server build for rust-embed. Both binaries are staged, stripped, and uploaded with the **unchanged** artifact names `djinn-server-bin` (`stage/djinn-server`) and `djinn-agent-worker-bin` (`stage/djinn-agent-worker`), `retention-days: 1`, `if-no-files-found: error`.

## Downstream wiring

Updated every `needs:` that referenced the old jobs:
- `server` image job: `needs: server-binary` → `needs: binaries`
- `runtime` image job: `needs: [runtime-base, worker-binary]` → `needs: [runtime-base, binaries]`

Image jobs are otherwise unchanged; they still download the same artifact names.

## Validation

- YAML parses (`yaml.safe_load`).
- No dangling `needs: server-binary` / `needs: worker-binary` references remain.
- Both artifact names still produced.
- actionlint not available on the runner; skipped.