### PR TITLE
fix(refinement): stop advocate writing attribution into the body; prune vague-AC false positives

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_readiness.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_readiness.rs
@@ -329,28 +329,25 @@ fn has_grounding(normalized: &str) -> bool {
 
 /// Returns (index, offending_text) for each vague AC found.
 fn find_vague_acs(acs: &[AcceptanceCriterionItem]) -> Vec<(usize, String)> {
+    // Words that almost always signal a vague, unverifiable criterion. This is
+    // a blunt substring match, so the list is deliberately conservative: words
+    // that legitimately appear in precise criteria — `clean` ("clean commit"),
+    // `correctly` ("correctly rejects X"), `fast` ("fast path"), `stable`
+    // ("stable API"), `proper` ("proper subset"), `good`, `effectively`
+    // ("effectively final"), `efficiently`, `smoothly`, `seamlessly` — were
+    // removed because they produced false positives that blocked good specs.
     let banned = [
         "works well",
         "improve",
         "better",
         "easy",
         "robust",
-        "fast",
         "user-friendly",
         "user friendly",
         "performant",
-        "stable",
-        "clean",
         "nice",
-        "good",
         "sufficient",
         "adequate",
-        "proper",
-        "correctly",
-        "smoothly",
-        "seamlessly",
-        "efficiently",
-        "effectively",
     ];
 
     let mut out = Vec::new();
@@ -561,6 +558,33 @@ src/main.rs
             }
             other => panic!("expected VagueAc, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn precise_criteria_with_technical_words_are_not_flagged_vague() {
+        // Regression: `clean`, `correctly`, `fast`, `stable`, `proper` appear in
+        // precise, verifiable criteria and must NOT be flagged — they used to
+        // false-positive (e.g. m2z3's "clean commit" / "clean CI sequence").
+        let acs = vec![
+            ac_text("A baseline report is generated at a named clean commit with the full git SHA"),
+            ac_text("The parser correctly rejects malformed input, proven by tests/parse_reject.rs"),
+            ac_text("The fast path returns cached results in under 5ms at p99"),
+            ac_text("The /v1/sessions endpoint exposes a stable v1 API contract"),
+            ac_structured("check produces a proper subset of the manifest entries"),
+        ];
+        assert!(
+            find_vague_acs(&acs).is_empty(),
+            "precise criteria containing technical uses of clean/correctly/fast/stable/proper must not be flagged vague",
+        );
+    }
+
+    #[test]
+    fn genuinely_vague_criteria_still_flagged() {
+        let acs = vec![
+            ac_text("The UI should be user-friendly and nice"),
+            ac_text("Make the system more robust and performant"),
+        ];
+        assert_eq!(find_vague_acs(&acs).len(), 2);
     }
 
     #[test]

--- a/server/crates/djinn-roles/src/prompts/advocate.md
+++ b/server/crates/djinn-roles/src/prompts/advocate.md
@@ -7,7 +7,7 @@ You are dispatched as part of the proposal refinement loop. Your responsibilitie
 1. **Draft and revise proposal specs** — produce clear, complete, and testable acceptance criteria that downstream epics and tasks can consume without ambiguity.
 2. **Address adversary objections** — when the Adversary produces blocking or non-blocking objections, you revise the proposal to resolve blocking objections and acknowledge non-blocking ones with rationale.
 3. **Author a visually rich spec** — proposals are reviewed by humans, so the spec must be easy to scan: use the `visual-spec` native skill and enrich the body with structured MDX (mockups, diagrams, file-structure/file-map blocks, real MDX code blocks) so reviewers see the design, not a wall of prose. A shallow, non-visual spec is a quality gap the Adversary will object to. This is **default behavior, not a deterministic DoR gate** — prose grounding remains sufficient for the deterministic readiness floor, but the tribunal expects MDX richness.
-4. **Maintain attribution** — every revision must be attributed by role, human author, and round number so proposal history remains revertable.
+4. **Keep the body pure spec** — the proposal body is the design a reader needs, not a changelog. Authorship (role, round, human author) is recorded automatically in the revision metadata, so you never write it into the body.
 
 You do NOT adjudicate disputes between objections. The Judge handles that after the Adversary is satisfied. You do NOT produce objections yourself — that is the Adversary's role.
 
@@ -22,6 +22,7 @@ You CAN:
 - Call `submit_work` to deliver your revised proposal spec.
 
 You MUST NOT:
+- Write attribution, changelog, or "this revision does X / responds to round N" meta-commentary into the proposal body. Reviewers want the spec, not a record of how it was edited — that authorship is tracked in revision metadata automatically. No `## Attribution`, `## Revision notes`, or `## Changelog` sections.
 - Produce objections or red-team challenges (the Adversary does this).
 - **Mark objections resolved or write to the debate trail — that is the Judge's job.** You revise the spec; the Judge reads your revision and decides which objections it satisfies. Just make the spec good.
 - Make MDX/block enrichment a hard gate — prose-grounded proposals must still pass DoR.


### PR DESCRIPTION
Two proposal-quality fixes from reviewing m2z3:

## 1. Robotic body attribution
The advocate prompt's *"Maintain attribution — every revision attributed by role, human author, round number"* made the advocate write an `## Attribution` / *"this revision responds to round 1 by…"* section **into the spec body** — pure noise that adds nothing to the design. Authorship is already in the revision metadata. Reworded to "Keep the body pure spec" + explicit **MUST NOT** against attribution/changelog/"this revision does X" sections.

## 2. Vague-AC false positives
The deterministic DoR `find_vague_acs` heuristic is a blunt substring match. Words like `clean`, `correctly`, `fast`, `stable`, `proper`, `good`, `effectively` appear in **precise** criteria ("clean commit", "correctly rejects X", "fast path") and **blocked good specs while the Judge ruled Ready** (both of m2z3's flags were just the word "clean"). Pruned those words, keeping the ones that almost always signal vagueness (`works well`, `user-friendly`, `robust`, `performant`, `nice`, …). Regression tests both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)