### PR TITLE
fix(deps): upgrade rmcp 0.16 → 1.8 (real fix for RUSTSEC-2026-0189 DNS-rebinding)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"
@@ -546,10 +546,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2708,7 +2706,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4291,7 +4289,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4329,7 +4327,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4715,9 +4713,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4747,9 +4745,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6891,7 +6889,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7400,8 +7398,10 @@ dependencies = [
  "crossbeam-utils",
  "digest",
  "either",
+ "errno",
  "form_urlencoded",
  "futures-channel",
+ "futures-core",
  "futures-executor",
  "futures-io",
  "futures-sink",
@@ -7413,6 +7413,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "indexmap 2.13.0",
  "insta",
  "libc",
  "libgit2-sys",
@@ -7447,6 +7448,7 @@ dependencies = [
  "sqlx-postgres",
  "stable_deref_trait",
  "syn 2.0.117",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-rustls",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -68,7 +68,7 @@ bytes = "1"
 git2 = "0.20"
 dirs = "6"
 protobuf = "3"
-rmcp = { version = "0.16", features = ["server", "client", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "1", features = ["server", "client", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
 libc = "0.2"
 ring = "0.17"
 base64 = "0.22"

--- a/server/crates/djinn-agent/Cargo.toml
+++ b/server/crates/djinn-agent/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = "1"
 futures = "0.3"
 async-stream = "0.3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "form"] }
-rmcp = { version = "0.16", features = ["server", "client", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "1", features = ["server", "client", "transport-io", "transport-streamable-http-server", "transport-streamable-http-client-reqwest"] }
 schemars = "1"
 regex = "1.12.3"
 git2 = "0.20"

--- a/server/crates/djinn-agent/src/mcp_client.rs
+++ b/server/crates/djinn-agent/src/mcp_client.rs
@@ -194,12 +194,10 @@ impl McpToolRegistry {
             .get(server_name.as_str())
             .ok_or_else(|| format!("MCP server `{server_name}` peer not found"))?;
 
-        let params = CallToolRequestParams {
-            name: original_name.to_string().into(),
-            arguments: arguments.map(|m| m.into_iter().collect()),
-            meta: None,
-            task: None,
-        };
+        // CallToolRequestParams is #[non_exhaustive] in rmcp 1.x; build via
+        // new() + field assignment (meta/task default to None).
+        let mut params = CallToolRequestParams::new(original_name.to_string());
+        params.arguments = arguments.map(|m| m.into_iter().collect());
 
         let result = peer.call_tool(params).await.map_err(|e| {
             format!("MCP tool call `{tool_name}` on server `{server_name}` failed: {e}")
@@ -554,12 +552,7 @@ mod tests {
     fn call_tool_result_text_content() {
         use rmcp::model::Content;
 
-        let result = CallToolResult {
-            content: vec![Content::text("hello world")],
-            is_error: None,
-            meta: None,
-            structured_content: None,
-        };
+        let result = CallToolResult::success(vec![Content::text("hello world")]);
         let json = call_tool_result_to_json(result).unwrap();
         assert_eq!(json, serde_json::json!({ "result": "hello world" }));
     }
@@ -568,12 +561,7 @@ mod tests {
     fn call_tool_result_json_content() {
         use rmcp::model::Content;
 
-        let result = CallToolResult {
-            content: vec![Content::text(r#"{"key": "value"}"#)],
-            is_error: None,
-            meta: None,
-            structured_content: None,
-        };
+        let result = CallToolResult::success(vec![Content::text(r#"{"key": "value"}"#)]);
         let json = call_tool_result_to_json(result).unwrap();
         assert_eq!(json, serde_json::json!({ "key": "value" }));
     }
@@ -582,12 +570,7 @@ mod tests {
     fn call_tool_result_error() {
         use rmcp::model::Content;
 
-        let result = CallToolResult {
-            content: vec![Content::text("something went wrong")],
-            is_error: Some(true),
-            meta: None,
-            structured_content: None,
-        };
+        let result = CallToolResult::error(vec![Content::text("something went wrong")]);
         let err = call_tool_result_to_json(result).unwrap_err();
         assert_eq!(err, "something went wrong");
     }

--- a/server/crates/djinn-control-plane/Cargo.toml
+++ b/server/crates/djinn-control-plane/Cargo.toml
@@ -16,7 +16,7 @@ djinn-provider = { path = "../djinn-provider" }
 djinn-stack = { path = "../djinn-stack" }
 async-trait = "0.1"
 dirs = "6"
-rmcp = { version = "0.16", features = ["server", "transport-streamable-http-server"] }
+rmcp = { version = "1", features = ["server", "transport-streamable-http-server"] }
 http = "1"
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/server/crates/djinn-control-plane/src/server.rs
+++ b/server/crates/djinn-control-plane/src/server.rs
@@ -21,9 +21,7 @@ use rmcp::{
         common::server_side_http::{ServerSseMessage, session_id},
         streamable_http_server::{
             SessionId, SessionManager, StreamableHttpServerConfig, StreamableHttpService,
-            session::local::{
-                LocalSessionManager, LocalSessionManagerError, SessionConfig, create_local_session,
-            },
+            session::local::{LocalSessionManager, LocalSessionManagerError, create_local_session},
         },
     },
 };
@@ -155,14 +153,14 @@ impl DjinnMcpServer {
         let result = if let Some(project_id) = parse_graph_schema_project_id(&uri) {
             let text = serde_json::to_string_pretty(&graph_schema_payload(project_id))
                 .expect("graph schema payload must serialize");
-            Some(ReadResourceResult {
-                contents: vec![ResourceContents::TextResourceContents {
+            Some(ReadResourceResult::new(vec![
+                ResourceContents::TextResourceContents {
                     uri,
                     mime_type: Some(GRAPH_SCHEMA_RESOURCE_MIME_TYPE.to_string()),
                     text,
                     meta: None,
-                }],
-            })
+                },
+            ]))
         } else {
             None
         };
@@ -231,9 +229,14 @@ impl DjinnMcpServer {
                 }
             },
             session_manager,
-            StreamableHttpServerConfig {
-                cancellation_token: cancel.child_token(),
-                ..Default::default()
+            {
+                // StreamableHttpServerConfig is #[non_exhaustive] in rmcp 1.x.
+                // Build via Default + field assignment, and set the Host-header
+                // allowlist (DNS-rebinding guard, RUSTSEC-2026-0189).
+                let mut config = StreamableHttpServerConfig::default();
+                config.cancellation_token = cancel.child_token();
+                config.allowed_hosts = mcp_allowed_hosts();
+                config
             },
         )
     }
@@ -432,10 +435,9 @@ pub struct SessionEndHookSessionManager {
 impl SessionEndHookSessionManager {
     pub fn new(state: McpState) -> Self {
         Self {
-            local: LocalSessionManager {
-                sessions: Default::default(),
-                session_config: SessionConfig::default(),
-            },
+            // `LocalSessionManager` is #[non_exhaustive] in rmcp 1.x; its
+            // Default already gives empty sessions + default SessionConfig.
+            local: LocalSessionManager::default(),
             state: Some(state),
             session_servers: RwLock::new(HashMap::new()),
             staged_server: RwLock::new(None),
@@ -544,22 +546,82 @@ impl SessionManager for SessionEndHookSessionManager {
     }
 }
 
+/// Compute the `Host`-header allowlist for the Streamable HTTP MCP server.
+///
+/// rmcp 1.x validates the inbound `Host` header to defend against DNS-rebinding
+/// attacks (RUSTSEC-2026-0189); an empty list disables the check (rmcp 0.16
+/// behaviour). We keep loopback allowed — local dev is the real DNS-rebinding
+/// target — and add the public ingress host derived from `DJINN_PUBLIC_URL`
+/// (djinn's OAuth issuer base). Operators may override with
+/// `DJINN_MCP_ALLOWED_HOSTS` (comma-separated authorities); set it to `*` to
+/// disable Host validation entirely.
+fn mcp_allowed_hosts() -> Vec<String> {
+    mcp_allowed_hosts_from(
+        std::env::var("DJINN_MCP_ALLOWED_HOSTS").ok().as_deref(),
+        std::env::var("DJINN_PUBLIC_URL").ok().as_deref(),
+    )
+}
+
+fn mcp_allowed_hosts_from(override_var: Option<&str>, public_url: Option<&str>) -> Vec<String> {
+    if let Some(raw) = override_var {
+        let raw = raw.trim();
+        if raw == "*" {
+            return Vec::new(); // empty list => rmcp allows any Host
+        }
+        let hosts: Vec<String> = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+        if !hosts.is_empty() {
+            return hosts;
+        }
+    }
+    let mut hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    // No port => rmcp matches this host on any port.
+    if let Some(host) = public_url.and_then(public_url_host)
+        && !hosts.contains(&host)
+    {
+        hosts.push(host);
+    }
+    hosts
+}
+
+/// Extract the bare host (no scheme, userinfo, port, or path) from a URL.
+fn public_url_host(url: &str) -> Option<String> {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let authority = after_scheme.split('/').next().unwrap_or("");
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+    let host = if let Some(rest) = authority.strip_prefix('[') {
+        // IPv6 literal, e.g. [::1]:8372
+        rest.split(']').next().unwrap_or("")
+    } else {
+        authority.split(':').next().unwrap_or("")
+    }
+    .trim();
+    (!host.is_empty()).then(|| host.to_string())
+}
+
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for DjinnMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::LATEST,
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .enable_resources()
-                .build(),
-            server_info: Implementation {
-                name: "djinn-server".to_string(),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                ..Default::default()
-            },
-            instructions: None,
-        }
+        // ServerInfo (= InitializeResult) and Implementation are
+        // #[non_exhaustive] in rmcp 1.x, so build via constructors + field
+        // assignment rather than struct literals.
+        let capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_resources()
+            .build();
+        let mut info = ServerInfo::new(capabilities);
+        info.protocol_version = ProtocolVersion::LATEST;
+        info.server_info = Implementation::new("djinn-server", env!("CARGO_PKG_VERSION"));
+        info.instructions = None;
+        info
     }
 
     fn list_resources(
@@ -584,5 +646,68 @@ impl ServerHandler for DjinnMcpServer {
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ReadResourceResult, McpError>> + Send + '_ {
         std::future::ready(self.read_resource_uri(request.uri))
+    }
+}
+
+#[cfg(test)]
+mod host_allowlist_tests {
+    use super::{mcp_allowed_hosts_from, public_url_host};
+
+    #[test]
+    fn public_url_host_strips_scheme_port_path() {
+        assert_eq!(
+            public_url_host("https://code.djinnai.io"),
+            Some("code.djinnai.io".into())
+        );
+        assert_eq!(
+            public_url_host("https://code.djinnai.io:443/mcp"),
+            Some("code.djinnai.io".into())
+        );
+        assert_eq!(
+            public_url_host("http://user@host.example:8372/x"),
+            Some("host.example".into())
+        );
+        assert_eq!(public_url_host("http://[::1]:8372/mcp"), Some("::1".into()));
+        assert_eq!(public_url_host("127.0.0.1:3000"), Some("127.0.0.1".into()));
+        assert_eq!(public_url_host(""), None);
+    }
+
+    #[test]
+    fn default_allows_loopback_only_when_no_public_url() {
+        let hosts = mcp_allowed_hosts_from(None, None);
+        assert_eq!(hosts, vec!["localhost", "127.0.0.1", "::1"]);
+    }
+
+    #[test]
+    fn public_url_host_is_added_to_loopback() {
+        let hosts = mcp_allowed_hosts_from(None, Some("https://code.djinnai.io/mcp"));
+        assert!(hosts.contains(&"code.djinnai.io".to_string()));
+        assert!(hosts.contains(&"localhost".to_string()));
+    }
+
+    #[test]
+    fn loopback_public_url_is_not_duplicated() {
+        let hosts = mcp_allowed_hosts_from(None, Some("http://127.0.0.1:8372"));
+        assert_eq!(hosts.iter().filter(|h| *h == "127.0.0.1").count(), 1);
+    }
+
+    #[test]
+    fn override_takes_precedence_and_splits_csv() {
+        let hosts = mcp_allowed_hosts_from(
+            Some("a.example, b.example:8080"),
+            Some("https://ignored.example"),
+        );
+        assert_eq!(hosts, vec!["a.example", "b.example:8080"]);
+    }
+
+    #[test]
+    fn star_override_disables_validation() {
+        assert!(mcp_allowed_hosts_from(Some("*"), Some("https://x.example")).is_empty());
+    }
+
+    #[test]
+    fn blank_override_falls_back_to_defaults() {
+        let hosts = mcp_allowed_hosts_from(Some("   "), None);
+        assert_eq!(hosts, vec!["localhost", "127.0.0.1", "::1"]);
     }
 }

--- a/server/crates/djinn-control-plane/src/tools/graph_tools/tests_registry_dispatch.inc
+++ b/server/crates/djinn-control-plane/src/tools/graph_tools/tests_registry_dispatch.inc
@@ -1313,25 +1313,43 @@
         let snapshot = include_str!(
             "../../../../../src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap"
         );
-        let code_graph_start = snapshot
-            .find("\"name\": \"code_graph\"")
+        // Parse the snapshot JSON body (after the insta metadata header) and
+        // assert structural wire-shape rather than brittle substrings. Note:
+        // schemars 1.x (rmcp 1.x) no longer emits a `title` on the input
+        // schema, so we pin the operation field's shape instead — it must
+        // stay a plain required string, not a generated enum from the partial
+        // registry slice.
+        let body = snapshot
+            .splitn(3, "---\n")
+            .nth(2)
+            .expect("insta snapshot body after metadata header");
+        let tools: Vec<serde_json::Value> =
+            serde_json::from_str(body).expect("MCP schema snapshot is JSON");
+        let code_graph = tools
+            .iter()
+            .find(|t| t.get("name").and_then(serde_json::Value::as_str) == Some("code_graph"))
             .expect("MCP tool schema snapshot should contain code_graph tool");
-        let code_graph_snapshot = &snapshot[code_graph_start..];
+        let input = &code_graph["input_schema"];
 
+        let required: Vec<&str> = input["required"]
+            .as_array()
+            .expect("code_graph input schema has a required array")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect();
         assert!(
-            code_graph_snapshot.contains("\"title\": \"CodeGraphParams\""),
-            "code_graph tool schema must remain backed by CodeGraphParams"
+            required.contains(&"operation") && required.contains(&"project"),
+            "operation/project should remain required fields, got {required:?}"
+        );
+
+        let operation = &input["properties"]["operation"];
+        assert_eq!(
+            operation.get("type").and_then(serde_json::Value::as_str),
+            Some("string"),
+            "operation should remain a string field"
         );
         assert!(
-            code_graph_snapshot.contains("\"operation\": {"),
-            "code_graph schema must still expose an operation property"
-        );
-        assert!(
-            code_graph_snapshot.contains("\"operation\",\n        \"project\""),
-            "operation/project should remain required fields in the MCP schema snapshot"
-        );
-        assert!(
-            code_graph_snapshot.contains("\"type\": \"string\"\n        },\n        \"page_limit\""),
-            "operation should remain a string field; the partial vxmw registry must not emit an enum"
+            operation.get("enum").is_none(),
+            "operation must not become a generated enum from the partial vxmw registry"
         );
     }

--- a/server/crates/djinn-mcp-extension/Cargo.toml
+++ b/server/crates/djinn-mcp-extension/Cargo.toml
@@ -21,7 +21,7 @@ djinn-telemetry = { path = "../djinn-telemetry" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "1"
-rmcp = { version = "0.16", features = ["server"] }
+rmcp = { version = "1", features = ["server"] }
 thiserror = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["v7"] }

--- a/server/crates/workspace-hack/Cargo.toml
+++ b/server/crates/workspace-hack/Cargo.toml
@@ -28,6 +28,7 @@ digest = { version = "0.10.7", features = ["mac", "oid", "std"] }
 either = { version = "1.15.0", features = ["serde", "use_std"] }
 form_urlencoded = { version = "1.2.2" }
 futures-channel = { version = "0.3.32", features = ["sink"] }
+futures-core = { version = "0.3.32" }
 futures-executor = { version = "0.3.32" }
 futures-io = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
@@ -37,6 +38,7 @@ hashbrown = { version = "0.16.1", features = ["serde"] }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 hyper = { version = "1.9.0", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["client-legacy", "server-auto", "service"] }
+indexmap = { version = "2.13.0" }
 insta = { version = "1.47.2", features = ["json", "redactions"] }
 libgit2-sys = { version = "0.18.3", default-features = false, features = ["https", "ssh", "vendored", "vendored-openssl"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
@@ -50,12 +52,12 @@ regex-automata = { version = "0.4.14", default-features = false, features = ["df
 regex-syntax = { version = "0.8.10" }
 reqwest-594e8ee84c453af0 = { package = "reqwest", version = "0.13.2", default-features = false, features = ["form", "json", "rustls", "stream"] }
 reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.28", features = ["blocking", "json", "macos-system-configuration", "rustls-tls", "rustls-tls-native-roots", "stream"] }
-rmcp = { version = "0.16.0", features = ["client", "transport-io", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
+rmcp = { version = "1.8.0", features = ["client", "transport-io", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 rustls = { version = "0.23.37", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 schemars = { version = "1.2.1", features = ["chrono04"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
-serde_json = { version = "1.0.149", features = ["alloc", "preserve_order", "raw_value"] }
+serde_json = { version = "1.0.149", features = ["alloc", "raw_value"] }
 sha2 = { version = "0.10.9" }
 slab = { version = "0.4.12" }
 smallvec = { version = "1.15.1", default-features = false, features = ["const_new", "serde"] }
@@ -63,6 +65,7 @@ sqlx = { version = "0.8.6", features = ["mysql", "postgres", "runtime-tokio-rust
 sqlx-mysql = { version = "0.8.6", default-features = false, features = ["any", "json", "migrate", "offline"] }
 sqlx-postgres = { version = "0.8.6", default-features = false, features = ["any", "json", "migrate", "offline"] }
 stable_deref_trait = { version = "1.2.1" }
+thiserror = { version = "2.0.18" }
 time = { version = "0.3.47", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "1.50.0", features = ["full", "test-util"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
@@ -91,11 +94,13 @@ digest = { version = "0.10.7", features = ["mac", "oid", "std"] }
 either = { version = "1.15.0", features = ["serde", "use_std"] }
 form_urlencoded = { version = "1.2.2" }
 futures-channel = { version = "0.3.32", features = ["sink"] }
+futures-core = { version = "0.3.32" }
 futures-io = { version = "0.3.32" }
 futures-sink = { version = "0.3.32" }
 futures-util = { version = "0.3.32", features = ["channel", "io", "sink"] }
 hashbrown = { version = "0.16.1", features = ["serde"] }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
+indexmap = { version = "2.13.0" }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
 memchr = { version = "2.8.0" }
 num-traits = { version = "0.2.19", features = ["i128", "libm"] }
@@ -106,7 +111,7 @@ regex-syntax = { version = "0.8.10" }
 rustls = { version = "0.23.37", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 serde = { version = "1.0.228", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
-serde_json = { version = "1.0.149", features = ["alloc", "preserve_order", "raw_value"] }
+serde_json = { version = "1.0.149", features = ["alloc", "raw_value"] }
 sha2 = { version = "0.10.9" }
 slab = { version = "0.4.12" }
 smallvec = { version = "1.15.1", default-features = false, features = ["const_new", "serde"] }
@@ -116,6 +121,7 @@ sqlx-mysql = { version = "0.8.6", default-features = false, features = ["any", "
 sqlx-postgres = { version = "0.8.6", default-features = false, features = ["any", "json", "migrate", "offline"] }
 stable_deref_trait = { version = "1.2.1" }
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+thiserror = { version = "2.0.18" }
 tokio = { version = "1.50.0", features = ["full", "test-util"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "net", "sync"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io", "time"] }
@@ -129,7 +135,6 @@ zerofrom = { version = "0.1.7", default-features = false, features = ["alloc", "
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
-chrono = { version = "0.4.44" }
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27.7", default-features = false, features = ["aws-lc-rs", "http1", "http2", "logging", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system"] }
@@ -138,6 +143,7 @@ openssl-sys = { version = "0.9.112", default-features = false, features = ["vend
 ring = { version = "0.17.14", features = ["std"] }
 rustls = { version = "0.23.37", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
 rustls-webpki = { version = "0.103.10", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+serde_json = { version = "1.0.149", default-features = false, features = ["preserve_order"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.8", features = ["cors", "follow-redirect"] }
@@ -148,10 +154,11 @@ libc = { version = "0.2.184", features = ["extra_traits"] }
 ring = { version = "0.17.14", features = ["std"] }
 rustls = { version = "0.23.37", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
 rustls-webpki = { version = "0.103.10", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+serde_json = { version = "1.0.149", default-features = false, features = ["preserve_order"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
-chrono = { version = "0.4.44" }
+errno = { version = "0.3.14" }
 getrandom = { version = "0.4.2", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27.7", default-features = false, features = ["aws-lc-rs", "http1", "http2", "logging", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1.20", default-features = false, features = ["client-proxy", "client-proxy-system"] }
@@ -160,15 +167,18 @@ ring = { version = "0.17.14", features = ["std"] }
 rustls = { version = "0.23.37", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
 rustls-webpki = { version = "0.103.10", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
 security-framework-sys = { version = "2.17.0" }
+serde_json = { version = "1.0.149", default-features = false, features = ["preserve_order"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5.3", default-features = false, features = ["retry", "timeout"] }
 tower-http = { version = "0.6.8", features = ["cors", "follow-redirect"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
+errno = { version = "0.3.14" }
 ring = { version = "0.17.14", features = ["std"] }
 rustls = { version = "0.23.37", default-features = false, features = ["aws-lc-rs", "aws_lc_rs"] }
 rustls-webpki = { version = "0.103.10", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+serde_json = { version = "1.0.149", default-features = false, features = ["preserve_order"] }
 
 ### END HAKARI SECTION
 

--- a/server/deny.toml
+++ b/server/deny.toml
@@ -45,12 +45,6 @@ ignore = [
     "RUSTSEC-2026-0183",
     # gix: undefined behavior with Signature from buffer
     "RUSTSEC-2026-0184",
-    # rmcp: DNS rebinding in Streamable HTTP server transport (missing Host
-    # header validation). Patched in rmcp >= 1.4.0; we are on 0.16.0 and the
-    # upgrade is a breaking major-version migration tracked separately. djinn's
-    # MCP server runs ingress-fronted + OAuth-authenticated, not as a loopback
-    # server, which is the primary DNS-rebinding target. Remove this on upgrade.
-    "RUSTSEC-2026-0189",
 ]
 
 # ---------------------------------------------------------------------------

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -21,21 +21,27 @@ expression: signatures
           "type": "string"
         },
         "description": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mcp_servers": {
           "description": "Additional MCP server refs for this agent.",
           "items": {
             "$ref": "#/$defs/AnyJson"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "model_preference": {
           "description": "Preferred model ID (falls back to project default).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "description": "Unique agent name within the project.",
@@ -50,13 +56,17 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AnyJson"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "system_prompt_extensions": {
           "description": "Additional system prompt content appended to the base role prompt.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -64,7 +74,6 @@ expression: signatures
         "name",
         "base_role"
       ],
-      "title": "AgentCreateParams",
       "type": "object"
     },
     "output_schema": {
@@ -83,8 +92,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -94,8 +105,10 @@ expression: signatures
         },
         "learned_prompt": {
           "description": "Machine-managed prompt learning state. Derived from active\nlearned_prompt_history amendments. Read-only in public surfaces;\nmutations flow through agent_amend_prompt (Planner) and the\nevaluator/confirmation loop.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mcp_servers": {
           "items": {
@@ -104,8 +117,10 @@ expression: signatures
           "type": "array"
         },
         "model_preference": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "type": "string"
@@ -126,7 +141,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "AgentSingleResponse",
       "type": "object"
     }
   },
@@ -142,18 +156,24 @@ expression: signatures
       "properties": {
         "base_role": {
           "description": "Filter by base role: worker, lead, planner, architect, reviewer.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -163,7 +183,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "AgentListParams",
       "type": "object"
     },
     "output_schema": {
@@ -187,8 +206,10 @@ expression: signatures
             },
             "learned_prompt": {
               "description": "Machine-managed prompt learning state. Derived from active\nlearned_prompt_history amendments. Read-only in public surfaces;\nmutations flow through agent_amend_prompt (Planner) and the\nevaluator/confirmation loop.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "mcp_servers": {
               "items": {
@@ -197,8 +218,10 @@ expression: signatures
               "type": "array"
             },
             "model_preference": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "name": {
               "type": "string"
@@ -242,34 +265,45 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AgentModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "has_more": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "total_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
-      "title": "AgentListResponse",
       "type": "object"
     }
   },
@@ -284,22 +318,25 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "agent_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
         },
         "window_days": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "AgentMetricsParams",
       "type": "object"
     },
     "output_schema": {
@@ -343,8 +380,10 @@ expression: signatures
               "$ref": "#/$defs/ExtractionQualityMetricEntry"
             },
             "learned_prompt": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "success_rate": {
               "format": "double",
@@ -400,12 +439,16 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AgentMetricEntry"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "window_days": {
           "format": "int64",
@@ -415,7 +458,6 @@ expression: signatures
       "required": [
         "window_days"
       ],
-      "title": "AgentMetricsResponse",
       "type": "object"
     }
   },
@@ -442,7 +484,6 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "AgentShowParams",
       "type": "object"
     },
     "output_schema": {
@@ -461,8 +502,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -472,8 +515,10 @@ expression: signatures
         },
         "learned_prompt": {
           "description": "Machine-managed prompt learning state. Derived from active\nlearned_prompt_history amendments. Read-only in public surfaces;\nmutations flow through agent_amend_prompt (Planner) and the\nevaluator/confirmation loop.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mcp_servers": {
           "items": {
@@ -482,8 +527,10 @@ expression: signatures
           "type": "array"
         },
         "model_preference": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "type": "string"
@@ -504,7 +551,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "AgentSingleResponse",
       "type": "object"
     }
   },
@@ -523,12 +569,16 @@ expression: signatures
       "properties": {
         "clear_learned_prompt": {
           "description": "Set to true to clear machine-managed learned_prompt back to NULL.\nAdmin/operator reset path; learned_prompt is otherwise managed through\nagent_amend_prompt and the evaluator loop.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "description": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "description": "Agent UUID or name.",
@@ -538,16 +588,22 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AnyJson"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "model_preference": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -557,19 +613,22 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AnyJson"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "system_prompt_extensions": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project",
         "id"
       ],
-      "title": "AgentUpdateParams",
       "type": "object"
     },
     "output_schema": {
@@ -588,8 +647,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -599,8 +660,10 @@ expression: signatures
         },
         "learned_prompt": {
           "description": "Machine-managed prompt learning state. Derived from active\nlearned_prompt_history amendments. Read-only in public surfaces;\nmutations flow through agent_amend_prompt (Planner) and the\nevaluator/confirmation loop.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mcp_servers": {
           "items": {
@@ -609,8 +672,10 @@ expression: signatures
           "type": "array"
         },
         "model_preference": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "type": "string"
@@ -631,7 +696,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "AgentSingleResponse",
       "type": "object"
     }
   },
@@ -652,20 +716,20 @@ expression: signatures
         "stale_threshold_hours": {
           "description": "Hours before an in_progress task is considered stale (default: 24).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "BoardHealthParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrBoardHealthResponse",
       "type": "object"
     }
   },
@@ -686,20 +750,20 @@ expression: signatures
         "stale_threshold_hours": {
           "description": "Hours before an in_progress task is considered stale (default: 24).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "BoardReconcileParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrBoardReconcileResponse",
       "type": "object"
     }
   },
@@ -717,8 +781,10 @@ expression: signatures
           "properties": {
             "description": {
               "description": "Optional human-readable explanation of why this rule exists,\nsurfaced in CI output so violations are self-documenting.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "from_glob": {
               "type": "string"
@@ -739,8 +805,10 @@ expression: signatures
             "end_line": {
               "description": "Inclusive 1-indexed last line of the hunk. Defaults to `start_line`\nwhen the caller passed a single-line hunk.",
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "file": {
               "description": "Repository-relative path of the file the hunk lives in.",
@@ -764,8 +832,10 @@ expression: signatures
         "by_depth_counts": {
           "default": null,
           "description": "df6s: per-depth counts for `impact`. When `Some(true)`, the\nresponse ships a `by_depth_counts: { \"1\": 12, \"2\": 7 }` map\nalongside the (sliced) impact list so triage can read the\ndepth distribution without walking every entry. Honoured by\n`impact` only; other ops ignore it. `summary_only=true`\nalready implies this — passing both is fine.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "changed_files": {
           "default": null,
@@ -773,8 +843,10 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "changed_ranges": {
           "default": null,
@@ -782,32 +854,42 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/ChangedRange"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "confidence": {
           "default": null,
           "description": "Confidence tier for `dead_symbols`: `high`, `med`, or `low`.\nDefault `high`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "context_filter": {
           "default": null,
           "description": "Optional coarse context substring for `query_subgraph`. Use this to\nnarrow the natural-language subgraph query to a subsystem, API, type,\nor concern when the initial response is too broad; returned\n`narrowing_hints` may suggest values for this field.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "current_head": {
           "default": null,
           "description": "jc47: the caller's current HEAD / git commit SHA. When supplied,\nevery successful `code_graph` response includes an additive\n`graph_staleness` object comparing this commit against the cached\ngraph blob's pinned commit. Omit to keep the previous response\nshape (no `graph_staleness` field). Empty/whitespace values are\nnormalized to `None` so clients that serialize every field as `\"\"`\ndon't accidentally trigger staleness computation. `caller_commit`\nand `currentHead` are accepted as aliases.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "direction": {
           "default": null,
           "description": "Edge direction filter for `neighbors`: `incoming`, `outgoing`, or omit for both.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "edge_filters": {
           "default": null,
@@ -815,69 +897,91 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "edge_kind": {
           "default": null,
           "description": "Optional edge-kind filter for `edges`; for `query_subgraph`, a\nsingle-kind compatibility alias used when `edge_filters` is omitted.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "end_line": {
           "default": null,
           "description": "1-indexed inclusive end line for `symbols_at`. Defaults to\n`start_line` when omitted.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "file": {
           "default": null,
           "description": "Repository-relative file path for `symbols_at`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "file_filter": {
           "default": null,
           "description": "Optional repository-relative path/file substring filter for\n`query_subgraph`. It narrows seed selection and traversal to matching\nfile paths. `file_glob` is also accepted as a compatibility alias and\nis used when `file_filter` is omitted.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "file_glob": {
           "default": null,
           "description": "Optional file glob restricting `hotspots` to a subset of paths. For\n`query_subgraph`, a path-filter compatibility alias used when\n`file_filter` is omitted.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "framework": {
           "default": null,
           "description": "Optional route framework filter for `route_map` discovery.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "from": {
           "default": null,
           "description": "Source node for `path`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "from_glob": {
           "default": null,
           "description": "Source path glob for `edges`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "from_sha": {
           "default": null,
           "description": "Base SHA for `detect_changes`. When paired with `to_sha`, the\nop runs `git diff --unified=0 from_sha..to_sha` and maps the\nresulting hunks to symbols. Mutually exclusive with\n`changed_files` only when both are absent — when both are\nprovided, line-level wins.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "group_by": {
           "default": null,
           "description": "Group results: only `file` is supported. Applies to `impact`/`neighbors`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "impact_targets": {
           "default": null,
@@ -885,111 +989,145 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "include_content": {
           "default": null,
           "description": "PR C1: when `true`, the `context` op populates\n`symbol_context.symbol.content` with the symbol's body text\nread from the project clone. Default `false` — bandwidth\nmatters; clients that already have the file open don't need\nthe body shipped over MCP.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "include_optional": {
           "default": null,
           "description": "Include optional response fields when computing `shape_check` drift.\nDefaults to `false`.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "key": {
           "default": null,
           "description": "The node key to query (file path or SCIP symbol string).\nRequired for `neighbors`, `impact`, `implementations`, and `describe`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind_filter": {
           "default": null,
           "description": "Kind filter, op-specific:\n- `ranked` / `search` / `cycles` / `orphans`: node kind — `file` or\n  `symbol`.\n- `query_subgraph`: node-kind narrowing for seeds/traversal — `file`\n  or `symbol`.\n- `neighbors`: edge kind — `reads` or `writes` (PR A3). Restricts\n  the response to neighbors connected by `Reads` / `Writes` edges\n  only, so callers can ask for \"who writes to field X\" without\n  post-filtering.\n- `flow`: flow-hit tier — `process` or `step`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind_hint": {
           "default": null,
           "description": "PR C2: optional kind hint biasing the C2 disambiguation score\nwhen `key` is a short identifier (e.g. `\"User\"`) and the\nresolver hits multiple candidates. Accepts the same labels the\nresolver emits: `\"file\"`, `\"class\"`, `\"interface\"`, `\"function\"`,\n`\"method\"`, `\"struct\"`, `\"enum\"`, etc.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "level": {
           "default": null,
           "description": "Semantic zoom level for `snapshot`: `symbol` keeps the existing\nfile/symbol-node payload shape; `community` is accepted for forward\ncompatibility with the collapsed community view.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "default": null,
           "description": "Maximum results for list operations. Defaults are op-specific:\n`ranked`/`search`/`neighbors`/`flow` default 20, `route_map`/\n`api_impact` default 50, `edges` default 100. For `impact`, this is\nmax traversal depth (default 3). Negative values are treated as zero by\nlegacy ops; new route/API/flow ops reject negative limits.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "max_depth": {
           "default": null,
           "description": "Optional max depth. For `path`, bounds shortest-path search depth. For\n`query_subgraph`, bounds traversal depth from selected seeds; omit to\nuse the backend default (currently 2). Values are clamped into 0..=8, so 0 means seed\nnodes only and larger values are capped at 8.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "max_files_per_commit": {
           "default": null,
           "description": "Max files per commit before a commit is skipped in the\n`coupling_hotspots` / `coupling_hubs` aggregation. Default 15.\nProtects the pair-count signal from lockfile refreshes,\ncodemods, and similar bulk rewrites that contribute `N^2`\npairs with essentially zero real coupling information.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "max_seeds": {
           "default": null,
           "description": "Maximum seed count for `query_subgraph`. Omit to use the backend\ndefault (currently 6). Positive values are clamped into 1..=32; zero/negative values\nare rejected. Returned seed debug metadata explains which seeds were\nselected and why.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "method": {
           "default": null,
           "description": "HTTP method for route-aware ops (`route_map`, `shape_check`,\n`api_impact`) when `route_id` is not supplied.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "min_confidence": {
           "default": null,
           "description": "Minimum edge confidence in `[0, 1]` for the `impact` BFS frontier\n(PR A2). Edges below this threshold are skipped — useful for\nexcluding `local`-prefixed references and other low-confidence SCIP\nsignals from the blast radius. Omit to keep every edge regardless of\nconfidence (default behaviour).",
           "format": "double",
-          "nullable": true,
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "min_size": {
           "default": null,
           "description": "Minimum SCC size for `cycles` (default 2).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "mode": {
           "default": null,
           "description": "PR B4: search mode for the `search` op. `\"name\"` (the legacy\nfast path) runs the canonical-graph name index only;\n`\"hybrid\"` blends lexical (`code_chunks` LIKE), semantic\n(Qdrant cosine), and structural signals via RRF k=60. The\neffective default is read from `DJINN_CODE_GRAPH_SEARCH_DEFAULT_MODE`\n(defaults to `\"name\"`); pass an explicit value to override.\nIgnored by every other op.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "module_glob": {
           "default": null,
           "description": "Optional module-path glob for `api_surface` (filter symbols by\n`file_path`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "offset": {
           "default": null,
           "description": "df6s: page offset for paginated traversal ops (`neighbors`,\n`impact`, `coupling_hotspots`). Sliced **only** when\nconstructing the agent-facing response DTO — the underlying\n`RepoDependencyGraph` traversal always runs to completion so\n`total` reflects the unsliced result count and pagination can\nnever be misread as \"the graph has no more nodes\". Empty\nstring is normalized to `None` via `normalize()`. Negative\nvalues are clamped to zero at the handler boundary.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "operation": {
           "description": "The operation to perform.\nOne of: `neighbors`, `ranked`, `impact`, `implementations`,\n`search`, `query_subgraph`, `route_map`, `shape_check`,\n`api_impact`, `flow`, `cycles`, `orphans`, `path`, `edges`,\n`symbols_at`, `diff_touches`, `detect_changes`, `describe`,\n`context`, `status`, `snapshot`, `workspaces`, and the other\ngraph analysis ops.",
@@ -999,20 +1137,26 @@ expression: signatures
           "default": null,
           "description": "df6s: distinct result cap for paginated traversal ops. For\n`neighbors` / `coupling_hotspots` this is the existing `limit`\n(re-aliased for clarity), so the field is **only** consumed by\nops where `limit` means something else — currently `impact`,\nwhere `limit` is the BFS depth. `impact` therefore reads\n`page_limit` for its result cap and keeps `limit` as the\ntraversal depth. Defaults to 100 when omitted; clamps to\n`[1, 1000]`. Sliced only at the response-DTO layer; the\ninternal traversal still runs to completion.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "path": {
           "default": null,
           "description": "Exact route path for `shape_check` / `api_impact` when `route_id` is\nnot supplied.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "path_glob": {
           "default": null,
           "description": "Route path glob for `route_map` discovery.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "description": "Project identifier — either the UUID (`project_id`) or the\ncanonical `\"owner/repo\"` slug. The handler resolves it to the\nserver-managed clone path via `djinn_core::paths::project_dir`\nbefore dispatching to the graph backend.",
@@ -1021,14 +1165,18 @@ expression: signatures
         "query": {
           "default": null,
           "description": "Query text, op-specific:\n- `search`: substring/name lookup text.\n- `query_subgraph`: required nonblank natural-language question used\n  to pick relevant seeds and infer useful traversal edge kinds.\n- `flow`: required nonblank natural-language query re-ranked over\n  process/step matches.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "route_id": {
           "default": null,
           "description": "Stable route id for route-aware ops. For `shape_check` and\n`api_impact`, callers must provide either `route_id` or both\n`method` and `path`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "rules": {
           "default": null,
@@ -1036,8 +1184,10 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/BoundaryRule"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "scope_crates": {
           "default": null,
@@ -1045,8 +1195,10 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "seed_entries": {
           "default": null,
@@ -1054,8 +1206,10 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "seed_sinks": {
           "default": null,
@@ -1063,34 +1217,44 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "since_days": {
           "default": null,
           "description": "Time-window (in days) for the `churn` op. Omit for all-time.\nClamped to `[1, 3650]` server-side.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "sort_by": {
           "default": null,
           "description": "Sort key for `ranked`: `pagerank` (default), `in_degree`, `out_degree`,\nor `total_degree`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "start_line": {
           "default": null,
           "description": "1-indexed inclusive start line for `symbols_at`.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "summary_only": {
           "default": null,
           "description": "df6s: counts-only mode for paginated traversal ops\n(`neighbors`, `impact`, `coupling_hotspots`). When `Some(true)`,\nthe response omits the large node/pair lists and instead ships\n`total` + the relevant counters (`by_depth_counts` for impact).\nDesigned for triage: a model can ask \"how big is the blast\nradius?\" without paying the token cost of every impacted\nsymbol. The internal traversal still runs to completion so\ngroup_by-file rollups report the full per-module count.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "symbols": {
           "default": null,
@@ -1098,77 +1262,95 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "target": {
           "default": null,
           "description": "Iter 28: target tier for the `complexity` op — `\"functions\"`\n(default) or `\"files\"`. The `functions` shape ranks individual\nfunction-like symbols; the `files` shape aggregates by file_path\nand returns per-file totals + worst-offender info. Reuses the\nshared `sort_by`, `file_glob`, and `limit` fields.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tests": {
           "default": null,
           "description": "v10: test-file filter. `\"include\"` (default for `snapshot` —\nreturns the whole graph), `\"exclude\"` (drop every node the graph\nbuilder marked `is_test`), or `\"only\"` (keep only test nodes).\nTest classification is the canonical `RepoGraphNode::is_test`\nflag (file-path convention OR SCIP `Test` role). Currently\nhonoured by the `snapshot` op; other ops keep their existing\ntest-handling.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "to": {
           "default": null,
           "description": "Destination node for `path`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "to_glob": {
           "default": null,
           "description": "Destination path glob for `edges`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "to_sha": {
           "default": null,
           "description": "Head SHA for `detect_changes`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "token_budget": {
           "default": null,
           "description": "Approximate response token budget for `query_subgraph`. Omit to use\nthe backend default (currently about 2000 tokens). Positive values below 1024 are clamped up to 1024,\nvalues above 32000 are clamped down to 32000, and zero/negative values\nare rejected. The result reports budget/truncation state so callers can\nretry with a narrower filter or a different budget.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "visibility": {
           "default": null,
           "description": "Visibility filter for `orphans`: `public`, `private`, or `any` (default).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "window_days": {
           "default": null,
           "description": "Churn look-back window in days for `hotspots` (default 90, clamped\nto 365).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "workspace": {
           "default": null,
           "description": "Optional workspace slug. Empty string is normalized to omitted. Use\n`operation = \"workspaces\"` to enumerate valid slugs and metadata\n(`slug`, `name`, `node_count`, `commit_sha`, `warmed_at`, `status`).\nKnown workspaces hard-scope listing/bounded ops such as `ranked`,\n`orphans`, `snapshot`, and `api_surface`. Traversal ops such as\n`impact`, `path`, `touches_hot_path`, and `query_subgraph` use the\nworkspace only while resolving seeds/endpoints, then keep the traversal\ncross-workspace so blast radius stays visible. Unknown non-empty slugs\nreturn unscoped results with `workspace_hint` candidate slugs where the\nresponse type supports hints; single-workspace graphs treat the parameter\nas a no-op.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "operation",
         "project"
       ],
-      "title": "CodeGraphParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrCodeGraphResponse",
       "type": "object"
     }
   },
@@ -1190,7 +1372,6 @@ expression: signatures
       "required": [
         "key_name"
       ],
-      "title": "CredentialDeleteInput",
       "type": "object"
     },
     "output_schema": {
@@ -1200,8 +1381,10 @@ expression: signatures
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "key_name": {
           "type": "string"
@@ -1219,7 +1402,6 @@ expression: signatures
         "deleted",
         "key_name"
       ],
-      "title": "CredentialDeleteResponse",
       "type": "object"
     }
   },
@@ -1236,11 +1418,12 @@ expression: signatures
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "CredentialListInput",
       "type": "object"
     },
     "output_schema": {
@@ -1285,7 +1468,6 @@ expression: signatures
       "required": [
         "credentials"
       ],
-      "title": "CredentialListResponse",
       "type": "object"
     }
   },
@@ -1319,8 +1501,10 @@ expression: signatures
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -1328,15 +1512,16 @@ expression: signatures
         "key_name",
         "api_key"
       ],
-      "title": "CredentialSetInput",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -1357,7 +1542,6 @@ expression: signatures
         "id",
         "key_name"
       ],
-      "title": "CredentialSetResponse",
       "type": "object"
     }
   },
@@ -1394,15 +1578,16 @@ expression: signatures
         "target_id": {
           "default": null,
           "description": "Required for `project` and `user`; must be omitted for `global`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "scope",
         "reason"
       ],
-      "title": "DispatchPauseParams",
       "type": "object"
     },
     "output_schema": {
@@ -1412,8 +1597,10 @@ expression: signatures
           "description": "Metadata recorded when dispatch is paused for a scope.",
           "properties": {
             "expires_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "paused_at": {
               "type": "string"
@@ -1453,14 +1640,15 @@ expression: signatures
               "$ref": "#/$defs/DispatchPause"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -1471,8 +1659,7 @@ expression: signatures
               "$ref": "#/$defs/DispatchPause"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
@@ -1480,8 +1667,10 @@ expression: signatures
           "$ref": "#/$defs/DispatchPauseScope"
         },
         "target_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -1489,7 +1678,6 @@ expression: signatures
         "changed",
         "scope"
       ],
-      "title": "DispatchPauseMutationResponse",
       "type": "object"
     }
   },
@@ -1521,8 +1709,7 @@ expression: signatures
               "$ref": "#/$defs/DispatchPauseScope"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "default": null,
@@ -1531,11 +1718,12 @@ expression: signatures
         "target_id": {
           "default": null,
           "description": "Required when filtering `project` or `user`; invalid for `global`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "DispatchPauseStatusParams",
       "type": "object"
     },
     "output_schema": {
@@ -1545,8 +1733,10 @@ expression: signatures
           "description": "Metadata recorded when dispatch is paused for a scope.",
           "properties": {
             "expires_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "paused_at": {
               "type": "string"
@@ -1584,8 +1774,7 @@ expression: signatures
                   "$ref": "#/$defs/DispatchPause"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ]
             },
@@ -1615,14 +1804,15 @@ expression: signatures
               "$ref": "#/$defs/DispatchPause"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -1633,8 +1823,7 @@ expression: signatures
               "$ref": "#/$defs/DispatchPauseScope"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
@@ -1644,20 +1833,20 @@ expression: signatures
               "$ref": "#/$defs/DispatchPauseState"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "target_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "ok"
       ],
-      "title": "DispatchPauseStatusResponse",
       "type": "object"
     }
   },
@@ -1690,14 +1879,15 @@ expression: signatures
         "target_id": {
           "default": null,
           "description": "Required for `project` and `user`; must be omitted for `global`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "scope"
       ],
-      "title": "DispatchResumeParams",
       "type": "object"
     },
     "output_schema": {
@@ -1707,8 +1897,10 @@ expression: signatures
           "description": "Metadata recorded when dispatch is paused for a scope.",
           "properties": {
             "expires_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "paused_at": {
               "type": "string"
@@ -1748,14 +1940,15 @@ expression: signatures
               "$ref": "#/$defs/DispatchPause"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -1766,8 +1959,7 @@ expression: signatures
               "$ref": "#/$defs/DispatchPause"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
@@ -1775,8 +1967,10 @@ expression: signatures
           "$ref": "#/$defs/DispatchPauseScope"
         },
         "target_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -1784,7 +1978,6 @@ expression: signatures
         "changed",
         "scope"
       ],
-      "title": "DispatchPauseMutationResponse",
       "type": "object"
     }
   },
@@ -1797,7 +1990,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Parameters for `doctor_fix`.",
       "properties": {
         "check_name": {
           "description": "The stable name of the check that owns the finding. Must match the\n`check_name` stored on the persisted finding row.",
@@ -1812,19 +2004,19 @@ expression: signatures
         "check_name",
         "finding_id"
       ],
-      "title": "DoctorFixParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `doctor_fix`.",
       "properties": {
         "check_name": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "finding_id": {
           "type": "string"
@@ -1838,7 +2030,6 @@ expression: signatures
         "check_name",
         "finding_id"
       ],
-      "title": "DoctorFixResponse",
       "type": "object"
     }
   },
@@ -1851,29 +2042,33 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Parameters for `doctor_list_findings`.\n\nAll filters are optional; an unset field means \"no narrowing on that\ndimension\". The `check` filter matches `check_name` exactly. The\n`since` filter is a lower-bound timestamp — rows with\n`created_at < since` are excluded. The value should be a UTC\nISO-8601 string matching the schema's `created_at` template so the\nstring comparison the repository issues in SQL is also a valid\nchronological comparison.\n\n`limit` is `i64` (not `usize`) so the generated MCP JSON schema\nlands on `format: int64` instead of the nonstandard `uint` pinned\nby `tool_schemas::mcp_tools_list_schemas_do_not_use_nonstandard_uint_…`.\nThe repository's defensive ceiling (`MAX_RECENT_FINDINGS`) still\napplies, and any caller value above it is silently clamped.",
       "properties": {
         "check": {
           "default": null,
           "description": "Optional check name to narrow on (matches `check_name` exactly).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "default": null,
           "description": "Optional cap on the number of findings returned. Clamped to\n`MAX_RECENT_FINDINGS` (the repository's defensive ceiling) when\nlarger. Defaults to the repository's defensive ceiling when\nomitted.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "since": {
           "default": null,
           "description": "Optional lower-bound timestamp filter. Rows with\n`created_at < since` are excluded. Defaults to \"no time\nfilter\" so callers can ask for \"the last N findings for\nthis check\" without a cutoff.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "DoctorListFindingsParams",
       "type": "object"
     },
     "output_schema": {
@@ -1891,8 +2086,10 @@ expression: signatures
             },
             "detail": {
               "description": "Free-form human-readable detail surfaced in reports.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "entity_ids": {
               "$ref": "#/$defs/AnyJson",
@@ -1912,16 +2109,17 @@ expression: signatures
                   "$ref": "#/$defs/AnyJson"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "Resolver inputs and outputs captured at check time. `None` for\nchecks with no associated resolver."
             },
             "run_id": {
               "description": "The run that produced this finding. `None` for ad-hoc inserts.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "severity": {
               "type": "string"
@@ -1939,11 +2137,12 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `doctor_list_findings`.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "filtered_by_check": {
           "description": "`true` when a filter was applied. Useful for the board / audit\nUI to display \"filtered by check X, since Y\" in the response.",
@@ -1976,7 +2175,6 @@ expression: signatures
         "filtered_by_since",
         "limit"
       ],
-      "title": "DoctorListFindingsResponse",
       "type": "object"
     }
   },
@@ -1989,7 +2187,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Parameters for `doctor_run`.",
       "properties": {
         "check_names": {
           "default": null,
@@ -1997,11 +2194,12 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "DoctorRunParams",
       "type": "object"
     },
     "output_schema": {
@@ -2030,8 +2228,10 @@ expression: signatures
             },
             "error": {
               "description": "Error message when `ran` is `false`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "findings": {
               "description": "Findings emitted by this check, with their persisted ids filled in.",
@@ -2079,11 +2279,12 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `doctor_run`.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -2114,7 +2315,6 @@ expression: signatures
         "results",
         "total_findings"
       ],
-      "title": "DoctorRunResponse",
       "type": "object"
     }
   },
@@ -2146,27 +2346,28 @@ expression: signatures
         "id",
         "read_source"
       ],
-      "title": "EpicReadSourceParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the read-only multi-repo read-source tools.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "read_sources": {
           "description": "The epic's read-source projects as `owner/repo` slugs.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "EpicReadSourcesResponse",
       "type": "object"
     }
   },
@@ -2193,7 +2394,6 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "EpicBlockersParams",
       "type": "object"
     },
     "output_schema": {
@@ -2224,21 +2424,23 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the epic-dependency listing tools.",
       "properties": {
         "blockers": {
           "items": {
             "$ref": "#/$defs/EpicBlockerItem"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "EpicBlockersResponse",
       "type": "object"
     }
   },
@@ -2265,7 +2467,6 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "EpicBlockersParams",
       "type": "object"
     },
     "output_schema": {
@@ -2296,21 +2497,23 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the epic-dependency listing tools.",
       "properties": {
         "blockers": {
           "items": {
             "$ref": "#/$defs/EpicBlockerItem"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "EpicBlockersResponse",
       "type": "object"
     }
   },
@@ -2337,7 +2540,6 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "EpicCloseParams",
       "type": "object"
     },
     "output_schema": {
@@ -2348,8 +2550,10 @@ expression: signatures
           "type": "boolean"
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "color": {
           "type": "string"
@@ -2359,8 +2563,10 @@ expression: signatures
         },
         "created_by_user_id": {
           "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": "string"
@@ -2369,8 +2575,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -2383,8 +2591,10 @@ expression: signatures
         },
         "originating_adr_id": {
           "description": "ADR-051 Epic C — mirrors `Epic::originating_adr_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
           "type": "string"
@@ -2402,7 +2612,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "EpicSingleResponse",
       "type": "object"
     }
   },
@@ -2418,22 +2627,25 @@ expression: signatures
       "properties": {
         "group_by": {
           "description": "Group results by: \"status\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
           "type": "string"
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "EpicCountParams",
       "type": "object"
     },
     "output_schema": {
@@ -2458,23 +2670,28 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "groups": {
           "items": {
             "$ref": "#/$defs/EpicCountGroup"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "total_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
-      "title": "EpicCountResponse",
       "type": "object"
     }
   },
@@ -2490,45 +2707,61 @@ expression: signatures
       "properties": {
         "auto_breakdown": {
           "description": "When `false`, the coordinator will NOT auto-dispatch a breakdown\nPlanner when this epic is created — the way to stage an epic without\nrunning it (replaces the old `drafting` status). Defaults to `true`.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "blocked_by": {
           "description": "Epic-level dependencies: UUIDs or short_ids of epics that must close\nbefore this epic's auto-breakdown can run.  Wired atomically at\ncreation time so the `epic_created` event is only emitted after\nblocker edges exist in the DB.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "color": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "emoji": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "memory_refs": {
           "description": "Memory reference URLs for this epic (e.g. ADR paths).",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "originating_adr_id": {
           "description": "ADR-051 Epic C — slug of the accepted ADR that spawned this\nepic.  Threaded into the breakdown Planner's session context\nso downstream task creation inherits the architectural rationale.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -2536,21 +2769,27 @@ expression: signatures
         },
         "proposal_id": {
           "description": "When this epic is created as part of decomposing a graduated proposal\n(Planner Mode D), pass the proposal UUID or short_id to record the\n`proposal → epic` link so the proposal can track what it became.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "read_sources": {
           "description": "Read-only multi-repo: other registered projects (UUIDs or\nowner/repo slugs) this epic's tasks may READ while still writing\nonly to `project`. Set this when the work consults another repo —\ne.g. migrating code FROM project A INTO this epic's project, pass\n`read_sources: [\"owner/A\"]`.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "status": {
           "description": "Initial status: only \"open\" (the default). Epics are open → closed;\npre-execution drafting lives in proposals now.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -2560,7 +2799,6 @@ expression: signatures
         "project",
         "title"
       ],
-      "title": "EpicCreateParams",
       "type": "object"
     },
     "output_schema": {
@@ -2571,8 +2809,10 @@ expression: signatures
           "type": "boolean"
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "color": {
           "type": "string"
@@ -2582,8 +2822,10 @@ expression: signatures
         },
         "created_by_user_id": {
           "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": "string"
@@ -2592,8 +2834,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -2606,8 +2850,10 @@ expression: signatures
         },
         "originating_adr_id": {
           "description": "ADR-051 Epic C — mirrors `Epic::originating_adr_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
           "type": "string"
@@ -2625,7 +2871,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "EpicSingleResponse",
       "type": "object"
     }
   },
@@ -2652,7 +2897,6 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "EpicDeleteParams",
       "type": "object"
     },
     "output_schema": {
@@ -2660,19 +2904,24 @@ expression: signatures
       "properties": {
         "deleted_task_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
-      "title": "EpicDeleteResponse",
       "type": "object"
     }
   },
@@ -2688,13 +2937,17 @@ expression: signatures
       "properties": {
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -2702,23 +2955,28 @@ expression: signatures
         },
         "sort": {
           "description": "Sort order: \"created\" (default), \"created_desc\", \"updated\", \"updated_desc\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "text": {
           "description": "Full-text search on title and description.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "EpicListParams",
       "type": "object"
     },
     "output_schema": {
@@ -2730,8 +2988,10 @@ expression: signatures
               "type": "boolean"
             },
             "closed_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "color": {
               "type": "string"
@@ -2741,8 +3001,10 @@ expression: signatures
             },
             "created_by_user_id": {
               "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "description": {
               "type": "string"
@@ -2761,8 +3023,10 @@ expression: signatures
             },
             "originating_adr_id": {
               "description": "ADR-051 Epic C — mirrors `Epic::originating_adr_id`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "owner": {
               "type": "string"
@@ -2803,34 +3067,45 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/EpicModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "has_more": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "total_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
-      "title": "EpicListResponse",
       "type": "object"
     }
   },
@@ -2857,27 +3132,28 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "EpicShowParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the read-only multi-repo read-source tools.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "read_sources": {
           "description": "The epic's read-source projects as `owner/repo` slugs.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "EpicReadSourcesResponse",
       "type": "object"
     }
   },
@@ -2909,27 +3185,28 @@ expression: signatures
         "id",
         "read_source"
       ],
-      "title": "EpicReadSourceParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the read-only multi-repo read-source tools.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "read_sources": {
           "description": "The epic's read-source projects as `owner/repo` slugs.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "EpicReadSourcesResponse",
       "type": "object"
     }
   },
@@ -2956,7 +3233,6 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "EpicReopenParams",
       "type": "object"
     },
     "output_schema": {
@@ -2967,8 +3243,10 @@ expression: signatures
           "type": "boolean"
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "color": {
           "type": "string"
@@ -2978,8 +3256,10 @@ expression: signatures
         },
         "created_by_user_id": {
           "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": "string"
@@ -2988,8 +3268,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -3002,8 +3284,10 @@ expression: signatures
         },
         "originating_adr_id": {
           "description": "ADR-051 Epic C — mirrors `Epic::originating_adr_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
           "type": "string"
@@ -3021,7 +3305,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "EpicSingleResponse",
       "type": "object"
     }
   },
@@ -3048,7 +3331,6 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "EpicShowParams",
       "type": "object"
     },
     "output_schema": {
@@ -3059,8 +3341,10 @@ expression: signatures
           "type": "boolean"
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_count": {
           "format": "int64",
@@ -3074,8 +3358,10 @@ expression: signatures
         },
         "created_by_user_id": {
           "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": "string"
@@ -3084,8 +3370,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -3106,8 +3394,10 @@ expression: signatures
         },
         "originating_adr_id": {
           "description": "ADR-051 Epic C — mirrors `Epic::originating_adr_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
           "type": "string"
@@ -3129,7 +3419,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "EpicShowResponse",
       "type": "object"
     }
   },
@@ -3149,18 +3438,24 @@ expression: signatures
         },
         "issue_type": {
           "description": "Filter by issue type: \"task\", \"feature\", or \"bug\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -3168,19 +3463,22 @@ expression: signatures
         },
         "sort": {
           "description": "Sort order: \"priority\" (default), \"created\", \"created_desc\",\n\"updated\", \"updated_desc\", \"closed\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project",
         "epic_id"
       ],
-      "title": "EpicTasksParams",
       "type": "object"
     },
     "output_schema": {
@@ -3219,12 +3517,16 @@ expression: signatures
               "type": "array"
             },
             "close_reason": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "closed_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "continuation_count": {
               "format": "int64",
@@ -3240,8 +3542,10 @@ expression: signatures
               "type": "string"
             },
             "epic_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -3262,8 +3566,10 @@ expression: signatures
               "type": "array"
             },
             "merge_commit_sha": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "owner": {
               "type": "string"
@@ -3313,37 +3619,48 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "has_more": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "tasks": {
           "items": {
             "$ref": "#/$defs/EpicTaskModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "total_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
-      "title": "EpicTasksResponse",
       "type": "object"
     }
   },
@@ -3362,28 +3679,38 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "blocked_by_remove": {
           "description": "Epic dependencies to remove (UUIDs or short_ids).",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "color": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "emoji": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "description": "Epic UUID or short_id.",
@@ -3394,12 +3721,16 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "owner": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -3407,19 +3738,22 @@ expression: signatures
         },
         "status": {
           "description": "Target lifecycle status: \"open\" or \"closed\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project",
         "id"
       ],
-      "title": "EpicUpdateParams",
       "type": "object"
     },
     "output_schema": {
@@ -3430,8 +3764,10 @@ expression: signatures
           "type": "boolean"
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "color": {
           "type": "string"
@@ -3441,8 +3777,10 @@ expression: signatures
         },
         "created_by_user_id": {
           "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "type": "string"
@@ -3451,8 +3789,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -3465,8 +3805,10 @@ expression: signatures
         },
         "originating_adr_id": {
           "description": "ADR-051 Epic C — mirrors `Epic::originating_adr_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
           "type": "string"
@@ -3484,7 +3826,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "EpicSingleResponse",
       "type": "object"
     }
   },
@@ -3500,8 +3841,10 @@ expression: signatures
       "properties": {
         "project": {
           "description": "Project path (accepted for API compatibility, currently unused).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "task_id": {
           "description": "Task ID to interrupt.",
@@ -3511,28 +3854,30 @@ expression: signatures
       "required": [
         "task_id"
       ],
-      "title": "ExecutionKillTaskParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
         },
         "task_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "ok"
       ],
-      "title": "ExecutionKillTaskResponse",
       "type": "object"
     }
   },
@@ -3545,8 +3890,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Params for the lean `get_block_catalog` tool (no fields required).",
-      "title": "GetBlockCatalogParams",
       "type": "object"
     },
     "output_schema": {
@@ -3571,7 +3914,6 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response envelope for `get_block_catalog`: a lean list of type/tag pairs.",
       "properties": {
         "blocks": {
           "items": {
@@ -3583,7 +3925,6 @@ expression: signatures
       "required": [
         "blocks"
       ],
-      "title": "GetBlockCatalogResponse",
       "type": "object"
     }
   },
@@ -3605,7 +3946,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "GetProjectDevcontainerStatusParams",
       "type": "object"
     },
     "output_schema": {
@@ -3613,8 +3953,10 @@ expression: signatures
         "WorkspaceWarmStatusEntry": {
           "properties": {
             "detail": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "indexer": {
               "type": "string"
@@ -3635,12 +3977,13 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Snapshot of a project's image-build state, used by the UI onboarding\nbanner.",
       "properties": {
         "error": {
           "description": "Populated on lookup failures; clients should surface this verbatim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "graph_warm_status": {
           "description": "Derived status for the UI banner. One of\n`pending | running | ready | warning | failed`. `pending` means no warm has\never run; `running` means the image is ready and a warm should be\nin flight (or imminent); `ready` means derived graph freshness exists;\n`warning` means a non-fatal graph-cache shrink backstop fired\n(see `scip_indexer::append_graph_cache_shrink_warning` and\n`canonical_graph::detect_graph_cache_shrink_warning`) — the cache\nis still fresh and graph usage is unaffected, but operators should\ninspect the matching `workspace_warm_statuses` row carrying the\nold/new node counts and commit SHA; `failed` mirrors the image\nbuild's failed status (no warm possible) or any\n`failed`/`timed_out` workspace warm status (which always overrides\na shrink warning).",
@@ -3648,13 +3991,17 @@ expression: signatures
         },
         "graph_warmed_at": {
           "description": "ISO-8601 UTC timestamp derived from per-workspace graph freshness\nor the merged repo graph cache. `None` means no freshness source has\ncompleted yet (cold project or failing pipeline). Dispatch no longer\nblocks on this value; it is badge metadata retained under a\ncompatibility field name.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "image_last_error": {
           "description": "Human-readable error from the most recent failed build, if any.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "image_status": {
           "description": "One of `none | building | ready | failed`. Reflects the project's\nassigned **catalog** image (migration 46) — projects no longer build a\nbespoke per-project image.",
@@ -3662,8 +4009,10 @@ expression: signatures
         },
         "image_tag": {
           "description": "Content-addressable image tag from the last successful build, or\n`None` when no build has completed.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_image": {
           "description": "`true` when the project has no catalog image assigned yet — it needs\nsetup (pick an image) before it can build/dispatch. The UI surfaces\nthis as a distinct \"Needs image\" state rather than a build status.",
@@ -3683,7 +4032,6 @@ expression: signatures
         "needs_image",
         "graph_warm_status"
       ],
-      "title": "GetProjectDevcontainerStatusResponse",
       "type": "object"
     }
   },
@@ -3705,7 +4053,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "GetProjectStackParams",
       "type": "object"
     },
     "output_schema": {
@@ -3766,23 +4113,31 @@ expression: signatures
           "properties": {
             "go": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "node": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "python": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "rust": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -3832,8 +4187,10 @@ expression: signatures
             },
             "primary_language": {
               "description": "The single language with the largest byte share (first entry of\n`languages` by construction), or `None` for an empty repo.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "runtimes": {
               "$ref": "#/$defs/Runtimes",
@@ -3877,8 +4234,10 @@ expression: signatures
             },
             "package_manager": {
               "description": "Package-manager slug pinned by the manifest, when it carries one.\nCurrently populated for `node` (`packageManager` or lockfile\nfallback) and `python` (`uv` / `poetry` / `pdm` / `pip`).",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "root": {
               "description": "Repo-relative path to the workspace directory (forward-slash,\nnever absolute, no `..`). The empty string represents the repo\nroot.",
@@ -3886,8 +4245,10 @@ expression: signatures
             },
             "toolchain": {
               "description": "Toolchain / version the manifest pins, in its raw form.\n* rust: channel from `rust-toolchain.toml` or\n  `package.rust-version` (e.g. `\"stable\"`, `\"1.85.0\"`,\n  `\"nightly-2026-04-01\"`).\n* node: major from `engines.node` (e.g. `\"22\"`).\n* python: major.minor from `requires-python` (e.g. `\"3.12\"`).\n* go: `go` directive (e.g. `\"1.22\"`).\n* java/ruby: currently unused — left `None`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -3901,8 +4262,10 @@ expression: signatures
       "properties": {
         "error": {
           "description": "Populated on lookup / deserialization failures; clients should\nsurface this verbatim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "stack": {
           "anyOf": [
@@ -3910,14 +4273,12 @@ expression: signatures
               "$ref": "#/$defs/Stack"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "Detected stack metadata, or `None` when the project exists but no\ndetection has run yet (default `{}` in the DB) or when the\npersisted JSON fails to deserialize."
         }
       },
-      "title": "GetProjectStackResponse",
       "type": "object"
     }
   },
@@ -3930,7 +4291,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "GithubAppInstallUrlParams",
       "type": "object"
     },
     "output_schema": {
@@ -3940,14 +4300,15 @@ expression: signatures
           "type": "string"
         },
         "url": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "status"
       ],
-      "title": "GithubAppInstallUrlResponse",
       "type": "object"
     }
   },
@@ -3960,7 +4321,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "GithubAppInstallationsParams",
       "type": "object"
     },
     "output_schema": {
@@ -3998,8 +4358,10 @@ expression: signatures
       "properties": {
         "install_url": {
           "description": "URL to install the App when the user has no installations (or\nwants to add one). Always populated if `GITHUB_APP_SLUG` is set.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "installations": {
           "items": {
@@ -4015,7 +4377,6 @@ expression: signatures
         "status",
         "installations"
       ],
-      "title": "GithubAppInstallationsResponse",
       "type": "object"
     }
   },
@@ -4033,8 +4394,10 @@ expression: signatures
           "default": null,
           "description": "Last line to return (1-based, inclusive). Omit for end of file.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "path": {
           "description": "File path within the repository (e.g. \"src/lib.rs\").",
@@ -4043,8 +4406,10 @@ expression: signatures
         "ref": {
           "default": null,
           "description": "Branch, tag, or commit SHA (default: HEAD / default branch).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "repo": {
           "description": "Repository in \"owner/repo\" format (e.g. \"tokio-rs/tokio\").",
@@ -4054,21 +4419,21 @@ expression: signatures
           "default": null,
           "description": "First line to return (1-based, inclusive). Omit for start of file.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
         "repo",
         "path"
       ],
-      "title": "GithubFetchFileParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ToolOutcomeGithubFetchFileResponse",
       "type": "object"
     }
   },
@@ -4086,11 +4451,12 @@ expression: signatures
           "default": null,
           "description": "Max number of repositories to return (1..=100). Defaults to 30.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
-      "title": "GithubListReposParams",
       "type": "object"
     },
     "output_schema": {
@@ -4105,8 +4471,10 @@ expression: signatures
               "type": "string"
             },
             "description": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "installation_id": {
               "description": "GitHub App installation id that surfaced this repo. Pass this back\nto [`project_add_from_github`] to pin the clone to the same\ninstallation without re-scanning.",
@@ -4150,7 +4518,6 @@ expression: signatures
         "status",
         "repos"
       ],
-      "title": "GithubListReposResponse",
       "type": "object"
     }
   },
@@ -4167,21 +4534,27 @@ expression: signatures
         "language": {
           "default": null,
           "description": "Programming language filter (e.g. \"Rust\", \"Python\", \"TypeScript\").",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "default": null,
           "description": "Maximum number of results to return (1–100, default 15).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "path": {
           "default": null,
           "description": "Path filter to search within specific directories (e.g. \"src/\").",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "query": {
           "description": "Search query string. Supports GitHub code search syntax.",
@@ -4190,20 +4563,20 @@ expression: signatures
         "repo": {
           "default": null,
           "description": "Repository filter in \"owner/repo\" format (e.g. \"tokio-rs/tokio\").",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "query"
       ],
-      "title": "GithubSearchParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ToolOutcomeGithubSearchResponse",
       "type": "object"
     }
   },
@@ -4355,8 +4728,7 @@ expression: signatures
                   "$ref": "#/$defs/CargoCachePolicy"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": {
@@ -4480,8 +4852,7 @@ expression: signatures
                   "$ref": "#/$defs/ClangLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4492,8 +4863,7 @@ expression: signatures
                   "$ref": "#/$defs/DotnetLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4504,8 +4874,7 @@ expression: signatures
                   "$ref": "#/$defs/GoLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4516,8 +4885,7 @@ expression: signatures
                   "$ref": "#/$defs/JavaLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4528,8 +4896,7 @@ expression: signatures
                   "$ref": "#/$defs/NodeLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4540,8 +4907,7 @@ expression: signatures
                   "$ref": "#/$defs/PythonLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4552,8 +4918,7 @@ expression: signatures
                   "$ref": "#/$defs/RubyLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4564,8 +4929,7 @@ expression: signatures
                   "$ref": "#/$defs/RustLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -4614,8 +4978,10 @@ expression: signatures
           "properties": {
             "default_package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "default_version": {
               "type": "string"
@@ -4666,21 +5032,27 @@ expression: signatures
             },
             "name": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "root": {
               "type": "string"
             },
             "slug": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tags": {
               "default": [],
@@ -4691,13 +5063,17 @@ expression: signatures
             },
             "toolchain": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -4715,8 +5091,10 @@ expression: signatures
         },
         "description": {
           "default": null,
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "description": "Unique display name (e.g. \"Go\", \"Rust\", \"Node\").",
@@ -4727,19 +5105,22 @@ expression: signatures
         "name",
         "config"
       ],
-      "title": "ImageCreateParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -4748,7 +5129,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ImageMutateResponse",
       "type": "object"
     }
   },
@@ -4769,19 +5149,22 @@ expression: signatures
       "required": [
         "id"
       ],
-      "title": "ImageDeleteParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -4790,7 +5173,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ImageMutateResponse",
       "type": "object"
     }
   },
@@ -4803,7 +5185,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "ImageListParams",
       "type": "object"
     },
     "output_schema": {
@@ -4947,8 +5328,7 @@ expression: signatures
                   "$ref": "#/$defs/CargoCachePolicy"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": {
@@ -5059,8 +5439,10 @@ expression: signatures
               "description": "The image's EnvironmentConfig (build fields)."
             },
             "description": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -5109,8 +5491,7 @@ expression: signatures
                   "$ref": "#/$defs/ClangLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5121,8 +5502,7 @@ expression: signatures
                   "$ref": "#/$defs/DotnetLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5133,8 +5513,7 @@ expression: signatures
                   "$ref": "#/$defs/GoLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5145,8 +5524,7 @@ expression: signatures
                   "$ref": "#/$defs/JavaLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5157,8 +5535,7 @@ expression: signatures
                   "$ref": "#/$defs/NodeLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5169,8 +5546,7 @@ expression: signatures
                   "$ref": "#/$defs/PythonLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5181,8 +5557,7 @@ expression: signatures
                   "$ref": "#/$defs/RubyLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5193,8 +5568,7 @@ expression: signatures
                   "$ref": "#/$defs/RustLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5243,8 +5617,10 @@ expression: signatures
           "properties": {
             "default_package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "default_version": {
               "type": "string"
@@ -5295,21 +5671,27 @@ expression: signatures
             },
             "name": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "root": {
               "type": "string"
             },
             "slug": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tags": {
               "default": [],
@@ -5320,13 +5702,17 @@ expression: signatures
             },
             "toolchain": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -5339,8 +5725,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "images": {
           "items": {
@@ -5356,7 +5744,6 @@ expression: signatures
         "status",
         "images"
       ],
-      "title": "ImageListResponse",
       "type": "object"
     }
   },
@@ -5386,19 +5773,22 @@ expression: signatures
         "id",
         "preset_ids"
       ],
-      "title": "ImageSetServicesParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -5407,7 +5797,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ImageMutateResponse",
       "type": "object"
     }
   },
@@ -5559,8 +5948,7 @@ expression: signatures
                   "$ref": "#/$defs/CargoCachePolicy"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": {
@@ -5684,8 +6072,7 @@ expression: signatures
                   "$ref": "#/$defs/ClangLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5696,8 +6083,7 @@ expression: signatures
                   "$ref": "#/$defs/DotnetLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5708,8 +6094,7 @@ expression: signatures
                   "$ref": "#/$defs/GoLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5720,8 +6105,7 @@ expression: signatures
                   "$ref": "#/$defs/JavaLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5732,8 +6116,7 @@ expression: signatures
                   "$ref": "#/$defs/NodeLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5744,8 +6127,7 @@ expression: signatures
                   "$ref": "#/$defs/PythonLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5756,8 +6138,7 @@ expression: signatures
                   "$ref": "#/$defs/RubyLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5768,8 +6149,7 @@ expression: signatures
                   "$ref": "#/$defs/RustLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -5818,8 +6198,10 @@ expression: signatures
           "properties": {
             "default_package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "default_version": {
               "type": "string"
@@ -5870,21 +6252,27 @@ expression: signatures
             },
             "name": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "root": {
               "type": "string"
             },
             "slug": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tags": {
               "default": [],
@@ -5895,13 +6283,17 @@ expression: signatures
             },
             "toolchain": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -5919,8 +6311,10 @@ expression: signatures
         },
         "description": {
           "default": null,
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -5934,19 +6328,22 @@ expression: signatures
         "name",
         "config"
       ],
-      "title": "ImageUpdateParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -5955,7 +6352,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ImageMutateResponse",
       "type": "object"
     }
   },
@@ -5976,14 +6372,18 @@ expression: signatures
         "limit": {
           "description": "Maximum number of results. Default: 20.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "min_weight": {
           "description": "Minimum association weight [0.0, 1.0]. Default: 0.0 (all associations).",
           "format": "double",
-          "nullable": true,
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
@@ -5993,7 +6393,6 @@ expression: signatures
         "project",
         "identifier"
       ],
-      "title": "AssociationsParams",
       "type": "object"
     },
     "output_schema": {
@@ -6061,8 +6460,10 @@ expression: signatures
           "type": "array"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "seed_entity_type": {
           "default": "note",
@@ -6073,7 +6474,6 @@ expression: signatures
       "required": [
         "associations"
       ],
-      "title": "MemoryAssociationsResponse",
       "type": "object"
     }
   },
@@ -6088,8 +6488,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "folder": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
@@ -6098,7 +6500,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "BrokenLinksParams",
       "type": "object"
     },
     "output_schema": {
@@ -6137,14 +6538,15 @@ expression: signatures
           "type": "array"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "broken_links"
       ],
-      "title": "MemoryBrokenLinksResponse",
       "type": "object"
     }
   },
@@ -6166,36 +6568,46 @@ expression: signatures
         "depth": {
           "description": "Link traversal depth (default 1).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "edge_kinds": {
           "description": "Optional list of edge kinds to include in graph traversal scoring.\nWhen provided, only edges whose `kind` matches one of these values\nparticipate in spreading activation. Omit to use all edge kinds.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "max_related": {
           "description": "Maximum related notes to return (default 10).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "min_confidence": {
           "description": "Minimum confidence threshold for related notes (default 0.1). Notes\nbelow this threshold are excluded from the context response. Set to 0.0\nto include all notes regardless of confidence.",
           "format": "double",
-          "nullable": true,
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
         },
         "task_id": {
           "description": "Optional task ID for task-affinity scoring in RRF retrieval.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "url": {
           "description": "Memory URI: \"memory://folder/note\", \"folder/note\", or \"folder/*\" for all\nnotes in a folder.",
@@ -6207,7 +6619,6 @@ expression: signatures
         "url",
         "budget"
       ],
-      "title": "BuildContextParams",
       "type": "object"
     },
     "output_schema": {
@@ -6258,8 +6669,10 @@ expression: signatures
               "type": "string"
             },
             "retrieval_anchor": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "status": {
               "type": "string"
@@ -6311,8 +6724,10 @@ expression: signatures
             },
             "score": {
               "format": "double",
-              "nullable": true,
-              "type": "number"
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "short_id": {
               "type": "string"
@@ -6351,8 +6766,10 @@ expression: signatures
             },
             "score": {
               "format": "float",
-              "nullable": true,
-              "type": "number"
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "superseded": {
               "description": "True when this note has been superseded by a newer note (stale-citation\nconfidence signal applied). Consumers should treat the content as\npotentially outdated.",
@@ -6388,8 +6805,10 @@ expression: signatures
             },
             "score": {
               "format": "float",
-              "nullable": true,
-              "type": "number"
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "superseded": {
               "description": "True when this note has been superseded by a newer note (stale-citation\nconfidence signal applied). Consumers should treat the content as\npotentially outdated.",
@@ -6436,8 +6855,10 @@ expression: signatures
           "type": "array"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "primary": {
           "items": {
@@ -6477,7 +6898,6 @@ expression: signatures
         "related_l1",
         "related_l0"
       ],
-      "title": "MemoryBuildContextResponse",
       "type": "object"
     }
   },
@@ -6498,7 +6918,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "CatalogParams",
       "type": "object"
     },
     "output_schema": {
@@ -6508,14 +6927,15 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "catalog"
       ],
-      "title": "MemoryCatalogResponse",
       "type": "object"
     }
   },
@@ -6531,8 +6951,10 @@ expression: signatures
       "properties": {
         "comment": {
           "description": "Optional reason for confirmation.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "identifier": {
           "description": "Note permalink or note ID.",
@@ -6546,36 +6968,44 @@ expression: signatures
         "project",
         "identifier"
       ],
-      "title": "MemoryConfirmParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "new_confidence": {
           "format": "double",
-          "nullable": true,
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "note_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "permalink": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "previous_confidence": {
           "format": "double",
-          "nullable": true,
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         }
       },
-      "title": "MemoryConfirmResponse",
       "type": "object"
     }
   },
