### PR TITLE
fix(visual-spec): make the skill a content→block authoring guide so the advocate uses MDX blocks

### DIFF
--- a/server/crates/djinn-agent/src/native_assets/visual-spec/SKILL.md
+++ b/server/crates/djinn-agent/src/native_assets/visual-spec/SKILL.md
@@ -5,21 +5,41 @@ machines.  The spec below governs how you write proposal markdown, how you
 enrich it toward MDX as the plan hardens, and how you treat the memory layer
 for learned refinements.
 
-## Progressive markdown-to-MDX enrichment
+## Use the right block for each kind of content
 
-Start every proposal in plain markdown.  As the plan stabilises and structural
-precision becomes load-bearing, promote blocks to MDX incrementally:
+Proposals are reviewed by humans. A wall of prose and plain code fences is hard
+to scan. A spec headed for graduation should be **richly visual**: reach for the
+MDX block that matches the content instead of leaving it as prose or a markdown
+fence. Pull the available vocabulary with `get_block_catalog` and map content to
+blocks:
 
-1. **Draft stage** — plain prose, bullet lists, and fenced code blocks.
-2. **Structural stage** — replace prose scaffolding with MDX components
-   (`<Callout>`, `<StepList>`, `<DependencyGraph>`) when the content is stable
-   enough that a malformed component would be worse than prose.
-3. **Spec stage** — every block that downstream tooling consumes (acceptance
-   criteria, task breakdowns, dependency edges) should be a first-class MDX
-   block with typed props.
+| Content | Use this block | Instead of |
+| --- | --- | --- |
+| A file / directory layout | `<FileTree>` | a ```text fence |
+| Code the proposal references | `<AnnotatedCode>` | a bare code fence |
+| Architecture, data flow, sequence, state | `<Diagram>` (mermaid) | prose describing the flow |
+| A request/response or API shape | `<ApiEndpoint>` | prose |
+| A decision with options + trade-offs | `<Decisions>` | a prose paragraph |
+| A key warning, note, or rationale | `<Callout>` | a bolded sentence |
+| Acceptance criteria / steps / tasks | `<Checklist>` | a `- [ ]` list |
+| A side-by-side comparison (before/after, A vs B) | `<Columns>` | stacked prose |
+| A before/after change | `<Diff>` | two code fences |
+| A UI mockup / screen layout | `<Wireframe>` | a prose description |
+| A large JSON example | `<JsonExplorer>` | a ```json fence |
+| Open questions for the team | `<QuestionForm>` | a bullet list |
 
-Never skip stages.  Premature MDX is worse than late MDX because it freezes
-structure before the content has settled.
+Rules of thumb:
+
+- A **file map is ALWAYS a `<FileTree>`**, never a text fence.
+- **Code the proposal references is ALWAYS `<AnnotatedCode>`**, never a bare fence.
+- Every proposal of any complexity should carry at least one `<Diagram>` of its
+  core flow or architecture.
+- **Never invent block tags.** Use only the registered vocabulary returned by
+  `get_block_catalog` — an unknown tag (e.g. a made-up `<ReadinessRemediation>`)
+  is rejected.
+
+Early throwaway notes can be plain markdown, but by the time a spec is being
+refined for graduation it should read like a polished design doc — not prose.
 
 ## Block authoring quality
 
@@ -37,16 +57,25 @@ a concrete claim or criterion, merge it into its parent.
 
 ## Diagrams
 
-A `<Diagram>` block MUST carry a non-empty, valid source — an empty or broken
+A `<Diagram>` MUST carry a non-empty, valid mermaid source — an empty or broken
 diagram renders as an "Empty mermaid diagram" / "Syntax error" box and is
 rejected at authoring time.
 
-- Put the diagram text in the `source` attribute as a template literal, e.g.
-  a flowchart with a `flowchart`/`graph` header and ASCII `-->` edges.
+Put the mermaid as the block's **children** (between the tags):
+
+```
+<Diagram id="flow" type="mermaid">
+flowchart LR
+  A["Start"] --> B["Validate input"] --> C["Done"]
+</Diagram>
+```
+
+- Use valid mermaid: a `flowchart` / `graph` header and ASCII `-->` edges.
+- **ALWAYS quote node labels** — `A["clippy -D warnings"]`, not
+  `A[clippy -D warnings]`. Unquoted `(`, `)`, `:`, `-`, or `/` break the parser.
+  This is the #1 cause of "Syntax error" diagrams. Use `<br/>` for line breaks
+  inside a quoted label.
 - Keep it small — a handful of nodes beats a dense, unreadable graph.
-- Quote node labels that contain special characters (`(`, `)`, `:`, `-`):
-  write `A["clippy -D warnings"]`, not `A[clippy -D warnings]` — unquoted
-  specials break the Mermaid parser.
 - NEVER emit an empty `<Diagram>`. If you cannot express a concrete diagram,
   use prose or a list instead.
 

