### PR TITLE
feat(codegraph): gate Complexity color toggle on functions being visible

### DIFF
--- a/ui/src/components/codegraph/GraphToolbar.tsx
+++ b/ui/src/components/codegraph/GraphToolbar.tsx
@@ -97,6 +97,19 @@ export function GraphToolbar({
 
   const disabled = !graphReady;
 
+  // The complexity heatmap colors function/method nodes by cognitive
+  // percentile, so it's only meaningful when those nodes are visible. The
+  // Architecture lens hides every symbol kind, so the heatmap would paint
+  // nothing — gate the toggle on functions being visible, not just on the
+  // data existing.
+  const functionsVisible =
+    symbolKindFilters.function === true || symbolKindFilters.method === true;
+  const complexityDisabledReason = !complexityAvailable
+    ? "No complexity data — graph not yet warmed for languages in the walker"
+    : !functionsVisible
+      ? "Complexity colors functions — switch to the Calls lens to use it"
+      : undefined;
+
   return (
     <div
       data-testid="graph-toolbar"
@@ -184,7 +197,8 @@ export function GraphToolbar({
         <ColorModeToggle
           mode={colorMode}
           onChange={setColorMode}
-          disabled={!complexityAvailable}
+          disabled={complexityDisabledReason !== undefined}
+          disabledReason={complexityDisabledReason}
         />
         <FocusDirectionToggle
           direction={focusDirection}
@@ -484,11 +498,14 @@ interface ColorModeToggleProps {
   mode: ColorMode;
   onChange: (mode: ColorMode) => void;
   /**
-   * `true` when the current snapshot has zero function nodes carrying
-   * a `cognitive` value — the heatmap would be degenerate, so we
-   * disable the toggle and surface a tooltip explaining why.
+   * `true` when the complexity heatmap can't be used right now — either the
+   * snapshot has no function nodes carrying a `cognitive` value, or the
+   * active lens hides functions so the heatmap would paint nothing. We
+   * disable the Complexity button and surface `disabledReason` as a tooltip.
    */
   disabled: boolean;
+  /** Human-readable reason shown in the tooltip when `disabled`. */
+  disabledReason?: string;
 }
 
 /**
@@ -497,7 +514,12 @@ interface ColorModeToggleProps {
  * heatmap. Sized to fit the existing toolbar's vertical rhythm so it
  * sits alongside the DOI focus controls without breaking layout.
  */
-function ColorModeToggle({ mode, onChange, disabled }: ColorModeToggleProps) {
+function ColorModeToggle({
+  mode,
+  onChange,
+  disabled,
+  disabledReason,
+}: ColorModeToggleProps) {
   return (
     <div className="flex items-center gap-1.5" data-testid="color-mode-toggle">
       <span className="text-[10px] font-medium uppercase tracking-wide text-zinc-500">
@@ -527,7 +549,8 @@ function ColorModeToggle({ mode, onChange, disabled }: ColorModeToggleProps) {
           label="Complexity"
           tooltip={
             disabled
-              ? "No complexity data — graph not yet warmed for languages in the walker"
+              ? (disabledReason ??
+                "No complexity data — graph not yet warmed for languages in the walker")
               : "Color nodes by cognitive-complexity percentile"
           }
         />

--- a/ui/src/stores/codeGraphStore.test.ts
+++ b/ui/src/stores/codeGraphStore.test.ts
@@ -285,6 +285,24 @@ describe("codeGraphStore", () => {
       expect(useCodeGraphStore.getState().activeLens).toBe("types");
     });
 
+    it("applyLens snaps complexity color mode back to topology when the lens hides functions", () => {
+      // Calls shows functions → complexity stays engaged.
+      useCodeGraphStore.getState().applyLens("calls");
+      useCodeGraphStore.getState().setColorMode("complexity");
+      expect(useCodeGraphStore.getState().colorMode).toBe("complexity");
+
+      // Architecture hides every symbol kind → heatmap would paint nothing,
+      // so the mode snaps back to topology.
+      useCodeGraphStore.getState().applyLens("architecture");
+      expect(useCodeGraphStore.getState().colorMode).toBe("topology");
+    });
+
+    it("applyLens leaves topology color mode untouched", () => {
+      useCodeGraphStore.getState().setColorMode("topology");
+      useCodeGraphStore.getState().applyLens("architecture");
+      expect(useCodeGraphStore.getState().colorMode).toBe("topology");
+    });
+
     it("toggleEdgeKind sets activeLens to null", () => {
       useCodeGraphStore.getState().applyLens("calls");
       expect(useCodeGraphStore.getState().activeLens).toBe("calls");

--- a/ui/src/stores/codeGraphStore.ts
+++ b/ui/src/stores/codeGraphStore.ts
@@ -500,12 +500,23 @@ export const useCodeGraphStore = create<
 
   applyLens: (lensId) => {
     const preset = LENS_PRESETS[lensId];
-    set({
+    // The complexity heatmap only colors function/method nodes; if the lens
+    // hides those (e.g. Architecture), snap the color mode back to topology
+    // so the canvas isn't stuck on a heatmap that paints nothing. Mirrors
+    // the guard in `setComplexityAvailable`.
+    const lensShowsFunctions =
+      preset.symbolKindFilters.function === true ||
+      preset.symbolKindFilters.method === true;
+    set((state) => ({
       nodeKindFilters: { ...preset.nodeKindFilters },
       symbolKindFilters: { ...preset.symbolKindFilters },
       edgeKindFilters: { ...preset.edgeKindFilters },
       activeLens: lensId,
-    });
+      colorMode:
+        !lensShowsFunctions && state.colorMode === "complexity"
+          ? "topology"
+          : state.colorMode,
+    }));
   },
 
   reset: () => {


### PR DESCRIPTION
## Feedback

"complexity when lens architecture is chosen doesn't tell me anything, it only works with calls, which actually shows the functions."

Correct: the cognitive-complexity heatmap colors **function/method** nodes, and the **Architecture lens hides every symbol kind** (`symbolKindFilters` all `false`), so the heatmap paints nothing — yet the toggle was enabled.

## Change

- **Disable the Complexity toggle unless functions are visible** (`symbolKindFilters.function || .method`), not just when complexity *data* exists. Tooltip when disabled-for-this-reason: "Complexity colors functions — switch to the Calls lens to use it."
- **`applyLens` snaps `colorMode` back to topology** when switching to a lens that hides functions (e.g. Architecture), mirroring the existing `setComplexityAvailable` guard — so the canvas never sticks on a heatmap that colors nothing.

## Tests

- Store: `applyLens("architecture")` snaps complexity→topology; topology is left untouched.
- `tsc` + store/toolbar tests (50) green; production `vite build` green.

Continues the post-deploy polish (#1060, #1061, #1062). Remaining from the same feedback: the empty dependents/dependencies panel — investigating separately.