@@ -6600,15 +7030,16 @@ expression: signatures
         "project",
         "identifier"
       ],
-      "title": "DeleteParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -6617,7 +7048,6 @@ expression: signatures
       "required": [
         "ok"
       ],
-      "title": "MemoryDeleteResponse",
       "type": "object"
     }
   },
@@ -6639,15 +7069,16 @@ expression: signatures
         },
         "sha": {
           "description": "Specific commit SHA. Omit to get the diff for the most recent change.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project",
         "permalink"
       ],
-      "title": "DiffParams",
       "type": "object"
     },
     "output_schema": {
@@ -6657,14 +7088,15 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "diff"
       ],
-      "title": "MemoryDiffResponse",
       "type": "object"
     }
   },
@@ -6683,8 +7115,10 @@ expression: signatures
         },
         "find_text": {
           "description": "Required for find_replace: exact text to search for.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "identifier": {
           "description": "Note permalink or title.",
@@ -6700,18 +7134,24 @@ expression: signatures
         "retrieval_anchor": {
           "default": null,
           "description": "Replace the note's retrieval anchor without modifying the note body.\nAlso accepted as `applies_when`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "section": {
           "description": "Required for replace_section: heading text identifying the section.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "type": {
           "description": "If provided and different from current type, move the note to the new\ntype's folder. Allowed values same as memory_write type.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -6720,7 +7160,6 @@ expression: signatures
         "operation",
         "content"
       ],
-      "title": "EditParams",
       "type": "object"
     },
     "output_schema": {
@@ -6798,47 +7237,67 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "content": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "deduplicated": {
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "file_path": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "folder": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "last_accessed": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "note_type": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "permalink": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposals": {
           "description": "Proposals reachable through this note's tasks/epics (via proposal_epics).",
@@ -6855,19 +7314,25 @@ expression: signatures
           "type": "array"
         },
         "retrieval_anchor": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tags": {
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "tasks": {
           "description": "Tasks whose memory_refs contain this note's permalink.",
@@ -6877,18 +7342,21 @@ expression: signatures
           "type": "array"
         },
         "title": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "updated_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "deduplicated"
       ],
