### PR TITLE
feat(settings): compact Codex row + group same-account subs + design-system provider select

### DIFF
--- a/ui/src/api/subscriptionProviders.test.ts
+++ b/ui/src/api/subscriptionProviders.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isSubscriptionProvider } from "./subscriptionProviders";
+import {
+  groupSubscriptionsByAccount,
+  isSubscriptionProvider,
+  type GroupableProvider,
+} from "./subscriptionProviders";
 
 describe("isSubscriptionProvider", () => {
   it("classifies known personal subscriptions as subscriptions", () => {
@@ -39,5 +43,75 @@ describe("isSubscriptionProvider", () => {
     ]) {
       expect(isSubscriptionProvider(id)).toBe(false);
     }
+  });
+});
+
+describe("groupSubscriptionsByAccount", () => {
+  const p = (id: string, name: string, env: string): GroupableProvider => ({
+    id,
+    name,
+    env_vars: [env],
+  });
+
+  it("collapses providers sharing a primary env var into one account card", () => {
+    const groups = groupSubscriptionsByAccount([
+      p("xiaomi", "Xiaomi", "XIAOMI_API_KEY"),
+      p("xiaomi-token-plan-cn", "Xiaomi Token Plan (China)", "XIAOMI_API_KEY"),
+      p("xiaomi-token-plan-ams", "Xiaomi Token Plan (Europe)", "XIAOMI_API_KEY"),
+      p("xiaomi-token-plan-sgp", "Xiaomi Token Plan (Singapore)", "XIAOMI_API_KEY"),
+      p("zai", "Z.AI", "ZHIPU_API_KEY"),
+      p("zai-coding-plan", "Z.AI Coding Plan", "ZHIPU_API_KEY"),
+      p("zhipuai", "Zhipu AI", "ZHIPU_API_KEY"),
+      p("zhipuai-coding-plan", "Zhipu AI Coding Plan", "ZHIPU_API_KEY"),
+      p("opencode", "OpenCode Zen", "OPENCODE_API_KEY"),
+      p("opencode-go", "OpenCode Go", "OPENCODE_API_KEY"),
+      p("kimi-for-coding", "Kimi For Coding", "KIMI_API_KEY"),
+      p("minimax-coding-plan", "MiniMax Token Plan", "MINIMAX_API_KEY"),
+    ]);
+
+    const byKey = new Map(groups.map((g) => [g.key, g]));
+
+    // Shared-key accounts collapse, with a sensible single display name.
+    expect(byKey.get("XIAOMI_API_KEY")?.name).toBe("Xiaomi");
+    expect(byKey.get("XIAOMI_API_KEY")?.providerIds).toEqual([
+      "xiaomi",
+      "xiaomi-token-plan-cn",
+      "xiaomi-token-plan-ams",
+      "xiaomi-token-plan-sgp",
+    ]);
+
+    // Z.AI + Zhipu (same ZHIPU_API_KEY) become one card, not four rows.
+    expect(byKey.get("ZHIPU_API_KEY")?.name).toBe("Z.AI / Zhipu");
+    expect(byKey.get("ZHIPU_API_KEY")?.providerIds).toEqual([
+      "zai",
+      "zai-coding-plan",
+      "zhipuai",
+      "zhipuai-coding-plan",
+    ]);
+
+    expect(byKey.get("OPENCODE_API_KEY")?.name).toBe("OpenCode");
+    expect(byKey.get("OPENCODE_API_KEY")?.providerIds).toEqual([
+      "opencode",
+      "opencode-go",
+    ]);
+
+    // Their own keys → standalone cards using the provider's own name.
+    expect(byKey.get("KIMI_API_KEY")?.name).toBe("Kimi For Coding");
+    expect(byKey.get("KIMI_API_KEY")?.providerIds).toEqual(["kimi-for-coding"]);
+    expect(byKey.get("MINIMAX_API_KEY")?.providerIds).toEqual([
+      "minimax-coding-plan",
+    ]);
+
+    // Exactly five account cards from twelve connected provider ids.
+    expect(groups).toHaveLength(5);
+  });
+
+  it("falls back to the provider id when a provider has no env vars", () => {
+    const groups = groupSubscriptionsByAccount([
+      { id: "weird", name: "Weird", env_vars: [] },
+    ]);
+    expect(groups).toEqual([
+      { key: "weird", name: "Weird", providerIds: ["weird"] },
+    ]);
   });
 });

--- a/ui/src/api/subscriptionProviders.ts
+++ b/ui/src/api/subscriptionProviders.ts
@@ -56,3 +56,77 @@ export function isSubscriptionProvider(providerId: string): boolean {
   if (SUBSCRIPTION_PREFIXES.some((prefix) => id.startsWith(prefix))) return true;
   return false;
 }
