### PR TITLE
feat(proposals): wireframe block with sandboxed --wf- tokens + shared zoom/pan surface

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/catalog.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/catalog.rs
@@ -242,6 +242,46 @@ define_blocks! {
                 { \"body\": \"### After\\nnew\" }]} />`.",
         fields { "columns" => string },
 
+    Wireframe => "wireframe", "Wireframe",
+        desc = "A low-fi HTML wireframe of ONE screen, rendered SAFELY in a \
+                sandboxed iframe with the `--wf-*` design tokens. The block \
+                CHILDREN are a self-contained HTML FRAGMENT of a single screen \
+                — real product layout and real content, not lorem. Author PLAIN \
+                semantic HTML and let the renderer style it: bare \
+                `h1`/`h2`/`h3`/`p`/`button`/`input`/`a`/`hr` are auto-themed (no \
+                classes needed) and helper classes carry the rest — `.wf-card` / \
+                `.wf-box` (a bordered padded container), `.wf-pill` / `.wf-chip` \
+                (a rounded tag; add `.accent` for the filled variant), \
+                `.wf-muted` (secondary text), and `button.primary` (or \
+                `[data-primary]`) for the accent button. For ANY custom color use \
+                the `--wf-*` tokens, NEVER a hex literal: `--wf-ink` (text), \
+                `--wf-muted`, `--wf-line` (borders), `--wf-paper` (page bg), \
+                `--wf-card` (surface), `--wf-accent` / `--wf-accent-fg` / \
+                `--wf-accent-soft`, `--wf-warn`, `--wf-ok`, `--wf-radius`. Lay out \
+                with inline flex/grid `style` (`display:flex;gap:10px;\
+                padding:16px;height:100%`). DO NOT emit `<html>`/`<body>`/\
+                `<style>`/`<script>` tags or set `font-family` — the renderer owns \
+                the document chrome and font. For icon-only controls or leading \
+                icons, write an EMPTY marker `<span data-icon=\"mail\"></span>` \
+                (or `<i data-icon=\"search\"></i>`); the renderer swaps it for an \
+                inline SVG (names incl. mail/search/menu/x/check/plus/user/bell/\
+                settings/chevronDown/etc., aliases supported). It is NOT a \
+                scripting surface — `<script>`, `on*=` handlers, and \
+                `javascript:` URIs are rejected at validation and stripped at \
+                render. Set the `surface` attribute to match the real footprint: \
+                `browser` (a web page w/ chrome), `desktop` (an app shell), \
+                `mobile` (a phone screen), `popover` (a small dropdown/menu), or \
+                `panel` (a side panel/inspector); default `desktop`. Example: \
+                `<Wireframe id=\"x\" surface=\"browser\">\\n<div \
+                style=\\\"display:flex;flex-direction:column;gap:10px;\
+                padding:16px;height:100%\\\"><h1>Sign in</h1><div \
+                class=\\\"wf-card\\\"><label>Email<input value=\\\"a@b.co\\\" />\
+                </label><button class=\\\"primary\\\">Sign in</button></div></div>\
+                \\n</Wireframe>`.",
+        fields {
+            "surface" => (enum ["browser", "desktop", "mobile", "popover", "panel"]),
+        },
+
     QuestionForm => "question-form", "QuestionForm",
         fields {
             "title" => string,

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/proposal_block_catalog.json
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/proposal_block_catalog.json
@@ -66,5 +66,9 @@
   {
     "type": "tabs",
     "tag": "Tabs"
+  },
+  {
+    "type": "wireframe",
+    "tag": "Wireframe"
   }
 ]

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
@@ -8,7 +8,7 @@ use super::*;
 #[test]
 fn registry_contains_v1_blocks() {
     let registry = proposal_block_registry();
-    assert_eq!(registry.len(), 17);
+    assert_eq!(registry.len(), 18);
     assert_eq!(registry["rich-text"].tag, "RichText");
     assert_eq!(registry["diagram"].tag, "Diagram");
     assert_eq!(registry["annotated-code"].tag, "AnnotatedCode");
@@ -25,6 +25,7 @@ fn registry_contains_v1_blocks() {
     assert_eq!(registry["openapi-spec"].tag, "OpenApi");
     assert_eq!(registry["tabs"].tag, "Tabs");
     assert_eq!(registry["columns"].tag, "Columns");
+    assert_eq!(registry["wireframe"].tag, "Wireframe");
     assert_eq!(registry["question-form"].tag, "QuestionForm");
     // The html block ships authoring guidance noting it is sandboxed.
     assert!(
@@ -63,6 +64,18 @@ fn registry_contains_v1_blocks() {
             .is_some_and(|d| d.contains("columns={[") && d.contains("body")),
         "columns block must advertise its JSON-array authoring format"
     );
+    // The wireframe block documents its `surface` enum + the `--wf-*` token /
+    // `data-icon` authoring contract.
+    assert_eq!(
+        registry["wireframe"].fields["surface"].enum_values.as_deref(),
+        Some(["browser", "desktop", "mobile", "popover", "panel"].as_slice())
+    );
+    assert!(
+        registry["wireframe"]
+            .description
+            .is_some_and(|d| d.contains("--wf-") && d.contains("data-icon")),
+        "wireframe block must advertise its --wf-* token + data-icon authoring contract"
+    );
 }
 
 #[test]
@@ -84,6 +97,7 @@ fn block_type_enum_covers_v1() {
         BlockType::OpenApiSpec,
         BlockType::Tabs,
         BlockType::Columns,
+        BlockType::Wireframe,
         BlockType::QuestionForm,
     ];
     for bt in types {
@@ -92,13 +106,13 @@ fn block_type_enum_covers_v1() {
     }
     // Single-sourced coverage check: every canonical (type_str, tag) pair is
     // reachable from the enum's `as_str()`/`tag()` projection.
-    assert_eq!(CANONICAL_BLOCK_TYPES.len(), 17);
+    assert_eq!(CANONICAL_BLOCK_TYPES.len(), 18);
 }
 
 #[test]
 fn block_registry_new_has_all_definitions() {
     let reg = BlockRegistry::new();
-    assert_eq!(reg.definitions().len(), 17);
+    assert_eq!(reg.definitions().len(), 18);
     assert!(reg.definition_for_tag("RichText").is_some());
     assert!(reg.definition_for_tag("UnknownTag").is_none());
     assert!(reg.tags().contains("RichText"));
@@ -115,8 +129,8 @@ fn registry_tags_match_canonical_v1_set() {
         CANONICAL_BLOCK_TYPES.iter().map(|(_, tag)| *tag).collect();
     assert_eq!(
         expected.len(),
-        17,
-        "canonical block list must cover all 17 v1 tags"
+        18,
+        "canonical block list must cover all 18 v1 tags"
     );
     let actual: std::collections::HashSet<&str> = proposal_block_tags().into_iter().collect();
     assert_eq!(

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -191,15 +191,17 @@ pub fn validate_mdx_body(body: &str, body_format: Option<&str>) -> Result<(), St
     Ok(())
 }
 
-/// Server-side backstop for the sandboxed `html` block (defense in depth).
+/// Server-side backstop for the sandboxed `html` and `wireframe` blocks (defense
+/// in depth).
 ///
 /// The primary defenses are the client-side iframe `sandbox=""` + restrictive
 /// CSP and the DOMPurify pass before render. This is a third layer that rejects
-/// the most dangerous *active* markup in an `html` block's children **before it
-/// is ever stored**, mirroring agent-native's server regex. It is deliberately
-/// conservative — only `<script>` tags, `on*=` event-handler attributes, and
-/// `javascript:` / `data:text/html` URIs are rejected, so benign formatted HTML
-/// (and inline SVG) still passes.
+/// the most dangerous *active* markup in a sandboxed-HTML block's children
+/// **before it is ever stored**, mirroring agent-native's server regex. It is
+/// deliberately conservative — only `<script>` tags, `on*=` event-handler
+/// attributes, and `javascript:` / `data:text/html` URIs are rejected, so benign
+/// formatted HTML (and inline SVG) still passes. Both `html` and `wireframe` are
+/// sandboxed-HTML surfaces, so both are gated identically.
 fn validate_html_block_safety(body: &str) -> Result<(), String> {
     let blocks = match parse_mdx_blocks(body) {
         Ok(blocks) => blocks,
@@ -208,15 +210,15 @@ fn validate_html_block_safety(body: &str) -> Result<(), String> {
         Err(_) => return Ok(()),
     };
     for block in blocks {
-        if block.block_type != "html" {
+        if block.block_type != "html" && block.block_type != "wireframe" {
             continue;
         }
         if let Some(reason) = first_unsafe_html_reason(&block.raw_content) {
             return Err(format!(
-                "Html block '{}' contains disallowed active markup ({reason}); \
-                 the html block renders sandboxed/sanitized static markup and \
+                "{} block '{}' contains disallowed active markup ({reason}); \
+                 the {} block renders sandboxed/sanitized static markup and \
                  is not a scripting surface",
-                block.id
+                block.tag, block.id, block.block_type
             ));
         }
     }
@@ -629,6 +631,16 @@ This runs on the hot path.
 
 <Columns id="compare" columns={[{ "body": "Before: the old approach." }, { "body": "After: the new approach." }]} />
 
+<Wireframe id="signin-screen" surface="browser">
+<div style="display:flex;flex-direction:column;gap:10px;padding:16px;height:100%">
+  <h1>Sign in</h1>
+  <div class="wf-card">
+    <label>Email<input value="jane@acme.co" /></label>
+    <button class="primary"><span data-icon="mail"></span> Continue</button>
+  </div>
+</div>
+</Wireframe>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached?
 </QuestionForm>
@@ -756,6 +768,52 @@ Should we use Redis or Memcached?
 "#;
         // The data:text/html URI (or the inline <script>) must be rejected.
         assert!(validate_mdx_body(body, Some("mdx")).is_err());
+    }
+
+    #[test]
+    fn mdx_body_wireframe_block_allows_benign_markup() {
+        // A benign wireframe (tokens + helper classes + a data-icon marker)
+        // passes the active-markup backstop.
+        let body = r#"
+<Wireframe id="ok" surface="desktop">
+<div style="display:flex;flex-direction:column;gap:10px;padding:16px">
+  <h1>Dashboard</h1>
+  <button class="primary"><span data-icon="plus"></span> New</button>
+</div>
+</Wireframe>
+"#;
+        assert!(validate_mdx_body(body, Some("mdx")).is_ok());
+    }
+
+    #[test]
+    fn mdx_body_wireframe_block_rejects_script_tag() {
+        let body = r#"
+<Wireframe id="bad" surface="desktop">
+<div>hi</div>
+<script>alert(1)</script>
+</Wireframe>
+"#;
+        let err = validate_mdx_body(body, Some("mdx")).unwrap_err();
+        assert!(err.contains("<script>"), "unexpected error: {err}");
+        assert!(
+            err.contains("Wireframe block 'bad'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn mdx_body_wireframe_block_rejects_event_handler() {
+        let body = r#"
+<Wireframe id="bad" surface="mobile">
+<img src="x" onerror="alert(1)" />
+</Wireframe>
+"#;
+        let err = validate_mdx_body(body, Some("mdx")).unwrap_err();
+        assert!(err.contains("on*= event handler"), "unexpected error: {err}");
+        assert!(
+            err.contains("Wireframe block 'bad'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/ui/src/components/MermaidDiagram.tsx
+++ b/ui/src/components/MermaidDiagram.tsx
@@ -18,11 +18,13 @@
  * accents/edges are the violet primary, node fills sit a hair above the card.
  * The stock-mermaid fallback is likewise forced transparent so it blends too.
  *
- * Wide-diagram readability: the rendered SVG is wrapped in a zoom/pan surface
- * (`ZoomPanSurface`) — fit-to-width by default (previous behavior preserved),
- * with wheel/trackpad zoom, click-drag pan, zoom-in/out/reset controls, and an
- * optional fullscreen dialog (`allowFullscreen`, default on; `ImpactFlowModal`
- * omits it since it already lives in a Dialog).
+ * Wide-diagram readability: the rendered SVG is wrapped in the shared
+ * `ZoomPanSurface` (extracted to `@/components/ZoomPanSurface`) — fit-to-width by
+ * default (previous behavior preserved), with wheel/trackpad zoom, click-drag
+ * pan, zoom-in/out/reset controls, and an optional fullscreen dialog
+ * (`allowFullscreen`, default on; `ImpactFlowModal` omits it since it already
+ * lives in a Dialog). The `mermaid-*` testid prefix and `"Diagram"` fullscreen
+ * title are passed so the existing render specs keep matching.
  *
  * Contract:
  *   - props: `{ source: string; className?: string; allowFullscreen?: boolean }`,
@@ -46,33 +48,11 @@
  * heavy SVG generation when parents re-render. The app is DARK-ONLY.
  */
 
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { memo, useEffect, useId, useMemo, useState } from "react";
 import DOMPurify from "dompurify";
-import {
-  ArrowExpandIcon,
-  ArrowReloadHorizontalIcon,
-  Cancel01Icon,
-  ZoomInAreaIcon,
-  ZoomOutAreaIcon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { ZoomPanSurface } from "@/components/ZoomPanSurface";
 import { DiagramFallback } from "@/components/proposals/blocks/DiagramFallback";
 import { normalizeMermaidSource } from "@/components/proposals/blocks/mermaidNormalize";
 
@@ -179,243 +159,17 @@ interface RenderState {
   error?: string;
 }
 
-const MIN_SCALE = 0.5;
-const MAX_SCALE = 4;
-const ZOOM_STEP = 1.25;
-
-interface Transform {
-  scale: number;
-  x: number;
-  y: number;
-}
-
-const IDENTITY: Transform = { scale: 1, x: 0, y: 0 };
-
-function clampScale(s: number): number {
-  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
-}
-
 /**
- * Zoom/pan surface around an already-rendered (sanitized) SVG. Fit-to-width by
- * default (the SVG keeps `max-w-full h-auto`), then a CSS `transform` (scale +
- * translate) layers interactive zoom on top — wheel/trackpad to zoom toward the
- * cursor, click-drag to pan when zoomed in. A tiny overlay exposes zoom-in,
- * zoom-out, reset(fit) and (optionally) fullscreen. Custom (no zoom/pan dep):
- * the whole behavior is one transform string + a handful of handlers.
+ * Render a sanitized SVG string as the zoomable child of `ZoomPanSurface`. The
+ * svg is sanitized upstream; injecting via `dangerouslySetInnerHTML` is the
+ * standard Mermaid integration pattern.
  */
-function ZoomPanSurface({
-  svg,
-  className,
-  allowFullscreen = true,
-  inFullscreen = false,
-}: {
-  svg: string;
-  className?: string;
-  allowFullscreen?: boolean;
-  inFullscreen?: boolean;
-}) {
-  const [transform, setTransform] = useState<Transform>(IDENTITY);
-  const [fullscreen, setFullscreen] = useState(false);
-  // `dragging` drives the render-time transition toggle (refs can't be read in
-  // render); `dragState` ref holds the live drag math, read only in handlers.
-  const [dragging, setDragging] = useState(false);
-  const viewportRef = useRef<HTMLDivElement | null>(null);
-  const dragState = useRef<{
-    startX: number;
-    startY: number;
-    originX: number;
-    originY: number;
-  } | null>(null);
-
-  const reset = useCallback(() => setTransform(IDENTITY), []);
-
-  // Zoom around the viewport center by a multiplicative factor.
-  const zoomBy = useCallback((factor: number) => {
-    setTransform((prev) => {
-      const nextScale = clampScale(prev.scale * factor);
-      if (nextScale === prev.scale) return prev;
-      // Keep the content centered: scale about the viewport center, so the
-      // existing translate is rescaled proportionally.
-      const ratio = nextScale / prev.scale;
-      return { scale: nextScale, x: prev.x * ratio, y: prev.y * ratio };
-    });
-  }, []);
-
-  const onWheel = useCallback(
-    (e: React.WheelEvent) => {
-      // Only hijack the wheel for zoom (don't fight page scroll otherwise).
-      if (!e.ctrlKey && !e.metaKey && Math.abs(e.deltaY) < 1) return;
-      e.preventDefault();
-      const viewport = viewportRef.current;
-      if (!viewport) return;
-      const rect = viewport.getBoundingClientRect();
-      const cx = e.clientX - rect.left - rect.width / 2;
-      const cy = e.clientY - rect.top - rect.height / 2;
-      setTransform((prev) => {
-        const dir = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
-        const nextScale = clampScale(prev.scale * dir);
-        if (nextScale === prev.scale) return prev;
-        const ratio = nextScale / prev.scale;
-        // Zoom toward the cursor: the point under the cursor stays put.
-        return {
-          scale: nextScale,
-          x: cx - (cx - prev.x) * ratio,
-          y: cy - (cy - prev.y) * ratio,
-        };
-      });
-    },
-    [],
-  );
-
-  const onPointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      if (transform.scale <= 1) return; // nothing to pan at fit
-      (e.target as Element).setPointerCapture?.(e.pointerId);
-      dragState.current = {
-        startX: e.clientX,
-        startY: e.clientY,
-        originX: transform.x,
-        originY: transform.y,
-      };
-      setDragging(true);
-    },
-    [transform],
-  );
-
-  const onPointerMove = useCallback((e: React.PointerEvent) => {
-    const drag = dragState.current;
-    if (!drag) return;
-    setTransform((prev) => ({
-      ...prev,
-      x: drag.originX + (e.clientX - drag.startX),
-      y: drag.originY + (e.clientY - drag.startY),
-    }));
-  }, []);
-
-  const endDrag = useCallback(() => {
-    dragState.current = null;
-    setDragging(false);
-  }, []);
-
-  const zoomed = transform.scale > 1;
-
-  const surface = (
-    <div
-      ref={viewportRef}
-      data-testid="mermaid-zoompan-viewport"
-      className={cn(
-        "relative w-full overflow-hidden",
-        zoomed ? "cursor-grab active:cursor-grabbing" : "cursor-default",
-        inFullscreen ? "h-full" : "max-h-[70vh]",
-      )}
-      onWheel={onWheel}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={endDrag}
-      onPointerLeave={endDrag}
-    >
-      <div
-        data-testid="mermaid-zoompan-content"
-        className="flex w-full items-center justify-center [&_svg]:h-auto [&_svg]:max-w-full"
-        style={{
-          transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
-          transformOrigin: "center center",
-          transition: dragging ? "none" : "transform 0.08s ease-out",
-        }}
-        // The svg is sanitized upstream; injecting via dangerouslySetInnerHTML
-        // is the standard Mermaid integration pattern.
-        dangerouslySetInnerHTML={{ __html: svg }}
-      />
-
-      {/* Controls overlay — top-right, compact ghost icon buttons. */}
-      <div
-        className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-border/60 bg-card/80 p-0.5 backdrop-blur"
-        data-testid="mermaid-controls"
-      >
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Zoom in"
-          title="Zoom in"
-          onClick={() => zoomBy(ZOOM_STEP)}
-        >
-          <HugeiconsIcon icon={ZoomInAreaIcon} size={14} />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Zoom out"
-          title="Zoom out"
-          onClick={() => zoomBy(1 / ZOOM_STEP)}
-        >
-          <HugeiconsIcon icon={ZoomOutAreaIcon} size={14} />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Reset zoom"
-          title="Reset to fit"
-          onClick={reset}
-        >
-          <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={14} />
-        </Button>
-        {allowFullscreen && !inFullscreen && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Fullscreen"
-            title="Fullscreen"
-            onClick={() => setFullscreen(true)}
-          >
-            <HugeiconsIcon icon={ArrowExpandIcon} size={14} />
-          </Button>
-        )}
-        {inFullscreen && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Exit fullscreen"
-            title="Exit fullscreen"
-            onClick={() => setFullscreen(false)}
-          >
-            <HugeiconsIcon icon={Cancel01Icon} size={14} />
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-
+function MermaidSvg({ svg }: { svg: string }) {
   return (
-    <div className={cn("w-full", className)}>
-      {surface}
-      {allowFullscreen && !inFullscreen && (
-        <Dialog open={fullscreen} onOpenChange={setFullscreen}>
-          <DialogContent
-            className="flex h-[90vh] max-w-[95vw] flex-col gap-2 sm:max-w-[95vw]"
-            data-testid="mermaid-fullscreen"
-          >
-            <DialogHeader>
-              <DialogTitle className="text-sm">Diagram</DialogTitle>
-            </DialogHeader>
-            <div className="min-h-0 flex-1 rounded-md border border-border/40">
-              {/* A fresh ZoomPanSurface in fullscreen mode (its own transform
-                  state, fills the dialog, no nested fullscreen button). */}
-              <ZoomPanSurface
-                svg={svg}
-                allowFullscreen={false}
-                inFullscreen
-                className="h-full"
-              />
-            </div>
-          </DialogContent>
-        </Dialog>
-      )}
-    </div>
+    <div
+      className="contents"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
   );
 }
 
@@ -505,7 +259,13 @@ function MermaidDiagramImpl({
 
   return (
     <div data-testid="mermaid-diagram" className={cn("w-full", className)}>
-      <ZoomPanSurface svg={state.svg} allowFullscreen={allowFullscreen} />
+      <ZoomPanSurface
+        allowFullscreen={allowFullscreen}
+        testIdPrefix="mermaid"
+        fullscreenTitle="Diagram"
+      >
+        <MermaidSvg svg={state.svg} />
+      </ZoomPanSurface>
     </div>
   );
 }

--- a/ui/src/components/ZoomPanSurface.test.tsx
+++ b/ui/src/components/ZoomPanSurface.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@/test/test-utils";
+
+import { ZoomPanSurface } from "./ZoomPanSurface";
+
+function scaleOf(el: HTMLElement): number {
+  const m = /scale\(([\d.]+)\)/.exec(el.style.transform);
+  return m ? Number(m[1]) : 1;
+}
+
+describe("ZoomPanSurface", () => {
+  it("renders arbitrary children and the zoom controls (fit-to-width by default)", () => {
+    render(
+      <ZoomPanSurface testIdPrefix="wf">
+        <div data-testid="payload">hello</div>
+      </ZoomPanSurface>,
+    );
+    expect(screen.getByTestId("payload")).toBeInTheDocument();
+    expect(screen.getByTestId("wf-controls")).toBeInTheDocument();
+    const content = screen.getByTestId("wf-zoompan-content");
+    expect(scaleOf(content)).toBe(1);
+  });
+
+  it("zoom-in scales up and reset restores fit", () => {
+    render(
+      <ZoomPanSurface testIdPrefix="wf">
+        <div>x</div>
+      </ZoomPanSurface>,
+    );
+    const content = screen.getByTestId("wf-zoompan-content");
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    expect(scaleOf(content)).toBeGreaterThan(1);
+    fireEvent.click(screen.getByRole("button", { name: "Reset zoom" }));
+    expect(scaleOf(content)).toBe(1);
+  });
+
+  it("hides the fullscreen toggle when allowFullscreen=false", () => {
+    const { rerender } = render(
+      <ZoomPanSurface testIdPrefix="wf">
+        <div>x</div>
+      </ZoomPanSurface>,
+    );
+    expect(
+      screen.getByRole("button", { name: "Fullscreen" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <ZoomPanSurface testIdPrefix="wf" allowFullscreen={false}>
+        <div>x</div>
+      </ZoomPanSurface>,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Fullscreen" }),
+    ).toBeNull();
+  });
+
+  it("framedContent makes the content layer pointer-events:none while dragging", () => {
+    render(
+      <ZoomPanSurface testIdPrefix="wf" framedContent>
+        <iframe title="framed" />
+      </ZoomPanSurface>,
+    );
+    const viewport = screen.getByTestId("wf-zoompan-viewport");
+    const content = screen.getByTestId("wf-zoompan-content");
+
+    // At fit (scale 1) there is nothing to pan, so no drag layer engages.
+    expect(content.style.pointerEvents).toBe("");
+
+    // Zoom in so a drag can start, then begin a drag: the content layer goes
+    // pointer-events:none so moves reach the viewport over the iframe.
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }));
+    fireEvent.pointerDown(viewport, { clientX: 10, clientY: 10, pointerId: 1 });
+    expect(content.style.pointerEvents).toBe("none");
+
+    fireEvent.pointerUp(viewport, { pointerId: 1 });
+    expect(content.style.pointerEvents).toBe("");
+  });
+
+  it("uses the testIdPrefix for all surface nodes", () => {
+    render(
+      <ZoomPanSurface testIdPrefix="mermaid">
+        <div>x</div>
+      </ZoomPanSurface>,
+    );
+    expect(screen.getByTestId("mermaid-zoompan-viewport")).toBeInTheDocument();
+    expect(screen.getByTestId("mermaid-zoompan-content")).toBeInTheDocument();
+    expect(screen.getByTestId("mermaid-controls")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ZoomPanSurface.tsx
+++ b/ui/src/components/ZoomPanSurface.tsx
@@ -1,0 +1,313 @@
+/**
+ * ZoomPanSurface — a content-agnostic zoom/pan/fullscreen surface.
+ *
+ * Extracted from `MermaidDiagram` so a single, dependency-free implementation
+ * backs every zoomable artboard: the Mermaid `Diagram` block (an SVG string) and
+ * the `Wireframe` block (a sandboxed `<iframe>`). It takes arbitrary
+ * `children` — whatever should be zoomed/panned — instead of an SVG string.
+ *
+ * Behavior (preserved verbatim from the Mermaid original):
+ *   - fit-to-width by default (`scale: 1`); the content keeps its own sizing,
+ *   - wheel/trackpad zoom TOWARD the cursor (the point under the cursor stays
+ *     put),
+ *   - click-drag pan once zoomed in past fit,
+ *   - a compact top-right control cluster: zoom-in, zoom-out, reset(fit), and an
+ *     optional fullscreen toggle that opens a fresh ZoomPanSurface in a Dialog.
+ *
+ * IFRAME WRINKLE (`framedContent`): a sandboxed `<iframe>` swallows pointer
+ * events, so `pointerdown`/`pointermove` never reach the viewport and drag-pan
+ * would be dead. When `framedContent` is set, while a drag is in progress we set
+ * `pointer-events: none` on the content layer so the moves land on the viewport
+ * instead — restoring drag-pan over a framed wireframe. Wheel-zoom already works
+ * because the wheel event targets the viewport, not the iframe.
+ *
+ * Custom (no zoom/pan dep): the whole behavior is one transform string plus a
+ * handful of handlers.
+ */
+
+import { useCallback, useRef, useState, type ReactNode } from "react";
+import {
+  ArrowExpandIcon,
+  ArrowReloadHorizontalIcon,
+  Cancel01Icon,
+  ZoomInAreaIcon,
+  ZoomOutAreaIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const MIN_SCALE = 0.5;
+const MAX_SCALE = 4;
+const ZOOM_STEP = 1.25;
+
+interface Transform {
+  scale: number;
+  x: number;
+  y: number;
+}
+
+const IDENTITY: Transform = { scale: 1, x: 0, y: 0 };
+
+function clampScale(s: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
+}
+
+export interface ZoomPanSurfaceProps {
+  /** The content to zoom/pan (an SVG, an iframe, any node). */
+  children: ReactNode;
+  className?: string;
+  /**
+   * Whether the control cluster includes a fullscreen toggle. Default `true`.
+   * Set `false` when the surface already lives inside a Dialog (avoids nested
+   * dialogs) — the fullscreen copy passes this.
+   */
+  allowFullscreen?: boolean;
+  /** Internal: this instance is the fullscreen copy (fills the dialog). */
+  inFullscreen?: boolean;
+  /**
+   * Set when `children` is (or contains) an `<iframe>` that swallows pointer
+   * events. While dragging, the content layer is made `pointer-events: none` so
+   * pan moves reach the viewport. Default `false` (e.g. inline SVG).
+   */
+  framedContent?: boolean;
+  /**
+   * Prefix for the `data-testid`s on the viewport/content/controls/fullscreen
+   * nodes. Defaults to `"zoompan"`. `MermaidDiagram` passes `"mermaid"` so its
+   * existing render specs keep matching `mermaid-zoompan-*` / `mermaid-controls`.
+   */
+  testIdPrefix?: string;
+  /** Title shown in the fullscreen dialog header. Default `"Preview"`. */
+  fullscreenTitle?: string;
+}
+
+/**
+ * Zoom/pan surface around arbitrary content. Fit-to-width by default, then a CSS
+ * `transform` (scale + translate) layers interactive zoom on top.
+ */
+export function ZoomPanSurface({
+  children,
+  className,
+  allowFullscreen = true,
+  inFullscreen = false,
+  framedContent = false,
+  testIdPrefix = "zoompan",
+  fullscreenTitle = "Preview",
+}: ZoomPanSurfaceProps) {
+  const [transform, setTransform] = useState<Transform>(IDENTITY);
+  const [fullscreen, setFullscreen] = useState(false);
+  // `dragging` drives the render-time transition toggle (refs can't be read in
+  // render); `dragState` ref holds the live drag math, read only in handlers.
+  const [dragging, setDragging] = useState(false);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const dragState = useRef<{
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+  } | null>(null);
+
+  const reset = useCallback(() => setTransform(IDENTITY), []);
+
+  // Zoom around the viewport center by a multiplicative factor.
+  const zoomBy = useCallback((factor: number) => {
+    setTransform((prev) => {
+      const nextScale = clampScale(prev.scale * factor);
+      if (nextScale === prev.scale) return prev;
+      // Keep the content centered: scale about the viewport center, so the
+      // existing translate is rescaled proportionally.
+      const ratio = nextScale / prev.scale;
+      return { scale: nextScale, x: prev.x * ratio, y: prev.y * ratio };
+    });
+  }, []);
+
+  const onWheel = useCallback((e: React.WheelEvent) => {
+    // Only hijack the wheel for zoom (don't fight page scroll otherwise).
+    if (!e.ctrlKey && !e.metaKey && Math.abs(e.deltaY) < 1) return;
+    e.preventDefault();
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const rect = viewport.getBoundingClientRect();
+    const cx = e.clientX - rect.left - rect.width / 2;
+    const cy = e.clientY - rect.top - rect.height / 2;
+    setTransform((prev) => {
+      const dir = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+      const nextScale = clampScale(prev.scale * dir);
+      if (nextScale === prev.scale) return prev;
+      const ratio = nextScale / prev.scale;
+      // Zoom toward the cursor: the point under the cursor stays put.
+      return {
+        scale: nextScale,
+        x: cx - (cx - prev.x) * ratio,
+        y: cy - (cy - prev.y) * ratio,
+      };
+    });
+  }, []);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (transform.scale <= 1) return; // nothing to pan at fit
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+      dragState.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        originX: transform.x,
+        originY: transform.y,
+      };
+      setDragging(true);
+    },
+    [transform],
+  );
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const drag = dragState.current;
+    if (!drag) return;
+    setTransform((prev) => ({
+      ...prev,
+      x: drag.originX + (e.clientX - drag.startX),
+      y: drag.originY + (e.clientY - drag.startY),
+    }));
+  }, []);
+
+  const endDrag = useCallback(() => {
+    dragState.current = null;
+    setDragging(false);
+  }, []);
+
+  const zoomed = transform.scale > 1;
+
+  const surface = (
+    <div
+      ref={viewportRef}
+      data-testid={`${testIdPrefix}-zoompan-viewport`}
+      className={cn(
+        "relative w-full overflow-hidden",
+        zoomed ? "cursor-grab active:cursor-grabbing" : "cursor-default",
+        inFullscreen ? "h-full" : "max-h-[70vh]",
+      )}
+      onWheel={onWheel}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerLeave={endDrag}
+    >
+      <div
+        data-testid={`${testIdPrefix}-zoompan-content`}
+        className="flex w-full items-center justify-center [&_svg]:h-auto [&_svg]:max-w-full"
+        style={{
+          transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+          transformOrigin: "center center",
+          transition: dragging ? "none" : "transform 0.08s ease-out",
+          // While dragging over a framed (iframe) child, let pointer moves fall
+          // through to the viewport so drag-pan works (the iframe would
+          // otherwise swallow them). Wheel-zoom is unaffected.
+          ...(framedContent && dragging
+            ? { pointerEvents: "none" as const }
+            : {}),
+        }}
+      >
+        {children}
+      </div>
+
+      {/* Controls overlay — top-right, compact ghost icon buttons. */}
+      <div
+        className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-border/60 bg-card/80 p-0.5 backdrop-blur"
+        data-testid={`${testIdPrefix}-controls`}
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Zoom in"
+          title="Zoom in"
+          onClick={() => zoomBy(ZOOM_STEP)}
+        >
+          <HugeiconsIcon icon={ZoomInAreaIcon} size={14} />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Zoom out"
+          title="Zoom out"
+          onClick={() => zoomBy(1 / ZOOM_STEP)}
+        >
+          <HugeiconsIcon icon={ZoomOutAreaIcon} size={14} />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Reset zoom"
+          title="Reset to fit"
+          onClick={reset}
+        >
+          <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={14} />
+        </Button>
+        {allowFullscreen && !inFullscreen && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Fullscreen"
+            title="Fullscreen"
+            onClick={() => setFullscreen(true)}
+          >
+            <HugeiconsIcon icon={ArrowExpandIcon} size={14} />
+          </Button>
+        )}
+        {inFullscreen && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Exit fullscreen"
+            title="Exit fullscreen"
+            onClick={() => setFullscreen(false)}
+          >
+            <HugeiconsIcon icon={Cancel01Icon} size={14} />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className={cn("w-full", className)}>
+      {surface}
+      {allowFullscreen && !inFullscreen && (
+        <Dialog open={fullscreen} onOpenChange={setFullscreen}>
+          <DialogContent
+            className="flex h-[90vh] max-w-[95vw] flex-col gap-2 sm:max-w-[95vw]"
+            data-testid={`${testIdPrefix}-fullscreen`}
+          >
+            <DialogHeader>
+              <DialogTitle className="text-sm">{fullscreenTitle}</DialogTitle>
+            </DialogHeader>
+            <div className="min-h-0 flex-1 rounded-md border border-border/40">
+              {/* A fresh ZoomPanSurface in fullscreen mode (its own transform
+                  state, fills the dialog, no nested fullscreen button). */}
+              <ZoomPanSurface
+                allowFullscreen={false}
+                inFullscreen
+                framedContent={framedContent}
+                testIdPrefix={testIdPrefix}
+                fullscreenTitle={fullscreenTitle}
+                className="h-full"
+              >
+                {children}
+              </ZoomPanSurface>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/proposals/blocks/SandboxedHtmlFrame.tsx
+++ b/ui/src/components/proposals/blocks/SandboxedHtmlFrame.tsx
@@ -9,6 +9,17 @@ export interface SandboxedHtmlFrameProps {
   title?: string;
   /** Extra classes for the iframe element. */
   className?: string;
+  /**
+   * Pre-built `srcdoc` document. When supplied it is used verbatim INSTEAD of
+   * `buildIframeSrcDoc(html)`, letting a caller inject a specialized document
+   * (e.g. the `Wireframe` block's `--wf-*` token srcdoc) while keeping this the
+   * single sandboxed-iframe component. The caller is responsible for sanitizing
+   * the body inside its builder — the `Wireframe` srcdoc reuses the same
+   * `sanitizeBlockHtml` + CSP + `sandbox=""` security as the default path.
+   */
+  srcDoc?: string;
+  /** Inline styles for the iframe (e.g. a fixed surface-preset width/height). */
+  style?: React.CSSProperties;
 }
 
 /**
@@ -31,8 +42,11 @@ export function SandboxedHtmlFrame({
   html,
   title = "Embedded HTML",
   className,
+  srcDoc: srcDocOverride,
+  style,
 }: SandboxedHtmlFrameProps) {
-  const srcDoc = useMemo(() => buildIframeSrcDoc(html), [html]);
+  const builtSrcDoc = useMemo(() => buildIframeSrcDoc(html), [html]);
+  const srcDoc = srcDocOverride ?? builtSrcDoc;
 
   return (
     <iframe
@@ -41,6 +55,7 @@ export function SandboxedHtmlFrame({
       sandbox={SANDBOX_VALUE}
       referrerPolicy="no-referrer"
       loading="lazy"
+      style={style}
       className={
         className ??
         "h-80 max-h-[32rem] w-full rounded-md border bg-background"

--- a/ui/src/components/proposals/blocks/WireframeBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/WireframeBlock.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/test-utils";
+
+import { WireframeBlock } from "./WireframeBlock";
+import { WIREFRAME_SURFACES } from "./wireframeHtml";
+
+function frame(): HTMLIFrameElement {
+  return screen.getByTitle("Wireframe mockup") as HTMLIFrameElement;
+}
+
+describe("WireframeBlock", () => {
+  it("renders the children inside a fully sandboxed iframe (no scripts, no same-origin)", () => {
+    render(
+      <WireframeBlock id="w1" attributes={{ surface: "desktop" }}>
+        {'<div class="wf-card"><h1>Sign in</h1></div>'}
+      </WireframeBlock>,
+    );
+    const iframe = frame();
+    expect(iframe.tagName).toBe("IFRAME");
+    expect(iframe.getAttribute("sandbox")).toBe("");
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-scripts");
+    const srcdoc = iframe.getAttribute("srcdoc") ?? "";
+    expect(srcdoc).toContain("--wf-ink:");
+    expect(srcdoc).toContain('<div class="wf-card">');
+    expect(srcdoc).toContain("Sign in");
+    expect(srcdoc).toContain("Content-Security-Policy");
+  });
+
+  it("applies the surface preset width (default desktop)", () => {
+    const { rerender } = render(
+      <WireframeBlock id="w2" attributes={{ surface: "mobile" }}>
+        {"<p>hi</p>"}
+      </WireframeBlock>,
+    );
+    expect(frame().style.width).toBe(`${WIREFRAME_SURFACES.mobile.width}px`);
+
+    // Missing/unknown surface falls back to the default desktop footprint.
+    rerender(
+      <WireframeBlock id="w2" attributes={{}}>
+        {"<p>hi</p>"}
+      </WireframeBlock>,
+    );
+    expect(frame().style.width).toBe(`${WIREFRAME_SURFACES.desktop.width}px`);
+  });
+
+  it("transforms data-icon markers into inline svg in the srcdoc", () => {
+    render(
+      <WireframeBlock id="w3" attributes={{ surface: "browser" }}>
+        {'<button><span data-icon="search"></span> Search</button>'}
+      </WireframeBlock>,
+    );
+    const srcdoc = frame().getAttribute("srcdoc") ?? "";
+    expect(srcdoc).toContain("<svg");
+    expect(srcdoc).toContain('class="wf-icon"');
+    expect(srcdoc).toContain('data-icon="search"');
+  });
+
+  it("strips active markup (scripts) from the wireframe srcdoc", () => {
+    render(
+      <WireframeBlock id="w4" attributes={{ surface: "desktop" }}>
+        {"<b>keep</b><script>alert(1)</script>"}
+      </WireframeBlock>,
+    );
+    const srcdoc = frame().getAttribute("srcdoc") ?? "";
+    expect(srcdoc).toContain("<b>keep</b>");
+    expect(srcdoc).not.toContain("alert(1)");
+  });
+
+  it("exposes zoom/pan controls and the block shell label", () => {
+    render(
+      <WireframeBlock id="w5" attributes={{ surface: "desktop" }}>
+        {"<p>body</p>"}
+      </WireframeBlock>,
+    );
+    expect(screen.getByText("Wireframe")).toBeInTheDocument();
+    expect(screen.getByTestId("wireframe-controls")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Zoom in" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reset zoom" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fullscreen" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a calm frame for empty/invalid children without throwing", () => {
+    expect(() =>
+      render(
+        <WireframeBlock id="w6" attributes={{ surface: "desktop" }}>
+          {""}
+        </WireframeBlock>,
+      ),
+    ).not.toThrow();
+    expect(frame().tagName).toBe("IFRAME");
+  });
+});

--- a/ui/src/components/proposals/blocks/WireframeBlock.tsx
+++ b/ui/src/components/proposals/blocks/WireframeBlock.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+
+import { ZoomPanSurface } from "@/components/ZoomPanSurface";
+import { BlockShell } from "./BlockShell";
+import { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
+import {
+  buildWireframeSrcDoc,
+  resolveWireframeSurface,
+  WIREFRAME_SURFACES,
+} from "./wireframeHtml";
+import { renderWireframeIconHtml } from "./wireframeIcons";
+import type { BlockProps } from "./types";
+
+/**
+ * Wireframe — a low-fi HTML mockup of ONE screen, rendered SAFELY.
+ *
+ * The block CHILDREN are a self-contained HTML fragment of one screen. They are
+ * run through the inline-icon transform (`renderWireframeIconHtml`, the
+ * `data-icon` marker → SVG pass), then sanitized + wrapped in the `--wf-*` design
+ * token srcdoc (`buildWireframeSrcDoc`) and painted in a fully sandboxed iframe
+ * (`SandboxedHtmlFrame`, `sandbox=""`, restrictive CSP). The framed surface keeps
+ * its `surface` preset width and sits inside a `ZoomPanSurface` so the reviewer
+ * can zoom/pan/fullscreen a dense mockup.
+ *
+ * Like `HtmlBlock`, it is NOT a scripting surface — scripts, event handlers, and
+ * `javascript:` URLs are stripped at three layers (server validation, DOMPurify,
+ * iframe sandbox).
+ *
+ * Graceful: empty/invalid children render a calm fallback frame, never throw.
+ */
+export function WireframeBlock({ children, attributes }: BlockProps) {
+  const rawHtml = typeof children === "string" ? children.trim() : "";
+  const surface = resolveWireframeSurface(attributes?.surface);
+  const preset = WIREFRAME_SURFACES[surface];
+
+  // Icons run BEFORE sanitize (markers → inline SVG, which the SVG-profile
+  // sanitizer keeps); the result is then sanitized + framed by the srcdoc
+  // builder. Memoized so re-renders don't re-run the string transform.
+  const srcDoc = useMemo(
+    () => buildWireframeSrcDoc(renderWireframeIconHtml(rawHtml), surface),
+    [rawHtml, surface],
+  );
+
+  return (
+    <BlockShell label="Wireframe" accent="text-violet-400">
+      <ZoomPanSurface
+        allowFullscreen
+        framedContent
+        testIdPrefix="wireframe"
+        fullscreenTitle="Wireframe"
+      >
+        <SandboxedHtmlFrame
+          html={rawHtml}
+          srcDoc={srcDoc}
+          title="Wireframe mockup"
+          // Fixed surface-preset width (centered); the surface min-height is the
+          // floor so a short screen still reads as that surface. The iframe is
+          // opaque-origin so it can't self-size — a max-height caps very tall
+          // mockups and the inner srcdoc scrolls.
+          className="mx-auto block max-h-[60vh] rounded-md border bg-background"
+          style={{
+            width: preset.width,
+            maxWidth: "100%",
+            height: preset.minHeight,
+          }}
+        />
+      </ZoomPanSurface>
+    </BlockShell>
+  );
+}
+
+// Re-export the surface preset map + type so callers/tests can read footprints
+// without reaching into the html builder module.
+export { WIREFRAME_SURFACES } from "./wireframeHtml";
+export type { WireframeSurface } from "./wireframeHtml";

--- a/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
+++ b/ui/src/components/proposals/blocks/__fixtures__/canonicalProposal.mdx
@@ -123,6 +123,17 @@ This runs on the hot path — keep allocations out of the loop.
 
 <Columns id="before-after" columns={[{ "body": "### Before\nThe **old** approach." }, { "body": "### After\nThe **new** approach." }]} />
 
+<Wireframe id="signin-screen" surface="browser">
+<div style="display:flex;flex-direction:column;gap:10px;padding:16px;height:100%">
+  <h1>Sign in</h1>
+  <p class="wf-muted">Use your work email to continue.</p>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:10px">
+    <label>Email<input value="jane@acme.co" /></label>
+    <button class="primary"><span data-icon="mail"></span> Continue</button>
+  </div>
+</div>
+</Wireframe>
+
 <QuestionForm id="open-questions" title="Open Questions">
 Should we use Redis or Memcached for caching?
 </QuestionForm>

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -16,7 +16,19 @@ export { OpenApiSpecBlock } from "./OpenApiSpecBlock";
 export { TabsBlock } from "./TabsBlock";
 export { ColumnsBlock } from "./ColumnsBlock";
 export { HtmlBlock } from "./HtmlBlock";
+export { WireframeBlock } from "./WireframeBlock";
 export { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
+export {
+  buildWireframeSrcDoc,
+  resolveWireframeSurface,
+  WIREFRAME_SURFACES,
+  DEFAULT_WIREFRAME_SURFACE,
+} from "./wireframeHtml";
+export type { WireframeSurface } from "./wireframeHtml";
+export {
+  renderWireframeIconHtml,
+  WIREFRAME_ICON_NAMES,
+} from "./wireframeIcons";
 export {
   sanitizeBlockHtml,
   buildIframeSrcDoc,

--- a/ui/src/components/proposals/blocks/registry.ts
+++ b/ui/src/components/proposals/blocks/registry.ts
@@ -21,6 +21,7 @@ import { QuestionFormBlock } from "./QuestionFormBlock";
 import { RichText } from "./RichText";
 import { TableBlock } from "./TableBlock";
 import { TabsBlock } from "./TabsBlock";
+import { WireframeBlock } from "./WireframeBlock";
 
 // ---------------------------------------------------------------------------
 // Field-schema contract
@@ -277,6 +278,18 @@ export const PROPOSAL_BLOCK_SPECS: readonly ProposalBlockSpec[] = [
     component: ColumnsBlock,
     fields: {
       columns: { type: "string" },
+    },
+  }),
+  defineBlock({
+    type: "wireframe",
+    tag: "Wireframe",
+    displayName: "Wireframe",
+    component: WireframeBlock,
+    fields: {
+      surface: {
+        type: "string",
+        enum_values: ["browser", "desktop", "mobile", "popover", "panel"],
+      },
     },
   }),
   // QuestionForm MUST remain LAST.

--- a/ui/src/components/proposals/blocks/wireframeHtml.test.ts
+++ b/ui/src/components/proposals/blocks/wireframeHtml.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWireframeSrcDoc,
+  DEFAULT_WIREFRAME_SURFACE,
+  resolveWireframeSurface,
+  WIREFRAME_SURFACES,
+  type WireframeSurface,
+} from "./wireframeHtml";
+
+describe("resolveWireframeSurface", () => {
+  it("passes through every known surface", () => {
+    for (const key of Object.keys(WIREFRAME_SURFACES) as WireframeSurface[]) {
+      expect(resolveWireframeSurface(key)).toBe(key);
+    }
+  });
+
+  it("is case-insensitive and trims", () => {
+    expect(resolveWireframeSurface(" Mobile ")).toBe("mobile");
+  });
+
+  it("falls back to the default for unknown/empty input", () => {
+    expect(resolveWireframeSurface("nonsense")).toBe(DEFAULT_WIREFRAME_SURFACE);
+    expect(resolveWireframeSurface("")).toBe(DEFAULT_WIREFRAME_SURFACE);
+    expect(resolveWireframeSurface(undefined)).toBe(DEFAULT_WIREFRAME_SURFACE);
+    expect(resolveWireframeSurface(null)).toBe(DEFAULT_WIREFRAME_SURFACE);
+  });
+});
+
+describe("buildWireframeSrcDoc", () => {
+  it("injects the --wf-* design tokens and a light-scheme fallback", () => {
+    const doc = buildWireframeSrcDoc("<h1>Hi</h1>", "desktop");
+    expect(doc).toContain("--wf-ink:");
+    expect(doc).toContain("--wf-paper:");
+    expect(doc).toContain("--wf-accent:");
+    expect(doc).toContain("--wf-card:");
+    expect(doc).toContain("--wf-line:");
+    expect(doc).toContain("--wf-muted:");
+    expect(doc).toContain("--wf-radius:");
+    // concrete djinn dark hex (iframe can't read parent css vars)
+    expect(doc).toContain("#8650f6");
+    // light-theme fallback like sandboxedHtml.ts
+    expect(doc).toContain("prefers-color-scheme: light");
+  });
+
+  it("embeds the helper classes and the restrictive CSP", () => {
+    const doc = buildWireframeSrcDoc("<div>x</div>", "desktop");
+    expect(doc).toContain(".wf-card");
+    expect(doc).toContain(".wf-pill");
+    expect(doc).toContain(".wf-muted");
+    expect(doc).toContain("Content-Security-Policy");
+    expect(doc).toContain("script-src 'none'");
+  });
+
+  it("maps each surface to its preset width and min-height", () => {
+    for (const [key, preset] of Object.entries(WIREFRAME_SURFACES)) {
+      const doc = buildWireframeSrcDoc("<p>x</p>", key);
+      expect(doc).toContain(`width:${preset.width}px`);
+      expect(doc).toContain(`min-height:${preset.minHeight}px`);
+    }
+  });
+
+  it("wraps the body in a .wf-root and preserves benign content", () => {
+    const doc = buildWireframeSrcDoc(
+      '<div class="wf-card"><h1>Sign in</h1></div>',
+      "browser",
+    );
+    expect(doc).toContain('<div class="wf-root">');
+    expect(doc).toContain('<div class="wf-card">');
+    expect(doc).toContain("Sign in");
+  });
+
+  it("strips scripts, event handlers, and javascript: URLs", () => {
+    const doc = buildWireframeSrcDoc(
+      '<b>keep</b><script>alert(1)</script>' +
+        '<img src="x" onerror="alert(2)">' +
+        '<a href="javascript:alert(3)">x</a>',
+      "desktop",
+    );
+    expect(doc).toContain("<b>keep</b>");
+    expect(doc).not.toContain("alert(1)");
+    expect(doc).not.toContain("onerror");
+    expect(doc).not.toContain("javascript:alert(3)");
+  });
+
+  it("does not throw on malformed/empty input and yields a calm empty surface", () => {
+    expect(() => buildWireframeSrcDoc("<div><span>", "desktop")).not.toThrow();
+    expect(() => buildWireframeSrcDoc("", "desktop")).not.toThrow();
+    expect(() => buildWireframeSrcDoc(undefined, "desktop")).not.toThrow();
+    expect(() => buildWireframeSrcDoc(null, "desktop")).not.toThrow();
+    // unknown surface still produces a valid doc at the default footprint
+    const doc = buildWireframeSrcDoc("<p>x</p>", "bogus");
+    expect(doc).toContain(
+      `width:${WIREFRAME_SURFACES[DEFAULT_WIREFRAME_SURFACE].width}px`,
+    );
+  });
+});

--- a/ui/src/components/proposals/blocks/wireframeHtml.ts
+++ b/ui/src/components/proposals/blocks/wireframeHtml.ts
@@ -1,0 +1,195 @@
+/**
+ * Srcdoc builder for the sandboxed `Wireframe` block.
+ *
+ * Sibling to `sandboxedHtml.ts`: it reuses that module's `sanitizeBlockHtml`
+ * (same DOMPurify config), the same restrictive CSP, and the same empty
+ * `sandbox=""` — so a wireframe is "sandboxed HTML + wireframe design tokens".
+ * On top of the sanitized fragment it injects a `<style>` block defining the
+ * `--wf-*` design tokens, a clean (non-sketch) font, the `.wf-*` helper classes,
+ * and bare-element auto-theming (h1/h2/h3/p/button/input/a/hr/…).
+ *
+ * WHY CONCRETE HEX: the frame is a `sandbox=""` opaque-origin iframe, so its CSS
+ * CANNOT read the parent app's CSS custom properties (`hsl(var(--foreground))`
+ * resolves to nothing inside the frame). Following the `DJINN_MERMAID_THEME`
+ * precedent we therefore hardcode the djinn dark-theme tokens as sRGB hex, plus a
+ * `prefers-color-scheme: light` fallback (mirroring `sandboxedHtml.ts`). The
+ * deferred hand-drawn/Excalifont sketch path is intentionally dropped — a clean
+ * system font stack is used.
+ */
+
+import { IFRAME_CSP, sanitizeBlockHtml } from "./sandboxedHtml";
+
+/** The wireframe surface presets — fixed content widths (px) + min-height floors. */
+export const WIREFRAME_SURFACES = {
+  browser: { width: 900, minHeight: 200, radius: 14 },
+  desktop: { width: 840, minHeight: 200, radius: 14 },
+  mobile: { width: 300, minHeight: 360, radius: 30 },
+  popover: { width: 360, minHeight: 120, radius: 16 },
+  panel: { width: 420, minHeight: 200, radius: 16 },
+} as const;
+
+export type WireframeSurface = keyof typeof WIREFRAME_SURFACES;
+
+export const DEFAULT_WIREFRAME_SURFACE: WireframeSurface = "desktop";
+
+/** Normalize an arbitrary attribute string into a known surface (or default). */
+export function resolveWireframeSurface(
+  surface: string | undefined | null,
+): WireframeSurface {
+  const key = (surface ?? "").trim().toLowerCase();
+  return key in WIREFRAME_SURFACES
+    ? (key as WireframeSurface)
+    : DEFAULT_WIREFRAME_SURFACE;
+}
+
+/**
+ * The `--wf-*` design tokens, resolved to concrete djinn DARK-theme sRGB hex
+ * (the iframe can't read parent CSS vars). A `prefers-color-scheme: light`
+ * override flips them for light viewers.
+ *
+ * Values trace to the djinn theme in `globals.css` (oklch) converted to hex,
+ * matching the `DJINN_MERMAID_THEME` palette where they overlap:
+ *   --wf-ink     ≈ --foreground (near-white)
+ *   --wf-muted   ≈ --muted-foreground
+ *   --wf-line    ≈ --border (white @ ~10% over the dark surface)
+ *   --wf-paper   ≈ --background
+ *   --wf-card    ≈ --card (a hair above the page)
+ *   --wf-accent  = --primary (djinn violet)
+ *   --wf-warn    = --destructive
+ */
+const WF_TOKENS_DARK = `
+  --wf-ink: #ededed;
+  --wf-muted: #9f9fa9;
+  --wf-line: #34343a;
+  --wf-paper: #18181b;
+  --wf-card: #1f1f22;
+  --wf-accent: #8650f6;
+  --wf-accent-fg: #fafafa;
+  --wf-accent-soft: rgba(134, 80, 246, 0.14);
+  --wf-warn: #e5484d;
+  --wf-ok: #8650f6;
+  --wf-radius: 9px;
+`;
+
+const WF_TOKENS_LIGHT = `
+  --wf-ink: #1f1f1d;
+  --wf-muted: #6b7280;
+  --wf-line: #d4d4d8;
+  --wf-paper: #ffffff;
+  --wf-card: #f7f7f8;
+  --wf-accent: #6d33e6;
+  --wf-accent-fg: #ffffff;
+  --wf-accent-soft: rgba(109, 51, 230, 0.10);
+  --wf-warn: #dc2626;
+  --wf-ok: #6d33e6;
+  --wf-radius: 9px;
+`;
+
+/**
+ * The full `<style>` body: tokens + clean font + `.wf-*` helper classes + bare
+ * semantic-element auto-theming. Ported from agent-native `blocks.css`'s
+ * `.plan-html-frame` rules, with the sketch font/rough overlay machinery
+ * removed and scoped under `.wf-root` (the frame body wrapper).
+ */
+function wireframeStyle(): string {
+  return `
+:root {${WF_TOKENS_DARK}}
+@media (prefers-color-scheme: light) { :root {${WF_TOKENS_LIGHT}} }
+
+html, body { margin: 0; padding: 0; background: transparent; }
+* { box-sizing: border-box; min-width: 0; }
+
+.wf-root {
+  width: 100%;
+  min-height: 100%;
+  background: var(--wf-paper);
+  color: var(--wf-ink);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter, sans-serif;
+  font-size: 14px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.wf-root h1 { font-size: 22px; font-weight: 700; line-height: 1.15; margin: 0 0 8px; }
+.wf-root h2 { font-size: 17px; font-weight: 700; line-height: 1.2; margin: 0 0 6px; }
+.wf-root h3 { font-size: 14px; font-weight: 700; margin: 0 0 4px; }
+.wf-root p { margin: 0 0 8px; }
+.wf-root small, .wf-root .wf-muted { color: var(--wf-muted); font-size: 12.5px; }
+.wf-root a { color: var(--wf-accent); text-decoration: none; }
+.wf-root hr { border: 0; border-top: 1.4px solid var(--wf-line); margin: 10px 0; }
+.wf-root img, .wf-root svg { max-width: 100%; }
+
+.wf-root .wf-icon {
+  display: inline-block; width: 1em; height: 1em; flex: 0 0 auto;
+  color: currentColor; vertical-align: -0.16em;
+}
+.wf-root .wf-icon-fallback {
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1.2px solid currentColor; border-radius: 999px;
+  font-size: 0.72em; font-weight: 700; line-height: 1;
+  width: 1.1em; height: 1.1em;
+}
+
+.wf-root button, .wf-root .wf-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  font: inherit; font-weight: 700; color: var(--wf-ink);
+  background: var(--wf-paper); border: 1.4px solid var(--wf-line);
+  border-radius: var(--wf-radius); padding: 7px 14px; cursor: default;
+}
+.wf-root button.primary, .wf-root .wf-btn.primary, .wf-root [data-primary] {
+  background: var(--wf-accent); border-color: var(--wf-accent); color: var(--wf-accent-fg);
+}
+
+.wf-root input, .wf-root textarea, .wf-root select {
+  font: inherit; color: var(--wf-ink); background: var(--wf-card);
+  border: 1.4px solid var(--wf-line); border-radius: var(--wf-radius);
+  padding: 8px 10px; width: 100%;
+}
+.wf-root input[type="checkbox"], .wf-root input[type="radio"] {
+  width: 16px; height: 16px; padding: 0; accent-color: var(--wf-accent); flex: 0 0 auto;
+}
+
+.wf-root .wf-card, .wf-root .wf-box {
+  background: var(--wf-card); border: 1.4px solid var(--wf-line);
+  border-radius: var(--wf-radius); padding: 12px;
+}
+.wf-root .wf-pill, .wf-root .wf-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  border: 1.4px solid var(--wf-line); border-radius: 999px;
+  padding: 2px 10px; font-size: 12.5px;
+}
+.wf-root .wf-pill.accent, .wf-root .wf-chip.accent {
+  border-color: var(--wf-accent); color: var(--wf-accent); background: var(--wf-accent-soft);
+}
+`;
+}
+
+/**
+ * Build the full `srcdoc` for a sandboxed wireframe iframe. The HTML is
+ * sanitized (DOMPurify, same config as the html block), wrapped in a `.wf-root`
+ * body, and the `--wf-*` token `<style>` is injected ahead of it. The output is
+ * intended ONLY for an `<iframe sandbox="" srcdoc={...}>`.
+ *
+ * The wrapper sets the fixed surface width so the frame keeps its footprint, with
+ * the surface's `min-height` as a floor. Robust against malformed input —
+ * `sanitizeBlockHtml` never throws and an empty/non-string body yields a calm
+ * empty surface rather than an error.
+ */
+export function buildWireframeSrcDoc(
+  html: string | undefined | null,
+  surface: WireframeSurface | string | undefined | null,
+): string {
+  const preset = WIREFRAME_SURFACES[resolveWireframeSurface(surface as string)];
+  const body = sanitizeBlockHtml(html);
+  return (
+    "<!doctype html><html><head>" +
+    `<meta http-equiv="Content-Security-Policy" content="${IFRAME_CSP}">` +
+    '<meta name="referrer" content="no-referrer">' +
+    "<style>" +
+    wireframeStyle() +
+    `.wf-root{width:${preset.width}px;max-width:100%;min-height:${preset.minHeight}px;}` +
+    "</style></head><body>" +
+    `<div class="wf-root">${body}</div>` +
+    "</body></html>"
+  );
+}

--- a/ui/src/components/proposals/blocks/wireframeIcons.test.ts
+++ b/ui/src/components/proposals/blocks/wireframeIcons.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  renderWireframeIconHtml,
+  WIREFRAME_ICON_NAMES,
+} from "./wireframeIcons";
+
+describe("renderWireframeIconHtml", () => {
+  it("replaces a data-icon marker with an inline svg carrying the .wf-icon class", () => {
+    const out = renderWireframeIconHtml('<span data-icon="mail"></span>');
+    expect(out).toContain("<svg");
+    expect(out).toContain('class="wf-icon"');
+    expect(out).toContain('data-icon="mail"');
+    expect(out).toContain("<path");
+    // The marker element itself is gone.
+    expect(out).not.toContain("data-icon=\"mail\"></span>");
+  });
+
+  it("supports both <span> and self-closing <i> markers", () => {
+    expect(renderWireframeIconHtml('<i data-icon="search"></i>')).toContain(
+      'data-icon="search"',
+    );
+    expect(renderWireframeIconHtml('<span data-icon="x" />')).toContain(
+      'data-icon="x"',
+    );
+  });
+
+  it("resolves aliases and separator/case variants to a canonical icon", () => {
+    // alias email -> mail
+    expect(renderWireframeIconHtml('<span data-icon="email"></span>')).toContain(
+      'data-icon="mail"',
+    );
+    // alias close -> x
+    expect(renderWireframeIconHtml('<span data-icon="close"></span>')).toContain(
+      'data-icon="x"',
+    );
+    // separator/case variant chevron-down -> chevronDown
+    expect(
+      renderWireframeIconHtml('<span data-icon="chevron-down"></span>'),
+    ).toContain('data-icon="chevronDown"');
+    // `icon`-prefixed
+    expect(
+      renderWireframeIconHtml('<span data-icon="iconSettings"></span>'),
+    ).toContain('data-icon="settings"');
+  });
+
+  it("carries an accessible label from aria-label or title; otherwise aria-hidden", () => {
+    const labelled = renderWireframeIconHtml(
+      '<span data-icon="mail" aria-label="Email"></span>',
+    );
+    expect(labelled).toContain('role="img"');
+    expect(labelled).toContain('aria-label="Email"');
+
+    const bare = renderWireframeIconHtml('<span data-icon="mail"></span>');
+    expect(bare).toContain('aria-hidden="true"');
+    expect(bare).not.toContain('role="img"');
+  });
+
+  it("drops an unknown icon to a safe ? fallback chip (no raw injection)", () => {
+    const out = renderWireframeIconHtml(
+      '<span data-icon="totally-not-an-icon"></span>',
+    );
+    expect(out).toContain("wf-icon-fallback");
+    expect(out).toContain(">?<");
+    // The unknown name is escaped into a data attribute, never an SVG path.
+    expect(out).not.toContain("<path");
+    expect(out).toContain('data-icon-name="totally-not-an-icon"');
+  });
+
+  it("escapes a malicious unknown icon name (no markup injection)", () => {
+    const out = renderWireframeIconHtml(
+      '<span data-icon="&quot;&gt;<script>alert(1)</script>"></span>',
+    );
+    // Whatever survives, the fallback must not contain a live script tag.
+    expect(out).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("leaves non-marker content untouched and never throws", () => {
+    const html = '<div class="wf-card"><h1>Sign in</h1><p>hello</p></div>';
+    expect(renderWireframeIconHtml(html)).toBe(html);
+    expect(renderWireframeIconHtml("")).toBe("");
+    expect(renderWireframeIconHtml(undefined)).toBe("");
+    expect(renderWireframeIconHtml(null)).toBe("");
+  });
+
+  it("replaces multiple markers in one pass", () => {
+    const out = renderWireframeIconHtml(
+      '<span data-icon="search"></span> q <i data-icon="user"></i>',
+    );
+    expect(out.match(/<svg/g) ?? []).toHaveLength(2);
+    expect(out).toContain('data-icon="search"');
+    expect(out).toContain('data-icon="user"');
+  });
+
+  it("exports a non-trivial curated icon set", () => {
+    expect(WIREFRAME_ICON_NAMES.length).toBeGreaterThanOrEqual(15);
+    expect(WIREFRAME_ICON_NAMES).toContain("mail");
+    expect(WIREFRAME_ICON_NAMES).toContain("search");
+    expect(WIREFRAME_ICON_NAMES).toContain("x");
+  });
+});

--- a/ui/src/components/proposals/blocks/wireframeIcons.ts
+++ b/ui/src/components/proposals/blocks/wireframeIcons.ts
@@ -1,0 +1,259 @@
+/**
+ * Inline-icon transform for the `Wireframe` block.
+ *
+ * Wireframe authors write an EMPTY marker element instead of an icon glyph or an
+ * icon word — `<span data-icon="mail"></span>` (or `<i data-icon="search"></i>`,
+ * self-closing `<span data-icon="x" />` also works). This pure string→string
+ * pass replaces every such marker with an inline Tabler-style `<svg>` built from
+ * a curated path map, BEFORE the HTML is sanitized + framed. No runtime dep — the
+ * SVG path strings live here.
+ *
+ * MARKER SYNTAX (the authoring contract):
+ *   - a `<span>` or `<i>` element carrying a `data-icon="<name>"` attribute,
+ *   - the element MUST be empty (no children) — `<span data-icon="mail"></span>`
+ *     or `<i data-icon="mail" />`,
+ *   - the `<name>` is matched case-/separator-insensitively (e.g. `chevron-down`,
+ *     `chevronDown`, `iconChevronDown` all resolve), then via an alias table
+ *     (`email→mail`, `close→x`, `more→dots`, …),
+ *   - an `aria-label` or `title` on the marker becomes the icon's accessible
+ *     label; otherwise the icon is `aria-hidden`,
+ *   - an UNKNOWN name renders a small `?` fallback chip (never raw author text,
+ *     never a thrown error) with the name HTML-escaped.
+ *
+ * Ported from agent-native `wireframe-icons.ts` (paths verbatim; the marker regex
+ * and normalization preserved).
+ */
+
+const ICON_PATHS = {
+  arrowLeft: [
+    '<path d="M5 12l14 0" />',
+    '<path d="M5 12l6 6" />',
+    '<path d="M5 12l6 -6" />',
+  ],
+  arrowRight: [
+    '<path d="M5 12l14 0" />',
+    '<path d="M13 18l6 -6" />',
+    '<path d="M13 6l6 6" />',
+  ],
+  bell: [
+    '<path d="M10 5a2 2 0 1 1 4 0a7 7 0 0 1 4 6v3a4 4 0 0 0 2 3h-16a4 4 0 0 0 2 -3v-3a7 7 0 0 1 4 -6" />',
+    '<path d="M9 17v1a3 3 0 0 0 6 0v-1" />',
+  ],
+  calendar: [
+    '<path d="M4 7a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2v-12z" />',
+    '<path d="M16 3v4" />',
+    '<path d="M8 3v4" />',
+    '<path d="M4 11h16" />',
+  ],
+  check: ['<path d="M5 12l5 5l10 -10" />'],
+  chevronDown: ['<path d="M6 9l6 6l6 -6" />'],
+  chevronLeft: ['<path d="M15 6l-6 6l6 6" />'],
+  chevronRight: ['<path d="M9 6l6 6l-6 6" />'],
+  chevronUp: ['<path d="M6 15l6 -6l6 6" />'],
+  dots: [
+    '<path d="M5 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+    '<path d="M12 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+    '<path d="M19 12m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />',
+  ],
+  edit: [
+    '<path d="M4 20h4l10.5 -10.5a2.8 2.8 0 1 0 -4 -4l-10.5 10.5v4" />',
+    '<path d="M13.5 6.5l4 4" />',
+  ],
+  lock: [
+    '<path d="M5 13a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v6a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2v-6z" />',
+    '<path d="M8 11v-4a4 4 0 1 1 8 0v4" />',
+    '<path d="M12 16l0 .01" />',
+  ],
+  mail: [
+    '<path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10z" />',
+    '<path d="M3 7l9 6l9 -6" />',
+  ],
+  menu: [
+    '<path d="M4 6l16 0" />',
+    '<path d="M4 12l16 0" />',
+    '<path d="M4 18l16 0" />',
+  ],
+  plus: ['<path d="M12 5l0 14" />', '<path d="M5 12l14 0" />'],
+  search: [
+    '<path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />',
+    '<path d="M21 21l-6 -6" />',
+  ],
+  send: [
+    '<path d="M10 14l11 -11" />',
+    '<path d="M21 3l-6.5 18a.55 .55 0 0 1 -1 0l-3.5 -7l-7 -3.5a.55 .55 0 0 1 0 -1l18 -6.5" />',
+  ],
+  settings: [
+    '<path d="M10.3 4.3a1 1 0 0 1 1.4 0l.6 .6a1 1 0 0 0 1 .24l.84 -.28a1 1 0 0 1 1.25 .6l.31 .9a1 1 0 0 0 .76 .65l.95 .16a1 1 0 0 1 .84 1.08l-.08 .98a1 1 0 0 0 .48 .9l.82 .52a1 1 0 0 1 .34 1.34l-.49 .86a1 1 0 0 0 0 1l.49 .86a1 1 0 0 1 -.34 1.34l-.82 .52a1 1 0 0 0 -.48 .9l.08 .98a1 1 0 0 1 -.84 1.08l-.95 .16a1 1 0 0 0 -.76 .65l-.31 .9a1 1 0 0 1 -1.25 .6l-.84 -.28a1 1 0 0 0 -1 .24l-.6 .6a1 1 0 0 1 -1.4 0l-.6 -.6a1 1 0 0 0 -1 -.24l-.84 .28a1 1 0 0 1 -1.25 -.6l-.31 -.9a1 1 0 0 0 -.76 -.65l-.95 -.16a1 1 0 0 1 -.84 -1.08l.08 -.98a1 1 0 0 0 -.48 -.9l-.82 -.52a1 1 0 0 1 -.34 -1.34l.49 -.86a1 1 0 0 0 0 -1l-.49 -.86a1 1 0 0 1 .34 -1.34l.82 -.52a1 1 0 0 0 .48 -.9l-.08 -.98a1 1 0 0 1 .84 -1.08l.95 -.16a1 1 0 0 0 .76 -.65l.31 -.9a1 1 0 0 1 1.25 -.6l.84 .28a1 1 0 0 0 1 -.24l.6 -.6z" />',
+    '<path d="M9 12a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />',
+  ],
+  trash: [
+    '<path d="M4 7l16 0" />',
+    '<path d="M10 11l0 6" />',
+    '<path d="M14 11l0 6" />',
+    '<path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12" />',
+    '<path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3" />',
+  ],
+  user: [
+    '<path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0" />',
+    '<path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />',
+  ],
+  x: ['<path d="M18 6l-12 12" />', '<path d="M6 6l12 12" />'],
+} as const;
+
+type IconName = keyof typeof ICON_PATHS;
+
+const ICON_ALIASES: Record<string, IconName> = {
+  add: "plus",
+  back: "arrowLeft",
+  close: "x",
+  collapse: "chevronUp",
+  caret: "chevronDown",
+  chevron: "chevronDown",
+  delete: "trash",
+  dropdown: "chevronDown",
+  down: "chevronDown",
+  email: "mail",
+  expand: "chevronDown",
+  forward: "arrowRight",
+  gear: "settings",
+  hamburger: "menu",
+  more: "dots",
+  next: "chevronRight",
+  password: "lock",
+  previous: "chevronLeft",
+  profile: "user",
+  right: "chevronRight",
+  remove: "trash",
+  submit: "send",
+  up: "chevronUp",
+};
+
+const ICON_MARKER_RE =
+  /<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))([^>]*)>(?:\s*)<\/\1>|<(span|i)\b([^>]*\s)?data-icon\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))([^>]*)\/>/gi;
+
+function normalizeIconName(value: string): IconName | null {
+  const normalized = value
+    .trim()
+    .replace(/^icon/i, "")
+    .replace(/[^a-z0-9]+/gi, " ")
+    .trim()
+    .replace(/\s+([a-z0-9])/gi, (_match, char: string) => char.toUpperCase())
+    .replace(/^./, (char) => char.toLowerCase());
+  return normalized in ICON_PATHS
+    ? (normalized as IconName)
+    : (ICON_ALIASES[normalized] ?? null);
+}
+
+function readAttribute(attrs: string, name: string): string | null {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = attrs.match(
+    new RegExp(
+      `\\b${escaped}\\s*=\\s*("[^"]*"|'[^']*'|[^\\s"'=<>` + "`" + `]+)`,
+      "i",
+    ),
+  );
+  if (!match) return null;
+  const raw = match[1] ?? "";
+  return decodeAttrEntities(raw.replace(/^["']|["']$/g, ""));
+}
+
+function decodeAttrEntities(value: string): string {
+  return value.replace(
+    /&(#x[0-9a-f]+|#\d+|amp|apos|quot|lt|gt);/gi,
+    (entity, body: string) => {
+      const normalized = body.toLowerCase();
+      if (normalized === "amp") return "&";
+      if (normalized === "apos") return "'";
+      if (normalized === "quot") return '"';
+      if (normalized === "lt") return "<";
+      if (normalized === "gt") return ">";
+
+      const isHex = normalized.startsWith("#x");
+      const digits = normalized.slice(isHex ? 2 : 1);
+      const codePoint = Number.parseInt(digits, isHex ? 16 : 10);
+      if (!Number.isFinite(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+        return entity;
+      }
+      try {
+        return String.fromCodePoint(codePoint);
+      } catch {
+        return entity;
+      }
+    },
+  );
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function iconAccessibility(label: string | null): string {
+  const accessibleLabel = label?.trim();
+  return accessibleLabel
+    ? `role="img" aria-label="${escapeAttr(accessibleLabel)}"`
+    : 'aria-hidden="true"';
+}
+
+function iconSvg(name: IconName, label: string | null): string {
+  return `<svg class="wf-icon" data-icon="${name}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" ${iconAccessibility(label)}>${ICON_PATHS[name].join("")}</svg>`;
+}
+
+function iconFallback(rawName: string, label: string | null): string {
+  const iconName = rawName.trim() || "unknown";
+  const accessibleLabel = label?.trim() || `Unsupported icon: ${iconName}`;
+  return `<span class="wf-icon wf-icon-fallback" data-icon="unknown" data-icon-name="${escapeAttr(iconName)}" role="img" aria-label="${escapeAttr(accessibleLabel)}">?</span>`;
+}
+
+/**
+ * Replace every `<span|i data-icon="…"></span>` marker in `html` with an inline
+ * SVG (known name) or a small `?` fallback chip (unknown name). Pure
+ * string→string; never throws. A non-string input yields an empty string.
+ */
+export function renderWireframeIconHtml(html: string | undefined | null): string {
+  if (typeof html !== "string" || html.length === 0) return "";
+  return html.replace(
+    ICON_MARKER_RE,
+    (
+      _match,
+      _tagA,
+      beforeA,
+      quotedA,
+      doubleA,
+      singleA,
+      bareA,
+      afterA,
+      _tagB,
+      beforeB,
+      quotedB,
+      doubleB,
+      singleB,
+      bareB,
+      afterB,
+    ) => {
+      const rawName =
+        doubleA ??
+        singleA ??
+        bareA ??
+        doubleB ??
+        singleB ??
+        bareB ??
+        quotedA ??
+        quotedB ??
+        "";
+      const name = normalizeIconName(rawName);
+      const attrs = `${beforeA ?? ""}${afterA ?? ""}${beforeB ?? ""}${afterB ?? ""}`;
+      const label =
+        readAttribute(attrs, "aria-label") ?? readAttribute(attrs, "title");
+      return name ? iconSvg(name, label) : iconFallback(rawName, label);
+    },
+  );
+}
+
+/** The set of icon names the wireframe block renders (excludes aliases). */
+export const WIREFRAME_ICON_NAMES: readonly IconName[] = Object.keys(
+  ICON_PATHS,
+) as IconName[];


### PR DESCRIPTION
## WU19 CORE — `wireframe` proposal block

Adds a new sandboxed **`wireframe`** proposal block: author-supplied HTML of ONE screen, themed by `--wf-*` design tokens, painted in a `sandbox=""` iframe, with single-artboard zoom/pan via a `ZoomPanSurface` extracted from the Mermaid component. Block count **17 → 18**. Zero new runtime deps.

### What's here
- **`ZoomPanSurface` (new, shared)** — `ui/src/components/ZoomPanSurface.tsx`. The zoom/pan/fullscreen machinery moved out of `MermaidDiagram` into a content-agnostic component taking `children: ReactNode`. All behavior preserved (wheel-zoom-to-cursor, drag-pan, zoom-in/out/reset, fullscreen Dialog). `MermaidDiagram` now passes its sanitized SVG as `children` with `testIdPrefix="mermaid"` so existing render specs stay green.
  - **iframe pointer-drag wrinkle:** a sandboxed iframe swallows pointer events, so `framedContent` makes the content layer `pointer-events:none` *while dragging* — pan moves land on the viewport. Wheel-zoom already targets the viewport.
- **`wireframeHtml.ts` (new)** — `buildWireframeSrcDoc(html, surface)` reuses `sanitizeBlockHtml` + the same CSP + `sandbox=""`, injects the `--wf-*` tokens as concrete djinn dark hex (iframe is opaque-origin) with a `prefers-color-scheme: light` fallback, plus `.wf-*` helpers + bare-element auto-theming. Clean font (sketch path deferred).
- **`wireframeIcons.ts` (new)** — `renderWireframeIconHtml`: pure string→string, replaces `<span data-icon="mail"></span>` markers with inline Tabler SVG (no dep). Unknown names → safe `?` chip. Runs BEFORE sanitize.
- **`WireframeBlock.tsx` (new)** — reads `attributes.surface` (default `desktop`), runs icons → srcdoc → `SandboxedHtmlFrame` (fixed surface-preset width) in `<ZoomPanSurface allowFullscreen framedContent>`.
- **Registered both sides:** Rust `catalog.rs` (`Wireframe` before QuestionForm, `surface` enum + authoring-contract `desc`), regenerated `proposal_block_catalog.json`, bumped count asserts, `validation.rs` extends the active-markup backstop to cover `wireframe` (+ rejection tests + canonical-all fixture), TS `registry.ts`/`index.ts`/fixture.

### Surface presets (width px / min-height floor)
browser 900/200 · desktop 840/200 · mobile 300/360 · popover 360/120 · panel 420/200

### Verification (local)
- Size guard: my files all under limits (`catalog.rs` 311 lines / 17.7 KB).
- Rust: 440 `djinn-control-plane` lib tests green (incl. new wireframe rejection + catalog-sync); clippy `--all-features` clean.
- merge_group guards: `mcp_tools_do_not_use_untyped_json_output` green; `tool_schemas` snapshot **unchanged**.
- UI: blocks + Mermaid + ZoomPanSurface vitest green; `tsc -b` clean; `build` succeeds.
- Pre-existing flakes only (ProposalsPage/UserConfigDialog/CodeGraphPage) — fail identically on pristine main, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)