### PR TITLE
feat(codegraph): color topology by crate (finer), drop background circles

### DIFF
--- a/ui/src/components/codegraph/CodeGraphCanvas.tsx
+++ b/ui/src/components/codegraph/CodeGraphCanvas.tsx
@@ -41,10 +41,7 @@ import {
   readEdgeRenderStats,
   type SnapshotPayload,
 } from "@/lib/codeGraphAdapter";
-import {
-  useSigmaGraph,
-  type CommunityHullRegion,
-} from "@/hooks/useSigmaGraph";
+import { useSigmaGraph } from "@/hooks/useSigmaGraph";
 import { useGraphReducers } from "@/hooks/useGraphReducers";
 import { selectCitationIds, useCodeGraphStore } from "@/stores/codeGraphStore";
 import { RendererCapabilityDialog } from "./RendererCapabilityDialog";
@@ -166,7 +163,6 @@ export function CodeGraphCanvas({
     reducers,
   );
   useAutoFocusOnCitations({ ready, layoutRunning, sigma });
-  const hullRegions = useCommunityHullRegions(sigma);
 
   useEffect(() => {
     setSigmaHandle(sigma);
@@ -245,7 +241,6 @@ export function CodeGraphCanvas({
   return (
     <div className="absolute inset-0" style={{ background: CANVAS_BACKGROUND }}>
       <RendererCapabilityDialog />
-      <CommunityHullOverlay regions={hullRegions} />
       <div
         ref={containerRef}
         data-testid="code-graph-canvas"
@@ -276,59 +271,6 @@ function useAutoFocusOnCitations({
     if (!ready || layoutRunning || !sigma) return;
     sigma.focusNodes(citationIds);
   }, [citationIds, layoutRunning, ready, sigma]);
-}
-
-function useCommunityHullRegions(
-  sigma: ReturnType<typeof useSigmaGraph>["sigma"],
-): CommunityHullRegion[] {
-  const [regions, setRegions] = useState<CommunityHullRegion[]>([]);
-
-  useEffect(() => {
-    if (!sigma) {
-      setRegions([]);
-      return;
-    }
-    const sync = () => setRegions(sigma.getCommunityHullRegions());
-    sync();
-    const off = sigma.on("afterRender", sync);
-    return off;
-  }, [sigma]);
-
-  return regions;
-}
-
-function CommunityHullOverlay({
-  regions,
-}: {
-  regions: CommunityHullRegion[];
-}) {
-  if (regions.length === 0) return null;
-  return (
-    <div
-      data-testid="community-hull-overlay"
-      className="pointer-events-none absolute inset-0 overflow-hidden"
-      aria-hidden="true"
-    >
-      {regions.map((region) => (
-        <div
-          key={region.id}
-          data-testid="community-hull-region"
-          className="absolute rounded-[999px] border opacity-70 transition-all duration-200 ease-out"
-          style={{
-            left: region.left,
-            top: region.top,
-            width: region.width,
-            height: region.height,
-            // Faint crate-colored tint, no outer glow — the boxShadow bloom
-            // was the dominant source of the washed-out "balls" look.
-            borderColor: `${region.color}26`,
-            background: `radial-gradient(circle at 50% 50%, ${region.color}12 0%, ${region.color}08 60%, transparent 74%)`,
-          }}
-          title={`${region.label} (${region.memberCount.toLocaleString()} nodes)`}
-        />
-      ))}
-    </div>
-  );
 }
 
 /**

--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -17,8 +17,11 @@ import {
   WORKSPACE_COLORS,
   buildGraphFromSnapshot,
   colorForCommunity,
+  colorForGroup,
   colorForNode,
   colorForWorkspace,
+  crateForPath,
+  GROUP_COLORS,
   deriveCommunityHulls,
   selectRenderableHulls,
   MIN_HULL_MEMBERS,
@@ -1510,7 +1513,7 @@ describe("massForNode", () => {
 });
 
 describe("colorForNode", () => {
-  it("colors symbols by community_id when present", () => {
+  it("colors symbols by the crate derived from the path (crates/<name> wins over community)", () => {
     const sym: SnapshotNode = {
       id: "s",
       kind: "symbol",
@@ -1518,50 +1521,54 @@ describe("colorForNode", () => {
       pagerank: 0,
       symbol_kind: "function",
       community_id: "cluster-7",
-      file_path: "any/path/file.ts",
+      file_path: "server/crates/djinn-graph/src/lib.rs",
     };
-    expect(colorForNode(sym)).toBe(colorForCommunity("cluster-7"));
+    // Crate from the path is the most specific signal and wins.
+    expect(colorForNode(sym)).toBe(colorForGroup("djinn-graph"));
   });
 
-  it("falls back to parent-directory hash when community_id is absent", () => {
+  it("uses the first path segment as the group for non-crates/ paths", () => {
     const sym: SnapshotNode = {
       id: "s",
       kind: "symbol",
       label: "x",
       pagerank: 0,
       symbol_kind: "function",
-      file_path: "server/crates/djinn-graph/src/lib.rs",
+      file_path: "ui/src/lib/codeGraphAdapter.ts",
     };
-    expect(colorForNode(sym)).toBe(
-      colorForCommunity("server/crates/djinn-graph/src"),
-    );
+    expect(colorForNode(sym)).toBe(colorForGroup("ui"));
   });
 
-  it("colors files by parent-directory hash so siblings share a hue", () => {
-    const a: SnapshotNode = {
-      id: "f1",
+  it("colors every node in a crate the same hue, regardless of kind", () => {
+    const sym: SnapshotNode = {
+      id: "a",
+      kind: "symbol",
+      label: "a",
+      pagerank: 0,
+      symbol_kind: "function",
+      file_path: "server/crates/djinn-graph/src/communities.rs",
+    };
+    const file: SnapshotNode = {
+      id: "b",
       kind: "file",
-      label: "page_worker.go",
-      file_path: "internal/worker/page_worker.go",
+      label: "lib.rs",
+      file_path: "server/crates/djinn-graph/src/lib.rs",
       pagerank: 0,
     };
-    const b: SnapshotNode = {
-      id: "f2",
-      kind: "file",
-      label: "interfaces.go",
-      file_path: "internal/worker/interfaces.go",
+    expect(colorForNode(sym)).toBe(colorForNode(file));
+    expect(colorForNode(sym)).toBe(colorForGroup("djinn-graph"));
+  });
+
+  it("falls back to the community when the node has no file path", () => {
+    const sym: SnapshotNode = {
+      id: "s",
+      kind: "symbol",
+      label: "x",
       pagerank: 0,
+      symbol_kind: "function",
+      community_id: "cluster-7",
     };
-    const c: SnapshotNode = {
-      id: "f3",
-      kind: "file",
-      label: "client.go",
-      file_path: "internal/strategies/connectwise/client.go",
-      pagerank: 0,
-    };
-    expect(colorForNode(a)).toBe(colorForCommunity("internal/worker"));
-    expect(colorForNode(a)).toBe(colorForNode(b));
-    expect(colorForNode(a)).not.toBe(colorForNode(c));
+    expect(colorForNode(sym)).toBe(colorForGroup("cluster-7"));
   });
 
   it("uses the project accent for folders that look like the project root", () => {
@@ -1573,53 +1580,6 @@ describe("colorForNode", () => {
         pagerank: 0,
       }),
     ).toBe("#a855f7");
-  });
-
-  it("colors any node by its crate (workspace) when the tag is present", () => {
-    // Crate wins over community_id, parent-dir, and folder hashing alike,
-    // so the whole topology view reads as crate regions.
-    const sym: SnapshotNode = {
-      id: "s",
-      kind: "symbol",
-      label: "x",
-      pagerank: 0,
-      symbol_kind: "function",
-      community_id: "cluster-7",
-      file_path: "server/crates/djinn-graph/src/lib.rs",
-      workspace: "djinn-graph",
-    };
-    expect(colorForNode(sym)).toBe(colorForWorkspace("djinn-graph"));
-
-    const file: SnapshotNode = {
-      id: "f",
-      kind: "file",
-      label: "lib.rs",
-      file_path: "server/crates/djinn-graph/src/lib.rs",
-      pagerank: 0,
-      workspace: "djinn-graph",
-    };
-    expect(colorForNode(file)).toBe(colorForWorkspace("djinn-graph"));
-  });
-
-  it("colors nodes in the same crate identically, regardless of kind or folder", () => {
-    const a: SnapshotNode = {
-      id: "a",
-      kind: "symbol",
-      label: "a",
-      pagerank: 0,
-      symbol_kind: "function",
-      file_path: "server/crates/djinn-graph/src/communities.rs",
-      workspace: "djinn-graph",
-    };
-    const b: SnapshotNode = {
-      id: "b",
-      kind: "file",
-      label: "lib.rs",
-      file_path: "server/crates/djinn-graph/src/lib.rs",
-      pagerank: 0,
-      workspace: "djinn-graph",
-    };
-    expect(colorForNode(a)).toBe(colorForNode(b));
   });
 
   it("colorForCommunity is deterministic across calls", () => {
@@ -1706,6 +1666,45 @@ const communitySnapshot: SnapshotPayload = {
   ],
 };
 
+describe("crateForPath / colorForGroup", () => {
+  it("extracts the crate name from a cargo workspace path", () => {
+    expect(crateForPath("server/crates/djinn-graph/src/lib.rs")).toBe(
+      "djinn-graph",
+    );
+    expect(crateForPath("crates/foo/mod.rs")).toBe("foo");
+    // directory node (no trailing file) still resolves the crate
+    expect(crateForPath("server/crates/djinn-agent")).toBe("djinn-agent");
+  });
+
+  it("uses the first path segment when there is no crates/ marker", () => {
+    expect(crateForPath("ui/src/lib/codeGraphAdapter.ts")).toBe("ui");
+    expect(crateForPath("server/src/main.rs")).toBe("server");
+    expect(crateForPath("README.md")).toBe("README.md");
+  });
+
+  it("colorForGroup is deterministic and from the group palette", () => {
+    expect(colorForGroup("djinn-graph")).toBe(colorForGroup("djinn-graph"));
+    expect(GROUP_COLORS).toContain(colorForGroup("djinn-graph"));
+  });
+
+  it("spreads distinct crates across multiple hues (not all one color)", () => {
+    const seen = new Set<string>();
+    for (const c of [
+      "djinn-graph",
+      "djinn-agent",
+      "djinn-control-plane",
+      "djinn-k8s",
+      "djinn-provider",
+      "djinn-db",
+      "ui",
+      "server",
+    ]) {
+      seen.add(colorForGroup(c));
+    }
+    expect(seen.size).toBeGreaterThanOrEqual(4);
+  });
+});
+
 describe("colorForNode (community)", () => {
   it("colors community nodes by their stable community_id", () => {
     const node: SnapshotNode = {
@@ -1715,7 +1714,7 @@ describe("colorForNode (community)", () => {
       pagerank: 0,
       community_id: "auth",
     };
-    expect(colorForNode(node)).toBe(colorForCommunity("auth"));
+    expect(colorForNode(node)).toBe(colorForGroup("auth"));
   });
 
   it("falls back to hashing the label when community_id is absent", () => {
@@ -1725,8 +1724,8 @@ describe("colorForNode (community)", () => {
       label: "auth-fallback",
       pagerank: 0,
     };
-    expect(colorForNode(node)).toBe(colorForCommunity("auth-fallback"));
-    expect(COMMUNITY_COLORS).toContain(colorForNode(node));
+    expect(colorForNode(node)).toBe(colorForGroup("auth-fallback"));
+    expect(GROUP_COLORS).toContain(colorForNode(node));
   });
 });
 

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -399,6 +399,55 @@ export function colorForCommunity(communityId: string): string {
 }
 
 /**
+ * Palette for the unified topology grouping (crate → community → folder).
+ * The two base palettes concatenated give ~20 distinct hues, enough that a
+ * monorepo's crates mostly each get their own colour. Vivid -500s first,
+ * lighter -400s after, all legible on the near-black canvas.
+ */
+export const GROUP_COLORS = [...COMMUNITY_COLORS, ...WORKSPACE_COLORS] as const;
+
+/**
+ * The crate / top-level module a repo-relative path belongs to. For a cargo
+ * workspace, `…/crates/<name>/…` → `<name>` (the actual crate); otherwise the
+ * first path segment (`ui`, `server`, …). This is the lever that fixes "all
+ * one colour": the server-side `workspace` tag is the coarse workspace member
+ * (`"server"` for everything under `server/crates/*`), so colouring by it
+ * paints the whole monorepo one hue. Empty string for blank input.
+ */
+export function crateForPath(filePath: string): string {
+  const m = /(?:^|\/)crates\/([^/]+)(?:\/|$)/.exec(filePath);
+  if (m) return m[1];
+  const slash = filePath.indexOf("/");
+  return slash > 0 ? filePath.slice(0, slash) : filePath;
+}
+
+/**
+ * Unified grouping key for topology colour, in the user's mental model:
+ * "crate if we have it, else community/folder — same thing." Prefer the crate
+ * derived from the file path, fall back to the detected community, then the
+ * parent folder, then the node's workspace tag. `null` when nothing applies
+ * (caller picks a neutral fallback).
+ */
+export function colorGroupKey(node: SnapshotNode): string | null {
+  if (node.file_path) {
+    const crate = crateForPath(node.file_path);
+    if (crate.length > 0) return crate;
+  }
+  if (node.community_id) return node.community_id;
+  if (node.file_path) {
+    const parent = parentDirectory(node.file_path);
+    if (parent.length > 0) return parent;
+  }
+  if (node.workspace) return node.workspace;
+  return null;
+}
+
+/** Deterministic hue for a grouping key from the {@link GROUP_COLORS} palette. */
+export function colorForGroup(key: string): string {
+  return GROUP_COLORS[fnv1a(key) % GROUP_COLORS.length];
+}
+
+/**
  * Key with the highest count in a tally map, ties broken by lexical order
  * for determinism. Returns `undefined` for an empty map. Used to pick a
  * community hull's dominant crate.
@@ -584,52 +633,31 @@ function workspaceBadge(workspace: string): string {
 }
 
 /**
- * Color routing. The **crate (workspace)** is the primary topology
- * grouping: every node carrying a `workspace` tag is colored by its
- * crate, so the canvas reads as a handful of crate regions sharing one
- * hue each instead of a per-community / per-folder hash rainbow. This is
- * the lever for "color per crate" — same crate, same color, regardless
- * of kind.
+ * Color routing. Every node is colored by a single **grouping key**
+ * ({@link colorGroupKey}) that prefers the most specific signal available —
+ * the crate derived from the path, else the detected community, else the
+ * parent folder. Same group → same hue, regardless of node kind, so the
+ * canvas reads as ~20 named crate regions instead of one flat color (the old
+ * coarse-`workspace` behavior) or a per-community hash rainbow.
  *
- * Projects without workspace tags (non-Rust repos, pre-workspace
- * snapshots) fall back to the prior hashing so they degrade gracefully:
- *   - Project: fixed purple accent.
- *   - Folder: hash the folder path so siblings under the same parent
- *     share a hue.
- *   - File: hash the parent directory so all files in a folder share a
- *     color.
- *   - Community: hash the stable `community_id`, falling back to the label.
- *   - Symbol: community_id (if F3 populated) → file_path's parent
- *     directory → fallback.
+ * The project root keeps a fixed apex accent; nodes with no usable key fall
+ * back to a neutral slate.
  */
 export function colorForNode(node: SnapshotNode): string {
-  // Crate wins for every kind when the snapshot carries workspace tags.
-  if (node.workspace) return colorForWorkspace(node.workspace);
-
+  // Project root keeps its apex accent no matter what its slug hashes to.
+  if (
+    node.kind === "folder" &&
+    (/project/i.test(node.label) || node.label === "" || !node.file_path)
+  ) {
+    return PROJECT_COLOR;
+  }
+  // Legacy community entries (not rendered) keep their own hue.
   if (node.kind === "community") {
-    if (node.community_id) return colorForCommunity(node.community_id);
-    return colorForCommunity(node.label || node.id);
+    return colorForGroup(node.community_id || node.label || node.id);
   }
-  if (node.kind === "folder") {
-    if (/project/i.test(node.label) || node.label === "" || !node.file_path) {
-      return PROJECT_COLOR;
-    }
-    return colorForCommunity(node.label);
-  }
-  if (node.kind === "file") {
-    const parent = node.file_path
-      ? parentDirectory(node.file_path)
-      : node.label;
-    if (parent.length === 0) return PROJECT_COLOR;
-    return colorForCommunity(parent);
-  }
-
-  if (node.community_id) return colorForCommunity(node.community_id);
-  if (node.file_path) {
-    const parent = parentDirectory(node.file_path);
-    if (parent.length > 0) return colorForCommunity(parent);
-  }
-  return SYMBOL_FALLBACK;
+  const key = colorGroupKey(node);
+  if (key) return colorForGroup(key);
+  return node.kind === "symbol" ? SYMBOL_FALLBACK : PROJECT_COLOR;
 }
 
 // ── Edge styling ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Feedback addressed

- "topology is all the same color so who cares"
- "these circles in the background ... don't tell me which crate that is"
- Mental model: "crate if we have it, else community/folder — same thing"

## 1. Color by a unified grouping key (crate → community → folder)

The "all one color" was a real bug: coloring used the server-side `workspace` tag, which is the **coarse workspace member** — `"server"` for *everything* under `server/crates/*`. So the whole monorepo hashed to one hue.

New `colorGroupKey(node)` picks the **most specific signal available**:
1. **crate** derived from the path — `…/crates/<name>/…` → `<name>` (e.g. `djinn-graph`), else the first path segment (`ui`, `server`)
2. else the detected **community**
3. else the **parent folder**

Colored from `GROUP_COLORS` (~20 hues = the community + workspace palettes concatenated), so each crate gets its own color and same-group nodes share a hue regardless of kind. Project root keeps its apex accent; keyless nodes fall back to neutral slate.

## 2. Remove the background hull circles

`CommunityHullOverlay` + `useCommunityHullRegions` are gone. They were uninformative same-color rings, **and** the region hook called `setRegions()` on every `afterRender` — a React re-render per frame. Removing it cleans the canvas and cuts per-frame work. (The adapter-level hull derivation is left in place, just unrendered — can be removed in a follow-up cleanup.)

## Tests

- `crateForPath`: crate extraction from `crates/<name>` and first-segment fallback (incl. directory nodes).
- `colorForGroup`: deterministic, from the palette, and spreads distinct crates across ≥4 hues (guards "all one color").
- `colorForNode`: crate-from-path wins over community; community fallback when no path; same crate → same hue across kinds.
- `tsc` + 126 adapter tests + canvas test green; production `vite build` green.

Part of the post-deploy polish series (#1060 loop fix, #1061 cull cut-off). Remaining from the same feedback: hide the Complexity toggle outside the Calls lens, and the empty dependents/dependencies panel — separate PRs.