### PR TITLE
fix(refinement): dispatch-failure ≠ dry round; recover zombie loops on restart

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -620,6 +620,13 @@ impl CoordinatorActor {
         health::reap_orphaned_taskrun_jobs_for_startup(&self.db, &startup_context).await;
         self.rehydrate_durable_dispatch_state().await;
 
+        // Reconcile refinements whose in-memory loop was lost across this
+        // restart: their durable `refinement_start` rows still report `active`
+        // but no loop drives them. Stop them cleanly so they don't linger as
+        // zombies. Runs before the loop starts, so `active_refinements` is
+        // empty and there is no race with a freshly-started refinement.
+        self.recover_interrupted_refinements().await;
+
         loop {
             tokio::select! {
                 biased;

--- a/server/crates/djinn-coordinator/src/refinement.rs
+++ b/server/crates/djinn-coordinator/src/refinement.rs
@@ -60,6 +60,10 @@ pub enum StopReason {
     HumanAccepted,
     /// The human rejected the refined spec at the final review (no re-loop).
     HumanRejected,
+    /// The in-memory loop was lost across a server restart and reconciled by
+    /// startup recovery. The spec is left as-is; the user can start a fresh
+    /// refinement.
+    Interrupted,
 }
 
 impl StopReason {
@@ -73,6 +77,7 @@ impl StopReason {
             StopReason::AgentFailure { .. } => "agent_failure",
             StopReason::HumanAccepted => "human_accepted",
             StopReason::HumanRejected => "human_rejected",
+            StopReason::Interrupted => "interrupted",
         }
     }
 }
@@ -203,6 +208,12 @@ pub struct RefinementLoopState {
     pub objection_signatures: HashMap<String, usize>,
     /// Per-round blocking objection counts: `(round, count)`.
     pub round_blocking_objections: Vec<(i32, usize)>,
+    /// Consecutive times a dispatched role session never actually ran (the
+    /// task closed with zero session rows — e.g. a runtime/devcontainer setup
+    /// failure). Reset to 0 whenever a session does run. Distinguishes "the
+    /// adversary ran and was dry" from "the adversary never started", so a
+    /// dispatch outage isn't silently treated as a dry round.
+    pub dispatch_failures: i32,
     /// Set when the loop terminates.
     pub stop_reason: Option<StopReason>,
 }
@@ -235,6 +246,7 @@ impl RefinementLoopState {
             attributed_user_id: None,
             objection_signatures: HashMap::new(),
             round_blocking_objections: Vec::new(),
+            dispatch_failures: 0,
             stop_reason: None,
         }
     }

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -41,6 +41,13 @@ use super::actor::CoordinatorActor;
 /// before treating it as stalled (conservative — sessions can take 5+ min).
 const REFINEMENT_SESSION_TIMEOUT: Duration = Duration::from_secs(900);
 
+/// How many consecutive times a refinement role session may fail to start
+/// (runtime/devcontainer setup failure, zero session rows) before the loop
+/// gives up and terminates instead of re-dispatching. Bounds the retry on a
+/// transient runtime outage (e.g. a cold post-deploy devcontainer warm) while
+/// still escalating a persistently broken environment.
+const REFINEMENT_DISPATCH_RETRY_CAP: i32 = 3;
+
 /// The in-flight session tracking for one active refinement loop.
 #[derive(Debug, Clone)]
 pub(super) struct RefinementSession {
@@ -110,8 +117,84 @@ impl CoordinatorActor {
                 return;
             }
 
-            // Session completed — process the outcome, then close the task so
-            // finished phase/round tasks don't linger `open` on the board.
+            // The slot is no longer running this task. That can mean two very
+            // different things:
+            //   (a) the agent session actually ran and finished — process its
+            //       outcome from the DB (debate trail / revisions); or
+            //   (b) the session never started (runtime/devcontainer setup
+            //       failure freed the slot before any session row was created).
+            // Treating (b) as a completed-but-"dry" round silently burns rounds
+            // on a dispatch outage and can hollow-converge the tribunal. Tell
+            // them apart by whether any session row exists for the task.
+            let session_ran = {
+                let event_bus = crate::events::event_bus_for(&self.events_tx);
+                let session_repo =
+                    djinn_db::SessionRepository::new(self.db.clone(), event_bus);
+                match session_repo.list_for_task(&session.task_id).await {
+                    Ok(sessions) => !sessions.is_empty(),
+                    // On a DB read error, fail safe toward "it ran" so we don't
+                    // spin forever re-dispatching.
+                    Err(e) => {
+                        tracing::warn!(
+                            proposal_id = %proposal_id,
+                            task_id = %session.task_id,
+                            error = %e,
+                            "Failed to read sessions for refinement task; assuming it ran"
+                        );
+                        true
+                    }
+                }
+            };
+
+            if !session_ran {
+                // Dispatch/setup failure: the role never executed. Re-dispatch
+                // the same phase on the next tick, bounded by a retry cap so a
+                // persistently broken runtime escalates instead of looping.
+                self.close_refinement_task(
+                    &session.task_id,
+                    "refinement role session never started (dispatch/setup failure)",
+                )
+                .await;
+                self.refinement_sessions.remove(proposal_id);
+                let over_cap = if let Some(state) = self.active_refinements.get_mut(proposal_id) {
+                    state.dispatch_failures += 1;
+                    state.dispatch_failures >= REFINEMENT_DISPATCH_RETRY_CAP
+                } else {
+                    true
+                };
+                if over_cap {
+                    tracing::warn!(
+                        proposal_id = %proposal_id,
+                        phase = ?session.phase,
+                        "Refinement role session repeatedly failed to start — terminating"
+                    );
+                    self.terminate_refinement(
+                        proposal_id,
+                        StopReason::AgentFailure {
+                            role: format!("{:?}", session.phase),
+                            error: format!(
+                                "role session failed to start {REFINEMENT_DISPATCH_RETRY_CAP} times \
+                                 (runtime/devcontainer setup failure)"
+                            ),
+                        },
+                    )
+                    .await;
+                } else {
+                    tracing::warn!(
+                        proposal_id = %proposal_id,
+                        phase = ?session.phase,
+                        "Refinement role session never started; will re-dispatch (not counted as dry)"
+                    );
+                }
+                return;
+            }
+
+            // Session actually ran — clear the dispatch-failure counter and
+            // process the outcome, then close the task so finished phase/round
+            // tasks don't linger `open` on the board.
+            if let Some(state) = self.active_refinements.get_mut(proposal_id) {
+                state.dispatch_failures = 0;
+            }
             self.process_refinement_outcome(proposal_id, &session).await;
             self.close_refinement_task(&session.task_id, "refinement phase complete")
                 .await;
@@ -743,6 +826,51 @@ impl CoordinatorActor {
             .map_err(|e| format!("failed to revert proposal body: {e}"))?;
 
         Ok(())
+    }
+
+    /// Startup reconciliation for refinements interrupted by a restart.
+    ///
+    /// A refinement's loop state lives only in memory (`active_refinements`),
+    /// but its `refinement_start` lifecycle row is durable. After a restart the
+    /// in-memory loop is gone yet the DB still reports the proposal as `active`,
+    /// so it becomes a "zombie": it makes no progress and the human cannot
+    /// resolve it. This runs ONCE, before the actor's message/tick loop begins
+    /// (so `active_refinements` is empty and there is no race with a fresh
+    /// start), and records a `refinement_stop` for every DB-dangling refinement
+    /// so the proposal returns to a clean, restartable state.
+    pub(super) async fn recover_interrupted_refinements(&mut self) {
+        let event_bus = crate::events::event_bus_for(&self.events_tx);
+        let proposal_repo = ProposalRepository::new(self.db.clone(), event_bus);
+        let dangling = match proposal_repo.dangling_refinement_proposal_ids().await {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to query dangling refinements for startup recovery"
+                );
+                return;
+            }
+        };
+        if dangling.is_empty() {
+            return;
+        }
+        tracing::info!(
+            count = dangling.len(),
+            "Reconciling refinements interrupted by restart"
+        );
+        for proposal_id in dangling {
+            // Skip anything already being driven in memory (defensive — this
+            // runs before the loop starts, so the map is normally empty).
+            if self.active_refinements.contains_key(&proposal_id) {
+                continue;
+            }
+            self.persist_refinement_stop(&proposal_id, &StopReason::Interrupted)
+                .await;
+            tracing::info!(
+                proposal_id = %proposal_id,
+                "Stopped interrupted refinement (lost across restart); proposal is restartable"
+            );
+        }
     }
 
     /// Persist refinement-stop lifecycle metadata.

