### PR TITLE
feat(proposals): add diff block

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -22,6 +22,7 @@ pub enum BlockType {
     ApiEndpoint,
     Decisions,
     FileTree,
+    Diff,
     QuestionForm,
 }
 
@@ -36,6 +37,7 @@ impl BlockType {
             BlockType::ApiEndpoint => "api-endpoint",
             BlockType::Decisions => "decisions",
             BlockType::FileTree => "file-tree",
+            BlockType::Diff => "diff",
             BlockType::QuestionForm => "question-form",
         }
     }
@@ -50,6 +52,7 @@ impl BlockType {
             BlockType::ApiEndpoint => "ApiEndpoint",
             BlockType::Decisions => "Decisions",
             BlockType::FileTree => "FileTree",
+            BlockType::Diff => "Diff",
             BlockType::QuestionForm => "QuestionForm",
         }
     }
@@ -144,6 +147,10 @@ pub struct ProposalBlockDefinition {
     pub block_type: &'static str,
     /// MDX component tag, e.g. `AnnotatedCode`.
     pub tag: &'static str,
+    /// Optional authoring guidance for the LLM: how to encode this block's
+    /// children/attributes. Absent for blocks whose shape is self-evident.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<&'static str>,
     /// Field schema keyed by field name.
     pub fields: BTreeMap<&'static str, ProposalBlockFieldSchema>,
 }
@@ -237,6 +244,21 @@ fn block(
     ProposalBlockDefinition {
         block_type,
         tag,
+        description: None,
+        fields,
+    }
+}
+
+fn block_with_description(
+    block_type: &'static str,
+    tag: &'static str,
+    description: &'static str,
+    fields: BTreeMap<&'static str, ProposalBlockFieldSchema>,
+) -> ProposalBlockDefinition {
+    ProposalBlockDefinition {
+        block_type,
+        tag,
+        description: Some(description),
         fields,
     }
 }
@@ -346,6 +368,29 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
                                 ("kind", enum_string_field(vec!["file", "dir"])),
                             ]))),
                         ),
+                    ]),
+                ),
+            ),
+            (
+                "diff",
+                block_with_description(
+                    "diff",
+                    "Diff",
+                    "A before/after code diff. The block CHILDREN are a git-style \
+                     unified diff: optional `diff --git`/`---`/`+++`/`@@ -old,+new @@` \
+                     headers, then body lines each prefixed with `+` (added line), \
+                     `-` (removed line), or a single leading space (unchanged context \
+                     line). Old and new line numbers are reconstructed from the `@@` \
+                     hunk headers. Set the optional `filename` attribute to the file \
+                     path (shown in the header) and the optional `lang` attribute to a \
+                     language hint (e.g. `ts`, `rust`). Example: \
+                     `<Diff id=\"x\" filename=\"src/add.ts\" lang=\"ts\">\\n@@ -1,2 +1,2 @@\\n \
+                     const a = 1;\\n-const b = 2;\\n+const b = 3;\\n</Diff>`. If the \
+                     children are not a valid unified diff the renderer falls back to a \
+                     plain code block, so always emit real `+`/`-`/` ` prefixed lines.",
+                    fields(vec![
+                        ("filename", string_field()),
+                        ("lang", string_field()),
                     ]),
                 ),
             ),
