### PR TITLE
perf(codegraph): cap rendered edges by salience to kill load hang

### DIFF
--- a/ui/src/components/codegraph/CodeGraphCanvas.tsx
+++ b/ui/src/components/codegraph/CodeGraphCanvas.tsx
@@ -31,12 +31,14 @@ import {
   RefreshIcon,
 } from "@hugeicons/core-free-icons";
 
+import type Graph from "graphology";
 import { fetchSnapshot } from "@/api/codeGraph";
 import {
   buildGraphFromSnapshot,
   filterSnapshotForWorkspace,
   isDoubleClick,
   parseSnapshotResponse,
+  readEdgeRenderStats,
   type SnapshotPayload,
 } from "@/lib/codeGraphAdapter";
 import {
@@ -250,7 +252,7 @@ export function CodeGraphCanvas({
         className="absolute inset-0 transition-opacity duration-200 ease-out"
         style={{ cursor: "grab" }}
       />
-      <CanvasOverlay state={state} visibleSnapshot={visibleSnapshot} />
+      <CanvasOverlay state={state} visibleSnapshot={visibleSnapshot} graph={graph} />
       {layoutRunning && visibleSnapshot?.nodes.length ? (
         <LayoutOptimizingPill />
       ) : null}
@@ -425,9 +427,10 @@ export function CitationStatusBadge() {
 interface CanvasOverlayProps {
   state: FetchState;
   visibleSnapshot: SnapshotPayload | null;
+  graph: Graph | null;
 }
 
-function CanvasOverlay({ state, visibleSnapshot }: CanvasOverlayProps) {
+function CanvasOverlay({ state, visibleSnapshot, graph }: CanvasOverlayProps) {
   if (state.status === "loading") {
     return (
       <CenterCard>
@@ -475,9 +478,37 @@ function CanvasOverlay({ state, visibleSnapshot }: CanvasOverlayProps) {
           </span>
         )}
       </Pill>
-      <Pill>{snapshot.edges.length.toLocaleString()} edges</Pill>
+      <EdgeCountPill snapshot={snapshot} graph={graph} />
     </div>
   );
+}
+
+/**
+ * Edge-count pill. When the salience cap trims the drawable set (large
+ * "All" snapshots), shows "N of M edges" with the rendered count first so
+ * it reads consistently with the node "capped from" treatment. Falls back
+ * to the raw snapshot edge count before the graph is built.
+ */
+function EdgeCountPill({
+  snapshot,
+  graph,
+}: {
+  snapshot: SnapshotPayload;
+  graph: Graph | null;
+}) {
+  const stats = graph ? readEdgeRenderStats(graph) : null;
+  if (stats && stats.rendered < stats.total) {
+    return (
+      <Pill>
+        {stats.rendered.toLocaleString()} edges
+        <span className="ml-1 text-amber-300">
+          (of {stats.total.toLocaleString()})
+        </span>
+      </Pill>
+    );
+  }
+  const count = stats?.rendered ?? snapshot.edges.length;
+  return <Pill>{count.toLocaleString()} edges</Pill>;
 }
 
 function CenterCard({ children }: { children: React.ReactNode }) {

--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -6,7 +6,9 @@ import {
   DOUBLE_CLICK_INTERVAL_MS,
   LOD_FAR_RATIO,
   LOD_MID_RATIO,
+  MAX_RENDERED_EDGES,
   PRECOMPUTED_LAYOUT_ATTRIBUTE,
+  readEdgeRenderStats,
   VIEWPORT_CULLING_MARGIN,
   VIEWPORT_CULLING_THRESHOLD,
   WORKSPACE_COLORS,
@@ -1300,6 +1302,76 @@ describe("buildGraphFromSnapshot", () => {
         graph2.getNodeAttribute(id, "y"),
       );
     }
+  });
+});
+
+describe("edge salience cap", () => {
+  // Build a dense snapshot: N symbol nodes with finite coordinates (so the
+  // precomputed branch is taken — fast, no layout) and `edgeCount`
+  // SymbolReference edges spread across them. `multi: true` lets duplicate
+  // endpoints coexist, so we can exceed the cap with a modest node count.
+  function denseSnapshot(
+    nodeCount: number,
+    edgeCount: number,
+    confidenceAt: (i: number) => number = () => 1,
+  ): SnapshotPayload {
+    const nodes: SnapshotNode[] = Array.from({ length: nodeCount }, (_, i) => ({
+      id: `symbol:n${i}`,
+      kind: "symbol",
+      label: `n${i}`,
+      symbol_kind: "function",
+      pagerank: 0.1,
+      x: i,
+      y: i,
+    }));
+    const edges = Array.from({ length: edgeCount }, (_, i) => ({
+      from: `symbol:n${i % nodeCount}`,
+      to: `symbol:n${(i + 1) % nodeCount}`,
+      kind: "SymbolReference",
+      confidence: confidenceAt(i),
+      reason: undefined,
+    }));
+    return {
+      project_id: "proj-dense",
+      git_head: "dense",
+      generated_at: "2026-04-28T00:00:00Z",
+      truncated: false,
+      total_nodes: nodeCount,
+      total_edges: edgeCount,
+      nodes,
+      edges,
+    };
+  }
+
+  it("caps rendered edges at MAX_RENDERED_EDGES and records the original total", () => {
+    const total = MAX_RENDERED_EDGES + 500;
+    const graph = buildGraphFromSnapshot(denseSnapshot(200, total));
+    expect(graph.size).toBe(MAX_RENDERED_EDGES);
+    expect(readEdgeRenderStats(graph)).toEqual({
+      rendered: MAX_RENDERED_EDGES,
+      total,
+    });
+  });
+
+  it("does not trim when drawable edges sit under the ceiling", () => {
+    const graph = buildGraphFromSnapshot(denseSnapshot(50, 100));
+    expect(graph.size).toBe(100);
+    expect(readEdgeRenderStats(graph)).toEqual({ rendered: 100, total: 100 });
+  });
+
+  it("keeps the highest-confidence edges when trimming", () => {
+    // Last `MAX` edges get confidence 1, the rest 0.1 — only the
+    // high-confidence tail should survive the salience sort.
+    const total = MAX_RENDERED_EDGES + 1000;
+    const graph = buildGraphFromSnapshot(
+      denseSnapshot(200, total, (i) => (i >= total - MAX_RENDERED_EDGES ? 1 : 0.1)),
+    );
+    expect(graph.size).toBe(MAX_RENDERED_EDGES);
+    let lowConfidenceKept = 0;
+    graph.forEachEdge((_e, attrs) => {
+      if ((attrs.confidence as number) < 0.5) lowConfidenceKept += 1;
+    });
+    expect(lowConfidenceKept).toBe(0);
   });
 });
 

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -638,6 +638,61 @@ function edgeBaseSize(nodeCount: number): number {
   return 1.0;
 }
 
+/**
+ * Ceiling on edges handed to Sigma. A 10k-node "All" snapshot drags in
+ * ~98k edges, and every one is a curved WebGL geometry — that volume is
+ * the dominant cost of the initial-load hang and renders as an
+ * undifferentiated wash anyway. Above this ceiling we keep only the
+ * highest-salience edges (see {@link edgeSalience}); the rest are
+ * dropped before they ever reach graphology/Sigma. Focused sub-views
+ * (single workspace, DOI expansion) sit far below the cap and are
+ * unaffected.
+ */
+export const MAX_RENDERED_EDGES = 12_000;
+
+/**
+ * Graph-level attribute carrying `{ rendered, total }` edge counts so the
+ * canvas can surface "N of M edges" when the salience cap trims the set.
+ * `total` counts drawable edges (post containment/self-loop/drop filters),
+ * matching what `rendered` is selected from.
+ */
+export const EDGE_RENDER_STATS_ATTRIBUTE = "edgeRenderStats";
+
+export interface EdgeRenderStats {
+  rendered: number;
+  total: number;
+}
+
+/** Read the `{ rendered, total }` edge counts stashed on a built graph. */
+export function readEdgeRenderStats(graph: Graph): EdgeRenderStats | null {
+  const stats = graph.getAttribute(EDGE_RENDER_STATS_ATTRIBUTE);
+  if (
+    stats &&
+    typeof stats === "object" &&
+    typeof (stats as EdgeRenderStats).rendered === "number" &&
+    typeof (stats as EdgeRenderStats).total === "number"
+  ) {
+    return stats as EdgeRenderStats;
+  }
+  return null;
+}
+
+/**
+ * Visual weight of a drawable edge — reuses the same factors that drive
+ * stroke `size`, so the edges that read most strongly on the canvas are
+ * exactly the ones the salience cap keeps: per-kind importance
+ * (structural/OOP spine over the call graph), per-edge confidence, and a
+ * cross-workspace boost.
+ */
+function edgeSalience(
+  multiplier: number,
+  confidence: number,
+  isCrossWorkspace: boolean,
+): number {
+  const confidenceFactor = 0.4 + confidence * 0.6;
+  return multiplier * confidenceFactor * (isCrossWorkspace ? 2.4 : 1);
+}
+
 // ── Adapter ─────────────────────────────────────────────────────────────────
 
 export interface BuildGraphOptions {
@@ -794,6 +849,19 @@ function addEdgesFromSnapshot(
   const { dropSelfLoops } = options;
   const nodeMap = new Map(snapshot.nodes.map((n) => [n.id, n]));
   const baseSize = edgeBaseSize(nodeCount);
+
+  // Collect drawable edges with their fully-resolved attributes and a
+  // salience score, then (if over the ceiling) keep only the strongest
+  // before touching graphology. Dropping at this layer keeps the trimmed
+  // edges out of Sigma's WebGL buffers entirely — the real load win.
+  interface DrawableEdge {
+    from: string;
+    to: string;
+    salience: number;
+    attrs: Record<string, unknown>;
+  }
+  const drawable: DrawableEdge[] = [];
+
   for (const edge of snapshot.edges) {
     // Containment edges (ContainsDefinition / DeclaredInFile /
     // MemberOf) are structural nesting metadata, not drawn or
@@ -812,26 +880,48 @@ function addEdgesFromSnapshot(
       !!targetWorkspace &&
       sourceWorkspace !== targetWorkspace;
     const crossWorkspaceColor = isCrossWorkspace ? "#facc15" : undefined;
-    graph.addEdge(edge.from, edge.to, {
-      kind: edge.kind,
-      confidence: edge.confidence,
-      reason: edge.reason,
-      sourceWorkspace,
-      targetWorkspace,
-      isCrossWorkspace,
-      crossWorkspace: isCrossWorkspace,
-      size:
-        baseSize *
-        style.sizeMultiplier *
-        confidenceFactor *
-        (isCrossWorkspace ? 2.4 : 1),
-      color: crossWorkspaceColor ?? style.color,
-      type: "curved",
-      curvature: (isCrossWorkspace ? 0.28 : 0.12) + 0.04,
-      zIndex: isCrossWorkspace ? 20 : 1,
-      lineStyle: isCrossWorkspace ? "dashed" : "solid",
+    drawable.push({
+      from: edge.from,
+      to: edge.to,
+      salience: edgeSalience(
+        style.sizeMultiplier,
+        edge.confidence,
+        isCrossWorkspace,
+      ),
+      attrs: {
+        kind: edge.kind,
+        confidence: edge.confidence,
+        reason: edge.reason,
+        sourceWorkspace,
+        targetWorkspace,
+        isCrossWorkspace,
+        crossWorkspace: isCrossWorkspace,
+        size: baseSize * style.sizeMultiplier * confidenceFactor *
+          (isCrossWorkspace ? 2.4 : 1),
+        color: crossWorkspaceColor ?? style.color,
+        type: "curved",
+        curvature: (isCrossWorkspace ? 0.28 : 0.12) + 0.04,
+        zIndex: isCrossWorkspace ? 20 : 1,
+        lineStyle: isCrossWorkspace ? "dashed" : "solid",
+      },
     });
   }
+
+  const total = drawable.length;
+  if (total > MAX_RENDERED_EDGES) {
+    // Highest salience first; the slice keeps the strongest MAX edges.
+    drawable.sort((a, b) => b.salience - a.salience);
+    drawable.length = MAX_RENDERED_EDGES;
+  }
+
+  for (const e of drawable) {
+    graph.addEdge(e.from, e.to, e.attrs);
+  }
+
+  graph.setAttribute(EDGE_RENDER_STATS_ATTRIBUTE, {
+    rendered: drawable.length,
+    total,
+  } satisfies EdgeRenderStats);
 }
 
 /**


### PR DESCRIPTION
## Problem

Opening the code graph on the full "All" view hangs. The node cap (`DEFAULT_NODE_CAP = 10_000`) bounds nodes, but **edges are uncapped** — a 10k-node snapshot pulls in **~98k edges**, and every one is rendered as a curved WebGL geometry (`defaultEdgeType: "curved"`). That edge volume is the dominant cost of the initial-load stall, and it renders as an undifferentiated wash anyway (the rainbow donut).

## Change

Cap drawable edges at `MAX_RENDERED_EDGES` (12k), applied in `addEdgesFromSnapshot` **before** edges reach graphology/Sigma:

- Collect drawable edges (post containment/self-loop/`drop` filters) with a **salience** score that reuses the exact factors already driving stroke `size` — per-kind weight (structural/OOP spine outranks the call graph), per-edge confidence, and the cross-workspace boost.
- Above the ceiling, sort by salience and keep the strongest 12k; drop the rest. Dropping at this layer keeps trimmed edges out of Sigma's WebGL buffers entirely — the real load win.
- Focused sub-views (single workspace, DOI expansion) sit far below the cap and are unaffected.
- Stash `{ rendered, total }` on the graph (`EDGE_RENDER_STATS_ATTRIBUTE`) and surface **"N of M edges"** in the count pill, mirroring the node "capped from" treatment.

This is the first of a small series addressing code-graph load perf + legibility. Follow-ups: straight edges at scale / glow reduction, and crate-based coloring.

## Tests

- 3 new unit tests in `codeGraphAdapter.test.ts`: caps at the ceiling and records the original total; no trim under the ceiling; keeps the highest-confidence edges when trimming.
- `tsc --noEmit` clean; full `codeGraphAdapter` suite green (111 tests).