-      "title": "MemoryNoteResponse",
       "type": "object"
     }
   },
@@ -6909,7 +7377,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ExtractedAuditParams",
       "type": "object"
     },
     "output_schema": {
@@ -6977,45 +7444,58 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/ExtractedNoteAuditFinding"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "demote_to_working_spec": {
           "items": {
             "$ref": "#/$defs/ExtractedNoteAuditFinding"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "merge_candidates": {
           "items": {
             "$ref": "#/$defs/ExtractedNoteAuditFinding"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "rerun_hint": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "scanned_note_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "underspecified": {
           "items": {
             "$ref": "#/$defs/ExtractedNoteAuditFinding"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "MemoryExtractedAuditResponse",
       "type": "object"
     }
   },
@@ -7036,7 +7516,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "GraphParams",
       "type": "object"
     },
     "output_schema": {
@@ -7156,8 +7635,10 @@ expression: signatures
           "type": "array"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "nodes": {
           "items": {
@@ -7178,7 +7659,6 @@ expression: signatures
         "nodes",
         "edges"
       ],
-      "title": "MemoryGraphResponse",
       "type": "object"
     }
   },
@@ -7194,11 +7674,12 @@ expression: signatures
       "properties": {
         "project": {
           "description": "Absolute path to the project directory.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "HealthParams",
       "type": "object"
     },
     "output_schema": {
@@ -7242,8 +7723,10 @@ expression: signatures
               "type": "integer"
             },
             "last_sweep_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -7275,12 +7758,16 @@ expression: signatures
       "properties": {
         "broken_link_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "lifecycle": {
           "anyOf": [
@@ -7288,20 +7775,23 @@ expression: signatures
               "$ref": "#/$defs/LifecycleHealth"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "low_confidence_note_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "orphan_note_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "recent_sweep": {
           "anyOf": [
@@ -7309,30 +7799,34 @@ expression: signatures
               "$ref": "#/$defs/RecentSweepMetrics"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "stale_note_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "stale_notes_by_folder": {
           "items": {
             "$ref": "#/$defs/StaleFolder"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "total_notes": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
-      "title": "MemoryHealthResponse",
       "type": "object"
     }
   },
@@ -7348,8 +7842,10 @@ expression: signatures
       "properties": {
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "permalink": {
           "type": "string"
@@ -7362,7 +7858,6 @@ expression: signatures
         "project",
         "permalink"
       ],
-      "title": "HistoryParams",
       "type": "object"
     },
     "output_schema": {
@@ -7395,8 +7890,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "history": {
           "items": {
@@ -7408,7 +7905,6 @@ expression: signatures
       "required": [
         "history"
       ],
-      "title": "MemoryHistoryResponse",
       "type": "object"
     }
   },
@@ -7425,32 +7921,39 @@ expression: signatures
         "depth": {
           "description": "Depth control: 0 = unlimited, 1 = exact folder (default), N = N levels.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "folder": {
           "description": "Filter by folder. Omit to list all notes.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
         },
         "status": {
           "description": "Explicit lifecycle status filter. Defaults to active; use archived or\ndeprecated to list non-live notes.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "type": {
           "description": "Filter by note type (e.g. \"adr\", \"reference\", \"research\").",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "ListParams",
       "type": "object"
     },
     "output_schema": {
@@ -7499,8 +8002,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "notes": {
           "items": {
@@ -7512,7 +8017,6 @@ expression: signatures
       "required": [
         "notes"
       ],
-      "title": "MemoryListResponse",
       "type": "object"
     }
   },
@@ -7534,8 +8038,10 @@ expression: signatures
         },
         "title": {
           "description": "Optional new title; keep current title if omitted.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "type": {
           "description": "New note type to move the note to. Use `proposed_adr` to recover a\nmis-routed ADR draft into `.djinn/decisions/proposed/`.",
@@ -7547,7 +8053,6 @@ expression: signatures
         "identifier",
         "type"
       ],
-      "title": "MoveParams",
       "type": "object"
     },
     "output_schema": {
@@ -7625,47 +8130,67 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "content": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "deduplicated": {
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "file_path": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "folder": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "last_accessed": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "note_type": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "permalink": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposals": {
           "description": "Proposals reachable through this note's tasks/epics (via proposal_epics).",
@@ -7682,19 +8207,25 @@ expression: signatures
           "type": "array"
         },
         "retrieval_anchor": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tags": {
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "tasks": {
           "description": "Tasks whose memory_refs contain this note's permalink.",
@@ -7704,18 +8235,21 @@ expression: signatures
           "type": "array"
         },
         "title": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "updated_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "deduplicated"
       ],
-      "title": "MemoryNoteResponse",
       "type": "object"
     }
   },
@@ -7730,8 +8264,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "folder": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
@@ -7740,7 +8276,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "OrphansParams",
       "type": "object"
     },
     "output_schema": {
@@ -7777,8 +8312,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "orphans": {
           "items": {
@@ -7790,7 +8327,6 @@ expression: signatures
       "required": [
         "orphans"
       ],
-      "title": "MemoryOrphansResponse",
       "type": "object"
     }
   },
@@ -7816,7 +8352,6 @@ expression: signatures
         "project",
         "identifier"
       ],
-      "title": "ReadParams",
       "type": "object"
     },
     "output_schema": {
@@ -7894,47 +8429,67 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "content": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "deduplicated": {
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "file_path": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "folder": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "last_accessed": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "note_type": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "permalink": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposals": {
           "description": "Proposals reachable through this note's tasks/epics (via proposal_epics).",
@@ -7951,19 +8506,25 @@ expression: signatures
           "type": "array"
         },
         "retrieval_anchor": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tags": {
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "tasks": {
           "description": "Tasks whose memory_refs contain this note's permalink.",
@@ -7973,18 +8534,21 @@ expression: signatures
           "type": "array"
         },
         "title": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "updated_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "deduplicated"
       ],
-      "title": "MemoryNoteResponse",
       "type": "object"
     }
   },
