### PR TITLE
fix(proposals): parse each top-level bullet as its own Open Question

### DIFF
--- a/ui/src/components/proposals/blocks/questionForm.test.ts
+++ b/ui/src/components/proposals/blocks/questionForm.test.ts
@@ -119,4 +119,99 @@ describe("parseQuestions", () => {
     expect(qs[0]!.question).toBe("First consideration here.");
     expect(qs[0]!.detail).toEqual(["Second consideration here."]);
   });
+
+  it("makes each top-level `?`-bullet its own question (flat list)", () => {
+    const body = [
+      "- Which database should we use?",
+      "- Do we need read replicas?",
+      "- Should auth be session-based?",
+      "- Where does the cache live?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs.map((q) => q.question)).toEqual([
+      "Which database should we use?",
+      "Do we need read replicas?",
+      "Should auth be session-based?",
+      "Where does the cache live?",
+    ]);
+    for (const q of qs) expect(q.detail).toEqual([]);
+  });
+
+  it("treats indented sub-bullets under a top-level question-bullet as detail", () => {
+    const body = [
+      "- Which caching layer should we pick?",
+      "  - Redis is the team default",
+      "  - Memcached is simpler to operate?",
+      "- Do we need replicas?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(2);
+    expect(qs[0]!.question).toBe("Which caching layer should we pick?");
+    expect(qs[0]!.detail).toEqual([
+      "Redis is the team default",
+      "Memcached is simpler to operate?",
+    ]);
+    expect(qs[1]!.question).toBe("Do we need replicas?");
+    expect(qs[1]!.detail).toEqual([]);
+  });
+
+  it("keeps a `?`-bullet nested under a numbered question as detail", () => {
+    const body = [
+      "1. Which database should we use?",
+      "- Is Postgres acceptable?",
+      "- Do we need replicas?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(1);
+    expect(qs[0]!.question).toBe("Which database should we use?");
+    expect(qs[0]!.detail).toEqual([
+      "Is Postgres acceptable?",
+      "Do we need replicas?",
+    ]);
+  });
+
+  it("keeps a `?`-bullet nested under a heading question as detail", () => {
+    const body = [
+      "### Auth model",
+      "- Should we use sessions?",
+      "- Should we use JWTs?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(1);
+    expect(qs[0]!.question).toBe("Auth model");
+    expect(qs[0]!.detail).toEqual([
+      "Should we use sessions?",
+      "Should we use JWTs?",
+    ]);
+  });
+
+  it("reads a uniformly-indented `?`-bullet list as separate questions", () => {
+    const body = [
+      "  - First open question here?",
+      "  - Second open question here?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs.map((q) => q.question)).toEqual([
+      "First open question here?",
+      "Second open question here?",
+    ]);
+    for (const q of qs) expect(q.detail).toEqual([]);
+  });
+
+  it("parses the r0io proposal's 6 open-question bullets as 6 questions", () => {
+    // Verbatim <QuestionForm> children from proposal r0io (the real bug case).
+    const body = [
+      "- Does the **architect** role also get the `visual-spec` native skill by default, or only the planner?",
+      "- How is the native skill **versioned across deploys** — a version stamp recorded in the proposal's revision trail, and what happens when a proposal authored under v1 is re-refined under v2?",
+      "- Should `get_block_catalog` also return the **canonical example body** (the `canonicalProposal.mdx` fixture), or only tags/fields — to keep the pull payload lean?",
+      "- Is **bare-`<` / `>` parser-hardening** in scope here (so authors need not backtick generics), or is it a separate parser proposal?",
+      "- Should there be a small **canonical section-skeleton** (Thesis / Problem / Objective / Decisions / Risks / Open-Questions) that the enricher targets, or does the skill stay structure-agnostic?",
+      "- Does the **immutability guarantee** need an enforcement test (assert native skills never appear in `agent_update`'s editable set), and where does that test live?",
+    ].join("\n");
+    const qs = parseQuestions(body);
+    expect(qs).toHaveLength(6);
+    for (const q of qs) expect(q.detail).toEqual([]);
+    expect(qs[0]!.question).toContain("architect");
+    expect(qs[5]!.question).toContain("immutability guarantee");
+  });
 });

