### PR TITLE
feat(proposals): render diagrams with beautiful-mermaid (fixes label rendering)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -44,6 +44,7 @@
     "@xyflow/react": "^12.10.2",
     "ai": "^6.0.143",
     "ansi-to-react": "^6.2.6",
+    "beautiful-mermaid": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       ansi-to-react:
         specifier: ^6.2.6
         version: 6.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      beautiful-mermaid:
+        specifier: ^1.1.3
+        version: 1.1.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3070,6 +3073,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  beautiful-mermaid@1.1.3:
+    resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
+
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
@@ -3641,6 +3647,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -9021,6 +9031,11 @@ snapshots:
 
   baseline-browser-mapping@2.10.13: {}
 
+  beautiful-mermaid@1.1.3:
+    dependencies:
+      elkjs: 0.11.1
+      entities: 7.0.1
+
   better-opn@3.0.2:
     dependencies:
       open: 8.4.2
@@ -9571,6 +9586,8 @@ snapshots:
       tapable: 2.3.2
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 

--- a/ui/src/components/MermaidDiagram.test.tsx
+++ b/ui/src/components/MermaidDiagram.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { renderMermaidSVG, THEMES } from "beautiful-mermaid";
+
+import { MermaidDiagram } from "./MermaidDiagram";
+import { normalizeMermaidSource } from "@/components/proposals/blocks/mermaidNormalize";
+
+// The real repro from the task: a `graph TD` with unicode arrows and node
+// labels carrying parentheses / `-D` / `--check` special chars — exactly the
+// LLM-authored shape that the previous `<foreignObject>` path silently blanked.
+const REPRO_SOURCE = `graph TD
+  PR[PR push] ⟶ A[clippy -D warnings (exists)]
+  PR ⟶ B[hakari verify (exists)]
+  PR ⟶ C[cargo-deny: advisories + licenses (NEW)]
+  PR ⟶ D[cargo-deny bans: sqlx wrapper-allowlist ratchet (NEW)]
+  PR ⟶ E[check-boundaries OR grep guard: no raw SQL outside djinn-db (NEW)]
+  PR ⟶ F[sqlx prepare --check on every PR, not just merge_group (MOVED)]`;
+
+const REPRO_LABELS = [
+  "PR push",
+  "clippy -D warnings (exists)",
+  "hakari verify (exists)",
+  "cargo-deny: advisories + licenses (NEW)",
+  "cargo-deny bans: sqlx wrapper-allowlist ratchet (NEW)",
+  "check-boundaries OR grep guard: no raw SQL outside djinn-db (NEW)",
+  "sqlx prepare --check on every PR, not just merge_group (MOVED)",
+];
+
+describe("beautiful-mermaid render contract", () => {
+  it("emits native SVG <text> labels (no <foreignObject>) for the normalized repro", () => {
+    const normalized = normalizeMermaidSource(REPRO_SOURCE);
+    const svg = renderMermaidSVG(normalized, {
+      ...THEMES["tokyo-night"],
+      font: "inherit",
+    });
+
+    // The whole point: real <text> elements, never the HTML-in-SVG
+    // <foreignObject> wrapper that the SVG-profile sanitize strips.
+    expect(svg).toContain("<text");
+    expect(svg).not.toContain("foreignObject");
+
+    // Every node label is present as visible text.
+    for (const label of REPRO_LABELS) {
+      expect(svg).toContain(label);
+    }
+  });
+
+  it("applies the tokyo-night dark theme background", () => {
+    const svg = renderMermaidSVG("graph TD\n  A[a] --> B[b]", {
+      ...THEMES["tokyo-night"],
+    });
+    // tokyo-night bg (#1a1b26) — keeps the diagram on djinn's near-black page.
+    expect(svg.toLowerCase()).toContain("#1a1b26");
+  });
+});
+
+describe("MermaidDiagram", () => {
+  it("renders the repro to an SVG with visible labels and no error fallback", async () => {
+    render(<MermaidDiagram source={REPRO_SOURCE} />);
+
+    const container = await screen.findByTestId("mermaid-diagram");
+
+    await waitFor(() => {
+      expect(container.querySelector("svg")).not.toBeNull();
+    });
+
+    // Did NOT fall through to the copy-source error fallback.
+    expect(screen.queryByTestId("mermaid-error")).toBeNull();
+
+    const svg = container.querySelector("svg")!;
+    expect(svg.querySelectorAll("text").length).toBeGreaterThan(0);
+    expect(container.textContent).toContain("PR push");
+    expect(container.textContent).toContain("cargo-deny: advisories + licenses (NEW)");
+  });
+
+  it("falls back to the copy-source surface on unrenderable input", async () => {
+    // Empty/blank source can't produce a diagram on either renderer → the
+    // graceful tertiary fallback, never a thrown exception or a blank block.
+    render(<MermaidDiagram source={"   "} />);
+
+    const fallback = await screen.findByTestId("mermaid-error");
+    expect(fallback).not.toBeNull();
+  });
+});

