### PR TITLE
fix(proposals): static inline mermaid, pan/zoom only in fullscreen

### DIFF
--- a/ui/src/components/MermaidDiagram.stories.tsx
+++ b/ui/src/components/MermaidDiagram.stories.tsx
@@ -79,3 +79,21 @@ export const BadSource: Story = {
     source: "this is not valid mermaid syntax !!!",
   },
 };
+
+/**
+ * Static inline mode (the proposal `Diagram` block path). The inline surface is
+ * a non-interactive overview: no wheel-zoom / drag-pan, and only a fullscreen
+ * button in the overlay. Clicking fullscreen opens the fully-interactive dialog.
+ */
+export const StaticInline: Story = {
+  args: {
+    inlineInteractive: false,
+    source: [
+      "flowchart TD",
+      "  a[Architect] --> b[Reviewer]",
+      "  b --> c[Worker]",
+      "  c --> d[Quality Gate]",
+      "  d --> e[Merge Queue]",
+    ].join("\n"),
+  },
+};

--- a/ui/src/components/MermaidDiagram.test.tsx
+++ b/ui/src/components/MermaidDiagram.test.tsx
@@ -134,4 +134,30 @@ describe("MermaidDiagram — zoom/pan controls", () => {
       ).toBeNull(),
     );
   });
