### PR TITLE
fix(refinement): unblock advocate visual-spec — shared skill-read gate + wire catalog tools in-pod

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/task_classifier.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/task_classifier.rs
@@ -51,15 +51,18 @@ pub(crate) enum NativeSkillTrigger {
 /// The classifier is purely synchronous, needs no DB or filesystem access,
 /// and is safe to call from unit tests with minimal `Task` stubs.
 ///
-/// Production callers that only have `issue_type` as a string (e.g.
-/// `mcp_resolve::classify_authoring_trigger` and the `skill_read` handler)
-/// inline the matching logic directly.  This function is the canonical
-/// `Task`-based API and is exercised by the unit tests below.
-pub(crate) fn classify_native_skill_trigger(
+/// Canonical (role, issue_type) → trigger mapping. **This is the single source
+/// of truth.** Every caller — session construction (`stage.rs` /
+/// `mcp_resolve.rs`) AND the `skill_read` handler — must route through here (or
+/// the `Task` wrapper below). They previously each inlined this match, which
+/// drifted: the `skill_read` copy stayed planner-only and rejected the Advocate
+/// ("not an assigned skill") even after session construction had assigned the
+/// skill, so the Advocate could never load `visual-spec`.
+pub(crate) fn classify_native_skill_trigger_by_type(
     role_name: &str,
-    task: &Task,
+    issue_type: &str,
 ) -> Option<NativeSkillTrigger> {
-    match (role_name, task.issue_type.as_str()) {
+    match (role_name, issue_type) {
         // `epic_breakdown` is the proposal-decomposition / AC-reconciliation
         // planner mode (Workflow D / Workflow E).  These are always
         // proposal-authoring sessions.
@@ -75,6 +78,15 @@ pub(crate) fn classify_native_skill_trigger(
         // All other (role, issue_type) pairs are non-authoring.
         _ => None,
     }
+}
+
+/// `Task`-based wrapper over [`classify_native_skill_trigger_by_type`] used by
+/// session construction, which has the full `Task`.
+pub(crate) fn classify_native_skill_trigger(
+    role_name: &str,
+    task: &Task,
+) -> Option<NativeSkillTrigger> {
+    classify_native_skill_trigger_by_type(role_name, task.issue_type.as_str())
 }
 
 #[cfg(test)]

--- a/server/crates/djinn-agent/src/extension/handlers.rs
+++ b/server/crates/djinn-agent/src/extension/handlers.rs
@@ -275,11 +275,13 @@ async fn call_skill_read(
             String::new()
         };
 
-        let trigger = if role == "planner" && task_issue_type == "epic_breakdown" {
-            Some(crate::actors::slot::lifecycle::task_classifier::NativeSkillTrigger::ProposalAuthoring)
-        } else {
-            None
-        };
+        // Route through the SAME classifier session construction uses, so this
+        // gate never drifts from the set of roles that actually get the skill
+        // assigned. (It used to hardcode planner-only and rejected the Advocate.)
+        let trigger = crate::actors::slot::lifecycle::task_classifier::classify_native_skill_trigger_by_type(
+            role,
+            &task_issue_type,
+        );
 
         if trigger.is_none() {
             return Err(format!(

--- a/server/crates/djinn-agent/src/extension/tests/proposal_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/proposal_dispatch_tests.rs
@@ -118,3 +118,36 @@ async fn call_tool_dispatches_proposal_block_patch_in_pod() {
         "block patch must land in the body"
     );
 }
+
+/// The Advocate discovers the MDX block vocabulary via `get_block_catalog`,
+/// which must Handle in-pod (it failed with "unknown djinn frontend tool").
+#[tokio::test]
+async fn call_tool_dispatches_get_block_catalog_in_pod() {
+    let db = create_test_db();
+    let project = create_test_project(&db).await;
+    let project_path = crate::extension::tests::project_fs_path(&project)
+        .to_string_lossy()
+        .into_owned();
+    let state = agent_context_from_db(db.clone(), CancellationToken::new());
+
+    let response = call_tool(
+        &state,
+        &crate::test_helpers::test_services(),
+        "get_block_catalog",
+        Some(serde_json::Map::new()),
+        Path::new(&project_path),
+        None,
+        Some("advocate"),
+        None,
+    )
+    .await
+    .expect("get_block_catalog dispatch should succeed (was 'unknown djinn frontend tool')");
+
+    assert!(
+        response
+            .get("blocks")
+            .and_then(|v| v.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "catalog must return a non-empty block vocabulary"
+    );
+}

--- a/server/crates/djinn-agent/src/extension/tests/skill_read_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/skill_read_tests.rs
@@ -374,6 +374,62 @@ async fn skill_read_rejects_visual_spec_in_non_authoring_planner_session() {
     );
 }
 
+/// `skill_read(name="visual-spec")` succeeds for the tribunal **Advocate** on a
+/// `refinement` task. Regression: the skill_read gate hardcoded planner-only and
+/// rejected the advocate ("not an assigned skill") even though session
+/// construction assigns the skill — so the advocate could never author rich MDX.
+#[tokio::test]
+async fn skill_read_serves_native_visual_spec_for_advocate_refinement_session() {
+    let db = create_test_db();
+    let state = agent_context_from_db(db.clone(), CancellationToken::new());
+    let services = crate::test_helpers::test_services();
+    let project = create_test_project(&db).await;
+    let epic = create_test_epic(&db, &project.id).await;
+
+    let task_repo = djinn_db::TaskRepository::new(db.clone(), djinn_core::events::EventBus::noop());
+    let task = task_repo
+        .create_in_project(
+            &project.id,
+            Some(&epic.id),
+            "Refinement advocate — revise proposal spec",
+            "advocate refinement task",
+            "",
+            "refinement",
+            1,
+            "test-owner",
+            None,
+            None,
+        )
+        .await
+        .expect("create refinement task");
+
+    let tmp = crate::test_helpers::test_tempdir("djinn-native-skill-advocate-");
+
+    let ok = call_tool(
+        &state,
+        &services,
+        "skill_read",
+        Some(
+            serde_json::json!({ "name": "visual-spec" })
+                .as_object()
+                .unwrap()
+                .clone(),
+        ),
+        tmp.path(),
+        Some(&task.short_id),
+        Some("advocate"),
+        None,
+    )
+    .await
+    .expect("skill_read should succeed for visual-spec in an advocate refinement session");
+
+    assert_eq!(ok.get("name").and_then(|v| v.as_str()), Some("visual-spec"));
+    assert!(
+        ok.get("content").and_then(|v| v.as_str()).unwrap().len() > 10,
+        "native body should be non-trivial"
+    );
+}
+
 /// `skill_read` rejects `visual-spec` for a non-planner role even when the
 /// task is `epic_breakdown`, because native skills are role-gated.
 #[tokio::test]

--- a/server/crates/djinn-mcp-extension/src/dispatch.rs
+++ b/server/crates/djinn-mcp-extension/src/dispatch.rs
@@ -252,6 +252,8 @@ async fn dispatch_proposal_tools(
         "proposal_show" => Some(task_epic::call_proposal_show(ctx, args).await),
         "proposal_update" => Some(task_epic::call_proposal_update(ctx, args).await),
         "proposal_block_patch" => Some(task_epic::call_proposal_block_patch(ctx, args).await),
+        "get_block_catalog" => Some(task_epic::call_get_block_catalog(ctx, args).await),
+        "proposal_blocks" => Some(task_epic::call_proposal_blocks(ctx, args).await),
         "proposal_debate_append" => Some(task_epic::call_proposal_debate_append(ctx, args).await),
         "proposal_debate_list" => Some(task_epic::call_proposal_debate_list(ctx, args).await),
         "proposal_debate_resolve" => Some(task_epic::call_proposal_debate_resolve(ctx, args).await),

--- a/server/crates/djinn-mcp-extension/src/handlers/task_epic.rs
+++ b/server/crates/djinn-mcp-extension/src/handlers/task_epic.rs
@@ -847,6 +847,28 @@ pub(crate) async fn call_proposal_block_patch(
     }))
 }
 
+/// Return the lean proposal MDX block vocabulary (type, tag pairs) for the
+/// in-pod agent. Static data — no DB. Wired into the agent dispatch so the
+/// Advocate can discover the block catalog when authoring visual MDX; without
+/// it `get_block_catalog` failed with "unknown djinn frontend tool".
+pub(crate) async fn call_get_block_catalog(
+    _ctx: &dyn ExtensionContext,
+    _arguments: &Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<serde_json::Value, String> {
+    let blocks = djinn_control_plane::tools::proposal_blocks::proposal_block_catalog();
+    Ok(serde_json::json!({ "blocks": blocks }))
+}
+
+/// Return the full v1 proposal MDX block registry (types, tags, field schemas)
+/// for the in-pod agent. Static data — no DB.
+pub(crate) async fn call_proposal_blocks(
+    _ctx: &dyn ExtensionContext,
+    _arguments: &Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<serde_json::Value, String> {
+    let blocks = djinn_control_plane::tools::proposal_blocks::proposal_block_registry();
+    Ok(serde_json::json!({ "blocks": blocks }))
+}
+
 pub(crate) async fn call_proposal_ac_amend(
     ctx: &dyn ExtensionContext,
     arguments: &Option<serde_json::Map<String, serde_json::Value>>,


### PR DESCRIPTION
## Why

Even after #1220 wired the advocate's role into visual-spec, the live advocate session **still** couldn't author rich MDX. Two more gaps:

1. `skill_read("visual-spec")` → **"not an assigned skill for this session"**. The skill_read handler **hardcoded** the authoring trigger as `planner + epic_breakdown` — a third copy of the classifier logic — so it rejected the advocate even though session construction now assigns the skill.
2. `get_block_catalog` / `proposal_blocks` → **"unknown djinn frontend tool"**. Same dispatch gap as `proposal_update`: in the advocate's schema but never wired into the in-pod agent dispatch.

## Fix

- Extract `classify_native_skill_trigger_by_type(role, issue_type)` as the **single source of truth**; route both session construction and the `skill_read` gate through it so they can't drift again (this drift was the whole bug).
- Add thin in-pod handlers for `get_block_catalog` / `proposal_blocks` (static catalog/registry, reusing control-plane's `proposal_block_catalog()` / `proposal_block_registry()`) and wire the dispatch arms.

Now the role list, the trigger classifier, and the skill_read gate all agree — the advocate can load visual-spec **and** discover + apply MDX blocks.

## Tests
`skill_read` serves visual-spec for an advocate refinement session; `get_block_catalog` dispatches in-pod; worker still rejected. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)