### PR TITLE
feat(codegraph): show only Architecture + Calls lenses

### DIFF
--- a/ui/src/components/codegraph/GraphToolbar.tsx
+++ b/ui/src/components/codegraph/GraphToolbar.tsx
@@ -240,11 +240,14 @@ export function GraphToolbar({
   );
 }
 
+// Only the two lenses that carry their weight are surfaced: Architecture
+// (folders/files — the structural skeleton) and Calls (functions/methods —
+// the call graph). The Types and Data-flow presets still exist in the store
+// (LENS_PRESETS) and can be re-surfaced here, but they added clutter without
+// clear value for this codebase.
 const LENS_OPTIONS: { id: LensId; label: string }[] = [
   { id: "architecture", label: "Architecture" },
   { id: "calls", label: "Calls" },
-  { id: "types", label: "Types" },
-  { id: "dataflow", label: "Data flow" },
 ];
 
 interface LensSelectorProps {


### PR DESCRIPTION
## Feedback

"I don't think Types and Data flow is relevant — I only see value in Architecture (Files) and Calls (Methods/Functions)."

## Change

Drop **Types** and **Data flow** from the toolbar lens selector, leaving **Architecture** and **Calls**. The presets stay in `LENS_PRESETS` (store), so they're a one-line re-add if ever wanted and existing lens tests stay green.

`tsc` + toolbar tests green; production `vite build` green.