### PR TITLE
fix(proposals): visible mermaid labels, robust label quoting, aligned code line numbers

### DIFF
--- a/ui/src/components/MermaidDiagram.tsx
+++ b/ui/src/components/MermaidDiagram.tsx
@@ -39,15 +39,27 @@ import { normalizeMermaidSource } from "@/components/proposals/blocks/mermaidNor
 // Initialize Mermaid exactly once at module load. `startOnLoad: false` keeps
 // it from auto-walking the DOM (we control rendering explicitly), and
 // `securityLevel: "strict"` blocks `<script>`/`<iframe>`/click handlers in
-// rendered output. The default `theme` follows our app's light/dark token
-// scheme well enough for now.
+// rendered output.
+//
+// `htmlLabels: false` is load-bearing: by default Mermaid renders flowchart
+// node labels as HTML inside a `<foreignObject>`. We sanitize the rendered SVG
+// with DOMPurify's *SVG* profile (below), which strips `<foreignObject>` and
+// its embedded HTML — leaving visibly empty node boxes. Forcing native SVG
+// `<text>` labels means the label markup survives the SVG-profile sanitize.
+//
+// `theme: "dark"` matches the app's dark-only palette so the diagram doesn't
+// render as a bright card on a dark page.
 let mermaidInitialized = false;
 function initMermaid() {
   if (mermaidInitialized) return;
   mermaid.initialize({
     startOnLoad: false,
     securityLevel: "strict",
-    theme: "default",
+    theme: "dark",
+    // Render labels as native SVG <text>, not <foreignObject> HTML, so the
+    // SVG-profile DOMPurify pass below can't strip them.
+    htmlLabels: false,
+    flowchart: { htmlLabels: false },
     // Defer fontFamily to the page CSS so we don't pull a Mermaid-specific
     // font into our font stack.
     fontFamily: "inherit",

--- a/ui/src/components/proposals/blocks/CodeBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/CodeBlock.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@/test/test-utils";
+
+import CodeBlock from "./CodeBlock";
+
+// The deny.toml repro from BUG C: with line numbers on, each logical source
+// line (including the `[advisories]` / `[licenses]` / `[bans]` section headers)
+// must render as exactly ONE row, with its number in the same row box.
+const TOML = [
+  "# server/deny.toml",
+  "[advisories]",
+  'yanked = "deny"',
+  "[licenses]",
+  'allow = ["MIT", "Apache-2.0"]',
+  "[bans]",
+  'multiple-versions = "warn"',
+].join("\n");
+
+describe("CodeBlock — line-number alignment", () => {
+  it("renders exactly one row per logical line with inline numbers", () => {
+    const { container } = render(
+      <CodeBlock language="toml" content={TOML} showLineNumbers />,
+    );
+
+    // Inline line numbers live INSIDE each row (one per line), not in a
+    // separate floated gutter <code>.
+    const numbers = container.querySelectorAll(
+      ".react-syntax-highlighter-line-number",
+    );
+    expect(numbers.length).toBe(7);
+
+    // Numbers are 1..7 in order.
+    const texts = Array.from(numbers).map((n) => n.textContent?.trim());
+    expect(texts).toEqual(["1", "2", "3", "4", "5", "6", "7"]);
+
+    // Each row is a block-level, non-wrapping element so a line can never split
+    // or drift out of alignment with its number.
+    const code = container.querySelector("code");
+    expect(code).not.toBeNull();
+    const rows = Array.from(code!.children).filter(
+      (el) =>
+        el.querySelector(".react-syntax-highlighter-line-number") !== null,
+    );
+    expect(rows.length).toBe(7);
+    for (const row of rows) {
+      const style = (row as HTMLElement).style;
+      expect(style.display).toBe("block");
+      expect(style.whiteSpace).toBe("pre");
+    }
+  });
+
+  it("keeps each section header on its own row (no split)", () => {
+    const { container } = render(
+      <CodeBlock language="toml" content={TOML} showLineNumbers />,
+    );
+    const code = container.querySelector("code")!;
+    const rows = Array.from(code.children).filter(
+      (el) =>
+        el.querySelector(".react-syntax-highlighter-line-number") !== null,
+    );
+    // Row 2 (index 1) is the `[advisories]` section header — its row text
+    // contains the full bracketed header and nothing from another line.
+    const row2Text = rows[1].textContent ?? "";
+    expect(row2Text).toContain("[advisories]");
+    expect(row2Text).not.toContain("yanked");
+  });
+
+  it("applies per-line props from lineProps to the matching row", () => {
+    const { container } = render(
+      <CodeBlock
+        language="toml"
+        content={TOML}
+        showLineNumbers
+        lineProps={(n) =>
+          n === 2 ? { "data-annotated": "true" } : { className: "plain-line" }
+        }
+      />,
+    );
+    const annotated = container.querySelectorAll('[data-annotated="true"]');
+    expect(annotated.length).toBe(1);
+    // The annotated row is line 2 → contains the `[advisories]` header.
+    expect(annotated[0].textContent).toContain("[advisories]");
+  });
+});

--- a/ui/src/components/proposals/blocks/CodeBlock.tsx
+++ b/ui/src/components/proposals/blocks/CodeBlock.tsx
@@ -1,6 +1,7 @@
-import type { CSSProperties, HTMLProps } from "react";
+import type { CSSProperties, HTMLProps, ReactNode } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import createElement from "react-syntax-highlighter/dist/esm/create-element";
 
 /**
  * The syntax-highlighting surface, split into its own module so `AnnotatedCode`
@@ -9,12 +10,78 @@ import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
  * the proposals' synchronous import graph keeps that bundle (and the test
  * suite's module load) small.
  *
- * When `showLineNumbers` is set the surface renders a left line-number gutter and
- * wraps each line in its own element, and `lineProps(lineNumber)` can attach
- * per-line props (refs via `onMouseEnter`, highlight classes, handlers) — this is
- * what `AnnotatedCode` uses to paint line-anchored annotation bands + hover
- * cross-highlighting on top of the Prism highlighting. The app is DARK-ONLY.
+ * Line numbers + alignment: the library's default `showLineNumbers` renders the
+ * gutter as a SEPARATE floated `<code>` block of all numbers, decoupled from the
+ * code body. When a code line wraps (or the two blocks' line-heights drift), the
+ * numbers desync from their lines and long lines split across visual rows. To
+ * guarantee one logical line === exactly one perfectly-aligned row, we instead:
+ *   - use `showInlineLineNumbers`, so each line number is a child of its own row
+ *     (same row box as the code — they can never drift apart), and
+ *   - supply a custom `renderer` that lays each row out as `display: block` with
+ *     `white-space: pre` (no wrapping → long lines scroll horizontally) and
+ *     merges in the per-line `lineProps` (refs/handlers/highlight classes) that
+ *     `AnnotatedCode` uses for its annotation bands + hover cross-highlighting.
+ *
+ * The app is DARK-ONLY.
  */
+
+type Row = Parameters<typeof createElement>[0]["node"];
+
+/**
+ * Render one aligned row per logical source line. Each row is a block-level
+ * element (so it owns a full row and can't be merged/split) with `white-space:
+ * pre` (long lines scroll horizontally instead of wrapping out of alignment).
+ * The inline line number is already the first child of each row.
+ */
+function makeRenderer(
+  lineProps?: (lineNumber: number) => HTMLProps<HTMLElement>,
+) {
+  return function lineRenderer({
+    rows,
+    stylesheet,
+    useInlineStyles,
+  }: {
+    rows: Row[];
+    stylesheet: Record<string, CSSProperties>;
+    useInlineStyles: boolean;
+  }): ReactNode {
+    return rows.map((node, i) => {
+      const lineNumber = i + 1;
+      const extra = lineProps ? lineProps(lineNumber) : undefined;
+
+      // Merge our per-line props (className/handlers/refs/style) into the row
+      // node's properties without losing Prism's own classes.
+      const baseClass = Array.isArray(node.properties?.className)
+        ? node.properties.className
+        : node.properties?.className
+          ? [node.properties.className]
+          : [];
+      const extraClass = extra?.className ? extra.className.split(/\s+/) : [];
+
+      node.properties = {
+        ...node.properties,
+        ...extra,
+        className: [...baseClass, ...extraClass],
+        style: {
+          // One block row per line; `pre` keeps long lines on a single row and
+          // lets the surrounding container scroll them horizontally.
+          display: "block",
+          whiteSpace: "pre",
+          ...(node.properties?.style as CSSProperties | undefined),
+          ...(extra?.style as CSSProperties | undefined),
+        },
+      };
+
+      return createElement({
+        node,
+        stylesheet,
+        useInlineStyles,
+        key: `code-line-${i}`,
+      });
+    });
+  };
+}
+
 export default function CodeBlock({
   language,
   content,
@@ -31,10 +98,14 @@ export default function CodeBlock({
       language={language}
       style={oneDark}
       showLineNumbers={showLineNumbers}
-      wrapLines={Boolean(lineProps)}
-      lineProps={lineProps}
+      // Inline line numbers keep each number in its line's own row box.
+      showInlineLineNumbers={showLineNumbers}
+      // Our renderer emits one aligned, non-wrapping block row per line and
+      // applies `lineProps` for AnnotatedCode's annotation bands.
+      renderer={showLineNumbers ? makeRenderer(lineProps) : undefined}
       lineNumberStyle={
         {
+          display: "inline-block",
           minWidth: "2.5rem",
           paddingRight: "1rem",
           textAlign: "right",

--- a/ui/src/components/proposals/blocks/mermaidNormalize.test.ts
+++ b/ui/src/components/proposals/blocks/mermaidNormalize.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { normalizeMermaidSource } from "./mermaidNormalize";
 
-describe("normalizeMermaidSource", () => {
+describe("normalizeMermaidSource — arrow/dash glyphs", () => {
   it("leaves ASCII edges untouched", () => {
     const src = "flowchart TD\n  A --> B\n  B -- label --> C";
     expect(normalizeMermaidSource(src)).toBe(src);
@@ -42,7 +42,7 @@ describe("normalizeMermaidSource", () => {
 
   it("preserves arrow glyphs inside quoted and paren/brace labels", () => {
     expect(normalizeMermaidSource('A("a → b")')).toBe('A("a → b")');
-    expect(normalizeMermaidSource("A{a → b}")).toBe("A{a → b}");
+    expect(normalizeMermaidSource("A{a → b}")).toBe('A{"a → b"}');
   });
 
   it("normalizes a structural arrow while preserving an in-label arrow", () => {
@@ -65,5 +65,133 @@ describe("normalizeMermaidSource", () => {
 
   it("returns empty/undefined-safe for empty input", () => {
     expect(normalizeMermaidSource("")).toBe("");
+  });
+});
+
+describe("normalizeMermaidSource — node-label auto-quoting", () => {
+  it("quotes a rectangle label with parens and -D flag", () => {
+    expect(normalizeMermaidSource("A[clippy -D warnings (exists)]")).toBe(
+      'A["clippy -D warnings (exists)"]',
+    );
+  });
+
+  it("quotes a label with a colon", () => {
+    expect(normalizeMermaidSource("C[cargo-deny: advisories]")).toBe(
+      'C["cargo-deny: advisories"]',
+    );
+  });
+
+  it("quotes a round-shape (...) label", () => {
+    expect(normalizeMermaidSource("A(do a thing: now)")).toBe(
+      'A("do a thing: now")',
+    );
+  });
+
+  it("quotes a rhombus {...} label", () => {
+    expect(normalizeMermaidSource("A{ok? (maybe)}")).toBe('A{"ok? (maybe)"}');
+  });
+
+  it("quotes a stadium ([...]) label", () => {
+    expect(normalizeMermaidSource("A([start: go])")).toBe('A(["start: go"])');
+  });
+
+  it("quotes a subroutine [[...]] label", () => {
+    expect(normalizeMermaidSource("A[[call: fn()]]")).toBe('A[["call: fn()"]]');
+  });
+
+  it("quotes a circle ((...)) label", () => {
+    expect(normalizeMermaidSource("A((node: x))")).toBe('A(("node: x"))');
+  });
+
+  it("quotes a hexagon {{...}} label", () => {
+    expect(normalizeMermaidSource("A{{decide: y/n}}")).toBe(
+      'A{{"decide: y/n"}}',
+    );
+  });
+
+  it("quotes a cylinder [(...)] label", () => {
+    expect(normalizeMermaidSource("A[(db: rows)]")).toBe('A[("db: rows")]');
+  });
+
+  it("leaves an already-quoted label untouched (idempotent)", () => {
+    const src = 'A["already (quoted)"]';
+    expect(normalizeMermaidSource(src)).toBe(src);
+    // Running twice yields the same result.
+    expect(normalizeMermaidSource(normalizeMermaidSource(src))).toBe(src);
+  });
+
+  it("re-running on already-quoted output is a no-op", () => {
+    const once = normalizeMermaidSource("A[clippy -D warnings (exists)]");
+    expect(normalizeMermaidSource(once)).toBe(once);
+  });
+
+  it("escapes inner double quotes to #quot;", () => {
+    expect(normalizeMermaidSource('A[say "hi" loud]')).toBe(
+      'A["say #quot;hi#quot; loud"]',
+    );
+  });
+
+  it("does not quote an empty label", () => {
+    expect(normalizeMermaidSource("A[]")).toBe("A[]");
+  });
+
+  it("quotes a simple alphanumeric label too (harmless, valid)", () => {
+    // Even simple labels get quoted; Mermaid accepts quoted simple labels.
+    expect(normalizeMermaidSource("A[plain]")).toBe('A["plain"]');
+  });
+
+  it("does not touch a pipe edge label |...|", () => {
+    // The edge label between two nodes must NOT be quoted (would break syntax).
+    expect(normalizeMermaidSource("A -->|yes: go| B")).toBe("A -->|yes: go| B");
+  });
+
+  it("quotes node labels on both ends of an edge", () => {
+    expect(normalizeMermaidSource("A[do (x)] --> B[do (y)]")).toBe(
+      'A["do (x)"] --> B["do (y)"]',
+    );
+  });
+});
+
+describe("normalizeMermaidSource — real LLM proposal repro", () => {
+  // The exact source from a real proposal that previously failed to parse:
+  // the `⟶` arrows AND the unquoted labels with `(`, `)`, `:`, `-D`, `--check`.
+  const REPRO = [
+    "graph TD",
+    "  PR[PR push] ⟶ A[clippy -D warnings (exists)]",
+    "  PR ⟶ B[hakari verify (exists)]",
+    "  PR ⟶ C[cargo-deny: advisories + licenses (NEW)]",
+    "  PR ⟶ D[cargo-deny bans: sqlx wrapper-allowlist ratchet (NEW)]",
+    "  PR ⟶ E[check-boundaries OR grep guard: no raw SQL outside djinn-db (NEW)]",
+    "  PR ⟶ F[sqlx prepare --check on every PR, not just merge_group (MOVED)]",
+  ].join("\n");
+
+  const EXPECTED = [
+    "graph TD",
+    '  PR["PR push"] --> A["clippy -D warnings (exists)"]',
+    '  PR --> B["hakari verify (exists)"]',
+    '  PR --> C["cargo-deny: advisories + licenses (NEW)"]',
+    '  PR --> D["cargo-deny bans: sqlx wrapper-allowlist ratchet (NEW)"]',
+    '  PR --> E["check-boundaries OR grep guard: no raw SQL outside djinn-db (NEW)"]',
+    '  PR --> F["sqlx prepare --check on every PR, not just merge_group (MOVED)"]',
+  ].join("\n");
+
+  it("normalizes arrows AND quotes every node label", () => {
+    expect(normalizeMermaidSource(REPRO)).toBe(EXPECTED);
+  });
+
+  it("each label line becomes quoted", () => {
+    const out = normalizeMermaidSource(REPRO);
+    expect(out).toContain('A["clippy -D warnings (exists)"]');
+    expect(out).toContain('C["cargo-deny: advisories + licenses (NEW)"]');
+    expect(out).toContain(
+      'F["sqlx prepare --check on every PR, not just merge_group (MOVED)"]',
+    );
+    // No raw `⟶` glyphs survive.
+    expect(out).not.toMatch(/⟶/);
+  });
+
+  it("is idempotent on the repro", () => {
+    const once = normalizeMermaidSource(REPRO);
+    expect(normalizeMermaidSource(once)).toBe(once);
   });
 });

--- a/ui/src/components/proposals/blocks/mermaidNormalize.ts
+++ b/ui/src/components/proposals/blocks/mermaidNormalize.ts
@@ -1,16 +1,28 @@
 /**
  * Mermaid source normalization.
  *
- * LLM- and human-authored diagram sources frequently use "prettified" unicode
- * arrow and dash glyphs (`→`, `⟶`, `⇒`, `➜`, em/en dashes) where Mermaid's
- * grammar requires the ASCII edge operators `-->` / `--`. Passing those glyphs
- * straight to `mermaid.render()` throws a parser error that we used to dump raw
- * to users.
+ * LLM- and human-authored diagram sources frequently trip Mermaid's flowchart
+ * grammar in two ways:
  *
- * `normalizeMermaidSource` rewrites only the arrow-/dash-like *edge* sequences
- * to their ASCII equivalents. It is intentionally conservative: it never touches
- * glyphs that appear inside node/edge *labels* (text in `[...]`, `(...)`,
- * `{...}`, `"..."`), so a label like `A["price → total"]` keeps its arrow.
+ *  1. "Prettified" unicode arrow/dash glyphs (`→`, `⟶`, `⇒`, `➜`, em/en dashes)
+ *     where the grammar wants the ASCII edge operators `-->` / `--`.
+ *  2. Node labels with unquoted special characters — `(`, `)`, `:`, `-D`,
+ *     `--check`, etc. — e.g. `A[clippy -D warnings (exists)]`. Mermaid's parser
+ *     reads the inner `(` as the start of a round-node shape and chokes.
+ *
+ * `normalizeMermaidSource` fixes both, conservatively:
+ *
+ *  - Arrow/dash edge sequences outside labels are rewritten to ASCII operators.
+ *    Glyphs inside node/edge labels (`[...]`, `(...)`, `{...}`, `"..."`) are left
+ *    untouched, so `A["price → total"]` keeps its arrow.
+ *  - Node-shape labels (`ID[...]`, `ID(...)`, `ID{...}`, and the compound shapes
+ *    `([...])`, `[[...]]`, `((...))`, `{{...}}`, `[(...)]`, `>...]`) get their
+ *    inner text wrapped in double quotes when it isn't already quoted, with any
+ *    inner `"` escaped to Mermaid's `#quot;` entity. Already-quoted labels are
+ *    left as-is, so the transform is idempotent.
+ *
+ * Anything still unparseable after this is handled by the caller's graceful
+ * copy-source fallback.
  */
 
 // Unicode arrow glyphs that authors use in place of the `-->` edge operator.
@@ -32,12 +44,115 @@ const ARROW_EDGE = new RegExp(
 const DASH_EDGE = new RegExp(`(^|\\s)${DASH_CLASS}+(\\s|$)`, "gu");
 
 /**
- * Normalize the structural (outside-label) part of a single line.
+ * The recognized node-shape bracket pairs, longest opener first so the compound
+ * shapes win over the single-char ones during matching. `open` is the literal
+ * opening delimiter; `close` is the matching closing delimiter that ends the
+ * label. The label text is whatever sits between them.
+ *
+ * `>` (the asymmetric/flag shape `id>text]`) opens with `>` and closes with `]`.
+ */
+const SHAPES: ReadonlyArray<{ open: string; close: string }> = [
+  { open: "([", close: "])" }, // stadium
+  { open: "[[", close: "]]" }, // subroutine
+  { open: "[(", close: ")]" }, // cylinder
+  { open: "((", close: "))" }, // circle
+  { open: "{{", close: "}}" }, // hexagon
+  { open: "[", close: "]" }, // rectangle
+  { open: "(", close: ")" }, // round
+  { open: "{", close: "}" }, // rhombus
+  { open: ">", close: "]" }, // asymmetric / flag
+];
+
+// A node id directly precedes a shape opener: word chars (Mermaid ids), with no
+// whitespace between the id and the bracket.
+const ID_CHAR = /[A-Za-z0-9_]/;
+
+/** Wrap a raw label in double quotes unless it's already a quoted string. */
+function quoteLabel(inner: string): string {
+  const trimmed = inner.trim();
+  // Already a single fully-quoted string → leave it (idempotent).
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return inner;
+  }
+  // Empty label → nothing to quote.
+  if (trimmed.length === 0) return inner;
+  // Escape any inner double quotes to Mermaid's entity, then wrap.
+  const escaped = inner.replace(/"/g, "#quot;");
+  return `"${escaped}"`;
+}
+
+/**
+ * Auto-quote node-shape labels on a single line.
+ *
+ * Scans left-to-right. Outside a label, when a shape opener is found that is
+ * immediately preceded by a node-id character, the matching close delimiter is
+ * located and the inner text quoted. Edge labels (`|...|`) and quoted strings
+ * are skipped verbatim so we never double-process or touch pipe labels.
+ */
+function quoteNodeLabels(line: string): string {
+  let out = "";
+  let i = 0;
+  const n = line.length;
+
+  while (i < n) {
+    const ch = line[i];
+
+    // Skip a pipe-delimited edge label verbatim: `|...|`.
+    if (ch === "|") {
+      const end = line.indexOf("|", i + 1);
+      if (end === -1) {
+        out += line.slice(i);
+        break;
+      }
+      out += line.slice(i, end + 1);
+      i = end + 1;
+      continue;
+    }
+
+    // Skip a bare quoted string verbatim (not part of a shape).
+    if (ch === '"') {
+      const end = line.indexOf('"', i + 1);
+      if (end === -1) {
+        out += line.slice(i);
+        break;
+      }
+      out += line.slice(i, end + 1);
+      i = end + 1;
+      continue;
+    }
+
+    // Try to match a node-shape opener at this position, but only when it is
+    // glued to a node id (the preceding emitted char is an id char). This keeps
+    // us from treating an edge operator's parens or a stray `(` as a shape.
+    const prev = out.length > 0 ? out[out.length - 1] : "";
+    if (ID_CHAR.test(prev)) {
+      const shape = SHAPES.find((s) => line.startsWith(s.open, i));
+      if (shape) {
+        const contentStart = i + shape.open.length;
+        const closeIdx = line.indexOf(shape.close, contentStart);
+        if (closeIdx !== -1) {
+          const inner = line.slice(contentStart, closeIdx);
+          out += shape.open + quoteLabel(inner) + shape.close;
+          i = closeIdx + shape.close.length;
+          continue;
+        }
+      }
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  return out;
+}
+
+/**
+ * Normalize the structural (outside-label) arrow/dash glyphs on a single line.
  *
  * Labels (`"..."`, `[...]`, `(...)`, `{...}`) are copied verbatim so an arrow
  * inside a label is preserved; only the edge operators between nodes change.
  */
-function normalizeLine(line: string): string {
+function normalizeArrowsLine(line: string): string {
   let out = "";
   let buf = "";
   let closing: string | null = null;
@@ -83,15 +198,23 @@ function normalizeLine(line: string): string {
 }
 
 /**
- * Normalize unicode arrow/dash edge glyphs to Mermaid's ASCII operators.
- * Conservative: only structural (outside-label) glyphs are rewritten, and the
- * source is returned untouched when no candidate glyph is present.
+ * Normalize a Mermaid source so LLM/human-authored diagrams parse:
+ *  1. unicode arrow/dash edge glyphs → ASCII `-->` / `--`,
+ *  2. unquoted node-shape labels → quoted (special chars made safe).
+ *
+ * Conservative and idempotent: glyph-free sources skip the arrow pass, and
+ * already-quoted labels are left untouched.
  */
 export function normalizeMermaidSource(source: string): string {
   if (!source) return source;
-  const hasCandidate = new RegExp(`${ARROW_CLASS}|${DASH_CLASS}`, "u").test(
-    source,
-  );
-  if (!hasCandidate) return source;
-  return source.split("\n").map(normalizeLine).join("\n");
+
+  const hasGlyph = new RegExp(`${ARROW_CLASS}|${DASH_CLASS}`, "u").test(source);
+
+  return source
+    .split("\n")
+    .map((line) => {
+      const arrowed = hasGlyph ? normalizeArrowsLine(line) : line;
+      return quoteNodeLabels(arrowed);
+    })
+    .join("\n");
 }


### PR DESCRIPTION
Fixes three user-reported rendering bugs in the already-shipped proposal blocks. UI-only; no registry/backend change.

## BUG A (P0) — Mermaid node labels rendered blank (empty boxes)
**Root cause:** Mermaid's default flowchart labels are HTML inside `<foreignObject>`. `MermaidDiagram.tsx` sanitizes the rendered SVG with DOMPurify's *SVG* profile, which strips `<foreignObject>` and its embedded HTML — leaving empty boxes.
**Fix:** Initialize Mermaid with `htmlLabels: false` (+ `flowchart: { htmlLabels: false }`) so labels render as native SVG `<text>`, which survives the SVG-profile sanitize. Also switched `theme` from `"default"` to `"dark"` to match the dark-only app.
Verified in a real browser: the BUG-B repro renders with 0 `<foreignObject>` and 13 visible `<text>` labels.

## BUG B (P0) — Mermaid failed to parse real LLM-authored diagrams
**Root cause:** node labels with unquoted special chars (`(`, `)`, `:`, `-D`, `--check`) break Mermaid's parser even after arrow normalization.
**Fix:** Extended `mermaidNormalize.ts` to auto-quote node-shape labels — `ID[...]`, `ID(...)`, `ID{...}`, and compound shapes `([...])`, `[[...]]`, `((...))`, `{{...}}`, `[(...)]`, `>...]`. Unquoted inner text is wrapped in `"..."` with inner `"` escaped to `#quot;`. Already-quoted labels are left as-is (idempotent); pipe edge labels `|...|` are skipped; arrow/dash glyph normalization is preserved. The exact real-proposal repro now parses and renders as a proper flowchart.

## BUG C (P1) — Code line numbers misaligned / lines split
**Root cause:** `react-syntax-highlighter`'s default `showLineNumbers` renders the gutter as a *separate* floated block decoupled from the code body; with `wrapLines` the rows are inline and drift out of alignment (TOML section headers like `[advisories]` split across rows).
**Fix:** `CodeBlock.tsx` now uses `showInlineLineNumbers` (each number lives in its own row box) plus a custom `renderer` that lays each logical line out as a `display: block; white-space: pre` row — one perfectly-aligned row per source line, long lines scroll horizontally (no wrap-induced desync). The renderer also merges in `lineProps`, so AnnotatedCode's annotation bands + hover cross-highlighting keep working.

## Tests
- `mermaidNormalize.test.ts`: 32 cases incl. the exact LLM repro (per-label quoting assertions), all shape variants, already-quoted/idempotent, inner-quote escaping, pipe-label safety.
- `CodeBlock.test.tsx` (new): deny.toml repro asserts exactly one row per line, inline numbers 1..7 in order, `display:block`/`white-space:pre`, section headers unsplit, and `lineProps` routing.
- Full `src/components/proposals` suite green (19 files, 233 tests). `tsc -b` clean; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
