### PR TITLE
fix(refinement): wire proposal_update/block_patch into the in-pod agent dispatch

### DIFF
--- a/server/crates/djinn-agent/src/extension/tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests.rs
@@ -21,6 +21,7 @@ mod lsp_tool_boundary_tests;
 mod memory_dispatch_tests;
 mod schema_snapshot_tests;
 mod skill_read_tests;
+mod proposal_dispatch_tests;
 mod task_kill_session_tests;
 mod tool_dispatch_tests;
 

--- a/server/crates/djinn-agent/src/extension/tests/proposal_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/proposal_dispatch_tests.rs
@@ -1,0 +1,120 @@
+//! In-pod agent dispatch tests for proposal authoring tools.
+//!
+//! The Advocate runs in a worker pod and dispatches through
+//! `djinn_mcp_extension`. `proposal_update` / `proposal_block_patch` were once
+//! only wired in the server-side control-plane dispatch, so the Advocate's body
+//! revisions failed with "unknown djinn frontend tool" and the tribunal could
+//! never converge. These tests drive the full agent `call_tool` path and assert
+//! the body is actually revised.
+
+use super::*;
+
+#[tokio::test]
+async fn call_tool_dispatches_proposal_update_revises_body() {
+    let db = create_test_db();
+    let project = create_test_project(&db).await;
+    let project_path = crate::extension::tests::project_fs_path(&project)
+        .to_string_lossy()
+        .into_owned();
+    let proposal_repo = djinn_db::ProposalRepository::new(db.clone(), EventBus::noop());
+    let proposal = proposal_repo
+        .create(djinn_db::ProposalCreateInput {
+            title: "advocate revises me",
+            body: "## Thesis\n\nThin body without DoR sections.",
+            acceptance_criteria: Some("[]"),
+            status: Some("building"),
+            body_format: None,
+        })
+        .await
+        .expect("create proposal");
+    let state = agent_context_from_db(db.clone(), CancellationToken::new());
+
+    let new_body =
+        "## Problem\n\nThe gap.\n\n## Scope\n\nIn and out.\n\n## Objectives\n\nMeasurable outcomes.";
+    let response = call_tool(
+        &state,
+        &crate::test_helpers::test_services(),
+        "proposal_update",
+        Some(
+            serde_json::json!({ "id": proposal.short_id, "body": new_body })
+                .as_object()
+                .expect("proposal_update args object")
+                .clone(),
+        ),
+        Path::new(&project_path),
+        None,
+        Some("advocate"),
+        None,
+    )
+    .await
+    .expect("proposal_update dispatch should succeed (was 'unknown djinn frontend tool')");
+
+    assert_eq!(response.get("ok").and_then(|v| v.as_bool()), Some(true));
+    let reloaded = proposal_repo
+        .resolve(&proposal.id)
+        .await
+        .expect("resolve")
+        .expect("proposal exists");
+    assert_eq!(reloaded.body, new_body, "advocate body revision must persist");
+    assert!(
+        reloaded.latest_revision_seq > proposal.latest_revision_seq,
+        "a material body revision must bump latest_revision_seq"
+    );
+}
+
+/// Companion for the optional progressive-enrichment path: the Advocate's
+/// `proposal_block_patch` must also Handle in-pod instead of erroring.
+#[tokio::test]
+async fn call_tool_dispatches_proposal_block_patch_in_pod() {
+    let db = create_test_db();
+    let project = create_test_project(&db).await;
+    let project_path = crate::extension::tests::project_fs_path(&project)
+        .to_string_lossy()
+        .into_owned();
+    let proposal_repo = djinn_db::ProposalRepository::new(db.clone(), EventBus::noop());
+    let proposal = proposal_repo
+        .create(djinn_db::ProposalCreateInput {
+            title: "enrich me",
+            body: "## Design\n\nReplace this paragraph with a block.",
+            acceptance_criteria: Some("[]"),
+            status: Some("building"),
+            body_format: None,
+        })
+        .await
+        .expect("create proposal");
+    let state = agent_context_from_db(db.clone(), CancellationToken::new());
+
+    let response = call_tool(
+        &state,
+        &crate::test_helpers::test_services(),
+        "proposal_block_patch",
+        Some(
+            serde_json::json!({
+                "id": proposal.short_id,
+                "selector": { "exact_text": "Replace this paragraph with a block." },
+                "operation": "replace",
+                "block_mdx": "Grounded replacement text.",
+            })
+            .as_object()
+            .expect("proposal_block_patch args object")
+            .clone(),
+        ),
+        Path::new(&project_path),
+        None,
+        Some("advocate"),
+        None,
+    )
+    .await
+    .expect("proposal_block_patch dispatch should succeed (was 'unknown djinn frontend tool')");
+
+    assert_eq!(response.get("ok").and_then(|v| v.as_bool()), Some(true));
+    let reloaded = proposal_repo
+        .resolve(&proposal.id)
+        .await
+        .expect("resolve")
+        .expect("proposal exists");
+    assert!(
+        reloaded.body.contains("Grounded replacement text."),
+        "block patch must land in the body"
+    );
+}

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
@@ -510,6 +510,99 @@ pub struct ProposalBlockPatchParams {
     pub note: Option<String>,
 }
 
