### PR TITLE
fix(ui): stop proposal diagrams overlapping + remove phantom page scrollbar

### DIFF
--- a/ui/src/components/ZoomPanSurface.tsx
+++ b/ui/src/components/ZoomPanSurface.tsx
@@ -221,7 +221,19 @@ export function ZoomPanSurface({
         interactive && zoomed
           ? "cursor-grab active:cursor-grabbing"
           : "cursor-default",
-        inFullscreen ? "h-full" : "max-h-[70vh]",
+        // Height policy:
+        //   - fullscreen fills its dialog (`h-full`),
+        //   - an INTERACTIVE inline surface caps at 70vh and CLIPS
+        //     (`overflow-hidden` above), so the cap is safe — content stays
+        //     inside the box and pan/zoom navigates it,
+        //   - a STATIC inline surface uses `overflow-visible`, so a `max-h`
+        //     cap would let a taller-than-70vh diagram bleed past its own box:
+        //     the next block lays out at the (capped) box bottom while the SVG
+        //     overflows on top of it (visible overlap) AND that escaped
+        //     overflow inflates the document height into a second scrollbar.
+        //     So a static surface takes its NATURAL height (no cap) — it "sits
+        //     at its natural fit" as intended; fullscreen handles inspection.
+        inFullscreen ? "h-full" : interactive ? "max-h-[70vh]" : "",
       )}
       // Static inline mode attaches NO wheel/drag handlers — no zoom capture,
       // no pan; the page scrolls right over it.

--- a/ui/src/components/proposals/blocks/BlockShell.tsx
+++ b/ui/src/components/proposals/blocks/BlockShell.tsx
@@ -38,7 +38,17 @@ export function BlockShell({
   children,
 }: BlockShellProps) {
   return (
-    <div className={cn("overflow-hidden rounded-lg border bg-card", className)}>
+    // `relative` makes the shell the containing block for any absolutely
+    // positioned descendant (e.g. the header's `sr-only` "Code language" label
+    // on `AnnotatedCode`). Without it, such a child anchors to `<body>` at its
+    // deep in-flow offset, inflating the document's scrollHeight and spawning a
+    // phantom page-level scrollbar alongside the real in-panel one.
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-lg border bg-card",
+        className,
+      )}
+    >
       <div className="flex items-center justify-between gap-3 border-b bg-muted/30 px-4 py-2">
         <span
           className={cn(


### PR DESCRIPTION
Two independent layout bugs on the proposal spec page, both diagnosed and verified live via Playwright.

## 1. Mermaid diagrams rendering on top of each other
The static (non-interactive) inline `ZoomPanSurface` viewport had **both** `max-h-[70vh]` and `overflow-visible`. A diagram taller than 70vh has its layout box clamped to 384px while the SVG (1039px) bleeds 656px past the bottom — so the next block lays out at the cap and the two overlap. The 70vh cap only makes sense for the *interactive* surface (which clips via `overflow-hidden`); static surfaces are meant to sit at their natural fit. Scoped the cap to interactive surfaces.

## 2. Double scrollbar
Independent of the diagrams. `AnnotatedCode`'s header renders an `sr-only` ("Code language") label which is `position: absolute`. `BlockShell`'s wrapper was not a containing block, so the label anchored to `<body>` at its deep in-flow offset, inflating `document.scrollHeight` to 7368px and spawning a page-level scrollbar alongside the real in-panel one. Added `relative` to `BlockShell`.

## Verification (Playwright, live page)
- SVG overflow past its box: **656px → 0** (no overlap)
- `<html>.scrollHeight`: **7368 → 548** (= viewport height, no document scroll)
- `tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)