### PR TITLE
feat(proposals): annotated-code line numbers + hover-card annotations

### DIFF
--- a/ui/src/components/proposals/blocks/AnnotatedCode.test.tsx
+++ b/ui/src/components/proposals/blocks/AnnotatedCode.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/test-utils";
+
+import { AnnotatedCode } from "./AnnotatedCode";
+
+const CODE = ["const a = 1;", "const b = 2;", "return a + b;"].join("\n");
+
+describe("AnnotatedCode", () => {
+  it("renders the block shell, a filename header (dir/basename split), language chip, and a copy button", () => {
+    render(
+      <AnnotatedCode
+        id="c1"
+        attributes={{ lang: "ts", filename: "src/utils/math.ts" }}
+      >
+        {CODE}
+      </AnnotatedCode>,
+    );
+    expect(screen.getByText("Code")).toBeInTheDocument();
+    expect(screen.getByText("math.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/utils/")).toBeInTheDocument();
+    expect(screen.getByText("ts")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy source" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a line-anchored annotation rail with a marker and the note text reachable", () => {
+    render(
+      <AnnotatedCode
+        id="c2"
+        attributes={{
+          lang: "ts",
+          annotations: JSON.stringify([
+            { lines: "3", note: "the sum is returned here", label: "Return" },
+          ]),
+        }}
+      >
+        {CODE}
+      </AnnotatedCode>,
+    );
+    // The optional label appears (footer rail + visually-hidden a11y stack).
+    expect(screen.getAllByText("Return").length).toBeGreaterThan(0);
+    // The marker pip number (1) is present.
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+    // The note text is reachable (visually-hidden a11y stack + Line label).
+    expect(screen.getByText("Line 3")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("the sum is returned here").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows a warning and still renders the block when annotations JSON is invalid", () => {
+    render(
+      <AnnotatedCode id="c3" attributes={{ lang: "ts", annotations: "{bad json" }}>
+        {CODE}
+      </AnnotatedCode>,
+    );
+    expect(screen.getByText(/could not be parsed/i)).toBeInTheDocument();
+    // The block still renders (no crash, code shell present).
+    expect(screen.getByText("Code")).toBeInTheDocument();
+  });
+
+  it("renders without annotations and without a warning when none are provided", () => {
+    render(
+      <AnnotatedCode id="c4" attributes={{ lang: "ts" }}>
+        {CODE}
+      </AnnotatedCode>,
+    );
+    expect(screen.getByText("Code")).toBeInTheDocument();
+    expect(screen.queryByText(/could not be parsed/i)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/proposals/blocks/AnnotatedCode.tsx
+++ b/ui/src/components/proposals/blocks/AnnotatedCode.tsx
@@ -1,29 +1,173 @@
-import { lazy, Suspense } from "react";
+import {
+  lazy,
+  Suspense,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLProps,
+} from "react";
+import {
+  Copy01Icon,
+  SourceCodeIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
 
 import type { BlockProps } from "./types";
 import { BlockShell } from "./BlockShell";
+import { splitFilename } from "./diff";
+import {
+  buildLineMarkerMap,
+  hasResolvedAnnotations,
+  parseAnnotationsAttr,
+  resolveAnnotations,
+  type ResolvedAnnotation,
+} from "./annotations";
+import {
+  AnnotationGutterMarker,
+  AnnotationHiddenStack,
+  AnnotationHoverCard,
+} from "./annotationRail";
+import {
+  anchorFromElements,
+  useAnnotationHover,
+} from "./annotationRail.helpers";
 
 // `react-syntax-highlighter` is heavy; load it only when a code block renders.
 const CodeBlock = lazy(() => import("./CodeBlock"));
 
+/** Long-file collapse threshold — above this we offer a "Show N lines" toggle. */
+const COLLAPSE_LINE_THRESHOLD = 40;
+/** Lines kept visible while collapsed. */
+const COLLAPSE_VISIBLE_LINES = 24;
+
 /**
- * AnnotatedCode — a syntax-highlighted code block with optional line notes.
- * Annotations come from the `annotations` attribute, a JSON string of
- * `{line, note}[]`, and render as small captions below the code. While the
- * highlighter chunk loads, the raw source shows in a plain `<pre>`.
+ * AnnotatedCode — a line-numbered, syntax-highlighted code block with optional
+ * line-anchored annotations.
+ *
+ * Header: a filename (dir/basename split) when `filename` is set, a language
+ * chip, and a copy-source button. Body: the Prism-highlighted source with a left
+ * line-number gutter. Annotations come from the `annotations` attribute (a JSON
+ * string of `{ lines | line, note, label? }[]`, where `lines` is `"3"` or
+ * `"3-5"`); each renders as an amber highlight band on its line(s) plus a
+ * numbered gutter pip, with the note shown in an on-hover portal card anchored
+ * beside the code. Hovering a line ↔ its note cross-highlights, annotated lines
+ * are keyboard-focusable (Enter/Space toggles the card, Escape closes), and a
+ * visually-hidden stack keeps every note reachable by assistive tech and tests.
+ *
+ * Robust: invalid `annotations` JSON renders the code WITHOUT annotations plus a
+ * quiet warning (never crashes, never silently swallows). The app is DARK-ONLY.
  */
 export function AnnotatedCode({ attributes, children }: BlockProps) {
-  const language = attributes.lang ?? "text";
-  const content = typeof children === "string" ? children.trim() : "";
+  const language = attributes.lang ?? attributes.language ?? "text";
+  const filename = attributes.filename?.trim() || undefined;
+  const content =
+    typeof children === "string" ? children.replace(/\s+$/, "") : "";
 
-  let annotations: { line: number; note: string }[] = [];
-  if (attributes.annotations) {
-    try {
-      annotations = JSON.parse(attributes.annotations);
-    } catch {
-      // Invalid JSON — ignore annotations
+  const lineCount = useMemo(
+    () => (content ? content.split("\n").length : 0),
+    [content],
+  );
+
+  // Parse + resolve annotations. `null` → the JSON attr was malformed.
+  const parsed = useMemo(
+    () => parseAnnotationsAttr(attributes.annotations),
+    [attributes.annotations],
+  );
+  const annotationsInvalid = parsed === null;
+  const resolved = useMemo(
+    () => resolveAnnotations(parsed ?? [], lineCount),
+    [parsed, lineCount],
+  );
+  const lineMarkers = useMemo(() => buildLineMarkerMap(resolved), [resolved]);
+  const hasAnnotations = hasResolvedAnnotations(resolved);
+
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const codeRef = useRef<HTMLDivElement | null>(null);
+  const hover = useAnnotationHover();
+  const activeIndex = hover.activeIndex;
+
+  const collapsible = lineCount > COLLAPSE_LINE_THRESHOLD;
+  const collapsed = collapsible && !expanded;
+  const hiddenLines = collapsible ? lineCount - COLLAPSE_VISIBLE_LINES : 0;
+
+  const copySource = () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    navigator.clipboard
+      .writeText(content)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      })
+      .catch(() => {
+        /* clipboard unavailable — ignore */
+      });
+  };
+
+  // Per-line props attach the amber band, gutter handling, hover/focus wiring,
+  // and keyboard access to lines that carry an annotation.
+  const lineProps = (lineNumber: number): HTMLProps<HTMLElement> => {
+    const markers = lineMarkers.get(lineNumber);
+    if (!markers || markers.length === 0) {
+      return { className: "annotated-code-line" };
     }
-  }
+    const primary = markers[0];
+    const active = markers.some((m) => m.index === activeIndex);
+
+    const openCard = (rowEl: HTMLElement | null) => {
+      const anchor = anchorFromElements(codeRef.current, rowEl);
+      if (anchor) hover.open(primary.index, anchor);
+    };
+
+    return {
+      "data-annotated": "true",
+      "data-annotation-index": String(primary.index),
+      "data-active": active ? "true" : undefined,
+      tabIndex: 0,
+      role: "button",
+      "aria-label": `Annotation ${primary.marker}: ${primary.annotation.note}`,
+      className: cn(
+        "annotated-code-line relative block cursor-pointer transition-colors",
+        active
+          ? "bg-amber-400/20"
+          : "bg-amber-400/[0.08] hover:bg-amber-400/15",
+      ),
+      style: { boxShadow: "inset 2px 0 0 0 rgb(251 191 36 / 0.7)" },
+      onMouseEnter: (event) => openCard(event.currentTarget as HTMLElement),
+      onMouseLeave: () => hover.scheduleClose(),
+      onFocus: (event) => openCard(event.currentTarget as HTMLElement),
+      onBlur: () => hover.scheduleClose(),
+      onKeyDown: (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          const anchor = anchorFromElements(
+            codeRef.current,
+            event.currentTarget as HTMLElement,
+          );
+          if (anchor) hover.toggle(primary.index, anchor);
+        } else if (event.key === "Escape") {
+          hover.close();
+        }
+      },
+    } as HTMLProps<HTMLElement>;
+  };
+
+  // Open the hover card for a footer-rail entry, anchored on its first
+  // annotated row (falls back to the code block itself).
+  const openForAnnotation = (item: ResolvedAnnotation) => {
+    const rowEl =
+      codeRef.current?.querySelector<HTMLElement>(
+        `[data-annotation-index="${item.index}"]`,
+      ) ?? codeRef.current;
+    const anchor = anchorFromElements(codeRef.current, rowEl);
+    if (anchor) hover.toggle(item.index, anchor);
+  };
+
+  const fileParts = filename ? splitFilename(filename) : null;
+  const langChip = language !== "text" ? language : null;
 
   const rawCode = (
     <pre className="overflow-x-auto px-4 py-4 font-mono text-xs text-foreground">
@@ -31,30 +175,130 @@ export function AnnotatedCode({ attributes, children }: BlockProps) {
     </pre>
   );
 
+  const meta = (
+    <span className="flex min-w-0 items-center gap-2">
+      {fileParts ? (
+        <span className="flex min-w-0 items-baseline gap-1.5 font-mono">
+          {fileParts.directory && (
+            <span className="min-w-0 truncate text-[11px] text-muted-foreground/70">
+              {fileParts.directory}/
+            </span>
+          )}
+          <span className="max-w-[14rem] truncate font-semibold text-foreground">
+            {fileParts.basename}
+          </span>
+        </span>
+      ) : null}
+      {langChip && <span className="font-mono">{langChip}</span>}
+      <button
+        type="button"
+        onClick={copySource}
+        title="Copy source"
+        aria-label={copied ? "Copied" : "Copy source"}
+        className="flex shrink-0 items-center gap-1 rounded border px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+      >
+        <HugeiconsIcon
+          icon={copied ? Tick02Icon : Copy01Icon}
+          size={12}
+          className={copied ? "text-emerald-400" : undefined}
+        />
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </span>
+  );
+
+  const activeItem =
+    activeIndex != null
+      ? resolved.find((r) => r.index === activeIndex) ?? null
+      : null;
+
   return (
-    <BlockShell
-      label="Code"
-      accent="text-orange-400"
-      flush
-      meta={language !== "text" ? <span className="font-mono">{language}</span> : null}
-    >
-      <Suspense fallback={rawCode}>
-        <CodeBlock language={language} content={content} />
-      </Suspense>
-      {annotations.length > 0 && (
-        <div className="space-y-1 border-t px-4 py-3">
-          {annotations.map((ann, i) => (
-            <div
-              key={i}
-              className="flex items-start gap-2 text-xs text-muted-foreground"
-            >
-              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono font-medium text-foreground">
-                L{ann.line}
-              </span>
-              <span>{ann.note}</span>
-            </div>
-          ))}
+    <BlockShell label="Code" accent="text-orange-400" flush meta={meta}>
+      {annotationsInvalid && (
+        <div className="flex items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-300">
+          <HugeiconsIcon icon={SourceCodeIcon} size={14} />
+          <span>
+            Annotations could not be parsed (invalid JSON) — showing code without
+            them.
+          </span>
         </div>
+      )}
+      <div ref={codeRef} className="relative">
+        <div
+          className={cn(
+            "annotated-code-surface relative overflow-x-auto",
+            collapsed && "max-h-[34rem] overflow-y-hidden",
+          )}
+        >
+          <Suspense fallback={rawCode}>
+            <CodeBlock
+              language={language}
+              content={content}
+              showLineNumbers
+              lineProps={hasAnnotations ? lineProps : undefined}
+            />
+          </Suspense>
+          {collapsed && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-card to-transparent" />
+          )}
+        </div>
+        {collapsible && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            className="flex w-full items-center justify-center border-t bg-muted/30 py-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          >
+            {collapsed ? `Show ${hiddenLines} more lines` : "Show less"}
+          </button>
+        )}
+
+        {/* Visually-hidden notes for assistive tech + tests. */}
+        <AnnotationHiddenStack items={resolved} />
+
+        {/* The on-hover note card (portaled, viewport-aware). */}
+        {activeItem && hover.anchor && (
+          <AnnotationHoverCard
+            item={activeItem}
+            anchor={hover.anchor}
+            onMouseEnter={hover.cancelClose}
+            onMouseLeave={hover.scheduleClose}
+            onClose={hover.close}
+          />
+        )}
+      </div>
+
+      {/* A compact summary rail listing each annotated span. Keeps notes
+          scannable without hovering and provides the two-way cross-highlight:
+          hovering an entry lights its gutter pip and the line band. */}
+      {hasAnnotations && (
+        <ul className="flex flex-wrap gap-1.5 border-t bg-muted/20 px-4 py-2">
+          {resolved
+            .filter((item) => item.range)
+            .map((item) => (
+              <li key={item.index}>
+                <button
+                  type="button"
+                  onClick={() => openForAnnotation(item)}
+                  title={item.annotation.note}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded border px-2 py-1 text-[11px] transition-colors",
+                    item.index === activeIndex
+                      ? "border-amber-300/40 bg-amber-300/10 text-foreground"
+                      : "border-border text-muted-foreground hover:border-amber-300/30 hover:text-foreground",
+                  )}
+                >
+                  <AnnotationGutterMarker
+                    marker={item.marker}
+                    active={item.index === activeIndex}
+                  />
+                  <span className="max-w-[18rem] truncate">
+                    {item.annotation.label ?? item.annotation.note}
+                  </span>
+                </button>
+              </li>
+            ))}
+        </ul>
       )}
     </BlockShell>
   );

--- a/ui/src/components/proposals/blocks/CodeBlock.tsx
+++ b/ui/src/components/proposals/blocks/CodeBlock.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties, HTMLProps } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 
@@ -7,23 +8,45 @@ import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
  * and only needed when a code block is actually on screen, so keeping it out of
  * the proposals' synchronous import graph keeps that bundle (and the test
  * suite's module load) small.
+ *
+ * When `showLineNumbers` is set the surface renders a left line-number gutter and
+ * wraps each line in its own element, and `lineProps(lineNumber)` can attach
+ * per-line props (refs via `onMouseEnter`, highlight classes, handlers) — this is
+ * what `AnnotatedCode` uses to paint line-anchored annotation bands + hover
+ * cross-highlighting on top of the Prism highlighting. The app is DARK-ONLY.
  */
 export default function CodeBlock({
   language,
   content,
+  showLineNumbers = false,
+  lineProps,
 }: {
   language: string;
   content: string;
+  showLineNumbers?: boolean;
+  lineProps?: (lineNumber: number) => HTMLProps<HTMLElement>;
 }) {
   return (
     <SyntaxHighlighter
       language={language}
       style={oneDark}
+      showLineNumbers={showLineNumbers}
+      wrapLines={Boolean(lineProps)}
+      lineProps={lineProps}
+      lineNumberStyle={
+        {
+          minWidth: "2.5rem",
+          paddingRight: "1rem",
+          textAlign: "right",
+          color: "var(--muted-foreground, #6b7280)",
+          userSelect: "none",
+        } as CSSProperties
+      }
       customStyle={{
         margin: 0,
         background: "transparent",
         fontSize: "0.78rem",
-        padding: "1rem",
+        padding: showLineNumbers ? "1rem 1rem 1rem 0" : "1rem",
       }}
       codeTagProps={{ style: { fontFamily: "var(--font-mono, monospace)" } }}
     >

--- a/ui/src/components/proposals/blocks/annotationRail.helpers.test.ts
+++ b/ui/src/components/proposals/blocks/annotationRail.helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveAnnotationHoverCardPosition,
+  type AnnotationAnchor,
+} from "./annotationRail.helpers";
+
+const CARD = { width: 280, height: 100 };
+const VIEWPORT = { width: 1200, height: 800 };
+
+function anchor(partial: Partial<AnnotationAnchor>): AnnotationAnchor {
+  return {
+    codeRight: 600,
+    codeLeft: 100,
+    lineCenter: 400,
+    lineBottom: 410,
+    ...partial,
+  };
+}
+
+describe("resolveAnnotationHoverCardPosition", () => {
+  it("places the card to the right of the code when there is room", () => {
+    const pos = resolveAnnotationHoverCardPosition(anchor({}), CARD, VIEWPORT);
+    // right edge (600) + gap (12)
+    expect(pos.left).toBe(612);
+    // vertically centered on the line
+    expect(pos.top).toBe(350);
+  });
+
+  it("falls back to the left when the right side would overflow", () => {
+    const pos = resolveAnnotationHoverCardPosition(
+      anchor({ codeRight: 1190, codeLeft: 700 }),
+      CARD,
+      VIEWPORT,
+    );
+    // left edge (700) - gap (12) - width (280)
+    expect(pos.left).toBe(408);
+  });
+
+  it("never positions the card outside the viewport", () => {
+    const pos = resolveAnnotationHoverCardPosition(
+      anchor({ codeRight: 1190, codeLeft: 10, lineCenter: 5 }),
+      CARD,
+      VIEWPORT,
+    );
+    expect(pos.left).toBeGreaterThanOrEqual(8);
+    expect(pos.left + CARD.width).toBeLessThanOrEqual(VIEWPORT.width - 8);
+    expect(pos.top).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/ui/src/components/proposals/blocks/annotationRail.helpers.ts
+++ b/ui/src/components/proposals/blocks/annotationRail.helpers.ts
@@ -1,0 +1,185 @@
+// Pure (React-free) geometry + the hover-intent controller hook for the shared
+// line-anchored annotation engine. Split out of `annotationRail.tsx` so that
+// module can export ONLY React components (Fast-Refresh requirement) while the
+// viewport-aware placement math stays unit-testable and reusable.
+
+import { useEffect, useRef, useState } from "react";
+
+/** The geometry the hover card anchors to (in viewport coordinates). */
+export interface AnnotationAnchor {
+  /** Right edge of the code block (where the card should start). */
+  codeRight: number;
+  /** Left edge of the code block (for the below-fallback alignment). */
+  codeLeft: number;
+  /** Vertical center of the hovered line. */
+  lineCenter: number;
+  /** Bottom of the hovered line (for the below-fallback placement). */
+  lineBottom: number;
+}
+
+export type AnnotationSide = "left" | "right";
+
+export const HOVER_CARD_WIDTH = 280;
+export const HOVER_CARD_GAP = 12;
+const HOVER_CARD_OVERHANG = 40;
+export const VIEWPORT_MARGIN = 8;
+
+function oppositeSide(side: AnnotationSide): AnnotationSide {
+  return side === "left" ? "right" : "left";
+}
+
+function clampWithinViewport(
+  value: number,
+  size: number,
+  viewportSize: number,
+): number {
+  return Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(value, viewportSize - size - VIEWPORT_MARGIN),
+  );
+}
+
+function hoverCardLeftForSide(
+  side: AnnotationSide,
+  anchor: AnnotationAnchor,
+  cardWidth: number,
+): number {
+  return side === "right"
+    ? anchor.codeRight + HOVER_CARD_GAP
+    : anchor.codeLeft - HOVER_CARD_GAP - cardWidth;
+}
+
+function hoverCardOverlapLeftForSide(
+  side: AnnotationSide,
+  anchor: AnnotationAnchor,
+  cardWidth: number,
+): number {
+  return side === "right"
+    ? anchor.codeRight - cardWidth + HOVER_CARD_OVERHANG
+    : anchor.codeLeft - HOVER_CARD_OVERHANG;
+}
+
+function hoverCardFitsSide(
+  side: AnnotationSide,
+  anchor: AnnotationAnchor,
+  cardWidth: number,
+  viewportWidth: number,
+): boolean {
+  const left = hoverCardLeftForSide(side, anchor, cardWidth);
+  return (
+    left >= VIEWPORT_MARGIN &&
+    left + cardWidth + VIEWPORT_MARGIN <= viewportWidth
+  );
+}
+
+/**
+ * Resolve the non-overlapping placement for the hover card: to the RIGHT of the
+ * code if it fits, then the opposite side, then overlapping the code from the
+ * fallback side, otherwise BELOW the line aligned to the code's left. Clamped
+ * within the viewport so the card is never cut off. Pure → unit-testable.
+ */
+export function resolveAnnotationHoverCardPosition(
+  anchor: AnnotationAnchor,
+  card: { width: number; height: number },
+  viewport: { width: number; height: number },
+  options: {
+    preferredSide?: AnnotationSide;
+    hoverFallbackSide?: AnnotationSide | "below";
+  } = {},
+): { top: number; left: number } {
+  const preferredSide = options.preferredSide ?? "right";
+  const hoverFallbackSide = options.hoverFallbackSide ?? "right";
+  const opposite = oppositeSide(preferredSide);
+
+  let left: number;
+  let top: number;
+  if (hoverCardFitsSide(preferredSide, anchor, card.width, viewport.width)) {
+    left = hoverCardLeftForSide(preferredSide, anchor, card.width);
+    top = anchor.lineCenter - card.height / 2;
+  } else if (hoverCardFitsSide(opposite, anchor, card.width, viewport.width)) {
+    left = hoverCardLeftForSide(opposite, anchor, card.width);
+    top = anchor.lineCenter - card.height / 2;
+  } else if (hoverFallbackSide === "left" || hoverFallbackSide === "right") {
+    left = hoverCardOverlapLeftForSide(hoverFallbackSide, anchor, card.width);
+    top = anchor.lineCenter - card.height / 2;
+  } else {
+    left = anchor.codeLeft;
+    top = anchor.lineBottom + HOVER_CARD_GAP;
+  }
+
+  left = clampWithinViewport(left, card.width, viewport.width);
+  top = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(top, viewport.height - card.height - VIEWPORT_MARGIN),
+  );
+  return { top, left };
+}
+
+/**
+ * Build an {@link AnnotationAnchor} from the code block element and the hovered
+ * row element. The card anchors to the code block's RIGHT edge and the row's
+ * vertical center, both in viewport coordinates (so a `fixed` portal lines up).
+ */
+export function anchorFromElements(
+  codeEl: HTMLElement | null,
+  rowEl: HTMLElement | null,
+): AnnotationAnchor | null {
+  if (!codeEl || !rowEl) return null;
+  const code = codeEl.getBoundingClientRect();
+  const row = rowEl.getBoundingClientRect();
+  return {
+    codeRight: code.right,
+    codeLeft: code.left,
+    lineCenter: row.top + row.height / 2,
+    lineBottom: row.bottom,
+  };
+}
+
+/**
+ * Hover-intent + tap controller for the on-hover note card. Exposes the active
+ * index + captured `anchor`, plus `open`/`toggle`/`close`/`scheduleClose`/
+ * `cancelClose` handlers. The short close delay lets the pointer cross the gap
+ * from the code line into the card itself without it disappearing.
+ */
+export function useAnnotationHover(delay = 130) {
+  const [active, setActive] = useState<{
+    index: number;
+    anchor: AnnotationAnchor;
+  } | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelClose = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+  const open = (index: number, anchor: AnnotationAnchor) => {
+    cancelClose();
+    setActive({ index, anchor });
+  };
+  const toggle = (index: number, anchor: AnnotationAnchor) => {
+    cancelClose();
+    setActive((prev) => (prev?.index === index ? null : { index, anchor }));
+  };
+  const close = () => {
+    cancelClose();
+    setActive(null);
+  };
+  const scheduleClose = () => {
+    cancelClose();
+    timer.current = setTimeout(() => setActive(null), delay);
+  };
+
+  useEffect(() => () => cancelClose(), []);
+
+  return {
+    activeIndex: active?.index ?? null,
+    anchor: active?.anchor ?? null,
+    open,
+    toggle,
+    close,
+    scheduleClose,
+    cancelClose,
+  } as const;
+}

--- a/ui/src/components/proposals/blocks/annotationRail.tsx
+++ b/ui/src/components/proposals/blocks/annotationRail.tsx
@@ -1,0 +1,238 @@
+// Reusable React UI for the shared line-anchored annotation engine. The pure
+// line-spec parsing + resolution lives in `annotations.ts`; the pure placement
+// geometry + the hover-intent hook live in `annotationRail.helpers.ts`. This
+// module owns ONLY the visible React components so the `annotated-code` block —
+// and, later, the `diff` block and others — render line notes identically:
+//
+//  - `AnnotationGutterMarker` — the numbered amber pip placed on an annotated row.
+//  - `AnnotationCard` — the single source of note-card markup (marker + line
+//    label + optional emphasis + note), used by both the a11y hidden stack and
+//    the on-hover popover.
+//  - `AnnotationHiddenStack` — a visually-hidden (sr-only) stack of every note so
+//    assistive tech and tests can reach the text without a persistent rail.
+//  - `AnnotationHoverCard` — the on-hover portal popover, viewport-aware placed
+//    beside the code (right → left → overlap → below).
+//
+// The app is DARK-ONLY. Notes carry plain-text bodies; this module renders them
+// as text (no markdown) to stay dependency-light and avoid nested block parsing.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+import { rangeLabel, type ResolvedAnnotation } from "./annotations";
+import {
+  HOVER_CARD_GAP,
+  HOVER_CARD_WIDTH,
+  resolveAnnotationHoverCardPosition,
+  VIEWPORT_MARGIN,
+  type AnnotationAnchor,
+} from "./annotationRail.helpers";
+
+/* ── Gutter marker ─────────────────────────────────────────────────────────── */
+
+/**
+ * The numbered amber pip rendered on an annotated code row's gutter. `active`
+ * brightens it when its note (or a co-located row) is hovered/focused.
+ */
+export function AnnotationGutterMarker({
+  marker,
+  active,
+  className,
+}: {
+  marker: number;
+  active?: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "inline-flex size-[15px] shrink-0 items-center justify-center rounded-full text-[9px] font-semibold leading-none tabular-nums transition-colors",
+        active
+          ? "bg-amber-300 text-amber-950 shadow-[0_0_0_3px_rgba(251,191,36,0.25)]"
+          : "bg-amber-300/20 text-amber-200",
+        className,
+      )}
+    >
+      {marker}
+    </span>
+  );
+}
+
+/* ── Note card ─────────────────────────────────────────────────────────────── */
+
+/**
+ * One line-anchored note card: marker pip, the resolved line span ("Line 8"),
+ * an optional label, and the plain-text note. Single source of card markup,
+ * rendered both by the hidden a11y stack and the on-hover popover.
+ */
+export function AnnotationCard({
+  item,
+  active = false,
+  className,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  item: ResolvedAnnotation;
+  active?: boolean;
+  className?: string;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}) {
+  return (
+    <div
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className={cn(
+        "rounded-lg border px-3.5 py-2.5 text-left transition-colors",
+        active
+          ? "border-amber-300/40 bg-amber-300/10"
+          : "border-border bg-card hover:border-amber-300/30",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+        <AnnotationGutterMarker marker={item.marker} active={active} />
+        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          {rangeLabel(item)}
+        </span>
+        {item.annotation.label && (
+          <span className="min-w-0 max-w-full flex-1 break-words text-[13px] font-semibold leading-snug text-foreground [overflow-wrap:anywhere]">
+            {item.annotation.label}
+          </span>
+        )}
+      </div>
+      <p className="mt-1 break-words text-[13px] leading-relaxed text-foreground/85 [overflow-wrap:anywhere]">
+        {item.annotation.note}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Visually-hidden stack of every resolved note. Clipped to a 1px box (the
+ * `sr-only` pattern) so the note text + marker pips stay in the accessibility
+ * tree and the DOM (assistive tech can reach them, tests reading `textContent`
+ * still see them) WITHOUT painting a persistent rail beside the code. The
+ * visible card appears only on hover/focus via {@link AnnotationHoverCard}.
+ */
+export function AnnotationHiddenStack({
+  items,
+}: {
+  items: readonly ResolvedAnnotation[];
+}) {
+  const resolved = useMemo(() => items.filter((item) => item.range), [items]);
+  if (resolved.length === 0) return null;
+  return (
+    <div
+      data-annotation-hidden-stack
+      className="absolute size-px overflow-hidden whitespace-nowrap border-0 p-0 [clip:rect(0,0,0,0)] [clip-path:inset(50%)]"
+    >
+      {resolved.map((item) => (
+        <AnnotationCard key={item.index} item={item} />
+      ))}
+    </div>
+  );
+}
+
+/* ── Hover popover (portal, anchored beside the code) ──────────────────────── */
+
+/**
+ * The single on-hover note card, portaled to `document.body` and positioned
+ * `fixed` so it escapes the code block's `overflow` and never reflows the code.
+ * Keeps itself open while hovered (mouse events forwarded) and closes on scroll
+ * so it never floats detached. Placement is measured one frame after mount (via
+ * `requestAnimationFrame`) so the rendered card size feeds the viewport-aware
+ * geometry without a synchronous setState-in-effect.
+ */
+export function AnnotationHoverCard({
+  item,
+  anchor,
+  onMouseEnter,
+  onMouseLeave,
+  onClose,
+}: {
+  item: ResolvedAnnotation;
+  anchor: AnnotationAnchor;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  onClose?: () => void;
+}) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let frame: number | null = null;
+    const measure = () => {
+      frame = null;
+      const rect = cardRef.current?.getBoundingClientRect();
+      const width = rect && rect.width > 0 ? rect.width : HOVER_CARD_WIDTH;
+      const height = rect && rect.height > 0 ? rect.height : 0;
+      setPos(
+        resolveAnnotationHoverCardPosition(
+          anchor,
+          { width, height },
+          { width: window.innerWidth || 0, height: window.innerHeight || 0 },
+        ),
+      );
+    };
+    if (typeof window.requestAnimationFrame === "function") {
+      frame = window.requestAnimationFrame(measure);
+    } else {
+      measure();
+    }
+    return () => {
+      if (frame != null && typeof window.cancelAnimationFrame === "function") {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, [anchor]);
+
+  useEffect(() => {
+    if (!onClose || typeof window === "undefined") return;
+    const handler = (event: Event) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        cardRef.current &&
+        cardRef.current.contains(target)
+      ) {
+        return;
+      }
+      onClose();
+    };
+    window.addEventListener("scroll", handler, { capture: true, passive: true });
+    return () =>
+      window.removeEventListener("scroll", handler, { capture: true });
+  }, [onClose]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      ref={cardRef}
+      role="tooltip"
+      data-annotation-hover-card
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className="pointer-events-auto fixed z-50 overflow-y-auto overscroll-contain"
+      style={{
+        top: pos?.top ?? anchor.lineCenter,
+        left: pos?.left ?? anchor.codeRight + HOVER_CARD_GAP,
+        width: HOVER_CARD_WIDTH,
+        maxHeight: `calc(100vh - ${VIEWPORT_MARGIN * 2}px)`,
+        visibility: pos ? "visible" : "hidden",
+      }}
+    >
+      <AnnotationCard
+        item={item}
+        active
+        className="shadow-lg shadow-black/40 backdrop-blur-md"
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/ui/src/components/proposals/blocks/annotations.test.ts
+++ b/ui/src/components/proposals/blocks/annotations.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLineMarkerMap,
+  coerceAnnotation,
+  hasResolvedAnnotations,
+  parseAnnotationsAttr,
+  parseLineRange,
+  rangeLabel,
+  resolveAnnotations,
+} from "./annotations";
+
+describe("parseLineRange", () => {
+  it("parses a single 1-based line", () => {
+    expect(parseLineRange("3", 10)).toEqual({ start: 3, end: 3 });
+  });
+
+  it("parses an inclusive range", () => {
+    expect(parseLineRange("3-5", 10)).toEqual({ start: 3, end: 5 });
+  });
+
+  it("tolerates surrounding and inner whitespace", () => {
+    expect(parseLineRange("  3 - 5 ", 10)).toEqual({ start: 3, end: 5 });
+  });
+
+  it("normalizes a reversed range", () => {
+    expect(parseLineRange("5-3", 10)).toEqual({ start: 3, end: 5 });
+  });
+
+  it("clamps a partially out-of-range range to the file", () => {
+    expect(parseLineRange("8-20", 10)).toEqual({ start: 8, end: 10 });
+    expect(parseLineRange("0-2", 10)).toEqual({ start: 1, end: 2 });
+  });
+
+  it("returns null for a fully out-of-range ref", () => {
+    expect(parseLineRange("20-25", 10)).toBeNull();
+    expect(parseLineRange("5", 0)).toBeNull();
+  });
+
+  it("returns null for malformed refs", () => {
+    expect(parseLineRange("abc", 10)).toBeNull();
+    expect(parseLineRange("3-", 10)).toBeNull();
+    expect(parseLineRange("", 10)).toBeNull();
+    expect(parseLineRange("3-5-7", 10)).toBeNull();
+  });
+});
+
+describe("coerceAnnotation", () => {
+  it("accepts the new { lines } shape", () => {
+    expect(coerceAnnotation({ lines: "3-5", note: "hi", label: "x" })).toEqual({
+      lines: "3-5",
+      note: "hi",
+      label: "x",
+    });
+  });
+
+  it("normalizes the legacy { line: number } shape", () => {
+    expect(coerceAnnotation({ line: 4, note: "hi" })).toEqual({
+      lines: "4",
+      note: "hi",
+    });
+  });
+
+  it("coerces a numeric `lines` value to a string", () => {
+    expect(coerceAnnotation({ lines: 7, note: "n" })).toEqual({
+      lines: "7",
+      note: "n",
+    });
+  });
+
+  it("drops empty labels", () => {
+    expect(coerceAnnotation({ lines: "1", note: "n", label: "  " })).toEqual({
+      lines: "1",
+      note: "n",
+    });
+  });
+
+  it("returns null when there is no usable line ref or content", () => {
+    expect(coerceAnnotation({ note: "no line" })).toBeNull();
+    expect(coerceAnnotation({ lines: "1" })).toBeNull();
+    expect(coerceAnnotation(null)).toBeNull();
+    expect(coerceAnnotation("nope")).toBeNull();
+  });
+});
+
+describe("parseAnnotationsAttr", () => {
+  it("returns an empty list for an absent/blank attr", () => {
+    expect(parseAnnotationsAttr(undefined)).toEqual([]);
+    expect(parseAnnotationsAttr("")).toEqual([]);
+    expect(parseAnnotationsAttr("   ")).toEqual([]);
+  });
+
+  it("parses a valid annotation array (both shapes)", () => {
+    const out = parseAnnotationsAttr(
+      JSON.stringify([
+        { line: 2, note: "legacy" },
+        { lines: "4-6", note: "range", label: "L" },
+      ]),
+    );
+    expect(out).toEqual([
+      { lines: "2", note: "legacy" },
+      { lines: "4-6", note: "range", label: "L" },
+    ]);
+  });
+
+  it("returns null on invalid JSON (so callers can warn, not swallow)", () => {
+    expect(parseAnnotationsAttr("{not json")).toBeNull();
+  });
+
+  it("returns null when the JSON is not an array", () => {
+    expect(parseAnnotationsAttr('{"lines":"1","note":"x"}')).toBeNull();
+  });
+
+  it("drops malformed entries but keeps valid ones", () => {
+    const out = parseAnnotationsAttr(
+      JSON.stringify([{ note: "no line" }, { lines: "1", note: "ok" }]),
+    );
+    expect(out).toEqual([{ lines: "1", note: "ok" }]);
+  });
+});
+
+describe("resolveAnnotations + line marker map", () => {
+  it("assigns stable 1-based markers to all annotations", () => {
+    const resolved = resolveAnnotations(
+      [
+        { lines: "2", note: "a" },
+        { lines: "999", note: "out" },
+        { lines: "4-5", note: "b" },
+      ],
+      10,
+    );
+    expect(resolved.map((r) => r.marker)).toEqual([1, 2, 3]);
+    expect(resolved[1].range).toBeNull();
+    expect(resolved[2].range).toEqual({ start: 4, end: 5 });
+  });
+
+  it("maps each covered line to its annotations", () => {
+    const resolved = resolveAnnotations(
+      [{ lines: "2-3", note: "a" }, { lines: "3", note: "b" }],
+      10,
+    );
+    const map = buildLineMarkerMap(resolved);
+    expect(map.get(2)?.map((r) => r.marker)).toEqual([1]);
+    expect(map.get(3)?.map((r) => r.marker)).toEqual([1, 2]);
+    expect(map.get(1)).toBeUndefined();
+  });
+
+  it("reports whether any annotation resolved", () => {
+    expect(
+      hasResolvedAnnotations(resolveAnnotations([{ lines: "1", note: "a" }], 5)),
+    ).toBe(true);
+    expect(
+      hasResolvedAnnotations(
+        resolveAnnotations([{ lines: "99", note: "a" }], 5),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("rangeLabel", () => {
+  it("labels a single line and a range", () => {
+    const [single, range] = resolveAnnotations(
+      [{ lines: "8", note: "a" }, { lines: "3-6", note: "b" }],
+      10,
+    );
+    expect(rangeLabel(single)).toBe("Line 8");
+    expect(rangeLabel(range)).toBe("Lines 3–6");
+  });
+
+  it("falls back to the raw ref for an unresolved annotation", () => {
+    const [item] = resolveAnnotations([{ lines: "99", note: "a" }], 5);
+    expect(rangeLabel(item)).toBe("Lines 99");
+  });
+});

--- a/ui/src/components/proposals/blocks/annotations.ts
+++ b/ui/src/components/proposals/blocks/annotations.ts
@@ -1,0 +1,170 @@
+// Pure (React-free) helpers for the shared line-anchored annotation engine used
+// by the `annotated-code` block (and ready to be adopted by `diff` and future
+// blocks). Kept in their own module so the line-spec parsing is unit-testable
+// without pulling React in.
+//
+// An annotation targets a 1-based line ref written as a single line ("3") or an
+// inclusive range ("3-5"). The block historically also stored the ref under a
+// numeric `line` field; both shapes are accepted here. Notes carry a `note`
+// string and an optional short `label`.
+//
+// Robustness: every parser is forgiving and never throws. Malformed or fully
+// out-of-range refs resolve to `null` so callers can ignore them gracefully
+// while still rendering the code. `parseAnnotationsAttr` returns `null` (not an
+// empty list) when the JSON itself is invalid, so the caller can distinguish
+// "no annotations" from "bad input" and surface a quiet warning.
+
+/** A raw annotation as authored on the block (before line refs are resolved). */
+export interface RawAnnotation {
+  /** 1-based line ref: a single line ("3") or an inclusive range ("3-5"). */
+  lines: string;
+  /** Optional short emphasis shown before the note. */
+  label?: string;
+  /** The note body (plain text). */
+  note: string;
+}
+
+/** An inclusive 1-based line span, clamped to the file's line count. */
+export interface LineRange {
+  start: number;
+  end: number;
+}
+
+/** A raw annotation resolved against the code's line count. */
+export interface ResolvedAnnotation {
+  /** Stable index into the original annotation list (hover/cross-highlight key). */
+  index: number;
+  /** 1-based marker number in authoring order. */
+  marker: number;
+  annotation: RawAnnotation;
+  /** Resolved span, or `null` when the ref was malformed / out of range. */
+  range: LineRange | null;
+}
+
+const LINE_RANGE_RE = /^\s*(\d+)\s*(?:-\s*(\d+)\s*)?$/;
+
+/**
+ * Parse a 1-based `lines` ref ("3" or "3-5") into an inclusive `[start, end]`
+ * pair clamped to `[1, lineCount]`. Returns `null` for malformed refs or refs
+ * that fall fully outside the file. A reversed range ("5-3") is normalized; a
+ * partially out-of-range range is clamped.
+ */
+export function parseLineRange(
+  ref: string,
+  lineCount: number,
+): LineRange | null {
+  const match = LINE_RANGE_RE.exec(ref);
+  if (!match) return null;
+  let start = Number.parseInt(match[1], 10);
+  let end = match[2] != null ? Number.parseInt(match[2], 10) : start;
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  if (start > end) [start, end] = [end, start];
+  if (lineCount <= 0) return null;
+  // Fully outside the file → ignore.
+  if (end < 1 || start > lineCount) return null;
+  return { start: Math.max(1, start), end: Math.min(lineCount, end) };
+}
+
+/**
+ * Coerce one loosely-typed annotation entry (as decoded from the JSON attr) into
+ * a {@link RawAnnotation}, or `null` if it carries no usable note/line ref. The
+ * legacy `{ line: number, note }` shape and the new `{ lines: string }` shape
+ * are both accepted; `line` is normalized to a string `lines` ref.
+ */
+export function coerceAnnotation(value: unknown): RawAnnotation | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+
+  let lines: string | undefined;
+  if (typeof record.lines === "string") {
+    lines = record.lines.trim();
+  } else if (typeof record.lines === "number") {
+    lines = String(record.lines);
+  } else if (typeof record.line === "string") {
+    lines = record.line.trim();
+  } else if (typeof record.line === "number") {
+    lines = String(record.line);
+  }
+  if (!lines) return null;
+
+  const note = typeof record.note === "string" ? record.note : "";
+  const label =
+    typeof record.label === "string" && record.label.trim()
+      ? record.label.trim()
+      : undefined;
+  if (!note && !label) return null;
+
+  return { lines, note, label };
+}
+
+/**
+ * Parse the block's `annotations` attribute (a JSON string of annotation
+ * objects) into a forgiving list. Returns `null` when the JSON is invalid OR is
+ * not an array, so the caller can render the code without annotations AND
+ * surface a quiet warning — never silently swallowing a malformed attr. Returns
+ * an empty array when the JSON is a valid-but-empty list.
+ */
+export function parseAnnotationsAttr(
+  raw: string | undefined,
+): RawAnnotation[] | null {
+  if (raw == null || raw.trim() === "") return [];
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(decoded)) return null;
+  return decoded
+    .map(coerceAnnotation)
+    .filter((entry): entry is RawAnnotation => entry !== null);
+}
+
+/**
+ * Resolve a raw annotation list into stable, marker-numbered records, parsing
+ * each `lines` ref against `lineCount`. Markers are authoring-order, 1-based,
+ * and assigned to ALL annotations (even unresolved ones) so numbering is stable
+ * regardless of which refs happen to match.
+ */
+export function resolveAnnotations(
+  annotations: readonly RawAnnotation[] | undefined,
+  lineCount: number,
+): ResolvedAnnotation[] {
+  return (annotations ?? []).map((annotation, index) => ({
+    index,
+    marker: index + 1,
+    annotation,
+    range: parseLineRange(annotation.lines, lineCount),
+  }));
+}
+
+/** Map a 1-based line number → the resolved annotations covering it. */
+export function buildLineMarkerMap(
+  resolved: readonly ResolvedAnnotation[],
+): Map<number, ResolvedAnnotation[]> {
+  const map = new Map<number, ResolvedAnnotation[]>();
+  for (const item of resolved) {
+    if (!item.range) continue;
+    for (let n = item.range.start; n <= item.range.end; n += 1) {
+      const list = map.get(n) ?? [];
+      list.push(item);
+      map.set(n, list);
+    }
+  }
+  return map;
+}
+
+/** Human label for a resolved annotation's span ("Line 8" / "Lines 3–6"). */
+export function rangeLabel(item: ResolvedAnnotation): string {
+  if (!item.range) return `Lines ${item.annotation.lines}`;
+  return item.range.start === item.range.end
+    ? `Line ${item.range.start}`
+    : `Lines ${item.range.start}–${item.range.end}`;
+}
+
+/** Whether a resolved list has at least one annotation worth a rail/marker. */
+export function hasResolvedAnnotations(
+  items: readonly ResolvedAnnotation[],
+): boolean {
+  return items.some((item) => item.range !== null);
+}

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -8,6 +8,38 @@ export { RichText } from "./RichText";
 export { Diagram } from "./Diagram";
 export { AnnotatedCode } from "./AnnotatedCode";
 export { DiffBlock } from "./DiffBlock";
+
+// Reusable line-anchored annotation engine (pure parsing + React rail UI). The
+// `annotated-code` block consumes it; `diff` and future blocks can adopt it.
+export {
+  parseLineRange,
+  parseAnnotationsAttr,
+  coerceAnnotation,
+  resolveAnnotations,
+  buildLineMarkerMap,
+  rangeLabel,
+  hasResolvedAnnotations,
+} from "./annotations";
+export type {
+  RawAnnotation,
+  LineRange,
+  ResolvedAnnotation,
+} from "./annotations";
+export {
+  AnnotationGutterMarker,
+  AnnotationCard,
+  AnnotationHiddenStack,
+  AnnotationHoverCard,
+} from "./annotationRail";
+export {
+  useAnnotationHover,
+  anchorFromElements,
+  resolveAnnotationHoverCardPosition,
+} from "./annotationRail.helpers";
+export type {
+  AnnotationAnchor,
+  AnnotationSide,
+} from "./annotationRail.helpers";
 export { BlockRenderer } from "./BlockRenderer";
 export type { BlockRendererProps } from "./BlockRenderer";
 export { parseMdxBody, isPascalCaseTag, extractBlockTags } from "./parseMdxBody";


### PR DESCRIPTION
## What

Upgrades the proposal **annotated-code** block by porting builder.io agent-native's treatment (gap analysis §3.3, roadmap P1 step 9), and extracts a **reusable line-anchored annotation engine** the diff block and future blocks can adopt. UI-only — `annotated-code` is an existing block, so no registry/backend change.

### Block upgrade (`AnnotatedCode.tsx`)
- **Line numbers** on the existing (lazy-loaded) Prism highlighting — `CodeBlock` gains `showLineNumbers` + per-line `lineProps`.
- **Filename header**: `filename` attr split into dir/basename, plus the language chip and a **copy-source button**.
- **Line-anchored annotations**: amber highlight band + numbered **gutter pip** on annotated line(s); the note shows in an **on-hover portal card** anchored beside the code (right → left → overlap → below). **Two-way cross-highlight** (line ↔ note), **keyboard accessible** (focusable rows; Enter/Space toggles, Escape closes), and a visually-hidden a11y stack keeps every note reachable.
- Accepts **line ranges** (`"3"` / `"3-5"`) and the legacy `{ line, note }` shape.
- **Long-file collapse** (>40 lines) with a "Show N lines" toggle.
- **Robust**: invalid `annotations` JSON renders the code *without* annotations plus a quiet warning — never crashes, never silently swallows (fixes gap §2.5).

### Reusable annotation-rail engine
- `annotations.ts` — pure line-spec parsing/resolution (`parseLineRange`, `parseAnnotationsAttr`, `resolveAnnotations`, `buildLineMarkerMap`, `rangeLabel`).
- `annotationRail.helpers.ts` — pure placement geometry (`resolveAnnotationHoverCardPosition`, `anchorFromElements`) + the `useAnnotationHover` hover-intent hook.
- `annotationRail.tsx` — the rail React components (`AnnotationGutterMarker`, `AnnotationCard`, `AnnotationHiddenStack`, `AnnotationHoverCard`).

All exported from `blocks/index.ts`. Reuses `BlockShell` + the shared badge palette. Dark-only.

## Tests
- `annotations.test.ts` — line-spec parser, JSON-attr parsing (valid/invalid/legacy), marker resolution.
- `annotationRail.helpers.test.ts` — hover-card placement geometry.
- `AnnotatedCode.test.tsx` — render smoke test (header/copy/annotation rail/invalid-JSON warning).

## Validation
- `tsc -b` clean
- `eslint` clean on changed files
- `vitest run --pool=vmThreads src/components/proposals` — 163 passed