### PR TITLE
feat(review): cross-model "Thorough review" + working-style presets (slice 3/6)

### DIFF
--- a/server/.sqlx/query-8affd7ec4b2120c3d6219fb001214133b82d4bef10a8b0e385c31bc69adf63e2.json
+++ b/server/.sqlx/query-8affd7ec4b2120c3d6219fb001214133b82d4bef10a8b0e385c31bc69adf63e2.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT model_id FROM sessions\n               WHERE task_id = $1 AND agent_type = $2\n               ORDER BY started_at DESC LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "model_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8affd7ec4b2120c3d6219fb001214133b82d4bef10a8b0e385c31bc69adf63e2"
+}

--- a/server/.sqlx/query-9da5b7b125fcbf3949e2f006c7db1dc47791b68548d403e562c65200dbefaf68.json
+++ b/server/.sqlx/query-9da5b7b125fcbf3949e2f006c7db1dc47791b68548d403e562c65200dbefaf68.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO user_settings (user_id, auto_approve_prs, diverse_review, created_at, updated_at)\n             VALUES ($1, FALSE, $2,\n                     to_char(now() at time zone 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),\n                     to_char(now() at time zone 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'))\n             ON CONFLICT (user_id) DO UPDATE SET\n                 diverse_review = EXCLUDED.diverse_review,\n                 updated_at = EXCLUDED.updated_at",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9da5b7b125fcbf3949e2f006c7db1dc47791b68548d403e562c65200dbefaf68"
+}

--- a/server/.sqlx/query-bd0b9fb74aac276668df8cd932718b671fd6e89bba7752f7eec738f972c2146f.json
+++ b/server/.sqlx/query-bd0b9fb74aac276668df8cd932718b671fd6e89bba7752f7eec738f972c2146f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT user_id, auto_approve_prs AS \"auto_approve_prs!: bool\",\n                      model_lanes, max_sessions, created_at, updated_at\n               FROM user_settings WHERE user_id = $1",
+  "query": "SELECT user_id, auto_approve_prs AS \"auto_approve_prs!: bool\",\n                      diverse_review AS \"diverse_review!: bool\",\n                      model_lanes, max_sessions, created_at, updated_at\n               FROM user_settings WHERE user_id = $1",
   "describe": {
     "columns": [
       {
@@ -15,21 +15,26 @@
       },
       {
         "ordinal": 2,
+        "name": "diverse_review!: bool",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
         "name": "model_lanes",
         "type_info": "Text"
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "max_sessions",
         "type_info": "Text"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "created_at",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "updated_at",
         "type_info": "Varchar"
       }
@@ -42,11 +47,12 @@
     "nullable": [
       false,
       false,
+      false,
       true,
       true,
       false,
       false
     ]
   },
-  "hash": "7a54b626f94cfe0d853159e55ee60ba9dd24618a8fba7be160e04e498d1158c3"
+  "hash": "bd0b9fb74aac276668df8cd932718b671fd6e89bba7752f7eec738f972c2146f"
 }

--- a/server/crates/djinn-agent/src/actors/coordinator/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/dispatch/task_dispatch.rs
@@ -534,6 +534,97 @@ impl CoordinatorActor {
         Ok(next_count)
     }
 
+    /// Cross-model ("Thorough") review steering for a reviewer dispatch.
+    ///
+    /// When the task creator has `diverse_review` enabled, reorder `model_ids`
+    /// (the resolved review-lane fallback list) so the first viable entry is a
+    /// model id DIFFERENT from the one that implemented the task. The
+    /// implementer's model id is read from the most recent `worker` session for
+    /// the task. Behavior:
+    ///
+    /// - `diverse_review` off, or no implementer model on file yet, or no
+    ///   distinct alternative exists → leave the order untouched (same-model
+    ///   review is the graceful fallback; the task is never blocked).
+    /// - Otherwise → stable-partition so all ids != implementer come first
+    ///   (priority preserved within each group), then ids == implementer.
+    ///
+    /// Records the outcome (log + `djinn_cross_model_review_total`) so the
+    /// substitution/fallback is observable.
+    #[cfg(not(test))]
+    async fn apply_diverse_review_ordering(
+        &self,
+        task: &djinn_core::models::Task,
+        creator: Option<&str>,
+        model_ids: &mut [String],
+    ) {
+        let Some(uid) = creator else {
+            return;
+        };
+        let us_repo = djinn_db::UserSettingsRepository::new(self.db.clone());
+        let diverse = match us_repo.get(uid).await {
+            // Default ON when the user has never written settings (matches the
+            // DB column default + `defaults_for`).
+            Ok(Some(s)) => s.diverse_review,
+            Ok(None) => true,
+            Err(_) => return,
+        };
+        if !diverse {
+            return;
+        }
+
+        // The model that implemented the task = the most recent worker session's
+        // model id. Unknown (no worker session yet) → nothing to diverge from.
+        let implementer = match djinn_db::SessionRepository::new(
+            self.db.clone(),
+            crate::events::event_bus_for(&self.events_tx),
+        )
+        .latest_model_for_task_role(&task.id, "worker")
+        .await
+        {
+            Ok(Some(m)) if !m.trim().is_empty() => m,
+            _ => return,
+        };
+
+        let has_alternative = model_ids.iter().any(|m| m != &implementer);
+        if !has_alternative {
+            // The whole viable review list collapses to the implementer's model
+            // — proceed same-model rather than blocking the review.
+            tracing::info!(
+                task_id = %task.short_id,
+                implementer_model = %implementer,
+                "CoordinatorActor: diverse review wanted but only the implementer's \
+                 model is viable — proceeding same-model"
+            );
+            djinn_telemetry::dispatch::record_cross_model_review("same_fallback");
+            return;
+        }
+
+        // Stable partition: ids != implementer keep their relative priority and
+        // move ahead of any id == implementer.
+        model_ids.sort_by_key(|m| m == &implementer);
+        tracing::info!(
+            task_id = %task.short_id,
+            implementer_model = %implementer,
+            reviewer_model = %model_ids.first().map(String::as_str).unwrap_or(""),
+            "CoordinatorActor: cross-model review — steering reviewer to a model \
+             distinct from the implementer"
+        );
+        djinn_telemetry::dispatch::record_cross_model_review("different");
+    }
+
+    /// Test-build no-op: the in-process dispatch fixtures seed no real users or
+    /// sessions, and `resolve_user_model_priority` already returns empty under
+    /// test, so cross-model steering has nothing to act on. The production path
+    /// is exercised via the live MCP/session flow + the repo-level unit tests.
+    #[cfg(test)]
+    async fn apply_diverse_review_ordering(
+        &self,
+        _task: &djinn_core::models::Task,
+        _creator: Option<&str>,
+        _model_ids: &mut [String],
+    ) {
+    }
+
     #[tracing::instrument(
         name = "djinn.dispatch",
         skip(self, model_ids, dispatch_fn),
@@ -1217,6 +1308,16 @@ impl CoordinatorActor {
                 if seen.insert(id.clone()) {
                     model_ids.push(id.clone());
                 }
+            }
+
+            // Cross-model ("Thorough") review: when this is a reviewer dispatch
+            // and the creator has `diverse_review` on, steer the fallback list so
+            // the first viable model id differs from the one that implemented the
+            // task. Reorders in place (entries != implementer first, preserving
+            // priority); collapses to same-model when nothing else is viable.
+            if role == "reviewer" {
+                self.apply_diverse_review_ordering(&task, creator.as_deref(), &mut model_ids)
+                    .await;
             }
 
             // No model whose provider this task's owner has connected → the task

--- a/server/crates/djinn-control-plane/src/tools/user_settings_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/user_settings_tools.rs
@@ -81,6 +81,11 @@ pub struct UserSettingsGetResponse {
     /// The sole admission control at dispatch; empty ⇒ default 1 per model.
     #[schemars(with = "std::collections::HashMap<String, i64>")]
     pub max_sessions: HashMap<String, u32>,
+    /// Cross-model ("Thorough") review. When true (the default), a task
+    /// dispatched to the reviewer role prefers a model id different from the one
+    /// that implemented it. A degenerate single-model selection falls back to
+    /// same-model review.
+    pub diverse_review: bool,
     pub error: Option<String>,
 }
 
@@ -100,6 +105,10 @@ pub struct UserSettingsSetParams {
     /// 1 per model). Omit to keep the current value.
     #[schemars(with = "Option<std::collections::HashMap<String, i64>>")]
     pub max_sessions: Option<HashMap<String, u32>>,
+    /// Enable or disable cross-model ("Thorough") review for THIS user. When on
+    /// (the default), the reviewer prefers a model id different from the
+    /// implementer's. Omit to keep the current value.
+    pub diverse_review: Option<bool>,
     /// Admin-only: act on behalf of this user id (e.g. another user to
     /// configure). Non-admins must omit it.
     #[serde(default)]
@@ -116,6 +125,8 @@ pub struct UserSettingsSetResponse {
     /// The resulting per-model concurrency caps after the patch.
     #[schemars(with = "Option<std::collections::HashMap<String, i64>>")]
     pub max_sessions: Option<HashMap<String, u32>>,
+    /// The resulting cross-model review toggle after the patch.
+    pub diverse_review: Option<bool>,
     pub error: Option<String>,
 }
 
@@ -146,6 +157,7 @@ impl DjinnMcpServer {
                         auto_approve_prs: false,
                         lanes: ModelLanesPayload::default(),
                         max_sessions: HashMap::new(),
+                        diverse_review: true,
                         error: Some(missing_session()),
                     });
                 }
