### PR TITLE
feat(codegraph): cut hull bloom — fewer, fainter community regions

### DIFF
--- a/ui/src/components/codegraph/CodeGraphCanvas.tsx
+++ b/ui/src/components/codegraph/CodeGraphCanvas.tsx
@@ -313,15 +313,16 @@ function CommunityHullOverlay({
         <div
           key={region.id}
           data-testid="community-hull-region"
-          className="absolute rounded-[999px] border opacity-80 transition-all duration-200 ease-out"
+          className="absolute rounded-[999px] border opacity-70 transition-all duration-200 ease-out"
           style={{
             left: region.left,
             top: region.top,
             width: region.width,
             height: region.height,
-            borderColor: `${region.color}66`,
-            background: `radial-gradient(circle at 50% 50%, ${region.color}24 0%, ${region.color}10 58%, transparent 72%)`,
-            boxShadow: `0 0 44px ${region.color}24`,
+            // Faint crate-colored tint, no outer glow — the boxShadow bloom
+            // was the dominant source of the washed-out "balls" look.
+            borderColor: `${region.color}26`,
+            background: `radial-gradient(circle at 50% 50%, ${region.color}12 0%, ${region.color}08 60%, transparent 74%)`,
           }}
           title={`${region.label} (${region.memberCount.toLocaleString()} nodes)`}
         />

--- a/ui/src/hooks/useSigmaGraph.ts
+++ b/ui/src/hooks/useSigmaGraph.ts
@@ -34,6 +34,7 @@ import type { Attributes } from "@/lib/codeGraphReducers";
 import {
   COMMUNITY_HULLS_ATTRIBUTE,
   PRECOMPUTED_LAYOUT_ATTRIBUTE,
+  selectRenderableHulls,
   type CommunityHull,
   type ViewportBounds,
 } from "@/lib/codeGraphAdapter";
@@ -394,10 +395,13 @@ export function useSigmaGraph(
       },
       getCommunityHullRegions: (): CommunityHullRegion[] => {
         try {
-          const hulls = graph.getAttribute(COMMUNITY_HULLS_ATTRIBUTE) as
+          const allHulls = graph.getAttribute(COMMUNITY_HULLS_ATTRIBUTE) as
             | CommunityHull[]
             | undefined;
-          if (!Array.isArray(hulls) || hulls.length === 0) return [];
+          if (!Array.isArray(allHulls) || allHulls.length === 0) return [];
+          // Only the largest communities earn a background region; the
+          // rest stay as bare crate-colored dots (see selectRenderableHulls).
+          const hulls = selectRenderableHulls(allHulls);
           const projector = (
             sigmaInstance as unknown as {
               graphToViewport?: (point: { x: number; y: number }) => {

--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -20,6 +20,9 @@ import {
   colorForNode,
   colorForWorkspace,
   deriveCommunityHulls,
+  selectRenderableHulls,
+  MIN_HULL_MEMBERS,
+  MAX_HULL_REGIONS,
   edgeStyleFor,
   filterSnapshotForWorkspace,
   hasPrecomputedCoordinates,
@@ -1832,6 +1835,45 @@ describe("deriveCommunityHulls", () => {
 
   it("returns an empty array when no community nodes or member ids exist", () => {
     expect(deriveCommunityHulls(fixtureSnapshot)).toEqual([]);
+  });
+});
+
+describe("selectRenderableHulls", () => {
+  function hull(id: string, memberCount: number): CommunityHull {
+    return {
+      id,
+      label: id,
+      keywords: undefined,
+      color: "#22c55e",
+      memberCount,
+      memberIds: [],
+      seed: 1,
+    };
+  }
+
+  it("drops hulls below the minimum member count", () => {
+    const selected = selectRenderableHulls([
+      hull("big", 50),
+      hull("tiny", MIN_HULL_MEMBERS - 1),
+      hull("edge", MIN_HULL_MEMBERS),
+    ]);
+    expect(selected.map((h) => h.id).sort()).toEqual(["big", "edge"]);
+  });
+
+  it("keeps only the largest MAX_HULL_REGIONS, by member count", () => {
+    const many = Array.from({ length: MAX_HULL_REGIONS + 10 }, (_, i) =>
+      hull(`c${i}`, 10 + i),
+    );
+    const selected = selectRenderableHulls(many);
+    expect(selected).toHaveLength(MAX_HULL_REGIONS);
+    // The smallest kept must be larger than the largest dropped.
+    const keptMin = Math.min(...selected.map((h) => h.memberCount));
+    expect(keptMin).toBe(10 + 10); // c0..c9 (counts 10..19) are dropped
+  });
+
+  it("is deterministic for equal member counts (id tiebreak)", () => {
+    const a = selectRenderableHulls([hull("b", 8), hull("a", 8)]);
+    expect(a.map((h) => h.id)).toEqual(["a", "b"]);
   });
 });
 

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -533,6 +533,39 @@ export function deriveCommunityHulls(
   return hulls;
 }
 
+/**
+ * Minimum member count for a community to be worth a background hull.
+ * Tiny clusters add a glowing blob each without conveying structure —
+ * dropping them is a lever against the "rainbow of balls" mush.
+ */
+export const MIN_HULL_MEMBERS = 6;
+
+/**
+ * Hard cap on rendered hulls. Even after the size filter, dozens of
+ * overlapping translucent regions read as noise; we keep the largest
+ * communities (the ones that actually shape the layout) and let the
+ * smaller ones live as bare crate-colored dots.
+ */
+export const MAX_HULL_REGIONS = 16;
+
+/**
+ * Pick the hulls worth drawing: drop communities below
+ * {@link MIN_HULL_MEMBERS} members, then keep the {@link MAX_HULL_REGIONS}
+ * largest by member count. Ties broken by id so the selection is stable
+ * across renders. Pure + exported so the render path stays thin and the
+ * policy is unit-testable.
+ */
+export function selectRenderableHulls(hulls: CommunityHull[]): CommunityHull[] {
+  return hulls
+    .filter((h) => h.memberCount >= MIN_HULL_MEMBERS)
+    .sort((a, b) =>
+      b.memberCount !== a.memberCount
+        ? b.memberCount - a.memberCount
+        : a.id.localeCompare(b.id, "en"),
+    )
+    .slice(0, MAX_HULL_REGIONS);
+}
+
 export function colorForWorkspace(workspace: string): string {
   return WORKSPACE_COLORS[fnv1a(workspace) % WORKSPACE_COLORS.length];
 }


### PR DESCRIPTION
## Problem

After the edge fixes (#1046, #1049) and crate coloring (#1047), the remaining "I can't see anything" source is the **community hull overlay**: it draws one glowing radial ball per community — a `0 0 44px` boxShadow glow plus a strong gradient/border — with **no cap on count**. Dozens of overlapping glowing orbs (the "balls" in the donut screenshot) wash the whole view out.

## Change

- **`selectRenderableHulls`** (new, pure, exported): drop communities below `MIN_HULL_MEMBERS` (6), then keep only the `MAX_HULL_REGIONS` (16) largest by member count, ties broken by id for stable selection. Smaller clusters live on as bare crate-colored dots. `getCommunityHullRegions` just calls it, so the policy is unit-testable instead of buried in the hook.
- **`CommunityHullOverlay`**: remove the outer `boxShadow` glow entirely and lower the gradient/border alphas, so a hull reads as a faint crate-colored tint behind its dots rather than a glowing orb.

### Note on the node halo
Sigma's default node program ignores `haloed`/`borderColor`/`borderSize` at rest (only the custom *hover* renderer draws a ring), so the always-on workspace halo attributes were never contributing to the bloom — left untouched to keep the diff focused.

## Tests

- `selectRenderableHulls`: drops sub-threshold hulls; keeps only the largest `MAX_HULL_REGIONS`; deterministic id tiebreak on equal counts.
- `tsc --noEmit` clean; 120 adapter tests + `useSigmaGraph.focusNodes` hook test green.

Fourth and final of the code-graph perf + legibility series (follows #1046, #1047, #1049).