### PR TITLE
feat(proposals): render Open Questions as a clean read-only list

### DIFF
--- a/ui/src/components/proposals/blocks/QuestionFormBlock.tsx
+++ b/ui/src/components/proposals/blocks/QuestionFormBlock.tsx
@@ -1,10 +1,92 @@
-import type { BlockProps } from "./types";
-import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { useMemo } from "react";
+import { HelpCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 
+import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { Badge } from "./blockBadges";
+import type { BlockProps } from "./types";
+import { parseQuestions } from "./questionForm";
+
+/**
+ * QuestionForm — a READ-ONLY list of outstanding questions on a proposal.
+ *
+ * This is deliberately NOT a form: there are no inputs, radios, checkboxes, or
+ * submit affordances. People answer out-of-band via proposal chat. The block
+ * just renders the questions the LLM hand-wrote (as the block's children prose)
+ * more nicely than a plain-markdown blob.
+ *
+ * The freeform children are parsed (`parseQuestions`) into individual questions
+ * — a numbered line, a `?`-terminated sentence, a bolded line, or a `###`
+ * heading starts a new question; following lines/bullets are that question's
+ * sub-detail. Each renders as a clean numbered card with a question-mark marker,
+ * the markdown-rendered question text, optional muted sub-detail, and a small
+ * "recommended" badge when the author tagged an item. If parsing yields nothing
+ * we fall back to the original `BlockMarkdown` render so a proposal never blanks.
+ */
 export function QuestionFormBlock({ children }: BlockProps) {
+  const content = typeof children === "string" ? children.trim() : "";
+  const questions = useMemo(() => parseQuestions(content), [content]);
+
+  // Parser produced nothing usable (or children weren't a string) — fall back
+  // to the original markdown render so an existing proposal never blanks.
+  if (questions.length === 0) {
+    return (
+      <BlockShell label="Open Questions" accent="text-pink-400">
+        <BlockMarkdown>{children}</BlockMarkdown>
+      </BlockShell>
+    );
+  }
+
   return (
-    <BlockShell label="Open Questions" accent="text-pink-400">
-      <BlockMarkdown>{children}</BlockMarkdown>
+    <BlockShell
+      label="Open Questions"
+      accent="text-pink-400"
+      meta={
+        <span>
+          {questions.length}{" "}
+          {questions.length === 1 ? "question" : "questions"}
+        </span>
+      }
+    >
+      <ol className="space-y-2.5">
+        {questions.map((q, index) => (
+          <li
+            key={`${index}-${q.question.slice(0, 24)}`}
+            className="flex gap-3 rounded-lg border bg-muted/20 px-3.5 py-3"
+          >
+            <span
+              className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-pink-500/15 text-pink-300"
+              aria-hidden
+            >
+              <HugeiconsIcon icon={HelpCircleIcon} size={15} />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-start justify-between gap-2">
+                <div className="prose prose-sm min-w-0 max-w-none font-medium text-foreground dark:prose-invert prose-p:my-0">
+                  <BlockMarkdown>{q.question}</BlockMarkdown>
+                </div>
+                {q.recommended && (
+                  <Badge accent="emerald" className="mt-0.5 shrink-0">
+                    recommended
+                  </Badge>
+                )}
+              </div>
+              {q.detail.length > 0 && (
+                <ul className="mt-1.5 space-y-1 border-l border-border/60 pl-3 text-xs text-muted-foreground">
+                  {q.detail.map((line, di) => (
+                    <li
+                      key={di}
+                      className="prose prose-sm max-w-none text-xs dark:prose-invert prose-p:my-0"
+                    >
+                      <BlockMarkdown>{line}</BlockMarkdown>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
     </BlockShell>
   );
 }

--- a/ui/src/components/proposals/blocks/questionForm.test.ts
+++ b/ui/src/components/proposals/blocks/questionForm.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { parseQuestions } from "./questionForm";
+
+describe("parseQuestions", () => {
+  it("returns [] for empty / whitespace input (fallback signal)", () => {
+    expect(parseQuestions("")).toEqual([]);
+    expect(parseQuestions("   \n  \n")).toEqual([]);
+  });
+
+  it("treats a single `?`-terminated line as one question", () => {
+    const qs = parseQuestions("Should we use Redis or Memcached for caching?");
+    expect(qs).toHaveLength(1);
+    expect(qs[0]!.question).toBe(
+      "Should we use Redis or Memcached for caching?",
+    );
+    expect(qs[0]!.detail).toEqual([]);
+    expect(qs[0]!.recommended).toBe(false);
+  });
+
+  it("splits numbered lines into separate questions", () => {
+    const body = [
+      "1. Which database should we use?",
+      "2) Do we need read replicas?",
+      "(3) Should auth be session-based?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs.map((q) => q.question)).toEqual([
+      "Which database should we use?",
+      "Do we need read replicas?",
+      "Should auth be session-based?",
+    ]);
+  });
+
+  it("splits `?`-terminated sentences into separate questions", () => {
+    const body = [
+      "Should we cache aggressively?",
+      "What is the eviction policy?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(2);
+    expect(qs[1]!.question).toBe("What is the eviction policy?");
+  });
+
+  it("starts a new question on a bold line and a heading", () => {
+    const body = [
+      "**Caching strategy**",
+      "Some context about caching.",
+      "### Auth model",
+      "Some context about auth.",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs.map((q) => q.question)).toEqual([
+      "Caching strategy",
+      "Auth model",
+    ]);
+    expect(qs[0]!.detail).toEqual(["Some context about caching."]);
+    expect(qs[1]!.detail).toEqual(["Some context about auth."]);
+  });
+
+  it("groups following plain lines and bullets as sub-detail", () => {
+    const body = [
+      "1. Which caching layer?",
+      "We expect ~10k req/s at peak.",
+      "- Redis is the team default",
+      "- Memcached is simpler to operate",
+      "2. Do we need replicas?",
+      "Only if read load grows.",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(2);
+    expect(qs[0]!.question).toBe("Which caching layer?");
+    expect(qs[0]!.detail).toEqual([
+      "We expect ~10k req/s at peak.",
+      "Redis is the team default",
+      "Memcached is simpler to operate",
+    ]);
+    expect(qs[1]!.detail).toEqual(["Only if read load grows."]);
+  });
+
+  it("flags items tagged (recommended) and strips the tag", () => {
+    const body = [
+      "1. Use Redis (recommended)",
+      "2. Use Memcached",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs[0]!.question).toBe("Use Redis");
+    expect(qs[0]!.recommended).toBe(true);
+    expect(qs[1]!.recommended).toBe(false);
+  });
+
+  it("attaches pre-header leading detail to the first question", () => {
+    const body = [
+      "Here are the open items to resolve before build:",
+      "1. Pick a database?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(1);
+    expect(qs[0]!.question).toBe("Pick a database?");
+    expect(qs[0]!.detail).toEqual([
+      "Here are the open items to resolve before build:",
+    ]);
+  });
+
+  it("falls back to a single question when no header is recognised", () => {
+    const body = "We still need to decide on the deployment region.";
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(1);
+    expect(qs[0]!.question).toBe(body);
+    expect(qs[0]!.detail).toEqual([]);
+  });
+
+  it("keeps multi-line no-header prose as one question with detail", () => {
+    const body = ["First consideration here.", "Second consideration here."].join(
+      "\n",
+    );
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(1);
+    expect(qs[0]!.question).toBe("First consideration here.");
+    expect(qs[0]!.detail).toEqual(["Second consideration here."]);
+  });
+});

--- a/ui/src/components/proposals/blocks/questionForm.ts
+++ b/ui/src/components/proposals/blocks/questionForm.ts
@@ -1,0 +1,153 @@
+// Pure (React-free) helpers for the "Open Questions" block. djinn stores the
+// outstanding questions as the block's *children text* — the LLM hand-writes
+// them as prose/bullets, NOT as a structured `questions={…}` prop (the schema's
+// `questions[]` field exists only to guide generation; see the Rust registry in
+// `proposal_blocks.rs`). So this parser folds that freeform markdown into a flat
+// list of questions, each with optional sub-detail lines, for a nicer read-only
+// render. Kept in its own module so it is unit-testable without pulling React in.
+//
+// This block is intentionally a READ-ONLY list — NOT a form. There is no answer
+// capture, no inputs, no submit. We only render the outstanding questions more
+// nicely than a plain-markdown blob.
+//
+// A new question starts on a line that is one of:
+//   1. a numbered line — `1.` / `1)` / `(1)`
+//   2. a `###`(+) markdown heading
+//   3. a **bolded** line — the whole (trimmed) line wrapped in `**…**`
+//   4. a line that ends in `?` (a question sentence)
+// Following plain lines or `-`/`*`/`+` bullets become that question's detail.
+// Anything before the first recognised question header is attached to the first
+// question as leading detail (or, if there is no header at all, the whole body
+// becomes a single question). Empty input yields `[]` so the caller can fall
+// back to the raw markdown render.
+
+/** One parsed outstanding question: its text plus optional muted sub-detail. */
+export interface ParsedQuestion {
+  /** The question text, markdown preserved for inline rendering. */
+  question: string;
+  /** Sub-points / clarifying detail lines shown as muted secondary text. */
+  detail: string[];
+  /** True when the author tagged the item "(recommended)". */
+  recommended: boolean;
+}
+
+/** Strip a trailing/inline `(recommended)` tag, returning the cleaned text. */
+function extractRecommended(text: string): { text: string; recommended: boolean } {
+  // Match `(recommended)` case-insensitively, anywhere, optionally bracketed.
+  const re = /\s*[([]?\s*recommended\s*[)\]]?/i;
+  if (re.test(text)) {
+    return { text: text.replace(re, "").trim(), recommended: true };
+  }
+  return { text: text.trim(), recommended: false };
+}
+
+/** A leading numbered marker: `1.`, `1)`, `(1)` — captured + stripped. */
+const NUMBERED = /^\s*\(?(\d{1,3})[.)]\s+(.*)$/;
+/** A markdown heading line: `#`..`######` followed by text. */
+const HEADING = /^\s*#{1,6}\s+(.*)$/;
+/** A bullet line: `-` / `*` / `+` followed by text. */
+const BULLET = /^\s*[-*+]\s+(.*)$/;
+
+/** True when a (trimmed) line is entirely wrapped in `**…**` (bold). */
+function isBoldLine(line: string): boolean {
+  const t = line.trim();
+  return /^\*\*[\s\S]+\*\*[.?!:]?$/.test(t) && t.length > 4;
+}
+
+/** Unwrap a fully-bold line's inner text (keeping a trailing `?`/punctuation). */
+function unwrapBold(line: string): string {
+  const t = line.trim();
+  const m = /^\*\*([\s\S]+?)\*\*([.?!:]?)$/.exec(t);
+  return m ? `${m[1]}${m[2] ?? ""}`.trim() : t;
+}
+
+/**
+ * Decide whether a non-empty line begins a NEW question. Returns the question
+ * text (markers stripped) when it does, otherwise `null` (it's detail).
+ */
+function asQuestionHeader(line: string): string | null {
+  const numbered = NUMBERED.exec(line);
+  if (numbered) return (numbered[2] ?? "").trim();
+
+  const heading = HEADING.exec(line);
+  if (heading) return (heading[1] ?? "").trim();
+
+  if (isBoldLine(line)) return unwrapBold(line);
+
+  // A sentence that ends in `?` (ignoring trailing markdown emphasis) is a
+  // question header — but a bullet/detail line that happens to end in `?` should
+  // stay detail, so bullets are excluded here (handled as detail below).
+  if (!BULLET.test(line) && /\?\s*\**\s*$/.test(line.trim())) {
+    return line.trim();
+  }
+
+  return null;
+}
+
+/**
+ * Parse the freeform <QuestionForm> body into a flat list of outstanding
+ * questions, each with optional sub-detail. Returns `[]` for empty/whitespace
+ * input so the caller can fall back to the raw markdown render. Never throws.
+ */
+export function parseQuestions(body: string): ParsedQuestion[] {
+  if (!body || !body.trim()) return [];
+  const lines = body.replace(/\r\n?/g, "\n").split("\n");
+
+  const questions: ParsedQuestion[] = [];
+  // Detail seen before any recognised header — attached to the first question.
+  const leading: string[] = [];
+
+  const pushDetail = (raw: string) => {
+    const bullet = BULLET.exec(raw);
+    const text = (bullet ? bullet[1] : raw).trim();
+    if (!text) return;
+    if (questions.length === 0) {
+      leading.push(text);
+    } else {
+      questions[questions.length - 1]!.detail.push(text);
+    }
+  };
+
+  for (const raw of lines) {
+    if (!raw.trim()) continue;
+
+    const header = asQuestionHeader(raw);
+    if (header !== null && header !== "") {
+      const { text, recommended } = extractRecommended(header);
+      // A header that becomes empty after stripping `(recommended)` is just a
+      // stray tag — treat it as detail rather than an empty question.
+      if (!text) {
+        if (recommended && questions.length > 0) {
+          questions[questions.length - 1]!.recommended = true;
+        }
+        continue;
+      }
+      questions.push({ question: text, detail: [], recommended });
+    } else {
+      pushDetail(raw);
+    }
+  }
+
+  // No header was ever recognised: treat the whole body as one question so the
+  // block still renders as a single clean card instead of falling back to raw.
+  if (questions.length === 0) {
+    const all = lines.map((l) => l.trim()).filter(Boolean);
+    if (all.length === 0) return [];
+    const first = all[0]!;
+    const { text, recommended } = extractRecommended(first);
+    return [
+      {
+        question: text || first,
+        detail: all.slice(1),
+        recommended,
+      },
+    ];
+  }
+
+  // Attach any leading pre-header detail to the first question.
+  if (leading.length > 0) {
+    questions[0]!.detail.unshift(...leading);
+  }
+
+  return questions;
+}


### PR DESCRIPTION
## What

Polishes the proposal **"Open Questions"** block (`question-form`) so the outstanding questions render as a clean, scannable numbered list instead of a plain-markdown blob — matching the recently-upgraded FileTree / DataModel / ApiEndpoint / Diff / AnnotatedCode blocks.

## Approach

- New pure, React-free parser `questionForm.ts` folds the freeform `<QuestionForm>` children prose into individual questions: a numbered line (`1.`/`1)`/`(1)`), a `?`-terminated sentence, a fully-bold line, or a `###` heading starts a new question; following plain lines / `-``*``+` bullets become that question's muted sub-detail.
- `QuestionFormBlock.tsx` renders each as a numbered question card inside `BlockShell` (label stays **"Open Questions"**): a question-mark marker, the markdown-rendered question text, optional muted sub-detail list, and a small `recommended` `Badge` when an item is tagged `(recommended)`.
- **Robust:** if parsing yields nothing it falls back to the original `BlockMarkdown` render, so an existing proposal never blanks or crashes.
- Vitest covers question splitting, sub-detail grouping, recommended-tag stripping, and the fallback.

## Important: read-only, intentionally NOT a form

This is a **read-only list of outstanding questions**. There are **no inputs, radios, checkboxes, write-ins, or submit/answer capture** — people answer out-of-band via proposal chat. No registry/backend change (`question-form` is an existing block). Dark-only; `@hugeicons/core-free-icons`.

## Validation

- `tsc -b` clean
- `eslint` clean on changed files
- `vitest run src/components/proposals` → 173 passed