### PR TITLE
fix(proposals): render Diagram source attribute + guards against empty/broken diagrams + table overflow

### DIFF
--- a/server/crates/djinn-agent/src/native_assets/visual-spec/SKILL.md
+++ b/server/crates/djinn-agent/src/native_assets/visual-spec/SKILL.md
@@ -35,6 +35,21 @@ Every block in a proposal must be:
 Avoid hollow blocks that exist only for layout.  If a section cannot state
 a concrete claim or criterion, merge it into its parent.
 
+## Diagrams
+
+A `<Diagram>` block MUST carry a non-empty, valid source — an empty or broken
+diagram renders as an "Empty mermaid diagram" / "Syntax error" box and is
+rejected at authoring time.
+
+- Put the diagram text in the `source` attribute as a template literal, e.g.
+  a flowchart with a `flowchart`/`graph` header and ASCII `-->` edges.
+- Keep it small — a handful of nodes beats a dense, unreadable graph.
+- Quote node labels that contain special characters (`(`, `)`, `:`, `-`):
+  write `A["clippy -D warnings"]`, not `A[clippy -D warnings]` — unquoted
+  specials break the Mermaid parser.
+- NEVER emit an empty `<Diagram>`. If you cannot express a concrete diagram,
+  use prose or a list instead.
+
 ## Bare `<` / `>` backtick constraint
 
 When you write literal angle brackets in markdown — for example `<div>`,

--- a/server/crates/djinn-agent/src/native_skills.rs
+++ b/server/crates/djinn-agent/src/native_skills.rs
@@ -18,7 +18,7 @@ use crate::skills::ResolvedSkill;
 /// way that downstream consumers (prompts, telemetry, lazy-loading caches)
 /// should detect.  The value is exposed through [`native_skill_version`] and
 /// embedded in the skill's metadata.
-pub const VISUAL_SPEC_VERSION: &str = "1.0.0";
+pub const VISUAL_SPEC_VERSION: &str = "1.1.0";
 
 // ─── Embedded asset ─────────────────────────────────────────────────────────
 

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/parser.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/parser.rs
@@ -295,6 +295,21 @@ pub fn validate_mdx_blocks(body: &str) -> Result<(), BlockError> {
             return Err(BlockError::UnknownBlock(tag));
         }
     }
+    // Don't-accept guard: a Diagram block must carry a source. An empty diagram
+    // renders as a broken box for human reviewers, so reject it at authoring
+    // time (block-patch / proposal_update) rather than letting it land.
+    for block in parse_mdx_blocks(body)? {
+        if block.block_type == "diagram" {
+            let source_empty = block
+                .attributes
+                .get("source")
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true);
+            if source_empty && block.raw_content.trim().is_empty() {
+                return Err(BlockError::EmptyDiagram(block.id));
+            }
+        }
+    }
     Ok(())
 }
 

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
@@ -278,6 +278,23 @@ graph TD;
 }
 
 #[test]
