### PR TITLE
fix(proposals): code-block line wrap/gutter + djinn-themed mermaid with zoom/pan

### DIFF
--- a/ui/src/components/MermaidDiagram.test.tsx
+++ b/ui/src/components/MermaidDiagram.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import { renderMermaidSVG, THEMES } from "beautiful-mermaid";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { renderMermaidSVG } from "beautiful-mermaid";
 
-import { MermaidDiagram } from "./MermaidDiagram";
+import { DJINN_MERMAID_THEME, MermaidDiagram } from "./MermaidDiagram";
 import { normalizeMermaidSource } from "@/components/proposals/blocks/mermaidNormalize";
 
 // The real repro from the task: a `graph TD` with unicode arrows and node
@@ -30,7 +30,8 @@ describe("beautiful-mermaid render contract", () => {
   it("emits native SVG <text> labels (no <foreignObject>) for the normalized repro", () => {
     const normalized = normalizeMermaidSource(REPRO_SOURCE);
     const svg = renderMermaidSVG(normalized, {
-      ...THEMES["tokyo-night"],
+      ...DJINN_MERMAID_THEME,
+      transparent: true,
       font: "inherit",
     });
 
@@ -45,12 +46,15 @@ describe("beautiful-mermaid render contract", () => {
     }
   });
 
-  it("applies the tokyo-night dark theme background", () => {
+  it("renders transparent (no opaque bg rect) so it blends into the card", () => {
     const svg = renderMermaidSVG("graph TD\n  A[a] --> B[b]", {
-      ...THEMES["tokyo-night"],
+      ...DJINN_MERMAID_THEME,
+      transparent: true,
     });
-    // tokyo-night bg (#1a1b26) — keeps the diagram on djinn's near-black page.
-    expect(svg.toLowerCase()).toContain("#1a1b26");
+    // The blend fix: with transparent:true the renderer must NOT paint the
+    // old tokyo-night band — and the djinn violet accent should be present.
+    expect(svg.toLowerCase()).not.toContain("#1a1b26");
+    expect(svg.toLowerCase()).toContain(DJINN_MERMAID_THEME.accent.toLowerCase());
   });
 });
 
@@ -80,5 +84,54 @@ describe("MermaidDiagram", () => {
 
     const fallback = await screen.findByTestId("mermaid-error");
     expect(fallback).not.toBeNull();
+  });
+});
+
+describe("MermaidDiagram — zoom/pan controls", () => {
+  function scaleOf(el: HTMLElement): number {
+    const t = el.style.transform;
+    const m = /scale\(([\d.]+)\)/.exec(t);
+    return m ? Number(m[1]) : 1;
+  }
+
+  it("exposes zoom-in/out/reset controls; zoom-in scales up and reset restores", async () => {
+    render(<MermaidDiagram source={REPRO_SOURCE} />);
+    await screen.findByTestId("mermaid-diagram");
+    await waitFor(() =>
+      expect(screen.getByTestId("mermaid-controls")).toBeInTheDocument(),
+    );
+
+    const content = screen.getByTestId("mermaid-zoompan-content");
+    expect(scaleOf(content)).toBe(1); // fit-to-width default
+
+    const zoomIn = screen.getByRole("button", { name: "Zoom in" });
+    const zoomOut = screen.getByRole("button", { name: "Zoom out" });
+    const reset = screen.getByRole("button", { name: "Reset zoom" });
+    expect(zoomIn).toBeInTheDocument();
+    expect(zoomOut).toBeInTheDocument();
+    expect(reset).toBeInTheDocument();
+
+    fireEvent.click(zoomIn);
+    await waitFor(() => expect(scaleOf(content)).toBeGreaterThan(1));
+
+    fireEvent.click(reset);
+    await waitFor(() => expect(scaleOf(content)).toBe(1));
+  });
+
+  it("shows a fullscreen toggle by default and hides it when allowFullscreen=false", async () => {
+    const { rerender } = render(<MermaidDiagram source={REPRO_SOURCE} />);
+    await screen.findByTestId("mermaid-diagram");
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Fullscreen" }),
+      ).toBeInTheDocument(),
+    );
+
+    rerender(<MermaidDiagram source={REPRO_SOURCE} allowFullscreen={false} />);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Fullscreen" }),
+      ).toBeNull(),
+    );
   });
 });

