### PR TITLE
perf(codegraph): cap drawable edges in the snapshot payload (the real cold-load fix)

### DIFF
--- a/server/src/mcp_bridge/graph_ops/tests/mod.rs
+++ b/server/src/mcp_bridge/graph_ops/tests/mod.rs
@@ -1297,5 +1297,6 @@ async fn context_imports_bucket_for_file_references_pr_c1() {
 mod complexity_refactor;
 mod flow;
 mod snapshot;
+mod snapshot_edge_cap;
 
 mod route;

--- a/server/src/mcp_bridge/graph_ops/tests/snapshot_edge_cap.rs
+++ b/server/src/mcp_bridge/graph_ops/tests/snapshot_edge_cap.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+/// The snapshot must cap the drawable-edge population so the wire payload
+/// stays small enough to parse on cold load, while keeping containment
+/// edges (the UI needs them to nest symbols) and reporting the full
+/// post-exclusion edge count.
+#[test]
+fn snapshot_caps_drawable_edges_but_keeps_containment() {
+    use crate::mcp_bridge::snapshot::SNAPSHOT_DRAWABLE_EDGE_CAP;
+    use djinn_control_plane::tools::graph_exclusions::GraphExclusions;
+    use djinn_graph::repo_graph::{
+        REPO_GRAPH_ARTIFACT_VERSION, RankedRepoGraphNode, RepoDependencyGraph, RepoGraphArtifact,
+        RepoGraphArtifactEdge, RepoGraphEdgeKind, RepoGraphNode, RepoGraphNodeKind,
+        RepoGraphRanking, RepoNodeKey,
+    };
+
+    // Complete graph over N symbols in one workspace ⇒ N*(N-1)/2 drawable
+    // (SymbolReference) edges, comfortably over the cap.
+    let n = 160usize;
+    let drawable_total = n * (n - 1) / 2;
+    assert!(
+        drawable_total > SNAPSHOT_DRAWABLE_EDGE_CAP,
+        "fixture must exceed the cap to exercise it"
+    );
+
+    let mk = |i: usize| RepoGraphNode {
+        id: RepoNodeKey::Symbol(format!("s{i}")),
+        kind: RepoGraphNodeKind::Symbol,
+        display_name: format!("s{i}"),
+        language: Some("rust".to_string()),
+        file_path: Some(PathBuf::from(format!("ws/src/s{i}.rs"))),
+        symbol: Some(format!("s{i}")),
+        symbol_kind: None,
+        is_external: false,
+        visibility: None,
+        signature: None,
+        documentation: vec![],
+        signature_parts: None,
+        is_test: false,
+        complexity: None,
+        workspace: Some("ws".to_string()),
+        route_framework: None,
+        route_handler_symbol: None,
+    };
+    let nodes: Vec<RepoGraphNode> = (0..n).map(mk).collect();
+    let mut edges: Vec<RepoGraphArtifactEdge> = Vec::new();
+    for i in 0..n {
+        for j in (i + 1)..n {
+            edges.push(RepoGraphArtifactEdge {
+                source: i,
+                target: j,
+                kind: RepoGraphEdgeKind::SymbolReference,
+                weight: 1.0,
+                evidence_count: 1,
+                confidence: 0.9,
+                reason: None,
+                step: None,
+            });
+        }
+    }
+    // A containment edge must survive the cap regardless.
+    edges.push(RepoGraphArtifactEdge {
+        source: 0,
+        target: 1,
+        kind: RepoGraphEdgeKind::ContainsDefinition,
+        weight: 1.0,
+        evidence_count: 1,
+        confidence: 0.95,
+        reason: None,
+        step: None,
+    });
+
+    let graph = RepoDependencyGraph::from_artifact(&RepoGraphArtifact {
+        version: REPO_GRAPH_ARTIFACT_VERSION,
+        nodes,
+        edges,
+        symbol_ranges: std::collections::BTreeMap::new(),
+        communities: vec![],
+        processes: vec![],
+        route_exclusion_config: Default::default(),
+        layout_positions: std::collections::BTreeMap::new(),
+    });
+    let ranking = RepoGraphRanking {
+        nodes: graph
+            .graph()
+            .node_indices()
+            .map(|node_index| RankedRepoGraphNode {
+                node_index,
+                key: graph.node(node_index).id.clone(),
+                kind: graph.node(node_index).kind,
+                score: 1.0,
+                page_rank: 1.0,
+                structural_weight: 1.0,
+                inbound_edge_weight: 0.0,
+                outbound_edge_weight: 0.0,
+                is_entry_point: false,
+                entry_point_distance: None,
+                fused_rank: 1.0,
+            })
+            .collect(),
+    };
+
+    let payload = build_snapshot_payload(
+        &graph,
+        &ranking,
+        "proj-test".to_string(),
+        "deadbeef".to_string(),
+        "2026-04-28T00:00:00Z".to_string(),
+        &GraphExclusions::empty(),
+        None,
+        SnapshotLevel::Symbol,
+        10_000,
+    );
+
+    let drawable_emitted = payload
+        .edges
+        .iter()
+        .filter(|e| e.kind == "SymbolReference")
+        .count();
+    let containment_emitted = payload
+        .edges
+        .iter()
+        .filter(|e| e.kind == "ContainsDefinition")
+        .count();
+
+    assert_eq!(
+        drawable_emitted, SNAPSHOT_DRAWABLE_EDGE_CAP,
+        "drawable edges capped to the ceiling, not shipped whole"
+    );
+    assert!(
+        containment_emitted >= 1,
+        "containment edge must survive the cap (nesting depends on it)"
+    );
+    assert!(
+        payload.total_edges >= drawable_total,
+        "total_edges reports the full post-exclusion count for the UI's \"N of M\""
+    );
+}

--- a/server/src/mcp_bridge/snapshot.rs
+++ b/server/src/mcp_bridge/snapshot.rs
@@ -5,8 +5,52 @@ use djinn_control_plane::bridge::{
 };
 use petgraph::visit::EdgeRef;
 
+use djinn_graph::repo_graph::RepoGraphEdgeKind;
+
 use super::bridges::{CoordinatorBridge, LspBridge, SlotPoolBridge};
 use super::graph_neighbors::format_node_key;
+
+/// Ceiling on the number of *drawable* (non-containment) edges shipped in a
+/// snapshot. A full graph can carry ~100k edges — overwhelmingly low-value
+/// `FileReference` links — which dominates the wire payload (tens of MB) and
+/// the client's `JSON.parse` + graph-build cost on cold load. The frontend
+/// only ever renders a salience-capped subset anyway (see `MAX_RENDERED_EDGES`
+/// in `ui/src/lib/codeGraphAdapter.ts`), so shipping more is pure waste.
+/// Containment and cross-workspace edges are kept regardless (see
+/// `build_snapshot_payload`); this caps only the cappable remainder.
+pub(crate) const SNAPSHOT_DRAWABLE_EDGE_CAP: usize = 12_000;
+
+/// Containment edges express structural nesting (a file/type contains a
+/// definition/member). The UI converts them into parent/child nesting
+/// metadata rather than drawing them, so they must survive the edge cap
+/// whenever both endpoints are present. Mirrors `CONTAINMENT_EDGE_KINDS`
+/// in `ui/src/lib/codeGraphAdapter.ts`.
+fn is_containment_edge_kind(kind: RepoGraphEdgeKind) -> bool {
+    matches!(
+        kind,
+        RepoGraphEdgeKind::ContainsDefinition
+            | RepoGraphEdgeKind::DeclaredInFile
+            | RepoGraphEdgeKind::MemberOf
+    )
+}
+
+/// Salience used to rank drawable edges when the payload exceeds
+/// `SNAPSHOT_DRAWABLE_EDGE_CAP`. Mirrors the frontend's edge-`size` factors
+/// (`EDGE_STYLES` per-kind multiplier × confidence factor in
+/// `ui/src/lib/codeGraphAdapter.ts`) so the server keeps the same edges the
+/// client would have kept — the per-kind weight (structural/OOP spine over
+/// the call graph) times per-edge confidence.
+fn drawable_edge_salience(kind: RepoGraphEdgeKind, confidence: f64) -> f64 {
+    let multiplier = match kind {
+        RepoGraphEdgeKind::Extends => 1.0,
+        RepoGraphEdgeKind::Implements => 0.9,
+        RepoGraphEdgeKind::SymbolReference => 0.8,
+        RepoGraphEdgeKind::EntryPointOf | RepoGraphEdgeKind::StepInProcess => 0.7,
+        RepoGraphEdgeKind::FileReference | RepoGraphEdgeKind::Writes => 0.6,
+        _ => 0.5,
+    };
+    multiplier * (0.4 + 0.6 * confidence)
+}
 use super::memory_enrichment::MemoryEnrichmentBridge;
 use super::{RepoGraphBridge, shared};
 use crate::server::AppState;
@@ -304,8 +348,19 @@ pub(crate) fn build_snapshot_payload(
     // whose source AND target survived the cap. `total_edges` is
     // the post-exclusion count (we drop edges that touch excluded
     // nodes so the totals match the visible graph).
+    //
+    // Edge payload cap (perf): keep every containment edge (the UI needs
+    // them to nest symbols in files) and every cross-workspace edge (the
+    // few highlighted inter-module links), then cap the remaining drawable
+    // edges to the highest `SNAPSHOT_DRAWABLE_EDGE_CAP` by salience. This
+    // is what makes the snapshot small enough to parse on cold load; the
+    // frontend re-applies the same salience cap. `total_edges` still
+    // reports the full post-exclusion count so the UI shows "N of M".
     let mut total_edges_post_excl: usize = 0;
-    let mut snapshot_edges: Vec<SnapshotEdge> = Vec::new();
+    let mut containment_edges: Vec<SnapshotEdge> = Vec::new();
+    let mut cross_workspace_edges: Vec<SnapshotEdge> = Vec::new();
+    // (salience, edge) for the cappable intra-workspace drawable edges.
+    let mut drawable_edges: Vec<(f64, SnapshotEdge)> = Vec::new();
     for edge_ref in graph.graph().edge_references() {
         let src_in = pagerank_lookup.contains_key(&edge_ref.source());
         let dst_in = pagerank_lookup.contains_key(&edge_ref.target());
@@ -319,14 +374,41 @@ pub(crate) fn build_snapshot_payload(
         let from_node = graph.node(edge_ref.source());
         let to_node = graph.node(edge_ref.target());
         let weight = edge_ref.weight();
-        snapshot_edges.push(SnapshotEdge {
+        let edge = SnapshotEdge {
             from: format_node_key(&from_node.id),
             to: format_node_key(&to_node.id),
             kind: format!("{:?}", weight.kind),
             confidence: weight.confidence,
             reason: weight.reason.clone(),
-        });
+        };
+        if is_containment_edge_kind(weight.kind) {
+            containment_edges.push(edge);
+        } else if from_node.workspace.is_some()
+            && to_node.workspace.is_some()
+            && from_node.workspace != to_node.workspace
+        {
+            cross_workspace_edges.push(edge);
+        } else {
+            drawable_edges.push((drawable_edge_salience(weight.kind, weight.confidence), edge));
+        }
     }
+
+    // Cap the cappable remainder to the budget left after the always-kept
+    // cross-workspace edges, keeping the highest-salience edges.
+    let intra_budget = SNAPSHOT_DRAWABLE_EDGE_CAP.saturating_sub(cross_workspace_edges.len());
+    if drawable_edges.len() > intra_budget {
+        drawable_edges.select_nth_unstable_by(intra_budget, |a, b| {
+            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        drawable_edges.truncate(intra_budget);
+    }
+
+    let mut snapshot_edges: Vec<SnapshotEdge> = Vec::with_capacity(
+        containment_edges.len() + cross_workspace_edges.len() + drawable_edges.len(),
+    );
+    snapshot_edges.append(&mut containment_edges);
+    snapshot_edges.append(&mut cross_workspace_edges);
+    snapshot_edges.extend(drawable_edges.into_iter().map(|(_, edge)| edge));
 
     // Sort edges deterministically (kind > from > to) so test snapshots
     // stay stable across runs.
@@ -572,5 +654,52 @@ fn community_centroid(
         (0.0, 0.0)
     } else {
         (sum_x / count as f64, sum_y / count as f64)
+    }
+}
+
+#[cfg(test)]
+mod edge_cap_tests {
+    use super::*;
+
+    #[test]
+    fn containment_kinds_are_classified_as_containment() {
+        for kind in [
+            RepoGraphEdgeKind::ContainsDefinition,
+            RepoGraphEdgeKind::DeclaredInFile,
+            RepoGraphEdgeKind::MemberOf,
+        ] {
+            assert!(
+                is_containment_edge_kind(kind),
+                "{kind:?} should be containment"
+            );
+        }
+        for kind in [
+            RepoGraphEdgeKind::FileReference,
+            RepoGraphEdgeKind::SymbolReference,
+            RepoGraphEdgeKind::Extends,
+            RepoGraphEdgeKind::EntryPointOf,
+        ] {
+            assert!(
+                !is_containment_edge_kind(kind),
+                "{kind:?} should be drawable"
+            );
+        }
+    }
+
+    #[test]
+    fn salience_ranks_structural_over_file_refs_and_rewards_confidence() {
+        // OOP spine outranks the file-reference wall at equal confidence,
+        // matching the frontend's EDGE_STYLES multipliers.
+        let extends = drawable_edge_salience(RepoGraphEdgeKind::Extends, 1.0);
+        let file_ref = drawable_edge_salience(RepoGraphEdgeKind::FileReference, 1.0);
+        assert!(
+            extends > file_ref,
+            "Extends ({extends}) should outrank FileReference ({file_ref})"
+        );
+
+        // Higher confidence wins within a kind.
+        let hi = drawable_edge_salience(RepoGraphEdgeKind::FileReference, 0.95);
+        let lo = drawable_edge_salience(RepoGraphEdgeKind::FileReference, 0.3);
+        assert!(hi > lo, "higher confidence should rank higher");
     }
 }


### PR DESCRIPTION
## The actual root cause

I drove the deployed `code-graph` view in a browser and profiled it. The hang is **not** WebGL render cost (my earlier PRs #1046–#1050) — it's the **snapshot payload size**:

- The snapshot ships **every edge**: ~98k for djinn, **71k of them low-value `FileReference`** links.
- That's a **~26 MB JSON** response (**20.8 MB is edges**), which the browser downloads and `JSON.parse`s on the main thread before anything renders.
- The backend `limit` caps *nodes* (10k); edges were uncapped. The frontend's own edge cap (`MAX_RENDERED_EDGES`) only runs **after** the 26MB parse, so it never helped the cold load.

Measured live: warm load ~0.5s, but the cold first open sat on "Loading code graph snapshot…" for 2+ minutes — the 26MB download+parse.

## Change

Cap edges server-side in `build_snapshot_payload`:

- **Keep every containment edge** (`ContainsDefinition`/`DeclaredInFile`/`MemberOf`) — the UI converts these to node-nesting metadata, so they must survive.
- **Keep every cross-workspace edge** (the few highlighted inter-module links; only ~24 here).
- **Cap the remaining drawable edges** to `SNAPSHOT_DRAWABLE_EDGE_CAP` (12k) by **salience**, mirroring the frontend's `EDGE_STYLES` per-kind weight × confidence ranking, so the server keeps the same edges the client would have.
- `total_edges` still reports the full post-exclusion count, so the "N of M edges" pill is unchanged.

For djinn this drops the payload from **~98k edges (26MB) → ~28k (~11MB)**, roughly halving the download + parse and removing the cold-load stall. (Containment ~16k is the floor; a future follow-up could intern edge endpoints as indices instead of repeating long string IDs to shrink further.)

## Tests

- Unit: containment classification; salience ranks structural > FileReference and rewards confidence.
- Integration: a >12k-drawable complete graph caps to exactly `SNAPSHOT_DRAWABLE_EDGE_CAP`, containment survives, and `total_edges` reports the full count.
- `cargo test` (14 snapshot tests green), `clippy --all-features -D warnings` clean, `rustfmt` clean.

## Note
This needs a **server deploy** to take effect on `code.djinnai.io` — the snapshot is generated server-side. Complements the frontend series (#1046–#1050) which cut render cost once the data is parsed.