### PR TITLE
fix(ci): wire check-boundaries main() to the tested violation helpers

### DIFF
--- a/server/ci/check_boundaries.rs
+++ b/server/ci/check_boundaries.rs
@@ -509,16 +509,11 @@ async fn main() {
         }
     };
 
-    let mut violations: Vec<(usize, &TomlRule, &str, &str)> = Vec::new();
-    for edge in &crate_graph.edges {
-        for cr in &compiled {
-            if cr.from_matcher.is_match(&edge.source) && cr.to_matcher.is_match(&edge.target) {
-                violations.push((cr.index, cr.rule, &edge.source, &edge.target));
-            }
-        }
-    }
+    // 7. Check + report. Use the same `check_violations` / `render_violation_report`
+    //    helpers the tests exercise, so `main` and the test suite share one code
+    //    path (and the helpers aren't dead code in the bin target).
+    let violations = check_violations(&crate_graph, &compiled);
 
-    // 7. Report.
     if violations.is_empty() {
         println!(
             "✓ No boundary violations found. (checked {} rule(s) against {} crate edge(s))",
@@ -528,19 +523,17 @@ async fn main() {
         std::process::exit(0);
     }
 
-    eprintln!("✗ {} boundary violation(s) found:\n", violations.len());
-    for (i, rule, from, to) in &violations {
-        eprintln!("  [{rule_index}] {from} → {to}", rule_index = i);
-        eprintln!("      rule name:  {}", rule.name);
-        if let Some(desc) = &rule.description {
-            eprintln!("      description: {desc}");
-        }
-        eprintln!("      from_key:   {from}");
-        eprintln!("      to_key:     {to}");
-        eprintln!("      witness:    {from} → {to}");
-        eprintln!();
-    }
-    std::process::exit(1);
+    // `check_violations` returns owned source/target strings; borrow them as
+    // `&str` for the renderer's slice-based signature.
+    let borrowed: Vec<(usize, &TomlRule, &str, &str)> = violations
+        .iter()
+        .map(|(index, rule, from, to)| (*index, *rule, from.as_str(), to.as_str()))
+        .collect();
+    let mut report = String::new();
+    let exit_code = render_violation_report(&mut report, &borrowed)
+        .expect("writing a boundary report to a String never fails");
+    eprint!("{report}");
+    std::process::exit(exit_code);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`main` is red on **Server Clippy** (`cargo clippy --all-targets --features qdrant -- -D warnings`):

```
error: function `check_violations` is never used      --> ci/check_boundaries.rs:554
error: function `render_violation_report` is never used --> ci/check_boundaries.rs:571
```

`ci/check_boundaries.rs` `main()` carries an **inline duplicate** of the forbidden-edge detection + reporting logic, while the extracted `check_violations` / `render_violation_report` helpers — which have a dedicated test suite — are never called from the bin. Under `--all-targets` (non-test bin target) they're dead code, and `-D warnings` fails. The two recently-merged boundary-checker PRs (#1264, #1265) each passed clippy alone, but their combination left the helpers orphaned. This blocks Server Clippy for **every** open PR.

## Fix

Rewire `main()` to call `check_violations` + `render_violation_report`, so the binary and the test suite exercise **one** code path and the duplication/dead-code is gone.

Behavior preserved:
- no violations → same `✓ No boundary violations found…` message, exit 0
- violations → same human-readable report on stderr, exit 1 (rendered via the helper, printed with `eprint!`)

## Verification

- `cargo clippy --all-targets --features qdrant -- -D warnings` ✅ (was failing on main)
- `cargo fmt --check` ✅
- `cargo test --bin check-boundaries --features qdrant` violation/report tests ✅ (7 passed)