@@ -156,6 +168,7 @@ impl DjinnMcpServer {
                         auto_approve_prs: false,
                         lanes: ModelLanesPayload::default(),
                         max_sessions: HashMap::new(),
+                        diverse_review: true,
                         error: Some(e),
                     });
                 }
@@ -168,6 +181,7 @@ impl DjinnMcpServer {
                 auto_approve_prs: s.auto_approve_prs,
                 lanes: s.lanes.unwrap_or_default().into(),
                 max_sessions: s.max_sessions.unwrap_or_default(),
+                diverse_review: s.diverse_review,
                 error: None,
             }),
             Err(e) => Json(UserSettingsGetResponse {
@@ -176,6 +190,7 @@ impl DjinnMcpServer {
                 auto_approve_prs: false,
                 lanes: ModelLanesPayload::default(),
                 max_sessions: HashMap::new(),
+                diverse_review: true,
                 error: Some(e.to_string()),
             }),
         }
@@ -202,6 +217,7 @@ impl DjinnMcpServer {
                         auto_approve_prs: None,
                         lanes: None,
                         max_sessions: None,
+                        diverse_review: None,
                         error: Some(missing_session()),
                     });
                 }
@@ -212,6 +228,7 @@ impl DjinnMcpServer {
                         auto_approve_prs: None,
                         lanes: None,
                         max_sessions: None,
+                        diverse_review: None,
                         error: Some(e),
                     });
                 }
@@ -225,6 +242,7 @@ impl DjinnMcpServer {
                 auto_approve_prs: None,
                 lanes: None,
                 max_sessions: None,
+                diverse_review: None,
                 error: Some(msg),
             })
         };
@@ -268,6 +286,16 @@ impl DjinnMcpServer {
             applied = true;
         }
 
+        // Cross-model ("Thorough") review toggle. No validation needed — it is a
+        // pure dispatch-time preference; a degenerate single-model selection
+        // falls back to same-model review.
+        if let Some(target) = p.diverse_review {
+            if let Err(e) = repo.upsert_diverse_review(&user_id, target).await {
+                return err(e.to_string());
+            }
+            applied = true;
+        }
+
         // A changed model selection or cap can make more work dispatchable now,
         // so kick a dispatch pass. No-op for auto-approve-only patches.
         if p.lanes.is_some() || p.max_sessions.is_some() {
@@ -281,6 +309,7 @@ impl DjinnMcpServer {
                 auto_approve_prs: Some(s.auto_approve_prs),
                 lanes: Some(s.lanes.unwrap_or_default().into()),
                 max_sessions: Some(s.max_sessions.unwrap_or_default()),
+                diverse_review: Some(s.diverse_review),
                 error: None,
             }),
             Err(e) => err(e.to_string()),

