### PR TITLE
feat(usage-analytics): estimated spend subtotal, per-user filter, label-resolving selects

### DIFF
--- a/server/crates/djinn-db/src/repositories/usage_analytics.rs
+++ b/server/crates/djinn-db/src/repositories/usage_analytics.rs
@@ -180,6 +180,10 @@ pub struct UsageAnalyticsQuery {
     pub model_id: Option<String>,
     /// Optional agent_type filter.
     pub agent_type: Option<String>,
+    /// Optional user filter. Matches the session's attributed user, preferring
+    /// the session creator and falling back to the task creator (same
+    /// attribution rule as the `by_user` breakdown).
+    pub user_id: Option<String>,
 }
 
 /// Overall totals across the entire queried date range (and matching filters).
@@ -190,9 +194,15 @@ pub struct UsageTotals {
     pub tokens_out: i64,
     pub cache_read_tokens: i64,
     pub cache_write_tokens: i64,
-    /// Aggregate cost in USD.  `None` when ANY matching session had no
-    /// pricing, preserving the "unpriced" signal.
+    /// Estimated spend in USD: the sum of `cost_usd` over the *priced* sessions
+    /// only (unpriced sessions are skipped, not treated as $0). This is a
+    /// notional figure at public API rates — usage on subscription/coding
+    /// plans is billed separately. `None` only when no matching session was
+    /// priced at all.
     pub total_cost_usd: Option<f64>,
+    /// Number of matching sessions whose `cost_usd` was NULL (unpriced model),
+    /// hence excluded from `total_cost_usd`. Lets the UI qualify the estimate.
+    pub unpriced_session_count: i64,
 }
 
 /// A single multi-dimensional time-series row: one day bucket for a particular