--- a/ui/src/components/MermaidDiagram.tsx
+++ b/ui/src/components/MermaidDiagram.tsx
@@ -11,12 +11,21 @@
  * SVG-profile sanitize, so node labels can't be silently stripped (the failure
  * mode of the previous stock-mermaid `<foreignObject>` path).
  *
- * Theme: `tokyo-night` (`#1a1b26` bg) — chosen to sit on djinn's near-black
- * (`oklch(0.141 0.005 285.823)`) dark-only palette without reading as a bright
- * card on a dark page.
+ * Theme: `DJINN_MERMAID_THEME` — a djinn-tokens-derived palette with a
+ * TRANSPARENT background so the diagram BLENDS into the surrounding BlockShell
+ * / card instead of painting an opaque band (the old `tokyo-night` `#1a1b26`
+ * read as a lighter rectangle clashing with `--card`). Text is near-white,
+ * accents/edges are the violet primary, node fills sit a hair above the card.
+ * The stock-mermaid fallback is likewise forced transparent so it blends too.
+ *
+ * Wide-diagram readability: the rendered SVG is wrapped in a zoom/pan surface
+ * (`ZoomPanSurface`) — fit-to-width by default (previous behavior preserved),
+ * with wheel/trackpad zoom, click-drag pan, zoom-in/out/reset controls, and an
+ * optional fullscreen dialog (`allowFullscreen`, default on; `ImpactFlowModal`
+ * omits it since it already lives in a Dialog).
  *
  * Contract:
- *   - props: `{ source: string; className?: string }`,
+ *   - props: `{ source: string; className?: string; allowFullscreen?: boolean }`,
  *   - normalizes unicode arrow/dash glyphs + auto-quotes node labels before
  *     render (LLM-authored sources frequently use `→`/`⟶`/`—` and unquoted
  *     special chars),
@@ -24,9 +33,9 @@
  *   - robust fallback chain so the block is never blank and never throws to the
  *     user:
  *       1. beautiful-mermaid (native `<text>`, themed) — primary,
- *       2. stock mermaid (`htmlLabels:false`, `theme:"dark"`) — secondary, for
- *          diagram types beautiful-mermaid doesn't fully support (e.g. some
- *          sequence diagrams),
+ *       2. stock mermaid (`htmlLabels:false`, `theme:"dark"`, transparent bg) —
+ *          secondary, for diagram types beautiful-mermaid doesn't fully support
+ *          (e.g. some sequence diagrams),
  *       3. the raw source in a styled `<pre>` with a copy-source button.
  *
  * `beautiful-mermaid` pulls ELK.js (heavyish), so consumers lazy-load this
@@ -34,13 +43,36 @@
  * `import()`ed inside the effect.
  *
  * Wrapped in `React.memo` so identical `source` strings don't re-trigger the
- * heavy SVG generation when parents re-render.
+ * heavy SVG generation when parents re-render. The app is DARK-ONLY.
  */
 
