### PR TITLE
feat(proposals): tabs + columns container blocks (recursive render)

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -31,6 +31,8 @@ pub enum BlockType {
     JsonExplorer,
     Html,
     OpenApiSpec,
+    Tabs,
+    Columns,
     QuestionForm,
 }
 
@@ -52,6 +54,8 @@ impl BlockType {
             BlockType::JsonExplorer => "json-explorer",
             BlockType::Html => "html",
             BlockType::OpenApiSpec => "openapi-spec",
+            BlockType::Tabs => "tabs",
+            BlockType::Columns => "columns",
             BlockType::QuestionForm => "question-form",
         }
     }
@@ -73,6 +77,8 @@ impl BlockType {
             BlockType::JsonExplorer => "JsonExplorer",
             BlockType::Html => "Html",
             BlockType::OpenApiSpec => "OpenApi",
+            BlockType::Tabs => "Tabs",
+            BlockType::Columns => "Columns",
             BlockType::QuestionForm => "QuestionForm",
         }
     }
@@ -565,6 +571,52 @@ pub static PROPOSAL_BLOCK_REGISTRY: LazyLock<BTreeMap<&'static str, ProposalBloc
                 ),
             ),
             (
+                "tabs",
+                block_with_description(
+                    "tabs",
+                    "Tabs",
+                    "A tabbed container: one tab strip whose active panel \
+                     recursively renders its own proposal-MDX body. The block is \
+                     SELF-CLOSING; all content lives in the `tabs` attribute as a \
+                     JSON array passed via a `{...}` expression: \
+                     `tabs={[{ \"label\": \"...\", \"body\": \"...mdx...\" }, ...]}`. \
+                     Each entry has a `label` (the tab button text) and a `body` \
+                     (a normal proposal-MDX string — the SAME grammar as the \
+                     top-level proposal body, so it may itself contain blocks like \
+                     `<Callout .../>` and inline **markdown**). The body is parsed \
+                     and rendered recursively (nesting is depth-capped). The first \
+                     tab is shown by default. Author the JSON with proper escaping \
+                     (newlines as `\\n`, quotes as `\\\"`). If the attribute is \
+                     missing or not valid JSON the block falls back gracefully. \
+                     Example: `<Tabs id=\"x\" tabs={[{ \"label\": \"Overview\", \
+                     \"body\": \"<Callout id=\\\"c\\\">Hi</Callout>\" }, { \"label\": \
+                     \"API\", \"body\": \"some **markdown**\" }]} />`.",
+                    fields(vec![("tabs", string_field())]),
+                ),
+            ),
+            (
+                "columns",
+                block_with_description(
+                    "columns",
+                    "Columns",
+                    "A responsive multi-column layout container: N columns side by \
+                     side on wide screens, stacked on narrow ones. The block is \
+                     SELF-CLOSING; all content lives in the `columns` attribute as \
+                     a JSON array passed via a `{...}` expression: \
+                     `columns={[{ \"body\": \"...mdx...\" }, { \"body\": \"...mdx...\" }]}`. \
+                     Each entry has a `body` (a normal proposal-MDX string — the \
+                     SAME grammar as the top-level proposal body, so it may itself \
+                     contain blocks like `<DataModel .../>` and inline **markdown**). \
+                     Each column body is parsed and rendered recursively (nesting is \
+                     depth-capped). Author the JSON with proper escaping (newlines \
+                     as `\\n`, quotes as `\\\"`). If the attribute is missing or not \
+                     valid JSON the block falls back gracefully. Example: \
+                     `<Columns id=\"x\" columns={[{ \"body\": \"### Before\\nold\" }, \
+                     { \"body\": \"### After\\nnew\" }]} />`.",
+                    fields(vec![("columns", string_field())]),
+                ),
+            ),
+            (
                 "question-form",
                 block(
                     "question-form",
@@ -991,7 +1043,7 @@ mod tests {
     #[test]
     fn registry_contains_v1_blocks() {
         let registry = proposal_block_registry();
-        assert_eq!(registry.len(), 15);
+        assert_eq!(registry.len(), 17);
         assert_eq!(registry["rich-text"].tag, "RichText");
         assert_eq!(registry["diagram"].tag, "Diagram");
         assert_eq!(registry["annotated-code"].tag, "AnnotatedCode");
@@ -1006,6 +1058,8 @@ mod tests {
         assert_eq!(registry["json-explorer"].tag, "JsonExplorer");
         assert_eq!(registry["html"].tag, "Html");
         assert_eq!(registry["openapi-spec"].tag, "OpenApi");
+        assert_eq!(registry["tabs"].tag, "Tabs");
+        assert_eq!(registry["columns"].tag, "Columns");
         assert_eq!(registry["question-form"].tag, "QuestionForm");
         // The html block ships authoring guidance noting it is sandboxed.
         assert!(
@@ -1028,6 +1082,22 @@ mod tests {
                 .is_some_and(|d| d.contains("unified diff")),
             "diff block must advertise unified-diff authoring guidance"
         );
+        // The tabs block documents its JSON-array `tabs` authoring format.
+        assert_eq!(registry["tabs"].fields["tabs"].field_type, "string");
+        assert!(
+            registry["tabs"]
+                .description
+                .is_some_and(|d| d.contains("tabs={[") && d.contains("body")),
+            "tabs block must advertise its JSON-array authoring format"
+        );
+        // The columns block documents its JSON-array `columns` authoring format.
+        assert_eq!(registry["columns"].fields["columns"].field_type, "string");
+        assert!(
+            registry["columns"]
+                .description
+                .is_some_and(|d| d.contains("columns={[") && d.contains("body")),
+            "columns block must advertise its JSON-array authoring format"
+        );
     }
 
     #[test]
@@ -1047,6 +1117,8 @@ mod tests {
             BlockType::JsonExplorer,
             BlockType::Html,
             BlockType::OpenApiSpec,
+            BlockType::Tabs,
+            BlockType::Columns,
             BlockType::QuestionForm,
         ];
         for bt in types {
@@ -1058,7 +1130,7 @@ mod tests {
     #[test]
     fn block_registry_new_has_all_definitions() {
         let reg = BlockRegistry::new();
-        assert_eq!(reg.definitions().len(), 15);
+        assert_eq!(reg.definitions().len(), 17);
         assert!(reg.definition_for_tag("RichText").is_some());
         assert!(reg.definition_for_tag("UnknownTag").is_none());
         assert!(reg.tags().contains("RichText"));
@@ -1085,6 +1157,8 @@ mod tests {
             "JsonExplorer",
             "Html",
             "OpenApi",
+            "Tabs",
+            "Columns",
             "QuestionForm",
         ]
         .into_iter()

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -625,6 +625,10 @@ This runs on the hot path.
 }
 </OpenApi>
 
+<Tabs id="views" tabs={[{ "label": "Overview", "body": "Some **markdown**." }, { "label": "Detail", "body": "More detail." }]} />
+
+<Columns id="compare" columns={[{ "body": "Before: the old approach." }, { "body": "After: the new approach." }]} />
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached?
 </QuestionForm>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -29,8 +29,11 @@
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.96.1",
         "@xyflow/react": "^12.10.2",
+        "acorn": "^8.17.0",
+        "acorn-jsx": "^5.3.2",
         "ai": "^6.0.143",
         "ansi-to-react": "^6.2.6",
+        "beautiful-mermaid": "^1.1.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -44,8 +47,15 @@
         "graphology-layout-forceatlas2": "^0.10.1",
         "graphology-layout-noverlap": "^0.4.2",
         "lucide-react": "^1.7.0",
+        "mdast-util-from-markdown": "^2.0.3",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-mdx-jsx": "^3.2.0",
         "media-chrome": "^4.18.3",
         "mermaid": "^11.4.0",
+        "micromark-extension-mdx-jsx": "^3.0.2",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.1",
         "motion": "^12.38.0",
         "nanoid": "^5.1.7",
         "radix-ui": "^1.4.3",
@@ -80,6 +90,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/dompurify": "^3.2.0",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -7620,6 +7631,28 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/beautiful-mermaid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/beautiful-mermaid/-/beautiful-mermaid-1.1.3.tgz",
+      "integrity": "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==",
+      "license": "MIT",
+      "dependencies": {
+        "elkjs": "^0.11.0",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/beautiful-mermaid/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/better-opn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
@@ -9848,6 +9881,20 @@
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
       "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -12571,6 +12618,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -13106,6 +13170,108 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -13147,6 +13313,33 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -13349,6 +13542,31 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -17527,6 +17745,19 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"

--- a/ui/src/components/proposals/blocks/BlockRenderer.tsx
+++ b/ui/src/components/proposals/blocks/BlockRenderer.tsx
@@ -1,10 +1,4 @@
-import { useMemo } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-
-import { getBlockByTag } from "@/lib/blockRegistry";
-
-import { parseMdxBody } from "./parseMdxBody";
+import { ProposalBlocks } from "./ProposalBlocks";
 
 export interface BlockRendererProps {
   body: string;
@@ -15,58 +9,16 @@ export interface BlockRendererProps {
  * resolved through the block registry and rendered as React components;
  * everything else is rendered as GitHub-flavoured markdown.
  *
+ * This is the top-level entry point; the actual segment→component rendering
+ * lives in {@link ProposalBlocks}, the single shared renderer that recursive
+ * container blocks (`Tabs`, `Columns`) reuse for their child bodies so there is
+ * never a second, drifting renderer.
+ *
  * Each block is wrapped in a `<div id={blockId}>` so browser anchors and the
  * deep-link highlight can scroll to a specific block. Feedback is a single
  * proposal-level thread (see `FeedbackThread`), not a per-block rail, so blocks
  * render full-width.
  */
 export function BlockRenderer({ body }: BlockRendererProps) {
-  const segments = useMemo(() => parseMdxBody(body), [body]);
-
-  return (
-    <div className="space-y-4">
-      {segments.map((segment) => {
-        if (segment.kind === "markdown") {
-          return (
-            <div
-              key={`md-${segment.text.slice(0, 32)}`}
-              className="prose prose-sm max-w-none dark:prose-invert"
-            >
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {segment.text}
-              </ReactMarkdown>
-            </div>
-          );
-        }
-
-        // Block segment — look up the component in the registry
-        const def = getBlockByTag(segment.tag);
-        if (!def) {
-          // Unknown tag: render as code-fenced text so nothing is silently lost
-          return (
-            <pre
-              key={`unknown-${segment.index}`}
-              className="overflow-x-auto rounded border border-dashed border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
-            >
-              {`<${segment.tag} ...>${segment.content}</${segment.tag}>`}
-            </pre>
-          );
-        }
-
-        const BlockComponent = def.component;
-
-        return (
-          <div
-            key={`block-${segment.id}-${segment.index}`}
-            id={segment.id}
-            className="scroll-mt-4"
-          >
-            <BlockComponent id={segment.id} attributes={segment.attributes}>
-              {segment.content}
-            </BlockComponent>
-          </div>
-        );
-      })}
-    </div>
-  );
+  return <ProposalBlocks body={body} />;
 }

--- a/ui/src/components/proposals/blocks/ColumnsBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/ColumnsBlock.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/test-utils";
+
+import { ColumnsBlock } from "./ColumnsBlock";
+import { MAX_BLOCK_DEPTH } from "./blockDepth";
+
+/** Build a valid `columns` JSON-attribute string from bodies. */
+function columnsAttr(bodies: string[]): string {
+  return JSON.stringify(bodies.map((body) => ({ body })));
+}
+
+describe("ColumnsBlock", () => {
+  it("renders N columns, each with its recursively-rendered body", () => {
+    const { container } = render(
+      <ColumnsBlock
+        id="c1"
+        attributes={{
+          columns: columnsAttr([
+            "First column body",
+            "Second column body",
+            "Third column body",
+          ]),
+        }}
+      />,
+    );
+
+    const grid = container.querySelector(".grid");
+    expect(grid).not.toBeNull();
+    // Three column cells.
+    expect(grid!.children).toHaveLength(3);
+    expect(screen.getByText("First column body")).toBeInTheDocument();
+    expect(screen.getByText("Third column body")).toBeInTheDocument();
+  });
+
+  it("applies the responsive stack-on-narrow class", () => {
+    const { container } = render(
+      <ColumnsBlock
+        id="c2"
+        attributes={{ columns: columnsAttr(["A", "B"]) }}
+      />,
+    );
+
+    const grid = container.querySelector(".grid");
+    // Single column on narrow, two columns at md+ — the stack class is present.
+    expect(grid!.className).toContain("grid-cols-1");
+    expect(grid!.className).toContain("md:grid-cols-2");
+  });
+
+  it("recursively renders a child block inside a column (e.g. a Callout)", () => {
+    render(
+      <ColumnsBlock
+        id="c3"
+        attributes={{
+          columns: columnsAttr([
+            '<Callout id="x" tone="success">Looks good.</Callout>',
+            "Plain other column",
+          ]),
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Success")).toBeInTheDocument();
+    expect(screen.getByText("Looks good.")).toBeInTheDocument();
+  });
+
+  it("caps runaway nesting via the depth guard", () => {
+    // Build columns nested one level deeper than the cap: at the cap the
+    // innermost body is rendered as plain markdown, not parsed for more blocks,
+    // so the number of nested grids is bounded (never infinite).
+    const innermost = "DEEP_LEAF";
+    let body = innermost;
+    for (let i = 0; i < MAX_BLOCK_DEPTH + 3; i++) {
+      body = `<Columns id="n${i}" columns={${columnsAttr([body])}} />`;
+    }
+
+    const { container } = render(
+      <ColumnsBlock id="root" attributes={{ columns: columnsAttr([body]) }} />,
+    );
+
+    // The leaf content is still rendered (recursion terminated gracefully).
+    expect(screen.getByText(/DEEP_LEAF/)).toBeInTheDocument();
+    // The number of grids is bounded by the depth cap, not the nesting count.
+    const grids = container.querySelectorAll(".grid");
+    expect(grids.length).toBeLessThanOrEqual(MAX_BLOCK_DEPTH + 2);
+  });
+
+  it("falls back gracefully when the columns attribute is invalid JSON (no throw)", () => {
+    expect(() =>
+      render(
+        <ColumnsBlock id="c4" attributes={{ columns: "[broken" }}>
+          {"Fallback markdown body"}
+        </ColumnsBlock>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByText("Fallback markdown body")).toBeInTheDocument();
+  });
+
+  it("shows a muted notice when invalid and no children", () => {
+    render(<ColumnsBlock id="c5" attributes={{ columns: "nope" }} />);
+    expect(screen.getByText("Could not render columns")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/proposals/blocks/ColumnsBlock.tsx
+++ b/ui/src/components/proposals/blocks/ColumnsBlock.tsx
@@ -1,0 +1,65 @@
+import { useId } from "react";
+import { DistributeHorizontalCenterIcon } from "@hugeicons/core-free-icons";
+
+import { cn } from "@/lib/utils";
+
+import { ProposalBlocks } from "./ProposalBlocks";
+import { ContainerFallback } from "./ContainerFallback";
+import { parseColumnsAttr } from "./containerAttr";
+import type { BlockProps } from "./types";
+
+/**
+ * Responsive Tailwind grid classes keyed by column count. Every layout collapses
+ * to a single stacked column on narrow screens and fans out to the column count
+ * at `md`+, so narrow viewports stack the panels instead of crushing them. Five
+ * or more columns reuse the 4-column class (wrapping into multiple rows).
+ */
+const COLS_CLASS: Record<number, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-1 md:grid-cols-2",
+  3: "grid-cols-1 md:grid-cols-3",
+  4: "grid-cols-1 md:grid-cols-4",
+};
+
+/** Resolve the responsive grid class for a column count (clamped to 1–4). */
+function gridColsClass(count: number): string {
+  return COLS_CLASS[Math.min(4, Math.max(1, count))] ?? COLS_CLASS[1];
+}
+
+/**
+ * Columns — a recursive container block. The `columns` attribute carries a JSON
+ * array (`columns={[{ "body" }, ...]}`) where each entry's `body` is a normal
+ * proposal-MDX string rendered RECURSIVELY through the shared
+ * {@link ProposalBlocks} renderer. Columns sit side by side on wide screens and
+ * stack on narrow ones.
+ *
+ * If the `columns` attribute is missing or not valid JSON the block renders a
+ * calm fallback (its children markdown, else a muted notice plus the raw
+ * attribute) — it never throws or blanks.
+ */
+export function ColumnsBlock({ attributes, children }: BlockProps) {
+  const columns = parseColumnsAttr(attributes.columns);
+  const baseId = useId();
+
+  if (!columns) {
+    return (
+      <ContainerFallback
+        kind="columns"
+        rawAttribute={attributes.columns}
+        icon={DistributeHorizontalCenterIcon}
+      >
+        {children}
+      </ContainerFallback>
+    );
+  }
+
+  return (
+    <div className={cn("grid gap-4", gridColsClass(columns.length))}>
+      {columns.map((column, index) => (
+        <div key={`${baseId}-col-${index}`} className="min-w-0">
+          <ProposalBlocks body={column.body} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/proposals/blocks/ContainerFallback.tsx
+++ b/ui/src/components/proposals/blocks/ContainerFallback.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { BlockMarkdown } from "./BlockShell";
+
+export interface ContainerFallbackProps {
+  /** Which container failed to parse — drives the muted notice copy. */
+  kind: "tabs" | "columns";
+  /** The raw `{...}` attribute text, shown for authoring debugging. */
+  rawAttribute?: string;
+  /** Leading icon (a hugeicons named import). */
+  icon: Parameters<typeof HugeiconsIcon>[0]["icon"];
+  /** The block's own children markdown, if any, preferred over the notice. */
+  children?: ReactNode;
+}
+
+/**
+ * Calm fallback for a container block (`Tabs` / `Columns`) whose JSON attribute
+ * is missing or invalid. Prefers rendering the block's own children markdown
+ * (so authored content is never lost); otherwise shows a muted notice plus the
+ * raw attribute text. Never throws, never blanks.
+ */
+export function ContainerFallback({
+  kind,
+  rawAttribute,
+  icon,
+  children,
+}: ContainerFallbackProps) {
+  const body = typeof children === "string" ? children.trim() : "";
+  if (body.length > 0) {
+    return (
+      <div className="rounded-lg border bg-card p-4">
+        <BlockMarkdown>{body}</BlockMarkdown>
+      </div>
+    );
+  }
+
+  const label = kind === "tabs" ? "Could not render tabs" : "Could not render columns";
+  return (
+    <div className="rounded-lg border border-dashed bg-muted/20 p-4 text-sm text-muted-foreground">
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon icon={icon} size={15} className="shrink-0" aria-hidden />
+        <span>{label}</span>
+      </div>
+      {rawAttribute ? (
+        <pre className="mt-2 overflow-x-auto rounded bg-background/60 p-2 text-xs">
+          {rawAttribute}
+        </pre>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/proposals/blocks/ProposalBlocks.tsx
+++ b/ui/src/components/proposals/blocks/ProposalBlocks.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { getBlockByTag } from "@/lib/blockRegistry";
+
+import { BlockDepthContext, MAX_BLOCK_DEPTH, useBlockDepth } from "./blockDepth";
+import { parseMdxBody } from "./parseMdxBody";
+
+/**
+ * Render an MDX body as plain GitHub-flavoured markdown — the recursion-cap
+ * fallback for container children that have nested too deep, and the render
+ * path for ordinary markdown segments.
+ */
+function MarkdownBody({ text }: { text: string }) {
+  return (
+    <div className="prose prose-sm max-w-none dark:prose-invert">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+    </div>
+  );
+}
+
+export interface ProposalBlocksProps {
+  /** A proposal-MDX body string (top-level or a container child). */
+  body: string;
+}
+
+/**
+ * Parse a proposal-MDX `body` and render each segment: custom block tags are
+ * resolved through the block registry and rendered as React components;
+ * everything else is rendered as GitHub-flavoured markdown.
+ *
+ * This is the SINGLE segment→component renderer shared by the top-level
+ * `BlockRenderer` and the recursive container blocks (`Tabs`, `Columns`) so
+ * there is never a second, drifting renderer. Container blocks call this with
+ * each child `body`; the `BlockDepthContext` increments on every nested render
+ * and, beyond {@link MAX_BLOCK_DEPTH}, the body is rendered as plain markdown to
+ * cap runaway nesting.
+ *
+ * Each block is wrapped in a `<div id={blockId}>` so browser anchors and the
+ * deep-link highlight can scroll to a specific block.
+ */
+export function ProposalBlocks({ body }: ProposalBlocksProps) {
+  const depth = useBlockDepth();
+  const segments = useMemo(() => parseMdxBody(body), [body]);
+
+  // Depth cap reached: stop parsing nested blocks and render the body as plain
+  // markdown so a pathological container-in-container body cannot loop.
+  if (depth > MAX_BLOCK_DEPTH) {
+    return <MarkdownBody text={body} />;
+  }
+
+  return (
+    <BlockDepthContext.Provider value={depth + 1}>
+      <div className="space-y-4">
+        {segments.map((segment) => {
+          if (segment.kind === "markdown") {
+            return (
+              <MarkdownBody
+                key={`md-${segment.text.slice(0, 32)}`}
+                text={segment.text}
+              />
+            );
+          }
+
+          // Block segment — look up the component in the registry.
+          const def = getBlockByTag(segment.tag);
+          if (!def) {
+            // Unknown tag: render as code-fenced text so nothing is silently lost.
+            return (
+              <pre
+                key={`unknown-${segment.index}`}
+                className="overflow-x-auto rounded border border-dashed border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+              >
+                {`<${segment.tag} ...>${segment.content}</${segment.tag}>`}
+              </pre>
+            );
+          }
+
+          const BlockComponent = def.component;
+
+          return (
+            <div
+              key={`block-${segment.id}-${segment.index}`}
+              id={segment.id}
+              className="scroll-mt-4"
+            >
+              <BlockComponent id={segment.id} attributes={segment.attributes}>
+                {segment.content}
+              </BlockComponent>
+            </div>
+          );
+        })}
+      </div>
+    </BlockDepthContext.Provider>
+  );
+}

--- a/ui/src/components/proposals/blocks/TabsBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/TabsBlock.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, userEvent } from "@/test/test-utils";
+
+import { TabsBlock } from "./TabsBlock";
+
+/** Build a valid `tabs` JSON-attribute string from entries. */
+function tabsAttr(entries: { label: string; body: string }[]): string {
+  return JSON.stringify(entries);
+}
+
+describe("TabsBlock", () => {
+  it("renders one tab button per entry and shows the first tab by default", () => {
+    render(
+      <TabsBlock
+        id="t1"
+        attributes={{
+          tabs: tabsAttr([
+            { label: "Overview", body: "First panel body" },
+            { label: "API", body: "Second panel body" },
+            { label: "Notes", body: "Third panel body" },
+          ]),
+        }}
+      />,
+    );
+
+    const tabButtons = screen.getAllByRole("tab");
+    expect(tabButtons).toHaveLength(3);
+    expect(tabButtons[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabButtons[1]).toHaveAttribute("aria-selected", "false");
+
+    // First panel is visible.
+    expect(screen.getByText("First panel body")).toBeInTheDocument();
+  });
+
+  it("switches the active panel when a tab is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <TabsBlock
+        id="t2"
+        attributes={{
+          tabs: tabsAttr([
+            { label: "One", body: "Panel one" },
+            { label: "Two", body: "Panel two" },
+          ]),
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Two" }));
+
+    expect(screen.getByRole("tab", { name: "Two" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Panel two")).toBeInTheDocument();
+  });
+
+  it("moves the active tab with arrow keys (keyboard accessible)", async () => {
+    const user = userEvent.setup();
+    render(
+      <TabsBlock
+        id="t3"
+        attributes={{
+          tabs: tabsAttr([
+            { label: "Alpha", body: "Alpha body" },
+            { label: "Beta", body: "Beta body" },
+          ]),
+        }}
+      />,
+    );
+
+    const first = screen.getByRole("tab", { name: "Alpha" });
+    first.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("tab", { name: "Beta" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByText("Beta body")).toBeInTheDocument();
+  });
+
+  it("recursively renders a child block inside a tab (e.g. a Callout)", () => {
+    render(
+      <TabsBlock
+        id="t4"
+        attributes={{
+          tabs: tabsAttr([
+            {
+              label: "WithCallout",
+              body: '<Callout id="c1" tone="warning">Be careful here.</Callout>',
+            },
+          ]),
+        }}
+      />,
+    );
+
+    // The recursively-rendered Callout shows its tone label and body.
+    expect(screen.getByText("Warning")).toBeInTheDocument();
+    expect(screen.getByText("Be careful here.")).toBeInTheDocument();
+  });
+
+  it("falls back gracefully when the tabs attribute is invalid JSON (no throw)", () => {
+    expect(() =>
+      render(
+        <TabsBlock id="t5" attributes={{ tabs: "{not valid json" }}>
+          {"Fallback markdown body"}
+        </TabsBlock>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.queryAllByRole("tab")).toHaveLength(0);
+    expect(screen.getByText("Fallback markdown body")).toBeInTheDocument();
+  });
+
+  it("shows a muted notice with the raw attribute when invalid and no children", () => {
+    render(<TabsBlock id="t6" attributes={{ tabs: "nope" }} />);
+    expect(screen.getByText("Could not render tabs")).toBeInTheDocument();
+    expect(screen.getByText("nope")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/proposals/blocks/TabsBlock.tsx
+++ b/ui/src/components/proposals/blocks/TabsBlock.tsx
@@ -1,0 +1,135 @@
+import { useId, useRef, useState } from "react";
+import { LayoutTable01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
+
+import { ProposalBlocks } from "./ProposalBlocks";
+import { ContainerFallback } from "./ContainerFallback";
+import { parseTabsAttr } from "./containerAttr";
+import type { BlockProps } from "./types";
+
+/**
+ * Tabs — a recursive container block. The `tabs` attribute carries a JSON array
+ * (`tabs={[{ "label", "body" }, ...]}`) where each entry's `body` is a normal
+ * proposal-MDX string rendered RECURSIVELY through the shared
+ * {@link ProposalBlocks} renderer (so a tab can itself contain a `<Callout/>`,
+ * inline markdown, or — depth-capped — another `<Tabs/>`).
+ *
+ * The tab strip is a proper ARIA `tablist`: arrow keys move focus and activate
+ * a tab, Home/End jump to the first/last tab, and the active tab uses djinn's
+ * violet accent. The first tab is shown by default.
+ *
+ * If the `tabs` attribute is missing or not valid JSON the block renders a calm
+ * fallback (its children markdown, else a muted notice plus the raw attribute)
+ * — it never throws or blanks.
+ */
+export function TabsBlock({ attributes, children }: BlockProps) {
+  const tabs = parseTabsAttr(attributes.tabs);
+  const baseId = useId();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [active, setActive] = useState(0);
+
+  if (!tabs) {
+    return (
+      <ContainerFallback
+        kind="tabs"
+        rawAttribute={attributes.tabs}
+        icon={LayoutTable01Icon}
+      >
+        {children}
+      </ContainerFallback>
+    );
+  }
+
+  const activeIndex = Math.min(active, tabs.length - 1);
+
+  const focusTab = (index: number) => {
+    const clamped = (index + tabs.length) % tabs.length;
+    setActive(clamped);
+    tabRefs.current[clamped]?.focus();
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent, index: number) => {
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        focusTab(index + 1);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        focusTab(index - 1);
+        break;
+      case "Home":
+        event.preventDefault();
+        focusTab(0);
+        break;
+      case "End":
+        event.preventDefault();
+        focusTab(tabs.length - 1);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-card">
+      <div className="flex items-center gap-2 border-b bg-muted/30 px-2">
+        <HugeiconsIcon
+          icon={LayoutTable01Icon}
+          size={15}
+          className="ml-1 shrink-0 text-muted-foreground"
+          aria-hidden
+        />
+        <div
+          role="tablist"
+          aria-label="Tabs"
+          className="flex min-w-0 flex-nowrap gap-1 overflow-x-auto"
+        >
+          {tabs.map((tab, index) => {
+            const selected = index === activeIndex;
+            return (
+              <button
+                key={`${baseId}-tab-${index}`}
+                ref={(el) => {
+                  tabRefs.current[index] = el;
+                }}
+                type="button"
+                role="tab"
+                id={`${baseId}-tab-${index}`}
+                aria-selected={selected}
+                aria-controls={`${baseId}-panel-${index}`}
+                tabIndex={selected ? 0 : -1}
+                onClick={() => setActive(index)}
+                onKeyDown={(event) => onKeyDown(event, index)}
+                className={cn(
+                  "-mb-px shrink-0 whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+                  selected
+                    ? "border-violet-400 text-violet-300"
+                    : "border-transparent text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      {tabs.map((tab, index) => (
+        <div
+          key={`${baseId}-panel-${index}`}
+          role="tabpanel"
+          id={`${baseId}-panel-${index}`}
+          aria-labelledby={`${baseId}-tab-${index}`}
+          hidden={index !== activeIndex}
+          className="p-4"
+        >
+          {index === activeIndex ? <ProposalBlocks body={tab.body} /> : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -119,6 +119,10 @@ This runs on the hot path — keep allocations out of the loop.
 }
 </OpenApi>
 
+<Tabs id="walkthrough" tabs={[{ "label": "Overview", "body": "<Callout id=\"tab-note\" tone=\"info\">Recursive **markdown** inside a tab.</Callout>" }, { "label": "Details", "body": "Plain markdown body with a list:\n\n- one\n- two" }]} />
+
+<Columns id="before-after" columns={[{ "body": "### Before\nThe **old** approach." }, { "body": "### After\nThe **new** approach." }]} />
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached for caching?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/blockDepth.ts
+++ b/ui/src/components/proposals/blocks/blockDepth.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Maximum container nesting depth. Container blocks (`Tabs`, `Columns`)
+ * recursively render their child bodies through the SAME segment→component
+ * mapping as the top-level proposal, so a pathological `tabs`-in-`tabs`-in-…
+ * body could recurse forever. Once the depth cap is reached a child body is
+ * rendered as plain markdown instead of being parsed for further blocks, which
+ * terminates the recursion while still showing the authored content.
+ */
+export const MAX_BLOCK_DEPTH = 4;
+
+/** Current container nesting depth (0 at the top level). */
+export const BlockDepthContext = createContext(0);
+
+/** Read the current container nesting depth. */
+export function useBlockDepth(): number {
+  return useContext(BlockDepthContext);
+}

--- a/ui/src/components/proposals/blocks/blocks.test.ts
+++ b/ui/src/components/proposals/blocks/blocks.test.ts
@@ -32,6 +32,8 @@ export const CANONICAL_V1_TAGS = [
   "JsonExplorer",
   "Html",
   "OpenApi",
+  "Tabs",
+  "Columns",
   "QuestionForm",
 ] as const;
 
@@ -235,6 +237,20 @@ describe("canonical proposal.mdx round-trip", () => {
     expect(getProposalBlockDefinitionByTag("OpenApi")!.type).toBe(
       "openapi-spec",
     );
+
+    // Tabs
+    const tabs = byTag.get("Tabs");
+    expect(tabs).toBeDefined();
+    expect(tabs!.id).toBe("walkthrough");
+    expect(tabs!.attributes.tabs).toContain("Overview");
+    expect(getProposalBlockDefinitionByTag("Tabs")!.type).toBe("tabs");
+
+    // Columns
+    const columns = byTag.get("Columns");
+    expect(columns).toBeDefined();
+    expect(columns!.id).toBe("before-after");
+    expect(columns!.attributes.columns).toContain("body");
+    expect(getProposalBlockDefinitionByTag("Columns")!.type).toBe("columns");
 
     // QuestionForm
     const questionForm = byTag.get("QuestionForm");

--- a/ui/src/components/proposals/blocks/containerAttr.ts
+++ b/ui/src/components/proposals/blocks/containerAttr.ts
@@ -1,0 +1,82 @@
+// Shared parsing for the JSON-attribute envelope used by the recursive
+// container blocks (`Tabs`, `Columns`). The MDX-AST parser stores a `{...}`
+// expression attribute as its raw inner expression text (see `parseMdxBody.ts`
+// / Rust `attributes_of`), which for the decided wire format is a JSON array
+// literal — parseable with `JSON.parse`. These helpers parse that text and
+// normalize each entry's `body` into a proposal-MDX string, returning `null`
+// (never throwing) so the caller can render a graceful fallback.
+
+/** One tab: a button `label` and a recursively-rendered proposal-MDX `body`. */
+export interface TabEntry {
+  label: string;
+  body: string;
+}
+
+/** One column: a recursively-rendered proposal-MDX `body`. */
+export interface ColumnEntry {
+  body: string;
+}
+
+/** Coerce an unknown value to a body string (non-string bodies become ""). */
+function asBody(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Parse a `{...}` container attribute value into an array of entries. Returns
+ * `null` when the attribute is missing, empty, not valid JSON, or not a JSON
+ * array — the signal for the block to render its graceful fallback. Never
+ * throws.
+ */
+function parseEntries(raw: string | undefined): unknown[] | null {
+  if (raw === undefined) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  return parsed;
+}
+
+/**
+ * Parse the `tabs` attribute (`tabs={[{ "label", "body" }, ...]}`) into
+ * normalized {@link TabEntry} items. Entries missing a usable `label` fall back
+ * to a positional `Tab N` label so a partly-malformed array still renders.
+ * Returns `null` for a missing / invalid / empty attribute.
+ */
+export function parseTabsAttr(raw: string | undefined): TabEntry[] | null {
+  const entries = parseEntries(raw);
+  if (!entries || entries.length === 0) return null;
+  return entries.map((entry, index) => {
+    const record =
+      entry && typeof entry === "object" && !Array.isArray(entry)
+        ? (entry as Record<string, unknown>)
+        : {};
+    const label =
+      typeof record.label === "string" && record.label.trim().length > 0
+        ? record.label
+        : `Tab ${index + 1}`;
+    return { label, body: asBody(record.body) };
+  });
+}
+
+/**
+ * Parse the `columns` attribute (`columns={[{ "body" }, ...]}`) into normalized
+ * {@link ColumnEntry} items. Returns `null` for a missing / invalid / empty
+ * attribute.
+ */
+export function parseColumnsAttr(raw: string | undefined): ColumnEntry[] | null {
+  const entries = parseEntries(raw);
+  if (!entries || entries.length === 0) return null;
+  return entries.map((entry) => {
+    const record =
+      entry && typeof entry === "object" && !Array.isArray(entry)
+        ? (entry as Record<string, unknown>)
+        : {};
+    return { body: asBody(record.body) };
+  });
+}

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -13,6 +13,8 @@ export { TableBlock } from "./TableBlock";
 export { ChecklistBlock } from "./ChecklistBlock";
 export { JsonExplorerBlock, JsonTree } from "./JsonExplorerBlock";
 export { OpenApiSpecBlock } from "./OpenApiSpecBlock";
+export { TabsBlock } from "./TabsBlock";
+export { ColumnsBlock } from "./ColumnsBlock";
 export { HtmlBlock } from "./HtmlBlock";
 export { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
 export {
@@ -55,6 +57,9 @@ export type {
 } from "./annotationRail.helpers";
 export { BlockRenderer } from "./BlockRenderer";
 export type { BlockRendererProps } from "./BlockRenderer";
+export { ProposalBlocks } from "./ProposalBlocks";
+export type { ProposalBlocksProps } from "./ProposalBlocks";
+export { MAX_BLOCK_DEPTH, useBlockDepth } from "./blockDepth";
 export { parseMdxBody, isPascalCaseTag, extractBlockTags } from "./parseMdxBody";
 export {
   PROPOSAL_BLOCK_REGISTRY,

--- a/ui/src/lib/blockRegistry.ts
+++ b/ui/src/lib/blockRegistry.ts
@@ -6,6 +6,7 @@ import {
   ApiEndpointBlock,
   CalloutBlock,
   ChecklistBlock,
+  ColumnsBlock,
   DataModelBlock,
   DecisionsBlock,
   Diagram,
@@ -17,6 +18,7 @@ import {
   QuestionFormBlock,
   RichText,
   TableBlock,
+  TabsBlock,
 } from "@/components/proposals/blocks";
 import {
   PROPOSAL_BLOCK_REGISTRY,
@@ -46,6 +48,8 @@ const BLOCK_COMPONENTS: Record<ProposalBlockType, ComponentType<BlockProps>> = {
   "json-explorer": JsonExplorerBlock,
   html: HtmlBlock,
   "openapi-spec": OpenApiSpecBlock,
+  tabs: TabsBlock,
+  columns: ColumnsBlock,
   "question-form": QuestionFormBlock,
 };
 
@@ -64,6 +68,8 @@ const BLOCK_DISPLAY_NAMES: Record<ProposalBlockType, string> = {
   "json-explorer": "JSON Explorer",
   html: "HTML",
   "openapi-spec": "OpenAPI Spec",
+  tabs: "Tabs",
+  columns: "Columns",
   "question-form": "Open Questions",
 };
 

--- a/ui/src/lib/proposalBlocks.ts
+++ b/ui/src/lib/proposalBlocks.ts
@@ -166,6 +166,20 @@ export const PROPOSAL_BLOCK_REGISTRY = {
     tag: "OpenApi",
     fields: {},
   },
+  tabs: {
+    type: "tabs",
+    tag: "Tabs",
+    fields: {
+      tabs: { type: "string" },
+    },
+  },
+  columns: {
+    type: "columns",
+    tag: "Columns",
+    fields: {
+      columns: { type: "string" },
+    },
+  },
   "question-form": {
     type: "question-form",
     tag: "QuestionForm",


### PR DESCRIPTION
## WU13 — recursive container blocks: `Tabs` + `Columns`

Adds two new CONTAINER proposal block types that recursively render child proposal-MDX bodies, the payoff of WU12's MDX-AST parsers (#1040/#1041) preserving `{...}` JSON-attribute envelopes.

Block-type count: **15 → 17** (`tabs`, `columns` inserted before `QuestionForm`, which stays last).

### Wire format (per WU12 decision)
Self-closing, JSON-attribute envelope (NOT nested MDX children):
- `<Tabs id=… tabs={[{ "label": "Overview", "body": "…mdx…" }, …]} />`
- `<Columns id=… columns={[{ "body": "…mdx…" }, …]} />`

Each entry's `body` is a normal proposal-MDX string parsed + rendered recursively. The MDX-AST parser already stores the `{...}` attribute as raw expression text; for valid JSON that is `JSON.parse`-able.

### Recursive render seam
- Extracted the top-level segment→component renderer into a single shared `ProposalBlocks` component; `BlockRenderer` now delegates to it. Tabs/Columns reuse the **same** renderer for child bodies — no second/forked renderer.
- Depth guard via `BlockDepthContext` (`MAX_BLOCK_DEPTH = 4`): beyond the cap a child body renders as plain markdown, so `tabs`-in-`tabs` can't infinite-loop.
- Graceful fallback (`ContainerFallback`): missing/invalid JSON renders the block's own children markdown, else a muted "Could not render tabs/columns" + the raw attribute. Never throws, never blanks.

### Components
- `TabsBlock`: ARIA `tablist`/`tab`/`tabpanel`, arrow/Home/End keyboard nav, violet active accent, first tab default.
- `ColumnsBlock`: responsive grid (`grid-cols-1 md:grid-cols-N`, clamped 1–4), stacks on narrow screens.

### Add-a-block-type checklist
- Rust `proposal_blocks.rs`: 2 enum variants + `as_str()`/`tag()` arms + 2 registry entries (with `tabs`/`columns` string field + `block_with_description` JSON-array authoring docs); len asserts 15→17; canonical-tag + enum-coverage tests updated.
- Rust `validation.rs`: `mdx_body_valid_all_canonical_blocks` gains `<Tabs/>` + `<Columns/>`.
- TS mirror: `proposalBlocks.ts`, `blockRegistry.ts` (`BLOCK_COMPONENTS` + `BLOCK_DISPLAY_NAMES`), `blocks/index.ts` exports.
- Parity: `blocks.test.ts` `CANONICAL_V1_TAGS` + per-block assertions; fixture `canonicalProposal.mdx` gains both blocks before `QuestionForm`.
- Snapshot: regenerated `tool_schemas` — **no diff** (new blocks reuse `string_field()`, so the tool's `$defs` schema is unchanged). `mcp-tools.gen.ts` untouched.

### Tests
- Rust: `cargo test -p djinn-control-plane --lib` 435/0; `validation` + `proposal_blocks` green; clippy `--all-features` clean; `tool_schemas` snapshot green (no change).
- UI: `TabsBlock.test.tsx` / `ColumnsBlock.test.tsx` (N tabs/columns, click switches panel, recursive Callout child, invalid JSON → graceful fallback no-throw, depth-guard caps runaway nesting, stack class present); full blocks + proposals suites green; `tsc -b` + eslint clean; `npm run build` succeeds.

No migration. `ui/package-lock.json` synced to the already-committed WU12 deps (the base lock was stale; required for CI `npm ci`) — no new dependency added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)