+/// Pure outcome of applying a block patch to a proposal body — the new body,
+/// its (possibly upgraded) `body_format`, and the revision `event_metadata`.
+pub struct BlockPatchOutcome {
+    pub new_body: String,
+    pub new_body_format: &'static str,
+    pub event_metadata: serde_json::Value,
+}
+
+/// Apply a single targeted MDX block patch to `existing_body`, returning the
+/// new body, its body_format, and the revision metadata.
+///
+/// This is the pure transformation shared by the server-side
+/// `proposal_block_patch` tool and the in-pod agent dispatch
+/// (`djinn-mcp-extension`), so both paths validate selectors and resulting MDX
+/// identically and produce byte-identical revisions. It does NOT resolve the
+/// proposal, enforce the author edit-gate, guard stale revisions, or persist —
+/// callers own those steps.
+pub fn apply_block_patch(
+    existing_body: &str,
+    existing_body_format: &str,
+    p: &ProposalBlockPatchParams,
+) -> Result<BlockPatchOutcome, String> {
+    if !matches!(p.operation.as_str(), "replace" | "wrap") {
+        return Err(format!(
+            "invalid operation: {:?} (expected replace or wrap)",
+            p.operation
+        ));
+    }
+    if p.block_mdx.is_empty() {
+        return Err("block_mdx must not be empty".to_string());
+    }
+
+    let range =
+        resolve_selector(existing_body, &p.selector).map_err(|e| format!("selector error: {e}"))?;
+
+    let new_body = match p.operation.as_str() {
+        "replace" => {
+            let mut body = String::with_capacity(
+                existing_body.len() - (range.end - range.start) + p.block_mdx.len(),
+            );
+            body.push_str(&existing_body[..range.start]);
+            body.push_str(&p.block_mdx);
+            body.push_str(&existing_body[range.end..]);
+            body
+        }
+        "wrap" => {
+            let selected = &existing_body[range.start..range.end];
+            let mut body = String::with_capacity(
+                existing_body.len() - (range.end - range.start) + p.block_mdx.len() + selected.len(),
+            );
+            body.push_str(&existing_body[..range.start]);
+            body.push_str(&p.block_mdx);
+            body.push_str(selected);
+            body.push_str(&existing_body[range.end..]);
+            body
+        }
+        _ => unreachable!(),
+    };
+
+    // Determine body_format: if the proposal is markdown and the patch
+    // introduces MDX block tags, upgrade to mdx.
+    let has_mdx_blocks = !extract_custom_block_tags(&new_body).is_empty();
+    let new_body_format = if existing_body_format == "mdx" || has_mdx_blocks {
+        "mdx"
+    } else {
+        "markdown"
+    };
+
+    if new_body_format == "mdx" {
+        validate_mdx_blocks(&new_body).map_err(|e| format!("resulting MDX is invalid: {e}"))?;
+        parse_mdx_blocks(&new_body).map_err(|e| format!("resulting MDX parse error: {e}"))?;
+    }
+    validate_design(&new_body)?;
+
+    let mut event_metadata = serde_json::json!({
+        "change_kind": "targeted_block_patch",
+        "selector": range.selector_description,
+        "range_start_byte": range.start,
+        "range_end_byte": range.end,
+        "native_skill_name": p.native_skill_name.as_deref().unwrap_or(""),
+        "native_skill_version": p.native_skill_version.as_deref().unwrap_or(""),
+    });
+    if let Some(ref note) = p.note {
+        event_metadata["note"] = serde_json::Value::String(note.clone());
+    }
+
+    Ok(BlockPatchOutcome {
+        new_body,
+        new_body_format,
+        event_metadata,
+    })
+}
+
 #[derive(Deserialize, schemars::JsonSchema)]
 pub struct ProposalDeleteParams {
     /// Proposal UUID or short_id.
@@ -1540,26 +1633,13 @@ impl DjinnMcpServer {
         &self,
         Parameters(p): Parameters<ProposalBlockPatchParams>,
     ) -> Json<ProposalSingleResponse> {
-        // 1. Validate operation.
-        if !matches!(p.operation.as_str(), "replace" | "wrap") {
-            return Json(err_single(format!(
-                "invalid operation: {:?} (expected replace or wrap)",
-                p.operation
-            )));
-        }
-
-        // 2. Validate block_mdx is non-empty.
-        if p.block_mdx.is_empty() {
-            return Json(err_single("block_mdx must not be empty".to_string()));
-        }
-
-        // 3. Resolve proposal.
+        // 1. Resolve proposal.
         let repo = ProposalRepository::new(self.state.db().clone(), self.state.event_bus());
         let Some(existing) = repo.resolve(&p.id).await.ok().flatten() else {
             return Json(err_single(proposal_not_found_error(&p.id)));
         };
 
-        // 4. Edit gate.
+        // 2. Edit gate.
         if let Err(e) = self
             .gate_proposal_edit(existing.author_user_id.as_deref())
             .await
@@ -1567,7 +1647,7 @@ impl DjinnMcpServer {
             return Json(err_single(e));
         }
 
-        // 5. Stale revision guard.
+        // 3. Stale revision guard.
         if let Some(expected_seq) = p.expected_latest_revision_seq
             && existing.latest_revision_seq != expected_seq
         {
@@ -1577,88 +1657,26 @@ impl DjinnMcpServer {
             )));
         }
 
