### PR TITLE
feat(services): expose DATABASE_URL + auto-install service client CLIs

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/service_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/service_tools.rs
@@ -24,7 +24,13 @@ pub struct ServicePresetDto {
     pub name: String,
     pub service_type: String,
     pub image: String,
+    /// Comma-separated list of env-var names the connection string is exported
+    /// under (e.g. `DATABASE_URL,TEST_POSTGRES_URL`).
     pub conn_env_var: String,
+    /// System (apt) package providing this service's CLI client, auto-installed
+    /// into images that attach the preset. `null` = none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_package: Option<String>,
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -59,6 +65,7 @@ impl DjinnMcpServer {
                         service_type: p.service_type,
                         image: p.image,
                         conn_env_var: p.conn_env_var,
+                        client_package: p.client_package,
                     })
                     .collect(),
             }),

--- a/server/crates/djinn-db/migrations_postgres/73_service_preset_conventions.sql
+++ b/server/crates/djinn-db/migrations_postgres/73_service_preset_conventions.sql
@@ -1,0 +1,30 @@
+-- 73_service_preset_conventions.sql
+--
+-- Two codebase-agnostic improvements to injectable backing-service presets:
+--
+-- 1. Expose a preset's rendered connection string under the conventional
+--    `DATABASE_URL` env var (the name most projects/agents reach for), in
+--    addition to the bespoke `TEST_POSTGRES_URL`. The `conn_env_var` column is
+--    overloaded as a comma-separated LIST of env-var names; the sidecar exports
+--    the same connection string under each. `DATABASE_URL` is listed first as
+--    the conventional default; `TEST_POSTGRES_URL` is retained for back-compat.
+--    Redis (`REDIS_URL`) / RabbitMQ (`AMQP_URL`) keep their single names.
+--
+-- 2. Per-preset client CLI package. When an image declares a service, the
+--    catalog-image build auto-installs that service's command-line client so an
+--    agent can reach for `psql` / `redis-cli` by default. Data-driven: a future
+--    preset just sets its own `client_package`. NULL = no client to install
+--    (e.g. RabbitMQ has no stable common CLI client package).
+
+-- Change 1: multi-name connection env vars for the Postgres preset.
+UPDATE service_presets
+   SET conn_env_var = 'DATABASE_URL,TEST_POSTGRES_URL'
+ WHERE id = 'preset-postgres-18';
+
+-- Change 2: per-preset client CLI package, auto-installed into images that
+-- attach the preset.
+ALTER TABLE service_presets ADD COLUMN IF NOT EXISTS client_package TEXT;
+
+UPDATE service_presets SET client_package = 'postgresql-client' WHERE id = 'preset-postgres-18';
+UPDATE service_presets SET client_package = 'redis-tools'       WHERE id = 'preset-redis-7';
+-- RabbitMQ intentionally left NULL: no stable common client package.

--- a/server/crates/djinn-db/src/repositories/service.rs
+++ b/server/crates/djinn-db/src/repositories/service.rs
@@ -22,7 +22,14 @@ pub struct ServicePreset {
     pub env: String,       // JSON object (text)
     pub resources: String, // JSON object (text)
     pub conn_template: String,
+    /// One OR MORE env-var names (comma-separated) the worker exports for this
+    /// connection. The same rendered connection string is emitted under each
+    /// name — e.g. `DATABASE_URL,TEST_POSTGRES_URL` exports both.
     pub conn_env_var: String,
+    /// Optional system (apt) package providing this service's command-line
+    /// client (e.g. `postgresql-client` for `psql`). Auto-installed into any
+    /// catalog image that attaches the preset. `None` = no client to install.
+    pub client_package: Option<String>,
 }
 
 fn map_preset(r: &sqlx::postgres::PgRow) -> ServicePreset {
@@ -36,11 +43,14 @@ fn map_preset(r: &sqlx::postgres::PgRow) -> ServicePreset {
         resources: r.get("resources"),
         conn_template: r.get("conn_template"),
         conn_env_var: r.get("conn_env_var"),
+        // NULL maps to None; tolerate the column being absent on older schemas.
+        client_package: r.try_get("client_package").ok().flatten(),
     }
 }
 
 const PRESET_COLS: &str = r#"id, name, service_type, image, port,