--- a/server/crates/djinn-core/src/models/user_settings.rs
+++ b/server/crates/djinn-core/src/models/user_settings.rs
@@ -110,6 +110,14 @@ pub struct UserSettings {
     /// migration 32). Caps are per-model, shared across lanes.
     #[cfg_attr(feature = "sqlx", sqlx(default))]
     pub max_sessions: Option<HashMap<String, u32>>,
+    /// Cross-model ("Thorough") review. When `true` (the default), a task
+    /// dispatched to the reviewer role prefers a model id different from the one
+    /// that implemented the task — the reviewer walks its review-lane fallback
+    /// list and takes the first id that differs from the implementer's. A
+    /// degenerate single-model selection silently falls back to same-model.
+    /// Persisted as a NOT-NULL boolean column (`user_settings.diverse_review`,
+    /// migration 78, default TRUE).
+    pub diverse_review: bool,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -124,6 +132,9 @@ impl UserSettings {
             auto_approve_prs: false,
             lanes: None,
             max_sessions: None,
+            // Cross-model review is on by default (DB column default TRUE), so a
+            // never-written user gets the same behavior as a migrated row.
+            diverse_review: true,
             created_at: String::new(),
             updated_at: String::new(),
         }

--- a/server/crates/djinn-db/migrations_postgres/78_user_settings_diverse_review.sql
+++ b/server/crates/djinn-db/migrations_postgres/78_user_settings_diverse_review.sql
@@ -1,0 +1,16 @@
+-- Cross-model ("Thorough") review toggle for the reviewer lane.
+--
+-- Slice 3 of proposal p8py ("Model setup UX"). Adds a per-user `diverse_review`
+-- boolean to `user_settings`. When ON (the default), a task dispatched to the
+-- reviewer role prefers a model id DIFFERENT from the one that implemented the
+-- task — walking the user's review-lane fallback list and taking the first
+-- entry whose model id differs from the implementer's. If the viable list
+-- collapses to the implementer's model, dispatch proceeds same-model rather
+-- than blocking the task.
+--
+-- Defaults TRUE so existing users get cross-model review without a manual opt-in
+-- (it is a no-op for anyone with fewer than 2 distinct model ids across their
+-- implement+review lanes — the dispatch path falls back to same-model).
+
+ALTER TABLE user_settings
+    ADD COLUMN diverse_review BOOLEAN NOT NULL DEFAULT TRUE;

--- a/server/crates/djinn-db/src/repositories/session.rs
+++ b/server/crates/djinn-db/src/repositories/session.rs
@@ -520,6 +520,31 @@ impl SessionRepository {
         .await?)
     }
 
