### PR TITLE
feat(proposals): add openapi-spec block ($ref resolve + example gen + tag grouping)

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -28,6 +28,7 @@ pub enum BlockType {
     Checklist,
     JsonExplorer,
     Html,
+    OpenApiSpec,
     QuestionForm,
 }
 
@@ -48,6 +49,7 @@ impl BlockType {
             BlockType::Checklist => "checklist",
             BlockType::JsonExplorer => "json-explorer",
             BlockType::Html => "html",
+            BlockType::OpenApiSpec => "openapi-spec",
             BlockType::QuestionForm => "question-form",
         }
     }
@@ -68,6 +70,7 @@ impl BlockType {
             BlockType::Checklist => "Checklist",
             BlockType::JsonExplorer => "JsonExplorer",
             BlockType::Html => "Html",
+            BlockType::OpenApiSpec => "OpenApi",
             BlockType::QuestionForm => "QuestionForm",
         }
     }
@@ -518,6 +521,31 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
                 ),
             ),
             (
+                "openapi-spec",
+                block_with_description(
+                    "openapi-spec",
+                    "OpenApi",
+                    "A whole-document OpenAPI 3.x (or Swagger 2) API reference, \
+                     rendered Redoc / Swagger-UI style. The block CHILDREN are a \
+                     complete OpenAPI document as JSON (an `openapi`/`swagger` \
+                     version, an `info` block, and a `paths` object; optional \
+                     `tags`, `servers`, and `components`). The renderer \
+                     `JSON.parse`s the children, resolves internal \
+                     `$ref`s (e.g. `#/components/schemas/User`, cycle-guarded), \
+                     groups operations by `tags` (operations with no tag fall into \
+                     a `default` group), and renders each operation as a \
+                     collapsible row: a colored METHOD pill + path + summary that \
+                     expands to its parameters, request body, and per-status \
+                     responses, with example bodies derived from the JSON schemas. \
+                     It is read-only. YAML is NOT supported in v1 — emit JSON (a \
+                     YAML or non-OpenAPI body falls back to a raw JSON render). \
+                     Example: `<OpenApi id=\"x\">\\n{\\n  \"openapi\": \"3.0.0\",\\n  \
+                     \"info\": { \"title\": \"My API\", \"version\": \"1.0.0\" },\\n  \
+                     \"paths\": {}\\n}\\n</OpenApi>`.",
+                    fields(vec![]),
+                ),
+            ),
+            (
                 "question-form",
                 block(
                     "question-form",
@@ -742,7 +770,7 @@ mod tests {
     #[test]
     fn registry_contains_v1_blocks() {
         let registry = proposal_block_registry();
-        assert_eq!(registry.len(), 14);
+        assert_eq!(registry.len(), 15);
         assert_eq!(registry["rich-text"].tag, "RichText");
         assert_eq!(registry["diagram"].tag, "Diagram");
         assert_eq!(registry["annotated-code"].tag, "AnnotatedCode");
@@ -756,6 +784,7 @@ mod tests {
         assert_eq!(registry["checklist"].tag, "Checklist");
         assert_eq!(registry["json-explorer"].tag, "JsonExplorer");
         assert_eq!(registry["html"].tag, "Html");
+        assert_eq!(registry["openapi-spec"].tag, "OpenApi");
         assert_eq!(registry["question-form"].tag, "QuestionForm");
         // The html block ships authoring guidance noting it is sandboxed.
         assert!(
@@ -763,6 +792,13 @@ mod tests {
                 .description
                 .is_some_and(|d| d.contains("sandboxed iframe")),
             "html block must advertise its sandboxed/sanitized render"
+        );
+        // The openapi-spec block ships authoring guidance noting $ref resolution.
+        assert!(
+            registry["openapi-spec"]
+                .description
+                .is_some_and(|d| d.contains("OpenAPI") && d.contains("$ref")),
+            "openapi-spec block must advertise OpenAPI/$ref authoring guidance"
         );
         // The diff block ships authoring guidance for the LLM.
         assert!(
@@ -789,6 +825,7 @@ mod tests {
             BlockType::Checklist,
             BlockType::JsonExplorer,
             BlockType::Html,
+            BlockType::OpenApiSpec,
             BlockType::QuestionForm,
         ];
         for bt in types {
@@ -800,7 +837,7 @@ mod tests {
     #[test]
     fn block_registry_new_has_all_definitions() {
         let reg = BlockRegistry::new();
-        assert_eq!(reg.definitions().len(), 14);
+        assert_eq!(reg.definitions().len(), 15);
         assert!(reg.definition_for_tag("RichText").is_some());
         assert!(reg.definition_for_tag("UnknownTag").is_none());
         assert!(reg.tags().contains("RichText"));
@@ -826,6 +863,7 @@ mod tests {
             "Checklist",
             "JsonExplorer",
             "Html",
+            "OpenApi",
             "QuestionForm",
         ]
         .into_iter()

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -617,6 +617,14 @@ This runs on the hot path.
 <div style="padding:8px"><strong>Formatted</strong> author markup.</div>
 </Html>
 
+<OpenApi id="petstore-api">
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Petstore", "version": "1.0.0" },
+  "paths": { "/pets": { "get": { "responses": { "200": {} } } } }
+}
+</OpenApi>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/OpenApiSpecBlock.tsx
+++ b/ui/src/components/proposals/blocks/OpenApiSpecBlock.tsx
@@ -1,0 +1,385 @@
+import { useMemo, useState } from "react";
+import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  LockKeyIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
+
+import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { JsonTree } from "./JsonExplorerBlock";
+import { Badge } from "./blockBadges";
+import {
+  httpMethodColor,
+  paramLocationColor,
+  statusCodeColor,
+} from "./blockBadgeColors";
+import { classifyStatus, normalizeMethod } from "./apiEndpoint";
+import {
+  isKnownParamLocation,
+  parseOpenApiSpec,
+  type OpenApiOperation,
+  type OpenApiParam,
+  type OpenApiResponse,
+  type OpenApiTagGroup,
+} from "./openApiSpec";
+import type { BlockProps } from "./types";
+
+/**
+ * OpenApiSpec — a Redoc / Swagger-UI-style API reference rendered from a whole
+ * OpenAPI 3 / Swagger 2 document.
+ *
+ * djinn does NOT serialize a structured prop; the block's payload is its
+ * *children string* — the complete OpenAPI document (JSON). We parse it (see
+ * `openApiSpec.ts`): internal `$ref`s are resolved (cycle-guarded), operations
+ * are grouped by tag (untagged → a `default` group), and each operation gets a
+ * params table, request body, and per-status responses with example bodies
+ * derived from the schemas. The renderer reuses the api-endpoint house style:
+ * method pills, param-location pills, status-code pills, and the shared
+ * interactive `JsonTree` for every example body.
+ *
+ * Graceful + read-only: if the children are not a parseable OpenAPI document the
+ * renderer falls back to the shared `JsonTree` (which itself falls back to a
+ * styled `<pre>`) plus the parse error, so an oddly-authored block never blanks
+ * or crashes. YAML is not supported in v1 — a YAML body yields an actionable
+ * fallback message (see `parseOpenApiSpec`).
+ */
+export function OpenApiSpecBlock({ attributes, children }: BlockProps) {
+  const content = typeof children === "string" ? children : "";
+  const title = attributes.title?.trim() || undefined;
+
+  const parsed = useMemo(() => parseOpenApiSpec(content), [content]);
+
+  if (!parsed.ok) {
+    return (
+      <BlockShell
+        label="OpenAPI"
+        accent="text-green-400"
+        flush
+        meta={
+          title ? <span className="truncate font-mono">{title}</span> : null
+        }
+      >
+        <div className="space-y-2 p-4">
+          <p className="text-[11px] text-amber-300">
+            Could not parse OpenAPI spec: {parsed.error}
+          </p>
+          <JsonTree code={content} label="OpenAPI" />
+        </div>
+      </BlockShell>
+    );
+  }
+
+  const spec = parsed.spec;
+  const meta = (
+    <span className="flex min-w-0 items-center gap-2">
+      {title ? (
+        <span className="truncate font-mono text-foreground">{title}</span>
+      ) : (
+        <span className="truncate font-mono text-foreground">
+          {spec.title || "API reference"}
+        </span>
+      )}
+      {spec.version && (
+        <span className="shrink-0 rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+          v{spec.version}
+        </span>
+      )}
+      <Badge accent="slate" className="shrink-0 normal-case">
+        {spec.format}
+      </Badge>
+    </span>
+  );
+
+  return (
+    <BlockShell label="OpenAPI" accent="text-green-400" flush meta={meta}>
+      <div className="flex flex-col gap-3 p-4">
+        {(spec.description?.trim() || spec.servers.length > 0) && (
+          <div className="rounded-lg border bg-card/50 px-3 py-2.5">
+            {spec.servers.length > 0 && (
+              <div className="mb-2 flex flex-wrap items-center gap-1.5">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Servers
+                </span>
+                {spec.servers.map((server) => (
+                  <span
+                    key={server}
+                    className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+                  >
+                    {server}
+                  </span>
+                ))}
+              </div>
+            )}
+            {spec.description?.trim() && (
+              <BlockMarkdown>{spec.description}</BlockMarkdown>
+            )}
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              {spec.operationCount}{" "}
+              {spec.operationCount === 1 ? "operation" : "operations"} across{" "}
+              {spec.groups.length}{" "}
+              {spec.groups.length === 1 ? "tag" : "tags"}
+            </p>
+          </div>
+        )}
+
+        {spec.groups.length === 0 ? (
+          <div className="rounded-lg border bg-card/50 px-3 py-6 text-center text-sm text-muted-foreground">
+            No operations found in this spec.
+          </div>
+        ) : (
+          spec.groups.map((group, index) => (
+            <TagGroup key={group.tag} group={group} defaultOpen={index === 0} />
+          ))
+        )}
+      </div>
+    </BlockShell>
+  );
+}
+
+/* ── Tag group (collapsible) ────────────────────────────────────────────────── */
+
+function TagGroup({
+  group,
+  defaultOpen,
+}: {
+  group: OpenApiTagGroup;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card/50">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-muted/40"
+      >
+        <HugeiconsIcon
+          icon={open ? ArrowDown01Icon : ArrowRight01Icon}
+          size={14}
+          className="shrink-0 text-muted-foreground"
+        />
+        <span className="font-semibold text-foreground">{group.tag}</span>
+        <span className="rounded-full bg-muted/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+          {group.operations.length}
+        </span>
+        {group.description && (
+          <span className="ml-1 min-w-0 flex-1 truncate text-xs text-muted-foreground">
+            {group.description}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="divide-y divide-border/60 border-t">
+          {group.operations.map((operation) => (
+            <OperationRow key={operation.id} operation={operation} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Operation row (collapsible) ────────────────────────────────────────────── */
+
+function OperationRow({ operation }: { operation: OpenApiOperation }) {
+  const [open, setOpen] = useState(false);
+  const method = normalizeMethod(operation.method);
+
+  const hasBody =
+    Boolean(operation.description?.trim()) ||
+    operation.params.length > 0 ||
+    Boolean(operation.requestExample || operation.requestContentType) ||
+    operation.responses.length > 0;
+
+  return (
+    <div className="overflow-hidden">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-muted/40"
+      >
+        <HugeiconsIcon
+          icon={open ? ArrowDown01Icon : ArrowRight01Icon}
+          size={13}
+          className="shrink-0 text-muted-foreground"
+        />
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 font-mono text-[11px] font-bold tracking-wide",
+            httpMethodColor(method),
+          )}
+        >
+          {operation.method}
+        </span>
+        <span
+          className={cn(
+            "min-w-0 truncate font-mono text-[13px] font-medium text-foreground",
+            operation.deprecated && "text-muted-foreground line-through",
+          )}
+        >
+          {operation.path}
+        </span>
+        {operation.summary && (
+          <span className="ml-1 min-w-0 flex-1 truncate text-xs text-muted-foreground">
+            {operation.summary}
+          </span>
+        )}
+        {operation.deprecated && (
+          <Badge accent="amber" className="shrink-0">
+            Deprecated
+          </Badge>
+        )}
+        {operation.secured && (
+          <HugeiconsIcon
+            icon={LockKeyIcon}
+            size={13}
+            className="shrink-0 text-amber-400/80"
+            aria-label="Requires authentication"
+          />
+        )}
+      </button>
+
+      {open && hasBody && (
+        <div className="flex flex-col gap-4 bg-muted/20 px-3 pb-4 pt-3">
+          {operation.description?.trim() && (
+            <BlockMarkdown>{operation.description}</BlockMarkdown>
+          )}
+
+          {operation.params.length > 0 && (
+            <ParamsSection params={operation.params} />
+          )}
+
+          {(operation.requestExample || operation.requestContentType) && (
+            <section>
+              <div className="mb-1.5 flex items-center gap-2">
+                <SectionLabel>Request body</SectionLabel>
+                {operation.requestContentType && (
+                  <span className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                    {operation.requestContentType}
+                  </span>
+                )}
+              </div>
+              {operation.requestExample && (
+                <JsonTree code={operation.requestExample} label="Example" />
+              )}
+            </section>
+          )}
+
+          {operation.responses.length > 0 && (
+            <ResponsesSection responses={operation.responses} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Parameters section ─────────────────────────────────────────────────────── */
+
+function ParamsSection({ params }: { params: OpenApiParam[] }) {
+  return (
+    <section>
+      <SectionLabel>Parameters</SectionLabel>
+      <div className="mt-1.5 overflow-hidden rounded-lg border bg-card/50">
+        <div className="divide-y divide-border/60">
+          {params.map((param, index) => (
+            <ParamRow key={`${param.name}-${param.in}-${index}`} param={param} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ParamRow({ param }: { param: OpenApiParam }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-2 text-[13px]">
+      <span className="font-mono font-medium text-foreground">
+        {param.name}
+      </span>
+      {param.in &&
+        (isKnownParamLocation(param.in) ? (
+          <span
+            className={cn(
+              "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide leading-none",
+              paramLocationColor(param.in),
+            )}
+          >
+            {param.in}
+          </span>
+        ) : (
+          <Badge accent="slate">{param.in}</Badge>
+        ))}
+      {param.type && (
+        <span className="rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+          {param.type}
+        </span>
+      )}
+      {param.required === true ? (
+        <Badge accent="red">required</Badge>
+      ) : (
+        <Badge accent="slate">optional</Badge>
+      )}
+      {param.description && (
+        <span className="w-full text-xs text-muted-foreground">
+          {param.description}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ── Responses section ──────────────────────────────────────────────────────── */
+
+function ResponsesSection({ responses }: { responses: OpenApiResponse[] }) {
+  return (
+    <section>
+      <SectionLabel>Responses</SectionLabel>
+      <div className="mt-1.5 flex flex-col gap-2">
+        {responses.map((response, index) => (
+          <ResponseRow key={`${response.status}-${index}`} response={response} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ResponseRow({ response }: { response: OpenApiResponse }) {
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card/50">
+      <div className="flex flex-wrap items-center gap-2 px-3 py-2 text-[13px]">
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5 font-mono text-[11px] font-bold leading-none",
+            statusCodeColor(classifyStatus(response.status)),
+          )}
+        >
+          {response.status}
+        </span>
+        {response.description && (
+          <span className="min-w-0 text-foreground">{response.description}</span>
+        )}
+      </div>
+      {response.example && (
+        <div className="border-t px-3 py-2">
+          <JsonTree code={response.example} label="Example" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Shared bits ────────────────────────────────────────────────────────────── */
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+      {children}
+    </div>
+  );
+}

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -82,6 +82,23 @@ This runs on the hot path — keep allocations out of the loop.
 </div>
 </Html>
 
+<OpenApi id="petstore-api">
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Petstore", "version": "1.0.0" },
+  "tags": [{ "name": "pets", "description": "Manage pets" }],
+  "paths": {
+    "/pets": {
+      "get": {
+        "tags": ["pets"],
+        "summary": "List pets",
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}
+</OpenApi>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached for caching?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/blocks.test.ts
+++ b/ui/src/components/proposals/blocks/blocks.test.ts
@@ -31,6 +31,7 @@ export const CANONICAL_V1_TAGS = [
   "Checklist",
   "JsonExplorer",
   "Html",
+  "OpenApi",
   "QuestionForm",
 ] as const;
 
@@ -225,6 +226,15 @@ describe("canonical proposal.mdx round-trip", () => {
     expect(html!.id).toBe("custom-markup");
     expect(html!.content).toContain("<strong>");
     expect(getProposalBlockDefinitionByTag("Html")!.type).toBe("html");
+
+    // OpenApi
+    const openApi = byTag.get("OpenApi");
+    expect(openApi).toBeDefined();
+    expect(openApi!.id).toBe("petstore-api");
+    expect(openApi!.content).toContain("openapi");
+    expect(getProposalBlockDefinitionByTag("OpenApi")!.type).toBe(
+      "openapi-spec",
+    );
 
     // QuestionForm
     const questionForm = byTag.get("QuestionForm");

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -12,6 +12,7 @@ export { CalloutBlock } from "./CalloutBlock";
 export { TableBlock } from "./TableBlock";
 export { ChecklistBlock } from "./ChecklistBlock";
 export { JsonExplorerBlock, JsonTree } from "./JsonExplorerBlock";
+export { OpenApiSpecBlock } from "./OpenApiSpecBlock";
 export { HtmlBlock } from "./HtmlBlock";
 export { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
 export {

--- a/ui/src/components/proposals/blocks/openApiSpec.test.ts
+++ b/ui/src/components/proposals/blocks/openApiSpec.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  UNTAGGED_GROUP,
+  isKnownParamLocation,
+  parseOpenApiSpec,
+  resolveRef,
+  schemaExample,
+} from "./openApiSpec";
+
+/** Parse a spec object (stringified) and assert it succeeded, returning it. */
+function parse(doc: unknown) {
+  const result = parseOpenApiSpec(JSON.stringify(doc));
+  if (!result.ok) {
+    throw new Error(`expected ok parse, got error: ${result.error}`);
+  }
+  return result.spec;
+}
+
+describe("parseOpenApiSpec — top-level", () => {
+  it("parses info, servers, and operation count", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "Widgets API", version: "2.1.0", description: "Hello" },
+      servers: [{ url: "https://api.example.com/v1" }],
+      paths: {
+        "/widgets": {
+          get: { tags: ["widgets"], responses: { "200": { description: "OK" } } },
+        },
+      },
+    });
+    expect(spec.title).toBe("Widgets API");
+    expect(spec.version).toBe("2.1.0");
+    expect(spec.description).toBe("Hello");
+    expect(spec.format).toBe("OpenAPI 3");
+    expect(spec.servers).toEqual(["https://api.example.com/v1"]);
+    expect(spec.operationCount).toBe(1);
+  });
+
+  it("detects Swagger 2 + host/basePath servers", () => {
+    const spec = parse({
+      swagger: "2.0",
+      info: { title: "Legacy", version: "1.0" },
+      host: "api.example.com",
+      basePath: "/v2",
+      paths: { "/ping": { get: { responses: { "200": {} } } } },
+    });
+    expect(spec.format).toBe("Swagger 2");
+    expect(spec.servers).toEqual(["api.example.com/v2"]);
+  });
+
+  it("returns an error for empty input", () => {
+    const result = parseOpenApiSpec("   ");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/empty/i);
+  });
+
+  it("returns an error for invalid JSON, hinting YAML when it looks like YAML", () => {
+    const result = parseOpenApiSpec("openapi: 3.0.0\ninfo:\n  title: X");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/YAML is not supported/i);
+  });
+
+  it("rejects valid JSON that is not an OpenAPI document (graceful fallback)", () => {
+    const result = parseOpenApiSpec('{"hello":"world","count":3}');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/not an openapi/i);
+  });
+
+  it("does not throw on a non-object JSON document", () => {
+    const result = parseOpenApiSpec("[1, 2, 3]");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseOpenApiSpec — tag grouping", () => {
+  it("groups operations by their declared tags", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1" },
+      tags: [
+        { name: "pets", description: "Manage pets" },
+        { name: "store" },
+      ],
+      paths: {
+        "/pets": {
+          get: { tags: ["pets"], responses: { "200": {} } },
+          post: { tags: ["pets"], responses: { "201": {} } },
+        },
+        "/store/order": {
+          get: { tags: ["store"], responses: { "200": {} } },
+        },
+      },
+    });
+    expect(spec.groups.map((g) => g.tag)).toEqual(["pets", "store"]);
+    expect(spec.groups[0].operations).toHaveLength(2);
+    expect(spec.groups[0].description).toBe("Manage pets");
+    expect(spec.groups[1].operations).toHaveLength(1);
+  });
+
+  it("buckets operations with no tag into the untagged default group, sunk last", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1" },
+      tags: [{ name: "alpha" }],
+      paths: {
+        "/a": { get: { tags: ["alpha"], responses: { "200": {} } } },
+        "/loose": { get: { responses: { "200": {} } } },
+      },
+    });
+    const tags = spec.groups.map((g) => g.tag);
+    expect(tags).toContain(UNTAGGED_GROUP);
+    expect(tags[tags.length - 1]).toBe(UNTAGGED_GROUP);
+    const untagged = spec.groups.find((g) => g.tag === UNTAGGED_GROUP);
+    expect(untagged!.operations).toHaveLength(1);
+    expect(untagged!.operations[0].path).toBe("/loose");
+  });
+
+  it("orders documented tags first, then undocumented tags alphabetically", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1" },
+      tags: [{ name: "zeta" }],
+      paths: {
+        "/z": { get: { tags: ["zeta"], responses: { "200": {} } } },
+        "/b": { get: { tags: ["beta"], responses: { "200": {} } } },
+        "/a": { get: { tags: ["alpha"], responses: { "200": {} } } },
+      },
+    });
+    expect(spec.groups.map((g) => g.tag)).toEqual(["zeta", "alpha", "beta"]);
+  });
+});
+
+describe("parseOpenApiSpec — params + responses", () => {
+  it("normalizes path/query params and merges path-level params", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1" },
+      paths: {
+        "/pets/{id}": {
+          parameters: [
+            {
+              name: "id",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          get: {
+            parameters: [
+              { name: "verbose", in: "query", schema: { type: "boolean" } },
+            ],
+            responses: { "200": { description: "OK" }, "404": {} },
+          },
+        },
+      },
+    });
+    const op = spec.groups[0].operations[0];
+    expect(op.params.map((p) => p.name)).toEqual(["id", "verbose"]);
+    expect(op.params[0].in).toBe("path");
+    expect(op.params[0].required).toBe(true);
+    expect(op.params[0].type).toBe("string");
+    expect(op.params[1].type).toBe("boolean");
+    expect(op.responses.map((r) => r.status)).toEqual(["200", "404"]);
+  });
+
+  it("marks operations secured by a global security requirement", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1" },
+      security: [{ apiKey: [] }],
+      paths: { "/secret": { get: { responses: { "200": {} } } } },
+    });
+    expect(spec.groups[0].operations[0].secured).toBe(true);
+  });
+
+  it("lets an operation opt out of global security with security: []", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1" },
+      security: [{ apiKey: [] }],
+      paths: { "/open": { get: { security: [], responses: { "200": {} } } } },
+    });
+    expect(spec.groups[0].operations[0].secured).toBe(false);
+  });
+});
+
+describe("resolveRef — $ref resolution + cycle guard", () => {
+  const root = {
+    components: {
+      schemas: {
+        User: { type: "object", properties: { name: { type: "string" } } },
+        "Weird/Name": { type: "string" },
+      },
+    },
+  };
+
+  it("resolves a nested local $ref", () => {
+    const resolved = resolveRef(
+      root,
+      "#/components/schemas/User",
+      new Set(),
+    ) as Record<string, unknown>;
+    expect(resolved.type).toBe("object");
+  });
+
+  it("decodes JSON-pointer escapes (~1 → /)", () => {
+    const resolved = resolveRef(
+      root,
+      "#/components/schemas/Weird~1Name",
+      new Set(),
+    ) as Record<string, unknown>;
+    expect(resolved.type).toBe("string");
+  });
+
+  it("returns undefined for external refs", () => {
+    expect(resolveRef(root, "https://x/User", new Set())).toBeUndefined();
+  });
+
+  it("returns undefined (cycle guard) when the ref is already on the path", () => {
+    const seen = new Set(["#/components/schemas/User"]);
+    expect(
+      resolveRef(root, "#/components/schemas/User", seen),
+    ).toBeUndefined();
+  });
+});
+
+describe("schemaExample — generation from schema", () => {
+  const root = {};
+
+  it("honors an explicit example", () => {
+    expect(schemaExample(root, { type: "string", example: "abc" }, new Set(), 0)).toBe(
+      "abc",
+    );
+  });
+
+  it("honors default then enum then a type placeholder", () => {
+    expect(
+      schemaExample(root, { type: "string", default: "d" }, new Set(), 0),
+    ).toBe("d");
+    expect(
+      schemaExample(root, { type: "string", enum: ["a", "b"] }, new Set(), 0),
+    ).toBe("a");
+    expect(schemaExample(root, { type: "string" }, new Set(), 0)).toBe(
+      "string",
+    );
+  });
+
+  it("emits typed placeholders for primitives", () => {
+    expect(schemaExample(root, { type: "integer" }, new Set(), 0)).toBe(0);
+    expect(schemaExample(root, { type: "boolean" }, new Set(), 0)).toBe(true);
+    expect(
+      schemaExample(root, { type: "string", format: "uuid" }, new Set(), 0),
+    ).toBe("00000000-0000-0000-0000-000000000000");
+  });
+
+  it("builds an object example from properties", () => {
+    const value = schemaExample(
+      root,
+      {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          count: { type: "integer" },
+        },
+      },
+      new Set(),
+      0,
+    );
+    expect(value).toEqual({ id: "string", count: 0 });
+  });
+
+  it("builds an array example with one representative item", () => {
+    const value = schemaExample(
+      root,
+      { type: "array", items: { type: "string" } },
+      new Set(),
+      0,
+    );
+    expect(value).toEqual(["string"]);
+  });
+
+  it("resolves a nested $ref inside the example", () => {
+    const refRoot = {
+      components: {
+        schemas: {
+          Address: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        },
+      },
+    };
+    const value = schemaExample(
+      refRoot,
+      {
+        type: "object",
+        properties: { home: { $ref: "#/components/schemas/Address" } },
+      },
+      new Set(),
+      0,
+    );
+    expect(value).toEqual({ home: { city: "string" } });
+  });
+
+  it("terminates on a circular $ref instead of recursing forever", () => {
+    const refRoot = {
+      components: {
+        schemas: {
+          Node: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+              next: { $ref: "#/components/schemas/Node" },
+            },
+          },
+        },
+      },
+    };
+    // Must not throw / hang. The cycle guard short-circuits the self-reference.
+    const value = schemaExample(
+      refRoot,
+      { $ref: "#/components/schemas/Node" },
+      new Set(),
+      0,
+    ) as Record<string, unknown>;
+    expect(value.value).toBe("string");
+    // The recursive `next` collapses to the unresolved ref node (no infinite tree).
+    expect(JSON.stringify(value).length).toBeLessThan(500);
+  });
+});
+
+describe("parseOpenApiSpec — request body + response examples from $ref", () => {
+  it("derives request + response example bodies from referenced schemas", () => {
+    const spec = parse({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1" },
+      paths: {
+        "/pets": {
+          post: {
+            tags: ["pets"],
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/NewPet" },
+                },
+              },
+            },
+            responses: {
+              "201": {
+                description: "Created",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Pet" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          NewPet: {
+            type: "object",
+            properties: { name: { type: "string" } },
+          },
+          Pet: {
+            type: "object",
+            properties: {
+              id: { type: "integer" },
+              name: { type: "string" },
+            },
+          },
+        },
+      },
+    });
+    const op = spec.groups[0].operations[0];
+    expect(op.requestContentType).toBe("application/json");
+    expect(op.requestExample).toContain('"name": "string"');
+    const created = op.responses.find((r) => r.status === "201");
+    expect(created!.example).toContain('"id": 0');
+    expect(created!.example).toContain('"name": "string"');
+  });
+
+  it("handles a circular model in a response without throwing", () => {
+    const result = parseOpenApiSpec(
+      JSON.stringify({
+        openapi: "3.0.0",
+        info: { title: "T", version: "1" },
+        paths: {
+          "/tree": {
+            get: {
+              responses: {
+                "200": {
+                  content: {
+                    "application/json": {
+                      schema: { $ref: "#/components/schemas/Node" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Node: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                children: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/Node" },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("isKnownParamLocation", () => {
+  it("recognizes the colored locations", () => {
+    expect(isKnownParamLocation("path")).toBe(true);
+    expect(isKnownParamLocation("query")).toBe(true);
+    expect(isKnownParamLocation("header")).toBe(true);
+    expect(isKnownParamLocation("cookie")).toBe(false);
+  });
+});

--- a/ui/src/components/proposals/blocks/openApiSpec.ts
+++ b/ui/src/components/proposals/blocks/openApiSpec.ts
@@ -1,0 +1,596 @@
+// Pure (React-free) helpers for the interactive openapi-spec block. djinn does
+// NOT serialize a structured prop — the block's payload arrives as its *children
+// string* (`segment.content`) = a whole OpenAPI 3 / Swagger 2 document. We parse
+// that text into a normalized shape the renderer walks: operations grouped by
+// tag, each carrying params / request body / per-status responses with `$ref`
+// models resolved and example bodies derived from schemas. Kept in its own
+// module so the parse / `$ref`-resolve / example-generate logic is unit-testable
+// without pulling React in.
+//
+// The parse is defensive: an empty, non-JSON, or non-OpenAPI payload yields
+// `{ ok: false }` with an error message, and the renderer falls back to a styled
+// raw render (it never throws and never blanks).
+//
+// YAML: `js-yaml` is NOT a declared UI dependency (only a transitive one), so v1
+// parses JSON only — `parseOpenApiSpec` is the single seam to extend when a YAML
+// parser is added. A YAML-looking body produces a clean, actionable fallback
+// error rather than a silent blank.
+
+import type { ParamLocation } from "./apiEndpoint";
+
+/* ── Public normalized shape ────────────────────────────────────────────────── */
+
+/** A single normalized parameter on an operation (path/query/header/cookie). */
+export interface OpenApiParam {
+  name: string;
+  /** Raw `in` location; the renderer maps known ones to a colored pill. */
+  in: string;
+  type?: string;
+  required?: boolean;
+  description?: string;
+}
+
+/** A single normalized response: a status token + description + example body. */
+export interface OpenApiResponse {
+  /** Raw status token, e.g. `200`, `4XX`, `default`. */
+  status: string;
+  description?: string;
+  /** A derived JSON example body (pretty-printed), when one is available. */
+  example?: string;
+}
+
+/** A single normalized operation (one method on one path). */
+export interface OpenApiOperation {
+  /** Stable per-operation key (`get /users`). */
+  id: string;
+  method: string;
+  path: string;
+  summary?: string;
+  description?: string;
+  deprecated?: boolean;
+  secured?: boolean;
+  params: OpenApiParam[];
+  requestContentType?: string;
+  requestExample?: string;
+  responses: OpenApiResponse[];
+}
+
+/** Operations sharing a tag, in document order. */
+export interface OpenApiTagGroup {
+  tag: string;
+  description?: string;
+  operations: OpenApiOperation[];
+}
+
+/** The fully normalized spec the renderer walks. */
+export interface NormalizedOpenApiSpec {
+  title?: string;
+  version?: string;
+  description?: string;
+  format: "OpenAPI 3" | "Swagger 2" | "Unknown";
+  servers: string[];
+  groups: OpenApiTagGroup[];
+  operationCount: number;
+}
+
+/** The discriminated result of {@link parseOpenApiSpec}. */
+export type OpenApiParseResult =
+  | { ok: true; spec: NormalizedOpenApiSpec }
+  | { ok: false; error: string };
+
+/** Tag used to bucket operations that declare no `tags`. */
+export const UNTAGGED_GROUP = "default";
+
+/** Max `$ref` resolution / example-recursion depth (cheap cycle backstop). */
+const MAX_EXAMPLE_DEPTH = 6;
+/** Max consecutive `$ref` hops before we give up (defends against ref chains). */
+const MAX_REF_HOPS = 20;
+/** Cap how many object properties an example object expands (huge-spec guard). */
+const MAX_EXAMPLE_PROPS = 40;
+/** Cap a stringified example so a pathological schema can't blow up the DOM. */
+const MAX_EXAMPLE_CHARS = 8_000;
+
+const HTTP_METHODS = [
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "head",
+  "options",
+  "trace",
+] as const;
+
+/* ── JSON value helpers ─────────────────────────────────────────────────────── */
+
+type Json = unknown;
+type JsonObject = Record<string, Json>;
+
+function isObject(value: Json): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asString(value: Json): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Param locations the api-endpoint pills color; everything else renders plain. */
+const KNOWN_LOCATIONS: ReadonlySet<string> = new Set<ParamLocation>([
+  "path",
+  "query",
+  "header",
+  "body",
+]);
+
+/** True when a location string maps to a colored param-location pill. */
+export function isKnownParamLocation(location: string): location is ParamLocation {
+  return KNOWN_LOCATIONS.has(location);
+}
+
+/* ── Top-level parse ────────────────────────────────────────────────────────── */
+
+/**
+ * Parse the raw spec children into a normalized spec. v1 supports JSON only —
+ * `js-yaml` is not a declared UI dependency. A YAML-looking body yields an
+ * actionable error so the renderer can fall back gracefully (never throws).
+ * This is the single seam to extend with YAML once a parser is a real dep.
+ */
+export function parseOpenApiSpec(raw: string): OpenApiParseResult {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    return {
+      ok: false,
+      error: "Empty spec — paste an OpenAPI 3 / Swagger 2 document.",
+    };
+  }
+
+  let doc: Json;
+  try {
+    doc = JSON.parse(trimmed);
+  } catch (error) {
+    // A `key: value` / `---` lead-in is almost certainly YAML, not malformed
+    // JSON — surface a targeted hint so the fallback is actionable.
+    const looksLikeYaml =
+      trimmed.startsWith("---") || /^[A-Za-z][\w-]*\s*:/m.test(trimmed);
+    const hint = looksLikeYaml
+      ? " (YAML is not supported yet — paste JSON, or convert the spec to JSON.)"
+      : "";
+    return {
+      ok: false,
+      error: `${error instanceof Error ? error.message : "Invalid JSON"}${hint}`,
+    };
+  }
+
+  if (!isObject(doc)) {
+    return { ok: false, error: "Spec must be a JSON object." };
+  }
+  // Reject documents with no OpenAPI/Swagger marker AND no paths — those are
+  // plausibly arbitrary JSON the author meant for a json-explorer block.
+  const hasMarker =
+    typeof doc.openapi === "string" || typeof doc.swagger === "string";
+  if (!hasMarker && !isObject(doc.paths)) {
+    return {
+      ok: false,
+      error:
+        "Not an OpenAPI document — expected an `openapi`/`swagger` version and a `paths` object.",
+    };
+  }
+
+  try {
+    return { ok: true, spec: normalizeSpec(doc) };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Could not interpret the spec document.",
+    };
+  }
+}
+
+/* ── $ref resolution (cycle-guarded) ────────────────────────────────────────── */
+
+/**
+ * Resolve a local JSON-pointer `$ref` (e.g. `#/components/schemas/User`) against
+ * the document root. Returns `undefined` for external refs or a ref already on
+ * the current resolution path (`seen`), which is the cycle guard. Decodes the
+ * `~1`/`~0` JSON-pointer escapes.
+ */
+export function resolveRef(
+  root: JsonObject,
+  ref: string,
+  seen: Set<string>,
+): Json | undefined {
+  if (!ref.startsWith("#/")) return undefined; // external refs unsupported
+  if (seen.has(ref)) return undefined; // cycle guard
+  seen.add(ref);
+  const segments = ref
+    .slice(2)
+    .split("/")
+    .map((seg) => seg.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let current: Json = root;
+  for (const segment of segments) {
+    if (!isObject(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+/**
+ * Follow `$ref` hops on a schema/param object until a concrete (non-`$ref`)
+ * value is reached, the chain dead-ends, or a cycle / hop budget is hit. The
+ * `seen` set carries the resolution path so a self-referential model terminates.
+ */
+function deref(root: JsonObject, value: Json, seen: Set<string>): Json {
+  let current = value;
+  let hops = 0;
+  while (isObject(current) && typeof current.$ref === "string" && hops < MAX_REF_HOPS) {
+    const resolved = resolveRef(root, current.$ref, seen);
+    if (resolved === undefined) return current; // unresolved → keep the ref node
+    current = resolved;
+    hops += 1;
+  }
+  return current;
+}
+
+/* ── Schema → type label + example generation ───────────────────────────────── */
+
+/** Short human type label for a (possibly `$ref`'d) schema. */
+function schemaTypeLabel(
+  root: JsonObject,
+  schema: Json,
+  seen: Set<string>,
+): string | undefined {
+  const resolved = deref(root, schema, new Set(seen));
+  if (!isObject(resolved)) return undefined;
+  if (typeof resolved.type === "string") {
+    if (resolved.type === "array" && resolved.items) {
+      const inner = schemaTypeLabel(root, resolved.items, seen);
+      return inner ? `${inner}[]` : "array";
+    }
+    return resolved.type;
+  }
+  if (typeof resolved.$ref === "string") return resolved.$ref.split("/").pop();
+  if (Array.isArray(resolved.enum)) return "enum";
+  if (resolved.properties) return "object";
+  if (resolved.oneOf || resolved.anyOf || resolved.allOf) return "object";
+  return undefined;
+}
+
+/**
+ * Build a representative example value from a JSON Schema. Honors `example` /
+ * `default` / `enum[0]` when present, else emits a type-based placeholder.
+ * Bounded by `MAX_EXAMPLE_DEPTH` and a `$ref`-cycle guard (each branch clones
+ * `seen`), so a recursive model terminates with a `…` sentinel rather than
+ * spinning.
+ */
+export function schemaExample(
+  root: JsonObject,
+  schema: Json,
+  seen: Set<string>,
+  depth: number,
+): Json {
+  if (depth > MAX_EXAMPLE_DEPTH) return "…";
+  const resolved = deref(root, schema, new Set(seen));
+  if (!isObject(resolved)) return resolved ?? null;
+
+  if (resolved.example !== undefined) return resolved.example;
+  if (resolved.default !== undefined) return resolved.default;
+  if (Array.isArray(resolved.enum) && resolved.enum.length > 0) {
+    return resolved.enum[0];
+  }
+
+  // Compose `allOf` members into a single object.
+  if (Array.isArray(resolved.allOf)) {
+    const merged: JsonObject = {};
+    for (const part of resolved.allOf) {
+      const value = schemaExample(root, part, seen, depth + 1);
+      if (isObject(value)) Object.assign(merged, value);
+    }
+    if (Object.keys(merged).length > 0) return merged;
+  }
+  // `oneOf` / `anyOf`: pick the first branch as the representative example.
+  const variant =
+    (Array.isArray(resolved.oneOf) && resolved.oneOf) ||
+    (Array.isArray(resolved.anyOf) && resolved.anyOf) ||
+    null;
+  if (variant && variant.length > 0) {
+    return schemaExample(root, variant[0], seen, depth + 1);
+  }
+
+  const type = resolved.type;
+  if (type === "object" || resolved.properties) {
+    const props = isObject(resolved.properties) ? resolved.properties : {};
+    const out: JsonObject = {};
+    for (const [key, propSchema] of Object.entries(props).slice(
+      0,
+      MAX_EXAMPLE_PROPS,
+    )) {
+      out[key] = schemaExample(root, propSchema, seen, depth + 1);
+    }
+    return out;
+  }
+  if (type === "array") {
+    return [schemaExample(root, resolved.items ?? {}, seen, depth + 1)];
+  }
+  if (type === "integer" || type === "number") return 0;
+  if (type === "boolean") return true;
+  if (type === "string") {
+    if (resolved.format === "date-time") return "2020-01-01T00:00:00Z";
+    if (resolved.format === "date") return "2020-01-01";
+    if (resolved.format === "uuid") {
+      return "00000000-0000-0000-0000-000000000000";
+    }
+    if (resolved.format === "email") return "user@example.com";
+    return "string";
+  }
+  return null;
+}
+
+/** Stringify a derived example, dropping empty values and bounding the size. */
+function stringifyExample(value: Json): string | undefined {
+  if (value === undefined) return undefined;
+  try {
+    const text = JSON.stringify(value, null, 2);
+    if (!text || text === "null" || text === "{}" || text === "[]") {
+      return undefined;
+    }
+    return text.length > MAX_EXAMPLE_CHARS
+      ? `${text.slice(0, MAX_EXAMPLE_CHARS)}\n…`
+      : text;
+  } catch {
+    return undefined;
+  }
+}
+
+/* ── Param / operation / response normalization ─────────────────────────────── */
+
+function normalizeParam(
+  root: JsonObject,
+  raw: Json,
+  seen: Set<string>,
+): OpenApiParam | undefined {
+  const param = deref(root, raw, new Set(seen));
+  if (!isObject(param)) return undefined;
+  const name = asString(param.name);
+  const location = asString(param.in);
+  if (!name || !location) return undefined;
+  // OpenAPI 3 nests the type under `schema`; Swagger 2 puts it on the param.
+  const type = schemaTypeLabel(root, param.schema, seen) ?? asString(param.type);
+  return {
+    name,
+    in: location,
+    type,
+    required: param.required === true,
+    description: asString(param.description),
+  };
+}
+
+function normalizeResponses(
+  root: JsonObject,
+  rawResponses: Json,
+): OpenApiResponse[] {
+  if (!isObject(rawResponses)) return [];
+  const responses: OpenApiResponse[] = [];
+  for (const [status, rawResponse] of Object.entries(rawResponses)) {
+    const response = deref(root, rawResponse, new Set());
+    let example: string | undefined;
+    if (isObject(response)) {
+      // OpenAPI 3: response.content[*].schema; Swagger 2: response.schema.
+      if (isObject(response.content)) {
+        const media = Object.values(response.content)[0];
+        if (isObject(media)) {
+          example =
+            stringifyExample(media.example) ??
+            stringifyExample(schemaExample(root, media.schema, new Set(), 0));
+        }
+      } else if (response.schema !== undefined) {
+        example = stringifyExample(
+          schemaExample(root, response.schema, new Set(), 0),
+        );
+      }
+    }
+    responses.push({
+      status,
+      description: isObject(response) ? asString(response.description) : undefined,
+      example,
+    });
+  }
+  return responses.sort((a, b) => a.status.localeCompare(b.status));
+}
+
+function normalizeOperation(
+  root: JsonObject,
+  path: string,
+  method: string,
+  rawOp: Json,
+  pathLevelParams: OpenApiParam[],
+  globalSecured: boolean,
+): OpenApiOperation | undefined {
+  if (!isObject(rawOp)) return undefined;
+
+  const params: OpenApiParam[] = [...pathLevelParams];
+  if (Array.isArray(rawOp.parameters)) {
+    for (const rawParam of rawOp.parameters) {
+      const normalized = normalizeParam(root, rawParam, new Set());
+      if (normalized) params.push(normalized);
+    }
+  }
+
+  // Request body: OpenAPI 3 `requestBody.content[*]`; Swagger 2 `in: body` param.
+  let requestContentType: string | undefined;
+  let requestExample: string | undefined;
+  const requestBody = deref(root, rawOp.requestBody, new Set());
+  if (isObject(requestBody) && isObject(requestBody.content)) {
+    const [contentType, media] = Object.entries(requestBody.content)[0] ?? [];
+    requestContentType = contentType;
+    if (isObject(media)) {
+      requestExample =
+        stringifyExample(media.example) ??
+        stringifyExample(schemaExample(root, media.schema, new Set(), 0));
+    }
+  } else {
+    // Swagger 2 carries the body schema on an `in: body` parameter.
+    const bodyParamRaw = Array.isArray(rawOp.parameters)
+      ? rawOp.parameters
+          .map((p) => deref(root, p, new Set()))
+          .find((p) => isObject(p) && asString((p as JsonObject).in) === "body")
+      : undefined;
+    if (isObject(bodyParamRaw)) {
+      requestContentType = "application/json";
+      requestExample = stringifyExample(
+        schemaExample(root, bodyParamRaw.schema, new Set(), 0),
+      );
+    }
+  }
+
+  // Swagger 2 `in: body` params are surfaced via the request body above; drop
+  // them from the visible param table so they don't double-render.
+  const visibleParams = params.filter((p) => p.in !== "body");
+
+  const responses = normalizeResponses(root, rawOp.responses);
+
+  const operationSecured =
+    Array.isArray(rawOp.security) && rawOp.security.length === 0
+      ? false // explicit opt-out
+      : Array.isArray(rawOp.security)
+        ? rawOp.security.some(
+            (req) => isObject(req) && Object.keys(req).length > 0,
+          )
+        : globalSecured || undefined;
+
+  return {
+    id: `${method} ${path}`,
+    method: method.toUpperCase(),
+    path,
+    summary: asString(rawOp.summary),
+    description: asString(rawOp.description),
+    deprecated: rawOp.deprecated === true,
+    secured: operationSecured,
+    params: visibleParams,
+    requestContentType,
+    requestExample,
+    responses,
+  };
+}
+
+/** The tags an operation belongs to, defaulting to the untagged group. */
+function operationTags(rawOp: JsonObject): string[] {
+  if (Array.isArray(rawOp.tags)) {
+    const tags = rawOp.tags.filter((t): t is string => typeof t === "string");
+    if (tags.length > 0) return tags;
+  }
+  return [UNTAGGED_GROUP];
+}
+
+function normalizeSpec(doc: JsonObject): NormalizedOpenApiSpec {
+  const format: NormalizedOpenApiSpec["format"] =
+    typeof doc.openapi === "string"
+      ? "OpenAPI 3"
+      : typeof doc.swagger === "string"
+        ? "Swagger 2"
+        : "Unknown";
+
+  const info = isObject(doc.info) ? doc.info : undefined;
+
+  // Servers: OpenAPI 3 `servers[].url`; Swagger 2 `host` + `basePath`.
+  const servers: string[] = [];
+  if (Array.isArray(doc.servers)) {
+    for (const server of doc.servers) {
+      if (isObject(server) && typeof server.url === "string") {
+        servers.push(server.url);
+      }
+    }
+  } else if (typeof doc.host === "string") {
+    const basePath = typeof doc.basePath === "string" ? doc.basePath : "";
+    servers.push(`${doc.host}${basePath}`);
+  }
+
+  // A non-empty global `security` requirement marks every operation secured
+  // unless the operation overrides it.
+  const globalSecured =
+    Array.isArray(doc.security) &&
+    doc.security.some((req) => isObject(req) && Object.keys(req).length > 0);
+
+  // Document-level tag order + descriptions.
+  const tagOrder: string[] = [];
+  const tagDescriptions = new Map<string, string>();
+  if (Array.isArray(doc.tags)) {
+    for (const tag of doc.tags) {
+      if (isObject(tag) && typeof tag.name === "string") {
+        tagOrder.push(tag.name);
+        if (typeof tag.description === "string") {
+          tagDescriptions.set(tag.name, tag.description);
+        }
+      }
+    }
+  }
+
+  const groups = new Map<string, OpenApiOperation[]>();
+  let operationCount = 0;
+
+  const paths = isObject(doc.paths) ? doc.paths : {};
+  for (const [path, rawPathItem] of Object.entries(paths)) {
+    const pathItem = deref(doc, rawPathItem, new Set());
+    if (!isObject(pathItem)) continue;
+
+    const pathLevelParams: OpenApiParam[] = [];
+    if (Array.isArray(pathItem.parameters)) {
+      for (const rawParam of pathItem.parameters) {
+        const normalized = normalizeParam(doc, rawParam, new Set());
+        if (normalized) pathLevelParams.push(normalized);
+      }
+    }
+
+    for (const method of HTTP_METHODS) {
+      const rawOp = pathItem[method];
+      if (!isObject(rawOp)) continue;
+      const operation = normalizeOperation(
+        doc,
+        path,
+        method,
+        rawOp,
+        pathLevelParams,
+        globalSecured,
+      );
+      if (!operation) continue;
+      operationCount += 1;
+      for (const tag of operationTags(rawOp)) {
+        const list = groups.get(tag) ?? [];
+        list.push(operation);
+        groups.set(tag, list);
+      }
+    }
+  }
+
+  // Order: documented tags first (in declared order), then any remaining tags
+  // alphabetically. The untagged `default` group always sinks to the end.
+  const remaining = [...groups.keys()]
+    .filter((tag) => !tagOrder.includes(tag))
+    .sort((a, b) => {
+      if (a === UNTAGGED_GROUP) return 1;
+      if (b === UNTAGGED_GROUP) return -1;
+      return a.localeCompare(b);
+    });
+  const orderedTagNames = [
+    ...tagOrder.filter((tag) => groups.has(tag) && tag !== UNTAGGED_GROUP),
+    ...remaining,
+  ];
+
+  const groupList: OpenApiTagGroup[] = orderedTagNames.map((tag) => ({
+    tag,
+    description: tagDescriptions.get(tag),
+    operations: groups.get(tag) ?? [],
+  }));
+
+  return {
+    title: info ? asString(info.title) : undefined,
+    version: info ? asString(info.version) : undefined,
+    description: info ? asString(info.description) : undefined,
+    format,
+    servers,
+    groups: groupList,
+    operationCount,
+  };
+}

--- a/ui/src/lib/blockRegistry.ts
+++ b/ui/src/lib/blockRegistry.ts
@@ -13,6 +13,7 @@ import {
   FileTreeBlock,
   HtmlBlock,
   JsonExplorerBlock,
+  OpenApiSpecBlock,
   QuestionFormBlock,
   RichText,
   TableBlock,
@@ -44,6 +45,7 @@ const BLOCK_COMPONENTS: Record<ProposalBlockType, ComponentType<BlockProps>> = {
   checklist: ChecklistBlock,
   "json-explorer": JsonExplorerBlock,
   html: HtmlBlock,
+  "openapi-spec": OpenApiSpecBlock,
   "question-form": QuestionFormBlock,
 };
 
@@ -61,6 +63,7 @@ const BLOCK_DISPLAY_NAMES: Record<ProposalBlockType, string> = {
   checklist: "Checklist",
   "json-explorer": "JSON Explorer",
   html: "HTML",
+  "openapi-spec": "OpenAPI Spec",
   "question-form": "Open Questions",
 };
 

--- a/ui/src/lib/proposalBlocks.ts
+++ b/ui/src/lib/proposalBlocks.ts
@@ -161,6 +161,11 @@ export const PROPOSAL_BLOCK_REGISTRY = {
     tag: "Html",
     fields: {},
   },
+  "openapi-spec": {
+    type: "openapi-spec",
+    tag: "OpenApi",
+    fields: {},
+  },
   "question-form": {
     type: "question-form",
     tag: "QuestionForm",


### PR DESCRIPTION
Adds a new \`openapi-spec\` proposal block that renders a whole OpenAPI 3 / Swagger 2 document Redoc / Swagger-UI style.

## What it does
- **Children = the OpenAPI document** (a string). Parsed defensively; non-OpenAPI / invalid / YAML input falls back to the shared \`JsonTree\` render plus an actionable error (never throws, never blanks).
- **\$ref resolution** for internal refs (\`#/components/schemas/...\`), nested, with a **cycle guard** (visited-set on the resolution path + bounded hop/recursion budget) so circular models terminate.
- **Tag grouping**: operations grouped by \`tags\`; untagged operations fall into a \`default\` group sunk to the end; documented tags ordered first, remaining alphabetically. Collapsible per tag.
- **Per operation**: METHOD pill + path + summary; parameters table (path/query/header) + request body + per-status responses — **reusing djinn's existing** method/param-location/status pills (\`blockBadgeColors\`/\`blockBadges\`), the \`JsonTree\` component, and hugeicons.
- **Schema → example generation**: representative example object from a JSON Schema (honors \`example\`/\`default\`/\`enum\`, else type placeholder), rendered via the existing JSON tree, depth-bounded.

## Add-a-block-type wiring
- Rust \`proposal_blocks.rs\`: \`BlockType::OpenApiSpec\` (\`openapi-spec\` / \`OpenApi\`), registry entry via \`block_with_description\`, all len + coverage assertions bumped (14 → 15).
- Rust \`validation.rs\`: \`openapi-spec\` added to \`mdx_body_valid_all_canonical_blocks\`.
- TS: \`proposalBlocks.ts\` (\`fields:{}\`, children-only), \`blockRegistry.ts\`, \`blocks/index.ts\`.
- Parity: \`blocks.test.ts\` \`CANONICAL_V1_TAGS\` + per-block assertion; \`canonicalProposal.mdx\` fixture. \`QuestionForm\` stays last.

## Notes
- **YAML not supported in v1**: \`js-yaml\` is only a transitive (not declared) UI dependency, so JSON-first parsing with a clean YAML→fallback path. No dep added. \`parseOpenApiSpec\` is the single seam to extend.
- **No schema snapshot change** (children-only block).
- **No migration.**

## Tests
- Rust: \`proposal_blocks\` 29 + \`validation\` 34 lib tests pass; \`cargo clippy --all-features\` clean.
- UI: 50 vitest tests (new \`openApiSpec.test.ts\` + \`blocks.test.ts\`) pass; \`tsc -b\` clean; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)