-    env::text AS env, resources::text AS resources, conn_template, conn_env_var"#;
+    env::text AS env, resources::text AS resources, conn_template, conn_env_var,
+    client_package"#;
 
 pub struct ServicePresetRepository {
     db: Database,
@@ -86,6 +96,9 @@ mod tests {
             .unwrap()
             .expect("pg preset");
         assert_eq!(pg.service_type, "postgres");
-        assert_eq!(pg.conn_env_var, "TEST_POSTGRES_URL");
+        // Migration 73 overloads conn_env_var as a comma-separated list so the
+        // sidecar exports the connection under the conventional DATABASE_URL too.
+        assert_eq!(pg.conn_env_var, "DATABASE_URL,TEST_POSTGRES_URL");
+        assert_eq!(pg.client_package.as_deref(), Some("postgresql-client"));
     }
 }

--- a/server/crates/djinn-image-controller/src/controller.rs
+++ b/server/crates/djinn-image-controller/src/controller.rs
@@ -33,7 +33,9 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use djinn_db::{Database, Image, ImageRepository, ImageStatus, ProjectRepository};
+use djinn_db::{
+    Database, Image, ImageRepository, ImageStatus, ProjectRepository, ServicePresetRepository,
+};
 use djinn_image_builder::{
     AgentWorkerImage, BuildContext, compute_environment_hash, generate_dockerfile,
 };
