### PR TITLE
fix(skills): resolve session task by UUID in skill_read so native skills load in production

### DIFF
--- a/server/crates/djinn-agent/src/extension/handlers.rs
+++ b/server/crates/djinn-agent/src/extension/handlers.rs
@@ -267,7 +267,13 @@ async fn call_skill_read(
         let task_issue_type = if let Some(task_id) = session_task_id {
             let task_repo =
                 djinn_db::TaskRepository::new(state.db.clone(), state.event_bus.clone());
-            match task_repo.get_by_short_id(task_id).await {
+            // `session_task_id` is the task UUID in production (the reply loop
+            // passes `ctx.task_id == task.id`), but callers/tests may pass a
+            // short_id. `resolve` accepts both — using `get_by_short_id` here
+            // silently returned None for the UUID, leaving issue_type empty so
+            // the authoring trigger never fired and `visual-spec` was never
+            // assignable to ANY role in production.
+            match task_repo.resolve(task_id).await {
                 Ok(Some(task)) => task.issue_type,
                 _ => String::new(),
             }

--- a/server/crates/djinn-agent/src/extension/tests/skill_read_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/skill_read_tests.rs
@@ -293,7 +293,7 @@ async fn skill_read_serves_native_visual_spec_for_authoring_planner_session() {
                 .clone(),
         ),
         tmp.path(),
-        Some(&task.short_id),
+        Some(&task.id), // production passes the task UUID, not short_id
         Some("planner"),
         None,
     )
@@ -361,7 +361,7 @@ async fn skill_read_rejects_visual_spec_in_non_authoring_planner_session() {
                 .clone(),
         ),
         tmp.path(),
-        Some(&task.short_id),
+        Some(&task.id), // production passes the task UUID, not short_id
         Some("planner"),
         None,
     )
@@ -416,7 +416,7 @@ async fn skill_read_serves_native_visual_spec_for_advocate_refinement_session() 
                 .clone(),
         ),
         tmp.path(),
-        Some(&task.short_id),
+        Some(&task.id), // production passes the task UUID, not short_id
         Some("advocate"),
         None,
     )
@@ -470,7 +470,7 @@ async fn skill_read_rejects_visual_spec_for_non_planner_role() {
                 .clone(),
         ),
         tmp.path(),
-        Some(&task.short_id),
+        Some(&task.id), // production passes the task UUID, not short_id
         Some("worker"),
         None,
     )
@@ -531,7 +531,7 @@ async fn skill_read_native_body_not_from_worktree() {
                 .clone(),
         ),
         tmp.path(),
-        Some(&task.short_id),
+        Some(&task.id), // production passes the task UUID, not short_id
         Some("planner"),
         None,
     )


### PR DESCRIPTION
## Why

The live tribunal advocate **still** got `skill_read("visual-spec")` → "not an assigned skill", even after the role list, classifier, and skill_read gate were all fixed.

Root cause: `call_skill_read` looked up the session task with `get_by_short_id(session_task_id)`, but the reply loop passes the task **UUID** (`ctx.task_id == task.id`), not a short_id. The lookup returned `None` → `task_issue_type` empty → the authoring trigger never fired → "not an assigned skill" **for every role in production, including the planner**. The unit tests passed only because they fed a `short_id`, masking the bug.

## Fix
- Use `TaskRepository::resolve` (accepts both UUID and short_id).
- Updated the skill_read tests to pass the task **UUID** (the production form) so they'd catch this regression.

This was the last gate blocking the advocate from loading `visual-spec` and authoring rich MDX. (The catalog tools `get_block_catalog`/`proposal_blocks` already dispatch in-pod as of the prior fix — confirmed in the live run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)