### PR TITLE
fix(proposals): Judge owns AC quality; drop deterministic vague-AC keyword check

### DIFF
--- a/server/crates/djinn-control-plane/src/server_tests.rs
+++ b/server/crates/djinn-control-plane/src/server_tests.rs
@@ -1176,69 +1176,6 @@ mod tests {
         );
     }
 
-    /// A vague AC like "Make it better" fails with the offending index/text.
-    #[tokio::test]
-    async fn proposal_update_in_review_with_vague_ac_fails() {
-        let db = Database::open_in_memory().unwrap();
-        let state = test_mcp_state(db.clone());
-        let project = create_project(&db, std::path::Path::new("")).await;
-        let server = DjinnMcpServer::new(state);
-
-        let created = server
-            .dispatch_tool(
-                "proposal_create",
-                json!({
-                    "title": "Proposal with vague AC",
-                    "body": "# Problem\nUsers cannot do X.\n\n# Scope\nIn scope: Y.\n\n# Objectives\nDeliver A.\n\n# Dependencies\nNone.\n\n# Open Questions\nWhat if D fails?\n\nEntry points: src/main.rs.\n",
-                    "acceptance_criteria": ["API returns 200"],
-                    "target_projects": [project.slug()],
-                }),
-            )
-            .await
-            .expect("dispatch proposal_create");
-        let id = created
-            .get("id")
-            .and_then(|v| v.as_str())
-            .expect("proposal id")
-            .to_string();
-
-        // First transition to in_review (should succeed).
-        server
-            .dispatch_tool(
-                "proposal_update",
-                json!({ "id": id, "status": "in_review" }),
-            )
-            .await
-            .expect("dispatch proposal_update in_review");
-
-        // Now update the AC to include a vague criterion while staying in_review.
-        let result = server
-            .dispatch_tool(
-                "proposal_update",
-                json!({
-                    "id": id,
-                    "acceptance_criteria": ["API returns 200", "Make it better"],
-                }),
-            )
-            .await
-            .expect("dispatch proposal_update");
-        let error = result.get("error").and_then(|v| v.as_str());
-        assert!(error.is_some(), "should fail vague AC check");
-        let error = error.unwrap();
-        assert!(
-            error.contains("Vague/unverifiable acceptance criterion"),
-            "error should mention vague AC: {error}"
-        );
-        assert!(
-            error.contains("Make it better"),
-            "error should contain the offending AC text: {error}"
-        );
-        assert!(
-            error.contains("#1"),
-            "error should contain the offending AC index: {error}"
-        );
-    }
-
     /// Existing MDX validation errors still win over readiness errors for
     /// malformed MDX.
     #[tokio::test]

--- a/server/crates/djinn-control-plane/src/tools/proposal_readiness.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_readiness.rs
@@ -30,9 +30,6 @@ impl ProposalReadinessResult {
                 ReadinessFailureDetail::MissingSection { check_name } => {
                     format!("Missing required coverage: {check_name}")
                 }
-                ReadinessFailureDetail::VagueAc { index, text } => {
-                    format!("Vague/unverifiable acceptance criterion #{index}: {text}")
-                }
                 ReadinessFailureDetail::Generic { message } => message.clone(),
             })
             .collect();
@@ -56,7 +53,6 @@ pub enum ReadinessCheck {
     ObjectiveCoverage,
     TargetCount,
     AcceptanceCriteriaCount,
-    VagueAcceptanceCriteria,
     Grounding,
     DependenciesCoverage,
     OpenQuestionsRisksCoverage,
@@ -67,7 +63,6 @@ pub enum ReadinessCheck {
 #[serde(rename_all = "snake_case")]
 pub enum ReadinessFailureDetail {
     MissingSection { check_name: String },
-    VagueAc { index: usize, text: String },
     Generic { message: String },
 }
 
@@ -132,13 +127,9 @@ pub fn evaluate_proposal_readiness(
         });
     }
 