@@ -307,13 +309,76 @@ impl ImageController {
     /// [`Self::enqueue`] but reads/writes the `images` row. `image` is the
     /// already-fetched row (callers have it in hand); `image_repo` is reused
     /// to avoid re-opening it.
+    /// Union the CLI client package (e.g. `postgresql-client`) of every backing
+    /// service preset attached to this image into `cfg.system_packages`.
+    ///
+    /// Codebase-agnostic and best-effort: any failure (junction read, preset
+    /// read, NULL/absent `client_package`, unknown preset) is logged and
+    /// skipped so a service-catalog problem never blocks the image build. The
+    /// dockerfile generator dedups + sorts `system_packages`, so duplicates with
+    /// a project's own apt packages are harmless.
+    async fn inject_preset_client_packages(
+        &self,
+        image_id: &str,
+        image_repo: &ImageRepository,
+        cfg: &mut EnvironmentConfig,
+    ) {
+        let preset_ids = match image_repo.list_service_presets(image_id).await {
+            Ok(ids) => ids,
+            Err(error) => {
+                warn!(
+                    image_id = %image_id,
+                    %error,
+                    "image_controller: list_service_presets failed; installing no service client packages"
+                );
+                return;
+            }
+        };
+        if preset_ids.is_empty() {
+            return;
+        }
+
+        let preset_repo = ServicePresetRepository::new(self.db.clone());
+        for preset_id in preset_ids {
+            match preset_repo.get(&preset_id).await {
+                Ok(Some(preset)) => {
+                    if let Some(pkg) = preset
+                        .client_package
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|p| !p.is_empty())
+                    {
+                        debug!(
+                            image_id = %image_id,
+                            preset_id = %preset_id,
+                            package = %pkg,
+                            "image_controller: adding service client package to image"
+                        );
+                        cfg.system_packages.push(pkg.to_string());
+                    }
+                }
+                Ok(None) => warn!(
+                    image_id = %image_id,
+                    preset_id = %preset_id,
+                    "image_controller: image references an unknown service preset; skipping client package"
+                ),
+                Err(error) => warn!(
+                    image_id = %image_id,
+                    preset_id = %preset_id,
+                    %error,
+                    "image_controller: service preset read failed; skipping client package"
+                ),
+            }
+        }
+    }
+
     pub async fn enqueue_image(
         &self,
         image_id: String,
         image_repo: &ImageRepository,
         image: Image,
     ) -> Result<()> {
-        let cfg: EnvironmentConfig =
+        let mut cfg: EnvironmentConfig =
             serde_json::from_str(&image.config).map_err(|e| ImageControllerError::ConfigParse {
                 project_id: image_id.clone(),
                 reason: e.to_string(),
@@ -323,6 +388,15 @@ impl ImageController {
                 project_id: image_id.clone(),
                 source,
             })?;
+
+        // Auto-install the CLI client of every backing service this image
+        // attaches (e.g. `postgresql-client` for `psql`) so an agent can reach
+        // for it by default. Best-effort: a NULL/absent client_package, unknown
+        // preset, or failed lookup logs and is skipped — never fail the build.
+        // Union into system_packages BEFORE the hash so the packages are part of
+        // the image identity; the dockerfile generator dedups + sorts them.
+        self.inject_preset_client_packages(&image_id, image_repo, &mut cfg)
+            .await;
 
         let agent_worker_ref = self.config.agent_worker_image.clone();
         let new_hash = compute_environment_hash(&cfg, &agent_worker_ref);

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -188,10 +188,11 @@ pub fn build_task_run_job(
     let labels = job_labels(&task_run_id_str);
     let job_name = format!("djinn-taskrun-{task_run_id}");
 
-    // Worker env carries the base task-run knobs plus one connection env var
-    // per injected backing service (e.g. TEST_POSTGRES_URL → 127.0.0.1:5432).
+    // Worker env carries the base task-run knobs plus the connection env var(s)
+    // per injected backing service (e.g. DATABASE_URL + TEST_POSTGRES_URL →
+    // 127.0.0.1:5432). A preset may declare more than one name.
     let mut worker_env = build_task_run_env(config, &task_run_id_str, project_id, policy);
-    worker_env.extend(services.iter().map(sidecar_conn_env));
+    worker_env.extend(services.iter().flat_map(sidecar_conn_env));
 
     let container = Container {
         name: "worker".to_string(),

--- a/server/crates/djinn-k8s/src/sidecar.rs
+++ b/server/crates/djinn-k8s/src/sidecar.rs
@@ -77,13 +77,25 @@ pub fn render_local_conn(conn_template: &str, port: i32) -> String {
         .replace("{port}", &port.to_string())
 }
 
-/// The env var the worker container exports for this service's connection.
-pub fn sidecar_conn_env(spec: &BackingServiceSpec) -> EnvVar {
-    EnvVar {
-        name: spec.conn_env_var.clone(),
-        value: Some(render_local_conn(&spec.conn_template, spec.port)),
-        ..EnvVar::default()
-    }
+/// The env var(s) the worker container exports for this service's connection.
+///
+/// `conn_env_var` is a comma-separated LIST of names (e.g.
+/// `DATABASE_URL,TEST_POSTGRES_URL`); the same rendered connection string is
+/// emitted under each so a project can reach for the conventional name
+/// (`DATABASE_URL`) or a bespoke one. Empty / whitespace-only entries are
+/// skipped.
+pub fn sidecar_conn_env(spec: &BackingServiceSpec) -> Vec<EnvVar> {
+    let value = render_local_conn(&spec.conn_template, spec.port);
+    spec.conn_env_var
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(|name| EnvVar {
+            name: name.to_string(),
+            value: Some(value.clone()),
+            ..EnvVar::default()
+        })
+        .collect()
 }
 
 /// Build the native-sidecar `Container` for one backing service. The caller
@@ -270,18 +282,30 @@ mod tests {
             cpu_limit: "500m".into(),
             memory_limit: "512Mi".into(),
             conn_template: "postgres://postgres:postgres@{host}:{port}/app_test".into(),
-            conn_env_var: "TEST_POSTGRES_URL".into(),
+            conn_env_var: "DATABASE_URL,TEST_POSTGRES_URL".into(),
         }
     }
 
     #[test]
     fn conn_env_renders_loopback_host() {
-        let env = sidecar_conn_env(&spec());
-        assert_eq!(env.name, "TEST_POSTGRES_URL");
-        assert_eq!(
-            env.value.as_deref(),
-            Some("postgres://postgres:postgres@127.0.0.1:5432/app_test")
-        );
+        let envs = sidecar_conn_env(&spec());
+        let expected = "postgres://postgres:postgres@127.0.0.1:5432/app_test";
+        // Both the conventional DATABASE_URL and the bespoke TEST_POSTGRES_URL
+        // are emitted with the same loopback connection string.
+        assert_eq!(envs.len(), 2);
+        assert_eq!(envs[0].name, "DATABASE_URL");
+        assert_eq!(envs[0].value.as_deref(), Some(expected));
+        assert_eq!(envs[1].name, "TEST_POSTGRES_URL");
+        assert_eq!(envs[1].value.as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn conn_env_skips_empty_and_whitespace_names() {
+        let mut s = spec();
+        s.conn_env_var = " DATABASE_URL , ,TEST_POSTGRES_URL,".into();
+        let envs = sidecar_conn_env(&s);
+        let names: Vec<&str> = envs.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["DATABASE_URL", "TEST_POSTGRES_URL"]);
     }
 
     #[test]

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -14089,7 +14089,13 @@ expression: signatures
       "$defs": {
         "ServicePresetDto": {
           "properties": {
+            "client_package": {
+              "description": "System (apt) package providing this service's CLI client, auto-installed\ninto images that attach the preset. `null` = none.",
+              "nullable": true,
+              "type": "string"
+            },
             "conn_env_var": {
+              "description": "Comma-separated list of env-var names the connection string is exported\nunder (e.g. `DATABASE_URL,TEST_POSTGRES_URL`).",
               "type": "string"
             },
             "id": {


### PR DESCRIPTION
## What & why

Two **codebase-agnostic** platform improvements to the backing-service sidecar feature. djinn runs task-run pods for *any* user codebase, so both changes make an injected service discoverable and usable by an arbitrary project without assuming djinn's own repo conventions (no seed data, no template DBs, no fixed ports beyond a preset's own standard ones).

### 1. Expose the connection under the conventional `DATABASE_URL`
`DATABASE_URL` is the env var most projects and AI agents reach for by default — but presets previously only exported a bespoke name (`TEST_POSTGRES_URL`). A preset can now declare **more than one** connection env-var name, and the sidecar exports the same rendered connection string under each.

- The multi-name list is a **comma-separated value in the existing `conn_env_var` column** (no column type change).
- Migration 73 sets the Postgres preset to `DATABASE_URL,TEST_POSTGRES_URL` — `DATABASE_URL` first (conventional), `TEST_POSTGRES_URL` kept for back-compat. Redis (`REDIS_URL`) / RabbitMQ (`AMQP_URL`) unchanged.
- `sidecar_conn_env` now returns `Vec<EnvVar>` (split on `,`, trim, skip empties, one `EnvVar` per name, all with the same loopback-rendered value). The `job.rs` caller `flat_map`s the result into the worker env.

### 2. Per-preset client CLI package, auto-installed into images that attach the preset
Agents reach for `psql` / `redis-cli` by default, so when an image declares a service we now ship that service's client.

- Migration 73 adds a nullable `service_presets.client_package` column and seeds: postgres → `postgresql-client`, redis → `redis-tools`, rabbitmq → NULL (no stable common client). Fully data-driven — a future preset just sets its own.
- The image-controller (`enqueue_image`) unions the `client_package` of every preset attached to the image into the build's `EnvironmentConfig.system_packages` **before** the environment hash, so the package becomes part of the image identity and the existing dockerfile generator dedups + sorts it into the `install-system.sh` apt list.
- **Best-effort & non-breaking:** a NULL/absent `client_package`, an unknown preset, or a failed preset/junction lookup logs and is skipped — it never fails the image build.

### How the client package is wired into the build
Catalog images are the only images with presets attached (junction `image_service_presets`, keyed by `image_id`). They build exclusively through `ImageController::enqueue_image`, which already holds the `image_id`, the `ImageRepository`, and the parsed `EnvironmentConfig`. A new best-effort `inject_preset_client_packages` helper reads `ImageRepository::list_service_presets` → `ServicePresetRepository::get` and pushes each non-empty `client_package` onto `cfg.system_packages` before `compute_environment_hash`. No new plumbing through the build job was needed.

## Files changed
- `server/crates/djinn-db/migrations_postgres/73_service_preset_conventions.sql` (new)
- `server/crates/djinn-db/src/repositories/service.rs` — `client_package` field + `PRESET_COLS` + `map_preset`; updated unit test
- `server/crates/djinn-k8s/src/sidecar.rs` — `sidecar_conn_env` → `Vec<EnvVar>`; updated + added unit tests
- `server/crates/djinn-k8s/src/job.rs` — caller now `flat_map`s the conn env vars
- `server/crates/djinn-image-controller/src/controller.rs` — `inject_preset_client_packages` best-effort union into `system_packages`
- `server/crates/djinn-control-plane/src/tools/service_tools.rs` — surface `client_package` in `service_preset_list` DTO
- `server/src/server/tests/snapshots/...mcp_tools_schema.snap` — regenerated for the new DTO field

## Local verification
- `cargo build` (full workspace): **pass**
- `cargo clippy -p djinn-k8s -p djinn-image-builder -p djinn-image-controller -p djinn-control-plane --all-targets -- -D warnings`: **pass** (the `djinn-db` `--all-targets` clippy failures are pre-existing `cloned_ref_to_slice_refs` lints in untouched `note/` test files on a clippy 1.96 bump — confirmed present on a clean tree)
- `cargo test -p djinn-k8s sidecar`: **pass** (4 tests, incl. both new conn-env assertions + the existing job sidecar test)
- `cargo test -p djinn-image-builder`: **pass** (17 unit + 2 golden)
- `cargo test -p djinn-image-controller`: **pass** (3 tests)
- `cargo test -p djinn-server --lib tool_schemas`: **pass** (14 tests; snapshot regenerated via `INSTA_UPDATE=always`)
- `cargo fmt`: clean on touched files
- Deferred to CI: the `service.rs` `default_presets_seeded` repo test and any other tests requiring a live Postgres (this worktree has no DB). Their assertions were updated to expect the migration-73 values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)