-import { memo, useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import DOMPurify from "dompurify";
+import {
+  ArrowExpandIcon,
+  ArrowReloadHorizontalIcon,
+  Cancel01Icon,
+  ZoomInAreaIcon,
+  ZoomOutAreaIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { DiagramFallback } from "@/components/proposals/blocks/DiagramFallback";
 import { normalizeMermaidSource } from "@/components/proposals/blocks/mermaidNormalize";
 
@@ -49,17 +81,45 @@ const SVG_SANITIZE_CONFIG = {
 } as const;
 
 /**
+ * djinn-matched diagram palette, derived from the dark-only theme tokens in
+ * `globals.css` and converted to sRGB hex (beautiful-mermaid wants concrete
+ * colors). Keys map to `RenderOptions`/`DiagramColors`:
+ *   bg      → background. We DON'T set it here; `transparent: true` is passed at
+ *             the call site so the BlockShell/card shows through (the core fix).
+ *             The value below is only a fallback for renderers that ignore
+ *             `transparent` — it's `--card`, so worst case it still blends.
+ *   fg      → primary text / node labels ≈ `--foreground` (near-white).
+ *   muted   → secondary text / edge labels ≈ `--muted-foreground`.
+ *   accent  → arrowheads / highlights = djinn VIOLET (`--primary`).
+ *   line    → edges/connectors: a muted violet-gray with enough contrast.
+ *   surface → node fill: a hair lighter than `--card`.
+ *   border  → node/group stroke: violet-tinted border.
+ */
+export const DJINN_MERMAID_THEME = {
+  bg: "#18181b", // --card (fallback only; we pass transparent:true)
+  fg: "#ededed", // --foreground (near-white)
+  muted: "#9f9fa9", // --muted-foreground
+  accent: "#8650f6", // --primary (violet)
+  line: "#55555b", // muted gray edges
+  surface: "#1f1f22", // a hair lighter than --card
+  border: "#584987", // violet-tinted border
+} as const;
+
+/**
  * Render via beautiful-mermaid (primary path). Dynamically imported so ELK.js
  * only loads when a diagram actually renders. Returns sanitized SVG markup.
  *
  * `renderMermaidSVG` is synchronous and takes `RenderOptions` shaped like the
- * theme's `DiagramColors` (bg/fg/line/accent/muted/…), so we spread the chosen
- * `THEMES[...]` entry directly into the options.
+ * theme's `DiagramColors` (bg/fg/line/accent/muted/surface/border), so we spread
+ * the djinn theme directly and force `transparent` so the card shows through.
  */
 async function renderWithBeautifulMermaid(source: string): Promise<string> {
-  const { renderMermaidSVG, THEMES } = await import("beautiful-mermaid");
+  const { renderMermaidSVG } = await import("beautiful-mermaid");
   const svg = renderMermaidSVG(source, {
-    ...THEMES["tokyo-night"],
+    ...DJINN_MERMAID_THEME,
+    // The core blend fix: no opaque background rectangle on the SVG, so the
+    // surrounding card paints through instead of a clashing band.
+    transparent: true,
     // Defer to page CSS instead of pulling a renderer-specific font.
     font: "inherit",
   });
@@ -70,7 +130,8 @@ let mermaidInitialized = false;
 /**
  * Render via stock mermaid (secondary fallback). `htmlLabels:false` forces
  * native SVG `<text>` so labels survive the SVG-profile sanitize even on this
- * path; `theme:"dark"` matches the app's dark-only palette.
+ * path; `theme:"dark"` matches the app's dark-only palette and a transparent
+ * `themeVariables.background` keeps this path blending into the card too.
  */
 async function renderWithStockMermaid(
   source: string,
@@ -85,6 +146,14 @@ async function renderWithStockMermaid(
       htmlLabels: false,
       flowchart: { htmlLabels: false },
       fontFamily: "inherit",
+      // Blend the fallback into the card: no opaque diagram background.
+      themeVariables: {
+        background: "transparent",
+        primaryColor: DJINN_MERMAID_THEME.surface,
+        primaryTextColor: DJINN_MERMAID_THEME.fg,
+        primaryBorderColor: DJINN_MERMAID_THEME.border,
+        lineColor: DJINN_MERMAID_THEME.line,
+      },
     });
     mermaidInitialized = true;
   }
@@ -96,6 +165,12 @@ export interface MermaidDiagramProps {
   /** Raw Mermaid source (e.g. `flowchart TD\n  a --> b`). */
   source: string;
   className?: string;
+  /**
+   * Whether the zoom/pan controls include a fullscreen toggle. Default `true`
+   * for the standalone proposal `Diagram` block; `ImpactFlowModal` sets this
+   * `false` because it already renders inside a Dialog (avoids nested dialogs).
+   */
+  allowFullscreen?: boolean;
 }
 
 interface RenderState {
@@ -104,14 +179,257 @@ interface RenderState {
   error?: string;
 }
 
-function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
+const MIN_SCALE = 0.5;
+const MAX_SCALE = 4;
+const ZOOM_STEP = 1.25;
+
+interface Transform {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+const IDENTITY: Transform = { scale: 1, x: 0, y: 0 };
+
+function clampScale(s: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
+}
+
+/**
+ * Zoom/pan surface around an already-rendered (sanitized) SVG. Fit-to-width by
+ * default (the SVG keeps `max-w-full h-auto`), then a CSS `transform` (scale +
+ * translate) layers interactive zoom on top — wheel/trackpad to zoom toward the
+ * cursor, click-drag to pan when zoomed in. A tiny overlay exposes zoom-in,
+ * zoom-out, reset(fit) and (optionally) fullscreen. Custom (no zoom/pan dep):
+ * the whole behavior is one transform string + a handful of handlers.
+ */
+function ZoomPanSurface({
+  svg,
+  className,
+  allowFullscreen = true,
+  inFullscreen = false,
+}: {
+  svg: string;
+  className?: string;
+  allowFullscreen?: boolean;
+  inFullscreen?: boolean;
+}) {
+  const [transform, setTransform] = useState<Transform>(IDENTITY);
+  const [fullscreen, setFullscreen] = useState(false);
+  // `dragging` drives the render-time transition toggle (refs can't be read in
+  // render); `dragState` ref holds the live drag math, read only in handlers.
+  const [dragging, setDragging] = useState(false);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const dragState = useRef<{
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+  } | null>(null);
+
+  const reset = useCallback(() => setTransform(IDENTITY), []);
+
+  // Zoom around the viewport center by a multiplicative factor.
+  const zoomBy = useCallback((factor: number) => {
+    setTransform((prev) => {
+      const nextScale = clampScale(prev.scale * factor);
+      if (nextScale === prev.scale) return prev;
+      // Keep the content centered: scale about the viewport center, so the
+      // existing translate is rescaled proportionally.
+      const ratio = nextScale / prev.scale;
+      return { scale: nextScale, x: prev.x * ratio, y: prev.y * ratio };
+    });
+  }, []);
+
+  const onWheel = useCallback(
+    (e: React.WheelEvent) => {
+      // Only hijack the wheel for zoom (don't fight page scroll otherwise).
+      if (!e.ctrlKey && !e.metaKey && Math.abs(e.deltaY) < 1) return;
+      e.preventDefault();
+      const viewport = viewportRef.current;
+      if (!viewport) return;
+      const rect = viewport.getBoundingClientRect();
+      const cx = e.clientX - rect.left - rect.width / 2;
+      const cy = e.clientY - rect.top - rect.height / 2;
+      setTransform((prev) => {
+        const dir = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+        const nextScale = clampScale(prev.scale * dir);
+        if (nextScale === prev.scale) return prev;
+        const ratio = nextScale / prev.scale;
+        // Zoom toward the cursor: the point under the cursor stays put.
+        return {
+          scale: nextScale,
+          x: cx - (cx - prev.x) * ratio,
+          y: cy - (cy - prev.y) * ratio,
+        };
+      });
+    },
+    [],
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (transform.scale <= 1) return; // nothing to pan at fit
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+      dragState.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        originX: transform.x,
+        originY: transform.y,
+      };
+      setDragging(true);
+    },
+    [transform],
+  );
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const drag = dragState.current;
+    if (!drag) return;
+    setTransform((prev) => ({
+      ...prev,
+      x: drag.originX + (e.clientX - drag.startX),
+      y: drag.originY + (e.clientY - drag.startY),
+    }));
+  }, []);
+
+  const endDrag = useCallback(() => {
+    dragState.current = null;
+    setDragging(false);
+  }, []);
+
+  const zoomed = transform.scale > 1;
+
+  const surface = (
+    <div
+      ref={viewportRef}
+      data-testid="mermaid-zoompan-viewport"
+      className={cn(
+        "relative w-full overflow-hidden",
+        zoomed ? "cursor-grab active:cursor-grabbing" : "cursor-default",
+        inFullscreen ? "h-full" : "max-h-[70vh]",
+      )}
+      onWheel={onWheel}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerLeave={endDrag}
+    >
+      <div
+        data-testid="mermaid-zoompan-content"
+        className="flex w-full items-center justify-center [&_svg]:h-auto [&_svg]:max-w-full"
+        style={{
+          transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+          transformOrigin: "center center",
+          transition: dragging ? "none" : "transform 0.08s ease-out",
+        }}
+        // The svg is sanitized upstream; injecting via dangerouslySetInnerHTML
+        // is the standard Mermaid integration pattern.
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+
+      {/* Controls overlay — top-right, compact ghost icon buttons. */}
+      <div
+        className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-border/60 bg-card/80 p-0.5 backdrop-blur"
+        data-testid="mermaid-controls"
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Zoom in"
+          title="Zoom in"
+          onClick={() => zoomBy(ZOOM_STEP)}
+        >
+          <HugeiconsIcon icon={ZoomInAreaIcon} size={14} />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Zoom out"
+          title="Zoom out"
+          onClick={() => zoomBy(1 / ZOOM_STEP)}
+        >
+          <HugeiconsIcon icon={ZoomOutAreaIcon} size={14} />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Reset zoom"
+          title="Reset to fit"
+          onClick={reset}
+        >
+          <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={14} />
+        </Button>
+        {allowFullscreen && !inFullscreen && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Fullscreen"
+            title="Fullscreen"
+            onClick={() => setFullscreen(true)}
+          >
+            <HugeiconsIcon icon={ArrowExpandIcon} size={14} />
+          </Button>
+        )}
+        {inFullscreen && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Exit fullscreen"
+            title="Exit fullscreen"
+            onClick={() => setFullscreen(false)}
+          >
+            <HugeiconsIcon icon={Cancel01Icon} size={14} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className={cn("w-full", className)}>
+      {surface}
+      {allowFullscreen && !inFullscreen && (
+        <Dialog open={fullscreen} onOpenChange={setFullscreen}>
+          <DialogContent
+            className="flex h-[90vh] max-w-[95vw] flex-col gap-2 sm:max-w-[95vw]"
+            data-testid="mermaid-fullscreen"
+          >
+            <DialogHeader>
+              <DialogTitle className="text-sm">Diagram</DialogTitle>
+            </DialogHeader>
+            <div className="min-h-0 flex-1 rounded-md border border-border/40">
+              {/* A fresh ZoomPanSurface in fullscreen mode (its own transform
+                  state, fills the dialog, no nested fullscreen button). */}
+              <ZoomPanSurface
+                svg={svg}
+                allowFullscreen={false}
+                inFullscreen
+                className="h-full"
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  );
+}
+
+function MermaidDiagramImpl({
+  source,
+  className,
+  allowFullscreen = true,
+}: MermaidDiagramProps) {
   // Stable id per instance — stock mermaid uses it as the SVG root id and
   // demands it be unique within the document and start with a letter.
   const reactId = useId();
   const renderId = `mermaid-${reactId.replace(/[^a-zA-Z0-9]/g, "")}`;
 
   const [state, setState] = useState<RenderState>({ status: "idle" });
-  const containerRef = useRef<HTMLDivElement | null>(null);
 
   // Rewrite unicode arrow/dash glyphs to ASCII edge operators + auto-quote
   // node labels before render. Both renderers want valid mermaid grammar.
@@ -174,26 +492,20 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
     );
   }
 
-  return (
-    <div
-      ref={containerRef}
-      data-testid="mermaid-diagram"
-      className={cn(
-        // SVGs render unstyled by default — let parents control sizing via
-        // `className`. Center horizontally so flowcharts don't hug the left
-        // edge of a wide modal.
-        "flex w-full items-center justify-center [&_svg]:max-w-full [&_svg]:h-auto",
-        className,
-      )}
-      // The svg is sanitized above; injecting via dangerouslySetInnerHTML is the
-      // standard Mermaid integration pattern.
-      dangerouslySetInnerHTML={
-        state.status === "ready" ? { __html: state.svg ?? "" } : undefined
-      }
-    >
-      {state.status !== "ready" ? (
+  if (state.status !== "ready" || !state.svg) {
+    return (
+      <div
+        data-testid="mermaid-diagram"
+        className={cn("flex w-full items-center justify-center", className)}
+      >
         <span className="text-xs text-muted-foreground">Rendering diagram…</span>
-      ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="mermaid-diagram" className={cn("w-full", className)}>
+      <ZoomPanSurface svg={state.svg} allowFullscreen={allowFullscreen} />
     </div>
   );
 }
@@ -201,5 +513,7 @@ function MermaidDiagramImpl({ source, className }: MermaidDiagramProps) {
 export const MermaidDiagram = memo(
   MermaidDiagramImpl,
   (prev, next) =>
-    prev.source === next.source && prev.className === next.className,
+    prev.source === next.source &&
+    prev.className === next.className &&
+    prev.allowFullscreen === next.allowFullscreen,
 );

--- a/ui/src/components/codegraph/ImpactFlowModal.tsx
+++ b/ui/src/components/codegraph/ImpactFlowModal.tsx
@@ -140,7 +140,9 @@ export function ImpactFlowModal({ open, onClose, impact }: ImpactFlowModalProps)
               current snapshot.
             </p>
           ) : (
-            <MermaidDiagram source={mermaidSource} />
+            // Already inside a Dialog — omit the nested fullscreen toggle
+            // (zoom/pan still available).
+            <MermaidDiagram source={mermaidSource} allowFullscreen={false} />
           )}
         </div>
 

--- a/ui/src/components/proposals/blocks/CodeBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/CodeBlock.test.tsx
@@ -65,6 +65,22 @@ describe("CodeBlock — line-number alignment", () => {
     expect(row2Text).not.toContain("yanked");
   });
 
+  it("carries the .djinn-code collision-guard hook on its surface", () => {
+    // The Prism `[section]` table-header token ships as `<span class="token
+    // table">`, which collides with Tailwind's global `.table { display: table }`
+    // utility and splits the row (BUG C). The fix is a `.djinn-code .token {
+    // display: inline }` guard in globals.css; jsdom can't compute the Tailwind
+    // layout, but it CAN assert the anchor class stays wired to the surface so
+    // the CSS guard keeps matching. Also assert the colliding token exists.
+    const { container } = render(
+      <CodeBlock language="toml" content={TOML} showLineNumbers />,
+    );
+    expect(container.querySelector(".djinn-code")).not.toBeNull();
+    // The `[advisories]` header tokenized to a `.token.table` span — the exact
+    // class that collides with Tailwind's `.table` utility.
+    expect(container.querySelector(".token.table")).not.toBeNull();
+  });
+
   it("applies per-line props from lineProps to the matching row", () => {
     const { container } = render(
       <CodeBlock

--- a/ui/src/components/proposals/blocks/CodeBlock.tsx
+++ b/ui/src/components/proposals/blocks/CodeBlock.tsx
@@ -96,6 +96,10 @@ export default function CodeBlock({
   return (
     <SyntaxHighlighter
       language={language}
+      // Stable hook for the Prism↔Tailwind token-class collision guard in
+      // globals.css. `useInlineStyles` means RSH never adds a `language-*`
+      // class to the <pre>/<code>, so this is our only reliable CSS anchor.
+      className="djinn-code"
       style={oneDark}
       showLineNumbers={showLineNumbers}
       // Inline line numbers keep each number in its line's own row box.

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -189,3 +189,36 @@ body {
     background: transparent;
   }
 }
+
+/*
+ * Prism ↔ Tailwind class-name collision guard (NOT in a layer, so it wins over
+ * Tailwind's layered utilities).
+ *
+ * react-syntax-highlighter emits Prism token spans with bare class names like
+ * `token table`, `token number`, `token italic`, `token bold`, `token hidden`,
+ * `token inline`, `token block`. Several of those collide with Tailwind utility
+ * classes (`.table { display: table }`, `.hidden`, `.block`, `.inline`, …),
+ * which then re-flow a single source line into multiple visual rows. The TOML
+ * `[section]` header is the worst case: its inner name tokenizes as
+ * `<span class="token table">`, Tailwind's `.table` makes it `display: table`,
+ * and `[` / `advisories` / `]` each break onto their own line — splitting the
+ * row and desyncing the line-number gutter.
+ *
+ * Force every token span inside a highlighted code surface back to inline flow
+ * and neutralize the layout-affecting utilities, so one source line === exactly
+ * one gutter-aligned row regardless of which grammar / token classes Prism
+ * emits. Color/weight tokens still come from the (inline) oneDark styles.
+ *
+ * Anchored on `.djinn-code` (the class CodeBlock puts on its highlighter
+ * surface): because the highlighter renders with inline styles it never adds a
+ * `language-*` class, so `.djinn-code` is the only stable hook.
+ */
+.djinn-code .token {
+  display: inline;
+}
+.djinn-code .token.italic {
+  font-style: italic;
+}
+.djinn-code .token.bold {
+  font-weight: 700;
+}


### PR DESCRIPTION
Batched polish for two SHIPPED proposal blocks, fixing two independent user-reported visual bugs. Independent files; the two fixes are cleanly separated.

## FIX 1 — Code block: short lines split + gutter misalignment
**Symptom:** rendering TOML, the table-header lines split after the `[` — `[advisories]` showed `[` on the numbered line and `advisories]` on an unnumbered line flush to the far-left margin (left of the gutter). Same for `[licenses]`, `[bans]`. The gutter desynced.

**Root cause (reproduced in a real browser via Storybook + Playwright):** Prism's TOML grammar tokenizes the `[section]` inner name as `<span class="token table">`, and Tailwind's global `.table { display: table }` utility **collided with the bare `table` class** — turning the token into a block-level table box so `[`, `advisories`, `]` each broke onto their own visual line (row height 3×) with the overflow reflowing flush-left under the inline line-number. jsdom couldn't reproduce it because it doesn't apply Tailwind's `display:table` layout; the structure was always correct, the bug was purely CSS class-name collision.

**Fix (one rule):** a `.djinn-code .token { display: inline }` collision guard in `globals.css` (plus `.italic`/`.bold` restorations), anchored on a new `djinn-code` class added to the highlighter surface — necessary because inline-styled react-syntax-highlighter never emits a `language-*` class to anchor against. Every logical source line now renders as exactly one gutter-aligned row; long lines still scroll horizontally; numbers stay right-aligned and in sync. Verified in-browser: the 22-line `deny.toml` → 18 uniform 19px rows, numbers 1–18 in order, no splits.

## FIX 2 — Mermaid: theme/background blend + wide-diagram zoom/pan
**(2a) Theme/blend:** the tokyo-night `#1a1b26` opaque background read as a lighter band clashing with djinn's card. Replaced it with `DJINN_MERMAID_THEME` derived from djinn's tokens (sRGB hex):

| role | hex | token |
|------|-----|-------|
| bg (fallback only) | `#18181b` | `--card` |
| fg / text | `#ededed` | `--foreground` |
| muted | `#9f9fa9` | `--muted-foreground` |
| accent / arrows | `#8650f6` | `--primary` (violet) |
| line / edges | `#55555b` | muted gray |
| surface / node fill | `#1f1f22` | hair above `--card` |
| border | `#584987` | violet-tinted |

The core fix is `transparent: true` so the BlockShell/card shows through (no opaque rect). The stock-mermaid fallback is likewise forced transparent via `themeVariables.background`. `font:"inherit"` kept. Verified in-browser: no `#1a1b26` band, violet accent present, diagram blends into the card.

**(2b) Zoom/pan:** wide flowcharts were unreadable when shrunk to fit. Added a **custom, no-dependency** zoom/pan surface (CSS `transform: scale+translate`): mouse-wheel/trackpad zoom toward the cursor, click-drag pan when zoomed in, and a small top-right overlay with zoom-in / zoom-out / reset(fit) buttons (hugeicons) plus a fullscreen toggle. Default view is fit-to-width (previous behavior preserved), zoomable 0.5×–4×. Fullscreen is a `Dialog` gated behind an `allowFullscreen` prop — default on for the proposal `Diagram` block; **`ImpactFlowModal` passes `allowFullscreen={false}`** because it already lives in a Dialog (zoom/pan still available, no nested dialog). The graceful error/copy-source fallback is untouched.

## Tests
- New: CodeBlock collision-guard regression (`.djinn-code` + `.token.table` present); MermaidDiagram transparent-blend assertion + zoom/pan controls (controls present, zoom-in scales up, reset restores) + fullscreen-toggle gating.
- `MermaidDiagram.test.tsx`, `AnnotatedCode.test.tsx`, `CodeBlock.test.tsx`, `blocks.test.ts` all green (full blocks suite: 318 passing). `tsc -b` clean. No new eslint errors on changed files. No Rust/migration changes.