### PR TITLE
fix(ui): resolve elkjs production build failure (beautiful-mermaid)

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -6,11 +6,22 @@ import { defineConfig } from "vite"
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      // elkjs main entry requires('web-worker') for Node — use browser bundle
-      "elkjs": path.resolve(__dirname, "./node_modules/elkjs/lib/elk.bundled.js"),
-    },
+    alias: [
+      { find: "@", replacement: path.resolve(__dirname, "./src") },
+      // elkjs's main entry requires('web-worker') for Node — point the bare
+      // specifier at the browser bundle instead. Use an EXACT (anchored) match:
+      // a plain string alias matches as a prefix, so it would also rewrite
+      // subpath imports like `elkjs/lib/elk.bundled.js` (used by
+      // beautiful-mermaid) into a doubled `.../elk.bundled.js/lib/elk.bundled.js`
+      // path that the production rollup/commonjs resolver fails to load.
+      {
+        find: /^elkjs$/,
+        replacement: path.resolve(
+          __dirname,
+          "./node_modules/elkjs/lib/elk.bundled.js",
+        ),
+      },
+    ],
   },
   clearScreen: false,
   server: {


### PR DESCRIPTION
## Problem

The CI release build (\`cd ui && pnpm build\`) failed during the production Vite/rollup pass:

\`\`\`
[commonjs--resolver] Could not load .../ui/node_modules/elkjs/lib/elk.bundled.js/lib/elk.bundled.js: ENOTDIR: not a directory
\`\`\`

Note the doubled path: \`elkjs/lib/elk.bundled.js/lib/elk.bundled.js\`.

## Root cause

\`ui/vite.config.ts\` aliased elkjs with a plain-string \`resolve.alias\` key:

\`\`\`ts
"elkjs": path.resolve(__dirname, "./node_modules/elkjs/lib/elk.bundled.js"),
\`\`\`

Plain-string alias keys match as a **prefix**. The recent beautiful-mermaid integration imports the elkjs *subpath* \`elkjs/lib/elk.bundled.js\`, so the prefix alias rewrote that into \`.../elk.bundled.js/lib/elk.bundled.js\` — the doubled, non-existent path. The dev server tolerated this; rollup's commonjs resolver did not, so only the production build broke.

## Fix

Switch \`resolve.alias\` to the array form and anchor the elkjs entry with an exact \`/^elkjs$/\` regex. Now only the bare \`elkjs\` specifier (used by \`elkLayout.ts\`, which needs the browser bundle to avoid Node's \`require('web-worker')\`) is aliased; beautiful-mermaid's subpath import passes through untouched. No diagram functionality is disabled.

## Verification

- \`npx vite build\` now completes (exit 0, \`✓ built in ~20s\`); all mermaid/diagram chunks build.
- \`npx tsc -b\` passes.
- \`MermaidDiagram.test.tsx\` — 4/4 tests pass.