### PR TITLE
feat(proposals): structured api-endpoint block renderer

### DIFF
--- a/ui/src/components/proposals/blocks/ApiEndpointBlock.tsx
+++ b/ui/src/components/proposals/blocks/ApiEndpointBlock.tsx
@@ -1,26 +1,338 @@
-import type { BlockProps } from "./types";
-import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { useMemo, useState } from "react";
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  CodeIcon,
+  LockKeyIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 
+import { cn } from "@/lib/utils";
+
+import { BlockMarkdown, BlockShell } from "./BlockShell";
+import type { BlockProps } from "./types";
+import {
+  classifyStatus,
+  hasStructuredContent,
+  mentionsAuth,
+  mentionsDeprecated,
+  normalizeMethod,
+  parseApiEndpointBody,
+  type ApiMethod,
+  type ApiParam,
+  type ApiResponse,
+  type ParamLocation,
+  type StatusClass,
+} from "./apiEndpoint";
+
+/**
+ * ApiEndpoint — a Swagger / Stripe-style API reference row.
+ *
+ * djinn does not serialize structured `request_schema` / `response_schema` JSON
+ * props; the endpoint detail is the block's `method` + `path` attributes plus its
+ * *children markdown* (a prose description, an optional `## Parameters` table /
+ * list, an optional `## Responses` table / list, and fenced JSON example bodies).
+ * We parse the children (see `apiEndpoint.ts`) into a structured shape and render:
+ *
+ *   - a color-coded METHOD pill (per verb) + mono path, with an optional
+ *     `Deprecated` badge and a lock icon when the body mentions auth/bearer;
+ *   - a markdown description;
+ *   - a PARAMETERS section (NAME · IN · TYPE · REQUIRED · DESCRIPTION) with
+ *     IN-location pills (path violet / query blue / header amber / body emerald)
+ *     and a red `required` marker;
+ *   - a RESPONSES section with status-code pills colored by leading digit
+ *     (2xx emerald / 4xx amber / 5xx red), each with an optional example body.
+ *
+ * JSON example bodies render in a styled code surface for now. A dedicated
+ * interactive json-explorer block is planned — see the TODO seam in `JsonExample`.
+ *
+ * If the children have no recognizable params / responses, we fall back to the
+ * method/path header + raw `BlockMarkdown` of the children so nothing is lost and
+ * the block never crashes.
+ */
 export function ApiEndpointBlock({ attributes, children }: BlockProps) {
-  const method = attributes.method?.toUpperCase();
+  const method = normalizeMethod(attributes.method);
+  const rawMethod = attributes.method?.trim().toUpperCase();
   const path = attributes.path;
+  const content = typeof children === "string" ? children : "";
+
+  const parsed = useMemo(() => parseApiEndpointBody(content), [content]);
+  const structured = hasStructuredContent(parsed);
+  const hasAuth = useMemo(() => mentionsAuth(content), [content]);
+  const deprecated = useMemo(() => mentionsDeprecated(content), [content]);
+
+  // Default-open: proposals render full-width and reviewers want detail up front.
+  const [open, setOpen] = useState(true);
+
+  const header = (
+    <span className="flex min-w-0 items-center gap-2">
+      <MethodPill method={method} raw={rawMethod} />
+      {path ? (
+        <span className="truncate font-mono text-foreground">{path}</span>
+      ) : null}
+      {deprecated && (
+        <span className="shrink-0 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-300">
+          Deprecated
+        </span>
+      )}
+      {hasAuth && (
+        <HugeiconsIcon
+          icon={LockKeyIcon}
+          size={13}
+          className="shrink-0 text-amber-400/80"
+          aria-label="Requires authentication"
+        />
+      )}
+    </span>
+  );
+
+  // No structured content — keep the method/path header and render the raw
+  // children markdown so an oddly-authored endpoint is never blanked.
+  if (!structured) {
+    return (
+      <BlockShell label="API Endpoint" accent="text-green-400" meta={header}>
+        <BlockMarkdown>{children}</BlockMarkdown>
+      </BlockShell>
+    );
+  }
 
   return (
-    <BlockShell
-      label="API Endpoint"
-      accent="text-green-400"
-      meta={
-        method || path ? (
-          <span className="flex min-w-0 items-center gap-2 font-mono">
-            {method ? (
-              <span className="font-semibold text-green-400">{method}</span>
-            ) : null}
-            {path ? <span className="truncate text-foreground">{path}</span> : null}
+    <BlockShell label="API Endpoint" accent="text-green-400" flush meta={header}>
+      <div className="flex flex-col">
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((value) => !value)}
+          className="flex items-center gap-1.5 px-4 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/40"
+        >
+          <HugeiconsIcon
+            icon={open ? ArrowDown01Icon : ArrowRight01Icon}
+            size={14}
+            className="shrink-0"
+          />
+          <span className="uppercase tracking-wider">
+            {open ? "Hide details" : "Show details"}
           </span>
-        ) : null
-      }
-    >
-      <BlockMarkdown>{children}</BlockMarkdown>
+          <span className="ml-1 flex items-center gap-2 normal-case">
+            {parsed.params.length > 0 && (
+              <span>
+                {parsed.params.length}{" "}
+                {parsed.params.length === 1 ? "param" : "params"}
+              </span>
+            )}
+            {parsed.responses.length > 0 && (
+              <span>
+                {parsed.responses.length}{" "}
+                {parsed.responses.length === 1 ? "response" : "responses"}
+              </span>
+            )}
+          </span>
+        </button>
+
+        {open && (
+          <div className="flex flex-col gap-4 px-4 pb-4">
+            {parsed.description && (
+              <BlockMarkdown>{parsed.description}</BlockMarkdown>
+            )}
+
+            {parsed.params.length > 0 && (
+              <ParamsSection params={parsed.params} />
+            )}
+
+            {parsed.requestExample && (
+              <section>
+                <SectionLabel>Request body</SectionLabel>
+                <JsonExample code={parsed.requestExample} />
+              </section>
+            )}
+
+            {parsed.responses.length > 0 && (
+              <ResponsesSection responses={parsed.responses} />
+            )}
+          </div>
+        )}
+      </div>
     </BlockShell>
+  );
+}
+
+/* ── Method pill ────────────────────────────────────────────────────────────── */
+
+/** Per-verb pill palette. Dark-only theme. */
+const METHOD_STYLE: Record<ApiMethod, string> = {
+  GET: "bg-emerald-500/15 text-emerald-300",
+  POST: "bg-blue-500/15 text-blue-300",
+  PUT: "bg-amber-500/15 text-amber-300",
+  PATCH: "bg-violet-500/15 text-violet-300",
+  DELETE: "bg-red-500/15 text-red-300",
+  HEAD: "bg-slate-500/15 text-slate-300",
+  OPTIONS: "bg-slate-500/15 text-slate-300",
+};
+
+function MethodPill({
+  method,
+  raw,
+}: {
+  method: ApiMethod | undefined;
+  raw: string | undefined;
+}) {
+  const label = method ?? raw;
+  if (!label) return null;
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded px-1.5 py-0.5 font-mono text-[11px] font-bold tracking-wide",
+        method ? METHOD_STYLE[method] : "bg-slate-500/15 text-slate-300",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+/* ── Parameters section ─────────────────────────────────────────────────────── */
+
+/** IN-location pill palette: path violet / query blue / header amber / body emerald. */
+const LOCATION_STYLE: Record<ParamLocation, string> = {
+  path: "bg-violet-500/15 text-violet-300",
+  query: "bg-blue-500/15 text-blue-300",
+  header: "bg-amber-500/15 text-amber-300",
+  body: "bg-emerald-500/15 text-emerald-300",
+};
+
+function ParamsSection({ params }: { params: ApiParam[] }) {
+  return (
+    <section>
+      <SectionLabel>Parameters</SectionLabel>
+      <div className="overflow-hidden rounded-lg border bg-card/50">
+        <div className="divide-y divide-border/60">
+          {params.map((param, index) => (
+            <ParamRow key={`${param.name}-${index}`} param={param} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ParamRow({ param }: { param: ApiParam }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-2 text-[13px]">
+      <span className="font-mono font-medium text-foreground">
+        {param.name}
+      </span>
+      {param.in && (
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none",
+            LOCATION_STYLE[param.in],
+          )}
+        >
+          {param.in}
+        </span>
+      )}
+      {param.type && (
+        <span className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+          {param.type}
+        </span>
+      )}
+      {param.required === true && (
+        <span className="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none text-red-300">
+          required
+        </span>
+      )}
+      {param.required === false && (
+        <span className="rounded bg-slate-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none text-slate-300">
+          optional
+        </span>
+      )}
+      {param.description && (
+        <span className="w-full text-xs text-muted-foreground">
+          {param.description}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ── Responses section ──────────────────────────────────────────────────────── */
+
+/** Status-code pill palette: 2xx emerald / 4xx amber / 5xx red / other slate. */
+const STATUS_STYLE: Record<StatusClass, string> = {
+  success: "bg-emerald-500/15 text-emerald-300",
+  info: "bg-slate-500/15 text-slate-300",
+  warn: "bg-amber-500/15 text-amber-300",
+  error: "bg-red-500/15 text-red-300",
+};
+
+function ResponsesSection({ responses }: { responses: ApiResponse[] }) {
+  return (
+    <section>
+      <SectionLabel>Responses</SectionLabel>
+      <div className="flex flex-col gap-2">
+        {responses.map((response, index) => (
+          <ResponseRow key={`${response.status}-${index}`} response={response} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ResponseRow({ response }: { response: ApiResponse }) {
+  const cls = classifyStatus(response.status);
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card/50">
+      <div className="flex flex-wrap items-center gap-2 px-3 py-2 text-[13px]">
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5 font-mono text-[11px] font-bold leading-none",
+            STATUS_STYLE[cls],
+          )}
+        >
+          {response.status}
+        </span>
+        {response.description && (
+          <span className="min-w-0 text-foreground">{response.description}</span>
+        )}
+      </div>
+      {response.example && (
+        <div className="border-t px-3 py-2">
+          <JsonExample code={response.example} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Shared bits ────────────────────────────────────────────────────────────── */
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A JSON / example body rendered in a styled code surface.
+ *
+ * TODO(json-explorer): when the dedicated interactive `json-explorer` block
+ * lands, upgrade JSON example bodies here to a collapsible, type-colored tree
+ * (Postman-style) instead of a flat `<pre>`. This component is the seam: detect
+ * parseable JSON, mount the explorer, and keep this `<pre>` as the fallback for
+ * non-JSON / unparseable bodies.
+ */
+function JsonExample({ code }: { code: string }) {
+  return (
+    <div className="overflow-hidden rounded-md border bg-muted/30">
+      <div className="flex items-center gap-1.5 border-b bg-muted/40 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <HugeiconsIcon icon={CodeIcon} size={12} className="shrink-0" />
+        Example
+      </div>
+      <pre className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-foreground">
+        {code}
+      </pre>
+    </div>
   );
 }

--- a/ui/src/components/proposals/blocks/apiEndpoint.test.ts
+++ b/ui/src/components/proposals/blocks/apiEndpoint.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyStatus,
+  hasStructuredContent,
+  mentionsAuth,
+  mentionsDeprecated,
+  normalizeMethod,
+  parseApiEndpointBody,
+} from "./apiEndpoint";
+
+describe("normalizeMethod", () => {
+  it("uppercases + accepts known verbs", () => {
+    expect(normalizeMethod("get")).toBe("GET");
+    expect(normalizeMethod("  Post ")).toBe("POST");
+    expect(normalizeMethod("DELETE")).toBe("DELETE");
+    expect(normalizeMethod("patch")).toBe("PATCH");
+    expect(normalizeMethod("options")).toBe("OPTIONS");
+  });
+
+  it("returns undefined for unknown / empty methods", () => {
+    expect(normalizeMethod("TRACE")).toBeUndefined();
+    expect(normalizeMethod("")).toBeUndefined();
+    expect(normalizeMethod(undefined)).toBeUndefined();
+  });
+});
+
+describe("classifyStatus", () => {
+  it("maps by leading digit", () => {
+    expect(classifyStatus("200")).toBe("success");
+    expect(classifyStatus("201")).toBe("success");
+    expect(classifyStatus("2xx")).toBe("success");
+    expect(classifyStatus("400")).toBe("warn");
+    expect(classifyStatus("404")).toBe("warn");
+    expect(classifyStatus("4XX")).toBe("warn");
+    expect(classifyStatus("500")).toBe("error");
+    expect(classifyStatus("503")).toBe("error");
+  });
+
+  it("treats 1xx / 3xx / default / other as info", () => {
+    expect(classifyStatus("100")).toBe("info");
+    expect(classifyStatus("301")).toBe("info");
+    expect(classifyStatus("default")).toBe("info");
+    expect(classifyStatus("")).toBe("info");
+  });
+});
+
+describe("mentionsAuth / mentionsDeprecated", () => {
+  it("detects auth keywords", () => {
+    expect(mentionsAuth("Requires a Bearer token.")).toBe(true);
+    expect(mentionsAuth("Authentication via OAuth.")).toBe(true);
+    expect(mentionsAuth("Pass an API key header.")).toBe(true);
+    expect(mentionsAuth("Returns a list of users.")).toBe(false);
+  });
+
+  it("detects deprecated marker", () => {
+    expect(mentionsDeprecated("This endpoint is deprecated.")).toBe(true);
+    expect(mentionsDeprecated("Stable endpoint.")).toBe(false);
+  });
+});
+
+describe("parseApiEndpointBody — fallback / prose only", () => {
+  it("returns no structured content for empty input", () => {
+    const parsed = parseApiEndpointBody("");
+    expect(parsed.params).toEqual([]);
+    expect(parsed.responses).toEqual([]);
+    expect(hasStructuredContent(parsed)).toBe(false);
+  });
+
+  it("keeps a plain description with no structured sections", () => {
+    const parsed = parseApiEndpointBody("Returns a list of all users.");
+    expect(parsed.description).toBe("Returns a list of all users.");
+    expect(parsed.params).toEqual([]);
+    expect(parsed.responses).toEqual([]);
+    expect(hasStructuredContent(parsed)).toBe(false);
+  });
+});
+
+describe("parseApiEndpointBody — parameters table", () => {
+  it("parses a name/in/type/required/description table", () => {
+    const body = [
+      "Fetch a user.",
+      "",
+      "## Parameters",
+      "",
+      "| name  | in    | type | required | description    |",
+      "| ----- | ----- | ---- | -------- | -------------- |",
+      "| id    | path  | uuid | yes      | the user id    |",
+      "| limit | query | int  | no       | page size      |",
+      "| token | header| str  | required | bearer token   |",
+    ].join("\n");
+    const parsed = parseApiEndpointBody(body);
+
+    expect(parsed.description).toBe("Fetch a user.");
+    expect(parsed.params).toHaveLength(3);
+
+    expect(parsed.params[0]).toMatchObject({
+      name: "id",
+      in: "path",
+      type: "uuid",
+      required: true,
+      description: "the user id",
+    });
+    expect(parsed.params[1]).toMatchObject({
+      name: "limit",
+      in: "query",
+      type: "int",
+      required: false,
+    });
+    expect(parsed.params[2]).toMatchObject({ name: "token", in: "header" });
+    expect(hasStructuredContent(parsed)).toBe(true);
+  });
+
+  it("parses a bulleted parameter list with qualifiers", () => {
+    const body = [
+      "### Params",
+      "- `id` (path, uuid, required) — the user id",
+      "- `q` (query, string) — search term",
+    ].join("\n");
+    const parsed = parseApiEndpointBody(body);
+
+    expect(parsed.params).toHaveLength(2);
+    expect(parsed.params[0]).toMatchObject({
+      name: "id",
+      in: "path",
+      type: "uuid",
+      required: true,
+      description: "the user id",
+    });
+    expect(parsed.params[1]).toMatchObject({
+      name: "q",
+      in: "query",
+      type: "string",
+      description: "search term",
+    });
+  });
+});
+
+describe("parseApiEndpointBody — responses", () => {
+  it("parses a status/description responses table", () => {
+    const body = [
+      "## Responses",
+      "",
+      "| status | description     |",
+      "| ------ | --------------- |",
+      "| 200    | the user object |",
+      "| 404    | not found       |",
+      "| 500    | server error    |",
+    ].join("\n");
+    const parsed = parseApiEndpointBody(body);
+
+    expect(parsed.responses).toHaveLength(3);
+    expect(parsed.responses[0]).toMatchObject({
+      status: "200",
+      description: "the user object",
+    });
+    expect(parsed.responses[1]).toMatchObject({ status: "404" });
+    expect(classifyStatus(parsed.responses[2]!.status)).toBe("error");
+  });
+
+  it("parses a bulleted responses list", () => {
+    const body = [
+      "## Responses",
+      "- 200 — OK, returns the resource",
+      "- 401: unauthorized",
+    ].join("\n");
+    const parsed = parseApiEndpointBody(body);
+
+    expect(parsed.responses).toHaveLength(2);
+    expect(parsed.responses[0]).toMatchObject({
+      status: "200",
+      description: "OK, returns the resource",
+    });
+    expect(parsed.responses[1]).toMatchObject({
+      status: "401",
+      description: "unauthorized",
+    });
+  });
+
+  it("attaches a fenced JSON example to a response", () => {
+    const body = [
+      "## Responses",
+      "- 200 — the user",
+      "```json",
+      '{ "id": "abc", "name": "Ada" }',
+      "```",
+    ].join("\n");
+    const parsed = parseApiEndpointBody(body);
+
+    expect(parsed.responses).toHaveLength(1);
+    expect(parsed.responses[0]!.example).toContain('"name": "Ada"');
+    expect(hasStructuredContent(parsed)).toBe(true);
+  });
+});
+
+describe("parseApiEndpointBody — request body", () => {
+  it("captures a request-section fenced body as the request example", () => {
+    const body = [
+      "Create a user.",
+      "",
+      "## Request Body",
+      "```json",
+      '{ "name": "Ada" }',
+      "```",
+    ].join("\n");
+    const parsed = parseApiEndpointBody(body);
+
+    expect(parsed.description).toBe("Create a user.");
+    expect(parsed.requestExample).toContain('"name": "Ada"');
+    expect(hasStructuredContent(parsed)).toBe(true);
+  });
+});
+
+describe("parseApiEndpointBody — robustness", () => {
+  it("does not split a section on a heading-like line inside a code fence", () => {
+    const body = [
+      "Describe it.",
+      "```",
+      "## Parameters (this is inside a fence, not a heading)",
+      "```",
+    ].join("\n");
+    const parsed = parseApiEndpointBody(body);
+    // No real Parameters section was opened, so no params parsed.
+    expect(parsed.params).toEqual([]);
+  });
+});

--- a/ui/src/components/proposals/blocks/apiEndpoint.ts
+++ b/ui/src/components/proposals/blocks/apiEndpoint.ts
@@ -1,0 +1,638 @@
+// Pure (React-free) helpers for the interactive api-endpoint block. These parse
+// the freeform body an author writes inside <ApiEndpoint>…</ApiEndpoint> — driven
+// by the block's `method` + `path` attributes — into a structured shape: a prose
+// description, a list of PARAMETERS (name / in / type / required / description),
+// and a list of RESPONSES (status code + description + example body). Kept in
+// their own module so they are unit-testable without pulling React in.
+//
+// djinn does NOT serialize a structured `params={…}` / `responses={…}` JSON prop
+// — the declared `request_schema` / `response_schema` fields are decorative
+// LLM-guidance only. The actual endpoint detail is the block's *children markdown*
+// (see the Rust `validation.rs` fixture:
+// `<ApiEndpoint id="get-users" method="GET" path="/api/users">Returns a list of
+// all users.</ApiEndpoint>`). So we parse the children. The LLM typically writes
+// some mix of:
+//
+//   1. A prose description (one or more paragraphs).
+//   2. A `## Parameters` (or `### Params`) section: a markdown table
+//        | name     | in    | type   | required | description     |
+//        | -------- | ----- | ------ | -------- | --------------- |
+//        | id       | path  | uuid   | yes      | the user id     |
+//      OR a bulleted list:
+//        - `id` (path, uuid, required) — the user id
+//        - `limit` (query, int) — page size
+//   3. A `## Responses` (or `### Response`) section: a markdown table
+//        | status | description        |
+//        | ------ | ------------------ |
+//        | 200    | the user object    |
+//        | 404    | not found          |
+//      OR a bulleted list / sub-headings, optionally with a fenced JSON body for
+//      each status.
+//   4. Fenced ```json example bodies, which we attach to the nearest response (or
+//      surface as a request example).
+//
+// Anything the parser can't make sense of yields an empty params/responses list
+// (the caller falls back to rendering the raw children markdown), so an oddly-
+// authored endpoint is never lost and never crashes.
+
+/* ── Public types ──────────────────────────────────────────────────────────── */
+
+/** HTTP verbs we color-code; anything else falls back to a neutral pill. */
+export type ApiMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "HEAD"
+  | "OPTIONS";
+
+export const API_METHODS: ApiMethod[] = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+];
+
+/** Where a parameter lives — drives the IN-location pill color. */
+export type ParamLocation = "path" | "query" | "header" | "body";
+
+export const PARAM_LOCATIONS: ParamLocation[] = [
+  "path",
+  "query",
+  "header",
+  "body",
+];
+
+/** A single parsed request parameter. */
+export interface ApiParam {
+  name: string;
+  in?: ParamLocation;
+  type?: string;
+  required?: boolean;
+  description?: string;
+}
+
+/** A single parsed response: a status code + optional description + JSON body. */
+export interface ApiResponse {
+  /** Raw status token, e.g. `200`, `2xx`, `default`. */
+  status: string;
+  description?: string;
+  /** A fenced JSON (or other) example body attached to this status. */
+  example?: string;
+}
+
+/** The full parsed endpoint body. */
+export interface ParsedApiEndpoint {
+  /** Prose description (markdown) preceding any structured sections. */
+  description?: string;
+  params: ApiParam[];
+  responses: ApiResponse[];
+  /** A request example body not tied to a specific response. */
+  requestExample?: string;
+}
+
+/* ── Method + status classification ─────────────────────────────────────────── */
+
+/** Coerce a raw `method` attribute to a known verb (uppercased), or undefined. */
+export function normalizeMethod(raw: string | undefined): ApiMethod | undefined {
+  if (!raw) return undefined;
+  const upper = raw.trim().toUpperCase();
+  return API_METHODS.includes(upper as ApiMethod)
+    ? (upper as ApiMethod)
+    : undefined;
+}
+
+/** Detect whether the children mention auth/bearer/token so we can show a lock. */
+export function mentionsAuth(body: string): boolean {
+  return /\b(auth(?:entication|orization|enticated)?|bearer|oauth|api[\s-]?key|jwt|token|credentials?|x-api-key)\b/i.test(
+    body,
+  );
+}
+
+/** Detect a `Deprecated` marker in the children. */
+export function mentionsDeprecated(body: string): boolean {
+  return /\bdeprecated\b/i.test(body);
+}
+
+/**
+ * Classify a status token by its leading digit into a coarse class. `2xx` →
+ * `success`, `4xx` → `warn`, `5xx` → `error`, `3xx`/`1xx`/`default`/other →
+ * `info`. Tolerates `2xx`, `2XX`, `200`, `default`.
+ */
+export type StatusClass = "success" | "info" | "warn" | "error";
+
+export function classifyStatus(status: string): StatusClass {
+  const lead = status.trim().charAt(0);
+  switch (lead) {
+    case "2":
+      return "success";
+    case "4":
+      return "warn";
+    case "5":
+      return "error";
+    default:
+      return "info";
+  }
+}
+
+/* ── Parameter location classification ──────────────────────────────────────── */
+
+const LOCATION_WORDS: Record<string, ParamLocation> = {
+  path: "path",
+  url: "path",
+  route: "path",
+  query: "query",
+  querystring: "query",
+  qs: "query",
+  search: "query",
+  header: "header",
+  headers: "header",
+  body: "body",
+  payload: "body",
+  formdata: "body",
+  form: "body",
+};
+
+/** Coerce a free-text location word to a known IN-location, or undefined. */
+function normalizeLocation(raw: string | undefined): ParamLocation | undefined {
+  if (!raw) return undefined;
+  const key = raw.trim().toLowerCase().replace(/[\s_-]+/g, "");
+  return LOCATION_WORDS[key];
+}
+
+/** Detect a `required` / `optional` hint (returns true / false / undefined). */
+function detectRequired(text: string): boolean | undefined {
+  if (/\b(optional|not\s*required|nullable)\b/i.test(text)) return false;
+  if (/\b(required|mandatory)\b/i.test(text)) return true;
+  if (/^\s*(yes|y|true|✓|x)\s*$/i.test(text)) return true;
+  if (/^\s*(no|n|false|-|–|—)\s*$/i.test(text)) return false;
+  return undefined;
+}
+
+/* ── Markdown table parsing ─────────────────────────────────────────────────── */
+
+/** Split a markdown table row `| a | b | c |` into trimmed cells. */
+function splitTableRow(line: string): string[] {
+  let row = line.trim();
+  if (row.startsWith("|")) row = row.slice(1);
+  if (row.endsWith("|")) row = row.slice(0, -1);
+  return row.split(/\s*(?<!\\)\|\s*/).map((c) => c.replace(/\\\|/g, "|").trim());
+}
+
+/** True when a row is a markdown table separator (`| --- | :--: |`). */
+function isSeparatorRow(cells: string[]): boolean {
+  return (
+    cells.length > 0 &&
+    cells.every((c) => /^:?-{1,}:?$/.test(c.replace(/\s/g, "")))
+  );
+}
+
+/** Find the header column index whose name matches any of `names`. */
+function findColumn(header: string[], names: string[]): number {
+  for (let i = 0; i < header.length; i++) {
+    const h = header[i]!.toLowerCase().trim();
+    if (names.some((n) => h === n || h.includes(n))) return i;
+  }
+  return -1;
+}
+
+/** Collect contiguous markdown-table lines (pipe-bearing) from a line array. */
+function collectTableLines(lines: string[]): string[] {
+  return lines.filter((l) => l.includes("|") && l.trim() !== "");
+}
+
+/* ── Parameter parsing ──────────────────────────────────────────────────────── */
+
+/**
+ * Parse a parameters section's lines into params. Tries a markdown table first
+ * (header + separator + rows), then falls back to a bulleted / plain list.
+ */
+function parseParams(lines: string[]): ApiParam[] {
+  const tableLines = collectTableLines(lines);
+  if (tableLines.length >= 2) {
+    const fromTable = parseParamTable(tableLines);
+    if (fromTable.length > 0) return fromTable;
+  }
+
+  const params: ApiParam[] = [];
+  for (const line of lines) {
+    const param = parseParamLine(line);
+    if (param) params.push(param);
+  }
+  return params;
+}
+
+/** Parse a `| name | in | type | required | description |` table into params. */
+function parseParamTable(lines: string[]): ApiParam[] {
+  if (lines.length < 2) return [];
+  const header = splitTableRow(lines[0]!);
+  const sep = splitTableRow(lines[1]!);
+  if (!isSeparatorRow(sep)) return [];
+
+  const nameCol = findColumn(header, ["name", "field", "param", "parameter"]);
+  const inCol = findColumn(header, ["in", "location", "where"]);
+  const typeCol = findColumn(header, ["type", "datatype", "schema"]);
+  const reqCol = findColumn(header, ["required", "req"]);
+  const descCol = findColumn(header, [
+    "description",
+    "desc",
+    "notes",
+    "note",
+    "details",
+  ]);
+
+  // A params table must at least have a recognizable name column.
+  if (nameCol < 0) return [];
+
+  const params: ApiParam[] = [];
+  for (let i = 2; i < lines.length; i++) {
+    const cells = splitTableRow(lines[i]!);
+    if (cells.length === 0 || cells.every((c) => c === "")) continue;
+    if (isSeparatorRow(cells)) continue;
+
+    const name = cleanInline((cells[nameCol] ?? "").trim());
+    if (!name) continue;
+
+    const type =
+      typeCol >= 0 ? cleanInline((cells[typeCol] ?? "").trim()) : undefined;
+    const location = inCol >= 0 ? normalizeLocation(cells[inCol]) : undefined;
+    const required =
+      reqCol >= 0 ? detectRequired(cells[reqCol] ?? "") : undefined;
+    const description =
+      descCol >= 0 ? cleanInline((cells[descCol] ?? "").trim()) : undefined;
+
+    params.push({
+      name,
+      in: location,
+      type: type || undefined,
+      required,
+      description: description || undefined,
+    });
+  }
+  return params;
+}
+
+/**
+ * Parse one freeform parameter line of the forms:
+ *   - `name` (path, uuid, required) — description
+ *   - name: type (query) — description
+ *   - name [header] string, optional — description
+ * Returns null when the leading token isn't an identifier.
+ */
+function parseParamLine(raw: string): ApiParam | null {
+  const line = raw.replace(/^\s*[-*+•]\s+/u, "").trim();
+  if (!line) return null;
+
+  // Leading name token: an identifier, optionally backticked, possibly with a
+  // `:type` immediately after.
+  const nameMatch =
+    /^`?([A-Za-z_$][\w$.[\]-]*)`?\s*(?::\s*`?([A-Za-z_$][\w$<>[\]. ]*?)`?)?\s*([\s\S]*)$/.exec(
+      line,
+    );
+  if (!nameMatch) return null;
+  const name = (nameMatch[1] ?? "").trim();
+  if (!name) return null;
+
+  let type = (nameMatch[2] ?? "").trim() || undefined;
+  let rest = (nameMatch[3] ?? "").trim();
+
+  // A bracketed/parenthesized qualifier block: `(path, uuid, required)` or
+  // `[query string]`. Pull the first one and mine it for in/type/required.
+  let location: ParamLocation | undefined;
+  let required: boolean | undefined;
+  const qualMatch = /^[([{]([^)\]}]*)[)\]}]\s*([\s\S]*)$/.exec(rest);
+  if (qualMatch) {
+    const inner = qualMatch[1] ?? "";
+    rest = (qualMatch[2] ?? "").trim();
+    for (const token of inner.split(/[,;]/)) {
+      const t = token.trim();
+      if (!t) continue;
+      const loc = normalizeLocation(t);
+      if (loc && !location) {
+        location = loc;
+        continue;
+      }
+      const req = detectRequired(t);
+      if (req !== undefined) {
+        required = req;
+        continue;
+      }
+      if (!type) type = t;
+    }
+  }
+
+  // Whatever IN / required hint remains in the trailing prose.
+  if (!location) location = normalizeLocation(matchLocationWord(rest));
+  if (required === undefined) {
+    const req = detectRequired(rest);
+    if (req !== undefined) required = req;
+  }
+
+  // The description is the trailing prose after stripping a leading separator.
+  const description = cleanInline(rest.replace(/^[—–\-:|]+\s*/u, "").trim());
+
+  // A bare line with no type, no qualifier, no separator, and a trailing
+  // sentence-ish blob is likely prose, not a param — but if it had a `:type`,
+  // a qualifier, or an IN/required hint we keep it.
+  const hasSignal =
+    type !== undefined ||
+    location !== undefined ||
+    required !== undefined ||
+    qualMatch !== null;
+  if (!hasSignal && !description) return null;
+
+  return {
+    name,
+    in: location,
+    type,
+    required,
+    description: description || undefined,
+  };
+}
+
+/** Find a standalone location word (`path`/`query`/`header`/`body`) in text. */
+function matchLocationWord(text: string): string | undefined {
+  const m =
+    /\b(path|query|querystring|header|headers|body|payload|route|url)\b/i.exec(
+      text,
+    );
+  return m?.[1];
+}
+
+/** Strip markdown inline code/emphasis markers for a clean cell value. */
+function cleanInline(text: string): string {
+  return text
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/\*\*([^*]*)\*\*/g, "$1")
+    .replace(/(?<!\*)\*(?!\*)([^*]*)\*/g, "$1")
+    .trim();
+}
+
+/* ── Response parsing ───────────────────────────────────────────────────────── */
+
+const STATUS_TOKEN = /\b([1-5][0-9x]{2}|default)\b/i;
+
+/**
+ * Parse a responses section's lines into responses. Tries a markdown table
+ * first (a `status` column), then a bulleted / sub-heading list. Fenced code
+ * blocks following a status are attached to it as an example.
+ */
+function parseResponses(lines: string[]): ApiResponse[] {
+  const { prose, codeBlocks } = splitFencedCode(lines);
+
+  const tableLines = collectTableLines(prose);
+  if (tableLines.length >= 2) {
+    const fromTable = parseResponseTable(tableLines);
+    if (fromTable.length > 0) {
+      attachExamples(fromTable, codeBlocks);
+      return fromTable;
+    }
+  }
+
+  const responses = parseResponseList(prose);
+  attachExamples(responses, codeBlocks);
+  return responses;
+}
+
+/** Parse a `| status | description |` table into responses. */
+function parseResponseTable(lines: string[]): ApiResponse[] {
+  if (lines.length < 2) return [];
+  const header = splitTableRow(lines[0]!);
+  const sep = splitTableRow(lines[1]!);
+  if (!isSeparatorRow(sep)) return [];
+
+  const statusCol = findColumn(header, ["status", "code", "http"]);
+  const descCol = findColumn(header, [
+    "description",
+    "desc",
+    "meaning",
+    "notes",
+    "note",
+    "body",
+  ]);
+  if (statusCol < 0) return [];
+
+  const responses: ApiResponse[] = [];
+  for (let i = 2; i < lines.length; i++) {
+    const cells = splitTableRow(lines[i]!);
+    if (cells.length === 0 || cells.every((c) => c === "")) continue;
+    if (isSeparatorRow(cells)) continue;
+
+    const rawStatus = cleanInline((cells[statusCol] ?? "").trim());
+    const statusMatch = STATUS_TOKEN.exec(rawStatus);
+    const status = statusMatch ? statusMatch[1]! : rawStatus;
+    if (!status) continue;
+
+    const description =
+      descCol >= 0 ? cleanInline((cells[descCol] ?? "").trim()) : undefined;
+    responses.push({ status, description: description || undefined });
+  }
+  return responses;
+}
+
+/** Parse a bulleted / sub-heading list of `status — description` lines. */
+function parseResponseList(lines: string[]): ApiResponse[] {
+  const responses: ApiResponse[] = [];
+  for (const raw of lines) {
+    const line = raw
+      .replace(/^\s*[-*+•]\s+/u, "")
+      .replace(/^#{1,6}\s+/u, "")
+      .trim();
+    if (!line) continue;
+
+    // Status must appear at (or very near) the start of the line.
+    const lead = line.slice(0, 32);
+    const match = STATUS_TOKEN.exec(lead);
+    if (!match || match.index > 3) continue;
+    const status = match[1]!;
+    const after = line.slice(match.index + status.length);
+    const description = cleanInline(after.replace(/^[—–\-:|)\s]+/u, "").trim());
+    responses.push({ status, description: description || undefined });
+  }
+  return responses;
+}
+
+/* ── Fenced-code extraction ─────────────────────────────────────────────────── */
+
+/** A fenced code block lifted out of the body, with the line it followed. */
+interface FencedBlock {
+  /** Index into the prose-line array AFTER which this block appeared. */
+  afterProseIndex: number;
+  lang: string;
+  code: string;
+}
+
+/**
+ * Strip ```fenced``` code blocks out of `lines`, returning the prose lines and
+ * the extracted blocks (each tagged with the prose-line index it followed so we
+ * can attach it to the right response).
+ */
+function splitFencedCode(lines: string[]): {
+  prose: string[];
+  codeBlocks: FencedBlock[];
+} {
+  const prose: string[] = [];
+  const codeBlocks: FencedBlock[] = [];
+  let inFence = false;
+  let fenceLang = "";
+  let buffer: string[] = [];
+
+  for (const line of lines) {
+    const fence = /^\s*```+\s*([\w-]*)\s*$/.exec(line);
+    if (fence) {
+      if (!inFence) {
+        inFence = true;
+        fenceLang = (fence[1] ?? "").toLowerCase();
+        buffer = [];
+      } else {
+        inFence = false;
+        codeBlocks.push({
+          afterProseIndex: prose.length - 1,
+          lang: fenceLang,
+          code: buffer.join("\n"),
+        });
+        buffer = [];
+      }
+      continue;
+    }
+    if (inFence) {
+      buffer.push(line);
+    } else {
+      prose.push(line);
+    }
+  }
+  // An unterminated fence: keep what we captured as a block so content isn't lost.
+  if (inFence && buffer.length > 0) {
+    codeBlocks.push({
+      afterProseIndex: prose.length - 1,
+      lang: fenceLang,
+      code: buffer.join("\n"),
+    });
+  }
+
+  return { prose, codeBlocks };
+}
+
+/**
+ * Attach each fenced code block to the response it most plausibly belongs to.
+ * The common case (one example per status, authored right under it) lands
+ * correctly; extra blocks append to the last response.
+ */
+function attachExamples(
+  responses: ApiResponse[],
+  codeBlocks: FencedBlock[],
+): void {
+  if (responses.length === 0 || codeBlocks.length === 0) return;
+  for (let i = 0; i < codeBlocks.length; i++) {
+    const target = responses[Math.min(i, responses.length - 1)]!;
+    const code = codeBlocks[i]!.code.trim();
+    if (!code) continue;
+    target.example = target.example ? `${target.example}\n\n${code}` : code;
+  }
+}
+
+/* ── Section partitioning ───────────────────────────────────────────────────── */
+
+type SectionKind = "description" | "params" | "responses" | "request";
+
+/** Classify a heading line into a known section, or null if it's not one. */
+function classifyHeading(line: string): SectionKind | null {
+  const m =
+    /^\s*#{1,6}\s+(.+?)\s*$/.exec(line) ??
+    /^\s*\*\*([^*]+)\*\*\s*:?\s*$/.exec(line.trim());
+  if (!m) return null;
+  const text = (m[1] ?? "").toLowerCase();
+  if (/\b(param(eter)?s?|arguments?|inputs?|query|path\s*param)/.test(text)) {
+    return "params";
+  }
+  if (/\b(responses?|returns?|status\s*codes?|output)/.test(text)) {
+    return "responses";
+  }
+  if (/\b(request|body|payload)\b/.test(text)) return "request";
+  return null;
+}
+
+/* ── Top-level parse ────────────────────────────────────────────────────────── */
+
+/**
+ * Parse the freeform <ApiEndpoint> children into a structured shape: a prose
+ * description, a list of parameters, and a list of responses. Returns empty
+ * arrays for params/responses when nothing structured is found, so the renderer
+ * can fall back to rendering the raw markdown.
+ */
+export function parseApiEndpointBody(body: string): ParsedApiEndpoint {
+  if (!body || !body.trim()) {
+    return { description: undefined, params: [], responses: [] };
+  }
+  const lines = body.replace(/\r\n?/g, "\n").split("\n");
+
+  // Partition into sections by heading. Everything before the first recognized
+  // section heading is the description; we track fenced state so a heading-like
+  // line inside a code fence doesn't split a section.
+  const descLines: string[] = [];
+  const paramLines: string[] = [];
+  const responseLines: string[] = [];
+  const requestLines: string[] = [];
+
+  let current: SectionKind = "description";
+  let inFence = false;
+
+  for (const line of lines) {
+    if (/^\s*```+/.test(line)) inFence = !inFence;
+
+    if (!inFence) {
+      const section = classifyHeading(line);
+      if (section) {
+        current = section;
+        continue; // drop the heading line itself
+      }
+    }
+
+    switch (current) {
+      case "params":
+        paramLines.push(line);
+        break;
+      case "responses":
+        responseLines.push(line);
+        break;
+      case "request":
+        requestLines.push(line);
+        break;
+      default:
+        descLines.push(line);
+    }
+  }
+
+  const params = parseParams(paramLines);
+  const responses = parseResponses(responseLines);
+
+  // A request section's fenced JSON becomes the request example.
+  let requestExample: string | undefined;
+  if (requestLines.length > 0) {
+    const { codeBlocks } = splitFencedCode(requestLines);
+    const first = codeBlocks.find((b) => b.code.trim());
+    if (first) requestExample = first.code.trim();
+  }
+
+  const description = descLines.join("\n").trim();
+
+  return {
+    description: description.length > 0 ? description : undefined,
+    params,
+    responses,
+    requestExample,
+  };
+}
+
+/** True when the parsed body has any structured content worth a rich render. */
+export function hasStructuredContent(parsed: ParsedApiEndpoint): boolean {
+  return (
+    parsed.params.length > 0 ||
+    parsed.responses.length > 0 ||
+    parsed.requestExample !== undefined
+  );
+}


### PR DESCRIPTION
Ports agent-native's Swagger/Stripe-style API reference treatment to djinn's proposal **api-endpoint** block (gap analysis §3.2). djinn serializes no structured JSON props, so the renderer is driven by the `method`/`path` attributes plus parsing the children markdown.

## What changed
- **Color-coded METHOD pill** per verb (GET emerald / POST blue / PUT amber / PATCH violet / DELETE red / HEAD-OPTIONS slate) + mono path, with an optional `Deprecated` badge and an auth lock icon when the body mentions auth/bearer/token.
- **PARAMETERS section** parsed from a markdown table OR a bulleted list → `NAME · IN · TYPE · REQUIRED · DESCRIPTION` with **IN-location pills** (path violet / query blue / header amber / body emerald) and a red `required` marker.
- **RESPONSES section** with **status-code pills** colored by leading digit (2xx emerald / 4xx amber / 5xx red) plus per-status JSON example bodies.
- **JSON example bodies** render in a styled code surface, with a clear `TODO(json-explorer)` seam to upgrade to the future interactive json-explorer block.
- **Backward compatible & robust**: with no recognizable params/responses, falls back to the method/path header + raw `BlockMarkdown` of the children so nothing is lost and the block never crashes.

## Structure
- Pure parse functions live in `apiEndpoint.ts` (React-free), mirroring the established `fileTree.ts` / `dataModel.ts` house pattern (parse children → structured render → graceful fallback, dark-only, `@hugeicons/react`, shared badge palette).
- `apiEndpoint.test.ts` (Vitest, 15 cases) covers method-pill mapping, param table + bulleted-list parsing, response table + list parsing, fenced-JSON example attachment, status-color mapping, and the prose-only fallback.

## Validation
- `tsc -b` clean
- `eslint` clean on changed files
- `vitest run src/components/proposals/blocks` → 95 passed