-    // 4. Vague / unverifiable AC phrases
-    for (index, vague) in find_vague_acs(acceptance_criteria) {
-        failures.push(ReadinessFailure {
-            check: ReadinessCheck::VagueAcceptanceCriteria,
-            detail: ReadinessFailureDetail::VagueAc { index, text: vague },
-        });
-    }
+    // 4. AC quality (vague / unverifiable / not agent-confirmable) is a
+    //    semantic judgment owned by the tribunal Judge (see judge.md
+    //    "Definition of Done"); this gate only checks structural presence.
 
     // 5. Grounding: file-map/code-path block OR named entry points in prose
     if !has_grounding(&normalized_body) {
@@ -325,48 +316,6 @@ fn has_grounding(normalized: &str) -> bool {
     false
 }
 
-// ── Vague AC heuristic ───────────────────────────────────────────────────────
-
-/// Returns (index, offending_text) for each vague AC found.
-fn find_vague_acs(acs: &[AcceptanceCriterionItem]) -> Vec<(usize, String)> {
-    // Words that almost always signal a vague, unverifiable criterion. This is
-    // a blunt substring match, so the list is deliberately conservative: words
-    // that legitimately appear in precise criteria — `clean` ("clean commit"),
-    // `correctly` ("correctly rejects X"), `fast` ("fast path"), `stable`
-    // ("stable API"), `proper` ("proper subset"), `good`, `effectively`
-    // ("effectively final"), `efficiently`, `smoothly`, `seamlessly` — were
-    // removed because they produced false positives that blocked good specs.
-    let banned = [
-        "works well",
-        "improve",
-        "better",
-        "easy",
-        "robust",
-        "user-friendly",
-        "user friendly",
-        "performant",
-        "nice",
-        "sufficient",
-        "adequate",
-    ];
-
-    let mut out = Vec::new();
-    for (i, ac) in acs.iter().enumerate() {
-        let text = match ac {
-            AcceptanceCriterionItem::Text(t) => t.clone(),
-            AcceptanceCriterionItem::Structured(s) => s.criterion.clone(),
-        };
-        let lower = text.to_lowercase();
-        for phrase in &banned {
-            if lower.contains(phrase) {
-                out.push((i, text.clone()));
-                break; // only report first vague phrase per AC
-            }
-        }
-    }
-    out
-}
-
 // ── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -375,13 +324,6 @@ mod tests {
 
     fn ac_text(text: &str) -> AcceptanceCriterionItem {
         AcceptanceCriterionItem::Text(text.to_string())
-    }
-
-    fn ac_structured(criterion: &str) -> AcceptanceCriterionItem {
-        AcceptanceCriterionItem::Structured(crate::tools::epic_ops::AcceptanceCriterionStatus {
-            criterion: criterion.to_string(),
-            met: false,
-        })
     }
 
     #[test]
@@ -508,107 +450,17 @@ Entry points: src/main.rs and src/lib.rs.
     }
 
     #[test]
