### PR TITLE
feat(proposals): add code block

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -26,6 +26,7 @@ pub enum BlockType {
     Callout,
     Table,
     Checklist,
+    Code,
     QuestionForm,
 }
 
@@ -44,6 +45,7 @@ impl BlockType {
             BlockType::Callout => "callout",
             BlockType::Table => "table",
             BlockType::Checklist => "checklist",
+            BlockType::Code => "code",
             BlockType::QuestionForm => "question-form",
         }
     }
@@ -62,6 +64,7 @@ impl BlockType {
             BlockType::Callout => "Callout",
             BlockType::Table => "Table",
             BlockType::Checklist => "Checklist",
+            BlockType::Code => "Code",
             BlockType::QuestionForm => "QuestionForm",
         }
     }
@@ -458,6 +461,33 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
                 ),
             ),
             (
+                "code",
+                block_with_description(
+                    "code",
+                    "Code",
+                    "A single syntax-highlighted code snippet — the standalone \
+                     code primitive (distinct from `AnnotatedCode`, which adds \
+                     line-anchored annotations). The block CHILDREN are the raw \
+                     source code. Set the optional `filename` attribute to a file \
+                     path (shown in the header, split into directory + basename) \
+                     and the optional `lang` attribute to a language hint (e.g. \
+                     `ts`, `rust`, `python`); when `lang` is omitted the language \
+                     is inferred from the filename extension. Set the optional \
+                     `caption` attribute for a one-line note under the snippet, \
+                     and `maxLines` to override the collapse threshold (default \
+                     40; `0` never collapses). The snippet shows line numbers, a \
+                     copy-source button, and a language switcher. Example: \
+                     `<Code id=\"x\" filename=\"src/util.ts\" lang=\"ts\">\\nexport \
+                     function clamp(v: number) { return v; }\\n</Code>`.",
+                    fields(vec![
+                        ("filename", string_field()),
+                        ("lang", string_field()),
+                        ("caption", string_field()),
+                        ("maxLines", string_field()),
+                    ]),
+                ),
+            ),
+            (
                 "question-form",
                 block(
                     "question-form",
@@ -682,7 +712,7 @@ mod tests {
     #[test]
     fn registry_contains_v1_blocks() {
         let registry = proposal_block_registry();
-        assert_eq!(registry.len(), 12);
+        assert_eq!(registry.len(), 13);
         assert_eq!(registry["rich-text"].tag, "RichText");
         assert_eq!(registry["diagram"].tag, "Diagram");
         assert_eq!(registry["annotated-code"].tag, "AnnotatedCode");
@@ -694,6 +724,7 @@ mod tests {
         assert_eq!(registry["callout"].tag, "Callout");
         assert_eq!(registry["table"].tag, "Table");
         assert_eq!(registry["checklist"].tag, "Checklist");
+        assert_eq!(registry["code"].tag, "Code");
         assert_eq!(registry["question-form"].tag, "QuestionForm");
         // The diff block ships authoring guidance for the LLM.
         assert!(
@@ -718,6 +749,7 @@ mod tests {
             BlockType::Callout,
             BlockType::Table,
             BlockType::Checklist,
+            BlockType::Code,
             BlockType::QuestionForm,
         ];
         for bt in types {
@@ -729,7 +761,7 @@ mod tests {
     #[test]
     fn block_registry_new_has_all_definitions() {
         let reg = BlockRegistry::new();
-        assert_eq!(reg.definitions().len(), 12);
+        assert_eq!(reg.definitions().len(), 13);
         assert!(reg.definition_for_tag("RichText").is_some());
         assert!(reg.definition_for_tag("UnknownTag").is_none());
         assert!(reg.tags().contains("RichText"));
@@ -753,6 +785,7 @@ mod tests {
             "Callout",
             "Table",
             "Checklist",
+            "Code",
             "QuestionForm",
         ]
         .into_iter()

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -509,6 +509,12 @@ This runs on the hot path.
 - [ ] Backfill job verified
 </Checklist>
 
+<Code id="snippet" filename="src/util.ts" lang="ts">
+export function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+</Code>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/CodeSnippetBlock.tsx
+++ b/ui/src/components/proposals/blocks/CodeSnippetBlock.tsx
@@ -1,0 +1,221 @@
+import { lazy, Suspense, useMemo, useState } from "react";
+import {
+  Copy01Icon,
+  SourceCodeIcon,
+  Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
+
+import type { BlockProps } from "./types";
+import { BlockShell } from "./BlockShell";
+import {
+  CODE_LANGUAGE_OPTIONS,
+  computeCollapse,
+  resolveCodeLanguage,
+  splitCodeFilename,
+} from "./code";
+
+// `react-syntax-highlighter` (Prism) is heavy; load it only when a code block
+// renders. The shared `CodeBlock` surface gives us syntax highlighting + a left
+// line-number gutter, so this block layers only the filename header, copy +
+// language switcher chrome, and the collapse-to-N-lines affordance on top.
+const CodeBlock = lazy(() => import("./CodeBlock"));
+
+/**
+ * The presentational code surface — filename header, copy-source + language
+ * switcher chrome, line-numbered highlighted body, and collapse-to-N-lines. It
+ * is intentionally free of any MDX/registry knowledge so it can be reused as the
+ * composable code primitive a future `tabs` block nests (pass a `filename`/`lang`
+ * and the snippet `code`).
+ *
+ * `Code` is distinct from `AnnotatedCode`: this is the plain single-snippet
+ * primitive (copy + switcher + collapse), whereas `AnnotatedCode` adds
+ * line-anchored annotation rails. The app is DARK-ONLY.
+ */
+export function CodeSurface({
+  code,
+  filename,
+  lang,
+  maxLines,
+  caption,
+}: {
+  code: string;
+  filename?: string;
+  lang?: string;
+  maxLines?: number;
+  caption?: string;
+}) {
+  // The active language can be re-picked via the switcher; it seeds from the
+  // authored `lang` attr (or filename inference), with "" meaning Auto.
+  const inferred = useMemo(
+    () => resolveCodeLanguage(lang, filename) ?? "",
+    [lang, filename],
+  );
+  const [selectedLang, setSelectedLang] = useState<string>("");
+  const effectiveLang = (selectedLang || inferred || "text").trim();
+
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const collapse = useMemo(
+    () => computeCollapse(code, expanded, maxLines),
+    [code, expanded, maxLines],
+  );
+
+  const fileParts = filename ? splitCodeFilename(filename) : null;
+  const langChip = effectiveLang !== "text" ? effectiveLang : null;
+
+  const copySource = () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    navigator.clipboard
+      .writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      })
+      .catch(() => {
+        /* clipboard unavailable — ignore */
+      });
+  };
+
+  const rawCode = (
+    <pre className="overflow-x-auto px-4 py-4 font-mono text-xs text-foreground">
+      {code}
+    </pre>
+  );
+
+  const meta = (
+    <span className="flex min-w-0 items-center gap-2">
+      {fileParts ? (
+        <span className="flex min-w-0 items-baseline gap-1.5 font-mono">
+          {fileParts.directory && (
+            <span className="min-w-0 truncate text-[11px] text-muted-foreground/70">
+              {fileParts.directory}/
+            </span>
+          )}
+          <span className="max-w-[14rem] truncate font-semibold text-foreground">
+            {fileParts.basename}
+          </span>
+        </span>
+      ) : null}
+      {/* Language switcher — re-highlights as a different grammar on demand.
+          "Auto" returns to the authored/inferred language. */}
+      <label className="flex items-center gap-1">
+        <span className="sr-only">Code language</span>
+        <select
+          aria-label="Code language"
+          value={selectedLang}
+          onChange={(event) => setSelectedLang(event.target.value)}
+          className="rounded border bg-muted/40 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          {CODE_LANGUAGE_OPTIONS.map((option) => (
+            <option key={option.value || "auto"} value={option.value}>
+              {option.value ? option.label : langChip ? `Auto (${langChip})` : "Auto"}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="button"
+        onClick={copySource}
+        title="Copy source"
+        aria-label={copied ? "Copied" : "Copy source"}
+        className="flex shrink-0 items-center gap-1 rounded border px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+      >
+        <HugeiconsIcon
+          icon={copied ? Tick02Icon : Copy01Icon}
+          size={12}
+          className={copied ? "text-emerald-400" : undefined}
+        />
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </span>
+  );
+
+  return (
+    <BlockShell label="Code" accent="text-cyan-400" flush meta={meta}>
+      <div className="relative">
+        <div
+          className={cn(
+            "relative overflow-x-auto",
+            collapse.collapsed && "max-h-[34rem] overflow-y-hidden",
+          )}
+        >
+          <Suspense fallback={rawCode}>
+            <CodeBlock
+              language={effectiveLang}
+              content={code}
+              showLineNumbers
+            />
+          </Suspense>
+          {collapse.collapsed && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-card to-transparent" />
+          )}
+        </div>
+        {collapse.collapsible && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+            className="flex w-full items-center justify-center border-t bg-muted/30 py-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          >
+            {collapse.collapsed
+              ? `Show all ${collapse.lineCount} lines`
+              : "Show less"}
+          </button>
+        )}
+      </div>
+      {caption && (
+        <p className="border-t bg-muted/20 px-4 py-2 text-[11px] text-muted-foreground">
+          {caption}
+        </p>
+      )}
+    </BlockShell>
+  );
+}
+
+/**
+ * CodeSnippetBlock — the standalone `Code` proposal block. A single
+ * syntax-highlighted snippet with a filename header (dir/basename split),
+ * copy-source button, language chip + switcher, line numbers, and
+ * collapse-to-N-lines. The snippet body is the block's children text; `filename`
+ * and `lang` are optional attributes, with `caption` shown beneath the surface.
+ *
+ * Thin wrapper around {@link CodeSurface} (the reusable primitive) — the wrapper
+ * owns MDX-attribute plumbing only, keeping the surface itself reusable for a
+ * future `tabs` container. Ported from agent-native's `code` block. Dark-only.
+ */
+export function CodeSnippetBlock({ attributes, children }: BlockProps) {
+  const code = typeof children === "string" ? children.replace(/\s+$/, "") : "";
+  const filename = attributes.filename?.trim() || undefined;
+  const lang = attributes.lang ?? attributes.language;
+  const caption = attributes.caption?.trim() || undefined;
+  const rawMax = attributes.maxLines ?? attributes.maxlines;
+  const parsedMax = rawMax != null ? Number(rawMax) : NaN;
+  const maxLines = Number.isFinite(parsedMax)
+    ? Math.max(0, Math.min(2000, Math.floor(parsedMax)))
+    : undefined;
+
+  if (!code) {
+    return (
+      <BlockShell label="Code" accent="text-cyan-400">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <HugeiconsIcon icon={SourceCodeIcon} size={14} />
+          <span>Empty code snippet.</span>
+        </div>
+      </BlockShell>
+    );
+  }
+
+  return (
+    <CodeSurface
+      code={code}
+      filename={filename}
+      lang={lang}
+      maxLines={maxLines}
+      caption={caption}
+    />
+  );
+}

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -68,6 +68,12 @@ This runs on the hot path — keep allocations out of the loop.
 - [ ] Docs updated — link the runbook
 </Checklist>
 
+<Code id="snippet" filename="src/util.ts" lang="ts">
+export function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+</Code>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached for caching?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/blocks.test.ts
+++ b/ui/src/components/proposals/blocks/blocks.test.ts
@@ -29,6 +29,7 @@ export const CANONICAL_V1_TAGS = [
   "Callout",
   "Table",
   "Checklist",
+  "Code",
   "QuestionForm",
 ] as const;
 
@@ -207,6 +208,15 @@ describe("canonical proposal.mdx round-trip", () => {
     expect(getProposalBlockDefinitionByTag("Checklist")!.type).toBe(
       "checklist",
     );
+
+    // Code
+    const code = byTag.get("Code");
+    expect(code).toBeDefined();
+    expect(code!.id).toBe("snippet");
+    expect(code!.attributes.filename).toBe("src/util.ts");
+    expect(code!.attributes.lang).toBe("ts");
+    expect(code!.content).toContain("export function");
+    expect(getProposalBlockDefinitionByTag("Code")!.type).toBe("code");
 
     // QuestionForm
     const questionForm = byTag.get("QuestionForm");

--- a/ui/src/components/proposals/blocks/code.test.ts
+++ b/ui/src/components/proposals/blocks/code.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CODE_LANGUAGE_OPTIONS,
+  DEFAULT_CODE_MAX_LINES,
+  computeCollapse,
+  inferCodeLanguageFromFilename,
+  normalizeCodeLanguage,
+  resolveCodeLanguage,
+  splitCodeFilename,
+} from "./code";
+
+describe("splitCodeFilename", () => {
+  it("splits directory and basename", () => {
+    expect(splitCodeFilename("src/server/auth.ts")).toEqual({
+      directory: "src/server",
+      basename: "auth.ts",
+    });
+  });
+
+  it("treats a bare filename as having no directory", () => {
+    expect(splitCodeFilename("auth.ts")).toEqual({
+      directory: null,
+      basename: "auth.ts",
+    });
+  });
+
+  it("trims and tolerates empty / undefined", () => {
+    expect(splitCodeFilename("  ")).toEqual({ directory: null, basename: "" });
+    expect(splitCodeFilename(undefined)).toEqual({
+      directory: null,
+      basename: "",
+    });
+  });
+
+  it("ignores leading and trailing slashes", () => {
+    expect(splitCodeFilename("/a/b/c.rs")).toEqual({
+      directory: "a/b",
+      basename: "c.rs",
+    });
+  });
+});
+
+describe("inferCodeLanguageFromFilename", () => {
+  it("infers from common extensions", () => {
+    expect(inferCodeLanguageFromFilename("a/b/main.rs")).toBe("rust");
+    expect(inferCodeLanguageFromFilename("auth.ts")).toBe("typescript");
+    expect(inferCodeLanguageFromFilename("view.tsx")).toBe("tsx");
+    expect(inferCodeLanguageFromFilename("config.yml")).toBe("yaml");
+    expect(inferCodeLanguageFromFilename("script.py")).toBe("python");
+  });
+
+  it("recognizes extension-less special filenames", () => {
+    expect(inferCodeLanguageFromFilename("Dockerfile")).toBe("bash");
+    expect(inferCodeLanguageFromFilename("path/to/Makefile")).toBe("makefile");
+  });
+
+  it("returns null for unknown / missing", () => {
+    expect(inferCodeLanguageFromFilename("notes")).toBeNull();
+    expect(inferCodeLanguageFromFilename("data.weirdext")).toBeNull();
+    expect(inferCodeLanguageFromFilename(undefined)).toBeNull();
+    expect(inferCodeLanguageFromFilename("")).toBeNull();
+  });
+});
+
+describe("normalizeCodeLanguage", () => {
+  it("lowercases and strips the language- prefix", () => {
+    expect(normalizeCodeLanguage("TypeScript")).toBe("typescript");
+    expect(normalizeCodeLanguage("language-rust")).toBe("rust");
+    expect(normalizeCodeLanguage("  Go  ")).toBe("go");
+  });
+
+  it("returns null for empty / undefined", () => {
+    expect(normalizeCodeLanguage("")).toBeNull();
+    expect(normalizeCodeLanguage("   ")).toBeNull();
+    expect(normalizeCodeLanguage(undefined)).toBeNull();
+  });
+});
+
+describe("resolveCodeLanguage", () => {
+  it("prefers an explicit lang over the filename", () => {
+    expect(resolveCodeLanguage("bash", "main.rs")).toBe("bash");
+  });
+
+  it("falls back to filename inference when lang is missing", () => {
+    expect(resolveCodeLanguage(undefined, "main.rs")).toBe("rust");
+    expect(resolveCodeLanguage("", "auth.ts")).toBe("typescript");
+  });
+
+  it("returns null when nothing resolves", () => {
+    expect(resolveCodeLanguage(undefined, "notes")).toBeNull();
+    expect(resolveCodeLanguage(undefined, undefined)).toBeNull();
+  });
+});
+
+describe("computeCollapse", () => {
+  const lines = (n: number) =>
+    Array.from({ length: n }, (_, i) => `line ${i}`).join("\n");
+
+  it("does not collapse short snippets under the default cap", () => {
+    const state = computeCollapse(lines(10), false);
+    expect(state.collapsible).toBe(false);
+    expect(state.collapsed).toBe(false);
+    expect(state.hiddenLines).toBe(0);
+    expect(state.lineCount).toBe(10);
+  });
+
+  it("collapses snippets over the default cap", () => {
+    const state = computeCollapse(lines(DEFAULT_CODE_MAX_LINES + 5), false);
+    expect(state.collapsible).toBe(true);
+    expect(state.collapsed).toBe(true);
+    expect(state.hiddenLines).toBe(5);
+  });
+
+  it("expands when expanded=true", () => {
+    const state = computeCollapse(lines(DEFAULT_CODE_MAX_LINES + 5), true);
+    expect(state.collapsible).toBe(true);
+    expect(state.collapsed).toBe(false);
+  });
+
+  it("honors an explicit maxLines cap", () => {
+    const state = computeCollapse(lines(20), false, 5);
+    expect(state.collapsible).toBe(true);
+    expect(state.hiddenLines).toBe(15);
+  });
+
+  it("never collapses when maxLines is 0", () => {
+    const state = computeCollapse(lines(1000), false, 0);
+    expect(state.collapsible).toBe(false);
+    expect(state.collapsed).toBe(false);
+    expect(state.hiddenLines).toBe(0);
+  });
+
+  it("reports zero lines for an empty snippet", () => {
+    expect(computeCollapse("", false).lineCount).toBe(0);
+  });
+});
+
+describe("CODE_LANGUAGE_OPTIONS", () => {
+  it("starts with the Auto sentinel", () => {
+    expect(CODE_LANGUAGE_OPTIONS[0]).toEqual({ value: "", label: "Auto" });
+  });
+
+  it("has unique values", () => {
+    const values = CODE_LANGUAGE_OPTIONS.map((o) => o.value);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/ui/src/components/proposals/blocks/code.ts
+++ b/ui/src/components/proposals/blocks/code.ts
@@ -1,0 +1,159 @@
+// Pure (React-free) helpers for the standalone `Code` block. The block renders a
+// single syntax-highlighted snippet (distinct from `AnnotatedCode`, which is for
+// line-anchored annotations). It deliberately holds ONE snippet — a "file rail"
+// of several files is a future `tabs` container holding `Code` blocks — so this
+// component is kept cleanly reusable as that primitive.
+//
+// Ported from agent-native's `code` block: filename dir/basename split, language
+// inference from the file extension, a language switcher option list, and the
+// collapse-to-N-lines math. Highlighting + line numbers are handled by the
+// existing `CodeBlock.tsx` Prism surface, so these helpers only cover the parts
+// that are pure and unit-testable.
+
+/** Default number of lines shown before the snippet collapses behind a toggle. */
+export const DEFAULT_CODE_MAX_LINES = 40;
+
+/**
+ * Split a filename into its directory prefix and basename for the header label,
+ * e.g. `src/server/auth.ts` → `{ directory: "src/server", basename: "auth.ts" }`.
+ * A bare filename has a `null` directory.
+ */
+export function splitCodeFilename(filename?: string): {
+  basename: string;
+  directory: string | null;
+} {
+  const value = filename?.trim() || "";
+  if (!value) return { basename: "", directory: null };
+  const segments = value.split("/").filter(Boolean);
+  const basename = segments[segments.length - 1] ?? value;
+  const directory =
+    segments.length > 1 ? segments.slice(0, -1).join("/") : null;
+  return { basename, directory };
+}
+
+/** Common file extension / shorthand → a Prism-friendly language name. */
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  cjs: "javascript",
+  cts: "typescript",
+  htm: "html",
+  js: "javascript",
+  json: "json",
+  jsonc: "json",
+  jsx: "jsx",
+  md: "markdown",
+  mdx: "markdown",
+  mjs: "javascript",
+  mts: "typescript",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  sh: "bash",
+  shell: "bash",
+  sql: "sql",
+  ts: "typescript",
+  tsx: "tsx",
+  yaml: "yaml",
+  yml: "yaml",
+};
+
+/**
+ * Best-effort language name from a filename / path extension, e.g. `auth.ts`
+ * → `typescript`. Recognizes a couple of extension-less names (Dockerfile,
+ * Makefile). Returns `null` when nothing can be inferred.
+ */
+export function inferCodeLanguageFromFilename(
+  filename?: string | null,
+): string | null {
+  const basename = filename?.split("/").pop()?.trim().toLowerCase();
+  if (!basename) return null;
+  if (basename === "dockerfile") return "bash";
+  if (basename === "makefile") return "makefile";
+  const extension = basename.includes(".")
+    ? basename.split(".").pop()
+    : undefined;
+  if (!extension) return null;
+  return EXTENSION_LANGUAGE[extension] ?? null;
+}
+
+/**
+ * Normalize a raw `lang` attribute to a lower-cased, `language-`-stripped hint,
+ * or `null` when empty so the caller can fall back to filename inference.
+ */
+export function normalizeCodeLanguage(value?: string | null): string | null {
+  const raw = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/^language-/, "");
+  return raw ? raw : null;
+}
+
+/**
+ * Resolve the effective language for a snippet: the explicit `lang` attribute
+ * wins, else infer from the filename, else `null` (plain text).
+ */
+export function resolveCodeLanguage(
+  lang?: string | null,
+  filename?: string | null,
+): string | null {
+  return normalizeCodeLanguage(lang) ?? inferCodeLanguageFromFilename(filename);
+}
+
+export interface CollapseState {
+  /** Whether a collapse toggle should be offered at all. */
+  collapsible: boolean;
+  /** Whether the snippet is currently collapsed (collapsible AND not expanded). */
+  collapsed: boolean;
+  /** Number of lines hidden while collapsed (0 when not collapsible). */
+  hiddenLines: number;
+  /** Total line count of the snippet. */
+  lineCount: number;
+}
+
+/**
+ * Compute the collapse state for a snippet. `maxLines` omitted ⇒ the default
+ * cap (40); `0` ⇒ never collapse (always show everything). A snippet is only
+ * collapsible when its line count exceeds the cap.
+ */
+export function computeCollapse(
+  code: string,
+  expanded: boolean,
+  maxLines?: number,
+): CollapseState {
+  const lineCount = code ? code.split("\n").length : 0;
+  const cap =
+    maxLines == null
+      ? DEFAULT_CODE_MAX_LINES
+      : maxLines > 0
+        ? maxLines
+        : null;
+  const collapsible = cap != null && lineCount > cap;
+  const collapsed = collapsible && !expanded;
+  const hiddenLines = collapsible ? lineCount - (cap as number) : 0;
+  return { collapsible, collapsed, hiddenLines, lineCount };
+}
+
+/** Option for the language switcher; `value: ""` is the Auto-detect sentinel. */
+export interface CodeLanguageOption {
+  value: string;
+  label: string;
+}
+
+/** Languages offered in the switcher menu (Auto first), matching agent-native. */
+export const CODE_LANGUAGE_OPTIONS: ReadonlyArray<CodeLanguageOption> = [
+  { value: "", label: "Auto" },
+  { value: "typescript", label: "TypeScript" },
+  { value: "javascript", label: "JavaScript" },
+  { value: "tsx", label: "TSX" },
+  { value: "jsx", label: "JSX" },
+  { value: "json", label: "JSON" },
+  { value: "html", label: "HTML" },
+  { value: "css", label: "CSS" },
+  { value: "bash", label: "Bash" },
+  { value: "python", label: "Python" },
+  { value: "sql", label: "SQL" },
+  { value: "yaml", label: "YAML" },
+  { value: "markdown", label: "Markdown" },
+  { value: "go", label: "Go" },
+  { value: "rust", label: "Rust" },
+  { value: "diff", label: "Diff" },
+];

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -11,6 +11,7 @@ export { DiffBlock } from "./DiffBlock";
 export { CalloutBlock } from "./CalloutBlock";
 export { TableBlock } from "./TableBlock";
 export { ChecklistBlock } from "./ChecklistBlock";
+export { CodeSnippetBlock, CodeSurface } from "./CodeSnippetBlock";
 
 // Reusable line-anchored annotation engine (pure parsing + React rail UI). The
 // `annotated-code` block consumes it; `diff` and future blocks can adopt it.

--- a/ui/src/lib/blockRegistry.ts
+++ b/ui/src/lib/blockRegistry.ts
@@ -6,6 +6,7 @@ import {
   ApiEndpointBlock,
   CalloutBlock,
   ChecklistBlock,
+  CodeSnippetBlock,
   DataModelBlock,
   DecisionsBlock,
   Diagram,
@@ -40,6 +41,7 @@ const BLOCK_COMPONENTS: Record<ProposalBlockType, ComponentType<BlockProps>> = {
   callout: CalloutBlock,
   table: TableBlock,
   checklist: ChecklistBlock,
+  code: CodeSnippetBlock,
   "question-form": QuestionFormBlock,
 };
 
@@ -55,6 +57,7 @@ const BLOCK_DISPLAY_NAMES: Record<ProposalBlockType, string> = {
   callout: "Callout",
   table: "Table",
   checklist: "Checklist",
+  code: "Code",
   "question-form": "Open Questions",
 };
 

--- a/ui/src/lib/proposalBlocks.ts
+++ b/ui/src/lib/proposalBlocks.ts
@@ -151,6 +151,16 @@ export const PROPOSAL_BLOCK_REGISTRY = {
     tag: "Checklist",
     fields: {},
   },
+  code: {
+    type: "code",
+    tag: "Code",
+    fields: {
+      filename: { type: "string" },
+      lang: { type: "string" },
+      caption: { type: "string" },
+      maxLines: { type: "string" },
+    },
+  },
   "question-form": {
     type: "question-form",
     tag: "QuestionForm",


### PR DESCRIPTION
## What

Adds a net-new **\`code\`** proposal block (MDX tag \`Code\`) — the standalone single-snippet code primitive, distinct from \`AnnotatedCode\` (which is for line-anchored annotations). Ports agent-native's \`code\` block.

### Render
- **Filename header** (dir/basename split) + language chip + **copy-source button** (1.2s "copied" reset).
- **Line numbers** (via the existing lazy Prism \`CodeBlock\` surface).
- **Language switcher** — a small select to re-highlight as a different grammar (Auto returns to the authored/inferred language).
- **Collapse-to-N-lines** (default 40; fade overlay + "Show all N lines" toggle; \`maxLines=0\` never collapses).
- Optional \`caption\` under the surface. Dark-only, reuses \`BlockShell\`.

### Reusable primitive
The presentational \`CodeSurface\` is exported separately from the \`CodeSnippetBlock\` MDX wrapper, so a future \`tabs\` block can nest it as the composable code primitive (pass \`code\`/\`filename\`/\`lang\`).

### Helpers + tests
Pure helpers (filename split, language inference from extension, collapse math, language-option list) live in \`code.ts\` with a Vitest (\`code.test.ts\`).

## Registry wiring (ADD-A-BLOCK-TYPE checklist)
- Rust \`proposal_blocks.rs\`: \`BlockType::Code\` variant + \`as_str()\`/\`tag()\` arms + \`block_with_description\` registry entry; updated all 4 tests (counts 12→13, enum list, canonical tag set).
- Rust \`validation.rs\`: \`<Code>\` added to the all-canonical-blocks fixture (before QuestionForm).
- TS: \`proposalBlocks.ts\` + \`blockRegistry.ts\` (component + display name) + \`index.ts\` export.
- Parity: \`blocks.test.ts\` CANONICAL_V1_TAGS + per-block assertion; \`canonicalProposal.mdx\` fixture. QuestionForm kept LAST.

## Validation
- \`tsc -b\` clean; eslint clean on changed files.
- \`vitest run src/components/proposals\` — 211 passed.
- \`cargo test -p djinn-control-plane proposal_blocks\` (29) + \`validation\` — pass.
- \`cargo test -p djinn-server server::tests::tool_schemas\` — 14 pass, snapshot unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)