### PR TITLE
fix(codegraph): stop perpetual render loop that makes large graphs unresponsive

### DIFF
--- a/ui/src/hooks/useGraphReducers.ts
+++ b/ui/src/hooks/useGraphReducers.ts
@@ -41,6 +41,7 @@ import { computePagerankPercentiles } from "@/lib/codeGraphLabels";
 import {
   lodTierForZoom,
   VIEWPORT_CULLING_THRESHOLD,
+  viewportBoundsEqual,
   type ViewportBounds,
 } from "@/lib/codeGraphAdapter";
 import {
@@ -459,10 +460,18 @@ export function useGraphReducers(
           nodeCountRef.current >= VIEWPORT_CULLING_THRESHOLD
             ? sigma.getViewportBounds()
             : null;
+        // `getViewportBounds()` returns a fresh object every call, so a
+        // reference (`!==`) comparison here is ALWAYS true — which would
+        // fire `refresh()` on every `afterRender`, and since `refresh()`
+        // schedules another render, that's a perpetual 60fps render loop
+        // (re-running every reducer each frame, even at idle). This only
+        // bites graphs past VIEWPORT_CULLING_THRESHOLD, where bounds are
+        // non-null. Compare by value so we only refresh when the viewport
+        // actually moved.
         if (
           ratio !== viewRef.current.cameraRatio ||
           lodTier !== viewRef.current.lodTier ||
-          viewportBounds !== viewRef.current.viewportBounds
+          !viewportBoundsEqual(viewportBounds, viewRef.current.viewportBounds)
         ) {
           viewRef.current = {
             ...viewRef.current,

--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -34,6 +34,7 @@ import {
   massForNode,
   parseSnapshotResponse,
   prettifyLabel,
+  viewportBoundsEqual,
   type CommunityHull,
   type LodTier,
   type SnapshotNode,
@@ -2049,6 +2050,31 @@ describe("isSymbolVisibleAtMidTier", () => {
 });
 
 // ── Viewport culling ─────────────────────────────────────────────────────
+
+describe("viewportBoundsEqual", () => {
+  it("treats distinct objects with equal fields as equal (no spurious refresh)", () => {
+    // This is the regression guard: getViewportBounds() returns a fresh
+    // object each call, so the afterRender handler must compare by VALUE.
+    // Identity comparison here would be `false` and spin a render loop.
+    const a: ViewportBounds = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+    const b: ViewportBounds = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+    expect(a).not.toBe(b); // distinct references
+    expect(viewportBoundsEqual(a, b)).toBe(true);
+  });
+
+  it("detects a real viewport change", () => {
+    const a: ViewportBounds = { minX: 0, minY: 0, maxX: 100, maxY: 100 };
+    expect(viewportBoundsEqual(a, { ...a, maxX: 101 })).toBe(false);
+    expect(viewportBoundsEqual(a, { ...a, minY: -1 })).toBe(false);
+  });
+
+  it("treats two nulls (culling inactive) as equal and null/object as changed", () => {
+    expect(viewportBoundsEqual(null, null)).toBe(true);
+    const a: ViewportBounds = { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+    expect(viewportBoundsEqual(a, null)).toBe(false);
+    expect(viewportBoundsEqual(null, a)).toBe(false);
+  });
+});
 
 describe("isInViewport", () => {
   const bounds: ViewportBounds = { minX: 0, minY: 0, maxX: 100, maxY: 100 };

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -1268,6 +1268,32 @@ export interface ViewportBounds {
 }
 
 /**
+ * Value-equality for viewport bounds. `sigma.getViewportBounds()` returns a
+ * fresh object on every call, so an identity (`!==`) comparison always reports
+ * a change. The reducer's `afterRender` handler uses that comparison to decide
+ * whether to `refresh()`; with identity comparison it refreshes every frame,
+ * and since `refresh()` schedules another render, that's a perpetual 60fps
+ * render loop (re-running every reducer each frame, even at idle) on graphs
+ * past `VIEWPORT_CULLING_THRESHOLD`. Comparing by value breaks the loop.
+ *
+ * Two `null`s are equal (culling inactive on both sides); a `null`/object
+ * mismatch is a change.
+ */
+export function viewportBoundsEqual(
+  a: ViewportBounds | null,
+  b: ViewportBounds | null,
+): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  return (
+    a.minX === b.minX &&
+    a.minY === b.minY &&
+    a.maxX === b.maxX &&
+    a.maxY === b.maxY
+  );
+}
+
+/**
  * Node-count threshold above which viewport culling activates.
  * Below this, all nodes are considered in-viewport (no culling).
  */


### PR DESCRIPTION
## Symptom

The code graph is **unresponsive** — pan/zoom impossible, "Page Unresponsive" dialog — on the large djinn graph, even after the payload fix (#1056) made it load fast.

## Root cause

In `useGraphReducers`, the `afterRender` handler recomputes viewport bounds and calls `sigma.refresh()` when the view changed. But it compared bounds with `!==`:

```ts
const viewportBounds = nodeCount >= VIEWPORT_CULLING_THRESHOLD ? sigma.getViewportBounds() : null;
if (ratio !== … || lodTier !== … || viewportBounds !== viewRef.current.viewportBounds) {
  sigma.refresh();
}
```

`sigma.getViewportBounds()` returns a **fresh object every call**, so `viewportBounds !== prev` is **always true**. Every `afterRender` fires `refresh()` → which schedules another render → `afterRender` → `refresh()` → … a **perpetual 60fps render loop**, re-running all ~22k node/edge reducers every frame, even at idle.

It only triggers past `VIEWPORT_CULLING_THRESHOLD` (8,000 nodes) — below that, `bounds` is `null` on both sides so `null !== null` is `false` and the loop never starts. That's exactly why only the big graph (~10k nodes) is clanky and small ones are fine. The constant full re-render pegs the main thread; with real input on top, it locks up.

## Fix

Compare bounds **by value** via a new `viewportBoundsEqual()` helper (placed in `codeGraphAdapter.ts`, not the hook, so the regression test stays off the sigma/WebGL import chain). `refresh()` now fires only when the camera actually moved — idle does **zero** work, and pan/zoom re-renders only during motion.

## Tests

`viewportBoundsEqual`: distinct objects with equal fields → equal (the regression guard — identity comparison would return false and spin the loop); real field changes → not equal; null/null → equal, null/object → changed.

`tsc` + 123 adapter tests + reducer/hook tests green; production `vite build` green.

Follows the code-graph series (#1046/#1047/#1049/#1050/#1056). If pan still feels heavy at 10k nodes after this (the reducers still run per-frame *during* motion), the next lever is lowering the default node cap for the "All" view — happy to follow up once this is verified live.