### PR TITLE
refactor(proposals): extract shared block badge/pill/change-chip module

### DIFF
--- a/ui/src/components/proposals/blocks/ApiEndpointBlock.tsx
+++ b/ui/src/components/proposals/blocks/ApiEndpointBlock.tsx
@@ -10,6 +10,12 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/utils";
 
 import { BlockMarkdown, BlockShell } from "./BlockShell";
+import {
+  ACCENT_BADGE,
+  httpMethodColor,
+  paramLocationColor,
+  statusCodeColor,
+} from "./blockBadgeColors";
 import type { BlockProps } from "./types";
 import {
   classifyStatus,
@@ -21,8 +27,6 @@ import {
   type ApiMethod,
   type ApiParam,
   type ApiResponse,
-  type ParamLocation,
-  type StatusClass,
 } from "./apiEndpoint";
 
 /**
@@ -71,7 +75,12 @@ export function ApiEndpointBlock({ attributes, children }: BlockProps) {
         <span className="truncate font-mono text-foreground">{path}</span>
       ) : null}
       {deprecated && (
-        <span className="shrink-0 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-300">
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            ACCENT_BADGE.amber,
+          )}
+        >
           Deprecated
         </span>
       )}
@@ -158,17 +167,6 @@ export function ApiEndpointBlock({ attributes, children }: BlockProps) {
 
 /* ── Method pill ────────────────────────────────────────────────────────────── */
 
-/** Per-verb pill palette. Dark-only theme. */
-const METHOD_STYLE: Record<ApiMethod, string> = {
-  GET: "bg-emerald-500/15 text-emerald-300",
-  POST: "bg-blue-500/15 text-blue-300",
-  PUT: "bg-amber-500/15 text-amber-300",
-  PATCH: "bg-violet-500/15 text-violet-300",
-  DELETE: "bg-red-500/15 text-red-300",
-  HEAD: "bg-slate-500/15 text-slate-300",
-  OPTIONS: "bg-slate-500/15 text-slate-300",
-};
-
 function MethodPill({
   method,
   raw,
@@ -182,7 +180,7 @@ function MethodPill({
     <span
       className={cn(
         "shrink-0 rounded px-1.5 py-0.5 font-mono text-[11px] font-bold tracking-wide",
-        method ? METHOD_STYLE[method] : "bg-slate-500/15 text-slate-300",
+        httpMethodColor(method),
       )}
     >
       {label}
@@ -191,14 +189,6 @@ function MethodPill({
 }
 
 /* ── Parameters section ─────────────────────────────────────────────────────── */
-
-/** IN-location pill palette: path violet / query blue / header amber / body emerald. */
-const LOCATION_STYLE: Record<ParamLocation, string> = {
-  path: "bg-violet-500/15 text-violet-300",
-  query: "bg-blue-500/15 text-blue-300",
-  header: "bg-amber-500/15 text-amber-300",
-  body: "bg-emerald-500/15 text-emerald-300",
-};
 
 function ParamsSection({ params }: { params: ApiParam[] }) {
   return (
@@ -225,7 +215,7 @@ function ParamRow({ param }: { param: ApiParam }) {
         <span
           className={cn(
             "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none",
-            LOCATION_STYLE[param.in],
+            paramLocationColor(param.in),
           )}
         >
           {param.in}
@@ -237,12 +227,22 @@ function ParamRow({ param }: { param: ApiParam }) {
         </span>
       )}
       {param.required === true && (
-        <span className="rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none text-red-300">
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none",
+            ACCENT_BADGE.red,
+          )}
+        >
           required
         </span>
       )}
       {param.required === false && (
-        <span className="rounded bg-slate-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none text-slate-300">
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none",
+            ACCENT_BADGE.slate,
+          )}
+        >
           optional
         </span>
       )}
@@ -256,14 +256,6 @@ function ParamRow({ param }: { param: ApiParam }) {
 }
 
 /* ── Responses section ──────────────────────────────────────────────────────── */
-
-/** Status-code pill palette: 2xx emerald / 4xx amber / 5xx red / other slate. */
-const STATUS_STYLE: Record<StatusClass, string> = {
-  success: "bg-emerald-500/15 text-emerald-300",
-  info: "bg-slate-500/15 text-slate-300",
-  warn: "bg-amber-500/15 text-amber-300",
-  error: "bg-red-500/15 text-red-300",
-};
 
 function ResponsesSection({ responses }: { responses: ApiResponse[] }) {
   return (
@@ -286,7 +278,7 @@ function ResponseRow({ response }: { response: ApiResponse }) {
         <span
           className={cn(
             "rounded px-1.5 py-0.5 font-mono text-[11px] font-bold leading-none",
-            STATUS_STYLE[cls],
+            statusCodeColor(cls),
           )}
         >
           {response.status}

--- a/ui/src/components/proposals/blocks/DataModelBlock.tsx
+++ b/ui/src/components/proposals/blocks/DataModelBlock.tsx
@@ -12,6 +12,8 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/utils";
 
 import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { Badge } from "./blockBadges";
+import { ACCENT_BADGE } from "./blockBadgeColors";
 import type { BlockProps } from "./types";
 import {
   parseDataModelBlock,
@@ -208,7 +210,10 @@ function FieldRow({ field }: { field: DataModelField }) {
           {field.enumValues.map((value) => (
             <span
               key={value}
-              className="rounded bg-violet-500/15 px-1.5 py-0.5 font-mono text-[10px] text-violet-300"
+              className={cn(
+                "rounded px-1.5 py-0.5 font-mono text-[10px]",
+                ACCENT_BADGE.violet,
+              )}
             >
               {value}
             </span>
@@ -218,11 +223,9 @@ function FieldRow({ field }: { field: DataModelField }) {
 
       {/* Right-aligned badges. */}
       <span className="ml-auto flex flex-wrap items-center justify-end gap-1">
-        {field.pk && (
-          <Badge className="bg-amber-500/15 text-amber-300">PK</Badge>
-        )}
+        {field.pk && <Badge accent="amber">PK</Badge>}
         {field.fk && (
-          <Badge className="bg-blue-500/15 text-blue-300">
+          <Badge accent="blue">
             FK
             <span className="ml-1 font-mono font-normal opacity-90">
               {field.fk.table}
@@ -230,11 +233,9 @@ function FieldRow({ field }: { field: DataModelField }) {
             </span>
           </Badge>
         )}
-        {field.nullable && (
-          <Badge className="bg-slate-500/15 text-slate-300">nullable</Badge>
-        )}
+        {field.nullable && <Badge accent="slate">nullable</Badge>}
         {field.default !== undefined && (
-          <Badge className="bg-emerald-500/15 text-emerald-300 normal-case">
+          <Badge accent="emerald" className="normal-case">
             = {field.default}
           </Badge>
         )}
@@ -246,25 +247,6 @@ function FieldRow({ field }: { field: DataModelField }) {
         </span>
       )}
     </div>
-  );
-}
-
-function Badge({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none",
-        className,
-      )}
-    >
-      {children}
-    </span>
   );
 }
 
@@ -311,7 +293,12 @@ function RelationsSection({ relations }: { relations: DataModelRelation[] }) {
               ({relation.label})
             </span>
             {relation.unresolved && (
-              <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-300">
+              <span
+                className={cn(
+                  "rounded px-1.5 py-0.5 text-[10px] font-medium",
+                  ACCENT_BADGE.amber,
+                )}
+              >
                 unresolved
               </span>
             )}

--- a/ui/src/components/proposals/blocks/FileTreeBlock.tsx
+++ b/ui/src/components/proposals/blocks/FileTreeBlock.tsx
@@ -11,12 +11,13 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/utils";
 
 import { BlockShell } from "./BlockShell";
+import { ChangeChip } from "./blockBadges";
+import { CHANGE_NAME_INK } from "./blockBadgeColors";
 import type { BlockProps } from "./types";
 import {
   buildFileTree,
   parseFileTreeBody,
   tallyChanges,
-  type FileChange,
   type TreeNode,
 } from "./fileTree";
 
@@ -120,36 +121,6 @@ export function FileTreeBlock({ attributes, children }: BlockProps) {
 
 const INDENT_STEP = 14; // px per nesting level — the explorer guide spacing.
 
-const CHANGE_GLYPH: Record<FileChange, string> = {
-  added: "A",
-  modified: "M",
-  deleted: "D",
-  renamed: "R",
-};
-
-const CHANGE_LABEL: Record<FileChange, string> = {
-  added: "Added",
-  modified: "Modified",
-  deleted: "Deleted",
-  renamed: "Renamed",
-};
-
-/** Tinted badge background + saturated text. Dark-only theme. */
-const CHANGE_BADGE: Record<FileChange, string> = {
-  added: "bg-emerald-500/15 text-emerald-300",
-  modified: "bg-blue-500/15 text-blue-300",
-  deleted: "bg-red-500/15 text-red-300",
-  renamed: "bg-violet-500/15 text-violet-300",
-};
-
-/** Accent ink for the file name, echoing its change color. */
-const CHANGE_NAME_INK: Record<FileChange, string> = {
-  added: "text-emerald-300",
-  modified: "text-blue-300",
-  deleted: "text-red-300 line-through",
-  renamed: "text-violet-300",
-};
-
 interface TreeRowsProps {
   nodes: TreeNode[];
   depth: number;
@@ -224,18 +195,7 @@ function TreeRows({ nodes, depth, collapsed, toggle }: TreeRowsProps) {
             >
               {node.name}
             </span>
-            {change && (
-              <span
-                title={CHANGE_LABEL[change]}
-                aria-label={CHANGE_LABEL[change]}
-                className={cn(
-                  "ml-0.5 flex size-4 shrink-0 items-center justify-center rounded text-[10px] font-bold leading-none",
-                  CHANGE_BADGE[change],
-                )}
-              >
-                {CHANGE_GLYPH[change]}
-              </span>
-            )}
+            {change && <ChangeChip status={change} className="ml-0.5" />}
             {node.note && (
               <span className="ml-1 min-w-0 flex-1 truncate text-xs text-muted-foreground">
                 {node.note}

--- a/ui/src/components/proposals/blocks/blockBadgeColors.test.ts
+++ b/ui/src/components/proposals/blocks/blockBadgeColors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACCENT_BADGE,
+  CHANGE_BADGE,
+  CHANGE_NAME_INK,
+  httpMethodColor,
+  paramLocationColor,
+  statusCodeColor,
+} from "./blockBadgeColors";
+
+describe("httpMethodColor", () => {
+  it("maps each known verb to its accent surface", () => {
+    expect(httpMethodColor("GET")).toBe(ACCENT_BADGE.emerald);
+    expect(httpMethodColor("POST")).toBe(ACCENT_BADGE.blue);
+    expect(httpMethodColor("PUT")).toBe(ACCENT_BADGE.amber);
+    expect(httpMethodColor("PATCH")).toBe(ACCENT_BADGE.violet);
+    expect(httpMethodColor("DELETE")).toBe(ACCENT_BADGE.red);
+    expect(httpMethodColor("HEAD")).toBe(ACCENT_BADGE.slate);
+    expect(httpMethodColor("OPTIONS")).toBe(ACCENT_BADGE.slate);
+  });
+
+  it("falls back to neutral slate for an unknown verb", () => {
+    expect(httpMethodColor(undefined)).toBe(ACCENT_BADGE.slate);
+  });
+});
+
+describe("statusCodeColor", () => {
+  it("maps each status class to its accent: 2xx emerald / 4xx amber / 5xx red", () => {
+    expect(statusCodeColor("success")).toBe(ACCENT_BADGE.emerald);
+    expect(statusCodeColor("warn")).toBe(ACCENT_BADGE.amber);
+    expect(statusCodeColor("error")).toBe(ACCENT_BADGE.red);
+    expect(statusCodeColor("info")).toBe(ACCENT_BADGE.slate);
+  });
+});
+
+describe("paramLocationColor", () => {
+  it("maps IN-location: path violet / query blue / header amber / body emerald", () => {
+    expect(paramLocationColor("path")).toBe(ACCENT_BADGE.violet);
+    expect(paramLocationColor("query")).toBe(ACCENT_BADGE.blue);
+    expect(paramLocationColor("header")).toBe(ACCENT_BADGE.amber);
+    expect(paramLocationColor("body")).toBe(ACCENT_BADGE.emerald);
+  });
+});
+
+describe("change vocabulary", () => {
+  it("keys A/M/D/R chips to added emerald / modified blue / deleted red / renamed violet", () => {
+    expect(CHANGE_BADGE.added).toBe(ACCENT_BADGE.emerald);
+    expect(CHANGE_BADGE.modified).toBe(ACCENT_BADGE.blue);
+    expect(CHANGE_BADGE.deleted).toBe(ACCENT_BADGE.red);
+    expect(CHANGE_BADGE.renamed).toBe(ACCENT_BADGE.violet);
+  });
+
+  it("strikes through the deleted name ink", () => {
+    expect(CHANGE_NAME_INK.deleted).toContain("line-through");
+    expect(CHANGE_NAME_INK.added).toBe("text-emerald-300");
+  });
+});

--- a/ui/src/components/proposals/blocks/blockBadgeColors.ts
+++ b/ui/src/components/proposals/blocks/blockBadgeColors.ts
@@ -1,0 +1,112 @@
+// Pure (React-free) half of the shared block visual vocabulary. The rewritten
+// FileTree / DataModel / ApiEndpoint blocks each independently grew the same
+// accent palette, A/M/D/R change colors, and HTTP-method / status-code maps.
+// This module is the single source of truth for those *class strings*; the
+// React components that wrap them (`Badge` / `Pill` / `ChangeChip`) live in
+// `blockBadges.tsx`. Keeping the color logic React-free makes it unit-testable
+// and reusable by the next blocks (diff, annotated-code, callout, table,
+// checklist).
+//
+// The app is DARK-ONLY: accents are a tinted `bg-<color>/15` surface with a
+// saturated `text-<color>-300` ink.
+
+import type { FileChange } from "./fileTree";
+import type { ApiMethod, ParamLocation, StatusClass } from "./apiEndpoint";
+
+/* ── Accent palette ─────────────────────────────────────────────────────────── */
+
+/** The named accents the blocks share. */
+export type AccentColor =
+  | "emerald"
+  | "blue"
+  | "amber"
+  | "violet"
+  | "red"
+  | "slate";
+
+/** Tinted badge surface + saturated ink, one entry per accent. Dark-only. */
+export const ACCENT_BADGE: Record<AccentColor, string> = {
+  emerald: "bg-emerald-500/15 text-emerald-300",
+  blue: "bg-blue-500/15 text-blue-300",
+  amber: "bg-amber-500/15 text-amber-300",
+  violet: "bg-violet-500/15 text-violet-300",
+  red: "bg-red-500/15 text-red-300",
+  slate: "bg-slate-500/15 text-slate-300",
+};
+
+/* ── A/M/D/R change vocabulary ──────────────────────────────────────────────── */
+
+/** Single-letter glyph for a change status. */
+export const CHANGE_GLYPH: Record<FileChange, string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+  renamed: "R",
+};
+
+/** Accessible label for a change status. */
+export const CHANGE_LABEL: Record<FileChange, string> = {
+  added: "Added",
+  modified: "Modified",
+  deleted: "Deleted",
+  renamed: "Renamed",
+};
+
+/** Tinted square chip background + saturated text, keyed by change status. */
+export const CHANGE_BADGE: Record<FileChange, string> = {
+  added: ACCENT_BADGE.emerald,
+  modified: ACCENT_BADGE.blue,
+  deleted: ACCENT_BADGE.red,
+  renamed: ACCENT_BADGE.violet,
+};
+
+/** Accent ink for a name echoing its change color (deleted is struck through). */
+export const CHANGE_NAME_INK: Record<FileChange, string> = {
+  added: "text-emerald-300",
+  modified: "text-blue-300",
+  deleted: "text-red-300 line-through",
+  renamed: "text-violet-300",
+};
+
+/* ── HTTP method + status-code + param-location colors ───────────────────────── */
+
+/** Per-verb accent. Anything unknown falls back to neutral slate. */
+const METHOD_ACCENT: Record<ApiMethod, AccentColor> = {
+  GET: "emerald",
+  POST: "blue",
+  PUT: "amber",
+  PATCH: "violet",
+  DELETE: "red",
+  HEAD: "slate",
+  OPTIONS: "slate",
+};
+
+/** Badge classes for an HTTP verb (neutral slate for an unknown/undefined verb). */
+export function httpMethodColor(method: ApiMethod | undefined): string {
+  return ACCENT_BADGE[method ? METHOD_ACCENT[method] : "slate"];
+}
+
+const STATUS_ACCENT: Record<StatusClass, AccentColor> = {
+  success: "emerald",
+  info: "slate",
+  warn: "amber",
+  error: "red",
+};
+
+/** Badge classes for a status class: 2xx emerald / 4xx amber / 5xx red / slate. */
+export function statusCodeColor(cls: StatusClass): string {
+  return ACCENT_BADGE[STATUS_ACCENT[cls]];
+}
+
+/** IN-location accent: path violet / query blue / header amber / body emerald. */
+const LOCATION_ACCENT: Record<ParamLocation, AccentColor> = {
+  path: "violet",
+  query: "blue",
+  header: "amber",
+  body: "emerald",
+};
+
+/** Badge classes for a parameter IN-location. */
+export function paramLocationColor(location: ParamLocation): string {
+  return ACCENT_BADGE[LOCATION_ACCENT[location]];
+}

--- a/ui/src/components/proposals/blocks/blockBadges.tsx
+++ b/ui/src/components/proposals/blocks/blockBadges.tsx
@@ -1,0 +1,76 @@
+// React components for the shared block visual vocabulary. The pure color logic
+// (accent palette, change/method/status maps, color helpers) lives React-free in
+// `blockBadges.ts`; this module only wraps it in the small reusable primitives
+// (`Badge` / `Pill` / `ChangeChip`) the blocks render. This is the design-system
+// seed the next blocks (diff, annotated-code, callout, table, checklist) reuse.
+//
+// The app is DARK-ONLY.
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import type { FileChange } from "./fileTree";
+import {
+  ACCENT_BADGE,
+  CHANGE_BADGE,
+  CHANGE_GLYPH,
+  CHANGE_LABEL,
+  type AccentColor,
+} from "./blockBadgeColors";
+
+/**
+ * A small uppercase tag (the "Badge" shape). `accent` picks a palette surface;
+ * pass `className` to override or extend (e.g. add `normal-case`, swap the
+ * surface). When neither is given the tag is transparent (caller styles it).
+ */
+export function Badge({
+  children,
+  accent,
+  className,
+}: {
+  children: ReactNode;
+  accent?: AccentColor;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none",
+        accent && ACCENT_BADGE[accent],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Alias of {@link Badge} — same uppercase-tag shape, read as a "pill". */
+export const Pill = Badge;
+
+/**
+ * The compact A/M/D/R square chip: added emerald, modified blue, deleted red,
+ * renamed violet. Carries an accessible label/title.
+ */
+export function ChangeChip({
+  status,
+  className,
+}: {
+  status: FileChange;
+  className?: string;
+}) {
+  return (
+    <span
+      title={CHANGE_LABEL[status]}
+      aria-label={CHANGE_LABEL[status]}
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center rounded text-[10px] font-bold leading-none",
+        CHANGE_BADGE[status],
+        className,
+      )}
+    >
+      {CHANGE_GLYPH[status]}
+    </span>
+  );
+}


### PR DESCRIPTION
## What

The three recently-rewritten proposal blocks — `FileTreeBlock`, `DataModelBlock`, `ApiEndpointBlock` — each independently defined the **same** visual vocabulary: an emerald/blue/amber/violet/red/slate accent palette (`bg-*/15 text-*-300`), small uppercase pills/badges, A/M/D/R change chips, an HTTP-method→color map, and a status-code→color classifier. This extracts that vocabulary into a shared, dark-only module.

## How

- **`blockBadgeColors.ts`** (pure, React-free, unit-testable):
  - `ACCENT_BADGE` palette (emerald/blue/amber/violet/red/slate)
  - `CHANGE_GLYPH` / `CHANGE_LABEL` / `CHANGE_BADGE` / `CHANGE_NAME_INK` (A/M/D/R)
  - `httpMethodColor(method)`, `statusCodeColor(cls)`, `paramLocationColor(loc)`
- **`blockBadges.tsx`** (components): `Badge` / `Pill` (alias) / `ChangeChip`
- Migrated the three blocks to import from the shared module; deleted their local color maps and the inline `Badge`/chip definitions.

Split into `.ts` (pure) + `.tsx` (components) to satisfy `react-refresh/only-export-components` and keep color logic React-free — mirrors the existing `apiEndpoint.ts`/`fileTree.ts` convention.

## No behavior/visual change

Pure dedupe — the rendered class sets are identical. This is the design-system seed the next blocks (diff, annotated-code, callout, table, checklist) will reuse.

## Validation

- `tsc -b` clean
- `eslint` clean on all changed files
- `vitest run src/components/proposals` — **8 files / 110 tests pass** (all existing per-block tests unchanged), plus a new `blockBadgeColors.test.ts` for the helpers.