### PR TITLE
fix(worker): checkpoint work on the failure/interrupt exit path

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -1211,6 +1211,13 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
         checkpoint_identity.clone(),
     );
 
+    // Clones reserved for the terminal "save before teardown" checkpoint fired
+    // after the supervisor returns (see below). `checkpoint_identity` is moved
+    // into the soft-deadline handler and `captured_workspace_path` into the
+    // supervisor services, so capture our copies before those moves.
+    let terminal_checkpoint_identity = checkpoint_identity.clone();
+    let terminal_captured_workspace_path = captured_workspace_path.clone();
+
     // Arm the in-pod soft deadline. The kubelet's `activeDeadlineSeconds` is a
     // hard backstop that SIGKILLs the Pod with no chance to save work; the soft
     // deadline fires `margin` ahead of it and drives the SAME graceful path as
@@ -1294,10 +1301,32 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     //    every host-bound trait call (DB writes, SSE publish, PR open)
     //    round-trips over RPC.
     let supervisor = TaskRunSupervisor::new(mirror, worker_services.clone());
-    let report = supervisor
+    let report_result = supervisor
         .run(spec.clone())
         .await
-        .context("task-run supervisor drive")?;
+        .context("task-run supervisor drive");
+
+    // Terminal "save before teardown" checkpoint. The supervisor only
+    // commits+pushes at a clean stage boundary, so an exit that breaks out
+    // mid-stage — a provider 401 / `Failed` stage outcome, a cancelled stage,
+    // or a drive-level error — would otherwise strand the worker's uncommitted
+    // in-flight edits (plus anything committed since the last ~180s periodic
+    // push) in the ephemeral clone. The SIGTERM and soft-deadline handlers
+    // checkpoint on their paths; this covers the in-process failure/interrupt
+    // exit that neither signal fires on, so a re-dispatch resumes from the work
+    // instead of redoing it. Idempotent: a no-op commit on a clean tree
+    // (successful runs already committed at the stage boundary) and a no-op push
+    // when the mirror is current. MUST run before `drop(supervisor)` below,
+    // which deletes the ephemeral stage clone the checkpoint reads from.
+    checkpoint_workspace(
+        &terminal_captured_workspace_path,
+        &spec.task_branch,
+        &terminal_checkpoint_identity,
+        &args.task_run_id,
+    )
+    .await;
+
+    let report = report_result?;
 
     // 8. Ship the terminal report back to the launcher as a `WorkerEvent::
     //    TerminalReport` on the same RPC connection. The launcher's


### PR DESCRIPTION
## Problem

The in-pod supervisor only commits+pushes the task branch at a **clean stage boundary** (`StageOutcome::WorkerDone`/`ArchitectDone`). Any exit that breaks out mid-stage returns *without* that commit+push:

- a provider **401 / `Failed` stage outcome** (e.g. Codex OAuth mid-run token expiry),
- a cancelled stage,
- a drive-level error.

The worker's three durability backstops don't cover this in-process exit:
- **SIGTERM** and **soft-deadline** handlers checkpoint (commit + push) — but only fire on those signals, not on an in-process failure return.
- The **periodic push** (every ~180s) is **push-only** (no commit), so it can't capture uncommitted edits.

Net: on a mid-stage failure, uncommitted in-flight edits — plus anything committed in the last <180s — are stranded in the ephemeral clone and lost. On re-dispatch the worker redoes that work.

## Fix

Fire the existing `checkpoint_workspace` (commit + push) right after `supervisor.run()` returns, **before `drop(supervisor)`** deletes the ephemeral stage clone the checkpoint reads from. Covers both the `Ok(report-with-Failed-outcome)` and the `Err(drive error)` paths.

Result: the common interrupt cases — notably a Codex/OAuth mid-run 401 (now refreshed-and-recovered host-side per #1268) — become effectively **lossless**: stop → commit+push → re-dispatch → resume on the task branch.

**Idempotent:** a no-op commit on a clean tree (successful runs already committed at the stage boundary) and a no-op push when the mirror is current — same function the SIGTERM/soft-deadline handlers already call speculatively.

## Scope

This closes the **signalled/in-process** failure-exit window. Unsignalled SIGKILL/OOM (no handler can run) is still bounded only by the 180s periodic push and is covered by the broader proposal *019f0f50 — never throw away worker output (capture-before-reap)*, which this is a clean subset of.

## Verification

- `cargo check -p djinn-agent-worker --all-features` ✅
- `cargo clippy -p djinn-agent-worker --all-features` ✅ (no warnings)
- `cargo fmt --check` ✅
- `cargo test -p djinn-agent-worker checkpoint` ✅ (3 passed)