### PR TITLE
feat(codegraph): crate legend with click-to-isolate

### DIFF
--- a/ui/src/components/codegraph/CodeGraphCanvas.tsx
+++ b/ui/src/components/codegraph/CodeGraphCanvas.tsx
@@ -35,6 +35,7 @@ import type Graph from "graphology";
 import { fetchSnapshot } from "@/api/codeGraph";
 import {
   buildGraphFromSnapshot,
+  computeCrateLegend,
   filterSnapshotForWorkspace,
   isDoubleClick,
   parseSnapshotResponse,
@@ -252,7 +253,81 @@ export function CodeGraphCanvas({
         <LayoutOptimizingPill />
       ) : null}
       <CitationStatusBadge />
+      <CrateLegend graph={graph} />
       <ComplexityLegend thresholds={complexityThresholds} />
+    </div>
+  );
+}
+
+/**
+ * Topology-mode legend: maps each crate/community color to its name + node
+ * count, and lets the user click a row to isolate that crate on the canvas
+ * (the node reducer hides everything else). Click the active row, or "All",
+ * to clear. Hidden in complexity mode (the ComplexityLegend owns that).
+ */
+function CrateLegend({ graph }: { graph: Graph | null }) {
+  const colorMode = useCodeGraphStore((s) => s.colorMode);
+  const crateFilter = useCodeGraphStore((s) => s.crateFilter);
+  const setCrateFilter = useCodeGraphStore((s) => s.setCrateFilter);
+  const entries = useMemo(
+    () => (graph ? computeCrateLegend(graph) : []),
+    [graph],
+  );
+  if (colorMode !== "topology" || entries.length === 0) return null;
+  // Cap the list so a huge monorepo doesn't paint a wall of rows; the long
+  // tail of tiny crates is rarely what you isolate by.
+  const shown = entries.slice(0, 18);
+  return (
+    <div
+      data-testid="crate-legend"
+      className="pointer-events-auto absolute left-3 top-16 flex max-h-[60vh] w-48 flex-col overflow-hidden rounded-lg border border-[#2d2d3d] bg-black/70 text-[11px] text-zinc-200 shadow backdrop-blur"
+    >
+      <div className="flex items-center justify-between border-b border-[#2d2d3d] px-2.5 py-1.5">
+        <span className="text-[9px] font-medium uppercase tracking-wide text-zinc-400">
+          Crates
+        </span>
+        {crateFilter !== null && (
+          <button
+            type="button"
+            onClick={() => setCrateFilter(null)}
+            className="text-[10px] text-blue-300 hover:text-blue-200"
+          >
+            Show all
+          </button>
+        )}
+      </div>
+      <div className="flex flex-col overflow-y-auto py-1">
+        {shown.map((entry) => {
+          const active = crateFilter === entry.key;
+          const dimmed = crateFilter !== null && !active;
+          return (
+            <button
+              key={entry.key}
+              type="button"
+              data-testid={`crate-legend-row-${entry.key}`}
+              onClick={() =>
+                setCrateFilter(active ? null : entry.key)
+              }
+              className={cn(
+                "flex items-center gap-2 px-2.5 py-1 text-left transition-colors hover:bg-white/5",
+                active && "bg-white/10",
+                dimmed && "opacity-45",
+              )}
+              title={`${entry.key} — ${entry.count.toLocaleString()} nodes`}
+            >
+              <span
+                aria-hidden
+                className="h-2.5 w-2.5 shrink-0 rounded-sm"
+                style={{ backgroundColor: entry.color }}
+              />
+              <span className="flex-1 truncate">{entry.key}</span>
+              <span className="shrink-0 tabular-nums text-[10px] text-zinc-500">
+                {entry.count.toLocaleString()}
+              </span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/ui/src/hooks/useGraphReducers.ts
+++ b/ui/src/hooks/useGraphReducers.ts
@@ -258,6 +258,7 @@ export function useGraphReducers(
   const focusDirection = useCodeGraphStore((s) => s.focusDirection);
   const doiRevealCount = useCodeGraphStore((s) => s.doiRevealCount);
   const expandedRegions = useCodeGraphStore((s) => s.expandedRegions);
+  const crateFilter = useCodeGraphStore((s) => s.crateFilter);
 
   // ── Lazy 1-hop neighbor set (memoized) ─────────────────────────────────
   const selectionNeighbors = useMemo<ReadonlySet<string>>(() => {
@@ -385,10 +386,13 @@ export function useGraphReducers(
       viewportBounds: viewRef.current.viewportBounds,
       // Click-to-expand regions from the store.
       expandedRegions,
+      // Crate isolation from the legend.
+      crateFilter,
     };
     sigma?.refresh();
   }, [
     sigma,
+    crateFilter,
     selectionId,
     selectionNeighbors,
     citationIds,

--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -18,6 +18,7 @@ import {
   buildGraphFromSnapshot,
   colorForCommunity,
   colorForGroup,
+  computeCrateLegend,
   colorForNode,
   colorForWorkspace,
   crateForPath,
@@ -1702,6 +1703,56 @@ describe("crateForPath / colorForGroup", () => {
       seen.add(colorForGroup(c));
     }
     expect(seen.size).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("computeCrateLegend", () => {
+  function snapshotFor(paths: string[]): SnapshotPayload {
+    return {
+      project_id: "p",
+      git_head: "h",
+      generated_at: "2026-04-28T00:00:00Z",
+      truncated: false,
+      total_nodes: paths.length,
+      total_edges: 0,
+      nodes: paths.map((fp, i) => ({
+        id: `symbol:n${i}`,
+        kind: "symbol",
+        label: `n${i}`,
+        symbol_kind: "function",
+        pagerank: 0.1,
+        x: i,
+        y: i,
+        file_path: fp,
+      })),
+      edges: [],
+    };
+  }
+
+  it("tallies crate groups with hue + count, sorted by count desc then key", () => {
+    const graph = buildGraphFromSnapshot(
+      snapshotFor([
+        "server/crates/djinn-graph/src/a.rs",
+        "server/crates/djinn-graph/src/b.rs",
+        "server/crates/djinn-graph/src/c.rs",
+        "server/crates/djinn-agent/src/a.rs",
+        "ui/src/main.ts",
+        "ui/src/app.ts",
+      ]),
+    );
+    const legend = computeCrateLegend(graph);
+    expect(legend.map((e) => [e.key, e.count])).toEqual([
+      ["djinn-graph", 3],
+      ["ui", 2],
+      ["djinn-agent", 1],
+    ]);
+    // Hues come from the group palette and match colorForGroup.
+    expect(legend[0].color).toBe(colorForGroup("djinn-graph"));
+  });
+
+  it("returns an empty legend for a graph with no grouped nodes", () => {
+    const graph = buildGraphFromSnapshot(snapshotFor([]));
+    expect(computeCrateLegend(graph)).toEqual([]);
   });
 });
 

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -447,6 +447,36 @@ export function colorForGroup(key: string): string {
   return GROUP_COLORS[fnv1a(key) % GROUP_COLORS.length];
 }
 
+/** One row of the crate legend: a grouping key, its hue, and node count. */
+export interface CrateLegendEntry {
+  key: string;
+  color: string;
+  count: number;
+}
+
+/**
+ * Tally the topology grouping keys present on a built graph into legend rows
+ * (key + hue + count), sorted by count desc then key for stable ordering.
+ * Reads the `colorGroup` attribute stamped by {@link addNode}, so the legend
+ * matches exactly how the dots are colored. Pure + exported for testing.
+ */
+export function computeCrateLegend(graph: Graph): CrateLegendEntry[] {
+  const counts = new Map<string, number>();
+  graph.forEachNode((_id, attrs) => {
+    const key = attrs.colorGroup;
+    if (typeof key === "string" && key.length > 0) {
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  });
+  return Array.from(counts, ([key, count]) => ({
+    key,
+    color: colorForGroup(key),
+    count,
+  })).sort((a, b) =>
+    b.count !== a.count ? b.count - a.count : a.key.localeCompare(b.key, "en"),
+  );
+}
+
 /**
  * Key with the highest count in a tally map, ties broken by lexical order
  * for determinism. Returns `undefined` for an empty map. Used to pick a
@@ -1123,6 +1153,12 @@ function addNode(
     symbolKind: node.symbol_kind,
     pagerank: node.pagerank,
     filePath: node.file_path,
+    /**
+     * The crate/community grouping key this node is colored by — stashed so
+     * the crate legend can tally groups and the crate filter can isolate one
+     * without re-deriving the key from the path on every reducer call.
+     */
+    colorGroup: colorGroupKey(node),
     communityId: node.community_id,
     workspaceKind: node.workspace_kind,
     workspace: node.workspace,

--- a/ui/src/lib/codeGraphReducers.test.ts
+++ b/ui/src/lib/codeGraphReducers.test.ts
@@ -232,6 +232,22 @@ describe("nodeReducer", () => {
     expect(out).toBe(attrs);
   });
 
+  it("hides nodes outside the isolated crate when crateFilter is set", () => {
+    const v = viewWith({ crateFilter: "djinn-graph" });
+    const inCrate = nodeReducer(
+      "a",
+      { color: "blue", size: 5, label: "A", colorGroup: "djinn-graph" },
+      v,
+    );
+    expect(inCrate.hidden).toBeUndefined();
+    const otherCrate = nodeReducer(
+      "b",
+      { color: "blue", size: 5, label: "B", colorGroup: "djinn-agent" },
+      v,
+    );
+    expect(otherCrate.hidden).toBe(true);
+  });
+
   it("de-emphasizes workspace context nodes even when no highlight is active", () => {
     const out = nodeReducer(
       "remote",

--- a/ui/src/lib/codeGraphReducers.ts
+++ b/ui/src/lib/codeGraphReducers.ts
@@ -137,6 +137,13 @@ export interface HighlightView {
    * so the user can progressively explore culled regions.
    */
   expandedRegions: ReadonlySet<string>;
+
+  /**
+   * Crate/community grouping key to isolate (from the legend). When set, the
+   * node reducer hides every node whose `colorGroup` differs, so the canvas
+   * shows just that crate. `null` shows all.
+   */
+  crateFilter: string | null;
 }
 
 /** Bitset-style flag describing which highlight layer wins for a node. */
@@ -175,6 +182,7 @@ export const EMPTY_HIGHLIGHT_VIEW: HighlightView = {
   lodTier: "close",
   viewportBounds: null,
   expandedRegions: new Set<string>(),
+  crateFilter: null,
 };
 
 /**
@@ -289,6 +297,13 @@ export function nodeReducer(
   // `isTest` (test files + symbols defined in them). Sits first so the
   // gate fires regardless of any other highlight/filter state.
   if (view.hideTests && attrs.isTest === true) {
+    return { ...attrs, hidden: true };
+  }
+
+  // Crate isolation (legend click): when a crate is pinned, hide every node
+  // that isn't in it so the canvas shows just that crate. Sits near the top
+  // with the other hard filters.
+  if (view.crateFilter !== null && attrs.colorGroup !== view.crateFilter) {
     return { ...attrs, hidden: true };
   }
 

--- a/ui/src/stores/codeGraphStore.test.ts
+++ b/ui/src/stores/codeGraphStore.test.ts
@@ -263,6 +263,22 @@ describe("codeGraphStore", () => {
     });
   });
 
+  describe("crateFilter", () => {
+    it("defaults to null, sets and clears the isolated crate", () => {
+      expect(useCodeGraphStore.getState().crateFilter).toBeNull();
+      useCodeGraphStore.getState().setCrateFilter("djinn-graph");
+      expect(useCodeGraphStore.getState().crateFilter).toBe("djinn-graph");
+      useCodeGraphStore.getState().setCrateFilter(null);
+      expect(useCodeGraphStore.getState().crateFilter).toBeNull();
+    });
+
+    it("reset clears the crate filter", () => {
+      useCodeGraphStore.getState().setCrateFilter("ui");
+      useCodeGraphStore.getState().reset();
+      expect(useCodeGraphStore.getState().crateFilter).toBeNull();
+    });
+  });
+
   describe("intent lenses", () => {
     it("defaults to architecture lens", () => {
       expect(useCodeGraphStore.getState().activeLens).toBe("architecture");

--- a/ui/src/stores/codeGraphStore.ts
+++ b/ui/src/stores/codeGraphStore.ts
@@ -274,6 +274,12 @@ export interface CodeGraphHighlightState {
   graphReady: boolean;
   selectedWorkspaceSlug: string | null;
   /**
+   * Topology grouping key (crate/community) to isolate via the crate legend.
+   * `null` = show all. When set, the node reducer hides nodes whose
+   * `colorGroup` differs, so the canvas shows just that crate.
+   */
+  crateFilter: string | null;
+  /**
    * Active intent lens. `null` means the user has manually toggled
    * individual filters (Advanced mode). Applying a lens replaces all
    * three filter maps from the preset.
@@ -318,6 +324,8 @@ export interface CodeGraphHighlightActions {
   /** Canvas reports whether the graph is ready (loaded with at least one node). */
   setGraphReady: (ready: boolean) => void;
   setSelectedWorkspaceSlug: (slug: string | null) => void;
+  /** Set/clear the isolated crate (legend click). Pass `null` to show all. */
+  setCrateFilter: (key: string | null) => void;
   /** Apply an intent lens, replacing all three filter maps from the preset. */
   applyLens: (lensId: LensId) => void;
   reset: () => void;
@@ -342,6 +350,7 @@ const INITIAL_STATE: CodeGraphHighlightState = {
   complexityAvailable: false,
   graphReady: false,
   selectedWorkspaceSlug: null,
+  crateFilter: null,
   activeLens: "architecture",
 };
 
@@ -496,6 +505,10 @@ export const useCodeGraphStore = create<
 
   setSelectedWorkspaceSlug: (slug) => {
     set({ selectedWorkspaceSlug: slug });
+  },
+
+  setCrateFilter: (key) => {
+    set({ crateFilter: key });
   },
 
   applyLens: (lensId) => {


### PR DESCRIPTION
## Feedback

"what do these colors mean? ideally I could go and filter by the community/crate, see them."

## Change

Topology colors are crates (#1062) but there was no key and no way to focus one. Adds a **legend overlay** (top-left, topology mode only):

- Each row = a crate's **hue + name + node count**, sorted by count desc.
- **Click a row to isolate that crate** — the node reducer hides everything whose `colorGroup` differs, so the canvas shows just that crate. Click the active row or **"Show all"** to clear.
- Capped at 18 rows so a big monorepo doesn't paint a wall; hidden in complexity mode (ComplexityLegend owns that).

### Wiring
- **adapter**: stamp `colorGroup` on each node in `addNode`; `computeCrateLegend(graph)` → `{key, color, count}[]` sorted.
- **store**: `crateFilter` slice + `setCrateFilter` (cleared on reset).
- **reducer**: hide nodes whose `colorGroup` ≠ the pinned crate.
- **canvas**: `CrateLegend` overlay.

## Tests

`computeCrateLegend` (tally/sort/empty), reducer isolation (in-crate visible, others hidden), store slice (set/clear/reset). `tsc` + 276 codegraph tests green; production `vite build` green.

Part of the post-deploy polish (#1060/#1061/#1062/#1064/#1066). The "no edges in Calls / empty panel" feedback is the separate proposal **t16t** (sparse symbol-level call edges from Rust trait dispatch). Complexity-per-file is a follow-up.