### PR TITLE
feat(proposals): add sandboxed html block + close unsafe svg escape hatch

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -27,6 +27,7 @@ pub enum BlockType {
     Table,
     Checklist,
     JsonExplorer,
+    Html,
     QuestionForm,
 }
 
@@ -46,6 +47,7 @@ impl BlockType {
             BlockType::Table => "table",
             BlockType::Checklist => "checklist",
             BlockType::JsonExplorer => "json-explorer",
+            BlockType::Html => "html",
             BlockType::QuestionForm => "question-form",
         }
     }
@@ -65,6 +67,7 @@ impl BlockType {
             BlockType::Table => "Table",
             BlockType::Checklist => "Checklist",
             BlockType::JsonExplorer => "JsonExplorer",
+            BlockType::Html => "Html",
             BlockType::QuestionForm => "QuestionForm",
         }
     }
@@ -495,6 +498,26 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
                 ),
             ),
             (
+                "html",
+                block_with_description(
+                    "html",
+                    "Html",
+                    "Author/agent-supplied HTML rendered SAFELY. The block \
+                     CHILDREN are the HTML document/fragment; it is sanitized \
+                     (DOMPurify, stripping scripts, `on*=` handlers, and \
+                     `javascript:` URLs) and rendered inside a fully sandboxed \
+                     iframe (`sandbox=\"\"`, restrictive CSP, no scripts, no \
+                     same-origin). Use it for rich static formatted markup or \
+                     inline SVG that the other blocks can't express. It is NOT a \
+                     scripting surface — `<script>`, event handlers, and \
+                     `javascript:`/`data:text/html` URLs are rejected at \
+                     validation time and stripped at render. Example: \
+                     `<Html id=\"x\">\\n<div style=\\\"padding:8px\\\"><strong>Hi\
+                     </strong></div>\\n</Html>`.",
+                    fields(vec![]),
+                ),
+            ),
+            (
                 "question-form",
                 block(
                     "question-form",
@@ -719,7 +742,7 @@ mod tests {
     #[test]
     fn registry_contains_v1_blocks() {
         let registry = proposal_block_registry();
-        assert_eq!(registry.len(), 13);
+        assert_eq!(registry.len(), 14);
         assert_eq!(registry["rich-text"].tag, "RichText");
         assert_eq!(registry["diagram"].tag, "Diagram");
         assert_eq!(registry["annotated-code"].tag, "AnnotatedCode");
@@ -732,7 +755,15 @@ mod tests {
         assert_eq!(registry["table"].tag, "Table");
         assert_eq!(registry["checklist"].tag, "Checklist");
         assert_eq!(registry["json-explorer"].tag, "JsonExplorer");
+        assert_eq!(registry["html"].tag, "Html");
         assert_eq!(registry["question-form"].tag, "QuestionForm");
+        // The html block ships authoring guidance noting it is sandboxed.
+        assert!(
+            registry["html"]
+                .description
+                .is_some_and(|d| d.contains("sandboxed iframe")),
+            "html block must advertise its sandboxed/sanitized render"
+        );
         // The diff block ships authoring guidance for the LLM.
         assert!(
             registry["diff"]
@@ -757,6 +788,7 @@ mod tests {
             BlockType::Table,
             BlockType::Checklist,
             BlockType::JsonExplorer,
+            BlockType::Html,
             BlockType::QuestionForm,
         ];
         for bt in types {
@@ -768,7 +800,7 @@ mod tests {
     #[test]
     fn block_registry_new_has_all_definitions() {
         let reg = BlockRegistry::new();
-        assert_eq!(reg.definitions().len(), 13);
+        assert_eq!(reg.definitions().len(), 14);
         assert!(reg.definition_for_tag("RichText").is_some());
         assert!(reg.definition_for_tag("UnknownTag").is_none());
         assert!(reg.tags().contains("RichText"));
@@ -793,6 +825,7 @@ mod tests {
             "Table",
             "Checklist",
             "JsonExplorer",
+            "Html",
             "QuestionForm",
         ]
         .into_iter()

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -3,7 +3,9 @@
 // Each function returns `Result<T, String>` where `Err` is a human-readable
 // message suitable for returning as a JSON `{ "error": ... }` response.
 
-use crate::tools::proposal_blocks::{extract_custom_block_tags, proposal_block_tags};
+use crate::tools::proposal_blocks::{
+    extract_custom_block_tags, parse_mdx_blocks, proposal_block_tags,
+};
 
 /// Decode the handful of HTML entities that LLM-authored plain text routinely
 /// over-escapes (e.g. a title arriving as `A &amp; B`). `&amp;` is decoded last
@@ -185,7 +187,101 @@ pub fn validate_mdx_body(body: &str, body_format: Option<&str>) -> Result<(), St
             return Err(format!("Unknown MDX block tag: '{tag}'"));
         }
     }
+    validate_html_block_safety(body)?;
     Ok(())
+}
+
+/// Server-side backstop for the sandboxed `html` block (defense in depth).
+///
+/// The primary defenses are the client-side iframe `sandbox=""` + restrictive
+/// CSP and the DOMPurify pass before render. This is a third layer that rejects
+/// the most dangerous *active* markup in an `html` block's children **before it
+/// is ever stored**, mirroring agent-native's server regex. It is deliberately
+/// conservative — only `<script>` tags, `on*=` event-handler attributes, and
+/// `javascript:` / `data:text/html` URIs are rejected, so benign formatted HTML
+/// (and inline SVG) still passes.
+fn validate_html_block_safety(body: &str) -> Result<(), String> {
+    let blocks = match parse_mdx_blocks(body) {
+        Ok(blocks) => blocks,
+        // Structural parse errors are surfaced by other validators; don't
+        // double-report here.
+        Err(_) => return Ok(()),
+    };
+    for block in blocks {
+        if block.block_type != "html" {
+            continue;
+        }
+        if let Some(reason) = first_unsafe_html_reason(&block.raw_content) {
+            return Err(format!(
+                "Html block '{}' contains disallowed active markup ({reason}); \
+                 the html block renders sandboxed/sanitized static markup and \
+                 is not a scripting surface",
+                block.id
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Return a short reason string if `content` carries dangerous active markup,
+/// or `None` if it is safe. Case-insensitive; whitespace inside the
+/// `javascript:` scheme is collapsed so obfuscated `java script:` is caught.
+fn first_unsafe_html_reason(content: &str) -> Option<&'static str> {
+    let lower = content.to_ascii_lowercase();
+    if lower.contains("<script") {
+        return Some("a <script> tag");
+    }
+    // `on…=` event handler attributes, e.g. `onerror=`, `onload =`.
+    if has_event_handler_attribute(&lower) {
+        return Some("an on*= event handler");
+    }
+    // `javascript:` / `vbscript:` / `data:text/html` URIs, tolerating
+    // intra-scheme whitespace used to dodge naive string matches.
+    let collapsed: String = lower.chars().filter(|c| !c.is_whitespace()).collect();
+    if collapsed.contains("javascript:")
+        || collapsed.contains("vbscript:")
+        || collapsed.contains("data:text/html")
+    {
+        return Some("a javascript:/data:text/html URI");
+    }
+    None
+}
+
+/// Detect an HTML `on<event>=` attribute (e.g. `onclick=`, `onerror =`).
+/// Looks for a word boundary, `on`, one or more ASCII-alpha event-name chars,
+/// optional whitespace, then `=`. Conservative: an `on`-prefixed plain word
+/// followed by `=` is rare in benign block markup.
+fn has_event_handler_attribute(lower: &str) -> bool {
+    let bytes = lower.as_bytes();
+    let mut i = 0;
+    while let Some(pos) = lower[i..].find("on") {
+        let start = i + pos;
+        i = start + 2;
+        // Require a boundary before `on` (start of string or non-alnum), so
+        // words like `button` / `iron` don't match.
+        let boundary = start == 0
+            || !bytes[start - 1].is_ascii_alphanumeric() && bytes[start - 1] != b'_';
+        if !boundary {
+            continue;
+        }
+        let mut j = i;
+        // event name: at least one alpha char.
+        while j < bytes.len() && bytes[j].is_ascii_alphabetic() {
+            j += 1;
+        }
+        if j == i {
+            continue;
+        }
+        // skip optional whitespace before `=`.
+        let mut k = j;
+        while k < bytes.len() && bytes[k].is_ascii_whitespace() {
+            k += 1;
+        }
+        if k < bytes.len() && bytes[k] == b'=' {
+            return true;
+        }
+    }
+    false
 }
 
 /// Validate reason: max 2,000 chars.
@@ -517,6 +613,10 @@ This runs on the hot path.
 }
 </JsonExplorer>
 
+<Html id="custom-markup">
+<div style="padding:8px"><strong>Formatted</strong> author markup.</div>
+</Html>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached?
 </QuestionForm>
@@ -584,6 +684,92 @@ Should we use Redis or Memcached?
     fn mdx_body_ignores_lowercase_html() {
         let body = "<div>\n  <span>plain html</span>\n</div>";
         assert!(validate_mdx_body(body, Some("mdx")).is_ok());
+    }
+
+    #[test]
+    fn mdx_body_html_block_allows_benign_markup() {
+        let body = r#"
+<Html id="ok">
+<div style="padding:8px"><strong>Hello</strong> <em>world</em></div>
+<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="red"/></svg>
+</Html>
+"#;
+        assert!(validate_mdx_body(body, Some("mdx")).is_ok());
+    }
+
+    #[test]
+    fn mdx_body_html_block_rejects_script_tag() {
+        let body = r#"
+<Html id="bad">
+<div>hi</div>
+<script>alert(1)</script>
+</Html>
+"#;
+        let err = validate_mdx_body(body, Some("mdx")).unwrap_err();
+        assert!(err.contains("<script>"), "unexpected error: {err}");
+        assert!(err.contains("Html block 'bad'"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn mdx_body_html_block_rejects_event_handler() {
+        let body = r#"
+<Html id="bad">
+<img src="x" onerror="alert(1)" />
+</Html>
+"#;
+        let err = validate_mdx_body(body, Some("mdx")).unwrap_err();
+        assert!(err.contains("on*= event handler"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn mdx_body_html_block_rejects_javascript_uri() {
+        let body = r#"
+<Html id="bad">
+<a href="javascript:alert(1)">click</a>
+</Html>
+"#;
+        let err = validate_mdx_body(body, Some("mdx")).unwrap_err();
+        assert!(
+            err.contains("javascript:/data:text/html"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn mdx_body_html_block_rejects_data_text_html_uri() {
+        let body = r#"
+<Html id="bad">
+<a href="data:text/html,<script>alert(1)</script>">x</a>
+</Html>
+"#;
+        // The data:text/html URI (or the inline <script>) must be rejected.
+        assert!(validate_mdx_body(body, Some("mdx")).is_err());
+    }
+
+    #[test]
+    fn html_safety_does_not_affect_other_blocks() {
+        // An `onClick`-looking handler inside a non-html block (e.g. RichText
+        // prose / code) is NOT subject to the html active-markup rejection.
+        let body = r#"
+<RichText id="r">
+Bind it with `el.onclick = fn` in the handler.
+</RichText>
+"#;
+        assert!(validate_mdx_body(body, Some("mdx")).is_ok());
+    }
+
+    #[test]
+    fn first_unsafe_html_reason_detects_obfuscated_scheme() {
+        // Intra-scheme whitespace is collapsed before matching.
+        assert!(first_unsafe_html_reason("<a href=\"java\nscript:x\">").is_some());
+        assert!(first_unsafe_html_reason("<div>plain text</div>").is_none());
+    }
+
+    #[test]
+    fn event_handler_detection_avoids_false_positives() {
+        // `iron` / `button=` style substrings must not trip the on*= matcher.
+        assert!(!has_event_handler_attribute("<button class=\"iron\">on the wall</button>"));
+        assert!(has_event_handler_attribute("<div onmouseover=\"x\">"));
     }
 
     #[test]

--- a/ui/src/components/proposals/blocks/Diagram.tsx
+++ b/ui/src/components/proposals/blocks/Diagram.tsx
@@ -1,9 +1,9 @@
-import { lazy, Suspense, useMemo } from "react";
-import DOMPurify from "dompurify";
+import { lazy, Suspense } from "react";
 
 import type { BlockProps } from "./types";
 import { BlockShell } from "./BlockShell";
 import { DiagramFallback } from "./DiagramFallback";
+import { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
 
 // Mermaid is a large dependency; load it only when a mermaid diagram renders.
 const MermaidDiagram = lazy(() =>
@@ -17,24 +17,15 @@ const MermaidDiagram = lazy(() =>
  *   - `mermaid` (default): rendered to an actual SVG via the shared
  *     `MermaidDiagram` component (arrow-normalized + DOMPurify'd, with a
  *     graceful copy-source fallback on parse failure),
- *   - `svg`: inlined after DOMPurify sanitization (defends against stored XSS),
+ *   - `svg`: rendered through the same sandboxed iframe surface as the `html`
+ *     block (DOMPurify + `sandbox=""` + restrictive CSP) — NO raw
+ *     `dangerouslySetInnerHTML`, closing the prior stored-XSS escape hatch,
  *   - anything else (e.g. `plantuml`, for which we have no client renderer):
  *     routed to the same graceful copy-source fallback instead of dumping raw.
  */
 export function Diagram({ attributes, children }: BlockProps) {
   const diagramType = attributes.type ?? "mermaid";
   const content = typeof children === "string" ? children.trim() : "";
-
-  // Sanitize author/agent SVG before inlining — the source may carry
-  // `<script>`/`onload=`/`javascript:` payloads. DOMPurify's SVG profile keeps
-  // the drawing intact while stripping active markup.
-  const sanitizedSvg = useMemo(
-    () =>
-      DOMPurify.sanitize(content, {
-        USE_PROFILES: { svg: true, svgFilters: true, html: true },
-      }),
-    [content],
-  );
 
   return (
     <BlockShell
@@ -53,11 +44,10 @@ export function Diagram({ attributes, children }: BlockProps) {
           <MermaidDiagram source={content} />
         </Suspense>
       ) : diagramType === "svg" ? (
-        <div
-          className="overflow-x-auto"
-          // Content is DOMPurify-sanitized above before injection.
-          dangerouslySetInnerHTML={{ __html: sanitizedSvg }}
-        />
+        // Author/agent SVG may carry `<script>`/`onload=`/`javascript:`
+        // payloads. Render it through the shared sandboxed surface (DOMPurify +
+        // locked-down iframe) instead of inlining it into the live DOM.
+        <SandboxedHtmlFrame html={content} title="Diagram SVG" />
       ) : (
         // No client renderer for this type (e.g. plantuml): show the source with
         // a copy button rather than a raw dump.

--- a/ui/src/components/proposals/blocks/HtmlBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/HtmlBlock.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/test-utils";
+
+import { HtmlBlock } from "./HtmlBlock";
+
+describe("HtmlBlock", () => {
+  it("renders a sandboxed iframe (no scripts, no same-origin)", () => {
+    render(
+      <HtmlBlock id="h1" attributes={{}}>
+        {"<div><strong>Hello</strong></div>"}
+      </HtmlBlock>,
+    );
+    const iframe = screen.getByTitle("Embedded HTML block") as HTMLIFrameElement;
+    expect(iframe.tagName).toBe("IFRAME");
+    // Fully locked-down sandbox.
+    expect(iframe.getAttribute("sandbox")).toBe("");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-scripts");
+  });
+
+  it("embeds sanitized content in the iframe srcdoc, stripping scripts", () => {
+    render(
+      <HtmlBlock id="h2" attributes={{}}>
+        {"<b>keep</b><script>alert(1)</script>"}
+      </HtmlBlock>,
+    );
+    const iframe = screen.getByTitle("Embedded HTML block") as HTMLIFrameElement;
+    const srcdoc = iframe.getAttribute("srcdoc") ?? "";
+    expect(srcdoc).toContain("<b>keep</b>");
+    expect(srcdoc).not.toContain("alert(1)");
+    expect(srcdoc).toContain("Content-Security-Policy");
+  });
+
+  it("renders the HTML block shell label", () => {
+    render(
+      <HtmlBlock id="h3" attributes={{}}>
+        {"<p>body</p>"}
+      </HtmlBlock>,
+    );
+    expect(screen.getByText("HTML")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/proposals/blocks/HtmlBlock.tsx
+++ b/ui/src/components/proposals/blocks/HtmlBlock.tsx
@@ -1,0 +1,25 @@
+import { BlockShell } from "./BlockShell";
+import { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
+import type { BlockProps } from "./types";
+
+/**
+ * Html — renders author/agent-supplied HTML SAFELY.
+ *
+ * The block CHILDREN are the HTML document/fragment (a string). It is rendered
+ * inside a fully sandboxed iframe (`sandbox=""`, restrictive CSP, no scripts, no
+ * same-origin) after a DOMPurify pass — see `SandboxedHtmlFrame` /
+ * `sandboxedHtml.ts`. This is the safe replacement for the old unsanitized
+ * raw-SVG `dangerouslySetInnerHTML` escape hatch.
+ *
+ * It is NOT a scripting surface: scripts, event handlers, and `javascript:` URLs
+ * are stripped at three layers (server validation, DOMPurify, iframe sandbox).
+ */
+export function HtmlBlock({ children }: BlockProps) {
+  const html = typeof children === "string" ? children.trim() : "";
+
+  return (
+    <BlockShell label="HTML" accent="text-sky-400">
+      <SandboxedHtmlFrame html={html} title="Embedded HTML block" />
+    </BlockShell>
+  );
+}

--- a/ui/src/components/proposals/blocks/SandboxedHtmlFrame.tsx
+++ b/ui/src/components/proposals/blocks/SandboxedHtmlFrame.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+
+import { buildIframeSrcDoc, SANDBOX_VALUE } from "./sandboxedHtml";
+
+export interface SandboxedHtmlFrameProps {
+  /** Untrusted author/agent HTML (or SVG). Sanitized + framed before render. */
+  html: string;
+  /** Accessible title for the iframe. */
+  title?: string;
+  /** Extra classes for the iframe element. */
+  className?: string;
+}
+
+/**
+ * Render untrusted HTML inside a fully locked-down sandboxed iframe.
+ *
+ * Security (defense-in-depth, see `sandboxedHtml.ts`):
+ *   - the HTML is DOMPurify-sanitized before it ever reaches the document,
+ *   - it is embedded in a `srcdoc` carrying a restrictive CSP `<meta>`,
+ *   - the iframe `sandbox=""` disables scripts AND same-origin — framed content
+ *     can only paint static formatted HTML/SVG; it cannot run code, navigate the
+ *     top window, submit forms, or reach the parent DOM.
+ *
+ * Because `sandbox=""` makes the framed document an opaque origin, the parent
+ * CANNOT read its layout height to auto-size (any such read throws a
+ * cross-origin error, and we must not add `allow-same-origin`+`allow-scripts`).
+ * We therefore use a sensible fixed viewport with internal scrolling — a bounded
+ * surface that never lets the framed content drive host layout.
+ */
+export function SandboxedHtmlFrame({
+  html,
+  title = "Embedded HTML",
+  className,
+}: SandboxedHtmlFrameProps) {
+  const srcDoc = useMemo(() => buildIframeSrcDoc(html), [html]);
+
+  return (
+    <iframe
+      title={title}
+      srcDoc={srcDoc}
+      sandbox={SANDBOX_VALUE}
+      referrerPolicy="no-referrer"
+      loading="lazy"
+      className={
+        className ??
+        "h-80 max-h-[32rem] w-full rounded-md border bg-background"
+      }
+    />
+  );
+}

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -1,6 +1,6 @@
 # Canonical Proposal
 
-This is a canonical proposal.mdx sample that exercises all eight v1 proposal block types. It is used by the UI and backend test suites to prove the registry/parser round-trip contract.
+This is a canonical proposal.mdx sample that exercises all v1 proposal block types. It is used by the UI and backend test suites to prove the registry/parser round-trip contract.
 
 <RichText id="intro">
 Welcome to the proposal. This is **rich text** content.
@@ -75,6 +75,12 @@ This runs on the hot path — keep allocations out of the loop.
   "labels": ["alpha", "beta"]
 }
 </JsonExplorer>
+
+<Html id="custom-markup">
+<div style="padding:8px">
+  <strong>Formatted</strong> author markup rendered in a sandboxed iframe.
+</div>
+</Html>
 
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached for caching?

--- a/ui/src/components/proposals/blocks/blocks.test.ts
+++ b/ui/src/components/proposals/blocks/blocks.test.ts
@@ -30,6 +30,7 @@ export const CANONICAL_V1_TAGS = [
   "Table",
   "Checklist",
   "JsonExplorer",
+  "Html",
   "QuestionForm",
 ] as const;
 
@@ -217,6 +218,13 @@ describe("canonical proposal.mdx round-trip", () => {
     expect(getProposalBlockDefinitionByTag("JsonExplorer")!.type).toBe(
       "json-explorer",
     );
+
+    // Html
+    const html = byTag.get("Html");
+    expect(html).toBeDefined();
+    expect(html!.id).toBe("custom-markup");
+    expect(html!.content).toContain("<strong>");
+    expect(getProposalBlockDefinitionByTag("Html")!.type).toBe("html");
 
     // QuestionForm
     const questionForm = byTag.get("QuestionForm");

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -12,6 +12,14 @@ export { CalloutBlock } from "./CalloutBlock";
 export { TableBlock } from "./TableBlock";
 export { ChecklistBlock } from "./ChecklistBlock";
 export { JsonExplorerBlock, JsonTree } from "./JsonExplorerBlock";
+export { HtmlBlock } from "./HtmlBlock";
+export { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
+export {
+  sanitizeBlockHtml,
+  buildIframeSrcDoc,
+  SANDBOX_VALUE,
+  IFRAME_CSP,
+} from "./sandboxedHtml";
 
 // Reusable line-anchored annotation engine (pure parsing + React rail UI). The
 // `annotated-code` block consumes it; `diff` and future blocks can adopt it.

--- a/ui/src/components/proposals/blocks/sandboxedHtml.test.ts
+++ b/ui/src/components/proposals/blocks/sandboxedHtml.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildIframeSrcDoc,
+  IFRAME_CSP,
+  SANDBOX_VALUE,
+  sanitizeBlockHtml,
+} from "./sandboxedHtml";
+
+describe("sanitizeBlockHtml", () => {
+  it("strips <script> tags", () => {
+    const out = sanitizeBlockHtml(
+      '<div>ok</div><script>alert(1)</script>',
+    );
+    expect(out).toContain("<div>ok</div>");
+    expect(out.toLowerCase()).not.toContain("<script");
+    expect(out).not.toContain("alert(1)");
+  });
+
+  it("strips on*= event-handler attributes", () => {
+    const out = sanitizeBlockHtml('<img src="x" onerror="alert(1)">');
+    expect(out.toLowerCase()).not.toContain("onerror");
+    expect(out).not.toContain("alert(1)");
+  });
+
+  it("strips javascript: URLs", () => {
+    const out = sanitizeBlockHtml('<a href="javascript:alert(1)">x</a>');
+    expect(out.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("strips data:text/html URLs", () => {
+    const out = sanitizeBlockHtml(
+      '<a href="data:text/html,<script>alert(1)</script>">x</a>',
+    );
+    expect(out.toLowerCase()).not.toContain("data:text/html");
+    expect(out.toLowerCase()).not.toContain("<script");
+  });
+
+  it("preserves benign formatting markup", () => {
+    const out = sanitizeBlockHtml(
+      '<div style="padding:8px"><strong>Hi</strong> <em>there</em></div>',
+    );
+    expect(out).toContain("<strong>");
+    expect(out).toContain("<em>");
+    expect(out).toContain("Hi");
+  });
+
+  it("preserves inline SVG drawing markup", () => {
+    const out = sanitizeBlockHtml(
+      '<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="red"/></svg>',
+    );
+    expect(out.toLowerCase()).toContain("<svg");
+    expect(out.toLowerCase()).toContain("<rect");
+  });
+
+  it("strips <script> inside SVG (onload/script payloads)", () => {
+    const out = sanitizeBlockHtml(
+      '<svg><script>alert(1)</script><a xlink:href="javascript:alert(1)">x</a></svg>',
+    );
+    expect(out.toLowerCase()).not.toContain("<script");
+    expect(out.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("removes <iframe> nested in the fragment", () => {
+    const out = sanitizeBlockHtml('<div>x</div><iframe src="evil"></iframe>');
+    expect(out.toLowerCase()).not.toContain("<iframe");
+  });
+
+  it("does not throw on malformed / unbalanced HTML", () => {
+    expect(() => sanitizeBlockHtml("<div><span>unclosed")).not.toThrow();
+    expect(() => sanitizeBlockHtml("</div></div>")).not.toThrow();
+    expect(sanitizeBlockHtml("plain text")).toContain("plain text");
+  });
+
+  it("returns empty string for empty / nullish input", () => {
+    expect(sanitizeBlockHtml("")).toBe("");
+    expect(sanitizeBlockHtml(undefined)).toBe("");
+    expect(sanitizeBlockHtml(null)).toBe("");
+  });
+});
+
+describe("buildIframeSrcDoc", () => {
+  it("embeds the restrictive CSP meta with script-src 'none'", () => {
+    const doc = buildIframeSrcDoc("<div>ok</div>");
+    expect(doc).toContain("Content-Security-Policy");
+    expect(doc).toContain(IFRAME_CSP);
+    expect(doc).toContain("script-src 'none'");
+    expect(doc).toContain("default-src 'none'");
+  });
+
+  it("embeds the sanitized body (script stripped) not the raw input", () => {
+    const doc = buildIframeSrcDoc("<b>keep</b><script>alert(1)</script>");
+    expect(doc).toContain("<b>keep</b>");
+    expect(doc).not.toContain("alert(1)");
+    expect(doc.toLowerCase()).not.toContain("<script>alert");
+  });
+
+  it("produces a complete html document", () => {
+    const doc = buildIframeSrcDoc("<p>hi</p>");
+    expect(doc.startsWith("<!doctype html>")).toBe(true);
+    expect(doc).toContain("<body>");
+    expect(doc).toContain("</html>");
+  });
+
+  it("never throws on malformed input", () => {
+    expect(() => buildIframeSrcDoc("<svg><foreignObject>")).not.toThrow();
+    expect(() => buildIframeSrcDoc("")).not.toThrow();
+  });
+});
+
+describe("sandbox constant", () => {
+  it("is the empty (fully locked) sandbox value — no scripts, no same-origin", () => {
+    expect(SANDBOX_VALUE).toBe("");
+    expect(SANDBOX_VALUE).not.toContain("allow-scripts");
+    expect(SANDBOX_VALUE).not.toContain("allow-same-origin");
+  });
+});

--- a/ui/src/components/proposals/blocks/sandboxedHtml.ts
+++ b/ui/src/components/proposals/blocks/sandboxedHtml.ts
@@ -1,0 +1,120 @@
+import DOMPurify, { type Config } from "dompurify";
+
+/**
+ * Security primitives for the sandboxed `html` block (and the `Diagram`
+ * `type="svg"` path, which reuses this surface).
+ *
+ * Author/agent-supplied HTML is UNTRUSTED. We never inline it into the live page
+ * DOM. Instead we apply defense-in-depth:
+ *
+ *  1. DOMPurify the markup (strip `<script>`, `on*=` handlers, `javascript:`
+ *     URLs) — see {@link sanitizeBlockHtml}.
+ *  2. Embed the sanitized markup in a fully locked-down `<iframe srcdoc>` with a
+ *     restrictive CSP `<meta>` and an empty `sandbox` attribute (no scripts, no
+ *     same-origin) — see {@link buildIframeSrcDoc}.
+ *
+ * The server-side validation layer (Rust `validation.rs`) is a third backstop
+ * that rejects the most dangerous active markup before it is ever stored.
+ *
+ * Keeping these pure (no React) makes them unit-testable in isolation.
+ */
+
+/**
+ * The minimal iframe `sandbox` value used for the html/svg render surface.
+ *
+ * Deliberately the EMPTY STRING: this disables scripts, same-origin access,
+ * forms, top-navigation, popups, and pointer-lock — the iframe can only paint
+ * static formatted HTML/SVG. `sandbox=""` is the most restrictive possible
+ * value; never widen this to include `allow-scripts` + `allow-same-origin`
+ * together (that combination lets framed content escape the sandbox).
+ */
+export const SANDBOX_VALUE = "";
+
+/**
+ * Content-Security-Policy embedded as a `<meta http-equiv>` inside the srcdoc
+ * document. A second belt on top of the empty sandbox: even if the sandbox were
+ * ever loosened, this blocks script execution, framing, form submission, and
+ * remote connections while still allowing static formatted HTML/SVG to render
+ * (inline styles + http(s)/data images).
+ */
+export const IFRAME_CSP =
+  "default-src 'none'; " +
+  "img-src data: https:; " +
+  "style-src 'unsafe-inline'; " +
+  "font-src data: https:; " +
+  "base-uri 'none'; " +
+  "form-action 'none'; " +
+  "frame-src 'none'; " +
+  "object-src 'none'; " +
+  "script-src 'none'";
+
+/**
+ * DOMPurify configuration shared by the html and svg surfaces. Allows static
+ * formatted HTML plus the full SVG drawing profile, and FORBIDS the active /
+ * structural elements that could execute or escape. `dompurify` already strips
+ * `on*=` handlers and `javascript:`/`data:text/html` URLs by default; the
+ * explicit FORBID list is belt-and-suspenders.
+ */
+const SANITIZE_CONFIG: Config = {
+  USE_PROFILES: { html: true, svg: true, svgFilters: true },
+  FORBID_TAGS: [
+    "script",
+    "iframe",
+    "object",
+    "embed",
+    "base",
+    "form",
+    "meta",
+    "link",
+    "noscript",
+    "frame",
+    "frameset",
+    "applet",
+  ],
+  FORBID_ATTR: ["srcdoc"],
+  // Never keep `javascript:`/`vbscript:`/`data:text/html` URLs.
+  ALLOW_UNKNOWN_PROTOCOLS: false,
+};
+
+/**
+ * Sanitize untrusted author/agent HTML (or SVG). Strips scripts, event-handler
+ * attributes, and dangerous URLs while preserving benign formatting and SVG
+ * drawing markup. Returns a string of sanitized HTML.
+ *
+ * Robust against malformed input — DOMPurify parses leniently and never throws;
+ * a non-string or empty input yields an empty string.
+ */
+export function sanitizeBlockHtml(html: string | undefined | null): string {
+  if (typeof html !== "string" || html.length === 0) return "";
+  // Without `RETURN_TRUSTED_TYPE`, sanitize returns a plain string; coerce to be
+  // explicit (the typed overload can widen to `string | TrustedHTML`).
+  return String(DOMPurify.sanitize(html, SANITIZE_CONFIG));
+}
+
+/**
+ * Build the full `srcdoc` document string for the sandboxed iframe. Sanitizes
+ * the body, embeds the restrictive CSP meta, and applies a small reset so the
+ * fragment renders legibly (transparent background so the host card shows
+ * through; theme-aware ink via `prefers-color-scheme`).
+ *
+ * The output is intended ONLY for an `<iframe sandbox="" srcdoc={...}>`.
+ */
+export function buildIframeSrcDoc(html: string | undefined | null): string {
+  const body = sanitizeBlockHtml(html);
+  return (
+    "<!doctype html><html><head>" +
+    `<meta http-equiv="Content-Security-Policy" content="${IFRAME_CSP}">` +
+    "<meta name=\"referrer\" content=\"no-referrer\">" +
+    "<style>" +
+    "html,body{margin:0;padding:0;background:transparent;}" +
+    "body{font-family:Inter,system-ui,-apple-system,sans-serif;color:#1f1f1d;" +
+    "font-size:14px;line-height:1.5;overflow-wrap:anywhere;}" +
+    "*{box-sizing:border-box;}" +
+    "img,svg,video{max-width:100%;height:auto;}" +
+    "a{color:#3b82f6;}" +
+    "@media(prefers-color-scheme:dark){body{color:#e8e8e6;}}" +
+    "</style></head><body>" +
+    body +
+    "</body></html>"
+  );
+}

--- a/ui/src/lib/blockRegistry.ts
+++ b/ui/src/lib/blockRegistry.ts
@@ -11,6 +11,7 @@ import {
   Diagram,
   DiffBlock,
   FileTreeBlock,
+  HtmlBlock,
   JsonExplorerBlock,
   QuestionFormBlock,
   RichText,
@@ -42,6 +43,7 @@ const BLOCK_COMPONENTS: Record<ProposalBlockType, ComponentType<BlockProps>> = {
   table: TableBlock,
   checklist: ChecklistBlock,
   "json-explorer": JsonExplorerBlock,
+  html: HtmlBlock,
   "question-form": QuestionFormBlock,
 };
 
@@ -58,6 +60,7 @@ const BLOCK_DISPLAY_NAMES: Record<ProposalBlockType, string> = {
   table: "Table",
   checklist: "Checklist",
   "json-explorer": "JSON Explorer",
+  html: "HTML",
   "question-form": "Open Questions",
 };
 

--- a/ui/src/lib/proposalBlocks.ts
+++ b/ui/src/lib/proposalBlocks.ts
@@ -156,6 +156,11 @@ export const PROPOSAL_BLOCK_REGISTRY = {
     tag: "JsonExplorer",
     fields: {},
   },
+  html: {
+    type: "html",
+    tag: "Html",
+    fields: {},
+  },
   "question-form": {
     type: "question-form",
     tag: "QuestionForm",


### PR DESCRIPTION
## What

Adds a new \`html\` proposal block that renders author/agent HTML **safely**, and closes the existing **stored-XSS** escape hatch in the \`Diagram\` \`type=\"svg\"\` path.

### Security design (defense-in-depth, 3 layers)
1. **Render layer** — HTML renders inside a fully locked-down iframe: \`sandbox=\"\"\` (no scripts, no same-origin), plus a restrictive CSP \`<meta>\` in the \`srcdoc\` (\`default-src 'none'; script-src 'none'; img-src data: https:; style-src 'unsafe-inline'; …\`). The framed content can only paint static formatted HTML/SVG.
2. **Sanitize layer** — HTML is DOMPurify-sanitized before it ever reaches the iframe \`srcdoc\` (strips \`<script>\`, \`on*=\` handlers, \`javascript:\`/\`data:text/html\` URLs; keeps the SVG drawing profile). Reuses the existing \`dompurify\` dep — no new sanitizer lib.
3. **Server/schema layer** — \`validation.rs\` rejects the most dangerous active markup in an \`html\` block's children **before storage** (\`<script\`, \`on*=\`, \`javascript:\`/\`vbscript:\`/\`data:text/html\`), mirroring agent-native's server regex. Conservative so benign HTML/SVG still passes.

### Close the escape hatch
\`Diagram.tsx\`'s \`type=\"svg\"\` path no longer uses raw \`dangerouslySetInnerHTML\`; it now routes through the same sandboxed surface (\`SandboxedHtmlFrame\`). The only remaining \`dangerouslySetInnerHTML\` on author content is the mermaid render path, which was already DOMPurify-sanitized (renderer-generated SVG).

## Block-type count
13 → 14 (\`html\` inserted before \`question-form\`, which stays last).

## Files
- \`ui/.../blocks/sandboxedHtml.ts\` (+test) — pure sanitizer + iframe-srcdoc builder
- \`ui/.../blocks/SandboxedHtmlFrame.tsx\` — sandboxed iframe React component
- \`ui/.../blocks/HtmlBlock.tsx\` (+test) — the \`html\` block
- \`ui/.../blocks/Diagram.tsx\` — svg path routed through the sandboxed surface
- TS registries: \`proposalBlocks.ts\`, \`blockRegistry.ts\`, \`blocks/index.ts\`, \`blocks.test.ts\`, canonical fixture
- Rust: \`proposal_blocks.rs\` (enum/registry + assertions), \`validation.rs\` (active-markup rejection + tests)

## Tests
- Rust: proposal_blocks 29/29, validation 34/34 (incl. 8 new html-safety tests), proposal_tools import/export 7/7, tool_schemas snapshot 14/14 (no shape change), clippy clean
- UI: blocks vitest 268/268 (incl. new sanitizer/HtmlBlock specs + parity), \`tsc -b\` clean, eslint clean

No migration needed. Schema snapshot unchanged (children-only block).