### PR TITLE
fix(chat): drive chat model picker from the Plan lane, not all lanes

### DIFF
--- a/ui/src/components/chat/ChatView.tsx
+++ b/ui/src/components/chat/ChatView.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchProviderModels, type ProviderModel } from '@/api/settings';
 import { userSettingsQueryOptions } from '@/api/queryOptions';
-import { lanesUnion } from '@/api/userSettings';
 import { sendChatMessage } from '@/api/chat';
 import { getChatSessionMessages } from '@/api/chatSessions';
 import { Shimmer } from '@/components/ai-elements/shimmer';
@@ -86,12 +85,13 @@ export function ChatView() {
   const { data: userSettings } = useQuery(userSettingsQueryOptions());
 
   // Order/filter the connected (tool_call-capable) models by the user's
-  // per-user, per-role lane selection. Chat is not role-scoped, so we take the
-  // distinct union across all lanes: when non-empty, show exactly those ids in
-  // priority order, dropping any that aren't connected. When empty, fall back
-  // to the full connected list.
+  // per-user, per-role lane selection. Chat is a plan/reason activity, so it
+  // follows the Plan lane only: when non-empty, show exactly those ids in
+  // priority order, dropping any that aren't connected. When empty (user has
+  // nothing in the plan lane), fall back to the full connected list so chat is
+  // never left with zero models.
   const models = useMemo<ProviderModel[]>(() => {
-    const selection = userSettings ? lanesUnion(userSettings.lanes) : [];
+    const selection = userSettings ? userSettings.lanes.plan : [];
     if (selection.length === 0) return connectedModels;
     const byId = new Map(connectedModels.map((m) => [m.id, m]));
     const ordered: ProviderModel[] = [];


### PR DESCRIPTION
## Bug
The chat composer's model picker listed **all** of the user's connected flagship models, but chat is a plan/reason activity and should follow the user's **Model Roles → Plan lane** only. A user whose Plan lane is just `gpt-5.5` still saw every connected model in the chat picker.

Root cause: in `ui/src/components/chat/ChatView.tsx`, the `models` memo built its selection from `lanesUnion(userSettings.lanes)` (which merges the plan + implement + review lanes) instead of just the plan lane.

## The fix (one spot, UI only)
The server is already correct — chat doesn't route through dispatch, so this is purely a picker-population bug.

In `ChatView.tsx`, the model-selection source changed from the union of all lanes to just the plan lane:
```diff
-    const selection = userSettings ? lanesUnion(userSettings.lanes) : [];
+    const selection = userSettings ? userSettings.lanes.plan : [];
```
The now-unused `lanesUnion` import was removed from this file. (`lanesUnion` itself stays in `ui/src/api/userSettings.ts` — the onboarding gate still uses it.)

## Fallback behavior (preserved)
If the plan-lane selection is empty (user has nothing in the Plan lane), the memo still falls back to the full `connectedModels` list, so the chat picker is never left with zero models. The default-model effect picks `modelOptions[0]`, which is now the plan-lane primary.

**Net effect:** a user whose Plan lane is just `gpt-5.5` now sees only GPT-5.5 in the chat picker, matching their settings.

## Verification
- `tsc -b` — clean (exit 0)
- vitest (chat-related: `chat.test.ts`, `chatStore.test.ts`, `components/chat/`) — 21 passed
- Full production `pnpm build` (vite) — succeeded
- eslint on the touched file — only 3 pre-existing `Date.now()` purity errors (identical count on `origin/main`, untouched lines; not introduced by this change)