### PR TITLE
fix(usage): reconcile /api/admin/usage backend with dashboard contract

### DIFF
--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -108,8 +108,8 @@ pub use repositories::{
     },
     task_run::{CreateTaskRunParams, TaskRunRepository},
     usage_analytics::{
-        BreakdownRow, DailySeriesRow, GroupDimension, ModelEffectivenessRow, ProjectModelMatrixRow,
-        UsageAnalyticsQuery, UsageAnalyticsRepository, UsageAnalyticsResult, UsageTotals,
+        EntityBreakdownRow, GroupDimension, ModelEffectivenessRow, ProjectModelMatrixRow,
+        SeriesDetailRow, UsageAnalyticsQuery, UsageAnalyticsRepository, UsageTotals,
     },
     user::{User, UserRepository},
     user_settings::UserSettingsRepository,

--- a/server/crates/djinn-db/src/repositories/usage_analytics.rs
+++ b/server/crates/djinn-db/src/repositories/usage_analytics.rs
@@ -1,16 +1,22 @@
 // ── Usage analytics repository ─────────────────────────────────────────────
 //
-// Provides raw daily-aggregate and breakdown queries over the `sessions` table
-// (plus optional dimension joins) for admin usage analytics.  All SQL uses
-// `substring(s.started_at, 1, 10)` for day bucketing — no `date_trunc` or
-// `generate_series`.
+// Provides aggregate queries over the `sessions` table (plus dimension joins)
+// for the admin usage analytics dashboard.  All day bucketing uses
+// `substring(s.started_at, 1, 10)` — no `date_trunc` or `generate_series`.
 //
 // Cost semantics: `cost_usd` is nullable on the sessions table.  When ANY
 // session in an aggregate group has a NULL cost (unpriced model), the group
 // aggregate cost is returned as NULL so the UI can render an em-dash instead
 // of $0.
-
-use std::fmt;
+//
+// The dashboard consumes a single response shaped exactly like the frontend
+// contract:
+//   - a multi-dimensional time series (per day × model × project × agent) so
+//     the Overview tab can group spend client-side;
+//   - four entity breakdowns (user / project / proposal / task) aggregated
+//     across the whole window;
+//   - worker-scoped per-model effectiveness;
+//   - a project × model matrix with per-cell outcome metrics.
 
 use sqlx::Row;
 
@@ -53,11 +59,15 @@ pub struct ModelEffectivenessRow {
 ///
 /// Groups usage by project and model across all agent types matching the
 /// endpoint filters. NULL-project sessions (chat sessions without a task)
-/// are preserved with an empty-string project_id.
+/// are preserved with an empty-string project_id.  Outcome metrics
+/// (`success_rate`, `avg_reopens`) are computed over the distinct tasks
+/// touched by the cell's sessions.
 #[derive(Clone, Debug, Default)]
 pub struct ProjectModelMatrixRow {
     /// Project ID, or empty string for sessions without a project.
     pub project_id: String,
+    /// Human-readable project name (empty when unknown / no project).
+    pub project_name: String,
     pub model_id: String,
     pub sessions: i64,
     /// Aggregate cost in USD. `None` when ANY session in the group had a NULL
@@ -65,6 +75,12 @@ pub struct ProjectModelMatrixRow {
     pub spend_usd: Option<f64>,
     pub tokens_in: i64,
     pub tokens_out: i64,
+    /// Distinct tasks touched by this cell's sessions.
+    pub task_count: i64,
+    /// Fraction of closed tasks that completed successfully (0.0–1.0).
+    pub success_rate: Option<f64>,
+    /// Average total_reopen_count across closed tasks in this cell.
+    pub avg_reopens: Option<f64>,
 }
 
 // ── Public types ──────────────────────────────────────────────────────────
@@ -81,20 +97,6 @@ pub enum GroupDimension {
 }
 
 impl GroupDimension {
-    /// SQL column expression for the group key.
-    fn group_expr(&self) -> &'static str {
-        match self {
-            Self::Model => "s.model_id",
-            Self::Project => "COALESCE(s.project_id, '')",
-            // User attribution: prefer session creator, fall back to task creator.
-            Self::User => "COALESCE(s.created_by_user_id, t.created_by_user_id, '')",
-            // Proposal: sessions → tasks → epics → proposal_epics → proposals
-            Self::Proposal => "COALESCE(pe.proposal_id, '')",
-            Self::Task => "COALESCE(s.task_id, '')",
-            Self::Agent => "s.agent_type",
-        }
-    }
-
     /// Human-readable label for the group key column in result rows.
     pub fn label(&self) -> &'static str {
         match self {
@@ -106,11 +108,59 @@ impl GroupDimension {
             Self::Agent => "agent_type",
         }
     }
-}
 
-impl fmt::Display for GroupDimension {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.label())
+    /// SQL expression yielding the entity id (group key) for breakdowns.
+    fn key_expr(&self) -> &'static str {
+        match self {
+            Self::Model => "s.model_id",
+            Self::Project => "COALESCE(s.project_id, '')",
+            // User attribution: prefer session creator, fall back to task creator.
+            Self::User => "COALESCE(s.created_by_user_id, t.created_by_user_id, '')",
+            Self::Proposal => "COALESCE(pe.proposal_id, '')",
+            Self::Task => "COALESCE(s.task_id, '')",
+            Self::Agent => "s.agent_type",
+        }
+    }
+
+    /// SQL expression yielding the human-readable display name for breakdowns.
+    /// Always wrapped in COALESCE so the column is non-null; the UI falls back
+    /// to the id when the name is empty.
+    fn name_expr(&self) -> &'static str {
+        match self {
+            Self::Model => "s.model_id",
+            Self::Project => "COALESCE(p.name, '')",
+            Self::User => "COALESCE(u.github_name, u.github_login, '')",
+            Self::Proposal => "COALESCE(pr.title, '')",
+            Self::Task => "COALESCE(t.title, '')",
+            Self::Agent => "s.agent_type",
+        }
+    }
+
+    /// Join clauses required to resolve this dimension's key and name.
+    /// The base relation is always `sessions s`.
+    fn joins(&self) -> &'static str {
+        match self {
+            Self::Model | Self::Agent => "LEFT JOIN tasks t ON t.id = s.task_id",
+            Self::Project => {
+                "LEFT JOIN tasks t ON t.id = s.task_id \
+                 LEFT JOIN projects p ON p.id = s.project_id"
+            }
+            Self::User => {
+                "LEFT JOIN tasks t ON t.id = s.task_id \
+                 LEFT JOIN users u \
+                    ON u.id = COALESCE(s.created_by_user_id, t.created_by_user_id)"
+            }
+            Self::Task => "LEFT JOIN tasks t ON t.id = s.task_id",
+            // Proposal: sessions → tasks → epics → proposal_epics → proposals.
+            // INNER JOIN proposal_epics restricts to sessions that trace to a
+            // proposal.
+            Self::Proposal => {
+                "LEFT JOIN tasks t ON t.id = s.task_id \
+                 LEFT JOIN epics e ON e.id = t.epic_id \
+                 INNER JOIN proposal_epics pe ON pe.epic_id = e.id \
+                 LEFT JOIN proposals pr ON pr.id = pe.proposal_id"
+            }
+        }
     }
 }
 
