### PR TITLE
fix(proposals): clear checklist checkbox marker + remove tabs-header vertical scroll

### DIFF
--- a/ui/.storybook/main.ts
+++ b/ui/.storybook/main.ts
@@ -1,7 +1,11 @@
 import type { StorybookConfig } from "@storybook/react-vite"
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  // Only `*.stories.*` — we intentionally do NOT glob `**/*.mdx`: the sole MDX
+  // under `src/` is `__fixtures__/canonicalProposal.mdx` (a sample *proposal*
+  // body, not a Storybook doc) which fails acorn indexing and 500s the whole
+  // story index. Add an explicit glob here if real Storybook MDX docs land.
+  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: ["@storybook/addon-links", "@storybook/addon-a11y", "@storybook/addon-docs"],
 
   framework: {

--- a/ui/src/components/proposals/blocks/ChecklistBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/ChecklistBlock.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@/test/test-utils";
+
+import { ChecklistBlock } from "./ChecklistBlock";
+
+const BODY = ["- [x] Ship it", "- [ ] Verify it"].join("\n");
+
+/**
+ * The unchecked marker previously used `Square01Icon`, whose hugeicons-3.3.0
+ * artwork is NOT a square — it draws an "x²"/chi-squared glyph (two diagonal
+ * strokes + a superscript-2 hook). We switched to `SquareIcon` (a plain rounded
+ * outline) for unchecked and keep `CheckmarkSquare02Icon` for checked. These
+ * specs lock in the rendered SVG path data so the math-glyph can't regress.
+ */
+describe("ChecklistBlock — marker glyphs", () => {
+  it("renders an empty square outline for unchecked and a checkmark for checked", () => {
+    const { container } = render(
+      <ChecklistBlock id="c1" attributes={{}}>
+        {BODY}
+      </ChecklistBlock>,
+    );
+
+    const items = container.querySelectorAll("li");
+    expect(items).toHaveLength(2);
+
+    const dOf = (li: Element) =>
+      [...li.querySelectorAll("svg path")].map((p) => p.getAttribute("d") ?? "");
+
+    // The rounded-square outline path shared by SquareIcon / CheckmarkSquare02.
+    const SQUARE_OUTLINE = "M2.5 12C2.5 7.52166";
+    const CHECK_TICK = "M8 12.5L10.5 15L16 9";
+
+    const checkedPaths = dOf(items[0]);
+    const uncheckedPaths = dOf(items[1]);
+
+    // Checked: rounded square + a tick.
+    expect(checkedPaths.some((d) => d.startsWith(SQUARE_OUTLINE))).toBe(true);
+    expect(checkedPaths).toContain(CHECK_TICK);
+
+    // Unchecked: a single rounded-square outline, NO tick.
+    expect(uncheckedPaths.some((d) => d.startsWith(SQUARE_OUTLINE))).toBe(true);
+    expect(uncheckedPaths).not.toContain(CHECK_TICK);
+
+    // Crucially: the old broken Square01 "x²" path must be gone everywhere.
+    const allPaths = [...checkedPaths, ...uncheckedPaths];
+    expect(allPaths.some((d) => d.startsWith("M2.71474 7.02474"))).toBe(false);
+  });
+
+  it("keeps the done/total tally and line-through on checked items", () => {
+    const { getByText, container } = render(
+      <ChecklistBlock id="c2" attributes={{}}>
+        {BODY}
+      </ChecklistBlock>,
+    );
+
+    expect(getByText("1/2 done")).toBeInTheDocument();
+
+    const checkedLabel = getByText("Ship it");
+    expect(checkedLabel.className).toContain("line-through");
+
+    // Read-only: no interactive checkboxes/inputs are rendered.
+    expect(container.querySelectorAll("input")).toHaveLength(0);
+  });
+});

--- a/ui/src/components/proposals/blocks/ChecklistBlock.tsx
+++ b/ui/src/components/proposals/blocks/ChecklistBlock.tsx
@@ -1,8 +1,5 @@
 import { useMemo } from "react";
-import {
-  CheckmarkSquare02Icon,
-  Square01Icon,
-} from "@hugeicons/core-free-icons";
+import { CheckmarkSquare02Icon, SquareIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { cn } from "@/lib/utils";
@@ -48,7 +45,7 @@ export function ChecklistBlock({ children }: BlockProps) {
         {items.map((item, index) => (
           <li key={index} className="flex items-start gap-2.5">
             <HugeiconsIcon
-              icon={item.checked ? CheckmarkSquare02Icon : Square01Icon}
+              icon={item.checked ? CheckmarkSquare02Icon : SquareIcon}
               size={18}
               className={cn(
                 "mt-0.5 shrink-0",

--- a/ui/src/components/proposals/blocks/ProposalBlocksPolish.stories.tsx
+++ b/ui/src/components/proposals/blocks/ProposalBlocksPolish.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ChecklistBlock } from "./ChecklistBlock";
+import { TabsBlock } from "./TabsBlock";
+
+/**
+ * Stories used to visually reproduce + verify two block polish fixes
+ * (checklist unchecked-marker glyph; tabs-header vertical scrollbar). These
+ * render in a real browser via Playwright/Storybook where the bugs are visible
+ * (jsdom cannot surface them).
+ */
+const meta = {
+  title: "Proposals/Blocks/Polish",
+  parameters: { layout: "padded" },
+} satisfies Meta;
+
+export default meta;
+
+const CHECKLIST_BODY = [
+  "- [x] Schema migration written",
+  "- [ ] Backfill job verified",
+  "- [ ] Docs updated — link the runbook",
+  "- [x] Rollback plan reviewed",
+].join("\n");
+
+export const Checklist: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 520 }}>
+      <ChecklistBlock id="checklist-demo" attributes={{}}>
+        {CHECKLIST_BODY}
+      </ChecklistBlock>
+    </div>
+  ),
+};
+
+const TABS_ATTR = JSON.stringify([
+  { label: "Overview", body: "Plain markdown body for the overview tab." },
+  { label: "Details", body: "Details body with a list:\n\n- one\n- two" },
+  { label: "Risks", body: "Risk notes for the third tab." },
+]);
+
+export const Tabs: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 520 }}>
+      <TabsBlock id="tabs-demo" attributes={{ tabs: TABS_ATTR }}>
+        {null}
+      </TabsBlock>
+    </div>
+  ),
+};

