### PR TITLE
feat(usage): price subscription-plan models + break out token KPI

### DIFF
--- a/server/crates/djinn-provider/src/catalog/service.rs
+++ b/server/crates/djinn-provider/src/catalog/service.rs
@@ -442,6 +442,11 @@ fn normalize(raw: HashMap<String, RawProvider>) -> (Vec<Provider>, HashMap<Strin
         providers.push(provider);
     }
 
+    // Borrow pay-as-you-go pricing into flat-rate plan providers so their usage
+    // is no longer dropped from spend analytics. Runs on every (re)load — both
+    // the embedded snapshot and live refresh paths go through `normalize`.
+    enrich_plan_pricing(&mut models_idx);
+
     providers.sort_by(|a, b| a.id.cmp(&b.id));
     (providers, models_idx)
 }
@@ -466,6 +471,78 @@ const MODEL_SOURCE_MAP: &[(&str, &str, Option<&str>)] = &[
     ("claude-code", "anthropic", None),
     ("gemini-cli", "google", None),
 ];
+
+// ── Plan → pay-as-you-go pricing reference mapping ────────────────────────────
+//
+// Consumer coding/token plans (e.g. `zai-coding-plan`) are billed as a flat
+// monthly subscription, so models.dev carries their models with all-zero
+// pricing. That makes their usage show as "unpriced" in spend analytics even
+// though the *same* underlying model has a published pay-as-you-go rate under
+// its first-party provider (e.g. `zai/glm-5`). We borrow that rate as the
+// public-API-rate ESTIMATE the usage dashboard already advertises ("Est. at
+// public API rates") so subscription usage is no longer silently dropped from
+// the spend stack.
+//
+// This deliberately mirrors [`MODEL_SOURCE_MAP`]: an explicit, auditable list
+// rather than a fuzzy heuristic. A plan model is only enriched when (a) its own
+// catalog pricing is all-zero and (b) the base provider exposes a model with a
+// matching canonical id that *is* priced. Plan-only models with no priced
+// counterpart (e.g. a `k2p7` whose base id is `kimi-k2.7`) stay unpriced —
+// unknown is never silently encoded as $0.
+//
+// (plan_provider_id, pay-as-you-go_provider_id)
+const PRICING_REFERENCE_MAP: &[(&str, &str)] = &[
+    ("zai-coding-plan", "zai"),
+    ("zhipuai-coding-plan", "zhipuai"),
+    ("minimax-coding-plan", "minimax"),
+    ("minimax-cn-coding-plan", "minimax-cn"),
+    ("kimi-for-coding", "moonshotai"),
+    ("xiaomi-token-plan-sgp", "xiaomi"),
+    ("xiaomi-token-plan-cn", "xiaomi"),
+    ("xiaomi-token-plan-ams", "xiaomi"),
+];
+
+/// Strip non-alphanumeric chars and lowercase so plan/base model ids match
+/// across cosmetic spelling differences (`MiniMax-M2.5` ↔ `minimax-m2.5`).
+fn canonical_model_id(id: &str) -> String {
+    id.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+/// Borrow pay-as-you-go pricing into flat-rate plan providers' zero-priced
+/// models (see [`PRICING_REFERENCE_MAP`]). Mutates `models_idx` in place. Only
+/// fills a plan model whose own pricing is all-zero, and only from a base model
+/// that is itself priced — existing pricing is never overwritten.
+fn enrich_plan_pricing(models_idx: &mut HashMap<String, Vec<Model>>) {
+    for (plan_id, base_id) in PRICING_REFERENCE_MAP {
+        // Index the base provider's priced models by canonical id.
+        let Some(base_models) = models_idx.get(*base_id) else {
+            continue;
+        };
+        let base_pricing: HashMap<String, Pricing> = base_models
+            .iter()
+            .filter(|m| has_nonzero_pricing(&m.pricing))
+            .map(|m| (canonical_model_id(&m.id), m.pricing.clone()))
+            .collect();
+        if base_pricing.is_empty() {
+            continue;
+        }
+
+        let Some(plan_models) = models_idx.get_mut(*plan_id) else {
+            continue;
+        };
+        for m in plan_models.iter_mut() {
+            if has_nonzero_pricing(&m.pricing) {
+                continue;
+            }
+            if let Some(pricing) = base_pricing.get(&canonical_model_id(&m.id)) {
+                m.pricing = pricing.clone();
+            }
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -687,6 +764,86 @@ mod tests {
             .expect("injected provider should exist");
         assert_eq!(injected.name, "Test Builtin");
         assert!(!injected.is_openai_compatible);
+    }
+
+    #[test]
+    fn enrich_plan_pricing_borrows_payg_rates_for_zero_priced_plan_models() {
+        // zero-priced plan model + matching priced base model → borrowed.
+        // zero-priced plan model with no base match → stays unpriced.
+        // already-priced plan model → never overwritten.
+        let zero = Pricing::default();
+        let base = Pricing {
+            input_per_million: 1.0,
+            output_per_million: 3.2,
+            cache_read_per_million: 0.2,
+            cache_write_per_million: 0.0,
+        };
+        let mk = |provider: &str, id: &str, pricing: Pricing| Model {
+            id: id.to_string(),
+            provider_id: provider.to_string(),
+            name: id.to_string(),
+            tool_call: true,
+            reasoning: true,
+            attachment: false,
+            context_window: 0,
+            output_limit: 0,
+            pricing,
+        };
+
+        let mut idx: HashMap<String, Vec<Model>> = HashMap::new();
+        // Base pay-as-you-go provider — note the cosmetic id-casing difference.
+        idx.insert("zai".to_string(), vec![mk("zai", "GLM-5", base.clone())]);
+        idx.insert(
+            "zai-coding-plan".to_string(),
+            vec![
+                mk("zai-coding-plan", "glm-5", zero.clone()), // canonical match → borrowed
+                mk("zai-coding-plan", "glm-only-plan", zero.clone()), // no base match → stays unpriced
+                mk("zai-coding-plan", "glm-paid", base.clone()), // already priced → untouched
+            ],
+        );
+
+        enrich_plan_pricing(&mut idx);
+
+        let plan = &idx["zai-coding-plan"];
+        let borrowed = plan.iter().find(|m| m.id == "glm-5").unwrap();
+        assert!(
+            has_nonzero_pricing(&borrowed.pricing),
+            "glm-5 should inherit zai/GLM-5 pricing"
+        );
+        assert_eq!(borrowed.pricing.input_per_million, 1.0);
+        assert_eq!(borrowed.pricing.output_per_million, 3.2);
+
+        let unmatched = plan.iter().find(|m| m.id == "glm-only-plan").unwrap();
+        assert!(
+            !has_nonzero_pricing(&unmatched.pricing),
+            "a plan-only model with no priced base counterpart stays unpriced"
+        );
+
+        let already = plan.iter().find(|m| m.id == "glm-paid").unwrap();
+        assert_eq!(
+            already.pricing.input_per_million, base.input_per_million,
+            "existing pricing must never be overwritten"
+        );
+    }
+
+    #[test]
+    fn enrich_plan_pricing_runs_during_normalize() {
+        // End-to-end through the public seed path: the embedded snapshot's
+        // zai-coding-plan models should resolve real pricing borrowed from `zai`
+        // (both are models.dev-native), so they're no longer "unpriced".
+        let catalog = CatalogService::new();
+        let plan_models = catalog.list_models("zai-coding-plan");
+        if plan_models.is_empty() {
+            return; // snapshot may not carry the plan provider; nothing to assert.
+        }
+        let pricing_map = catalog.pricing_for_all_models();
+        let any_priced = plan_models.iter().any(|m| {
+            pricing_map.contains_key(&format!("zai-coding-plan/{}", m.id))
+        });
+        assert!(
+            any_priced,
+            "at least one zai-coding-plan model should be priced via the zai reference map"
+        );
     }
 
     #[test]

--- a/server/src/server/usage_analytics.rs
+++ b/server/src/server/usage_analytics.rs
@@ -253,6 +253,19 @@ struct UsageKpiDto {
     /// when the card needs no caption.
     #[serde(skip_serializing_if = "Option::is_none")]
     caption: Option<String>,
+    /// Optional composition of the headline value (e.g. the Tokens card split
+    /// into input / cached / output). The UI renders these as a small inline
+    /// row beneath the value. `None` when the card has no breakdown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    breakdown: Option<Vec<UsageKpiPartDto>>,
+}
+
+/// One labelled component of a KPI's headline value (see
+/// [`UsageKpiDto::breakdown`]). The UI formats `value` as a compact number.
+#[derive(Serialize)]
+struct UsageKpiPartDto {
+    label: String,
+    value: f64,
 }
 
 /// A point in the multi-dimensional time series.  Carries the model / project /
@@ -418,6 +431,7 @@ fn build_kpis(totals: &UsageTotals, previous: &UsageTotals) -> Vec<UsageKpiDto> 
                 .map(format_currency)
                 .unwrap_or_default(),
             caption: Some(spend_caption(totals.unpriced_session_count)),
+            breakdown: None,
         },
         UsageKpiDto {
             label: "Tokens".to_string(),
@@ -425,6 +439,24 @@ fn build_kpis(totals: &UsageTotals, previous: &UsageTotals) -> Vec<UsageKpiDto> 
             delta_pct: pct_delta(tokens, prev_tokens),
             formatted: String::new(),
             caption: None,
+            // Split the headline token count into the three meaningful buckets:
+            // fresh input, cache-read (cached input), and output. Cache-read is
+            // tracked separately from `tokens_in`, so this is purely additive
+            // context, not a re-slice of the `tokens` total.
+            breakdown: Some(vec![
+                UsageKpiPartDto {
+                    label: "Input".to_string(),
+                    value: totals.tokens_in as f64,
+                },
+                UsageKpiPartDto {
+                    label: "Cached".to_string(),
+                    value: totals.cache_read_tokens as f64,
+                },
+                UsageKpiPartDto {
+                    label: "Output".to_string(),
+                    value: totals.tokens_out as f64,
+                },
+            ]),
         },
         UsageKpiDto {
             label: "Sessions".to_string(),
@@ -432,6 +464,7 @@ fn build_kpis(totals: &UsageTotals, previous: &UsageTotals) -> Vec<UsageKpiDto> 
             delta_pct: pct_delta(totals.session_count as f64, previous.session_count as f64),
             formatted: String::new(),
             caption: None,
+            breakdown: None,
         },
         UsageKpiDto {
             label: "Cache reads".to_string(),
@@ -442,6 +475,7 @@ fn build_kpis(totals: &UsageTotals, previous: &UsageTotals) -> Vec<UsageKpiDto> 
             ),
             formatted: String::new(),
             caption: None,
+            breakdown: None,
         },
     ]
 }