--- a/ui/src/components/proposals/blocks/questionForm.ts
+++ b/ui/src/components/proposals/blocks/questionForm.ts
@@ -15,11 +15,15 @@
 //   2. a `###`(+) markdown heading
 //   3. a **bolded** line — the whole (trimmed) line wrapped in `**…**`
 //   4. a line that ends in `?` (a question sentence)
-// Following plain lines or `-`/`*`/`+` bullets become that question's detail.
-// Anything before the first recognised question header is attached to the first
-// question as leading detail (or, if there is no header at all, the whole body
-// becomes a single question). Empty input yields `[]` so the caller can fall
-// back to the raw markdown render.
+//   5. a TOP-LEVEL `-`/`*`/`+` bullet that ends in `?` — the most common
+//      authoring pattern is a flat bulleted list of questions, so each base-
+//      indentation question-bullet is its own question.
+// Following plain lines, or bullets that are INDENTED under the current
+// question / do not end in `?`, become that question's detail. Anything before
+// the first recognised question header is attached to the first question as
+// leading detail (or, if there is no header at all, the whole body becomes a
+// single question). Empty input yields `[]` so the caller can fall back to the
+// raw markdown render.
 
 /** One parsed outstanding question: its text plus optional muted sub-detail. */
 export interface ParsedQuestion {
@@ -48,6 +52,22 @@ const HEADING = /^\s*#{1,6}\s+(.*)$/;
 /** A bullet line: `-` / `*` / `+` followed by text. */
 const BULLET = /^\s*[-*+]\s+(.*)$/;
 
+/** Leading-whitespace indent of a line, counting a tab as 2 spaces (file-tree
+ * parser convention) so a top-level `- q?` is distinguishable from a nested
+ * `  - detail?`. */
+function indentOf(line: string): number {
+  const ws = /^[ \t]*/.exec(line)?.[0] ?? "";
+  let n = 0;
+  for (const ch of ws) n += ch === "\t" ? 2 : 1;
+  return n;
+}
+
+/** True when a (trimmed) line ends in `?`, ignoring trailing markdown emphasis
+ * (e.g. `…?**` or `…?*`). */
+function endsInQuestion(line: string): boolean {
+  return /\?\s*\**\s*$/.test(line.trim());
+}
+
 /** True when a (trimmed) line is entirely wrapped in `**…**` (bold). */
 function isBoldLine(line: string): boolean {
   const t = line.trim();
@@ -74,14 +94,33 @@ function asQuestionHeader(line: string): string | null {
 
   if (isBoldLine(line)) return unwrapBold(line);
 
-  // A sentence that ends in `?` (ignoring trailing markdown emphasis) is a
-  // question header — but a bullet/detail line that happens to end in `?` should
-  // stay detail, so bullets are excluded here (handled as detail below).
-  if (!BULLET.test(line) && /\?\s*\**\s*$/.test(line.trim())) {
+  // A non-bullet sentence that ends in `?` (ignoring trailing markdown emphasis)
+  // is a question header. Bullets are handled separately in the parse loop,
+  // where indentation is available to tell a top-level question-bullet from a
+  // nested detail bullet.
+  if (!BULLET.test(line) && endsInQuestion(line)) {
     return line.trim();
   }
 
   return null;
+}
+
+/**
+ * The base indentation of the bulleted list — the minimum indent among all
+ * bullet lines — so a list authored at column 0 OR uniformly indented both read
+ * their top-level bullets as questions. Returns `null` when there are no
+ * bullets.
+ */
+function baseBulletIndent(lines: string[]): number | null {
+  let base: number | null = null;
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    if (BULLET.test(line)) {
+      const indent = indentOf(line);
+      if (base === null || indent < base) base = indent;
+    }
+  }
+  return base;
 }
 
 /**
@@ -97,6 +136,14 @@ export function parseQuestions(body: string): ParsedQuestion[] {
   // Detail seen before any recognised header — attached to the first question.
   const leading: string[] = [];
 
+  // The base (minimum) indent of the bulleted list, so a top-level question-
+  // bullet is distinguishable from a nested detail bullet. `null` = no bullets.
+  const base = baseBulletIndent(lines);
+  // Whether the CURRENT question was opened by a top-level question-bullet. Only
+  // in this "bullet-list" mode does a following base-indent `?`-bullet start a
+  // new question; bullets under a numbered/heading/bold question stay its detail.
+  let inBulletList = false;
+
   const pushDetail = (raw: string) => {
     const bullet = BULLET.exec(raw);
     const text = (bullet ? bullet[1] : raw).trim();
@@ -108,21 +155,42 @@ export function parseQuestions(body: string): ParsedQuestion[] {
     }
   };
 
+  const pushQuestion = (header: string, fromBullet: boolean): void => {
+    const { text, recommended } = extractRecommended(header);
+    // A header that becomes empty after stripping `(recommended)` is just a
+    // stray tag — treat it as detail rather than an empty question.
+    if (!text) {
+      if (recommended && questions.length > 0) {
+        questions[questions.length - 1]!.recommended = true;
+      }
+      return;
+    }
+    questions.push({ question: text, detail: [], recommended });
+    inBulletList = fromBullet;
+  };
+
   for (const raw of lines) {
     if (!raw.trim()) continue;
 
+    const bullet = BULLET.exec(raw);
+    if (bullet) {
+      // A top-level bullet that is a question is its own question — but only
+      // when it sits at the list's base indent AND we are not collecting
+      // detail bullets under a non-bullet (numbered/heading/bold) question.
+      const topLevel = base !== null && indentOf(raw) <= base;
+      const startsQuestion =
+        topLevel && endsInQuestion(raw) && (questions.length === 0 || inBulletList);
+      if (startsQuestion) {
+        pushQuestion((bullet[1] ?? "").trim(), true);
+      } else {
+        pushDetail(raw);
+      }
+      continue;
+    }
+
     const header = asQuestionHeader(raw);
     if (header !== null && header !== "") {
-      const { text, recommended } = extractRecommended(header);
-      // A header that becomes empty after stripping `(recommended)` is just a
-      // stray tag — treat it as detail rather than an empty question.
-      if (!text) {
-        if (recommended && questions.length > 0) {
-          questions[questions.length - 1]!.recommended = true;
-        }
-        continue;
-      }
-      questions.push({ question: text, detail: [], recommended });
+      pushQuestion(header, false);
     } else {
       pushDetail(raw);
     }


### PR DESCRIPTION
## Problem

The proposal **Open Questions** (`QuestionForm`) block collapsed a flat bulleted list of questions into a SINGLE question. `parseQuestions` in `ui/src/components/proposals/blocks/questionForm.ts` explicitly excluded bullets from being question headers, so a flat `- …?` list (the most common authoring pattern, e.g. proposal `r0io`'s 6 questions) recognized no header at all and fell back to "first line = the one question, rest = its detail" → rendered "1 question" + 5 detail bullets.

## Fix (indentation-aware)

A `-`/`*`/`+` bullet now starts a NEW question when it:
- ends in `?` (ignoring trailing markdown emphasis), AND
- sits at the list's **base indent** (the minimum indent among all bullets, so a list authored at column 0 OR uniformly indented both work; tabs count as 2), AND
- is not collecting detail under a non-bullet (numbered/heading/bold) question — tracked via an `inBulletList` flag so a `?`-bullet nested under a `1.`/`###`/`**bold**` header stays that header's detail.

A bullet that is indented relative to the base level, or does not end in `?`, stays detail. All existing header forms (numbered, `###` heading, `**bold**`, non-bullet `?`-sentence) are unchanged. The whole-body-as-one-question fallback now only triggers for a genuine single prose blob, not a flat `?`-bullet list.

This fixes **all** proposals' Open-Questions rendering; no proposal content is edited.

## Verification

- New tests: flat N-bullet list → N questions/0 detail; top-level question with indented sub-bullets → 1 + detail; `?`-bullet nested under numbered/heading → detail; uniformly-indented bullet list → separate; verbatim `r0io` 6-bullet body → **6 questions**. Existing tests unchanged.
- `questionForm.test.ts`: 16 passed. Full `proposals/blocks` suite: 28 files / 325 passed.
- `tsc -b` clean, `eslint` clean on changed files, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)