### PR TITLE
feat(codegraph): color topology by crate, not community-hash rainbow

### DIFF
--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -1497,6 +1497,53 @@ describe("colorForNode", () => {
     ).toBe("#a855f7");
   });
 
+  it("colors any node by its crate (workspace) when the tag is present", () => {
+    // Crate wins over community_id, parent-dir, and folder hashing alike,
+    // so the whole topology view reads as crate regions.
+    const sym: SnapshotNode = {
+      id: "s",
+      kind: "symbol",
+      label: "x",
+      pagerank: 0,
+      symbol_kind: "function",
+      community_id: "cluster-7",
+      file_path: "server/crates/djinn-graph/src/lib.rs",
+      workspace: "djinn-graph",
+    };
+    expect(colorForNode(sym)).toBe(colorForWorkspace("djinn-graph"));
+
+    const file: SnapshotNode = {
+      id: "f",
+      kind: "file",
+      label: "lib.rs",
+      file_path: "server/crates/djinn-graph/src/lib.rs",
+      pagerank: 0,
+      workspace: "djinn-graph",
+    };
+    expect(colorForNode(file)).toBe(colorForWorkspace("djinn-graph"));
+  });
+
+  it("colors nodes in the same crate identically, regardless of kind or folder", () => {
+    const a: SnapshotNode = {
+      id: "a",
+      kind: "symbol",
+      label: "a",
+      pagerank: 0,
+      symbol_kind: "function",
+      file_path: "server/crates/djinn-graph/src/communities.rs",
+      workspace: "djinn-graph",
+    };
+    const b: SnapshotNode = {
+      id: "b",
+      kind: "file",
+      label: "lib.rs",
+      file_path: "server/crates/djinn-graph/src/lib.rs",
+      pagerank: 0,
+      workspace: "djinn-graph",
+    };
+    expect(colorForNode(a)).toBe(colorForNode(b));
+  });
+
   it("colorForCommunity is deterministic across calls", () => {
     expect(colorForCommunity("alpha")).toBe(colorForCommunity("alpha"));
   });
@@ -1648,6 +1695,48 @@ describe("deriveCommunityHulls", () => {
       "symbol:scip-rust . . . User#",
       "symbol:scip-rust . . . main()",
     ]);