--- a/server/crates/djinn-db/src/repositories/proposal.rs
+++ b/server/crates/djinn-db/src/repositories/proposal.rs
@@ -906,6 +906,30 @@ impl ProposalRepository {
         Ok(())
     }
 
+    /// Return the proposal IDs whose refinement is currently dangling — i.e.
+    /// they have more `refinement_start` lifecycle events than `refinement_stop`
+    /// events, so a refinement was started but never recorded as stopped.
+    ///
+    /// On a clean run this is exactly the set the coordinator is actively
+    /// driving in memory. After a server restart the in-memory loops are lost
+    /// but these DB rows remain, leaving "zombie" refinements that report
+    /// `active` yet make no progress. Startup recovery uses this to reconcile
+    /// them.
+    pub async fn dangling_refinement_proposal_ids(&self) -> Result<Vec<String>> {
+        self.db.ensure_initialized().await?;
+        let ids = sqlx::query_scalar::<_, String>(
+            r#"SELECT proposal_id
+               FROM proposal_revisions
+               WHERE event_kind IN ('refinement_start', 'refinement_stop')
+               GROUP BY proposal_id
+               HAVING SUM(CASE WHEN event_kind = 'refinement_start' THEN 1 ELSE 0 END)
+                    > SUM(CASE WHEN event_kind = 'refinement_stop' THEN 1 ELSE 0 END)"#,
+        )
+        .fetch_all(self.db.pool())
+        .await?;
+        Ok(ids)
+    }
+
     /// Find the latest verdict override for a proposal. Returns
     /// `Some((override_on_revision_seq, override_metadata_json))` when an
     /// active override exists, or `None` when no override has been recorded.
