### PR TITLE
feat(proposals): syntax-highlight the diff block

### DIFF
--- a/ui/src/components/proposals/blocks/DiffBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/DiffBlock.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@/test/test-utils";
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@/test/test-utils";
 
 import { DiffBlock } from "./DiffBlock";
 
@@ -11,6 +11,28 @@ const UNIFIED_DIFF = [
   "+  return sum;",
   " }",
 ].join("\n");
+
+// A rust diff with a long unchanged run so collapse kicks in (> 6 context rows).
+const RUST_DIFF = [
+  "@@ -1,12 +1,12 @@",
+  " fn run_chat_loop() {",
+  "     let a = 1;",
+  "     let b = 2;",
+  "     let c = 3;",
+  "     let d = 4;",
+  "     let e = 5;",
+  "     let f = 6;",
+  "     let g = 7;",
+  "-    let total = a + b;",
+  "+    let total = a + b + c;",
+  "     println!(\"{total}\");",
+  " }",
+].join("\n");
+
+// Each test starts from a clean, default (unified) persisted view mode.
+beforeEach(() => {
+  window.localStorage.clear();
+});
 
 describe("DiffBlock", () => {
   it("renders a unified diff with filename, +/- stats, and code lines", () => {
@@ -56,5 +78,93 @@ describe("DiffBlock", () => {
       </DiffBlock>,
     );
     expect(screen.getByText("No changes")).toBeInTheDocument();
+  });
+
+  it("syntax-highlights the code with Prism tokens while keeping the +/- tint", async () => {
+    const { container } = render(
+      <DiffBlock id="d4" attributes={{ filename: "src/loop.rs", lang: "rust" }}>
+        {RUST_DIFF}
+      </DiffBlock>,
+    );
+
+    // The Prism surface lazy-loads; once it does, code lines tokenize into
+    // coloured `.token` spans (RSH inlines the oneDark colour onto each token).
+    const tokens = await waitFor(() => {
+      const found = container.querySelectorAll("span.token");
+      expect(found.length).toBeGreaterThan(0);
+      return found;
+    });
+    // A `let` keyword token carries an inline colour — proof of highlighting.
+    const keyword = Array.from(tokens).find((t) => t.textContent === "let");
+    expect(keyword).toBeTruthy();
+    expect((keyword as HTMLElement).style.color).not.toBe("");
+
+    // The +/- tint still rides underneath: the added/removed rows keep their
+    // low-alpha emerald/rose backgrounds (token colours show through them).
+    expect(container.querySelector(".bg-emerald-500\\/10")).not.toBeNull();
+    expect(container.querySelector(".bg-red-500\\/10")).not.toBeNull();
+
+    // Stats still computed correctly (+1 / −1).
+    expect(screen.getByText("+1")).toBeInTheDocument();
+    expect(screen.getByText("−1")).toBeInTheDocument();
+  });
+
+  it("keeps the collapsible unchanged run and toggle working under highlighting", () => {
+    render(
+      <DiffBlock id="d5" attributes={{ filename: "src/loop.rs", lang: "rust" }}>
+        {RUST_DIFF}
+      </DiffBlock>,
+    );
+    // The long unchanged run collapses behind an expandable control.
+    const toggle = screen.getByRole("button", { name: /unchanged line/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+    expect(
+      screen.getByRole("button", { name: /unchanged line/i }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("highlights both columns in split view (and the toggle persists)", async () => {
+    const { container } = render(
+      <DiffBlock id="d6" attributes={{ filename: "src/loop.rs", lang: "rust" }}>
+        {RUST_DIFF}
+      </DiffBlock>,
+    );
+    // Switch to split view.
+    fireEvent.click(screen.getByRole("button", { name: "Split" }));
+    expect(screen.getByRole("button", { name: "Split" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    // The choice is persisted to localStorage.
+    expect(window.localStorage.getItem("djinn:proposal-diff-view-mode")).toBe(
+      "split",
+    );
+    // Both side-by-side columns highlight (tokens present in each half).
+    await waitFor(() => {
+      const columns = container.querySelectorAll(".flex-1");
+      expect(columns.length).toBeGreaterThanOrEqual(2);
+      for (const col of [columns[0], columns[1]]) {
+        expect(
+          within(col as HTMLElement).getAllByText(
+            (_, el) => el?.classList.contains("token") ?? false,
+          ).length,
+        ).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  it("falls back to plain (uncoloured) code when the language is unknown", async () => {
+    const { container } = render(
+      <DiffBlock id="d7" attributes={{ lang: "totally-unknown-lang" }}>
+        {UNIFIED_DIFF}
+      </DiffBlock>,
+    );
+    // The added line text renders intact as a single (untokenized) node — no
+    // crash, just no colour.
+    expect(screen.getByText("const sum = a + b;")).toBeInTheDocument();
+    // Give the (no-op) lazy path a tick; still no token spans appear.
+    await Promise.resolve();
+    expect(container.querySelector("span.token")).toBeNull();
   });
 });

--- a/ui/src/components/proposals/blocks/DiffBlock.tsx
+++ b/ui/src/components/proposals/blocks/DiffBlock.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   ArrowRight01Icon,
   LayoutTwoColumnIcon,
@@ -11,6 +17,8 @@ import { cn } from "@/lib/utils";
 
 import { BlockShell } from "./BlockShell";
 import type { BlockProps } from "./types";
+import { resolveCodeLanguage } from "./code";
+import { useDiffHighlighter } from "./useDiffHighlighter";
 import {
   diffStats,
   isDiffLike,
@@ -152,6 +160,16 @@ export function DiffBlock({ attributes, children }: BlockProps) {
   const stats = useMemo(() => diffStats(rows), [rows]);
   const fileParts = useMemo(() => splitFilename(filename), [filename]);
 
+  // Resolve the authored `lang` (and any filename hint) to a Prism grammar the
+  // exact same way the standalone Code block does, then lazily load the Prism
+  // surface and get a memoized per-line highlighter. Unknown/no language → a
+  // plain-text identity fn (graceful, uncoloured fallback).
+  const resolvedLang = useMemo(
+    () => resolveCodeLanguage(lang, filename) ?? undefined,
+    [lang, filename],
+  );
+  const highlightLine = useDiffHighlighter(resolvedLang);
+
   const toggleRun = (key: number) =>
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -234,11 +252,11 @@ export function DiffBlock({ attributes, children }: BlockProps) {
             No changes
           </div>
         ) : mode === "split" ? (
-          <SplitView rows={rows} lang={lang} />
+          <SplitView rows={rows} highlightLine={highlightLine} />
         ) : (
           <UnifiedView
             rows={rows}
-            lang={lang}
+            highlightLine={highlightLine}
             expanded={expanded}
             onToggleRun={toggleRun}
           />
@@ -278,20 +296,42 @@ function ModeButton({
   );
 }
 
+/* ── Highlighted code cell ─────────────────────────────────────────────────── */
+
+/** A per-line highlighter: maps one line of code to coloured token nodes. */
+type HighlightLine = (text: string) => ReactNode;
+
+/**
+ * One diff row's code, run through the Prism per-line highlighter so language
+ * tokens get their `oneDark` colours. The +/-/context tint lives on the row
+ * background (`ROW_BG`) underneath, kept low-alpha so the coloured tokens stay
+ * readable through it. An empty line renders a single space to keep row height.
+ */
+function DiffCode({
+  text,
+  highlightLine,
+}: {
+  text: string;
+  highlightLine: HighlightLine;
+}) {
+  return (
+    <span className={CODE_CLASS}>{text ? highlightLine(text) : " "}</span>
+  );
+}
+
 /* ── Unified view ──────────────────────────────────────────────────────────── */
 
 function UnifiedView({
   rows,
-  lang,
+  highlightLine,
   expanded,
   onToggleRun,
 }: {
   rows: DiffRow[];
-  lang?: string;
+  highlightLine: HighlightLine;
   expanded: Set<number>;
   onToggleRun: (key: number) => void;
 }) {
-  void lang;
   const segments = useMemo(() => segmentRows(rows), [rows]);
   let runIndex = 0;
   return (
@@ -310,19 +350,31 @@ function UnifiedView({
                 />
                 {open &&
                   segment.rows.map((row, ri) => (
-                    <UnifiedRow key={`run-${key}-${ri}`} row={row} />
+                    <UnifiedRow
+                      key={`run-${key}-${ri}`}
+                      row={row}
+                      highlightLine={highlightLine}
+                    />
                   ))}
               </div>
             );
           }
-          return <UnifiedRow key={idx} row={segment} />;
+          return (
+            <UnifiedRow key={idx} row={segment} highlightLine={highlightLine} />
+          );
         })}
       </div>
     </div>
   );
 }
 
-function UnifiedRow({ row }: { row: DiffRow }) {
+function UnifiedRow({
+  row,
+  highlightLine,
+}: {
+  row: DiffRow;
+  highlightLine: HighlightLine;
+}) {
   return (
     <div className={cn("flex min-h-5 min-w-full", ROW_BG[row.kind])}>
       <span className={LINE_NO_CLASS}>{row.oldNo ?? ""}</span>
@@ -336,7 +388,7 @@ function UnifiedRow({ row }: { row: DiffRow }) {
       >
         {SIGN[row.kind]}
       </span>
-      <span className={CODE_CLASS}>{row.text || " "}</span>
+      <DiffCode text={row.text} highlightLine={highlightLine} />
     </div>
   );
 }
@@ -371,22 +423,37 @@ function CollapsedRow({
 
 /* ── Split (side-by-side) view ─────────────────────────────────────────────── */
 
-function SplitView({ rows, lang }: { rows: DiffRow[]; lang?: string }) {
-  void lang;
+function SplitView({
+  rows,
+  highlightLine,
+}: {
+  rows: DiffRow[];
+  highlightLine: HighlightLine;
+}) {
   const pairs = useMemo(() => pairSplitRows(rows), [rows]);
   return (
     <div className="flex w-full py-1">
       <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden border-r">
         <div className="inline-block min-w-full">
           {pairs.map((pair, idx) => (
-            <SplitCell key={`old-${idx}`} row={pair.left} side="old" />
+            <SplitCell
+              key={`old-${idx}`}
+              row={pair.left}
+              side="old"
+              highlightLine={highlightLine}
+            />
           ))}
         </div>
       </div>
       <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden">
         <div className="inline-block min-w-full">
           {pairs.map((pair, idx) => (
-            <SplitCell key={`new-${idx}`} row={pair.right} side="new" />
+            <SplitCell
+              key={`new-${idx}`}
+              row={pair.right}
+              side="new"
+              highlightLine={highlightLine}
+            />
           ))}
         </div>
       </div>
@@ -394,7 +461,15 @@ function SplitView({ rows, lang }: { rows: DiffRow[]; lang?: string }) {
   );
 }
 
-function SplitCell({ row, side }: { row?: DiffRow; side: "old" | "new" }) {
+function SplitCell({
+  row,
+  side,
+  highlightLine,
+}: {
+  row?: DiffRow;
+  side: "old" | "new";
+  highlightLine: HighlightLine;
+}) {
   if (!row) {
     return (
       <div className="flex min-h-5 min-w-full bg-muted/20">
@@ -419,7 +494,7 @@ function SplitCell({ row, side }: { row?: DiffRow; side: "old" | "new" }) {
       >
         {showSign ? sign : " "}
       </span>
-      <span className={CODE_CLASS}>{row.text || " "}</span>
+      <DiffCode text={row.text} highlightLine={highlightLine} />
     </div>
   );
 }

--- a/ui/src/components/proposals/blocks/ProposalBlocksPolish.stories.tsx
+++ b/ui/src/components/proposals/blocks/ProposalBlocksPolish.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ChecklistBlock } from "./ChecklistBlock";
+import { DiffBlock } from "./DiffBlock";
 import { TabsBlock } from "./TabsBlock";
 
 /**
@@ -45,6 +46,37 @@ export const Tabs: StoryObj = {
       <TabsBlock id="tabs-demo" attributes={{ tabs: TABS_ATTR }}>
         {null}
       </TabsBlock>
+    </div>
+  ),
+};
+
+// A `lang="rust"` diff (modelled on proposal 3in8's run_chat_loop change) used
+// to verify the diff block now Prism-highlights the code UNDER the +/- tint.
+const RUST_DIFF = [
+  "@@ -1,9 +1,11 @@",
+  " async fn run_chat_loop(state: &State, session_id: Uuid) -> Result<()> {",
+  "     let mut turns = 0u32;",
+  "-    let model = state.default_model.clone();",
+  "+    let model = resolve_model(state, session_id).await?;",
+  "+    let breaker = state.breaker_for(&model);",
+  "     loop {",
+  "-        let reply = call_model(&model, &history).await?;",
+  "+        let reply = call_model(&model, &history).await.context(\"chat turn\")?;",
+  "         history.push(reply);",
+  "         turns += 1;",
+  "     }",
+  " }",
+].join("\n");
+
+export const RustDiff: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 760 }}>
+      <DiffBlock
+        id="diff-rust-demo"
+        attributes={{ filename: "server/src/chat/loop.rs", lang: "rust" }}
+      >
+        {RUST_DIFF}
+      </DiffBlock>
     </div>
   ),
 };

--- a/ui/src/components/proposals/blocks/diffHighlight.test.tsx
+++ b/ui/src/components/proposals/blocks/diffHighlight.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@/test/test-utils";
+
+import { makeLineHighlighter } from "./diffHighlight";
+
+describe("makeLineHighlighter", () => {
+  it("tokenizes a line into coloured Prism token spans for a known language", () => {
+    const highlight = makeLineHighlighter("rust");
+    const { container } = render(<span>{highlight("let sum = a + b;")}</span>);
+    // Prism tokens render as `.token` spans (RSH's `useInlineStyles` collapses
+    // the grammar class to `token` and moves the oneDark colour to an inline
+    // style — exactly as the standalone Code block does).
+    const tokens = container.querySelectorAll("span.token");
+    expect(tokens.length).toBeGreaterThan(0);
+    // The `let` keyword is one of them, carrying an inline oneDark colour.
+    const keyword = Array.from(tokens).find((t) => t.textContent === "let");
+    expect(keyword).toBeTruthy();
+    expect((keyword as HTMLElement).style.color).not.toBe("");
+    // The full line text is preserved across the token spans.
+    expect(container.textContent).toBe("let sum = a + b;");
+  });
+
+  it("caches the result so repeated calls return identical nodes", () => {
+    const highlight = makeLineHighlighter("typescript");
+    const first = highlight("const x = 1;");
+    const second = highlight("const x = 1;");
+    // Same memoized React node reference (no re-tokenization).
+    expect(first).toBe(second);
+  });
+
+  it("returns the raw text for an empty/unknown/plaintext language", () => {
+    for (const lang of [undefined, "", "text", "plaintext", "diff"]) {
+      const highlight = makeLineHighlighter(lang);
+      // Identity: the exact string back, no token spans.
+      expect(highlight("let x = 1;")).toBe("let x = 1;");
+    }
+  });
+
+  it("returns the raw text for a language refractor does not know", () => {
+    const highlight = makeLineHighlighter("not-a-real-language");
+    expect(highlight("let x = 1;")).toBe("let x = 1;");
+  });
+});

--- a/ui/src/components/proposals/blocks/diffHighlight.tsx
+++ b/ui/src/components/proposals/blocks/diffHighlight.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import refractor from "refractor";
+import createElement from "react-syntax-highlighter/dist/esm/create-element";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+/**
+ * The Prism token-highlighting surface for the Diff block, split into its own
+ * module so `DiffBlock` can lazy-load it. We deliberately reuse the EXACT same
+ * infrastructure as `CodeBlock.tsx`:
+ *   - `refractor` is the very AST generator `react-syntax-highlighter`'s `Prism`
+ *     export wraps (its `prism.js` does `import refractor from "refractor"`), so
+ *     importing it here adds no second highlighter — every language grammar is
+ *     already registered.
+ *   - RSH's `createElement` turns a refractor hast node into a React element,
+ *     applying the `oneDark` token styles inline (the same `style={oneDark}` the
+ *     CodeBlock surface passes). This gives diff tokens the identical language
+ *     colours the standalone Code block uses.
+ *
+ * Why per-LINE highlighting (not one whole-body pass): the Diff block owns its
+ * own layout — dual old/new line-number gutters, a +/-/context sign gutter,
+ * collapsible unchanged runs, and a side-by-side split view. A single Prism
+ * <pre> can't lay any of that out. So instead we expose a `highlightLine(text)`
+ * that returns the highlighted token nodes for ONE diff row's code, which each
+ * row drops in place of its previous plain `{row.text}` string. This is exactly
+ * how GitHub-style diff viewers highlight (line-oriented), keeps every existing
+ * affordance intact, and is trivially memoizable per (language, text).
+ *
+ * Robustness / graceful fallback: an unknown/empty language, or any refractor
+ * throw, yields the plain text back (uncoloured, never a crash). The app is
+ * DARK-ONLY.
+ */
+
+/** Convert a refractor hast tree into React nodes with `oneDark` token styles. */
+function nodesToReact(
+  nodes: ReturnType<typeof refractor.highlight>,
+  keyPrefix: string,
+): ReactNode[] {
+  return nodes.map((node, i) =>
+    createElement({
+      node,
+      stylesheet: oneDark,
+      useInlineStyles: true,
+      key: `${keyPrefix}-${i}`,
+    }),
+  );
+}
+
+/**
+ * Build a memoized per-line highlighter for a given language. Returns a function
+ * that maps a single line of code to its highlighted React token nodes. When the
+ * language is unknown/absent (or highlighting throws), the function returns the
+ * raw text so the row renders as plain (uncoloured) monospace — the graceful
+ * fallback. Results are cached per line text so re-renders (toggle/collapse/
+ * hover) never re-tokenize, and split view reuses the unified view's work.
+ */
+export function makeLineHighlighter(
+  language?: string,
+): (text: string) => ReactNode {
+  const lang = language?.trim().toLowerCase();
+  // No language, plaintext, or a grammar refractor doesn't know → identity.
+  if (!lang || lang === "text" || lang === "plaintext" || lang === "diff") {
+    return (text: string) => text;
+  }
+  if (!refractor.registered(lang)) {
+    return (text: string) => text;
+  }
+
+  const cache = new Map<string, ReactNode>();
+  return (text: string): ReactNode => {
+    if (text === "") return text;
+    const hit = cache.get(text);
+    if (hit !== undefined) return hit;
+    let rendered: ReactNode;
+    try {
+      const tree = refractor.highlight(text, lang);
+      rendered = nodesToReact(tree, "tok");
+    } catch {
+      rendered = text;
+    }
+    cache.set(text, rendered);
+    return rendered;
+  };
+}

--- a/ui/src/components/proposals/blocks/useDiffHighlighter.ts
+++ b/ui/src/components/proposals/blocks/useDiffHighlighter.ts
@@ -1,0 +1,58 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+
+import type { makeLineHighlighter } from "./diffHighlight";
+
+/**
+ * Lazy, memoized per-line syntax highlighter for the Diff block.
+ *
+ * `react-syntax-highlighter` + `refractor` (every Prism grammar) is a large
+ * dependency, exactly as for `AnnotatedCode`/`CodeBlock` — so the highlighting
+ * surface (`./diffHighlight`) is loaded via a dynamic `import()` only when a diff
+ * with a real language is actually mounted, keeping it out of the proposals'
+ * synchronous bundle and the test suite's module graph.
+ *
+ * While the chunk is loading (and during SSR / when no usable language is
+ * resolved) the returned function is the identity — the row renders as plain
+ * monospace text, which IS the graceful fallback. Once loaded, the function
+ * tokenizes a single diff line to `oneDark`-coloured React nodes, memoized per
+ * line text inside `makeLineHighlighter`, so toggling unified/split, expanding a
+ * collapsed run, or hovering never re-tokenizes.
+ */
+const PLAIN = (text: string): ReactNode => text;
+
+export function useDiffHighlighter(
+  language?: string,
+): (text: string) => ReactNode {
+  // The loaded factory (held in state so a render that follows the load picks
+  // it up); `null` until the dynamic import lands.
+  const [factory, setFactory] = useState<typeof makeLineHighlighter | null>(
+    null,
+  );
+
+  // Only load Prism when there's actually a language worth highlighting.
+  const enabled = useMemo(() => {
+    const lang = language?.trim().toLowerCase();
+    return !!lang && lang !== "text" && lang !== "plaintext" && lang !== "diff";
+  }, [language]);
+
+  useEffect(() => {
+    if (!enabled || factory) return;
+    let cancelled = false;
+    void import("./diffHighlight").then((mod) => {
+      if (cancelled) return;
+      // Wrap in a function-updater (the factory is itself a function, which
+      // `setState` would otherwise call).
+      setFactory(() => mod.makeLineHighlighter);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, factory]);
+
+  // Rebuild the per-line highlighter (and its line cache) only when the language
+  // changes or the module first becomes available.
+  return useMemo(() => {
+    if (!enabled || !factory) return PLAIN;
+    return factory(language);
+  }, [enabled, factory, language]);
+}

--- a/ui/src/types/refractor.d.ts
+++ b/ui/src/types/refractor.d.ts
@@ -1,0 +1,22 @@
+// Minimal ambient typings for the subset of `refractor` the Diff block's
+// highlighter uses. `refractor` is already a (transitive) dependency of
+// `react-syntax-highlighter` — its `Prism` export is built on it — so we add no
+// new package, only the types it ships without. The returned nodes are hast
+// element/text nodes, shape-compatible with RSH's `createElement` `rendererNode`.
+declare module "refractor" {
+  import type { createElementProps } from "react-syntax-highlighter";
+
+  /** Hast nodes refractor emits, shape-compatible with RSH's `createElement`. */
+  type RefractorNode = createElementProps["node"];
+
+  interface Refractor {
+    /** Tokenize `value` as `language`, returning a hast node tree. Throws on an
+     *  unregistered language. */
+    highlight(value: string, language: string): RefractorNode[];
+    /** Whether a language (or alias) grammar is registered. */
+    registered(language: string): boolean;
+  }
+
+  const refractor: Refractor;
+  export default refractor;
+}


### PR DESCRIPTION
## What

The proposal **Diff** block now Prism-syntax-highlights its code (e.g. a `lang="rust"` diff) **under** the +/- add/remove tint, instead of rendering flat monospace. User feedback: a rust code diff had no highlighting and wanted it combined into something nicer to read.

## How

Reuses the **exact** existing Prism infrastructure — no new highlighter, no new npm dep:

- `diffHighlight.tsx` — `makeLineHighlighter(lang)` runs one diff line through `refractor` (the same AST generator `react-syntax-highlighter`'s `Prism` export wraps) and converts the hast tree to React nodes via RSH's own `createElement` + `oneDark` (the same `style={oneDark}` `CodeBlock.tsx` uses). This is the line-oriented analogue of the `makeRenderer`/`lineProps` pattern in `CodeBlock`/`AnnotatedCode`. Tokens collapse to `.token` spans with inline oneDark colours.
- `useDiffHighlighter.ts` — a hook that **lazy-loads** the Prism surface via dynamic `import()` (its own `diffHighlight-*.js` chunk, exactly like `AnnotatedCode` lazy-loads `CodeBlock`), only when a diff with a real language is mounted. Before the chunk lands / for unknown/no language / SSR, it returns the identity fn → plain monospace (the **graceful fallback**).
- `DiffBlock.tsx` — resolves the authored `lang` (+ filename hint) through the existing `resolveCodeLanguage`, then each unified row and **both** split columns render `highlightLine(row.text)` in place of the old plain `{row.text}`. The +/- tint stays on the row background (`ROW_BG`, low-alpha `bg-emerald-500/10` / `bg-red-500/10`) so coloured tokens show through and stay readable.

Everything preserved: dual old/new line numbers, +N/−N counts, collapsible unchanged runs, the persisted unified/split toggle, the filename header, the non-diff plain-`<pre>` fallback, and the #1054 `overflow-y-hidden` containers.

## Performance

Highlighting is memoized per `(language, line text)` inside `makeLineHighlighter`'s cache and the hook's `useMemo`, so toggling unified/split, expanding a collapsed run, or hovering never re-tokenizes; split view reuses the unified view's cached lines.

## Verify

- `diffHighlight.test.tsx` (new) — asserts coloured `.token` spans, per-line caching, and identity fallback for empty/unknown/plaintext languages.
- `DiffBlock.test.tsx` (extended) — highlighted tokens render with the +/- tint intact, collapse toggle + counts still work, split view highlights both columns + persists the toggle, unknown-lang falls back to plain.
- All 388 proposal-blocks tests pass; `tsc -b` clean; new files eslint-clean; `npm run build` succeeds (`diffHighlight-*.js` is its own lazy chunk); lockfile untouched.
- Playwright before/after on a `lang="rust"` story (`Proposals/Blocks/Polish` → `RustDiff`): before = flat monospace (0 token spans, tint only); after = 90 coloured tokens (purple keywords, blue identifiers, green strings) with the red/green tint intact in **both** unified and split views.

No Rust, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)