+  });
+
+  it("colors the hull by its members' dominant crate so it matches the dots", () => {
+    // Three members carry community_id "alpha": two in crate "graph",
+    // one in crate "core". The hull should take the majority crate's hue,
+    // which is exactly what colorForNode assigns those member dots.
+    const snapshot: SnapshotPayload = {
+      ...fixtureSnapshot,
+      nodes: [
+        {
+          id: "m1",
+          kind: "symbol",
+          label: "m1",
+          pagerank: 0,
+          symbol_kind: "function",
+          community_id: "alpha",
+          workspace: "graph",
+        },
+        {
+          id: "m2",
+          kind: "symbol",
+          label: "m2",
+          pagerank: 0,
+          symbol_kind: "function",
+          community_id: "alpha",
+          workspace: "graph",
+        },
+        {
+          id: "m3",
+          kind: "symbol",
+          label: "m3",
+          pagerank: 0,
+          symbol_kind: "function",
+          community_id: "alpha",
+          workspace: "core",
+        },
+      ],
+      edges: [],
+    };
+    const hulls = deriveCommunityHulls(snapshot);
+    const alpha = hulls.find((h) => h.id === "alpha");
+    expect(alpha?.color).toBe(colorForWorkspace("graph"));
   });
 
   it("is deterministic across calls", () => {

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -398,6 +398,23 @@ export function colorForCommunity(communityId: string): string {
   return COMMUNITY_COLORS[fnv1a(communityId) % COMMUNITY_COLORS.length];
 }
 
+/**
+ * Key with the highest count in a tally map, ties broken by lexical order
+ * for determinism. Returns `undefined` for an empty map. Used to pick a
+ * community hull's dominant crate.
+ */
+function dominantKey(counts: Map<string, number>): string | undefined {
+  let best: string | undefined;
+  let bestCount = -1;
+  for (const [key, count] of counts) {
+    if (count > bestCount || (count === bestCount && best !== undefined && key < best)) {
+      best = key;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
 // ── Community hull metadata ────────────────────────────────────────────────
 
 /**
@@ -456,7 +473,7 @@ export function deriveCommunityHulls(
 ): CommunityHull[] {
   const visibleMembers = new Map<
     string,
-    { ids: Set<string>; legacy?: SnapshotNode }
+    { ids: Set<string>; legacy?: SnapshotNode; workspaces: Map<string, number> }
   >();
 
   for (const node of snapshot.nodes) {
@@ -468,28 +485,44 @@ export function deriveCommunityHulls(
         // Prefer the first legacy entry encountered; do not overwrite.
         if (!entry.legacy) entry.legacy = node;
       } else {
-        visibleMembers.set(cid, { ids: new Set(), legacy: node });
+        visibleMembers.set(cid, {
+          ids: new Set(),
+          legacy: node,
+          workspaces: new Map(),
+        });
       }
       continue;
     }
     if (!node.community_id) continue;
     const cid = node.community_id;
-    const entry = visibleMembers.get(cid);
-    if (entry) {
-      entry.ids.add(node.id);
-    } else {
-      visibleMembers.set(cid, { ids: new Set([node.id]) });
+    let entry = visibleMembers.get(cid);
+    if (!entry) {
+      entry = { ids: new Set(), workspaces: new Map() };
+      visibleMembers.set(cid, entry);
+    }
+    entry.ids.add(node.id);
+    if (node.workspace) {
+      entry.workspaces.set(
+        node.workspace,
+        (entry.workspaces.get(node.workspace) ?? 0) + 1,
+      );
     }
   }
 
   const hulls: CommunityHull[] = [];
   for (const [cid, entry] of visibleMembers) {
     const legacy = entry.legacy;
+    // Match the hull background to the crate its members are colored by,
+    // so the region and the dots inside it read as one crate. Falls back
+    // to the per-community hue when no member carries a workspace tag.
+    const dominantWorkspace = dominantKey(entry.workspaces);
     hulls.push({
       id: cid,
       label: legacy?.label ?? cid,
       keywords: legacy ? normalizeKeywords(legacy.keywords) : undefined,
-      color: colorForCommunity(cid),
+      color: dominantWorkspace
+        ? colorForWorkspace(dominantWorkspace)
+        : colorForCommunity(cid),
       memberCount: legacy?.member_count ?? entry.ids.size,
       memberIds: Array.from(entry.ids).sort((a, b) => a.localeCompare(b, "en")),
       seed: fnv1a(cid),
@@ -518,20 +551,28 @@ function workspaceBadge(workspace: string): string {
 }
 
 /**
- * Color routing:
+ * Color routing. The **crate (workspace)** is the primary topology
+ * grouping: every node carrying a `workspace` tag is colored by its
+ * crate, so the canvas reads as a handful of crate regions sharing one
+ * hue each instead of a per-community / per-folder hash rainbow. This is
+ * the lever for "color per crate" — same crate, same color, regardless
+ * of kind.
+ *
+ * Projects without workspace tags (non-Rust repos, pre-workspace
+ * snapshots) fall back to the prior hashing so they degrade gracefully:
  *   - Project: fixed purple accent.
  *   - Folder: hash the folder path so siblings under the same parent
- *     share a hue — the canvas reads as colored regions per top-level
- *     module instead of one indigo band.
+ *     share a hue.
  *   - File: hash the parent directory so all files in a folder share a
- *     color. This is the lever that breaks up the blue file wall.
- *   - Community: hash the stable `community_id` so each collapsed blob
- *     gets a distinct, deterministic hue. Falls back to the label when
- *     the id is absent (shouldn't happen for real server payloads).
+ *     color.
+ *   - Community: hash the stable `community_id`, falling back to the label.
  *   - Symbol: community_id (if F3 populated) → file_path's parent
  *     directory → fallback.
  */
 export function colorForNode(node: SnapshotNode): string {
+  // Crate wins for every kind when the snapshot carries workspace tags.
+  if (node.workspace) return colorForWorkspace(node.workspace);
+
   if (node.kind === "community") {
     if (node.community_id) return colorForCommunity(node.community_id);
     return colorForCommunity(node.label || node.id);


### PR DESCRIPTION
## Problem

The topology color channel was unreadable — "so many colors I can't see anything." Root cause: the fill hashed `community_id` (or, when communities are sparse, the parent directory) into a 12-hue palette. Hundreds of clusters collapsed into 12 colors with heavy hash collisions and no spatial meaning. The per-community hull blobs piled on a second layer of color noise.

## Change

Make the **crate (workspace)** the topology grouping — "color per crate," as requested:

- **`colorForNode`**: when a node carries a `workspace` tag, color it by crate for *every* kind (folder/file/symbol). Same crate → same hue, so the canvas reads as a handful of crate regions instead of a rainbow. Projects without workspace tags (non-Rust repos, pre-workspace snapshots) fall back to the prior community/folder hashing unchanged.
- **`deriveCommunityHulls`**: color each hull by its members' **dominant crate** (ties broken lexically for determinism) so the background region and the dots inside it share one hue. Community geometry still defines the tight spatial regions — only the *color* channel collapses to crate, so many communities within one crate now read as a single crate-colored area.

Nodes already carried `workspace`, and `colorForWorkspace` already existed (it was wired only to the node border/halo) — this routes the main fill + hull color through it.

## Tests

- `colorForNode` colors by crate for every kind when `workspace` is set, and identically across kinds in the same crate.
- `deriveCommunityHulls` colors a hull by its members' dominant crate.
- Existing community/folder fallback tests stay green (their fixtures carry no workspace).
- `tsc --noEmit` clean; full codegraph suites green (114 adapter + 108 reducer/layout/label).

Second of a small series on code-graph load perf + legibility (follows #1046). Follow-up: straight edges at scale + glow/bloom reduction.