@@ -8000,22 +8564,25 @@ expression: signatures
       "properties": {
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
         },
         "timeframe": {
           "description": "Timeframe string, e.g. \"7d\", \"24h\", \"today\", \"last week\". Default: \"7d\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "RecentParams",
       "type": "object"
     },
     "output_schema": {
@@ -8064,8 +8631,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "notes": {
           "items": {
@@ -8077,7 +8646,6 @@ expression: signatures
       "required": [
         "notes"
       ],
-      "title": "MemoryRecentResponse",
       "type": "object"
     }
   },
@@ -8093,8 +8661,10 @@ expression: signatures
       "properties": {
         "force": {
           "description": "If true, re-embed every note even if its content hash already matches.\nDefault false: only notes with missing or stale embeddings are repaired.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "project": {
           "description": "Project path, slug, or id (same forms accepted by other memory tools).",
@@ -8104,7 +8674,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "RepairEmbeddingsParams",
       "type": "object"
     },
     "output_schema": {
@@ -8149,8 +8718,10 @@ expression: signatures
         },
         "error": {
           "description": "Top-level failure: project not found, embedding provider unavailable, etc.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "failed": {
           "description": "Notes whose re-embed attempt failed (Qdrant down, model error, …).",
@@ -8191,7 +8762,6 @@ expression: signatures
         "code_chunks_up_to_date",
         "code_chunks_failed"
       ],
-      "title": "MemoryRepairEmbeddingsResponse",
       "type": "object"
     }
   },