@@ -3851,6 +3875,53 @@ mod tests {
         .unwrap();
         assert_eq!(r2["block_id"], "metric-tile");
         assert_eq!(r2["selector"], "section: '## Metrics'");
+    }
+
+    /// `dangling_refinement_proposal_ids` reports a proposal exactly while it
+    /// has more `refinement_start` than `refinement_stop` lifecycle rows — the
+    /// signal startup recovery uses to reconcile refinements lost across a
+    /// restart.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dangling_refinement_ids_track_unmatched_start() {
+        let repo = ProposalRepository::new(test_db(), EventBus::noop());
+        let p = repo.create(create_input("Dangling Refinement")).await.unwrap();
+
+        // No refinement lifecycle yet → not dangling.
+        assert!(
+            repo.dangling_refinement_proposal_ids()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // A start with no matching stop → dangling.
+        repo.record_refinement_lifecycle(&p.id, "refinement_start", None)
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.dangling_refinement_proposal_ids().await.unwrap(),
+            vec![p.id.clone()]
+        );
+
+        // An awaiting_review event does not balance the start → still dangling.
+        repo.record_refinement_lifecycle(&p.id, "refinement_awaiting_review", None)
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.dangling_refinement_proposal_ids().await.unwrap(),
+            vec![p.id.clone()]
+        );
+
+        // A matching stop → balanced → no longer dangling.
+        repo.record_refinement_lifecycle(&p.id, "refinement_stop", None)
+            .await
+            .unwrap();
+        assert!(
+            repo.dangling_refinement_proposal_ids()
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     /// Status-only updates and the `status_change` audit events they emit


### PR DESCRIPTION
Two robustness gaps found while verifying the tribunal wiring fix (#1207) live on v0.6.54.

## 1. Dispatch failure was silently treated as a "dry" round

A role session that **never started** (runtime/devcontainer setup failure freed the slot before any session row existed) was processed exactly like a session that ran and found nothing — a dry round. A post-deploy devcontainer warm-up could burn the entire round budget and hollow-converge the tribunal. (Observed: a fresh run's first rounds force-closed with `session_count: 0` and the loop advanced as if dry.)

**Fix:** distinguish the two by whether any session row exists for the task (`SessionRepository::list_for_task`). If none ran, re-dispatch the same phase, bounded by `REFINEMENT_DISPATCH_RETRY_CAP` (3) → escalate to `AgentFailure` instead of advancing. A session that actually ran resets the counter. New `dispatch_failures` field on `RefinementLoopState`.

## 2. Refinements zombied across a restart

A refinement's loop lives only in memory (`active_refinements`), but its `refinement_start` lifecycle row is durable. After a restart the DB still reports the proposal `active` while no loop drives it — it makes no progress and the human can't resolve it (split-brain: control-plane reads the DB, coordinator reads memory).

**Fix:** `ProposalRepository::dangling_refinement_proposal_ids()` (proposals with more `refinement_start` than `refinement_stop` rows) + a one-time startup reconciliation `recover_interrupted_refinements()` that records a `refinement_stop` (`StopReason::Interrupted`) for each, returning the proposal to a clean, restartable state. Runs before the actor's message/tick loop starts, so `active_refinements` is empty and it can't race a freshly-started refinement.

## Test
- `cargo clippy -p djinn-coordinator -p djinn-db -- -D warnings` clean.
- Coordinator refinement tests (28) pass.
- New DB test `dangling_refinement_ids_track_unmatched_start` (start→dangling, awaiting_review→still dangling, stop→clean) passes against Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)