### PR TITLE
fix(prompts): raise system-prompt cap so planner guidance isn't truncated

### DIFF
--- a/server/crates/djinn-agent/src/prompts.rs
+++ b/server/crates/djinn-agent/src/prompts.rs
@@ -15,7 +15,15 @@ use djinn_core::models::Task;
 /// Hard cap on rendered system prompt size (chars). Individual sections have
 /// their own soft limits, but this catches cases where multiple sections
 /// combine to blow past a reasonable size.
-const MAX_SYSTEM_PROMPT_CHARS: usize = 31_000;
+///
+/// Sized to fit the largest legitimate prompt — the Planner decomposition mode
+/// (`base.md` + `planner.md` + `planner/decomposition.md` + tool schemas + task
+/// fields), which is ~35K after the planner prompt-contract guidance landed. The
+/// old 31K cap silently truncated the tail of `decomposition.md` (the
+/// "prune unverifiable AC instead of escalating" contract), so the planner never
+/// saw guidance it was explicitly given. All in-use models have >=128K context,
+/// so a ~48K system prompt is comfortably within budget.
+const MAX_SYSTEM_PROMPT_CHARS: usize = 48_000;
 
 // ─── Embedded templates ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem (main is red → merge queue wedged)

`prompts::tests::planner_prompt_prunes_unverifiable_acceptance_criteria` is failing **deterministically on `main`**, which fails the `merge_group` CI for **every** PR (observed: #942, #943, #944, #945, #946) — nothing can merge.

Root cause: the rendered Planner/decomposition system prompt exceeds the **31,000-char** `MAX_SYSTEM_PROMPT_CHARS` cap (`prompts.rs:18`). `smart_truncate` then drops the tail of `decomposition.md` — including the "prune unverifiable AC instead of escalating" contract the test asserts on.

```
base.md            1,508
planner.md         7,409
decomposition.md  18,924   ← #940 (planner prompt contract) added +138 lines
                  ───────
                  27,841  + planner tool schemas + task fields  → > 31,000
```

So commit #940 (`chore(iuk0): Planner prompt contract`) pushed the prompt over the cap, and the very guidance it added gets **silently truncated before the planner LLM ever sees it** — both in the test and in production (this also drops the escalate-loop guardrail).

## Fix

Raise `MAX_SYSTEM_PROMPT_CHARS` 31,000 → 48,000. Every in-use model (gpt-5.5, kimi, glm, minimax) has ≥128K context, so a ~35K planner system prompt is well within budget. Restores the truncated guidance in production and turns the test green.

## Verification

- `cargo test -p djinn-agent --lib prompts::tests` → 57 passed, 0 failed (incl. the previously-red `planner_prompt_prunes_unverifiable_acceptance_criteria`)

## Note

This unblocks the merge queue for the whole team; it should land before #944 and #946 (which are only blocked because `main` is red).