@@ -121,7 +171,8 @@ pub struct UsageAnalyticsQuery {
     pub from: String,
     /// Exclusive upper bound.
     pub to: String,
-    /// How to group breakdown rows.
+    /// Retained for API compatibility; the dashboard computes all four entity
+    /// breakdowns regardless of this value.
     pub group_by: GroupDimension,
     /// Optional project filter.
     pub project_id: Option<String>,
@@ -129,38 +180,6 @@ pub struct UsageAnalyticsQuery {
     pub model_id: Option<String>,
     /// Optional agent_type filter.
     pub agent_type: Option<String>,
-}
-
-/// A single day's aggregate row in the time-series output.
-#[derive(Clone, Debug, Default)]
-pub struct DailySeriesRow {
-    /// ISO date prefix, e.g. `"2025-03-14"`.
-    pub day: String,
-    pub session_count: i64,
-    pub tokens_in: i64,
-    pub tokens_out: i64,
-    pub cache_read_tokens: i64,
-    pub cache_write_tokens: i64,
-    /// Aggregate cost in USD.  `None` when ANY session in this day had no
-    /// pricing (NULL `cost_usd`), preserving the "unpriced" signal.
-    pub total_cost_usd: Option<f64>,
-}
-
-/// A single row in the breakdown result, keyed by the chosen `GroupDimension`.
-#[derive(Clone, Debug, Default)]
-pub struct BreakdownRow {
-    /// The group key value (model id, user id, proposal id, etc.).
-    /// Empty string represents "no value" (e.g. chat sessions without a task).
-    pub group_key: String,
-    /// ISO date prefix for this row's day bucket.
-    pub day: String,
-    pub session_count: i64,
-    pub tokens_in: i64,
-    pub tokens_out: i64,
-    pub cache_read_tokens: i64,
-    pub cache_write_tokens: i64,
-    /// Aggregate cost in USD.  NULL-unpriced semantics preserved.
-    pub total_cost_usd: Option<f64>,
 }
 
 /// Overall totals across the entire queried date range (and matching filters).
@@ -176,12 +195,47 @@ pub struct UsageTotals {
     pub total_cost_usd: Option<f64>,
 }
 
-/// Aggregated result bundle returned by [`UsageAnalyticsRepository::query`].
+/// A single multi-dimensional time-series row: one day bucket for a particular
+/// (model, project, agent_type) combination.  The dashboard sums these client
+/// side to render spend grouped by any one of those dimensions.
 #[derive(Clone, Debug, Default)]
-pub struct UsageAnalyticsResult {
-    pub totals: UsageTotals,
-    pub series: Vec<DailySeriesRow>,
-    pub breakdown: Vec<BreakdownRow>,
+pub struct SeriesDetailRow {
+    /// ISO date prefix, e.g. `"2025-03-14"`.
+    pub day: String,
+    pub model: String,
+    /// Project id, or empty string for sessions without a project.
+    pub project_id: String,
+    /// Human-readable project name (empty when unknown).
+    pub project_name: String,
+    pub agent_type: String,
+    pub session_count: i64,
+    pub tokens_in: i64,
+    pub tokens_out: i64,
+    /// Distinct tasks touched in this bucket.
+    pub task_count: i64,
+    /// Aggregate cost in USD.  `None` when any session in the bucket was
+    /// unpriced (NULL `cost_usd`).
+    pub cost: Option<f64>,
+}
+
+/// A single aggregated entity-breakdown row (one user / project / proposal /
+/// task), summarised across the whole queried window.
+#[derive(Clone, Debug, Default)]
+pub struct EntityBreakdownRow {
+    /// The entity id (user id, project id, proposal id, task id).
+    pub id: String,
+    /// Human-readable display name; empty when unknown.
+    pub name: String,
+    /// Aggregate cost in USD.  NULL-unpriced semantics preserved.
+    pub cost: Option<f64>,
+    pub tokens_in: i64,
+    pub tokens_out: i64,
+    /// Distinct tasks attributed to this entity.
+    pub task_count: i64,
+    /// Fraction of closed tasks that completed successfully (0.0–1.0).
+    pub success_rate: Option<f64>,
+    /// Average total_reopen_count across this entity's closed tasks.
+    pub avg_reopens: Option<f64>,
 }
 
 // ── Repository ────────────────────────────────────────────────────────────
@@ -195,91 +249,48 @@ impl UsageAnalyticsRepository {
         Self { db }
     }
 
-    /// Run all three analytics queries (totals, daily series, breakdown)
-    /// against the given filters and return the combined result.
-    pub async fn query(&self, params: &UsageAnalyticsQuery) -> Result<UsageAnalyticsResult> {
-        self.db.ensure_initialized().await?;
+    // ── Shared filter construction ─────────────────────────────────────────
 
-        let totals = self.fetch_totals(params).await?;
-        let series = self.fetch_daily_series(params).await?;
-        let breakdown = self.fetch_breakdown(params).await?;
-
-        Ok(UsageAnalyticsResult {
-            totals,
-            series,
-            breakdown,
-        })
-    }
-
-    // ── Internal queries ──────────────────────────────────────────────────
-
-    /// Shared FROM + WHERE clause fragment.
-    ///
-    /// Joins:
-    ///   - `LEFT JOIN tasks t ON t.id = s.task_id` (for user attribution and
-    ///     optional task/project dimension joins)
-    ///   - `LEFT JOIN epics e ON e.id = t.epic_id` (for proposal grouping)
-    ///   - `LEFT JOIN proposal_epics pe ON pe.epic_id = e.id` (proposal link)
-    ///
-    /// Returns `(from_clause, where_clause, binds)` where `binds` is the
-    /// ordered list of parameter values.
-    fn build_from_where(params: &UsageAnalyticsQuery) -> (String, String, Vec<String>) {
+    /// Build the session-level WHERE conditions (date range + optional
+    /// project / model / agent filters) and their ordered bind values.  All
+    /// conditions reference `sessions s`, so this composes with any joins.
+    fn session_filters(params: &UsageAnalyticsQuery) -> (Vec<String>, Vec<String>) {
         let mut conditions: Vec<String> = Vec::new();
         let mut binds: Vec<String> = Vec::new();
-        let mut bind_idx: usize = 1;
+        let mut idx: usize = 1;
 
-        // Date range filter (always first two binds).
-        conditions.push(format!("s.started_at >= ${bind_idx}"));
+        conditions.push(format!("s.started_at >= ${idx}"));
         binds.push(params.from.clone());
-        bind_idx += 1;
+        idx += 1;
 
-        conditions.push(format!("s.started_at < ${bind_idx}"));
+        conditions.push(format!("s.started_at < ${idx}"));
         binds.push(params.to.clone());
-        bind_idx += 1;
+        idx += 1;
 
         if let Some(ref project_id) = params.project_id {
-            conditions.push(format!("s.project_id = ${bind_idx}"));
+            conditions.push(format!("s.project_id = ${idx}"));
             binds.push(project_id.clone());
-            bind_idx += 1;
+            idx += 1;
         }
 
         if let Some(ref model_id) = params.model_id {
-            conditions.push(format!("s.model_id = ${bind_idx}"));
+            conditions.push(format!("s.model_id = ${idx}"));
             binds.push(model_id.clone());
-            bind_idx += 1;
+            idx += 1;
         }
 
         if let Some(ref agent_type) = params.agent_type {
-            conditions.push(format!("s.agent_type = ${bind_idx}"));
+            conditions.push(format!("s.agent_type = ${idx}"));
             binds.push(agent_type.clone());
         }
 
-        // When grouping by proposal, only include sessions that trace to a
-        // proposal (INNER join).  For other dimensions, include all sessions
-        // (LEFT join) so chat sessions with no task/project are counted.
-        let proposal_join = if params.group_by == GroupDimension::Proposal {
-            "INNER JOIN proposal_epics pe ON pe.epic_id = e.id"
-        } else {
-            "LEFT JOIN proposal_epics pe ON pe.epic_id = e.id"
-        };
-
-        let from_clause = format!(
-            "FROM sessions s \
-             LEFT JOIN tasks t ON t.id = s.task_id \
-             LEFT JOIN epics e ON e.id = t.epic_id \
-             {proposal_join}"
-        );
-
-        let where_clause = if conditions.is_empty() {
-            String::new()
-        } else {
-            format!("WHERE {}", conditions.join(" AND "))
-        };
-
-        (from_clause, where_clause, binds)
+        (conditions, binds)
     }
 
-    /// Bind parameters onto a `sqlx::query()` builder.
+    fn where_clause(conditions: &[String]) -> String {
+        format!("WHERE {}", conditions.join(" AND "))
+    }
+
     fn bind_all<'q>(
         query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
         binds: &'q [String],
@@ -293,124 +304,181 @@ impl UsageAnalyticsRepository {
 
     // ── Totals ────────────────────────────────────────────────────────────
 
-    async fn fetch_totals(&self, params: &UsageAnalyticsQuery) -> Result<UsageTotals> {
-        let (from_clause, where_clause, binds) = Self::build_from_where(params);
+    /// Window totals across all matching sessions (no dimension joins so an
+    /// epic mapped to multiple proposals cannot inflate the counts).
+    pub async fn totals(&self, params: &UsageAnalyticsQuery) -> Result<UsageTotals> {
+        self.db.ensure_initialized().await?;
+
+        let (conditions, binds) = Self::session_filters(params);
+        let where_clause = Self::where_clause(&conditions);
 
         let sql = format!(
             "SELECT \
-                COUNT(*)                          AS \"session_count!\", \
-                COALESCE(SUM(s.tokens_in)::bigint, 0)     AS \"tokens_in!\", \
-                COALESCE(SUM(s.tokens_out)::bigint, 0)    AS \"tokens_out!\", \
-                COALESCE(SUM(s.cache_read_tokens)::bigint, 0)  AS \"cache_read_tokens!\", \
-                COALESCE(SUM(s.cache_write_tokens)::bigint, 0) AS \"cache_write_tokens!\", \
-                CASE \
-                    WHEN bool_or(s.cost_usd IS NULL) THEN NULL \
-                    ELSE SUM(s.cost_usd) \
-                END AS \"total_cost_usd\" \
-             {from_clause} {where_clause}"
+                COUNT(*)                                       AS session_count, \
+                COALESCE(SUM(s.tokens_in)::bigint, 0)          AS tokens_in, \
+                COALESCE(SUM(s.tokens_out)::bigint, 0)         AS tokens_out, \
+                COALESCE(SUM(s.cache_read_tokens)::bigint, 0)  AS cache_read_tokens, \
+                COALESCE(SUM(s.cache_write_tokens)::bigint, 0) AS cache_write_tokens, \
+                CASE WHEN bool_or(s.cost_usd IS NULL) THEN NULL ELSE SUM(s.cost_usd) END \
+                                                               AS total_cost_usd \
+             FROM sessions s {where_clause}"
         );
 
-        let query = sqlx::query(&sql);
-        let query = Self::bind_all(query, &binds);
+        let query = Self::bind_all(sqlx::query(&sql), &binds);
         let row = query.fetch_one(self.db.pool()).await?;
 
         Ok(UsageTotals {
-            session_count: row.get("session_count!"),
-            tokens_in: row.get("tokens_in!"),
-            tokens_out: row.get("tokens_out!"),
-            cache_read_tokens: row.get("cache_read_tokens!"),
-            cache_write_tokens: row.get("cache_write_tokens!"),
+            session_count: row.get("session_count"),
+            tokens_in: row.get("tokens_in"),
+            tokens_out: row.get("tokens_out"),
+            cache_read_tokens: row.get("cache_read_tokens"),
+            cache_write_tokens: row.get("cache_write_tokens"),
             total_cost_usd: row.get("total_cost_usd"),
         })
     }
 
-    // ── Daily series ──────────────────────────────────────────────────────
+    // ── Multi-dimensional time series ──────────────────────────────────────
 
-    async fn fetch_daily_series(
+    /// Daily series carrying model / project / agent dimensions so the UI can
+    /// group spend client-side.  One row per (day, model, project, agent).
+    pub async fn series_detailed(
         &self,
         params: &UsageAnalyticsQuery,
-    ) -> Result<Vec<DailySeriesRow>> {
-        let (from_clause, where_clause, binds) = Self::build_from_where(params);
+    ) -> Result<Vec<SeriesDetailRow>> {
+        self.db.ensure_initialized().await?;
+
+        let (conditions, binds) = Self::session_filters(params);
+        let where_clause = Self::where_clause(&conditions);
 
         let sql = format!(
             "SELECT \
-                substring(s.started_at, 1, 10)    AS \"day!\", \
-                COUNT(*)                          AS \"session_count!\", \
-                COALESCE(SUM(s.tokens_in)::bigint, 0)     AS \"tokens_in!\", \
-                COALESCE(SUM(s.tokens_out)::bigint, 0)    AS \"tokens_out!\", \
-                COALESCE(SUM(s.cache_read_tokens)::bigint, 0)  AS \"cache_read_tokens!\", \
-                COALESCE(SUM(s.cache_write_tokens)::bigint, 0) AS \"cache_write_tokens!\", \
-                CASE \
-                    WHEN bool_or(s.cost_usd IS NULL) THEN NULL \
-                    ELSE SUM(s.cost_usd) \
-                END AS \"total_cost_usd\" \
-             {from_clause} {where_clause} \
-             GROUP BY substring(s.started_at, 1, 10) \
+                substring(s.started_at, 1, 10)                AS day, \
+                s.model_id                                    AS model, \
+                COALESCE(s.project_id, '')                    AS project_id, \
+                COALESCE(p.name, '')                          AS project_name, \
+                s.agent_type                                  AS agent_type, \
+                COUNT(*)                                       AS session_count, \
+                COALESCE(SUM(s.tokens_in)::bigint, 0)          AS tokens_in, \
+                COALESCE(SUM(s.tokens_out)::bigint, 0)         AS tokens_out, \
+                COUNT(DISTINCT s.task_id)                      AS task_count, \
+                CASE WHEN bool_or(s.cost_usd IS NULL) THEN NULL ELSE SUM(s.cost_usd) END \
+                                                               AS cost \
+             FROM sessions s \
+             LEFT JOIN projects p ON p.id = s.project_id \
+             {where_clause} \
+             GROUP BY substring(s.started_at, 1, 10), s.model_id, \
+                      COALESCE(s.project_id, ''), COALESCE(p.name, ''), s.agent_type \
              ORDER BY 1"
         );
 
-        let query = sqlx::query(&sql);
-        let query = Self::bind_all(query, &binds);
+        let query = Self::bind_all(sqlx::query(&sql), &binds);
         let rows = query.fetch_all(self.db.pool()).await?;
 
         Ok(rows
             .into_iter()
-            .map(|r| DailySeriesRow {
-                day: r.get("day!"),
-                session_count: r.get("session_count!"),
-                tokens_in: r.get("tokens_in!"),
-                tokens_out: r.get("tokens_out!"),
-                cache_read_tokens: r.get("cache_read_tokens!"),
-                cache_write_tokens: r.get("cache_write_tokens!"),
-                total_cost_usd: r.get("total_cost_usd"),
+            .map(|r| SeriesDetailRow {
+                day: r.get("day"),
+                model: r.get("model"),
+                project_id: r.get("project_id"),
+                project_name: r.get("project_name"),
+                agent_type: r.get("agent_type"),
+                session_count: r.get("session_count"),
+                tokens_in: r.get("tokens_in"),
+                tokens_out: r.get("tokens_out"),
+                task_count: r.get("task_count"),
+                cost: r.get("cost"),
             })
             .collect())
     }
 
-    // ── Breakdown by group dimension ──────────────────────────────────────
+    // ── Entity breakdown (user / project / proposal / task) ────────────────
 
-    async fn fetch_breakdown(&self, params: &UsageAnalyticsQuery) -> Result<Vec<BreakdownRow>> {
-        let (from_clause, where_clause, binds) = Self::build_from_where(params);
-        let group_expr = params.group_by.group_expr();
+    /// Aggregate breakdown for a single entity dimension across the whole
+    /// window.  Spend / tokens are session-level sums; `success_rate` and
+    /// `avg_reopens` are computed over the entity's distinct tasks so multiple
+    /// sessions on one task cannot overweight the outcome metrics.
+    pub async fn entity_breakdown(
+        &self,
+        params: &UsageAnalyticsQuery,
+        dimension: GroupDimension,
+    ) -> Result<Vec<EntityBreakdownRow>> {
+        self.db.ensure_initialized().await?;
+
+        let (conditions, binds) = Self::session_filters(params);
+        let where_clause = Self::where_clause(&conditions);
+        let key_expr = dimension.key_expr();
+        let name_expr = dimension.name_expr();
+        let joins = dimension.joins();
 
         let sql = format!(
-            "SELECT \
-                {group_expr}                     AS \"group_key!\", \
-                substring(s.started_at, 1, 10)   AS \"day!\", \
-                COUNT(*)                         AS \"session_count!\", \
-                COALESCE(SUM(s.tokens_in)::bigint, 0)    AS \"tokens_in!\", \
-                COALESCE(SUM(s.tokens_out)::bigint, 0)   AS \"tokens_out!\", \
-                COALESCE(SUM(s.cache_read_tokens)::bigint, 0)  AS \"cache_read_tokens!\", \
-                COALESCE(SUM(s.cache_write_tokens)::bigint, 0) AS \"cache_write_tokens!\", \
-                CASE \
-                    WHEN bool_or(s.cost_usd IS NULL) THEN NULL \
-                    ELSE SUM(s.cost_usd) \
-                END AS \"total_cost_usd\" \
-             {from_clause} {where_clause} \
-             GROUP BY {group_expr}, substring(s.started_at, 1, 10) \
-             ORDER BY 2, 1"
+            "WITH base AS ( \
+                SELECT \
+                    {key_expr}  AS entity_id, \
+                    {name_expr} AS entity_name, \
+                    s.cost_usd, s.tokens_in, s.tokens_out, s.task_id, \
+                    t.status, t.close_reason, t.total_reopen_count \
+                FROM sessions s {joins} {where_clause} \
+             ), \
+             sess AS ( \
+                SELECT \
+                    entity_id, \
+                    MAX(entity_name) AS entity_name, \
+                    CASE WHEN bool_or(cost_usd IS NULL) THEN NULL ELSE SUM(cost_usd) END AS cost, \
+                    COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
+                    COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out, \
+                    COUNT(DISTINCT task_id) AS task_count \
+                FROM base GROUP BY entity_id \
+             ), \
+             task_agg AS ( \
+                SELECT \
+                    entity_id, \
+                    COUNT(DISTINCT CASE WHEN status = 'closed' AND close_reason = 'completed' \
+                                        THEN task_id END) AS completed_count, \
+                    COUNT(DISTINCT CASE WHEN status = 'closed' THEN task_id END) AS closed_count, \
+                    AVG(CASE WHEN status = 'closed' \
+                             THEN total_reopen_count::DOUBLE PRECISION END) AS avg_reopens \
+                FROM ( \
+                    SELECT DISTINCT entity_id, task_id, status, close_reason, total_reopen_count \
+                    FROM base \
+                ) distinct_tasks \
+                GROUP BY entity_id \
+             ) \
+             SELECT \
+                 sess.entity_id    AS entity_id, \
+                 sess.entity_name  AS entity_name, \
+                 sess.cost         AS cost, \
+                 sess.tokens_in    AS tokens_in, \
+                 sess.tokens_out   AS tokens_out, \
+                 sess.task_count   AS task_count, \
+                 CASE WHEN ta.closed_count > 0 \
+                      THEN ta.completed_count::DOUBLE PRECISION / ta.closed_count::DOUBLE PRECISION \
+                      END          AS success_rate, \
+                 ta.avg_reopens    AS avg_reopens \
+             FROM sess \
+             LEFT JOIN task_agg ta ON ta.entity_id = sess.entity_id \
+             WHERE sess.entity_id <> '' \
+             ORDER BY sess.cost DESC NULLS LAST"
         );
 
-        let query = sqlx::query(&sql);
-        let query = Self::bind_all(query, &binds);
+        let query = Self::bind_all(sqlx::query(&sql), &binds);
         let rows = query.fetch_all(self.db.pool()).await?;
 
         Ok(rows
             .into_iter()
-            .map(|r| BreakdownRow {
-                group_key: r.get("group_key!"),
-                day: r.get("day!"),
-                session_count: r.get("session_count!"),
-                tokens_in: r.get("tokens_in!"),
-                tokens_out: r.get("tokens_out!"),
-                cache_read_tokens: r.get("cache_read_tokens!"),
-                cache_write_tokens: r.get("cache_write_tokens!"),
-                total_cost_usd: r.get("total_cost_usd"),
+            .map(|r| EntityBreakdownRow {
+                id: r.get("entity_id"),
+                name: r.get("entity_name"),
+                cost: r.get("cost"),
+                tokens_in: r.get("tokens_in"),
+                tokens_out: r.get("tokens_out"),
+                task_count: r.get("task_count"),
+                success_rate: r.get("success_rate"),
+                avg_reopens: r.get("avg_reopens"),
             })
             .collect())
     }
 
-    // ── Model effectiveness (worker-scoped) ──────────────────────────────
+    // ── Model effectiveness (worker-scoped) + project × model matrix ───────
 
     /// Run effectiveness and project-model matrix queries and return the
     /// combined result.  Effectiveness is always scoped to worker sessions;
@@ -427,98 +495,64 @@ impl UsageAnalyticsRepository {
         Ok((effectiveness, matrix))
     }
 
-    /// Build FROM + WHERE for the model effectiveness query.
-    ///
-    /// Always scopes to `agent_type = 'worker'`.  Applies date range,
-    /// `project_id`, and `model_id` endpoint filters; the `agent_type`
-    /// filter from the endpoint query is intentionally ignored here because
-    /// effectiveness is defined over worker sessions only.
+    /// Build FROM + WHERE for the worker-scoped model effectiveness query.
+    /// Always scopes to `agent_type = 'worker'`; the endpoint `agent_type`
+    /// filter is intentionally ignored because effectiveness is defined over
+    /// worker sessions only.
     fn build_effectiveness_from_where(
         params: &UsageAnalyticsQuery,
     ) -> (String, String, Vec<String>) {
         let mut conditions: Vec<String> = Vec::new();
         let mut binds: Vec<String> = Vec::new();
-        let mut bind_idx: usize = 1;
+        let mut idx: usize = 1;
 
-        // Date range (same as base query).
-        conditions.push(format!("s.started_at >= ${bind_idx}"));
+        conditions.push(format!("s.started_at >= ${idx}"));
         binds.push(params.from.clone());
-        bind_idx += 1;
+        idx += 1;
 
-        conditions.push(format!("s.started_at < ${bind_idx}"));
+        conditions.push(format!("s.started_at < ${idx}"));
         binds.push(params.to.clone());
-        bind_idx += 1;
+        idx += 1;
 
-        // Always worker-scoped.
-        conditions.push(format!("s.agent_type = ${bind_idx}"));
+        conditions.push(format!("s.agent_type = ${idx}"));
         binds.push("worker".to_string());
-        bind_idx += 1;
+        idx += 1;
 
         if let Some(ref project_id) = params.project_id {
-            conditions.push(format!("s.project_id = ${bind_idx}"));
+            conditions.push(format!("s.project_id = ${idx}"));
             binds.push(project_id.clone());
-            bind_idx += 1;
+            idx += 1;
         }
 
         if let Some(ref model_id) = params.model_id {
-            conditions.push(format!("s.model_id = ${bind_idx}"));
+            conditions.push(format!("s.model_id = ${idx}"));
             binds.push(model_id.clone());
-            // bind_idx not incremented — last use
         }
 
-        let from_clause = "FROM sessions s \
-             JOIN tasks t ON t.id = s.task_id"
-            .to_string();
-
+        let from_clause = "FROM sessions s JOIN tasks t ON t.id = s.task_id".to_string();
         let where_clause = format!("WHERE {}", conditions.join(" AND "));
 
         (from_clause, where_clause, binds)
     }
 
-    /// Per-model effectiveness metrics over worker sessions.
-    ///
-    /// Uses shared-credit attribution: each completed task counts for every
-    /// model that ran at least one worker session on it.  Success rate,
-    /// average reopens, and verification pass rate are computed over distinct
-    /// shared-credit tasks per model (not raw worker-session rows) so that
-    /// multiple sessions on the same task cannot inflate rates above 1.0.
     async fn fetch_model_effectiveness(
         &self,
         params: &UsageAnalyticsQuery,
     ) -> Result<Vec<ModelEffectivenessRow>> {
         let (from_clause, where_clause, binds) = Self::build_effectiveness_from_where(params);
 
-        // Use CTEs to separate session-level aggregates (spend, tokens,
-        // sessions) from task-level outcome metrics.  Task outcomes are
-        // computed over DISTINCT (model_id, task_id) pairs so that multiple
-        // worker sessions on the same task cannot overweight success_rate,
-        // avg_reopens, or cost_per_completed_task.
-        //
-        // `filtered_sessions` — rows matching the effectiveness WHERE clause
-        //     (date range, worker scope, optional project/model filters).
-        // `session_agg` — per-model session/spend/tokens rollup.
-        // `task_agg` — per-model task-outcome rollup over distinct
-        //     (model_id, task_id) pairs, using task properties from the
-        //     tasks table (which are functionally dependent on task_id).
         let sql = format!(
             "WITH filtered_sessions AS ( \
                 SELECT \
-                    s.model_id, \
-                    s.task_id, \
-                    s.cost_usd, \
-                    s.tokens_in, \
-                    s.tokens_out, \
-                    t.status, \
-                    t.close_reason, \
-                    t.total_reopen_count \
+                    s.model_id, s.task_id, s.cost_usd, s.tokens_in, s.tokens_out, \
+                    t.status, t.close_reason, t.total_reopen_count \
                 {from_clause} {where_clause} \
              ), \
              session_agg AS ( \
                 SELECT \
                     model_id, \
                     COUNT(*) AS sessions, \
-                    CASE WHEN bool_or(cost_usd IS NULL) \
-                         THEN NULL ELSE SUM(cost_usd) END AS spend_usd, \
+                    CASE WHEN bool_or(cost_usd IS NULL) THEN NULL ELSE SUM(cost_usd) END AS spend_usd, \
                     COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
                     COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out \
                 FROM filtered_sessions \
@@ -527,64 +561,49 @@ impl UsageAnalyticsRepository {
              task_agg AS ( \
                 SELECT \
                     model_id, \
-                    COUNT(DISTINCT \
-                        CASE WHEN status = 'closed' \
-                                  AND close_reason = 'completed' \
-                             THEN task_id END) AS completed_count, \
-                    COUNT(DISTINCT \
-                        CASE WHEN status = 'closed' \
-                             THEN task_id END) AS closed_count, \
+                    COUNT(DISTINCT CASE WHEN status = 'closed' AND close_reason = 'completed' \
+                                        THEN task_id END) AS completed_count, \
+                    COUNT(DISTINCT CASE WHEN status = 'closed' THEN task_id END) AS closed_count, \
                     AVG(CASE WHEN status = 'closed' \
-                             THEN total_reopen_count::DOUBLE PRECISION \
-                             ELSE NULL END) AS avg_reopens \
+                             THEN total_reopen_count::DOUBLE PRECISION END) AS avg_reopens \
                 FROM ( \
-                    SELECT DISTINCT \
-                        model_id, task_id, status, close_reason, \
-                        total_reopen_count \
+                    SELECT DISTINCT model_id, task_id, status, close_reason, total_reopen_count \
                     FROM filtered_sessions \
                 ) distinct_tasks \
                 GROUP BY model_id \
              ) \
              SELECT \
-                 sa.model_id                                AS \"model_id!\", \
-                 sa.sessions                                AS \"sessions!\", \
-                 sa.spend_usd                               AS \"spend_usd\", \
-                 sa.tokens_in                               AS \"tokens_in!\", \
-                 sa.tokens_out                              AS \"tokens_out!\", \
-                 COALESCE(ta.completed_count, 0)            AS \"shared_credit_completed_task_count!\", \
-                 COALESCE( \
-                     ta.completed_count::DOUBLE PRECISION \
-                     / GREATEST(1, ta.closed_count)::DOUBLE PRECISION, \
-                     0.0 \
-                 )                                          AS \"success_rate!\", \
-                 COALESCE(ta.avg_reopens, 0.0)              AS \"avg_reopens!\" \
+                 sa.model_id                     AS model_id, \
+                 sa.sessions                     AS sessions, \
+                 sa.spend_usd                    AS spend_usd, \
+                 sa.tokens_in                    AS tokens_in, \
+                 sa.tokens_out                   AS tokens_out, \
+                 COALESCE(ta.completed_count, 0) AS shared_credit_completed_task_count, \
+                 CASE WHEN ta.closed_count > 0 \
+                      THEN ta.completed_count::DOUBLE PRECISION / ta.closed_count::DOUBLE PRECISION \
+                      END                        AS success_rate, \
+                 ta.avg_reopens                  AS avg_reopens \
              FROM session_agg sa \
              LEFT JOIN task_agg ta ON ta.model_id = sa.model_id \
              ORDER BY sa.model_id"
         );
 
-        let mut query = sqlx::query(&sql);
-        for val in &binds {
-            query = query.bind(val.clone());
-        }
+        let query = Self::bind_all(sqlx::query(&sql), &binds);
         let rows = query.fetch_all(self.db.pool()).await?;
 
         Ok(rows
             .into_iter()
             .map(|r| {
-                let sessions: i64 = r.get("sessions!");
+                let sessions: i64 = r.get("sessions");
                 let spend_usd: Option<f64> = r.get("spend_usd");
-                let tokens_in: i64 = r.get("tokens_in!");
-                let tokens_out: i64 = r.get("tokens_out!");
-                let completed: i64 = r.get("shared_credit_completed_task_count!");
+                let tokens_in: i64 = r.get("tokens_in");
+                let tokens_out: i64 = r.get("tokens_out");
+                let completed: i64 = r.get("shared_credit_completed_task_count");
 
-                // cost_per_completed_task: NULL when no completed tasks or
-                // all sessions were unpriced (NULL cost_usd).
                 let cost_per_completed_task = match (spend_usd, completed) {
                     (Some(cost), c) if c > 0 => Some(cost / c as f64),
                     _ => None,
                 };
-                // tokens_per_task: NULL when no completed tasks.
                 let tokens_per_task = if completed > 0 {
                     Some((tokens_in + tokens_out) as f64 / completed as f64)
                 } else {
@@ -592,14 +611,14 @@ impl UsageAnalyticsRepository {
                 };
 
                 ModelEffectivenessRow {
-                    model_id: r.get("model_id!"),
+                    model_id: r.get("model_id"),
                     sessions,
                     spend_usd,
                     tokens_in,
                     tokens_out,
                     shared_credit_completed_task_count: completed,
-                    success_rate: r.get("success_rate!"),
-                    avg_reopens: r.get("avg_reopens!"),
+                    success_rate: r.get("success_rate"),
+                    avg_reopens: r.get("avg_reopens"),
                     cost_per_completed_task,
                     tokens_per_task,
                 }
@@ -607,46 +626,90 @@ impl UsageAnalyticsRepository {
             .collect())
     }
 
-    // ── Project × model matrix ───────────────────────────────────────────
-
-    /// Project × model usage matrix.  Groups all sessions (all agent types)
-    /// by project and model, applying all endpoint filters.  NULL-project
-    /// sessions are preserved with an empty-string project_id.
+    /// Project × model usage matrix.  Groups all sessions (all agent types) by
+    /// project and model, applying all endpoint filters.  NULL-project
+    /// sessions are preserved with an empty-string project_id.  Outcome
+    /// metrics are computed over the distinct tasks touched by each cell.
     async fn fetch_project_model_matrix(
         &self,
         params: &UsageAnalyticsQuery,
     ) -> Result<Vec<ProjectModelMatrixRow>> {
-        let (from_clause, where_clause, binds) = Self::build_from_where(params);
+        let (conditions, binds) = Self::session_filters(params);
+        let where_clause = Self::where_clause(&conditions);
 
         let sql = format!(
-            "SELECT \
-                COALESCE(s.project_id, '')               AS \"project_id!\", \
-                s.model_id                               AS \"model_id!\", \
-                COUNT(*)                                 AS \"sessions!\", \
-                CASE \
-                    WHEN bool_or(s.cost_usd IS NULL) THEN NULL \
-                    ELSE SUM(s.cost_usd) \
-                END                                      AS \"spend_usd\", \
-                COALESCE(SUM(s.tokens_in)::bigint, 0)            AS \"tokens_in!\", \
-                COALESCE(SUM(s.tokens_out)::bigint, 0)           AS \"tokens_out!\" \
-             {from_clause} {where_clause} \
-             GROUP BY COALESCE(s.project_id, ''), s.model_id \
-             ORDER BY 1, 2"
+            "WITH base AS ( \
+                SELECT \
+                    COALESCE(s.project_id, '') AS project_id, \
+                    COALESCE(p.name, '')       AS project_name, \
+                    s.model_id                 AS model_id, \
+                    s.cost_usd, s.tokens_in, s.tokens_out, s.task_id, \
+                    t.status, t.close_reason, t.total_reopen_count \
+                FROM sessions s \
+                LEFT JOIN projects p ON p.id = s.project_id \
+                LEFT JOIN tasks t ON t.id = s.task_id \
+                {where_clause} \
+             ), \
+             sess AS ( \
+                SELECT \
+                    project_id, MAX(project_name) AS project_name, model_id, \
+                    COUNT(*) AS sessions, \
+                    CASE WHEN bool_or(cost_usd IS NULL) THEN NULL ELSE SUM(cost_usd) END AS spend_usd, \
+                    COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
+                    COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out, \
+                    COUNT(DISTINCT task_id) AS task_count \
+                FROM base GROUP BY project_id, model_id \
+             ), \
+             task_agg AS ( \
+                SELECT \
+                    project_id, model_id, \
+                    COUNT(DISTINCT CASE WHEN status = 'closed' AND close_reason = 'completed' \
+                                        THEN task_id END) AS completed_count, \
+                    COUNT(DISTINCT CASE WHEN status = 'closed' THEN task_id END) AS closed_count, \
+                    AVG(CASE WHEN status = 'closed' \
+                             THEN total_reopen_count::DOUBLE PRECISION END) AS avg_reopens \
+                FROM ( \
+                    SELECT DISTINCT project_id, model_id, task_id, status, close_reason, \
+                           total_reopen_count \
+                    FROM base \
+                ) distinct_tasks \
+                GROUP BY project_id, model_id \
+             ) \
+             SELECT \
+                 sess.project_id   AS project_id, \
+                 sess.project_name AS project_name, \
+                 sess.model_id     AS model_id, \
+                 sess.sessions     AS sessions, \
+                 sess.spend_usd    AS spend_usd, \
+                 sess.tokens_in    AS tokens_in, \
+                 sess.tokens_out   AS tokens_out, \
+                 sess.task_count   AS task_count, \
+                 CASE WHEN ta.closed_count > 0 \
+                      THEN ta.completed_count::DOUBLE PRECISION / ta.closed_count::DOUBLE PRECISION \
+                      END           AS success_rate, \
+                 ta.avg_reopens    AS avg_reopens \
+             FROM sess \
+             LEFT JOIN task_agg ta \
+                ON ta.project_id = sess.project_id AND ta.model_id = sess.model_id \
+             ORDER BY 1, 3"
         );
 
-        let query = sqlx::query(&sql);
-        let query = Self::bind_all(query, &binds);
+        let query = Self::bind_all(sqlx::query(&sql), &binds);
         let rows = query.fetch_all(self.db.pool()).await?;
 
         Ok(rows
             .into_iter()
             .map(|r| ProjectModelMatrixRow {
-                project_id: r.get("project_id!"),
-                model_id: r.get("model_id!"),
-                sessions: r.get("sessions!"),
+                project_id: r.get("project_id"),
+                project_name: r.get("project_name"),
+                model_id: r.get("model_id"),
+                sessions: r.get("sessions"),
                 spend_usd: r.get("spend_usd"),
-                tokens_in: r.get("tokens_in!"),
-                tokens_out: r.get("tokens_out!"),
+                tokens_in: r.get("tokens_in"),
+                tokens_out: r.get("tokens_out"),
+                task_count: r.get("task_count"),
+                success_rate: r.get("success_rate"),
+                avg_reopens: r.get("avg_reopens"),
             })
             .collect())
     }
@@ -669,45 +732,34 @@ mod tests {
     }
 
     #[test]
-    fn group_dimension_display_matches_label() {
-        for dim in [
-            GroupDimension::Model,
-            GroupDimension::Project,
-            GroupDimension::User,
-            GroupDimension::Proposal,
-            GroupDimension::Task,
-            GroupDimension::Agent,
-        ] {
-            assert_eq!(dim.to_string(), dim.label());
-        }
-    }
-
-    #[test]
-    fn group_dimension_sql_expressions() {
-        // Verify SQL expressions are reasonable and non-empty.
-        assert!(!GroupDimension::Model.group_expr().is_empty());
-        assert!(!GroupDimension::Project.group_expr().is_empty());
-        assert!(!GroupDimension::User.group_expr().is_empty());
-        assert!(!GroupDimension::Proposal.group_expr().is_empty());
-        assert!(!GroupDimension::Task.group_expr().is_empty());
-        assert!(!GroupDimension::Agent.group_expr().is_empty());
-    }
-
-    #[test]
-    fn user_group_uses_coalesce() {
-        let expr = GroupDimension::User.group_expr();
+    fn user_dimension_key_uses_creator_fallback() {
+        let expr = GroupDimension::User.key_expr();
         assert!(expr.contains("COALESCE"));
         assert!(expr.contains("created_by_user_id"));
     }
 
     #[test]
-    fn proposal_group_joins_through_epics() {
-        let expr = GroupDimension::Proposal.group_expr();
-        assert!(expr.contains("proposal_id"));
+    fn proposal_dimension_inner_joins_proposal_epics() {
+        assert!(GroupDimension::Proposal.joins().contains("INNER JOIN proposal_epics"));
+        assert!(GroupDimension::Proposal.name_expr().contains("pr.title"));
     }
 
     #[test]
-    fn usage_analytics_query_clone_debug() {
+    fn breakdown_dimensions_have_non_empty_sql() {
+        for dim in [
+            GroupDimension::User,
+            GroupDimension::Project,
+            GroupDimension::Proposal,
+            GroupDimension::Task,
+        ] {
+            assert!(!dim.key_expr().is_empty());
+            assert!(!dim.name_expr().is_empty());
+            assert!(dim.joins().contains("tasks t"));
+        }
+    }
+
+    #[test]
+    fn session_filters_emit_date_bounds_first() {
         let q = UsageAnalyticsQuery {
             from: "2025-01-01".into(),
             to: "2025-02-01".into(),
@@ -716,81 +768,48 @@ mod tests {
             model_id: None,
             agent_type: Some("worker".into()),
         };
-        let q2 = q.clone();
-        assert_eq!(q2.from, "2025-01-01");
-        assert_eq!(q2.to, "2025-02-01");
-        assert_eq!(q2.group_by, GroupDimension::Model);
-        assert_eq!(q2.project_id.as_deref(), Some("proj-1"));
-        assert!(q2.model_id.is_none());
-        assert_eq!(q2.agent_type.as_deref(), Some("worker"));
-
-        // Verify Debug is derived (doesn't panic).
-        let _dbg = format!("{q:?}");
-    }
-
-    #[test]
-    fn daily_series_row_default() {
-        let row = DailySeriesRow::default();
-        assert_eq!(row.day, "");
-        assert_eq!(row.session_count, 0);
-        assert_eq!(row.tokens_in, 0);
-        assert_eq!(row.tokens_out, 0);
-        assert_eq!(row.cache_read_tokens, 0);
-        assert_eq!(row.cache_write_tokens, 0);
-        assert!(row.total_cost_usd.is_none());
-    }
-
-    #[test]
-    fn breakdown_row_default() {
-        let row = BreakdownRow::default();
-        assert_eq!(row.group_key, "");
-        assert_eq!(row.day, "");
-        assert!(row.total_cost_usd.is_none());
+        let (conditions, binds) = UsageAnalyticsRepository::session_filters(&q);
+        assert_eq!(conditions[0], "s.started_at >= $1");
+        assert_eq!(conditions[1], "s.started_at < $2");
+        assert_eq!(binds[0], "2025-01-01");
+        assert_eq!(binds[1], "2025-02-01");
+        // project_id present, model_id absent, agent_type present → 4 binds.
+        assert_eq!(binds.len(), 4);
+        assert_eq!(binds[2], "proj-1");
+        assert_eq!(binds[3], "worker");
     }
 
     #[test]
     fn usage_totals_default() {
         let totals = UsageTotals::default();
         assert_eq!(totals.session_count, 0);
-        assert_eq!(totals.tokens_in, 0);
-        assert_eq!(totals.tokens_out, 0);
-        assert_eq!(totals.cache_read_tokens, 0);
-        assert_eq!(totals.cache_write_tokens, 0);
         assert!(totals.total_cost_usd.is_none());
     }
 
     #[test]
-    fn usage_analytics_result_default() {
-        let result = UsageAnalyticsResult::default();
-        assert_eq!(result.totals.session_count, 0);
-        assert!(result.series.is_empty());
-        assert!(result.breakdown.is_empty());
+    fn series_detail_row_default() {
+        let row = SeriesDetailRow::default();
+        assert_eq!(row.day, "");
+        assert_eq!(row.session_count, 0);
+        assert!(row.cost.is_none());
     }
 
     #[test]
-    fn model_effectiveness_row_default() {
-        let row = ModelEffectivenessRow::default();
-        assert_eq!(row.model_id, "");
-        assert_eq!(row.sessions, 0);
-        assert!(row.spend_usd.is_none());
-        assert_eq!(row.tokens_in, 0);
-        assert_eq!(row.tokens_out, 0);
-        assert_eq!(row.shared_credit_completed_task_count, 0);
+    fn entity_breakdown_row_default() {
+        let row = EntityBreakdownRow::default();
+        assert_eq!(row.id, "");
+        assert_eq!(row.task_count, 0);
+        assert!(row.cost.is_none());
         assert!(row.success_rate.is_none());
-        assert!(row.avg_reopens.is_none());
-        assert!(row.cost_per_completed_task.is_none());
-        assert!(row.tokens_per_task.is_none());
     }
 
     #[test]
     fn project_model_matrix_row_default() {
         let row = ProjectModelMatrixRow::default();
         assert_eq!(row.project_id, "");
-        assert_eq!(row.model_id, "");
-        assert_eq!(row.sessions, 0);
+        assert_eq!(row.project_name, "");
         assert!(row.spend_usd.is_none());
-        assert_eq!(row.tokens_in, 0);
-        assert_eq!(row.tokens_out, 0);
+        assert!(row.success_rate.is_none());
     }
 
     #[test]
@@ -810,7 +829,6 @@ mod tests {
         let row2 = row.clone();
         assert_eq!(row2.model_id, "gpt-4");
         assert_eq!(row2.shared_credit_completed_task_count, 3);
-        // Debug doesn't panic.
         let _dbg = format!("{row:?}");
     }
 }

--- a/server/crates/djinn-db/tests/usage_analytics_totals.rs
+++ b/server/crates/djinn-db/tests/usage_analytics_totals.rs
@@ -1,5 +1,6 @@
-//! Integration test: verify `UsageAnalyticsRepository::query()` returns correct
-//! `UsageTotals` against a live Postgres database.
+//! Integration test: verify `UsageAnalyticsRepository::totals()` /
+//! `series_detailed()` / `entity_breakdown()` return correct aggregates
+//! against a live Postgres database.
 //!
 //! Guards against the NUMERIC→i64 decode panic that occurred because
 //! `SUM(bigint)` returns `NUMERIC` in Postgres.  The fix casts each integer
@@ -223,23 +224,27 @@ async fn usage_totals_decodes_i64_from_sum() {
         agent_type: None,
     };
 
-    let result = repo.query(&params).await.expect("query should succeed");
+    let totals = repo.totals(&params).await.expect("totals should succeed");
 
-    assert_eq!(result.totals.session_count, 1);
-    assert_eq!(result.totals.tokens_in, 1234);
-    assert_eq!(result.totals.tokens_out, 5678);
-    assert_eq!(result.totals.cache_read_tokens, 100);
-    assert_eq!(result.totals.cache_write_tokens, 200);
+    assert_eq!(totals.session_count, 1);
+    assert_eq!(totals.tokens_in, 1234);
+    assert_eq!(totals.tokens_out, 5678);
+    assert_eq!(totals.cache_read_tokens, 100);
+    assert_eq!(totals.cache_write_tokens, 200);
     // total_cost_usd should be Some(0.042) — no NULL sessions, so no NULL
     // cost semantic applies.
-    let cost = result.totals.total_cost_usd.expect("cost should be Some");
+    let cost = totals.total_cost_usd.expect("cost should be Some");
     assert!((cost - 0.042_f64).abs() < 1e-9, "cost mismatch: {cost}");
 
-    // Series should have exactly one day bucket.
-    assert_eq!(result.series.len(), 1);
-    assert_eq!(result.series[0].day, "2025-06-15");
-    assert_eq!(result.series[0].tokens_in, 1234);
-    assert_eq!(result.series[0].tokens_out, 5678);
+    // Detailed series should have exactly one (day, model, project, agent) row.
+    let series = repo
+        .series_detailed(&params)
+        .await
+        .expect("series should succeed");
+    assert_eq!(series.len(), 1);
+    assert_eq!(series[0].day, "2025-06-15");
+    assert_eq!(series[0].tokens_in, 1234);
+    assert_eq!(series[0].tokens_out, 5678);
 }
 
 /// Verify NULL-cost semantics: when ANY matching session has NULL cost_usd,
@@ -260,23 +265,24 @@ async fn usage_totals_null_cost_semantics_preserved() {
         agent_type: None,
     };
 
-    let result = repo.query(&params).await.expect("query should succeed");
+    let totals = repo.totals(&params).await.expect("totals should succeed");
 
-    assert_eq!(result.totals.session_count, 2);
+    assert_eq!(totals.session_count, 2);
     // Token counts should be summed correctly across both sessions.
-    assert_eq!(result.totals.tokens_in, 1234 + 999);
-    assert_eq!(result.totals.tokens_out, 5678 + 888);
-    assert_eq!(result.totals.cache_read_tokens, 100 + 50);
-    assert_eq!(result.totals.cache_write_tokens, 200 + 75);
+    assert_eq!(totals.tokens_in, 1234 + 999);
+    assert_eq!(totals.tokens_out, 5678 + 888);
+    assert_eq!(totals.cache_read_tokens, 100 + 50);
+    assert_eq!(totals.cache_write_tokens, 200 + 75);
     // Because one session has NULL cost_usd, total_cost_usd must be NULL.
     assert!(
-        result.totals.total_cost_usd.is_none(),
+        totals.total_cost_usd.is_none(),
         "expected NULL total_cost_usd when any session is unpriced, got {:?}",
-        result.totals.total_cost_usd,
+        totals.total_cost_usd,
     );
 }
 
-/// Verify the breakdown query also decodes correctly (same SUM→NUMERIC hazard).
+/// Verify the entity breakdown query also decodes correctly (same SUM→NUMERIC
+/// hazard) and aggregates tokens per entity.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn breakdown_decodes_i64_from_sum() {
     let db = create_test_db();
@@ -292,13 +298,14 @@ async fn breakdown_decodes_i64_from_sum() {
         agent_type: None,
     };
 
-    let result = repo.query(&params).await.expect("query should succeed");
+    let rows = repo
+        .entity_breakdown(&params, GroupDimension::Project)
+        .await
+        .expect("entity_breakdown should succeed");
 
-    assert_eq!(result.breakdown.len(), 1);
-    assert_eq!(result.breakdown[0].tokens_in, 1234);
-    assert_eq!(result.breakdown[0].tokens_out, 5678);
-    assert_eq!(result.breakdown[0].cache_read_tokens, 100);
-    assert_eq!(result.breakdown[0].cache_write_tokens, 200);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].tokens_in, 1234);
+    assert_eq!(rows[0].tokens_out, 5678);
 }
 
 // ── Model effectiveness regression tests ───────────────────────────────────

--- a/server/src/server/tests/usage_analytics.rs
+++ b/server/src/server/tests/usage_analytics.rs
@@ -1,9 +1,11 @@
 // Endpoint contract regressions for `GET /api/admin/usage`.
 //
-// These tests exercise the HTTP handler layer — admin gating, response shape,
-// query-parameter validation, and rollup/pagination behaviour that repository-
-// only tests cannot prove.  They follow the same `seed_admin_session` +
-// `test_helpers::create_test_app_with_db` pattern used by `tests/agents.rs`.
+// These tests exercise the HTTP handler layer — admin gating, the frontend
+// response contract (kpis / time_series / breakdowns / model_effectiveness /
+// project_model_matrix / generated_at), query-parameter validation, and
+// rollup behaviour that repository-only tests cannot prove.  They follow the
+// same `seed_admin_session` + `test_helpers::create_test_app_with_db` pattern
+// used by `tests/agents.rs`.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -157,10 +159,6 @@ async fn seed_task_row(db: &djinn_db::Database, seed: TaskSeed<'_>) -> String {
 
 /// Seed raw session rows directly into the database for integration-level
 /// contract tests that need actual query results.
-///
-/// Inserts sessions with the given `started_at` prefix (first 10 chars must be
-/// a valid ISO date), `model_id`, `agent_type`, `project_id`, and optional
-/// `cost_usd`.
 async fn seed_session_row(db: &djinn_db::Database, seed: SessionSeed<'_>) {
     let id = uuid::Uuid::now_v7().to_string();
     sqlx::query(
@@ -199,10 +197,18 @@ async fn seed_project(db: &djinn_db::Database, project_id: &str, name: &str) {
     .expect("failed to seed project");
 }
 
-fn model_effectiveness_row<'a>(rows: &'a [Value], model_id: &str) -> &'a Value {
+/// Find a model_effectiveness row by its (renamed) `model` field.
+fn model_effectiveness_row<'a>(rows: &'a [Value], model: &str) -> &'a Value {
     rows.iter()
-        .find(|row| row.get("model_id").and_then(Value::as_str) == Some(model_id))
-        .unwrap_or_else(|| panic!("missing model_effectiveness row for {model_id}: {rows:?}"))
+        .find(|row| row.get("model").and_then(Value::as_str) == Some(model))
+        .unwrap_or_else(|| panic!("missing model_effectiveness row for {model}: {rows:?}"))
+}
+
+/// Convenience: extract a top-level array field as a slice of Values.
+fn array_field<'a>(body: &'a Value, field: &str) -> &'a Vec<Value> {
+    body.get(field)
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("expected array field '{field}' in {body}"))
 }
 
 // ── Admin gating ─────────────────────────────────────────────────────────────
@@ -213,12 +219,7 @@ async fn nonadmin_request_is_rejected_with_403() {
     let nonadmin_cookie = seed_nonadmin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
-    let (status, body) = get_usage(
-        &app,
-        "from=2025-01-01&to=2025-02-01",
-        Some(&nonadmin_cookie),
-    )
-    .await;
+    let (status, body) = get_usage(&app, "preset=30d", Some(&nonadmin_cookie)).await;
 
     assert_eq!(status, StatusCode::FORBIDDEN);
     assert!(
@@ -235,7 +236,7 @@ async fn unauthenticated_request_is_rejected_with_401() {
     let db = test_helpers::create_test_db();
     let app = test_helpers::create_test_app_with_db(db);
 
-    let (status, body) = get_usage(&app, "from=2025-01-01&to=2025-02-01", None).await;
+    let (status, body) = get_usage(&app, "preset=30d", None).await;
 
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert!(
@@ -250,24 +251,23 @@ async fn unauthenticated_request_is_rejected_with_401() {
 // ── Response shape ───────────────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn admin_request_returns_all_six_top_level_fields() {
+async fn admin_request_returns_frontend_contract_fields() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
     let (status, body) =
-        get_usage(&app, "from=2025-01-01&to=2025-02-01", Some(&admin_cookie)).await;
+        get_usage(&app, "start=2025-01-01&end=2025-02-01", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::OK);
 
     for field in [
-        "totals",
-        "previous_totals",
-        "series",
-        "breakdown",
+        "kpis",
+        "time_series",
+        "breakdowns",
         "model_effectiveness",
         "project_model_matrix",
-        "granularity",
+        "generated_at",
     ] {
         assert!(
             body.get(field).is_some(),
@@ -275,272 +275,136 @@ async fn admin_request_returns_all_six_top_level_fields() {
         );
     }
 
-    // Verify types
-    assert!(body.get("totals").unwrap().is_object());
-    assert!(body.get("previous_totals").unwrap().is_object());
-    assert!(body.get("series").unwrap().is_array());
-    assert!(body.get("breakdown").unwrap().is_array());
+    assert!(body.get("kpis").unwrap().is_array());
+    assert!(body.get("time_series").unwrap().is_array());
     assert!(body.get("model_effectiveness").unwrap().is_array());
     assert!(body.get("project_model_matrix").unwrap().is_array());
-    assert_eq!(body.get("granularity").unwrap().as_str().unwrap(), "day");
+    assert!(body.get("generated_at").unwrap().is_string());
+
+    let breakdowns = body.get("breakdowns").unwrap();
+    for field in ["by_user", "by_project", "by_proposal", "by_task"] {
+        assert!(
+            breakdowns.get(field).map(Value::is_array).unwrap_or(false),
+            "missing breakdowns.{field}: {breakdowns}"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn totals_and_previous_totals_contain_expected_scalar_fields() {
+async fn kpis_have_label_value_and_delta_fields() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
     let (status, body) =
-        get_usage(&app, "from=2025-01-01&to=2025-02-01", Some(&admin_cookie)).await;
+        get_usage(&app, "start=2025-01-01&end=2025-02-01", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::OK);
+    let kpis = array_field(&body, "kpis");
+    assert_eq!(kpis.len(), 4, "expected four KPI cards, got {}", kpis.len());
 
-    for key in ["totals", "previous_totals"] {
-        let obj = body.get(key).unwrap();
-        for field in [
-            "session_count",
-            "tokens_in",
-            "tokens_out",
-            "cache_read_tokens",
-            "cache_write_tokens",
-            "total_cost_usd",
-        ] {
-            assert!(
-                obj.get(field).is_some(),
-                "missing '{field}' in {key}: {obj}"
-            );
-        }
+    let labels: Vec<&str> = kpis
+        .iter()
+        .filter_map(|k| k.get("label").and_then(Value::as_str))
+        .collect();
+    assert!(labels.contains(&"Spend"), "expected a Spend KPI: {labels:?}");
+
+    for kpi in kpis {
+        assert!(kpi.get("label").unwrap().is_string());
+        // value and delta_pct may be null but the keys must exist.
+        assert!(kpi.get("value").is_some());
+        assert!(kpi.get("delta_pct").is_some());
+        assert!(kpi.get("formatted").unwrap().is_string());
     }
 }
 
 // ── Granularity and rollups ──────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn granularity_week_is_accepted_and_reflected_in_response() {
+async fn granularity_week_and_month_are_accepted() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
-    let (status, body) = get_usage(
-        &app,
-        "from=2025-01-01&to=2025-02-01&granularity=week",
-        Some(&admin_cookie),
-    )
-    .await;
-
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body.get("granularity").unwrap().as_str().unwrap(), "week");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn granularity_month_is_accepted_and_reflected_in_response() {
-    let db = test_helpers::create_test_db();
-    let admin_cookie = seed_admin_session(&db).await;
-    let app = test_helpers::create_test_app_with_db(db);
-
-    let (status, body) = get_usage(
-        &app,
-        "from=2025-01-01&to=2025-04-01&granularity=month",
-        Some(&admin_cookie),
-    )
-    .await;
-
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body.get("granularity").unwrap().as_str().unwrap(), "month");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn weekly_rollup_and_previous_window_with_seeded_data() {
-    let db = test_helpers::create_test_db();
-    let admin_cookie = seed_admin_session(&db).await;
-
-    // Seed a project so FK constraints pass.
-    seed_project(&db, "proj-rollup", "rollup-project").await;
-
-    // Seed sessions across two weeks:
-    //   Window (2025-03-10..2025-03-17): 2 sessions
-    //   Previous window (2025-03-03..2025-03-10): 1 session
-    seed_session_row(
-        &db,
-        SessionSeed {
-            project_id: "proj-rollup",
-            model_id: "model-a",
-            agent_type: "worker",
-            started_at: "2025-03-11T10:00:00Z",
-            tokens_in: 100,
-            tokens_out: 50,
-            cache_read_tokens: 10,
-            cache_write_tokens: 5,
-            cost_usd: Some(0.50),
-            task_id: None,
-        },
-    )
-    .await;
-    seed_session_row(
-        &db,
-        SessionSeed {
-            project_id: "proj-rollup",
-            model_id: "model-a",
-            agent_type: "worker",
-            started_at: "2025-03-12T10:00:00Z",
-            tokens_in: 200,
-            tokens_out: 100,
-            cache_read_tokens: 20,
-            cache_write_tokens: 10,
-            cost_usd: Some(1.00),
-            task_id: None,
-        },
-    )
-    .await;
-    seed_session_row(
-        &db,
-        SessionSeed {
-            project_id: "proj-rollup",
-            model_id: "model-a",
-            agent_type: "worker",
-            started_at: "2025-03-05T10:00:00Z",
-            tokens_in: 300,
-            tokens_out: 150,
-            cache_read_tokens: 30,
-            cache_write_tokens: 15,
-            cost_usd: Some(1.50),
-            task_id: None,
-        },
-    )
-    .await;
-
-    let app = test_helpers::create_test_app_with_db(db);
-
-    let (status, body) = get_usage(
-        &app,
-        "from=2025-03-10&to=2025-03-17&granularity=week",
-        Some(&admin_cookie),
-    )
-    .await;
-
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body.get("granularity").unwrap().as_str().unwrap(), "week");
-
-    // The main window totals should reflect the 2 sessions.
-    let totals = body.get("totals").unwrap();
-    assert_eq!(totals.get("session_count").unwrap().as_i64().unwrap(), 2);
-    assert_eq!(totals.get("tokens_in").unwrap().as_i64().unwrap(), 300);
-    assert_eq!(totals.get("tokens_out").unwrap().as_i64().unwrap(), 150);
-
-    // Previous totals should reflect the 1 session in the prior week.
-    let prev = body.get("previous_totals").unwrap();
-    assert_eq!(prev.get("session_count").unwrap().as_i64().unwrap(), 1);
-    assert_eq!(prev.get("tokens_in").unwrap().as_i64().unwrap(), 300);
-
-    // Weekly series should have at most one rolled-up bucket (Mon 2025-03-10).
-    let series = body.get("series").unwrap().as_array().unwrap();
-    assert!(
-        !series.is_empty(),
-        "weekly series should have at least one point"
-    );
-    // All points should be week-start dates (Monday).
-    for point in series {
-        let day = point.get("day").unwrap().as_str().unwrap();
-        assert!(
-            day.starts_with("2025-03-"),
-            "expected March 2025 week-start, got {day}"
-        );
+    for gran in ["week", "month"] {
+        let (status, body) = get_usage(
+            &app,
+            &format!("start=2025-01-01&end=2025-04-01&granularity={gran}"),
+            Some(&admin_cookie),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "granularity={gran} should be accepted");
+        assert!(body.get("time_series").unwrap().is_array());
     }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn monthly_rollup_with_seeded_data() {
+async fn weekly_rollup_buckets_to_week_start_and_counts_sessions() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
 
-    seed_project(&db, "proj-monthly", "monthly-project").await;
+    seed_project(&db, "proj-rollup", "rollup-project").await;
 
-    // Seed sessions across two months.
-    seed_session_row(
-        &db,
-        SessionSeed {
-            project_id: "proj-monthly",
-            model_id: "model-a",
-            agent_type: "worker",
-            started_at: "2025-01-15T10:00:00Z",
-            tokens_in: 100,
-            tokens_out: 50,
-            cache_read_tokens: 10,
-            cache_write_tokens: 5,
-            cost_usd: Some(0.50),
-            task_id: None,
-        },
-    )
-    .await;
-    seed_session_row(
-        &db,
-        SessionSeed {
-            project_id: "proj-monthly",
-            model_id: "model-a",
-            agent_type: "worker",
-            started_at: "2025-01-20T10:00:00Z",
-            tokens_in: 200,
-            tokens_out: 100,
-            cache_read_tokens: 20,
-            cache_write_tokens: 10,
-            cost_usd: Some(1.00),
-            task_id: None,
-        },
-    )
-    .await;
-    seed_session_row(
-        &db,
-        SessionSeed {
-            project_id: "proj-monthly",
-            model_id: "model-b",
-            agent_type: "worker",
-            started_at: "2025-02-10T10:00:00Z",
-            tokens_in: 300,
-            tokens_out: 150,
-            cache_read_tokens: 30,
-            cache_write_tokens: 15,
-            cost_usd: Some(1.50),
-            task_id: None,
-        },
-    )
-    .await;
+    // Window 2025-03-10..2025-03-17: 2 sessions; previous week: 1 session.
+    for (started, tin, tout, cost) in [
+        ("2025-03-11T10:00:00Z", 100, 50, 0.50),
+        ("2025-03-12T10:00:00Z", 200, 100, 1.00),
+        ("2025-03-05T10:00:00Z", 300, 150, 1.50),
+    ] {
+        seed_session_row(
+            &db,
+            SessionSeed {
+                project_id: "proj-rollup",
+                model_id: "model-a",
+                agent_type: "worker",
+                started_at: started,
+                tokens_in: tin,
+                tokens_out: tout,
+                cache_read_tokens: 10,
+                cache_write_tokens: 5,
+                cost_usd: Some(cost),
+                task_id: None,
+            },
+        )
+        .await;
+    }
 
     let app = test_helpers::create_test_app_with_db(db);
 
     let (status, body) = get_usage(
         &app,
-        "from=2025-01-01&to=2025-03-01&granularity=month",
+        "start=2025-03-10&end=2025-03-17&granularity=week",
         Some(&admin_cookie),
     )
     .await;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body.get("granularity").unwrap().as_str().unwrap(), "month");
 
-    // Totals should cover all 3 sessions.
-    let totals = body.get("totals").unwrap();
-    assert_eq!(totals.get("session_count").unwrap().as_i64().unwrap(), 3);
+    // Sessions KPI should reflect the 2 sessions in the main window.
+    let kpis = array_field(&body, "kpis");
+    let sessions_kpi = kpis
+        .iter()
+        .find(|k| k.get("label").and_then(Value::as_str) == Some("Sessions"))
+        .expect("Sessions KPI");
+    assert_eq!(sessions_kpi.get("value").unwrap().as_f64().unwrap(), 2.0);
 
-    // Monthly series should have at most 2 buckets (Jan and Feb).
-    let series = body.get("series").unwrap().as_array().unwrap();
-    assert!(
-        series.len() <= 2,
-        "expected at most 2 monthly buckets, got {}",
-        series.len()
-    );
+    // Weekly series buckets to the Monday week-start (2025-03-10).
+    let series = array_field(&body, "time_series");
+    assert!(!series.is_empty(), "weekly series should have a point");
+    for point in series {
+        let date = point.get("date").unwrap().as_str().unwrap();
+        assert_eq!(date, "2025-03-10", "expected week-start Monday, got {date}");
+    }
 }
 
 // ── Nullable cost semantics ──────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn null_cost_fields_serialize_as_json_null() {
+async fn null_cost_yields_null_spend_kpi_and_series_cost() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
 
     seed_project(&db, "proj-nullcost", "nullcost-project").await;
-
-    // Seed a session with NULL cost_usd.
     seed_session_row(
         &db,
         SessionSeed {
@@ -552,7 +416,7 @@ async fn null_cost_fields_serialize_as_json_null() {
             tokens_out: 50,
             cache_read_tokens: 10,
             cache_write_tokens: 5,
-            cost_usd: None, // unpriced
+            cost_usd: None,
             task_id: None,
         },
     )
@@ -561,24 +425,27 @@ async fn null_cost_fields_serialize_as_json_null() {
     let app = test_helpers::create_test_app_with_db(db);
 
     let (status, body) =
-        get_usage(&app, "from=2025-03-01&to=2025-04-01", Some(&admin_cookie)).await;
+        get_usage(&app, "start=2025-03-01&end=2025-04-01", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::OK);
 
-    // total_cost_usd must be JSON null (not 0.0) when sessions are unpriced.
-    let totals = body.get("totals").unwrap();
+    let kpis = array_field(&body, "kpis");
+    let spend = kpis
+        .iter()
+        .find(|k| k.get("label").and_then(Value::as_str) == Some("Spend"))
+        .expect("Spend KPI");
     assert!(
-        totals.get("total_cost_usd").unwrap().is_null(),
-        "expected null total_cost_usd for unpriced sessions, got: {}",
-        totals.get("total_cost_usd").unwrap()
+        spend.get("value").unwrap().is_null(),
+        "expected null Spend value for unpriced sessions, got: {}",
+        spend.get("value").unwrap()
     );
 
-    // previous_totals should also have null cost (no sessions in previous window).
-    let prev = body.get("previous_totals").unwrap();
+    let series = array_field(&body, "time_series");
+    assert!(!series.is_empty());
     assert!(
-        prev.get("total_cost_usd").unwrap().is_null(),
-        "expected null total_cost_usd in previous_totals, got: {}",
-        prev.get("total_cost_usd").unwrap()
+        series[0].get("cost").unwrap().is_null(),
+        "expected null series cost for unpriced bucket, got: {}",
+        series[0].get("cost").unwrap()
     );
 }
 
@@ -592,7 +459,7 @@ async fn invalid_granularity_returns_400() {
 
     let (status, body) = get_usage(
         &app,
-        "from=2025-01-01&to=2025-02-01&granularity=hourly",
+        "start=2025-01-01&end=2025-02-01&granularity=hourly",
         Some(&admin_cookie),
     )
     .await;
@@ -606,24 +473,16 @@ async fn invalid_granularity_returns_400() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn invalid_group_by_returns_400() {
+async fn invalid_preset_returns_400() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
-    let (status, body) = get_usage(
-        &app,
-        "from=2025-01-01&to=2025-02-01&group_by=invalid_dimension",
-        Some(&admin_cookie),
-    )
-    .await;
+    let (status, body) = get_usage(&app, "preset=90d", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let msg = body.get("_raw").and_then(|v| v.as_str()).unwrap_or("");
-    assert!(
-        msg.contains("group_by") || msg.contains("invalid_dimension"),
-        "expected group_by error, got: {msg}"
-    );
+    assert!(msg.contains("preset") || msg.contains("90d"), "got: {msg}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -632,9 +491,8 @@ async fn reversed_date_range_returns_400() {
     let admin_cookie = seed_admin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
-    // from >= to
     let (status, body) =
-        get_usage(&app, "from=2025-03-01&to=2025-03-01", Some(&admin_cookie)).await;
+        get_usage(&app, "start=2025-03-01&end=2025-03-01", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let msg = body.get("_raw").and_then(|v| v.as_str()).unwrap_or("");
@@ -650,24 +508,8 @@ async fn invalid_date_format_returns_400() {
     let admin_cookie = seed_admin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
-    let (status, body) =
-        get_usage(&app, "from=not-a-date&to=2025-02-01", Some(&admin_cookie)).await;
-
-    assert_eq!(status, StatusCode::BAD_REQUEST);
-    let msg = body.get("_raw").and_then(|v| v.as_str()).unwrap_or("");
-    assert!(
-        msg.contains("from") || msg.contains("YYYY-MM-DD"),
-        "expected date format error, got: {msg}"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn invalid_month_day_returns_400() {
-    let db = test_helpers::create_test_db();
-    let admin_cookie = seed_admin_session(&db).await;
-    let app = test_helpers::create_test_app_with_db(db);
-
-    let (status, _) = get_usage(&app, "from=2025-02-30&to=2025-03-01", Some(&admin_cookie)).await;
+    let (status, _) =
+        get_usage(&app, "start=not-a-date&end=2025-02-01", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
@@ -680,18 +522,17 @@ async fn omitted_query_params_apply_defaults() {
     let admin_cookie = seed_admin_session(&db).await;
     let app = test_helpers::create_test_app_with_db(db);
 
-    // No query params at all — should default to day granularity and succeed.
     let (status, body) = get_usage(&app, "", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body.get("granularity").unwrap().as_str().unwrap(), "day");
-    assert!(body.get("totals").unwrap().is_object());
+    assert!(body.get("kpis").unwrap().is_array());
+    assert!(body.get("generated_at").unwrap().is_string());
 }
 
 // ── Model effectiveness field coverage ─────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn admin_request_with_worker_session_returns_model_effectiveness_fields() {
+async fn model_effectiveness_uses_frontend_field_names() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
 
@@ -726,105 +567,40 @@ async fn admin_request_with_worker_session_returns_model_effectiveness_fields() 
     let app = test_helpers::create_test_app_with_db(db);
 
     let (status, body) =
-        get_usage(&app, "from=2025-03-01&to=2025-04-01", Some(&admin_cookie)).await;
+        get_usage(&app, "start=2025-03-01&end=2025-04-01", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::OK);
 
-    let me = body.get("model_effectiveness").unwrap().as_array().unwrap();
-    assert!(
-        !me.is_empty(),
-        "model_effectiveness should have at least one element"
-    );
+    let me = array_field(&body, "model_effectiveness");
+    assert!(!me.is_empty(), "model_effectiveness should have a row");
 
-    let first = model_effectiveness_row(me, "test-model");
+    let row = model_effectiveness_row(me, "test-model");
     for field in [
-        "model_id",
-        "sessions",
-        "tokens_in",
-        "tokens_out",
-        "completed_task_count",
+        "model",
+        "task_count",
         "success_rate",
         "avg_reopens",
-        "cost_per_completed_task",
-        "tokens_per_task",
+        "cost_per_task",
+        "total_cost",
+        "total_tokens",
+        "session_count",
+        "completed_task_count",
     ] {
         assert!(
-            first.get(field).is_some(),
-            "missing model_effectiveness field '{field}' in response: {first}"
+            row.get(field).is_some(),
+            "missing model_effectiveness field '{field}' in {row}"
         );
     }
-
-    assert!(first.get("model_id").unwrap().is_string());
-    assert!(first.get("sessions").unwrap().is_number());
-    assert!(first.get("tokens_in").unwrap().is_number());
-    assert!(first.get("tokens_out").unwrap().is_number());
-    assert!(first.get("completed_task_count").unwrap().is_number());
-    assert!(first.get("success_rate").unwrap().is_number());
-    assert!(first.get("avg_reopens").unwrap().is_number());
-    assert!(first.get("cost_per_completed_task").unwrap().is_number());
-    assert!(first.get("tokens_per_task").unwrap().is_number());
+    assert!(row.get("model").unwrap().is_string());
+    assert!(row.get("session_count").unwrap().is_number());
+    assert_eq!(row.get("total_tokens").unwrap().as_i64().unwrap(), 150);
+    // Repository-only names must not leak into the API.
+    assert!(row.get("model_id").is_none());
+    assert!(row.get("spend_usd").is_none());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn model_effectiveness_response_contains_all_metric_fields() {
-    let db = test_helpers::create_test_db();
-    let admin_cookie = seed_admin_session(&db).await;
-
-    seed_project(&db, "proj-metrics", "metrics-project").await;
-    let task_id = seed_task_row(
-        &db,
-        TaskSeed {
-            project_id: "proj-metrics",
-            status: "closed",
-            close_reason: Some("completed"),
-            total_reopen_count: 2,
-        },
-    )
-    .await;
-    seed_session_row(
-        &db,
-        SessionSeed {
-            project_id: "proj-metrics",
-            model_id: "metric-model",
-            agent_type: "worker",
-            started_at: "2025-03-11T10:00:00Z",
-            tokens_in: 1000,
-            tokens_out: 500,
-            cache_read_tokens: 100,
-            cache_write_tokens: 50,
-            cost_usd: Some(2.50),
-            task_id: Some(&task_id),
-        },
-    )
-    .await;
-
-    let app = test_helpers::create_test_app_with_db(db);
-
-    let (status, body) =
-        get_usage(&app, "from=2025-03-01&to=2025-04-01", Some(&admin_cookie)).await;
-
-    assert_eq!(status, StatusCode::OK);
-
-    let me = body.get("model_effectiveness").unwrap().as_array().unwrap();
-    assert!(
-        !me.is_empty(),
-        "model_effectiveness should have at least one element"
-    );
-
-    let first = model_effectiveness_row(me, "metric-model");
-    assert!(first.get("model_id").unwrap().is_string());
-    assert!(first.get("sessions").unwrap().is_number());
-    assert!(first.get("tokens_in").unwrap().is_number());
-    assert!(first.get("tokens_out").unwrap().is_number());
-    assert!(first.get("completed_task_count").unwrap().is_number());
-    assert!(first.get("success_rate").unwrap().is_number());
-    assert!(first.get("avg_reopens").unwrap().is_number());
-    assert!(first.get("cost_per_completed_task").unwrap().is_number());
-    assert!(first.get("tokens_per_task").unwrap().is_number());
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn model_effectiveness_null_cost_serializes_correctly() {
+async fn model_effectiveness_null_cost_serializes_total_cost_null() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
 
@@ -850,7 +626,7 @@ async fn model_effectiveness_null_cost_serializes_correctly() {
             tokens_out: 50,
             cache_read_tokens: 10,
             cache_write_tokens: 5,
-            cost_usd: None, // NULL cost
+            cost_usd: None,
             task_id: Some(&task_id),
         },
     )
@@ -859,39 +635,95 @@ async fn model_effectiveness_null_cost_serializes_correctly() {
     let app = test_helpers::create_test_app_with_db(db);
 
     let (status, body) =
-        get_usage(&app, "from=2025-03-01&to=2025-04-01", Some(&admin_cookie)).await;
+        get_usage(&app, "start=2025-03-01&end=2025-04-01", Some(&admin_cookie)).await;
 
     assert_eq!(status, StatusCode::OK);
 
-    let me = body.get("model_effectiveness").unwrap().as_array().unwrap();
+    let me = array_field(&body, "model_effectiveness");
+    let row = model_effectiveness_row(me, "unpriced-model");
     assert!(
-        !me.is_empty(),
-        "model_effectiveness should have at least one element"
-    );
-
-    let first = model_effectiveness_row(me, "unpriced-model");
-    assert!(
-        first.get("spend_usd").unwrap().is_null(),
-        "expected spend_usd to be JSON null for unpriced model, got: {}",
-        first.get("spend_usd").unwrap()
+        row.get("total_cost").unwrap().is_null(),
+        "expected total_cost null for unpriced model, got: {}",
+        row.get("total_cost").unwrap()
     );
 }
 
-// ── Breakdown group_by dimension ─────────────────────────────────────────────
+// ── Entity breakdowns + matrix ───────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn all_group_by_dimensions_are_accepted() {
+async fn breakdowns_and_matrix_populate_from_seeded_session() {
     let db = test_helpers::create_test_db();
     let admin_cookie = seed_admin_session(&db).await;
+
+    seed_project(&db, "proj-bd", "breakdown-project").await;
+    let task_id = seed_task_row(
+        &db,
+        TaskSeed {
+            project_id: "proj-bd",
+            status: "closed",
+            close_reason: Some("completed"),
+            total_reopen_count: 1,
+        },
+    )
+    .await;
+    seed_session_row(
+        &db,
+        SessionSeed {
+            project_id: "proj-bd",
+            model_id: "model-bd",
+            agent_type: "worker",
+            started_at: "2025-03-11T10:00:00Z",
+            tokens_in: 100,
+            tokens_out: 50,
+            cache_read_tokens: 10,
+            cache_write_tokens: 5,
+            cost_usd: Some(4.00),
+            task_id: Some(&task_id),
+        },
+    )
+    .await;
+
     let app = test_helpers::create_test_app_with_db(db);
 
-    for dim in ["model", "project", "user", "proposal", "task", "agent"] {
-        let (status, _) = get_usage(
-            &app,
-            &format!("from=2025-01-01&to=2025-02-01&group_by={dim}"),
-            Some(&admin_cookie),
-        )
-        .await;
-        assert_eq!(status, StatusCode::OK, "group_by={dim} should be accepted");
-    }
+    let (status, body) =
+        get_usage(&app, "start=2025-03-01&end=2025-04-01", Some(&admin_cookie)).await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    // by_project: a row keyed by the project id with the human-readable name.
+    let by_project = array_field(body.get("breakdowns").unwrap(), "by_project");
+    let proj_row = by_project
+        .iter()
+        .find(|r| r.get("id").and_then(Value::as_str) == Some("proj-bd"))
+        .expect("by_project row for proj-bd");
+    assert_eq!(
+        proj_row.get("name").unwrap().as_str().unwrap(),
+        "breakdown-project"
+    );
+    assert!((proj_row.get("cost").unwrap().as_f64().unwrap() - 4.0).abs() < 1e-9);
+
+    // by_task: a row keyed by the task id, carrying a task_id link field and a
+    // derived cost_per_task.
+    let by_task = array_field(body.get("breakdowns").unwrap(), "by_task");
+    let task_row = by_task
+        .iter()
+        .find(|r| r.get("id").and_then(Value::as_str) == Some(task_id.as_str()))
+        .expect("by_task row for the seeded task");
+    assert_eq!(
+        task_row.get("task_id").unwrap().as_str().unwrap(),
+        task_id.as_str()
+    );
+    assert!((task_row.get("cost_per_task").unwrap().as_f64().unwrap() - 4.0).abs() < 1e-9);
+
+    // project_model_matrix: a cell for (proj-bd, model-bd) with frontend names.
+    let matrix = array_field(&body, "project_model_matrix");
+    let cell = matrix
+        .iter()
+        .find(|c| {
+            c.get("project_id").and_then(Value::as_str) == Some("proj-bd")
+                && c.get("model").and_then(Value::as_str) == Some("model-bd")
+        })
+        .expect("matrix cell for proj-bd/model-bd");
+    assert!((cell.get("total_cost").unwrap().as_f64().unwrap() - 4.0).abs() < 1e-9);
+    assert_eq!(cell.get("total_tokens").unwrap().as_i64().unwrap(), 150);
 }

--- a/server/src/server/usage_analytics.rs
+++ b/server/src/server/usage_analytics.rs
@@ -1,11 +1,15 @@
 // HTTP handler for the `/api/admin/usage` REST endpoint consumed by the
 // admin analytics UI.
 //
-// Returns the proposal response shape for usage/cost reporting:
-// `totals`, `previous_totals`, `series`, `breakdown`, `model_effectiveness`,
-// and `project_model_matrix`. The repository deliberately returns daily rows;
-// this handler maps those ISO day buckets into requested day/week/month periods
-// using deterministic Rust date arithmetic.
+// Emits exactly the shape the dashboard consumes:
+//   `kpis`, `time_series`, `breakdowns` (by_user/by_project/by_proposal/by_task),
+//   `model_effectiveness`, `project_model_matrix`, and `generated_at`.
+//
+// The repository returns daily multi-dimensional series rows; this handler
+// maps those ISO day buckets into requested day/week/month periods using
+// deterministic Rust date arithmetic, derives the KPI cards from the current
+// and previous window totals, and renames repository fields to the frontend
+// contract.
 
 use axum::{
     Json, Router,
@@ -20,8 +24,8 @@ use serde::{Deserialize, Serialize};
 use crate::server::AppState;
 use crate::server::auth::require_admin;
 use djinn_db::{
-    BreakdownRow, DailySeriesRow, GroupDimension, ModelEffectivenessRow, ProjectModelMatrixRow,
-    UsageAnalyticsQuery, UsageAnalyticsRepository, UsageAnalyticsResult, UsageTotals,
+    EntityBreakdownRow, GroupDimension, ModelEffectivenessRow, ProjectModelMatrixRow,
+    SeriesDetailRow, UsageAnalyticsQuery, UsageAnalyticsRepository, UsageTotals,
 };
 
 pub(super) fn router() -> Router<AppState> {
@@ -33,16 +37,21 @@ pub(super) fn router() -> Router<AppState> {
 
 // ── Query parsing ────────────────────────────────────────────────────────────
 
-/// Raw query params deserialised from the request URL.  All are optional;
-/// defaults and validation are applied in [`UsageQuery::into_typed`].
+/// Raw query params deserialised from the request URL.  Mirrors the frontend
+/// `UsageAnalyticsFilters` exactly.  All are optional; defaults and validation
+/// are applied in [`UsageQuery::into_typed`].
 #[derive(Debug, Deserialize)]
 struct UsageQuery {
-    from: Option<String>,
-    to: Option<String>,
+    /// Shorthand date range; mutually exclusive with start/end.
+    preset: Option<String>,
+    /// ISO start date (inclusive); used only when `preset` is absent.
+    start: Option<String>,
+    /// ISO end date (exclusive); used only when `preset` is absent.
+    end: Option<String>,
     granularity: Option<String>,
-    group_by: Option<String>,
     project_id: Option<String>,
-    model_id: Option<String>,
+    /// Model identifier filter.
+    model: Option<String>,
     agent_type: Option<String>,
 }
 
@@ -70,32 +79,11 @@ impl Granularity {
     }
 }
 
-/// Parse a `group_by` query value into the repository's `GroupDimension`.
-/// Accepts the same identifiers used in the SQL column expressions.
-fn parse_group_by(raw: Option<&str>) -> Result<GroupDimension, (StatusCode, String)> {
-    match raw.map(str::to_ascii_lowercase).as_deref() {
-        None | Some("model") => Ok(GroupDimension::Model),
-        Some("project") => Ok(GroupDimension::Project),
-        Some("user") => Ok(GroupDimension::User),
-        Some("proposal") => Ok(GroupDimension::Proposal),
-        Some("task") => Ok(GroupDimension::Task),
-        Some("agent") => Ok(GroupDimension::Agent),
-        Some(other) => Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "invalid group_by '{other}' (expected model, project, user, proposal, task, or agent)"
-            ),
-        )),
-    }
-}
-
-/// Default `from`/`to` window (last 30 days, ISO-8601) when the client omits
-/// either bound.  Kept here rather than the repository so the endpoint owns
-/// its own HTTP-facing defaults.
-fn default_window() -> (String, String) {
+/// A `from`/`to` window ending now and spanning `days` days, in RFC3339.
+fn window_days(days: i64) -> (String, String) {
     use time::format_description::well_known::Rfc3339;
     let now = time::OffsetDateTime::now_utc();
-    let start = now - time::Duration::days(30);
+    let start = now - time::Duration::days(days);
     let to = now.format(&Rfc3339).unwrap_or_default();
     let from = start.format(&Rfc3339).unwrap_or_default();
     (from, to)
@@ -106,11 +94,15 @@ fn default_window() -> (String, String) {
 /// either a date (`YYYY-MM-DD`) or a timestamp whose first 10 characters are an
 /// ISO date prefix.
 fn parse_iso_date_prefix(name: &str, value: &str) -> Result<time::Date, (StatusCode, String)> {
-    let Some(date) = value.get(..10) else {
-        return Err((
+    let invalid = || {
+        (
             StatusCode::BAD_REQUEST,
             format!("invalid {name}: expected YYYY-MM-DD or ISO-8601 timestamp"),
-        ));
+        )
+    };
+
+    let Some(date) = value.get(..10) else {
+        return Err(invalid());
     };
 
     let bytes = date.as_bytes();
@@ -122,53 +114,17 @@ fn parse_iso_date_prefix(name: &str, value: &str) -> Result<time::Date, (StatusC
             .enumerate()
             .all(|(idx, b)| idx == 4 || idx == 7 || b.is_ascii_digit());
     if !valid_shape {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!("invalid {name}: expected YYYY-MM-DD or ISO-8601 timestamp"),
-        ));
+        return Err(invalid());
     }
 
-    let year = date[0..4].parse::<i32>().map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("invalid {name}: expected YYYY-MM-DD or ISO-8601 timestamp"),
-        )
-    })?;
-    let month = date[5..7].parse::<u8>().map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("invalid {name}: expected YYYY-MM-DD or ISO-8601 timestamp"),
-        )
-    })?;
-    let day = date[8..10].parse::<u8>().map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("invalid {name}: expected YYYY-MM-DD or ISO-8601 timestamp"),
-        )
-    })?;
-    let month = time::Month::try_from(month).map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("invalid {name}: expected YYYY-MM-DD or ISO-8601 timestamp"),
-        )
-    })?;
-    time::Date::from_calendar_date(year, month, day).map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("invalid {name}: expected YYYY-MM-DD or ISO-8601 timestamp"),
-        )
-    })
-}
-
-fn validate_date_bound(name: &str, value: String) -> Result<String, (StatusCode, String)> {
-    parse_iso_date_prefix(name, &value)?;
-
-    Ok(value)
+    let year = date[0..4].parse::<i32>().map_err(|_| invalid())?;
+    let month = date[5..7].parse::<u8>().map_err(|_| invalid())?;
+    let day = date[8..10].parse::<u8>().map_err(|_| invalid())?;
+    let month = time::Month::try_from(month).map_err(|_| invalid())?;
+    time::Date::from_calendar_date(year, month, day).map_err(|_| invalid())
 }
 
 fn validate_date_range(from: String, to: String) -> Result<(String, String), (StatusCode, String)> {
-    let from = validate_date_bound("from", from)?;
-    let to = validate_date_bound("to", to)?;
     let from_date = parse_iso_date_prefix("from", &from)?;
     let to_date = parse_iso_date_prefix("to", &to)?;
     if from_date >= to_date {
@@ -221,24 +177,52 @@ fn previous_window_query(
 }
 
 impl UsageQuery {
+    /// Resolve the effective `from`/`to` window from `preset` or `start`/`end`,
+    /// applying a default 30-day window when nothing is supplied.
+    fn resolve_window(&self) -> Result<(String, String), (StatusCode, String)> {
+        if let Some(preset) = self.preset.as_deref().filter(|s| !s.is_empty()) {
+            let days = match preset.to_ascii_lowercase().as_str() {
+                "7d" => 7,
+                "30d" => 30,
+                other => {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!("invalid preset '{other}' (expected 7d or 30d)"),
+                    ));
+                }
+            };
+            return Ok(window_days(days));
+        }
+
+        let (default_from, default_to) = window_days(30);
+        let from = self
+            .start
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(default_from);
+        let to = self
+            .end
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(default_to);
+        validate_date_range(from, to)
+    }
+
     /// Validate the raw params and produce the typed repository query plus the
     /// parsed granularity.  Returns an HTTP-style error tuple on bad input.
     fn into_typed(self) -> Result<(UsageAnalyticsQuery, Granularity), (StatusCode, String)> {
         let granularity = Granularity::parse(self.granularity.as_deref())?;
-        let group_by = parse_group_by(self.group_by.as_deref())?;
-
-        let (default_from, default_to) = default_window();
-        let from = self.from.unwrap_or(default_from);
-        let to = self.to.unwrap_or(default_to);
-        let (from, to) = validate_date_range(from, to)?;
+        let (from, to) = self.resolve_window()?;
 
         Ok((
             UsageAnalyticsQuery {
                 from,
                 to,
-                group_by,
+                // The dashboard computes all four entity breakdowns; group_by is
+                // retained only for repository API compatibility.
+                group_by: GroupDimension::Model,
                 project_id: self.project_id.filter(|s| !s.is_empty()),
-                model_id: self.model_id.filter(|s| !s.is_empty()),
+                model_id: self.model.filter(|s| !s.is_empty()),
                 agent_type: self.agent_type.filter(|s| !s.is_empty()),
             },
             granularity,
@@ -247,157 +231,203 @@ impl UsageQuery {
 }
 
 // ── Response DTOs ────────────────────────────────────────────────────────────
-//
-// Cost fields are `Option<f64>` to preserve the repository's NULL/unpriced
-// semantics: an aggregate group with any unpriced model surfaces `null` in
-// JSON so the UI can render an em-dash instead of `$0`.
 
+/// A single KPI card derived from the current vs previous window totals.
 #[derive(Serialize)]
-struct TotalsDto {
-    session_count: i64,
-    tokens_in: i64,
-    tokens_out: i64,
-    cache_read_tokens: i64,
-    cache_write_tokens: i64,
-    total_cost_usd: Option<f64>,
+struct UsageKpiDto {
+    label: String,
+    /// Numeric value; `null` when unavailable (e.g. unpriced spend).
+    value: Option<f64>,
+    /// Period-over-period change as a fraction (0.12 == +12%); `null` when the
+    /// previous window was empty.
+    delta_pct: Option<f64>,
+    /// Pre-formatted display value (currency); empty string lets the UI fall
+    /// back to compact-number formatting of `value`.
+    formatted: String,
 }
 
-impl From<UsageTotals> for TotalsDto {
-    fn from(t: UsageTotals) -> Self {
-        Self {
-            session_count: t.session_count,
-            tokens_in: t.tokens_in,
-            tokens_out: t.tokens_out,
-            cache_read_tokens: t.cache_read_tokens,
-            cache_write_tokens: t.cache_write_tokens,
-            total_cost_usd: t.total_cost_usd,
-        }
-    }
-}
-
+/// A point in the multi-dimensional time series.  Carries the model / project /
+/// agent dimensions so the Overview tab can group spend client-side.
 #[derive(Serialize)]
 struct SeriesPointDto {
-    day: String,
-    session_count: i64,
+    date: String,
+    /// Spend in USD; `null` when any session in the bucket was unpriced.
+    cost: Option<f64>,
     tokens_in: i64,
     tokens_out: i64,
-    cache_read_tokens: i64,
-    cache_write_tokens: i64,
-    total_cost_usd: Option<f64>,
+    task_count: i64,
+    model: String,
+    project_id: String,
+    project_name: String,
+    agent_type: String,
 }
 
-impl From<DailySeriesRow> for SeriesPointDto {
-    fn from(r: DailySeriesRow) -> Self {
+/// A breakdown row for one entity (user / project / proposal / task).
+#[derive(Serialize)]
+struct BreakdownRowDto {
+    id: String,
+    name: String,
+    cost: Option<f64>,
+    tokens_in: i64,
+    tokens_out: i64,
+    task_count: i64,
+    success_rate: Option<f64>,
+    avg_reopens: Option<f64>,
+    cost_per_task: Option<f64>,
+    /// Present only for the by_task breakdown; lets the UI build a task link.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task_id: Option<String>,
+    /// Present only for the by_proposal breakdown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proposal_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct BreakdownsDto {
+    by_user: Vec<BreakdownRowDto>,
+    by_project: Vec<BreakdownRowDto>,
+    by_proposal: Vec<BreakdownRowDto>,
+    by_task: Vec<BreakdownRowDto>,
+}
+
+/// Per-model effectiveness, renamed to the frontend contract.
+#[derive(Serialize)]
+struct ModelEffectivenessDto {
+    model: String,
+    task_count: i64,
+    success_rate: Option<f64>,
+    avg_reopens: Option<f64>,
+    cost_per_task: Option<f64>,
+    total_cost: Option<f64>,
+    total_tokens: i64,
+    tokens_in: i64,
+    tokens_out: i64,
+    session_count: i64,
+    /// Shared-credit completed-task count (== task_count); surfaced separately
+    /// so the UI can label the attribution semantics.
+    completed_task_count: i64,
+}
+
+impl From<ModelEffectivenessRow> for ModelEffectivenessDto {
+    fn from(r: ModelEffectivenessRow) -> Self {
         Self {
-            day: r.day,
-            session_count: r.session_count,
+            model: r.model_id,
+            task_count: r.shared_credit_completed_task_count,
+            success_rate: r.success_rate,
+            avg_reopens: r.avg_reopens,
+            cost_per_task: r.cost_per_completed_task,
+            total_cost: r.spend_usd,
+            total_tokens: r.tokens_in + r.tokens_out,
             tokens_in: r.tokens_in,
             tokens_out: r.tokens_out,
-            cache_read_tokens: r.cache_read_tokens,
-            cache_write_tokens: r.cache_write_tokens,
-            total_cost_usd: r.total_cost_usd,
+            session_count: r.sessions,
+            completed_task_count: r.shared_credit_completed_task_count,
+        }
+    }
+}
+
+/// Project × model matrix cell, renamed to the frontend contract.
+#[derive(Serialize)]
+struct ProjectModelCellDto {
+    project_id: String,
+    project_name: String,
+    model: String,
+    cost_per_task: Option<f64>,
+    success_rate: Option<f64>,
+    avg_reopens: Option<f64>,
+    total_cost: Option<f64>,
+    total_tokens: i64,
+}
+
+impl From<ProjectModelMatrixRow> for ProjectModelCellDto {
+    fn from(r: ProjectModelMatrixRow) -> Self {
+        let cost_per_task = match (r.spend_usd, r.task_count) {
+            (Some(cost), n) if n > 0 => Some(cost / n as f64),
+            _ => None,
+        };
+        Self {
+            project_id: r.project_id,
+            project_name: r.project_name,
+            model: r.model_id,
+            cost_per_task,
+            success_rate: r.success_rate,
+            avg_reopens: r.avg_reopens,
+            total_cost: r.spend_usd,
+            total_tokens: r.tokens_in + r.tokens_out,
         }
     }
 }
 
 #[derive(Serialize)]
-struct BreakdownPointDto {
-    group_key: String,
-    day: String,
-    session_count: i64,
-    tokens_in: i64,
-    tokens_out: i64,
-    cache_read_tokens: i64,
-    cache_write_tokens: i64,
-    total_cost_usd: Option<f64>,
+struct UsageResponse {
+    kpis: Vec<UsageKpiDto>,
+    time_series: Vec<SeriesPointDto>,
+    breakdowns: BreakdownsDto,
+    model_effectiveness: Vec<ModelEffectivenessDto>,
+    project_model_matrix: Vec<ProjectModelCellDto>,
+    /// RFC3339 timestamp when the response was generated.
+    generated_at: String,
 }
 
-impl From<BreakdownRow> for BreakdownPointDto {
-    fn from(r: BreakdownRow) -> Self {
-        Self {
-            group_key: r.group_key,
-            day: r.day,
-            session_count: r.session_count,
-            tokens_in: r.tokens_in,
-            tokens_out: r.tokens_out,
-            cache_read_tokens: r.cache_read_tokens,
-            cache_write_tokens: r.cache_write_tokens,
-            total_cost_usd: r.total_cost_usd,
-        }
+// ── Derivations ──────────────────────────────────────────────────────────────
+
+/// Currency formatting that mirrors the frontend `formatCurrency` precision.
+fn format_currency(value: f64) -> String {
+    if value >= 100.0 {
+        format!("${value:.0}")
+    } else {
+        format!("${value:.2}")
     }
 }
 
-#[derive(Debug, Default)]
-struct UsageAccumulator {
-    session_count: i64,
-    tokens_in: i64,
-    tokens_out: i64,
-    cache_read_tokens: i64,
-    cache_write_tokens: i64,
-    total_cost_usd: f64,
-    cost_known: bool,
-}
-
-impl UsageAccumulator {
-    fn add_values(
-        &mut self,
-        session_count: i64,
-        tokens_in: i64,
-        tokens_out: i64,
-        cache_read_tokens: i64,
-        cache_write_tokens: i64,
-        total_cost_usd: Option<f64>,
-    ) {
-        self.session_count += session_count;
-        self.tokens_in += tokens_in;
-        self.tokens_out += tokens_out;
-        self.cache_read_tokens += cache_read_tokens;
-        self.cache_write_tokens += cache_write_tokens;
-
-        let has_usage = session_count != 0
-            || tokens_in != 0
-            || tokens_out != 0
-            || cache_read_tokens != 0
-            || cache_write_tokens != 0;
-        match total_cost_usd {
-            Some(cost) if self.cost_known => self.total_cost_usd += cost,
-            Some(_) => {}
-            None if has_usage => self.cost_known = false,
-            None => {}
-        }
-    }
-
-    fn into_series_point(self, day: String) -> SeriesPointDto {
-        SeriesPointDto {
-            day,
-            session_count: self.session_count,
-            tokens_in: self.tokens_in,
-            tokens_out: self.tokens_out,
-            cache_read_tokens: self.cache_read_tokens,
-            cache_write_tokens: self.cache_write_tokens,
-            total_cost_usd: self.cost_known.then_some(self.total_cost_usd),
-        }
-    }
-
-    fn into_breakdown_point(self, group_key: String, day: String) -> BreakdownPointDto {
-        BreakdownPointDto {
-            group_key,
-            day,
-            session_count: self.session_count,
-            tokens_in: self.tokens_in,
-            tokens_out: self.tokens_out,
-            cache_read_tokens: self.cache_read_tokens,
-            cache_write_tokens: self.cache_write_tokens,
-            total_cost_usd: self.cost_known.then_some(self.total_cost_usd),
-        }
+/// Period-over-period change as a fraction; `None` when the prior value is ~0.
+fn pct_delta(current: f64, previous: f64) -> Option<f64> {
+    if previous.abs() < f64::EPSILON {
+        None
+    } else {
+        Some((current - previous) / previous)
     }
 }
 
-fn empty_accumulator() -> UsageAccumulator {
-    UsageAccumulator {
-        cost_known: true,
-        ..UsageAccumulator::default()
-    }
+/// Build the KPI cards from current and previous window totals.
+fn build_kpis(totals: &UsageTotals, previous: &UsageTotals) -> Vec<UsageKpiDto> {
+    let spend_delta = match (totals.total_cost_usd, previous.total_cost_usd) {
+        (Some(cur), Some(prev)) => pct_delta(cur, prev),
+        _ => None,
+    };
+
+    let tokens = (totals.tokens_in + totals.tokens_out) as f64;
+    let prev_tokens = (previous.tokens_in + previous.tokens_out) as f64;
+
+    vec![
+        UsageKpiDto {
+            label: "Spend".to_string(),
+            value: totals.total_cost_usd,
+            delta_pct: spend_delta,
+            formatted: totals.total_cost_usd.map(format_currency).unwrap_or_default(),
+        },
+        UsageKpiDto {
+            label: "Tokens".to_string(),
+            value: Some(tokens),
+            delta_pct: pct_delta(tokens, prev_tokens),
+            formatted: String::new(),
+        },
+        UsageKpiDto {
+            label: "Sessions".to_string(),
+            value: Some(totals.session_count as f64),
+            delta_pct: pct_delta(totals.session_count as f64, previous.session_count as f64),
+            formatted: String::new(),
+        },
+        UsageKpiDto {
+            label: "Cache reads".to_string(),
+            value: Some(totals.cache_read_tokens as f64),
+            delta_pct: pct_delta(
+                totals.cache_read_tokens as f64,
+                previous.cache_read_tokens as f64,
+            ),
+            formatted: String::new(),
+        },
+    ]
 }
 
 fn week_start(date: time::Date) -> Result<time::Date, (StatusCode, String)> {
@@ -434,179 +464,132 @@ fn period_start(day: &str, granularity: Granularity) -> Result<String, (StatusCo
     Ok(format_date(start))
 }
 
+/// Accumulates spend (preserving NULL-unpriced semantics) and token/task
+/// counters for a rolled-up series bucket.
+struct SeriesAccumulator {
+    tokens_in: i64,
+    tokens_out: i64,
+    task_count: i64,
+    cost_sum: f64,
+    cost_known: bool,
+    any_usage: bool,
+}
+
+impl Default for SeriesAccumulator {
+    fn default() -> Self {
+        // `cost_known` starts true and flips to false the first time an
+        // unpriced (NULL cost) row with usage is folded in.
+        Self {
+            tokens_in: 0,
+            tokens_out: 0,
+            task_count: 0,
+            cost_sum: 0.0,
+            cost_known: true,
+            any_usage: false,
+        }
+    }
+}
+
+impl SeriesAccumulator {
+    fn add(&mut self, row: &SeriesDetailRow) {
+        self.tokens_in += row.tokens_in;
+        self.tokens_out += row.tokens_out;
+        self.task_count += row.task_count;
+        self.any_usage = true;
+        match row.cost {
+            Some(cost) if self.cost_known => self.cost_sum += cost,
+            Some(_) => {}
+            None => self.cost_known = false,
+        }
+    }
+
+    fn cost(&self) -> Option<f64> {
+        if self.cost_known && self.any_usage {
+            Some(self.cost_sum)
+        } else {
+            None
+        }
+    }
+}
+
+/// Roll up the daily multi-dimensional series into the requested granularity,
+/// grouping by (period, model, project, agent).
 fn rollup_series(
-    rows: Vec<DailySeriesRow>,
+    rows: Vec<SeriesDetailRow>,
     granularity: Granularity,
 ) -> Result<Vec<SeriesPointDto>, (StatusCode, String)> {
-    if granularity == Granularity::Day {
-        return Ok(rows.into_iter().map(Into::into).collect());
-    }
+    // Key: (period, model, project_id, project_name, agent_type). project_name
+    // is part of the key purely to carry it through; it is functionally
+    // dependent on project_id.
+    type Key = (String, String, String, String, String);
+    let mut buckets: BTreeMap<Key, SeriesAccumulator> = BTreeMap::new();
 
-    let mut by_period: BTreeMap<String, UsageAccumulator> = BTreeMap::new();
     for row in rows {
         let period = period_start(&row.day, granularity)?;
-        by_period
-            .entry(period)
-            .or_insert_with(empty_accumulator)
-            .add_values(
-                row.session_count,
-                row.tokens_in,
-                row.tokens_out,
-                row.cache_read_tokens,
-                row.cache_write_tokens,
-                row.total_cost_usd,
-            );
+        let key = (
+            period,
+            row.model.clone(),
+            row.project_id.clone(),
+            row.project_name.clone(),
+            row.agent_type.clone(),
+        );
+        buckets.entry(key).or_default().add(&row);
     }
 
-    Ok(by_period
+    Ok(buckets
         .into_iter()
-        .map(|(day, acc)| acc.into_series_point(day))
-        .collect())
-}
-
-fn rollup_breakdown(
-    rows: Vec<BreakdownRow>,
-    granularity: Granularity,
-) -> Result<Vec<BreakdownPointDto>, (StatusCode, String)> {
-    if granularity == Granularity::Day {
-        let mut rows: Vec<_> = rows.into_iter().map(Into::into).collect();
-        rows.sort_by(|a: &BreakdownPointDto, b| {
-            a.group_key
-                .cmp(&b.group_key)
-                .then_with(|| a.day.cmp(&b.day))
-        });
-        return Ok(rows);
-    }
-
-    let mut by_group_period: BTreeMap<(String, String), UsageAccumulator> = BTreeMap::new();
-    for row in rows {
-        let period = period_start(&row.day, granularity)?;
-        by_group_period
-            .entry((row.group_key, period))
-            .or_insert_with(empty_accumulator)
-            .add_values(
-                row.session_count,
-                row.tokens_in,
-                row.tokens_out,
-                row.cache_read_tokens,
-                row.cache_write_tokens,
-                row.total_cost_usd,
-            );
-    }
-
-    Ok(by_group_period
-        .into_iter()
-        .map(|((group_key, day), acc)| acc.into_breakdown_point(group_key, day))
-        .collect())
-}
-
-/// Per-model effectiveness row.  Computed over worker sessions only.
-///
-/// Completed-task attribution uses shared-credit: every model that ran at
-/// least one worker session on a completed task receives credit for that task.
-/// The `completed_task_count` field reflects this shared-credit semantics;
-/// UI code should label it accordingly (e.g. "Tasks (shared credit)").
-#[derive(Serialize)]
-struct ModelEffectivenessDto {
-    model_id: String,
-    sessions: i64,
-    /// Aggregate spend in USD. NULL when all worker sessions for this model
-    /// used unpriced models.
-    spend_usd: Option<f64>,
-    tokens_in: i64,
-    tokens_out: i64,
-    /// Shared-credit completed-task count.
-    completed_task_count: i64,
-    success_rate: Option<f64>,
-    avg_reopens: Option<f64>,
-    /// Cost per completed task. NULL when no completed tasks or unpriced.
-    cost_per_completed_task: Option<f64>,
-    /// Average total tokens per completed task.
-    tokens_per_task: Option<f64>,
-}
-
-impl From<ModelEffectivenessRow> for ModelEffectivenessDto {
-    fn from(r: ModelEffectivenessRow) -> Self {
-        Self {
-            model_id: r.model_id,
-            sessions: r.sessions,
-            spend_usd: r.spend_usd,
-            tokens_in: r.tokens_in,
-            tokens_out: r.tokens_out,
-            completed_task_count: r.shared_credit_completed_task_count,
-            success_rate: r.success_rate,
-            avg_reopens: r.avg_reopens,
-            cost_per_completed_task: r.cost_per_completed_task,
-            tokens_per_task: r.tokens_per_task,
-        }
-    }
-}
-
-/// Project × model matrix entry for frontend consumption.
-#[derive(Serialize)]
-struct ProjectModelMatrixDto {
-    project_id: String,
-    model_id: String,
-    sessions: i64,
-    spend_usd: Option<f64>,
-    tokens_in: i64,
-    tokens_out: i64,
-}
-
-impl From<ProjectModelMatrixRow> for ProjectModelMatrixDto {
-    fn from(r: ProjectModelMatrixRow) -> Self {
-        Self {
-            project_id: r.project_id,
-            model_id: r.model_id,
-            sessions: r.sessions,
-            spend_usd: r.spend_usd,
-            tokens_in: r.tokens_in,
-            tokens_out: r.tokens_out,
-        }
-    }
-}
-
-#[derive(Serialize)]
-struct UsageResponse {
-    /// Echoes the requested granularity so the UI can label axes.
-    granularity: Granularity,
-    /// Overall totals across the queried window.
-    totals: TotalsDto,
-    /// Totals for the preceding window of equal length.
-    previous_totals: TotalsDto,
-    /// Time series for the window at the requested period granularity.
-    series: Vec<SeriesPointDto>,
-    /// Breakdown rows grouped by the requested dimension and period.
-    breakdown: Vec<BreakdownPointDto>,
-    /// Per-model effectiveness metrics (worker-scoped, shared-credit attribution).
-    model_effectiveness: Vec<ModelEffectivenessDto>,
-    /// Project × model spend/token matrix.
-    project_model_matrix: Vec<ProjectModelMatrixDto>,
-}
-
-impl UsageResponse {
-    fn from_results(
-        result: UsageAnalyticsResult,
-        previous_totals: UsageTotals,
-        granularity: Granularity,
-        effectiveness_rows: Vec<ModelEffectivenessRow>,
-        matrix_rows: Vec<ProjectModelMatrixRow>,
-    ) -> Result<Self, (StatusCode, String)> {
-        let UsageAnalyticsResult {
-            totals,
-            series,
-            breakdown,
-        } = result;
-        Ok(Self {
-            granularity,
-            totals: totals.into(),
-            previous_totals: previous_totals.into(),
-            series: rollup_series(series, granularity)?,
-            breakdown: rollup_breakdown(breakdown, granularity)?,
-            model_effectiveness: effectiveness_rows.into_iter().map(Into::into).collect(),
-            project_model_matrix: matrix_rows.into_iter().map(Into::into).collect(),
+        .map(|((date, model, project_id, project_name, agent_type), acc)| SeriesPointDto {
+            date,
+            cost: acc.cost(),
+            tokens_in: acc.tokens_in,
+            tokens_out: acc.tokens_out,
+            task_count: acc.task_count,
+            model,
+            project_id,
+            project_name,
+            agent_type,
         })
+        .collect())
+}
+
+/// Map a repository breakdown row to the response DTO, deriving cost-per-task
+/// and attaching the entity-specific link id.
+fn breakdown_row(row: EntityBreakdownRow, dimension: GroupDimension) -> BreakdownRowDto {
+    let cost_per_task = match (row.cost, row.task_count) {
+        (Some(cost), n) if n > 0 => Some(cost / n as f64),
+        _ => None,
+    };
+    let (task_id, proposal_id) = match dimension {
+        GroupDimension::Task => (Some(row.id.clone()), None),
+        GroupDimension::Proposal => (None, Some(row.id.clone())),
+        _ => (None, None),
+    };
+    BreakdownRowDto {
+        id: row.id,
+        name: row.name,
+        cost: row.cost,
+        tokens_in: row.tokens_in,
+        tokens_out: row.tokens_out,
+        task_count: row.task_count,
+        success_rate: row.success_rate,
+        avg_reopens: row.avg_reopens,
+        cost_per_task,
+        task_id,
+        proposal_id,
     }
+}
+
+fn breakdown_rows(rows: Vec<EntityBreakdownRow>, dimension: GroupDimension) -> Vec<BreakdownRowDto> {
+    rows.into_iter()
+        .map(|row| breakdown_row(row, dimension))
+        .collect()
+}
+
+fn now_rfc3339() -> String {
+    use time::format_description::well_known::Rfc3339;
+    time::OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_default()
 }
 
 // ── Handler ──────────────────────────────────────────────────────────────────
@@ -622,31 +605,50 @@ async fn usage_handler(
 ) -> Result<Json<UsageResponse>, (StatusCode, String)> {
     require_admin(&state, &headers).await?;
     let (query, granularity) = q.into_typed()?;
-
     let previous_query = previous_window_query(&query)?;
+
     let repo = UsageAnalyticsRepository::new(state.db().clone());
-    let result = repo
-        .query(&query)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    let previous = repo
-        .query(&previous_query)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let internal = |e: djinn_db::Error| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string());
 
-    // Model effectiveness (worker-scoped) and project × model matrix.
-    let (effectiveness_rows, matrix_rows) = repo
-        .query_effectiveness(&query)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let totals = repo.totals(&query).await.map_err(internal)?;
+    let previous = repo.totals(&previous_query).await.map_err(internal)?;
+    let series = repo.series_detailed(&query).await.map_err(internal)?;
 
-    Ok(Json(UsageResponse::from_results(
-        result,
-        previous.totals,
-        granularity,
-        effectiveness_rows,
-        matrix_rows,
-    )?))
+    let by_user = repo
+        .entity_breakdown(&query, GroupDimension::User)
+        .await
+        .map_err(internal)?;
+    let by_project = repo
+        .entity_breakdown(&query, GroupDimension::Project)
+        .await
+        .map_err(internal)?;
+    let by_proposal = repo
+        .entity_breakdown(&query, GroupDimension::Proposal)
+        .await
+        .map_err(internal)?;
+    let by_task = repo
+        .entity_breakdown(&query, GroupDimension::Task)
+        .await
+        .map_err(internal)?;
+
+    let (effectiveness_rows, matrix_rows) =
+        repo.query_effectiveness(&query).await.map_err(internal)?;
+
+    let response = UsageResponse {
+        kpis: build_kpis(&totals, &previous),
+        time_series: rollup_series(series, granularity)?,
+        breakdowns: BreakdownsDto {
+            by_user: breakdown_rows(by_user, GroupDimension::User),
+            by_project: breakdown_rows(by_project, GroupDimension::Project),
+            by_proposal: breakdown_rows(by_proposal, GroupDimension::Proposal),
+            by_task: breakdown_rows(by_task, GroupDimension::Task),
+        },
+        model_effectiveness: effectiveness_rows.into_iter().map(Into::into).collect(),
+        project_model_matrix: matrix_rows.into_iter().map(Into::into).collect(),
+        generated_at: now_rfc3339(),
+    };
+
+    Ok(Json(response))
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -655,16 +657,24 @@ async fn usage_handler(
 mod tests {
     use super::*;
 
+    fn empty_query() -> UsageQuery {
+        UsageQuery {
+            preset: None,
+            start: None,
+            end: None,
+            granularity: None,
+            project_id: None,
+            model: None,
+            agent_type: None,
+        }
+    }
+
     #[test]
     fn granularity_parses_known_values() {
         assert_eq!(Granularity::parse(None).unwrap(), Granularity::Day);
-        assert_eq!(Granularity::parse(Some("day")).unwrap(), Granularity::Day);
         assert_eq!(Granularity::parse(Some("DAY")).unwrap(), Granularity::Day);
         assert_eq!(Granularity::parse(Some("week")).unwrap(), Granularity::Week);
-        assert_eq!(
-            Granularity::parse(Some("month")).unwrap(),
-            Granularity::Month
-        );
+        assert_eq!(Granularity::parse(Some("month")).unwrap(), Granularity::Month);
     }
 
     #[test]
@@ -675,262 +685,78 @@ mod tests {
     }
 
     #[test]
-    fn group_by_parses_all_dimensions() {
-        assert_eq!(parse_group_by(None).unwrap(), GroupDimension::Model);
-        assert_eq!(
-            parse_group_by(Some("model")).unwrap(),
-            GroupDimension::Model
-        );
-        assert_eq!(
-            parse_group_by(Some("project")).unwrap(),
-            GroupDimension::Project
-        );
-        assert_eq!(parse_group_by(Some("user")).unwrap(), GroupDimension::User);
-        assert_eq!(
-            parse_group_by(Some("proposal")).unwrap(),
-            GroupDimension::Proposal
-        );
-        assert_eq!(parse_group_by(Some("task")).unwrap(), GroupDimension::Task);
-        assert_eq!(
-            parse_group_by(Some("agent")).unwrap(),
-            GroupDimension::Agent
-        );
-    }
-
-    #[test]
-    fn group_by_rejects_unknown() {
-        let err = parse_group_by(Some("foo")).unwrap_err();
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
-        assert!(err.1.contains("foo"));
-    }
-
-    #[test]
-    fn into_typed_applies_defaults_and_filters_blanks() {
+    fn into_typed_maps_model_filter_and_drops_blanks() {
         let q = UsageQuery {
-            from: Some("2025-01-01".into()),
-            to: Some("2025-02-01".into()),
+            start: Some("2025-01-01".into()),
+            end: Some("2025-02-01".into()),
             granularity: Some("day".into()),
-            group_by: Some("model".into()),
             project_id: Some("proj-1".into()),
-            model_id: Some("".into()),
-            agent_type: None,
+            model: Some("".into()),
+            ..empty_query()
         };
         let (typed, gran) = q.into_typed().unwrap();
         assert_eq!(typed.from, "2025-01-01");
         assert_eq!(typed.to, "2025-02-01");
-        assert_eq!(typed.group_by, GroupDimension::Model);
         assert_eq!(typed.project_id.as_deref(), Some("proj-1"));
-        assert!(typed.model_id.is_none(), "blank strings must be dropped");
-        assert!(typed.agent_type.is_none());
+        assert!(typed.model_id.is_none(), "blank model must be dropped");
         assert_eq!(gran, Granularity::Day);
     }
 
     #[test]
     fn into_typed_supplies_default_window_when_omitted() {
-        let q = UsageQuery {
-            from: None,
-            to: None,
-            granularity: None,
-            group_by: None,
-            project_id: None,
-            model_id: None,
-            agent_type: None,
-        };
-        let (typed, gran) = q.into_typed().unwrap();
+        let (typed, gran) = empty_query().into_typed().unwrap();
         assert!(!typed.from.is_empty());
         assert!(!typed.to.is_empty());
         assert_eq!(gran, Granularity::Day);
-        assert_eq!(typed.group_by, GroupDimension::Model);
     }
 
     #[test]
-    fn into_typed_rejects_invalid_date_bounds() {
-        let q = UsageQuery {
-            from: Some("2025-02-30".into()),
-            to: Some("2025-03-01".into()),
-            granularity: None,
-            group_by: None,
-            project_id: None,
-            model_id: None,
-            agent_type: None,
+    fn preset_30d_window_is_wider_than_7d() {
+        let span = |preset: &str| {
+            let q = UsageQuery {
+                preset: Some(preset.into()),
+                ..empty_query()
+            };
+            let (typed, _) = q.into_typed().unwrap();
+            let from = parse_iso_date_prefix("from", &typed.from).unwrap();
+            let to = parse_iso_date_prefix("to", &typed.to).unwrap();
+            to.to_julian_day() - from.to_julian_day()
         };
+        assert!(span("30d") > span("7d"));
+    }
 
+    #[test]
+    fn invalid_preset_returns_400() {
+        let q = UsageQuery {
+            preset: Some("90d".into()),
+            ..empty_query()
+        };
         let err = q.into_typed().unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
-        assert!(err.1.contains("from"));
+        assert!(err.1.contains("90d"));
     }
 
     #[test]
-    fn into_typed_rejects_reversed_date_range() {
+    fn into_typed_rejects_reversed_custom_range() {
         let q = UsageQuery {
-            from: Some("2025-03-01".into()),
-            to: Some("2025-03-01".into()),
-            granularity: None,
-            group_by: None,
-            project_id: None,
-            model_id: None,
-            agent_type: None,
+            start: Some("2025-03-01".into()),
+            end: Some("2025-03-01".into()),
+            ..empty_query()
         };
-
         let err = q.into_typed().unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
         assert!(err.1.contains("from must be before to"));
     }
 
     #[test]
-    fn totals_dto_preserves_null_cost() {
-        let dto: TotalsDto = UsageTotals {
-            session_count: 3,
-            tokens_in: 100,
-            tokens_out: 50,
-            cache_read_tokens: 10,
-            cache_write_tokens: 5,
-            total_cost_usd: None,
-        }
-        .into();
-        assert_eq!(dto.session_count, 3);
-        assert!(dto.total_cost_usd.is_none());
-
-        let json = serde_json::to_value(&dto).unwrap();
-        assert!(json.get("total_cost_usd").unwrap().is_null());
-    }
-
-    #[test]
-    fn series_dto_preserves_cost() {
-        let dto: SeriesPointDto = DailySeriesRow {
-            day: "2025-03-14".into(),
-            session_count: 1,
-            tokens_in: 2,
-            tokens_out: 3,
-            cache_read_tokens: 4,
-            cache_write_tokens: 5,
-            total_cost_usd: Some(1.23),
-        }
-        .into();
-        assert_eq!(dto.day, "2025-03-14");
-        assert_eq!(dto.total_cost_usd, Some(1.23));
-    }
-
-    #[test]
-    fn response_shape_has_all_fields() {
-        let result = UsageAnalyticsResult::default();
-        let resp = UsageResponse::from_results(
-            result,
-            UsageTotals::default(),
-            Granularity::Day,
-            Vec::new(),
-            Vec::new(),
-        )
-        .unwrap();
-        let json = serde_json::to_value(&resp).unwrap();
-        for field in [
-            "totals",
-            "previous_totals",
-            "series",
-            "breakdown",
-            "model_effectiveness",
-            "project_model_matrix",
-            "granularity",
-        ] {
-            assert!(json.get(field).is_some(), "missing response field: {field}");
-        }
-        assert!(json.get("series").unwrap().is_array());
-        assert!(json.get("model_effectiveness").unwrap().is_array());
-        assert!(json.get("project_model_matrix").unwrap().is_array());
-    }
-
-    #[test]
-    fn model_effectiveness_dto_has_all_metric_fields() {
-        // Verify that a ModelEffectivenessDto serialises with all required
-        // metric fields, including shared-credit completed_task_count,
-        // avg_reopens, and tokens_per_task.
-        let row = ModelEffectivenessRow {
-            model_id: "test-model".into(),
-            sessions: 10,
-            spend_usd: Some(2.50),
-            tokens_in: 1000,
-            tokens_out: 500,
-            shared_credit_completed_task_count: 3,
-            success_rate: Some(0.67),
-            avg_reopens: Some(0.5),
-            cost_per_completed_task: Some(0.83),
-            tokens_per_task: Some(500.0),
+    fn into_typed_rejects_invalid_date() {
+        let q = UsageQuery {
+            start: Some("2025-02-30".into()),
+            end: Some("2025-03-01".into()),
+            ..empty_query()
         };
-        let dto: ModelEffectivenessDto = row.into();
-        let json = serde_json::to_value(&dto).unwrap();
-
-        assert_eq!(
-            json.get("model_id").unwrap().as_str().unwrap(),
-            "test-model"
-        );
-        assert_eq!(json.get("sessions").unwrap().as_i64().unwrap(), 10);
-        assert!((json.get("spend_usd").unwrap().as_f64().unwrap() - 2.50).abs() < 0.01);
-        assert_eq!(json.get("tokens_in").unwrap().as_i64().unwrap(), 1000);
-        assert_eq!(json.get("tokens_out").unwrap().as_i64().unwrap(), 500);
-        // Shared-credit completed task count — field name documents the
-        // attribution semantics so the UI can label it accurately.
-        assert_eq!(
-            json.get("completed_task_count").unwrap().as_i64().unwrap(),
-            3
-        );
-        assert!((json.get("success_rate").unwrap().as_f64().unwrap() - 0.67).abs() < 0.01);
-        assert!((json.get("avg_reopens").unwrap().as_f64().unwrap() - 0.5).abs() < 0.01);
-        assert!(
-            (json
-                .get("cost_per_completed_task")
-                .unwrap()
-                .as_f64()
-                .unwrap()
-                - 0.83)
-                .abs()
-                < 0.01
-        );
-        assert!((json.get("tokens_per_task").unwrap().as_f64().unwrap() - 500.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn model_effectiveness_dto_preserves_null_spend() {
-        // When all worker sessions use unpriced models, spend and
-        // cost_per_completed_task must be NULL (not zero).
-        let row = ModelEffectivenessRow {
-            model_id: "unpriced-model".into(),
-            sessions: 5,
-            spend_usd: None,
-            tokens_in: 200,
-            tokens_out: 100,
-            shared_credit_completed_task_count: 2,
-            success_rate: Some(1.0),
-            avg_reopens: Some(0.0),
-            cost_per_completed_task: None,
-            tokens_per_task: Some(150.0),
-        };
-        let dto: ModelEffectivenessDto = row.into();
-        let json = serde_json::to_value(&dto).unwrap();
-
-        assert!(json.get("spend_usd").unwrap().is_null());
-        assert!(json.get("cost_per_completed_task").unwrap().is_null());
-        assert!(!json.get("tokens_per_task").unwrap().is_null());
-    }
-
-    #[test]
-    fn project_model_matrix_dto_serialises_correctly() {
-        let row = ProjectModelMatrixRow {
-            project_id: "proj-1".into(),
-            model_id: "model-a".into(),
-            sessions: 7,
-            spend_usd: Some(1.23),
-            tokens_in: 300,
-            tokens_out: 150,
-        };
-        let dto: ProjectModelMatrixDto = row.into();
-        let json = serde_json::to_value(&dto).unwrap();
-
-        assert_eq!(json.get("project_id").unwrap().as_str().unwrap(), "proj-1");
-        assert_eq!(json.get("model_id").unwrap().as_str().unwrap(), "model-a");
-        assert_eq!(json.get("sessions").unwrap().as_i64().unwrap(), 7);
-        assert!((json.get("spend_usd").unwrap().as_f64().unwrap() - 1.23).abs() < 0.01);
-        assert_eq!(json.get("tokens_in").unwrap().as_i64().unwrap(), 300);
-        assert_eq!(json.get("tokens_out").unwrap().as_i64().unwrap(), 150);
+        let err = q.into_typed().unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
     }
 
     #[test]
@@ -938,129 +764,229 @@ mod tests {
         let query = UsageAnalyticsQuery {
             from: "2025-03-10".into(),
             to: "2025-03-17".into(),
-            group_by: GroupDimension::Project,
+            group_by: GroupDimension::Model,
             project_id: Some("proj-1".into()),
             model_id: Some("model-1".into()),
             agent_type: Some("worker".into()),
         };
-
         let previous = previous_window_query(&query).unwrap();
         assert_eq!(previous.from, "2025-03-03");
         assert_eq!(previous.to, "2025-03-10");
-        assert_eq!(previous.group_by, GroupDimension::Project);
         assert_eq!(previous.project_id.as_deref(), Some("proj-1"));
-        assert_eq!(previous.model_id.as_deref(), Some("model-1"));
-        assert_eq!(previous.agent_type.as_deref(), Some("worker"));
     }
 
     #[test]
-    fn weekly_rollup_sums_daily_rows_and_preserves_unknown_cost() {
-        let rows = vec![
-            DailySeriesRow {
-                day: "2025-03-03".into(),
-                session_count: 1,
-                tokens_in: 10,
-                tokens_out: 20,
-                cache_read_tokens: 3,
-                cache_write_tokens: 4,
-                total_cost_usd: Some(0.5),
-            },
-            DailySeriesRow {
-                day: "2025-03-05".into(),
-                session_count: 2,
-                tokens_in: 30,
-                tokens_out: 40,
-                cache_read_tokens: 5,
-                cache_write_tokens: 6,
-                total_cost_usd: None,
-            },
-            DailySeriesRow {
-                day: "2025-03-10".into(),
-                session_count: 3,
-                tokens_in: 50,
-                tokens_out: 60,
-                cache_read_tokens: 7,
-                cache_write_tokens: 8,
-                total_cost_usd: Some(1.5),
-            },
-        ];
-
-        let rolled = rollup_series(rows, Granularity::Week).unwrap();
-        assert_eq!(rolled.len(), 2);
-        assert_eq!(rolled[0].day, "2025-03-03");
-        assert_eq!(rolled[0].session_count, 3);
-        assert_eq!(rolled[0].tokens_in, 40);
-        assert!(rolled[0].total_cost_usd.is_none());
-        assert_eq!(rolled[1].day, "2025-03-10");
-        assert_eq!(rolled[1].total_cost_usd, Some(1.5));
-    }
-
-    #[test]
-    fn monthly_breakdown_rollup_keeps_groups_separate_and_sorted() {
-        let rows = vec![
-            BreakdownRow {
-                group_key: "b".into(),
-                day: "2025-02-01".into(),
-                session_count: 1,
-                tokens_in: 2,
-                tokens_out: 3,
-                cache_read_tokens: 4,
-                cache_write_tokens: 5,
-                total_cost_usd: Some(0.1),
-            },
-            BreakdownRow {
-                group_key: "a".into(),
-                day: "2025-01-31".into(),
-                session_count: 2,
-                tokens_in: 3,
-                tokens_out: 4,
-                cache_read_tokens: 5,
-                cache_write_tokens: 6,
-                total_cost_usd: Some(0.2),
-            },
-            BreakdownRow {
-                group_key: "a".into(),
-                day: "2025-01-15".into(),
-                session_count: 3,
-                tokens_in: 4,
-                tokens_out: 5,
-                cache_read_tokens: 6,
-                cache_write_tokens: 7,
-                total_cost_usd: Some(0.3),
-            },
-        ];
-
-        let rolled = rollup_breakdown(rows, Granularity::Month).unwrap();
-        assert_eq!(rolled.len(), 2);
-        assert_eq!(rolled[0].group_key, "a");
-        assert_eq!(rolled[0].day, "2025-01-01");
-        assert_eq!(rolled[0].session_count, 5);
-        assert_eq!(rolled[0].tokens_in, 7);
-        assert_eq!(rolled[0].total_cost_usd, Some(0.5));
-        assert_eq!(rolled[1].group_key, "b");
-        assert_eq!(rolled[1].day, "2025-02-01");
-    }
-
-    #[test]
-    fn previous_totals_uses_supplied_repository_totals() {
-        let previous_totals = UsageTotals {
-            session_count: 2,
-            tokens_in: 11,
-            tokens_out: 12,
-            cache_read_tokens: 13,
-            cache_write_tokens: 14,
-            total_cost_usd: Some(0.42),
+    fn build_kpis_emits_four_cards_with_deltas() {
+        let totals = UsageTotals {
+            session_count: 10,
+            tokens_in: 100,
+            tokens_out: 100,
+            cache_read_tokens: 50,
+            cache_write_tokens: 5,
+            total_cost_usd: Some(20.0),
         };
-        let resp = UsageResponse::from_results(
-            UsageAnalyticsResult::default(),
-            previous_totals,
-            Granularity::Day,
-            Vec::new(),
-            Vec::new(),
-        )
-        .unwrap();
-        assert_eq!(resp.previous_totals.session_count, 2);
-        assert_eq!(resp.previous_totals.tokens_in, 11);
-        assert_eq!(resp.previous_totals.total_cost_usd, Some(0.42));
+        let previous = UsageTotals {
+            session_count: 5,
+            tokens_in: 50,
+            tokens_out: 50,
+            cache_read_tokens: 25,
+            cache_write_tokens: 0,
+            total_cost_usd: Some(10.0),
+        };
+        let kpis = build_kpis(&totals, &previous);
+        assert_eq!(kpis.len(), 4);
+
+        let spend = &kpis[0];
+        assert_eq!(spend.label, "Spend");
+        assert_eq!(spend.value, Some(20.0));
+        assert!((spend.delta_pct.unwrap() - 1.0).abs() < 1e-9, "doubled spend = +100%");
+        assert!(spend.formatted.starts_with('$'));
+
+        let tokens = &kpis[1];
+        assert_eq!(tokens.value, Some(200.0));
+        assert!(tokens.formatted.is_empty());
+    }
+
+    #[test]
+    fn build_kpis_null_spend_yields_null_value_and_delta() {
+        let totals = UsageTotals {
+            total_cost_usd: None,
+            ..UsageTotals::default()
+        };
+        let kpis = build_kpis(&totals, &UsageTotals::default());
+        assert_eq!(kpis[0].label, "Spend");
+        assert!(kpis[0].value.is_none());
+        assert!(kpis[0].delta_pct.is_none());
+        assert!(kpis[0].formatted.is_empty());
+        // Previous window empty → token delta is null, not a divide-by-zero.
+        assert!(kpis[1].delta_pct.is_none());
+    }
+
+    fn series_row(day: &str, model: &str, cost: Option<f64>) -> SeriesDetailRow {
+        SeriesDetailRow {
+            day: day.into(),
+            model: model.into(),
+            project_id: "p1".into(),
+            project_name: "Proj One".into(),
+            agent_type: "worker".into(),
+            session_count: 1,
+            tokens_in: 10,
+            tokens_out: 5,
+            task_count: 1,
+            cost,
+        }
+    }
+
+    #[test]
+    fn rollup_series_day_is_identity_per_dimension() {
+        let rows = vec![
+            series_row("2025-03-10", "a", Some(1.0)),
+            series_row("2025-03-10", "b", Some(2.0)),
+        ];
+        let points = rollup_series(rows, Granularity::Day).unwrap();
+        assert_eq!(points.len(), 2);
+        assert!(points.iter().all(|p| p.date == "2025-03-10"));
+    }
+
+    #[test]
+    fn rollup_series_week_groups_same_dimension_and_preserves_null_cost() {
+        let rows = vec![
+            series_row("2025-03-03", "a", Some(1.0)),
+            series_row("2025-03-05", "a", None),
+            series_row("2025-03-04", "b", Some(3.0)),
+        ];
+        let points = rollup_series(rows, Granularity::Week).unwrap();
+        // model a (two rows, one unpriced) collapses to one bucket with null
+        // cost; model b stays separate.
+        let a = points.iter().find(|p| p.model == "a").unwrap();
+        assert_eq!(a.date, "2025-03-03");
+        assert_eq!(a.tokens_in, 20);
+        assert!(a.cost.is_none(), "any unpriced row makes the bucket null");
+        let b = points.iter().find(|p| p.model == "b").unwrap();
+        assert_eq!(b.cost, Some(3.0));
+    }
+
+    #[test]
+    fn breakdown_row_sets_links_and_cost_per_task() {
+        let row = EntityBreakdownRow {
+            id: "task-1".into(),
+            name: "A task".into(),
+            cost: Some(4.0),
+            tokens_in: 10,
+            tokens_out: 10,
+            task_count: 2,
+            success_rate: Some(0.5),
+            avg_reopens: Some(1.0),
+        };
+        let task = breakdown_row(row.clone(), GroupDimension::Task);
+        assert_eq!(task.task_id.as_deref(), Some("task-1"));
+        assert!(task.proposal_id.is_none());
+        assert_eq!(task.cost_per_task, Some(2.0));
+
+        let proposal = breakdown_row(row.clone(), GroupDimension::Proposal);
+        assert_eq!(proposal.proposal_id.as_deref(), Some("task-1"));
+        assert!(proposal.task_id.is_none());
+
+        let user = breakdown_row(row, GroupDimension::User);
+        assert!(user.task_id.is_none() && user.proposal_id.is_none());
+    }
+
+    #[test]
+    fn breakdown_row_zero_tasks_has_null_cost_per_task() {
+        let row = EntityBreakdownRow {
+            id: "u1".into(),
+            name: "user".into(),
+            cost: Some(3.0),
+            tokens_in: 1,
+            tokens_out: 1,
+            task_count: 0,
+            success_rate: None,
+            avg_reopens: None,
+        };
+        let dto = breakdown_row(row, GroupDimension::User);
+        assert!(dto.cost_per_task.is_none());
+    }
+
+    #[test]
+    fn model_effectiveness_dto_renames_to_frontend_contract() {
+        let row = ModelEffectivenessRow {
+            model_id: "gpt".into(),
+            sessions: 4,
+            spend_usd: Some(2.0),
+            tokens_in: 100,
+            tokens_out: 50,
+            shared_credit_completed_task_count: 3,
+            success_rate: Some(0.75),
+            avg_reopens: Some(0.2),
+            cost_per_completed_task: Some(0.66),
+            tokens_per_task: Some(50.0),
+        };
+        let dto: ModelEffectivenessDto = row.into();
+        let json = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json.get("model").unwrap().as_str().unwrap(), "gpt");
+        assert_eq!(json.get("task_count").unwrap().as_i64().unwrap(), 3);
+        assert_eq!(json.get("completed_task_count").unwrap().as_i64().unwrap(), 3);
+        assert_eq!(json.get("session_count").unwrap().as_i64().unwrap(), 4);
+        assert_eq!(json.get("total_tokens").unwrap().as_i64().unwrap(), 150);
+        assert!((json.get("total_cost").unwrap().as_f64().unwrap() - 2.0).abs() < 1e-9);
+        assert!((json.get("cost_per_task").unwrap().as_f64().unwrap() - 0.66).abs() < 1e-9);
+        // Repository-only names must not leak.
+        assert!(json.get("model_id").is_none());
+        assert!(json.get("spend_usd").is_none());
+    }
+
+    #[test]
+    fn project_model_cell_dto_derives_cost_per_task_and_renames() {
+        let row = ProjectModelMatrixRow {
+            project_id: "p1".into(),
+            project_name: "Proj".into(),
+            model_id: "m1".into(),
+            sessions: 2,
+            spend_usd: Some(6.0),
+            tokens_in: 30,
+            tokens_out: 20,
+            task_count: 3,
+            success_rate: Some(1.0),
+            avg_reopens: Some(0.0),
+        };
+        let dto: ProjectModelCellDto = row.into();
+        let json = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json.get("model").unwrap().as_str().unwrap(), "m1");
+        assert_eq!(json.get("project_name").unwrap().as_str().unwrap(), "Proj");
+        assert_eq!(json.get("total_tokens").unwrap().as_i64().unwrap(), 50);
+        assert!((json.get("cost_per_task").unwrap().as_f64().unwrap() - 2.0).abs() < 1e-9);
+        assert!((json.get("total_cost").unwrap().as_f64().unwrap() - 6.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn response_serialises_with_frontend_contract_fields() {
+        let response = UsageResponse {
+            kpis: build_kpis(&UsageTotals::default(), &UsageTotals::default()),
+            time_series: Vec::new(),
+            breakdowns: BreakdownsDto {
+                by_user: Vec::new(),
+                by_project: Vec::new(),
+                by_proposal: Vec::new(),
+                by_task: Vec::new(),
+            },
+            model_effectiveness: Vec::new(),
+            project_model_matrix: Vec::new(),
+            generated_at: "2025-06-20T00:00:00Z".into(),
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        for field in [
+            "kpis",
+            "time_series",
+            "breakdowns",
+            "model_effectiveness",
+            "project_model_matrix",
+            "generated_at",
+        ] {
+            assert!(json.get(field).is_some(), "missing field {field}");
+        }
+        let breakdowns = json.get("breakdowns").unwrap();
+        for field in ["by_user", "by_project", "by_proposal", "by_task"] {
+            assert!(breakdowns.get(field).unwrap().is_array(), "missing {field}");
+        }
     }
 }

--- a/ui/src/components/usage/UsageBreakdownsTab.tsx
+++ b/ui/src/components/usage/UsageBreakdownsTab.tsx
@@ -49,11 +49,12 @@ const DEFAULT_SORT: Record<BreakdownKind, SortKey> = {
 };
 
 export function UsageBreakdownsTab({ data }: { data: UsageAnalyticsResponse }) {
+  const breakdowns = data.breakdowns;
   const configs: BreakdownConfig[] = [
-    { kind: "user", value: "user", label: "By User", rows: data.breakdowns.by_user },
-    { kind: "project", value: "project", label: "By Project", rows: data.breakdowns.by_project },
-    { kind: "proposal", value: "proposal", label: "By Proposal", rows: data.breakdowns.by_proposal },
-    { kind: "task", value: "task", label: "By Task", rows: data.breakdowns.by_task },
+    { kind: "user", value: "user", label: "By User", rows: breakdowns?.by_user ?? [] },
+    { kind: "project", value: "project", label: "By Project", rows: breakdowns?.by_project ?? [] },
+    { kind: "proposal", value: "proposal", label: "By Proposal", rows: breakdowns?.by_proposal ?? [] },
+    { kind: "task", value: "task", label: "By Task", rows: breakdowns?.by_task ?? [] },
   ];
 
   return (

--- a/ui/src/components/usage/UsageOverviewTab.tsx
+++ b/ui/src/components/usage/UsageOverviewTab.tsx
@@ -90,7 +90,7 @@ export function UsageOverviewTab({
   const [grouping, setGrouping] = useState<SpendGrouping>("model");
 
   const seriesRows = useMemo(
-    () => buildSeriesRows(data.time_series, data, grouping),
+    () => buildSeriesRows(data.time_series ?? [], data, grouping),
     [data, grouping],
   );
 
@@ -100,7 +100,7 @@ export function UsageOverviewTab({
 
   return (
     <div className="space-y-4">
-      <KpiRow kpis={data.kpis} />
+      <KpiRow kpis={data.kpis ?? []} />
 
       <ChartSection
         title="Spend over time"
@@ -339,8 +339,8 @@ function buildSeriesRows(
   grouping: SpendGrouping,
 ): SeriesRow[] {
   const projectNames = new Map<string, string>();
-  for (const row of data.breakdowns.by_project) projectNames.set(row.id, row.name);
-  for (const cell of data.project_model_matrix) {
+  for (const row of data.breakdowns?.by_project ?? []) projectNames.set(row.id, row.name);
+  for (const cell of data.project_model_matrix ?? []) {
     projectNames.set(cell.project_id, cell.project_name);
   }
 

--- a/ui/src/pages/UsageDashboardPage.tsx
+++ b/ui/src/pages/UsageDashboardPage.tsx
@@ -51,15 +51,17 @@ export function UsageDashboardPage() {
   // ── Empty-state detection ─────────────────────────────────────────────────
   const isEmpty = useMemo(() => {
     if (!data) return false;
+    // Guard every nested array: a malformed/partial response must render the
+    // empty state rather than crash the whole admin page.
     return (
-      data.kpis.length === 0 &&
-      data.time_series.length === 0 &&
-      data.model_effectiveness.length === 0 &&
-      data.project_model_matrix.length === 0 &&
-      data.breakdowns.by_user.length === 0 &&
-      data.breakdowns.by_project.length === 0 &&
-      data.breakdowns.by_proposal.length === 0 &&
-      data.breakdowns.by_task.length === 0
+      (data.kpis?.length ?? 0) === 0 &&
+      (data.time_series?.length ?? 0) === 0 &&
+      (data.model_effectiveness?.length ?? 0) === 0 &&
+      (data.project_model_matrix?.length ?? 0) === 0 &&
+      (data.breakdowns?.by_user?.length ?? 0) === 0 &&
+      (data.breakdowns?.by_project?.length ?? 0) === 0 &&
+      (data.breakdowns?.by_proposal?.length ?? 0) === 0 &&
+      (data.breakdowns?.by_task?.length ?? 0) === 0
     );
   }, [data]);
 


### PR DESCRIPTION
## Problem

`/admin/usage` crashed on load with **\`Cannot read properties of undefined (reading 'length')\`** in `UsageDashboardPage`'s `isEmpty` useMemo.

Root cause: the frontend dashboard (PRs #734–#740) was built against a contract the backend (PRs #764–#918) never served. The endpoint returned `{ granularity, totals, previous_totals, series, breakdown, model_effectiveness, project_model_matrix }`, but the UI casts the response to `{ kpis, time_series, breakdowns: { by_user, by_project, by_proposal, by_task }, model_effectiveness, project_model_matrix, generated_at }` — with differently named fields. At runtime `data.kpis` / `data.time_series` / `data.breakdowns` were all `undefined`, so the page white-screened. The dashboard had effectively never rendered real data.

## Fix (full reconciliation)

Make the backend emit exactly the frontend contract; the UI consumes it directly.

**Repository (`djinn-db`)**
- `totals()` — window totals over `sessions` only (drops the `proposal_epics` join that could inflate counts when an epic maps to multiple proposals).
- `series_detailed()` — multi-dimensional daily series (day × model × project × agent) so the Overview tab can group spend client-side.
- `entity_breakdown(dim)` — four aggregate breakdowns (user / project / proposal / task) with cost, tokens, distinct `task_count`, `success_rate` and `avg_reopens` computed over **distinct tasks** (no session-multiplicity inflation), plus human-readable names via `users`/`projects`/`proposals`/`tasks` joins.
- `project_model_matrix` — enriched with `project_name` and per-cell outcome metrics.

**Handler**
- Accepts the frontend query params (`preset` 7d/30d, `start`, `end`, `granularity`, `project_id`, `model`, `agent_type`).
- Derives the four KPI cards (Spend / Tokens / Sessions / Cache reads) from current-vs-previous window with period-over-period deltas.
- Rolls the detailed series up to day/week/month and renames repository fields to the frontend contract; preserves NULL-unpriced cost semantics.

**Frontend**
- Defensive guards on every nested array read (`isEmpty`, `buildSeriesRows`, breakdown configs, `KpiRow`) so any future shape drift degrades to the empty state instead of crashing the admin page.

## Notes
- Optional expandable detail in the Breakdowns tab (`model_split`, per-row `time_series`) is intentionally not populated yet; the UI already degrades gracefully ("No per-model detail supplied"). Follow-up if desired.

## Testing
- `cargo test -p djinn-db` (unit + `usage_analytics_totals` integration) — green against live Postgres.
- `cargo test -p djinn-server --lib server::tests::usage_analytics` (15 handler integration tests) — green against live Postgres.
- Handler + repository unit tests — green.
- `cargo clippy -p djinn-server -p djinn-db --all-features --tests` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)