@@ -252,8 +262,10 @@ impl UsageAnalyticsRepository {
     // ── Shared filter construction ─────────────────────────────────────────
 
     /// Build the session-level WHERE conditions (date range + optional
-    /// project / model / agent filters) and their ordered bind values.  All
-    /// conditions reference `sessions s`, so this composes with any joins.
+    /// project / model / agent / user filters) and their ordered bind values.
+    /// Conditions reference `sessions s` and, for the user filter, `tasks t`;
+    /// every caller therefore joins `tasks t ON t.id = s.task_id` (a 1:1 join
+    /// that cannot inflate counts).
     fn session_filters(params: &UsageAnalyticsQuery) -> (Vec<String>, Vec<String>) {
         let mut conditions: Vec<String> = Vec::new();
         let mut binds: Vec<String> = Vec::new();
@@ -282,6 +294,16 @@ impl UsageAnalyticsRepository {
         if let Some(ref agent_type) = params.agent_type {
             conditions.push(format!("s.agent_type = ${idx}"));
             binds.push(agent_type.clone());
+            idx += 1;
+        }
+
+        if let Some(ref user_id) = params.user_id {
+            // Same attribution as the `by_user` breakdown: session creator,
+            // falling back to the task creator.
+            conditions.push(format!(
+                "COALESCE(s.created_by_user_id, t.created_by_user_id) = ${idx}"
+            ));
+            binds.push(user_id.clone());
         }
 
         (conditions, binds)
@@ -304,8 +326,14 @@ impl UsageAnalyticsRepository {
 
     // ── Totals ────────────────────────────────────────────────────────────
 
-    /// Window totals across all matching sessions (no dimension joins so an
-    /// epic mapped to multiple proposals cannot inflate the counts).
+    /// Window totals across all matching sessions. The `tasks t` join is 1:1
+    /// (`t.id = s.task_id`) so it cannot inflate counts; it exists only so the
+    /// optional user filter can fall back to the task creator.
+    ///
+    /// Spend is the priced subtotal — `SUM(s.cost_usd)` naturally skips
+    /// unpriced (NULL-cost) sessions — and `unpriced_session_count` reports
+    /// how many sessions were excluded, so the UI can show an honest estimate
+    /// instead of collapsing the whole total to "—".
     pub async fn totals(&self, params: &UsageAnalyticsQuery) -> Result<UsageTotals> {
         self.db.ensure_initialized().await?;
 
@@ -319,9 +347,11 @@ impl UsageAnalyticsRepository {
                 COALESCE(SUM(s.tokens_out)::bigint, 0)         AS tokens_out, \
                 COALESCE(SUM(s.cache_read_tokens)::bigint, 0)  AS cache_read_tokens, \
                 COALESCE(SUM(s.cache_write_tokens)::bigint, 0) AS cache_write_tokens, \
-                CASE WHEN bool_or(s.cost_usd IS NULL) THEN NULL ELSE SUM(s.cost_usd) END \
-                                                               AS total_cost_usd \
-             FROM sessions s {where_clause}"
+                SUM(s.cost_usd)                                AS total_cost_usd, \
+                COUNT(*) FILTER (WHERE s.cost_usd IS NULL)     AS unpriced_session_count \
+             FROM sessions s \
+             LEFT JOIN tasks t ON t.id = s.task_id \
+             {where_clause}"
         );
 
         let query = Self::bind_all(sqlx::query(&sql), &binds);
@@ -334,6 +364,7 @@ impl UsageAnalyticsRepository {
             cache_read_tokens: row.get("cache_read_tokens"),
             cache_write_tokens: row.get("cache_write_tokens"),
             total_cost_usd: row.get("total_cost_usd"),
+            unpriced_session_count: row.get("unpriced_session_count"),
         })
     }
 
@@ -361,10 +392,10 @@ impl UsageAnalyticsRepository {
                 COALESCE(SUM(s.tokens_in)::bigint, 0)          AS tokens_in, \
                 COALESCE(SUM(s.tokens_out)::bigint, 0)         AS tokens_out, \
                 COUNT(DISTINCT s.task_id)                      AS task_count, \
-                CASE WHEN bool_or(s.cost_usd IS NULL) THEN NULL ELSE SUM(s.cost_usd) END \
-                                                               AS cost \
+                SUM(s.cost_usd)                                AS cost \
              FROM sessions s \
              LEFT JOIN projects p ON p.id = s.project_id \
+             LEFT JOIN tasks t ON t.id = s.task_id \
              {where_clause} \
              GROUP BY substring(s.started_at, 1, 10), s.model_id, \
                       COALESCE(s.project_id, ''), COALESCE(p.name, ''), s.agent_type \
@@ -423,7 +454,7 @@ impl UsageAnalyticsRepository {
                 SELECT \
                     entity_id, \
                     MAX(entity_name) AS entity_name, \
-                    CASE WHEN bool_or(cost_usd IS NULL) THEN NULL ELSE SUM(cost_usd) END AS cost, \
+                    SUM(cost_usd) AS cost, \
                     COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
                     COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out, \
                     COUNT(DISTINCT task_id) AS task_count \
@@ -527,6 +558,14 @@ impl UsageAnalyticsRepository {
         if let Some(ref model_id) = params.model_id {
             conditions.push(format!("s.model_id = ${idx}"));
             binds.push(model_id.clone());
+            idx += 1;
+        }
+
+        if let Some(ref user_id) = params.user_id {
+            conditions.push(format!(
+                "COALESCE(s.created_by_user_id, t.created_by_user_id) = ${idx}"
+            ));
+            binds.push(user_id.clone());
         }
 
         let from_clause = "FROM sessions s JOIN tasks t ON t.id = s.task_id".to_string();
@@ -552,7 +591,7 @@ impl UsageAnalyticsRepository {
                 SELECT \
                     model_id, \
                     COUNT(*) AS sessions, \
-                    CASE WHEN bool_or(cost_usd IS NULL) THEN NULL ELSE SUM(cost_usd) END AS spend_usd, \
+                    SUM(cost_usd) AS spend_usd, \
                     COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
                     COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out \
                 FROM filtered_sessions \
@@ -654,7 +693,7 @@ impl UsageAnalyticsRepository {
                 SELECT \
                     project_id, MAX(project_name) AS project_name, model_id, \
                     COUNT(*) AS sessions, \
-                    CASE WHEN bool_or(cost_usd IS NULL) THEN NULL ELSE SUM(cost_usd) END AS spend_usd, \
+                    SUM(cost_usd) AS spend_usd, \
                     COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
                     COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out, \
                     COUNT(DISTINCT task_id) AS task_count \
@@ -771,16 +810,24 @@ mod tests {
             project_id: Some("proj-1".into()),
             model_id: None,
             agent_type: Some("worker".into()),
+            user_id: Some("user-1".into()),
         };
         let (conditions, binds) = UsageAnalyticsRepository::session_filters(&q);
         assert_eq!(conditions[0], "s.started_at >= $1");
         assert_eq!(conditions[1], "s.started_at < $2");
         assert_eq!(binds[0], "2025-01-01");
         assert_eq!(binds[1], "2025-02-01");
-        // project_id present, model_id absent, agent_type present → 4 binds.
-        assert_eq!(binds.len(), 4);
+        // project_id present, model_id absent, agent_type + user present → 5 binds.
+        assert_eq!(binds.len(), 5);
         assert_eq!(binds[2], "proj-1");
         assert_eq!(binds[3], "worker");
+        assert_eq!(binds[4], "user-1");
+        // The user filter must reference the task-creator fallback so it can
+        // bind against the COALESCE attribution column.
+        assert!(
+            conditions.last().unwrap().contains("created_by_user_id"),
+            "user filter should use the COALESCE attribution column"
+        );
     }
 
     #[test]

--- a/server/crates/djinn-db/tests/usage_analytics_totals.rs
+++ b/server/crates/djinn-db/tests/usage_analytics_totals.rs
@@ -28,6 +28,7 @@ fn effectiveness_params() -> UsageAnalyticsQuery {
         project_id: None,
         model_id: None,
         agent_type: None,
+        user_id: None,
     }
 }
 
@@ -222,6 +223,7 @@ async fn usage_totals_decodes_i64_from_sum() {
         project_id: None,
         model_id: None,
         agent_type: None,
+        user_id: None,
     };
 
     let totals = repo.totals(&params).await.expect("totals should succeed");
@@ -231,10 +233,10 @@ async fn usage_totals_decodes_i64_from_sum() {
     assert_eq!(totals.tokens_out, 5678);
     assert_eq!(totals.cache_read_tokens, 100);
     assert_eq!(totals.cache_write_tokens, 200);
-    // total_cost_usd should be Some(0.042) — no NULL sessions, so no NULL
-    // cost semantic applies.
+    // total_cost_usd should be Some(0.042) — the only session is priced.
     let cost = totals.total_cost_usd.expect("cost should be Some");
     assert!((cost - 0.042_f64).abs() < 1e-9, "cost mismatch: {cost}");
+    assert_eq!(totals.unpriced_session_count, 0);
 
     // Detailed series should have exactly one (day, model, project, agent) row.
     let series = repo
@@ -247,10 +249,11 @@ async fn usage_totals_decodes_i64_from_sum() {
     assert_eq!(series[0].tokens_out, 5678);
 }
 
-/// Verify NULL-cost semantics: when ANY matching session has NULL cost_usd,
-/// the aggregate total_cost_usd must be NULL (not $0).
+/// Verify priced-subtotal semantics: a mix of priced and unpriced sessions
+/// yields the sum over the *priced* sessions only (not NULL, not $0), and the
+/// unpriced sessions are counted separately so the UI can qualify the estimate.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn usage_totals_null_cost_semantics_preserved() {
+async fn usage_totals_reports_priced_subtotal_and_unpriced_count() {
     let db = create_test_db();
     seed_session(&db).await;
     seed_unpriced_session(&db).await;
@@ -263,6 +266,7 @@ async fn usage_totals_null_cost_semantics_preserved() {
         project_id: None,
         model_id: None,
         agent_type: None,
+        user_id: None,
     };
 
     let totals = repo.totals(&params).await.expect("totals should succeed");
@@ -273,12 +277,45 @@ async fn usage_totals_null_cost_semantics_preserved() {
     assert_eq!(totals.tokens_out, 5678 + 888);
     assert_eq!(totals.cache_read_tokens, 100 + 50);
     assert_eq!(totals.cache_write_tokens, 200 + 75);
-    // Because one session has NULL cost_usd, total_cost_usd must be NULL.
+    // Spend is the priced subtotal (only the 0.042 session is priced); the
+    // unpriced session is excluded from the sum but counted.
+    let cost = totals
+        .total_cost_usd
+        .expect("priced subtotal should be Some when at least one session is priced");
+    assert!((cost - 0.042_f64).abs() < 1e-9, "cost mismatch: {cost}");
+    assert_eq!(
+        totals.unpriced_session_count, 1,
+        "exactly one unpriced session should be counted"
+    );
+}
+
+/// When *every* matching session is unpriced, the priced subtotal is NULL
+/// (nothing to sum) and all sessions are reported as unpriced.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn usage_totals_all_unpriced_yields_none_subtotal() {
+    let db = create_test_db();
+    seed_unpriced_session(&db).await;
+
+    let repo = UsageAnalyticsRepository::new(db);
+    let params = UsageAnalyticsQuery {
+        from: "2025-01-01".into(),
+        to: "2025-12-31".into(),
+        group_by: GroupDimension::Model,
+        project_id: None,
+        model_id: None,
+        agent_type: None,
+        user_id: None,
+    };
+
+    let totals = repo.totals(&params).await.expect("totals should succeed");
+
+    assert_eq!(totals.session_count, 1);
     assert!(
         totals.total_cost_usd.is_none(),
-        "expected NULL total_cost_usd when any session is unpriced, got {:?}",
+        "expected NULL subtotal when no session is priced, got {:?}",
         totals.total_cost_usd,
     );
+    assert_eq!(totals.unpriced_session_count, 1);
 }
 
 /// Verify the entity breakdown query also decodes correctly (same SUM→NUMERIC
@@ -296,6 +333,7 @@ async fn breakdown_decodes_i64_from_sum() {
         project_id: None,
         model_id: None,
         agent_type: None,
+        user_id: None,
     };
 
     let rows = repo

--- a/server/src/server/usage_analytics.rs
+++ b/server/src/server/usage_analytics.rs
@@ -53,6 +53,8 @@ struct UsageQuery {
     /// Model identifier filter.
     model: Option<String>,
     agent_type: Option<String>,
+    /// User identifier filter (session creator, falling back to task creator).
+    user_id: Option<String>,
 }
 
 /// Time-series bucket granularity. Repository rows are daily; week/month
@@ -173,6 +175,7 @@ fn previous_window_query(
         project_id: query.project_id.clone(),
         model_id: query.model_id.clone(),
         agent_type: query.agent_type.clone(),
+        user_id: query.user_id.clone(),
     })
 }
 
@@ -224,6 +227,7 @@ impl UsageQuery {
                 project_id: self.project_id.filter(|s| !s.is_empty()),
                 model_id: self.model.filter(|s| !s.is_empty()),
                 agent_type: self.agent_type.filter(|s| !s.is_empty()),
+                user_id: self.user_id.filter(|s| !s.is_empty()),
             },
             granularity,
         ))
@@ -244,6 +248,11 @@ struct UsageKpiDto {
     /// Pre-formatted display value (currency); empty string lets the UI fall
     /// back to compact-number formatting of `value`.
     formatted: String,
+    /// Optional qualifier shown under the value (e.g. that spend is an
+    /// estimate at API rates, and how many sessions were unpriced). `None`
+    /// when the card needs no caption.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    caption: Option<String>,
 }
 
 /// A point in the multi-dimensional time series.  Carries the model / project /
@@ -408,18 +417,21 @@ fn build_kpis(totals: &UsageTotals, previous: &UsageTotals) -> Vec<UsageKpiDto> 
                 .total_cost_usd
                 .map(format_currency)
                 .unwrap_or_default(),
+            caption: Some(spend_caption(totals.unpriced_session_count)),
         },
         UsageKpiDto {
             label: "Tokens".to_string(),
             value: Some(tokens),
             delta_pct: pct_delta(tokens, prev_tokens),
             formatted: String::new(),
+            caption: None,
         },
         UsageKpiDto {
             label: "Sessions".to_string(),
             value: Some(totals.session_count as f64),
             delta_pct: pct_delta(totals.session_count as f64, previous.session_count as f64),
             formatted: String::new(),
+            caption: None,
         },
         UsageKpiDto {
             label: "Cache reads".to_string(),
@@ -429,8 +441,23 @@ fn build_kpis(totals: &UsageTotals, previous: &UsageTotals) -> Vec<UsageKpiDto> 
                 previous.cache_read_tokens as f64,
             ),
             formatted: String::new(),
+            caption: None,
         },
     ]