@@ -8207,8 +8777,10 @@ expression: signatures
       "properties": {
         "background": {
           "description": "When true, schedule enrichment on a background tokio task and return\nimmediately with `status=\"queued\"`. When false (the default), run the\npass synchronously and embed the structured report in the response.\n\nBackground execution mirrors the diei roadmap's \"best-effort, never\nblocks retrieval\" constraint: the spawn path yields to the runtime so\n`memory_graph` (and the wider MCP surface) keep serving while the\npass runs.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "project": {
           "description": "Project path, slug, or id (same forms accepted by other memory tools).",
@@ -8218,7 +8790,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "RunEnrichmentParams",
       "type": "object"
     },
     "output_schema": {
@@ -8228,8 +8799,10 @@ expression: signatures
           "properties": {
             "evidence_quote": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "source_note_id": {
               "type": "string"
@@ -8254,8 +8827,10 @@ expression: signatures
             },
             "evidence_quote": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "kind": {
               "type": "string"
@@ -8358,17 +8933,20 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "MCP response for `memory_run_enrichment`. The `report` is present when\n`status=\"completed\"` (foreground execution). For\n`status=\"queued\"` (background execution) the report is `None`; the pass\nemits the structured report through its own `INFO` log line at finish.",
       "properties": {
         "error": {
           "description": "Top-level failure: project not found, enrichment subsystem not\nconfigured, provider errors that propagate before the pass begins.\nPer-batch provider failures land in `report.warnings` rather than\nhere — the pass is best-effort and never blocks retrieval.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project_id": {
           "description": "Resolved DB project id (slug → id translation is performed by the\ntool's project resolver, same as every other memory tool).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "report": {
           "anyOf": [
@@ -8376,8 +8954,7 @@ expression: signatures
               "$ref": "#/$defs/EnrichmentReport"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "Structured enrichment report. Present only when\n`status=\"completed\"`. None when queued, and None when the trigger\nfails (in which case `error` is populated)."
@@ -8390,7 +8967,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "MemoryRunEnrichmentResponse",
       "type": "object"
     }
   },
@@ -8409,25 +8985,33 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "entity_types": {
           "description": "Optional list of entity types to include: \"note\", \"proposal\".\nOmit (or pass null) to include both. Pass [\"note\"] for notes-only,\n[\"proposal\"] for proposals-only. Pass [] to return no results.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "folder": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
@@ -8436,15 +9020,16 @@ expression: signatures
           "type": "string"
         },
         "type": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project",
         "query"
       ],
-      "title": "SearchParams",
       "type": "object"
     },
     "output_schema": {
@@ -8496,8 +9081,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "results": {
           "items": {
@@ -8509,7 +9096,6 @@ expression: signatures
       "required": [
         "results"
       ],
-      "title": "MemorySearchResponse",
       "type": "object"
     }
   },
@@ -8534,7 +9120,6 @@ expression: signatures
         "project",
         "permalink"
       ],
-      "title": "TaskRefsParams",
       "type": "object"
     },
     "output_schema": {
@@ -8589,8 +9174,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposals": {
           "items": {
@@ -8608,7 +9195,6 @@ expression: signatures
       "required": [
         "tasks"
       ],
-      "title": "MemoryTaskRefsResponse",
       "type": "object"
     }
   },
@@ -8632,28 +9218,36 @@ expression: signatures
         "retrieval_anchor": {
           "default": null,
           "description": "Objective situation where this note should be retrieved. Also accepted as\n`applies_when` for prompt/API language compatibility.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "scope_paths": {
           "description": "Crate/module path prefixes this note applies to. Empty array means global.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "status": {
           "description": "Optional explicit status for routed note types. For ADRs, `proposed`\nwrites into `.djinn/decisions/proposed/`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tags": {
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -8669,7 +9263,6 @@ expression: signatures
         "content",
         "type"
       ],
-      "title": "WriteParams",
       "type": "object"
     },
     "output_schema": {
@@ -8747,47 +9340,67 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "content": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "deduplicated": {
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "file_path": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "folder": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "last_accessed": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "note_type": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "permalink": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposals": {
           "description": "Proposals reachable through this note's tasks/epics (via proposal_epics).",
@@ -8804,19 +9417,25 @@ expression: signatures
           "type": "array"
         },
         "retrieval_anchor": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tags": {
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "tasks": {
           "description": "Tasks whose memory_refs contain this note's permalink.",
@@ -8826,18 +9445,21 @@ expression: signatures
           "type": "array"
         },
         "title": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "updated_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "deduplicated"
       ],
-      "title": "MemoryNoteResponse",
       "type": "object"
     }
   },
@@ -8858,11 +9480,12 @@ expression: signatures
         },
         "model": {
           "description": "Model ID (required for reset and enable actions).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ModelHealthInput",
       "type": "object"
     },
     "output_schema": {
@@ -8878,8 +9501,10 @@ expression: signatures
             },
             "cooldown_seconds_remaining": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "disable_ttl_trips": {
               "format": "int64",
@@ -8890,8 +9515,10 @@ expression: signatures
             },
             "scope": {
               "description": "Owning user the breaker bucket is scoped to; `null` = shared/system\nbucket (org-shared credential). Health is tracked per `(scope, model)`,\nso the same model can appear once per user that has used it.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "total_failures": {
               "format": "int64",
@@ -8919,8 +9546,10 @@ expression: signatures
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "models": {
           "items": {
@@ -8933,7 +9562,6 @@ expression: signatures
         "action",
         "models"
       ],
-      "title": "ModelHealthResponse",
       "type": "object"
     }
   },
@@ -8947,7 +9575,6 @@ expression: signatures
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "title": "OrgPolicyGetParams",
       "type": "object"
     },
     "output_schema": {
@@ -9023,8 +9650,10 @@ expression: signatures
           "description": "Org-default per-role lanes new members inherit when they have none."
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "lock_level": {
           "description": "`flexible` (members may override) | `locked` (org assignment authoritative).",
@@ -9048,7 +9677,6 @@ expression: signatures
         "default_lanes",
         "lock_level"
       ],
-      "title": "OrgPolicyGetResponse",
       "type": "object"
     }
   },
@@ -9101,8 +9729,10 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "default_lanes": {
           "anyOf": [
@@ -9110,8 +9740,7 @@ expression: signatures
               "$ref": "#/$defs/OrgDefaultLanesPayload"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "default": null,
@@ -9120,11 +9749,12 @@ expression: signatures
         "lock_level": {
           "default": null,
           "description": "Lane lock level: `flexible` or `locked`. Omit to keep the current value.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "OrgPolicySetParams",
       "type": "object"
     },
     "output_schema": {
@@ -9175,8 +9805,10 @@ expression: signatures
           "$ref": "#/$defs/OrgDefaultLanesPayload"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "lock_level": {
           "type": "string"
@@ -9192,7 +9824,6 @@ expression: signatures
         "default_lanes",
         "lock_level"
       ],
-      "title": "OrgPolicySetResponse",
       "type": "object"
     }
   },
@@ -9210,8 +9841,10 @@ expression: signatures
           "properties": {
             "description": {
               "description": "Optional human-readable explanation of why this rule exists,\nsurfaced in CI output so violations are self-documenting.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "from_glob": {
               "type": "string"
@@ -9232,8 +9865,10 @@ expression: signatures
             "end_line": {
               "description": "Inclusive 1-indexed last line of the hunk. Defaults to `start_line`\nwhen the caller passed a single-line hunk.",
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "file": {
               "description": "Repository-relative path of the file the hunk lives in.",
@@ -9256,45 +9891,58 @@ expression: signatures
           "properties": {
             "blast_radius": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "hot_path_overlap": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "hotspot_overlap": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "touched_boundary_violations": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "touched_cycles": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "touched_deprecated": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "touched_symbols": {
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Input parameters for the `pr_review_context` meta-tool.",
       "properties": {
         "boundary_rules": {
           "default": [],
@@ -9310,8 +9958,7 @@ expression: signatures
               "$ref": "#/$defs/PrReviewCaps"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "Per-list result caps. Missing fields fall back to the defaults\nencoded in `ResolvedCaps::default_caps`."
@@ -9327,8 +9974,10 @@ expression: signatures
           "default": null,
           "description": "Churn look-back window for the hotspot overlap. Defaults to 90.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Project identifier — either the UUID (`project_id`) or the\ncanonical `\"owner/repo\"` slug. The handler resolves it to the\nserver-managed clone path via `djinn_core::paths::project_dir`\nbefore dispatching to the graph backend.",
@@ -9355,13 +10004,11 @@ expression: signatures
         "project",
         "changed_ranges"
       ],
-      "title": "PrReviewContextParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrPrReviewContextResponse",
       "type": "object"
     }
   },
@@ -9379,14 +10026,18 @@ expression: signatures
           "default": null,
           "description": "GitHub App installation id that has access to this repo. When\nomitted, the server scans the user's installations and picks one\nthat contains `owner/repo`.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "name": {
           "default": null,
           "description": "Optional project display name. Defaults to `{owner}/{repo}`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
           "description": "GitHub owner (user or organization).",
@@ -9395,8 +10046,10 @@ expression: signatures
         "ref": {
           "default": null,
           "description": "Optional branch to check out after cloning. Defaults to the repo's\ndefault branch as reported by the GitHub API.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "repo": {
           "description": "GitHub repository name.",
@@ -9407,7 +10060,6 @@ expression: signatures
         "owner",
         "repo"
       ],
-      "title": "ProjectAddFromGithubParams",
       "type": "object"
     },
     "output_schema": {
@@ -9449,7 +10101,6 @@ expression: signatures
         "status",
         "project"
       ],
-      "title": "ProjectAddResponse",
       "type": "object"
     }
   },
@@ -9471,7 +10122,6 @@ expression: signatures
       "required": [
         "project_id"
       ],
-      "title": "ProjectBranchesParams",
       "type": "object"
     },
     "output_schema": {
@@ -9484,8 +10134,10 @@ expression: signatures
           "type": "array"
         },
         "current": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -9495,7 +10147,6 @@ expression: signatures
         "status",
         "branches"
       ],
-      "title": "ProjectBranchesResponse",
       "type": "object"
     }
   },
@@ -9516,7 +10167,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ProjectConfigGetParams",
       "type": "object"
     },
     "output_schema": {
@@ -9551,8 +10201,10 @@ expression: signatures
           "type": "boolean"
         },
         "sync_remote": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "target_branch": {
           "type": "string"
@@ -9565,7 +10217,6 @@ expression: signatures
         "auto_merge",
         "sync_enabled"
       ],
-      "title": "ProjectConfigResponse",
       "type": "object"
     }
   },
@@ -9594,7 +10245,6 @@ expression: signatures
         "key",
         "value"
       ],
-      "title": "ProjectConfigSetParams",
       "type": "object"
     },
     "output_schema": {
@@ -9629,8 +10279,10 @@ expression: signatures
           "type": "boolean"
         },
         "sync_remote": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "target_branch": {
           "type": "string"
@@ -9643,7 +10295,6 @@ expression: signatures
         "auto_merge",
         "sync_enabled"
       ],
-      "title": "ProjectConfigResponse",
       "type": "object"
     }
   },
@@ -9665,7 +10316,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ProjectEnvironmentConfigGetParams",
       "type": "object"
     },
     "output_schema": {
@@ -9809,8 +10459,7 @@ expression: signatures
                   "$ref": "#/$defs/CargoCachePolicy"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": {
@@ -9934,8 +10583,7 @@ expression: signatures
                   "$ref": "#/$defs/ClangLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -9946,8 +10594,7 @@ expression: signatures
                   "$ref": "#/$defs/DotnetLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -9958,8 +10605,7 @@ expression: signatures
                   "$ref": "#/$defs/GoLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -9970,8 +10616,7 @@ expression: signatures
                   "$ref": "#/$defs/JavaLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -9982,8 +10627,7 @@ expression: signatures
                   "$ref": "#/$defs/NodeLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -9994,8 +10638,7 @@ expression: signatures
                   "$ref": "#/$defs/PythonLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10006,8 +10649,7 @@ expression: signatures
                   "$ref": "#/$defs/RubyLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10018,8 +10660,7 @@ expression: signatures
                   "$ref": "#/$defs/RustLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10068,8 +10709,10 @@ expression: signatures
           "properties": {
             "default_package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "default_version": {
               "type": "string"
@@ -10120,21 +10763,27 @@ expression: signatures
             },
             "name": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "root": {
               "type": "string"
             },
             "slug": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tags": {
               "default": [],
@@ -10145,13 +10794,17 @@ expression: signatures
             },
             "toolchain": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -10169,24 +10822,29 @@ expression: signatures
               "$ref": "#/$defs/EnvironmentConfig"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "The raw JSON config currently in `projects.environment_config`.\nEmpty object `{}` when the row hasn't been reseeded yet."
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "selected_image_id": {
           "description": "The catalog image this project is assigned to, if any (for the picker).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "selected_image_name": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -10195,7 +10853,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ProjectEnvironmentConfigGetResponse",
       "type": "object"
     }
   },
@@ -10217,7 +10874,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ProjectEnvironmentConfigResetParams",
       "type": "object"
     },
     "output_schema": {
@@ -10361,8 +11017,7 @@ expression: signatures
                   "$ref": "#/$defs/CargoCachePolicy"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": {
@@ -10486,8 +11141,7 @@ expression: signatures
                   "$ref": "#/$defs/ClangLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10498,8 +11152,7 @@ expression: signatures
                   "$ref": "#/$defs/DotnetLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10510,8 +11163,7 @@ expression: signatures
                   "$ref": "#/$defs/GoLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10522,8 +11174,7 @@ expression: signatures
                   "$ref": "#/$defs/JavaLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10534,8 +11185,7 @@ expression: signatures
                   "$ref": "#/$defs/NodeLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10546,8 +11196,7 @@ expression: signatures
                   "$ref": "#/$defs/PythonLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10558,8 +11207,7 @@ expression: signatures
                   "$ref": "#/$defs/RubyLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10570,8 +11218,7 @@ expression: signatures
                   "$ref": "#/$defs/RustLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -10620,8 +11267,10 @@ expression: signatures
           "properties": {
             "default_package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "default_version": {
               "type": "string"
@@ -10672,21 +11321,27 @@ expression: signatures
             },
             "name": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "root": {
               "type": "string"
             },
             "slug": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tags": {
               "default": [],
@@ -10697,13 +11352,17 @@ expression: signatures
             },
             "toolchain": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -10721,15 +11380,16 @@ expression: signatures
               "$ref": "#/$defs/EnvironmentConfig"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "The freshly-generated auto-detected config, on success."
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -10738,7 +11398,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ProjectEnvironmentConfigResetResponse",
       "type": "object"
     }
   },
@@ -10890,8 +11549,7 @@ expression: signatures
                   "$ref": "#/$defs/CargoCachePolicy"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": {
@@ -11015,8 +11673,7 @@ expression: signatures
                   "$ref": "#/$defs/ClangLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11027,8 +11684,7 @@ expression: signatures
                   "$ref": "#/$defs/DotnetLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11039,8 +11695,7 @@ expression: signatures
                   "$ref": "#/$defs/GoLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11051,8 +11706,7 @@ expression: signatures
                   "$ref": "#/$defs/JavaLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11063,8 +11717,7 @@ expression: signatures
                   "$ref": "#/$defs/NodeLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11075,8 +11728,7 @@ expression: signatures
                   "$ref": "#/$defs/PythonLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11087,8 +11739,7 @@ expression: signatures
                   "$ref": "#/$defs/RubyLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11099,8 +11750,7 @@ expression: signatures
                   "$ref": "#/$defs/RustLanguage"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "default": null
@@ -11149,8 +11799,10 @@ expression: signatures
           "properties": {
             "default_package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "default_version": {
               "type": "string"
@@ -11201,21 +11853,27 @@ expression: signatures
             },
             "name": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "package_manager": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "root": {
               "type": "string"
             },
             "slug": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tags": {
               "default": [],
@@ -11226,13 +11884,17 @@ expression: signatures
             },
             "toolchain": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "version": {
               "default": null,
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -11257,15 +11919,16 @@ expression: signatures
         "project",
         "config"
       ],
-      "title": "ProjectEnvironmentConfigSetParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -11274,7 +11937,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ProjectEnvironmentConfigSetResponse",
       "type": "object"
     }
   },
@@ -11296,7 +11958,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ProjectGraphExclusionsGetParams",
       "type": "object"
     },
     "output_schema": {
@@ -11329,7 +11990,6 @@ expression: signatures
         "status",
         "project"
       ],
-      "title": "ProjectGraphExclusionsResponse",
       "type": "object"
     }
   },
@@ -11342,7 +12002,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Partial-update payload. Either field may be `None` — the repository\nleaves the corresponding column untouched when the caller only wants\nto rewrite one of the two lists.",
       "properties": {
         "graph_excluded_paths": {
           "default": null,
@@ -11350,8 +12009,10 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "graph_orphan_ignore": {
           "default": null,
@@ -11359,8 +12020,10 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "project": {
           "type": "string"
@@ -11369,7 +12032,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ProjectGraphExclusionsSetParams",
       "type": "object"
     },
     "output_schema": {
@@ -11402,7 +12064,6 @@ expression: signatures
         "status",
         "project"
       ],
-      "title": "ProjectGraphExclusionsResponse",
       "type": "object"
     }
   },
@@ -11455,7 +12116,6 @@ expression: signatures
       "required": [
         "projects"
       ],
-      "title": "ProjectListResponse",
       "type": "object"
     }
   },
@@ -11477,7 +12137,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ProjectRemoveParams",
       "type": "object"
     },
     "output_schema": {
@@ -11519,7 +12178,6 @@ expression: signatures
         "status",
         "project"
       ],
-      "title": "ProjectRemoveResponse",
       "type": "object"
     }
   },
@@ -11536,8 +12194,10 @@ expression: signatures
         "image_id": {
           "default": null,
           "description": "Image id to assign, or null/omit to clear the assignment (the project\nkeeps its current environment config).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project": {
           "description": "Project UUID or `owner/repo` slug.",
@@ -11547,19 +12207,22 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "ProjectSetImageParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -11568,7 +12231,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "ImageMutateResponse",
       "type": "object"
     }
   },
@@ -11592,15 +12254,16 @@ expression: signatures
         },
         "role": {
           "description": "`primary` (a write-target, default) or `reference` (read-only context).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id",
         "project"
       ],
-      "title": "ProposalTargetParams",
       "type": "object"
     },
     "output_schema": {
@@ -11615,13 +12278,17 @@ expression: signatures
             },
             "project_name": {
               "description": "Human-friendly project name, resolved by the handler.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "project_path": {
               "description": "`owner/repo` slug, resolved by the handler for display chips.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "role": {
               "description": "`primary` (a write-target) or `reference` (read-only context).",
@@ -11639,18 +12306,21 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "targets": {
           "items": {
             "$ref": "#/$defs/ProposalTargetModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "ProposalTargetsResponse",
       "type": "object"
     }
   },
@@ -11672,21 +12342,24 @@ expression: signatures
                   "$ref": "#/$defs/ByteRangeSelector"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "Byte range selector: start is inclusive, end is exclusive. If\n`expected_text` is provided and does not match the body at that byte\nrange, the patch is rejected (stale-range guard)."
             },
             "exact_text": {
               "description": "Match a contiguous substring of the body. Must occur exactly once;\nzero matches or ambiguous (multiple) matches are rejected.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "heading_text": {
               "description": "Match a markdown heading by its text (without the `#` prefix). The\nmatched range includes the heading line itself and all content up to\n(but not including) the next heading at the same or higher level, or\nthe end of the body.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -11701,8 +12374,10 @@ expression: signatures
             },
             "expected_text": {
               "description": "When set, the body text at `[start..end)` must equal this value or the\npatch is rejected. Guards against stale ranges after concurrent edits.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "start": {
               "description": "Inclusive byte offset of the target range.",
@@ -11726,8 +12401,10 @@ expression: signatures
         "expected_latest_revision_seq": {
           "description": "If set, reject the patch when the proposal's latest_revision_seq does\nnot equal this value. Guards against concurrent edits.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "id": {
           "description": "Proposal UUID or short_id.",
@@ -11735,18 +12412,24 @@ expression: signatures
         },
         "native_skill_name": {
           "description": "Name of the native skill producing this patch (e.g. \"visual-spec\").\nPersisted in the revision event_metadata for provenance.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "native_skill_version": {
           "description": "Pinned version of the native skill.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "note": {
           "description": "Optional free-form note persisted alongside the revision metadata.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "operation": {
           "description": "Operation: `replace` replaces the selected range, `wrap` wraps it.",
@@ -11763,7 +12446,6 @@ expression: signatures
         "operation",
         "block_mdx"
       ],
-      "title": "ProposalBlockPatchParams",
       "type": "object"
     },
     "output_schema": {
@@ -11804,8 +12486,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -11816,19 +12500,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -11836,8 +12526,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -11846,18 +12538,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -11871,8 +12569,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -11887,7 +12587,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -11900,7 +12599,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "ProposalBlocksParams",
       "type": "object"
     },
     "output_schema": {
@@ -11909,8 +12607,10 @@ expression: signatures
           "properties": {
             "description": {
               "description": "Optional authoring guidance for the LLM: how to encode this block's\nchildren/attributes. Absent for blocks whose shape is self-evident.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "fields": {
               "additionalProperties": {
@@ -11941,15 +12641,19 @@ expression: signatures
               "items": {
                 "type": "string"
               },
-              "nullable": true,
-              "type": "array"
+              "type": [
+                "array",
+                "null"
+              ]
             },
             "fields": {
               "additionalProperties": {
                 "$ref": "#/$defs/ProposalBlockFieldSchema"
               },
-              "nullable": true,
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             },
             "items": {
               "anyOf": [
@@ -11957,8 +12661,7 @@ expression: signatures
                   "$ref": "#/$defs/ProposalBlockFieldSchema"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ]
             },
@@ -11985,7 +12688,6 @@ expression: signatures
       "required": [
         "blocks"
       ],
-      "title": "ProposalBlocksResponse",
       "type": "object"
     }
   },
@@ -12031,31 +12733,41 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AcceptanceCriterionItem"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "body": {
           "description": "Spec body (markdown or MDX depending on `body_format`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body_format": {
           "description": "Body encoding: `markdown` (default) or `mdx` (block-aware).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "description": "Initial status: `triage`, `draft` (default), or `in_review`. Proposer-\nrole authors are always placed in `triage` regardless of this value.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "target_projects": {
           "description": "Target projects (UUIDs or owner/repo slugs) this proposal touches.\nEditable later via proposal_add_target / proposal_remove_target.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -12064,7 +12776,6 @@ expression: signatures
       "required": [
         "title"
       ],
-      "title": "ProposalCreateParams",
       "type": "object"
     },
     "output_schema": {
@@ -12105,8 +12816,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -12117,19 +12830,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -12137,8 +12856,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -12147,18 +12868,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -12172,8 +12899,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -12188,7 +12917,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -12218,8 +12946,10 @@ expression: signatures
         },
         "author_model": {
           "description": "Model id when `author_kind == \"agent\"`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "blocking": {
           "default": false,
@@ -12245,8 +12975,10 @@ expression: signatures
         },
         "source_task_id": {
           "description": "Optional source task attribution.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -12257,7 +12989,6 @@ expression: signatures
         "against_revision_seq",
         "round"
       ],
-      "title": "ProposalDebateAppendParams",
       "type": "object"
     },
     "output_schema": {
@@ -12279,12 +13010,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "blocking": {
               "description": "When true, this entry blocks proposal readiness.",
@@ -12308,21 +13043,29 @@ expression: signatures
             },
             "reopened_at": {
               "description": "When set alongside `resolved_at`, the entry was reopened.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reopened_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_at": {
               "description": "When set, the entry has been resolved. `None` while open.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "round": {
               "description": "Debate round (1-based).",
@@ -12330,8 +13073,10 @@ expression: signatures
               "type": "integer"
             },
             "source_task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -12361,17 +13106,17 @@ expression: signatures
               "$ref": "#/$defs/ProposalDebateTrailModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProposalDebateTrailResponse",
       "type": "object"
     }
   },
@@ -12393,7 +13138,6 @@ expression: signatures
       "required": [
         "proposal_id"
       ],
-      "title": "ProposalDebateListParams",
       "type": "object"
     },
     "output_schema": {
@@ -12415,12 +13159,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "blocking": {
               "description": "When true, this entry blocks proposal readiness.",
@@ -12444,21 +13192,29 @@ expression: signatures
             },
             "reopened_at": {
               "description": "When set alongside `resolved_at`, the entry was reopened.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reopened_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_at": {
               "description": "When set, the entry has been resolved. `None` while open.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "round": {
               "description": "Debate round (1-based).",
@@ -12466,8 +13222,10 @@ expression: signatures
               "type": "integer"
             },
             "source_task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -12495,19 +13253,24 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/ProposalDebateTrailModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProposalDebateTrailListResponse",
       "type": "object"
     }
   },