-    fn vague_ac_reported_with_index_and_text() {
-        let body = r#"
-# Problem
-Users cannot do X.
-# Scope
-In scope: Y.
-# Objectives
-Deliver A.
-# Dependencies
-None.
-# Open Questions
-What if D fails?
-## File map
-```file-map
-src/main.rs
-```
-"#;
-        let acs = vec![
-            ac_text("API returns 200"),
-            ac_text("The UI should be user-friendly"),
-            ac_structured("Performance should improve"),
-        ];
-        let result = evaluate_proposal_readiness(body, &acs, 1);
-        assert!(!result.ready);
-        let vague_failures: Vec<_> = result
-            .failures
-            .iter()
-            .filter(|f| f.check == ReadinessCheck::VagueAcceptanceCriteria)
-            .collect();
-        assert_eq!(vague_failures.len(), 2);
-
-        // Verify exact index/text for the first vague AC
-        let detail1 = &vague_failures[0].detail;
-        match detail1 {
-            ReadinessFailureDetail::VagueAc { index, text } => {
-                assert_eq!(*index, 1);
-                assert_eq!(text, "The UI should be user-friendly");
-            }
-            other => panic!("expected VagueAc, got {other:?}"),
-        }
-
-        // Verify exact index/text for the second vague AC
-        let detail2 = &vague_failures[1].detail;
-        match detail2 {
-            ReadinessFailureDetail::VagueAc { index, text } => {
-                assert_eq!(*index, 2);
-                assert_eq!(text, "Performance should improve");
-            }
-            other => panic!("expected VagueAc, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn precise_criteria_with_technical_words_are_not_flagged_vague() {
-        // Regression: `clean`, `correctly`, `fast`, `stable`, `proper` appear in
-        // precise, verifiable criteria and must NOT be flagged — they used to
-        // false-positive (e.g. m2z3's "clean commit" / "clean CI sequence").
-        let acs = vec![
-            ac_text("A baseline report is generated at a named clean commit with the full git SHA"),
-            ac_text("The parser correctly rejects malformed input, proven by tests/parse_reject.rs"),
-            ac_text("The fast path returns cached results in under 5ms at p99"),
-            ac_text("The /v1/sessions endpoint exposes a stable v1 API contract"),
-            ac_structured("check produces a proper subset of the manifest entries"),
-        ];
-        assert!(
-            find_vague_acs(&acs).is_empty(),
-            "precise criteria containing technical uses of clean/correctly/fast/stable/proper must not be flagged vague",
-        );
-    }
-
-    #[test]
-    fn genuinely_vague_criteria_still_flagged() {
-        let acs = vec![
-            ac_text("The UI should be user-friendly and nice"),
-            ac_text("Make the system more robust and performant"),
-        ];
-        assert_eq!(find_vague_acs(&acs).len(), 2);
-    }
-
-    #[test]
     fn to_error_string_format() {
         let result = ProposalReadinessResult {
             ready: false,
-            failures: vec![
-                ReadinessFailure {
-                    check: ReadinessCheck::ProblemCoverage,
-                    detail: ReadinessFailureDetail::MissingSection {
-                        check_name: "problem".to_string(),
-                    },
+            failures: vec![ReadinessFailure {
+                check: ReadinessCheck::ProblemCoverage,
+                detail: ReadinessFailureDetail::MissingSection {
+                    check_name: "problem".to_string(),
                 },
-                ReadinessFailure {
-                    check: ReadinessCheck::VagueAcceptanceCriteria,
-                    detail: ReadinessFailureDetail::VagueAc {
-                        index: 0,
-                        text: "Make it better".to_string(),
-                    },
-                },
-            ],
+            }],
         };
         let msg = result.to_error_string().unwrap();
         assert!(msg.contains("Missing required coverage: problem"));
-        assert!(msg.contains("Vague/unverifiable acceptance criterion #0: Make it better"));
     }
 }

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
@@ -877,10 +877,6 @@ async fn build_gate_status(
                 crate::tools::proposal_readiness::ReadinessFailureDetail::MissingSection {
                     check_name,
                 } => format!("Missing required coverage: {check_name}"),
-                crate::tools::proposal_readiness::ReadinessFailureDetail::VagueAc {
-                    index,
-                    text,
-                } => format!("Vague/unverifiable acceptance criterion #{index}: {text}"),
                 crate::tools::proposal_readiness::ReadinessFailureDetail::Generic { message } => {
                     message.clone()
                 }
@@ -4831,86 +4827,6 @@ What happens if D fails?
         let signoffs = repo.signoffs(&proposal.id).await.unwrap();
         assert_eq!(signoffs.len(), 1, "one sign-off should be recorded");
     }
-
-    /// An `in_review` proposal with a vague AC fails technical sign-off with
-    /// the offending AC index/text in the error message.
-    ///
-    /// Uses a direct status update to simulate legacy data that was advanced
-    /// before the readiness gate was in place.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn in_review_proposal_with_vague_ac_fails_signoff() {
-        let (server, db, user_id) = setup_test_server_and_user().await;
-        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
-
-        // Create a proposal with a clean body but vague AC.
-        let proposal = repo
-            .create(ProposalCreateInput {
-                title: "Vague AC Review",
-                body: ready_body(),
-                acceptance_criteria: Some(
-                    r#"[{"criterion":"API returns 200","met":false},{"criterion":"The UI should be user-friendly","met":false}]"#,
-                ),
-                status: None,
-                body_format: None,
-            })
-            .await
-            .unwrap();
-        let project = ProjectRepository::new(db.clone(), EventBus::noop())
-            .create("svc-review-vague", "test", "svc-review-vague")
-            .await
-            .unwrap();
-        repo.add_target(&proposal.id, &project.id, "primary")
-            .await
-            .unwrap();
-
-        // Directly advance the status to `in_review` to simulate legacy
-        // data that pre-dates the readiness gate.
-        ProposalRepository::new(db.clone(), EventBus::noop())
-            .set_status(&proposal.id, "in_review")
-            .await
-            .unwrap();
-
-        // Attempt the technical sign-off — it should fail because the
-        // vague AC makes the proposal not ready.
-        let response = djinn_core::auth_context::SESSION_USER_ID
-            .scope(Some(user_id), async {
-                server
-                    .dispatch_tool(
-                        "proposal_signoff",
-                        serde_json::json!({ "id": proposal.id, "kind": "technical" }),
-                    )
-                    .await
-            })
-            .await
-            .unwrap();
-
-        let error = response.get("error").and_then(|v| v.as_str());
-        assert!(
-            error.is_some(),
-            "expected readiness error, got: {response:?}"
-        );
-        let error = error.unwrap();
-        assert!(
-            error.contains("proposal not ready for review"),
-            "error should mention readiness: {error}"
-        );
-        assert!(
-            error.contains("Vague/unverifiable acceptance criterion"),
-            "error should mention vague AC: {error}"
-        );
-        assert!(
-            error.contains("user-friendly"),
-            "error should include the offending AC text: {error}"
-        );
-
-        // Proposal must still be `in_review` — no new sign-off was recorded.
-        let stored = repo.get(&proposal.id).await.unwrap().unwrap();
-        assert_eq!(stored.status, "in_review");
-
-        // No sign-offs should exist.
-        let signoffs = repo.signoffs(&proposal.id).await.unwrap();
-        assert!(signoffs.is_empty(), "no sign-offs should be recorded");
-    }
 }
 
 // ── Graduation readiness regression tests (task 9fjy) ───────────────────