+}
+
+/// Caption for the Spend card. Spend is a notional figure at public API rates
+/// (usage on subscription / coding plans is billed separately), and unpriced
+/// sessions are excluded from the sum rather than counted as $0.
+fn spend_caption(unpriced_session_count: i64) -> String {
+    let mut caption = "Est. at public API rates".to_string();
+    if unpriced_session_count > 0 {
+        caption.push_str(&format!(
+            " · {unpriced_session_count} unpriced session{} excluded",
+            if unpriced_session_count == 1 { "" } else { "s" }
+        ));
+    }
+    caption
 }
 
 fn week_start(date: time::Date) -> Result<time::Date, (StatusCode, String)> {
@@ -674,6 +701,7 @@ mod tests {
             project_id: None,
             model: None,
             agent_type: None,
+            user_id: None,
         }
     }
 
@@ -779,11 +807,13 @@ mod tests {
             project_id: Some("proj-1".into()),
             model_id: Some("model-1".into()),
             agent_type: Some("worker".into()),
+            user_id: Some("user-1".into()),
         };
         let previous = previous_window_query(&query).unwrap();
         assert_eq!(previous.from, "2025-03-03");
         assert_eq!(previous.to, "2025-03-10");
         assert_eq!(previous.project_id.as_deref(), Some("proj-1"));
