### PR TITLE
fix(proposals): declared file-tree status tokens + flatten Open Questions

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -365,9 +365,22 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
             ),
             (
                 "file-tree",
-                block(
+                block_with_description(
                     "file-tree",
                     "FileTree",
+                    "A file & change tree. The block CHILDREN are the tree text: \
+                     either an indented ASCII tree (folders end in `/`, files sit \
+                     under a deeper indent) OR one slash-path per line. DECLARE each \
+                     file's change status with a single leading token immediately \
+                     followed by whitespace, then the path: `+` = added/new, `~` = \
+                     modified, `-` = removed/deleted, `>` = renamed/moved; NO token \
+                     means unchanged. Status comes ONLY from this token — words like \
+                     `new`/`modified` are NOT inferred. A trailing note after the \
+                     path (e.g. `~ src/x.rs — wire the route` or `src/y.ts: helper`) \
+                     renders as a muted caption. Example: \
+                     `<FileTree id=\"x\" root=\"src\">\\n+ src/added.rs\\n~ src/main.rs \
+                     bump version\\n- src/old.rs\\n</FileTree>`. Unparseable bodies \
+                     fall back to a raw monospace render.",
                     fields(vec![
                         ("root", string_field()),
                         (

--- a/ui/src/components/proposals/blocks/FileTreeBlock.tsx
+++ b/ui/src/components/proposals/blocks/FileTreeBlock.tsx
@@ -25,8 +25,9 @@ import {
  * FileTree — an interactive VS Code / GitHub-explorer file & change tree.
  *
  * The freeform body text (indented ASCII tree OR one slash-path per line, with
- * optional `(NEW)`/`(MODIFIED)`/`(DELETED)`/`(RENAMED)` markers and trailing
- * notes) is parsed into a flat file list, then folded into a nested folder tree
+ * an optional DECLARED leading status token — `+` added, `~` modified, `-`
+ * removed, `>` renamed, none = unchanged — and trailing notes) is parsed into a
+ * flat file list, then folded into a nested folder tree
  * (folders before files, single-child chains compacted). Folders expand/collapse
  * (top level open by default); files carry an A/M/D/R change badge and a muted
  * inline note. A header tallies `+N ~N −N »N`.

--- a/ui/src/components/proposals/blocks/QuestionFormBlock.tsx
+++ b/ui/src/components/proposals/blocks/QuestionFormBlock.tsx
@@ -18,10 +18,12 @@ import { parseQuestions } from "./questionForm";
  * The freeform children are parsed (`parseQuestions`) into individual questions
  * — a numbered line, a `?`-terminated sentence, a bolded line, or a `###`
  * heading starts a new question; following lines/bullets are that question's
- * sub-detail. Each renders as a clean numbered card with a question-mark marker,
- * the markdown-rendered question text, optional muted sub-detail, and a small
- * "recommended" badge when the author tagged an item. If parsing yields nothing
- * we fall back to the original `BlockMarkdown` render so a proposal never blanks.
+ * sub-detail. Each renders as a clean numbered ROW (separated by subtle dividers,
+ * NOT a card-in-card) with a question-mark marker, the markdown-rendered question
+ * text, optional muted sub-detail, and a small "recommended" badge when the
+ * author tagged an item. The single outer BlockShell is the only card. If parsing
+ * yields nothing we fall back to the original `BlockMarkdown` render so a proposal
+ * never blanks.
  */
 export function QuestionFormBlock({ children }: BlockProps) {
   const content = typeof children === "string" ? children.trim() : "";
@@ -48,11 +50,11 @@ export function QuestionFormBlock({ children }: BlockProps) {
         </span>
       }
     >
-      <ol className="space-y-2.5">
+      <ol className="divide-y divide-border/60">
         {questions.map((q, index) => (
           <li
             key={`${index}-${q.question.slice(0, 24)}`}
-            className="flex gap-3 rounded-lg border bg-muted/20 px-3.5 py-3"
+            className="flex gap-3 py-3 first:pt-0 last:pb-0"
           >
             <span
               className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-pink-500/15 text-pink-300"

--- a/ui/src/components/proposals/blocks/fileTree.test.ts
+++ b/ui/src/components/proposals/blocks/fileTree.test.ts
@@ -61,15 +61,21 @@ describe("parseFileTreeBody", () => {
     ]);
   });
 
-  it("parses inline (NEW)/(MODIFIED)/(DELETED)/(RENAMED) status markers", () => {
+  it("reads the DECLARED leading status token (+ ~ - >) for each kind", () => {
     const files = parseFileTreeBody(
       [
-        "src/added.ts (NEW)",
-        "src/changed.ts (MODIFIED)",
-        "src/gone.ts (DELETED)",
-        "src/moved.ts (RENAMED)",
+        "+ src/added.ts",
+        "~ src/changed.ts",
+        "- src/gone.ts",
+        "> src/moved.ts",
       ].join("\n"),
     );
+    expect(files.map((f) => f.path)).toEqual([
+      "src/added.ts",
+      "src/changed.ts",
+      "src/gone.ts",
+      "src/moved.ts",
+    ]);
     expect(files.map((f) => f.change)).toEqual([
       "added",
       "modified",
@@ -78,23 +84,82 @@ describe("parseFileTreeBody", () => {
     ]);
   });
 
-  it("accepts common status synonyms case-insensitively", () => {
+  it("accepts the U+2212 minus sign as a removed token", () => {
+    const files = parseFileTreeBody("− src/gone.ts");
+    expect(files[0]).toMatchObject({ path: "src/gone.ts", change: "deleted" });
+  });
+
+  it("leaves a row with no token as unchanged", () => {
+    const files = parseFileTreeBody("src/stable.ts\nsrc/other.ts");
+    expect(files.every((f) => f.change === undefined)).toBe(true);
+  });
+
+  it("does NOT infer status from English words like new/modified/deleted", () => {
+    // Words in a trailing note are notes, never status — only the token decides.
     const files = parseFileTreeBody(
-      ["a.ts (added)", "b.ts (Removed)", "c.ts (updated)", "d.ts (moved)"].join(
-        "\n",
-      ),
+      [
+        "src/a.ts (NEW)",
+        "src/b.ts (MODIFIED)",
+        "src/c.ts — newly added",
+      ].join("\n"),
     );
-    expect(files.map((f) => f.change)).toEqual([
-      "added",
-      "deleted",
-      "modified",
-      "renamed",
+    expect(files.every((f) => f.change === undefined)).toBe(true);
+    expect(files[0]).toMatchObject({ path: "src/a.ts", note: "NEW" });
+    expect(files[1]).toMatchObject({ path: "src/b.ts", note: "MODIFIED" });
+    expect(files[2]).toMatchObject({ path: "src/c.ts", note: "newly added" });
+  });
+
+  it("treats a status token as status, NOT as a bullet glyph (collision)", () => {
+    // `-`/`+` followed by whitespace are declared tokens, not list bullets.
+    const files = parseFileTreeBody("- src/removed.ts\n+ src/created.ts");
+    expect(files.map((f) => f.change)).toEqual(["deleted", "added"]);
+    expect(files.map((f) => f.path)).toEqual([
+      "src/removed.ts",
+      "src/created.ts",
     ]);
   });
 
-  it("extracts a trailing note as a caption, keeping it distinct from a status", () => {
+  it("still treats `*` as a plain bullet (unchanged file)", () => {
+    const files = parseFileTreeBody("* src/keep.ts");
+    expect(files[0]).toMatchObject({ path: "src/keep.ts" });
+    expect(files[0]!.change).toBeUndefined();
+  });
+
+  it("requires whitespace after the token: `-rf`/`~` paths are not tokens", () => {
+    const files = parseFileTreeBody("-rf.txt\n~cache.tmp");
+    expect(files.map((f) => f.path)).toEqual(["-rf.txt", "~cache.tmp"]);
+    expect(files.every((f) => f.change === undefined)).toBe(true);
+  });
+
+  it("honors declared tokens inside an indented tree", () => {
+    const body = [
+      "src/",
+      "  + added.rs",
+      "  ~ changed.rs",
+      "  routes/",
+      "    - gone.ts",
+    ].join("\n");
+    const files = parseFileTreeBody(body);
+    expect(files).toEqual([
+      { path: "src/added.rs", name: "added.rs", change: "added", note: undefined },
+      {
+        path: "src/changed.rs",
+        name: "changed.rs",
+        change: "modified",
+        note: undefined,
+      },
+      {
+        path: "src/routes/gone.ts",
+        name: "gone.ts",
+        change: "deleted",
+        note: undefined,
+      },
+    ]);
+  });
+
+  it("extracts a trailing note as a caption alongside a declared token", () => {
     const files = parseFileTreeBody(
-      "Cargo.toml (add [workspace.lints])\nsrc/x.rs (MODIFIED) wire the new route",
+      "Cargo.toml — add [workspace.lints]\n~ src/x.rs wire the new route",
     );
     expect(files[0]).toMatchObject({
       path: "Cargo.toml",
@@ -116,8 +181,8 @@ describe("parseFileTreeBody", () => {
     expect(files[1]).toMatchObject({ path: "src/b.ts", note: "helper" });
   });
 
-  it("attaches status/note to a bare folder row that carries them", () => {
-    const files = parseFileTreeBody("src/legacy/ (DELETED) drop the old module");
+  it("attaches a declared token + note to a bare folder row", () => {
+    const files = parseFileTreeBody("- src/legacy/ drop the old module");
     expect(files).toHaveLength(1);
     expect(files[0]).toMatchObject({
       path: "src/legacy",
@@ -126,7 +191,7 @@ describe("parseFileTreeBody", () => {
     });
   });
 
-  it("ignores bare folder header rows with no change/note", () => {
+  it("ignores bare folder header rows with no token/note", () => {
     const files = parseFileTreeBody("src/\nsrc/main.rs");
     expect(files.map((f) => f.path)).toEqual(["src/main.rs"]);
   });
@@ -137,8 +202,17 @@ describe("parseFileTreeBody", () => {
     expect(files.map((f) => f.path)).toEqual(["src/main.rs", "src/lib.rs"]);
   });
 
+  it("honors a declared token after a tree glyph", () => {
+    const body = ["src", "  ├─ ~ main.rs", "  └─ + lib.rs"].join("\n");
+    const files = parseFileTreeBody(body);
+    expect(files).toEqual([
+      { path: "src/main.rs", name: "main.rs", change: "modified", note: undefined },
+      { path: "src/lib.rs", name: "lib.rs", change: "added", note: undefined },
+    ]);
+  });
+
   it("dedupes repeated paths, keeping the first", () => {
-    const files = parseFileTreeBody("a.ts (NEW)\na.ts (MODIFIED)");
+    const files = parseFileTreeBody("+ a.ts\n~ a.ts");
     expect(files).toHaveLength(1);
     expect(files[0]!.change).toBe("added");
   });
@@ -184,7 +258,7 @@ describe("buildFileTree", () => {
   });
 
   it("carries change + note onto file leaves", () => {
-    const files = parseFileTreeBody("src/x.ts (NEW) added the route");
+    const files = parseFileTreeBody("+ src/x.ts added the route");
     const tree = buildFileTree(files);
     const folder = tree[0] as { children: TreeNode[] };
     expect(folder.children[0]).toMatchObject({
@@ -196,14 +270,14 @@ describe("buildFileTree", () => {
 });
 
 describe("tallyChanges", () => {
-  it("counts each change kind", () => {
+  it("counts each declared change kind", () => {
     const files = parseFileTreeBody(
       [
-        "a.ts (NEW)",
-        "b.ts (NEW)",
-        "c.ts (MODIFIED)",
-        "d.ts (DELETED)",
-        "e.ts (RENAMED)",
+        "+ a.ts",
+        "+ b.ts",
+        "~ c.ts",
+        "- d.ts",
+        "> e.ts",
         "f.ts",
       ].join("\n"),
     );

--- a/ui/src/components/proposals/blocks/fileTree.ts
+++ b/ui/src/components/proposals/blocks/fileTree.ts
@@ -12,19 +12,38 @@
 //   1. Indented ASCII tree — folders end in `/` (or simply have children under a
 //      deeper indent), files sit beneath them:
 //        src/
-//          main.rs
+//          ~ main.rs
 //          routes/
-//            git.ts (NEW)
+//            + git.ts
 //
 //   2. One slash-path per line:
 //        src/main.rs
-//        src/routes/git.ts (MODIFIED)  -- why it changed
+//        ~ src/routes/git.ts  -- why it changed
 //
-// A per-file change status is derived from an inline marker like `(NEW)`,
-// `(MODIFIED)`, `(DELETED)`, or `(RENAMED)`. A trailing note/description after
-// the path (e.g. `Cargo.toml (add [workspace.lints])` or `foo.ts — does X`) is
-// surfaced as a muted caption. Anything the parser can't make sense of yields an
-// empty file list, so the caller can fall back to the raw <pre>.
+// ── Declared status-token grammar ──────────────────────────────────────────
+// A file's change status is DECLARED by the author with a single leading token,
+// never inferred from English words. The token, when present, is the FIRST
+// non-whitespace character of the row (after any ASCII tree-drawing glyphs like
+// `├ └ │` have been stripped) and MUST be immediately followed by whitespace and
+// then the path:
+//
+//        +  path   → added      (a.k.a. new)
+//        ~  path   → modified
+//        -  path   → removed    (deleted); `−` (U+2212) is accepted too
+//        >  path   → renamed    (moved)
+//     (none) path  → unchanged
+//
+// Token vs bullet-glyph collision: `+` and `-` are ALSO common list bullets, so
+// the declared token is resolved FIRST and takes precedence — a leading `+`/`-`/
+// `~`/`>` followed by whitespace is ALWAYS a status token, not a bullet. Only the
+// `*` glyph (which is not a status token) is still treated as a plain bullet, so
+// `* foo.ts` is an unchanged file. A token must be followed by whitespace: `-x`
+// (no space) is not a token and is parsed as the path `-x`.
+//
+// A trailing note/description after the path (e.g. `Cargo.toml — sets lints` or
+// `foo.ts: does X`) is still surfaced as a muted caption. Anything the parser
+// can't make sense of yields an empty file list, so the caller can fall back to
+// the raw <pre>.
 
 /** The kind of change applied to a file, driving its single-letter badge. */
 export type FileChange = "added" | "modified" | "deleted" | "renamed";
@@ -69,55 +88,33 @@ export interface ChangeTally {
   renamed: number;
 }
 
-/* ── Status + note parsing ─────────────────────────────────────────────────── */
+/* ── Declared status token + note parsing ──────────────────────────────────── */
 
-// Maps the words an author might use in an inline `(…)` marker to a status.
-const STATUS_WORDS: Record<string, FileChange> = {
-  new: "added",
-  added: "added",
-  add: "added",
-  create: "added",
-  created: "added",
-  a: "added",
-  modified: "modified",
-  modify: "modified",
-  changed: "modified",
-  change: "modified",
-  updated: "modified",
-  update: "modified",
-  edit: "modified",
-  edited: "modified",
-  m: "modified",
-  deleted: "deleted",
-  delete: "deleted",
-  removed: "deleted",
-  remove: "deleted",
-  del: "deleted",
-  d: "deleted",
-  renamed: "renamed",
-  rename: "renamed",
-  moved: "renamed",
-  move: "renamed",
-  r: "renamed",
+/** Maps a leading declared status token to its change kind. */
+const STATUS_TOKENS: Record<string, FileChange> = {
+  "+": "added",
+  "~": "modified",
+  "-": "deleted",
+  "−": "deleted", // U+2212 MINUS SIGN, as some authors paste it.
+  ">": "renamed",
 };
 
 /**
- * Pull a leading `(STATUS)` marker out of a trailing-text fragment. Only a
- * marker whose entire content is a recognised status word counts (so a genuine
- * note like `(add [workspace.lints])` is left as a note, not eaten as a status).
+ * Pull a leading DECLARED status token out of a row. The token must be the first
+ * character and be immediately followed by whitespace (so `-x` with no space is
+ * NOT a token — it's a literal path). On a match the token + its trailing
+ * whitespace are stripped and the matching change is returned; otherwise the row
+ * is returned unchanged with no status. Status is NEVER inferred from words.
  */
-function extractStatusMarker(text: string): {
-  change?: FileChange;
-  rest: string;
-} {
-  const trimmed = text.trim();
-  const match = /^\(([A-Za-z]+)\)\s*([\s\S]*)$/.exec(trimmed);
-  if (match) {
-    const word = (match[1] ?? "").toLowerCase();
-    const change = STATUS_WORDS[word];
-    if (change) return { change, rest: (match[2] ?? "").trim() };
+function extractStatusToken(row: string): { change?: FileChange; rest: string } {
+  const first = row[0] ?? "";
+  const change = STATUS_TOKENS[first];
+  // Require whitespace after the token so a path that merely starts with the
+  // character (e.g. `~/home`, `-rf`) is not mistaken for a declared status.
+  if (change && /\s/.test(row[1] ?? "")) {
+    return { change, rest: row.slice(1).replace(/^\s+/u, "") };
   }
-  return { rest: trimmed };
+  return { rest: row };
 }
 
 /** Strip a leading note separator (dash/colon/hash) and unwrap a `(note)`. */
@@ -136,10 +133,18 @@ function cleanNote(text: string): string | undefined {
 function parseRow(raw: string): ParsedFile | null {
   let rest = raw.trim();
   if (!rest) return null;
-  // Strip ASCII tree-drawing glyphs / bullet markers, keeping path + trailing.
-  rest = rest.replace(/^[│|`'+*\s]*[├└][\s─-]*/u, "").trim();
+  // Strip ASCII tree-drawing glyphs first (purely structural, never a status).
+  rest = rest.replace(/^[│|`'*\s]*[├└][\s─]*/u, "").trim();
   rest = rest.replace(/^[│|]\s*/u, "").trim();
-  rest = rest.replace(/^[-*+]\s+/u, "").trim();
+  if (!rest) return null;
+
+  // Resolve a DECLARED leading status token (`+ ~ - >`) BEFORE any bullet
+  // stripping, so the token wins the collision with `+`/`-` list bullets.
+  const status = extractStatusToken(rest);
+  const change = status.change;
+  rest = status.rest;
+  // Only the `*` glyph remains a plain bullet now (`+`/`-` are status tokens).
+  rest = rest.replace(/^\*\s+/u, "").trim();
   if (!rest) return null;
 
   const firstSpace = rest.search(/\s/);
@@ -161,13 +166,7 @@ function parseRow(raw: string): ParsedFile | null {
   // A path token must not contain angle brackets and must have real content.
   if (!path || /[<>]/.test(path)) return null;
 
-  let change: FileChange | undefined;
-  let note: string | undefined;
-  if (trailing) {
-    const marker = extractStatusMarker(trailing);
-    change = marker.change;
-    note = cleanNote(marker.rest);
-  }
+  const note: string | undefined = trailing ? cleanNote(trailing) : undefined;
 
   const isFolder = path.endsWith("/");
   const cleanPath = path.replace(/\/+$/, "");
@@ -192,9 +191,15 @@ function parseRowSegment(raw: string): {
   note?: string;
 } | null {
   let rest = raw.trim();
-  rest = rest.replace(/^[├└][\s─-]*/u, "").trim();
+  rest = rest.replace(/^[├└][\s─]*/u, "").trim();
   rest = rest.replace(/^[│|]\s*/u, "").trim();
-  rest = rest.replace(/^[-*+]\s+/u, "").trim();
+  if (!rest) return null;
+
+  // DECLARED status token wins over `+`/`-` bullets; resolve it first.
+  const status = extractStatusToken(rest);
+  const change = status.change;
+  rest = status.rest;
+  rest = rest.replace(/^\*\s+/u, "").trim();
   if (!rest) return null;
 
   const firstSpace = rest.search(/\s/);
@@ -210,13 +215,7 @@ function parseRowSegment(raw: string): {
   const segment = token.replace(/\/+$/, "");
   if (!segment || !/[A-Za-z0-9._]/.test(segment)) return null;
 
-  let change: FileChange | undefined;
-  let note: string | undefined;
-  if (trailing) {
-    const marker = extractStatusMarker(trailing);
-    change = marker.change;
-    note = cleanNote(marker.rest);
-  }
+  const note: string | undefined = trailing ? cleanNote(trailing) : undefined;
 
   return { segment, rawEndsWithSlash, change, note };
 }


### PR DESCRIPTION
Two independent polish fixes for proposal blocks, batched (independent files).

## FIX 1 — FileTree declared per-file status tokens (not heuristic)
The author now DECLARES each file's change status with an explicit leading token; status is never inferred from English words.

Token grammar (token must be immediately followed by whitespace, then the path):
- `+ path` → added (new)
- `~ path` → modified
- `- path` → removed (deleted); `−` U+2212 accepted too
- `> path` → renamed (moved)
- `(none) path` → unchanged

Collision handling: the declared token is resolved BEFORE bullet-glyph stripping, so a leading `+`/`-` followed by whitespace is always a status token, never a list bullet. Only `*` remains a plain bullet. A token requires trailing whitespace, so paths like `~/home` or `-rf.txt` are literal paths, not tokens. Tokens are honored in indented-tree rows, flat slash-path rows, and after ASCII tree-drawing glyphs.

- Removed the `STATUS_WORDS` map and the `(NEW)`/`(MODIFIED)`/`(DELETED)`/`(RENAMED)` word-inference path entirely.
- Trailing human notes after the path are still parsed and surfaced as a muted caption.
- Module-header doc comment, `FileTreeBlock.tsx` doc, and the Rust registry `description` (now `block_with_description`) document the new grammar so the authoring LLM emits tokens. This is runtime data only — no schema snapshot change.
- `fileTree.test.ts` rewritten: declared-token cases per kind, bullet-collision cases, no-token=unchanged, "does not infer from words", tree-glyph + token, indented-tree tokens.

## FIX 2 — Open Questions: flatten card-in-card
`QuestionFormBlock` rendered each question as a bordered `bg-muted/20` card inside the outer BlockShell card (block-in-block). Flattened to a clean numbered list: `divide-y divide-border/60` rows with no per-row border/background. Single BlockShell only. Keeps the question-mark marker, markdown-rendered question, muted sub-detail, "recommended" badge, and the empty-parse markdown fallback.

## Verification (local)
- UI vitest (`fileTree.test.ts` + `questionForm.test.ts`): 35 passed
- `tsc -b`: clean
- `eslint` on changed files: clean
- `SQLX_OFFLINE=true cargo test -p djinn-control-plane --lib proposal_blocks`: 29 passed (no INSTA snapshot update needed)