@@ -574,7 +619,7 @@ mod tests {
     #[test]
     fn registry_contains_v1_blocks() {
         let registry = proposal_block_registry();
-        assert_eq!(registry.len(), 8);
+        assert_eq!(registry.len(), 9);
         assert_eq!(registry["rich-text"].tag, "RichText");
         assert_eq!(registry["diagram"].tag, "Diagram");
         assert_eq!(registry["annotated-code"].tag, "AnnotatedCode");
@@ -582,7 +627,15 @@ mod tests {
         assert_eq!(registry["api-endpoint"].tag, "ApiEndpoint");
         assert_eq!(registry["decisions"].tag, "Decisions");
         assert_eq!(registry["file-tree"].tag, "FileTree");
+        assert_eq!(registry["diff"].tag, "Diff");
         assert_eq!(registry["question-form"].tag, "QuestionForm");
+        // The diff block ships authoring guidance for the LLM.
+        assert!(
+            registry["diff"]
+                .description
+                .is_some_and(|d| d.contains("unified diff")),
+            "diff block must advertise unified-diff authoring guidance"
+        );
     }
 
     #[test]
@@ -595,6 +648,7 @@ mod tests {
             BlockType::ApiEndpoint,
             BlockType::Decisions,
             BlockType::FileTree,
+            BlockType::Diff,
             BlockType::QuestionForm,
         ];
         for bt in types {
@@ -606,7 +660,7 @@ mod tests {
     #[test]
     fn block_registry_new_has_all_definitions() {
         let reg = BlockRegistry::new();
-        assert_eq!(reg.definitions().len(), 8);
+        assert_eq!(reg.definitions().len(), 9);
         assert!(reg.definition_for_tag("RichText").is_some());
         assert!(reg.definition_for_tag("UnknownTag").is_none());
         assert!(reg.tags().contains("RichText"));
@@ -626,6 +680,7 @@ mod tests {
             "ApiEndpoint",
             "Decisions",
             "FileTree",
+            "Diff",
             "QuestionForm",
         ]
         .into_iter()

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -448,7 +448,7 @@ fn main() {}
     }
 
     #[test]
-    fn mdx_body_valid_all_eight_canonical_blocks() {
+    fn mdx_body_valid_all_canonical_blocks() {
         // This is the Rust-side counterpart to the canonical proposal.mdx fixture
         // used by the UI test suite. It proves that backend validation accepts
         // every v1 block type when they appear together in a single MDX body.
@@ -483,6 +483,15 @@ We chose JWT over session cookies.
   src/
     main.rs
 </FileTree>
+
+<Diff id="add-fn" filename="src/add.ts" lang="ts">
+@@ -1,3 +1,4 @@
+ export function add(a: number, b: number) {
+-  return a + b;
++  const sum = a + b;
++  return sum;
+ }
+</Diff>
 
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached?

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -11360,6 +11360,11 @@ expression: signatures
       "$defs": {
         "ProposalBlockDefinition": {
           "properties": {
+            "description": {
+              "description": "Optional authoring guidance for the LLM: how to encode this block's\nchildren/attributes. Absent for blocks whose shape is self-evident.",
+              "nullable": true,
+              "type": "string"
+            },
             "fields": {
               "additionalProperties": {
                 "$ref": "#/$defs/ProposalBlockFieldSchema"

--- a/ui/src/components/proposals/blocks/DiffBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/DiffBlock.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/test-utils";
+
+import { DiffBlock } from "./DiffBlock";
+
+const UNIFIED_DIFF = [
+  "@@ -1,3 +1,4 @@",
+  " export function add(a: number, b: number) {",
+  "-  return a + b;",
+  "+  const sum = a + b;",
+  "+  return sum;",
+  " }",
+].join("\n");
+
+describe("DiffBlock", () => {
+  it("renders a unified diff with filename, +/- stats, and code lines", () => {
+    render(
+      <DiffBlock id="d1" attributes={{ filename: "src/add.ts", lang: "ts" }}>
+        {UNIFIED_DIFF}
+      </DiffBlock>,
+    );
+    // Header label + filename basename split.
+    expect(screen.getByText("Diff")).toBeInTheDocument();
+    expect(screen.getByText("add.ts")).toBeInTheDocument();
+    expect(screen.getByText("src")).toBeInTheDocument();
+    // +N / −N stats.
+    expect(screen.getByText("+2")).toBeInTheDocument();
+    expect(screen.getByText("−1")).toBeInTheDocument();
+    // A removed and an added body line render.
+    expect(screen.getByText("const sum = a + b;")).toBeInTheDocument();
+    expect(screen.getByText("return a + b;")).toBeInTheDocument();
+    // Both view toggles exist.
+    expect(
+      screen.getByRole("button", { name: "Unified" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Split" })).toBeInTheDocument();
+  });
+
+  it("falls back to a plain code block when children are not diff-like", () => {
+    render(
+      <DiffBlock id="d2" attributes={{}}>
+        {"Just some prose, not a diff at all."}
+      </DiffBlock>,
+    );
+    expect(
+      screen.getByText("Just some prose, not a diff at all."),
+    ).toBeInTheDocument();
+    // No view-mode toggle in the fallback.
+    expect(screen.queryByRole("button", { name: "Split" })).toBeNull();
+  });
+
+  it("renders a 'No changes' state for a diff hunk with only context", () => {
+    render(
+      <DiffBlock id="d3" attributes={{}}>
+        {"@@ -1,2 +1,2 @@\n unchanged line one\n unchanged line two"}
+      </DiffBlock>,
+    );
+    expect(screen.getByText("No changes")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/proposals/blocks/DiffBlock.tsx
+++ b/ui/src/components/proposals/blocks/DiffBlock.tsx
@@ -1,0 +1,428 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowRight01Icon,
+  LayoutTwoColumnIcon,
+  LeftToRightListBulletIcon,
+  MoreHorizontalIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
+
+import { BlockShell } from "./BlockShell";
+import type { BlockProps } from "./types";
+import {
+  diffStats,
+  isDiffLike,
+  pairSplitRows,
+  parseUnifiedDiff,
+  segmentRows,
+  splitFilename,
+  type DiffMode,
+  type DiffRow,
+  type DiffRowKind,
+  type SplitRow,
+} from "./diff";
+
+/**
+ * Diff — a GitHub-style before/after diff renderer for proposal specs.
+ *
+ * The block's children are a git-style unified diff (optional `diff --git`/
+ * `---`/`+++`/`@@` headers; body lines prefixed `+`/`-`/` `). The parser
+ * reconstructs old + new line numbers, then this component renders either a
+ * UNIFIED view (one column, dual line-number gutters + sign gutter) or a SPLIT
+ * view (old | new columns with half-empty cells for pure adds/removes). The
+ * toggle choice persists in localStorage and syncs across mounted diffs.
+ *
+ * Long runs of unchanged context collapse into an expandable "Show N unchanged
+ * lines" row (keeping ~3 lines of edge context). A `+N −N` stat sits in the
+ * header next to the filename (basename / dir split when `filename` is set).
+ *
+ * Robust + graceful: if the children text is not diff-like (no `+`/`-` lines and
+ * no `@@` hunk), it falls back to a plain code `<pre>` so an oddly-authored block
+ * never blanks or crashes. The code surface is forced LTR.
+ */
+
+const DIFF_MODE_STORAGE_KEY = "djinn:proposal-diff-view-mode";
+const DIFF_MODE_STORAGE_EVENT = "djinn:proposal-diff-view-mode-change";
+
+const ROW_BG: Record<DiffRowKind, string> = {
+  added: "bg-emerald-500/10",
+  removed: "bg-red-500/10",
+  context: "",
+};
+
+const GUTTER_BG: Record<DiffRowKind, string> = {
+  added: "bg-emerald-500/15",
+  removed: "bg-red-500/15",
+  context: "bg-muted/40",
+};
+
+const SIGN_COLOR: Record<DiffRowKind, string> = {
+  added: "text-emerald-300",
+  removed: "text-red-300",
+  context: "text-muted-foreground",
+};
+
+const SIGN: Record<DiffRowKind, string> = {
+  added: "+",
+  removed: "−",
+  context: " ",
+};
+
+const LINE_NO_CLASS =
+  "w-[3.25rem] shrink-0 select-none px-2 py-0 text-right font-mono text-[11px] leading-5 text-muted-foreground/70 tabular-nums";
+
+const CODE_CLASS =
+  "block min-w-max flex-1 whitespace-pre px-2 py-0 font-mono text-xs leading-5 text-foreground";
+
+function isDiffMode(value: unknown): value is DiffMode {
+  return value === "unified" || value === "split";
+}
+
+function readStoredMode(): DiffMode | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const value = window.localStorage?.getItem(DIFF_MODE_STORAGE_KEY);
+    return isDiffMode(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persisted, cross-diff-synced view-mode preference. Defaults to "unified";
+ * writing the mode mirrors it to localStorage and broadcasts a same-tab event so
+ * every mounted diff updates in lock-step (the native `storage` event only fires
+ * across tabs).
+ */
+function usePreferredDiffMode() {
+  // Seed straight from storage so the first paint already reflects the saved
+  // preference (this is a client-only render path) — no setState-in-effect.
+  const [mode, setMode] = useState<DiffMode>(() => readStoredMode() ?? "unified");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== DIFF_MODE_STORAGE_KEY) return;
+      if (isDiffMode(event.newValue)) setMode(event.newValue);
+    };
+    const onCustom = (event: Event) => {
+      const next = (event as CustomEvent<unknown>).detail;
+      if (isDiffMode(next)) setMode(next);
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(DIFF_MODE_STORAGE_EVENT, onCustom);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(DIFF_MODE_STORAGE_EVENT, onCustom);
+    };
+  }, []);
+
+  const setPreferred = useCallback((next: DiffMode) => {
+    setMode(next);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage?.setItem(DIFF_MODE_STORAGE_KEY, next);
+      window.dispatchEvent(
+        new CustomEvent<DiffMode>(DIFF_MODE_STORAGE_EVENT, { detail: next }),
+      );
+    } catch {
+      // Storage may be unavailable in private/sandboxed contexts; the local
+      // component state still updated.
+    }
+  }, []);
+
+  return [mode, setPreferred] as const;
+}
+
+export function DiffBlock({ attributes, children }: BlockProps) {
+  const filename = attributes.filename?.trim() || undefined;
+  const lang = attributes.lang?.trim() || undefined;
+  const content = typeof children === "string" ? children.replace(/^\n+/, "") : "";
+
+  const [mode, setMode] = usePreferredDiffMode();
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
+
+  const diffLike = useMemo(() => isDiffLike(content), [content]);
+  const rows = useMemo(
+    () => (diffLike ? parseUnifiedDiff(content) : []),
+    [content, diffLike],
+  );
+  const stats = useMemo(() => diffStats(rows), [rows]);
+  const fileParts = useMemo(() => splitFilename(filename), [filename]);
+
+  const toggleRun = (key: number) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  const meta = (
+    <span className="flex min-w-0 items-center gap-2 font-mono">
+      {filename ? (
+        <span className="flex min-w-0 items-baseline gap-1.5">
+          <span className="max-w-[14rem] truncate font-semibold text-foreground">
+            {fileParts.basename}
+          </span>
+          {fileParts.directory && (
+            <span className="min-w-0 truncate text-[11px] text-muted-foreground/70">
+              {fileParts.directory}
+            </span>
+          )}
+        </span>
+      ) : null}
+      {lang && !filename ? <span>{lang}</span> : null}
+      {diffLike && (rows.length > 0 ? (
+        <span className="flex shrink-0 items-center gap-2">
+          <span className="text-emerald-400">+{stats.added}</span>
+          <span className="text-red-400">−{stats.removed}</span>
+        </span>
+      ) : null)}
+      {diffLike && (
+        <span className="ml-auto flex shrink-0 items-center overflow-hidden rounded-md border">
+          <ModeButton
+            active={mode === "unified"}
+            onClick={() => setMode("unified")}
+            icon={LeftToRightListBulletIcon}
+            label="Unified"
+          />
+          <ModeButton
+            active={mode === "split"}
+            onClick={() => setMode("split")}
+            icon={LayoutTwoColumnIcon}
+            label="Split"
+          />
+        </span>
+      )}
+    </span>
+  );
+
+  // Not diff-like — fall back to a plain code surface so the authored text is
+  // never lost or misrendered.
+  if (!diffLike) {
+    return (
+      <BlockShell
+        label="Diff"
+        accent="text-sky-400"
+        flush
+        meta={
+          filename || lang ? (
+            <span className="truncate font-mono">{filename ?? lang}</span>
+          ) : null
+        }
+      >
+        <pre
+          dir="ltr"
+          className="overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed text-foreground [unicode-bidi:isolate]"
+        >
+          {content}
+        </pre>
+      </BlockShell>
+    );
+  }
+
+  const noChanges = stats.added === 0 && stats.removed === 0;
+
+  return (
+    <BlockShell label="Diff" accent="text-sky-400" flush meta={meta}>
+      <div dir="ltr" className="[unicode-bidi:isolate]">
+        {noChanges ? (
+          <div className="px-4 py-6 text-center font-mono text-sm text-muted-foreground">
+            No changes
+          </div>
+        ) : mode === "split" ? (
+          <SplitView rows={rows} lang={lang} />
+        ) : (
+          <UnifiedView
+            rows={rows}
+            lang={lang}
+            expanded={expanded}
+            onToggleRun={toggleRun}
+          />
+        )}
+      </div>
+    </BlockShell>
+  );
+}
+
+function ModeButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: typeof LeftToRightListBulletIcon;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      title={label}
+      className={cn(
+        "flex cursor-pointer items-center gap-1 px-2 py-1 text-[11px] font-medium transition-colors",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
+      )}
+    >
+      <HugeiconsIcon icon={icon} size={13} />
+      {label}
+    </button>
+  );
+}
+
+/* ── Unified view ──────────────────────────────────────────────────────────── */
+
+function UnifiedView({
+  rows,
+  lang,
+  expanded,
+  onToggleRun,
+}: {
+  rows: DiffRow[];
+  lang?: string;
+  expanded: Set<number>;
+  onToggleRun: (key: number) => void;
+}) {
+  void lang;
+  const segments = useMemo(() => segmentRows(rows), [rows]);
+  let runIndex = 0;
+  return (
+    <div className="overflow-x-auto py-1">
+      <div className="w-max min-w-full">
+        {segments.map((segment, idx) => {
+          if ("collapsed" in segment) {
+            const key = runIndex++;
+            const open = expanded.has(key);
+            return (
+              <div key={`run-${key}`}>
+                <CollapsedRow
+                  count={segment.rows.length}
+                  open={open}
+                  onClick={() => onToggleRun(key)}
+                />
+                {open &&
+                  segment.rows.map((row, ri) => (
+                    <UnifiedRow key={`run-${key}-${ri}`} row={row} />
+                  ))}
+              </div>
+            );
+          }
+          return <UnifiedRow key={idx} row={segment} />;
+        })}
+      </div>
+    </div>
+  );
+}
+
+function UnifiedRow({ row }: { row: DiffRow }) {
+  return (
+    <div className={cn("flex min-h-5 min-w-full", ROW_BG[row.kind])}>
+      <span className={LINE_NO_CLASS}>{row.oldNo ?? ""}</span>
+      <span className={LINE_NO_CLASS}>{row.newNo ?? ""}</span>
+      <span
+        className={cn(
+          "w-6 shrink-0 select-none py-0 text-center font-mono text-xs font-semibold leading-5",
+          GUTTER_BG[row.kind],
+          SIGN_COLOR[row.kind],
+        )}
+      >
+        {SIGN[row.kind]}
+      </span>
+      <span className={CODE_CLASS}>{row.text || " "}</span>
+    </div>
+  );
+}
+
+function CollapsedRow({
+  count,
+  open,
+  onClick,
+}: {
+  count: number;
+  open: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-expanded={open}
+      className="flex w-full cursor-pointer items-center gap-2 border-y bg-muted/40 px-3 py-1 text-left text-[11px] text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+    >
+      <HugeiconsIcon
+        icon={open ? ArrowRight01Icon : MoreHorizontalIcon}
+        size={13}
+        className={cn("shrink-0", open && "rotate-90")}
+      />
+      <span>
+        {open ? "Hide" : "Show"} {count} unchanged line{count === 1 ? "" : "s"}
+      </span>
+    </button>
+  );
+}
+
+/* ── Split (side-by-side) view ─────────────────────────────────────────────── */
+
+function SplitView({ rows, lang }: { rows: DiffRow[]; lang?: string }) {
+  void lang;
+  const pairs = useMemo(() => pairSplitRows(rows), [rows]);
+  return (
+    <div className="flex w-full py-1">
+      <div className="min-w-0 flex-1 overflow-x-auto border-r">
+        <div className="inline-block min-w-full">
+          {pairs.map((pair, idx) => (
+            <SplitCell key={`old-${idx}`} row={pair.left} side="old" />
+          ))}
+        </div>
+      </div>
+      <div className="min-w-0 flex-1 overflow-x-auto">
+        <div className="inline-block min-w-full">
+          {pairs.map((pair, idx) => (
+            <SplitCell key={`new-${idx}`} row={pair.right} side="new" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SplitCell({ row, side }: { row?: DiffRow; side: "old" | "new" }) {
+  if (!row) {
+    return (
+      <div className="flex min-h-5 min-w-full bg-muted/20">
+        <span className={LINE_NO_CLASS} />
+        <span className="w-6 shrink-0 bg-muted/30" />
+        <span className={CODE_CLASS}> </span>
+      </div>
+    );
+  }
+  const sign = side === "old" ? "−" : "+";
+  const showSign = row.kind !== "context";
+  const lineNo = side === "old" ? row.oldNo : row.newNo;
+  return (
+    <div className={cn("flex min-h-5 min-w-full", ROW_BG[row.kind])}>
+      <span className={LINE_NO_CLASS}>{lineNo ?? ""}</span>
+      <span
+        className={cn(
+          "w-6 shrink-0 select-none py-0 text-center font-mono text-xs font-semibold leading-5",
+          GUTTER_BG[row.kind],
+          SIGN_COLOR[row.kind],
+        )}
+      >
+        {showSign ? sign : " "}
+      </span>
+      <span className={CODE_CLASS}>{row.text || " "}</span>
+    </div>
+  );
+}
+
+/** Re-export used to keep `SplitRow` in the type graph for consumers/tests. */
+export type { SplitRow };

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -42,6 +42,15 @@ We chose JWT over session cookies for stateless auth.
   tests/
 </FileTree>
 
+<Diff id="add-fn" filename="src/add.ts" lang="ts">
+@@ -1,3 +1,4 @@
+ export function add(a: number, b: number) {
+-  return a + b;
++  const sum = a + b;
++  return sum;
+ }
+</Diff>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached for caching?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/blocks.test.ts
+++ b/ui/src/components/proposals/blocks/blocks.test.ts
@@ -25,6 +25,7 @@ export const CANONICAL_V1_TAGS = [
   "ApiEndpoint",
   "Decisions",
   "FileTree",
+  "Diff",
   "QuestionForm",
 ] as const;
 
@@ -40,7 +41,7 @@ const CANONICAL_MDX = (await import("./__fixtures__/canonicalProposal.mdx?raw"))
 // ------------------------------------------------------------------------------
 
 describe("canonical tag set parity", () => {
-  it("PROPOSAL_BLOCK_REGISTRY contains exactly the eight canonical v1 tags", () => {
+  it("PROPOSAL_BLOCK_REGISTRY contains exactly the canonical v1 tags", () => {
     const registryTags = Object.values(PROPOSAL_BLOCK_REGISTRY).map(
       (def) => def.tag,
     );
@@ -74,7 +75,7 @@ describe("canonical tag set parity", () => {
 // ------------------------------------------------------------------------------
 
 describe("canonical proposal.mdx round-trip", () => {
-  it("parses all eight v1 block types from the canonical fixture", () => {
+  it("parses all canonical v1 block types from the canonical fixture", () => {
     const segments = parseMdxBody(CANONICAL_MDX);
     const blockSegments = segments.filter((s) => s.kind === "block");
     const extractedTags = blockSegments.map((s) => s.tag);
@@ -97,7 +98,7 @@ describe("canonical proposal.mdx round-trip", () => {
     }
   });
 
-  it("asserts parsed tag, block id, and registry mapping consistency for all eight v1 types", () => {
+  it("asserts parsed tag, block id, and registry mapping consistency for all v1 types", () => {
     const segments = parseMdxBody(CANONICAL_MDX);
     const blockSegments = segments.filter((s) => s.kind === "block");
 
@@ -170,6 +171,15 @@ describe("canonical proposal.mdx round-trip", () => {
     expect(fileTree!.attributes.root).toBe("src");
     expect(fileTree!.content).toContain("main.rs");
     expect(getProposalBlockDefinitionByTag("FileTree")!.type).toBe("file-tree");
+
+    // Diff
+    const diff = byTag.get("Diff");
+    expect(diff).toBeDefined();
+    expect(diff!.id).toBe("add-fn");
+    expect(diff!.attributes.filename).toBe("src/add.ts");
+    expect(diff!.attributes.lang).toBe("ts");
+    expect(diff!.content).toContain("@@");
+    expect(getProposalBlockDefinitionByTag("Diff")!.type).toBe("diff");
 
     // QuestionForm
     const questionForm = byTag.get("QuestionForm");

--- a/ui/src/components/proposals/blocks/diff.test.ts
+++ b/ui/src/components/proposals/blocks/diff.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COLLAPSE_THRESHOLD,
+  diffStats,
+  isDiffLike,
+  pairSplitRows,
+  parseUnifiedDiff,
+  segmentRows,
+  splitFilename,
+  type CollapsedRun,
+  type DiffRow,
+} from "./diff";
+
+const SAMPLE = [
+  "@@ -1,3 +1,4 @@",
+  " export function add(a, b) {",
+  "-  return a + b;",
+  "+  const sum = a + b;",
+  "+  return sum;",
+  " }",
+].join("\n");
+
+describe("isDiffLike", () => {
+  it("accepts a body with a hunk header", () => {
+    expect(isDiffLike("@@ -1 +1 @@\n-a\n+b")).toBe(true);
+  });
+
+  it("accepts a headerless body with +/- lines", () => {
+    expect(isDiffLike(" context\n-old\n+new")).toBe(true);
+  });
+
+  it("rejects plain prose", () => {
+    expect(isDiffLike("This is just a sentence.\nNo diff here.")).toBe(false);
+  });
+
+  it("rejects an empty / whitespace body", () => {
+    expect(isDiffLike("")).toBe(false);
+    expect(isDiffLike("   \n  ")).toBe(false);
+  });
+
+  it("does not treat a bare `+++`/`---` file header as diff content", () => {
+    // Only file headers, no actual body change lines and no hunk → not diff-like.
+    expect(isDiffLike("--- a/x\n+++ b/x")).toBe(false);
+  });
+});
+
+describe("parseUnifiedDiff — hunk parse + old/new numbering", () => {
+  it("reconstructs old and new line numbers from the @@ header", () => {
+    const rows = parseUnifiedDiff(SAMPLE);
+    expect(rows.map((r) => [r.kind, r.oldNo, r.newNo, r.text])).toEqual([
+      ["context", 1, 1, "export function add(a, b) {"],
+      ["removed", 2, undefined, "  return a + b;"],
+      ["added", undefined, 2, "  const sum = a + b;"],
+      ["added", undefined, 3, "  return sum;"],
+      ["context", 3, 4, "}"],
+    ]);
+  });
+
+  it("strips file/index/rename header lines from the row stream", () => {
+    const body = [
+      "diff --git a/x.ts b/x.ts",
+      "index 111..222 100644",
+      "--- a/x.ts",
+      "+++ b/x.ts",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+    ].join("\n");
+    const rows = parseUnifiedDiff(body);
+    expect(rows.map((r) => r.kind)).toEqual(["removed", "added"]);
+    expect(rows[0].oldNo).toBe(1);
+    expect(rows[1].newNo).toBe(1);
+  });
+
+  it("numbers a headerless diff from line 1", () => {
+    const rows = parseUnifiedDiff(" a\n-b\n+c\n d");
+    expect(rows.map((r) => [r.oldNo, r.newNo])).toEqual([
+      [1, 1],
+      [2, undefined],
+      [undefined, 2],
+      [3, 3],
+    ]);
+  });
+
+  it("drops a `\\ No newline at end of file` marker", () => {
+    const rows = parseUnifiedDiff("@@ -1 +1 @@\n-a\n\\ No newline at end of file\n+b");
+    expect(rows.map((r) => r.kind)).toEqual(["removed", "added"]);
+  });
+
+  it("returns [] for empty input and never throws on garbage", () => {
+    expect(parseUnifiedDiff("")).toEqual([]);
+    expect(() => parseUnifiedDiff("@@ broken header @@\n??!!")).not.toThrow();
+  });
+});
+
+describe("diffStats", () => {
+  it("counts added and removed rows", () => {
+    expect(diffStats(parseUnifiedDiff(SAMPLE))).toEqual({ added: 2, removed: 1 });
+  });
+});
+
+describe("segmentRows — collapse-run logic", () => {
+  function contextRows(count: number): DiffRow[] {
+    return Array.from({ length: count }, (_, i) => ({
+      kind: "context" as const,
+      oldNo: i + 1,
+      newNo: i + 1,
+      text: `line ${i + 1}`,
+    }));
+  }
+
+  it("does not collapse a short run", () => {
+    const rows = contextRows(COLLAPSE_THRESHOLD);
+    const segments = segmentRows(rows);
+    expect(segments.every((s) => !("collapsed" in s))).toBe(true);
+    expect(segments).toHaveLength(COLLAPSE_THRESHOLD);
+  });
+
+  it("collapses a long interior run keeping edge context", () => {
+    const rows: DiffRow[] = [
+      { kind: "removed", oldNo: 1, text: "x" },
+      ...contextRows(20),
+      { kind: "added", newNo: 22, text: "y" },
+    ];
+    const segments = segmentRows(rows);
+    const collapsed = segments.find(
+      (s): s is CollapsedRun => "collapsed" in s,
+    );
+    expect(collapsed).toBeDefined();
+    // 20 context rows → 3 head + hidden + 3 tail.
+    expect(collapsed!.rows.length).toBe(20 - 3 - 3);
+    // The change rows stay visible at each end.
+    expect(segments[0]).toMatchObject({ kind: "removed" });
+    expect(segments[segments.length - 1]).toMatchObject({ kind: "added" });
+  });
+
+  it("collapses a long leading run to only the inner edge", () => {
+    const rows: DiffRow[] = [
+      ...contextRows(20),
+      { kind: "added", newNo: 21, text: "y" },
+    ];
+    const segments = segmentRows(rows);
+    // Leading run keeps no head context, only the inner tail edge + hidden.
+    const visibleContext = segments.filter(
+      (s) => !("collapsed" in s) && (s as DiffRow).kind === "context",
+    );
+    expect(visibleContext).toHaveLength(3);
+  });
+
+  it("never collapses changed rows", () => {
+    const rows: DiffRow[] = Array.from({ length: 10 }, (_, i) => ({
+      kind: "added" as const,
+      newNo: i + 1,
+      text: `+${i}`,
+    }));
+    const segments = segmentRows(rows);
+    expect(segments.some((s) => "collapsed" in s)).toBe(false);
+  });
+});
+
+describe("pairSplitRows — split reconstruction", () => {
+  it("mirrors context rows on both columns", () => {
+    const rows = parseUnifiedDiff(" a\n b");
+    const pairs = pairSplitRows(rows);
+    expect(pairs).toHaveLength(2);
+    expect(pairs[0].left).toBe(pairs[0].right);
+  });
+
+  it("pairs a removed line with the corresponding added line", () => {
+    const rows = parseUnifiedDiff("@@ -1 +1 @@\n-old\n+new");
+    const pairs = pairSplitRows(rows);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].left).toMatchObject({ kind: "removed", text: "old" });
+    expect(pairs[0].right).toMatchObject({ kind: "added", text: "new" });
+  });
+
+  it("leaves half-empty cells for an unbalanced add", () => {
+    // 1 removed, 2 added → 2 split rows, second has no left cell.
+    const rows = parseUnifiedDiff("@@ -1 +1,2 @@\n-old\n+new1\n+new2");
+    const pairs = pairSplitRows(rows);
+    expect(pairs).toHaveLength(2);
+    expect(pairs[0].left).toMatchObject({ text: "old" });
+    expect(pairs[1].left).toBeUndefined();
+    expect(pairs[1].right).toMatchObject({ text: "new2" });
+  });
+});
+
+describe("splitFilename", () => {
+  it("splits a path into basename + directory", () => {
+    expect(splitFilename("src/routes/add.ts")).toEqual({
+      basename: "add.ts",
+      directory: "src/routes",
+    });
+  });
+
+  it("returns no directory for a bare filename", () => {
+    expect(splitFilename("add.ts")).toEqual({
+      basename: "add.ts",
+      directory: null,
+    });
+  });
+
+  it("handles an absent filename", () => {
+    expect(splitFilename(undefined)).toEqual({
+      basename: "",
+      directory: null,
+    });
+  });
+});

--- a/ui/src/components/proposals/blocks/diff.ts
+++ b/ui/src/components/proposals/blocks/diff.ts
@@ -1,0 +1,244 @@
+// Pure (React-free) helpers for the interactive Diff block. These parse the
+// unified-diff text an author writes inside <Diff>…</Diff> into numbered diff
+// rows (with reconstructed old/new line numbers), pair those rows into split
+// (side-by-side) columns, and collapse long unchanged runs. Kept in their own
+// module so they are unit-testable without pulling React in.
+//
+// djinn's MDX stores the diff as the block's *children text* — a git-style
+// unified diff: optional `diff --git`/`index`/`---`/`+++`/`@@` headers, then a
+// body whose lines are prefixed `+` (added), `-` (removed), or ` ` (context).
+// `filename` and `lang` are optional attributes (cosmetic header / highlight
+// hint) and are NOT parsed here.
+//
+// Robustness: if the children text doesn't look like a unified diff (no `+`/`-`
+// prefixed lines and no `@@` hunk header), `isDiffLike` returns false so the
+// React component can fall back to a plain code <pre> instead of rendering an
+// empty or misleading diff. The parser itself never throws.
+
+/** The display layout for a diff body. */
+export type DiffMode = "unified" | "split";
+
+/** Which kind of line a diff row represents. */
+export type DiffRowKind = "context" | "added" | "removed";
+
+/** A single rendered diff row with reconstructed 1-based line numbers. */
+export interface DiffRow {
+  kind: DiffRowKind;
+  /** Line number in the OLD file (absent for added rows). */
+  oldNo?: number;
+  /** Line number in the NEW file (absent for removed rows). */
+  newNo?: number;
+  /** The line text WITHOUT its `+`/`-`/` ` prefix. */
+  text: string;
+}
+
+/** A contiguous run of context rows collapsed when longer than the threshold. */
+export interface CollapsedRun {
+  collapsed: true;
+  rows: DiffRow[];
+}
+
+/** A diff segment: either a visible row or a collapsed run of context rows. */
+export type DiffSegment = DiffRow | CollapsedRun;
+
+/** A paired split-view row: old line on the left, new line on the right. */
+export interface SplitRow {
+  left?: DiffRow;
+  right?: DiffRow;
+}
+
+/** Number of context lines above which an unchanged run is collapsed. */
+export const COLLAPSE_THRESHOLD = 6;
+/** Context lines kept visible at each edge of a collapsed run. */
+export const CONTEXT_EDGE = 3;
+
+const HUNK_HEADER = /^@@\s*-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s*@@/;
+
+/**
+ * Diff file headers that carry no body content. They precede the hunks and must
+ * not be numbered as context/added/removed rows.
+ */
+function isFileHeaderLine(line: string): boolean {
+  return (
+    line.startsWith("diff --git ") ||
+    line.startsWith("index ") ||
+    line.startsWith("--- ") ||
+    line.startsWith("+++ ") ||
+    line.startsWith("new file mode ") ||
+    line.startsWith("deleted file mode ") ||
+    line.startsWith("rename from ") ||
+    line.startsWith("rename to ") ||
+    line.startsWith("similarity index ") ||
+    line.startsWith("old mode ") ||
+    line.startsWith("new mode ")
+  );
+}
+
+/**
+ * Heuristic: does this children text look like a unified diff we can render? We
+ * accept it if there is at least one `@@` hunk header OR at least one body line
+ * that starts with `+`/`-` (but is not a `+++`/`---` file header). Anything else
+ * (plain prose, a bare code snippet) returns false so the caller can fall back
+ * to a plain code block.
+ */
+export function isDiffLike(text: string): boolean {
+  if (!text.trim()) return false;
+  const lines = text.split("\n");
+  for (const line of lines) {
+    if (HUNK_HEADER.test(line)) return true;
+    if (line.startsWith("+++ ") || line.startsWith("--- ")) continue;
+    if (line.startsWith("+") || line.startsWith("-")) return true;
+  }
+  return false;
+}
+
+/**
+ * Parse a unified diff into numbered rows. Line numbers are reconstructed from
+ * `@@ -old,+new @@` hunk headers when present; absent a hunk header we number
+ * from 1 (a "headerless" diff — just `+`/`-`/` ` prefixed lines). File header
+ * lines (`diff --git`, `---`, `+++`, `@@`, mode/rename lines) are dropped from
+ * the row stream. A `\ No newline at end of file` marker line is also dropped.
+ *
+ * Never throws: malformed hunk headers fall back to continuing the current
+ * counters; lines with no recognizable prefix are treated as context.
+ */
+export function parseUnifiedDiff(text: string): DiffRow[] {
+  const rows: DiffRow[] = [];
+  if (!text) return rows;
+
+  const lines = text.split("\n");
+  // Drop a single trailing empty element produced by a trailing newline so a
+  // diff ending in "\n" does not emit a phantom blank context row.
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+
+  let oldNo = 0;
+  let newNo = 0;
+  let seenHunk = false;
+
+  for (const line of lines) {
+    const hunk = HUNK_HEADER.exec(line);
+    if (hunk) {
+      oldNo = Number.parseInt(hunk[1], 10) - 1;
+      newNo = Number.parseInt(hunk[3], 10) - 1;
+      seenHunk = true;
+      continue;
+    }
+    if (isFileHeaderLine(line)) continue;
+    // "\ No newline at end of file" — a marker, not content.
+    if (line.startsWith("\\")) continue;
+
+    const sign = line.charAt(0);
+    const body = line.slice(1);
+    if (sign === "+") {
+      newNo += 1;
+      rows.push({ kind: "added", newNo, text: body });
+    } else if (sign === "-") {
+      oldNo += 1;
+      rows.push({ kind: "removed", oldNo, text: body });
+    } else {
+      // Context line. A leading single space is the unified-diff context marker;
+      // strip it. A fully empty line (no prefix at all) is context too.
+      const contextText = sign === " " ? body : line;
+      oldNo += 1;
+      newNo += 1;
+      rows.push({ kind: "context", oldNo, newNo, text: contextText });
+    }
+  }
+
+  // A headerless diff that never saw a hunk still numbered from 1 above, which
+  // is the desired behaviour, so `seenHunk` is only informational.
+  void seenHunk;
+  return rows;
+}
+
+/**
+ * Count added / removed rows for the `+N −N` header stat.
+ */
+export function diffStats(rows: DiffRow[]): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const row of rows) {
+    if (row.kind === "added") added += 1;
+    else if (row.kind === "removed") removed += 1;
+  }
+  return { added, removed };
+}
+
+/**
+ * Group rows into segments, collapsing interior runs of more than
+ * COLLAPSE_THRESHOLD context rows (keeping CONTEXT_EDGE visible at each side).
+ * Leading and trailing runs collapse too, but keep only the inner edge visible
+ * (no point showing context that has no adjacent change). Changed rows are never
+ * collapsed.
+ */
+export function segmentRows(rows: DiffRow[]): DiffSegment[] {
+  const segments: DiffSegment[] = [];
+
+  const collapseRun = (run: DiffRow[], atStart: boolean, atEnd: boolean) => {
+    if (run.length <= COLLAPSE_THRESHOLD) {
+      for (const row of run) segments.push(row);
+      return;
+    }
+    const head = atStart ? [] : run.slice(0, CONTEXT_EDGE);
+    const tail = atEnd ? [] : run.slice(run.length - CONTEXT_EDGE);
+    const hidden = run.slice(head.length, run.length - tail.length);
+    for (const row of head) segments.push(row);
+    if (hidden.length > 0) segments.push({ collapsed: true, rows: hidden });
+    for (const row of tail) segments.push(row);
+  };
+
+  let i = 0;
+  while (i < rows.length) {
+    if (rows[i].kind !== "context") {
+      segments.push(rows[i]);
+      i += 1;
+      continue;
+    }
+    let j = i;
+    while (j < rows.length && rows[j].kind === "context") j += 1;
+    const run = rows.slice(i, j);
+    collapseRun(run, i === 0, j === rows.length);
+    i = j;
+  }
+  return segments;
+}
+
+/**
+ * Pair removed lines (left) with added lines (right) so a modification shows the
+ * old and new side by side; context lines mirror on both columns. Leftover adds
+ * or removes fall through as half-empty rows (GitHub split behaviour).
+ */
+export function pairSplitRows(rows: DiffRow[]): SplitRow[] {
+  const out: SplitRow[] = [];
+  let i = 0;
+  while (i < rows.length) {
+    const row = rows[i];
+    if (row.kind === "context") {
+      out.push({ left: row, right: row });
+      i += 1;
+      continue;
+    }
+    const removed: DiffRow[] = [];
+    const added: DiffRow[] = [];
+    while (i < rows.length && rows[i].kind === "removed") removed.push(rows[i++]);
+    while (i < rows.length && rows[i].kind === "added") added.push(rows[i++]);
+    const max = Math.max(removed.length, added.length);
+    for (let k = 0; k < max; k += 1) {
+      out.push({ left: removed[k], right: added[k] });
+    }
+  }
+  return out;
+}
+
+/** Split a `filename` into `{ basename, directory }` for the header. */
+export function splitFilename(filename?: string): {
+  basename: string;
+  directory: string | null;
+} {
+  const value = filename?.trim() || "";
+  if (!value) return { basename: "", directory: null };
+  const segments = value.split("/").filter(Boolean);
+  const basename = segments[segments.length - 1] ?? value;
+  const directory = segments.length > 1 ? segments.slice(0, -1).join("/") : null;
+  return { basename, directory };
+}

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -7,6 +7,7 @@ export { QuestionFormBlock } from "./QuestionFormBlock";
 export { RichText } from "./RichText";
 export { Diagram } from "./Diagram";
 export { AnnotatedCode } from "./AnnotatedCode";
+export { DiffBlock } from "./DiffBlock";
 export { BlockRenderer } from "./BlockRenderer";
 export type { BlockRendererProps } from "./BlockRenderer";
 export { parseMdxBody, isPascalCaseTag, extractBlockTags } from "./parseMdxBody";

--- a/ui/src/lib/blockRegistry.ts
+++ b/ui/src/lib/blockRegistry.ts
@@ -7,6 +7,7 @@ import {
   DataModelBlock,
   DecisionsBlock,
   Diagram,
+  DiffBlock,
   FileTreeBlock,
   QuestionFormBlock,
   RichText,
@@ -32,6 +33,7 @@ const BLOCK_COMPONENTS: Record<ProposalBlockType, ComponentType<BlockProps>> = {
   "api-endpoint": ApiEndpointBlock,
   decisions: DecisionsBlock,
   "file-tree": FileTreeBlock,
+  diff: DiffBlock,
   "question-form": QuestionFormBlock,
 };
 
@@ -43,6 +45,7 @@ const BLOCK_DISPLAY_NAMES: Record<ProposalBlockType, string> = {
   "api-endpoint": "API Endpoint",
   decisions: "Decisions",
   "file-tree": "File Tree",
+  diff: "Diff",
   "question-form": "Open Questions",
 };
 

--- a/ui/src/lib/proposalBlocks.ts
+++ b/ui/src/lib/proposalBlocks.ts
@@ -123,6 +123,14 @@ export const PROPOSAL_BLOCK_REGISTRY = {
       },
     },
   },
+  diff: {
+    type: "diff",
+    tag: "Diff",
+    fields: {
+      filename: { type: "string" },
+      lang: { type: "string" },
+    },
+  },
   "question-form": {
     type: "question-form",
     tag: "QuestionForm",


### PR DESCRIPTION
## What

Adds the first net-new proposal block type: **`diff`** (MDX tag `Diff`, type `diff`) — a GitHub-style before/after diff renderer. This is WU5 from the proposal-blocks gap analysis (§3.4 — the highest-value missing block).

### Component (`DiffBlock.tsx` + pure `diff.ts`)
The block's children are a git-style **unified diff** (optional `diff --git`/`---`/`+++`/`@@` headers; body lines prefixed `+`/`-`/` `). `filename` and `lang` are optional attributes.

- Parses the unified diff into rows, reconstructing old + new line numbers from `@@` hunk headers.
- **Unified view (default)** + **Split view** (old | new columns, half-empty cells for pure adds/removes). Toggle choice persists in `localStorage` and syncs across mounted diffs.
- Dual old/new line-number columns, sign gutter, per-line add/remove highlight (emerald/red), `+N −N` header stat, filename basename/dir split.
- **Collapsible unchanged runs** (>6 context lines collapse, keeping ~3 edge lines).
- Robust + graceful: non-diff-like children fall back to a plain code `<pre>` — never crashes. Code surface forced LTR.
- Pure differ/parser extracted to `diff.ts` with a Vitest suite (hunk parse, old/new numbering, split reconstruction, collapse-run logic, fallback) + a render smoke test.

### Backend + parity (first net-new block → touches both registries)
- **Rust registry** (`proposal_blocks.rs`): new `Diff` `BlockType`, registry entry with an authoring-guidance `description` (new optional field on `ProposalBlockDefinition`).
- **TS mirror**: `proposalBlocks.ts` + `blockRegistry.ts` (`diff` → `DiffBlock`, display name "Diff").
- **Parity test + fixtures**: `CANONICAL_V1_TAGS` += `Diff`; canonical `.mdx` fixture (UI) + Rust validation fixture both gain a `<Diff>` block.
- **Tool-schema insta snapshot** regenerated (5-line add for the new `description` field — no unrelated churn).

## Validation
- `tsc -b` clean; `eslint` clean on changed files.
- `vitest` green (134 tests incl. updated parity test).
- `cargo test -p djinn-server server::tests::tool_schemas` — 14 pass, snapshot matches.
- `cargo check -p djinn-control-plane --all-features` compiles; proposal_blocks + validation unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)