### PR TITLE
feat(usage): price Kimi plan, surface cached tokens, hide empty rows

### DIFF
--- a/server/crates/djinn-db/src/repositories/usage_analytics.rs
+++ b/server/crates/djinn-db/src/repositories/usage_analytics.rs
@@ -41,6 +41,8 @@ pub struct ModelEffectivenessRow {
     pub spend_usd: Option<f64>,
     pub tokens_in: i64,
     pub tokens_out: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    pub cache_read_tokens: i64,
     /// Shared-credit completed-task count: number of distinct completed tasks
     /// that had at least one worker session using this model.
     pub shared_credit_completed_task_count: i64,
@@ -75,6 +77,8 @@ pub struct ProjectModelMatrixRow {
     pub spend_usd: Option<f64>,
     pub tokens_in: i64,
     pub tokens_out: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    pub cache_read_tokens: i64,
     /// Distinct tasks touched by this cell's sessions.
     pub task_count: i64,
     /// Fraction of closed tasks that completed successfully (0.0–1.0).
@@ -221,6 +225,8 @@ pub struct SeriesDetailRow {
     pub session_count: i64,
     pub tokens_in: i64,
     pub tokens_out: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    pub cache_read_tokens: i64,
     /// Distinct tasks touched in this bucket.
     pub task_count: i64,
     /// Aggregate cost in USD.  `None` when any session in the bucket was
@@ -240,6 +246,8 @@ pub struct EntityBreakdownRow {
     pub cost: Option<f64>,
     pub tokens_in: i64,
     pub tokens_out: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    pub cache_read_tokens: i64,
     /// Distinct tasks attributed to this entity.
     pub task_count: i64,
     /// Fraction of closed tasks that completed successfully (0.0–1.0).
@@ -391,6 +399,7 @@ impl UsageAnalyticsRepository {
                 COUNT(*)                                       AS session_count, \
                 COALESCE(SUM(s.tokens_in)::bigint, 0)          AS tokens_in, \
                 COALESCE(SUM(s.tokens_out)::bigint, 0)         AS tokens_out, \
+                COALESCE(SUM(s.cache_read_tokens)::bigint, 0)  AS cache_read_tokens, \
                 COUNT(DISTINCT s.task_id)                      AS task_count, \
                 SUM(s.cost_usd)                                AS cost \
              FROM sessions s \
@@ -416,6 +425,7 @@ impl UsageAnalyticsRepository {
                 session_count: r.get("session_count"),
                 tokens_in: r.get("tokens_in"),
                 tokens_out: r.get("tokens_out"),
+                cache_read_tokens: r.get("cache_read_tokens"),
                 task_count: r.get("task_count"),
                 cost: r.get("cost"),
             })
@@ -446,7 +456,7 @@ impl UsageAnalyticsRepository {
                 SELECT \
                     {key_expr}  AS entity_id, \
                     {name_expr} AS entity_name, \
-                    s.cost_usd, s.tokens_in, s.tokens_out, s.task_id, \
+                    s.cost_usd, s.tokens_in, s.tokens_out, s.cache_read_tokens, s.task_id, \
                     t.status, t.close_reason, t.total_reopen_count \
                 FROM sessions s {joins} {where_clause} \
              ), \
@@ -457,6 +467,7 @@ impl UsageAnalyticsRepository {
                     SUM(cost_usd) AS cost, \
                     COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
                     COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out, \
+                    COALESCE(SUM(cache_read_tokens)::bigint, 0) AS cache_read_tokens, \
                     COUNT(DISTINCT task_id) AS task_count \
                 FROM base GROUP BY entity_id \
              ), \
@@ -480,6 +491,7 @@ impl UsageAnalyticsRepository {
                  sess.cost         AS cost, \
                  sess.tokens_in    AS tokens_in, \
                  sess.tokens_out   AS tokens_out, \
+                 sess.cache_read_tokens AS cache_read_tokens, \
                  sess.task_count   AS task_count, \
                  CASE WHEN ta.closed_count > 0 \
                       THEN ta.completed_count::DOUBLE PRECISION / ta.closed_count::DOUBLE PRECISION \
@@ -502,6 +514,7 @@ impl UsageAnalyticsRepository {
                 cost: r.get("cost"),
                 tokens_in: r.get("tokens_in"),
                 tokens_out: r.get("tokens_out"),
+                cache_read_tokens: r.get("cache_read_tokens"),
                 task_count: r.get("task_count"),
                 success_rate: r.get("success_rate"),
                 avg_reopens: r.get("avg_reopens"),
@@ -584,6 +597,7 @@ impl UsageAnalyticsRepository {
             "WITH filtered_sessions AS ( \
                 SELECT \
                     s.model_id, s.task_id, s.cost_usd, s.tokens_in, s.tokens_out, \
+                    s.cache_read_tokens, \
                     t.status, t.close_reason, t.total_reopen_count \
                 {from_clause} {where_clause} \
              ), \
@@ -593,7 +607,8 @@ impl UsageAnalyticsRepository {
                     COUNT(*) AS sessions, \
                     SUM(cost_usd) AS spend_usd, \
                     COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
-                    COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out \
+                    COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out, \
+                    COALESCE(SUM(cache_read_tokens)::bigint, 0) AS cache_read_tokens \
                 FROM filtered_sessions \
                 GROUP BY model_id \
              ), \
@@ -617,6 +632,7 @@ impl UsageAnalyticsRepository {
                  sa.spend_usd                    AS spend_usd, \
                  sa.tokens_in                    AS tokens_in, \
                  sa.tokens_out                   AS tokens_out, \
+                 sa.cache_read_tokens            AS cache_read_tokens, \
                  COALESCE(ta.completed_count, 0) AS shared_credit_completed_task_count, \
                  CASE WHEN ta.closed_count > 0 \
                       THEN ta.completed_count::DOUBLE PRECISION / ta.closed_count::DOUBLE PRECISION \
@@ -655,6 +671,7 @@ impl UsageAnalyticsRepository {
                     spend_usd,
                     tokens_in,
                     tokens_out,
+                    cache_read_tokens: r.get("cache_read_tokens"),
                     shared_credit_completed_task_count: completed,
                     success_rate: r.get("success_rate"),
                     avg_reopens: r.get("avg_reopens"),
@@ -682,7 +699,7 @@ impl UsageAnalyticsRepository {
                     COALESCE(s.project_id, '') AS project_id, \
                     COALESCE(p.name, '')       AS project_name, \
                     s.model_id                 AS model_id, \
-                    s.cost_usd, s.tokens_in, s.tokens_out, s.task_id, \
+                    s.cost_usd, s.tokens_in, s.tokens_out, s.cache_read_tokens, s.task_id, \
                     t.status, t.close_reason, t.total_reopen_count \
                 FROM sessions s \
                 LEFT JOIN projects p ON p.id = s.project_id \
@@ -696,6 +713,7 @@ impl UsageAnalyticsRepository {
                     SUM(cost_usd) AS spend_usd, \
                     COALESCE(SUM(tokens_in)::bigint, 0)  AS tokens_in, \
                     COALESCE(SUM(tokens_out)::bigint, 0) AS tokens_out, \
+                    COALESCE(SUM(cache_read_tokens)::bigint, 0) AS cache_read_tokens, \
                     COUNT(DISTINCT task_id) AS task_count \
                 FROM base GROUP BY project_id, model_id \
              ), \
@@ -722,6 +740,7 @@ impl UsageAnalyticsRepository {
                  sess.spend_usd    AS spend_usd, \
                  sess.tokens_in    AS tokens_in, \
                  sess.tokens_out   AS tokens_out, \
+                 sess.cache_read_tokens AS cache_read_tokens, \
                  sess.task_count   AS task_count, \
                  CASE WHEN ta.closed_count > 0 \
                       THEN ta.completed_count::DOUBLE PRECISION / ta.closed_count::DOUBLE PRECISION \
@@ -746,6 +765,7 @@ impl UsageAnalyticsRepository {
                 spend_usd: r.get("spend_usd"),
                 tokens_in: r.get("tokens_in"),
                 tokens_out: r.get("tokens_out"),
+                cache_read_tokens: r.get("cache_read_tokens"),
                 task_count: r.get("task_count"),
                 success_rate: r.get("success_rate"),
                 avg_reopens: r.get("avg_reopens"),
@@ -871,6 +891,7 @@ mod tests {
             spend_usd: Some(1.23),
             tokens_in: 100,
             tokens_out: 50,
+            cache_read_tokens: 40,
             shared_credit_completed_task_count: 3,
             success_rate: Some(0.67),
             avg_reopens: Some(0.5),

--- a/server/crates/djinn-provider/src/catalog/service.rs
+++ b/server/crates/djinn-provider/src/catalog/service.rs
@@ -502,6 +502,23 @@ const PRICING_REFERENCE_MAP: &[(&str, &str)] = &[
     ("xiaomi-token-plan-ams", "xiaomi"),
 ];
 
+/// Explicit per-model pricing aliases for plan models whose id has **no**
+/// canonical match in the base provider's catalog, so [`PRICING_REFERENCE_MAP`]
+/// alone can't price them.
+///
+/// Kimi for Coding ships coding ids (`k2p7`, `k2p5`) that don't appear in
+/// moonshotai's pay-as-you-go list (which uses `kimi-k2-thinking`, `kimi-k2.5`,
+/// …). They're the same Kimi-K2 family billed at the standard K2 rate, so we
+/// point them at `moonshotai/kimi-k2-thinking` ($0.6 in / $2.5 out / $0.15
+/// cache). The second tuple field is the **canonical** plan-model id (see
+/// [`canonical_model_id`]).
+///
+/// (plan_provider_id, canonical_plan_model_id, base_provider_id, base_model_id)
+const PRICING_MODEL_ALIAS: &[(&str, &str, &str, &str)] = &[
+    ("kimi-for-coding", "k2p7", "moonshotai", "kimi-k2-thinking"),
+    ("kimi-for-coding", "k2p5", "moonshotai", "kimi-k2-thinking"),
+];
+
 /// Strip non-alphanumeric chars and lowercase so plan/base model ids match
 /// across cosmetic spelling differences (`MiniMax-M2.5` ↔ `minimax-m2.5`).
 fn canonical_model_id(id: &str) -> String {
@@ -512,24 +529,47 @@ fn canonical_model_id(id: &str) -> String {
 }
 
 /// Borrow pay-as-you-go pricing into flat-rate plan providers' zero-priced
-/// models (see [`PRICING_REFERENCE_MAP`]). Mutates `models_idx` in place. Only
-/// fills a plan model whose own pricing is all-zero, and only from a base model
-/// that is itself priced — existing pricing is never overwritten.
+/// models. Mutates `models_idx` in place. Only fills a plan model whose own
+/// pricing is all-zero, and only from a base model that is itself priced —
+/// existing pricing is never overwritten.
+///
+/// Two sources feed the per-plan canonical-id → pricing lookup: the base
+/// provider's whole priced model list ([`PRICING_REFERENCE_MAP`]) and explicit
+/// per-model aliases for ids that don't canonically match ([`PRICING_MODEL_ALIAS`]).
 fn enrich_plan_pricing(models_idx: &mut HashMap<String, Vec<Model>>) {
+    // Phase 1: resolve every plan's canonical-id → Pricing lookup while only
+    // borrowing `models_idx` immutably (so phase 2 can take a mutable borrow).
+    let mut plan_lookups: HashMap<&str, HashMap<String, Pricing>> = HashMap::new();
+
     for (plan_id, base_id) in PRICING_REFERENCE_MAP {
-        // Index the base provider's priced models by canonical id.
-        let Some(base_models) = models_idx.get(*base_id) else {
-            continue;
-        };
-        let base_pricing: HashMap<String, Pricing> = base_models
-            .iter()
-            .filter(|m| has_nonzero_pricing(&m.pricing))
-            .map(|m| (canonical_model_id(&m.id), m.pricing.clone()))
-            .collect();
-        if base_pricing.is_empty() {
+        if let Some(base_models) = models_idx.get(*base_id) {
+            let entry = plan_lookups.entry(*plan_id).or_default();
+            for m in base_models {
+                if has_nonzero_pricing(&m.pricing) {
+                    entry.insert(canonical_model_id(&m.id), m.pricing.clone());
+                }
+            }
+        }
+    }
+
+    for (plan_id, plan_model_canon, base_id, base_model) in PRICING_MODEL_ALIAS {
+        let pricing = models_idx
+            .get(*base_id)
+            .and_then(|ms| ms.iter().find(|m| m.id == *base_model))
+            .map(|m| m.pricing.clone());
+        if let Some(pricing) = pricing.filter(has_nonzero_pricing) {
+            plan_lookups
+                .entry(*plan_id)
+                .or_default()
+                .insert((*plan_model_canon).to_string(), pricing);
+        }
+    }
+
+    // Phase 2: fill any zero-priced plan model that has a lookup hit.
+    for (plan_id, lookup) in &plan_lookups {
+        if lookup.is_empty() {
             continue;
         }
-
         let Some(plan_models) = models_idx.get_mut(*plan_id) else {
             continue;
         };
@@ -537,7 +577,7 @@ fn enrich_plan_pricing(models_idx: &mut HashMap<String, Vec<Model>>) {
             if has_nonzero_pricing(&m.pricing) {
                 continue;
             }
-            if let Some(pricing) = base_pricing.get(&canonical_model_id(&m.id)) {
+            if let Some(pricing) = lookup.get(&canonical_model_id(&m.id)) {
                 m.pricing = pricing.clone();
             }
         }
@@ -824,6 +864,56 @@ mod tests {
             already.pricing.input_per_million, base.input_per_million,
             "existing pricing must never be overwritten"
         );
+    }
+
+    #[test]
+    fn enrich_plan_pricing_applies_explicit_model_alias() {
+        // kimi-for-coding ships `k2p7`/`k2p5`, which don't canonically match any
+        // moonshotai id — they must be priced via PRICING_MODEL_ALIAS instead.
+        let kimi_rate = Pricing {
+            input_per_million: 0.6,
+            output_per_million: 2.5,
+            cache_read_per_million: 0.15,
+            cache_write_per_million: 0.0,
+        };
+        let mk = |provider: &str, id: &str, pricing: Pricing| Model {
+            id: id.to_string(),
+            provider_id: provider.to_string(),
+            name: id.to_string(),
+            tool_call: true,
+            reasoning: true,
+            attachment: false,
+            context_window: 0,
+            output_limit: 0,
+            pricing,
+        };
+
+        let mut idx: HashMap<String, Vec<Model>> = HashMap::new();
+        idx.insert(
+            "moonshotai".to_string(),
+            vec![mk("moonshotai", "kimi-k2-thinking", kimi_rate.clone())],
+        );
+        idx.insert(
+            "kimi-for-coding".to_string(),
+            vec![
+                mk("kimi-for-coding", "k2p7", Pricing::default()),
+                mk("kimi-for-coding", "k2p5", Pricing::default()),
+            ],
+        );
+
+        enrich_plan_pricing(&mut idx);
+
+        for id in ["k2p7", "k2p5"] {
+            let m = idx["kimi-for-coding"]
+                .iter()
+                .find(|m| m.id == id)
+                .unwrap();
+            assert!(
+                has_nonzero_pricing(&m.pricing),
+                "{id} should be priced via the explicit kimi alias"
+            );
+            assert_eq!(m.pricing.output_per_million, 2.5);
+        }
     }
 
     #[test]

--- a/server/src/server/usage_analytics.rs
+++ b/server/src/server/usage_analytics.rs
@@ -277,6 +277,8 @@ struct SeriesPointDto {
     cost: Option<f64>,
     tokens_in: i64,
     tokens_out: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    tokens_cached: i64,
     task_count: i64,
     model: String,
     project_id: String,
@@ -292,6 +294,8 @@ struct BreakdownRowDto {
     cost: Option<f64>,
     tokens_in: i64,
     tokens_out: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    tokens_cached: i64,
     task_count: i64,
     success_rate: Option<f64>,
     avg_reopens: Option<f64>,
@@ -324,6 +328,8 @@ struct ModelEffectivenessDto {
     total_tokens: i64,
     tokens_in: i64,
     tokens_out: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    tokens_cached: i64,
     session_count: i64,
     /// Shared-credit completed-task count (== task_count); surfaced separately
     /// so the UI can label the attribution semantics.
@@ -342,6 +348,7 @@ impl From<ModelEffectivenessRow> for ModelEffectivenessDto {
             total_tokens: r.tokens_in + r.tokens_out,
             tokens_in: r.tokens_in,
             tokens_out: r.tokens_out,
+            tokens_cached: r.cache_read_tokens,
             session_count: r.sessions,
             completed_task_count: r.shared_credit_completed_task_count,
         }
@@ -359,6 +366,8 @@ struct ProjectModelCellDto {
     avg_reopens: Option<f64>,
     total_cost: Option<f64>,
     total_tokens: i64,
+    /// Cache-read (cached input) tokens — priced separately from fresh input.
+    tokens_cached: i64,
 }
 
 impl From<ProjectModelMatrixRow> for ProjectModelCellDto {
@@ -376,6 +385,7 @@ impl From<ProjectModelMatrixRow> for ProjectModelCellDto {
             avg_reopens: r.avg_reopens,
             total_cost: r.spend_usd,
             total_tokens: r.tokens_in + r.tokens_out,
+            tokens_cached: r.cache_read_tokens,
         }
     }
 }
@@ -533,6 +543,7 @@ fn period_start(day: &str, granularity: Granularity) -> Result<String, (StatusCo
 struct SeriesAccumulator {
     tokens_in: i64,
     tokens_out: i64,
+    tokens_cached: i64,
     task_count: i64,
     cost_sum: f64,
     cost_known: bool,
@@ -546,6 +557,7 @@ impl Default for SeriesAccumulator {
         Self {
             tokens_in: 0,
             tokens_out: 0,
+            tokens_cached: 0,
             task_count: 0,
             cost_sum: 0.0,
             cost_known: true,
@@ -558,6 +570,7 @@ impl SeriesAccumulator {
     fn add(&mut self, row: &SeriesDetailRow) {
         self.tokens_in += row.tokens_in;
         self.tokens_out += row.tokens_out;
+        self.tokens_cached += row.cache_read_tokens;
         self.task_count += row.task_count;
         self.any_usage = true;
         match row.cost {
@@ -608,6 +621,7 @@ fn rollup_series(
                 cost: acc.cost(),
                 tokens_in: acc.tokens_in,
                 tokens_out: acc.tokens_out,
+                tokens_cached: acc.tokens_cached,
                 task_count: acc.task_count,
                 model,
                 project_id,
@@ -636,6 +650,7 @@ fn breakdown_row(row: EntityBreakdownRow, dimension: GroupDimension) -> Breakdow
         cost: row.cost,
         tokens_in: row.tokens_in,
         tokens_out: row.tokens_out,
+        tokens_cached: row.cache_read_tokens,
         task_count: row.task_count,
         success_rate: row.success_rate,
         avg_reopens: row.avg_reopens,
@@ -941,6 +956,7 @@ mod tests {
             session_count: 1,
             tokens_in: 10,
             tokens_out: 5,
+            cache_read_tokens: 3,
             task_count: 1,
             cost,
         }
@@ -983,6 +999,7 @@ mod tests {
             cost: Some(4.0),
             tokens_in: 10,
             tokens_out: 10,
+            cache_read_tokens: 4,
             task_count: 2,
             success_rate: Some(0.5),
             avg_reopens: Some(1.0),
@@ -1008,6 +1025,7 @@ mod tests {
             cost: Some(3.0),
             tokens_in: 1,
             tokens_out: 1,
+            cache_read_tokens: 0,
             task_count: 0,
             success_rate: None,
             avg_reopens: None,
@@ -1024,6 +1042,7 @@ mod tests {
             spend_usd: Some(2.0),
             tokens_in: 100,
             tokens_out: 50,
+            cache_read_tokens: 40,
             shared_credit_completed_task_count: 3,
             success_rate: Some(0.75),
             avg_reopens: Some(0.2),
@@ -1057,6 +1076,7 @@ mod tests {
             spend_usd: Some(6.0),
             tokens_in: 30,
             tokens_out: 20,
+            cache_read_tokens: 12,
             task_count: 3,
             success_rate: Some(1.0),
             avg_reopens: Some(0.0),

--- a/ui/src/api/analytics.ts
+++ b/ui/src/api/analytics.ts
@@ -62,6 +62,8 @@ export interface UsageTimeSeriesPoint {
   cost: number | null;
   tokens_in: number;
   tokens_out: number;
+  /** Cache-read (cached input) tokens — priced separately from fresh input. */
+  tokens_cached?: number;
   task_count: number;
   /** Optional dimension key (model, project, agent_type) when grouped. */
   group_key?: string;
@@ -93,6 +95,8 @@ export interface UsageBreakdownRow {
   cost: number | null;
   tokens_in: number;
   tokens_out: number;
+  /** Cache-read (cached input) tokens — priced separately from fresh input. */
+  tokens_cached?: number;
   task_count: number;
   success_rate: number | null;
   avg_reopens: number | null;
@@ -116,6 +120,8 @@ export interface UsageModelEffectiveness {
   total_tokens: number;
   tokens_in?: number;
   tokens_out?: number;
+  /** Cache-read (cached input) tokens — priced separately from fresh input. */
+  tokens_cached?: number;
   session_count?: number;
   completed_task_count?: number;
   reopen_count?: number;
@@ -130,6 +136,8 @@ export interface UsageProjectModelCell {
   avg_reopens: number | null;
   total_cost: number | null;
   total_tokens: number;
+  /** Cache-read (cached input) tokens — priced separately from fresh input. */
+  tokens_cached?: number;
 }
 
 /**

--- a/ui/src/components/usage/UsageBreakdownsTab.tsx
+++ b/ui/src/components/usage/UsageBreakdownsTab.tsx
@@ -156,7 +156,7 @@ function BreakdownTable({ config }: { config: BreakdownConfig }) {
                         <MetricText value={formatPercent(row.success_rate)} />
                         <MetricText value={formatAverageReopens(row.avg_reopens)} />
                         <MetricText value={formatInteger(row.task_count)} />
-                        <MetricText value={formatCompactNumber(row.tokens_in + row.tokens_out)} detail={`${formatCompactNumber(row.tokens_in)} in · ${formatCompactNumber(row.tokens_out)} out`} />
+                        <MetricText value={formatCompactNumber(row.tokens_in + row.tokens_out)} detail={`${formatCompactNumber(row.tokens_in)} in · ${formatCompactNumber(row.tokens_cached ?? 0)} cached · ${formatCompactNumber(row.tokens_out)} out`} />
                       </div>
                       {hasDetail && (
                         <CollapsibleContent>

--- a/ui/src/components/usage/UsageModelsTab.tsx
+++ b/ui/src/components/usage/UsageModelsTab.tsx
@@ -40,9 +40,18 @@ const METRICS: MetricSpec[] = [
 ];
 
 export function UsageModelsTab({ data }: { data: UsageAnalyticsResponse }) {
-  const stats = useMemo(() => buildMetricStats(data.model_effectiveness), [data]);
+  // Hide models that recorded no tokens at all (e.g. a model whose only runs
+  // were empty/failed sessions) — they add noise with nothing to compare.
+  const models = useMemo(
+    () =>
+      data.model_effectiveness.filter(
+        (row) => totalTokens(row.tokens_in, row.tokens_out, row.total_tokens) > 0,
+      ),
+    [data],
+  );
+  const stats = useMemo(() => buildMetricStats(models), [models]);
 
-  if (data.model_effectiveness.length === 0) {
+  if (models.length === 0) {
     return (
       <div className="rounded-lg border border-dashed border-border bg-card/50 px-4 py-8 text-center">
         <p className="text-sm font-medium text-foreground">No worker model data</p>
@@ -69,7 +78,7 @@ export function UsageModelsTab({ data }: { data: UsageAnalyticsResponse }) {
             </p>
           </div>
           <Badge variant="outline" className="text-muted-foreground">
-            {formatInteger(data.model_effectiveness.length)} models
+            {formatInteger(models.length)} models
           </Badge>
         </div>
       </div>
@@ -91,7 +100,7 @@ export function UsageModelsTab({ data }: { data: UsageAnalyticsResponse }) {
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {[...data.model_effectiveness]
+            {[...models]
               .sort(
                 (a, b) =>
                   (b.task_count ?? 0) - (a.task_count ?? 0) ||
@@ -127,7 +136,7 @@ export function UsageModelsTab({ data }: { data: UsageAnalyticsResponse }) {
                     <div>{formatCompactNumber(totalTokens(row.tokens_in, row.tokens_out, row.total_tokens))}</div>
                     {(row.tokens_in !== undefined || row.tokens_out !== undefined) && (
                       <div className="text-xs text-muted-foreground">
-                        {formatCompactNumber(row.tokens_in ?? 0)} in · {formatCompactNumber(row.tokens_out ?? 0)} out
+                        {formatCompactNumber(row.tokens_in ?? 0)} in · {formatCompactNumber(row.tokens_cached ?? 0)} cached · {formatCompactNumber(row.tokens_out ?? 0)} out
                       </div>
                     )}
                   </td>

--- a/ui/src/components/usage/UsageOverviewTab.tsx
+++ b/ui/src/components/usage/UsageOverviewTab.tsx
@@ -48,6 +48,8 @@ interface BarRow {
   label: string;
   cost: number | null;
   tokens: number;
+  /** Cache-read (cached input) tokens, of the total `tokens`. */
+  cached: number;
 }
 
 const CHART_COLORS = [
@@ -295,6 +297,7 @@ function SpendBarChart({ title, rows }: { title: string; rows: BarRow[] }) {
           }}
           enableLabel={false}
           theme={nivoTheme}
+          tooltip={({ data, color }) => <SpendBarTooltip data={data} color={color} />}
         />
       ) : (
         <ChartEmptyState
@@ -308,6 +311,38 @@ function SpendBarChart({ title, rows }: { title: string; rows: BarRow[] }) {
         />
       )}
     </ChartSection>
+  );
+}
+
+/** Tooltip for the spend bars: spend plus the token total and cached split. */
+function SpendBarTooltip({
+  data,
+  color,
+}: {
+  data: ChartDatum & { fullLabel?: string; Tokens?: number; Cached?: number };
+  color: string;
+}) {
+  const tokens = Number(data.Tokens ?? 0);
+  const cached = Number(data.Cached ?? 0);
+  return (
+    <div className="rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs shadow-md">
+      <div className="flex items-center gap-1.5 font-medium text-foreground">
+        <span
+          className="inline-block h-2 w-2 rounded-[2px]"
+          style={{ backgroundColor: color }}
+          aria-hidden
+        />
+        <span className="truncate" title={data.fullLabel ?? String(data.label)}>
+          {data.fullLabel ?? String(data.label)}
+        </span>
+      </div>
+      <div className="mt-1 tabular-nums text-foreground">
+        {formatCurrency(Number(data.Spend ?? 0))}
+      </div>
+      <div className="mt-0.5 tabular-nums text-muted-foreground">
+        {formatCompactNumber(tokens)} tokens · {formatCompactNumber(cached)} cached
+      </div>
+    </div>
   );
 }
 
@@ -422,12 +457,16 @@ function buildStackedSpend(rows: SeriesRow[]): {
 }
 
 function buildSpendByModel(data: UsageAnalyticsResponse): BarRow[] {
-  const modelRows = data.model_effectiveness.map((row) => ({
-    id: row.model,
-    label: row.model,
-    cost: row.total_cost,
-    tokens: row.total_tokens,
-  }));
+  // Skip models with no tokens at all — they add empty bars/legend rows.
+  const modelRows = data.model_effectiveness
+    .filter((row) => row.total_tokens > 0)
+    .map((row) => ({
+      id: row.model,
+      label: row.model,
+      cost: row.total_cost,
+      tokens: row.total_tokens,
+      cached: row.tokens_cached ?? 0,
+    }));
 
   if (modelRows.length > 0) return sortAndLimitRows(modelRows);
 
@@ -457,9 +496,11 @@ function rollupTimeSeries(
       label,
       cost: null,
       tokens: 0,
+      cached: 0,
     };
     if (point.cost !== null) current.cost = (current.cost ?? 0) + point.cost;
     current.tokens += point.tokens_in + point.tokens_out;
+    current.cached += point.tokens_cached ?? 0;
     byGroup.set(label, current);
   }
   return Array.from(byGroup.values());
@@ -481,8 +522,10 @@ function buildBarChart(rows: BarRow[]): {
     return {
       bucket: row.id,
       label: truncateLabel(row.label),
+      fullLabel: row.label,
       Spend: row.cost ?? 0,
       Tokens: row.tokens,
+      Cached: row.cached,
     };
   });
   return { data, hasPricedCost };

--- a/ui/src/components/usage/UsageProjectModelMatrixTab.test.tsx
+++ b/ui/src/components/usage/UsageProjectModelMatrixTab.test.tsx
@@ -73,7 +73,9 @@ describe("UsageProjectModelMatrixTab", () => {
             model: "model-b",
             cost_per_task: 0,
             total_cost: 0,
-            total_tokens: 0,
+            // Zero *cost* but non-zero tokens: still rendered (only zero-token
+            // rows/columns are hidden — see the dedicated test below).
+            total_tokens: 500,
           }),
         ])}
       />,
@@ -84,5 +86,19 @@ describe("UsageProjectModelMatrixTab", () => {
     expect(screen.getByText("No priced cost/task")).toBeInTheDocument();
     expect(screen.getByText("Tokens 1.2K")).toBeInTheDocument();
     expect(screen.getAllByText("$0.00").length).toBeGreaterThan(0);
+  });
+
+  it("hides blank-project rows and zero-token model columns", () => {
+    const matrix = buildProjectModelMatrix([
+      // Real usage.
+      matrixCell({ project_id: "project-a", model: "model-a", total_tokens: 1000 }),
+      // Blank project (chat/system) — must not appear as a row.
+      matrixCell({ project_id: "", project_name: "", model: "model-a", total_tokens: 50 }),
+      // Model that never recorded a token — must not appear as a column.
+      matrixCell({ project_id: "project-a", model: "model-zero", total_tokens: 0 }),
+    ]);
+
+    expect(matrix.projects.map((p) => p.id)).toEqual(["project-a"]);
+    expect(matrix.models).toEqual(["model-a"]);
   });
 });

--- a/ui/src/components/usage/UsageProjectModelMatrixTab.tsx
+++ b/ui/src/components/usage/UsageProjectModelMatrixTab.tsx
@@ -233,10 +233,10 @@ function ProjectModelCell({
   if (!cell) {
     return (
       <td
-        className="border-b border-border p-2"
+        className="h-full border-b border-border p-2"
         title={`${projectName} / ${model}: never ran`}
       >
-        <div className="flex min-h-20 items-center justify-center rounded-md border border-dashed border-border bg-muted/20 text-xs text-muted-foreground">
+        <div className="flex h-full min-h-24 items-center justify-center rounded-md border border-dashed border-border bg-muted/20 text-xs text-muted-foreground">
           <span className="sr-only">Never ran</span>
           <span aria-hidden>{EM_DASH}</span>
         </div>
@@ -247,15 +247,16 @@ function ProjectModelCell({
   const value = getMetricValue(cell, metric.key);
   const label = metric.format(value);
   const intensity = getMetricIntensity(value, scale, metric);
+  const cached = cell.tokens_cached ?? 0;
   const title = `${projectName} / ${model}: ${metric.label} ${label}; spend ${formatCurrency(
     cell.total_cost,
-  )}; tokens ${formatCompactNumber(cell.total_tokens)}`;
+  )}; tokens ${formatCompactNumber(cell.total_tokens)} (${formatCompactNumber(cached)} cached)`;
 
   return (
-    <td className="border-b border-border p-2" title={title}>
+    <td className="h-full border-b border-border p-2" title={title}>
       <div
         className={cn(
-          "min-h-20 rounded-md border px-3 py-2 tabular-nums transition-colors",
+          "flex h-full min-h-24 flex-col rounded-md border px-3 py-2 tabular-nums transition-colors",
           value === null || value === undefined
             ? "border-dashed border-border bg-muted/20"
             : "border-primary/20 bg-primary/10",
@@ -272,9 +273,12 @@ function ProjectModelCell({
             {metric.emptyLabel}
           </div>
         )}
-        <div className="mt-3 space-y-0.5 text-xs text-muted-foreground">
+        <div className="mt-auto space-y-0.5 pt-3 text-xs text-muted-foreground">
           <div>Spend {formatCurrency(cell.total_cost)}</div>
-          <div>Tokens {formatCompactNumber(cell.total_tokens)}</div>
+          <div>
+            Tokens {formatCompactNumber(cell.total_tokens)}
+            {cached > 0 && ` · ${formatCompactNumber(cached)} cached`}
+          </div>
         </div>
       </div>
     </td>
@@ -289,11 +293,27 @@ interface MetricScale {
 export function buildProjectModelMatrix(
   cells: UsageProjectModelCell[],
 ): BuiltMatrix {
+  // Drop sessions with no project (chat/system runs carry an empty project_id
+  // and would render as a nameless leading row), and drop any project row or
+  // model column that recorded zero tokens across the whole window.
+  const scoped = cells.filter((cell) => cell.project_id !== "");
+  const projectTokens = new Map<string, number>();
+  const modelTokens = new Map<string, number>();
+  for (const cell of scoped) {
+    projectTokens.set(
+      cell.project_id,
+      (projectTokens.get(cell.project_id) ?? 0) + cell.total_tokens,
+    );
+    modelTokens.set(cell.model, (modelTokens.get(cell.model) ?? 0) + cell.total_tokens);
+  }
+
   const projectsById = new Map<string, MatrixProject>();
   const models = new Set<string>();
   const cellsByPair = new Map<string, UsageProjectModelCell>();
 
-  for (const cell of cells) {
+  for (const cell of scoped) {
+    if ((projectTokens.get(cell.project_id) ?? 0) === 0) continue;
+    if ((modelTokens.get(cell.model) ?? 0) === 0) continue;
     projectsById.set(cell.project_id, {
       id: cell.project_id,
       name: cell.project_name || cell.project_id,


### PR DESCRIPTION
Follow-ups from reviewing the Usage dashboard after the plan-pricing work (#1038).

## 1. Kimi plan now priced
`kimi-for-coding` ships coding ids (`k2p7`, `k2p5`) that don't canonically
match anything in moonshotai's pay-as-you-go list, so `PRICING_REFERENCE_MAP`
alone left them at \$0. Added an explicit `PRICING_MODEL_ALIAS`
(plan-model → base-model) applied as a fallback in `enrich_plan_pricing`;
`k2p7`/`k2p5` now price at the standard Kimi-K2 rate (`moonshotai/kimi-k2-thinking`,
\$0.6 in / \$2.5 out / \$0.15 cache).

## 2. Cached input tokens surfaced everywhere
Cache-read tokens are priced differently from fresh input but were only in the
Tokens KPI. Threaded `cache_read_tokens` through all four analytics aggregates
(time series, entity breakdown, model effectiveness, project×model matrix) as a
new `tokens_cached` field and surfaced it:
- Models table token cell → `in · cached · out`
- Breakdowns rows → `in · cached · out`
- Matrix cell tokens → `Tokens N · C cached`
- Spend-by-model & spend-by-agent bars → custom tooltip showing spend + tokens + cached

## 3. Noise removal
- Hide models with **zero total tokens** from the Models table and the
  spend-by-model chart (e.g. a model whose only runs were empty/failed sessions).
- Hide **blank-project** (chat/system, empty `project_id`) rows and
  **zero-token model columns** from the Project × Model Matrix.

## 4. Matrix polish
Matrix cards are now equal-height (`h-full` flex column with bottom-aligned
spend/tokens) instead of ragged.

## Test
- `cargo test -p djinn-provider catalog::service` — added
  `enrich_plan_pricing_applies_explicit_model_alias`; 14 pass.
- `cargo test -p djinn-server --lib server::usage_analytics` — 20 pass (updated
  the 5 row/DTO test literals for the new field).
- `cargo clippy -p djinn-db -p djinn-provider -p djinn-server --lib` clean.
- UI: `tsc -b` + `vite build` clean; `vitest UsageProjectModelMatrixTab` 3 pass
  (added a hide-blank-project/zero-token-column test).

Note: SQL aggregates use runtime `sqlx::query(&sql)` (not the macro), so the new
columns need no `sqlx prepare`.