### PR TITLE
feat(proposals): add json-explorer block + wire into api-endpoint examples

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -26,6 +26,7 @@ pub enum BlockType {
     Callout,
     Table,
     Checklist,
+    JsonExplorer,
     QuestionForm,
 }
 
@@ -44,6 +45,7 @@ impl BlockType {
             BlockType::Callout => "callout",
             BlockType::Table => "table",
             BlockType::Checklist => "checklist",
+            BlockType::JsonExplorer => "json-explorer",
             BlockType::QuestionForm => "question-form",
         }
     }
@@ -62,6 +64,7 @@ impl BlockType {
             BlockType::Callout => "Callout",
             BlockType::Table => "Table",
             BlockType::Checklist => "Checklist",
+            BlockType::JsonExplorer => "JsonExplorer",
             BlockType::QuestionForm => "QuestionForm",
         }
     }
@@ -458,6 +461,27 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
                 ),
             ),
             (
+                "json-explorer",
+                block_with_description(
+                    "json-explorer",
+                    "JsonExplorer",
+                    "An interactive, collapsible typed JSON tree (browser-devtools \
+                     / Postman style). The block CHILDREN are a single JSON \
+                     document — an object, array, or primitive. The renderer \
+                     `JSON.parse`s the children and walks the value: object/array \
+                     nodes show a chevron + a one-line summary (`3 keys` / `5 \
+                     items`) and expand/collapse, and leaf values are \
+                     type-colored (string, number, boolean, null). It is \
+                     read-only. If the children are not valid JSON the renderer \
+                     falls back to a plain code block, so always emit a single \
+                     valid JSON document. Set the optional `title` attribute to a \
+                     heading shown in the block header. Example: \
+                     `<JsonExplorer id=\"x\" title=\"Sample response\">\\n{\\n  \
+                     \"id\": \"abc\",\\n  \"active\": true\\n}\\n</JsonExplorer>`.",
+                    fields(vec![]),
+                ),
+            ),
+            (
                 "question-form",
                 block(
                     "question-form",
@@ -682,7 +706,7 @@ mod tests {
     #[test]
     fn registry_contains_v1_blocks() {
         let registry = proposal_block_registry();
-        assert_eq!(registry.len(), 12);
+        assert_eq!(registry.len(), 13);
         assert_eq!(registry["rich-text"].tag, "RichText");
         assert_eq!(registry["diagram"].tag, "Diagram");
         assert_eq!(registry["annotated-code"].tag, "AnnotatedCode");
@@ -694,6 +718,7 @@ mod tests {
         assert_eq!(registry["callout"].tag, "Callout");
         assert_eq!(registry["table"].tag, "Table");
         assert_eq!(registry["checklist"].tag, "Checklist");
+        assert_eq!(registry["json-explorer"].tag, "JsonExplorer");
         assert_eq!(registry["question-form"].tag, "QuestionForm");
         // The diff block ships authoring guidance for the LLM.
         assert!(
@@ -718,6 +743,7 @@ mod tests {
             BlockType::Callout,
             BlockType::Table,
             BlockType::Checklist,
+            BlockType::JsonExplorer,
             BlockType::QuestionForm,
         ];
         for bt in types {
@@ -729,7 +755,7 @@ mod tests {
     #[test]
     fn block_registry_new_has_all_definitions() {
         let reg = BlockRegistry::new();
-        assert_eq!(reg.definitions().len(), 12);
+        assert_eq!(reg.definitions().len(), 13);
         assert!(reg.definition_for_tag("RichText").is_some());
         assert!(reg.definition_for_tag("UnknownTag").is_none());
         assert!(reg.tags().contains("RichText"));
@@ -753,6 +779,7 @@ mod tests {
             "Callout",
             "Table",
             "Checklist",
+            "JsonExplorer",
             "QuestionForm",
         ]
         .into_iter()

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -509,6 +509,14 @@ This runs on the hot path.
 - [ ] Backfill job verified
 </Checklist>
 
+<JsonExplorer id="config-sample">
+{
+  "enabled": true,
+  "retries": 3,
+  "labels": ["alpha", "beta"]
+}
+</JsonExplorer>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/ApiEndpointBlock.tsx
+++ b/ui/src/components/proposals/blocks/ApiEndpointBlock.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react";
 import {
   ArrowDown01Icon,
   ArrowRight01Icon,
-  CodeIcon,
   LockKeyIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -10,6 +9,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/utils";
 
 import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { JsonTree } from "./JsonExplorerBlock";
 import {
   ACCENT_BADGE,
   httpMethodColor,
@@ -307,24 +307,11 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * A JSON / example body rendered in a styled code surface.
- *
- * TODO(json-explorer): when the dedicated interactive `json-explorer` block
- * lands, upgrade JSON example bodies here to a collapsible, type-colored tree
- * (Postman-style) instead of a flat `<pre>`. This component is the seam: detect
- * parseable JSON, mount the explorer, and keep this `<pre>` as the fallback for
- * non-JSON / unparseable bodies.
+ * A JSON / example body rendered with the shared interactive `json-explorer`
+ * tree: parseable JSON becomes a collapsible, type-colored tree (Postman-style)
+ * and any non-JSON / unparseable body gracefully falls back to a styled `<pre>`
+ * — both handled inside `JsonTree`, so an example is never lost or misrendered.
  */
 function JsonExample({ code }: { code: string }) {
-  return (
-    <div className="overflow-hidden rounded-md border bg-muted/30">
-      <div className="flex items-center gap-1.5 border-b bg-muted/40 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-        <HugeiconsIcon icon={CodeIcon} size={12} className="shrink-0" />
-        Example
-      </div>
-      <pre className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-foreground">
-        {code}
-      </pre>
-    </div>
-  );
+  return <JsonTree code={code} label="Example" />;
 }

--- a/ui/src/components/proposals/blocks/JsonExplorerBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/JsonExplorerBlock.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@/test/test-utils";
+
+import { JsonExplorerBlock, JsonTree } from "./JsonExplorerBlock";
+
+describe("JsonExplorerBlock", () => {
+  it("renders a typed tree with keys, type-colored values, and counts", () => {
+    render(
+      <JsonExplorerBlock id="j1" attributes={{ title: "Sample" }}>
+        {'{ "id": "abc", "active": true, "tags": ["a", "b"] }'}
+      </JsonExplorerBlock>,
+    );
+    // Header label (shell + tree toolbar both say JSON) + title.
+    expect(screen.getAllByText("JSON").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Sample")).toBeInTheDocument();
+    // Keys render (quoted).
+    expect(screen.getByText('"id"')).toBeInTheDocument();
+    expect(screen.getByText('"active"')).toBeInTheDocument();
+    // A string and a boolean leaf render.
+    expect(screen.getByText('"abc"')).toBeInTheDocument();
+    expect(screen.getByText("true")).toBeInTheDocument();
+  });
+
+  it("collapses a nested container and shows its summary on toggle", () => {
+    render(
+      <JsonExplorerBlock id="j2" attributes={{}}>
+        {'{ "outer": { "a": 1, "b": 2, "c": 3 } }'}
+      </JsonExplorerBlock>,
+    );
+    // The nested object key is present (root expanded by default).
+    const toggle = screen.getByText('"outer"').closest("button");
+    expect(toggle).not.toBeNull();
+    // Collapse the nested object: its key-count summary appears.
+    fireEvent.click(toggle!);
+    expect(screen.getByText("3 keys")).toBeInTheDocument();
+  });
+
+  it("exposes expand-all / collapse-all controls for containers", () => {
+    render(
+      <JsonExplorerBlock id="j3" attributes={{}}>
+        {'{ "a": { "b": 1 } }'}
+      </JsonExplorerBlock>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Expand all" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Collapse all" }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to a styled <pre> + error when children are not valid JSON", () => {
+    render(
+      <JsonExplorerBlock id="j4" attributes={{}}>
+        {"not json at all { oops"}
+      </JsonExplorerBlock>,
+    );
+    expect(screen.getByText("not json at all { oops")).toBeInTheDocument();
+    expect(screen.getByText(/Could not parse JSON/)).toBeInTheDocument();
+    // No tree actions in the fallback.
+    expect(screen.queryByRole("button", { name: "Expand all" })).toBeNull();
+  });
+});
+
+describe("JsonTree (reusable surface)", () => {
+  it("renders a custom label and a tree for parseable JSON", () => {
+    render(<JsonTree code={'{ "k": 1 }'} label="Example" />);
+    expect(screen.getByText("Example")).toBeInTheDocument();
+    expect(screen.getByText('"k"')).toBeInTheDocument();
+  });
+
+  it("falls back to a <pre> for non-JSON examples", () => {
+    render(<JsonTree code={"plain text body"} label="Example" />);
+    expect(screen.getByText("plain text body")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Expand all" })).toBeNull();
+  });
+});

--- a/ui/src/components/proposals/blocks/JsonExplorerBlock.tsx
+++ b/ui/src/components/proposals/blocks/JsonExplorerBlock.tsx
@@ -1,0 +1,346 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  ArrowRight01Icon,
+  CodeIcon,
+  Copy01Icon,
+  Tick02Icon,
+  UnfoldLessIcon,
+  UnfoldMoreIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
+
+import { BlockShell } from "./BlockShell";
+import type { BlockProps } from "./types";
+import {
+  JSON_EXPLORER_DEFAULT_COLLAPSED_DEPTH,
+  containerEntries,
+  containerSummary,
+  formatLeaf,
+  isContainer,
+  isNonEmptyContainer,
+  parseJsonValue,
+  valueKind,
+  type JsonObject,
+  type JsonValue,
+} from "./jsonExplorer";
+
+/**
+ * JsonExplorer — a browser-devtools / Postman-style collapsible, type-colored
+ * JSON tree for proposal specs.
+ *
+ * djinn does NOT serialize a structured prop; the block's payload is its
+ * *children string* (`segment.content`). We `JSON.parse` that text (see
+ * `jsonExplorer.ts`) and walk the value as a tree: object/array nodes get a
+ * chevron + a one-line summary (`3 keys` / `5 items`) and toggle open/closed;
+ * leaf values are type-colored (string emerald, number sky, boolean violet,
+ * null muted). An expand-all / collapse-all control flips every node at once,
+ * and a copy button yanks the pretty-printed payload.
+ *
+ * Graceful + read-only: if the children are not valid JSON the renderer falls
+ * back to a styled `<pre>` of the raw text plus the parse error, so an
+ * oddly-authored block never blanks or crashes. The tree is display-only.
+ */
+export function JsonExplorerBlock({ attributes, children }: BlockProps) {
+  const content = typeof children === "string" ? children : "";
+  const title = attributes.title?.trim() || undefined;
+
+  return (
+    <BlockShell
+      label="JSON"
+      accent="text-teal-400"
+      flush
+      meta={title ? <span className="truncate font-mono">{title}</span> : null}
+    >
+      <JsonTree code={content} className="rounded-none border-0" />
+    </BlockShell>
+  );
+}
+
+/* ── Type-color tokens ──────────────────────────────────────────────────────── */
+
+const KIND_CLASS: Record<string, string> = {
+  string: "text-emerald-300",
+  number: "text-sky-300",
+  boolean: "text-violet-300",
+  null: "italic text-muted-foreground",
+};
+
+const KEY_CLASS = "text-rose-300";
+const PUNCT_CLASS = "text-muted-foreground/70";
+
+/* ── Reusable tree surface ──────────────────────────────────────────────────── */
+
+/**
+ * The reusable JSON-tree surface: a bordered code panel with an `Example`-style
+ * header (label + expand/collapse-all + copy) and the collapsible tree (or a
+ * `<pre>` fallback for non-JSON). The `json-explorer` block wraps it in a
+ * `BlockShell`; the `api-endpoint` block reuses it directly to upgrade its JSON
+ * example bodies — both share one fallback path.
+ *
+ * `pulse` carries an `expand`/`collapse` intent plus a nonce; bumping the nonce
+ * remounts the tree so every node re-seeds from the new open/closed state.
+ */
+export function JsonTree({
+  code,
+  label = "JSON",
+  collapsedDepth = JSON_EXPLORER_DEFAULT_COLLAPSED_DEPTH,
+  className,
+}: {
+  code: string;
+  label?: string;
+  collapsedDepth?: number;
+  className?: string;
+}) {
+  const parsed = useMemo(() => parseJsonValue(code), [code]);
+  const [pulse, setPulse] = useState<{ open: boolean; nonce: number } | null>(
+    null,
+  );
+  const [copied, setCopied] = useState(false);
+
+  const value = parsed.ok ? parsed.value : null;
+  const showTreeActions = value !== null && isNonEmptyContainer(value);
+
+  const copyPayload = useCallback(() => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return;
+    const text = parsed.ok
+      ? JSON.stringify(parsed.value, null, 2)
+      : code;
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      })
+      .catch(() => {
+        /* clipboard unavailable — ignore */
+      });
+  }, [code, parsed]);
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-md border bg-muted/30",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 border-b bg-muted/40 px-2.5 py-1">
+        <span className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <HugeiconsIcon icon={CodeIcon} size={12} className="shrink-0" />
+          {label}
+        </span>
+        <span className="flex items-center gap-1">
+          {showTreeActions && (
+            <>
+              <TreeActionButton
+                onClick={() =>
+                  setPulse((prev) => ({
+                    open: true,
+                    nonce: (prev?.nonce ?? 0) + 1,
+                  }))
+                }
+                icon={UnfoldMoreIcon}
+                label="Expand all"
+              />
+              <TreeActionButton
+                onClick={() =>
+                  setPulse((prev) => ({
+                    open: false,
+                    nonce: (prev?.nonce ?? 0) + 1,
+                  }))
+                }
+                icon={UnfoldLessIcon}
+                label="Collapse all"
+              />
+            </>
+          )}
+          <button
+            type="button"
+            onClick={copyPayload}
+            title="Copy JSON"
+            aria-label={copied ? "Copied" : "Copy JSON"}
+            className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+          >
+            <HugeiconsIcon
+              icon={copied ? Tick02Icon : Copy01Icon}
+              size={12}
+              className={copied ? "text-emerald-400" : undefined}
+            />
+          </button>
+        </span>
+      </div>
+
+      <div
+        dir="ltr"
+        className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-foreground [unicode-bidi:isolate]"
+      >
+        {parsed.ok ? (
+          <JsonNode
+            key={pulse?.nonce ?? 0}
+            value={parsed.value}
+            depth={0}
+            collapsedDepth={collapsedDepth}
+            forceOpen={pulse}
+          />
+        ) : (
+          <div className="space-y-1.5">
+            <pre className="overflow-x-auto whitespace-pre-wrap break-words">
+              {code || "—"}
+            </pre>
+            <p className="text-[11px] text-amber-300">
+              Could not parse JSON: {parsed.error}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TreeActionButton({
+  onClick,
+  icon,
+  label,
+}: {
+  onClick: () => void;
+  icon: typeof UnfoldMoreIcon;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className="flex shrink-0 items-center rounded px-1 py-0.5 text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+    >
+      <HugeiconsIcon icon={icon} size={13} />
+    </button>
+  );
+}
+
+/* ── Tree node ──────────────────────────────────────────────────────────────── */
+
+interface JsonNodeProps {
+  /** The object key or array index label for this node (root has none). */
+  label?: string | number;
+  value: JsonValue;
+  depth: number;
+  /** Depth beyond which nodes start collapsed. */
+  collapsedDepth: number;
+  /** Global expand/collapse pulse — seeds the open state when its nonce changes. */
+  forceOpen: { open: boolean; nonce: number } | null;
+  /** True when this node has a following sibling (renders a trailing comma). */
+  trailingComma?: boolean;
+}
+
+/**
+ * A single tree node. Containers carry their own open/closed state, seeded from
+ * `collapsedDepth` (or the global pulse when one is active). The whole tree is
+ * remounted on a pulse via a `key`, so each node simply re-seeds — no effect
+ * gymnastics. Leaves render inline with their type color.
+ */
+function JsonNode({
+  label,
+  value,
+  depth,
+  collapsedDepth,
+  forceOpen,
+  trailingComma,
+}: JsonNodeProps) {
+  const container = isContainer(value);
+  const entries = container ? containerEntries(value) : [];
+  const empty = entries.length === 0;
+  const [open, setOpen] = useState(forceOpen?.open ?? depth < collapsedDepth);
+
+  const keyEl =
+    label !== undefined ? (
+      <>
+        <span className={KEY_CLASS}>
+          {typeof label === "number" ? label : JSON.stringify(label)}
+        </span>
+        <span className={PUNCT_CLASS}>: </span>
+      </>
+    ) : null;
+
+  if (!container) {
+    return (
+      <div className="flex items-start py-px leading-relaxed">
+        <span className="whitespace-pre">{keyEl}</span>
+        <span className={KIND_CLASS[valueKind(value)]}>{formatLeaf(value)}</span>
+        {trailingComma && <span className={PUNCT_CLASS}>,</span>}
+      </div>
+    );
+  }
+
+  const isArray = Array.isArray(value);
+  const openBrace = isArray ? "[" : "{";
+  const closeBrace = isArray ? "]" : "}";
+
+  return (
+    <div className="leading-relaxed">
+      <button
+        type="button"
+        aria-expanded={open}
+        disabled={empty}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          "flex w-full items-start gap-1 rounded py-px text-left transition-colors",
+          !empty && "hover:bg-muted/50",
+          empty && "cursor-default",
+        )}
+      >
+        <HugeiconsIcon
+          icon={ArrowRight01Icon}
+          size={13}
+          className={cn(
+            "mt-0.5 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-90",
+            empty && "opacity-0",
+          )}
+        />
+        <span className="min-w-0 whitespace-pre-wrap break-words">
+          {keyEl}
+          <span className={PUNCT_CLASS}>{openBrace}</span>
+          {!open && !empty && (
+            <span className="ml-1 text-muted-foreground/80">
+              {containerSummary(value as JsonValue[] | JsonObject)}
+            </span>
+          )}
+          {(!open || empty) && (
+            <span className={PUNCT_CLASS}>
+              {empty ? "" : " … "}
+              {closeBrace}
+              {trailingComma ? "," : ""}
+            </span>
+          )}
+        </span>
+      </button>
+
+      {open && !empty && (
+        <>
+          <div className="ml-[6px] border-l border-border/70 pl-3.5">
+            {entries.map(([entryKey, entryValue], index) => (
+              <JsonNode
+                key={String(entryKey)}
+                label={entryKey}
+                value={entryValue}
+                depth={depth + 1}
+                collapsedDepth={collapsedDepth}
+                forceOpen={forceOpen}
+                trailingComma={index < entries.length - 1}
+              />
+            ))}
+          </div>
+          <div className="flex items-start">
+            <span className="ml-[19px] whitespace-pre">
+              <span className={PUNCT_CLASS}>{closeBrace}</span>
+              {trailingComma && <span className={PUNCT_CLASS}>,</span>}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -68,6 +68,14 @@ This runs on the hot path — keep allocations out of the loop.
 - [ ] Docs updated — link the runbook
 </Checklist>
 
+<JsonExplorer id="config-sample">
+{
+  "enabled": true,
+  "retries": 3,
+  "labels": ["alpha", "beta"]
+}
+</JsonExplorer>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached for caching?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/blocks.test.ts
+++ b/ui/src/components/proposals/blocks/blocks.test.ts
@@ -29,6 +29,7 @@ export const CANONICAL_V1_TAGS = [
   "Callout",
   "Table",
   "Checklist",
+  "JsonExplorer",
   "QuestionForm",
 ] as const;
 
@@ -206,6 +207,15 @@ describe("canonical proposal.mdx round-trip", () => {
     expect(checklist!.content).toContain("[x]");
     expect(getProposalBlockDefinitionByTag("Checklist")!.type).toBe(
       "checklist",
+    );
+
+    // JsonExplorer
+    const jsonExplorer = byTag.get("JsonExplorer");
+    expect(jsonExplorer).toBeDefined();
+    expect(jsonExplorer!.id).toBe("config-sample");
+    expect(jsonExplorer!.content).toContain("\"enabled\"");
+    expect(getProposalBlockDefinitionByTag("JsonExplorer")!.type).toBe(
+      "json-explorer",
     );
 
     // QuestionForm

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -11,6 +11,7 @@ export { DiffBlock } from "./DiffBlock";
 export { CalloutBlock } from "./CalloutBlock";
 export { TableBlock } from "./TableBlock";
 export { ChecklistBlock } from "./ChecklistBlock";
+export { JsonExplorerBlock, JsonTree } from "./JsonExplorerBlock";
 
 // Reusable line-anchored annotation engine (pure parsing + React rail UI). The
 // `annotated-code` block consumes it; `diff` and future blocks can adopt it.

--- a/ui/src/components/proposals/blocks/jsonExplorer.test.ts
+++ b/ui/src/components/proposals/blocks/jsonExplorer.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  containerEntries,
+  containerSummary,
+  formatLeaf,
+  isContainer,
+  isNonEmptyContainer,
+  parseJsonValue,
+  valueKind,
+  type JsonObject,
+} from "./jsonExplorer";
+
+describe("parseJsonValue", () => {
+  it("parses a JSON object", () => {
+    const result = parseJsonValue('{ "id": "abc", "active": true }');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ id: "abc", active: true });
+    }
+  });
+
+  it("parses a JSON array", () => {
+    const result = parseJsonValue("[1, 2, 3]");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual([1, 2, 3]);
+  });
+
+  it("parses nested structures", () => {
+    const result = parseJsonValue(
+      '{ "user": { "roles": ["admin", "ops"] }, "count": 2 }',
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        user: { roles: ["admin", "ops"] },
+        count: 2,
+      });
+    }
+  });
+
+  it("parses primitives at the root", () => {
+    expect(parseJsonValue("42")).toEqual({ ok: true, value: 42 });
+    expect(parseJsonValue('"hi"')).toEqual({ ok: true, value: "hi" });
+    expect(parseJsonValue("true")).toEqual({ ok: true, value: true });
+    expect(parseJsonValue("null")).toEqual({ ok: true, value: null });
+  });
+
+  it("tolerates leading/trailing whitespace", () => {
+    const result = parseJsonValue('\n  { "ok": true }\n');
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails gracefully on invalid JSON with an error message", () => {
+    const result = parseJsonValue("{ not: valid json }");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.length).toBeGreaterThan(0);
+  });
+
+  it("treats empty / whitespace input as a recoverable failure", () => {
+    expect(parseJsonValue("").ok).toBe(false);
+    expect(parseJsonValue("   \n ").ok).toBe(false);
+  });
+});
+
+describe("valueKind", () => {
+  it("classifies every JSON value kind", () => {
+    expect(valueKind("s")).toBe("string");
+    expect(valueKind(3)).toBe("number");
+    expect(valueKind(true)).toBe("boolean");
+    expect(valueKind(null)).toBe("null");
+    expect(valueKind([1])).toBe("array");
+    expect(valueKind({ a: 1 })).toBe("object");
+  });
+});
+
+describe("container helpers", () => {
+  it("isContainer distinguishes containers from primitives and null", () => {
+    expect(isContainer({ a: 1 })).toBe(true);
+    expect(isContainer([1])).toBe(true);
+    expect(isContainer(null)).toBe(false);
+    expect(isContainer("x")).toBe(false);
+    expect(isContainer(1)).toBe(false);
+  });
+
+  it("isNonEmptyContainer is false for empty containers", () => {
+    expect(isNonEmptyContainer({})).toBe(false);
+    expect(isNonEmptyContainer([])).toBe(false);
+    expect(isNonEmptyContainer({ a: 1 })).toBe(true);
+    expect(isNonEmptyContainer([1])).toBe(true);
+    expect(isNonEmptyContainer("x")).toBe(false);
+  });
+
+  it("containerEntries yields indexed entries for arrays and keyed for objects", () => {
+    expect(containerEntries(["a", "b"])).toEqual([
+      [0, "a"],
+      [1, "b"],
+    ]);
+    const obj: JsonObject = { id: 1, name: "x" };
+    expect(containerEntries(obj)).toEqual([
+      ["id", 1],
+      ["name", "x"],
+    ]);
+  });
+
+  it("containerSummary is singular/plural aware", () => {
+    expect(containerSummary([1])).toBe("1 item");
+    expect(containerSummary([1, 2])).toBe("2 items");
+    expect(containerSummary({ a: 1 })).toBe("1 key");
+    expect(containerSummary({ a: 1, b: 2 })).toBe("2 keys");
+  });
+});
+
+describe("formatLeaf", () => {
+  it("quotes strings, lowercases null, stringifies number/boolean", () => {
+    expect(formatLeaf("hi")).toBe('"hi"');
+    expect(formatLeaf(null)).toBe("null");
+    expect(formatLeaf(42)).toBe("42");
+    expect(formatLeaf(true)).toBe("true");
+  });
+});

--- a/ui/src/components/proposals/blocks/jsonExplorer.ts
+++ b/ui/src/components/proposals/blocks/jsonExplorer.ts
@@ -1,0 +1,120 @@
+// Pure (React-free) helpers for the interactive json-explorer block. djinn does
+// NOT serialize a structured JSON prop — the block's payload arrives as its
+// *children string* (`segment.content`). So we `JSON.parse` that text into a
+// value and the renderer walks it as a collapsible typed tree. Kept in its own
+// module so the parsing/summarising logic is unit-testable without React.
+//
+// The parse is defensive: an empty or invalid payload yields `{ ok: false }`
+// with an error message, and the renderer falls back to a styled `<pre>` of the
+// raw text (it never throws and never blanks). The default expand depth keeps
+// deep payloads scannable while showing the top levels up front.
+
+/** The default depth beyond which container nodes start collapsed. */
+export const JSON_EXPLORER_DEFAULT_COLLAPSED_DEPTH = 2;
+
+/** A parsed JSON value — the recursive shape the tree renderer walks. */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** A `{ key: value }` object node (not an array, not a primitive). */
+export type JsonObject = { [key: string]: JsonValue };
+
+/** The discriminated result of {@link parseJsonValue}. */
+export type JsonParseResult =
+  | { ok: true; value: JsonValue }
+  | { ok: false; error: string };
+
+/** The coarse value kind, used to pick a type color in the renderer. */
+export type JsonValueKind =
+  | "string"
+  | "number"
+  | "boolean"
+  | "null"
+  | "array"
+  | "object";
+
+/**
+ * Parse a raw children string into a JSON value. Returns a discriminated result
+ * so the caller renders a tree on `ok` and a raw `<pre>` fallback otherwise.
+ * Empty / whitespace-only input is treated as a (recoverable) parse failure so
+ * the renderer falls back rather than rendering an empty tree.
+ */
+export function parseJsonValue(raw: string): JsonParseResult {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    return { ok: false, error: "Empty payload — nothing to explore." };
+  }
+  try {
+    return { ok: true, value: JSON.parse(trimmed) as JsonValue };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Invalid JSON",
+    };
+  }
+}
+
+/** True when the value is a container (array or non-null object). */
+export function isContainer(value: JsonValue): value is JsonValue[] | JsonObject {
+  return value !== null && typeof value === "object";
+}
+
+/** True when the value is a container with at least one child entry. */
+export function isNonEmptyContainer(
+  value: JsonValue,
+): value is JsonValue[] | JsonObject {
+  if (!isContainer(value)) return false;
+  return Array.isArray(value)
+    ? value.length > 0
+    : Object.keys(value).length > 0;
+}
+
+/** The coarse kind of a value, for type-colored leaf rendering. */
+export function valueKind(value: JsonValue): JsonValueKind {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  switch (typeof value) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    default:
+      return "object";
+  }
+}
+
+/** The ordered `[key, value]` entries of a container (array indices or keys). */
+export function containerEntries(
+  value: JsonValue[] | JsonObject,
+): Array<[string | number, JsonValue]> {
+  return Array.isArray(value)
+    ? value.map((item, index) => [index, item] as [number, JsonValue])
+    : Object.entries(value);
+}
+
+/**
+ * A devtools-style one-line summary for a collapsed container, e.g.
+ * `5 items` for an array or `3 keys` for an object. Singular/plural aware.
+ */
+export function containerSummary(value: JsonValue[] | JsonObject): string {
+  if (Array.isArray(value)) {
+    const count = value.length;
+    return `${count} ${count === 1 ? "item" : "items"}`;
+  }
+  const count = Object.keys(value).length;
+  return `${count} ${count === 1 ? "key" : "keys"}`;
+}
+
+/** Render a primitive leaf to its JSON text (strings quoted, null lowercased). */
+export function formatLeaf(value: string | number | boolean | null): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  return String(value);
+}

--- a/ui/src/lib/blockRegistry.ts
+++ b/ui/src/lib/blockRegistry.ts
@@ -11,6 +11,7 @@ import {
   Diagram,
   DiffBlock,
   FileTreeBlock,
+  JsonExplorerBlock,
   QuestionFormBlock,
   RichText,
   TableBlock,
@@ -40,6 +41,7 @@ const BLOCK_COMPONENTS: Record<ProposalBlockType, ComponentType<BlockProps>> = {
   callout: CalloutBlock,
   table: TableBlock,
   checklist: ChecklistBlock,
+  "json-explorer": JsonExplorerBlock,
   "question-form": QuestionFormBlock,
 };
 
@@ -55,6 +57,7 @@ const BLOCK_DISPLAY_NAMES: Record<ProposalBlockType, string> = {
   callout: "Callout",
   table: "Table",
   checklist: "Checklist",
+  "json-explorer": "JSON Explorer",
   "question-form": "Open Questions",
 };
 

--- a/ui/src/lib/proposalBlocks.ts
+++ b/ui/src/lib/proposalBlocks.ts
@@ -151,6 +151,11 @@ export const PROPOSAL_BLOCK_REGISTRY = {
     tag: "Checklist",
     fields: {},
   },
+  "json-explorer": {
+    type: "json-explorer",
+    tag: "JsonExplorer",
+    fields: {},
+  },
   "question-form": {
     type: "question-form",
     tag: "QuestionForm",


### PR DESCRIPTION
## Summary

Adds a new `json-explorer` proposal block — a read-only, collapsible, type-colored JSON tree (browser-devtools / Postman style) — and wires it into the `api-endpoint` block so request/response JSON example bodies render as the interactive tree instead of a flat `<pre>`.

The block follows the djinn data-model invariant: structured props are NOT serialized, so the JSON payload arrives as the block's **children string** (`segment.content`). The renderer `JSON.parse`s the children and walks the value; on any parse error (or empty/non-JSON input) it falls back gracefully to a styled `<pre>` of the raw text plus the parse error — it never throws and never blanks.

## What it does
- **`json-explorer` block**: object/array nodes show a chevron + one-line summary (`3 keys` / `5 items`) and toggle open/closed per node; expand-all / collapse-all flips every node; leaf values are type-colored (string emerald, number sky, boolean violet, null muted); a copy button yanks the pretty-printed payload. Read-only.
- **api-endpoint wiring**: the documented `JsonExample` seam now mounts the shared `JsonTree` surface (reused, not the whole block shell) for request/response example bodies, with the same graceful `<pre>` fallback for non-JSON examples.

## Add-a-block-type checklist
Block-type count: **12 → 13** (`json-explorer` inserted before `question-form`, which stays last in every ordered list).
- Rust registry (`proposal_blocks.rs`): new `BlockType::JsonExplorer` variant + `as_str()`/`tag()` arms; `block_with_description(...)` registry entry (children = a JSON document; renders as a collapsible typed tree); 4 in-file unit tests bumped (`registry_contains_v1_blocks` 12→13, `block_type_enum_covers_v1`, `registry_tags_match_canonical_v1_set`, `block_registry_new_has_all_definitions` 12→13).
- Rust validation fixture (`validation.rs`): `<JsonExplorer>` added to `mdx_body_valid_all_canonical_blocks` before QuestionForm.
- TS mirror: `proposalBlocks.ts` (`fields: {}`, no attrs), `blockRegistry.ts` (`BLOCK_COMPONENTS` + display name "JSON Explorer"), component exported from `blocks/index.ts`.
- Parity: `blocks.test.ts` `CANONICAL_V1_TAGS` (before QuestionForm, matching Rust order) + per-block assertion; `<JsonExplorer>` instance in `canonicalProposal.mdx`.
- **No schema-shape change** (children-only block, `fields(vec![])`) → no snapshot regeneration; `mcp_tools_schema_snapshot` verified unchanged.

## Tests
- New focused unit tests for the parser/helpers (`jsonExplorer.test.ts`: valid object/array/nested/primitives + invalid-JSON & empty fallback) and the component (`JsonExplorerBlock.test.tsx`: tree render, collapse summary, expand/collapse controls, non-JSON fallback; plus reusable `JsonTree`).
- UI: blocks parity suite + apiEndpoint suite green; `tsc -b` clean; eslint clean on changed files.
- Rust: `proposal_blocks` (29) + validation fixture green; `clippy --all-features` clean; snapshot test unchanged.

No migration needed.