### PR TITLE
fix(proposals): graceful mermaid render + sanitize svg block

### DIFF
--- a/ui/src/components/MermaidDiagram.tsx
+++ b/ui/src/components/MermaidDiagram.tsx
@@ -11,7 +11,11 @@
  *     so we never inline-eval untrusted source,
  *   - renders into a sanitized container (DOMPurify) so even a `securityLevel`
  *     regression can't smuggle script tags through,
- *   - falls back to a `<pre>` block with the raw source on render error.
+ *   - normalizes unicode arrow/dash glyphs to Mermaid's ASCII edge operators
+ *     before render (LLM-authored sources frequently use `→`/`⟶`/`—`),
+ *   - on render failure falls back to a graceful surface: the raw source in a
+ *     styled `<pre>` with a copy-source button plus a calm one-line message,
+ *     never the raw developer exception and never a blank block.
  *
  * The component is wrapped in `React.memo` so identical `source` strings
  * don't re-trigger Mermaid's heavy SVG generation when parents re-render.
@@ -21,6 +25,7 @@ import {
   memo,
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -28,6 +33,8 @@ import mermaid from "mermaid";
 import DOMPurify from "dompurify";
 
 import { cn } from "@/lib/utils";
+import { DiagramFallback } from "@/components/proposals/blocks/DiagramFallback";
+import { normalizeMermaidSource } from "@/components/proposals/blocks/mermaidNormalize";
 
 // Initialize Mermaid exactly once at module load. `startOnLoad: false` keeps
 // it from auto-walking the DOM (we control rendering explicitly), and
@@ -70,6 +77,13 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
   const [state, setState] = useState<RenderState>({ status: "idle" });
   const containerRef = useRef<HTMLDivElement | null>(null);
 
+  // Rewrite unicode arrow/dash glyphs to ASCII edge operators before render.
+  // Conservative: only structural (outside-label) glyphs change.
+  const normalizedSource = useMemo(
+    () => normalizeMermaidSource(source),
+    [source],
+  );
+
   useEffect(() => {
     let cancelled = false;
     initMermaid();
@@ -77,7 +91,7 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
 
     (async () => {
       try {
-        const { svg } = await mermaid.render(renderId, source);
+        const { svg } = await mermaid.render(renderId, normalizedSource);
         if (cancelled) return;
         // Belt-and-braces: even with `securityLevel: "strict"`, sanitize the
         // SVG before injecting. DOMPurify's default profile preserves SVG
@@ -98,23 +112,17 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
     return () => {
       cancelled = true;
     };
-  }, [source, renderId]);
+  }, [normalizedSource, renderId]);
 
   if (state.status === "error") {
+    // Never dump the raw parser exception or blank the block: show the original
+    // source with a copy button and a calm one-line reason.
     return (
-      <div
-        className={cn(
-          "rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs",
-          className,
-        )}
-        data-testid="mermaid-error"
-      >
-        <p className="mb-2 font-medium text-destructive">
-          Mermaid render failed: {state.error}
-        </p>
-        <pre className="overflow-auto whitespace-pre-wrap font-mono text-[11px] text-muted-foreground">
-          {source}
-        </pre>
+      <div className={className} data-testid="mermaid-error">
+        <DiagramFallback
+          source={source}
+          message={`Could not render diagram: ${state.error}`}
+        />
       </div>
     );
   }

--- a/ui/src/components/proposals/blocks/Diagram.tsx
+++ b/ui/src/components/proposals/blocks/Diagram.tsx
@@ -1,7 +1,9 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useMemo } from "react";
+import DOMPurify from "dompurify";
 
 import type { BlockProps } from "./types";
 import { BlockShell } from "./BlockShell";
+import { DiagramFallback } from "./DiagramFallback";
 
 // Mermaid is a large dependency; load it only when a mermaid diagram renders.
 const MermaidDiagram = lazy(() =>
@@ -13,19 +15,25 @@ const MermaidDiagram = lazy(() =>
 /**
  * Diagram — renders based on the `type` attribute:
  *   - `mermaid` (default): rendered to an actual SVG via the shared
- *     `MermaidDiagram` component (sandboxed + DOMPurify'd),
- *   - `svg`: inlined as-is,
+ *     `MermaidDiagram` component (arrow-normalized + DOMPurify'd, with a
+ *     graceful copy-source fallback on parse failure),
+ *   - `svg`: inlined after DOMPurify sanitization (defends against stored XSS),
  *   - anything else (e.g. `plantuml`, for which we have no client renderer):
- *     falls back to the raw source in a code block.
+ *     routed to the same graceful copy-source fallback instead of dumping raw.
  */
 export function Diagram({ attributes, children }: BlockProps) {
   const diagramType = attributes.type ?? "mermaid";
   const content = typeof children === "string" ? children.trim() : "";
 
-  const rawSource = (
-    <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
-      <code>{content}</code>
-    </pre>
+  // Sanitize author/agent SVG before inlining — the source may carry
+  // `<script>`/`onload=`/`javascript:` payloads. DOMPurify's SVG profile keeps
+  // the drawing intact while stripping active markup.
+  const sanitizedSvg = useMemo(
+    () =>
+      DOMPurify.sanitize(content, {
+        USE_PROFILES: { svg: true, svgFilters: true, html: true },
+      }),
+    [content],
   );
 
   return (
@@ -47,10 +55,16 @@ export function Diagram({ attributes, children }: BlockProps) {
       ) : diagramType === "svg" ? (
         <div
           className="overflow-x-auto"
-          dangerouslySetInnerHTML={{ __html: content }}
+          // Content is DOMPurify-sanitized above before injection.
+          dangerouslySetInnerHTML={{ __html: sanitizedSvg }}
         />
       ) : (
-        rawSource
+        // No client renderer for this type (e.g. plantuml): show the source with
+        // a copy button rather than a raw dump.
+        <DiagramFallback
+          source={content}
+          message={`No renderer for "${diagramType}" diagrams — showing source.`}
+        />
       )}
     </BlockShell>
   );

--- a/ui/src/components/proposals/blocks/DiagramFallback.tsx
+++ b/ui/src/components/proposals/blocks/DiagramFallback.tsx
@@ -1,0 +1,56 @@
+import { Check, Copy } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useClipboard } from "@/hooks/useClipboard";
+
+export interface DiagramFallbackProps {
+  /** The raw diagram source to display and copy. */
+  source: string;
+  /**
+   * Optional calm one-line reason shown below the source, e.g.
+   * "Could not render diagram: <message>". Omit for the "no renderer"
+   * (plantuml) case where there's nothing wrong, just unsupported.
+   */
+  message?: string;
+  className?: string;
+}
+
+/**
+ * Graceful diagram fallback — shows the raw source in a styled `<pre>` with a
+ * copy-source button and (optionally) a calm muted one-line message. Used when a
+ * diagram fails to render or has no client renderer, so we never surface a raw
+ * developer exception or a blank block.
+ */
+export function DiagramFallback({
+  source,
+  message,
+  className,
+}: DiagramFallbackProps) {
+  const { copy, copied } = useClipboard();
+
+  return (
+    <div className={cn("space-y-2", className)} data-testid="diagram-fallback">
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => void copy(source)}
+          aria-label="Copy diagram source"
+          title="Copy source"
+          className="absolute right-2 top-2 flex size-7 items-center justify-center rounded-md border border-border/60 bg-background/80 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {copied ? (
+            <Check className="size-4 text-emerald-400" />
+          ) : (
+            <Copy className="size-4" />
+          )}
+        </button>
+        <pre className="overflow-auto whitespace-pre-wrap rounded-md border bg-muted p-3 pr-10 font-mono text-[11px] text-muted-foreground">
+          {source}
+        </pre>
+      </div>
+      {message ? (
+        <p className="text-xs text-muted-foreground">{message}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/proposals/blocks/mermaidNormalize.test.ts
+++ b/ui/src/components/proposals/blocks/mermaidNormalize.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeMermaidSource } from "./mermaidNormalize";
+
+describe("normalizeMermaidSource", () => {
+  it("leaves ASCII edges untouched", () => {
+    const src = "flowchart TD\n  A --> B\n  B -- label --> C";
+    expect(normalizeMermaidSource(src)).toBe(src);
+  });
+
+  it("returns the source unchanged when no candidate glyph is present", () => {
+    const src = "graph LR; x---y";
+    expect(normalizeMermaidSource(src)).toBe(src);
+  });
+
+  it("normalizes the U+2192 right arrow to -->", () => {
+    expect(normalizeMermaidSource("A → B")).toBe("A --> B");
+  });
+
+  it("normalizes the U+27F6 long arrow to -->", () => {
+    expect(normalizeMermaidSource("A ⟶ B")).toBe("A --> B");
+  });
+
+  it("normalizes ⇒ and ➜ arrow variants to -->", () => {
+    expect(normalizeMermaidSource("A ⇒ B")).toBe("A --> B");
+    expect(normalizeMermaidSource("A ➜ B")).toBe("A --> B");
+  });
+
+  it("normalizes a dash+arrow run (—→) to -->", () => {
+    expect(normalizeMermaidSource("A —→ B")).toBe("A --> B");
+  });
+
+  it("normalizes a bare em/en dash edge to --", () => {
+    expect(normalizeMermaidSource("A — B")).toBe("A -- B");
+    expect(normalizeMermaidSource("A – B")).toBe("A -- B");
+  });
+
+  it("preserves arrow glyphs inside bracket labels", () => {
+    const src = 'A["price → total"] --> B';
+    expect(normalizeMermaidSource(src)).toBe(src);
+  });
+
+  it("preserves arrow glyphs inside quoted and paren/brace labels", () => {
+    expect(normalizeMermaidSource('A("a → b")')).toBe('A("a → b")');
+    expect(normalizeMermaidSource("A{a → b}")).toBe("A{a → b}");
+  });
+
+  it("normalizes a structural arrow while preserving an in-label arrow", () => {
+    const src = 'A["x → y"] → B';
+    expect(normalizeMermaidSource(src)).toBe('A["x → y"] --> B');
+  });
+
+  it("does not rewrite a dash glyph embedded in a word", () => {
+    // Em-dash inside a token (no surrounding whitespace) is left alone.
+    expect(normalizeMermaidSource("flowchart TD")).toBe("flowchart TD");
+    expect(normalizeMermaidSource("foo—bar")).toBe("foo—bar");
+  });
+
+  it("handles multiple edges across lines", () => {
+    const src = "flowchart TD\n  A → B\n  B ⟶ C";
+    expect(normalizeMermaidSource(src)).toBe(
+      "flowchart TD\n  A --> B\n  B --> C",
+    );
+  });
+
+  it("returns empty/undefined-safe for empty input", () => {
+    expect(normalizeMermaidSource("")).toBe("");
+  });
+});

--- a/ui/src/components/proposals/blocks/mermaidNormalize.ts
+++ b/ui/src/components/proposals/blocks/mermaidNormalize.ts
@@ -1,0 +1,97 @@
+/**
+ * Mermaid source normalization.
+ *
+ * LLM- and human-authored diagram sources frequently use "prettified" unicode
+ * arrow and dash glyphs (`→`, `⟶`, `⇒`, `➜`, em/en dashes) where Mermaid's
+ * grammar requires the ASCII edge operators `-->` / `--`. Passing those glyphs
+ * straight to `mermaid.render()` throws a parser error that we used to dump raw
+ * to users.
+ *
+ * `normalizeMermaidSource` rewrites only the arrow-/dash-like *edge* sequences
+ * to their ASCII equivalents. It is intentionally conservative: it never touches
+ * glyphs that appear inside node/edge *labels* (text in `[...]`, `(...)`,
+ * `{...}`, `"..."`), so a label like `A["price → total"]` keeps its arrow.
+ */
+
+// Unicode arrow glyphs that authors use in place of the `-->` edge operator.
+//   → U+2192  ⟶ U+27F6  ⇒ U+21D2  ➜ U+279C  ⇨ U+21E8  ➡ U+27A1  ➔ U+2794
+const ARROW_GLYPHS = "→⟶⇒➜⇨➡➔➙➞";
+// Em/en dash + horizontal bar, used in place of the `--` link operator.
+const DASH_GLYPHS = "—–―";
+
+const ARROW_CLASS = `[${ARROW_GLYPHS}]`;
+const DASH_CLASS = `[${DASH_GLYPHS}]`;
+
+// A directed edge: an optional leading dash run, then an arrow glyph, bounded by
+// whitespace (or line edges) so we don't rewrite a glyph embedded in a word.
+const ARROW_EDGE = new RegExp(
+  `(^|\\s)(?:${DASH_CLASS}+\\s*)?${ARROW_CLASS}(\\s|$)`,
+  "gu",
+);
+// An undirected link: a bare run of dashes bounded by whitespace.
+const DASH_EDGE = new RegExp(`(^|\\s)${DASH_CLASS}+(\\s|$)`, "gu");
+
+/**
+ * Normalize the structural (outside-label) part of a single line.
+ *
+ * Labels (`"..."`, `[...]`, `(...)`, `{...}`) are copied verbatim so an arrow
+ * inside a label is preserved; only the edge operators between nodes change.
+ */
+function normalizeLine(line: string): string {
+  let out = "";
+  let buf = "";
+  let closing: string | null = null;
+
+  const flushOutside = () => {
+    if (!buf) return;
+    // Directed edges first (arrow glyph, optionally preceded by dashes), then
+    // any remaining bare dash runs become undirected links.
+    let seg = buf.replace(
+      ARROW_EDGE,
+      (_m, pre: string, post: string) => `${pre}-->${post}`,
+    );
+    seg = seg.replace(
+      DASH_EDGE,
+      (_m, pre: string, post: string) => `${pre}--${post}`,
+    );
+    out += seg;
+    buf = "";
+  };
+
+  for (const ch of line) {
+    if (closing) {
+      out += ch;
+      if (ch === closing) closing = null;
+      continue;
+    }
+    if (ch === '"') {
+      flushOutside();
+      out += ch;
+      closing = '"';
+      continue;
+    }
+    if (ch === "[" || ch === "(" || ch === "{") {
+      flushOutside();
+      out += ch;
+      closing = ch === "[" ? "]" : ch === "(" ? ")" : "}";
+      continue;
+    }
+    buf += ch;
+  }
+  flushOutside();
+  return out;
+}
+
+/**
+ * Normalize unicode arrow/dash edge glyphs to Mermaid's ASCII operators.
+ * Conservative: only structural (outside-label) glyphs are rewritten, and the
+ * source is returned untouched when no candidate glyph is present.
+ */
+export function normalizeMermaidSource(source: string): string {
+  if (!source) return source;
+  const hasCandidate = new RegExp(`${ARROW_CLASS}|${DASH_CLASS}`, "u").test(
+    source,
+  );
+  if (!hasCandidate) return source;
+  return source.split("\n").map(normalizeLine).join("\n");
+}


### PR DESCRIPTION
## WU1 — P0 critical proposal-block bugs (UI only)

Closes three confirmed P0 bugs in proposal-spec "blocks" rendering (gap analysis §2):

### 1. Mermaid raw-error dump (live user-facing bug)
`MermaidDiagram.tsx` passed source straight to `mermaid.render()`. Unicode arrows/dashes (`→` `⟶` `⇒` `➜`, em/en dashes used as edges) threw a parser error we rendered **raw** to users.
- **Normalize before render:** a conservative `normalizeMermaidSource()` rewrites only *structural* arrow/dash glyphs to ASCII `-->`/`--`; glyphs inside labels (`[...]`/`(...)`/`{...}`/`"..."`) are preserved.
- **Graceful fallback:** on render failure we now show the source in a styled `<pre>` + a copy-source button + a calm one-line `Could not render diagram: <message>` — never the raw developer exception, never a blank block (shape ported from agent-native `MermaidBlock.tsx`).

### 2. Unsanitized SVG (stored XSS)
`Diagram.tsx` `type="svg"` inlined content via `dangerouslySetInnerHTML` with **no sanitization**. Now run through DOMPurify (same dep/profile pattern as `MermaidDiagram.tsx`) before injection.

### 3. `plantuml` had no renderer
`type="plantuml"` fell through to a raw dump. Now routed to the same graceful copy-source fallback.

## Validation
- `tsc -b` clean
- `eslint` clean on changed files (the one `set-state-in-effect` error in MermaidDiagram is pre-existing on main)
- `vitest run src/components/proposals` green; adds 13 unit tests for the arrow-normalization helper

UI only — no backend/schema changes.