### PR TITLE
fix(oauth): refresh Codex/Copilot token on mid-run 401 instead of revoking

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/helpers/mod.rs
+++ b/server/crates/djinn-agent/src/actors/slot/helpers/mod.rs
@@ -90,6 +90,7 @@ pub use provider_resolution::{
     OAuthAuthMethodWire, OAuthCapabilitiesWire, OAuthConfigWire, OAuthFormatFamilyWire,
     ProviderCredential, auth_method_for_provider, capabilities_for_provider, default_base_url,
     format_family_for_provider, load_provider_credential, parse_model_id,
+    refresh_oauth_credential_after_401,
 };
 #[allow(unused_imports)]
 pub(crate) use provider_resolution::{

--- a/server/crates/djinn-agent/src/actors/slot/helpers/provider_resolution.rs
+++ b/server/crates/djinn-agent/src/actors/slot/helpers/provider_resolution.rs
@@ -304,6 +304,76 @@ impl OAuthConfigWire {
 /// window — tracked as a follow-up.)
 static CODEX_REFRESH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// Attempt a host-side silent OAuth token refresh after a mid-run 401.
+///
+/// The worker pod is dispatched with a *static* OAuth access-token snapshot and
+/// no refresh capability of its own (the wire format carries only the bearer
+/// token — see [`OAuthConfigWire`], which has no `refresh_token`/`expires_at`).
+/// A task-run that outlives the access token's TTL therefore 401s mid-run even
+/// though the refresh token is still valid. That 401 surfaces as
+/// `ProviderFailureClass::AuthInvalid`, which the terminal-failure handler would
+/// otherwise treat as a *revoked* credential (escalating breaker trip +
+/// `mark_revoked` + a "reconnect required" prompt) — a false positive when the
+/// credential merely needed refreshing.
+///
+/// This mirrors the expired-token refresh branch of [`load_provider_credential`]
+/// — same single-flight [`CODEX_REFRESH_LOCK`], same load/refresh/save — but is
+/// callable from the failure handler so the refreshed token is persisted for the
+/// next dispatch to pick up.
+///
+/// Returns `true` when the model is OAuth-backed and the token is now live
+/// (refresh succeeded, or a peer dispatch already refreshed it) — i.e. the 401
+/// was a recoverable expiry, not a dead credential. Returns `false` for
+/// non-OAuth (API-key) providers and for a refresh that itself fails
+/// (`invalid_grant` = genuinely revoked refresh token), in which case the caller
+/// should fall back to marking the credential revoked.
+pub async fn refresh_oauth_credential_after_401(model_id: &str, app_state: &AgentContext) -> bool {
+    let Ok((provider_id, _model_name)) = parse_model_id(model_id) else {
+        return false;
+    };
+    let effective_oauth_id = match provider_id.as_str() {
+        "chatgpt_codex" | "githubcopilot" => provider_id.as_str(),
+        other => djinn_provider::catalog::builtin::resolve_oauth_provider(other).unwrap_or(other),
+    };
+    let credential_repo =
+        CredentialRepository::new(app_state.db.clone(), app_state.event_bus.clone());
+    match effective_oauth_id {
+        "chatgpt_codex" => {
+            // Single-flight with the dispatch refresh path so we never race the
+            // single-use refresh token (see CODEX_REFRESH_LOCK).
+            let _guard = CODEX_REFRESH_LOCK.lock().await;
+            let Some(current) =
+                crate::oauth::codex::CodexTokens::load_from_db(&credential_repo).await
+            else {
+                return false;
+            };
+            // A peer dispatch may have already refreshed while we waited on the
+            // lock — if the stored token is live again, the 401 is already
+            // resolved; don't burn (and rotate) another single-use refresh.
+            if !current.is_expired() {
+                return true;
+            }
+            crate::oauth::codex::refresh_cached_token(&current, &credential_repo)
+                .await
+                .is_ok()
+        }
+        "githubcopilot" => {
+            let Some(current) =
+                crate::oauth::copilot::CopilotTokens::load_from_db(&credential_repo).await
+            else {
+                return false;
+            };
+            if !current.is_expired() {
+                return true;
+            }
+            crate::oauth::copilot::refresh_copilot_token(&current, &credential_repo)
+                .await
+                .is_ok()
+        }
+        _ => false,
+    }
+}
+
 pub async fn load_provider_credential(
     provider_id: &str,
     app_state: &AgentContext,

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -48,6 +48,7 @@ use crate::supervisor::{RoleKind, SupervisorFlow, TaskRunSpec, services_for_agen
 
 use super::helpers::{
     conflict_context_for_dispatch, default_target_branch, load_provider_credential, parse_model_id,
+    refresh_oauth_credential_after_401,
 };
 
 fn supervisor_rpc_span(op: &'static str, session_id: &str, task_id: &str) -> tracing::Span {
@@ -775,32 +776,58 @@ pub(super) async fn dispatch_task_runtime(
                         (false, None)
                     }
                     djinn_runtime::ProviderFailureClass::AuthInvalid => {
-                        // A 401/revoked credential is deterministic — trip the
-                        // breaker IMMEDIATELY (like a throttle) so dispatch fails
-                        // over to the user's next model at once, and persist +
-                        // surface the revocation so the owner is told to
-                        // reconnect (F5-safe row + live event). Escalate the
-                        // cooldown cap: unlike a quota throttle, a dead credential
-                        // is a genuine model-health problem that should stay
-                        // demoted longer the more it keeps failing.
-                        app_state.health_tracker.record_stall(
-                            creator_scope.as_deref(),
-                            &model_id,
-                            true,
-                        );
-                        surface_credential_revocation(
-                            &app_state,
-                            creator_scope.as_deref(),
-                            &model_id,
-                        )
-                        .await;
-                        // Throttle-like for the per-task redispatch ladder: a dead
-                        // credential must never march the task to terminal
-                        // force-close. With a healthy fallback the breaker hold
-                        // makes dispatch fail over; with none the task parks until
-                        // the owner reconnects (which clears the breaker via the
-                        // credential-updated event).
-                        (true, None)
+                        // A 401 on an OAuth-backed credential (chatgpt_codex /
+                        // githubcopilot) is usually a mid-run ACCESS-TOKEN
+                        // EXPIRY, not a dead credential: the worker pod holds a
+                        // static token snapshot with no in-pod refresh (the wire
+                        // format carries only the bearer token), so a run that
+                        // outlives the access token's TTL 401s even though the
+                        // refresh token is still valid. Try a host-side silent
+                        // refresh FIRST — only a refresh that itself fails
+                        // (`invalid_grant`) or a non-OAuth API key is a true
+                        // revocation.
+                        if refresh_oauth_credential_after_401(&model_id, &app_state).await {
+                            // Recovered: the refreshed token is persisted, so the
+                            // next dispatch resumes on it. Fail this run over
+                            // WITHOUT escalating the cooldown cap and WITHOUT
+                            // marking the credential revoked — `escalate = false`
+                            // keeps `disable_ttl_trips` from ratcheting, while the
+                            // stall floor still prevents an instant re-select of
+                            // the just-failed pod before the new token is live.
+                            app_state.health_tracker.record_stall(
+                                creator_scope.as_deref(),
+                                &model_id,
+                                false,
+                            );
+                            (true, None)
+                        } else {
+                            // Genuinely dead credential — trip the breaker
+                            // IMMEDIATELY (like a throttle) so dispatch fails over
+                            // to the user's next model at once, and persist +
+                            // surface the revocation so the owner is told to
+                            // reconnect (F5-safe row + live event). Escalate the
+                            // cooldown cap: unlike a quota throttle, a dead
+                            // credential is a genuine model-health problem that
+                            // should stay demoted longer the more it keeps failing.
+                            app_state.health_tracker.record_stall(
+                                creator_scope.as_deref(),
+                                &model_id,
+                                true,
+                            );
+                            surface_credential_revocation(
+                                &app_state,
+                                creator_scope.as_deref(),
+                                &model_id,
+                            )
+                            .await;
+                            // Throttle-like for the per-task redispatch ladder: a
+                            // dead credential must never march the task to terminal
+                            // force-close. With a healthy fallback the breaker hold
+                            // makes dispatch fail over; with none the task parks
+                            // until the owner reconnects (which clears the breaker
+                            // via the credential-updated event).
+                            (true, None)
+                        }
                     }
                 };
                 // Side-channel for the coordinator's per-task redispatch logic

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -308,19 +308,12 @@ pub(super) async fn dispatch_task_runtime(
     // the `SESSION_USER_ID` task-local (migration 28) — a task uses ITS
     // CREATOR's credential, falling back to the org-shared one when the column
     // is NULL (background / pre-multiuser tasks); and (2) the commit-author
-    // identity. The `Task` model doesn't surface this column, so read it
-    // directly. A lookup error or missing column is non-fatal: we just resolve
-    // org-shared / fall back to the bot identity, preserving historical
-    // behaviour.
-    let created_by_user_id: Option<String> = sqlx::query_scalar!(
-        "SELECT created_by_user_id FROM tasks WHERE id = $1",
-        task.id
-    )
-    .fetch_optional(app_state.db.pool())
-    .await
-    .ok()
-    .flatten()
-    .flatten();
+    // identity. The `Task` model doesn't surface this column, so read it through
+    // the djinn-db repository layer. A lookup error or missing column is
+    // non-fatal: we just resolve org-shared / fall back to the bot identity,
+    // preserving historical behaviour.
+    let created_by_user_id: Option<String> =
+        task_repo.created_by_user_id(&task.id).await.ok().flatten();
 
     // ── Resolve the commit-author identity (Vercel-friendly attribution) ──
     //


### PR DESCRIPTION
## Root cause

`openai/gpt-5.5` (and any OAuth-backed model) kept getting **auto-disabled and flagged "reconnect required"** despite a healthy credential.

A worker pod is dispatched with a **static OAuth access-token snapshot** and no in-pod refresh capability — `OAuthConfigWire` carries only the bearer token (no `refresh_token`/`expires_at`). The host refreshes the token **only at the dispatch boundary** (`load_provider_credential`, 60s expiry buffer), and Codex access tokens default to a **~1h TTL** (`expires_in.unwrap_or(3600)`). So any task-run that outlives the TTL **401s mid-run** even though the refresh token is still valid.

That 401 surfaced as `ProviderFailureClass::AuthInvalid`, and the terminal handler treated it as a dead credential:
- `record_stall(escalate=true)` → ratcheted the model-health cooldown cap (`disable_ttl_trips`), and
- `surface_credential_revocation` → `mark_revoked`, demanding a manual reconnect.

Evidence: `model_health` showed `openai/gpt-5.5` with `disable_ttl_trips: 15` but only `total_failures: 30` — mathematically impossible via the gentle 3-strike `record_failure` path (would need ~45+), so the trips are 1-strike escalating `record_stall(escalate=true)` events. The only `openai` credential is `chatgpt_codex` OAuth (no API key), so the model runs on the consumer Codex backend where long runs cross the token TTL.

## Fix

On an `AuthInvalid` terminal failure, attempt a **host-side silent refresh first** (`refresh_oauth_credential_after_401`), mirroring the expired-token branch of `load_provider_credential` — same single-flight `CODEX_REFRESH_LOCK`, same load/refresh/save, so the refreshed token is persisted for the next dispatch to pick up.

- **Refresh succeeds (or a peer already refreshed):** fail the run over with `record_stall(escalate=false)` — no cooldown-cap ratchet, no revocation. Re-dispatch resumes on the fresh token.
- **Non-OAuth API key, or refresh fails (`invalid_grant` = genuinely dead refresh token):** original `escalate=true` + `mark_revoked` path, unchanged.

Covers both OAuth providers (`chatgpt_codex`, `githubcopilot`).

## Scope / follow-up

This stops the **false revocation + escalating demotion**. It does not stop the in-flight run from dying at the 401 (the pod still has no in-pod refresh) — eliminating that entirely would require shipping the refresh token into the pod + RPC write-back of the rotated token, a larger change worth a separate PR.

## Verification

- `cargo check -p djinn-agent --all-features` ✅
- `cargo clippy -p djinn-agent -p djinn-provider --all-features` ✅ (no warnings)
- `cargo fmt --check` ✅