### PR TITLE
fix(breaker): treat Codex/OpenAI empty-200 over-quota as throttle, not failure

### DIFF
--- a/server/crates/djinn-agent/src/actors/coordinator/dispatch/session_recovery.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/dispatch/session_recovery.rs
@@ -215,8 +215,10 @@ impl CoordinatorActor {
             // `is_available` gate consults (cloned into slots), so this trip is
             // visible to the very next dispatch pass.
             if never_active {
+                // A first-call hang is a genuine model/backend-health signal
+                // (not a quota throttle), so escalate the cooldown cap.
                 self.health
-                    .record_stall(scope.as_deref(), &session.model_id);
+                    .record_stall(scope.as_deref(), &session.model_id, true);
             } else {
                 self.health
                     .record_failure(scope.as_deref(), &session.model_id);

--- a/server/crates/djinn-agent/src/actors/coordinator/tests/session_reaping.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/tests/session_reaping.rs
@@ -32,7 +32,7 @@ async fn stalled_model_is_skipped_and_dispatch_fails_over_to_next() {
     let model_ids = vec![bad.clone(), good.clone()];
 
     // Trip the preferred model on a zero-token stall.
-    actor.health.record_stall(None, &bad);
+    actor.health.record_stall(None, &bad, true);
     assert!(!actor.health.is_available(None, &bad));
     assert!(actor.health.is_available(None, &good));
 
@@ -75,7 +75,7 @@ async fn stalled_model_recovers_after_cooldown_expires() {
     let actor = coordinator_actor_for_tests(&db, &tx);
 
     let bad = "openai/gpt-5.5".to_string();
-    actor.health.record_stall(None, &bad);
+    actor.health.record_stall(None, &bad, true);
     assert!(!actor.health.is_available(None, &bad));
 
     // Simulate cooldown expiry, then a successful run resets the breaker.

--- a/server/crates/djinn-agent/src/actors/slot/reply_loop/error_handling.rs
+++ b/server/crates/djinn-agent/src/actors/slot/reply_loop/error_handling.rs
@@ -142,6 +142,39 @@ pub(super) fn should_retry_empty_assistant_turn(
     }
 }
 
+/// Discriminate a **reasoning-only** turn from a quota **empty-200** when the
+/// assembled assistant content is empty (idea 5).
+///
+/// Both surface as "empty assistant turn", but they are opposite failure modes:
+/// - All counts zero (`reasoning_tokens == 0`): a genuine empty-200. On the
+///   Codex/OpenAI consumer backend this is the over-quota account answering with
+///   an empty `response.completed` — a THROTTLE that should drive failover.
+/// - `reasoning_tokens > 0` with no visible message and no tool call: the model
+///   spent reasoning tokens but emitted nothing usable (a reasoning-only stall,
+///   e.g. encrypted reasoning we couldn't surface, or summaries-off). This is NOT
+///   a throttle — the backend answered, the model just didn't externalize a
+///   result. The right response is a NUDGE asking it to emit its answer / call a
+///   tool, not a failover.
+///
+/// Returns `true` when the empty turn is reasoning-only and should be nudged.
+pub(super) fn empty_turn_is_reasoning_only(reasoning_tokens_out: u32) -> bool {
+    reasoning_tokens_out > 0
+}
+
+/// Build the nudge injected after a reasoning-only empty turn (see
+/// [`empty_turn_is_reasoning_only`]). It tells the model its visible output was
+/// empty and asks it to actually emit the answer or call a tool this turn.
+pub(super) fn reasoning_only_nudge_message() -> Message {
+    Message::user(
+        "<system-reminder>\n\
+         Your previous turn produced reasoning but NO visible output and NO tool \
+         call, so nothing was delivered. Do not just think — this turn you MUST \
+         either reply with your answer as text or call an appropriate tool to make \
+         progress.\n\
+         </system-reminder>",
+    )
+}
+
 /// Backoff before retrying an empty / no-event provider turn. A 200-empty
 /// completion is a refusal/throttle signal, not a transient blip — notably the
 /// ChatGPT-account Codex backend (`chatgpt.com/backend-api/codex`) signals
@@ -255,6 +288,32 @@ mod tests {
         // Defensive: clamps so an out-of-range retry never panics or runs away.
         assert_eq!(empty_turn_backoff(0), std::time::Duration::from_secs(3));
         assert_eq!(empty_turn_backoff(10), std::time::Duration::from_secs(27));
+    }
+
+    #[test]
+    fn empty_turn_reasoning_only_discriminator() {
+        // Idea 5: an empty assistant turn that spent reasoning tokens is a
+        // reasoning-only stall (nudge), distinct from an all-zero quota empty-200
+        // (throttle/failover). The reasoning-token count is the discriminator.
+        assert!(
+            empty_turn_is_reasoning_only(1),
+            "reasoning tokens spent → reasoning-only stall (nudge path)"
+        );
+        assert!(empty_turn_is_reasoning_only(512));
+        assert!(
+            !empty_turn_is_reasoning_only(0),
+            "all-zero empty turn → genuine empty-200 (throttle path)"
+        );
+        // The nudge body must steer the model to externalize output / call a tool.
+        let msg = reasoning_only_nudge_message();
+        let text: String = msg
+            .content
+            .iter()
+            .filter_map(djinn_provider::message::ContentBlock::as_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("NO visible output"), "{text}");
+        assert!(text.contains("system-reminder"), "{text}");
     }
 
     #[test]

--- a/server/crates/djinn-agent/src/actors/slot/reply_loop/turn.rs
+++ b/server/crates/djinn-agent/src/actors/slot/reply_loop/turn.rs
@@ -17,8 +17,9 @@ use super::budget::{
     SessionBudgetPolicy, hard_budget_threshold_exceeded, soft_budget_threshold_exceeded,
 };
 use super::error_handling::{
-    BudgetWindDownIgnored, MAX_COMPACTION_RETRIES, empty_turn_backoff, is_context_length_error,
-    is_orphaned_tool_call_error, next_nudge_message, should_retry_after_tool_call_compaction,
+    BudgetWindDownIgnored, MAX_COMPACTION_RETRIES, empty_turn_backoff,
+    empty_turn_is_reasoning_only, is_context_length_error, is_orphaned_tool_call_error,
+    next_nudge_message, reasoning_only_nudge_message, should_retry_after_tool_call_compaction,
     should_retry_empty_assistant_turn, should_retry_empty_stream, soft_budget_converge_message,
     tool_choice_for_turn, wind_down_message,
 };
@@ -30,6 +31,18 @@ use super::persistence::{persist_session_message, serialize_llm_input, serialize
 use super::streaming::{StreamLoopContext, StreamTurnState, consume_provider_stream};
 use super::tool_dispatch::{ToolDispatchContext, collect_tool_results, tool_runtime_metadata};
 
+/// True when `model_id` (a `provider/model` string) is served by the Codex /
+/// OpenAI consumer backend that signals over-quota by answering a turn with an
+/// empty 200 (`response.completed`, zero tokens) instead of an HTTP 429. The
+/// `chatgpt_codex` OAuth backend is rate-limited per ChatGPT *account*; the
+/// `openai` Responses backend can throttle the same way on a depleted key. For
+/// these families an exhausted empty-turn streak is a THROTTLE (account over
+/// quota), not a broken model — see [`empty_turn_terminal_error`].
+fn is_codex_openai_family(model_id: &str) -> bool {
+    let provider = model_id.split('/').next().unwrap_or("").to_ascii_lowercase();
+    matches!(provider.as_str(), "openai" | "chatgpt_codex")
+}
+
 /// Build the terminal error for a reply loop that gave up after the bounded
 /// empty/no-event-turn retries.
 ///
@@ -40,22 +53,39 @@ use super::tool_dispatch::{ToolDispatchContext, collect_tool_results, tool_runti
 /// events) returned a plain `anyhow` error → classified `None` → breaker never
 /// fed → dispatch re-selected the dead model forever (it broke `twty`/`oy1q`).
 ///
-/// We mirror the Codex empty-200 mid-stream path (`from_stream_error`'s default)
-/// and use `ProviderInternal { status: 500 }`, which `classify_provider_failure`
-/// maps to the GENTLE consecutive-failure breaker (`Failure`): a one-off blip is
-/// absorbed (a successful session resets the streak) but a model that produces
-/// empty turns on EVERY dispatch finally auto-disables / fails over. We do NOT
-/// use `EmptyCompletion`, which is deliberately `None` (it has its own in-loop
-/// backoff for Codex consumer-backend throttling). The readable diagnostic rides
-/// along as `.context` so the existing string-based detectors still match on the
-/// top-level Display.
-fn empty_turn_terminal_error(kind: &str, retries: u32, diag: String) -> anyhow::Error {
-    anyhow::Error::new(djinn_provider::provider::ProviderError::ProviderInternal { status: 500 })
-        .context(format!(
-            "provider returned {retries} empty {kind} turns — the backend likely refused or \
-             throttled the request (a ChatGPT-account Codex rate limit returns empty 200s, \
-             not 429s; verify provider/account status or switch to an API-key backend); {diag}"
-        ))
+/// The class is **provider-family-gated** because the two failures look
+/// identical (empty turn, zero tokens) but mean opposite things:
+/// - For the Codex / OpenAI consumer family ([`is_codex_openai_family`]) an
+///   exhausted empty-turn streak is a THROTTLE: the ChatGPT account is over its
+///   per-account quota and is answering with empty 200s instead of a 429. We
+///   emit `EmptyCompletion`, which `classify_provider_failure` now routes to the
+///   `Throttle` arm (`record_stall`: clean immediate failover, cooldown floored
+///   so the next dispatch picks another model, NO `disable_ttl_trips`
+///   escalation since a quota resets on a clock, not on model health).
+/// - For every OTHER provider (e.g. `kimi-for-coding/k2p7`) a model that produces
+///   empty turns on EVERY dispatch is genuinely dead, so we keep
+///   `ProviderInternal { status: 500 }` → the GENTLE consecutive-failure breaker
+///   (`Failure`): a one-off blip is absorbed (a successful session resets the
+///   streak) but a persistently-empty model finally auto-disables / fails over.
+///
+/// The readable diagnostic rides along as `.context` so the existing
+/// string-based detectors still match on the top-level Display.
+fn empty_turn_terminal_error(
+    kind: &str,
+    retries: u32,
+    model_id: &str,
+    diag: String,
+) -> anyhow::Error {
+    let class = if is_codex_openai_family(model_id) {
+        djinn_provider::provider::ProviderError::EmptyCompletion
+    } else {
+        djinn_provider::provider::ProviderError::ProviderInternal { status: 500 }
+    };
+    anyhow::Error::new(class).context(format!(
+        "provider returned {retries} empty {kind} turns — the backend likely refused or \
+         throttled the request (a ChatGPT-account Codex rate limit returns empty 200s, \
+         not 429s; verify provider/account status or switch to an API-key backend); {diag}"
+    ))
 }
 
 fn permission_denial_text(text: &str) -> bool {
@@ -805,6 +835,7 @@ pub(crate) async fn run_reply_loop(
                 return Err(empty_turn_terminal_error(
                     "no-event",
                     empty_turn_retries,
+                    model_id,
                     diag,
                 ));
             }
@@ -829,6 +860,30 @@ pub(crate) async fn run_reply_loop(
             }
 
             if assistant_content.is_empty() {
+                // ── Idea 5: reasoning-only stall vs quota empty-200 ──────────
+                // The model spent reasoning tokens but produced no visible
+                // message and no tool call. This is NOT the Codex/OpenAI
+                // over-quota empty-200 (which has ALL counts zero, including
+                // reasoning) — the backend answered, the model just didn't
+                // externalize a result. Drive a NUDGE asking it to emit output /
+                // call a tool, NOT the empty-turn throttle terminal that would
+                // fail over off a healthy model. The all-zero case falls through
+                // to the retry/terminal path below, which is the only path that
+                // reaches `empty_turn_terminal_error` (idea 1's throttle).
+                if empty_turn_is_reasoning_only(turn_reasoning_out) {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        session_id = %session_id,
+                        turn = turns,
+                        reasoning_tokens_out = turn_reasoning_out,
+                        "ReplyLoop: reasoning-only empty turn (reasoning spent, no visible \
+                         output/tool-call) — nudging instead of failing over"
+                    );
+                    let nudge = reasoning_only_nudge_message();
+                    persist_session_message(&msg_repo, session_id, task_id, &nudge).await;
+                    conversation.push(nudge);
+                    continue;
+                }
                 if let Some(next_retry) =
                     should_retry_empty_assistant_turn(assistant_content.is_empty(), empty_turn_retries)
                 {
@@ -847,6 +902,7 @@ pub(crate) async fn run_reply_loop(
                 return Err(empty_turn_terminal_error(
                     "assistant",
                     empty_turn_retries,
+                    model_id,
                     diag,
                 ));
             }
@@ -1309,13 +1365,13 @@ mod tests {
         // it returned a plain `anyhow!` string → downcast failed → `None` → the
         // breaker was never fed and the dead model was re-selected forever.
         for kind in ["no-event", "assistant"] {
-            let err = empty_turn_terminal_error(kind, 2, "diag".to_string());
+            let err = empty_turn_terminal_error(kind, 2, "kimi-for-coding/k2p7", "diag".to_string());
             let typed = err
                 .downcast_ref::<ProviderError>()
                 .expect("terminal empty-turn error must carry a typed ProviderError source");
-            // ProviderInternal{500} mirrors the Codex empty-200 path and maps to
-            // the GENTLE consecutive-failure breaker (`Failure`), NOT
-            // `EmptyCompletion` (which classifies as `None` by design).
+            // A non-Codex empty turn = genuinely dead model → ProviderInternal{500}
+            // → the GENTLE consecutive-failure breaker (`Failure`), so a
+            // persistently-empty model finally auto-disables (dead-model protection).
             assert_eq!(*typed, ProviderError::ProviderInternal { status: 500 });
             assert!(
                 typed.retryable(),
@@ -1326,5 +1382,41 @@ mod tests {
             assert!(display.contains("empty"), "{kind}: {display}");
             assert!(display.contains("diag"), "{kind}: {display}");
         }
+    }
+
+    #[test]
+    fn empty_turn_terminal_error_codex_family_is_throttle_not_failure() {
+        // The Codex / OpenAI consumer backend signals an over-quota ACCOUNT by
+        // answering a turn with an empty 200 (zero-token `response.completed`),
+        // not an HTTP 429. An exhausted empty-turn streak on that family is a
+        // THROTTLE — emit `EmptyCompletion`, which `classify_provider_failure`
+        // routes to the `Throttle` arm (clean failover, no breaker escalation),
+        // NOT `ProviderInternal{500}` (which would miscount a throttle as a
+        // broken provider and escalate the auto-disable cooldown).
+        for model_id in ["openai/gpt-5.5", "chatgpt_codex/codex-mini", "OpenAI/Gpt-5.5"] {
+            for kind in ["no-event", "assistant"] {
+                let err = empty_turn_terminal_error(kind, 2, model_id, "diag".to_string());
+                let typed = err
+                    .downcast_ref::<ProviderError>()
+                    .expect("terminal empty-turn error must carry a typed ProviderError source");
+                assert_eq!(
+                    *typed,
+                    ProviderError::EmptyCompletion,
+                    "{model_id}/{kind}: Codex/OpenAI empty turn must classify as EmptyCompletion (throttle)"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn is_codex_openai_family_gating() {
+        assert!(is_codex_openai_family("openai/gpt-5.5"));
+        assert!(is_codex_openai_family("chatgpt_codex/codex-mini"));
+        assert!(is_codex_openai_family("OPENAI/gpt-5.5"));
+        // Other providers must keep the dead-model `ProviderInternal{500}` path.
+        assert!(!is_codex_openai_family("kimi-for-coding/k2p7"));
+        assert!(!is_codex_openai_family("anthropic/claude-sonnet-4-5"));
+        assert!(!is_codex_openai_family("synthetic/Kimi-K2.5"));
+        assert!(!is_codex_openai_family(""));
     }
 }

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -603,9 +603,11 @@ pub(crate) async fn run_supervisor_dispatch(
     // terminal MAX_DISPATCH_FAILURES streak (A3) and redispatches with backoff
     // rather than immediately re-hanging on the same model.
     if handshake_timed_out {
+        // An infra handshake failure is a genuine "this model/backend is bad
+        // right now" signal (not a quota throttle), so escalate the cooldown cap.
         app_state
             .health_tracker
-            .record_stall(creator_scope.as_deref(), &model_id);
+            .record_stall(creator_scope.as_deref(), &model_id, true);
         app_state.health_tracker.note_task_provider_failure(
             &task.id,
             djinn_provider::catalog::health::TaskFailureSignal {
@@ -754,9 +756,15 @@ pub(crate) async fn run_supervisor_dispatch(
             if let Some(class) = provider_failure_class_for_report(&report) {
                 let (is_throttle, retry_after_ms) = match class {
                     djinn_runtime::ProviderFailureClass::Throttle { retry_after_ms } => {
-                        app_state
-                            .health_tracker
-                            .record_stall(creator_scope.as_deref(), &model_id);
+                        // A throttle (rate-limit / Codex empty-200 account quota)
+                        // resets on a clock, not on model health — trip for
+                        // immediate failover but do NOT escalate the cooldown cap
+                        // (`escalate = false`); only genuine failures ratchet it.
+                        app_state.health_tracker.record_stall(
+                            creator_scope.as_deref(),
+                            &model_id,
+                            false,
+                        );
                         (true, retry_after_ms)
                     }
                     djinn_runtime::ProviderFailureClass::Failure => {
@@ -770,10 +778,15 @@ pub(crate) async fn run_supervisor_dispatch(
                         // breaker IMMEDIATELY (like a throttle) so dispatch fails
                         // over to the user's next model at once, and persist +
                         // surface the revocation so the owner is told to
-                        // reconnect (F5-safe row + live event).
-                        app_state
-                            .health_tracker
-                            .record_stall(creator_scope.as_deref(), &model_id);
+                        // reconnect (F5-safe row + live event). Escalate the
+                        // cooldown cap: unlike a quota throttle, a dead credential
+                        // is a genuine model-health problem that should stay
+                        // demoted longer the more it keeps failing.
+                        app_state.health_tracker.record_stall(
+                            creator_scope.as_deref(),
+                            &model_id,
+                            true,
+                        );
                         surface_credential_revocation(
                             &app_state,
                             creator_scope.as_deref(),

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -101,6 +101,26 @@ use djinn_runtime::{LoopGuardKind as RuntimeLoopGuardKind, LoopGuardTrip, Provid
 
 use super::SupervisorCallbackContext;
 
+/// Conservative quota-reset window synthesized for an exhausted Codex/OpenAI
+/// empty-200 throttle (idea A6/idea 3).
+///
+/// The ChatGPT consumer Codex backend signals an over-quota *account* by
+/// answering a turn with an empty 200 (`response.completed`, zero tokens)
+/// instead of an HTTP 429 — so unlike a real 429 there is **no `Retry-After` /
+/// rate-limit-reset header** to read (the empty-200 arrives as a normal stream
+/// end, never through the client's status-error path that parses headers in
+/// `provider/client.rs::retry_after_ms`). Without a provider-stated window the
+/// per-task redispatch cooldown would otherwise probe the model again on the
+/// fast 60/120/240s ladder, immediately re-hitting the still-exhausted quota.
+///
+/// We therefore floor the redispatch cooldown on a conservative constant: an
+/// account quota resets on a clock (typically hourly/daily), not in seconds, so
+/// a ~20-minute hold lets dispatch fail over to the user's next model and avoids
+/// hammering the depleted account while still self-healing well within a normal
+/// reset window. This is the floor only — a longer escalating cooldown still
+/// wins via `max()`.
+const CODEX_EMPTY_QUOTA_RETRY_AFTER_MS: u64 = 20 * 60 * 1000;
+
 /// Classify a reply-loop terminal error into the breaker-relevant
 /// [`ProviderFailureClass`] the host should act on, or `None` when the host
 /// circuit-breaker should stay out of it.
@@ -120,12 +140,23 @@ use super::SupervisorCallbackContext;
 ///   keeps rejecting, or a flapping backend. Fed to the gentler
 ///   consecutive-failure breaker so a single transient blip doesn't demote the
 ///   user's preferred model; only repeats trip it.
-/// - `RateLimit` → [`ProviderFailureClass::Throttle`]. A throttle/quota signal;
-///   fed to the immediate-failover breaker so dispatch moves to the next model
-///   at once with a cooldown that outlasts the task's redispatch ladder. The
-///   provider's `retry_after_ms` (a `Retry-After` / rate-limit-reset window, if
-///   it supplied one) rides along so the coordinator can floor the redispatch
-///   cooldown on a multi-hour reset instead of probing on the fixed ladder (A6).
+/// - `RateLimit` | `EmptyCompletion` → [`ProviderFailureClass::Throttle`]. A
+///   throttle/quota signal; fed to the immediate-failover breaker
+///   (`record_stall`) so dispatch moves to the next model at once with a
+///   cooldown that outlasts the task's redispatch ladder. `RateLimit` is an
+///   explicit 429: its `retry_after_ms` (a `Retry-After` / rate-limit-reset
+///   window, if the provider supplied one) rides along so the coordinator can
+///   floor the redispatch cooldown on a multi-hour reset instead of probing on
+///   the fixed ladder (A6). `EmptyCompletion` is the Codex/OpenAI consumer
+///   backend's *implicit* throttle: an over-quota ACCOUNT answers a turn with an
+///   empty 200 (zero-token `response.completed`) instead of a 429, so the reply
+///   loop classifies an exhausted empty-turn streak on that family as
+///   `EmptyCompletion` (see `reply_loop::turn::empty_turn_terminal_error`). It
+///   carries no header, so we synthesize a conservative
+///   [`CODEX_EMPTY_QUOTA_RETRY_AFTER_MS`] window. Routing it here (instead of the
+///   old `None`) stops a *throttle* from being miscounted as a broken provider
+///   via `record_failure`, which polluted health stats and escalated the
+///   auto-disable cooldown for what is merely an account over quota.
 /// - `Transport` → [`ProviderFailureClass::Failure`]. A hard network death
 ///   (connection refused / instant timeout / broken stream) that kills the
 ///   session with no work done — quiet-but-broken, just like a 5xx. Fed to the
@@ -133,12 +164,9 @@ use super::SupervisorCallbackContext;
 ///   successful session resets the counter via `record_success`) but a model
 ///   that dies on every dispatch finally auto-disables instead of being
 ///   re-selected forever (the kimi-for-coding/k2p7 incident).
-/// - `ContextOverflow` | `EmptyCompletion` → `None`. Excluded by design:
-///   ContextOverflow is handled by reactive compaction (not a model health
-///   problem); EmptyCompletion has its own empty-turn backoff breaker in the
-///   reply loop (Codex consumer-backend throttling), so demoting the model here
-///   would punish mere throttling. Tripping the breaker on these would
-///   needlessly demote a healthy model.
+/// - `ContextOverflow` → `None`. Excluded by design: handled by reactive
+///   compaction (the conversation is too big, not a model-health problem).
+///   Tripping the breaker on it would needlessly demote a healthy model.
 /// - An untyped/legacy error (no `ProviderError` source) → `None`, so non-
 ///   provider failures (git, tools, finalize-tool misuse) never trip it.
 fn classify_provider_failure(err: &anyhow::Error) -> Option<ProviderFailureClass> {
@@ -155,6 +183,18 @@ fn classify_provider_failure(err: &anyhow::Error) -> Option<ProviderFailureClass
         ProviderError::RateLimit { .. } => Some(ProviderFailureClass::Throttle {
             retry_after_ms: provider_err.retry_after_ms(),
         }),
+        // The Codex/OpenAI consumer backend's implicit throttle: an over-quota
+        // account answers a turn with an empty 200 (zero-token
+        // `response.completed`) instead of a 429, surfaced as `EmptyCompletion`
+        // by `reply_loop::turn::empty_turn_terminal_error` for that family only.
+        // Route it to the SAME immediate-failover `Throttle` path as a 429 so a
+        // throttle is no longer miscounted as a broken provider (which would feed
+        // `record_failure` and escalate the auto-disable cooldown). There is no
+        // `Retry-After` header on an empty 200, so floor the redispatch cooldown
+        // on a conservative synthesized quota window.
+        ProviderError::EmptyCompletion => Some(ProviderFailureClass::Throttle {
+            retry_after_ms: Some(CODEX_EMPTY_QUOTA_RETRY_AFTER_MS),
+        }),
         // A hard transport failure (connection refused, instant timeout, broken
         // stream) that kills the session is "quiet but broken" the same way a 5xx
         // is: the model produced no work and exited fast, invisible to the
@@ -167,12 +207,10 @@ fn classify_provider_failure(err: &anyhow::Error) -> Option<ProviderFailureClass
         // (the kimi-for-coding/k2p7 incident: instant Transport death, 0 tokens,
         // re-dispatched forever, absent from model_health) finally auto-disables.
         ProviderError::Transport => Some(ProviderFailureClass::Failure),
-        // EmptyCompletion has its own empty-turn backoff breaker in the reply loop
-        // (Codex consumer-backend throttling answers a turn with an empty 200);
-        // tripping the model-health breaker on it would wrongly demote a model
-        // that is merely being throttled. ContextOverflow is handled by reactive
-        // compaction — also not a model-health problem. Both stay `None`.
-        ProviderError::ContextOverflow | ProviderError::EmptyCompletion => None,
+        // ContextOverflow is handled by reactive compaction (the conversation is
+        // too big), not a model-health problem — stays `None` so the breaker
+        // doesn't demote a healthy model.
+        ProviderError::ContextOverflow => None,
     }
 }
 
@@ -982,20 +1020,36 @@ mod tests {
 
     #[test]
     fn breaker_excluded_variants_map_to_none() {
-        // ContextOverflow → reactive compaction; EmptyCompletion → empty-turn
-        // backoff breaker. None must feed the model-health breaker. (Transport is
-        // NO LONGER excluded — a hard transport death now feeds the gentle
-        // consecutive-failure breaker; see `transport_error_is_breaker_worthy`.)
-        for e in [
-            ProviderError::ContextOverflow,
-            ProviderError::EmptyCompletion,
-        ] {
-            assert_eq!(
-                classify_provider_failure(&typed(e.clone())),
-                None,
-                "{e:?} must not feed the breaker",
-            );
-        }
+        // ContextOverflow → reactive compaction (not a model-health problem), so
+        // it must NOT feed the model-health breaker. (Transport is NO LONGER
+        // excluded — a hard transport death feeds the gentle consecutive-failure
+        // breaker; see `transport_error_is_breaker_worthy`. EmptyCompletion is NO
+        // LONGER excluded either — it is now the Codex/OpenAI implicit throttle;
+        // see `empty_completion_maps_to_throttle_with_synthesized_window`.)
+        assert_eq!(
+            classify_provider_failure(&typed(ProviderError::ContextOverflow)),
+            None,
+            "ContextOverflow must not feed the breaker",
+        );
+    }
+
+    #[test]
+    fn empty_completion_maps_to_throttle_with_synthesized_window() {
+        // An exhausted Codex/OpenAI empty-200 streak is an account-quota THROTTLE,
+        // not a broken provider. It must route to the immediate-failover
+        // `Throttle` class (→ `record_stall`), NOT `record_failure`, and — since
+        // the empty 200 carries no `Retry-After` header — floor the redispatch
+        // cooldown on the conservative synthesized quota window so the next
+        // dispatch doesn't re-probe the still-exhausted account on the fast ladder.
+        assert_eq!(
+            classify_provider_failure(&typed(ProviderError::EmptyCompletion)),
+            Some(ProviderFailureClass::Throttle {
+                retry_after_ms: Some(CODEX_EMPTY_QUOTA_RETRY_AFTER_MS),
+            }),
+        );
+        // Sanity-check the constant is a conservative multi-minute window, not a
+        // few-second probe value.
+        const { assert!(CODEX_EMPTY_QUOTA_RETRY_AFTER_MS >= 10 * 60 * 1000) };
     }
 
     #[test]
@@ -1174,16 +1228,12 @@ mod tests {
     }
 
     #[test]
-    fn empty_completion_and_context_overflow_stay_out_of_the_breaker() {
-        // EmptyCompletion has its own empty-turn backoff (Codex consumer-backend
-        // throttling answers with an empty 200); demoting the model here would
-        // punish mere throttling. ContextOverflow is handled by reactive
-        // compaction. Both must stay `None` even after the Transport change.
-        assert_eq!(
-            classify_provider_failure(&anyhow::Error::new(ProviderError::EmptyCompletion)),
-            None,
-            "EmptyCompletion is handled by the empty-turn backoff, not the model-health breaker",
-        );
+    fn context_overflow_stays_out_of_the_breaker() {
+        // ContextOverflow is handled by reactive compaction (the conversation is
+        // too big), so it must stay `None` even after the Transport change.
+        // (EmptyCompletion is no longer `None` — it is the Codex/OpenAI implicit
+        // throttle and maps to `Throttle`; see
+        // `empty_completion_maps_to_throttle_with_synthesized_window`.)
         assert_eq!(
             classify_provider_failure(&anyhow::Error::new(ProviderError::ContextOverflow)),
             None,

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -301,7 +301,18 @@ impl HealthTracker {
     /// model in the creator's ordered list instead of re-selecting the bad one.
     /// The cooldown still auto-expires (self-heal), and repeated stalls escalate
     /// `disable_ttl_trips` so a persistently-bad model stays demoted at the cap.
-    pub fn record_stall(&self, scope: Option<&str>, model_id: &str) {
+    ///
+    /// `escalate` controls whether this trip advances `disable_ttl_trips` (which
+    /// grows the cooldown cap across repeated trips):
+    /// - `true` for a genuine `Failure` / `AuthInvalid` / infra-stall signal — a
+    ///   persistently-bad model SHOULD stay demoted longer the more it misbehaves.
+    /// - `false` for a **throttle-classified** stall (the Codex/OpenAI empty-200
+    ///   account-quota signal). A quota resets on a clock, not on model health, so
+    ///   escalating the cooldown cap is wrong: the model isn't getting "more
+    ///   broken", the account is merely over quota until its window resets. We
+    ///   still apply the `STALL_MIN_COOLDOWN` floor so failover still happens —
+    ///   we just don't ratchet the cap.
+    pub fn record_stall(&self, scope: Option<&str>, model_id: &str, escalate: bool) {
         let mut map = self.inner.lock().unwrap();
         let key = HealthKey::new(scope, model_id);
         let state = map.entry(key.clone()).or_default();
@@ -325,7 +336,11 @@ impl HealthTracker {
         let cooldown = state.compute_cooldown().max(STALL_MIN_COOLDOWN);
         state.auto_disabled = true;
         state.cooldown_until = Some(Instant::now() + cooldown);
-        state.disable_ttl_trips += 1;
+        // A throttle resets on a clock, not on model health — don't ratchet the
+        // escalating cooldown cap for it (idea 6). Genuine failures still do.
+        if escalate {
+            state.disable_ttl_trips += 1;
+        }
         djinn_telemetry::breaker::increment_trip();
         tracing::warn!(
             model_id = %key.model_id,
@@ -806,7 +821,7 @@ mod tests {
     fn stall_trips_immediately_without_consecutive_threshold() {
         let ht = HealthTracker::new();
         // A single stall (well below CIRCUIT_BREAKER_THRESHOLD) disables the model.
-        ht.record_stall(S, TEST_MODEL);
+        ht.record_stall(S, TEST_MODEL, true);
         assert!(!ht.is_available(S, TEST_MODEL));
         let h = ht.model_health(S, TEST_MODEL);
         assert!(h.auto_disabled);
@@ -824,7 +839,7 @@ mod tests {
         const MAX_TASK_REDISPATCH_COOLDOWN_SECS: u64 = 240;
 
         let ht = HealthTracker::new();
-        ht.record_stall(S, TEST_MODEL);
+        ht.record_stall(S, TEST_MODEL, true);
         let remaining = ht
             .model_health(S, TEST_MODEL)
             .cooldown_seconds_remaining
@@ -841,7 +856,7 @@ mod tests {
     #[test]
     fn stall_self_heals_after_cooldown_then_success_resets() {
         let ht = HealthTracker::new();
-        ht.record_stall(S, TEST_MODEL);
+        ht.record_stall(S, TEST_MODEL, true);
         assert!(!ht.is_available(S, TEST_MODEL));
 
         // Cooldown expires → model auto-re-enables (one-off stall self-heals).
@@ -861,7 +876,7 @@ mod tests {
     fn repeated_stalls_escalate_trips_and_stay_capped() {
         let ht = HealthTracker::new();
         for expected_trip in 1..=4 {
-            ht.record_stall(S, TEST_MODEL);
+            ht.record_stall(S, TEST_MODEL, true);
             let h = ht.model_health(S, TEST_MODEL);
             assert_eq!(h.disable_ttl_trips, expected_trip);
             assert!(h.auto_disabled);
@@ -875,15 +890,42 @@ mod tests {
     }
 
     #[test]
+    fn throttle_stalls_trip_for_failover_without_escalating_the_cap() {
+        // Idea 6: a throttle-classified stall (`escalate = false`) — the
+        // Codex/OpenAI empty-200 account-quota signal — must still trip the
+        // breaker (so dispatch fails over) AND floor the cooldown at the cap (so
+        // the model is unavailable past the task redispatch ladder), but it must
+        // NOT advance `disable_ttl_trips`: a quota resets on a clock, not on model
+        // health, so ratcheting the escalating cooldown cap would be wrong.
+        let ht = HealthTracker::new();
+        for _ in 1..=4 {
+            ht.record_stall(S, TEST_MODEL, false);
+            let h = ht.model_health(S, TEST_MODEL);
+            // Tripped + floored for failover, exactly like a genuine stall.
+            assert!(h.auto_disabled);
+            assert!(!ht.is_available(S, TEST_MODEL));
+            let remaining = h.cooldown_seconds_remaining.unwrap();
+            assert!(remaining <= STALL_MIN_COOLDOWN.as_secs());
+            assert!(remaining >= STALL_MIN_COOLDOWN.as_secs().saturating_sub(1));
+            // …but the escalation cap counter never advances.
+            assert_eq!(
+                h.disable_ttl_trips, 0,
+                "a throttle stall must not escalate disable_ttl_trips",
+            );
+            expire_cooldown(&ht, S, TEST_MODEL);
+        }
+    }
+
+    #[test]
     fn stall_while_cooling_down_does_not_shorten_cooldown() {
         let ht = HealthTracker::new();
-        ht.record_stall(S, TEST_MODEL);
+        ht.record_stall(S, TEST_MODEL, true);
         let first = ht.model_health(S, TEST_MODEL);
         assert_eq!(first.disable_ttl_trips, 1);
 
         // A second stall arriving while still cooling down is a no-op for the
         // cooldown window (no re-trip, no reset) — it only bumps failure counts.
-        ht.record_stall(S, TEST_MODEL);
+        ht.record_stall(S, TEST_MODEL, true);
         let second = ht.model_health(S, TEST_MODEL);
         assert_eq!(second.disable_ttl_trips, 1, "no re-trip while cooling down");
         assert_eq!(second.consecutive_failures, 2);
@@ -898,7 +940,7 @@ mod tests {
         let a = Some("user-a");
         let b = Some("user-b");
 
-        ht.record_stall(a, TEST_MODEL);
+        ht.record_stall(a, TEST_MODEL, true);
 
         assert!(!ht.is_available(a, TEST_MODEL), "A's bucket is disabled");
         assert!(ht.is_available(b, TEST_MODEL), "B's bucket is untouched");
@@ -916,11 +958,11 @@ mod tests {
     #[test]
     fn enable_and_reset_all_scopes_hit_every_bucket() {
         let ht = HealthTracker::new();
-        ht.record_stall(Some("user-a"), TEST_MODEL);
-        ht.record_stall(Some("user-b"), TEST_MODEL);
-        ht.record_stall(None, TEST_MODEL);
+        ht.record_stall(Some("user-a"), TEST_MODEL, true);
+        ht.record_stall(Some("user-b"), TEST_MODEL, true);
+        ht.record_stall(None, TEST_MODEL, true);
         // A different model must be left alone.
-        ht.record_stall(Some("user-a"), "other-model");
+        ht.record_stall(Some("user-a"), "other-model", true);
 
         let re_enabled = ht.enable_model_all_scopes(TEST_MODEL);
         assert_eq!(re_enabled, 3);
@@ -1082,9 +1124,9 @@ mod tests {
     fn breaker_metric_snapshot_covers_closed_half_open_and_open() {
         let ht = HealthTracker::new();
         ht.record_success(Some("user-closed"), "closed-model");
-        ht.record_stall(Some("user-half"), "half-model");
+        ht.record_stall(Some("user-half"), "half-model", true);
         expire_cooldown(&ht, Some("user-half"), "half-model");
-        ht.record_stall(None, "open-model");
+        ht.record_stall(None, "open-model", true);
 
         let snapshot = ht.breaker_metric_snapshot();
         assert_eq!(snapshot.len(), 3);
@@ -1110,7 +1152,7 @@ mod tests {
             ht.record_failure(Some("trip-metric-user"), "trip-metric-model");
         }
         ht.record_failure(Some("trip-metric-user"), "trip-metric-model");
-        ht.record_stall(Some("trip-metric-user"), "trip-metric-model");
+        ht.record_stall(Some("trip-metric-user"), "trip-metric-model", true);
 
         assert_eq!(
             ht.model_health(Some("trip-metric-user"), "trip-metric-model")

--- a/server/crates/djinn-provider/src/provider/format/openai_responses.rs
+++ b/server/crates/djinn-provider/src/provider/format/openai_responses.rs
@@ -442,11 +442,27 @@ fn parse_responses_line(line: &str, accumulated_items: &mut Vec<OutputItemInfo>)
                 .filter(|i| matches!(i, OutputItemInfo::Reasoning { .. }))
                 .count();
             if n_msg == 0 && n_call == 0 {
+                // Idea 5: distinguish the two empty-output modes for downstream
+                // triage. `n_reasoning > 0` = reasoning-only stall (the model
+                // spent reasoning but emitted nothing usable; the reply loop
+                // nudges it). All-zero = a genuine empty-200, which on the
+                // Codex/OpenAI consumer backend is the over-quota account
+                // answering with an empty `response.completed` (a throttle that
+                // drives failover). The reply loop's authoritative discriminator
+                // is the reasoning-token count from the usage frame, not these
+                // final-item counts (encrypted/summary-off reasoning may surface
+                // no reasoning item), but logging both aids diagnosis.
+                let mode = if n_reasoning > 0 {
+                    "reasoning-only stall"
+                } else {
+                    "all-zero (likely Codex/OpenAI quota empty-200 throttle)"
+                };
                 tracing::warn!(
                     target: "djinn_provider::request",
                     total_items = final_items.len(),
                     reasoning_items = n_reasoning,
-                    "openai_responses: response.completed with NO message and NO function_call (reasoning-only/empty) — surfaces upstream as an empty assistant turn"
+                    mode,
+                    "openai_responses: response.completed with NO message and NO function_call — surfaces upstream as an empty assistant turn"
                 );
             }
 

--- a/server/src/server/tests/router.rs
+++ b/server/src/server/tests/router.rs
@@ -46,7 +46,7 @@ async fn metrics_returns_prometheus_text_without_auth() {
     let state = AppState::new(test_helpers::create_test_db(), CancellationToken::new());
     state
         .health_tracker()
-        .record_stall(Some("metrics-user"), "metrics-model");
+        .record_stall(Some("metrics-user"), "metrics-model", true);
     let app = server::router(state, false);
 
     let req = axum::http::Request::builder()


### PR DESCRIPTION
## Problem

`openai/gpt-5.5` (and any model on the ChatGPT/Codex *consumer* OAuth backend) gets auto-disabled far too often (observed 9 failures / 8 successes, 6 disable-trips). Root cause: that backend signals an over-quota **account** by answering a turn with an empty 200 (zero-token `response.completed`), **not** an HTTP 429. An exhausted empty-turn streak was wrapped as `ProviderInternal{500}` → classified `Failure` → fed to the consecutive-failure circuit breaker. So a **throttle** (account over quota) was miscounted as a **broken provider**, polluting model-health stats and escalating the auto-disable cooldown.

This had been mis-framed 3× before because `ProviderError::EmptyCompletion` is **never constructed in production** — the prior "empty turns are already excluded from the breaker" reasoning was about dead code.

## Changes (no new model/provider connections)

1. **Idea 1 — reclassify (root cause).** `empty_turn_terminal_error` (`turn.rs`) is now provider-family-gated via `is_codex_openai_family`: the Codex/OpenAI family emits `EmptyCompletion` (throttle); every **other** provider keeps `ProviderInternal{500}` so a genuinely dead model (e.g. `kimi/k2p7`) still trips the failure breaker (dead-model protection preserved). `classify_provider_failure` (`stage.rs`) moves `EmptyCompletion` from the `None` arm into the existing `Throttle` arm → `record_stall` (clean immediate failover) instead of `record_failure`.

2. **Idea 3 — synthesized quota window.** The empty-200 carries no `Retry-After` header (verified — it arrives as a normal stream end, not an HTTP status error), so `EmptyCompletion → Throttle` supplies a conservative `CODEX_EMPTY_QUOTA_RETRY_AFTER_MS` (~20 min) to floor the redispatch cooldown instead of probing on the 60/120/240s ladder.

3. **Idea 6 — no cap escalation on throttle.** `record_stall` gains an `escalate: bool`. Throttle-classified stalls trip + floor the cooldown (so failover happens) but do **not** ratchet `disable_ttl_trips` — a quota resets on a clock, not on model health. Genuine `Failure`/`AuthInvalid`/infra stalls still escalate.

4. **Idea 5 — reasoning-only vs quota empty-200.** A turn that spent reasoning tokens but produced no visible output/tool-call (`turn_reasoning_out > 0`) is a different failure mode than a quota empty-200 (all counts zero). The former now drives a **nudge** (asking the model to externalize output / call a tool) rather than failing over a healthy model; only the all-zero case reaches the throttle terminal.

## Verification

- `cargo test -p djinn-provider --lib` → 350 passed
- Targeted `djinn-agent --lib` tests for all touched modules pass; remaining full-suite failures are pre-existing flaky concurrency/timing tests (confirmed identical on a clean tree)
- `cargo clippy -p djinn-provider -p djinn-agent --all-targets --all-features -- -D warnings` → clean
- New unit tests: provider-family gating (codex→EmptyCompletion, kimi→ProviderInternal{500}); `EmptyCompletion`→Throttle with synthesized window; `record_stall` escalate=false trips without ratcheting the cap; reasoning-only discriminator + nudge body.

## Follow-ups (deliberately out of scope)

- Idea 2 (add an OpenAI **platform** API key preferred over Codex) — the durable cure, but involves connecting a new paid backend.
- Idea 4 (healthy non-Codex fallback in the model-priority list) — config.