### PR TITLE
ci(quality-gate): run the production vite build on UI PRs

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -502,6 +502,17 @@ jobs:
       - name: Tests
         run: pnpm test
 
+      # Run the real production bundler — the same `pnpm build` the release
+      # workflow runs. `tsc --noEmit` resolves types (often via hoisted /
+      # transitive paths) and the dev server resolves lazily, so both
+      # tolerate a dependency that's present-but-undeclared under pnpm's
+      # strict node_modules, plus loose vite alias prefix-matches. Only the
+      # production `vite build` enforces the real module graph. Without this
+      # step those failures slip through a green PR and only surface at tag
+      # time in release.yml (e.g. the elkjs alias and refractor regressions).
+      - name: Production build
+        run: pnpm build
+
   # ── Quality gate ────────────────────────────────────────────────────
   # If you change this job's name, also update the branch-protection rule
   # (and the merge-queue config) that requires "Quality Gate" as THE

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -71,6 +71,9 @@ jobs:
               - '.github/workflows/quality-gate.yml'
             ui:
               - 'ui/**'
+              # Re-run the UI gate when its own workflow changes, so edits to
+              # the build/test steps are exercised on the PR that makes them.
+              - '.github/workflows/quality-gate.yml'
 
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  Cache Warming (main push only)                                 ║


### PR DESCRIPTION
## Problem

Two UI build failures reached a release tag in this batch — both **green on the PR, red in `release.yml` at tag time**:
1. an **elkjs** vite alias prefix-match, and
2. a transitively-present-but-**undeclared `refractor`** import under pnpm's strict `node_modules`.

Root cause: the `UI Frontend` Quality Gate job runs `pnpm tsc --noEmit` + `pnpm test`, but **never the production bundler**. `tsc` resolves types via hoisted/transitive paths and the dev server resolves lazily, so both tolerate an undeclared dependency and loose alias prefix-matches. Only the production `vite build` enforces the real module graph — and that only ran in `release.yml`, at tag time.

## Change

Add a **`Production build`** step (`pnpm build` — identical to release.yml's UI build) to the `UI Frontend` job, after type check + tests. This closes the whole class of "green PR → red release" failures by exercising the exact bundler the release uses.

## Validation

- Ran `pnpm install --frozen-lockfile && pnpm build` on current `main` (which includes #1058's refractor fix): **green, built in ~22s**.
- YAML validated; step lands in the right job.
- Cost: ~30–60s added to PRs that touch `ui/` (the job is gated on `needs.changes.outputs.ui == 'true'`).

A dep-lint (knip/depcheck) was considered but rejected: it would catch undeclared deps but not the elkjs alias case. The real bundler catches both.