+
+/**
+ * Minimal shape the grouping helper needs from a connected provider. Kept
+ * structural (not the generated `ConnectedProvider`) so the helper stays
+ * trivially unit-testable without the MCP types.
+ */
+export interface GroupableProvider {
+  id: string;
+  name: string;
+  /** Provider env vars; the FIRST is the primary credential / account key. */
+  env_vars: string[];
+}
+
+/**
+ * One "account" card: every connected provider id that shares a single
+ * underlying credential (the same primary env var). Many regional / plan-tier
+ * provider ids (e.g. all four Xiaomi token-plan endpoints) are the same paid
+ * account behind one API key, so they collapse into one removable card.
+ */
+export interface SubscriptionGroup {
+  /** Stable key for the group — the shared primary env var (or provider id). */
+  key: string;
+  /** Human display name for the account (see `GROUP_DISPLAY_NAMES`). */
+  name: string;
+  /** Every connected provider id in the group (Remove disconnects all of them). */
+  providerIds: string[];
+}
+
+/**
+ * Display-name overrides for known shared-credential accounts, keyed by the
+ * primary env var. Without an override the group falls back to the shortest /
+ * cleanest member provider name, which is fine for one-off subscriptions but
+ * reads oddly for multi-endpoint accounts (e.g. "Z.AI" vs "Zhipu AI Coding
+ * Plan" for the same `ZHIPU_API_KEY`).
+ */
+const GROUP_DISPLAY_NAMES: Record<string, string> = {
+  XIAOMI_API_KEY: "Xiaomi",
+  ZHIPU_API_KEY: "Z.AI / Zhipu",
+  OPENCODE_API_KEY: "OpenCode",
+};
+
+/** The grouping key for a provider: its primary env var, or its id if it has none. */
+function accountKey(provider: GroupableProvider): string {
+  return provider.env_vars[0] ?? provider.id;
+}
+
+/**
+ * Collapse connected providers into one card per underlying account.
+ *
+ * Providers sharing a primary env var (`env_vars[0]`) are the same paid
+ * subscription connected via one stored credential, so they render as a single
+ * card whose Remove disconnects every member provider id. Group order follows
+ * first-appearance of the input (callers pre-sort by name); member ids keep
+ * input order so the canonical (shortest-id) base provider tends to lead.
+ */
+export function groupSubscriptionsByAccount(
+  providers: GroupableProvider[],
+): SubscriptionGroup[] {
+  const groups = new Map<string, SubscriptionGroup>();
+  for (const provider of providers) {
+    const key = accountKey(provider);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.providerIds.push(provider.id);
+      continue;
+    }
+    groups.set(key, {
+      key,
+      name: GROUP_DISPLAY_NAMES[key] ?? provider.name,
+      providerIds: [provider.id],
+    });
+  }
+  return Array.from(groups.values());
+}

