### PR TITLE
perf(codegraph): draw straight edges at scale instead of beziers

### DIFF
--- a/ui/src/hooks/useSigmaGraph.focusNodes.test.ts
+++ b/ui/src/hooks/useSigmaGraph.focusNodes.test.ts
@@ -61,6 +61,10 @@ vi.mock("@sigma/edge-curve", () => ({
   default: class MockEdgeCurveProgram {},
 }));
 
+vi.mock("sigma/rendering", () => ({
+  EdgeRectangleProgram: class MockEdgeRectangleProgram {},
+}));
+
 vi.mock("graphology-layout-forceatlas2/worker", () => ({
   default: class MockSupervisor {
     start = vi.fn();

--- a/ui/src/hooks/useSigmaGraph.test.tsx
+++ b/ui/src/hooks/useSigmaGraph.test.tsx
@@ -67,6 +67,12 @@ vi.mock("@sigma/edge-curve", () => ({
   default: class MockEdgeCurveProgram {},
 }));
 
+// `sigma/rendering` touches WebGL2RenderingContext at module load, which
+// jsdom lacks — stub the straight-edge program the same way.
+vi.mock("sigma/rendering", () => ({
+  EdgeRectangleProgram: class MockEdgeRectangleProgram {},
+}));
+
 // FA2 worker — track every constructor / start / stop / kill so the
 // test can assert which side effects fired on each branch.
 const fa2Instances: {

--- a/ui/src/hooks/useSigmaGraph.ts
+++ b/ui/src/hooks/useSigmaGraph.ts
@@ -38,6 +38,7 @@ import {
   type ViewportBounds,
 } from "@/lib/codeGraphAdapter";
 import EdgeCurveProgram from "@sigma/edge-curve";
+import { EdgeRectangleProgram } from "sigma/rendering";
 import forceAtlas2 from "graphology-layout-forceatlas2";
 import FA2LayoutSupervisor from "graphology-layout-forceatlas2/worker";
 import noverlap from "graphology-layout-noverlap";
@@ -211,6 +212,11 @@ export function useSigmaGraph(
         defaultEdgeType: "curved",
         edgeProgramClasses: {
           curved: EdgeCurveProgram,
+          // Straight (rectangle) program for dense graphs — far cheaper
+          // than tessellating a bezier per edge. The adapter assigns the
+          // "straight" type to intra-crate edges above
+          // STRAIGHT_EDGE_THRESHOLD.
+          straight: EdgeRectangleProgram,
         },
         labelFont: "JetBrains Mono, ui-monospace, monospace",
         labelSize: 11,

--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -4,10 +4,13 @@ import {
   COMMUNITY_HULLS_ATTRIBUTE,
   CONTAINMENT_EDGE_KINDS,
   DOUBLE_CLICK_INTERVAL_MS,
+  CURVED_EDGE_TYPE,
   LOD_FAR_RATIO,
   LOD_MID_RATIO,
   MAX_RENDERED_EDGES,
   PRECOMPUTED_LAYOUT_ATTRIBUTE,
+  STRAIGHT_EDGE_THRESHOLD,
+  STRAIGHT_EDGE_TYPE,
   readEdgeRenderStats,
   VIEWPORT_CULLING_MARGIN,
   VIEWPORT_CULLING_THRESHOLD,
@@ -1372,6 +1375,77 @@ describe("edge salience cap", () => {
       if ((attrs.confidence as number) < 0.5) lowConfidenceKept += 1;
     });
     expect(lowConfidenceKept).toBe(0);
+  });
+
+  it("draws straight edges once the rendered set is dense", () => {
+    const graph = buildGraphFromSnapshot(
+      denseSnapshot(200, STRAIGHT_EDGE_THRESHOLD + 50),
+    );
+    let straight = 0;
+    let curved = 0;
+    graph.forEachEdge((_e, attrs) => {
+      if (attrs.type === STRAIGHT_EDGE_TYPE) straight += 1;
+      if (attrs.type === CURVED_EDGE_TYPE) curved += 1;
+    });
+    // All intra-crate edges (no workspace tags in the fixture) go straight.
+    expect(straight).toBe(STRAIGHT_EDGE_THRESHOLD + 50);
+    expect(curved).toBe(0);
+    // Straight edges carry no curvature attribute.
+    graph.forEachEdge((_e, attrs) => {
+      expect(attrs.curvature).toBeUndefined();
+    });
+  });
+
+  it("keeps curved edges for sparse graphs", () => {
+    const graph = buildGraphFromSnapshot(denseSnapshot(50, 100));
+    graph.forEachEdge((_e, attrs) => {
+      expect(attrs.type).toBe(CURVED_EDGE_TYPE);
+      expect(attrs.curvature).toBeGreaterThan(0);
+    });
+  });
+
+  it("keeps cross-crate edges curved even in a dense graph", () => {
+    // Two crates; every edge crosses between them, so all stay curved
+    // and dashed regardless of density.
+    const n = 300;
+    const edgeCount = STRAIGHT_EDGE_THRESHOLD + 100;
+    const nodes: SnapshotNode[] = Array.from({ length: n }, (_, i) => ({
+      id: `symbol:n${i}`,
+      kind: "symbol",
+      label: `n${i}`,
+      symbol_kind: "function",
+      pagerank: 0.1,
+      x: i,
+      y: i,
+      workspace: i % 2 === 0 ? "crate-a" : "crate-b",
+    }));
+    const edges = Array.from({ length: edgeCount }, (_, i) => ({
+      // even -> odd guarantees a crate-a -> crate-b crossing.
+      from: `symbol:n${(i * 2) % n}`,
+      to: `symbol:n${(i * 2 + 1) % n}`,
+      kind: "SymbolReference",
+      confidence: 1,
+      reason: undefined,
+    }));
+    const graph = buildGraphFromSnapshot({
+      project_id: "p",
+      git_head: "g",
+      generated_at: "2026-04-28T00:00:00Z",
+      truncated: false,
+      total_nodes: n,
+      total_edges: edgeCount,
+      nodes,
+      edges,
+    });
+    let crossCurved = 0;
+    graph.forEachEdge((_e, attrs) => {
+      if (attrs.isCrossWorkspace === true) {
+        expect(attrs.type).toBe(CURVED_EDGE_TYPE);
+        expect(attrs.lineStyle).toBe("dashed");
+        crossCurved += 1;
+      }
+    });
+    expect(crossCurved).toBeGreaterThan(0);
   });
 });
 

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -692,6 +692,23 @@ function edgeBaseSize(nodeCount: number): number {
 export const MAX_RENDERED_EDGES = 12_000;
 
 /**
+ * Above this many rendered edges, intra-crate edges switch from curved
+ * beziers to straight lines. Curved edges tessellate a quadratic curve
+ * into many GPU segments; at a few thousand edges that geometry is the
+ * bulk of the per-frame cost and the curvature is imperceptible in the
+ * dense wash anyway. The few cross-crate edges stay curved + dashed so
+ * they remain legible as the highlighted inter-module links. Focused
+ * sub-views (single crate, DOI expansion) sit below the threshold and
+ * keep the prettier curved rendering.
+ */
+export const STRAIGHT_EDGE_THRESHOLD = 2_500;
+
+/** Sigma edge-program type for straight (rectangle) edges. */
+export const STRAIGHT_EDGE_TYPE = "straight";
+/** Sigma edge-program type for curved (bezier) edges. */
+export const CURVED_EDGE_TYPE = "curved";
+
+/**
  * Graph-level attribute carrying `{ rendered, total }` edge counts so the
  * canvas can surface "N of M edges" when the salience cap trims the set.
  * `total` counts drawable edges (post containment/self-loop/drop filters),
@@ -898,6 +915,7 @@ function addEdgesFromSnapshot(
   interface DrawableEdge {
     from: string;
     to: string;
+    isCrossWorkspace: boolean;
     salience: number;
     attrs: Record<string, unknown>;
   }
@@ -924,6 +942,7 @@ function addEdgesFromSnapshot(
     drawable.push({
       from: edge.from,
       to: edge.to,
+      isCrossWorkspace,
       salience: edgeSalience(
         style.sizeMultiplier,
         edge.confidence,
@@ -940,8 +959,6 @@ function addEdgesFromSnapshot(
         size: baseSize * style.sizeMultiplier * confidenceFactor *
           (isCrossWorkspace ? 2.4 : 1),
         color: crossWorkspaceColor ?? style.color,
-        type: "curved",
-        curvature: (isCrossWorkspace ? 0.28 : 0.12) + 0.04,
         zIndex: isCrossWorkspace ? 20 : 1,
         lineStyle: isCrossWorkspace ? "dashed" : "solid",
       },
@@ -955,8 +972,19 @@ function addEdgesFromSnapshot(
     drawable.length = MAX_RENDERED_EDGES;
   }
 
+  // Decide the edge program from the *rendered* count: dense graphs draw
+  // intra-crate edges as cheap straight lines, sparse ones keep curves.
+  const dense = drawable.length > STRAIGHT_EDGE_THRESHOLD;
   for (const e of drawable) {
-    graph.addEdge(e.from, e.to, e.attrs);
+    const curved = e.isCrossWorkspace || !dense;
+    graph.addEdge(e.from, e.to, {
+      ...e.attrs,
+      type: curved ? CURVED_EDGE_TYPE : STRAIGHT_EDGE_TYPE,
+      // curvature only applies to the bezier program; straight edges omit it.
+      ...(curved
+        ? { curvature: (e.isCrossWorkspace ? 0.28 : 0.12) + 0.04 }
+        : {}),
+    });
   }
 
   graph.setAttribute(EDGE_RENDER_STATS_ATTRIBUTE, {


### PR DESCRIPTION
## Problem

Every edge is rendered as a curved bezier (`defaultEdgeType: "curved"`, `EdgeCurveProgram`). A bezier tessellates into many GPU segments per edge; at a few thousand edges that geometry dominates per-frame cost — the other half of the load-time stall (#1046 capped the *count*; this addresses the *per-edge cost*). The curvature is also imperceptible in a dense wash.

## Change

Density-aware edge program, decided from the **rendered** edge count (after the salience cap):

- Above `STRAIGHT_EDGE_THRESHOLD` (2.5k rendered edges), intra-crate edges use the **straight** (`EdgeRectangleProgram`) program — far cheaper than a bezier, and registered alongside the curved program.
- The few **cross-crate** edges stay **curved + dashed** regardless of density, so they remain legible as the highlighted inter-module links.
- Focused sub-views (single crate, DOI expansion) sit below the threshold and keep the prettier curved rendering.
- `type`/`curvature` are assigned in the add loop (after the cap), since the choice depends on the final rendered count; straight edges omit `curvature`.

The `edgeReducer` spreads `...attrs` and only overrides color/size/zIndex/hidden — it never touches `type`, so the program choice survives selection/DOI highlighting.

## Tests

- dense graph → all intra-crate edges straight, no `curvature`.
- sparse graph → edges stay curved with curvature.
- two-crate dense graph → every cross-crate edge stays curved + dashed.
- Hook tests mock `sigma/rendering` (it touches `WebGL2RenderingContext` at import, which jsdom lacks), mirroring the existing `@sigma/edge-curve` mock.
- `tsc --noEmit` clean; 117 adapter tests + `useSigmaGraph.focusNodes` hook tests green.

Third of the code-graph perf + legibility series (follows #1046, #1047). Planned follow-up: glow/bloom + hull-opacity reduction (now that node fill encodes crate, the always-on workspace halo is redundant).