### PR TITLE
feat(provider): flagship model map + codex/subscription policy data (pr 1/3)

### DIFF
--- a/server/crates/djinn-control-plane/src/state.rs
+++ b/server/crates/djinn-control-plane/src/state.rs
@@ -248,16 +248,30 @@ impl McpState {
             })
             .collect();
 
-        // Org-policy gate: reject any model on a blocked subscription provider
-        // before the connectivity check, with a distinct message.
+        // Org-policy gate: reject any model on a blocked subscription before the
+        // connectivity check, with a distinct message. We resolve each model to
+        // its governable subscription IDENTITY (not just its namespace provider)
+        // so a blocked ChatGPT/Codex sub catches `openai/...-codex` models even
+        // though they surface under the `openai` namespace — while a plain openai
+        // BYO API key stays ungoverned.
         let blocked = self.blocked_subscription_ids().await;
         if !blocked.is_empty() {
-            let mut blocked_hits: Vec<String> = configured_provider_ids
+            let mut blocked_hits: Vec<String> = models
                 .iter()
-                .filter(|pid| blocked.contains(&pid.to_ascii_lowercase()))
-                .cloned()
+                .filter_map(|model| {
+                    let provider_id = model
+                        .split_once('/')
+                        .map(|(pid, _)| pid)
+                        .unwrap_or(model.as_str());
+                    djinn_provider::catalog::builtin::governable_subscription_for_model(
+                        provider_id,
+                        model,
+                    )
+                    .filter(|sub| blocked.contains(&sub.to_ascii_lowercase()))
+                })
                 .collect();
             blocked_hits.sort();
+            blocked_hits.dedup();
             if !blocked_hits.is_empty() {
                 return Err(format!(
                     "models reference subscriptions blocked by org policy: {}",

--- a/server/crates/djinn-control-plane/src/tools/org_policy_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/org_policy_tools.rs
@@ -125,23 +125,57 @@ fn jurisdiction_str(j: Jurisdiction) -> &'static str {
     }
 }
 
-/// All subscription provider ids the catalog currently exposes, paired with
-/// their display name. This is the universe the admin allow/block table is
-/// drawn over — drawn from the live catalog so newly-surfaced models.dev
-/// subscriptions appear automatically.
+/// Canonical key used to collapse duplicate provider ids that name the same
+/// real subscription (e.g. the catalog carries both `github-copilot` and
+/// `githubcopilot` — same GitHub Copilot sub). Lowercased, separators stripped.
+fn canonical_sub_key(id: &str) -> String {
+    id.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+/// The de-duplicated universe of **governable subscriptions** for the admin
+/// allow/block table: each supported subscription provider once, paired with a
+/// display name. Drawn from the live catalog (so newly-surfaced models.dev
+/// subscriptions appear automatically), plus the merged-child subscriptions the
+/// catalog hides (notably ChatGPT/Codex, which merges into `openai`). Duplicate
+/// ids for the same real sub (e.g. the two GitHub Copilot entries) collapse to a
+/// single row. Non-subscription API providers are never included.
+///
+/// Each entry is `(id, display_name)` where `id` is the stored/blocklist form.
 fn subscription_universe(server: &DjinnMcpServer) -> Vec<(String, String)> {
+    use std::collections::HashSet;
+
     let merged = builtin::merged_provider_ids();
-    let mut out: Vec<(String, String)> = server
-        .state
-        .catalog()
-        .list_providers()
-        .into_iter()
-        .filter(|p| !merged.contains(&p.id))
-        .filter(|p| builtin::is_subscription_provider(&p.id))
-        .map(|p| (p.id.clone(), p.name.clone()))
-        .collect();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<(String, String)> = Vec::new();
+
+    // 1. Merged-child subscriptions the catalog hides (e.g. chatgpt_codex →
+    //    openai). These are governable in their own right even though their
+    //    models surface under the parent namespace, so they must appear here.
+    for bp in builtin::BUILTIN_PROVIDERS {
+        if bp.merge_into.is_some() && builtin::is_subscription_provider(bp.id) {
+            let key = canonical_sub_key(bp.id);
+            if seen.insert(key) {
+                out.push((bp.id.to_string(), bp.display_name.to_string()));
+            }
+        }
+    }
+
+    // 2. Subscriptions the catalog exposes directly (skip hidden merged parents'
+    //    children already added above, and collapse alias duplicates).
+    for p in server.state.catalog().list_providers() {
+        if merged.contains(&p.id) || !builtin::is_subscription_provider(&p.id) {
+            continue;
+        }
+        let key = canonical_sub_key(&p.id);
+        if seen.insert(key) {
+            out.push((p.id.clone(), p.name.clone()));
+        }
+    }
+
     out.sort_by(|a, b| a.0.cmp(&b.0));
-    out.dedup_by(|a, b| a.0 == b.0);
     out
 }
 

--- a/server/crates/djinn-control-plane/src/tools/provider_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/provider_tools.rs
@@ -47,6 +47,7 @@ fn model_to_output(m: &Model) -> ProviderModelOutput {
     } else {
         format!("{}/{}", m.provider_id, m.id)
     };
+    let recommended = builtin::is_recommended_model(&m.provider_id, &m.id);
     ProviderModelOutput {
         id: full_id,
         provider_id: m.provider_id.clone(),
@@ -56,6 +57,7 @@ fn model_to_output(m: &Model) -> ProviderModelOutput {
         attachment: m.attachment,
         context_window: m.context_window,
         output_limit: m.output_limit,
+        recommended,
         pricing: ModelPricingOutput {
             input_per_million: m.pricing.input_per_million,
             output_per_million: m.pricing.output_per_million,
@@ -261,6 +263,12 @@ pub struct ProviderModelOutput {
     pub attachment: bool,
     pub context_window: i64,
     pub output_limit: i64,
+    /// Whether this is a curated flagship the UI should surface as
+    /// "recommended" (latest state-of-the-art model for its provider). Set from
+    /// the server-side flagship map (`builtin::is_recommended_model`); a provider
+    /// with no curated recommendation has this `false` on every model and the UI
+    /// falls back to showing all of them.
+    pub recommended: bool,
     pub pricing: ModelPricingOutput,
 }
 
@@ -815,6 +823,11 @@ impl DjinnMcpServer {
                                 .unwrap_or(&out.id)
                                 .to_string();
                             out.id = format!("{display_pid}/{rest}");
+                            // Recompute `recommended` under the parent namespace
+                            // so a merged child's flagship (e.g. a chatgpt_codex
+                            // model re-tagged to openai) is still marked.
+                            out.recommended =
+                                builtin::is_recommended_model(&out.provider_id, &out.id);
                         }
                         out
                     })

--- a/server/crates/djinn-control-plane/tests/provider_tools.rs
+++ b/server/crates/djinn-control-plane/tests/provider_tools.rs
@@ -347,3 +347,113 @@ async fn org_policy_get_reports_jurisdiction_and_lock_default() {
         );
     }
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn org_policy_subscription_enumeration_includes_codex_chinese_and_dedupes_copilot() {
+    let harness = McpTestHarness::new().await;
+    let result = harness
+        .call_tool("org_policy_get", json!({}))
+        .await
+        .expect("org_policy_get dispatch");
+    let subs = result["subscriptions"].as_array().expect("subscriptions");
+
+    let by_id = |id: &str| subs.iter().find(|s| s["id"] == id);
+
+    // ChatGPT/Codex is a governable subscription, classified US — even though it
+    // is a merged child the catalog otherwise hides under `openai`.
+    let codex = by_id("chatgpt_codex").expect("chatgpt_codex must be enumerated");
+    assert_eq!(codex["jurisdiction"], "us", "codex is US-hosted");
+
+    // Connected Chinese subs are classified CN.
+    for cn_id in ["minimax-coding-plan", "kimi-for-coding", "zai-coding-plan"] {
+        let item = by_id(cn_id).unwrap_or_else(|| panic!("{cn_id} must be enumerated"));
+        assert_eq!(item["jurisdiction"], "cn", "{cn_id} should be China-hosted");
+    }
+
+    // The two GitHub Copilot ids (`github-copilot` + `githubcopilot`) collapse to
+    // exactly one row.
+    let copilot_count = subs
+        .iter()
+        .filter(|s| {
+            s["id"]
+                .as_str()
+                .map(|id| {
+                    let canon: String = id
+                        .chars()
+                        .filter(|c| c.is_ascii_alphanumeric())
+                        .flat_map(|c| c.to_lowercase())
+                        .collect();
+                    canon == "githubcopilot"
+                })
+                .unwrap_or(false)
+        })
+        .count();
+    assert_eq!(
+        copilot_count, 1,
+        "GitHub Copilot must be de-duplicated to one row"
+    );
+
+    // Non-subscription API providers are never listed.
+    assert!(
+        by_id("openai").is_none(),
+        "plain openai api key is not governed"
+    );
+    assert!(by_id("anthropic").is_none());
+    assert!(by_id("fireworks-ai").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn org_policy_blocks_codex_subscription_via_openai_namespaced_models() {
+    let harness = McpTestHarness::new().await;
+    let db = harness.db().clone();
+
+    // Connect the openai provider so the connectivity check passes; the test
+    // then isolates the org-policy gate (codex block) from connectivity.
+    CredentialRepository::new(db, EventBus::noop())
+        .set("openai", "OPENAI_API_KEY", "sk-test")
+        .await
+        .unwrap();
+
+    // Baseline: a codex model (surfaced under the openai namespace) validates.
+    harness
+        .state()
+        .validate_models_for_user(&["openai/gpt-5.3-codex".to_string()], None)
+        .await
+        .expect("codex model validates before block");
+
+    // Admin blocks the ChatGPT/Codex subscription by its own identity.
+    let set = harness
+        .call_tool(
+            "org_policy_set",
+            json!({"blocked_subscriptions": ["chatgpt_codex"]}),
+        )
+        .await
+        .expect("org_policy_set dispatch");
+    assert!(
+        set["blocked_subscriptions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == "chatgpt_codex"),
+        "codex sub must be storable in the blocklist (it is a subscription)"
+    );
+
+    // Enforcement: a codex model namespaced `openai/...` is now rejected, because
+    // it resolves to the blocked chatgpt_codex subscription identity.
+    let err = harness
+        .state()
+        .validate_models_for_user(&["openai/gpt-5.3-codex".to_string()], None)
+        .await
+        .expect_err("codex model must be rejected once the sub is blocked");
+    assert!(
+        err.contains("blocked by org policy"),
+        "rejection should mention org policy, got: {err}"
+    );
+
+    // A plain openai API-key model is NOT governed by the codex block.
+    harness
+        .state()
+        .validate_models_for_user(&["openai/gpt-5.5".to_string()], None)
+        .await
+        .expect("plain openai api-key model stays ungoverned");
+}

--- a/server/crates/djinn-provider/src/catalog/builtin.rs
+++ b/server/crates/djinn-provider/src/catalog/builtin.rs
@@ -523,6 +523,36 @@ pub fn is_subscription_provider(provider_id: &str) -> bool {
     classify_provider(provider_id).is_subscription()
 }
 
+/// Resolve the **governable subscription identity** a `(provider_id, model_id)`
+/// reference belongs to, if any.
+///
+/// This bridges the one case where a subscription's models are surfaced under a
+/// *different* provider namespace than the subscription's own id: the ChatGPT/
+/// Codex OAuth subscription (`chatgpt_codex`) merges into `openai`, so its models
+/// are namespaced `openai/...-codex` everywhere a member sees them. A plain
+/// `openai` BYO **API key** is NOT a subscription and must stay ungoverned, so we
+/// can't just treat all of `openai` as the codex sub — we key off the `codex`
+/// model marker (the same marker [`MODEL_SOURCE_MAP`] uses to source the codex
+/// model list from openai).
+///
+/// Returns (lowercased, matching the stored blocklist form):
+/// - `Some("chatgpt_codex")` for an `openai` model whose id marks it a Codex
+///   model (so org policy can block the Codex sub without touching plain openai).
+/// - `Some(provider_id)` when the provider itself is a subscription.
+/// - `None` for non-subscription providers (plain API keys), which are never
+///   governed by the org allow/block list.
+pub fn governable_subscription_for_model(provider_id: &str, model_id: &str) -> Option<String> {
+    // Codex models surface under the openai namespace; recognise them by the
+    // `codex` marker and attribute them to the chatgpt_codex subscription.
+    if canonical_id(provider_id) == "openai" && model_id.to_ascii_lowercase().contains("codex") {
+        return Some("chatgpt_codex".to_string());
+    }
+    if is_subscription_provider(provider_id) {
+        return Some(provider_id.to_ascii_lowercase());
+    }
+    None
+}
+
 /// Id-pattern rule for personal coding/token plans and consumer vendor subs
 /// that are **not** hand-registered as built-ins (models.dev-native only).
 ///
@@ -675,6 +705,93 @@ pub fn provider_jurisdiction(provider_id: &str) -> Jurisdiction {
     }
 
     Jurisdiction::Other
+}
+
+// ── Curated flagship / "recommended" model map ───────────────────────────────
+//
+// For each SUPPORTED provider, the latest state-of-the-art flagship model id(s).
+// This is the curated subset the UI marks "recommended" so members aren't shown
+// every historical variant (no GPT-5.2/5.3/5.4 when 5.5 exists, no o1/o3
+// clutter). A provider absent from this map has NO recommended model — the UI
+// falls back to showing all of its models.
+//
+// ──────────────────────────────────────────────────────────────────────────────
+// MAINTENANCE: when a provider ships a new flagship, update the one slice below
+// (it is a single-line edit per provider). Model ids are the **bare** ids as
+// they appear in the provider's own catalog list (NOT `provider/` prefixed) —
+// matching is done on (provider_id, bare model id). For merged children whose
+// models are re-namespaced to a parent (e.g. `chatgpt_codex` → `openai`), list
+// the ids under the CHILD's own id; the lookup also resolves the parent-
+// namespaced form so the recommendation survives re-tagging.
+// ──────────────────────────────────────────────────────────────────────────────
+//
+// (provider_id, &[flagship bare model ids])
+const RECOMMENDED_MODELS: &[(&str, &[&str])] = &[
+    // Single-vendor subs / first-party APIs → the one current flagship (+ its
+    // codex/coding variant where the vendor ships a distinct one).
+    //
+    // OpenAI (BYO API key): current GPT-5.5 family flagship + the latest Codex.
+    ("openai", &["gpt-5.5", "gpt-5.3-codex"]),
+    // ChatGPT/Codex subscription: the same Codex flagship, under the child id.
+    ("chatgpt_codex", &["gpt-5.3-codex"]),
+    // Anthropic: current Claude Opus flagship.
+    ("anthropic", &["claude-opus-4-8"]),
+    // MiniMax coding plan: current MiniMax flagship.
+    ("minimax-coding-plan", &["MiniMax-M3"]),
+    // Kimi for Coding: current Kimi K2.7 Code flagship.
+    ("kimi-for-coding", &["k2p7"]),
+    // Z.AI / Zhipu coding plan: current GLM flagship.
+    ("zai-coding-plan", &["glm-5.2"]),
+    // Xiaomi MiMo token plan (SGP region variant we hand-register): MiMo flagship.
+    ("xiaomi-token-plan-sgp", &["mimo-v2.5-pro"]),
+    // Multi-model gateways expose many third-party models → a SMALL curated set
+    // of the current top models, not a single flagship.
+    //
+    // OpenCode Zen: top Anthropic/OpenAI/Google flagships it proxies.
+    (
+        "opencode",
+        &["claude-opus-4-8", "gpt-5.5", "gemini-3.1-pro"],
+    ),
+    // Fireworks AI: top open-weight flagships it serves (bare ids are slash
+    // paths in the live catalog).
+    (
+        "fireworks-ai",
+        &[
+            "accounts/fireworks/models/glm-5p2",
+            "accounts/fireworks/models/minimax-m3",
+            "accounts/fireworks/models/kimi-k2p7-code",
+        ],
+    ),
+];
+
+/// Curated flagship / "recommended" model ids for `provider_id` — the latest
+/// state-of-the-art model(s) the UI surfaces as recommended. Empty slice when
+/// the provider has no curated recommendation (UI shows all its models).
+///
+/// See [`RECOMMENDED_MODELS`] for the (1-line-per-provider) curated map.
+pub fn recommended_model_ids(provider_id: &str) -> &'static [&'static str] {
+    RECOMMENDED_MODELS
+        .iter()
+        .find(|(id, _)| *id == provider_id)
+        .map(|(_, ids)| *ids)
+        .unwrap_or(&[])
+}
+
+/// Whether `(provider_id, model_id)` is a curated flagship the UI marks
+/// "recommended". Accepts either a bare model id or a `provider/...`-qualified
+/// id, and tolerates merged-child re-namespacing: a model re-tagged to a parent
+/// provider (e.g. a `chatgpt_codex` model surfaced under `openai`) still matches
+/// the recommendation registered under the parent. Matching is case-sensitive
+/// on the model id (catalog ids are canonical).
+pub fn is_recommended_model(provider_id: &str, model_id: &str) -> bool {
+    // Strip a leading `provider_id/` qualifier if present, keeping the rest of
+    // the (possibly multi-segment) model id intact.
+    let bare = model_id
+        .strip_prefix(&format!("{provider_id}/"))
+        .unwrap_or(model_id);
+    recommended_model_ids(provider_id)
+        .iter()
+        .any(|id| *id == bare || *id == model_id)
 }
 
 /// Strip non-alphanumeric chars and lowercase for fuzzy ID matching.
@@ -837,6 +954,94 @@ mod tests {
         assert_eq!(
             provider_jurisdiction("acme-token-plan-sgp"),
             Jurisdiction::Other
+        );
+    }
+
+    #[test]
+    fn recommended_map_picks_current_flagships_not_clutter() {
+        // OpenAI: the GPT-5.5 flagship + latest codex are recommended; older
+        // GPT-5.x variants and o-series are not.
+        assert!(is_recommended_model("openai", "gpt-5.5"));
+        assert!(is_recommended_model("openai", "gpt-5.3-codex"));
+        assert!(is_recommended_model("openai", "openai/gpt-5.5")); // qualified form
+        assert!(!is_recommended_model("openai", "gpt-5.4"));
+        assert!(!is_recommended_model("openai", "gpt-5.2"));
+        assert!(!is_recommended_model("openai", "o3"));
+        assert!(!is_recommended_model("openai", "gpt-4o"));
+
+        // Single-vendor subs → one flagship each.
+        assert!(is_recommended_model("minimax-coding-plan", "MiniMax-M3"));
+        assert!(!is_recommended_model("minimax-coding-plan", "MiniMax-M2"));
+        assert!(is_recommended_model("kimi-for-coding", "k2p7"));
+        assert!(!is_recommended_model("kimi-for-coding", "k2p5"));
+        assert!(is_recommended_model("zai-coding-plan", "glm-5.2"));
+        assert!(!is_recommended_model("zai-coding-plan", "glm-4.7"));
+        assert!(is_recommended_model(
+            "xiaomi-token-plan-sgp",
+            "mimo-v2.5-pro"
+        ));
+        assert!(is_recommended_model("anthropic", "claude-opus-4-8"));
+
+        // Codex child id resolves its own flagship, and the parent-namespaced
+        // form (after re-tagging) still matches the openai recommendation.
+        assert!(is_recommended_model("chatgpt_codex", "gpt-5.3-codex"));
+
+        // Multi-model gateway → a small curated set, not one and not all.
+        let oc = recommended_model_ids("opencode");
+        assert!(
+            oc.len() > 1 && oc.len() <= 4,
+            "opencode set should be small"
+        );
+        assert!(is_recommended_model("opencode", "gpt-5.5"));
+        assert!(!is_recommended_model("opencode", "claude-3-5-haiku"));
+        assert!(is_recommended_model(
+            "fireworks-ai",
+            "accounts/fireworks/models/glm-5p2"
+        ));
+        assert!(is_recommended_model(
+            "fireworks-ai",
+            "fireworks-ai/accounts/fireworks/models/minimax-m3"
+        ));
+
+        // Unmapped provider ⇒ nothing recommended (UI shows all).
+        assert!(recommended_model_ids("aws_bedrock").is_empty());
+        assert!(!is_recommended_model("aws_bedrock", "anything"));
+    }
+
+    #[test]
+    fn codex_is_a_governable_us_subscription() {
+        // chatgpt_codex itself is a subscription, hosted in the US.
+        assert!(is_subscription_provider("chatgpt_codex"));
+        assert_eq!(provider_jurisdiction("chatgpt_codex"), Jurisdiction::Us);
+
+        // A codex model surfaced under the openai namespace is attributed to the
+        // chatgpt_codex subscription (so org policy can block it)…
+        assert_eq!(
+            governable_subscription_for_model("openai", "openai/gpt-5.3-codex").as_deref(),
+            Some("chatgpt_codex")
+        );
+        assert_eq!(
+            governable_subscription_for_model("openai", "gpt-5.5-codex").as_deref(),
+            Some("chatgpt_codex")
+        );
+        // …while a plain openai API-key model stays UNGOVERNED.
+        assert_eq!(
+            governable_subscription_for_model("openai", "openai/gpt-5.5"),
+            None
+        );
+        // A genuine subscription provider maps to its own (lowercased) id.
+        assert_eq!(
+            governable_subscription_for_model(
+                "minimax-coding-plan",
+                "minimax-coding-plan/MiniMax-M3"
+            )
+            .as_deref(),
+            Some("minimax-coding-plan")
+        );
+        // Non-subscription providers are never governable.
+        assert_eq!(
+            governable_subscription_for_model("anthropic", "anthropic/x"),
+            None
         );
     }
 

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -14348,6 +14348,10 @@ expression: signatures
             "reasoning": {
               "type": "boolean"
             },
+            "recommended": {
+              "description": "Whether this is a curated flagship the UI should surface as\n\"recommended\" (latest state-of-the-art model for its provider). Set from\nthe server-side flagship map (`builtin::is_recommended_model`); a provider\nwith no curated recommendation has this `false` on every model and the UI\nfalls back to showing all of them.",
+              "type": "boolean"
+            },
             "tool_call": {
               "type": "boolean"
             }
@@ -14361,6 +14365,7 @@ expression: signatures
             "attachment",
             "context_window",
             "output_limit",
+            "recommended",
             "pricing"
           ],
           "type": "object"
@@ -14527,6 +14532,10 @@ expression: signatures
             "reasoning": {
               "type": "boolean"
             },
+            "recommended": {
+              "description": "Whether this is a curated flagship the UI should surface as\n\"recommended\" (latest state-of-the-art model for its provider). Set from\nthe server-side flagship map (`builtin::is_recommended_model`); a provider\nwith no curated recommendation has this `false` on every model and the UI\nfalls back to showing all of them.",
+              "type": "boolean"
+            },
             "tool_call": {
               "type": "boolean"
             }
@@ -14540,6 +14549,7 @@ expression: signatures
             "attachment",
             "context_window",
             "output_limit",
+            "recommended",
             "pricing"
           ],
           "type": "object"
@@ -14647,6 +14657,10 @@ expression: signatures
             "reasoning": {
               "type": "boolean"
             },
+            "recommended": {
+              "description": "Whether this is a curated flagship the UI should surface as\n\"recommended\" (latest state-of-the-art model for its provider). Set from\nthe server-side flagship map (`builtin::is_recommended_model`); a provider\nwith no curated recommendation has this `false` on every model and the UI\nfalls back to showing all of them.",
+              "type": "boolean"
+            },
             "tool_call": {
               "type": "boolean"
             }
@@ -14660,6 +14674,7 @@ expression: signatures
             "attachment",
             "context_window",
             "output_limit",
+            "recommended",
             "pricing"
           ],
           "type": "object"

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -5779,6 +5779,11 @@ export namespace ProposalBlocksOutputSchema {
   }
   export interface ProposalBlockDefinition {
   /**
+   * Optional authoring guidance for the LLM: how to encode this block's
+   * children/attributes. Absent for blocks whose shape is self-evident.
+   */
+  description?: string
+  /**
    * Field schema keyed by field name.
    */
   fields: {
@@ -7170,6 +7175,14 @@ export namespace ProviderModelLookupOutputSchema {
   pricing: ModelPricingOutput
   provider_id: string
   reasoning: boolean
+  /**
+   * Whether this is a curated flagship the UI should surface as
+   * "recommended" (latest state-of-the-art model for its provider). Set from
+   * the server-side flagship map (`builtin::is_recommended_model`); a provider
+   * with no curated recommendation has this `false` on every model and the UI
+   * falls back to showing all of them.
+   */
+  recommended: boolean
   tool_call: boolean
   [k: string]: any
   }
@@ -7210,6 +7223,14 @@ export namespace ProviderModelsOutputSchema {
   pricing: ModelPricingOutput
   provider_id: string
   reasoning: boolean
+  /**
+   * Whether this is a curated flagship the UI should surface as
+   * "recommended" (latest state-of-the-art model for its provider). Set from
+   * the server-side flagship map (`builtin::is_recommended_model`); a provider
+   * with no curated recommendation has this `false` on every model and the UI
+   * falls back to showing all of them.
+   */
+  recommended: boolean
   tool_call: boolean
   [k: string]: any
   }
@@ -7250,6 +7271,14 @@ export namespace ProviderModelsConnectedOutputSchema {
   pricing: ModelPricingOutput
   provider_id: string
   reasoning: boolean
+  /**
+   * Whether this is a curated flagship the UI should surface as
+   * "recommended" (latest state-of-the-art model for its provider). Set from
+   * the server-side flagship map (`builtin::is_recommended_model`); a provider
+   * with no curated recommendation has this `false` on every model and the UI
+   * falls back to showing all of them.
+   */
+  recommended: boolean
   tool_call: boolean
   [k: string]: any
   }

--- a/ui/src/components/AgentConfig.stories.tsx
+++ b/ui/src/components/AgentConfig.stories.tsx
@@ -14,6 +14,7 @@ const availableModels: ProviderModel[] = [
     pricing: { input_per_million: 3, output_per_million: 15, cache_read_per_million: 0.3, cache_write_per_million: 3.75 },
     reasoning: false,
     tool_call: true,
+    recommended: false,
   },
   {
     id: "gpt-4o",
@@ -25,6 +26,7 @@ const availableModels: ProviderModel[] = [
     pricing: { input_per_million: 2.5, output_per_million: 10, cache_read_per_million: 1.25, cache_write_per_million: 0 },
     reasoning: false,
     tool_call: true,
+    recommended: false,
   },
   {
     id: "deepseek-coder",
@@ -36,6 +38,7 @@ const availableModels: ProviderModel[] = [
     pricing: { input_per_million: 0.14, output_per_million: 0.28, cache_read_per_million: 0, cache_write_per_million: 0 },
     reasoning: false,
     tool_call: true,
+    recommended: false,
   },
   {
     id: "gemini-2.5-pro",
@@ -47,6 +50,7 @@ const availableModels: ProviderModel[] = [
     pricing: { input_per_million: 1.25, output_per_million: 10, cache_read_per_million: 0, cache_write_per_million: 0 },
     reasoning: true,
     tool_call: true,
+    recommended: false,
   },
 ];
 


### PR DESCRIPTION
Server foundation (PR 1/3) for the **Model Roles / provider** fix round. The two follow-up UI PRs (2a presets/model-list, 2b connections + org-policy admin) consume the data this PR produces. **No UI feature work here.**

## What it does

### 1. Curated flagship map + `recommended` field
- New `recommended_model_ids(provider_id)` / `is_recommended_model(provider_id, model_id)` in `djinn-provider`'s `catalog/builtin.rs` — the latest state-of-the-art flagship model id(s) per supported provider (no GPT-5.2/5.3/5.4 when 5.5 exists, no o1/o3 clutter). Single-vendor subs → one flagship; multi-model gateways (`opencode`, `fireworks-ai`) → a small curated set. The map is documented as a **1-line-per-provider** update.
- New boolean **`recommended`** on `ProviderModelOutput`, set from the map. Survives merged-child re-namespacing (a `chatgpt_codex` flagship surfaced under `openai` is still flagged).

Flagship picks (derived from each provider's live model list): `openai` → `gpt-5.5` + `gpt-5.3-codex`; `chatgpt_codex` → `gpt-5.3-codex`; `anthropic` → `claude-opus-4-8`; `minimax-coding-plan` → `MiniMax-M3`; `kimi-for-coding` → `k2p7`; `zai-coding-plan` → `glm-5.2`; `xiaomi-token-plan-sgp` → `mimo-v2.5-pro`; `opencode` → `{claude-opus-4-8, gpt-5.5, gemini-3.1-pro}`; `fireworks-ai` → `{glm-5p2, minimax-m3, kimi-k2p7-code}`. Unmapped provider ⇒ nothing recommended (UI shows all).

### 2. ChatGPT/Codex is a governable US subscription
`openai` (BYO API key) stays `api_key`/ungoverned. Codex models surface under the `openai` namespace, so a new `governable_subscription_for_model(provider_id, model_id)` attributes `openai/...-codex` models to the `chatgpt_codex` subscription identity (jurisdiction **Us**). `validate_models_for_user` now enforces blocks via that identity — blocking `chatgpt_codex` hides/rejects codex models while plain `openai/gpt-5.5` stays connectable.

### 3. Corrected governable-subscription enumeration
`subscription_universe` (backing `org_policy_get.subscriptions`) now: includes merged-child subs (**ChatGPT/Codex, US**) the catalog otherwise hides; includes connected Chinese subs (minimax/kimi/zai/zhipu/xiaomi → **CN**); collapses the duplicate GitHub Copilot ids (`github-copilot` + `githubcopilot`) into one; never lists non-subscription API providers.

### 4. Org-default lane assignment — verified complete
`org_policy_get`/`org_policy_set` already read AND write the org-default plan/implement/review lanes + lock level (slice 5). No setter gap, so **no migration** (highest on main is 79; a from-scratch apply of all 79 migrations was verified clean — 79 distinct versions).

## Tests
- `builtin.rs`: flagship-not-clutter; codex-as-US-sub + `governable_subscription_for_model`.
- `tests/provider_tools.rs`: enumeration includes codex (US) / chinese (CN) / dedupes copilot; codex block enforced via `openai/...-codex` while plain openai stays ungoverned.
- Regenerated `mcp-tools.gen.ts` + the tool-schema insta snapshot for the new `recommended` field.

## Verified
`cargo build`, `cargo clippy --all-features`, `cargo fmt`, `cargo nextest` (djinn-provider 570, djinn-control-plane `provider_tools` 13, djinn-server `tool_schemas` 14) — all green. UI `tsc --noEmit` clean; `settingsStore` vitest green. No SQL changed.

## For PR-2a / PR-2b
- **PR-2a (presets/model-list):** every model now carries `recommended: boolean`; filter/sort on it to show the flagship subset, fall back to all when a provider has none.
- **PR-2b (connections + org-policy UI):** `org_policy_get.subscriptions` is the corrected grouped universe (`id`, `name`, `jurisdiction`, `blocked`) — render grouped US/EU/China/Other; `chatgpt_codex` is the blocklist id for ChatGPT/Codex; copilot is a single row. Org-default lanes + lock are already readable/writable via `org_policy_get`/`org_policy_set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)