@@ -12528,14 +13291,15 @@ expression: signatures
         "user_id": {
           "default": null,
           "description": "Optional user ID to attribute the reopen action to. When omitted,\nfalls back to the current session user (if any). Passed through\nto the audit trail as `reopened_by_user_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id"
       ],
-      "title": "ProposalDebateReopenParams",
       "type": "object"
     },
     "output_schema": {
@@ -12557,12 +13321,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "blocking": {
               "description": "When true, this entry blocks proposal readiness.",
@@ -12586,21 +13354,29 @@ expression: signatures
             },
             "reopened_at": {
               "description": "When set alongside `resolved_at`, the entry was reopened.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reopened_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_at": {
               "description": "When set, the entry has been resolved. `None` while open.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "round": {
               "description": "Debate round (1-based).",
@@ -12608,8 +13384,10 @@ expression: signatures
               "type": "integer"
             },
             "source_task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -12639,17 +13417,17 @@ expression: signatures
               "$ref": "#/$defs/ProposalDebateTrailModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProposalDebateTrailResponse",
       "type": "object"
     }
   },
@@ -12671,7 +13449,6 @@ expression: signatures
       "required": [
         "id"
       ],
-      "title": "ProposalDebateResolveParams",
       "type": "object"
     },
     "output_schema": {
@@ -12693,12 +13470,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "blocking": {
               "description": "When true, this entry blocks proposal readiness.",
@@ -12722,21 +13503,29 @@ expression: signatures
             },
             "reopened_at": {
               "description": "When set alongside `resolved_at`, the entry was reopened.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reopened_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_at": {
               "description": "When set, the entry has been resolved. `None` while open.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "round": {
               "description": "Debate round (1-based).",
@@ -12744,8 +13533,10 @@ expression: signatures
               "type": "integer"
             },
             "source_task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -12775,17 +13566,17 @@ expression: signatures
               "$ref": "#/$defs/ProposalDebateTrailModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProposalDebateTrailResponse",
       "type": "object"
     }
   },
@@ -12807,22 +13598,24 @@ expression: signatures
       "required": [
         "id"
       ],
-      "title": "ProposalDeleteParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
-      "title": "ProposalDeleteResponse",
       "type": "object"
     }
   },
@@ -12844,7 +13637,6 @@ expression: signatures
       "required": [
         "id"
       ],
-      "title": "ProposalExportParams",
       "type": "object"
     },
     "output_schema": {
@@ -12885,8 +13677,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -12897,19 +13691,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -12917,8 +13717,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -12927,18 +13729,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -12952,8 +13760,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -12968,7 +13778,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -12984,21 +13793,27 @@ expression: signatures
       "properties": {
         "author_kind": {
           "description": "`user` (default) or `ai`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "author_model": {
           "description": "Model id when author_kind is `ai`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
         },
         "parent_id": {
           "description": "Parent feedback id for a threaded reply.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
           "description": "Proposal UUID or short_id.",
@@ -13009,7 +13824,6 @@ expression: signatures
         "proposal_id",
         "body"
       ],
-      "title": "ProposalFeedbackAddParams",
       "type": "object"
     },
     "output_schema": {
@@ -13021,12 +13835,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "body": {
               "type": "string"
@@ -13038,26 +13856,34 @@ expression: signatures
               "type": "string"
             },
             "parent_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "proposal_id": {
               "type": "string"
             },
             "resolved_at": {
               "description": "When set, the feedback is resolved (addressed or dismissed) and collapsed\nout of the active thread.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_revision_seq": {
               "description": "The revision that addressed this feedback (`null` when dismissed without\na spec change).",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -13077,8 +13903,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "feedback": {
           "anyOf": [
@@ -13086,13 +13914,11 @@ expression: signatures
               "$ref": "#/$defs/ProposalFeedbackModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         }
       },
-      "title": "ProposalFeedbackResponse",
       "type": "object"
     }
   },
@@ -13113,14 +13939,15 @@ expression: signatures
         "resolved_revision_seq": {
           "description": "The proposal revision that addressed this feedback (omit for a plain\ndismissal with no spec change).",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
         "id"
       ],
-      "title": "ProposalFeedbackResolveParams",
       "type": "object"
     },
     "output_schema": {
@@ -13132,12 +13959,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "body": {
               "type": "string"
@@ -13149,26 +13980,34 @@ expression: signatures
               "type": "string"
             },
             "parent_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "proposal_id": {
               "type": "string"
             },
             "resolved_at": {
               "description": "When set, the feedback is resolved (addressed or dismissed) and collapsed\nout of the active thread.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_revision_seq": {
               "description": "The revision that addressed this feedback (`null` when dismissed without\na spec change).",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -13188,8 +14027,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "feedback": {
           "anyOf": [
@@ -13197,13 +14038,11 @@ expression: signatures
               "$ref": "#/$defs/ProposalFeedbackModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         }
       },
-      "title": "ProposalFeedbackResponse",
       "type": "object"
     }
   },
@@ -13223,14 +14062,15 @@ expression: signatures
         },
         "owner_user_id": {
           "description": "Build owner — must be a participant (author or a sign-off giver).\nDefaults to the kicking-off user.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id"
       ],
-      "title": "ProposalGraduateParams",
       "type": "object"
     },
     "output_schema": {
@@ -13271,8 +14111,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -13283,19 +14125,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -13303,8 +14151,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -13313,18 +14163,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -13338,8 +14194,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -13354,7 +14212,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -13376,7 +14233,6 @@ expression: signatures
       "required": [
         "mdx"
       ],
-      "title": "ProposalImportParams",
       "type": "object"
     },
     "output_schema": {
@@ -13417,8 +14273,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -13429,19 +14287,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -13449,8 +14313,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -13459,18 +14325,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -13484,8 +14356,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -13500,7 +14374,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -13516,40 +14389,53 @@ expression: signatures
       "properties": {
         "author": {
           "description": "Filter by author user id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "sort": {
           "description": "Sort order: \"created_desc\" (default), \"created\", \"updated\", \"updated_desc\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "target_project": {
           "description": "Filter to proposals targeting this project (UUID or owner/repo slug).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "text": {
           "description": "Full-text search on title and body.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProposalListParams",
       "type": "object"
     },
     "output_schema": {
@@ -13589,8 +14475,10 @@ expression: signatures
               "type": "array"
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "body": {
               "type": "string"
@@ -13601,12 +14489,16 @@ expression: signatures
             },
             "build_owner_user_id": {
               "description": "Build owner once graduated.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "closed_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "created_at": {
               "type": "string"
@@ -13617,8 +14509,10 @@ expression: signatures
             "last_reconciled_revision_seq": {
               "description": "Last proposal revision that the in-flight build has reconciled against.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "latest_revision_seq": {
               "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -13627,13 +14521,17 @@ expression: signatures
             },
             "linked_spike_task_id": {
               "description": "When parked for needs-evidence: the linked spike task id.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "needs_evidence_claim": {
               "description": "When parked for needs-evidence: the named feasibility claim.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pending_reconcile": {
               "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -13647,8 +14545,10 @@ expression: signatures
               "type": "string"
             },
             "superseded_by": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "title": {
               "type": "string"
@@ -13682,37 +14582,48 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "has_more": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "proposals": {
           "items": {
             "$ref": "#/$defs/ProposalModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "total_count": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
-      "title": "ProposalListResponse",
       "type": "object"
     }
   },
@@ -13732,29 +14643,36 @@ expression: signatures
         },
         "id": {
           "description": "Proposal UUID or short_id. Alias for `proposal_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "preview": {
           "description": "When true, compute blast radius without closing tasks, closing/unlinking the epic, or killing sessions.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "proposal_id": {
           "description": "Proposal UUID or short_id. Alias for `id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "reason": {
           "description": "Why obsolete work is being force-closed. Defaults to a reconcile teardown reason.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "epic_id"
       ],
-      "title": "ProposalReconcileObsoleteEpicParams",
       "type": "object"
     },
     "output_schema": {
@@ -13765,16 +14683,22 @@ expression: signatures
           "type": "boolean"
         },
         "blocked_feedback_body": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "blocked_feedback_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "epic_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "epics_closed": {
           "description": "Target epic closed, or that would be closed in preview.",
@@ -13782,8 +14706,10 @@ expression: signatures
           "type": "integer"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "merged_tasks": {
           "default": [],
@@ -13801,8 +14727,10 @@ expression: signatures
           "type": "boolean"
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "sessions_killed": {
           "description": "Running target-epic worker sessions killed, or live sessions in preview.",
@@ -13823,7 +14751,6 @@ expression: signatures
         "tasks_closed",
         "sessions_killed"
       ],
-      "title": "ProposalReconcileObsoleteEpicResponse",
       "type": "object"
     }
   },
@@ -13843,14 +14770,15 @@ expression: signatures
         },
         "reason": {
           "description": "Why another round is being demanded. Recorded in proposal history.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "proposal_id"
       ],
-      "title": "ProposalRefinementDemandRoundParams",
       "type": "object"
     },
     "output_schema": {
@@ -13898,8 +14826,10 @@ expression: signatures
             "current_round": {
               "description": "Current debate round (1-based). `None` when refinement has not started.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "dry_rounds": {
               "description": "How many consecutive adversary dry rounds have been observed.",
@@ -13908,8 +14838,10 @@ expression: signatures
             },
             "judge_summary": {
               "description": "The judge's summary shown alongside the accept/reject review.\n`None` unless `awaiting_review` is true.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "needs_evidence": {
               "anyOf": [
@@ -13917,8 +14849,7 @@ expression: signatures
                   "$ref": "#/$defs/NeedsEvidenceStatus"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "When the proposal is parked for a needs-evidence spike, this contains\nthe claim and spike task reference. `None` when not parked."
@@ -13926,13 +14857,17 @@ expression: signatures
             "snapshot_revision_seq": {
               "description": "The pre-refinement snapshot revision seq (the diff baseline) when\n`awaiting_review` is true.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "stop_reason": {
               "description": "When set, refinement has stopped for this reason.\nValues: `adversary_dry`, `round_cap`, `spawn_cap`, `repeated_objection`,\n`agent_failure`, or `null` (still running / not started).",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "total_entries": {
               "description": "Total debate-trail entries produced so far.",
@@ -13949,19 +14884,22 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `proposal_refinement_demand_round`.",
       "properties": {
         "accepted": {
           "description": "True when the demand was accepted and a new round started.",
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "refinement": {
           "anyOf": [
@@ -13969,8 +14907,7 @@ expression: signatures
               "$ref": "#/$defs/ProposalRefinementStatusModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "Refinement status after the demand."
@@ -13979,7 +14916,6 @@ expression: signatures
       "required": [
         "accepted"
       ],
-      "title": "DemandRoundResponse",
       "type": "object"
     }
   },
@@ -14000,8 +14936,10 @@ expression: signatures
         "feedback": {
           "default": null,
           "description": "Optional reviewer note — why accepted/rejected. Recorded for the audit\ntrail.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
           "description": "Proposal UUID or short_id.",
@@ -14012,20 +14950,22 @@ expression: signatures
         "proposal_id",
         "decision"
       ],
-      "title": "ProposalRefinementResolveParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `proposal_refinement_resolve`.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "resolved": {
           "description": "True when the human's accept/reject was applied.",
@@ -14035,7 +14975,6 @@ expression: signatures
       "required": [
         "resolved"
       ],
-      "title": "ResolveReviewResponse",
       "type": "object"
     }
   },
@@ -14052,8 +14991,10 @@ expression: signatures
         "owner_user_id": {
           "default": null,
           "description": "User the refinement run is attributed to: owner of the spawned\nrefinement (tribunal) tasks and the scope for per-user role-model\nresolution. Omit to attribute the run to the proposal author.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
           "description": "Proposal UUID or short_id.",
@@ -14063,7 +15004,6 @@ expression: signatures
       "required": [
         "proposal_id"
       ],
-      "title": "ProposalRefinementStartParams",
       "type": "object"
     },
     "output_schema": {
@@ -14111,8 +15051,10 @@ expression: signatures
             "current_round": {
               "description": "Current debate round (1-based). `None` when refinement has not started.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "dry_rounds": {
               "description": "How many consecutive adversary dry rounds have been observed.",
@@ -14121,8 +15063,10 @@ expression: signatures
             },
             "judge_summary": {
               "description": "The judge's summary shown alongside the accept/reject review.\n`None` unless `awaiting_review` is true.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "needs_evidence": {
               "anyOf": [
@@ -14130,8 +15074,7 @@ expression: signatures
                   "$ref": "#/$defs/NeedsEvidenceStatus"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "When the proposal is parked for a needs-evidence spike, this contains\nthe claim and spike task reference. `None` when not parked."
@@ -14139,13 +15082,17 @@ expression: signatures
             "snapshot_revision_seq": {
               "description": "The pre-refinement snapshot revision seq (the diff baseline) when\n`awaiting_review` is true.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "stop_reason": {
               "description": "When set, refinement has stopped for this reason.\nValues: `adversary_dry`, `round_cap`, `spawn_cap`, `repeated_objection`,\n`agent_failure`, or `null` (still running / not started).",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "total_entries": {
               "description": "Total debate-trail entries produced so far.",
@@ -14162,15 +15109,18 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `proposal_refinement_start`.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "refinement": {
           "anyOf": [
@@ -14178,14 +15128,12 @@ expression: signatures
               "$ref": "#/$defs/ProposalRefinementStatusModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "The initial refinement status after starting."
         }
       },
-      "title": "ProposalRefinementStartResponse",
       "type": "object"
     }
   },
@@ -14207,7 +15155,6 @@ expression: signatures
       "required": [
         "proposal_id"
       ],
-      "title": "ProposalRefinementStatusParams",
       "type": "object"
     },
     "output_schema": {
@@ -14255,8 +15202,10 @@ expression: signatures
             "current_round": {
               "description": "Current debate round (1-based). `None` when refinement has not started.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "dry_rounds": {
               "description": "How many consecutive adversary dry rounds have been observed.",
@@ -14265,8 +15214,10 @@ expression: signatures
             },
             "judge_summary": {
               "description": "The judge's summary shown alongside the accept/reject review.\n`None` unless `awaiting_review` is true.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "needs_evidence": {
               "anyOf": [
@@ -14274,8 +15225,7 @@ expression: signatures
                   "$ref": "#/$defs/NeedsEvidenceStatus"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "When the proposal is parked for a needs-evidence spike, this contains\nthe claim and spike task reference. `None` when not parked."
@@ -14283,13 +15233,17 @@ expression: signatures
             "snapshot_revision_seq": {
               "description": "The pre-refinement snapshot revision seq (the diff baseline) when\n`awaiting_review` is true.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "stop_reason": {
               "description": "When set, refinement has stopped for this reason.\nValues: `adversary_dry`, `round_cap`, `spawn_cap`, `repeated_objection`,\n`agent_failure`, or `null` (still running / not started).",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "total_entries": {
               "description": "Total debate-trail entries produced so far.",
@@ -14306,15 +15260,18 @@ expression: signatures
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `proposal_refinement_status`.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "refinement": {
           "anyOf": [
@@ -14322,13 +15279,11 @@ expression: signatures
               "$ref": "#/$defs/ProposalRefinementStatusModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         }
       },
-      "title": "ProposalRefinementStatusResponse",
       "type": "object"
     }
   },
@@ -14352,15 +15307,16 @@ expression: signatures
         },
         "role": {
           "description": "`primary` (a write-target, default) or `reference` (read-only context).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id",
         "project"
       ],
-      "title": "ProposalTargetParams",
       "type": "object"
     },
     "output_schema": {
@@ -14375,13 +15331,17 @@ expression: signatures
             },
             "project_name": {
               "description": "Human-friendly project name, resolved by the handler.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "project_path": {
               "description": "`owner/repo` slug, resolved by the handler for display chips.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "role": {
               "description": "`primary` (a write-target) or `reference` (read-only context).",
@@ -14399,18 +15359,21 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "targets": {
           "items": {
             "$ref": "#/$defs/ProposalTargetModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "ProposalTargetsResponse",
       "type": "object"
     }
   },
@@ -14432,7 +15395,6 @@ expression: signatures
       "required": [
         "id"
       ],
-      "title": "ProposalShowParams",
       "type": "object"
     },
     "output_schema": {
@@ -14525,12 +15487,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "blocking": {
               "description": "When true, this entry blocks proposal readiness.",
@@ -14554,21 +15520,29 @@ expression: signatures
             },
             "reopened_at": {
               "description": "When set alongside `resolved_at`, the entry was reopened.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "reopened_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_at": {
               "description": "When set, the entry has been resolved. `None` while open.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "round": {
               "description": "Debate round (1-based).",
@@ -14576,8 +15550,10 @@ expression: signatures
               "type": "integer"
             },
             "source_task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -14623,8 +15599,10 @@ expression: signatures
             },
             "reconciled_at_revision_seq": {
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "status": {
               "type": "string"
@@ -14648,12 +15626,16 @@ expression: signatures
               "type": "string"
             },
             "author_model": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "body": {
               "type": "string"
@@ -14665,26 +15647,34 @@ expression: signatures
               "type": "string"
             },
             "parent_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "proposal_id": {
               "type": "string"
             },
             "resolved_at": {
               "description": "When set, the feedback is resolved (addressed or dismissed) and collapsed\nout of the active thread.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "resolved_revision_seq": {
               "description": "The revision that addressed this feedback (`null` when dismissed without\na spec change).",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "updated_at": {
               "type": "string"
@@ -14736,13 +15726,17 @@ expression: signatures
             },
             "judge_verdict_body": {
               "description": "Latest judge verdict body text, when a judge has issued a verdict.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "judge_verdict_id": {
               "description": "Latest judge verdict entry id, when a judge has issued a verdict.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "needs_evidence": {
               "anyOf": [
@@ -14750,8 +15744,7 @@ expression: signatures
                   "$ref": "#/$defs/NeedsEvidenceStatus"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "Needs-evidence spike parking state. `None` when not parked."
@@ -14826,8 +15819,10 @@ expression: signatures
               "type": "array"
             },
             "author_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "body": {
               "type": "string"
@@ -14838,12 +15833,16 @@ expression: signatures
             },
             "build_owner_user_id": {
               "description": "Build owner once graduated.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "closed_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "created_at": {
               "type": "string"
@@ -14854,8 +15853,10 @@ expression: signatures
             "last_reconciled_revision_seq": {
               "description": "Last proposal revision that the in-flight build has reconciled against.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "latest_revision_seq": {
               "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -14864,13 +15865,17 @@ expression: signatures
             },
             "linked_spike_task_id": {
               "description": "When parked for needs-evidence: the linked spike task id.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "needs_evidence_claim": {
               "description": "When parked for needs-evidence: the named feasibility claim.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "pending_reconcile": {
               "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -14884,8 +15889,10 @@ expression: signatures
               "type": "string"
             },
             "superseded_by": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "title": {
               "type": "string"
@@ -14930,8 +15937,10 @@ expression: signatures
             "current_round": {
               "description": "Current debate round (1-based). `None` when refinement has not started.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "dry_rounds": {
               "description": "How many consecutive adversary dry rounds have been observed.",
@@ -14940,8 +15949,10 @@ expression: signatures
             },
             "judge_summary": {
               "description": "The judge's summary shown alongside the accept/reject review.\n`None` unless `awaiting_review` is true.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "needs_evidence": {
               "anyOf": [
@@ -14949,8 +15960,7 @@ expression: signatures
                   "$ref": "#/$defs/NeedsEvidenceStatus"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "When the proposal is parked for a needs-evidence spike, this contains\nthe claim and spike task reference. `None` when not parked."
@@ -14958,13 +15968,17 @@ expression: signatures
             "snapshot_revision_seq": {
               "description": "The pre-refinement snapshot revision seq (the diff baseline) when\n`awaiting_review` is true.",
               "format": "int32",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "stop_reason": {
               "description": "When set, refinement has stopped for this reason.\nValues: `adversary_dry`, `round_cap`, `spawn_cap`, `repeated_objection`,\n`agent_failure`, or `null` (still running / not started).",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "total_entries": {
               "description": "Total debate-trail entries produced so far.",
@@ -14998,16 +16012,20 @@ expression: signatures
               "type": "string"
             },
             "edited_by_user_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "event_kind": {
               "description": "`spec_revision` for material spec snapshots, `status_change` for\nlifecycle-only history rows.",
               "type": "string"
             },
             "event_metadata": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -15017,12 +16035,16 @@ expression: signatures
               "type": "integer"
             },
             "status_from": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "status_to": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "title": {
               "type": "string"
@@ -15081,13 +16103,17 @@ expression: signatures
             },
             "project_name": {
               "description": "Human-friendly project name, resolved by the handler.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "project_path": {
               "description": "`owner/repo` slug, resolved by the handler for display chips.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "role": {
               "description": "`primary` (a write-target) or `reference` (read-only context).",
@@ -15109,26 +16135,34 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/ProposalDebateTrailModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "epics": {
           "items": {
             "$ref": "#/$defs/ProposalEpicModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "feedback": {
           "items": {
             "$ref": "#/$defs/ProposalFeedbackModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "gate_status": {
           "anyOf": [
@@ -15136,8 +16170,7 @@ expression: signatures
               "$ref": "#/$defs/ProposalGateStatusModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "Composed gate status: deterministic DoR + tribunal conditions.\nAlways present on a successful `proposal_show` response."
@@ -15155,8 +16188,7 @@ expression: signatures
               "$ref": "#/$defs/ProposalModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ]
         },
@@ -15166,8 +16198,7 @@ expression: signatures
               "$ref": "#/$defs/ProposalRefinementStatusModel"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "Refinement session status (active round, stop reason, update authority).\n`None` when refinement has not been started for this proposal."
@@ -15176,25 +16207,30 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/ProposalRevisionModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "signoffs": {
           "items": {
             "$ref": "#/$defs/ProposalSignoffModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "targets": {
           "items": {
             "$ref": "#/$defs/ProposalTargetModel"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "ProposalShowResponse",
       "type": "object"
     }
   },
@@ -15221,7 +16257,6 @@ expression: signatures
         "id",
         "kind"
       ],
-      "title": "ProposalSignoffParams",
       "type": "object"
     },
     "output_schema": {
@@ -15262,8 +16297,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -15274,19 +16311,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -15294,8 +16337,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -15304,18 +16349,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -15329,8 +16380,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -15345,7 +16398,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -15372,7 +16424,6 @@ expression: signatures
         "id",
         "kind"
       ],
-      "title": "ProposalSignoffParams",
       "type": "object"
     },
     "output_schema": {
@@ -15413,8 +16464,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -15425,19 +16478,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -15445,8 +16504,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -15455,18 +16516,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -15480,8 +16547,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -15496,7 +16565,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -15520,20 +16588,23 @@ expression: signatures
         },
         "preview": {
           "description": "When true on `abort`, compute and return the blast radius (epics, open\ntasks, running sessions) WITHOUT mutating anything.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "reason": {
           "description": "Why the build is being stopped. Recorded as the force-close reason on\neach torn-down task. Required for `abort`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id",
         "mode"
       ],
-      "title": "ProposalStopBuildParams",
       "type": "object"
     },
     "output_schema": {
@@ -15545,8 +16616,10 @@ expression: signatures
           "type": "integer"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mode": {
           "type": "string"
@@ -15559,8 +16632,10 @@ expression: signatures
           "type": "boolean"
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "sessions_killed": {
           "description": "Running worker sessions killed (abort) or live now (preview).",
@@ -15569,8 +16644,10 @@ expression: signatures
         },
         "status": {
           "description": "Resulting proposal status (`approved` after a non-preview abort,\n`building` after freeze/unfreeze/preview).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tasks_closed": {
           "description": "Worker tasks force-closed (abort) or open right now (preview).",
@@ -15586,7 +16663,6 @@ expression: signatures
         "tasks_closed",
         "sessions_killed"
       ],
-      "title": "ProposalStopBuildResponse",
       "type": "object"
     }
   },
@@ -15632,17 +16708,23 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AcceptanceCriterionItem"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "body": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body_format": {
           "description": "Body encoding: `markdown` (default) or `mdx` (block-aware).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "description": "Proposal UUID or short_id.",
@@ -15650,23 +16732,28 @@ expression: signatures
         },
         "status": {
           "description": "draft | in_review | approved | building | done | rejected | archived | superseded.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "superseded_by": {
           "description": "UUID or short_id of the proposal that supersedes this one.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id"
       ],
-      "title": "ProposalUpdateParams",
       "type": "object"
     },
     "output_schema": {
@@ -15707,8 +16794,10 @@ expression: signatures
           "type": "array"
         },
         "author_user_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "type": "string"
@@ -15719,19 +16808,25 @@ expression: signatures
         },
         "build_owner_user_id": {
           "description": "Build owner once graduated.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "closed_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "created_at": {
           "type": "string"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -15739,8 +16834,10 @@ expression: signatures
         "last_reconciled_revision_seq": {
           "description": "Last proposal revision that the in-flight build has reconciled against.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "latest_revision_seq": {
           "description": "Head revision number (sign-offs anchored earlier are stale).",
@@ -15749,18 +16846,24 @@ expression: signatures
         },
         "linked_spike_task_id": {
           "description": "When parked for needs-evidence: the linked spike task id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "needs_evidence_claim": {
           "description": "When parked for needs-evidence: the named feasibility claim.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_reconcile": {
           "description": "True when the in-flight build is behind the latest proposal revision.",
@@ -15774,8 +16877,10 @@ expression: signatures
           "type": "string"
         },
         "superseded_by": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -15790,7 +16895,6 @@ expression: signatures
           "type": "string"
         }
       },
-      "title": "ProposalSingleResponse",
       "type": "object"
     }
   },
@@ -15807,8 +16911,10 @@ expression: signatures
         "overridden_verdict_entry_id": {
           "default": null,
           "description": "Optional debate-trail entry id of the verdict being overridden.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "proposal_id": {
           "description": "Proposal UUID or short_id.",
@@ -15823,16 +16929,16 @@ expression: signatures
         "proposal_id",
         "reason"
       ],
-      "title": "ProposalVerdictOverrideParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for `proposal_verdict_override`.",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "overridden": {
           "description": "True when the override was recorded.",
@@ -15841,18 +16947,21 @@ expression: signatures
         "override_on_revision_seq": {
           "description": "The revision seq the override is scoped to. Later revisions make\nthis override stale.",
           "format": "int32",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "proposal_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "overridden"
       ],
-      "title": "VerdictOverrideResponse",
       "type": "object"
     }
   },
@@ -15869,11 +16978,12 @@ expression: signatures
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProviderCatalogInput",
       "type": "object"
     },
     "output_schema": {
@@ -15930,8 +17040,10 @@ expression: signatures
             },
             "revoked_reason": {
               "description": "When set, the stored credential for this provider was rejected by the\nprovider (a 401 during a run) and marked revoked. The provider is\nreported disconnected (`connected = false`, no `connection_methods`) and\nthis human-readable reason is carried so the UI can show\n\"Disconnected — <reason>\" persistently (survives reload — it comes from\nthe persisted `credentials.revoked_at/reason`, not a transient event).\nReconnecting the provider clears it.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -15969,7 +17081,6 @@ expression: signatures
         "providers",
         "total"
       ],
-      "title": "ProviderCatalogResponse",
       "type": "object"
     }
   },
@@ -15986,11 +17097,12 @@ expression: signatures
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProviderConnectedInput",
       "type": "object"
     },
     "output_schema": {
@@ -16047,8 +17159,10 @@ expression: signatures
             },
             "revoked_reason": {
               "description": "When set, the stored credential for this provider was rejected by the\nprovider (a 401 during a run) and marked revoked. The provider is\nreported disconnected (`connected = false`, no `connection_methods`) and\nthis human-readable reason is carried so the UI can show\n\"Disconnected — <reason>\" persistently (survives reload — it comes from\nthe persisted `credentials.revoked_at/reason`, not a transient event).\nReconnecting the provider clears it.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -16086,7 +17200,6 @@ expression: signatures
         "providers",
         "total"
       ],
-      "title": "ProviderConnectedResponse",
       "type": "object"
     }
   },
@@ -16108,7 +17221,6 @@ expression: signatures
       "required": [
         "model_id"
       ],
-      "title": "ProviderModelLookupInput",
       "type": "object"
     },
     "output_schema": {
@@ -16235,8 +17347,10 @@ expression: signatures
           "properties": {
             "body": {
               "description": "Bounded upstream detail (response body, provider message) when\navailable. Truncated to [`MAX_BODY_EXCERPT_BYTES`] bytes with a\n`[truncated: N bytes omitted]` marker if the raw body was longer. The\nraw body is preserved internally for `tracing::warn!` but never\nserialized into the agent-visible envelope.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "error": {
               "description": "Human-readable message describing what went wrong. Always present.",
@@ -16248,31 +17362,38 @@ expression: signatures
                   "$ref": "#/$defs/ErrorClass"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "Coarse failure class. Assigned at construction time from a typed\nsource (HTTP status, provider error variant). Omitted from the wire\nwhen unknown — the legacy envelope shape (without this field) is\nstill valid."
             },
             "hint": {
               "description": "Actionable next step the agent can take to recover or disambiguate.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "method": {
               "description": "The logical operation that failed — typically the MCP tool name (e.g.\n\"provider_model_lookup\") or the upstream method (\"GET /search/code\").",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "path": {
               "description": "The resource the call targeted — a model id, repo path, PR ref, URL, etc.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "status": {
               "description": "Status as a numeric HTTP code (e.g. \"404\", \"422\") or a coarse category\n(e.g. \"not_found\", \"rate_limited\", \"network\"). Stored as a string so a\nnumeric HTTP status and a symbolic category share one field.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -16289,8 +17410,7 @@ expression: signatures
               "$ref": "#/$defs/ToolError"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "G3 structured-error envelope, populated on a 404-style miss (the model id\nis not in the catalog). Lets the agent branch on `status == \"404\"` and\nfollow the `hint` instead of re-guessing the same bad id. Absent on a hit."
@@ -16310,7 +17430,6 @@ expression: signatures
         "found",
         "model"
       ],
-      "title": "ProviderModelLookupResponse",
       "type": "object"
     }
   },
@@ -16332,7 +17451,6 @@ expression: signatures
       "required": [
         "provider_id"
       ],
-      "title": "ProviderModelsInput",
       "type": "object"
     },
     "output_schema": {
@@ -16436,7 +17554,6 @@ expression: signatures
         "models",
         "total"
       ],
-      "title": "ProviderModelsResponse",
       "type": "object"
     }
   },
@@ -16453,11 +17570,12 @@ expression: signatures
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "ProviderModelsConnectedInput",
       "type": "object"
     },
     "output_schema": {
@@ -16557,7 +17675,6 @@ expression: signatures
         "models",
         "total"
       ],
-      "title": "ProviderModelsConnectedResponse",
       "type": "object"
     }
   },
@@ -16578,22 +17695,25 @@ expression: signatures
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "provider_id"
       ],
-      "title": "ProviderOauthStartInput",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "builtin_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "configured_keys": {
           "items": {
@@ -16602,24 +17722,32 @@ expression: signatures
           "type": "array"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "expires_in": {
           "description": "Device-code: how long, in seconds, the user has to complete sign-in.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "goose_provider_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "interval": {
           "description": "Device-code: recommended polling interval in seconds (informational —\nthe server does the polling, not the client).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "oauth_supported": {
           "type": "boolean"
@@ -16639,18 +17767,24 @@ expression: signatures
         },
         "user_code": {
           "description": "Device-code: the short code the user must enter at `verification_uri`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "verification_uri": {
           "description": "Device-code: the bare URL the user opens to enter the code manually.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "verification_uri_complete": {
           "description": "Device-code: convenience URL with `user_code` pre-filled as a query\nparam; the UI can surface this as a \"click to open\" link.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -16661,7 +17795,6 @@ expression: signatures
         "configured_keys",
         "pending"
       ],
-      "title": "ProviderOauthStartResponse",
       "type": "object"
     }
   },
@@ -16683,7 +17816,6 @@ expression: signatures
       "required": [
         "provider_id"
       ],
-      "title": "ProviderRemoveInput",
       "type": "object"
     },
     "output_schema": {
@@ -16697,8 +17829,10 @@ expression: signatures
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "oauth_cleared": {
           "type": "boolean"
@@ -16721,7 +17855,6 @@ expression: signatures
         "custom_provider_deleted",
         "oauth_cleared"
       ],
-      "title": "ProviderRemoveResponse",
       "type": "object"
     }
   },