--- a/ui/src/components/MermaidDiagram.tsx
+++ b/ui/src/components/MermaidDiagram.tsx
@@ -1,70 +1,95 @@
 /**
  * MermaidDiagram — reusable Mermaid renderer.
  *
- * PR D4: shared between `ImpactFlowModal` (blast-radius visualization) and
- * the chat citation pipeline (PR D5), with a future home in Process flows
- * (Epic F2).
+ * Shared between `ImpactFlowModal` (blast-radius visualization) and the
+ * proposal `Diagram` block, so a single change here covers every place we
+ * render Mermaid.
+ *
+ * Renders via `beautiful-mermaid` (`renderMermaidSVG`): a pure-TS renderer that
+ * emits native SVG `<text>` (not `<foreignObject>` HTML) with editor-grade
+ * themes. Native `<text>` is the load-bearing win — it survives DOMPurify's
+ * SVG-profile sanitize, so node labels can't be silently stripped (the failure
+ * mode of the previous stock-mermaid `<foreignObject>` path).
+ *
+ * Theme: `tokyo-night` (`#1a1b26` bg) — chosen to sit on djinn's near-black
+ * (`oklch(0.141 0.005 285.823)`) dark-only palette without reading as a bright
+ * card on a dark page.
  *
  * Contract:
- *   - props: `{ source: string; className?: string }`
- *   - initializes Mermaid once at module load with `securityLevel: "strict"`
- *     so we never inline-eval untrusted source,
- *   - renders into a sanitized container (DOMPurify) so even a `securityLevel`
- *     regression can't smuggle script tags through,
- *   - normalizes unicode arrow/dash glyphs to Mermaid's ASCII edge operators
- *     before render (LLM-authored sources frequently use `→`/`⟶`/`—`),
- *   - on render failure falls back to a graceful surface: the raw source in a
- *     styled `<pre>` with a copy-source button plus a calm one-line message,
- *     never the raw developer exception and never a blank block.
+ *   - props: `{ source: string; className?: string }`,
+ *   - normalizes unicode arrow/dash glyphs + auto-quotes node labels before
+ *     render (LLM-authored sources frequently use `→`/`⟶`/`—` and unquoted
+ *     special chars),
+ *   - sanitizes the rendered SVG (DOMPurify, SVG profile) before injecting,
+ *   - robust fallback chain so the block is never blank and never throws to the
+ *     user:
+ *       1. beautiful-mermaid (native `<text>`, themed) — primary,
+ *       2. stock mermaid (`htmlLabels:false`, `theme:"dark"`) — secondary, for
+ *          diagram types beautiful-mermaid doesn't fully support (e.g. some
+ *          sequence diagrams),
+ *       3. the raw source in a styled `<pre>` with a copy-source button.
  *
- * The component is wrapped in `React.memo` so identical `source` strings
- * don't re-trigger Mermaid's heavy SVG generation when parents re-render.
+ * `beautiful-mermaid` pulls ELK.js (heavyish), so consumers lazy-load this
+ * component (see `Diagram.tsx`'s `React.lazy` + `Suspense`) and the renderer is
+ * `import()`ed inside the effect.
+ *
+ * Wrapped in `React.memo` so identical `source` strings don't re-trigger the
+ * heavy SVG generation when parents re-render.
  */
 
