### PR TITLE
fix(refinement): pause checkpoint loop until the pending revision is resolved

### DIFF
--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -137,6 +137,38 @@ impl CoordinatorActor {
         let round = state.current_round;
         let revision_seq = state.current_revision_seq;
 
+        // Checkpoint pause gate: when an advocate revision is awaiting human
+        // approval/rejection, do NOT dispatch the next phase. The loop resumes
+        // on a later tick once the pending checkpoint is resolved (approve
+        // applies it to the live spec; reject discards it). Without this gate,
+        // checkpoint mode runs every round autonomously and the per-round body
+        // reverts compound — silently applying the advocate's edits to the live
+        // spec across rounds without the human ever approving them.
+        if state.update_authority() == UpdateAuthority::Checkpoint {
+            let event_bus = crate::events::event_bus_for(&self.events_tx);
+            let proposal_repo = ProposalRepository::new(self.db.clone(), event_bus);
+            match proposal_repo
+                .has_pending_checkpoint_revisions(proposal_id)
+                .await
+            {
+                Ok(true) => {
+                    tracing::info!(
+                        proposal_id = %proposal_id,
+                        "Refinement paused: advocate revision awaiting checkpoint approval"
+                    );
+                    return;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        proposal_id = %proposal_id,
+                        error = %e,
+                        "Failed to check pending checkpoints; proceeding with dispatch"
+                    );
+                }
+            }
+        }
+
         // The user this run is attributed to (task owner + model scope).
         // Falls back to the proposal author when not explicitly set.
         let attributed_user_id = self


### PR DESCRIPTION
## Problem

In checkpoint mode the refinement tribunal **never waited for human approval**. After the advocate proposed a revision, `process_advocate_outcome` advanced the phase and the loop kept running rounds. Worse, each round's body-revert targeted the *previous pending* revision (`state.current_revision_seq`), so across rounds the advocate's edits **compounded onto the live spec** — silently overwriting the author's proposal while *also* leaving multiple pending revisions, and the loop ran several rounds unattended.

Observed: a checkpoint run produced 2 autonomous rounds, the live spec ended on advocate content (rev 5), and there were 2 stale pending revisions.

## Fix

Add a **pause gate** at the top of `dispatch_next_refinement_phase`: if the proposal has an unresolved pending checkpoint revision, the loop does **not** dispatch the next phase and returns. It resumes on a later tick once the human resolves it:
- **Approve** → the pending revision is applied to the live spec → no pending → loop resumes.
- **Reject** → the pending revision is discarded → loop resumes.

This bounds checkpoint mode to **exactly one pending revision at a time** and keeps the live spec pinned to the author's content until they explicitly approve. The single per-cycle body-revert now correctly targets the author's original revision.

Uses the existing `ProposalRepository::has_pending_checkpoint_revisions` — no schema/query changes.

## Tests

Refinement state-machine tests unchanged — **28 pass**, clippy clean. The gate itself is DB-backed (verified live post-deploy).

## Follow-ups (separate PRs, in flight)

- Remove the auto-accept mode entirely (checkpoint becomes the only mode) + revision-history UI cleanup.
- Tribunal role fix: adversary/judge stages currently run the *advocate* prompt+tools (`stage.rs` uses the generic role, not the resolved `runtime_role`) — which is why the adversary produces zero objections.