### PR TITLE
fix(proposals): stop overflow-x containers promoting a stray vertical scrollbar

### DIFF
--- a/ui/src/components/proposals/blocks/AnnotatedCode.test.tsx
+++ b/ui/src/components/proposals/blocks/AnnotatedCode.test.tsx
@@ -74,4 +74,21 @@ describe("AnnotatedCode", () => {
     expect(screen.getByText("Code")).toBeInTheDocument();
     expect(screen.queryByText(/could not be parsed/i)).not.toBeInTheDocument();
   });
+
+  it("clips the code surface vertically so overflow-x never promotes a stray vertical scrollbar", () => {
+    // Regression: the surface used only `overflow-x-auto` in its expanded
+    // state, which the browser promotes the *other* axis to `auto`, rendering a
+    // stray VERTICAL scrollbar on the proposal detail page. The surface is
+    // content-height, so vertical clipping is a no-op except that it stops the
+    // promotion. `overflow-y-hidden` must be present regardless of collapse.
+    const { container } = render(
+      <AnnotatedCode id="c5" attributes={{ lang: "ts" }}>
+        {CODE}
+      </AnnotatedCode>,
+    );
+    const surface = container.querySelector(".annotated-code-surface");
+    expect(surface).toBeTruthy();
+    expect(surface).toHaveClass("overflow-x-auto");
+    expect(surface).toHaveClass("overflow-y-hidden");
+  });
 });