@@ -4985,88 +4901,6 @@ What happens if D fails?
             .set_status(proposal_id, "approved")
             .await
             .unwrap();
-    }
-
-    /// An approved proposal with vague AC fails graduation; the error
-    /// includes the offending AC index/text and the proposal remains
-    /// `approved` with no breakdown task or build owner.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn approved_vague_ac_fails_graduation_with_details() {
-        let (server, db, user_id) = setup_test_server_and_user().await;
-        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
-        let project = ProjectRepository::new(db.clone(), EventBus::noop())
-            .create("svc-grad-vague", "test", "svc-grad-vague")
-            .await
-            .unwrap();
-
-        // Create with clean body but vague AC.
-        let proposal = djinn_core::auth_context::SESSION_USER_ID
-            .scope(Some(user_id.clone()), async {
-                repo.create(ProposalCreateInput {
-                    title: "Vague AC Graduation",
-                    body: ready_body(),
-                    acceptance_criteria: Some(
-                        r#"[{"criterion":"API returns 200","met":false},{"criterion":"The UI should be user-friendly","met":false}]"#,
-                    ),
-                    status: None,
-                    body_format: None,
-                })
-                .await
-            })
-            .await
-            .unwrap();
-        repo.add_target(&proposal.id, &project.id, "primary")
-            .await
-            .unwrap();
-
-        // Directly advance to `approved` to simulate legacy data.
-        force_approved(&db, &proposal.id).await;
-
-        // Attempt graduation.
-        let response = djinn_core::auth_context::SESSION_USER_ID
-            .scope(Some(user_id), async {
-                server
-                    .dispatch_tool(
-                        "proposal_graduate",
-                        serde_json::json!({ "id": proposal.id }),
-                    )
-                    .await
-            })
-            .await
-            .unwrap();
-
-        let error = response.get("error").and_then(|v| v.as_str());
-        assert!(
-            error.is_some(),
-            "expected readiness error, got: {response:?}"
-        );
-        let error = error.unwrap();
-        assert!(
-            error.contains("proposal not ready for review"),
-            "error should mention readiness: {error}"
-        );
-        assert!(
-            error.contains("Vague/unverifiable acceptance criterion"),
-            "error should mention vague AC: {error}"
-        );
-        assert!(
-            error.contains("user-friendly"),
-            "error should include the offending AC text: {error}"
-        );
-
-        // Proposal must still be `approved` — graduation was blocked.
-        let stored = repo.get(&proposal.id).await.unwrap().unwrap();
-        assert_eq!(stored.status, "approved", "status must remain approved");
-
-        // No breakdown task or build owner should be set.
-        assert!(
-            stored.build_breakdown_task_id.is_none(),
-            "no breakdown task should be created"
-        );
-        assert!(
-            stored.build_owner_user_id.is_none(),
-            "no build owner should be set"
-        );
     }
 
     /// An approved proposal missing required readiness sections fails

