### PR TITLE
feat(proposals): interactive file-tree block renderer

### DIFF
--- a/ui/src/components/proposals/blocks/FileTreeBlock.tsx
+++ b/ui/src/components/proposals/blocks/FileTreeBlock.tsx
@@ -1,27 +1,249 @@
-import type { BlockProps } from "./types";
+import { useMemo, useState } from "react";
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  File01Icon,
+  Folder01Icon,
+  FolderOpenIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
+
 import { BlockShell } from "./BlockShell";
+import type { BlockProps } from "./types";
+import {
+  buildFileTree,
+  parseFileTreeBody,
+  tallyChanges,
+  type FileChange,
+  type TreeNode,
+} from "./fileTree";
 
 /**
- * FileTree — renders the tree source as preformatted monospace text. We
- * deliberately do NOT run it through markdown: markdown collapses the single
- * newlines that give a file tree its shape into one run-on paragraph, which is
- * exactly the "where's my tree?" bug. `whitespace-pre` keeps the author's
- * indentation and line breaks intact.
+ * FileTree — an interactive VS Code / GitHub-explorer file & change tree.
+ *
+ * The freeform body text (indented ASCII tree OR one slash-path per line, with
+ * optional `(NEW)`/`(MODIFIED)`/`(DELETED)`/`(RENAMED)` markers and trailing
+ * notes) is parsed into a flat file list, then folded into a nested folder tree
+ * (folders before files, single-child chains compacted). Folders expand/collapse
+ * (top level open by default); files carry an A/M/D/R change badge and a muted
+ * inline note. A header tallies `+N ~N −N »N`.
+ *
+ * If parsing yields nothing (weird input), we fall back to the original raw
+ * `<pre>` so an existing proposal never blanks or crashes.
  */
 export function FileTreeBlock({ attributes, children }: BlockProps) {
   const root = attributes.root;
   const content = typeof children === "string" ? children.trim() : "";
+
+  const files = useMemo(() => parseFileTreeBody(content), [content]);
+  const tree = useMemo(() => buildFileTree(files), [files]);
+  const counts = useMemo(() => tallyChanges(files), [files]);
+  const changeTotal =
+    counts.added + counts.modified + counts.deleted + counts.renamed;
+
+  // Top-level folders default open; deeper folders collapse so the tree is
+  // scannable. Keyed by full folder path.
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    const seed = (nodes: TreeNode[], depth: number) => {
+      for (const node of nodes) {
+        if (node.kind === "folder") {
+          initial[node.path] = depth >= 1;
+          seed(node.children, depth + 1);
+        }
+      }
+    };
+    seed(tree, 0);
+    return initial;
+  });
+
+  const toggle = (path: string) =>
+    setCollapsed((current) => ({ ...current, [path]: !current[path] }));
+
+  // Parsing produced no usable files — fall back to the raw monospace render so
+  // an oddly-authored tree is never lost.
+  if (files.length === 0) {
+    return (
+      <BlockShell
+        label="Files"
+        accent="text-slate-400"
+        flush
+        meta={
+          root ? <span className="truncate font-mono">{root}</span> : null
+        }
+      >
+        <pre className="overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed text-foreground">
+          {content}
+        </pre>
+      </BlockShell>
+    );
+  }
 
   return (
     <BlockShell
       label="Files"
       accent="text-slate-400"
       flush
-      meta={root ? <span className="truncate font-mono">{root}</span> : null}
+      meta={
+        <span className="flex min-w-0 items-center gap-2 font-mono">
+          {root ? <span className="truncate">{root}</span> : null}
+          <span className="text-muted-foreground">
+            {files.length} {files.length === 1 ? "file" : "files"}
+          </span>
+          {changeTotal > 0 && (
+            <span className="flex items-center gap-1.5">
+              {counts.added > 0 && (
+                <span className="text-emerald-400">+{counts.added}</span>
+              )}
+              {counts.modified > 0 && (
+                <span className="text-blue-400">~{counts.modified}</span>
+              )}
+              {counts.deleted > 0 && (
+                <span className="text-red-400">−{counts.deleted}</span>
+              )}
+              {counts.renamed > 0 && (
+                <span className="text-violet-400">»{counts.renamed}</span>
+              )}
+            </span>
+          )}
+        </span>
+      }
     >
-      <pre className="overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed text-foreground">
-        {content}
-      </pre>
+      <div className="py-1.5 text-[13px]">
+        <TreeRows nodes={tree} depth={0} collapsed={collapsed} toggle={toggle} />
+      </div>
     </BlockShell>
+  );
+}
+
+const INDENT_STEP = 14; // px per nesting level — the explorer guide spacing.
+
+const CHANGE_GLYPH: Record<FileChange, string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+};
+
+const CHANGE_LABEL: Record<FileChange, string> = {
+  added: "Added",
+  modified: "Modified",
+  deleted: "Deleted",
+  renamed: "Renamed",
+};
+
+/** Tinted badge background + saturated text. Dark-only theme. */
+const CHANGE_BADGE: Record<FileChange, string> = {
+  added: "bg-emerald-500/15 text-emerald-300",
+  modified: "bg-blue-500/15 text-blue-300",
+  deleted: "bg-red-500/15 text-red-300",
+  renamed: "bg-violet-500/15 text-violet-300",
+};
+
+/** Accent ink for the file name, echoing its change color. */
+const CHANGE_NAME_INK: Record<FileChange, string> = {
+  added: "text-emerald-300",
+  modified: "text-blue-300",
+  deleted: "text-red-300 line-through",
+  renamed: "text-violet-300",
+};
+
+interface TreeRowsProps {
+  nodes: TreeNode[];
+  depth: number;
+  collapsed: Record<string, boolean>;
+  toggle: (path: string) => void;
+}
+
+function TreeRows({ nodes, depth, collapsed, toggle }: TreeRowsProps) {
+  return (
+    <>
+      {nodes.map((node) => {
+        const indent = depth * INDENT_STEP;
+        if (node.kind === "folder") {
+          const isCollapsed = collapsed[node.path] ?? false;
+          return (
+            <div key={`d:${node.path}`}>
+              <button
+                type="button"
+                aria-expanded={!isCollapsed}
+                onClick={() => toggle(node.path)}
+                style={{ paddingLeft: indent + 12 }}
+                className="flex w-full items-center gap-1.5 rounded-md py-1 pr-3 text-left transition-colors hover:bg-muted/50"
+              >
+                <HugeiconsIcon
+                  icon={isCollapsed ? ArrowRight01Icon : ArrowDown01Icon}
+                  size={14}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <HugeiconsIcon
+                  icon={isCollapsed ? Folder01Icon : FolderOpenIcon}
+                  size={15}
+                  className="shrink-0 text-sky-400/80"
+                />
+                <span className="min-w-0 truncate font-medium text-foreground">
+                  {node.name}
+                </span>
+              </button>
+              {!isCollapsed && (
+                <TreeRows
+                  nodes={node.children}
+                  depth={depth + 1}
+                  collapsed={collapsed}
+                  toggle={toggle}
+                />
+              )}
+            </div>
+          );
+        }
+
+        const change = node.change;
+        return (
+          <div
+            key={`f:${node.path}`}
+            style={{ paddingLeft: indent + 12 + 18 }}
+            className="flex items-center gap-1.5 py-1 pr-3"
+          >
+            <HugeiconsIcon
+              icon={File01Icon}
+              size={15}
+              className={cn(
+                "shrink-0",
+                change === "deleted"
+                  ? "text-muted-foreground"
+                  : "text-muted-foreground/80",
+              )}
+            />
+            <span
+              className={cn(
+                "min-w-0 truncate font-medium",
+                change ? CHANGE_NAME_INK[change] : "text-foreground",
+              )}
+            >
+              {node.name}
+            </span>
+            {change && (
+              <span
+                title={CHANGE_LABEL[change]}
+                aria-label={CHANGE_LABEL[change]}
+                className={cn(
+                  "ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-[10px] font-bold leading-none",
+                  CHANGE_BADGE[change],
+                )}
+              >
+                {CHANGE_GLYPH[change]}
+              </span>
+            )}
+            {node.note && (
+              <span className="ml-1 min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                {node.note}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </>
   );
 }

--- a/ui/src/components/proposals/blocks/fileTree.test.ts
+++ b/ui/src/components/proposals/blocks/fileTree.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFileTree,
+  parseFileTreeBody,
+  tallyChanges,
+  type TreeNode,
+} from "./fileTree";
+
+/** Collapse a derived tree into a `kind:path` line list for compact assertions. */
+function flatten(nodes: TreeNode[], out: string[] = []): string[] {
+  for (const node of nodes) {
+    out.push(`${node.kind === "folder" ? "D" : "F"}:${node.path}`);
+    if (node.kind === "folder") flatten(node.children, out);
+  }
+  return out;
+}
+
+describe("parseFileTreeBody", () => {
+  it("returns [] for empty / whitespace input", () => {
+    expect(parseFileTreeBody("")).toEqual([]);
+    expect(parseFileTreeBody("   \n  \n")).toEqual([]);
+  });
+
+  it("parses one slash-path per line", () => {
+    const files = parseFileTreeBody(
+      "src/main.rs\nsrc/routes/git.ts\nCargo.toml",
+    );
+    expect(files.map((f) => f.path)).toEqual([
+      "src/main.rs",
+      "src/routes/git.ts",
+      "Cargo.toml",
+    ]);
+    expect(files.every((f) => f.change === undefined)).toBe(true);
+  });
+
+  it("reconstructs paths from an indented ASCII tree", () => {
+    const body = [
+      "src/",
+      "  main.rs",
+      "  routes/",
+      "    git.ts",
+      "    auth.ts",
+      "Cargo.toml",
+    ].join("\n");
+    const files = parseFileTreeBody(body);
+    expect(files.map((f) => f.path)).toEqual([
+      "src/main.rs",
+      "src/routes/git.ts",
+      "src/routes/auth.ts",
+      "Cargo.toml",
+    ]);
+  });
+
+  it("treats a row whose next row is more deeply indented as a folder even without a trailing slash", () => {
+    const body = ["src", "  main.rs", "  lib", "    util.rs"].join("\n");
+    const files = parseFileTreeBody(body);
+    expect(files.map((f) => f.path)).toEqual([
+      "src/main.rs",
+      "src/lib/util.rs",
+    ]);
+  });
+
+  it("parses inline (NEW)/(MODIFIED)/(DELETED)/(RENAMED) status markers", () => {
+    const files = parseFileTreeBody(
+      [
+        "src/added.ts (NEW)",
+        "src/changed.ts (MODIFIED)",
+        "src/gone.ts (DELETED)",
+        "src/moved.ts (RENAMED)",
+      ].join("\n"),
+    );
+    expect(files.map((f) => f.change)).toEqual([
+      "added",
+      "modified",
+      "deleted",
+      "renamed",
+    ]);
+  });
+
+  it("accepts common status synonyms case-insensitively", () => {
+    const files = parseFileTreeBody(
+      ["a.ts (added)", "b.ts (Removed)", "c.ts (updated)", "d.ts (moved)"].join(
+        "\n",
+      ),
+    );
+    expect(files.map((f) => f.change)).toEqual([
+      "added",
+      "deleted",
+      "modified",
+      "renamed",
+    ]);
+  });
+
+  it("extracts a trailing note as a caption, keeping it distinct from a status", () => {
+    const files = parseFileTreeBody(
+      "Cargo.toml (add [workspace.lints])\nsrc/x.rs (MODIFIED) wire the new route",
+    );
+    expect(files[0]).toMatchObject({
+      path: "Cargo.toml",
+      note: "add [workspace.lints]",
+    });
+    expect(files[0]!.change).toBeUndefined();
+    expect(files[1]).toMatchObject({
+      path: "src/x.rs",
+      change: "modified",
+      note: "wire the new route",
+    });
+  });
+
+  it("treats an em/en-dash or colon as a note separator", () => {
+    const files = parseFileTreeBody(
+      "src/a.ts — does the thing\nsrc/b.ts: helper",
+    );
+    expect(files[0]).toMatchObject({ path: "src/a.ts", note: "does the thing" });
+    expect(files[1]).toMatchObject({ path: "src/b.ts", note: "helper" });
+  });
+
+  it("attaches status/note to a bare folder row that carries them", () => {
+    const files = parseFileTreeBody("src/legacy/ (DELETED) drop the old module");
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      path: "src/legacy",
+      change: "deleted",
+      note: "drop the old module",
+    });
+  });
+
+  it("ignores bare folder header rows with no change/note", () => {
+    const files = parseFileTreeBody("src/\nsrc/main.rs");
+    expect(files.map((f) => f.path)).toEqual(["src/main.rs"]);
+  });
+
+  it("strips ASCII tree-drawing glyphs", () => {
+    const body = ["src", "  ├─ main.rs", "  └─ lib.rs"].join("\n");
+    const files = parseFileTreeBody(body);
+    expect(files.map((f) => f.path)).toEqual(["src/main.rs", "src/lib.rs"]);
+  });
+
+  it("dedupes repeated paths, keeping the first", () => {
+    const files = parseFileTreeBody("a.ts (NEW)\na.ts (MODIFIED)");
+    expect(files).toHaveLength(1);
+    expect(files[0]!.change).toBe("added");
+  });
+
+  it("returns [] when every line is pure punctuation (no path-ish token)", () => {
+    expect(parseFileTreeBody("---\n===\n***")).toEqual([]);
+  });
+});
+
+describe("buildFileTree", () => {
+  it("derives a nested folder tree, folders before files", () => {
+    const files = parseFileTreeBody(
+      ["src/routes/git.ts", "src/main.rs", "Cargo.toml"].join("\n"),
+    );
+    const tree = buildFileTree(files);
+    // folders before files at each level: src/ then Cargo.toml at the root.
+    expect(flatten(tree)).toEqual([
+      "D:src",
+      "D:src/routes",
+      "F:src/routes/git.ts",
+      "F:src/main.rs",
+      "F:Cargo.toml",
+    ]);
+  });
+
+  it("compacts single-child folder chains into one row", () => {
+    const files = parseFileTreeBody("a/b/c/deep.ts");
+    const tree = buildFileTree(files);
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({ kind: "folder", name: "a/b/c" });
+    expect((tree[0] as { children: TreeNode[] }).children[0]).toMatchObject({
+      kind: "file",
+      path: "a/b/c/deep.ts",
+    });
+  });
+
+  it("does NOT compact a folder that has more than one child", () => {
+    const files = parseFileTreeBody("a/b/one.ts\na/c/two.ts");
+    const tree = buildFileTree(files);
+    // `a` has two folder children (b, c) so it must not be compacted away.
+    expect(tree[0]).toMatchObject({ kind: "folder", name: "a" });
+    expect((tree[0] as { children: TreeNode[] }).children).toHaveLength(2);
+  });
+
+  it("carries change + note onto file leaves", () => {
+    const files = parseFileTreeBody("src/x.ts (NEW) added the route");
+    const tree = buildFileTree(files);
+    const folder = tree[0] as { children: TreeNode[] };
+    expect(folder.children[0]).toMatchObject({
+      kind: "file",
+      change: "added",
+      note: "added the route",
+    });
+  });
+});
+
+describe("tallyChanges", () => {
+  it("counts each change kind", () => {
+    const files = parseFileTreeBody(
+      [
+        "a.ts (NEW)",
+        "b.ts (NEW)",
+        "c.ts (MODIFIED)",
+        "d.ts (DELETED)",
+        "e.ts (RENAMED)",
+        "f.ts",
+      ].join("\n"),
+    );
+    expect(tallyChanges(files)).toEqual({
+      added: 2,
+      modified: 1,
+      deleted: 1,
+      renamed: 1,
+    });
+  });
+});

--- a/ui/src/components/proposals/blocks/fileTree.ts
+++ b/ui/src/components/proposals/blocks/fileTree.ts
@@ -1,0 +1,441 @@
+// Pure (React-free) helpers for the interactive file-tree block. These parse the
+// freeform tree text an author writes inside <FileTree>…</FileTree> into a flat
+// list of files (with a change status + note), then fold those flat slash-paths
+// into a nested folder tree. Kept in their own module so they are unit-testable
+// without pulling React in.
+//
+// djinn's MDX stores the tree as the block's *children text* (see the Rust
+// `validation.rs` fixture: `<FileTree root="src"> src/\n  main.rs </FileTree>`),
+// NOT as a structured `entries={…}` JSON prop. So the parser tolerates BOTH of
+// the two authoring styles seen in the wild:
+//
+//   1. Indented ASCII tree — folders end in `/` (or simply have children under a
+//      deeper indent), files sit beneath them:
+//        src/
+//          main.rs
+//          routes/
+//            git.ts (NEW)
+//
+//   2. One slash-path per line:
+//        src/main.rs
+//        src/routes/git.ts (MODIFIED)  -- why it changed
+//
+// A per-file change status is derived from an inline marker like `(NEW)`,
+// `(MODIFIED)`, `(DELETED)`, or `(RENAMED)`. A trailing note/description after
+// the path (e.g. `Cargo.toml (add [workspace.lints])` or `foo.ts — does X`) is
+// surfaced as a muted caption. Anything the parser can't make sense of yields an
+// empty file list, so the caller can fall back to the raw <pre>.
+
+/** The kind of change applied to a file, driving its single-letter badge. */
+export type FileChange = "added" | "modified" | "deleted" | "renamed";
+
+/** A single parsed file: its full slash path plus optional status + note. */
+export interface ParsedFile {
+  /** Full slash-delimited path, e.g. `src/routes/git.ts`. */
+  path: string;
+  /** Last path segment (file name). */
+  name: string;
+  change?: FileChange;
+  /** Trailing human note after the path, if any. */
+  note?: string;
+}
+
+/** A folder node in the derived nested tree. */
+export interface FolderNode {
+  kind: "folder";
+  /** Display name (may be a compacted `a/b/c` chain). */
+  name: string;
+  /** Full slash path of the folder — a stable key. */
+  path: string;
+  children: TreeNode[];
+}
+
+/** A file leaf in the derived nested tree. */
+export interface FileNode {
+  kind: "file";
+  name: string;
+  path: string;
+  change?: FileChange;
+  note?: string;
+}
+
+export type TreeNode = FolderNode | FileNode;
+
+/** Tally of changes across the tree, for the summary header. */
+export interface ChangeTally {
+  added: number;
+  modified: number;
+  deleted: number;
+  renamed: number;
+}
+
+/* ── Status + note parsing ─────────────────────────────────────────────────── */
+
+// Maps the words an author might use in an inline `(…)` marker to a status.
+const STATUS_WORDS: Record<string, FileChange> = {
+  new: "added",
+  added: "added",
+  add: "added",
+  create: "added",
+  created: "added",
+  a: "added",
+  modified: "modified",
+  modify: "modified",
+  changed: "modified",
+  change: "modified",
+  updated: "modified",
+  update: "modified",
+  edit: "modified",
+  edited: "modified",
+  m: "modified",
+  deleted: "deleted",
+  delete: "deleted",
+  removed: "deleted",
+  remove: "deleted",
+  del: "deleted",
+  d: "deleted",
+  renamed: "renamed",
+  rename: "renamed",
+  moved: "renamed",
+  move: "renamed",
+  r: "renamed",
+};
+
+/**
+ * Pull a leading `(STATUS)` marker out of a trailing-text fragment. Only a
+ * marker whose entire content is a recognised status word counts (so a genuine
+ * note like `(add [workspace.lints])` is left as a note, not eaten as a status).
+ */
+function extractStatusMarker(text: string): {
+  change?: FileChange;
+  rest: string;
+} {
+  const trimmed = text.trim();
+  const match = /^\(([A-Za-z]+)\)\s*([\s\S]*)$/.exec(trimmed);
+  if (match) {
+    const word = (match[1] ?? "").toLowerCase();
+    const change = STATUS_WORDS[word];
+    if (change) return { change, rest: (match[2] ?? "").trim() };
+  }
+  return { rest: trimmed };
+}
+
+/** Strip a leading note separator (dash/colon/hash) and unwrap a `(note)`. */
+function cleanNote(text: string): string | undefined {
+  let noteText = text.replace(/^[—–\-:#]+\s*/u, "").trim();
+  const wrapped = /^\(([\s\S]*)\)$/.exec(noteText);
+  if (wrapped) noteText = (wrapped[1] ?? "").trim();
+  return noteText || undefined;
+}
+
+/**
+ * Split one authored row (already de-indented) into its leading token (a path or
+ * segment), change status, and note. Returns null when the leading token doesn't
+ * look like a path/segment.
+ */
+function parseRow(raw: string): ParsedFile | null {
+  let rest = raw.trim();
+  if (!rest) return null;
+  // Strip ASCII tree-drawing glyphs / bullet markers, keeping path + trailing.
+  rest = rest.replace(/^[│|`'+*\s]*[├└][\s─-]*/u, "").trim();
+  rest = rest.replace(/^[│|]\s*/u, "").trim();
+  rest = rest.replace(/^[-*+]\s+/u, "").trim();
+  if (!rest) return null;
+
+  const firstSpace = rest.search(/\s/);
+  let path = rest;
+  let trailing = "";
+  if (firstSpace !== -1) {
+    path = rest.slice(0, firstSpace);
+    trailing = rest.slice(firstSpace + 1).trim();
+  }
+
+  // A trailing `:` on the path token introduces a note (`src/x.ts: helper`).
+  const colon = path.indexOf(":");
+  if (colon !== -1) {
+    const after = path.slice(colon + 1);
+    path = path.slice(0, colon);
+    trailing = after ? `${after} ${trailing}`.trim() : trailing;
+  }
+
+  // A path token must not contain angle brackets and must have real content.
+  if (!path || /[<>]/.test(path)) return null;
+
+  let change: FileChange | undefined;
+  let note: string | undefined;
+  if (trailing) {
+    const marker = extractStatusMarker(trailing);
+    change = marker.change;
+    note = cleanNote(marker.rest);
+  }
+
+  const isFolder = path.endsWith("/");
+  const cleanPath = path.replace(/\/+$/, "");
+  if (!cleanPath) return null;
+  // Reject tokens with no path-ish character at all (pure punctuation).
+  if (!/[A-Za-z0-9._]/.test(cleanPath)) return null;
+
+  // A bare folder row (e.g. `src/`) with no status/note carries no file — its
+  // descendants supply the folder structure via their own paths.
+  if (isFolder && !change && !note) return null;
+
+  const segments = cleanPath.split("/").filter(Boolean);
+  const name = segments[segments.length - 1] ?? cleanPath;
+  return { path: cleanPath, name, change, note };
+}
+
+/** Parse a single tree row's own SEGMENT name (not a full path) + status + note. */
+function parseRowSegment(raw: string): {
+  segment: string;
+  rawEndsWithSlash: boolean;
+  change?: FileChange;
+  note?: string;
+} | null {
+  let rest = raw.trim();
+  rest = rest.replace(/^[├└][\s─-]*/u, "").trim();
+  rest = rest.replace(/^[│|]\s*/u, "").trim();
+  rest = rest.replace(/^[-*+]\s+/u, "").trim();
+  if (!rest) return null;
+
+  const firstSpace = rest.search(/\s/);
+  let token = rest;
+  let trailing = "";
+  if (firstSpace !== -1) {
+    token = rest.slice(0, firstSpace);
+    trailing = rest.slice(firstSpace + 1).trim();
+  }
+  if (!token || /[<>]/.test(token)) return null;
+
+  const rawEndsWithSlash = token.endsWith("/");
+  const segment = token.replace(/\/+$/, "");
+  if (!segment || !/[A-Za-z0-9._]/.test(segment)) return null;
+
+  let change: FileChange | undefined;
+  let note: string | undefined;
+  if (trailing) {
+    const marker = extractStatusMarker(trailing);
+    change = marker.change;
+    note = cleanNote(marker.rest);
+  }
+
+  return { segment, rawEndsWithSlash, change, note };
+}
+
+/** Indentation width of a line; tabs count as 2 columns. */
+function indentWidth(line: string): number {
+  let width = 0;
+  for (const ch of line) {
+    if (ch === " ") width += 1;
+    else if (ch === "\t") width += 2;
+    else break;
+  }
+  return width;
+}
+
+/**
+ * Reconstruct full slash-paths from an indentation-based ASCII tree. Each row's
+ * indentation depth maps to a folder stack; a row ending in `/` (or one whose
+ * next row is more deeply indented) is a folder, others are files.
+ */
+function parseIndentedTree(lines: string[]): ParsedFile[] {
+  const rows = lines
+    .map((line) => ({ indent: indentWidth(line), text: line.trim() }))
+    .filter((r) => r.text.length > 0);
+  if (rows.length === 0) return [];
+
+  const hasIndent = rows.some((r) => r.indent > 0);
+  if (!hasIndent) return [];
+
+  const files: ParsedFile[] = [];
+  const stack: { indent: number; segment: string }[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    while (stack.length > 0 && stack[stack.length - 1]!.indent >= row.indent) {
+      stack.pop();
+    }
+
+    const parsed = parseRowSegment(row.text);
+    if (!parsed) continue;
+
+    // A single-token "segment" that itself contains slashes is a slash-path
+    // pasted into an indented tree; treat it as a full path from the stack root.
+    const next = rows[i + 1];
+    const isFolderByIndent = next ? next.indent > row.indent : false;
+    const isFolder = parsed.rawEndsWithSlash || isFolderByIndent;
+
+    const prefix = stack.map((s) => s.segment).join("/");
+    const fullPath = prefix
+      ? `${prefix}/${parsed.segment}`
+      : parsed.segment;
+
+    if (isFolder) {
+      stack.push({ indent: row.indent, segment: parsed.segment });
+      if (parsed.change || parsed.note) {
+        files.push({
+          path: fullPath,
+          name: parsed.segment.split("/").pop() ?? parsed.segment,
+          change: parsed.change,
+          note: parsed.note,
+        });
+      }
+    } else {
+      files.push({
+        path: fullPath,
+        name: parsed.segment.split("/").pop() ?? parsed.segment,
+        change: parsed.change,
+        note: parsed.note,
+      });
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Parse the freeform <FileTree> body into a flat list of files. Tries the
+ * indentation-based ASCII-tree interpretation first (the legacy authoring
+ * style); if that yields nothing, falls back to treating each non-empty line as
+ * an independent slash-path. Returns `[]` for input it can't parse so the caller
+ * can fall back to a raw render.
+ */
+export function parseFileTreeBody(body: string): ParsedFile[] {
+  if (!body || !body.trim()) return [];
+  const lines = body.replace(/\r\n?/g, "\n").split("\n");
+
+  const indented = parseIndentedTree(lines);
+  if (indented.length > 0) return dedupe(indented);
+
+  const flat: ParsedFile[] = [];
+  for (const line of lines) {
+    const parsed = parseRow(line);
+    if (parsed) flat.push(parsed);
+  }
+  return dedupe(flat);
+}
+
+/** Drop duplicate paths, keeping the first (which preserves authored order). */
+function dedupe(files: ParsedFile[]): ParsedFile[] {
+  const seen = new Set<string>();
+  const out: ParsedFile[] = [];
+  for (const file of files) {
+    if (seen.has(file.path)) continue;
+    seen.add(file.path);
+    out.push(file);
+  }
+  return out;
+}
+
+/* ── Tree construction (flat paths → nested folders) ───────────────────────── */
+
+interface FolderBuild {
+  name: string;
+  path: string;
+  folders: Map<string, FolderBuild>;
+  files: FileNode[];
+  order: string[];
+}
+
+function makeFolder(name: string, path: string): FolderBuild {
+  return { name, path, folders: new Map(), files: [], order: [] };
+}
+
+/**
+ * Build a nested folder tree from flat files. Folders are derived purely from
+ * each path's slash segments; insertion order is preserved within a folder, with
+ * folders sorted before files at each level (conventional explorer ordering).
+ * Single-child folder chains are compacted into one `a/b/c` row.
+ */
+export function buildFileTree(files: ParsedFile[]): TreeNode[] {
+  const root = makeFolder("", "");
+
+  for (const file of files) {
+    const segments = file.path.split("/").filter(Boolean);
+    if (segments.length === 0) continue;
+    const fileName = segments[segments.length - 1]!;
+    const folderSegments = segments.slice(0, -1);
+
+    let cursor = root;
+    let prefix = "";
+    for (const segment of folderSegments) {
+      prefix = prefix ? `${prefix}/${segment}` : segment;
+      let next = cursor.folders.get(segment);
+      if (!next) {
+        next = makeFolder(segment, prefix);
+        cursor.folders.set(segment, next);
+        cursor.order.push(`d:${segment}`);
+      }
+      cursor = next;
+    }
+
+    cursor.files.push({
+      kind: "file",
+      name: fileName,
+      path: file.path,
+      change: file.change,
+      note: file.note,
+    });
+    cursor.order.push(`f:${cursor.files.length - 1}`);
+  }
+
+  const materialize = (folder: FolderBuild): TreeNode[] => {
+    const nodes: TreeNode[] = [];
+    for (const key of folder.order) {
+      if (key.startsWith("d:")) {
+        const child = folder.folders.get(key.slice(2));
+        if (!child) continue;
+        nodes.push({
+          kind: "folder",
+          name: child.name,
+          path: child.path,
+          children: materialize(child),
+        });
+      } else {
+        const file = folder.files[Number(key.slice(2))];
+        if (file) nodes.push(file);
+      }
+    }
+    return [
+      ...nodes.filter((node) => node.kind === "folder"),
+      ...nodes.filter((node) => node.kind === "file"),
+    ];
+  };
+
+  return compactTree(materialize(root));
+}
+
+/** Collapse single-child folder chains into one `a/b/c` row (explorer style). */
+function compactFolderNode(folder: FolderNode): FolderNode {
+  const names = [folder.name];
+  let path = folder.path;
+  let children = folder.children;
+
+  while (children.length === 1 && children[0]?.kind === "folder") {
+    const child = children[0];
+    names.push(child.name);
+    path = child.path;
+    children = child.children;
+  }
+
+  return {
+    kind: "folder",
+    name: names.join("/"),
+    path,
+    children: compactTree(children),
+  };
+}
+
+function compactTree(nodes: TreeNode[]): TreeNode[] {
+  return nodes.map((node) =>
+    node.kind === "folder" ? compactFolderNode(node) : node,
+  );
+}
+
+/** Tally the change kinds across a flat file list, for the summary header. */
+export function tallyChanges(files: ParsedFile[]): ChangeTally {
+  const tally: ChangeTally = { added: 0, modified: 0, deleted: 0, renamed: 0 };
+  for (const file of files) {
+    if (file.change) tally[file.change] += 1;
+  }
+  return tally;
+}


### PR DESCRIPTION
## What

Replaces the flat `<pre>` `FileTree` proposal block with a real interactive explorer tree, porting agent-native's treatment (WU2 of the proposal-blocks gap analysis).

- **Nested tree from flat slash-paths** — folders before files, single-child folder chains compacted; folders expand/collapse with the top level open by default (chevron + folder open/closed icon, file icon for leaves).
- **A/M/D/R change badges** — single-letter badges per file (added = emerald, modified = blue, deleted = red + strikethrough, renamed = violet) and a `+N ~N −N »N` change tally in the header.
- **Per-file notes** — a trailing description after a path (e.g. `Cargo.toml (add [workspace.lints])`) shows as a muted inline caption.
- **Backward compatible** — parses both the legacy indented ASCII tree and one-slash-path-per-line authoring, tolerates pasted ASCII tree glyphs, and derives status from inline `(NEW)`/`(MODIFIED)`/`(DELETED)`/`(RENAMED)` markers (plus common synonyms). Falls back to the original raw `<pre>` when parsing yields nothing, so no existing proposal can blank or crash.

## How

- Pure `path → tree` + status/note parsing helpers live in a separate `fileTree.ts` (React-free, unit-tested).
- The renderer (`FileTreeBlock.tsx`) consumes them, using the existing `@hugeicons` icon set and shared `BlockShell` chrome. Dark-only, consistent with the other blocks.
- Data source: djinn stores the tree as the block's freeform children text (not a structured `entries={…}` JSON prop), so the parser works off that text.

## Validation

- `tsc -b` clean
- `eslint` clean on changed files
- `vitest run src/components/proposals` green (64 tests; 18 new in `fileTree.test.ts` for tree derivation + status/note parsing)