### PR TITLE
fix(refinement-ui): keep lifecycle out of revision history; show pending revisions when stopped

### DIFF
--- a/ui/src/components/proposals/ProposalHistory.tsx
+++ b/ui/src/components/proposals/ProposalHistory.tsx
@@ -96,7 +96,11 @@ export function ProposalHistory({ detail }: { detail: ProposalDetail }) {
       cur.includes(id) ? cur.filter((s) => s !== id) : [...cur, id],
     );
 
-  const statusEvents = history.filter((r) => r.event_kind !== "spec_revision");
+  // Only genuine status transitions count as history rows (refinement
+  // lifecycle events and checkpoint reverts are dropped at render time).
+  const statusEvents = history.filter(
+    (r) => r.event_kind !== "spec_revision" && (r.status_from || r.status_to),
+  );
 
   // A lone seed revision has nothing to compare against yet, but status audit
   // events still need to be visible even when no material spec edit exists.
@@ -117,47 +121,12 @@ export function ProposalHistory({ detail }: { detail: ProposalDetail }) {
           const bodyFormat = revisionBodyFormat(r);
           const titleChanged = !!prev && prev.title !== r.title;
           if (!isSpecRevision) {
-            const hasTransition = !!(r.status_from || r.status_to);
-            const lifecycleLabel =
-              r.event_kind === "refinement_start"
-                ? "Refinement started"
-                : r.event_kind === "refinement_stop"
-                  ? "Refinement stopped"
-                  : null;
-            // Drop no-info noise rows: refinement lifecycle events and
-            // checkpoint reverts carry no status_from/status_to, so without a
-            // recognised lifecycle label they would render as a meaningless
-            // "Status changed (— → —)" row.
-            if (!hasTransition && !lifecycleLabel) return null;
-            if (!hasTransition && lifecycleLabel) {
-              return (
-                <li key={r.id}>
-                  <div className="flex w-full items-center gap-2 px-3 py-2 text-sm">
-                    <Badge variant="secondary" className="font-mono">
-                      {r.event_kind}
-                    </Badge>
-                    <span className="font-medium">{lifecycleLabel}</span>
-                    <span className="flex min-w-0 items-center gap-1.5">
-                      <UserAvatar user={editor} className="size-4" />
-                      <span className="truncate">
-                        {editor
-                          ? userDisplayName(editor)
-                          : r.edited_by_user_id
-                            ? "unknown"
-                            : "—"}
-                      </span>
-                    </span>
-                    <time
-                      dateTime={r.created_at}
-                      title={r.created_at}
-                      className="ml-auto shrink-0 text-xs text-muted-foreground"
-                    >
-                      {relativeTime(r.created_at)}
-                    </time>
-                  </div>
-                </li>
-              );
-            }
+            // Only genuine status transitions belong in the spec revision
+            // history. Refinement lifecycle events (refinement_start/stop) are
+            // a separate concern shown in the Refinement panel, and checkpoint
+            // reverts carry no transition — drop them all so this section stays
+            // about the spec itself.
+            if (!(r.status_from || r.status_to)) return null;
             const statusLabel =
               r.status_to === "done"
                 ? "Marked done (implemented externally)"

--- a/ui/src/components/proposals/ProposalRefinement.tsx
+++ b/ui/src/components/proposals/ProposalRefinement.tsx
@@ -109,7 +109,11 @@ export function ProposalRefinement({
   }, [proposalId]);
 
   useEffect(() => {
-    if (status?.active) {
+    // Fetch pending checkpoint revisions whenever any exist — even after the
+    // loop has STOPPED. A stopped refinement can still have advocate revisions
+    // awaiting your approve/reject; gating this on `active` left them invisible
+    // (only the count showed, with a "refresh to see details" fallback).
+    if (status?.active || (status?.pending_checkpoint_count ?? 0) > 0) {
       fetchPending();
     }
   }, [status?.active, status?.pending_checkpoint_count, fetchPending]);


### PR DESCRIPTION
Two UI follow-ups after the refinement-flow fixes (#1194/#1196/#1198), from reviewing the live proposal page:

1. **Refinement lifecycle doesn't belong in REVISION HISTORY.** `refinement_start`/`refinement_stop` events (and checkpoint reverts) were being rendered (labelled) inside the spec revision history — but they're a separate concern already represented in the Refinement panel. Now the history shows only spec revisions + genuine status transitions; all non-spec/no-transition events are dropped.

2. **Pending revisions weren't shown once refinement stopped (bug).** The pending-revisions fetch (`proposal_refinement_checkpoint_list`) was gated on `status.active`. A stopped refinement with advocate revisions still awaiting approve/reject showed only `PENDING REVISIONS (2)` + a *"refresh to see details"* fallback and never the cards. Fix: fetch whenever `pending_checkpoint_count > 0`, active or not.

Frontend-only. `tsc --noEmit` clean.