### PR TITLE
fix(ui): declare refractor as direct dep (production build fix)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -78,6 +78,7 @@
     "react-markdown": "^9.0.1",
     "react-router-dom": "^7.13.2",
     "react-syntax-highlighter": "^15.6.1",
+    "refractor": "^3.6.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.0",
     "shadcn": "^3.8.5",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       react-syntax-highlighter:
         specifier: ^15.6.1
         version: 15.6.6(react@19.2.4)
+      refractor:
+        specifier: ^3.6.0
+        version: 3.6.0
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2


### PR DESCRIPTION
## Problem

The v0.6.42 release build failed at **Build UI**:

```
[vite]: Rollup failed to resolve import "refractor" from "ui/src/components/proposals/blocks/diffHighlight.tsx".
```

## Root cause

PR #1055 (diff-block syntax highlighting) added `diffHighlight.tsx`, which does `import refractor from "refractor"` directly. `refractor` was only present **transitively** via `react-syntax-highlighter`. Under pnpm's strict `node_modules`, an undeclared dependency is not symlinked into `ui/node_modules/`, so a clean CI install can't resolve it and the production rollup build fails. (The dev server / PR typecheck tolerated it.)

## Fix

Declare `refractor` as a direct dependency, pinned `^3.6.0` to match the version `react-syntax-highlighter` already resolves (the v3 default-export API the code uses: `.highlight`, `.registered`).

## Verification
- `vite build` ✓ (built in 20.76s)
- `tsc -b` clean