+
+  it("static inline (inlineInteractive=false) shows ONLY a fullscreen button — no zoom trio, no inline zoom", async () => {
+    render(
+      <MermaidDiagram source={REPRO_SOURCE} inlineInteractive={false} />,
+    );
+    await screen.findByTestId("mermaid-diagram");
+    await waitFor(() =>
+      expect(screen.getByTestId("mermaid-controls")).toBeInTheDocument(),
+    );
+
+    // Only the fullscreen toggle survives inline.
+    expect(
+      screen.getByRole("button", { name: "Fullscreen" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Zoom in" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Zoom out" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reset zoom" })).toBeNull();
+
+    // No wheel-zoom on the inline viewport (no handler attached).
+    const viewport = screen.getByTestId("mermaid-zoompan-viewport");
+    const content = screen.getByTestId("mermaid-zoompan-content");
+    expect(scaleOf(content)).toBe(1);
+    fireEvent.wheel(viewport, { deltaY: -200, ctrlKey: true });
+    expect(scaleOf(content)).toBe(1);
+    expect(viewport.className).toContain("overflow-visible");
+  });
 });

--- a/ui/src/components/MermaidDiagram.tsx
+++ b/ui/src/components/MermaidDiagram.tsx
@@ -151,6 +151,15 @@ export interface MermaidDiagramProps {
    * `false` because it already renders inside a Dialog (avoids nested dialogs).
    */
   allowFullscreen?: boolean;
+  /**
+   * Whether the INLINE diagram is itself pan/zoom-interactive. Default `true`.
+   * The proposal `Diagram` block sets this `false` so the inline diagram is a
+   * STATIC overview (no wheel/drag, only a fullscreen button) — inspection
+   * moves into the fullscreen dialog, which stays fully interactive.
+   * `ImpactFlowModal` keeps the default `true` (it has no fullscreen to fall
+   * back to, so inline must stay interactive).
+   */
+  inlineInteractive?: boolean;
 }
 
 interface RenderState {
@@ -177,6 +186,7 @@ function MermaidDiagramImpl({
   source,
   className,
   allowFullscreen = true,
+  inlineInteractive = true,
 }: MermaidDiagramProps) {
   // Stable id per instance — stock mermaid uses it as the SVG root id and
   // demands it be unique within the document and start with a letter.
@@ -261,6 +271,7 @@ function MermaidDiagramImpl({
     <div data-testid="mermaid-diagram" className={cn("w-full", className)}>
       <ZoomPanSurface
         allowFullscreen={allowFullscreen}
+        inlineInteractive={inlineInteractive}
         testIdPrefix="mermaid"
         fullscreenTitle="Diagram"
       >
@@ -275,5 +286,6 @@ export const MermaidDiagram = memo(
   (prev, next) =>
     prev.source === next.source &&
     prev.className === next.className &&
-    prev.allowFullscreen === next.allowFullscreen,
+    prev.allowFullscreen === next.allowFullscreen &&
+    prev.inlineInteractive === next.inlineInteractive,
 );

--- a/ui/src/components/ZoomPanSurface.test.tsx
+++ b/ui/src/components/ZoomPanSurface.test.tsx
@@ -76,6 +76,69 @@ describe("ZoomPanSurface", () => {
     expect(content.style.pointerEvents).toBe("");
   });
 
+  describe("static inline mode (inlineInteractive=false)", () => {
+    it("shows ONLY the fullscreen control (no zoom-in/out/reset)", () => {
+      render(
+        <ZoomPanSurface testIdPrefix="wf" inlineInteractive={false}>
+          <div>x</div>
+        </ZoomPanSurface>,
+      );
+      // The overlay still renders, but only the fullscreen toggle is in it.
+      expect(
+        screen.getByRole("button", { name: "Fullscreen" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Zoom in" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Zoom out" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Reset zoom" })).toBeNull();
+    });
+
+    it("does NOT wheel-zoom or drag-pan the inline viewport", () => {
+      render(
+        <ZoomPanSurface testIdPrefix="wf" inlineInteractive={false}>
+          <div>x</div>
+        </ZoomPanSurface>,
+      );
+      const viewport = screen.getByTestId("wf-zoompan-viewport");
+      const content = screen.getByTestId("wf-zoompan-content");
+      expect(scaleOf(content)).toBe(1);
+
+      // Wheel does nothing (no handler attached) — scale stays at fit.
+      fireEvent.wheel(viewport, { deltaY: -200, ctrlKey: true });
+      expect(scaleOf(content)).toBe(1);
+
+      // Drag does nothing either — no pan translate is applied.
+      fireEvent.pointerDown(viewport, {
+        clientX: 10,
+        clientY: 10,
+        pointerId: 1,
+      });
+      fireEvent.pointerMove(viewport, {
+        clientX: 80,
+        clientY: 80,
+        pointerId: 1,
+      });
+      fireEvent.pointerUp(viewport, { pointerId: 1 });
+      expect(content.style.transform).not.toMatch(/translate\((?!0px, 0px)/);
+
+      // The static viewport must not clip/capture scroll.
+      expect(viewport.className).toContain("overflow-visible");
+      expect(viewport.className).not.toContain("overflow-hidden");
+    });
+
+    it("static + no fullscreen renders no empty controls overlay", () => {
+      render(
+        <ZoomPanSurface
+          testIdPrefix="wf"
+          inlineInteractive={false}
+          allowFullscreen={false}
+        >
+          <div>x</div>
+        </ZoomPanSurface>,
+      );
+      expect(screen.queryByTestId("wf-controls")).toBeNull();
+    });
+  });
+
   it("uses the testIdPrefix for all surface nodes", () => {
     render(
       <ZoomPanSurface testIdPrefix="mermaid">

--- a/ui/src/components/ZoomPanSurface.tsx
+++ b/ui/src/components/ZoomPanSurface.tsx
@@ -70,6 +70,20 @@ export interface ZoomPanSurfaceProps {
    * dialogs) — the fullscreen copy passes this.
    */
   allowFullscreen?: boolean;
+  /**
+   * Whether the INLINE viewport is itself pan/zoom-interactive. Default `true`
+   * (current behavior). When `false` the inline surface is a STATIC overview:
+   *   - no wheel-zoom / drag-pan handlers are attached (the page scrolls
+   *     normally over it, no scroll capture), and the content sits at its
+   *     default fit,
+   *   - the controls overlay shows ONLY the fullscreen toggle (zoom-in /
+   *     zoom-out / reset are hidden) — inspection happens in fullscreen.
+   * The FULLSCREEN dialog copy is always fully interactive regardless of this
+   * flag (it omits this prop, so it defaults back to `true`). Pair with
+   * `allowFullscreen` — a static surface with no fullscreen has no interaction
+   * at all, so don't set both off.
+   */
+  inlineInteractive?: boolean;
   /** Internal: this instance is the fullscreen copy (fills the dialog). */
   inFullscreen?: boolean;
   /**
@@ -98,9 +112,13 @@ export function ZoomPanSurface({
   allowFullscreen = true,
   inFullscreen = false,
   framedContent = false,
+  inlineInteractive = true,
   testIdPrefix = "zoompan",
   fullscreenTitle = "Preview",
 }: ZoomPanSurfaceProps) {
+  // The fullscreen dialog copy is always interactive; only the inline surface
+  // honors `inlineInteractive`. `inFullscreen` therefore forces interaction on.
+  const interactive = inFullscreen || inlineInteractive;
   const [transform, setTransform] = useState<Transform>(IDENTITY);
   const [fullscreen, setFullscreen] = useState(false);
   // `dragging` drives the render-time transition toggle (refs can't be read in
@@ -183,20 +201,35 @@ export function ZoomPanSurface({
 
   const zoomed = transform.scale > 1;
 
+  // Which controls render: zoom trio only when interactive; a fullscreen OR
+  // exit toggle depending on mode. If nothing would show (the unsupported
+  // static + no-fullscreen combo), skip the empty overlay box entirely.
+  const showFullscreenToggle = allowFullscreen && !inFullscreen;
+  const showExitToggle = inFullscreen;
+  const showControls = interactive || showFullscreenToggle || showExitToggle;
+
   const surface = (
     <div
       ref={viewportRef}
       data-testid={`${testIdPrefix}-zoompan-viewport`}
       className={cn(
-        "relative w-full overflow-hidden",
-        zoomed ? "cursor-grab active:cursor-grabbing" : "cursor-default",
+        "relative w-full",
+        // A static inline surface must NOT capture scroll: leave overflow
+        // visible so the content sits at its natural fit and the page scrolls
+        // normally over it. Interactive surfaces clip + grab as before.
+        interactive ? "overflow-hidden" : "overflow-visible",
+        interactive && zoomed
+          ? "cursor-grab active:cursor-grabbing"
+          : "cursor-default",
         inFullscreen ? "h-full" : "max-h-[70vh]",
       )}
-      onWheel={onWheel}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={endDrag}
-      onPointerLeave={endDrag}
+      // Static inline mode attaches NO wheel/drag handlers — no zoom capture,
+      // no pan; the page scrolls right over it.
+      onWheel={interactive ? onWheel : undefined}
+      onPointerDown={interactive ? onPointerDown : undefined}
+      onPointerMove={interactive ? onPointerMove : undefined}
+      onPointerUp={interactive ? endDrag : undefined}
+      onPointerLeave={interactive ? endDrag : undefined}
     >
       <div
         data-testid={`${testIdPrefix}-zoompan-content`}
@@ -217,41 +250,48 @@ export function ZoomPanSurface({
       </div>
 
       {/* Controls overlay — top-right, compact ghost icon buttons. */}
+      {showControls && (
       <div
         className="absolute right-2 top-2 flex items-center gap-1 rounded-md border border-border/60 bg-card/80 p-0.5 backdrop-blur"
         data-testid={`${testIdPrefix}-controls`}
       >
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Zoom in"
-          title="Zoom in"
-          onClick={() => zoomBy(ZOOM_STEP)}
-        >
-          <HugeiconsIcon icon={ZoomInAreaIcon} size={14} />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Zoom out"
-          title="Zoom out"
-          onClick={() => zoomBy(1 / ZOOM_STEP)}
-        >
-          <HugeiconsIcon icon={ZoomOutAreaIcon} size={14} />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Reset zoom"
-          title="Reset to fit"
-          onClick={reset}
-        >
-          <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={14} />
-        </Button>
-        {allowFullscreen && !inFullscreen && (
+        {/* Zoom-in / zoom-out / reset belong to interactive surfaces only. A
+            static inline overview shows ONLY the fullscreen toggle below. */}
+        {interactive && (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Zoom in"
+              title="Zoom in"
+              onClick={() => zoomBy(ZOOM_STEP)}
+            >
+              <HugeiconsIcon icon={ZoomInAreaIcon} size={14} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Zoom out"
+              title="Zoom out"
+              onClick={() => zoomBy(1 / ZOOM_STEP)}
+            >
+              <HugeiconsIcon icon={ZoomOutAreaIcon} size={14} />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Reset zoom"
+              title="Reset to fit"
+              onClick={reset}
+            >
+              <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={14} />
+            </Button>
+          </>
+        )}
+        {showFullscreenToggle && (
           <Button
             type="button"
             variant="ghost"
@@ -263,7 +303,7 @@ export function ZoomPanSurface({
             <HugeiconsIcon icon={ArrowExpandIcon} size={14} />
           </Button>
         )}
-        {inFullscreen && (
+        {showExitToggle && (
           <Button
             type="button"
             variant="ghost"
@@ -276,6 +316,7 @@ export function ZoomPanSurface({
           </Button>
         )}
       </div>
+      )}
     </div>
   );
 

--- a/ui/src/components/proposals/blocks/Diagram.tsx
+++ b/ui/src/components/proposals/blocks/Diagram.tsx
@@ -39,7 +39,10 @@ export function Diagram({ attributes, children }: BlockProps) {
             </div>
           }
         >
-          <MermaidDiagram source={content} />
+          {/* Inline proposal diagrams are a STATIC overview: no inline
+              pan/zoom, only a fullscreen button. Inspection (pan/zoom + all
+              controls) happens in the fullscreen dialog. */}
+          <MermaidDiagram source={content} inlineInteractive={false} />
         </Suspense>
       ) : diagramType === "svg" ? (
         // Author/agent SVG may carry `<script>`/`onload=`/`javascript:`


### PR DESCRIPTION
## What

Inline proposal Mermaid diagrams are now a **static overview**: no inline pan/zoom, and the controls overlay shows **only the fullscreen button**. Pan/zoom + the zoom-in/zoom-out/reset controls live **only in the fullscreen view**.

## Why

User feedback: on the proposal screen the inline diagram should be a static figure — you shouldn't scroll/pan/zoom it inline, and the zoom-in/out/reset buttons clutter it. Inspection belongs in fullscreen.

## How

- `ZoomPanSurface` gains `inlineInteractive?: boolean` (default `true`, preserving current behavior). When `false`:
  - the inline viewport attaches **no** wheel-zoom / drag-pan handlers (page scrolls normally over it; `overflow-visible`, no scroll capture), content sits at default fit,
  - the controls overlay shows **only** the fullscreen toggle (zoom-in/out/reset hidden),
  - the **fullscreen `Dialog` copy stays fully interactive** (it omits the prop → defaults to `true`; `inFullscreen` also forces interaction on).
- `MermaidDiagram` threads `inlineInteractive` through to `ZoomPanSurface` (added to the memo comparison).
- The proposal `Diagram` block sets `inlineInteractive={false}`.
- `ImpactFlowModal` is **unchanged** — it keeps the default (`inlineInteractive` true) with `allowFullscreen={false}`, so it has no fullscreen to fall back to and stays fully pan/zoom-interactive inline.
- Degenerate static + no-fullscreen combo renders no empty overlay box.

## Verify

- `ui` vitest: `ZoomPanSurface.test.tsx` + `MermaidDiagram.test.tsx` — 15/15 pass (new static-inline specs: only fullscreen control, no wheel/drag, interactive mode + fullscreen dialog unchanged).
- `tsc -b` clean, eslint clean on changed files (one pre-existing `set-state-in-effect` finding on an untouched `MermaidDiagram.tsx` line is baseline on main), `npm run build` succeeds.
- **Playwright (Storybook)**:
  - Proposal `StaticInline` story: inline overlay = ONLY `Fullscreen`; wheel + drag = no transform change; `overflow-visible`.
  - Clicking fullscreen → dialog with Zoom in/out/reset + Exit; Zoom-in scales to 1.5625 (interactive).
  - `Flowchart` (default) story: all four controls, `overflow-hidden` (unchanged).
  - `ImpactFlowModal` story: three zoom controls, no fullscreen, Zoom-in scales to 1.5625 — still interactive.