-        // 6. Resolve selector to a byte range in the body.
-        let range = match resolve_selector(&existing.body, &p.selector) {
-            Ok(r) => r,
-            Err(e) => return Json(err_single(format!("selector error: {e}"))),
+        // 4. Apply the patch (selector resolution, body build, MDX validation,
+        //    and metadata) via the shared pure transformation.
+        let outcome = match apply_block_patch(&existing.body, &existing.body_format, &p) {
+            Ok(o) => o,
+            Err(e) => return Json(err_single(e)),
         };
 
-        // 7. Build the new body.
-        let new_body = match p.operation.as_str() {
-            "replace" => {
-                let mut body = String::with_capacity(
-                    existing.body.len() - (range.end - range.start) + p.block_mdx.len(),
-                );
-                body.push_str(&existing.body[..range.start]);
-                body.push_str(&p.block_mdx);
-                body.push_str(&existing.body[range.end..]);
-                body
-            }
-            "wrap" => {
-                let selected = &existing.body[range.start..range.end];
-                let mut body = String::with_capacity(
-                    existing.body.len() - (range.end - range.start)
-                        + p.block_mdx.len()
-                        + selected.len(),
-                );
-                body.push_str(&existing.body[..range.start]);
-                // Insert the block_mdx before the selected content.
-                body.push_str(&p.block_mdx);
-                body.push_str(selected);
-                body.push_str(&existing.body[range.end..]);
-                body
-            }
-            _ => unreachable!(),
-        };
-
-        // 8. Validate the resulting MDX body.
-        // Determine body_format: if the proposal is markdown and the patch
-        // introduces MDX block tags, upgrade to mdx.
-        let has_mdx_blocks = !extract_custom_block_tags(&new_body).is_empty();
-        let new_body_format = if existing.body_format == "mdx" || has_mdx_blocks {
-            "mdx"
-        } else {
-            "markdown"
-        };
-
-        if new_body_format == "mdx" {
-            if let Err(e) = validate_mdx_blocks(&new_body) {
-                return Json(err_single(format!("resulting MDX is invalid: {e}")));
-            }
-            if let Err(e) = parse_mdx_blocks(&new_body) {
-                return Json(err_single(format!("resulting MDX parse error: {e}")));
-            }
-        }
-        if let Err(e) = validate_design(&new_body) {
-            return Json(err_single(e));
-        }
-
-        // 9. Build event_metadata for the targeted block-patch revision.
-        let mut metadata = serde_json::json!({
-            "change_kind": "targeted_block_patch",
-            "selector": range.selector_description,
-            "range_start_byte": range.start,
-            "range_end_byte": range.end,
-            "native_skill_name": p.native_skill_name.as_deref().unwrap_or(""),
-            "native_skill_version": p.native_skill_version.as_deref().unwrap_or(""),
-        });
-        if let Some(ref note) = p.note {
-            metadata["note"] = serde_json::Value::String(note.clone());
-        }
-
-        // 10. Persist through the revisioning path.
+        // 5. Persist through the revisioning path.
         let ac_json = existing.acceptance_criteria.clone();
         match repo
             .update(
                 &existing.id,
                 djinn_db::ProposalUpdateInput {
                     title: &existing.title,
-                    body: &new_body,
+                    body: &outcome.new_body,
                     acceptance_criteria: &ac_json,
                     status: &existing.status,
                     superseded_by: existing.superseded_by.as_deref(),
-                    body_format: Some(new_body_format),
-                    event_metadata: Some(&metadata),
+                    body_format: Some(outcome.new_body_format),
+                    event_metadata: Some(&outcome.event_metadata),
                 },
             )
             .await

--- a/server/crates/djinn-mcp-extension/src/dispatch.rs
+++ b/server/crates/djinn-mcp-extension/src/dispatch.rs
@@ -250,6 +250,8 @@ async fn dispatch_proposal_tools(
 ) -> Option<Result<serde_json::Value, String>> {
     match name {
         "proposal_show" => Some(task_epic::call_proposal_show(ctx, args).await),
+        "proposal_update" => Some(task_epic::call_proposal_update(ctx, args).await),
+        "proposal_block_patch" => Some(task_epic::call_proposal_block_patch(ctx, args).await),
         "proposal_debate_append" => Some(task_epic::call_proposal_debate_append(ctx, args).await),
         "proposal_debate_list" => Some(task_epic::call_proposal_debate_list(ctx, args).await),
         "proposal_debate_resolve" => Some(task_epic::call_proposal_debate_resolve(ctx, args).await),

--- a/server/crates/djinn-mcp-extension/src/handlers/task_epic.rs
+++ b/server/crates/djinn-mcp-extension/src/handlers/task_epic.rs
@@ -8,6 +8,12 @@ use std::collections::HashSet;
 use djinn_control_plane::tools::epic_ops::{
     EpicShowRequest, EpicTasksRequest, EpicUpdateDeltaRequest,
 };
+use djinn_control_plane::tools::proposal_tools::{
+    ProposalBlockPatchParams, ProposalUpdateParams, apply_block_patch,
+};
+use djinn_control_plane::tools::validation::{
+    validate_ac_count, validate_design, validate_mdx_body, validate_proposal_status, validate_title,
+};
 use djinn_control_plane::tools::task_tools::{
     CommentTaskRequest as SharedCommentTaskRequest, CreateTaskRequest as SharedCreateTaskRequest,
     UpdateTaskRequest as SharedUpdateTaskRequest, add_task_comment as shared_add_task_comment,
@@ -704,6 +710,140 @@ pub(crate) async fn call_proposal_ac_set(
         "short_id": updated.short_id,
         "met": met,
         "total": parsed.len(),
+    }))
+}
+
+/// Revise a proposal's body / title / acceptance-criteria (in-pod agent path).
+///
+/// Mirrors the server-side `proposal_update` tool but reuses the shared
+/// validators and reaches the DB through [`ProposalRepository`] like the other
+/// agent-side proposal handlers. This is the Advocate's PRIMARY refinement
+/// action: most adversary objections demand body content (Problem / Scope /
+/// Objectives / grounding), and `proposal_update(body=…)` is the only way to add
+/// it. The in-pod dispatch never wired this tool before, so the Advocate's
+/// `proposal_update` calls failed with "unknown djinn frontend tool" and the
+/// tribunal could never converge.
+///
+/// The `in_review` composed DoR gate is intentionally NOT applied here: the
+/// refinement loop owns graduation; the Advocate only revises the spec. The
+/// authoring-attribution `event_metadata` is left `None` — the coordinator's
+/// refinement dispatch tags the resulting revision(s) with
+/// `source = "refinement_loop"` after the session.
+pub(crate) async fn call_proposal_update(
+    ctx: &dyn ExtensionContext,
+    arguments: &Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<serde_json::Value, String> {
+    let p: ProposalUpdateParams = parse_args(arguments)?;
+    let proposal_repo = ProposalRepository::new(ctx.db(), ctx.event_bus());
+    let Some(existing) = proposal_repo.resolve(&p.id).await.ok().flatten() else {
+        return Err(format!("proposal not found: {}", p.id));
+    };
+
+    let title = match &p.title {
+        Some(t) => validate_title(t)?,
+        None => existing.title.clone(),
+    };
+    let body = p.body.as_deref().unwrap_or(&existing.body);
+    validate_design(body)?;
+    let body_format = p
+        .body_format
+        .as_deref()
+        .unwrap_or(existing.body_format.as_str());
+    validate_mdx_body(body, Some(body_format))?;
+
+    let ac_json = if let Some(ac) = &p.acceptance_criteria {
+        validate_ac_count(ac.len())?;
+        serde_json::to_string(ac).unwrap_or_else(|_| "[]".to_string())
+    } else {
+        existing.acceptance_criteria.clone()
+    };
+
+    let status = p.status.as_deref().unwrap_or(&existing.status);
+    validate_proposal_status(status)?;
+
+    let superseded_by = if let Some(s) = &p.superseded_by {
+        match proposal_repo.resolve(s).await.ok().flatten() {
+            Some(target) => Some(target.id),
+            None => return Err(format!("superseded_by proposal not found: {s}")),
+        }
+    } else {
+        existing.superseded_by.clone()
+    };
+
+    let updated = proposal_repo
+        .update(
+            &existing.id,
+            djinn_db::ProposalUpdateInput {
+                title: &title,
+                body,
+                acceptance_criteria: &ac_json,
+                status,
+                superseded_by: superseded_by.as_deref(),
+                body_format: p.body_format.as_deref(),
+                event_metadata: None,
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(serde_json::json!({
+        "ok": true,
+        "id": updated.id,
+        "short_id": updated.short_id,
+        "status": updated.status,
+        "latest_revision_seq": updated.latest_revision_seq,
+    }))
+}
+
+/// Apply a targeted MDX block patch to a proposal body (in-pod agent path).
+///
+/// Mirrors the server-side `proposal_block_patch` tool, reusing the shared
+/// [`apply_block_patch`] transformation so selector resolution and MDX
+/// validation are byte-identical across both paths. Wired into the agent
+/// dispatch alongside [`call_proposal_update`] so the Advocate's optional
+/// progressive-enrichment patches succeed instead of erroring as unknown tools.
+pub(crate) async fn call_proposal_block_patch(
+    ctx: &dyn ExtensionContext,
+    arguments: &Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<serde_json::Value, String> {
+    let p: ProposalBlockPatchParams = parse_args(arguments)?;
+    let proposal_repo = ProposalRepository::new(ctx.db(), ctx.event_bus());
+    let Some(existing) = proposal_repo.resolve(&p.id).await.ok().flatten() else {
+        return Err(format!("proposal not found: {}", p.id));
+    };
+
+    if let Some(expected_seq) = p.expected_latest_revision_seq
+        && existing.latest_revision_seq != expected_seq
+    {
+        return Err(format!(
+            "stale revision: expected latest_revision_seq={}, but proposal has {}",
+            expected_seq, existing.latest_revision_seq
+        ));
+    }
+
+    let outcome = apply_block_patch(&existing.body, &existing.body_format, &p)?;
+
+    let updated = proposal_repo
+        .update(
+            &existing.id,
+            djinn_db::ProposalUpdateInput {
+                title: &existing.title,
+                body: &outcome.new_body,
+                acceptance_criteria: &existing.acceptance_criteria,
+                status: &existing.status,
+                superseded_by: existing.superseded_by.as_deref(),
+                body_format: Some(outcome.new_body_format),
+                event_metadata: Some(&outcome.event_metadata),
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(serde_json::json!({
+        "ok": true,
+        "id": updated.id,
+        "short_id": updated.short_id,
+        "latest_revision_seq": updated.latest_revision_seq,
     }))
 }
 


### PR DESCRIPTION
## The actual root cause of the tribunal never converging

The live m2z3 run never converged, and the advocate appeared to "do nothing". The debate trail's advocate rebuttals reveal why:

> both `proposal_update` and `proposal_block_patch` returned `unknown djinn frontend tool` despite retries with UUID and short id.

The Advocate runs **in a worker pod** and dispatches through `djinn-mcp-extension` (`dispatch_proposal_tools` → agent-local handlers → `"unknown djinn frontend tool"`). But `proposal_update` / `proposal_block_patch` were only wired in the **server-side control-plane** dispatch — never in the agent dispatch. So:

- `proposal_ac_set` (wired) **worked** → judge saw "structured acceptance_criteria have now been populated".
- `proposal_update` (NOT wired) **failed** every round → body never revised → judge rejected every round on "body still lacks Problem/Scope/grounding/…" → round-cap, never converge.

The earlier redesign (#1218: judge-decided resolution, single revision, no checkpoint) is necessary but **not sufficient** without this — the Advocate must be able to revise the body.

## Fix

- Extract the block-patch transformation into a pure `pub apply_block_patch(...) -> BlockPatchOutcome` in control-plane; refactor the server tool to use it → **single source** of selector/MDX logic across both dispatch paths.
- Add `call_proposal_update` / `call_proposal_block_patch` to `djinn-mcp-extension` (mirroring the other agent-side proposal handlers via `ProposalRepository`, reusing the shared validators) and wire both into `dispatch_proposal_tools`.
- The `in_review` composed DoR gate is intentionally not applied on the agent path (the refinement loop owns graduation); authoring `event_metadata` stays `None` so the coordinator tags revisions `source=refinement_loop`.

## Tests
- New regression tests drive the full agent `call_tool` dispatch for both tools and assert the body is actually revised — would have caught the missing arm.
- Server-side `block_patch`/`proposal_update` tests unchanged and green; clippy `-D warnings` clean; full workspace `--all-targets` compiles against a live test DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)