--- a/ui/src/components/CodexSignInCard.tsx
+++ b/ui/src/components/CodexSignInCard.tsx
@@ -10,11 +10,15 @@ import {
 import { HugeiconsIcon } from '@hugeicons/react';
 
 import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import { startProviderOAuth, removeProviderFull } from '@/api/server';
 import { showToast } from '@/lib/toast';
-import { cn } from '@/lib/utils';
 
-type CardPhase =
+type RowPhase =
   | { kind: 'idle' }
   | {
       kind: 'pending';
@@ -30,32 +34,34 @@ interface Props {
   /**
    * Caller-provided flag indicating that `chatgpt_codex` already has a live
    * token in the vault. When true — and the user hasn't started a new sign-in
-   * attempt — the card renders a compact "connected" state instead of the
-   * sign-in CTA.
+   * attempt — the row renders its compact "connected" state (Reconnect /
+   * Disconnect) instead of the sign-in CTA.
    */
   alreadyConnected?: boolean;
   /**
    * Set when the codex credential was rejected (a 401 during a run) and marked
-   * revoked server-side. Renders a "Disconnected — <reason>" banner above the
-   * reconnect CTA. Persisted server-side, so it shows on a fresh page load too.
+   * revoked server-side. Surfaces a "Disconnected — <reason>" hint on the row.
+   * Persisted server-side, so it shows on a fresh page load too.
    */
   revokedReason?: string;
-  /** Invoked after a successful sign-in so the parent can refresh state. */
+  /** Invoked after a successful sign-in/disconnect so the parent can refresh. */
   onConnected?: () => void;
-  className?: string;
 }
 
-export function CodexSignInCard({
-  alreadyConnected,
-  revokedReason,
-  onConnected,
-  className,
-}: Props) {
-  const [phase, setPhase] = useState<CardPhase>({ kind: 'idle' });
+/**
+ * ChatGPT / Codex as a compact subscription ROW (matching the other connected
+ * subscriptions) instead of a full-bleed card. The row carries the device-code
+ * sign-in when disconnected, and Reconnect + Disconnect when connected — the
+ * device-code flow + credential management live in an inline popover so the row
+ * itself stays one line.
+ */
+export function CodexSignInRow({ alreadyConnected, revokedReason, onConnected }: Props) {
+  const [phase, setPhase] = useState<RowPhase>({ kind: 'idle' });
   const [removing, setRemoving] = useState(false);
-  // Show the green "connected" panel when either the parent told us we're
-  // already connected (and the user hasn't interacted) or the flow just
-  // completed in this session.
+  const [open, setOpen] = useState(false);
+
+  // Show the connected state when either the parent told us we're already
+  // connected (and the user hasn't interacted) or the flow just completed.
   const showConnected =
     phase.kind === 'just_connected' || (phase.kind === 'idle' && alreadyConnected);
 
@@ -93,18 +99,17 @@ export function CodexSignInCard({
   };
 
   // Codex connects under the `openai` provider (merge_into), but its credential
-  // is stored as `chatgpt_codex`. The generic SettingsPage chip list gates
-  // removal on `openai` (not self-serve) so it never exposes a Remove here —
-  // disconnect the codex credential directly by its own provider id.
+  // is stored as `chatgpt_codex` — disconnect by that own provider id.
   const handleRemove = async () => {
     setRemoving(true);
     try {
       await removeProviderFull('chatgpt_codex');
       setPhase({ kind: 'idle' });
+      setOpen(false);
       showToast.success('ChatGPT disconnected', {
         description: 'You can sign in again to reconnect.',
       });
-      onConnected?.(); // let the parent reload provider/credential state
+      onConnected?.();
     } catch (error) {
       showToast.error('Could not disconnect', {
         description: error instanceof Error ? error.message : 'Unknown error',
@@ -123,128 +128,155 @@ export function CodexSignInCard({
     }
   };
 
-  return (
-    <div
-      className={cn(
-        'relative flex flex-col gap-4 rounded-2xl border border-primary/40 bg-gradient-to-br from-primary/[0.06] to-transparent p-7 h-full overflow-hidden',
-        className,
-      )}
-    >
-      <div className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full bg-primary/20 blur-3xl" />
-      <div className="pointer-events-none absolute -left-6 -bottom-6 h-20 w-20 rounded-full bg-primary/10 blur-3xl" />
+  const subtitle = showConnected
+    ? 'Connected · personal subscription'
+    : revokedReason
+      ? `Disconnected — ${revokedReason}`
+      : 'Sign in with a device code · no API key needed';
 
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/15">
-          <HugeiconsIcon icon={SparklesIcon} size={20} className="text-primary" />
-        </div>
-        <div>
-          <h3 className="text-base font-semibold text-foreground">ChatGPT / Codex</h3>
-          <p className="text-xs text-muted-foreground">Sign in with a device code</p>
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3">
+      <div className="flex min-w-0 items-center gap-2.5">
+        {showConnected ? (
+          <HugeiconsIcon
+            icon={CheckmarkCircle04Icon}
+            size={16}
+            className="shrink-0 text-green-500"
+          />
+        ) : (
+          <HugeiconsIcon icon={SparklesIcon} size={16} className="shrink-0 text-primary" />
+        )}
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-foreground">ChatGPT / Codex</div>
+          <div
+            className={
+              'truncate text-xs ' +
+              (revokedReason && !showConnected ? 'text-destructive' : 'text-muted-foreground')
+            }
+          >
+            {subtitle}
+          </div>
         </div>
       </div>
 
-      {revokedReason && phase.kind === 'idle' && !showConnected && (
-        <div className="flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-          <HugeiconsIcon icon={AlertCircleIcon} size={14} className="shrink-0 mt-0.5" />
-          <span>
-            <span className="font-semibold">Disconnected.</span> {revokedReason}
-          </span>
-        </div>
-      )}
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next && phase.kind !== 'pending') setPhase({ kind: 'idle' });
+        }}
+      >
+        {showConnected ? (
+          <PopoverTrigger render={<Button size="sm" variant="outline" />}>
+            Manage
+          </PopoverTrigger>
+        ) : (
+          <PopoverTrigger
+            render={<Button size="sm" />}
+            onClick={() => {
+              // Kick off the device-code flow as the popover opens.
+              if (phase.kind === 'idle') void handleConnect();
+            }}
+          >
+            Sign in
+          </PopoverTrigger>
+        )}
 
-      {phase.kind === 'idle' && !showConnected && (
-        <>
-          <p className="text-sm leading-relaxed text-muted-foreground flex-1">
-            Sign in with your ChatGPT Plus, Pro, or Team account. Works from any browser — no
-            local port-forwarding required.
-          </p>
-          <span className="inline-flex self-start rounded-full bg-green-500/15 px-3 py-1 text-xs font-medium text-green-400">
-            No API key needed
-          </span>
-          <Button size="lg" className="w-full text-sm" onClick={() => void handleConnect()}>
-            Continue with ChatGPT
-          </Button>
-        </>
-      )}
-
-      {phase.kind === 'pending' && (
-        <>
-          <div className="flex flex-col gap-3 flex-1">
-            <p className="text-sm leading-relaxed text-muted-foreground">
-              Open the sign-in page in your browser and enter this code:
-            </p>
-            <div className="flex items-center gap-2">
-              <code className="flex-1 rounded-lg border border-border bg-card px-4 py-3 text-center text-2xl font-mono font-semibold tracking-widest text-foreground">
-                {phase.userCode}
-              </code>
-              <Button
-                type="button"
-                variant="outline"
-                size="lg"
-                onClick={() => void handleCopyCode(phase.userCode)}
-                aria-label="Copy code"
-              >
-                <HugeiconsIcon icon={Copy01Icon} size={18} />
-              </Button>
+        <PopoverContent className="w-80">
+          <div className="flex flex-col gap-3">
+            <div>
+              <div className="text-sm font-semibold text-foreground">ChatGPT / Codex</div>
+              <p className="text-xs text-muted-foreground">
+                Sign in with your ChatGPT Plus, Pro, or Team account from any browser — no
+                local port-forwarding required.
+              </p>
             </div>
-            <p className="flex items-center gap-2 text-xs text-muted-foreground">
-              <HugeiconsIcon icon={Loading02Icon} size={14} className="animate-spin shrink-0" />
-              Waiting for you to complete sign-in
-              {phase.expiresInSecs ? ` (expires in ${Math.floor(phase.expiresInSecs / 60)} min)` : ''}…
-            </p>
+
+            {phase.kind === 'pending' && (
+              <div className="flex flex-col gap-2">
+                <p className="text-xs text-muted-foreground">
+                  Open the sign-in page and enter this code:
+                </p>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 rounded-lg border border-border bg-card px-3 py-2 text-center text-lg font-mono font-semibold tracking-widest text-foreground">
+                    {phase.userCode}
+                  </code>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => void handleCopyCode(phase.userCode)}
+                    aria-label="Copy code"
+                  >
+                    <HugeiconsIcon icon={Copy01Icon} size={16} />
+                  </Button>
+                </div>
+                <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <HugeiconsIcon icon={Loading02Icon} size={14} className="shrink-0 animate-spin" />
+                  Waiting for sign-in
+                  {phase.expiresInSecs
+                    ? ` (expires in ${Math.floor(phase.expiresInSecs / 60)} min)`
+                    : ''}
+                  …
+                </p>
+                <a
+                  href={phase.verificationUriComplete}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
+                >
+                  Open sign-in page
+                  <HugeiconsIcon icon={LinkForwardIcon} size={16} />
+                </a>
+              </div>
+            )}
+
+            {phase.kind === 'error' && (
+              <>
+                <p className="flex items-start gap-2 text-xs text-destructive">
+                  <HugeiconsIcon icon={AlertCircleIcon} size={14} className="mt-0.5 shrink-0" />
+                  <span>{phase.message}</span>
+                </p>
+                <Button size="sm" className="w-full" onClick={() => void handleConnect()}>
+                  Try again
+                </Button>
+              </>
+            )}
+
+            {phase.kind !== 'pending' && phase.kind !== 'error' && !showConnected && (
+              <Button size="sm" className="w-full" onClick={() => void handleConnect()}>
+                Continue with ChatGPT
+              </Button>
+            )}
+
+            {showConnected && (
+              <div className="flex flex-col gap-2">
+                <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-green-500/15 px-3 py-1 text-xs font-medium text-green-400">
+                  <HugeiconsIcon icon={CheckmarkCircle04Icon} size={14} />
+                  Connected
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => void handleConnect()}
+                >
+                  Reconnect
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={removing}
+                  className="w-full text-destructive hover:text-destructive"
+                  onClick={() => void handleRemove()}
+                >
+                  {removing ? 'Removing…' : 'Remove / Disconnect'}
+                </Button>
+              </div>
+            )}
           </div>
-          <a
-            href={phase.verificationUriComplete}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 transition-colors"
-          >
-            Open sign-in page
-            <HugeiconsIcon icon={LinkForwardIcon} size={16} />
-          </a>
-        </>
-      )}
-
-      {showConnected && (
-        <>
-          <p className="text-sm leading-relaxed text-muted-foreground flex-1">
-            Your ChatGPT account is signed in. Djinn keeps your tokens refreshed automatically.
-          </p>
-          <span className="inline-flex self-start items-center gap-1.5 rounded-full bg-green-500/15 px-3 py-1 text-xs font-medium text-green-400">
-            <HugeiconsIcon icon={CheckmarkCircle04Icon} size={14} />
-            Connected
-          </span>
-          <Button
-            variant="outline"
-            size="lg"
-            className="w-full text-sm"
-            onClick={() => void handleConnect()}
-          >
-            Reconnect
-          </Button>
-          <Button
-            variant="ghost"
-            size="lg"
-            disabled={removing}
-            className="w-full text-sm text-destructive hover:text-destructive"
-            onClick={() => void handleRemove()}
-          >
-            {removing ? 'Removing…' : 'Remove / Disconnect'}
-          </Button>
-        </>
-      )}
-
-      {phase.kind === 'error' && (
-        <>
-          <p className="flex items-start gap-2 text-sm text-destructive">
-            <HugeiconsIcon icon={AlertCircleIcon} size={16} className="shrink-0 mt-0.5" />
-            <span>{phase.message}</span>
-          </p>
-          <Button size="lg" className="w-full text-sm" onClick={() => void handleConnect()}>
-            Try again
-          </Button>
-        </>
-      )}
-    </div>
+        </PopoverContent>
+      </Popover>
+    </li>
   );
 }

--- a/ui/src/components/settings/ConnectionsTab.test.tsx
+++ b/ui/src/components/settings/ConnectionsTab.test.tsx
@@ -10,19 +10,59 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 const connected: ConnectedProvider[] = [
-  // Codex sub (oauth on openai) — rendered by its own card, not a row.
+  // Codex sub (oauth on openai) — rendered by its own compact row, not a
+  // generic subscription card.
   {
     id: "openai",
     name: "OpenAI",
     connection_methods: ["oauth"],
     env_vars: ["OPENAI_API_KEY"],
   } as ConnectedProvider,
-  // A personal subscription connected by API key.
+  // A personal subscription connected by API key (standalone, own key).
   {
     id: "kimi-for-coding",
     name: "Kimi for Coding",
     connection_methods: ["credential"],
     env_vars: ["KIMI_API_KEY"],
+  } as ConnectedProvider,
+  // Four Xiaomi endpoints that share ONE credential — must collapse to a
+  // single "Xiaomi" account card, not four rows.
+  {
+    id: "xiaomi",
+    name: "Xiaomi",
+    connection_methods: ["credential"],
+    env_vars: ["XIAOMI_API_KEY"],
+  } as ConnectedProvider,
+  {
+    id: "xiaomi-token-plan-cn",
+    name: "Xiaomi Token Plan (China)",
+    connection_methods: ["credential"],
+    env_vars: ["XIAOMI_API_KEY"],
+  } as ConnectedProvider,
+  {
+    id: "xiaomi-token-plan-ams",
+    name: "Xiaomi Token Plan (Europe)",
+    connection_methods: ["credential"],
+    env_vars: ["XIAOMI_API_KEY"],
+  } as ConnectedProvider,
+  {
+    id: "xiaomi-token-plan-sgp",
+    name: "Xiaomi Token Plan (Singapore)",
+    connection_methods: ["credential"],
+    env_vars: ["XIAOMI_API_KEY"],
+  } as ConnectedProvider,
+  // Z.AI + Zhipu coding plans share ZHIPU_API_KEY — one "Z.AI / Zhipu" card.
+  {
+    id: "zai-coding-plan",
+    name: "Z.AI Coding Plan",
+    connection_methods: ["credential"],
+    env_vars: ["ZHIPU_API_KEY"],
+  } as ConnectedProvider,
+  {
+    id: "zhipuai",
+    name: "Zhipu AI",
+    connection_methods: ["credential"],
+    env_vars: ["ZHIPU_API_KEY"],
   } as ConnectedProvider,
   // An org-provided API key.
   {
@@ -43,24 +83,34 @@ vi.mock("@/api/userConfig", async (importOriginal) => {
 });
 
 describe("ConnectionsTab", () => {
-  it("splits connected providers into subscription vs org-provided buckets", async () => {
+  it("splits providers into buckets and collapses same-account subscriptions", async () => {
     render(<ConnectionsTab />);
 
     // Bucket headings.
     expect(await screen.findByText("Your subscriptions")).toBeInTheDocument();
     expect(screen.getByText("Provided by your org")).toBeInTheDocument();
 
-    // Personal subscription is a first-class removable row.
+    // Standalone personal subscription is a first-class removable row.
     expect(await screen.findByText("Kimi for Coding")).toBeInTheDocument();
-    expect(screen.getByText("Connected · personal subscription")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^remove$/i })).toBeInTheDocument();
 
-    // Org-provided key shows as managed (no remove button for it).
+    // The four Xiaomi endpoints collapse to ONE "Xiaomi" card.
+    expect(screen.getByText("Xiaomi")).toBeInTheDocument();
+    expect(screen.queryByText("Xiaomi Token Plan (China)")).not.toBeInTheDocument();
+    expect(screen.queryByText("Xiaomi Token Plan (Europe)")).not.toBeInTheDocument();
+
+    // Z.AI + Zhipu collapse to ONE "Z.AI / Zhipu" card (the separate-rows bug).
+    expect(screen.getByText("Z.AI / Zhipu")).toBeInTheDocument();
+    expect(screen.queryByText("Zhipu AI")).not.toBeInTheDocument();
+
+    // Multi-plan accounts surface a plan count; each removable card has a Remove.
+    expect(screen.getAllByText(/personal subscription · \d+ plans/).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: /^remove$/i }).length).toBeGreaterThan(0);
+
+    // Org-provided key shows as managed (no Remove for it).
     expect(await screen.findByText("Anthropic")).toBeInTheDocument();
     expect(screen.getByText("Managed by your org")).toBeInTheDocument();
 
-    // The Codex/openai oauth row is NOT duplicated as a plain provider row —
-    // it's owned by the ChatGPT/Codex card. The card heading is present.
+    // ChatGPT/Codex is its own compact row, not duplicated as a plain provider.
     expect(screen.getByText("ChatGPT / Codex")).toBeInTheDocument();
   });
 });

--- a/ui/src/components/settings/ConnectionsTab.tsx
+++ b/ui/src/components/settings/ConnectionsTab.tsx
@@ -7,7 +7,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { ConfirmButton } from "@/components/ConfirmButton";
-import { CodexSignInCard } from "@/components/CodexSignInCard";
+import { CodexSignInRow } from "@/components/CodexSignInCard";
 import { InlineError } from "@/components/InlineError";
 import { ApiKeyConnectForm } from "@/components/userConfig/ProviderSection";
 import { userConfigKeys } from "@/components/userConfig/userConfigKeys";
@@ -18,16 +18,23 @@ import {
   fetchUserConnectedProviders,
 } from "@/api/userConfig";
 import { removeProviderFull } from "@/api/server";
-import { isSubscriptionProvider } from "@/api/subscriptionProviders";
+import {
+  type SubscriptionGroup,
+  groupSubscriptionsByAccount,
+  isSubscriptionProvider,
+} from "@/api/subscriptionProviders";
 import { showToast } from "@/lib/toast";
 
 /**
- * Connections tab — provider auth for the signed-in user. Reworked so every
- * connected provider is a first-class row in one of two buckets:
+ * Connections tab — provider auth for the signed-in user. Every connection is a
+ * compact row in one of two buckets:
  *
  *  - **Your subscriptions** — personal subscriptions (ChatGPT/Codex OAuth + the
  *    BYO-key coding plans). Per-user and removable; removing deletes only the
- *    caller's own credential server-side.
+ *    caller's own credential server-side. Connected coding-plan providers that
+ *    share one underlying credential (same primary env var — e.g. all four
+ *    Xiaomi token-plan endpoints, or Z.AI + Zhipu coding plans) collapse into a
+ *    single account card whose Remove disconnects the whole group.
  *  - **Provided by your org** — operator/admin-provisioned API keys (Anthropic,
  *    OpenAI API, Google, …). Shown as managed and locked (not removable from
  *    here — they're set via Helm/operator config).
@@ -62,22 +69,27 @@ export function ConnectionsTab() {
     openaiProvider as { revoked_reason?: string } | undefined
   )?.revoked_reason;
 
-  // Split connected providers into the two buckets. The Codex sub is rendered by
-  // its dedicated OAuth card, so an `openai`-via-oauth row is excluded here to
-  // avoid a duplicate; a plain `openai` API key still lands in the org bucket.
-  const { subscriptions, orgProvided } = useMemo(() => {
+  // Split connected providers into the two buckets, then collapse subscriptions
+  // by shared credential. The Codex sub is rendered by its dedicated OAuth row,
+  // so an `openai`-via-oauth row is excluded here to avoid a duplicate; a plain
+  // `openai` API key still lands in the org bucket.
+  const { subscriptionGroups, orgProvided } = useMemo(() => {
     const subs: ConnectedProvider[] = [];
     const org: ConnectedProvider[] = [];
     for (const provider of connected.data ?? []) {
       const isCodexRow =
         provider.id === "openai" && provider.connection_methods.includes("oauth");
-      if (isCodexRow) continue; // owned by the Codex card below
+      if (isCodexRow) continue; // owned by the Codex row below
       if (isSubscriptionProvider(provider.id)) subs.push(provider);
       else org.push(provider);
     }
     const byName = (a: ConnectedProvider, b: ConnectedProvider) =>
       a.name.localeCompare(b.name);
-    return { subscriptions: subs.sort(byName), orgProvided: org.sort(byName) };
+    subs.sort(byName);
+    return {
+      subscriptionGroups: groupSubscriptionsByAccount(subs),
+      orgProvided: org.sort(byName),
+    };
   }, [connected.data]);
 
   if (connected.isError) {
@@ -108,21 +120,20 @@ export function ConnectionsTab() {
           </p>
         </div>
 
-        <CodexSignInCard
-          alreadyConnected={codexConnected}
-          revokedReason={codexRevokedReason}
-          onConnected={refresh}
-        />
-
         {loading ? (
           <CardSkeleton />
-        ) : subscriptions.length > 0 ? (
+        ) : (
           <ul className="flex flex-col gap-2">
-            {subscriptions.map((provider) => (
-              <SubscriptionCard key={provider.id} provider={provider} onRemoved={refresh} />
+            <CodexSignInRow
+              alreadyConnected={codexConnected}
+              revokedReason={codexRevokedReason}
+              onConnected={refresh}
+            />
+            {subscriptionGroups.map((group) => (
+              <SubscriptionGroupCard key={group.key} group={group} onRemoved={refresh} />
             ))}
           </ul>
-        ) : null}
+        )}
 
         <ApiKeyConnectForm
           targetId={SELF_TARGET}
@@ -170,19 +181,25 @@ function CardSkeleton() {
   );
 }
 
-/** A connected personal subscription — first-class row, removable by the owner. */
-function SubscriptionCard({
-  provider,
+/**
+ * A connected personal-subscription account — a first-class row, removable by
+ * the owner. One row stands for every provider id that shares the account's
+ * credential, so Remove disconnects all of them.
+ */
+function SubscriptionGroupCard({
+  group,
   onRemoved,
 }: {
-  provider: ConnectedProvider;
+  group: SubscriptionGroup;
   onRemoved: () => void;
 }) {
   const remove = useMutation({
-    mutationFn: () => removeProviderFull(provider.id),
+    // Disconnect every provider id in the group. They share one credential, but
+    // removing each by id is idempotent server-side and clears any per-id state.
+    mutationFn: () => Promise.all(group.providerIds.map((id) => removeProviderFull(id))),
     onSuccess: () => {
       showToast.success("Subscription removed", {
-        description: `Disconnected ${provider.name}.`,
+        description: `Disconnected ${group.name}.`,
       });
       onRemoved();
     },
@@ -193,18 +210,28 @@ function SubscriptionCard({
     },
   });
 
+  const planCount = group.providerIds.length;
+  const subtitle =
+    planCount > 1
+      ? `Connected · personal subscription · ${planCount} plans`
+      : "Connected · personal subscription";
+
   return (
     <li className="flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3">
       <div className="flex min-w-0 items-center gap-2.5">
         <HugeiconsIcon icon={CheckmarkCircle04Icon} size={16} className="shrink-0 text-green-500" />
         <div className="min-w-0">
-          <div className="truncate text-sm font-medium text-foreground">{provider.name}</div>
-          <div className="truncate text-xs text-muted-foreground">Connected · personal subscription</div>
+          <div className="truncate text-sm font-medium text-foreground">{group.name}</div>
+          <div className="truncate text-xs text-muted-foreground">{subtitle}</div>
         </div>
       </div>
       <ConfirmButton
         title="Remove subscription"
-        description={`Disconnect "${provider.name}" and delete the stored key/token for your account?`}
+        description={
+          planCount > 1
+            ? `Disconnect "${group.name}" and delete the stored key for your account? This removes all ${planCount} connected plans on this account.`
+            : `Disconnect "${group.name}" and delete the stored key/token for your account?`
+        }
         confirmLabel="Remove"
         onConfirm={() => remove.mutate()}
         size="sm"

--- a/ui/src/components/userConfig/ProviderSection.tsx
+++ b/ui/src/components/userConfig/ProviderSection.tsx
@@ -11,6 +11,14 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { InlineError } from "@/components/InlineError";
@@ -25,7 +33,6 @@ import {
 } from "@/api/userConfig";
 import { getServerBaseUrl } from "@/api/serverUrl";
 import { showToast } from "@/lib/toast";
-import { cn } from "@/lib/utils";
 
 import { userConfigKeys } from "./userConfigKeys";
 
@@ -151,6 +158,13 @@ export function ApiKeyConnectForm({
     () => catalog.filter((p) => p.env_vars.length > 0),
     [catalog],
   );
+  // base-ui's Combobox takes a flat `items` list + an id→label resolver so the
+  // trigger renders the chosen provider's name (not its raw id).
+  const keyProviderIds = useMemo(() => keyProviders.map((p) => p.id), [keyProviders]);
+  const providerLabel = useMemo(
+    () => new Map(keyProviders.map((p) => [p.id, p.name])),
+    [keyProviders],
+  );
 
   const selected = keyProviders.find((p) => p.id === providerId);
   const keyName = selected?.env_vars[0] ?? "";
@@ -193,27 +207,33 @@ export function ApiKeyConnectForm({
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
         <div className="flex flex-1 flex-col gap-1.5">
           <Label htmlFor="user-config-provider">Provider</Label>
-          <select
-            id="user-config-provider"
-            value={providerId}
+          <Combobox
+            items={keyProviderIds}
+            value={providerId || null}
+            onValueChange={(v) => setProviderId(typeof v === "string" ? v : "")}
+            itemToStringLabel={(id) => providerLabel.get(id) ?? id}
             disabled={catalogLoading || mutation.isPending}
-            onChange={(e) => setProviderId(e.target.value)}
-            className={cn(
-              "h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none",
-              "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50",
-              "disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30",
-            )}
           >
-            <option value="">
-              {catalogLoading ? "Loading providers…" : "Select a provider…"}
-            </option>
-            {keyProviders.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-                {connectedIds.has(p.id) ? " (connected)" : ""}
-              </option>
-            ))}
-          </select>
+            <ComboboxInput
+              id="user-config-provider"
+              showClear={Boolean(providerId)}
+              placeholder={catalogLoading ? "Loading providers…" : "Select a provider…"}
+              className="w-full"
+            />
+            <ComboboxContent>
+              <ComboboxList>
+                <ComboboxEmpty>No providers found</ComboboxEmpty>
+                {keyProviders.map((p) => (
+                  <ComboboxItem key={p.id} value={p.id}>
+                    <span className="truncate">{p.name}</span>
+                    {connectedIds.has(p.id) ? (
+                      <span className="ml-1.5 text-xs text-muted-foreground">connected</span>
+                    ) : null}
+                  </ComboboxItem>
+                ))}
+              </ComboboxList>
+            </ComboboxContent>
+          </Combobox>
         </div>
 
         <div className="flex flex-[2] flex-col gap-1.5">


### PR DESCRIPTION
## What changed (Connections settings tab — UI only)

### 1. ChatGPT/Codex is now a compact ROW
`CodexSignInCard` is replaced by `CodexSignInRow`: a one-line row matching the other connected subscriptions ("ChatGPT / Codex / Connected · personal subscription"). Its full behavior is preserved via an inline **popover**:
- Disconnected → **Sign in** kicks off the device-code flow (code + copy + "Open sign-in page" link) inside the popover.
- Connected → **Manage** popover with **Reconnect** and **Remove / Disconnect** (still removes the `chatgpt_codex` credential).
- A revoked credential surfaces a "Disconnected — <reason>" hint on the row.

### 2. Same-account plans collapse into ONE card each
Connected subscriptions are grouped by their **shared primary env var** (`env_vars[0]`) via `groupSubscriptionsByAccount`. Providers that share one stored credential render as a single account card; **Remove disconnects every provider id in the group**. Grouping rule + resulting cards:

| Account card | Grouped by | Provider ids collapsed |
|---|---|---|
| **Xiaomi** | `XIAOMI_API_KEY` | `xiaomi`, `xiaomi-token-plan-cn`, `xiaomi-token-plan-ams`, `xiaomi-token-plan-sgp` |
| **Z.AI / Zhipu** | `ZHIPU_API_KEY` | `zai`, `zai-coding-plan`, `zhipuai`, `zhipuai-coding-plan` (fixes the Z.AI vs Zhipu duplicate-row bug) |
| **OpenCode** | `OPENCODE_API_KEY` | `opencode`, `opencode-go` |
| **Kimi For Coding** | `KIMI_API_KEY` | standalone |
| **MiniMax Token Plan** | `MINIMAX_API_KEY` | standalone |
| **ChatGPT / Codex** | own token | its own row |

Multi-plan cards show a "· N plans" hint and a Remove confirmation that calls out it disconnects all plans on the account. Display names come from a small env-var → name override map, falling back to the provider's own name.

### 3. Design-system Select for the provider picker
The raw HTML `<select>` in "Connect with an API key" is replaced with the design-system **`Combobox`** (`@/components/ui/combobox`) — the same control the Kanban board's "all types" / "all owners" filters use (`BoardFilterHeader.tsx`). Single-select + searchable; pick-provider → paste-key → Connect behavior unchanged.

## Scope
- UI only; no server changes (grouping is a presentation concern over the existing `provider_connected` data).
- Touched: `ConnectionsTab.tsx`, `subscriptionProviders.ts` (+ test), `CodexSignInCard.tsx`, `ProviderSection.tsx` (the API-key form), and reuses the design-system Combobox. Did **not** touch the Model Roles UI.

## Verification
- `tsc -b` clean
- vitest green (subscription grouping unit tests + ConnectionsTab bucket/collapse tests)
- eslint clean on touched files
- **`pnpm build` (vite production build) succeeds** ✅