### PR TITLE
fix(codegraph): viewport culling cut off visible nodes when zoomed in

### DIFF
--- a/ui/src/hooks/useSigmaGraph.ts
+++ b/ui/src/hooks/useSigmaGraph.ts
@@ -364,30 +364,42 @@ export function useSigmaGraph(
       getViewportBounds: (): ViewportBounds | null => {
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const cam = (sigmaInstance as any).getCamera?.();
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const container = (sigmaInstance as any).getContainer?.();
-          if (!cam || !container) return null;
-          const ratio = cam.ratio;
-          const cx = cam.x;
-          const cy = cam.y;
+          // `viewportToGraph` converts screen pixels → graph coordinates,
+          // correctly accounting for the camera (pan + zoom). The previous
+          // implementation derived bounds from raw `camera.x/y/ratio`, which
+          // live in Sigma's NORMALIZED framed space — comparing those against
+          // node *graph* coordinates (the culling test in `codeGraphReducers`)
+          // is a coordinate-space mismatch, so it culled the wrong rectangle
+          // and nodes vanished on the left/bottom when zoomed in.
+          const vToG = (
+            sigmaInstance as unknown as {
+              viewportToGraph?: (point: { x: number; y: number }) => {
+                x: number;
+                y: number;
+              };
+            }
+          ).viewportToGraph?.bind(sigmaInstance);
+          if (!container || !vToG) return null;
+          const w = container.clientWidth ?? 800;
+          const h = container.clientHeight ?? 600;
+          // Convert the two viewport corners. Screen Y grows downward while
+          // graph Y grows upward, so take min/max rather than assuming order.
+          const a = vToG({ x: 0, y: 0 });
+          const b = vToG({ x: w, y: h });
           if (
-            typeof ratio !== "number" ||
-            !Number.isFinite(ratio) ||
-            typeof cx !== "number" ||
-            typeof cy !== "number"
+            !Number.isFinite(a.x) ||
+            !Number.isFinite(a.y) ||
+            !Number.isFinite(b.x) ||
+            !Number.isFinite(b.y)
           ) {
             return null;
           }
-          const w = container.clientWidth ?? 800;
-          const h = container.clientHeight ?? 600;
-          const halfW = (w * ratio) / 2;
-          const halfH = (h * ratio) / 2;
           return {
-            minX: cx - halfW,
-            maxX: cx + halfW,
-            minY: cy - halfH,
-            maxY: cy + halfH,
+            minX: Math.min(a.x, b.x),
+            maxX: Math.max(a.x, b.x),
+            minY: Math.min(a.y, b.y),
+            maxY: Math.max(a.y, b.y),
           };
         } catch {
           return null;


### PR DESCRIPTION
## Symptom

Zooming in, nodes render only in a sub-rectangle (e.g. upper-right) while the rest of the visible canvas is empty — "looks like there's a square it renders stuff in and the rest doesn't show up."

## Root cause

`getViewportBounds()` derived the culling rectangle from raw `camera.x / camera.y / camera.ratio`, which are in Sigma's **normalized framed space** ([0,1]-ish). The culling test in `codeGraphReducers` (`isInViewport(node.x, node.y, bounds)`) compares those bounds against node **graph coordinates** (e.g. x≈361). Mismatched coordinate spaces → the "viewport" rectangle has nothing to do with what's actually on screen → symbols outside the bogus rectangle get `hidden: true`. Only bites graphs past `VIEWPORT_CULLING_THRESHOLD` (8k), and it became visible now that zoom/pan actually works (#1060).

## Fix

Use Sigma's `viewportToGraph()` to convert the two viewport corners `(0,0)` and `(width,height)` into graph coordinates, then min/max them (screen-Y grows down, graph-Y grows up). Now the culling rectangle matches the visible viewport, so on-screen nodes stay visible and only genuinely off-screen ones are culled. Falls back to `null` (culling off, all nodes shown) if the API is missing.

## Validation

`tsc` clean, reducer + hook tests green, production `vite build` green. Coordinate-source fix inside the Sigma handle (integration-level); will confirm live after deploy.