+        assert_eq!(previous.user_id.as_deref(), Some("user-1"));
     }
 
     #[test]
@@ -795,6 +825,7 @@ mod tests {
             cache_read_tokens: 50,
             cache_write_tokens: 5,
             total_cost_usd: Some(20.0),
+            unpriced_session_count: 0,
         };
         let previous = UsageTotals {
             session_count: 5,
@@ -803,6 +834,7 @@ mod tests {
             cache_read_tokens: 25,
             cache_write_tokens: 0,
             total_cost_usd: Some(10.0),
+            unpriced_session_count: 0,
         };
         let kpis = build_kpis(&totals, &previous);
         assert_eq!(kpis.len(), 4);
@@ -815,6 +847,8 @@ mod tests {
             "doubled spend = +100%"
         );
         assert!(spend.formatted.starts_with('$'));
+        // No unpriced sessions → caption is the bare estimate qualifier.
+        assert_eq!(spend.caption.as_deref(), Some("Est. at public API rates"));
 
         let tokens = &kpis[1];
         assert_eq!(tokens.value, Some(200.0));
@@ -834,6 +868,33 @@ mod tests {
         assert!(kpis[0].formatted.is_empty());
         // Previous window empty → token delta is null, not a divide-by-zero.
         assert!(kpis[1].delta_pct.is_none());
+    }
+
+    #[test]
+    fn spend_caption_notes_excluded_unpriced_sessions() {
+        assert_eq!(spend_caption(0), "Est. at public API rates");
+        assert_eq!(
+            spend_caption(1),
+            "Est. at public API rates · 1 unpriced session excluded"
+        );
+        assert_eq!(
+            spend_caption(5),
+            "Est. at public API rates · 5 unpriced sessions excluded"
+        );
+    }
+
+    #[test]
+    fn build_kpis_spend_caption_reports_unpriced_count() {
+        let totals = UsageTotals {
+            total_cost_usd: Some(12.5),
+            unpriced_session_count: 3,
+            ..UsageTotals::default()
+        };
+        let kpis = build_kpis(&totals, &UsageTotals::default());
+        assert_eq!(
+            kpis[0].caption.as_deref(),
+            Some("Est. at public API rates · 3 unpriced sessions excluded")
+        );
     }
 
     fn series_row(day: &str, model: &str, cost: Option<f64>) -> SeriesDetailRow {

--- a/ui/src/api/analytics.ts
+++ b/ui/src/api/analytics.ts
@@ -31,6 +31,8 @@ export interface UsageAnalyticsFilters {
   model?: string;
   /** Filter to a specific agent base role / type. */
   agent_type?: string;
+  /** Filter to a specific user (session creator, falling back to task creator). */
+  user_id?: string;
 }
 
 // ── Response types ─────────────────────────────────────────────────────────
@@ -42,6 +44,8 @@ export interface UsageKpi {
   delta_pct: number | null;
   /** Formatted display value for the KPI card. */
   formatted: string;
+  /** Optional qualifier shown under the value (e.g. spend estimate basis). */
+  caption?: string | null;
 }
 
 export interface UsageTimeSeriesPoint {
@@ -155,6 +159,7 @@ export function buildUsageAnalyticsQueryString(filters: UsageAnalyticsFilters): 
   if (filters.project_id) params.set("project_id", filters.project_id);
   if (filters.model) params.set("model", filters.model);
   if (filters.agent_type) params.set("agent_type", filters.agent_type);
+  if (filters.user_id) params.set("user_id", filters.user_id);
 
   const qs = params.toString();
   return qs ? `?${qs}` : "";

--- a/ui/src/components/usage/UsageDashboardFilters.tsx
+++ b/ui/src/components/usage/UsageDashboardFilters.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import type {
   DateRangePreset,
   Granularity,
@@ -25,30 +26,34 @@ const ALL_VALUE = "__all__";
 /** Internal date-range mode that adds "custom" on top of the API presets. */
 const CUSTOM_VALUE = "custom";
 
-const DATE_PRESETS: { value: DateRangePreset; label: string }[] = [
+/** Option shape consumed by base-ui's `Select.items`, which makes
+ * `<SelectValue />` render the option's human label instead of the raw value
+ * (otherwise the trigger shows e.g. `__all__` / `30d` / `day`). */
+interface SelectItemOption {
+  value: string;
+  label: string;
+}
+
+const DATE_ITEMS: SelectItemOption[] = [
   { value: "7d", label: "Last 7 days" },
   { value: "30d", label: "Last 30 days" },
+  { value: CUSTOM_VALUE, label: "Custom range" },
 ];
 
-const GRANULARITIES: { value: Granularity; label: string }[] = [
+const GRANULARITIES: SelectItemOption[] = [
   { value: "day", label: "Daily" },
   { value: "week", label: "Weekly" },
   { value: "month", label: "Monthly" },
 ];
 
 /** Known agent base roles — mirrors `BaseRole` from `@/api/agents`. */
-const AGENT_TYPES: { value: string; label: string }[] = [
+const AGENT_TYPES: SelectItemOption[] = [
   { value: "worker", label: "Worker" },
   { value: "reviewer", label: "Reviewer" },
   { value: "lead", label: "Lead" },
   { value: "planner", label: "Planner" },
   { value: "architect", label: "Architect" },
 ];
-
-interface ProjectOption {
-  id: string;
-  name: string;
-}
 
 interface UsageDashboardFiltersBarProps {
   /** The canonical filter object shared by every dashboard tab. */
@@ -75,7 +80,7 @@ export function UsageDashboardFiltersBar({
   // ── Derive selector options from the analytics response metadata ──────────
   // Source projects from breakdown rows and matrix cells so options stay
   // populated even when one section is sparse.  Resilient to empty data.
-  const projectOptions = useMemo<ProjectOption[]>(() => {
+  const projectOptions = useMemo<SelectItemOption[]>(() => {
     const seen = new Map<string, string>();
     for (const row of data?.breakdowns.by_project ?? []) {
       if (row.id) seen.set(row.id, row.name || row.id);
@@ -85,14 +90,26 @@ export function UsageDashboardFiltersBar({
         seen.set(cell.project_id, cell.project_name || cell.project_id);
       }
     }
-    return Array.from(seen, ([id, name]) => ({ id, name }));
+    return Array.from(seen, ([value, label]) => ({ value, label }));
   }, [data]);
 
-  const modelOptions = useMemo<string[]>(() => {
+  const modelOptions = useMemo<SelectItemOption[]>(() => {
     const seen = new Set<string>();
     for (const m of data?.model_effectiveness ?? []) seen.add(m.model);
     for (const cell of data?.project_model_matrix ?? []) seen.add(cell.model);
-    return Array.from(seen).sort();
+    return Array.from(seen)
+      .sort()
+      .map((value) => ({ value, label: value }));
+  }, [data]);
+
+  // Users are sourced from the by_user breakdown — the only place the backend
+  // surfaces the user dimension. Falls back to the id when a name is missing.
+  const userOptions = useMemo<SelectItemOption[]>(() => {
+    const seen = new Map<string, string>();
+    for (const row of data?.breakdowns.by_user ?? []) {
+      if (row.id) seen.set(row.id, row.name || row.id);
+    }
+    return Array.from(seen, ([value, label]) => ({ value, label }));
   }, [data]);
 
   // ── Date range mode ───────────────────────────────────────────────────────
@@ -113,23 +130,13 @@ export function UsageDashboardFiltersBar({
     }
   };
 
-  // ── Single-select helpers ─────────────────────────────────────────────────
-  const selectValue = (v: string | undefined) => v ?? ALL_VALUE;
-
-  const handleSingleChange =
-    (field: "project_id" | "model" | "agent_type") => (value: string) => {
-      onChange({
-        ...filters,
-        [field]: value === ALL_VALUE ? undefined : value,
-      });
-    };
-
   return (
     <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border bg-card px-4 py-3">
       {/* Date range preset / custom */}
       <div className="flex flex-col gap-1.5">
         <Label className="text-xs text-muted-foreground">Date range</Label>
         <Select
+          items={DATE_ITEMS}
           value={dateMode}
           onValueChange={(v) =>
             typeof v === "string" && handleDateModeChange(v)
@@ -139,12 +146,11 @@ export function UsageDashboardFiltersBar({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {DATE_PRESETS.map((p) => (
+            {DATE_ITEMS.map((p) => (
               <SelectItem key={p.value} value={p.value}>
                 {p.label}
               </SelectItem>
             ))}
-            <SelectItem value={CUSTOM_VALUE}>Custom range</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -189,17 +195,15 @@ export function UsageDashboardFiltersBar({
         </>
       )}
 
-      {/* Granularity */}
+      {/* Granularity — always has a value, so no "all" option. */}
       <div className="flex flex-col gap-1.5">
         <Label className="text-xs text-muted-foreground">Granularity</Label>
         <Select
-          value={selectValue(filters.granularity)}
+          items={GRANULARITIES}
+          value={filters.granularity ?? "day"}
           onValueChange={(v) => {
             if (typeof v === "string") {
-              onChange({
-                ...filters,
-                granularity: v === ALL_VALUE ? undefined : (v as Granularity),
-              });
+              onChange({ ...filters, granularity: v as Granularity });
             }
           }}
         >
@@ -216,80 +220,99 @@ export function UsageDashboardFiltersBar({
         </Select>
       </div>
 
-      {/* Project */}
-      <div className="flex flex-col gap-1.5">
-        <Label className="text-xs text-muted-foreground">Project</Label>
-        <Select
-          value={selectValue(filters.project_id)}
-          onValueChange={(v) =>
-            typeof v === "string" && handleSingleChange("project_id")(v)
-          }
-        >
-          <SelectTrigger
-            className="h-8 w-[160px] text-xs"
-            title="Project filter"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL_VALUE}>All projects</SelectItem>
-            {projectOptions.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <FilterSelect
+        label="Project"
+        allLabel="All projects"
+        title="Project filter"
+        width="w-[160px]"
+        options={projectOptions}
+        value={filters.project_id}
+        onSelect={(value) => onChange({ ...filters, project_id: value })}
+      />
 
-      {/* Model */}
-      <div className="flex flex-col gap-1.5">
-        <Label className="text-xs text-muted-foreground">Model</Label>
-        <Select
-          value={selectValue(filters.model)}
-          onValueChange={(v) =>
-            typeof v === "string" && handleSingleChange("model")(v)
-          }
-        >
-          <SelectTrigger className="h-8 w-[180px] text-xs" title="Model filter">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL_VALUE}>All models</SelectItem>
-            {modelOptions.map((m) => (
-              <SelectItem key={m} value={m}>
-                {m}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <FilterSelect
+        label="Model"
+        allLabel="All models"
+        title="Model filter"
+        width="w-[180px]"
+        options={modelOptions}
+        value={filters.model}
+        onSelect={(value) => onChange({ ...filters, model: value })}
+      />
 
-      {/* Agent type */}
-      <div className="flex flex-col gap-1.5">
-        <Label className="text-xs text-muted-foreground">Agent type</Label>
-        <Select
-          value={selectValue(filters.agent_type)}
-          onValueChange={(v) =>
-            typeof v === "string" && handleSingleChange("agent_type")(v)
-          }
-        >
-          <SelectTrigger
-            className="h-8 w-[130px] text-xs"
-            title="Agent type filter"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ALL_VALUE}>All types</SelectItem>
-            {AGENT_TYPES.map((a) => (
-              <SelectItem key={a.value} value={a.value}>
-                {a.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <FilterSelect
+        label="User"
+        allLabel="All users"
+        title="User filter"
+        width="w-[160px]"
+        options={userOptions}
+        value={filters.user_id}
+        onSelect={(value) => onChange({ ...filters, user_id: value })}
+      />
+
+      <FilterSelect
+        label="Agent type"
+        allLabel="All types"
+        title="Agent type filter"
+        width="w-[130px]"
+        options={AGENT_TYPES}
+        value={filters.agent_type}
+        onSelect={(value) => onChange({ ...filters, agent_type: value })}
+      />
+    </div>
+  );
+}
+
+/**
+ * A single "all-or-one" filter dropdown. Prepends an "All …" sentinel option
+ * and passes `items` to the Select so the trigger renders the chosen option's
+ * label rather than the raw value (no stray `__all__` in the UI).
+ */
+function FilterSelect({
+  label,
+  allLabel,
+  title,
+  width,
+  options,
+  value,
+  onSelect,
+}: {
+  label: string;
+  allLabel: string;
+  title: string;
+  width: string;
+  options: SelectItemOption[];
+  /** Current filter value, or `undefined` when unset ("all"). */
+  value: string | undefined;
+  /** Receives the selected value, or `undefined` when "all" is chosen. */
+  onSelect: (value: string | undefined) => void;
+}) {
+  const items = useMemo<SelectItemOption[]>(
+    () => [{ value: ALL_VALUE, label: allLabel }, ...options],
+    [allLabel, options],
+  );
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <Select
+        items={items}
+        value={value ?? ALL_VALUE}
+        onValueChange={(v) =>
+          typeof v === "string" && onSelect(v === ALL_VALUE ? undefined : v)
+        }
+      >
+        <SelectTrigger className={cn("h-8 text-xs", width)} title={title}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map((it) => (
+            <SelectItem key={it.value} value={it.value}>
+              {it.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </div>
   );
 }

--- a/ui/src/components/usage/UsageOverviewTab.tsx
+++ b/ui/src/components/usage/UsageOverviewTab.tsx
@@ -109,6 +109,7 @@ export function UsageOverviewTab({
           <div className="flex items-center gap-2">
             <Label className="text-xs text-muted-foreground">Group by</Label>
             <Select
+              items={GROUPING_OPTIONS}
               value={grouping}
               onValueChange={(value) => {
                 if (isSpendGrouping(value)) setGrouping(value);
@@ -202,6 +203,14 @@ function KpiCard({ kpi }: { kpi: UsageKpi }) {
       <p className="mt-1 truncate text-2xl font-semibold tabular-nums tracking-tight text-foreground">
         {value}
       </p>
+      {kpi.caption && (
+        <p
+          className="mt-1 truncate text-[11px] text-muted-foreground"
+          title={kpi.caption}
+        >
+          {kpi.caption}
+        </p>
+      )}
       <div
         className={cn(
           "mt-2 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",


### PR DESCRIPTION
## Why

The admin **Usage & Analytics** dashboard had several issues (from a UI review):

1. **Total "Spend" always showed "—"** despite the charts showing real money. The SQL aggregates used NULL-poisoning: if *any* session in a group was unpriced, the whole group's cost collapsed to NULL. The deployment mixes many models with no models.dev pricing (the coding-plan/gateway models: zai, xiaomi, minimax, kimi, fireworks), so the grand total was *always* NULL.
2. **Cost framing was unclear.** Spend is a notional figure at public API rates. Most usage runs via subscription / coding plans (e.g. OpenAI via the Codex plan) which are billed separately — the dashboard shows what that usage *would* cost via API.
3. **No per-user filter**, even though `by_user` is already a known dimension.
4. **Raw `__all__` / `30d` / `day` leaking into select triggers** instead of human labels.

## What

- **Priced-subtotal spend.** Every spend aggregate (totals, series, breakdowns, model effectiveness, project×model matrix) now uses `SUM(cost_usd)` (which naturally skips unpriced sessions) instead of NULL-poisoning. `totals` also returns `unpriced_session_count`. NULL only when *nothing* in the window was priced.
- **Honest framing.** The Spend KPI carries a caption: `Est. at public API rates · N unpriced sessions excluded`.
- **Per-user filter.** New `user_id` query param → SQL filter (attributed via `COALESCE(session creator, task creator)`, same rule as the `by_user` breakdown) → a new **User** dropdown sourced from `by_user`.
- **Label-resolving selects.** base-ui's `<Select.Value>` renders the raw value unless the root gets an `items` map. Passed `items` to every dashboard select via a reusable `FilterSelect` for the all-or-one filters, so triggers show "All models" / "Daily" / "Last 30 days".

## Notes
- Cache-read / cache-write tokens were *already* priced separately and correctly — no change there.
- The cost math itself was correct; this PR fixes display semantics + framing, not the per-token pricing.

## Test
- New: priced-subtotal + unpriced-count semantics (totals & all-unpriced), per-user filter binding, spend-caption formatting.
- Green locally: `djinn-db`/`djinn-server` unit + integration tests (against the test Postgres), `tsc -b`, `eslint`, `cargo fmt --check`.