### PR TITLE
fix(coordinator): park stuck-CI tasks behind a remediation blocker instead of force-closing

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -8,6 +8,23 @@ fn record_task_parked_metric() {
     djinn_telemetry::task::increment_parked();
 }
 
+/// Which kind of remediation task to create for a stuck source task.
+///
+/// Both kinds create a `Planner remediation [<short_id>]: <title>` review task
+/// and block the source on it. They differ in WHO is expected to resolve it:
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RemediationKind {
+    /// A Planner is dispatched to auto-remediate (reshape / dedupe / spike). When
+    /// it closes, `emit_unblocked_tasks` revives the source automatically.
+    Planner,
+    /// Repeated automated remediation already failed — this requires a HUMAN.
+    /// No Planner (or any agent) is dispatched, so the remediation never
+    /// auto-resolves; the source stays held (open + blocked) until a human
+    /// closes the remediation task. Idempotent: skipped when the source is
+    /// already held by an unresolved blocker.
+    HumanReview,
+}
+
 impl CoordinatorActor {
     fn session_taxonomy_has_durable_artifacts(taxonomy: &serde_json::Value) -> bool {
         taxonomy
@@ -458,25 +475,30 @@ impl CoordinatorActor {
         reason: &str,
         ci_failure_sections: Option<&str>,
     ) -> bool {
-        // Second strike (terminal): the Planner has ALREADY intervened on this
-        // task at least `MAX_PLANNER_INTERVENTIONS` time(s) and it has STILL
+        // Second strike (terminal hold): the Planner has ALREADY intervened on
+        // this task at least `MAX_PLANNER_INTERVENTIONS` time(s) and it has STILL
         // churned back up to the reopen threshold. The reshape/rescope did not
         // unstick it. Escalating again just calls `reset_intervention_counters`
         // (reopen_count→0, intervention_count++) and the worker loops anew,
         // monopolizing the (often single) dispatch slot indefinitely — the txr4
         // query_subgraph case burned 37 sessions / ~11h / 10 total reopens behind
-        // one gpt-5.5 slot, starving every other ready task. Park it terminally so
-        // the queue drains. The work and its branch persist; the close reason is
-        // recoverable (reopen with sharper scope or a different approach).
+        // one gpt-5.5 slot, starving every other ready task. Hold it indefinitely
+        // on a HUMAN instead of force-closing: a human-review remediation task
+        // blocks the source, which is parked back to `open` so it consumes no
+        // dispatch slot (`list_ready` skips blocked-open tasks) yet stays
+        // revivable — `emit_unblocked_tasks` resurfaces it the moment a human
+        // resolves the remediation. The work and its branch persist; nothing is
+        // auto-closed.
         if task.intervention_count >= MAX_PLANNER_INTERVENTIONS {
             let reason = format!(
-                "Auto-parked: {} planner intervention(s) failed to break the rework loop \
-                 (intervention_count={}, total_reopen_count={}). The same acceptance criteria kept \
-                 failing across repeated rounds even after the planner reshaped the scope, so \
-                 re-dispatching would only loop again and hold the dispatch slot. Closed to free \
-                 capacity for other ready tasks; the branch and prior work are preserved. Reopen \
-                 with a sharpened scope, a decomposed subtask for the specific unmet criterion, or \
-                 a different model/approach if this work is still wanted.",
+                "Auto-parked for human review: {} planner intervention(s) failed to break the \
+                 rework loop (intervention_count={}, total_reopen_count={}). The same acceptance \
+                 criteria kept failing across repeated rounds even after the planner reshaped the \
+                 scope, so re-dispatching would only loop again and hold the dispatch slot. The \
+                 task is held (open + blocked on a human-review remediation task) so it frees the \
+                 dispatch slot for other ready tasks while its branch and prior work are \
+                 preserved. A human must resolve the remediation task to release it, or close \
+                 this task if the work is no longer wanted.",
                 task.intervention_count, task.intervention_count, task.total_reopen_count,
             );
             tracing::warn!(
@@ -484,10 +506,10 @@ impl CoordinatorActor {
                 intervention_count = task.intervention_count,
                 total_reopen_count = task.total_reopen_count,
                 reopen_count = task.reopen_count,
-                "CoordinatorActor: second-strike — parking unconvergeable task after repeated planner interventions"
+                "CoordinatorActor: second-strike — holding unconvergeable task on human review after repeated planner interventions"
             );
-            // Clear streak/cooldown so the close isn't shadowed by stale backoff
-            // state, then terminally close (ForceClose) with the recoverable reason.
+            // Clear streak/cooldown so the hold isn't shadowed by stale backoff
+            // state.
             self.dispatch_failure_streak.remove(&task.id);
             self.dispatch_cooldowns.remove(&task.id);
             self.last_dispatched.remove(&task.id);
@@ -495,23 +517,35 @@ impl CoordinatorActor {
             self.clear_durable_dispatch_backoff_state(
                 &task.id,
                 Some(&task.short_id),
-                "planner_second_strike_terminal_close_clear",
+                "planner_second_strike_human_hold_clear",
             )
             .await;
-            if self.terminally_fail_task(task, role, &reason).await {
-                record_task_parked_metric();
-            }
-            if let Err(e) = self
-                .task_repo()
-                .set_status_with_reason(&task.id, "closed", Some(&reason))
-                .await
-            {
+            // Interrupt any running session for this task so parking it actually
+            // frees the dispatch slot (a parked task must not keep burning one).
+            let session_repo = djinn_db::SessionRepository::new(
+                self.db.clone(),
+                crate::events::event_bus_for(&self.events_tx),
+            );
+            if let Err(e) = session_repo.interrupt_running_for_task(&task.id).await {
                 tracing::warn!(
                     task_id = %task.short_id,
                     error = %e,
-                    "CoordinatorActor: failed to preserve planner second-strike close reason"
+                    "CoordinatorActor: failed to interrupt running sessions while parking second-strike task"
                 );
             }
+            // Ensure a HUMAN-review remediation task blocks the source (creating
+            // one only if it isn't already held), THEN park the source to `open`.
+            // The blocker is added before the park, so the open task is never
+            // dispatchable without its blocker in place.
+            self.create_remediation_task(
+                &task.id,
+                &reason,
+                &task.project_id,
+                RemediationKind::HumanReview,
+            )
+            .await;
+            self.park_source_open(&task.id, &reason).await;
+            record_task_parked_metric();
             return true;
         }
 
@@ -656,6 +690,30 @@ impl CoordinatorActor {
         reason: &str,
         project_id: &str,
     ) {
+        self.create_remediation_task(source_task_id, reason, project_id, RemediationKind::Planner)
+            .await;
+    }
+
+    /// Create a remediation review task that blocks the stuck `source_task_id`,
+    /// add a linking comment, and (for [`RemediationKind::Planner`]) dispatch the
+    /// Planner to it.
+    ///
+    /// Called when Lead calls `request_planner`, when auto-escalation fires on the
+    /// 2nd `request_lead` for the same task, and on the CI-loop / second-strike
+    /// park paths. Per ADR-051 §8 the Planner is the escalation ceiling above Lead
+    /// — it owns the board and decides whether to reshape, dedupe, or (if the issue
+    /// requires deeper code-structural reasoning) dispatch an Architect spike.
+    ///
+    /// For [`RemediationKind::HumanReview`] no agent is dispatched (a human must
+    /// resolve it) and creation is skipped when the source is already held by an
+    /// unresolved blocker.
+    pub(crate) async fn create_remediation_task(
+        &mut self,
+        source_task_id: &str,
+        reason: &str,
+        project_id: &str,
+        kind: RemediationKind,
+    ) {
         let task_repo = TaskRepository::new(
             self.db.clone(),
             crate::events::event_bus_for(&self.events_tx),
@@ -671,61 +729,89 @@ impl CoordinatorActor {
         let source_creator = source_task
             .as_ref()
             .and_then(|t| t.created_by_user_id.clone());
-        let model_ids = self
-            .resolve_dispatch_models_for_role("planner", source_creator.as_deref())
-            .await;
-        if model_ids.is_empty() {
-            tracing::warn!(
-                source_task_id = %source_task_id,
-                "CoordinatorActor: planner escalation — no model configured for planner role"
-            );
-            return;
+
+        // Human-review remediation is idempotent: if the source is already held
+        // by an unresolved blocker, a remediation task already exists — don't
+        // stack a fresh one on every park tick.
+        if kind == RemediationKind::HumanReview
+            && let Some(src) = source_task.as_ref()
+        {
+            match task_repo.list_blockers(&src.id).await {
+                Ok(blockers) if blockers.iter().any(|b| b.status != "closed") => {
+                    tracing::info!(
+                        source_task_id = %src.short_id,
+                        "CoordinatorActor: human-review remediation skipped — source already held by an unresolved blocker"
+                    );
+                    return;
+                }
+                _ => {}
+            }
         }
 
-        // Per-user, per-model concurrency cap: the planner escalation must
-        // consume the SAME shared per-(creator, model) budget as every other
-        // dispatch path (worker, reviewer, lead, architect). Without this a
-        // planner dispatch admitted in the same tick as worker dispatches can
-        // overshoot max_sessions (observed: 2 worker + 1 reviewer = 3 > cap 2).
-        // Filter to only models where the creator is under their cap, using a
-        // fresh DB + inflight-ledger snapshot so a just-recorded admission in
-        // this same tick is visible.
-        let model_ids: Vec<String> = if let Some(creator) = source_creator.as_deref() {
-            let running = self.effective_running_by_user_model().await;
-            let caps = djinn_db::UserSettingsRepository::new(self.db.clone())
-                .get(creator)
-                .await
-                .ok()
-                .flatten()
-                .and_then(|s| s.max_sessions)
-                .unwrap_or_default();
-            let mut filtered: Vec<String> = Vec::new();
-            for m in &model_ids {
-                let cap = caps.get(m).copied().unwrap_or(1);
-                if model_under_user_cap(&running, creator, m, cap) {
-                    filtered.push(m.clone());
+        // Models + project path are only needed to DISPATCH the Planner. A
+        // human-review remediation is never dispatched, so it needs neither —
+        // and must not bail out when no planner model is configured.
+        let (model_ids, project_path): (Vec<String>, Option<String>) = match kind {
+            RemediationKind::Planner => {
+                let model_ids = self
+                    .resolve_dispatch_models_for_role("planner", source_creator.as_deref())
+                    .await;
+                if model_ids.is_empty() {
+                    tracing::warn!(
+                        source_task_id = %source_task_id,
+                        "CoordinatorActor: planner escalation — no model configured for planner role"
+                    );
+                    return;
                 }
-            }
-            if filtered.is_empty() {
-                tracing::debug!(
-                    source_task_id = %source_task_id,
-                    creator,
-                    "CoordinatorActor: planner escalation deferred — creator at per-model concurrency cap"
-                );
-                return;
-            }
-            filtered
-        } else {
-            model_ids
-        };
 
-        let Some(project_path) = self.project_path_for_id(project_id).await else {
-            tracing::warn!(
-                project_id = %project_id,
-                source_task_id = %source_task_id,
-                "CoordinatorActor: planner escalation — project path not found"
-            );
-            return;
+                // Per-user, per-model concurrency cap: the planner escalation must
+                // consume the SAME shared per-(creator, model) budget as every other
+                // dispatch path (worker, reviewer, lead, architect). Without this a
+                // planner dispatch admitted in the same tick as worker dispatches can
+                // overshoot max_sessions (observed: 2 worker + 1 reviewer = 3 > cap 2).
+                // Filter to only models where the creator is under their cap, using a
+                // fresh DB + inflight-ledger snapshot so a just-recorded admission in
+                // this same tick is visible.
+                let model_ids: Vec<String> = if let Some(creator) = source_creator.as_deref() {
+                    let running = self.effective_running_by_user_model().await;
+                    let caps = djinn_db::UserSettingsRepository::new(self.db.clone())
+                        .get(creator)
+                        .await
+                        .ok()
+                        .flatten()
+                        .and_then(|s| s.max_sessions)
+                        .unwrap_or_default();
+                    let mut filtered: Vec<String> = Vec::new();
+                    for m in &model_ids {
+                        let cap = caps.get(m).copied().unwrap_or(1);
+                        if model_under_user_cap(&running, creator, m, cap) {
+                            filtered.push(m.clone());
+                        }
+                    }
+                    if filtered.is_empty() {
+                        tracing::debug!(
+                            source_task_id = %source_task_id,
+                            creator,
+                            "CoordinatorActor: planner escalation deferred — creator at per-model concurrency cap"
+                        );
+                        return;
+                    }
+                    filtered
+                } else {
+                    model_ids
+                };
+
+                let Some(project_path) = self.project_path_for_id(project_id).await else {
+                    tracing::warn!(
+                        project_id = %project_id,
+                        source_task_id = %source_task_id,
+                        "CoordinatorActor: planner escalation — project path not found"
+                    );
+                    return;
+                };
+                (model_ids, Some(project_path))
+            }
+            RemediationKind::HumanReview => (Vec::new(), None),
         };
 
         // Name the review task after the work it is solving, not just a
@@ -745,9 +831,20 @@ impl CoordinatorActor {
             .as_ref()
             .map(|t| format!("{} ({})", t.title, t.short_id))
             .unwrap_or_else(|| source_task_id.to_string());
-        let description = format!(
-            "Escalated from task {source_label}. Lead could not resolve — Planner review required.\n\nReason: {reason}"
-        );
+        let (description, instructions) = match kind {
+            RemediationKind::Planner => (
+                format!(
+                    "Escalated from task {source_label}. Lead could not resolve — Planner review required.\n\nReason: {reason}"
+                ),
+                "Review the escalated task and either resolve it, reshape the work, or leave a 'Requires human review' comment.",
+            ),
+            RemediationKind::HumanReview => (
+                format!(
+                    "Escalated from task {source_label}. Repeated automated remediation FAILED — this requires HUMAN review.\n\nDo NOT auto-resolve: a human must close THIS task to release the blocked source task.\n\nReason: {reason}"
+                ),
+                "Repeated automated remediation failed. Requires human review — do not auto-resolve; a human must close this task to release the blocked source task.",
+            ),
+        };
         let review_task = match djinn_core::auth_context::SESSION_USER_ID
             .scope(
                 source_creator,
@@ -756,7 +853,7 @@ impl CoordinatorActor {
                     None,
                     &title,
                     &description,
-                    "Review the escalated task and either resolve it, reshape the work, or leave a 'Requires human review' comment.",
+                    instructions,
                     "review",
                     0,
                     "system",
@@ -795,14 +892,48 @@ impl CoordinatorActor {
             );
         }
 
-        // Log a comment on the source task linking to the planner review task.
-        let comment_payload = serde_json::json!({
-            "body": format!(
+        // Tag the human-review remediation task with `human-review-hold` so the
+        // UI can surface a "needs your review" indicator on it (the actual item
+        // a human must act on; closing it revives the held source task). Reuse
+        // the existing `update` writer (no new compile-time-checked query) —
+        // re-pass the freshly-created task's own fields and override only
+        // `labels`. Non-fatal: a failed label write still leaves the hold in
+        // place via the blocker + comment.
+        if kind == RemediationKind::HumanReview
+            && let Err(e) = task_repo
+                .update(
+                    &review_task.id,
+                    &review_task.title,
+                    &review_task.description,
+                    &review_task.design,
+                    review_task.priority,
+                    &review_task.owner,
+                    "[\"human-review-hold\"]",
+                    &review_task.acceptance_criteria,
+                )
+                .await
+        {
+            tracing::warn!(
+                error = %e,
+                review_task_id = %review_task.short_id,
+                "CoordinatorActor: human-review remediation — failed to set human-review-hold label"
+            );
+        }
+
+        // Log a comment on the source task linking to the remediation review task.
+        let comment_body = match kind {
+            RemediationKind::Planner => format!(
                 "[PLANNER_ESCALATION] Escalated to Planner review task {}. Reason: {}",
                 review_task.short_id, reason
-            )
-        })
-        .to_string();
+            ),
+            RemediationKind::HumanReview => format!(
+                "[HUMAN_REVIEW_HOLD] Held on human-review remediation task {} after repeated \
+                 automated remediation failed. This task stays open + blocked until a human \
+                 resolves it. Reason: {}",
+                review_task.short_id, reason
+            ),
+        };
+        let comment_payload = serde_json::json!({ "body": comment_body }).to_string();
         let _ = task_repo
             .log_activity(
                 Some(source_task_id),
@@ -813,6 +944,19 @@ impl CoordinatorActor {
             )
             .await;
 
+        // Human-review remediation is intentionally NOT dispatched to any agent —
+        // a human must resolve it, so the source stays held until they do.
+        if kind == RemediationKind::HumanReview {
+            tracing::info!(
+                review_task_id = %review_task.short_id,
+                source_task_id = %source_task_id,
+                project_id = %project_id,
+                "CoordinatorActor: human-review remediation created; awaiting human resolution (no agent dispatched)"
+            );
+            return;
+        }
+
+        let project_path = project_path.expect("planner remediation resolves a project path");
         let task_id = review_task.id.clone();
         let project_path_owned = project_path.clone();
         let outcome = self

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
@@ -69,16 +69,18 @@ impl CoordinatorActor {
     /// 4. **Diff-empty short-circuit.** If the PR head has no commits ahead of
     ///    base on GitHub (`ahead_by == 0`), the previous worker iteration
     ///    produced no new diff — re-dispatching cannot change anything. We
-    ///    escalate to the Planner and force-close instead of looping.
+    ///    escalate to the Planner and PARK (hold the source on the remediation
+    ///    blocker) instead of looping.
     ///
     /// 5. **Cycle cap.** Each CI-failure rework records a `pr_ci_cycle` marker.
-    ///    Past `PR_CI_FAILURE_THRESHOLD` we escalate to the Planner and
-    ///    force-close rather than redispatch. Escalation is terminal — the
-    ///    counter is never reset on the reopen that re-arms the loop.
+    ///    Past `PR_CI_FAILURE_THRESHOLD` we escalate to the Planner and PARK
+    ///    rather than redispatch. Escalation is terminal — the counter is never
+    ///    reset on the reopen that re-arms the loop.
     ///
     /// Returns `true` when the event was *consumed* (the task was transitioned
-    /// — either reworked or force-closed) and the caller should run its
-    /// post-transition cache cleanup and `continue`. Returns `false` when the
+    /// — either reworked or parked on a remediation blocker) and the caller
+    /// should run its post-transition cache cleanup and `continue`. Returns
+    /// `false` when the
     /// failures were all non-blocking and the caller should fall through to its
     /// normal (CI-passed) handling.
     #[allow(clippy::too_many_arguments)]
@@ -211,6 +213,11 @@ impl CoordinatorActor {
             let sections_text = ci_failure_sections.join("\n");
             self.route_planner_intervention(task, "worker", &reason, Some(&sections_text))
                 .await;
+            // The intervention escalated + blocked the source; park it to `open`
+            // so it is genuinely HELD (not left in pr_draft/pr_review where the
+            // poller keeps re-polling the red PR) and revivable when the
+            // remediation closes.
+            self.park_source_open(task_id, &reason).await;
             return true;
         }
 
@@ -269,6 +276,10 @@ impl CoordinatorActor {
             let sections_text = ci_failure_sections.join("\n");
             self.route_planner_intervention(task, "worker", &reason, Some(&sections_text))
                 .await;
+            // Park the source to `open` so it is held by the blocker the
+            // intervention added (not left in pr_draft/pr_review) and revivable
+            // when the remediation closes.
+            self.park_source_open(task_id, &reason).await;
             return true;
         }
         // If Some(false): normal worker bug, fall through to existing retry path.
@@ -296,9 +307,9 @@ impl CoordinatorActor {
                     task_id = %task_short_id,
                     pr = pull_number,
                     sha = %current_sha,
-                    "PR poller: CI failed but branch is diff-empty vs base — escalating + force-closing"
+                    "PR poller: CI failed but branch is diff-empty vs base — escalating + parking (held on remediation blocker)"
                 );
-                self.escalate_ci_failure_and_close(task, pr_url, &reason, &ci_failure_sections)
+                self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
                     .await;
                 return true;
             }
@@ -355,9 +366,9 @@ impl CoordinatorActor {
                 pr = pull_number,
                 round,
                 threshold = PR_CI_FAILURE_THRESHOLD,
-                "PR poller: CI-failure rework threshold exceeded — escalating + force-closing"
+                "PR poller: CI-failure rework threshold exceeded — escalating + parking (held on remediation blocker)"
             );
-            self.escalate_ci_failure_and_close(task, pr_url, &reason, &ci_failure_sections)
+            self.escalate_ci_failure_and_park(task, pr_url, &reason, &ci_failure_sections)
                 .await;
             return true;
         }
@@ -422,11 +433,14 @@ impl CoordinatorActor {
         true
     }
 
-    /// Terminal escalation for a CI-failure loop the worker can't resolve
-    /// (diff-empty re-emit, or cycle cap exceeded). Logs a visibility comment,
-    /// dispatches a Planner escalation, then `ForceClose`s the task so it
-    /// leaves the rework loop. Never resets the CI-cycle counter.
-    pub(crate) async fn escalate_ci_failure_and_close(
+    /// Park (HOLD) a CI-failure loop the worker can't resolve (diff-empty
+    /// re-emit, or cycle cap exceeded). Logs a visibility comment, dispatches a
+    /// Planner remediation (which creates a remediation task and BLOCKS the
+    /// source on it), then parks the source back to `open` so it is held by that
+    /// blocker — NOT force-closed. `list_ready` filters the blocked-open task out
+    /// of dispatch (no slot consumed) and `emit_unblocked_tasks` revives it the
+    /// moment the remediation closes. Never resets the CI-cycle counter.
+    pub(crate) async fn escalate_ci_failure_and_park(
         &mut self,
         task: &djinn_core::models::Task,
         pr_url: &str,
@@ -462,8 +476,9 @@ impl CoordinatorActor {
             );
         }
 
-        // Escalate to the Planner (ADR-051 §8 escalation ceiling) before
-        // force-closing, so a human / Planner sees why the task gave up.
+        // Escalate to the Planner (ADR-051 §8 escalation ceiling), which creates
+        // a remediation task and BLOCKS the source on it, so a human / Planner
+        // sees why the task gave up and can drive it forward.
         let enriched_reason = if ci_failure_sections.is_empty() {
             reason.to_string()
         } else {
@@ -475,14 +490,30 @@ impl CoordinatorActor {
         self.dispatch_planner_escalation(&task.id, &enriched_reason, &task.project_id)
             .await;
 
-        self.apply_pr_transition(&task.id, TransitionAction::ForceClose, Some(reason))
-            .await;
+        // Park (hold) the source on the blocker just added — NOT force-close.
+        // The blocker was added by `dispatch_planner_escalation` BEFORE this
+        // park, so the open task is never dispatchable without its blocker.
+        self.park_source_open(&task.id, reason).await;
         self.pr_status_cache.remove(&task.id);
         self.pr_draft_first_seen.remove(&task.id);
         self.review_stuck_sha_first_seen.remove(&task.id);
         self.merge_fail_count.remove(&task.id);
         self.delegated_to_github.remove(&task.id);
         self.conversations_resolved.remove(&task.id);
+    }
+
+    /// Park a stuck source task: move it to `open` so it is HELD by the
+    /// remediation blocker that the escalation path already added — never
+    /// closed, never left in `pr_draft`/`pr_review` (where the PR poller would
+    /// keep re-polling its red PR). A no-op when the task is already `open`.
+    ///
+    /// Ordering contract: callers MUST add the remediation blocker BEFORE
+    /// calling this, so there is no window where the open task is dispatchable
+    /// without its blocker. Once parked, `list_ready` filters it out (blocked)
+    /// and `emit_unblocked_tasks` revives it when the remediation closes.
+    pub(crate) async fn park_source_open(&self, task_id: &str, reason: &str) {
+        self.apply_pr_transition(task_id, TransitionAction::ParkForRemediation, Some(reason))
+            .await;
     }
 }
 pub(crate) fn is_merge_queue_405(

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -720,9 +720,20 @@ async fn reopen_loop_guard_second_strike_chaos_parks_without_rearming() {
         "second strike is handled terminally instead of redispatching"
     );
     assert_eq!(parked.reopen_count, REOPEN_INTERVENTION_THRESHOLD + 1);
-    harness
-        .assert_task_status("closed", Some("planner intervention"))
-        .await;
+    // Second strike now HOLDS the task on a human rather than force-closing it:
+    // it stays `open` and blocked (the first-strike planner review is still an
+    // unresolved blocker, so no fresh remediation is stacked) so it consumes no
+    // dispatch slot yet is revivable when a human resolves the remediation.
+    harness.assert_task_status("open", None).await;
+    assert!(
+        !harness
+            .repo
+            .list_blockers(&harness.task_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "parked source must remain held by an unresolved remediation blocker"
+    );
     harness.assert_dispatch_backoff_cleared().await;
     harness.assert_capacity_released().await;
     harness
@@ -738,7 +749,7 @@ async fn reopen_loop_guard_second_strike_chaos_parks_without_rearming() {
         terminal_recheck_handled,
         "terminal second-strike recheck is consumed rather than redispatched"
     );
-    assert_eq!(terminal_recheck.status, "closed");
+    assert_eq!(terminal_recheck.status, "open");
     assert_eq!(
         harness.planner_intervention_markers().await.len(),
         marker_count_after_park,
@@ -954,6 +965,35 @@ async fn loop_guard_routes_to_planner_without_dispatch_failure_streak() {
     );
 }
 
+/// Drain the already-buffered broadcast events (the transition + any
+/// `emit_unblocked_tasks` follow-ups are emitted synchronously before the
+/// awaited transition returns) and report whether a `task_updated` for
+/// `task_id` was observed.
+async fn wait_for_task_updated(
+    events: &mut broadcast::Receiver<DjinnEventEnvelope>,
+    task_id: &str,
+) -> bool {
+    loop {
+        match events.try_recv() {
+            Ok(env) => {
+                if env.entity_type == "task"
+                    && env.action == "updated"
+                    && env
+                        .payload
+                        .get("task")
+                        .and_then(|t| t.get("id"))
+                        .and_then(|v| v.as_str())
+                        == Some(task_id)
+                {
+                    return true;
+                }
+            }
+            Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+            Err(_) => return false,
+        }
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn loop_guard_second_strike_parks_task() {
     let db = test_helpers::create_test_db();
@@ -976,21 +1016,120 @@ async fn loop_guard_second_strike_parks_task() {
 
     let parked = repo.get(&task.id).await.unwrap().unwrap();
     assert_eq!(
-        parked.status, "closed",
-        "second-strike guard trip force-closes the task"
+        parked.status, "open",
+        "second-strike guard trip HOLDS the task (open + blocked) instead of force-closing it"
     );
     assert!(
-        parked
-            .close_reason
-            .as_deref()
-            .is_some_and(|reason| reason.contains("planner intervention")),
-        "second-strike close reason should preserve the recoverable planner-intervention park message"
+        parked.close_reason.is_none(),
+        "a held (parked) task must not carry a close_reason; got {:?}",
+        parked.close_reason
     );
+
+    // The hold creates a HUMAN-review remediation task and blocks the source on
+    // it, so the source is held until a human resolves the remediation.
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert_eq!(
+        blockers.len(),
+        1,
+        "second strike must block the source on a single human-review remediation task"
+    );
+    let remediation_id = blockers[0].task_id.clone();
+    let remediation = repo.get(&remediation_id).await.unwrap().unwrap();
+    assert_eq!(remediation.issue_type, "review");
+    assert!(
+        remediation.title.starts_with("Planner remediation ["),
+        "remediation keeps the `Planner remediation [<short_id>]: <title>` convention; got {:?}",
+        remediation.title
+    );
+
     assert!(
         planner_intervention_markers(&repo, &task.id)
             .await
             .is_empty(),
         "second strike parks without writing a fresh marker"
+    );
+
+    // Closing the remediation revives the held source via emit_unblocked_tasks.
+    let mut events = tx.subscribe();
+    repo.transition(
+        &remediation_id,
+        djinn_core::models::TransitionAction::Close,
+        "human",
+        "user",
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let revived = wait_for_task_updated(&mut events, &task.id).await;
+    assert!(
+        revived,
+        "closing the human-review remediation must emit a TaskUpdated reviving the held source"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ci_loop_park_holds_source_open_and_revives_on_remediation_close() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = make_task_with_reopen_count(&db, &tx, 0).await;
+
+    // Simulate a task whose draft PR has red, non-converging required CI.
+    repo.set_status(&task.id, "pr_draft").await.unwrap();
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(task.status, "pr_draft");
+
+    actor
+        .escalate_ci_failure_and_park(
+            &task,
+            "https://github.com/acme/repo/pull/7",
+            "Required CI keeps failing on the same fingerprint; the worker is not converging.",
+            &["**Failed job:** server-clippy (failure)".to_string()],
+        )
+        .await;
+
+    // The source is PARKED: `open` (NOT closed, NOT pr_draft) and held by a
+    // remediation blocker, so `list_ready` filters it out — no slot consumed.
+    let parked = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        parked.status, "open",
+        "CI-loop park leaves the source open, not closed/pr_draft"
+    );
+    assert_eq!(
+        parked.close_reason, None,
+        "a parked (held) source must not carry a close_reason"
+    );
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert_eq!(
+        blockers.len(),
+        1,
+        "CI-loop park must hold the source on a single remediation blocker"
+    );
+    let remediation_id = blockers[0].task_id.clone();
+    let remediation = repo.get(&remediation_id).await.unwrap().unwrap();
+    assert!(
+        remediation.title.starts_with("Planner remediation ["),
+        "remediation keeps the `Planner remediation [<short_id>]: <title>` convention; got {:?}",
+        remediation.title
+    );
+
+    // Closing the remediation revives the held source via emit_unblocked_tasks.
+    let mut events = tx.subscribe();
+    repo.transition(
+        &remediation_id,
+        djinn_core::models::TransitionAction::Close,
+        "human",
+        "user",
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        wait_for_task_updated(&mut events, &task.id).await,
+        "closing the CI-loop remediation must emit a TaskUpdated reviving the parked source"
     );
 }
 
@@ -1259,10 +1398,12 @@ async fn intervention_is_idempotent_per_reopen_count() {
 
 /// Second strike: once the Planner has already intervened
 /// (`intervention_count >= MAX_PLANNER_INTERVENTIONS`) and the task has
-/// STILL climbed back to the reopen threshold, the coordinator parks it
-/// terminally instead of escalating to the Planner again — no new marker,
-/// no new review task, and the task ends up `closed`. This is the loop
-/// breaker for the txr4 case (rescope didn't help → stop hogging the slot).
+/// STILL climbed back to the reopen threshold, the coordinator HOLDS it on a
+/// human instead of escalating to the Planner again — it stays `open` (never
+/// auto-closed), blocked on a freshly created human-review remediation task,
+/// and writes no new intervention marker. This is the loop breaker for the
+/// txr4 case (rescope didn't help → stop hogging the slot), now revivable when
+/// a human resolves the remediation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn second_strike_parks_task_after_prior_intervention() {
     let db = test_helpers::create_test_db();
@@ -1289,15 +1430,20 @@ async fn second_strike_parks_task_after_prior_intervention() {
         "second strike must handle the task (caller skips worker dispatch)"
     );
 
-    // Parked terminally — task is closed.
+    // Held on a human — task stays open, never auto-closed.
     let parked = repo.get(&task.id).await.unwrap().unwrap();
     assert_eq!(
-        parked.status, "closed",
-        "second strike force-closes the task"
+        parked.status, "open",
+        "second strike HOLDS the task open (blocked) instead of force-closing it"
+    );
+    assert_eq!(
+        parked.close_reason, None,
+        "a held (parked) task must not carry a close_reason"
     );
 
-    // No planner intervention marker for this reopen count, and no new
-    // planner review task — the loop is broken, not re-escalated.
+    // No planner intervention marker for this reopen count — the rework loop is
+    // broken (not re-escalated to the planner). The hold instead creates a
+    // single HUMAN-review remediation task that blocks the source.
     assert!(
         !planner_intervention_markers(&repo, &task.id)
             .await
@@ -1305,12 +1451,18 @@ async fn second_strike_parks_task_after_prior_intervention() {
             .any(|m| m["reopen_count"] == REOPEN_INTERVENTION_THRESHOLD),
         "second strike must not write a new planner intervention marker"
     );
-    let reviews = repo.list_by_status("open").await.unwrap();
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert_eq!(
+        blockers.len(),
+        1,
+        "second strike holds the source on exactly one human-review remediation blocker"
+    );
+    let remediation = repo.get(&blockers[0].task_id).await.unwrap().unwrap();
+    assert_eq!(remediation.issue_type, "review");
     assert!(
-        !reviews
-            .iter()
-            .any(|t| t.issue_type == "review" && t.project_id == parked.project_id),
-        "second strike must not create another planner review task"
+        remediation.title.starts_with("Planner remediation ["),
+        "remediation keeps the `Planner remediation [<short_id>]: <title>` convention; got {:?}",
+        remediation.title
     );
 }
 
@@ -1319,7 +1471,7 @@ async fn second_strike_parks_task_after_prior_intervention() {
 // These tests verify that CI failure sections are properly threaded through
 // escalation paths — the core wiring added by epic nnij.
 
-/// `escalate_ci_failure_and_close` includes CI failure sections in both the
+/// `escalate_ci_failure_and_park` includes CI failure sections in both the
 /// visibility comment and the escalation reason passed to
 /// `dispatch_planner_escalation`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1340,7 +1492,7 @@ async fn escalate_ci_failure_includes_sections_in_comment_and_reason() {
     let pr_url = "https://github.com/owner/repo/pull/42";
 
     actor
-        .escalate_ci_failure_and_close(&task, pr_url, reason, &sections)
+        .escalate_ci_failure_and_park(&task, pr_url, reason, &sections)
         .await;
 
     // The visibility comment must contain "**CI Failure Details:**" and each
@@ -1362,7 +1514,7 @@ async fn escalate_ci_failure_includes_sections_in_comment_and_reason() {
     let escalation_comment = comments
         .iter()
         .find(|c| c.payload.contains("**PR CI Escalation**"))
-        .expect("escalate_ci_failure_and_close must log a PR CI Escalation comment");
+        .expect("escalate_ci_failure_and_park must log a PR CI Escalation comment");
     assert!(
         escalation_comment
             .payload
@@ -1414,7 +1566,7 @@ async fn escalate_ci_failure_includes_sections_in_comment_and_reason() {
     );
 }
 
-/// `escalate_ci_failure_and_close` with empty sections omits the CI Failure
+/// `escalate_ci_failure_and_park` with empty sections omits the CI Failure
 /// Details block from both the visibility comment and the escalation reason.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn escalate_ci_failure_with_empty_sections_omits_details() {
@@ -1429,7 +1581,7 @@ async fn escalate_ci_failure_with_empty_sections_omits_details() {
     let pr_url = "https://github.com/owner/repo/pull/42";
 
     actor
-        .escalate_ci_failure_and_close(&task, pr_url, reason, &sections)
+        .escalate_ci_failure_and_park(&task, pr_url, reason, &sections)
         .await;
 
     let comments = repo

--- a/server/crates/djinn-core/src/models/task.rs
+++ b/server/crates/djinn-core/src/models/task.rs
@@ -304,6 +304,12 @@ pub enum TransitionAction {
     PrMerge,
     /// GitHub App signals changes requested on PR — transitions pr_review → open.
     PrChangesRequested,
+    /// CI-loop remediation park: hold the source task by moving it back to
+    /// `open` so its already-added remediation blocker keeps it out of dispatch
+    /// (`list_ready` filters blocked-open tasks) until the remediation closes
+    /// and `emit_unblocked_tasks` revives it. Unlike `PrCiFailed` / `Reopen`
+    /// this is a HOLD, not a rework, so it does NOT increment `reopen_count`.
+    ParkForRemediation,
     /// Non-worker role (planner/architect) completed with file changes —
     /// route through the approved → PR pipeline instead of closing directly.
     SubmitForMerge,
@@ -356,6 +362,7 @@ impl TransitionAction {
             "pr_conflict" => Ok(Self::PrConflict),
             "pr_merge" => Ok(Self::PrMerge),
             "pr_changes_requested" => Ok(Self::PrChangesRequested),
+            "park_for_remediation" => Ok(Self::ParkForRemediation),
             "submit_for_merge" => Ok(Self::SubmitForMerge),
             other => Err(Error::Internal(format!(
                 "unknown transition action: {other}"
@@ -727,6 +734,29 @@ pub fn compute_transition(
             }
             TransitionApply::simple(TaskStatus::Approved)
         }
+
+        TransitionAction::ParkForRemediation => {
+            // Park (hold) the source on its remediation blocker by landing it at
+            // `open`. Legal from every pre-terminal in-flight state a CI-loop
+            // park can observe; a no-op when the task is already `open`. Unlike
+            // `PrCiFailed` / `Reopen` it does NOT bump `reopen_count` — this is a
+            // hold pending remediation, not another rework round.
+            if !matches!(
+                from,
+                TaskStatus::PrDraft
+                    | TaskStatus::PrReview
+                    | TaskStatus::InProgress
+                    | TaskStatus::Open
+                    | TaskStatus::NeedsTaskReview
+                    | TaskStatus::InTaskReview
+                    | TaskStatus::Approved
+            ) {
+                return bad(
+                    "park_for_remediation is only valid from pr_draft, pr_review, in_progress, open, needs_task_review, in_task_review, or approved",
+                );
+            }
+            TransitionApply::simple(TaskStatus::Open)
+        }
     })
 }
 
@@ -772,6 +802,7 @@ pub fn compute_transition_for_issue_type(
                 | TransitionAction::PrConflict
                 | TransitionAction::PrMerge
                 | TransitionAction::PrChangesRequested
+                | TransitionAction::ParkForRemediation
         );
         if !allowed {
             return Err(Error::InvalidTransition(format!(
@@ -800,7 +831,7 @@ mod tests {
         TaskStatus::Closed,
     ];
 
-    const ACTIONS: [TransitionAction; 26] = [
+    const ACTIONS: [TransitionAction; 27] = [
         TransitionAction::Start,
         TransitionAction::ResumeWorker,
         TransitionAction::SubmitTaskReview,
@@ -827,6 +858,7 @@ mod tests {
         TransitionAction::PrConflict,
         TransitionAction::PrMerge,
         TransitionAction::PrChangesRequested,
+        TransitionAction::ParkForRemediation,
     ];
 
     fn expected_status(action: &TransitionAction, from: &TaskStatus) -> Option<TaskStatus> {
@@ -894,6 +926,16 @@ mod tests {
                 Some(TaskStatus::Closed)
             }
             (TransitionAction::PrChangesRequested, TaskStatus::PrReview) => Some(TaskStatus::Open),
+            (
+                TransitionAction::ParkForRemediation,
+                TaskStatus::PrDraft
+                | TaskStatus::PrReview
+                | TaskStatus::InProgress
+                | TaskStatus::Open
+                | TaskStatus::NeedsTaskReview
+                | TaskStatus::InTaskReview
+                | TaskStatus::Approved,
+            ) => Some(TaskStatus::Open),
             (TransitionAction::SubmitForMerge, TaskStatus::InProgress) => {
                 Some(TaskStatus::Approved)
             }

--- a/ui/src/components/TaskCard.tsx
+++ b/ui/src/components/TaskCard.tsx
@@ -87,10 +87,16 @@ function formatCompactDuration(totalSeconds: number): string {
 
 // --- Status badge for in-flight cards ---
 
+// Label set by the coordinator on the human-review remediation task when
+// repeated automated remediation fails. Closing that task revives the held
+// source task — so it's the one item a human must act on.
+const HUMAN_REVIEW_HOLD_LABEL = "human-review-hold";
+
+function hasHumanReviewHold(task: Task): boolean {
+  return task.labels?.includes(HUMAN_REVIEW_HOLD_LABEL) ?? false;
+}
+
 function getStatusBadge(status: string, hasSession: boolean, allAcMet: boolean): { label: string; className: string } | null {
-  if (status === "needs_lead_intervention" && !hasSession) {
-    return { label: "agent stuck", className: "text-red-400" };
-  }
   if ((status === "needs_task_review" || status === "in_task_review") && !hasSession && allAcMet) {
     return { label: "merging", className: "text-green-400 animate-pulse" };
   }
@@ -113,11 +119,10 @@ function StatusBadge({ status, hasSession, allAcMet }: { status: string; hasSess
 // --- Card tint based on status ---
 
 function getCardTint(task: Task): { ring: string; bg: string; hover: string; actionsBg: string } | null {
-  if (task.status === "needs_lead_intervention" && !task.active_session) {
-    return { ring: "ring-red-500/40", bg: "bg-red-500/5", hover: "hover:bg-red-500/10 hover:ring-red-500/60", actionsBg: "bg-red-500/10 text-white" };
-  }
-  if ((task.status === "needs_lead_intervention" && task.active_session) || task.status === "in_lead_intervention") {
-    return { ring: "ring-red-500/40", bg: "bg-red-500/5", hover: "hover:bg-red-500/10 hover:ring-red-500/60", actionsBg: "bg-red-500/10 text-white" };
+  // Human-review remediation hold: the one item a human must act on. Subtle
+  // amber tint so it stands out without the alarm of the old red "stuck" tint.
+  if (hasHumanReviewHold(task)) {
+    return { ring: "ring-amber-500/40", bg: "bg-amber-500/5", hover: "hover:bg-amber-500/10 hover:ring-amber-500/60", actionsBg: "bg-amber-500/10 text-white" };
   }
   return null;
 }
@@ -189,6 +194,7 @@ export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
   const acTotal = ac.length;
   const acMet = ac.filter((c: { met?: boolean }) => c.met).length;
   const cardTint = getCardTint(task);
+  const needsReview = hasHumanReviewHold(task);
   const isSettingUp = task.status === "in_progress" && !task.active_session;
 
   return (
@@ -273,6 +279,17 @@ export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
           {isInFlight && (
             <span className="inline-flex items-center gap-1" data-testid="taskcard-status-badge">
               <StatusBadge status={task.status} hasSession={!!task.active_session} allAcMet={acTotal > 0 && acMet === acTotal} />
+            </span>
+          )}
+
+          {/* Human-review remediation hold — not in-flight (status `open`), so
+              render its own status text outside the isInFlight gate. */}
+          {needsReview && (
+            <span
+              className="inline-flex items-center gap-1"
+              data-testid="taskcard-needs-review-badge"
+            >
+              <span className="text-[10px] font-medium text-amber-400">needs your review</span>
             </span>
           )}
 


### PR DESCRIPTION
## Problem

When a PR's required CI keeps failing such that a worker can't make progress, the coordinator was supposed to spawn a *Planner remediation* task, block the stuck task on it, and reopen the stuck task only once the remediation finishes. The mechanism (`dispatch_planner_escalation`) already created the remediation task (`Planner remediation [id]: title`) and `add_blocker`'d the source — **then immediately force-closed the source.**

Because `emit_unblocked_tasks` only revives tasks `WHERE status = 'open'`, the force-close permanently disabled the blocker-hold: a closed source can never auto-resurface when its remediation closes. The first-strike path was leaky the other way — it escalated but left the source in `pr_draft`, so the pr_poller kept re-polling the red PR and it was never revivable either.

Observed on task `4ym7` (a CI job whose own required check could not pass on its branch): the PR looped `pr_draft → open → …` and the worker spun on an unfixable red check.

## Fix — park, don't close

A "park" now leaves the source `open` + blocked (slot freed via `list_ready`, pr_poller ignores it, revivable via the existing `emit_unblocked_tasks`).

| Path | Before | After |
|------|--------|-------|
| same-signature / scope-inversion | escalate, left in `pr_draft` (never revivable) | escalate + **park to `open`** |
| diff-empty / cycle-cap | escalate → **`ForceClose`** | `escalate_ci_failure_and_park` → **park to `open`** |
| second strike | **`set_status closed`** | **human-review hold** (open remediation, held indefinitely, never auto-closed) |

- New `TaskStatus` transition `ParkForRemediation` (→ `open`, no reopen increment).
- Blocker is added **before** the park, so there is no window where the open task is dispatchable without its blocker.
- `RemediationKind { Planner, HumanReview }`. `HumanReview` is idempotent, never dispatched, stays open until a human closes it — then `emit_unblocked_tasks` revives the source as a fresh attempt.

## UI

Human-review remediation tasks carry a `human-review-hold` label. `TaskCard` drops the now-auto-handled **"agent stuck"** indicator (+ its red tint) and shows a small amber **"needs your review"** status (+ subtle tint) on the held remediation task — the one open item a human must close to release the source.

## Tests
- New `ci_loop_park_holds_source_open_and_revives_on_remediation_close`: parks a `pr_draft` task, asserts it ends `open` (not closed/pr_draft) with one `Planner remediation` blocker, then closes the remediation and asserts the source is revived.
- 3 existing second-strike tests updated to assert open+blocked+revivable instead of force-closed.
- `cargo check`/`test` for `djinn-core` + `djinn-coordinator`, and UI `pnpm build` + eslint + TaskCard vitest all pass locally.

## Note
Also removes the red tint for *active* lead-intervention (`in_lead_intervention` with a live session), not just the no-session stuck case — happy to restore that one branch if in-progress lead interventions should still stand out.