### PR TITLE
feat(codegraph): complexity heatmap per file (worst-function aggregate)

### DIFF
--- a/ui/src/components/codegraph/GraphToolbar.tsx
+++ b/ui/src/components/codegraph/GraphToolbar.tsx
@@ -97,17 +97,19 @@ export function GraphToolbar({
 
   const disabled = !graphReady;
 
-  // The complexity heatmap colors function/method nodes by cognitive
-  // percentile, so it's only meaningful when those nodes are visible. The
-  // Architecture lens hides every symbol kind, so the heatmap would paint
-  // nothing — gate the toggle on functions being visible, not just on the
-  // data existing.
+  // The complexity heatmap colors function nodes by cognitive percentile, and
+  // file nodes by their worst function (aggregate). So it's meaningful when
+  // either functions OR files are visible — i.e. the Calls or Architecture
+  // lens. It only paints nothing when neither is shown (e.g. a types-only
+  // view). Gate the toggle on that, not just on the data existing.
   const functionsVisible =
     symbolKindFilters.function === true || symbolKindFilters.method === true;
+  const filesVisible = nodeKindFilters.file === true;
+  const complexityNodesVisible = functionsVisible || filesVisible;
   const complexityDisabledReason = !complexityAvailable
     ? "No complexity data — graph not yet warmed for languages in the walker"
-    : !functionsVisible
-      ? "Complexity colors functions — switch to the Calls lens to use it"
+    : !complexityNodesVisible
+      ? "Complexity colors files and functions — switch to the Architecture or Calls lens"
       : undefined;
 
   return (

--- a/ui/src/hooks/useGraphReducers.ts
+++ b/ui/src/hooks/useGraphReducers.ts
@@ -274,6 +274,12 @@ export function useGraphReducers(
     if (!graph) return null;
     const values: number[] = [];
     for (const id of graph.nodes()) {
+      // Sample symbol (function) cognitive only. File nodes now carry an
+      // aggregate `cognitive` (their worst function) so the heatmap works in
+      // the Architecture lens, but those aggregates must not skew the
+      // percentile distribution — files are colored *against* the function
+      // thresholds, not mixed into them.
+      if (graph.getNodeAttribute(id, "kind") !== "symbol") continue;
       const cog = graph.getNodeAttribute(id, "cognitive");
       if (typeof cog === "number" && Number.isFinite(cog)) values.push(cog);
     }
@@ -290,6 +296,10 @@ export function useGraphReducers(
     if (!graph) return new Set();
     const pairs: Array<{ id: string; cognitive: number | null }> = [];
     for (const id of graph.nodes()) {
+      // Symbol nodes only — a file's aggregate `cognitive` equals its worst
+      // function, so including files would halo the file and that function
+      // redundantly.
+      if (graph.getNodeAttribute(id, "kind") !== "symbol") continue;
       const cog = graph.getNodeAttribute(id, "cognitive");
       pairs.push({
         id,

--- a/ui/src/lib/codeGraphAdapter.test.ts
+++ b/ui/src/lib/codeGraphAdapter.test.ts
@@ -657,6 +657,69 @@ describe("hasPrecomputedCoordinates", () => {
   });
 });
 
+describe("buildGraphFromSnapshot (file complexity)", () => {
+  it("stamps file nodes with their worst function's cognitive", () => {
+    const snapshot: SnapshotPayload = {
+      project_id: "p",
+      git_head: "h",
+      generated_at: "2026-04-28T00:00:00Z",
+      truncated: false,
+      total_nodes: 4,
+      total_edges: 0,
+      nodes: [
+        {
+          id: "file:src/a.rs",
+          kind: "file",
+          label: "a.rs",
+          file_path: "src/a.rs",
+          pagerank: 0.5,
+          x: 0,
+          y: 0,
+        },
+        {
+          id: "symbol:f1",
+          kind: "symbol",
+          label: "f1",
+          symbol_kind: "function",
+          file_path: "src/a.rs",
+          pagerank: 0.1,
+          cognitive: 4,
+          x: 1,
+          y: 1,
+        },
+        {
+          id: "symbol:f2",
+          kind: "symbol",
+          label: "f2",
+          symbol_kind: "function",
+          file_path: "src/a.rs",
+          pagerank: 0.1,
+          cognitive: 11,
+          x: 2,
+          y: 2,
+        },
+        {
+          id: "file:src/empty.rs",
+          kind: "file",
+          label: "empty.rs",
+          file_path: "src/empty.rs",
+          pagerank: 0.2,
+          x: 3,
+          y: 3,
+        },
+      ],
+      edges: [],
+    };
+    const graph = buildGraphFromSnapshot(snapshot);
+    // File with functions → max cognitive (11, not 4 or 15).
+    expect(graph.getNodeAttribute("file:src/a.rs", "cognitive")).toBe(11);
+    // File with no complexity-bearing symbols → no cognitive stamped.
+    expect(
+      graph.getNodeAttribute("file:src/empty.rs", "cognitive"),
+    ).toBeUndefined();
+  });
+});
+
 describe("buildGraphFromSnapshot", () => {
   it("emits one graphology node per snapshot node, excluding containment edges", () => {
     const graph = buildGraphFromSnapshot(fixtureSnapshot);

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -929,6 +929,7 @@ export function buildGraphFromSnapshot(
       dropSelfLoops,
     });
     applyContainmentNesting(graph, snapshot);
+    stampFileComplexity(graph);
     graph.setAttribute(PRECOMPUTED_LAYOUT_ATTRIBUTE, true);
     return graph;
   }
@@ -955,8 +956,40 @@ export function buildGraphFromSnapshot(
     dropSelfLoops,
   });
   applyContainmentNesting(graph, snapshot);
+  stampFileComplexity(graph);
 
   return graph;
+}
+
+/**
+ * Give file nodes a `cognitive` value so the complexity heatmap works in the
+ * Architecture (Files) lens, not just Calls (Functions). A file's complexity
+ * is its **worst function** — the max `cognitive` over the symbol nodes that
+ * share its path. Max (not sum) keeps the value on the same scale as function
+ * cognitive, so it reads as a percentile against the same thresholds (which
+ * are sampled from symbol nodes only — see `useGraphReducers`). Files with no
+ * complexity-bearing symbols are left without a `cognitive` attribute.
+ */
+function stampFileComplexity(graph: Graph): void {
+  const maxByPath = new Map<string, number>();
+  graph.forEachNode((_id, attrs) => {
+    if (attrs.kind !== "symbol") return;
+    const cog = attrs.cognitive;
+    const path = attrs.filePath;
+    if (typeof cog !== "number" || !Number.isFinite(cog)) return;
+    if (typeof path !== "string" || path.length === 0) return;
+    const prev = maxByPath.get(path);
+    if (prev === undefined || cog > prev) maxByPath.set(path, cog);
+  });
+  if (maxByPath.size === 0) return;
+  graph.forEachNode((id, attrs) => {
+    if (attrs.kind !== "file") return;
+    const path =
+      typeof attrs.filePath === "string" ? attrs.filePath : undefined;
+    if (!path) return;
+    const max = maxByPath.get(path);
+    if (max !== undefined) graph.setNodeAttribute(id, "cognitive", max);
+  });
 }
 
 function addEdgesFromSnapshot(

--- a/ui/src/stores/codeGraphStore.test.ts
+++ b/ui/src/stores/codeGraphStore.test.ts
@@ -285,15 +285,22 @@ describe("codeGraphStore", () => {
       expect(useCodeGraphStore.getState().activeLens).toBe("types");
     });
 
-    it("applyLens snaps complexity color mode back to topology when the lens hides functions", () => {
-      // Calls shows functions → complexity stays engaged.
+    it("applyLens keeps complexity in lenses that show files or functions", () => {
+      // Calls shows functions, Architecture shows files (colored by their
+      // worst function) — both keep the heatmap engaged.
       useCodeGraphStore.getState().applyLens("calls");
       useCodeGraphStore.getState().setColorMode("complexity");
       expect(useCodeGraphStore.getState().colorMode).toBe("complexity");
-
-      // Architecture hides every symbol kind → heatmap would paint nothing,
-      // so the mode snaps back to topology.
       useCodeGraphStore.getState().applyLens("architecture");
+      expect(useCodeGraphStore.getState().colorMode).toBe("complexity");
+    });
+
+    it("applyLens snaps complexity to topology for a lens with neither files nor functions", () => {
+      useCodeGraphStore.getState().applyLens("calls");
+      useCodeGraphStore.getState().setColorMode("complexity");
+      // Types shows classes/structs (no functions) and no file nodes → the
+      // heatmap would paint nothing, so the mode snaps back to topology.
+      useCodeGraphStore.getState().applyLens("types");
       expect(useCodeGraphStore.getState().colorMode).toBe("topology");
     });
 

--- a/ui/src/stores/codeGraphStore.ts
+++ b/ui/src/stores/codeGraphStore.ts
@@ -500,11 +500,13 @@ export const useCodeGraphStore = create<
 
   applyLens: (lensId) => {
     const preset = LENS_PRESETS[lensId];
-    // The complexity heatmap only colors function/method nodes; if the lens
-    // hides those (e.g. Architecture), snap the color mode back to topology
-    // so the canvas isn't stuck on a heatmap that paints nothing. Mirrors
-    // the guard in `setComplexityAvailable`.
-    const lensShowsFunctions =
+    // The complexity heatmap colors function nodes and file nodes (by their
+    // worst function); if the lens shows neither (e.g. a types-only view),
+    // snap the color mode back to topology so the canvas isn't stuck on a
+    // heatmap that paints nothing. Mirrors the guard in
+    // `setComplexityAvailable`.
+    const lensShowsComplexityNodes =
+      preset.nodeKindFilters.file === true ||
       preset.symbolKindFilters.function === true ||
       preset.symbolKindFilters.method === true;
     set((state) => ({
@@ -513,7 +515,7 @@ export const useCodeGraphStore = create<
       edgeKindFilters: { ...preset.edgeKindFilters },
       activeLens: lensId,
       colorMode:
-        !lensShowsFunctions && state.colorMode === "complexity"
+        !lensShowsComplexityNodes && state.colorMode === "complexity"
           ? "topology"
           : state.colorMode,
     }));


### PR DESCRIPTION
## Feedback

"can't we make it so the complexity is calculated per file or something?"

## Change

The cognitive-complexity heatmap only worked in the **Calls** lens (functions). Now it also works in the **Architecture (Files)** lens: a file's complexity = its **worst function** — the max `cognitive` over the symbols sharing its path, stamped onto file nodes by `stampFileComplexity`. Max (not sum) keeps the value on the same scale as function cognitive, so a file reads as a percentile against the same green→red thresholds.

- **Thresholds + the top-N refactor halo sample symbol nodes only**, so the new file aggregates are *colored against* the function distribution without skewing the percentiles or double-haloing a file and its worst function.
- **Re-enabled the Complexity toggle when files OR functions are visible** (it was functions-only as of #1064, which disabled it in Architecture). `applyLens` now only snaps complexity→topology for a lens that shows *neither* (e.g. Types).

## Tests

- `stampFileComplexity`: a file gets its worst function's cognitive (max=11, not 4 or sum); a function-less file gets none.
- store: `applyLens` keeps complexity in Architecture **and** Calls; snaps to topology only for Types.
- `tsc` + adapter/store/toolbar suites green (178); production `vite build` green.

Final item from the latest round of `/code-graph` feedback (#1066 lens cleanup, #1068 crate legend). The "no edges in Calls / empty panel" remains proposal **t16t** (trait-dispatch call edges).