--- a/ui/src/components/proposals/blocks/AnnotatedCode.tsx
+++ b/ui/src/components/proposals/blocks/AnnotatedCode.tsx
@@ -195,7 +195,7 @@ export function AnnotatedCode({ attributes, children }: BlockProps) {
   const langChip = language !== "text" ? language : null;
 
   const rawCode = (
-    <pre className="overflow-x-auto px-4 py-4 font-mono text-xs text-foreground">
+    <pre className="overflow-x-auto overflow-y-hidden px-4 py-4 font-mono text-xs text-foreground">
       {content}
     </pre>
   );
@@ -271,8 +271,8 @@ export function AnnotatedCode({ attributes, children }: BlockProps) {
       <div ref={codeRef} className="relative">
         <div
           className={cn(
-            "annotated-code-surface relative overflow-x-auto",
-            collapsed && "max-h-[34rem] overflow-y-hidden",
+            "annotated-code-surface relative overflow-x-auto overflow-y-hidden",
+            collapsed && "max-h-[34rem]",
           )}
         >
           <Suspense fallback={rawCode}>

--- a/ui/src/components/proposals/blocks/ContainerFallback.tsx
+++ b/ui/src/components/proposals/blocks/ContainerFallback.tsx
@@ -43,7 +43,7 @@ export function ContainerFallback({
         <span>{label}</span>
       </div>
       {rawAttribute ? (
-        <pre className="mt-2 overflow-x-auto rounded bg-background/60 p-2 text-xs">
+        <pre className="mt-2 overflow-x-auto overflow-y-hidden rounded bg-background/60 p-2 text-xs">
           {rawAttribute}
         </pre>
       ) : null}

--- a/ui/src/components/proposals/blocks/DiffBlock.tsx
+++ b/ui/src/components/proposals/blocks/DiffBlock.tsx
@@ -216,7 +216,7 @@ export function DiffBlock({ attributes, children }: BlockProps) {
       >
         <pre
           dir="ltr"
-          className="overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed text-foreground [unicode-bidi:isolate]"
+          className="overflow-x-auto overflow-y-hidden px-4 py-3 font-mono text-xs leading-relaxed text-foreground [unicode-bidi:isolate]"
         >
           {content}
         </pre>
@@ -295,7 +295,7 @@ function UnifiedView({
   const segments = useMemo(() => segmentRows(rows), [rows]);
   let runIndex = 0;
   return (
-    <div className="overflow-x-auto py-1">
+    <div className="overflow-x-auto overflow-y-hidden py-1">
       <div className="w-max min-w-full">
         {segments.map((segment, idx) => {
           if ("collapsed" in segment) {
@@ -376,14 +376,14 @@ function SplitView({ rows, lang }: { rows: DiffRow[]; lang?: string }) {
   const pairs = useMemo(() => pairSplitRows(rows), [rows]);
   return (
     <div className="flex w-full py-1">
-      <div className="min-w-0 flex-1 overflow-x-auto border-r">
+      <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden border-r">
         <div className="inline-block min-w-full">
           {pairs.map((pair, idx) => (
             <SplitCell key={`old-${idx}`} row={pair.left} side="old" />
           ))}
         </div>
       </div>
-      <div className="min-w-0 flex-1 overflow-x-auto">
+      <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden">
         <div className="inline-block min-w-full">
           {pairs.map((pair, idx) => (
             <SplitCell key={`new-${idx}`} row={pair.right} side="new" />

--- a/ui/src/components/proposals/blocks/FileTreeBlock.tsx
+++ b/ui/src/components/proposals/blocks/FileTreeBlock.tsx
@@ -76,7 +76,7 @@ export function FileTreeBlock({ attributes, children }: BlockProps) {
           root ? <span className="truncate font-mono">{root}</span> : null
         }
       >
-        <pre className="overflow-x-auto px-4 py-3 font-mono text-xs leading-relaxed text-foreground">
+        <pre className="overflow-x-auto overflow-y-hidden px-4 py-3 font-mono text-xs leading-relaxed text-foreground">
           {content}
         </pre>
       </BlockShell>

--- a/ui/src/components/proposals/blocks/JsonExplorerBlock.tsx
+++ b/ui/src/components/proposals/blocks/JsonExplorerBlock.tsx
@@ -173,7 +173,7 @@ export function JsonTree({
 
       <div
         dir="ltr"
-        className="overflow-x-auto px-3 py-2 font-mono text-xs leading-relaxed text-foreground [unicode-bidi:isolate]"
+        className="overflow-x-auto overflow-y-hidden px-3 py-2 font-mono text-xs leading-relaxed text-foreground [unicode-bidi:isolate]"
       >
         {parsed.ok ? (
           <JsonNode
@@ -185,7 +185,7 @@ export function JsonTree({
           />
         ) : (
           <div className="space-y-1.5">
-            <pre className="overflow-x-auto whitespace-pre-wrap break-words">
+            <pre className="overflow-x-auto overflow-y-hidden whitespace-pre-wrap break-words">
               {code || "—"}
             </pre>
             <p className="text-[11px] text-amber-300">

--- a/ui/src/components/proposals/blocks/ProposalBlocks.tsx
+++ b/ui/src/components/proposals/blocks/ProposalBlocks.tsx
@@ -70,7 +70,7 @@ export function ProposalBlocks({ body }: ProposalBlocksProps) {
             return (
               <pre
                 key={`unknown-${segment.index}`}
-                className="overflow-x-auto rounded border border-dashed border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+                className="overflow-x-auto overflow-y-hidden rounded border border-dashed border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
               >
                 {`<${segment.tag} ...>${segment.content}</${segment.tag}>`}
               </pre>

--- a/ui/src/components/proposals/blocks/TableBlock.tsx
+++ b/ui/src/components/proposals/blocks/TableBlock.tsx
@@ -30,7 +30,7 @@ export function TableBlock({ children }: BlockProps) {
 
   return (
     <BlockShell label="Table" accent="text-slate-400" flush>
-      <div className="overflow-x-auto" dir="ltr">
+      <div className="overflow-x-auto overflow-y-hidden" dir="ltr">
         <table className="w-full border-collapse text-left text-sm">
           <thead>
             <tr className="border-b border-border bg-muted/30">

--- a/ui/src/components/proposals/blocks/overflowPromotion.test.tsx
+++ b/ui/src/components/proposals/blocks/overflowPromotion.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@/test/test-utils";
+
+import { TableBlock } from "./TableBlock";
+import { FileTreeBlock } from "./FileTreeBlock";
+import { DiffBlock } from "./DiffBlock";
+import { JsonExplorerBlock } from "./JsonExplorerBlock";
+
+/**
+ * Regression: proposal block scroll containers used `overflow-x-auto` with no
+ * explicit `overflow-y`. Per the CSS overflow spec a non-`visible` value on one
+ * axis promotes the *other* axis to `auto`, so a 1px vertical content overrun
+ * renders a stray VERTICAL scrollbar. On the proposal detail page this showed
+ * up as a SECOND vertical scrollbar next to the page scrollbar. Every
+ * horizontal-only container must clip vertically (`overflow-y-hidden`); the
+ * PAGE owns vertical scroll.
+ */
+describe("block scroll containers never promote a stray vertical scrollbar", () => {
+  function expectHorizontalOnly(el: Element | null | undefined) {
+    expect(el).toBeTruthy();
+    expect(el).toHaveClass("overflow-x-auto");
+    expect(el).toHaveClass("overflow-y-hidden");
+  }
+
+  it("TableBlock wide-table wrapper clips vertically", () => {
+    const body = [
+      "| Name | Type | Notes |",
+      "| ---- | ---- | ----- |",
+      "| id   | uuid | primary key with a very long description column |",
+    ].join("\n");
+    const { container } = render(
+      <TableBlock id="t-overflow" attributes={{}}>
+        {body}
+      </TableBlock>,
+    );
+    expectHorizontalOnly(container.querySelector(".overflow-x-auto"));
+  });
+
+  it("FileTreeBlock raw-fallback pre clips vertically", () => {
+    // Unparseable body falls back to the raw monospace <pre>, the only
+    // horizontal-scroll container in this block.
+    const { container } = render(
+      <FileTreeBlock id="ft-overflow" attributes={{}}>
+        {"%%% not a file tree at all, just a very long single line %%%"}
+      </FileTreeBlock>,
+    );
+    expectHorizontalOnly(container.querySelector("pre.overflow-x-auto"));
+  });
+
+  it("DiffBlock unified pre clips vertically", () => {
+    const diff = [
+      "@@ -1,2 +1,2 @@",
+      "-const oldValueWithAVeryLongNameThatForcesHorizontalScroll = 1;",
+      "+const newValueWithAVeryLongNameThatForcesHorizontalScroll = 2;",
+    ].join("\n");
+    const { container } = render(
+      <DiffBlock id="d-overflow" attributes={{ filename: "x.ts", lang: "ts" }}>
+        {diff}
+      </DiffBlock>,
+    );
+    for (const el of container.querySelectorAll(".overflow-x-auto")) {
+      expect(el).toHaveClass("overflow-y-hidden");
+    }
+    expect(
+      container.querySelectorAll(".overflow-x-auto").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("JsonExplorerBlock tree container clips vertically", () => {
+    const { container } = render(
+      <JsonExplorerBlock id="j-overflow" attributes={{}}>
+        {'{ "id": "abc", "nested": { "a": 1, "b": 2 } }'}
+      </JsonExplorerBlock>,
+    );
+    for (const el of container.querySelectorAll(".overflow-x-auto")) {
+      expect(el).toHaveClass("overflow-y-hidden");
+    }
+    expect(
+      container.querySelectorAll(".overflow-x-auto").length,
+    ).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

Proposal block scroll containers use `overflow-x-auto` for horizontal scrolling but set **no explicit `overflow-y`**. Per the CSS overflow spec, a non-`visible` value on one axis **promotes the other axis to `auto`**. So any 1px vertical content overrun (e.g. a horizontal scrollbar reserving layout height, or sub-pixel row rounding) renders a stray **vertical** scrollbar inside the block.

On the proposal **detail page** this surfaces as a **second vertical scrollbar** sitting next to the page scrollbar. These containers are content-height — the **page** owns vertical scroll — so they must only ever scroll horizontally.

Two instances were already fixed: Mermaid (#1039) and the Tabs header strip (#1053). This PR fixes the rest of the class.

## Fix

Add `overflow-y-hidden` to every horizontal-only block container so the other axis can never be promoted:

- `TableBlock.tsx` — wide-table wrapper
- `AnnotatedCode.tsx` — raw `<pre>` fallback **and** the `annotated-code-surface` (made `overflow-y-hidden` unconditional; `max-h-[34rem]` stays collapse-only, gradient untouched — the expanded surface is content-height so clipping is a no-op)
- `DiffBlock.tsx` — unified `<pre>`, the unified-rows wrapper, and both split-view side-by-side columns
- `FileTreeBlock.tsx` — raw-fallback `<pre>`
- `JsonExplorerBlock.tsx` — tree container + parse-error `<pre>`
- `ProposalBlocks.tsx` + `ContainerFallback.tsx` — the unknown-block fallback `<pre>`s

Deliberately **left** untouched: `annotationRail.tsx` (an intentional `overflow-y-auto` popover) and `TabsBlock.tsx` (already fixed in #1053).

## Verification

- Reproduced in a real browser (Vite dev + Playwright) against proposal **18e4** ("Decompose the djinn-agent god crate" — FileTree + Table + AnnotatedCode, no Tabs). A controlled box with the exact failing geometry: **BEFORE** (`overflow-x-auto` only) → computed `overflow-y: auto`, vertical scrollbar rendered (10px); **AFTER** (`overflow-x-auto overflow-y-hidden`) → computed `overflow-y: hidden`, no vertical scrollbar. Page-level: **2 vertical scrollbars → 1**, horizontal scroll preserved.
- `ui` blocks vitest suite: **371 passed**; added a dedicated `overflowPromotion.test.tsx` regression suite + an AnnotatedCode surface assertion.
- `tsc -b` clean, eslint clean on changed files, `npm run build` succeeds.
- No Rust, no migration; `package-lock.json` untouched.