### PR TITLE
fix(proposals): kill stray second scrollbar on wireframe blocks

### DIFF
--- a/ui/src/components/proposals/blocks/WireframeBlock.tsx
+++ b/ui/src/components/proposals/blocks/WireframeBlock.tsx
@@ -67,6 +67,12 @@ export function WireframeBlock({ children }: BlockProps) {
  * The wireframe surface: the drawing as monospace `<pre>` in Monaspace Radon at a
  * muted grey. `whitespace-pre` keeps every authored cell; `overflow-x-auto` lets
  * a wide screen scroll rather than wrap (wrapping would shear the boxes).
+ *
+ * `overflow-y-hidden` is required, not incidental: per the CSS overflow spec a
+ * non-`visible` value on one axis promotes the other axis from `visible` to
+ * `auto`, so `overflow-x-auto` alone would render a stray VERTICAL scrollbar on
+ * a 1px overrun — a second scrollbar beside the page's. The PAGE owns vertical
+ * scroll; the figure only ever scrolls horizontally.
  */
 function AsciiPre({ ascii, muted }: { ascii: string; muted?: boolean }) {
   return (
@@ -82,7 +88,7 @@ function AsciiPre({ ascii, muted }: { ascii: string; muted?: boolean }) {
         fontVariantLigatures: "none",
       }}
       className={cn(
-        "overflow-x-auto whitespace-pre text-[13px] text-zinc-300",
+        "overflow-x-auto overflow-y-hidden whitespace-pre text-[13px] text-zinc-300",
         muted && "italic text-muted-foreground/60",
       )}
     >

--- a/ui/src/components/proposals/blocks/overflowPromotion.test.tsx
+++ b/ui/src/components/proposals/blocks/overflowPromotion.test.tsx
@@ -4,6 +4,7 @@ import { render } from "@/test/test-utils";
 import { FileTreeBlock } from "./FileTreeBlock";
 import { DiffBlock } from "./DiffBlock";
 import { JsonExplorerBlock } from "./JsonExplorerBlock";
+import { WireframeBlock } from "./WireframeBlock";
 
 /**
  * Regression: proposal block scroll containers used `overflow-x-auto` with no
@@ -49,6 +50,22 @@ describe("block scroll containers never promote a stray vertical scrollbar", () 
     expect(
       container.querySelectorAll(".overflow-x-auto").length,
     ).toBeGreaterThan(0);
+  });
+
+  it("WireframeBlock ascii pre clips vertically", () => {
+    // A tall + wide ASCII drawing is the only horizontal-scroll container in
+    // this block; without overflow-y-hidden the horizontal scrollbar's own
+    // height triggers a stray vertical scrollbar beside the page's.
+    const wide = "+" + "-".repeat(200) + "+";
+    const tall = Array.from({ length: 40 }, (_, i) => `| row ${i}`).join("\n");
+    const { container } = render(
+      <WireframeBlock id="w-overflow" attributes={{}}>
+        {`${wide}\n${tall}\n${wide}`}
+      </WireframeBlock>,
+    );
+    expectHorizontalOnly(
+      container.querySelector('[data-testid="wireframe-ascii"]'),
+    );
   });
 
   it("JsonExplorerBlock tree container clips vertically", () => {


### PR DESCRIPTION
## Problem

The proposal detail page showed **two vertical scrollbars** — the page's own scrollbar plus a stray second one — when a proposal contains a wireframe block (the #1070 ASCII/svgbob feature).

## Root cause

`WireframeBlock`'s ASCII `<pre>` set only `overflow-x-auto`. Per the [CSS overflow spec](https://www.w3.org/TR/css-overflow-3/#overflow-properties), a non-`visible` value on one axis promotes the *other* axis from `visible` to `auto`. So a 1px vertical overrun — e.g. the horizontal scrollbar's own height eating into the client box — rendered an unwanted vertical scrollbar right next to the page's.

Every sibling block (FileTree, Diff, JsonExplorer, AnnotatedCode, Tabs…) already pairs `overflow-x-auto` with `overflow-y-hidden`, and there's an `overflowPromotion.test.tsx` regression suite documenting exactly this "second vertical scrollbar" symptom. WireframeBlock was added later and was the one horizontal-scroll block that missed both the class and the test.

## Fix

- Add `overflow-y-hidden` to the wireframe `<pre>` so it scrolls horizontally only; the page owns vertical scroll.
- Extend `overflowPromotion.test.tsx` to cover `WireframeBlock` so this can't silently regress.

## Verification

- `overflowPromotion.test.tsx` — 4 passed (incl. new wireframe case)
- `WireframeBlock.test.tsx` — 6 passed
- `tsc --noEmit` clean, eslint clean on changed files