--- a/ui/src/components/proposals/blocks/TabsBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/TabsBlock.test.tsx
@@ -100,6 +100,29 @@ describe("TabsBlock", () => {
     expect(screen.getByText("Be careful here.")).toBeInTheDocument();
   });
 
+  it("never lets the tab-header strip scroll vertically (overflow-y hidden)", () => {
+    // Regression: the tablist previously used only `overflow-x-auto`, which the
+    // browser promotes the *other* axis to `auto`, so the buttons' `-mb-px` +
+    // `border-b-2` overran the strip by 1px and rendered a stray VERTICAL
+    // scrollbar. The header must clip vertically.
+    render(
+      <TabsBlock
+        id="tscroll"
+        attributes={{
+          tabs: tabsAttr([
+            { label: "Overview", body: "a" },
+            { label: "Details", body: "b" },
+            { label: "Risks", body: "c" },
+          ]),
+        }}
+      />,
+    );
+
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toHaveClass("overflow-y-hidden");
+    expect(tablist).toHaveClass("overflow-x-auto");
+  });
+
   it("falls back gracefully when the tabs attribute is invalid JSON (no throw)", () => {
     expect(() =>
       render(

--- a/ui/src/components/proposals/blocks/TabsBlock.tsx
+++ b/ui/src/components/proposals/blocks/TabsBlock.tsx
@@ -87,7 +87,7 @@ export function TabsBlock({ attributes, children }: BlockProps) {
         <div
           role="tablist"
           aria-label="Tabs"
-          className="flex min-w-0 flex-nowrap gap-1 overflow-x-auto"
+          className="flex min-w-0 flex-nowrap gap-1 overflow-x-auto overflow-y-hidden"
         >
           {tabs.map((tab, index) => {
             const selected = index === activeIndex;


### PR DESCRIPTION
Two user-reported visual bugs in proposal blocks. Both reproduced AND verified fixed in a real browser (Storybook + Playwright) — jsdom cannot surface either.

## BUG 1 — Checklist unchecked marker rendered as a "χ²" (chi-squared / x²) glyph
**Root cause:** in `@hugeicons/core-free-icons@3.3.0`, `Square01Icon` is **mislabeled artwork** — its three SVG paths draw two diagonal strokes + a superscript-2 hook (a math glyph), NOT a square. The export name is valid; the picture is wrong. So at `size={18}` every unchecked item read as "x²" ("are we doing math?").

**Fix:** unchecked → `SquareIcon` (a plain rounded-square outline — literally the base square of `CheckmarkSquare02Icon` without the tick). Checked stays `CheckmarkSquare02Icon`. Both are valid ESM exports in `dist/esm/index.js`. Read-only behavior, the `N/M done` tally, line-through on checked, and the `BlockMarkdown` fallback are all unchanged. Playwright AFTER screenshot reads as an empty checkbox.

## BUG 2 — Tabs header strip showed a thin vertical scrollbar
**Root cause:** the tablist used only `overflow-x-auto`. Per CSS, when one overflow axis is non-`visible` the other is promoted to `auto`, so `overflow-y` computed as `auto`. The tab buttons' `-mb-px` + `border-b-2` overran the clipped strip by 1px (`scrollHeight 38 > clientHeight 37`) → stray vertical scrollbar.

**Fix:** add `overflow-y-hidden` to the tablist so the header never scrolls vertically; horizontal overflow still scrolls. Tab switching/keyboard nav unchanged (verified by click in browser + existing specs).

## Verification
- `ChecklistBlock`/`TabsBlock`/`checklist` specs: pass (added a ChecklistBlock component spec that locks the marker path data + asserts the old x² path is gone, and a TabsBlock `overflow-y-hidden` regression spec).
- Full blocks suite: **366 passed**.
- `tsc -b` clean; `eslint` clean on changed files; `npm run build` green.
- Playwright before/after screenshots captured for BOTH bugs.

## Note
`.storybook/main.ts` no longer globs `**/*.mdx`: the only `src` MDX is `__fixtures__/canonicalProposal.mdx` (a sample *proposal* body, not a Storybook doc) which fails acorn indexing and 500s the entire story index — a pre-existing breakage that blocked block-story verification.