+    /// The `model_id` of the most recent session for `task_id` whose
+    /// `agent_type` matches `agent_type` (e.g. `"worker"` to find the model that
+    /// implemented the task). `None` when no such session exists yet.
+    ///
+    /// Used by the cross-model ("Thorough") review path: at reviewer dispatch we
+    /// look up the implementer's model id so the reviewer can pick a different
+    /// one. Reads the latest by `started_at` so a re-implemented task uses the
+    /// model of its newest worker run.
+    pub async fn latest_model_for_task_role(
+        &self,
+        task_id: &str,
+        agent_type: &str,
+    ) -> Result<Option<String>> {
+        self.db.ensure_initialized().await?;
+        Ok(sqlx::query_scalar!(
+            r#"SELECT model_id FROM sessions
+               WHERE task_id = $1 AND agent_type = $2
+               ORDER BY started_at DESC LIMIT 1"#,
+            task_id,
+            agent_type,
+        )
+        .fetch_optional(self.db.pool())
+        .await?)
+    }
+
     pub async fn count_for_task(&self, task_id: &str) -> Result<i64> {
         self.db.ensure_initialized().await?;
         Ok(sqlx::query_scalar!(
@@ -1135,6 +1160,59 @@ mod tests {
         .unwrap();
 
         (epic.project_id, task_id)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn latest_model_for_task_role_returns_newest_matching_session() {
+        let db = test_db();
+        let (bus, _captured) = capturing_bus();
+        db.ensure_initialized().await.unwrap();
+        let (project_id, task_id) = create_task(&db, bus.clone()).await;
+        let repo = SessionRepository::new(db.clone(), bus.clone());
+
+        // No worker session yet → None.
+        assert_eq!(
+            repo.latest_model_for_task_role(&task_id, "worker")
+                .await
+                .unwrap(),
+            None
+        );
+
+        // First worker run on model A, then a re-implementation on model B.
+        for model in ["openai/gpt-a", "anthropic/opus-b"] {
+            repo.create(CreateSessionParams {
+                project_id: &project_id,
+                task_id: Some(&task_id),
+                model,
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: None,
+                pricing: None,
+            })
+            .await
+            .unwrap();
+        }
+        // A reviewer session must NOT be picked up by the "worker" lookup.
+        repo.create(CreateSessionParams {
+            project_id: &project_id,
+            task_id: Some(&task_id),
+            model: "x/reviewer-model",
+            agent_type: "reviewer",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+        })
+        .await
+        .unwrap();
+
+        // Newest worker session's model (B) wins.
+        assert_eq!(
+            repo.latest_model_for_task_role(&task_id, "worker")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("anthropic/opus-b")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-db/src/repositories/user_settings.rs
+++ b/server/crates/djinn-db/src/repositories/user_settings.rs
@@ -56,6 +56,7 @@ impl UserSettingsRepository {
         // decode it directly.
         let row = sqlx::query!(
             r#"SELECT user_id, auto_approve_prs AS "auto_approve_prs!: bool",
+                      diverse_review AS "diverse_review!: bool",
                       model_lanes, max_sessions, created_at, updated_at
                FROM user_settings WHERE user_id = $1"#,
             user_id,
@@ -67,6 +68,7 @@ impl UserSettingsRepository {
             auto_approve_prs: r.auto_approve_prs,
             lanes: parse_lanes(r.model_lanes.as_deref()),
             max_sessions: parse_max_sessions(r.max_sessions.as_deref()),
+            diverse_review: r.diverse_review,
             created_at: r.created_at,
             updated_at: r.updated_at,
         }))
@@ -115,6 +117,31 @@ impl UserSettingsRepository {
                      to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
              ON CONFLICT (user_id) DO UPDATE SET
                  auto_approve_prs = EXCLUDED.auto_approve_prs,
+                 updated_at = EXCLUDED.updated_at"#,
+            user_id,
+            value,
+        )
+        .execute(self.db.pool())
+        .await?;
+        self.get(user_id).await?.ok_or_else(|| {
+            crate::Error::Internal(format!(
+                "user_settings row missing after upsert for {user_id}"
+            ))
+        })
+    }
+
+    /// Upsert the `diverse_review` (cross-model "Thorough" review) toggle.
+    /// Returns the resulting row. On first write the row is inserted with
+    /// `auto_approve_prs = FALSE` and the explicit `diverse_review` value.
+    pub async fn upsert_diverse_review(&self, user_id: &str, value: bool) -> Result<UserSettings> {
+        self.db.ensure_initialized().await?;
+        sqlx::query!(
+            r#"INSERT INTO user_settings (user_id, auto_approve_prs, diverse_review, created_at, updated_at)
+             VALUES ($1, FALSE, $2,
+                     to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+                     to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
+             ON CONFLICT (user_id) DO UPDATE SET
+                 diverse_review = EXCLUDED.diverse_review,
                  updated_at = EXCLUDED.updated_at"#,
             user_id,
             value,
@@ -400,6 +427,30 @@ mod tests {
                 "x/y".to_string(),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn diverse_review_defaults_true_and_round_trips() {
+        let db = Database::open_in_memory().expect("in-memory db");
+        let user_id = seed_user(&db, "diverse").await;
+        let repo = UserSettingsRepository::new(db);
+
+        // Never-written user: defaults to true (matches the DB column default).
+        assert!(repo.get_or_default(&user_id).await.unwrap().diverse_review);
+
+        // Toggle off, then back on — round-trips and does not clobber lanes.
+        repo.upsert_lanes(
+            &user_id,
+            &ModelLanes::from_flat(vec!["openai/gpt-5.5".to_string()]),
+        )
+        .await
+        .unwrap();
+        let off = repo.upsert_diverse_review(&user_id, false).await.unwrap();
+        assert!(!off.diverse_review);
+        assert_eq!(off.lanes.unwrap().plan, vec!["openai/gpt-5.5".to_string()]);
+
+        let on = repo.upsert_diverse_review(&user_id, true).await.unwrap();
+        assert!(on.diverse_review);
     }
 
     #[tokio::test]

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -9,6 +9,7 @@ pub const PROMETHEUS_TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
 const DISPATCH_ATTEMPTS_TOTAL: &str = "djinn_dispatch_attempts_total";
 const DISPATCH_LAST_SUCCESS_TIMESTAMP: &str = "djinn_dispatch_last_success_timestamp";
 const DISPATCH_COOLDOWNS_ACTIVE: &str = "djinn_dispatch_cooldowns_active";
+const CROSS_MODEL_REVIEW_TOTAL: &str = "djinn_cross_model_review_total";
 const INFLIGHT_LEDGER_SIZE: &str = "djinn_inflight_ledger_size";
 const USER_CAP_UTILIZATION: &str = "djinn_user_cap_utilization";
 const SLOT_POOL: &str = "djinn_slot_pool";
@@ -638,6 +639,17 @@ pub mod dispatch {
     /// need to hold any application lock across an await to emit telemetry.
     pub fn increment_attempt(outcome: &'static str) {
         metrics::counter!(super::DISPATCH_ATTEMPTS_TOTAL, "outcome" => outcome).increment(1);
+    }
+
+    /// Cross-model ("Thorough") review outcome at reviewer dispatch.
+    ///
+    /// `result = "different"` when the reviewer was steered to a model id
+    /// distinct from the implementer's; `result = "same_fallback"` when the
+    /// review-lane list collapsed to the implementer's model id and dispatch
+    /// proceeded same-model. Only emitted when the creator has `diverse_review`
+    /// enabled and an implementer model id was known.
+    pub fn record_cross_model_review(result: &'static str) {
+        metrics::counter!(super::CROSS_MODEL_REVIEW_TOTAL, "result" => result).increment(1);
     }
 
     pub fn record_last_success_now() {

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -1,5 +1,8 @@
 // Touch to advance main HEAD and trigger a warm job (verification warm-base
 // cargo cache validation, 2026-06-16). No behavior change.
+//
+// djinn:allow-oversize — flat registry of metric definitions; grows by one
+// const/helper per new metric. Just over the 50 KiB byte guard.
 use std::sync::OnceLock;
 
 use metrics_exporter_prometheus::{BuildError, PrometheusBuilder, PrometheusHandle};

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -16823,6 +16823,10 @@ expression: signatures
           "description": "Auto-approve PRs that are otherwise ready to merge. When true, the\npoller POSTs an APPROVE review using this user's GitHub token at the\nmoment the PR has CI green + no conflicts + no existing approvals.\nDefaults to false. Each task's `created_by_user_id` decides whose\ntoggle applies; background-agent tasks (`created_by_user_id IS NULL`)\nare never auto-approved.",
           "type": "boolean"
         },
+        "diverse_review": {
+          "description": "Cross-model (\"Thorough\") review. When true (the default), a task\ndispatched to the reviewer role prefers a model id different from the one\nthat implemented it. A degenerate single-model selection falls back to\nsame-model review.",
+          "type": "boolean"
+        },
         "error": {
           "nullable": true,
           "type": "string"
@@ -16852,7 +16856,8 @@ expression: signatures
         "ok",
         "auto_approve_prs",
         "lanes",
-        "max_sessions"
+        "max_sessions",
+        "diverse_review"
       ],
       "title": "UserSettingsGetResponse",
       "type": "object"
@@ -16902,6 +16907,11 @@ expression: signatures
       "properties": {
         "auto_approve_prs": {
           "description": "Enable or disable auto-approve. Omit to keep the current value.",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "diverse_review": {
+          "description": "Enable or disable cross-model (\"Thorough\") review for THIS user. When on\n(the default), the reviewer prefers a model id different from the\nimplementer's. Omit to keep the current value.",
           "nullable": true,
           "type": "boolean"
         },
@@ -16975,6 +16985,11 @@ expression: signatures
           "type": "boolean"
         },
         "auto_approve_prs": {
+          "nullable": true,
+          "type": "boolean"
+        },
+        "diverse_review": {
+          "description": "The resulting cross-model review toggle after the patch.",
           "nullable": true,
           "type": "boolean"
         },

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -8331,6 +8331,13 @@ export namespace UserSettingsGetOutputSchema {
    * are never auto-approved.
    */
   auto_approve_prs: boolean
+  /**
+   * Cross-model ("Thorough") review. When true (the default), a task
+   * dispatched to the reviewer role prefers a model id different from the one
+   * that implemented it. A degenerate single-model selection falls back to
+   * same-model review.
+   */
+  diverse_review: boolean
   error?: string
   lanes: ModelLanesPayload
   /**
@@ -8376,6 +8383,12 @@ export namespace UserSettingsSetInputSchema {
    * Enable or disable auto-approve. Omit to keep the current value.
    */
   auto_approve_prs?: boolean
+  /**
+   * Enable or disable cross-model ("Thorough") review for THIS user. When on
+   * (the default), the reviewer prefers a model id different from the
+   * implementer's. Omit to keep the current value.
+   */
+  diverse_review?: boolean
   /**
    * Per-ROLE ordered model lanes for THIS user (each highest priority first),
    * as full `provider/model` ids: `plan` (planner/architect/chat),
@@ -8428,6 +8441,10 @@ export namespace UserSettingsSetOutputSchema {
   export interface UserSettingsSetOutput {
   applied: boolean
   auto_approve_prs?: boolean
+  /**
+   * The resulting cross-model review toggle after the patch.
+   */
+  diverse_review?: boolean
   error?: string
   /**
    * The resulting per-role model lanes after the patch.

--- a/ui/src/api/userConfig.ts
+++ b/ui/src/api/userConfig.ts
@@ -77,6 +77,11 @@ export interface UserModelSelection {
   lanes: ModelLanes;
   /** Per-model concurrency caps keyed by full `"provider/model"` id. */
   maxSessions: Record<string, number>;
+  /**
+   * Cross-model ("Thorough") review toggle. When true (the default), the
+   * reviewer prefers a model id different from the implementer's.
+   */
+  diverseReview: boolean;
 }
 
 function parseMaxSessions(raw: unknown): Record<string, number> {
@@ -94,19 +99,26 @@ export async function fetchUserModelSelection(
   return {
     lanes: parseLanes(response.lanes),
     maxSessions: parseMaxSessions(response.max_sessions),
+    diverseReview: response.diverse_review !== false,
   };
 }
 
-/** Persist the target user's per-role model lanes and per-model caps. */
+/**
+ * Persist the target user's per-role model lanes, per-model caps, and the
+ * cross-model review toggle. `diverseReview` is optional — omit it to leave the
+ * server value untouched (e.g. a lanes-only save).
+ */
 export async function saveUserModelSelection(
   targetUserId: string,
   lanes: ModelLanes,
   maxSessions: Record<string, number>,
+  diverseReview?: boolean,
 ): Promise<UserModelSelection> {
   const response = await callMcpTool("user_settings_set", {
     ...targetArgs(targetUserId),
     lanes,
     max_sessions: maxSessions,
+    ...(diverseReview === undefined ? {} : { diverse_review: diverseReview }),
   });
   if (!response.ok) {
     throw new Error(response.error ?? "Failed to save user models");
@@ -114,6 +126,7 @@ export async function saveUserModelSelection(
   return {
     lanes: parseLanes(response.lanes),
     maxSessions: parseMaxSessions(response.max_sessions),
+    diverseReview: response.diverse_review !== false,
   };
 }
 

--- a/ui/src/api/userSettings.ts
+++ b/ui/src/api/userSettings.ts
@@ -57,6 +57,12 @@ export interface UserSettings {
    * `{}` when unset; consumers default missing entries to 1.
    */
   maxSessions: Record<string, number>;
+  /**
+   * Cross-model ("Thorough") review. When true (the default), the reviewer
+   * prefers a model id different from the implementer's. A degenerate
+   * single-model selection falls back to same-model review.
+   */
+  diverseReview: boolean;
 }
 
 interface RawGet {
@@ -65,6 +71,7 @@ interface RawGet {
   auto_approve_prs?: boolean;
   lanes?: Partial<ModelLanes> | null;
   max_sessions?: Record<string, number> | null;
+  diverse_review?: boolean | null;
   error?: string | null;
 }
 
@@ -74,6 +81,7 @@ interface RawSet {
   auto_approve_prs?: boolean | null;
   lanes?: Partial<ModelLanes> | null;
   max_sessions?: Record<string, number> | null;
+  diverse_review?: boolean | null;
   error?: string | null;
 }
 
@@ -90,6 +98,8 @@ export async function fetchUserSettings(): Promise<UserSettings> {
     autoApprovePrs: Boolean(resp?.auto_approve_prs),
     lanes: parseLanes(resp?.lanes),
     maxSessions: parseMaxSessions(resp?.max_sessions),
+    // Cross-model review defaults ON; only an explicit `false` disables it.
+    diverseReview: resp?.diverse_review !== false,
   };
 }
 
@@ -99,6 +109,8 @@ export async function patchUserSettings(patch: {
   lanes?: ModelLanes;
   /** Per-model caps keyed by full `"provider/model"` id. Omit to keep current. */
   maxSessions?: Record<string, number>;
+  /** Cross-model ("Thorough") review toggle. Omit to keep current. */
+  diverseReview?: boolean;
 }): Promise<UserSettings> {
   const args: Record<string, unknown> = {};
   if (patch.autoApprovePrs !== undefined) {
@@ -110,6 +122,9 @@ export async function patchUserSettings(patch: {
   if (patch.maxSessions !== undefined) {
     args.max_sessions = patch.maxSessions;
   }
+  if (patch.diverseReview !== undefined) {
+    args.diverse_review = patch.diverseReview;
+  }
   const resp = (await callMcpTool("user_settings_set", args)) as RawSet;
   if (resp?.ok === false) {
     throw new Error(resp.error ?? "failed to save user settings");
@@ -118,5 +133,6 @@ export async function patchUserSettings(patch: {
     autoApprovePrs: Boolean(resp?.auto_approve_prs),
     lanes: parseLanes(resp?.lanes),
     maxSessions: parseMaxSessions(resp?.max_sessions),
+    diverseReview: resp?.diverse_review !== false,
   };
 }

--- a/ui/src/components/UserConfigDialog.test.tsx
+++ b/ui/src/components/UserConfigDialog.test.tsx
@@ -134,10 +134,12 @@ function mockSuccessfulLoads() {
   vi.mocked(fetchUserModelSelection).mockResolvedValue({
     lanes: { plan: ["openai/gpt-5"], implement: [], review: [] },
     maxSessions: { "openai/gpt-5": 3 },
+    diverseReview: true,
   });
   vi.mocked(saveUserModelSelection).mockResolvedValue({
     lanes: { plan: ["openai/gpt-5"], implement: [], review: [] },
     maxSessions: { "openai/gpt-5": 3 },
+    diverseReview: true,
   });
   vi.mocked(setUserCredential).mockResolvedValue(undefined);
   vi.mocked(startUserOAuth).mockResolvedValue({ kind: "connected" });

--- a/ui/src/components/userConfig/ModelSection.tsx
+++ b/ui/src/components/userConfig/ModelSection.tsx
@@ -37,6 +37,14 @@ import { showToast } from "@/lib/toast";
 
 import { userConfigKeys } from "./userConfigKeys";
 import { formatProvider } from "./providerDisplay";
+import {
+  PRESETS,
+  type PresetKey,
+  canEnableDiverseReview,
+  lanesForPreset,
+  reviewDiversityModelIds,
+} from "./presets";
+import { cn } from "@/lib/utils";
 
 /** Strips the provider prefix from a model id ("openai/gpt-5" → "gpt-5"). */
 export function stripProviderPrefix(modelId: string): string {
@@ -77,6 +85,10 @@ export function ModelSection({ targetId }: { targetId: string }) {
   // they save, otherwise we mirror whatever the server last returned.
   const [lanes, setLanes] = useState<ModelLanes>(emptyLanes);
   const [caps, setCaps] = useState<Record<string, number>>({});
+  // Cross-model ("Thorough") review toggle. Defaults ON (server default); the
+  // gate below disables interaction when fewer than 2 distinct model ids are
+  // reachable by the Implement + Review lanes.
+  const [diverseReview, setDiverseReview] = useState(true);
   const [dirty, setDirty] = useState(false);
   const [lastServer, setLastServer] = useState<typeof selection.data>(undefined);
 
@@ -85,6 +97,7 @@ export function ModelSection({ targetId }: { targetId: string }) {
     if (!dirty) {
       setLanes(selection.data.lanes);
       setCaps(selection.data.maxSessions);
+      setDiverseReview(selection.data.diverseReview);
     }
   }
 
@@ -101,16 +114,31 @@ export function ModelSection({ targetId }: { targetId: string }) {
     return set;
   }, [lanes]);
 
+  // Cross-model review gate: needs ≥2 distinct model ids reachable by the
+  // Implement + Review lanes. Recomputed from the live working copy, so it
+  // re-enables automatically the moment a 2nd distinct id is added (no save).
+  const reviewDistinctIds = useMemo(() => reviewDiversityModelIds(lanes), [lanes]);
+  const diverseReviewEnabled = reviewDistinctIds.size >= 2;
+  // The single model id available when the gate is closed (for the hint copy).
+  const soleReviewModel = useMemo(() => {
+    const [only] = reviewDistinctIds;
+    return only ? stripProviderPrefix(only) : undefined;
+  }, [reviewDistinctIds]);
+  // Effective toggle value: forced off in the UI when the gate is closed, even
+  // if the persisted value is true (dispatch already falls back to same-model).
+  const effectiveDiverseReview = diverseReview && diverseReviewEnabled;
+
   const saveMutation = useMutation({
     mutationFn: () => {
       // Only persist caps for models still selected in some lane, default 1.
       const maxSessions: Record<string, number> = {};
       for (const id of allSelected) maxSessions[id] = caps[id] ?? 1;
-      return saveUserModelSelection(targetId, lanes, maxSessions);
+      return saveUserModelSelection(targetId, lanes, maxSessions, diverseReview);
     },
     onSuccess: (saved) => {
       setLanes(saved.lanes);
       setCaps(saved.maxSessions);
+      setDiverseReview(saved.diverseReview);
       setDirty(false);
       queryClient.setQueryData(userConfigKeys.modelSelection(targetId), saved);
       showToast.success("Model roles saved");
@@ -140,6 +168,26 @@ export function ModelSection({ targetId }: { targetId: string }) {
   };
   const updateCap = (id: string, value: number) => {
     setCaps((prev) => ({ ...prev, [id]: value }));
+    setDirty(true);
+  };
+
+  // Apply a working-style preset: overwrite the lanes from the connected models
+  // and (for Max quality) force cross-model review ON when ≥2 distinct model
+  // ids exist. Lanes stay user-editable afterward — a preset is just a seed.
+  const applyPreset = (preset: PresetKey) => {
+    const nextLanes = lanesForPreset(preset, connectedModels.data ?? []);
+    setLanes(nextLanes);
+    if (preset === "maxQuality") {
+      // Force ON only in the non-degenerate (≥2 distinct) case; otherwise leave
+      // it as-is (dispatch falls back to same-model, surfaced by the hint).
+      setDiverseReview(canEnableDiverseReview(nextLanes));
+    }
+    setDirty(true);
+  };
+
+  const toggleDiverseReview = () => {
+    if (!diverseReviewEnabled) return; // gated — see hint
+    setDiverseReview((prev) => !prev);
     setDirty(true);
   };
 
@@ -185,6 +233,16 @@ export function ModelSection({ targetId }: { targetId: string }) {
         </div>
       ) : (
         <div className="flex flex-col gap-5">
+          <PresetBar onApply={applyPreset} />
+
+          <ThoroughReviewToggle
+            checked={effectiveDiverseReview}
+            enabled={diverseReviewEnabled}
+            soleModel={soleReviewModel}
+            saving={saveMutation.isPending}
+            onToggle={toggleDiverseReview}
+          />
+
           {MODEL_LANE_KEYS.map((lane) => (
             <LaneEditor
               key={lane}
@@ -204,6 +262,100 @@ export function ModelSection({ targetId }: { targetId: string }) {
         </div>
       )}
     </section>
+  );
+}
+
+/** The two working-style presets (Balanced / Max quality). */
+function PresetBar({ onApply }: { onApply: (preset: PresetKey) => void }) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border bg-card/40 p-4">
+      <div>
+        <h4 className="text-sm font-semibold text-foreground">Working style</h4>
+        <p className="text-xs text-muted-foreground/70">
+          A quick start — sets the lanes below from your connected models. You can
+          still tweak each lane afterward.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <Button
+            key={preset.key}
+            variant="outline"
+            size="sm"
+            className="h-auto flex-col items-start gap-0.5 px-3 py-2 text-left"
+            onClick={() => onApply(preset.key)}
+          >
+            <span className="font-semibold">{preset.title}</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              {preset.description}
+            </span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Cross-model ("Thorough") review toggle. Disabled — with a Connections-tab
+ * hint — until ≥2 distinct model ids are reachable by the Implement + Review
+ * lanes. Re-enables automatically when a 2nd distinct id appears.
+ */
+function ThoroughReviewToggle({
+  checked,
+  enabled,
+  soleModel,
+  saving,
+  onToggle,
+}: {
+  checked: boolean;
+  enabled: boolean;
+  soleModel: string | undefined;
+  saving: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border bg-card/40 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h4 className="text-sm font-semibold text-foreground">Thorough review</h4>
+          <p className="text-xs text-muted-foreground/70">
+            Have a different model review the code than the one that wrote it —
+            catches more issues by avoiding a single model's blind spots.
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          aria-label="Thorough review"
+          disabled={!enabled || saving}
+          onClick={onToggle}
+          className={cn(
+            "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border transition-colors",
+            checked ? "border-primary bg-primary" : "border-border bg-muted",
+            enabled ? "cursor-pointer" : "cursor-not-allowed opacity-50",
+            saving && "opacity-60",
+          )}
+        >
+          <span
+            className={cn(
+              "inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform",
+              checked ? "translate-x-6" : "translate-x-1",
+            )}
+          />
+        </button>
+      </div>
+      {!enabled && (
+        <p className="text-xs text-amber-600 dark:text-amber-500">
+          Connect a second model to enable cross-model review
+          {soleModel ? ` — only ${soleModel} is available` : ""}. Add another model
+          in the{" "}
+          <span className="font-medium">Connections</span> tab, then put it in the
+          Implement or Review lane.
+        </p>
+      )}
+    </div>
   );
 }
 

--- a/ui/src/components/userConfig/presets.test.ts
+++ b/ui/src/components/userConfig/presets.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import type { UserModel } from "@/api/userConfig";
+import {
+  canEnableDiverseReview,
+  lanesForPreset,
+  rankByCost,
+  rankByQuality,
+  reviewDiversityModelIds,
+} from "./presets";
+
+function model(id: string, opts: Partial<UserModel> = {}): UserModel {
+  return {
+    id,
+    name: id,
+    provider_id: id.split("/")[0] ?? "p",
+    attachment: false,
+    context_window: 0,
+    output_limit: 0,
+    reasoning: false,
+    tool_call: true,
+    pricing: {
+      input_per_million: 0,
+      output_per_million: 0,
+      cache_read_per_million: 0,
+      cache_write_per_million: 0,
+    },
+    ...opts,
+  } as UserModel;
+}
+
+const SMART = model("anthropic/opus", {
+  reasoning: true,
+  pricing: { input_per_million: 15, output_per_million: 75, cache_read_per_million: 0, cache_write_per_million: 0 },
+});
+const CHEAP = model("openai/mini", {
+  reasoning: false,
+  pricing: { input_per_million: 1, output_per_million: 4, cache_read_per_million: 0, cache_write_per_million: 0 },
+});
+const MID = model("fireworks/kimi", {
+  reasoning: true,
+  pricing: { input_per_million: 3, output_per_million: 9, cache_read_per_million: 0, cache_write_per_million: 0 },
+});
+
+describe("rankByQuality / rankByCost", () => {
+  it("ranks reasoning models first, then by descending price", () => {
+    const ranked = rankByQuality([CHEAP, SMART, MID]).map((m) => m.id);
+    // SMART + MID reason; SMART pricier → first. CHEAP (no reasoning) last.
+    expect(ranked).toEqual(["anthropic/opus", "fireworks/kimi", "openai/mini"]);
+  });
+
+  it("ranks cheapest first regardless of reasoning", () => {
+    const ranked = rankByCost([SMART, CHEAP, MID]).map((m) => m.id);
+    expect(ranked).toEqual(["openai/mini", "fireworks/kimi", "anthropic/opus"]);
+  });
+});
+
+describe("lanesForPreset", () => {
+  it("balanced: smart-first plan, cheap-first implement/review", () => {
+    const lanes = lanesForPreset("balanced", [SMART, CHEAP, MID]);
+    expect(lanes.plan[0]).toBe("anthropic/opus");
+    expect(lanes.implement[0]).toBe("openai/mini");
+    expect(lanes.review[0]).toBe("openai/mini");
+  });
+
+  it("maxQuality: best model first in every lane", () => {
+    const lanes = lanesForPreset("maxQuality", [SMART, CHEAP, MID]);
+    expect(lanes.plan[0]).toBe("anthropic/opus");
+    expect(lanes.implement[0]).toBe("anthropic/opus");
+    expect(lanes.review[0]).toBe("anthropic/opus");
+  });
+
+  it("returns empty lanes for no connected models", () => {
+    expect(lanesForPreset("balanced", [])).toEqual({ plan: [], implement: [], review: [] });
+  });
+});
+
+describe("cross-model review gate", () => {
+  it("counts distinct model ids across implement + review", () => {
+    const ids = reviewDiversityModelIds({
+      plan: ["x/1"],
+      implement: ["a/1"],
+      review: ["a/1", "b/2"],
+    });
+    expect([...ids].sort()).toEqual(["a/1", "b/2"]);
+  });
+
+  it("requires ≥2 distinct ids to enable", () => {
+    expect(canEnableDiverseReview({ plan: [], implement: ["a/1"], review: ["a/1"] })).toBe(false);
+    expect(canEnableDiverseReview({ plan: [], implement: ["a/1"], review: ["b/2"] })).toBe(true);
+    expect(canEnableDiverseReview({ plan: [], implement: ["a/1", "b/2"], review: [] })).toBe(true);
+  });
+
+  it("distinct is by model id, not provider (one provider, many models)", () => {
+    // Both ids are Fireworks-hosted but different models → counts as 2 distinct.
+    expect(
+      canEnableDiverseReview({ plan: [], implement: ["fireworks/kimi"], review: ["fireworks/qwen"] }),
+    ).toBe(true);
+  });
+
+  it("plan-lane models do NOT count toward the review gate", () => {
+    expect(canEnableDiverseReview({ plan: ["a/1", "b/2"], implement: ["a/1"], review: ["a/1"] })).toBe(
+      false,
+    );
+  });
+});

--- a/ui/src/components/userConfig/presets.ts
+++ b/ui/src/components/userConfig/presets.ts
@@ -1,0 +1,109 @@
+import type { UserModel } from "@/api/userConfig";
+import { type ModelLanes } from "@/api/userSettings";
+
+/**
+ * Working-style presets for the Model Roles tab (slice 3 of p8py). Exactly two,
+ * plus the cross-model review toggle — there is deliberately NO "Max savings".
+ *
+ * A preset is a convenience that seeds the three lanes (plan / implement /
+ * review) from the user's connected+allowed models. The lanes remain the
+ * persisted source of truth and stay user-editable underneath; picking a preset
+ * just overwrites them with sensible defaults.
+ *
+ * - `balanced`   — a smart model up top in Plan, cheaper models in
+ *                  Implement/Review. The everyday default.
+ * - `maxQuality` — the best model in every lane. Also forces cross-model review
+ *                  ON when ≥2 distinct model ids exist (the dispatch falls back
+ *                  to same-model in the single-model degenerate case).
+ */
+export type PresetKey = "balanced" | "maxQuality";
+
+export const PRESETS: { key: PresetKey; title: string; description: string }[] = [
+  {
+    key: "balanced",
+    title: "Balanced",
+    description: "Smart model for planning, cheaper models to build and review.",
+  },
+  {
+    key: "maxQuality",
+    title: "Max quality",
+    description: "Best model everywhere, with cross-model review when possible.",
+  },
+];
+
+/** Combined per-token price of a model (input + output). Higher = pricier. */
+function priceOf(model: UserModel): number {
+  const p = model.pricing;
+  return (p?.input_per_million ?? 0) + (p?.output_per_million ?? 0);
+}
+
+/**
+ * Rank connected models best → worst as a capability proxy. Reasoning models
+ * outrank non-reasoning ones; within each group, pricier outranks cheaper
+ * (price is a coarse stand-in for capability when no quality score exists).
+ * Ties break on id for stable, deterministic output.
+ */
+export function rankByQuality(models: UserModel[]): UserModel[] {
+  return [...models].sort((a, b) => {
+    const reasoning = Number(b.reasoning) - Number(a.reasoning);
+    if (reasoning !== 0) return reasoning;
+    const price = priceOf(b) - priceOf(a);
+    if (price !== 0) return price;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/** Rank connected models cheapest → priciest (ties break on id). */
+export function rankByCost(models: UserModel[]): UserModel[] {
+  return [...models].sort((a, b) => {
+    const price = priceOf(a) - priceOf(b);
+    if (price !== 0) return price;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/**
+ * Build the lane selection for a preset from the user's connected models.
+ *
+ * Lanes are ordered fallback lists, so we seed each lane with the full ranked
+ * list (best/cheapest first) — that gives a sensible primary plus automatic
+ * fallbacks. Returns all-empty lanes when the user has no connected models.
+ *
+ * - `balanced`   — Plan ranked by quality; Implement + Review ranked by cost.
+ * - `maxQuality` — every lane ranked by quality.
+ */
+export function lanesForPreset(preset: PresetKey, models: UserModel[]): ModelLanes {
+  if (models.length === 0) {
+    return { plan: [], implement: [], review: [] };
+  }
+  const byQuality = rankByQuality(models).map((m) => m.id);
+  const byCost = rankByCost(models).map((m) => m.id);
+
+  if (preset === "maxQuality") {
+    return { plan: byQuality, implement: byQuality, review: byQuality };
+  }
+  // balanced
+  return { plan: byQuality, implement: byCost, review: byCost };
+}
+
+/**
+ * Distinct model ids reachable by the Implement + Review lanes. "Distinct" is by
+ * model id, NOT provider — one provider can host many models. This is the set
+ * the cross-model review gate counts.
+ */
+export function reviewDiversityModelIds(lanes: ModelLanes): Set<string> {
+  const ids = new Set<string>();
+  for (const id of lanes.implement) ids.add(id);
+  for (const id of lanes.review) ids.add(id);
+  return ids;
+}
+
+/**
+ * Whether cross-model ("Thorough") review can be enabled: it needs ≥2 distinct
+ * model ids across the Implement + Review lanes. Below that the reviewer can
+ * never pick a model different from the implementer, so the toggle is disabled
+ * (and re-enables automatically once a 2nd distinct id appears).
+ */
+export function canEnableDiverseReview(lanes: ModelLanes): boolean {
+  return reviewDiversityModelIds(lanes).size >= 2;
+}


### PR DESCRIPTION
Slice **3 of 6** of proposal **p8py** ("Model setup UX"). Builds directly on slice 2's per-role model lanes (plan / implement / review).

## What it does

### A. Working-style presets (Model Roles tab)
Exactly two presets — **Balanced** and **Max quality** (no "Max savings") — that seed the three lanes from the user's connected models. Balanced puts a smart model in Plan and cheaper models in Implement/Review; Max quality uses the best model in every lane. Lanes stay user-editable underneath — a preset is just a seed. Ranking uses a quality proxy (reasoning-first, then price) and a cost proxy (cheapest-first). New pure helpers live in `ui/src/components/userConfig/presets.ts` with unit tests.

### B. "Thorough review" toggle = cross-model review
New per-user `diverse_review` boolean (**default true**).
- **UI gate**: the toggle is **disabled** until ≥2 **distinct model ids** are reachable by the Implement+Review lanes (distinct by **model id, not provider** — Fireworks can host many). Shows a hint linking to the Connections tab, and **re-enables automatically** when a 2nd distinct id appears (computed from the live working copy, no save needed).
- **Max quality** forces the toggle ON **only** when ≥2 distinct ids exist; in the single-model degenerate case it does not force it (dispatch falls back to same-model).

### C. Dispatch: reviewer ≠ implementer
When `diverse_review` is on and a task is dispatched to the **reviewer** role, the resolved review-lane fallback list is stable-partitioned so the first viable model id differs from the implementer's. The **implementer's model id** is read from the most recent `worker` session for the task (`sessions.model_id` where `agent_type = 'worker'`, newest by `started_at`) via the new `SessionRepository::latest_model_for_task_role`. If the viable list collapses to the implementer's model, dispatch proceeds **same-model** (never blocks the task). The substitution/fallback is logged and counted via `djinn_cross_model_review_total{result="different"|"same_fallback"}`.

## Where `diverse_review` lives
- `user_settings.diverse_review` — NOT-NULL boolean, **migration 78**, default TRUE.
- Threaded through `UserSettings` (core), `UserSettingsRepository::upsert_diverse_review` + read path, the `user_settings_get`/`user_settings_set` MCP tools, the regenerated schema snapshot, the UI `mcp-tools.gen` types, and the `userSettings`/`userConfig` API clients.

## Migration number
**78** — highest on freshly-fetched `origin/main` was **77** (slice 2's `model_lanes`).

## Verification
- Rust: `cargo build` (offline), `cargo clippy --all-features` on all touched crates — clean. `cargo fmt` clean on touched files.
- Tests: `djinn-db` user_settings + new `diverse_review` round-trip/default test + `latest_model_for_task_role` test; full `djinn-agent` dispatch suite (189 passed); `djinn-server` `tool_schemas` (14 passed, snapshot regenerated).
- **From-scratch migration apply**: applied ALL migrations (1→78) to a brand-new empty DB — no duplicate-version error. `cargo sqlx prepare --check --workspace` passes; `.sqlx` cache regenerated.
- UI: `tsc -b` typecheck clean, `vite build` succeeds, `vitest` (presets + UserConfigDialog) 13 passed, `mcp-tools.gen` regeneration is stable.
- Not blocking but noted: a pre-existing `react-refresh/only-export-components` eslint error on `ModelSection.tsx` (`stripProviderPrefix`) exists on slice-2 main, unchanged here (eslint exit code 0).

## Out of scope (later slices)
First-run onboarding sheet (4); org allow/block + jurisdiction (5); removing Sessions input + autoscaling (6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
