### PR TITLE
ci: gate Quality Gate on Server Size Guard

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -515,6 +515,7 @@ jobs:
     if: always() && github.event_name != 'push'
     needs:
       - server-clippy
+      - server-size-guard
       - server-migrations-guard
       - server-test
       - server-sqlx-cache
@@ -524,6 +525,7 @@ jobs:
         run: |
           results=(
             "${{ needs.server-clippy.result }}"
+            "${{ needs.server-size-guard.result }}"
             "${{ needs.server-migrations-guard.result }}"
             "${{ needs.server-test.result }}"
             "${{ needs.server-sqlx-cache.result }}"


### PR DESCRIPTION
## What

`server-size-guard` runs on PRs but was **not** part of the `Quality Gate` roll-up's `needs:`/result array — and Quality Gate is the *single* required status check for branch protection + the merge queue. So a failing source-file size guard never blocked a PR or a merge.

This adds `server-size-guard` to the gate's `needs:` and result check, making oversized Rust source files (`scripts/check-file-size.sh`, 1500 lines / 50KB default) a hard blocker.

## Why now

`proposal_blocks.rs` crossed the 1500-line limit while we added block types and merged anyway (Size Guard was FAILURE on #1043). Follow-up: the next registry PR (WU16) splits that file back under the limit.