### PR TITLE
feat(proposals): ADR decision cards with declared status badges

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -359,9 +359,26 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
             ),
             (
                 "decisions",
-                block(
+                block_with_description(
                     "decisions",
                     "Decisions",
+                    "ADR-style architecture decision records. The block CHILDREN are \
+                     markdown: write ONE decision per `### Title` heading (`##` also \
+                     accepted). DECLARE each decision's status with an explicit \
+                     `Status:` line directly under the heading — one of exactly \
+                     `proposed`, `accepted`, `rejected`, `deprecated`, `superseded` \
+                     (or an inline `[accepted]` marker on the heading line). Status \
+                     comes ONLY from this declared token; it is NEVER inferred from \
+                     words in the prose. Omit the line for no status badge. A \
+                     superseded record may name its replacement: \
+                     `Status: superseded by #3`. Optionally structure the body with \
+                     `Context`, `Decision`, and `Consequences` sub-section labels \
+                     (plain label, `Context:`, `**Decision**`, or `#### Consequences` \
+                     all work); otherwise the body renders as freeform markdown. \
+                     Example: `<Decisions id=\"x\">\\n### Use JWT for stateless auth\\n\
+                     Status: accepted\\n\\nContext\\nWe scale horizontally.\\n\\n\
+                     Decision\\nAdopt short-lived JWTs.\\n</Decisions>`. A body with no \
+                     `##`/`###` headings falls back to a plain markdown render.",
                     fields(vec![(
                         "items",
                         array_field(object_field(fields(vec![

--- a/ui/src/components/proposals/blocks/DecisionsBlock.tsx
+++ b/ui/src/components/proposals/blocks/DecisionsBlock.tsx
@@ -1,10 +1,150 @@
-import type { BlockProps } from "./types";
-import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { useMemo } from "react";
 
+import { BlockMarkdown, BlockShell } from "./BlockShell";
+import { Badge } from "./blockBadges";
+import type { AccentColor } from "./blockBadgeColors";
+import type { BlockProps } from "./types";
+import {
+  parseDecisions,
+  type DecisionStatus,
+  type ParsedDecision,
+} from "./decisions";
+
+/**
+ * Decisions — an ADR-style list of architecture decision records.
+ *
+ * djinn does not serialize a structured `items={…}` JSON prop; the decisions are
+ * the block's *children markdown* (one `### Title` heading per decision, an
+ * optional `Status: <token>` line, then optional Context/Decision/Consequences
+ * sub-sections or freeform body). We parse that into cards (`parseDecisions`) and
+ * render each as a flattened row — title + DECLARED status badge, then sections.
+ *
+ * Status is read ONLY from an explicit declared token (the ADR vocabulary:
+ * proposed · accepted · rejected · deprecated · superseded). It is never inferred
+ * from English prose; a card with no declared status shows NO badge.
+ *
+ * If parsing yields no recognisable decisions, we fall back to the original
+ * `BlockMarkdown` render so a hand-authored block never blanks or crashes.
+ */
 export function DecisionsBlock({ children }: BlockProps) {
+  const content = typeof children === "string" ? children : "";
+  const decisions = useMemo(() => parseDecisions(content), [content]);
+
+  // Parsing produced nothing usable — fall back to the raw markdown render so a
+  // block that doesn't match our ADR shape is never lost.
+  if (decisions.length === 0) {
+    return (
+      <BlockShell label="Decisions" accent="text-amber-500">
+        <BlockMarkdown>{children}</BlockMarkdown>
+      </BlockShell>
+    );
+  }
+
   return (
-    <BlockShell label="Decisions" accent="text-amber-500">
-      <BlockMarkdown>{children}</BlockMarkdown>
+    <BlockShell
+      label="Decisions"
+      accent="text-amber-500"
+      meta={
+        <span>
+          {decisions.length} {decisions.length === 1 ? "decision" : "decisions"}
+        </span>
+      }
+    >
+      <ol className="divide-y divide-border/60">
+        {decisions.map((decision, index) => (
+          <DecisionCard
+            key={`${index}-${decision.title.slice(0, 24)}`}
+            decision={decision}
+          />
+        ))}
+      </ol>
     </BlockShell>
+  );
+}
+
+/* ── Status → color ─────────────────────────────────────────────────────────── */
+
+/**
+ * ADR status → accent color. Tones chosen for intuitive read: proposed (in-flight)
+ * slate, accepted (good) emerald, rejected (no) red, deprecated (fading) amber,
+ * superseded (replaced) violet.
+ */
+const STATUS_ACCENT: Record<DecisionStatus, AccentColor> = {
+  proposed: "slate",
+  accepted: "emerald",
+  rejected: "red",
+  deprecated: "amber",
+  superseded: "violet",
+};
+
+/* ── Decision card ──────────────────────────────────────────────────────────── */
+
+function DecisionCard({ decision }: { decision: ParsedDecision }) {
+  const { title, status, supersededBy, sections, body } = decision;
+
+  return (
+    <li className="py-3 first:pt-0 last:pb-0">
+      <div className="flex items-start justify-between gap-2">
+        <h4 className="min-w-0 flex-1 text-sm font-semibold text-foreground">
+          {title}
+        </h4>
+        {status && (
+          <Badge accent={STATUS_ACCENT[status]} className="mt-0.5 shrink-0">
+            {status}
+          </Badge>
+        )}
+      </div>
+
+      {supersededBy && (
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          superseded by{" "}
+          <span className="font-medium text-foreground/80">{supersededBy}</span>
+        </p>
+      )}
+
+      {sections ? (
+        <div className="mt-2 space-y-2">
+          {sections.context && (
+            <DecisionSection label="Context" markdown={sections.context} />
+          )}
+          {sections.decision && (
+            <DecisionSection label="Decision" markdown={sections.decision} />
+          )}
+          {sections.consequences && (
+            <DecisionSection
+              label="Consequences"
+              markdown={sections.consequences}
+            />
+          )}
+        </div>
+      ) : null}
+
+      {body && (
+        <div className="prose prose-sm mt-2 max-w-none text-sm dark:prose-invert prose-p:my-1">
+          <BlockMarkdown>{body}</BlockMarkdown>
+        </div>
+      )}
+    </li>
+  );
+}
+
+/* ── ADR sub-section ────────────────────────────────────────────────────────── */
+
+function DecisionSection({
+  label,
+  markdown,
+}: {
+  label: string;
+  markdown: string;
+}) {
+  return (
+    <div className="border-l border-border/60 pl-3">
+      <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div className="prose prose-sm mt-0.5 max-w-none text-sm dark:prose-invert prose-p:my-1">
+        <BlockMarkdown>{markdown}</BlockMarkdown>
+      </div>
+    </div>
   );
 }

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -32,7 +32,27 @@ Returns a list of all users.
 </ApiEndpoint>
 
 <Decisions id="auth-choice">
-We chose JWT over session cookies for stateless auth.
+### Use JWT for stateless auth
+Status: accepted
+
+Context
+We need authentication that survives horizontal scaling without sticky sessions.
+
+Decision
+Adopt short-lived JWTs validated at the edge.
+
+Consequences
+No central session store; revocation needs a denylist.
+
+### Session cookies
+Status: rejected
+
+Operationally simpler but requires sticky routing we want to avoid.
+
+### Opaque DB tokens
+Status: superseded by #1
+
+Earlier direction before we settled on JWTs.
 </Decisions>
 
 <FileTree id="project-layout" root="src">

--- a/ui/src/components/proposals/blocks/decisions.test.ts
+++ b/ui/src/components/proposals/blocks/decisions.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DECISION_STATUSES,
+  parseDecisions,
+  type DecisionStatus,
+} from "./decisions";
+
+describe("parseDecisions", () => {
+  it("returns [] for empty / whitespace input (caller falls back)", () => {
+    expect(parseDecisions("")).toEqual([]);
+    expect(parseDecisions("   \n  \n")).toEqual([]);
+  });
+
+  it("returns [] when the body has no headings (fully-unparseable → fallback)", () => {
+    // Freeform prose with no `##`/`###` heading is not a decision card.
+    const result = parseDecisions(
+      "We chose JWT over session cookies for stateless auth.",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("parses each declared ADR status token into a badge status", () => {
+    for (const token of DECISION_STATUSES) {
+      const result = parseDecisions(`### Some Decision\nStatus: ${token}\n`);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.status).toBe(token);
+      expect(result[0]!.title).toBe("Some Decision");
+    }
+  });
+
+  it("does NOT infer status from prose (no declared token ⇒ no status)", () => {
+    // Body says 'we accepted' but no `Status:` line — must NOT become accepted.
+    const result = parseDecisions(
+      "### Use JWT\nWe accepted this after weighing the rejected alternatives.\n",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]!.status).toBeUndefined();
+    expect(result[0]!.body).toContain("We accepted this");
+  });
+
+  it("ignores an invalid declared token (still no status, line consumed)", () => {
+    const result = parseDecisions("### Decision\nStatus: maybe-later\n");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.status).toBeUndefined();
+    // The bogus status line must not leak into the rendered body.
+    expect(result[0]!.body ?? "").not.toContain("maybe-later");
+  });
+
+  it("reads a declared status from an inline [token] heading marker", () => {
+    const result = parseDecisions("### Use a queue [accepted]\nSome body.\n");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.status).toBe("accepted");
+    expect(result[0]!.title).toBe("Use a queue");
+  });
+
+  it("lets an explicit Status: line override the inline heading marker", () => {
+    const result = parseDecisions(
+      "### Use a queue [proposed]\nStatus: accepted\nbody\n",
+    );
+    expect(result[0]!.status).toBe("accepted");
+  });
+
+  it("leaves a real bracketed title word alone (not a valid token)", () => {
+    const result = parseDecisions("### Adopt [internal] tooling\nbody\n");
+    expect(result[0]!.title).toBe("Adopt [internal] tooling");
+    expect(result[0]!.status).toBeUndefined();
+  });
+
+  it("parses ADR Context / Decision / Consequences sub-sections", () => {
+    const md = [
+      "### Use JWT for stateless auth",
+      "Status: accepted",
+      "",
+      "Context",
+      "We scale horizontally without sticky sessions.",
+      "",
+      "Decision",
+      "Adopt short-lived JWTs validated at the edge.",
+      "",
+      "Consequences",
+      "No central session store; revocation needs a denylist.",
+    ].join("\n");
+    const result = parseDecisions(md);
+    expect(result).toHaveLength(1);
+    const d = result[0]!;
+    expect(d.status).toBe("accepted");
+    expect(d.sections?.context).toContain("horizontally");
+    expect(d.sections?.decision).toContain("short-lived JWTs");
+    expect(d.sections?.consequences).toContain("denylist");
+    expect(d.body).toBeUndefined();
+  });
+
+  it("parses sub-section labels written as markdown headings / colon form", () => {
+    const md = [
+      "## Pick Postgres",
+      "Status: accepted",
+      "#### Context:",
+      "We need transactions.",
+      "**Decision**",
+      "Use Postgres 16.",
+    ].join("\n");
+    const result = parseDecisions(md);
+    expect(result[0]!.sections?.context).toContain("transactions");
+    expect(result[0]!.sections?.decision).toContain("Postgres 16");
+  });
+
+  it("keeps a freeform body when there are no ADR sub-sections", () => {
+    const result = parseDecisions(
+      "### Use REST not GraphQL\nStatus: accepted\n\nSimpler for our small surface area.\n",
+    );
+    expect(result[0]!.sections).toBeUndefined();
+    expect(result[0]!.body).toContain("Simpler for our small surface area.");
+  });
+
+  it("surfaces 'superseded by …' target text", () => {
+    const result = parseDecisions(
+      "### Old token scheme\nStatus: superseded by #3\nLegacy approach.\n",
+    );
+    expect(result[0]!.status).toBe("superseded");
+    expect(result[0]!.supersededBy).toBe("#3");
+  });
+
+  it("handles a superseded status with no 'by' target", () => {
+    const result = parseDecisions("### Old\nStatus: superseded\n");
+    expect(result[0]!.status).toBe("superseded");
+    expect(result[0]!.supersededBy).toBeUndefined();
+  });
+
+  it("parses a mixed multi-decision block", () => {
+    const md = [
+      "### Use JWT",
+      "Status: accepted",
+      "Decision",
+      "Short-lived JWTs.",
+      "",
+      "### Sticky sessions",
+      "Status: rejected",
+      "Operationally fragile.",
+      "",
+      "### Edge caching",
+      "No status declared here, just prose.",
+    ].join("\n");
+    const result = parseDecisions(md);
+    expect(result).toHaveLength(3);
+
+    expect(result[0]!.title).toBe("Use JWT");
+    expect(result[0]!.status).toBe("accepted");
+    expect(result[0]!.sections?.decision).toContain("Short-lived");
+
+    expect(result[1]!.title).toBe("Sticky sessions");
+    expect(result[1]!.status).toBe("rejected");
+    expect(result[1]!.body).toContain("Operationally fragile.");
+
+    expect(result[2]!.title).toBe("Edge caching");
+    expect(result[2]!.status).toBeUndefined();
+    expect(result[2]!.body).toContain("No status declared");
+  });
+
+  it("tolerates a **Status:** line with bold and bracketed value", () => {
+    const result = parseDecisions("### D\n**Status:** [deprecated]\n");
+    expect(result[0]!.status).toBe("deprecated");
+  });
+
+  it("status is case-insensitive on the declared token", () => {
+    const result = parseDecisions("### D\nStatus: Accepted\n");
+    expect(result[0]!.status).toBe("accepted");
+  });
+
+  it("exposes the canonical ADR status vocabulary", () => {
+    expect(DECISION_STATUSES).toEqual([
+      "proposed",
+      "accepted",
+      "rejected",
+      "deprecated",
+      "superseded",
+    ] satisfies DecisionStatus[]);
+  });
+});

--- a/ui/src/components/proposals/blocks/decisions.ts
+++ b/ui/src/components/proposals/blocks/decisions.ts
@@ -1,0 +1,313 @@
+// Pure (React-free) helpers for the ADR-style "Decisions" block. djinn stores a
+// proposal's architecture decisions as the block's *children markdown* — the LLM
+// hand-writes them, NOT as a structured `items={…}` prop (the schema's `items[]`
+// field exists only to guide generation; see the Rust registry in
+// `proposal_blocks.rs`). So this parser folds that freeform markdown into a flat
+// list of decision records, each an ADR card (title + DECLARED status + optional
+// Context/Decision/Consequences sections). Kept in its own module so it is
+// unit-testable without pulling React in.
+//
+// AUTHORING FORMAT (ADR-style):
+//
+//   ### Use JWT for stateless auth
+//   Status: accepted
+//
+//   Context
+//   We need auth that survives horizontal scaling without sticky sessions.
+//
+//   Decision
+//   Adopt short-lived JWTs validated at the edge.
+//
+//   Consequences
+//   No central session store; revocation needs a denylist.
+//
+// Rules this parser enforces:
+//   • A `## Title` / `### Title` heading starts each decision card. A status may
+//     also be DECLARED inline on the heading as a `[accepted]` marker.
+//   • Status is read ONLY from an explicit declared token — a `Status: <token>`
+//     line directly under the heading, or an inline `[<token>]` heading marker.
+//     The token must be one of the ADR vocabulary words (`proposed`, `accepted`,
+//     `rejected`, `deprecated`, `superseded`). It is NEVER inferred from English
+//     prose in the body. No declared token ⇒ `status` is `undefined` (no badge).
+//   • A `superseded` decision may name what supersedes it: `Status: superseded by
+//     #3` (or `… by ADR-3`, `… by the event-bus decision`). The trailing text is
+//     surfaced as `supersededBy`.
+//   • Optional ADR sub-sections `Context`, `Decision`, `Consequences` (as their
+//     own sub-heading line or a `Context:` label) are split out; anything else is
+//     the freeform `body`.
+//
+// Empty / heading-less input yields `[]` so the caller can fall back to the raw
+// markdown render. Never throws.
+
+/* ── Public types ──────────────────────────────────────────────────────────── */
+
+/** The ADR status vocabulary. Status is DECLARED, never inferred from prose. */
+export type DecisionStatus =
+  | "proposed"
+  | "accepted"
+  | "rejected"
+  | "deprecated"
+  | "superseded";
+
+/** The ordered, canonical ADR status tokens (for validation + docs). */
+export const DECISION_STATUSES: readonly DecisionStatus[] = [
+  "proposed",
+  "accepted",
+  "rejected",
+  "deprecated",
+  "superseded",
+];
+
+/** The optional ADR sub-sections parsed out of a decision body. */
+export interface DecisionSections {
+  /** "Context" — the forces / problem that motivated the decision. */
+  context?: string;
+  /** "Decision" — what was decided. */
+  decision?: string;
+  /** "Consequences" — the resulting trade-offs. */
+  consequences?: string;
+}
+
+/** One parsed ADR decision card. */
+export interface ParsedDecision {
+  /** The decision title (heading text, status marker stripped). */
+  title: string;
+  /** The DECLARED status, or `undefined` when none was declared. */
+  status?: DecisionStatus;
+  /**
+   * For a `superseded` decision, the trailing text naming what supersedes it
+   * (e.g. `#3`, `ADR-7`, `the event-bus decision`). Undefined otherwise.
+   */
+  supersededBy?: string;
+  /** Parsed ADR sub-sections, when the body uses Context/Decision/Consequences. */
+  sections?: DecisionSections;
+  /**
+   * The freeform body markdown when no ADR sub-sections were found (or the
+   * residual prose before the first sub-section). Undefined when empty.
+   */
+  body?: string;
+}
+
+/* ── Status-token detection (DECLARED only) ─────────────────────────────────── */
+
+/** Lowercase lookup of the valid status tokens. */
+const STATUS_SET = new Set<string>(DECISION_STATUSES);
+
+/** Coerce an arbitrary token to a `DecisionStatus`, or `undefined` if invalid. */
+function asStatus(token: string | undefined): DecisionStatus | undefined {
+  const t = token?.trim().toLowerCase();
+  return t && STATUS_SET.has(t) ? (t as DecisionStatus) : undefined;
+}
+
+/**
+ * Parse a declared status value such as `accepted`, `superseded by #3`, or
+ * `[rejected]`. Returns the matched status plus any trailing "by …" text. Returns
+ * `undefined` status when the leading word isn't a valid ADR token (do NOT guess).
+ */
+function parseStatusValue(raw: string): {
+  status?: DecisionStatus;
+  supersededBy?: string;
+} {
+  const cleaned = raw.trim().replace(/[.;,]+$/, "");
+  // Leading token = the status word; the remainder is the optional "by …" tail.
+  const m = /^([A-Za-z-]+)\b\s*(.*)$/.exec(cleaned);
+  if (!m) return {};
+  const status = asStatus(m[1]);
+  if (!status) return {};
+  let tail = (m[2] ?? "").trim();
+  if (status === "superseded" && tail) {
+    // Drop a leading "by" connector: `superseded by #3` → `#3`.
+    tail = tail.replace(/^by\s+/i, "").trim();
+    return { status, supersededBy: tail || undefined };
+  }
+  return { status };
+}
+
+/* ── Heading + status-line detection ────────────────────────────────────────── */
+
+/** A markdown heading line `## …` / `### …` (we accept any depth as a card start). */
+const HEADING = /^\s*(#{1,6})\s+(.+?)\s*$/;
+
+/**
+ * A `Status: <token>` declaration line. Tolerates `Status -`, `**Status:**`, and
+ * a bracketed value. Captures the raw value for {@link parseStatusValue}.
+ */
+const STATUS_LINE =
+  /^\s*\*{0,2}status\*{0,2}\s*[:=-]\s*\*{0,2}\s*\[?\s*([^\]\n]+?)\s*\]?\s*\*{0,2}\s*$/i;
+
+/**
+ * An inline status marker on a heading line: a trailing `[accepted]` /
+ * `(accepted)`. Returns the parsed status + the heading with the marker removed.
+ * Only fires for a valid ADR token so a real bracketed title word is left alone.
+ */
+function extractHeadingStatus(title: string): {
+  title: string;
+  status?: DecisionStatus;
+  supersededBy?: string;
+} {
+  const m = /^(.*?)\s*[[(]\s*([^\])]+?)\s*[\])]\s*$/.exec(title.trim());
+  if (m) {
+    const parsed = parseStatusValue(m[2] ?? "");
+    if (parsed.status) {
+      return { title: (m[1] ?? "").trim(), ...parsed };
+    }
+  }
+  return { title: title.trim() };
+}
+
+/* ── ADR sub-section detection ──────────────────────────────────────────────── */
+
+/** The recognised ADR sub-section labels, keyed to the `DecisionSections` field. */
+const SECTION_KEYS: Record<string, keyof DecisionSections> = {
+  context: "context",
+  decision: "decision",
+  consequences: "consequences",
+};
+
+/**
+ * Detect an ADR sub-section header line: a `Context` / `Decision` / `Consequences`
+ * label, optionally as a markdown heading (`#### Context`), bolded (`**Context**`),
+ * or colon-suffixed (`Context:`). Returns the section key, or `null`.
+ */
+function asSectionHeader(line: string): keyof DecisionSections | null {
+  let t = line.trim();
+  // Strip a leading markdown heading marker.
+  t = t.replace(/^#{1,6}\s+/, "");
+  // Unwrap surrounding bold.
+  t = t.replace(/^\*\*(.+?)\*\*$/, "$1");
+  // Drop a trailing colon.
+  t = t.replace(/:$/, "").trim().toLowerCase();
+  return SECTION_KEYS[t] ?? null;
+}
+
+/* ── Per-decision body parsing ──────────────────────────────────────────────── */
+
+/**
+ * Split a decision's body lines into ADR sub-sections + leftover prose. The
+ * status line (already consumed by the caller) is not present here.
+ */
+function parseBody(lines: string[]): {
+  sections?: DecisionSections;
+  body?: string;
+} {
+  const sections: DecisionSections = {};
+  const lead: string[] = [];
+  let current: keyof DecisionSections | null = null;
+  const buffers: Partial<Record<keyof DecisionSections, string[]>> = {};
+  let sawSection = false;
+
+  for (const raw of lines) {
+    const header = asSectionHeader(raw);
+    if (header) {
+      current = header;
+      sawSection = true;
+      buffers[header] ??= [];
+      continue;
+    }
+    if (current) {
+      buffers[current]!.push(raw);
+    } else {
+      lead.push(raw);
+    }
+  }
+
+  if (sawSection) {
+    for (const key of Object.keys(buffers) as (keyof DecisionSections)[]) {
+      const text = (buffers[key] ?? []).join("\n").trim();
+      if (text) sections[key] = text;
+    }
+  }
+
+  const body = lead.join("\n").trim() || undefined;
+  const hasSections = Object.keys(sections).length > 0;
+  return {
+    sections: hasSections ? sections : undefined,
+    body,
+  };
+}
+
+/* ── Top-level parse ────────────────────────────────────────────────────────── */
+
+/** A heading-delimited raw section: its title line + the body lines beneath it. */
+interface RawCard {
+  title: string;
+  lines: string[];
+}
+
+/**
+ * Parse the freeform <Decisions> body into ADR decision cards. Returns `[]` for
+ * empty/whitespace input, OR when the body has no `##`/`###` headings (so the
+ * caller falls back to the raw markdown render rather than inventing a card).
+ * Never throws.
+ */
+export function parseDecisions(body: string): ParsedDecision[] {
+  if (!body || !body.trim()) return [];
+  const lines = body.replace(/\r\n?/g, "\n").split("\n");
+
+  // Partition into heading-delimited cards. Prose before the first heading is
+  // discarded (it can't belong to a titled decision) — the heading IS the card.
+  const cards: RawCard[] = [];
+  let current: RawCard | null = null;
+  for (const line of lines) {
+    const heading = HEADING.exec(line);
+    // A heading starts a NEW card UNLESS it is an ADR sub-section label written
+    // as a markdown heading (`#### Context`) inside the decision currently being
+    // built — those belong to the open card's body, not a new decision.
+    if (heading && !(current && asSectionHeader(line))) {
+      current = { title: (heading[2] ?? "").trim(), lines: [] };
+      cards.push(current);
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+
+  // No headings at all → let the caller fall back to plain markdown.
+  if (cards.length === 0) return [];
+
+  const decisions: ParsedDecision[] = [];
+  for (const card of cards) {
+    const headingResult = extractHeadingStatus(card.title);
+    const title = headingResult.title;
+    if (!title) continue;
+
+    let status = headingResult.status;
+    let supersededBy = headingResult.supersededBy;
+
+    // Look for a `Status:` line: scan from the top, skipping blank lines, until
+    // the first non-blank line. Status is ONLY honoured when it's that first
+    // content line directly under the heading (declared, not buried in prose).
+    const bodyLines = [...card.lines];
+    let firstContentIdx = -1;
+    for (let i = 0; i < bodyLines.length; i++) {
+      if (bodyLines[i]!.trim() === "") continue;
+      firstContentIdx = i;
+      break;
+    }
+    if (firstContentIdx >= 0) {
+      const statusMatch = STATUS_LINE.exec(bodyLines[firstContentIdx]!);
+      if (statusMatch) {
+        const parsed = parseStatusValue(statusMatch[1] ?? "");
+        // An explicit `Status:` line always wins over an inline heading marker.
+        if (parsed.status) {
+          status = parsed.status;
+          supersededBy = parsed.supersededBy;
+        }
+        // Consume the status line regardless of validity so a declared-but-
+        // misspelled token never leaks into the rendered body.
+        bodyLines.splice(firstContentIdx, 1);
+      }
+    }
+
+    const { sections, body: cardBody } = parseBody(bodyLines);
+
+    decisions.push({
+      title,
+      ...(status ? { status } : {}),
+      ...(supersededBy ? { supersededBy } : {}),
+      ...(sections ? { sections } : {}),
+      ...(cardBody ? { body: cardBody } : {}),
+    });
+  }
+
+  return decisions;
+}


### PR DESCRIPTION
Upgrades the existing `decisions` proposal block from a flat markdown passthrough into ADR-style decision cards with DECLARED status badges. Render-only — NOT a new block type (no BlockType variant, canonical tag lists/counts untouched, schema snapshot unchanged).

## Authoring format (declared status only — never inferred from prose)
- One decision per `### Title` (or `## Title`) heading.
- Status DECLARED via a `Status: <token>` line directly under the heading, or an inline `[token]` marker on the heading. Vocabulary: `proposed` · `accepted` · `rejected` · `deprecated` · `superseded`. No declared token ⇒ no badge.
- `Status: superseded by #3` surfaces the replacement as muted text.
- Optional ADR sub-sections `Context` / `Decision` / `Consequences` (plain label, `Context:`, `**Decision**`, or `#### Consequences`); otherwise freeform markdown body.
- Graceful fallback to `BlockMarkdown` when children have no headings — never throws, never blanks.

## Status → color
proposed=slate · accepted=emerald · rejected=red · deprecated=amber · superseded=violet (via `blockBadgeColors` ACCENT_BADGE).

## Files
- `ui/src/components/proposals/blocks/decisions.ts` (new) — React-free parser.
- `ui/src/components/proposals/blocks/decisions.test.ts` (new) — 17 cases.
- `ui/src/components/proposals/blocks/DecisionsBlock.tsx` — flattened cards (divide-y rows, one BlockShell, like Open Questions).
- `server/crates/djinn-control-plane/src/tools/proposal_blocks.rs` — `decisions` entry converted `block(...)` → `block_with_description(...)`; documents the authoring format. Fields shape unchanged → no snapshot churn.
- `ui/.../__fixtures__/canonicalProposal.mdx` — existing `decisions` instance enriched with 3 ADR cards (QuestionForm stays last).

## Verification
- UI: `decisions.test.ts` 17/17, full blocks suite 311/311, `tsc -b` clean, eslint clean on changed files.
- Rust: `cargo test -p djinn-control-plane --lib proposal_blocks` 29/29 (incl. `registry.len() == 15`), `tool_schemas` snapshot passed WITHOUT update, clippy clean.
- No migration. Block-type count unchanged (15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)