--- a/server/crates/djinn-roles/src/prompts/advocate.md
+++ b/server/crates/djinn-roles/src/prompts/advocate.md
@@ -17,6 +17,7 @@ You CAN:
 - Read the adversary's objections via `proposal_debate_list` — **do this first.** Each objection has an `id`, a `body`, and `blocking`/`resolved` flags. The objections are NOT in your task description — read them with this tool.
 - **Revise the proposal BODY** via `proposal_update` — this is your primary action. Most objections ask for content in the spec *body* (e.g. explicit Problem / Scope / Objectives / Dependencies / Risks sections, a file-map/code-path grounding block). `proposal_update(body=...)` is the only way to add them; setting acceptance criteria alone does NOT satisfy a body-coverage objection.
 - Set structured acceptance criteria via `proposal_ac_set`.
+- **Keep the title in sync** via `proposal_update(title=...)` — if your body revisions move the spec away from its title (common when a proposal was seeded by merging or stub-captured ideas, so it still wears a placeholder like "Merged: A + B + C"), rewrite the title to a crisp, accurate name. The title is yours to own; nothing else in the tribunal sets it.
 - Load the `visual-spec` native skill via `skill_read(name="visual-spec")` and enrich the body with structured MDX (mockups, diagrams, file-structure blocks, real MDX code blocks) via `proposal_block_patch`. See **Visual Enrichment** below — a visually rich spec is the expected outcome.
 - Write memory notes documenting design decisions and rationale.
 - Call `submit_work` to deliver your revised proposal spec.

--- a/server/crates/djinn-roles/src/prompts/judge.md
+++ b/server/crates/djinn-roles/src/prompts/judge.md
@@ -15,15 +15,39 @@ You are dispatched ONLY after the Adversary produces no new blocking objections 
 
 **Approve** when:
 - All blocking objections have been resolved or explicitly rebutted with evidence.
-- Acceptance criteria are testable, unambiguous, and checkable by downstream roles.
+- Every acceptance criterion passes the **Definition of Done** below.
 - No new blocking issues are apparent from your independent review.
 - The Adversary has been dry for the required consecutive rounds.
 
 **Reject** when:
 - A blocking objection remains unresolved or the rebuttal is insufficient.
-- Acceptance criteria are still ambiguous or untestable.
+- Any acceptance criterion fails the **Definition of Done** (vague, or not
+  confirmable by the executing role).
 - You identify a blocking issue the Adversary overlooked.
 - The loop did not converge (speculation or adversarial gaming detected).