--- a/ui/src/api/analytics.ts
+++ b/ui/src/api/analytics.ts
@@ -37,6 +37,11 @@ export interface UsageAnalyticsFilters {
 
 // ── Response types ─────────────────────────────────────────────────────────
 
+export interface UsageKpiPart {
+  label: string;
+  value: number;
+}
+
 export interface UsageKpi {
   label: string;
   value: number | null;
@@ -46,6 +51,8 @@ export interface UsageKpi {
   formatted: string;
   /** Optional qualifier shown under the value (e.g. spend estimate basis). */
   caption?: string | null;
+  /** Optional composition of the value (e.g. Tokens → input / cached / output). */
+  breakdown?: UsageKpiPart[] | null;
 }
 
 export interface UsageTimeSeriesPoint {

--- a/ui/src/components/usage/UsageOverviewTab.tsx
+++ b/ui/src/components/usage/UsageOverviewTab.tsx
@@ -211,6 +211,22 @@ function KpiCard({ kpi }: { kpi: UsageKpi }) {
           {kpi.caption}
         </p>
       )}
+      {kpi.breakdown && kpi.breakdown.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+          {kpi.breakdown.map((part) => (
+            <span
+              key={part.label}
+              className="text-[11px] text-muted-foreground"
+              title={`${part.label}: ${part.value.toLocaleString()}`}
+            >
+              {part.label}{" "}
+              <span className="tabular-nums font-medium text-foreground">
+                {formatCompactNumber(part.value)}
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
       <div
         className={cn(
           "mt-2 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",


### PR DESCRIPTION
## Why

The Usage & Analytics dashboard showed pricing **only** for OpenAI — every
subscription/coding-plan model (zai-coding-plan, minimax-coding-plan,
kimi-for-coding, xiaomi-token-plan, zhipuai-coding-plan, …) was dropped from the
spend stack as "unpriced". Root cause: models.dev carries those flat-rate plans
with all-zero per-token pricing, while the **same underlying model** has a
published pay-as-you-go rate under its first-party provider (`zai/glm-5` =
\$1/\$3.2/\$0.2, `minimax/MiniMax-M2.5` = \$0.3/\$1.2/\$0.03/\$0.375, …). OpenAI
worked only because `chatgpt_codex` already re-sources its models (with pricing)
from `openai` via `MODEL_SOURCE_MAP`.

## What

**Pricing (forward-only):**
- New `PRICING_REFERENCE_MAP` (plan → pay-as-you-go provider), mirroring the
  existing `MODEL_SOURCE_MAP` philosophy — explicit and auditable, not a fuzzy
  heuristic.
- `enrich_plan_pricing()` runs inside `normalize()` (so it covers **both** the
  embedded snapshot and live models.dev refresh). It borrows a base provider's
  rate into a plan model only when the plan model's own pricing is all-zero
  **and** a base model with a matching canonical id is itself priced.
- Existing pricing is never overwritten; plan-only models with no priced
  counterpart (e.g. a `k2p7` whose base id is `kimi-k2.7`) stay unpriced —
  unknown is never silently encoded as \$0.
- Flows through `find_model()` (new sessions snapshot real pricing) and
  `pricing_for_all_models()` (startup backfill map).
- **Forward-only by design.** Historical sessions keep their stored snapshot;
  the VPS data will be fixed by hand out of band.

**Token KPI breakdown:**
- The "Tokens" card now shows its composition — **Input / Cached / Output** —
  via an optional `breakdown` on the KPI DTO, rendered as a compact inline row.

## Test
- `cargo test -p djinn-provider catalog::service` — added two tests
  (`enrich_plan_pricing_borrows_payg_rates_for_zero_priced_plan_models`,
  `enrich_plan_pricing_runs_during_normalize`); the latter confirms the embedded
  snapshot's `zai-coding-plan` models resolve real pricing end-to-end. All 12 pass.
- `cargo clippy -p djinn-server --lib` clean.
- UI `tsc -b` + `eslint` clean.