@@ -16741,19 +17874,22 @@ expression: signatures
         },
         "base_url": {
           "description": "Provider API base URL (e.g. https://api.openai.com/v1). The probe appends /models.\nWhen omitted, the server resolves it from the catalog using provider_id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "provider_id": {
           "description": "Provider identifier. Used for logging and to resolve base_url from the catalog when not supplied.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "api_key"
       ],
-      "title": "ProviderValidateInput",
       "type": "object"
     },
     "output_schema": {
@@ -16786,7 +17922,6 @@ expression: signatures
         "models",
         "http_status"
       ],
-      "title": "ProviderValidateResponse",
       "type": "object"
     }
   },
@@ -16808,15 +17943,16 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "RetriggerImageBuildParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
           "type": "string"
@@ -16825,7 +17961,6 @@ expression: signatures
       "required": [
         "status"
       ],
-      "title": "RetriggerImageBuildResponse",
       "type": "object"
     }
   },
@@ -16838,7 +17973,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "ServicePresetListParams",
       "type": "object"
     },
     "output_schema": {
@@ -16847,8 +17981,10 @@ expression: signatures
           "properties": {
             "client_package": {
               "description": "System (apt) package providing this service's CLI client, auto-installed\ninto images that attach the preset. `null` = none.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "conn_env_var": {
               "description": "Comma-separated list of env-var names the connection string is exported\nunder (e.g. `DATABASE_URL,TEST_POSTGRES_URL`).",
@@ -16880,8 +18016,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "presets": {
           "items": {
@@ -16897,7 +18035,6 @@ expression: signatures
         "status",
         "presets"
       ],
-      "title": "ServicePresetListResponse",
       "type": "object"
     }
   },
@@ -16919,7 +18056,6 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "SessionActiveParams",
       "type": "object"
     },
     "output_schema": {
@@ -16939,8 +18075,10 @@ expression: signatures
               "type": "integer"
             },
             "ended_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -16950,13 +18088,17 @@ expression: signatures
             },
             "parked_reason": {
               "description": "Optional deliberate-park reason for terminal sessions, e.g. `budget`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "project_id": {
               "description": "`None` for chat sessions (global, user-scoped); `Some(_)` for every\nother agent type. See `SessionRecord::project_id`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "started_at": {
               "type": "string"
@@ -16965,8 +18107,10 @@ expression: signatures
               "type": "string"
             },
             "task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tokens_in": {
               "format": "int64",
@@ -16978,8 +18122,10 @@ expression: signatures
             },
             "workspace_path": {
               "description": "Authoritative workspace path for the session, sourced from the\nattached `task_run` (via `sessions.task_run_id`). `None` when the\nsession is not attached to a task run or the run has no recorded\nworkspace.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -16999,29 +18145,36 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "recovery_triggered": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "sessions": {
           "items": {
             "$ref": "#/$defs/SessionToolSession"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "stale_sessions": {
           "items": {
             "$ref": "#/$defs/SessionToolSession"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "SessionActiveResponse",
       "type": "object"
     }
   },
@@ -17048,7 +18201,6 @@ expression: signatures
         "task_id",
         "project"
       ],
-      "title": "SessionForTaskParams",
       "type": "object"
     },
     "output_schema": {
@@ -17056,42 +18208,53 @@ expression: signatures
       "properties": {
         "duration_seconds": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "model_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
         },
         "session": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "session_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "task_id": {
           "type": "string"
         },
         "workspace_path": {
           "description": "Workspace path resolved from the session's attached `task_run`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "ok",
         "task_id"
       ],
-      "title": "SessionForTaskResponse",
       "type": "object"
     }
   },
@@ -17108,16 +18271,19 @@ expression: signatures
         "project": {
           "default": null,
           "description": "Optional project hint (slug or UUID). Only needed to disambiguate a\n`short_id`; a task UUID resolves globally without it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "task_id": {
           "description": "Task UUID or short_id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "SessionListParams",
       "type": "object"
     },
     "output_schema": {
@@ -17137,8 +18303,10 @@ expression: signatures
               "type": "integer"
             },
             "ended_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -17148,13 +18316,17 @@ expression: signatures
             },
             "parked_reason": {
               "description": "Optional deliberate-park reason for terminal sessions, e.g. `budget`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "project_id": {
               "description": "`None` for chat sessions (global, user-scoped); `Some(_)` for every\nother agent type. See `SessionRecord::project_id`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "started_at": {
               "type": "string"
@@ -17163,8 +18335,10 @@ expression: signatures
               "type": "string"
             },
             "task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tokens_in": {
               "format": "int64",
@@ -17176,8 +18350,10 @@ expression: signatures
             },
             "workspace_path": {
               "description": "Authoritative workspace path for the session, sourced from the\nattached `task_run` (via `sessions.task_run_id`). `None` when the\nsession is not attached to a task run or the run has no recorded\nworkspace.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -17197,22 +18373,27 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "sessions": {
           "items": {
             "$ref": "#/$defs/SessionToolSession"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "task_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "SessionListResponse",
       "type": "object"
     }
   },
@@ -17239,7 +18420,6 @@ expression: signatures
         "id",
         "project"
       ],
-      "title": "SessionMessagesParams",
       "type": "object"
     },
     "output_schema": {
@@ -17267,30 +18447,39 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "agent_type": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "messages": {
           "items": {
             "$ref": "#/$defs/SessionMessage"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "model_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "session_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "SessionMessagesResponse",
       "type": "object"
     }
   },
@@ -17317,7 +18506,6 @@ expression: signatures
         "id",
         "project"
       ],
-      "title": "SessionShowParams",
       "type": "object"
     },
     "output_schema": {
@@ -17336,12 +18524,16 @@ expression: signatures
           "type": "integer"
         },
         "ended_at": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "type": "string"
@@ -17351,13 +18543,17 @@ expression: signatures
         },
         "parked_reason": {
           "description": "Optional deliberate-park reason for terminal sessions, e.g. `budget`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "project_id": {
           "description": "`None` for chat sessions (global, user-scoped); `Some(_)` for every\nother agent type. See `SessionRecord::project_id`.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "started_at": {
           "type": "string"
@@ -17366,8 +18562,10 @@ expression: signatures
           "type": "string"
         },
         "task_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tokens_in": {
           "format": "int64",
@@ -17379,11 +18577,12 @@ expression: signatures
         },
         "workspace_path": {
           "description": "Authoritative workspace path for the session, sourced from the\nattached `task_run` (via `sessions.task_run_id`). `None` when the\nsession is not attached to a task run or the run has no recorded\nworkspace.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "SessionShowResponse",
       "type": "object"
     }
   },
@@ -17399,11 +18598,12 @@ expression: signatures
       "properties": {
         "key": {
           "description": "Optional settings key to fetch (defaults to settings.raw).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "SettingsGetParams",
       "type": "object"
     },
     "output_schema": {
@@ -17413,8 +18613,10 @@ expression: signatures
           "description": "Metadata recorded when dispatch is paused for a scope.",
           "properties": {
             "expires_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "paused_at": {
               "type": "string"
@@ -17440,8 +18642,10 @@ expression: signatures
             "dispatch_limit": {
               "description": "Maximum number of tasks to dispatch per cycle (default 50).",
               "format": "int64",
-              "nullable": true,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "dispatch_pause": {
               "anyOf": [
@@ -17449,8 +18653,7 @@ expression: signatures
                   "$ref": "#/$defs/DispatchPause"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ],
               "description": "Global emergency stop for task dispatch. Missing in older settings rows means unpaused."
@@ -17461,26 +18664,34 @@ expression: signatures
                 "type": "integer"
               },
               "description": "LEGACY/ignored. Per-model concurrency caps are now **per-user**\n(`user_settings.max_sessions`) and the slot pool is elastic, so this\nglobal field is no longer written or read. Retained only so existing\n`settings.raw` rows still parse under `deny_unknown_fields`.",
-              "nullable": true,
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             },
             "memory_mount_enabled": {
               "description": "Enable the ADR-057 Linux memory mount for filesystem-first note workflows. Disabled by default; requires a Linux build with the `memory-mount` cargo feature. The mounted path serves the current session-selected task/worktree view when available and otherwise falls back to the canonical `main` view.",
-              "nullable": true,
-              "type": "boolean"
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "memory_mount_path": {
               "description": "Absolute filesystem path where the Linux FUSE mount should be attached. The directory must already exist and be empty at startup. This path hosts the current session-selected memory view; Djinn does not expose additional branch directories in this slice.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "models": {
               "description": "Ordered list of models available to agents, e.g. `[\"openai/gpt-4o\"]`.",
               "items": {
                 "type": "string"
               },
-              "nullable": true,
-              "type": "array"
+              "type": [
+                "array",
+                "null"
+              ]
             }
           },
           "type": "object"
@@ -17489,8 +18700,10 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "exists": {
           "type": "boolean"
@@ -17499,8 +18712,10 @@ expression: signatures
           "type": "string"
         },
         "raw_value": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "settings": {
           "$ref": "#/$defs/DjinnSettings"
@@ -17511,7 +18726,6 @@ expression: signatures
         "exists",
         "settings"
       ],
-      "title": "SettingsGetResponse",
       "type": "object"
     }
   },
@@ -17524,7 +18738,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "SettingsResetParams",
       "type": "object"
     },
     "output_schema": {
@@ -17534,8 +18747,10 @@ expression: signatures
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -17545,7 +18760,6 @@ expression: signatures
         "ok",
         "deleted"
       ],
