### PR TITLE
fix(refinement-ui): add a Restart button to the stopped refinement panel

### DIFF
--- a/ui/src/components/proposals/ProposalRefinement.test.tsx
+++ b/ui/src/components/proposals/ProposalRefinement.test.tsx
@@ -93,6 +93,30 @@ describe("ProposalRefinement", () => {
     expect(screen.getByText(/Adversary exhausted/)).toBeInTheDocument();
   });
 
+  it("offers a restart button for an interrupted refinement", () => {
+    // A stopped refinement must offer a way forward — otherwise an
+    // interrupted run (e.g. one lost across a deploy) is a dead end in the UI.
+    const status: ProposalRefinementStatus = {
+      active: false,
+      current_round: 1,
+      dry_rounds: 0,
+      total_entries: 0,
+      update_authority: "checkpoint",
+      stop_reason: "interrupted",
+    };
+    render(
+      <ProposalRefinement
+        proposalId={proposalId}
+        status={status}
+        canStart={false}
+        onChanged={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /Restart refinement/ }),
+    ).toBeInTheDocument();
+  });
+
   it("explains same-model fallback in the status panel", () => {
     const status: ProposalRefinementStatus = {
       active: true,

--- a/ui/src/components/proposals/ProposalRefinement.tsx
+++ b/ui/src/components/proposals/ProposalRefinement.tsx
@@ -182,6 +182,21 @@ export function ProposalRefinement({
           </p>
         )}
 
+        {/* Stopped — let the user run a fresh tribunal from here. Without this
+            a stopped/interrupted refinement is a dead end (e.g. a run lost
+            across a deploy leaves nothing actionable in the UI). */}
+        {!status.active && (
+          <div className="space-y-1 border-t pt-2">
+            <Button size="sm" disabled={busy} onClick={handleStart}>
+              {busy ? "Starting…" : "Restart refinement"}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Runs a fresh Adversary → Advocate → Judge tribunal from the current
+              spec.
+            </p>
+          </div>
+        )}
+
         {/* Converged — single human review of the full refined result. */}
         {status.active && status.awaiting_review && (
           <div className="space-y-3 rounded-md border border-primary/40 bg-primary/5 p-3">


### PR DESCRIPTION
## Problem

A stopped/interrupted refinement is a dead end in the UI. The panel renders `Stopped: <reason>` with no action — so a run lost across a deploy (`StopReason::Interrupted`, added in #1210) leaves the user unable to do anything. Reported as feedback.

## Fix

Show a **Restart refinement** button whenever the refinement is not active. It kicks off a fresh Adversary → Advocate → Judge tribunal from the current spec via the existing start handler.

## Test
- `pnpm tsc --noEmit` clean.
- New test `offers a restart button for an interrupted refinement`; ProposalRefinement suite 23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)