### PR TITLE
feat(settings): first-class subscription cards + org-policy sub list & default-assignment editor (pr 2b/3)

### DIFF
--- a/ui/src/api/subscriptionProviders.test.ts
+++ b/ui/src/api/subscriptionProviders.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { isSubscriptionProvider } from "./subscriptionProviders";
+
+describe("isSubscriptionProvider", () => {
+  it("classifies known personal subscriptions as subscriptions", () => {
+    for (const id of [
+      "chatgpt_codex",
+      "kimi-for-coding",
+      "minimax-coding-plan",
+      "zai-coding-plan",
+      "zhipuai-coding-plan",
+      "opencode",
+      "xiaomi-token-plan-sgp",
+      "xiaomi-token-plan-cn",
+      "moonshotai-coding",
+      "alibaba-qwen-plan",
+    ]) {
+      expect(isSubscriptionProvider(id)).toBe(true);
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(isSubscriptionProvider("Kimi-For-Coding")).toBe(true);
+  });
+
+  it("classifies fungible API-key providers as NOT subscriptions", () => {
+    for (const id of [
+      "anthropic",
+      "openai",
+      "google",
+      "azure",
+      "aws",
+      "vertex",
+      "fireworks-ai",
+      "mistral",
+      "groq",
+      "some-random-openai-compat",
+    ]) {
+      expect(isSubscriptionProvider(id)).toBe(false);
+    }
+  });
+});

--- a/ui/src/api/subscriptionProviders.ts
+++ b/ui/src/api/subscriptionProviders.ts
@@ -1,0 +1,58 @@
+/**
+ * Client-side mirror of the server's subscription/API-key provider
+ * classification (`djinn_provider::catalog::builtin::is_subscription_provider`).
+ *
+ * Personal subscriptions (ChatGPT/Codex, Kimi, MiniMax, Z.AI, Zhipu, Xiaomi,
+ * OpenCode, …) are connected per-user and removable by their owner; everything
+ * else (Anthropic, OpenAI API, Google, Azure, AWS, Vertex, Fireworks, generic
+ * OpenAI-compatible keys) is a fungible API key that — in the hosted product —
+ * the operator provisions for the org. The Connections tab uses this split to
+ * sort connected providers into the "Your subscriptions" vs "Provided by your
+ * org" buckets, mirroring the server's per-user credential ownership rules.
+ *
+ * Kept in lockstep with the Rust source; the set is small and stable.
+ */
+
+/** Exact subscription provider ids (hand-registered builtins + models.dev-native). */
+const SUBSCRIPTION_IDS = new Set([
+  "chatgpt_codex",
+  "minimax-coding-plan",
+  "kimi-for-coding",
+  "opencode",
+  "opencode-go",
+  "zai",
+  "zai-coding-plan",
+  "zhipuai",
+  "zhipuai-coding-plan",
+]);
+
+/** Consumer-subscription vendor prefixes (regional/plan-tier variants). */
+const SUBSCRIPTION_PREFIXES = [
+  "xiaomi",
+  "moonshotai",
+  "alibaba",
+  "tencent",
+  "stepfun",
+  "kuae-cloud",
+  "umans-ai",
+];
+
+/** Coding/token-plan id suffixes used across vendors' consumer plans. */
+const SUBSCRIPTION_SUFFIXES = ["-coding-plan", "-token-plan", "-for-coding"];
+
+/**
+ * True when `providerId` is a personal subscription (per-user, removable).
+ *
+ * NOTE on `openai`: the ChatGPT/Codex OAuth subscription is merged into the
+ * `openai` provider id server-side, so a connected `openai` row can be EITHER a
+ * Codex subscription (oauth) or a plain BYO API key. Callers that need to tell
+ * them apart should inspect the connection method (`oauth` ⇒ Codex sub); this
+ * helper alone reports `openai` as NOT a subscription (its API-key identity).
+ */
+export function isSubscriptionProvider(providerId: string): boolean {
+  const id = providerId.toLowerCase();
+  if (SUBSCRIPTION_IDS.has(id)) return true;
+  if (SUBSCRIPTION_SUFFIXES.some((suffix) => id.includes(suffix))) return true;
+  if (SUBSCRIPTION_PREFIXES.some((prefix) => id.startsWith(prefix))) return true;
+  return false;
+}

--- a/ui/src/components/settings/AiPolicyTab.tsx
+++ b/ui/src/components/settings/AiPolicyTab.tsx
@@ -15,6 +15,8 @@ import {
   jurisdictionLabel,
   saveOrgPolicy,
 } from "@/api/orgPolicy";
+import type { ModelLanes } from "@/api/userSettings";
+import { OrgDefaultLanesSection } from "./OrgDefaultLanesSection";
 import { showToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
@@ -76,6 +78,7 @@ export function AiPolicyTab() {
   return (
     <div className="flex flex-col gap-6">
       <SubscriptionPolicySection policy={policy} saving={mutation.isPending} onSave={mutation.mutate} />
+      <OrgDefaultLanesSection policy={policy} saving={mutation.isPending} onSave={mutation.mutate} />
       <LaneLockSection policy={policy} saving={mutation.isPending} onSave={mutation.mutate} />
     </div>
   );
@@ -84,7 +87,11 @@ export function AiPolicyTab() {
 interface SectionProps {
   policy: OrgPolicy;
   saving: boolean;
-  onSave: (patch: { blockedSubscriptions?: string[]; lockLevel?: LockLevel }) => void;
+  onSave: (patch: {
+    blockedSubscriptions?: string[];
+    defaultLanes?: ModelLanes;
+    lockLevel?: LockLevel;
+  }) => void;
 }
 
 function SubscriptionPolicySection({ policy, saving, onSave }: SectionProps) {
@@ -196,8 +203,9 @@ function LaneLockSection({ policy, saving, onSave }: SectionProps) {
       <div>
         <h2 className="text-xl font-bold text-foreground">Model role lock</h2>
         <p className="text-sm text-muted-foreground">
-          When locked, the org-default model role assignment is authoritative — members can&apos;t
-          override their plan / implement / review lanes. When flexible, the default only seeds new
+          Controls whether the org-default assignment above is enforced. When
+          locked, it&apos;s authoritative — members can&apos;t override their plan /
+          implement / review lanes. When flexible, the default only seeds new
           members and they may change it.
         </p>
       </div>

--- a/ui/src/components/settings/ConnectionsTab.test.tsx
+++ b/ui/src/components/settings/ConnectionsTab.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConnectedProvider } from "@/api/userConfig";
+import { render, screen } from "@/test/test-utils";
+
+import { ConnectionsTab } from "./ConnectionsTab";
+
+vi.mock("@/lib/toast", () => ({
+  showToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const connected: ConnectedProvider[] = [
+  // Codex sub (oauth on openai) — rendered by its own card, not a row.
+  {
+    id: "openai",
+    name: "OpenAI",
+    connection_methods: ["oauth"],
+    env_vars: ["OPENAI_API_KEY"],
+  } as ConnectedProvider,
+  // A personal subscription connected by API key.
+  {
+    id: "kimi-for-coding",
+    name: "Kimi for Coding",
+    connection_methods: ["credential"],
+    env_vars: ["KIMI_API_KEY"],
+  } as ConnectedProvider,
+  // An org-provided API key.
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    connection_methods: ["credential"],
+    env_vars: ["ANTHROPIC_API_KEY"],
+  } as ConnectedProvider,
+];
+
+vi.mock("@/api/userConfig", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/userConfig")>();
+  return {
+    ...actual,
+    fetchUserConnectedProviders: vi.fn(async () => connected),
+    fetchUserCatalog: vi.fn(async () => []),
+  };
+});
+
+describe("ConnectionsTab", () => {
+  it("splits connected providers into subscription vs org-provided buckets", async () => {
+    render(<ConnectionsTab />);
+
+    // Bucket headings.
+    expect(await screen.findByText("Your subscriptions")).toBeInTheDocument();
+    expect(screen.getByText("Provided by your org")).toBeInTheDocument();
+
+    // Personal subscription is a first-class removable row.
+    expect(await screen.findByText("Kimi for Coding")).toBeInTheDocument();
+    expect(screen.getByText("Connected · personal subscription")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^remove$/i })).toBeInTheDocument();
+
+    // Org-provided key shows as managed (no remove button for it).
+    expect(await screen.findByText("Anthropic")).toBeInTheDocument();
+    expect(screen.getByText("Managed by your org")).toBeInTheDocument();
+
+    // The Codex/openai oauth row is NOT duplicated as a plain provider row —
+    // it's owned by the ChatGPT/Codex card. The card heading is present.
+    expect(screen.getByText("ChatGPT / Codex")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/settings/ConnectionsTab.tsx
+++ b/ui/src/components/settings/ConnectionsTab.tsx
@@ -1,0 +1,240 @@
+import { useCallback, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CheckmarkCircle04Icon,
+  LockIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { ConfirmButton } from "@/components/ConfirmButton";
+import { CodexSignInCard } from "@/components/CodexSignInCard";
+import { InlineError } from "@/components/InlineError";
+import { ApiKeyConnectForm } from "@/components/userConfig/ProviderSection";
+import { userConfigKeys } from "@/components/userConfig/userConfigKeys";
+import {
+  type ConnectedProvider,
+  SELF_TARGET,
+  fetchUserCatalog,
+  fetchUserConnectedProviders,
+} from "@/api/userConfig";
+import { removeProviderFull } from "@/api/server";
+import { isSubscriptionProvider } from "@/api/subscriptionProviders";
+import { showToast } from "@/lib/toast";
+
+/**
+ * Connections tab — provider auth for the signed-in user. Reworked so every
+ * connected provider is a first-class row in one of two buckets:
+ *
+ *  - **Your subscriptions** — personal subscriptions (ChatGPT/Codex OAuth + the
+ *    BYO-key coding plans). Per-user and removable; removing deletes only the
+ *    caller's own credential server-side.
+ *  - **Provided by your org** — operator/admin-provisioned API keys (Anthropic,
+ *    OpenAI API, Google, …). Shown as managed and locked (not removable from
+ *    here — they're set via Helm/operator config).
+ */
+export function ConnectionsTab() {
+  const queryClient = useQueryClient();
+
+  const connected = useQuery({
+    queryKey: userConfigKeys.connectedProviders(SELF_TARGET),
+    queryFn: () => fetchUserConnectedProviders(SELF_TARGET),
+  });
+  const catalog = useQuery({
+    queryKey: userConfigKeys.catalog(SELF_TARGET),
+    queryFn: () => fetchUserCatalog(SELF_TARGET),
+  });
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: userConfigKeys.connectedProviders(SELF_TARGET),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: userConfigKeys.connectedModels(SELF_TARGET),
+    });
+  }, [queryClient]);
+
+  // ChatGPT/Codex connects under the `openai` provider via builtin merge — an
+  // `oauth` connection method on `openai` means Codex is signed in. (A plain
+  // `openai` API key, by contrast, is an org-provided key.)
+  const openaiProvider = (connected.data ?? []).find((p) => p.id === "openai");
+  const codexConnected = openaiProvider?.connection_methods.includes("oauth") ?? false;
+  const codexRevokedReason = (
+    openaiProvider as { revoked_reason?: string } | undefined
+  )?.revoked_reason;
+
+  // Split connected providers into the two buckets. The Codex sub is rendered by
+  // its dedicated OAuth card, so an `openai`-via-oauth row is excluded here to
+  // avoid a duplicate; a plain `openai` API key still lands in the org bucket.
+  const { subscriptions, orgProvided } = useMemo(() => {
+    const subs: ConnectedProvider[] = [];
+    const org: ConnectedProvider[] = [];
+    for (const provider of connected.data ?? []) {
+      const isCodexRow =
+        provider.id === "openai" && provider.connection_methods.includes("oauth");
+      if (isCodexRow) continue; // owned by the Codex card below
+      if (isSubscriptionProvider(provider.id)) subs.push(provider);
+      else org.push(provider);
+    }
+    const byName = (a: ConnectedProvider, b: ConnectedProvider) =>
+      a.name.localeCompare(b.name);
+    return { subscriptions: subs.sort(byName), orgProvided: org.sort(byName) };
+  }, [connected.data]);
+
+  if (connected.isError) {
+    return (
+      <InlineError
+        message={
+          connected.error instanceof Error
+            ? connected.error.message
+            : "Failed to load connected providers"
+        }
+        onRetry={() => void connected.refetch()}
+      />
+    );
+  }
+
+  const loading = connected.isLoading;
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* ── Your subscriptions ─────────────────────────────────────────── */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-foreground">Your subscriptions</h2>
+          <p className="text-sm text-muted-foreground">
+            Personal subscriptions connected to your account — sign in with ChatGPT,
+            or paste a coding-plan key (Kimi, MiniMax, Z.AI, Xiaomi, OpenCode…). These
+            are yours and you can remove them at any time.
+          </p>
+        </div>
+
+        <CodexSignInCard
+          alreadyConnected={codexConnected}
+          revokedReason={codexRevokedReason}
+          onConnected={refresh}
+        />
+
+        {loading ? (
+          <CardSkeleton />
+        ) : subscriptions.length > 0 ? (
+          <ul className="flex flex-col gap-2">
+            {subscriptions.map((provider) => (
+              <SubscriptionCard key={provider.id} provider={provider} onRemoved={refresh} />
+            ))}
+          </ul>
+        ) : null}
+
+        <ApiKeyConnectForm
+          targetId={SELF_TARGET}
+          catalog={catalog.data ?? []}
+          connectedIds={new Set((connected.data ?? []).map((p) => p.id))}
+          catalogLoading={catalog.isLoading}
+          onConnected={refresh}
+        />
+      </section>
+
+      {/* ── Provided by your org ───────────────────────────────────────── */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-foreground">Provided by your org</h2>
+          <p className="text-sm text-muted-foreground">
+            API keys your operator provisions for everyone (Anthropic, OpenAI API,
+            Google, Azure, AWS, Vertex AI…). They&apos;re managed centrally — ask your
+            operator to change or unset a key.
+          </p>
+        </div>
+
+        {loading ? (
+          <CardSkeleton />
+        ) : orgProvided.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-border bg-card/50 px-4 py-4 text-sm text-muted-foreground">
+            No org-provided API keys yet. Your operator can set Helm-managed keys.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {orgProvided.map((provider) => (
+              <OrgProvidedCard key={provider.id} provider={provider} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function CardSkeleton() {
+  return (
+    <div className="rounded-lg border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
+      Loading…
+    </div>
+  );
+}
+
+/** A connected personal subscription — first-class row, removable by the owner. */
+function SubscriptionCard({
+  provider,
+  onRemoved,
+}: {
+  provider: ConnectedProvider;
+  onRemoved: () => void;
+}) {
+  const remove = useMutation({
+    mutationFn: () => removeProviderFull(provider.id),
+    onSuccess: () => {
+      showToast.success("Subscription removed", {
+        description: `Disconnected ${provider.name}.`,
+      });
+      onRemoved();
+    },
+    onError: (error) => {
+      showToast.error("Could not remove subscription", {
+        description: error instanceof Error ? error.message : "Unknown error",
+      });
+    },
+  });
+
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3">
+      <div className="flex min-w-0 items-center gap-2.5">
+        <HugeiconsIcon icon={CheckmarkCircle04Icon} size={16} className="shrink-0 text-green-500" />
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-foreground">{provider.name}</div>
+          <div className="truncate text-xs text-muted-foreground">Connected · personal subscription</div>
+        </div>
+      </div>
+      <ConfirmButton
+        title="Remove subscription"
+        description={`Disconnect "${provider.name}" and delete the stored key/token for your account?`}
+        confirmLabel="Remove"
+        onConfirm={() => remove.mutate()}
+        size="sm"
+        variant="outline"
+        disabled={remove.isPending}
+      >
+        {remove.isPending ? "Removing…" : "Remove"}
+      </ConfirmButton>
+    </li>
+  );
+}
+
+/** A connected org-provided API key — managed/locked, not removable here. */
+function OrgProvidedCard({ provider }: { provider: ConnectedProvider }) {
+  return (
+    <li
+      className="flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3"
+      title="Provisioned via deployment (Helm). Ask your operator to unset the key."
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        <HugeiconsIcon icon={CheckmarkCircle04Icon} size={16} className="shrink-0 text-green-500" />
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-foreground">{provider.name}</div>
+          <div className="truncate text-xs text-muted-foreground">Managed by your org</div>
+        </div>
+      </div>
+      <span className="flex shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground">
+        <HugeiconsIcon icon={LockIcon} size={13} aria-label="Provisioned via deployment" />
+        Managed
+      </span>
+    </li>
+  );
+}

--- a/ui/src/components/settings/OrgDefaultLanesSection.test.tsx
+++ b/ui/src/components/settings/OrgDefaultLanesSection.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { UserModel } from "@/api/userConfig";
+import type { OrgPolicy } from "@/api/orgPolicy";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+
+import { OrgDefaultLanesSection } from "./OrgDefaultLanesSection";
+
+vi.mock("@/lib/toast", () => ({
+  showToast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/api/userConfig", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/userConfig")>();
+  return {
+    ...actual,
+    fetchUserConnectedModels: vi.fn(
+      async () =>
+        [
+          { id: "openai/gpt-5", name: "GPT-5", provider_id: "openai", tool_call: true },
+          {
+            id: "anthropic/claude-sonnet-4",
+            name: "Claude Sonnet 4",
+            provider_id: "anthropic",
+            tool_call: true,
+          },
+        ] as UserModel[],
+    ),
+  };
+});
+
+const policy: OrgPolicy = {
+  subscriptions: [],
+  blockedSubscriptions: [],
+  defaultLanes: { plan: ["openai/gpt-5"], implement: [], review: [] },
+  lockLevel: "flexible",
+};
+
+describe("OrgDefaultLanesSection", () => {
+  it("renders the org-default lanes and seeded model", async () => {
+    render(<OrgDefaultLanesSection policy={policy} saving={false} onSave={vi.fn()} />);
+
+    expect(await screen.findByText("Org-default model roles")).toBeInTheDocument();
+    // Lane headings appear after the admin's connected models load.
+    expect(await screen.findByText("Plan")).toBeInTheDocument();
+    expect(screen.getByText("Implement")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    // The seeded plan-lane model renders.
+    expect(await screen.findByText("GPT-5")).toBeInTheDocument();
+  });
+
+  it("removing a model dirties the editor and saves defaultLanes", async () => {
+    const onSave = vi.fn();
+    render(<OrgDefaultLanesSection policy={policy} saving={false} onSave={onSave} />);
+
+    const removeBtn = await screen.findByRole("button", { name: /remove gpt-5/i });
+    await userEvent.click(removeBtn);
+
+    const saveBtn = await screen.findByRole("button", { name: /save default/i });
+    await userEvent.click(saveBtn);
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const patch = onSave.mock.calls.at(-1)?.[0] as { defaultLanes?: { plan: string[] } };
+    expect(patch.defaultLanes?.plan).toEqual([]);
+  });
+});

--- a/ui/src/components/settings/OrgDefaultLanesSection.tsx
+++ b/ui/src/components/settings/OrgDefaultLanesSection.tsx
@@ -1,0 +1,255 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Delete02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Button } from "@/components/ui/button";
+import { InlineError } from "@/components/InlineError";
+import {
+  AddModelButton,
+  stripProviderPrefix,
+} from "@/components/userConfig/ModelSection";
+import { formatProvider } from "@/components/userConfig/providerDisplay";
+import { userConfigKeys } from "@/components/userConfig/userConfigKeys";
+import {
+  type UserModel,
+  SELF_TARGET,
+  fetchUserConnectedModels,
+} from "@/api/userConfig";
+import {
+  MODEL_LANE_KEYS,
+  type ModelLaneKey,
+  type ModelLanes,
+} from "@/api/userSettings";
+import type { LockLevel, OrgPolicy } from "@/api/orgPolicy";
+import { cn } from "@/lib/utils";
+
+/** Human-friendly labels + the agents each org-default lane drives. */
+const LANE_META: Record<ModelLaneKey, { title: string; roles: string }> = {
+  plan: { title: "Plan", roles: "Planner, Architect, Chat" },
+  implement: { title: "Implement", roles: "Worker" },
+  review: { title: "Review", roles: "Reviewer" },
+};
+
+interface Props {
+  policy: OrgPolicy;
+  saving: boolean;
+  onSave: (patch: { defaultLanes?: ModelLanes; lockLevel?: LockLevel }) => void;
+}
+
+/**
+ * Admin-only org-default role-assignment editor. Sets the plan / implement /
+ * review lanes that seed every member (and, when the lock below is on, that
+ * members can't override). Persists via `org_policy_set`'s `default_lanes`.
+ *
+ * The model picker is seeded from the admin's own connected models — the
+ * realistic universe an admin chooses an org default from. It reuses the Model
+ * Roles tab's `AddModelButton`; the rest is a minimal ordered list (priority
+ * high → low per lane) so it stays independent of the per-user lane editor.
+ */
+export function OrgDefaultLanesSection({ policy, saving, onSave }: Props) {
+  const connectedModels = useQuery({
+    queryKey: userConfigKeys.connectedModels(SELF_TARGET),
+    queryFn: () => fetchUserConnectedModels(SELF_TARGET),
+  });
+
+  // Working copy seeded from the server, isolated until Save. Re-seed when the
+  // server value changes and we have no unsaved edits.
+  const [lanes, setLanes] = useState<ModelLanes>(policy.defaultLanes);
+  const [dirty, setDirty] = useState(false);
+  const [lastServer, setLastServer] = useState<ModelLanes>(policy.defaultLanes);
+  if (policy.defaultLanes !== lastServer) {
+    setLastServer(policy.defaultLanes);
+    if (!dirty) setLanes(policy.defaultLanes);
+  }
+
+  const modelsById = useMemo(() => {
+    const map = new Map<string, UserModel>();
+    for (const model of connectedModels.data ?? []) map.set(model.id, model);
+    return map;
+  }, [connectedModels.data]);
+
+  const locked = policy.lockLevel === "locked";
+
+  const addModel = (lane: ModelLaneKey, model: UserModel) => {
+    setLanes((prev) =>
+      prev[lane].includes(model.id)
+        ? prev
+        : { ...prev, [lane]: [...prev[lane], model.id] },
+    );
+    setDirty(true);
+  };
+  const removeModel = (lane: ModelLaneKey, id: string) => {
+    setLanes((prev) => ({ ...prev, [lane]: prev[lane].filter((m) => m !== id) }));
+    setDirty(true);
+  };
+  const move = (lane: ModelLaneKey, index: number, dir: -1 | 1) => {
+    setLanes((prev) => {
+      const order = [...prev[lane]];
+      const next = index + dir;
+      if (next < 0 || next >= order.length) return prev;
+      [order[index], order[next]] = [order[next], order[index]];
+      return { ...prev, [lane]: order };
+    });
+    setDirty(true);
+  };
+
+  const save = () => {
+    onSave({ defaultLanes: lanes });
+    setDirty(false);
+  };
+
+  return (
+    <section className="flex flex-col gap-3 border-t border-border pt-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-bold text-foreground">Org-default model roles</h2>
+          <p className="text-sm text-muted-foreground">
+            The plan / implement / review lanes new members start with (priority
+            high → low per lane).{" "}
+            {locked
+              ? "Lock is ON below — this assignment is authoritative and members can't override it."
+              : "Lock is OFF below — this only seeds new members, who may then change their own lanes."}
+          </p>
+        </div>
+        {dirty && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            disabled={saving}
+            onClick={save}
+          >
+            {saving ? "Saving…" : "Save default"}
+          </Button>
+        )}
+      </div>
+
+      {connectedModels.isError ? (
+        <InlineError
+          message={
+            connectedModels.error instanceof Error
+              ? connectedModels.error.message
+              : "Failed to load models"
+          }
+          onRetry={() => void connectedModels.refetch()}
+        />
+      ) : connectedModels.isLoading ? (
+        <div className="py-6 text-center text-sm text-muted-foreground">Loading models…</div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {(connectedModels.data?.length ?? 0) === 0 && (
+            <p className="rounded-lg border border-dashed border-border bg-card/50 px-4 py-3 text-xs text-muted-foreground">
+              Connect a provider on the Connections tab to pick org-default models.
+              You can still leave a lane empty — it falls back to the deployment default.
+            </p>
+          )}
+          {MODEL_LANE_KEYS.map((lane) => (
+            <OrgLaneEditor
+              key={lane}
+              lane={lane}
+              order={lanes[lane]}
+              modelsById={modelsById}
+              availableToAdd={(connectedModels.data ?? []).filter(
+                (model) => !lanes[lane].includes(model.id),
+              )}
+              onAdd={(model) => addModel(lane, model)}
+              onRemove={(id) => removeModel(lane, id)}
+              onMove={(index, dir) => move(lane, index, dir)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function OrgLaneEditor({
+  lane,
+  order,
+  modelsById,
+  availableToAdd,
+  onAdd,
+  onRemove,
+  onMove,
+}: {
+  lane: ModelLaneKey;
+  order: string[];
+  modelsById: Map<string, UserModel>;
+  availableToAdd: UserModel[];
+  onAdd: (model: UserModel) => void;
+  onRemove: (id: string) => void;
+  onMove: (index: number, dir: -1 | 1) => void;
+}) {
+  const meta = LANE_META[lane];
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border bg-card/40 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h4 className="text-sm font-semibold text-foreground">{meta.title}</h4>
+          <p className="text-xs text-muted-foreground/70">{meta.roles}</p>
+        </div>
+        <AddModelButton models={availableToAdd} onSelect={onAdd} />
+      </div>
+      {order.length === 0 ? (
+        <div className="rounded-md border border-dashed p-4 text-center text-xs text-muted-foreground">
+          No org-default for this role. Add one — or it falls back to the deployment default.
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {order.map((modelId, index) => {
+            const model = modelsById.get(modelId);
+            const providerId = model?.provider_id ?? modelId.split("/")[0] ?? "unknown";
+            const name = model?.name ?? stripProviderPrefix(modelId);
+            return (
+              <li
+                key={modelId}
+                className="flex items-center gap-3 rounded-lg border bg-card px-4 py-3"
+              >
+                <div className="flex shrink-0 flex-col">
+                  <button
+                    type="button"
+                    aria-label="Move up"
+                    disabled={index === 0}
+                    onClick={() => onMove(index, -1)}
+                    className={cn(
+                      "px-1 text-xs text-muted-foreground hover:text-foreground",
+                      index === 0 && "opacity-30",
+                    )}
+                  >
+                    ▲
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Move down"
+                    disabled={index === order.length - 1}
+                    onClick={() => onMove(index, 1)}
+                    className={cn(
+                      "px-1 text-xs text-muted-foreground hover:text-foreground",
+                      index === order.length - 1 && "opacity-30",
+                    )}
+                  >
+                    ▼
+                  </button>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-semibold">{name}</div>
+                  <div className="text-xs text-muted-foreground/60">{formatProvider(providerId)}</div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Remove ${name}`}
+                  onClick={() => onRemove(modelId)}
+                  className="h-8 w-8 shrink-0 p-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                >
+                  <HugeiconsIcon icon={Delete02Icon} size={16} />
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ui/src/hooks/settings/useProviders.ts
+++ b/ui/src/hooks/settings/useProviders.ts
@@ -9,15 +9,22 @@ import {
   type Provider,
   type ProviderCredential,
 } from '@/api/server';
+import { isSubscriptionProvider } from '@/api/subscriptionProviders';
 import { showToast } from '@/lib/toast';
 
 /**
- * Providers that users can self-serve via the UI (device-code OAuth). Every
- * other provider is expected to be deployment-provisioned; removing one from
- * the UI only clears the vault row but will be re-bootstrapped on the next
- * server restart from the operator-supplied env var.
+ * Providers a user can self-serve (connect AND remove) from the UI: every
+ * personal subscription (ChatGPT/Codex device-code OAuth + the BYO-key coding
+ * plans — Kimi, MiniMax, Z.AI, Xiaomi, OpenCode, …). Removing one deletes only
+ * the acting user's own credential server-side (`owner_user_id = current_user`),
+ * so it never touches an org-provided key. Non-subscription providers are
+ * deployment/operator-provisioned: a UI "remove" would only clear the vault row
+ * and the next server restart re-bootstraps it from the operator env var, so we
+ * keep those locked (managed).
  */
-const SELF_SERVE_PROVIDER_IDS = new Set(['chatgpt_codex']);
+function isSelfServe(providerId: string): boolean {
+  return providerId === 'chatgpt_codex' || isSubscriptionProvider(providerId);
+}
 
 export function useProviders() {
   const [providers, setProviders] = useState<Provider[]>([]);
@@ -95,7 +102,7 @@ export function useProviders() {
 
   const removeProvider = useCallback(
     async (providerId: string) => {
-      if (!SELF_SERVE_PROVIDER_IDS.has(providerId)) {
+      if (!isSelfServe(providerId)) {
         showToast.error('Provisioned via deployment', {
           description:
             'API-key providers are configured through Helm values. Ask your operator to unset the key.',
@@ -119,7 +126,7 @@ export function useProviders() {
   );
 
   const isSelfServeProvider = useCallback(
-    (providerId: string) => SELF_SERVE_PROVIDER_IDS.has(providerId),
+    (providerId: string) => isSelfServe(providerId),
     [],
   );
 

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,126 +1,15 @@
-import { Delete02Icon, LockIcon } from '@hugeicons/core-free-icons';
-import { HugeiconsIcon } from '@hugeicons/react';
 import { InlineError } from '@/components/InlineError';
 import { AgentConfig } from '@/components/AgentConfig';
-import { CodexSignInCard } from '@/components/CodexSignInCard';
-import { ConfirmButton } from '@/components/ConfirmButton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ModelSection } from '@/components/userConfig/ModelSection';
 import { AiPolicyTab } from '@/components/settings/AiPolicyTab';
+import { ConnectionsTab } from '@/components/settings/ConnectionsTab';
 import { useAuthUser } from '@/components/AuthGate';
 import { SELF_TARGET } from '@/api/userConfig';
-import { useProviders } from '@/hooks/settings/useProviders';
 import { useAgentConfig } from '@/hooks/settings/useAgentConfig';
 import { useUserSettings } from '@/hooks/settings/useUserSettings';
 import { useServerHealth } from '@/hooks/useServerHealth';
 import { cn } from '@/lib/utils';
-
-/** Connections tab — provider auth only (connect / disconnect). No model picking. */
-function ConnectionsTab() {
-  const {
-    configuredProviders,
-    loading,
-    loadError,
-    loadData,
-    removeProvider,
-    isSelfServeProvider,
-  } = useProviders();
-
-  if (loading) {
-    return <div className="rounded-lg border border-border bg-card p-6">Loading providers...</div>;
-  }
-
-  if (loadError) {
-    return <InlineError message={loadError} onRetry={() => void loadData()} />;
-  }
-
-  // Codex OAuth is folded into the `openai` provider via builtin merge
-  // (chatgpt_codex.merge_into = "openai"), and openai itself has no native
-  // OAuth — so `oauth` in openai's connection_methods means Codex is signed in.
-  const openaiProvider = configuredProviders.find((p) => p.id === 'openai');
-  const codexConnected = openaiProvider?.connection_methods.includes('oauth') ?? false;
-  // When the codex credential was revoked (a 401 during a run) the server reports
-  // openai disconnected + carries the reason; surface it so the user reconnects.
-  const codexRevokedReason = openaiProvider?.revoked_reason;
-
-  return (
-    <div className="flex flex-col gap-3">
-      <div>
-        <h2 className="text-xl font-bold text-foreground">ChatGPT / Codex</h2>
-        <p className="text-sm text-muted-foreground">
-          Sign in with your ChatGPT subscription. All other providers (Anthropic, OpenAI API,
-          Google, Azure, AWS, Vertex AI) are provisioned by your operator via Helm values —
-          they show up automatically once configured.
-        </p>
-      </div>
-
-      {/* Always render: shows the sign-in CTA when disconnected, and the
-          connected state (with a Remove/Disconnect button) when connected. */}
-      <CodexSignInCard
-        alreadyConnected={codexConnected}
-        revokedReason={codexRevokedReason}
-        onConnected={() => void loadData()}
-      />
-
-      <div className="rounded-lg border border-border bg-card px-4 py-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="text-sm font-medium text-muted-foreground shrink-0">Connected:</span>
-          {configuredProviders.length === 0 ? (
-            <EmptyConnectedMessage />
-          ) : (
-            configuredProviders.map((provider) => {
-              const removable = isSelfServeProvider(provider.id);
-              return (
-                <span
-                  key={provider.id}
-                  className="flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-sm"
-                  title={
-                    removable
-                      ? undefined
-                      : 'Provisioned via deployment (Helm). Ask your operator to unset the key.'
-                  }
-                >
-                  {provider.name}
-                  {removable ? (
-                    <ConfirmButton
-                      title="Remove provider"
-                      description={`Sign out of "${provider.name}" and delete the stored tokens?`}
-                      confirmLabel="Remove"
-                      onConfirm={() => removeProvider(provider.id)}
-                      size="sm"
-                      variant="ghost"
-                    >
-                      <HugeiconsIcon
-                        icon={Delete02Icon}
-                        size={13}
-                        className="text-destructive"
-                      />
-                    </ConfirmButton>
-                  ) : (
-                    <HugeiconsIcon
-                      icon={LockIcon}
-                      size={13}
-                      className="text-muted-foreground"
-                      aria-label="Provisioned via deployment"
-                    />
-                  )}
-                </span>
-              );
-            })
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function EmptyConnectedMessage() {
-  return (
-    <span className="text-sm text-muted-foreground">
-      None yet. Sign in above, or ask your operator to set a Helm-managed API key.
-    </span>
-  );
-}
 
 /** Model Roles tab — per-user, per-role model lanes + the per-role agent config. */
 function ModelRolesTab() {


### PR DESCRIPTION
PR 2b/3 of the provider/settings UI fix round (branched from `main` after PR-1 merged). Stays in the **Connections** + **Org AI Policy** lane; PR-2a owns Model Roles (presets/ModelSection/lane editor — untouched here, imported read-only).

## Connections tab — subs are now first-class
Replaced the flat removable-chip list with two clearly separated card buckets:

- **Your subscriptions** (per-user, removable): the ChatGPT/Codex OAuth card (device-code reconnect kept) **plus** a first-class card for every connected coding-plan subscription (Kimi, MiniMax, Z.AI, Zhipu, Xiaomi, OpenCode, …), each with a Remove action; and the API-key connect form to add more.
- **Provided by your org** (managed/locked): operator/admin API keys (Anthropic, OpenAI API, Google, Azure, AWS, Vertex, Fireworks, generic compat) shown as "Managed by your org", not removable.

New `ConnectionsTab` component (`ui/src/components/settings/ConnectionsTab.tsx`); the old inline `ConnectionsTab`/`EmptyConnectedMessage` in `SettingsPage.tsx` is removed.

Bucketing mirrors the server's per-user credential rules via a new client classifier `ui/src/api/subscriptionProviders.ts` (a faithful mirror of `djinn_provider::catalog::builtin::is_subscription_provider`). The ChatGPT/Codex row (`openai` via `oauth`) is excluded from the generic rows so it isn't duplicated alongside its dedicated card; a plain `openai` API key still lands in the org bucket.

`useProviders` self-serve set widened from just `chatgpt_codex` to **every** subscription, so per-user subs are removable. `provider_remove` deletes only the caller's own credential (`owner_user_id = current_user`) server-side, so org keys are never affected.

## Org AI Policy tab — correct list + the missing editor
- **Subscription access** already renders PR-1's corrected `org_policy_get.subscriptions` (Codex present as `chatgpt_codex`, Copilot collapsed to one row, Chinese subs present) grouped by jurisdiction (US / EU / China / Other) with per-row allow/block toggles + the one-click "Block all China-hosted subscriptions". Blocking writes `org_policy_set { blocked_subscriptions }` keyed by the row `id`.
- **Added the org-default role-assignment editor** (`OrgDefaultLanesSection`, admin-only): sets the org-default plan / implement / review lanes (priority-ordered, add/remove/reorder) that the lock governs, seeded from the admin's connected models, persisted via `org_policy_set { default_lanes }`. Reuses the Model Roles tab's `AddModelButton` by import; the rest is a minimal local lane list (no edits to the per-user lane editor). The lock toggle copy now explicitly references "the assignment above".

## Verification
- `tsc -b` typecheck: **pass**.
- Targeted vitest (settings + userConfig + hooks): **27 pass**, including new tests for the subscription classifier, Connections buckets, and the org-default editor.
- eslint on all authored/edited files: **clean**. (One pre-existing `set-state-in-effect` lint on `useProviders.ts:70` is unrelated — present on `main`, in code I didn't touch.)
- `vite build`: **not verified locally** — fails identically on pristine `main` due to a local `elkjs`/vite resolver glitch (`elk.bundled.js/lib/elk.bundled.js` ENOTDIR), unrelated to this change; all 3853 modules including the new files transform fine.
- No Rust touched (server side was PR-1).

## SettingsPage region (for PR-2a conflict watch)
`ui/src/pages/SettingsPage.tsx`: removed the inline `ConnectionsTab` + `EmptyConnectedMessage` functions and their now-unused imports; wired in `<ConnectionsTab />` from the new component. The `<TabsContent value="connections">` wiring is unchanged. PR-2a removing a legacy list elsewhere on this page should not collide with the Connections region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)