-import {
-  memo,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import mermaid from "mermaid";
+import { memo, useEffect, useId, useMemo, useRef, useState } from "react";
 import DOMPurify from "dompurify";
 
 import { cn } from "@/lib/utils";
 import { DiagramFallback } from "@/components/proposals/blocks/DiagramFallback";
 import { normalizeMermaidSource } from "@/components/proposals/blocks/mermaidNormalize";
 
-// Initialize Mermaid exactly once at module load. `startOnLoad: false` keeps
-// it from auto-walking the DOM (we control rendering explicitly), and
-// `securityLevel: "strict"` blocks `<script>`/`<iframe>`/click handlers in
-// rendered output.
-//
-// `htmlLabels: false` is load-bearing: by default Mermaid renders flowchart
-// node labels as HTML inside a `<foreignObject>`. We sanitize the rendered SVG
-// with DOMPurify's *SVG* profile (below), which strips `<foreignObject>` and
-// its embedded HTML — leaving visibly empty node boxes. Forcing native SVG
-// `<text>` labels means the label markup survives the SVG-profile sanitize.
-//
-// `theme: "dark"` matches the app's dark-only palette so the diagram doesn't
-// render as a bright card on a dark page.
-let mermaidInitialized = false;
-function initMermaid() {
-  if (mermaidInitialized) return;
-  mermaid.initialize({
-    startOnLoad: false,
-    securityLevel: "strict",
-    theme: "dark",
-    // Render labels as native SVG <text>, not <foreignObject> HTML, so the
-    // SVG-profile DOMPurify pass below can't strip them.
-    htmlLabels: false,
-    flowchart: { htmlLabels: false },
-    // Defer fontFamily to the page CSS so we don't pull a Mermaid-specific
-    // font into our font stack.
-    fontFamily: "inherit",
+const SVG_SANITIZE_CONFIG = {
+  USE_PROFILES: { svg: true, svgFilters: true },
+} as const;
+
+/**
+ * Render via beautiful-mermaid (primary path). Dynamically imported so ELK.js
+ * only loads when a diagram actually renders. Returns sanitized SVG markup.
+ *
+ * `renderMermaidSVG` is synchronous and takes `RenderOptions` shaped like the
+ * theme's `DiagramColors` (bg/fg/line/accent/muted/…), so we spread the chosen
+ * `THEMES[...]` entry directly into the options.
+ */
+async function renderWithBeautifulMermaid(source: string): Promise<string> {
+  const { renderMermaidSVG, THEMES } = await import("beautiful-mermaid");
+  const svg = renderMermaidSVG(source, {
+    ...THEMES["tokyo-night"],
+    // Defer to page CSS instead of pulling a renderer-specific font.
+    font: "inherit",
   });
-  mermaidInitialized = true;
+  return DOMPurify.sanitize(svg, SVG_SANITIZE_CONFIG);
+}
+
+let mermaidInitialized = false;
+/**
+ * Render via stock mermaid (secondary fallback). `htmlLabels:false` forces
+ * native SVG `<text>` so labels survive the SVG-profile sanitize even on this
+ * path; `theme:"dark"` matches the app's dark-only palette.
+ */
+async function renderWithStockMermaid(
+  source: string,
+  renderId: string,
+): Promise<string> {
+  const mermaid = (await import("mermaid")).default;
+  if (!mermaidInitialized) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: "dark",
+      htmlLabels: false,
+      flowchart: { htmlLabels: false },
+      fontFamily: "inherit",
+    });
+    mermaidInitialized = true;
+  }
+  const { svg } = await mermaid.render(renderId, source);
+  return DOMPurify.sanitize(svg, SVG_SANITIZE_CONFIG);
 }
 
 export interface MermaidDiagramProps {
@@ -80,17 +105,16 @@ interface RenderState {
 }
 
 function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
-  // Stable ids per instance — Mermaid uses these as the SVG root id and
-  // demands they be unique within the document.
+  // Stable id per instance — stock mermaid uses it as the SVG root id and
+  // demands it be unique within the document and start with a letter.
   const reactId = useId();
-  // Mermaid id rules: must start with a letter and contain no special chars.
   const renderId = `mermaid-${reactId.replace(/[^a-zA-Z0-9]/g, "")}`;
 
   const [state, setState] = useState<RenderState>({ status: "idle" });
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  // Rewrite unicode arrow/dash glyphs to ASCII edge operators before render.
-  // Conservative: only structural (outside-label) glyphs change.
+  // Rewrite unicode arrow/dash glyphs to ASCII edge operators + auto-quote
+  // node labels before render. Both renderers want valid mermaid grammar.
   const normalizedSource = useMemo(
     () => normalizeMermaidSource(source),
     [source],
@@ -98,26 +122,37 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
 
   useEffect(() => {
     let cancelled = false;
-    initMermaid();
     setState({ status: "rendering" });
 
     (async () => {
+      // Primary: beautiful-mermaid (native <text>, themed).
       try {
-        const { svg } = await mermaid.render(renderId, normalizedSource);
+        const sanitized = await renderWithBeautifulMermaid(normalizedSource);
         if (cancelled) return;
-        // Belt-and-braces: even with `securityLevel: "strict"`, sanitize the
-        // SVG before injecting. DOMPurify's default profile preserves SVG
-        // structure while stripping scripts and event handlers.
-        const sanitized = DOMPurify.sanitize(svg, {
-          USE_PROFILES: { svg: true, svgFilters: true },
-        });
         setState({ status: "ready", svg: sanitized });
-      } catch (err) {
-        if (cancelled) return;
-        setState({
-          status: "error",
-          error: err instanceof Error ? err.message : String(err),
-        });
+        return;
+      } catch (primaryErr) {
+        // Secondary: stock mermaid (covers diagram types beautiful-mermaid
+        // doesn't fully support).
+        try {
+          const sanitized = await renderWithStockMermaid(
+            normalizedSource,
+            renderId,
+          );
+          if (cancelled) return;
+          setState({ status: "ready", svg: sanitized });
+          return;
+        } catch {
+          if (cancelled) return;
+          // Tertiary: copy-source fallback (handled by the error branch).
+          setState({
+            status: "error",
+            error:
+              primaryErr instanceof Error
+                ? primaryErr.message
+                : String(primaryErr),
+          });
+        }
       }
     })();
 
@@ -144,14 +179,14 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
       ref={containerRef}
       data-testid="mermaid-diagram"
       className={cn(
-        // Mermaid's SVGs render unstyled by default — let parents control
-        // sizing via `className`. We center horizontally so flowcharts
-        // don't hug the left edge of a wide modal.
+        // SVGs render unstyled by default — let parents control sizing via
+        // `className`. Center horizontally so flowcharts don't hug the left
+        // edge of a wide modal.
         "flex w-full items-center justify-center [&_svg]:max-w-full [&_svg]:h-auto",
         className,
       )}
-      // The svg is sanitized above; injecting via dangerouslySetInnerHTML
-      // is the standard Mermaid integration pattern.
+      // The svg is sanitized above; injecting via dangerouslySetInnerHTML is the
+      // standard Mermaid integration pattern.
       dangerouslySetInnerHTML={
         state.status === "ready" ? { __html: state.svg ?? "" } : undefined
       }
@@ -165,5 +200,6 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
 
 export const MermaidDiagram = memo(
   MermaidDiagramImpl,
-  (prev, next) => prev.source === next.source && prev.className === next.className,
+  (prev, next) =>
+    prev.source === next.source && prev.className === next.className,
 );


### PR DESCRIPTION
## What

Swaps djinn's stock mermaid.js render path for [`beautiful-mermaid`](https://github.com/lukilabs/beautiful-mermaid) (`renderMermaidSVG`), a pure-TS renderer that emits **native SVG `<text>`** instead of `<foreignObject>` HTML. This is applied at the root — `ui/src/components/MermaidDiagram.tsx` — so it covers **both** places we render mermaid: the proposal **Diagram block** and the codegraph **ImpactFlowModal**.

## Why

The previous stock-mermaid path (PR #1023) rendered flowchart node labels as HTML inside `<foreignObject>`. Our DOMPurify *SVG-profile* sanitize strips `<foreignObject>`, which silently blanked node labels in some cases. `beautiful-mermaid` emits real `<text>` elements that survive the sanitize, so labels always render. It's also prettier (editor-grade themes).

## Details

- **Theme:** `tokyo-night` (`#1a1b26` bg) — matches djinn's near-black dark-only palette (`oklch(0.141 0.005 285.823)`).
- **Preprocessing kept:** `normalizeMermaidSource` still runs (unicode arrow/dash glyph → ASCII operators, node-label auto-quoting).
- **Sanitize kept:** rendered SVG is DOMPurify'd (SVG profile) before `dangerouslySetInnerHTML` injection.
- **Robust fallback chain** (never blank, never throws to the user): beautiful-mermaid → stock mermaid (covers diagram types beautiful-mermaid doesn't fully support, e.g. some sequence diagrams) → copy-source `<pre>`.
- **Lazy:** beautiful-mermaid (pulls ELK.js) is `import()`ed inside the render effect; consumers keep the existing `React.lazy` + `Suspense`. Stock mermaid kept as a fallback dep.
- **Public API unchanged:** `{ source, className? }` — consumers need no change.

## Tests

- New `MermaidDiagram.test.tsx`: asserts the real CI-gate repro renders to an SVG with native `<text>` + all six node labels visible, the tokyo-night dark bg, and that blank input falls through to the copy-source surface.
- Existing proposals suite (233 tests) + ImpactFlowModal suite green.
- `tsc -b` clean, `pnpm install --frozen-lockfile` consistent.

Visually verified: the real repro renders as a clean dark flowchart with every label fully visible (including special chars like `clippy -D warnings (exists)` and `sqlx prepare --check ... (MOVED)`).