+
+## Definition of Done — acceptance-criteria quality
+
+You are the authoritative judge of AC quality — a keyword heuristic cannot tell
+a vague criterion from a precise one, so you make the real call. Judge each
+criterion by ONE test: **can the role that will execute this work — a worker
+writing code, a reviewer reading a diff, CI running tests — actually confirm it
+from its own tool surface, within a session?** A good AC is objective and
+checkable in the repo (a file/function exists, a test passes, a command exits 0,
+an endpoint returns X, a script produces output Y).
+
+**Reject criteria that no agent can confirm**, for example:
+- Business / usage metrics: "10 users onboarded", "X% logs reduced", "adoption
+  improves", "users can transact live in production".
+- External / operator-only proofs: manual UX review, an SLA measured in prod, a
+  paid third-party API run, an external dashboard reading.
+- Pure adjectives with no observable test: "fast", "robust", "clean", "scalable"
+  with no measurable threshold or command behind them.
+
+Such criteria belong in runbook/context prose, NOT in acceptance criteria. When
+a criterion fails this test, reject with a verdict that names which AC is
+unverifiable and what observable form it should take instead — the Advocate then
+rewrites it (via `proposal_ac_set` / `proposal_update`).
 
 ## How to record your verdict — READ THIS CAREFULLY
 

--- a/server/crates/djinn-roles/src/prompts/judge.md
+++ b/server/crates/djinn-roles/src/prompts/judge.md
@@ -47,7 +47,7 @@ an endpoint returns X, a script produces output Y).
 Such criteria belong in runbook/context prose, NOT in acceptance criteria. When
 a criterion fails this test, reject with a verdict that names which AC is
 unverifiable and what observable form it should take instead — the Advocate then
-rewrites it (via `proposal_ac_set` / `proposal_update`).
+rewrites it.
 
 ## How to record your verdict — READ THIS CAREFULLY
 


### PR DESCRIPTION
## What

The tribunal Judge now owns acceptance-criteria quality via an explicit "Definition of Done" (committed in judge.md on this branch). This removes the fragile deterministic "vague acceptance criterion" keyword check from the proposal Definition-of-Ready gate, plus all its plumbing and dependent tests.

The old `find_vague_acs` was a blunt substring match (`improve`, `better`, `robust`, ...) that false-positived on precise criteria and could never actually judge verifiability. The DoR gate now only checks structural presence; semantic AC quality is the Judge's call.

### Removed
- `find_vague_acs` + its call site in `evaluate_proposal_readiness`
- `ReadinessCheck::VagueAcceptanceCriteria` and `ReadinessFailureDetail::VagueAc` variants + their Display arms (in both `proposal_readiness.rs` and the DoR-gate mapping in `proposal_tools.rs`)
- All tests asserting vague-AC blocking: `vague_ac_reported_with_index_and_text`, `precise_criteria_with_technical_words_are_not_flagged_vague`, `genuinely_vague_criteria_still_flagged`, `in_review_proposal_with_vague_ac_fails_signoff`, `approved_vague_ac_fails_graduation_with_details`, `proposal_update_in_review_with_vague_ac_fails`

### Also
- **judge.md**: dropped tool references (`proposal_ac_set`/`proposal_update`) the Judge role does not have registered — the Judge only adjudicates; the Advocate rewrites. Keeps the prompt schema-snapshot test green.
- **advocate.md**: added a "Keep the title in sync" authority bullet so the Advocate renames placeholder/merged titles via `proposal_update(title=...)` (prompt-only; the tool already accepts `title`).

## Verification
- `cargo clippy -p djinn-control-plane --all-targets -- -D warnings` — clean
- `cargo test -p djinn-control-plane --lib -- proposal_readiness` — 6 passed
- `cargo test -p djinn-agent --lib -- prompts::tests::advocate role_prompts_reference_only_registered_tools` — passed
- DB-backed gate tests run in the merge-group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)