--- a/server/crates/djinn-agent/src/native_skills.rs
+++ b/server/crates/djinn-agent/src/native_skills.rs
@@ -18,7 +18,7 @@ use crate::skills::ResolvedSkill;
 /// way that downstream consumers (prompts, telemetry, lazy-loading caches)
 /// should detect.  The value is exposed through [`native_skill_version`] and
 /// embedded in the skill's metadata.
-pub const VISUAL_SPEC_VERSION: &str = "1.1.0";
+pub const VISUAL_SPEC_VERSION: &str = "1.2.0";
 
 // ─── Embedded asset ─────────────────────────────────────────────────────────
 
@@ -85,9 +85,9 @@ impl NativeSkill {
 const NATIVE_SKILLS: &[NativeSkill] = &[NativeSkill {
     name: "visual-spec",
     version: VISUAL_SPEC_VERSION,
-    description: "Proposal and plan authoring conventions: progressive \
-                  markdown-to-MDX enrichment, block quality, bare-angle \
-                  backtick constraint, and memory as the learned layer.",
+    description: "Proposal and plan authoring conventions: choosing the right \
+                  MDX block for each kind of content, diagram/block quality, the \
+                  bare-angle backtick constraint, and memory as the learned layer.",
     trust_level: "platform",
     // `planner` authors proposals during decomposition; `advocate` authors and
     // revises the proposal spec during tribunal refinement. Both produce
@@ -278,17 +278,19 @@ mod tests {
     }
 
     #[test]
-    fn visual_spec_content_includes_progressive_enrichment() {
+    fn visual_spec_content_teaches_block_usage() {
+        // The skill must map content kinds to concrete MDX blocks so the
+        // advocate authors rich specs (FileTree/AnnotatedCode/Diagram) rather
+        // than walls of prose.
         let skill = native_skill("visual-spec").unwrap();
         let lower = skill.content.to_lowercase();
-        assert!(
-            lower.contains("progressive"),
-            "visual-spec content must teach progressive markdown-to-MDX enrichment",
-        );
-        assert!(
-            lower.contains("mdx"),
-            "visual-spec content must mention MDX enrichment",
-        );
+        assert!(lower.contains("mdx"), "visual-spec must mention MDX");
+        for block in ["filetree", "annotatedcode", "diagram", "callout"] {
+            assert!(
+                lower.contains(block),
+                "visual-spec content must guide use of the {block} block",
+            );
+        }
     }
 
     #[test]

--- a/server/crates/djinn-agent/src/prompts/tests/visual_spec.rs
+++ b/server/crates/djinn-agent/src/prompts/tests/visual_spec.rs
@@ -71,8 +71,8 @@ fn planner_prompt_includes_native_visual_spec_with_version_and_guidance() {
         "visual-spec content must mention the bare-angle backtick constraint"
     );
     assert!(
-        lower.contains("progressive"),
-        "visual-spec content must teach progressive markdown-to-MDX enrichment"
+        lower.contains("filetree") && lower.contains("annotatedcode"),
+        "visual-spec content must map content kinds to concrete MDX blocks"
     );
     assert!(
         lower.contains("mdx"),


### PR DESCRIPTION
## Why

The tribunal advocate loaded `visual-spec` (now that skill_read works) but **still produced walls of prose** — one broken `<Diagram>` and a hallucinated `<ReadinessRemediation>` in 39k chars — while a hand-authored proposal of the same kind used FileTree, AnnotatedCode, Callout ×5, Columns ×2, Wireframe, etc.

The skill was the problem. Its *"progressive markdown-to-MDX enrichment / start in prose / premature MDX is worse / never skip stages"* framing actively kept the advocate **in prose** — exactly backwards for a refinement advocate finalizing a spec for graduation.

## Fix — rewrite the skill into a content→block guide

- Replace the prose-first progression with a **content→block mapping**: file map → `FileTree`, code → `AnnotatedCode`, flow/architecture → `Diagram`, decision → `Decisions`, key note → `Callout`, comparison → `Columns`, mockup → `Wireframe`, … — with hard rules:
  - a file map is **ALWAYS** `FileTree` (never a text fence),
  - referenced code is **ALWAYS** `AnnotatedCode`,
  - every non-trivial proposal carries a `Diagram`,
  - **never invent block tags** — use only `get_block_catalog`'s vocabulary (kills the hallucinated `<ReadinessRemediation>`).
- **Diagrams:** author mermaid as block **children** (the form that renders) and **ALWAYS quote node labels** — the #1 cause of "Syntax error" diagrams.

`VISUAL_SPEC_VERSION` → 1.2.0; tests updated to assert the block-usage guidance. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)