-      "title": "SettingsResetResponse",
       "type": "object"
     }
   },
@@ -17562,29 +18776,36 @@ expression: signatures
         "dispatch_limit": {
           "description": "Maximum number of tasks to dispatch per cycle. Omit to keep current value.",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "memory_mount_enabled": {
           "description": "Enable the Linux-only ADR-057 memory FUSE mount for filesystem-first note workflows. Disabled by default; requires a Linux build with the `memory-mount` cargo feature. The mounted path serves the current session-selected task/worktree view when available and otherwise falls back to the canonical `main` view.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "memory_mount_path": {
           "description": "Absolute path for the Linux memory mount. The directory must already exist and be empty at startup. This path hosts the current session-selected memory view; no additional branch directories are exposed in this slice.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "models": {
           "description": "Ordered list of models available to all agents (e.g. [\"openai/gpt-4o\"]). Omit to keep current value.\nThis is the deployment FALLBACK list (used for tasks with no creator and\nusers with no per-user selection); per-user model selection + concurrency\ncaps live in `user_settings_*`.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "SettingsSetParams",
       "type": "object"
     },
     "output_schema": {
@@ -17594,8 +18815,10 @@ expression: signatures
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -17605,7 +18828,6 @@ expression: signatures
         "ok",
         "applied"
       ],
-      "title": "SettingsSetResponse",
       "type": "object"
     }
   },
@@ -17634,7 +18856,6 @@ expression: signatures
         "status",
         "version"
       ],
-      "title": "PingResponse",
       "type": "object"
     }
   },
@@ -17650,33 +18871,45 @@ expression: signatures
       "properties": {
         "actor_role": {
           "description": "Filter by actor_role (e.g. \"lead\", \"reviewer\", \"worker\", \"system\").",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "event_type": {
           "description": "Filter by event_type (e.g. \"status_changed\", \"comment\").",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "from_time": {
           "description": "ISO-8601 lower bound on created_at.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "description": "Task UUID or short_id (optional - omit to query all tasks).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -17684,20 +18917,20 @@ expression: signatures
         },
         "to_time": {
           "description": "ISO-8601 upper bound on created_at.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "TaskActivityListParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskActivityListResponse",
       "type": "object"
     }
   },
@@ -17717,20 +18950,20 @@ expression: signatures
         },
         "project": {
           "description": "Absolute project path. Optional - task IDs are globally unique.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id"
       ],
-      "title": "TaskBlockedListParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskBlockedListResponse",
       "type": "object"
     }
   },
@@ -17757,13 +18990,11 @@ expression: signatures
         "project",
         "id"
       ],
-      "title": "TaskBlockersListParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskBlockersListResponse",
       "type": "object"
     }
   },
@@ -17779,19 +19010,25 @@ expression: signatures
       "properties": {
         "label": {
           "description": "Filter by label value.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "owner": {
           "description": "Filter by owner email.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority_max": {
           "description": "Maximum priority to include (0=highest).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -17799,20 +19036,20 @@ expression: signatures
         },
         "session_id": {
           "description": "Session ID of the claiming agent (recorded as actor_id in the activity log).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "TaskClaimParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskClaimSuccess",
       "type": "object"
     }
   },
@@ -17827,12 +19064,16 @@ expression: signatures
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "actor_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "actor_role": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "body": {
           "description": "Comment body text.",
@@ -17852,13 +19093,11 @@ expression: signatures
         "id",
         "body"
       ],
-      "title": "TaskCommentAddParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrActivityEntryResponse",
       "type": "object"
     }
   },
@@ -17874,45 +19113,55 @@ expression: signatures
       "properties": {
         "group_by": {
           "description": "Group results by: \"status\", \"priority\", \"issue_type\", or \"epic\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "issue_type": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "label": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
           "type": "string"
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "text": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "TaskCountParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskCountSuccess",
       "type": "object"
     }
   },
@@ -17957,63 +19206,85 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AcceptanceCriterionItem"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "agent_type": {
           "description": "Specialist role name to route this task (e.g. \"rust-expert\").",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "blocked_by": {
           "description": "Task IDs (UUID or short_id) that block this task. Blockers are set atomically at creation.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "description": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "design": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "epic_id": {
           "description": "Parent epic ID - UUID or short_id (required).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "issue_type": {
           "description": "Task type: \"task\" (default), \"feature\", \"bug\", \"spike\", \"research\", \"planning\", or \"review\".\nSpike, research, planning, and review use a simple lifecycle: open → in_progress → closed.\nPlanning tasks are routed to the Planner; spike and review tasks are routed to the Architect.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "labels": {
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "memory_refs": {
           "description": "Memory note permalinks to attach to this task at creation.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "owner": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -18021,8 +19292,10 @@ expression: signatures
         },
         "status": {
           "description": "Optional initial status. Allowed value: \"open\" (default).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "title": {
           "type": "string"
@@ -18032,13 +19305,11 @@ expression: signatures
         "project",
         "title"
       ],
-      "title": "TaskCreateParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskResponse",
       "type": "object"
     }
   },
@@ -18054,28 +19325,38 @@ expression: signatures
       "properties": {
         "issue_type": {
           "description": "Positive (\"task\") or negative (\"!epic\") issue_type filter.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "label": {
           "description": "Filter by label value.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "offset": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "priority": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -18083,23 +19364,28 @@ expression: signatures
         },
         "sort": {
           "description": "Sort order: \"priority\" (default), \"created\", \"created_desc\",\n\"updated\", \"updated_desc\", \"closed\".",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "status": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "text": {
           "description": "Full-text search on title and description.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project"
       ],
-      "title": "TaskListParams",
       "type": "object"
     },
     "output_schema": {
@@ -18139,7 +19425,6 @@ expression: signatures
             },
             "active_session": {
               "description": "Active running session for this task, if any.",
-              "nullable": true,
               "properties": {
                 "agent_type": {
                   "type": "string"
@@ -18164,20 +19449,29 @@ expression: signatures
                 "started_at",
                 "status"
               ],
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             },
             "agent_type": {
               "description": "Specialist role name assigned to this task, if any.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "close_reason": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "closed_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "continuation_count": {
               "format": "int64",
@@ -18188,8 +19482,10 @@ expression: signatures
             },
             "created_by_user_id": {
               "description": "Stable `users.id` of whoever this task belongs to (session creator, or\nthe parent epic's creator for Planner-spawned tasks). `None` for tasks\nwith no human owner. Resolve to a display name via the org user list.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "description": {
               "type": "string"
@@ -18198,8 +19494,10 @@ expression: signatures
               "type": "string"
             },
             "epic_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -18218,8 +19516,10 @@ expression: signatures
               "type": "array"
             },
             "last_intervention_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "memory_refs": {
               "items": {
@@ -18228,22 +19528,28 @@ expression: signatures
               "type": "array"
             },
             "merge_commit_sha": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "merge_conflict_metadata": {
               "additionalProperties": true,
               "description": "JSON metadata about an active merge conflict (files, branches).",
-              "nullable": true,
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             },
             "owner": {
               "type": "string"
             },
             "pr_url": {
               "description": "URL of the associated pull request, once one has been opened.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "priority": {
               "format": "int64",
@@ -18335,7 +19641,6 @@ expression: signatures
         "offset",
         "has_more"
       ],
-      "title": "TaskListResponse",
       "type": "object"
     }
   },
@@ -18362,13 +19667,11 @@ expression: signatures
         "id",
         "project"
       ],
-      "title": "TaskMemoryRefsParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskMemoryRefsResponse",
       "type": "object"
     }
   },
@@ -18384,24 +19687,32 @@ expression: signatures
       "properties": {
         "label": {
           "description": "Filter by label value.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "owner": {
           "description": "Filter by owner email.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority_max": {
           "description": "Maximum priority to include (0=highest, higher numbers=lower priority).",
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
@@ -18411,13 +19722,11 @@ expression: signatures
       "required": [
         "project"
       ],
-      "title": "TaskReadyParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskReadyResponse",
       "type": "object"
     }
   },
@@ -18437,20 +19746,20 @@ expression: signatures
         },
         "project": {
           "description": "Absolute project path. Optional - task IDs are globally unique.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "id"
       ],
-      "title": "TaskShowParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskShowResponse",
       "type": "object"
     }
   },
@@ -18467,16 +19776,19 @@ expression: signatures
         "project": {
           "default": null,
           "description": "Optional project hint (slug or UUID). Only needed to disambiguate a\n`short_id`; a task UUID resolves globally without it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "task_id": {
           "description": "Task UUID or short_id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "TaskTimelineParams",
       "type": "object"
     },
     "output_schema": {
@@ -18497,8 +19809,10 @@ expression: signatures
               "type": "integer"
             },
             "ended_at": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
               "type": "string"
@@ -18508,13 +19822,17 @@ expression: signatures
             },
             "parked_reason": {
               "description": "Optional deliberate-park reason for terminal sessions, e.g. `budget`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "project_id": {
               "description": "`None` for chat sessions (global, user-scoped); `Some(_)` for every\nother agent type. See `SessionRecord::project_id`.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "started_at": {
               "type": "string"
@@ -18523,8 +19841,10 @@ expression: signatures
               "type": "string"
             },
             "task_id": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "tokens_in": {
               "format": "int64",
@@ -18536,8 +19856,10 @@ expression: signatures
             },
             "workspace_path": {
               "description": "Authoritative workspace path for the session, sourced from the\nattached `task_run` (via `sessions.task_run_id`). `None` when the\nsession is not attached to a task run or the run has no recorded\nworkspace.",
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
@@ -18564,8 +19886,7 @@ expression: signatures
                   "$ref": "#/$defs/AnyJson"
                 },
                 {
-                  "const": null,
-                  "nullable": true
+                  "type": "null"
                 }
               ]
             },
@@ -18580,8 +19901,10 @@ expression: signatures
               "$ref": "#/$defs/AnyJson"
             },
             "summary": {
-              "nullable": true,
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "timestamp": {
               "type": "string"
@@ -18637,29 +19960,36 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/TimelineActivity"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "messages": {
           "items": {
             "$ref": "#/$defs/TimelineMessage"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "sessions": {
           "items": {
             "$ref": "#/$defs/SessionToolSession"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         }
       },
-      "title": "TaskTimelineResponse",
       "type": "object"
     }
   },
@@ -18678,12 +20008,16 @@ expression: signatures
           "type": "string"
         },
         "actor_id": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "actor_role": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "description": "Task UUID or short_id.",
@@ -18695,13 +20029,17 @@ expression: signatures
         },
         "reason": {
           "description": "Required for:\ntask_review_reject, task_review_reject_conflict,\npr_changes_requested,\nreopen, release, release_task_review, force_close.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "target_status": {
           "description": "Required when action = \"user_override\". Allowed values: open, in_progress,\nneeds_task_review, in_task_review, approved, pr_draft, pr_review, closed.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -18709,13 +20047,11 @@ expression: signatures
         "id",
         "action"
       ],
-      "title": "TaskTransitionParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskResponse",
       "type": "object"
     }
   },
@@ -18761,42 +20097,56 @@ expression: signatures
           "items": {
             "$ref": "#/$defs/AcceptanceCriterionItem"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "agent_type": {
           "description": "Specialist role name to assign (set None/\"\" to clear).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "blocked_by_add": {
           "description": "Task IDs (UUID or short_id) to add as blockers of this task.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "blocked_by_remove": {
           "description": "Task IDs (UUID or short_id) to remove as blockers of this task.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "description": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "design": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "epic_id": {
           "description": "New parent epic UUID or short_id.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "id": {
           "description": "Task UUID or short_id.",
@@ -18807,62 +20157,74 @@ expression: signatures
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "labels_remove": {
           "description": "Labels to remove.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "memory_refs_add": {
           "description": "Memory note permalinks to add to this task.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "memory_refs_remove": {
           "description": "Memory note permalinks to remove from this task.",
           "items": {
             "type": "string"
           },
-          "nullable": true,
-          "type": "array"
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "owner": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "priority": {
           "format": "int64",
-          "nullable": true,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "project": {
           "description": "Absolute project path.",
           "type": "string"
         },
         "title": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
         "project",
         "id"
       ],
-      "title": "TaskUpdateParams",
       "type": "object"
     },
     "output_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
-      "title": "ErrorOrTaskResponse",
       "type": "object"
     }
   },
@@ -18875,7 +20237,6 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "title": "ToolchainVersionsParams",
       "type": "object"
     },
     "output_schema": {
@@ -18899,7 +20260,6 @@ expression: signatures
         "status",
         "versions"
       ],
-      "title": "ToolchainVersionsResponse",
       "type": "object"
     }
   },
@@ -18916,11 +20276,12 @@ expression: signatures
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "UserSettingsGetParams",
       "type": "object"
     },
     "output_schema": {
@@ -18971,8 +20332,10 @@ expression: signatures
           "type": "boolean"
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "lane_locked": {
           "description": "True when the org AI policy locks lane assignment: the member may not\nedit lanes (UI disables the controls; the server rejects lane writes).",
@@ -18995,8 +20358,10 @@ expression: signatures
         },
         "user_id": {
           "description": "`users.id` of the signed-in caller (echoed so the UI can sanity-check identity).",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -19008,7 +20373,6 @@ expression: signatures
         "diverse_review",
         "diverse_refinement"
       ],
-      "title": "UserSettingsGetResponse",
       "type": "object"
     }
   },
@@ -19056,18 +20420,24 @@ expression: signatures
       "properties": {
         "auto_approve_prs": {
           "description": "Enable or disable auto-approve. Omit to keep the current value.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "diverse_refinement": {
           "description": "Enable or disable cross-model (\"Diverse\") refinement for THIS user. When\non (the default), proposal-refinement roles prefer a different model from\nthe primary task model. Falls back to same-model when alternatives are\nunavailable. Omit to keep the current value.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "diverse_review": {
           "description": "Enable or disable cross-model (\"Thorough\") review for THIS user. When on\n(the default), the reviewer prefers a model id different from the\nimplementer's. Omit to keep the current value.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "lanes": {
           "anyOf": [
@@ -19075,8 +20445,7 @@ expression: signatures
               "$ref": "#/$defs/ModelLanesPayload"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "Per-ROLE ordered model lanes for THIS user (each highest priority first),\nas full `provider/model` ids: `plan` (planner/architect/chat),\n`implement` (worker), `review` (reviewer). Each id must be a model on a\nprovider this user has connected. Pass all-empty lanes to clear the\nselection (→ global fallback). Omit to keep the current value."
@@ -19087,17 +20456,20 @@ expression: signatures
             "type": "integer"
           },
           "description": "Per-model concurrency caps for THIS user (`{ \"provider/model\": cap }`).\nHow many sessions of each model may run concurrently for this user — the\nsole admission control (no global ceiling). Pass `{}` to clear (→ default\n1 per model). Omit to keep the current value.",
-          "nullable": true,
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "target_user_id": {
           "default": null,
           "description": "Admin-only: act on behalf of this user id (e.g. another user to\nconfigure). Non-admins must omit it.",
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
-      "title": "UserSettingsSetParams",
       "type": "object"
     },
     "output_schema": {
@@ -19139,22 +20511,30 @@ expression: signatures
           "type": "boolean"
         },
         "auto_approve_prs": {
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "diverse_refinement": {
           "description": "The resulting cross-model refinement toggle after the patch.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "diverse_review": {
           "description": "The resulting cross-model review toggle after the patch.",
-          "nullable": true,
-          "type": "boolean"
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "error": {
-          "nullable": true,
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "lanes": {
           "anyOf": [
@@ -19162,8 +20542,7 @@ expression: signatures
               "$ref": "#/$defs/ModelLanesPayload"
             },
             {
-              "const": null,
-              "nullable": true
+              "type": "null"
             }
           ],
           "description": "The resulting per-role model lanes after the patch."
@@ -19174,8 +20553,10 @@ expression: signatures
             "type": "integer"
           },
           "description": "The resulting per-model concurrency caps after the patch.",
-          "nullable": true,
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "ok": {
           "type": "boolean"
@@ -19185,7 +20566,6 @@ expression: signatures
         "ok",
         "applied"
       ],
-      "title": "UserSettingsSetResponse",
       "type": "object"
     }
   }

--- a/server/src/server/tests/tool_schemas.rs
+++ b/server/src/server/tests/tool_schemas.rs
@@ -41,12 +41,12 @@ fn assert_environment_config_workspace_metadata_schema(
     let workspace = &schema["$defs"]["Workspace"];
     assert_eq!(
         workspace["properties"]["slug"],
-        json!({"default": null, "nullable": true, "type": "string"}),
+        json!({"default": null, "type": ["string", "null"]}),
         "{context} Workspace.slug schema drifted"
     );
     assert_eq!(
         workspace["properties"]["name"],
-        json!({"default": null, "nullable": true, "type": "string"}),
+        json!({"default": null, "type": ["string", "null"]}),
         "{context} Workspace.name schema drifted"
     );
     assert_eq!(
@@ -309,13 +309,15 @@ async fn code_graph_schema_unchanged_by_registry_dispatch_refactor() {
         "code_graph outputSchema must stay `additionalProperties: true` so every \
          `CodeGraphResponse` variant passes through the `ErrorOr` envelope unchanged"
     );
-    assert_eq!(
-        output
-            .get("title")
-            .and_then(Value::as_str)
-            .unwrap_or_default(),
-        "ErrorOrCodeGraphResponse",
-        "code_graph outputSchema envelope title must stay `ErrorOrCodeGraphResponse`"
+    // schemars 1.x (via rmcp 1.x) no longer emits a `title` for this derived
+    // envelope wrapper. The functional wire-shape (object + additionalProperties)
+    // asserted above is what variant pass-through depends on; the title was a
+    // cosmetic annotation, so its absence under the new schema generator is fine.
+    assert!(
+        output.get("title").is_none(),
+        "code_graph outputSchema envelope no longer carries a title under schemars 1.x; \
+         got {:?}",
+        output.get("title")
     );
 
     // The description advertises the full operation surface. The
@@ -656,10 +658,11 @@ async fn session_surfaces_advertise_nullable_parked_reason() {
     let list = find_tool("session_list");
     let show = find_tool("session_show");
     let timeline = find_tool("task_timeline");
+    // schemars 1.x (via rmcp 1.x) renders nullable Option<T> as a JSON Schema
+    // 2020-12 type array rather than the `nullable: true` extension.
     let expected = json!({
         "description": "Optional deliberate-park reason for terminal sessions, e.g. `budget`.",
-        "nullable": true,
-        "type": "string"
+        "type": ["string", "null"]
     });
 
     assert_eq!(


### PR DESCRIPTION
## What & why

Replaces the temporary `deny.toml` ignore from #1301 with the **actual fix**: upgrade **rmcp 0.16 → 1.8**, which adds `Host`-header validation to the Streamable HTTP server transport — closing the DNS-rebinding advisory **RUSTSEC-2026-0189** at the source.

## Breaking-change migration

rmcp 1.x marks several model/transport structs `#[non_exhaustive]`, so struct-literal construction no longer compiles. Migrated to constructors + field assignment:

- **`server.rs`**: `ReadResourceResult::new`, `ServerInfo::new` + field assignment, `Implementation::new`, `LocalSessionManager::default()`, and `StreamableHttpServerConfig` via `default()` + field assignment.
- **`mcp_client.rs`**: `CallToolRequestParams::new(...)` + field assignment; `CallToolResult::success()/error()` in tests.

The migration was surprisingly small — the `#[tool]`/`tool_router` macro system and `Parameters`/`Json`/`object` API are unchanged. Only 6 construction sites across 2 files.

## The new security control: Host allowlist

rmcp 1.x defaults `allowed_hosts` to **loopback-only**, which would reject djinn's ingress-fronted prod traffic. New `mcp_allowed_hosts()` helper:
- **Default**: loopback (`localhost`/`127.0.0.1`/`::1`) **plus** the `DJINN_PUBLIC_URL` ingress host — so local dev (the real DNS-rebinding target) stays protected *and* prod's ingress host is admitted.
- **Override**: `DJINN_MCP_ALLOWED_HOSTS` (comma-separated authorities); `*` disables validation.
- Unit-tested (7 tests covering parsing, loopback default, public-url derivation, override, `*`).

## Also in this PR
- **Remove** the `RUSTSEC-2026-0189` ignore from `deny.toml` (now genuinely fixed).
- **Bump `anyhow` 1.0.102 → 1.0.103** — `RUSTSEC-2026-0190` (`downcast_mut` unsoundness, published 2026-06-25, was red on `main` too). Lockfile-only.
- **Regenerate `workspace-hack`** for the rmcp bump.

## Verification
- `cargo check --workspace --all-targets` — clean (rmcp-related); remaining failures are pre-existing local `SQLX_OFFLINE` cache gaps in `djinn-db`/`djinn-provider` tests, unrelated.
- `cargo clippy -p djinn-control-plane -p djinn-agent -p djinn-mcp-extension --all-features -D warnings` — clean.
- `cargo deny check` — **`advisories ok, bans ok, licenses ok, sources ok`** (no ignores needed for 0189/0190).
- New host-allowlist tests + rewritten `CallToolResult` tests pass.
- Pre-existing failing test `resolve_server_config_substitutes_env_and_credentials` confirmed failing on `main` without these changes (env-dependent), not introduced here.