+fn validate_mdx_blocks_rejects_empty_diagram() {
+    // No source attribute and no children → broken "Empty mermaid diagram" box.
+    let body = r#"<Diagram id="flow" type="mermaid" source="" />"#;
+    let err = validate_mdx_blocks(body).unwrap_err();
+    assert_eq!(err, BlockError::EmptyDiagram("flow".to_string()));
+    assert!(err.to_string().contains("has no source"));
+}
+
+#[test]
+fn validate_mdx_blocks_accepts_diagram_with_source_attribute() {
+    // Source carried in the `source` attribute (the form agents author with).
+    let body = r#"<Diagram id="flow" type="mermaid" source={`flowchart LR
+  A[Start] --> B[End]`} />"#;
+    assert!(validate_mdx_blocks(body).is_ok());
+}
+
+#[test]
 fn validate_mdx_blocks_rejects_unknown_tag() {
     let body = r#"
 <RichText id="intro" />

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/types.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/types.rs
@@ -23,6 +23,9 @@ pub enum BlockError {
     UnclosedBlock(String),
     /// A low-level regex or parsing failure.
     ParseError(String),
+    /// A `Diagram` block carries no source (empty `source` attribute and empty
+    /// children) — it would render as a broken "Empty mermaid diagram" box.
+    EmptyDiagram(String),
 }
 
 impl std::fmt::Display for BlockError {
@@ -37,6 +40,11 @@ impl std::fmt::Display for BlockError {
                 write!(f, "unclosed <{tag}> block (no closing </{tag}> found)")
             }
             BlockError::ParseError(msg) => write!(f, "block parser error: {msg}"),
+            BlockError::EmptyDiagram(id) => write!(
+                f,
+                "Diagram block `{id}` has no source — provide a non-empty `source` \
+                 (e.g. `source={{`flowchart LR; A-->B`}}`) or block content"
+            ),
         }
     }
 }

--- a/ui/src/components/proposals/blocks/Diagram.tsx
+++ b/ui/src/components/proposals/blocks/Diagram.tsx
@@ -22,9 +22,47 @@ const MermaidDiagram = lazy(() =>
  *   - anything else (e.g. `plantuml`, for which we have no client renderer):
  *     routed to the same graceful copy-source fallback instead of dumping raw.
  */
+/** Unwrap an MDX expression-attribute value that the parser stores verbatim:
+ *  `source={`…`}` / `source={"…"}` arrive here as a template-literal or quoted
+ *  string (delimiters included). Strip a single matching pair so mermaid sees
+ *  the raw source, not a leading backtick. */
+function unwrapExprValue(s: string): string {
+  const t = s.trim();
+  if (t.length >= 2) {
+    const open = t[0];
+    const close = t[t.length - 1];
+    if (
+      (open === "`" && close === "`") ||
+      (open === '"' && close === '"') ||
+      (open === "'" && close === "'")
+    ) {
+      return t.slice(1, -1);
+    }
+  }
+  return s;
+}
+
+/** A diagram's source comes from the `source` schema field (preferred) or the
+ *  block children. The `source` attribute is the form agents author with
+ *  (`<Diagram type="mermaid" source={`…`} />`); reading children only — as this
+ *  did before — dropped that source entirely and rendered an empty diagram. */
+function diagramSource(
+  source: string | undefined,
+  children: BlockProps["children"],
+): string {
+  if (typeof source === "string" && source.trim().length > 0) {
+    return unwrapExprValue(source).trim();
+  }
+  return typeof children === "string" ? children.trim() : "";
+}
+
 export function Diagram({ attributes, children }: BlockProps) {
   const diagramType = attributes.type ?? "mermaid";
-  const content = typeof children === "string" ? children.trim() : "";
+  const content = diagramSource(attributes.source, children);
+
+  // Guard: never render an empty/whitespace-only diagram. An empty source
+  // renders as a broken "Empty mermaid diagram" box — drop the block instead.
+  if (!content) return null;
 
   // De-chromed: a diagram should just BE there — no grey card, no "DIAGRAM"
   // header bar. It reads as a figure inside the document, the same way an image

--- a/ui/src/components/proposals/blocks/ProposalBlocks.tsx
+++ b/ui/src/components/proposals/blocks/ProposalBlocks.tsx
@@ -1,11 +1,23 @@
 import { useMemo } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { getBlockByTag } from "@/lib/blockRegistry";
 
 import { BlockDepthContext, MAX_BLOCK_DEPTH, useBlockDepth } from "./blockDepth";
 import { parseMdxBody } from "./parseMdxBody";
+
+/** Wide GFM tables (e.g. a multi-column criteria catalog) overflow the proposal
+ *  column and break the layout. Wrap them so they scroll horizontally instead. */
+export const proposalMarkdownComponents: Components = {
+  table({ node: _node, ...props }) {
+    return (
+      <div className="overflow-x-auto">
+        <table {...props} />
+      </div>
+    );
+  },
+};
 
 /**
  * Render an MDX body as plain GitHub-flavoured markdown — the recursion-cap
@@ -15,7 +27,9 @@ import { parseMdxBody } from "./parseMdxBody";
 function MarkdownBody({ text }: { text: string }) {
   return (
     <div className="prose prose-sm max-w-none dark:prose-invert">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={proposalMarkdownComponents}>
+        {text}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/ui/src/components/proposals/blocks/index.ts
+++ b/ui/src/components/proposals/blocks/index.ts
@@ -73,3 +73,5 @@ export type {
   ProposalBlockFieldSchema,
   ProposalBlockRegistry,
 } from "./blockRegistry";
+
+export { proposalMarkdownComponents } from "./ProposalBlocks";

--- a/ui/src/pages/ProposalsPage.tsx
+++ b/ui/src/pages/ProposalsPage.tsx
@@ -9,7 +9,10 @@ import { callMcpTool } from "@/api/mcpClient";
 import { usersQueryOptions } from "@/api/queryOptions";
 import { userDisplayName, type OrgUser } from "@/api/users";
 import { AcceptanceChecklist } from "@/components/AcceptanceChecklist";
-import { BlockRenderer } from "@/components/proposals/blocks";
+import {
+  BlockRenderer,
+  proposalMarkdownComponents,
+} from "@/components/proposals/blocks";
 import { AcceptanceProgressBadge } from "@/components/AcceptanceProgressBadge";
 import { UserAvatar } from "@/components/UserAvatar";
 import { CopyButton } from "@/components/CopyButton";
@@ -586,7 +589,10 @@ function ProposalDetailView({
             <BlockRenderer body={proposal.body || ""} />
           ) : (
             <div className="prose prose-sm max-w-none dark:prose-invert">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={proposalMarkdownComponents}
+              >
                 {proposal.body || "_No spec body yet._"}
               </ReactMarkdown>
             </div>


### PR DESCRIPTION
## Why

The tribunal advocate produced a **valid** mermaid flowchart, but the UI showed "Empty mermaid diagram" / "Syntax error", and a wide criteria table overflowed the column.

## Fixes

1. **Diagram rendering (the real bug):** `Diagram.tsx` read the mermaid only from block *children*, but agents author it in the **`source` attribute** (`<Diagram type="mermaid" source={`flowchart LR …`} />`) — the schema's field. So `content` was always empty. Now reads `source` first (unwrapping the `{`…`}` / `{"…"}` expression-attribute form the parser stores verbatim), falling back to children. Renders nothing for a genuinely-empty diagram instead of the broken box.

2. **Don't-accept guard (backend):** `validate_mdx_blocks` rejects a `Diagram` with empty `source` AND empty children (new `BlockError::EmptyDiagram`) — a bad block fails at block-patch/proposal_update time instead of landing.

3. **Table overflow (UI):** wrap GFM tables in `overflow-x-auto` (shared `proposalMarkdownComponents`) for both MDX markdown segments and plain bodies.

Plus: visual-spec skill gains a **Diagrams** section (non-empty/valid mermaid, quote special-char labels, never emit an empty diagram); `VISUAL_SPEC_VERSION` → 1.1.0.

## Tests
Backend rejects empty diagram / accepts source-attribute diagram; UI block tests (315) + typecheck green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)