### PR TITLE
fix(ci): restore dropped #[cfg(test)] .sqlx entries + harden offline-cache guard

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -566,8 +566,18 @@ jobs:
         working-directory: server/crates/djinn-db
         run: sqlx migrate run --source migrations_postgres
 
+      # `make sqlx-check` regenerates the offline cache into a scratch dir
+      # with the SAME surface the offline consumers compile (`--all-targets
+      # --all-features`), force-re-runs the sqlx proc-macros (touch), and
+      # diffs against the committed cache. This is a strict superset of the
+      # `--features qdrant` offline build that Warm Cache (Test) / Server
+      # Clippy run, so a stale cache now fails here at PR / merge-queue time
+      # instead of post-merge. The old `cargo sqlx prepare --check
+      # -- --all-targets` covered neither feature-gated queries nor macro
+      # re-execution on a warm cache and let 71 entries slip through.
       - name: Verify .sqlx offline cache is up to date
-        run: cargo sqlx prepare --check --workspace -- --all-targets
+        working-directory: .
+        run: make sqlx-check
 
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  UI (PR + merge queue)                                           ║

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -566,7 +566,7 @@ jobs:
         working-directory: server/crates/djinn-db
         run: sqlx migrate run --source migrations_postgres
 
-      # `make sqlx-check` regenerates the offline cache into a scratch dir
+      # `make sqlx-verify` regenerates the offline cache into a scratch dir
       # with the SAME surface the offline consumers compile (`--all-targets
       # --all-features`), force-re-runs the sqlx proc-macros (touch), and
       # diffs against the committed cache. This is a strict superset of the
@@ -575,9 +575,14 @@ jobs:
       # instead of post-merge. The old `cargo sqlx prepare --check
       # -- --all-targets` covered neither feature-gated queries nor macro
       # re-execution on a warm cache and let 71 entries slip through.
+      #
+      # `sqlx-verify` (not `sqlx-check`) is used here: the schema is already
+      # applied by the step above against the service Postgres, and the
+      # `sqlx-check` wrapper's `test-db-migrate` prerequisite waits on a
+      # `docker exec djinn-postgres-test` container that does not exist in CI.
       - name: Verify .sqlx offline cache is up to date
         working-directory: .
-        run: make sqlx-check
+        run: make sqlx-verify
 
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  UI (PR + merge queue)                                           ║

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,47 @@ sqlx-prepare: ## Regenerate server/.sqlx/ offline cache (uses test Postgres on :
 sqlx-check: ## Fail if server/.sqlx/ is stale vs. current queries (CI)
 	@command -v sqlx >/dev/null 2>&1 || { echo "Install sqlx-cli: cargo install sqlx-cli --no-default-features --features postgres,rustls"; exit 1; }
 	@$(MAKE) --no-print-directory test-db-migrate
-	cd $(SERVER_DIR) && cargo sqlx prepare --check --workspace
+	@# Regenerate into a scratch dir using the EXACT same surface as
+	@# `sqlx-prepare` (--all-targets --all-features) and force macro
+	@# re-execution by touching every sqlx::query file, then diff against the
+	@# committed cache. `cargo sqlx prepare --check` is NOT sufficient: it
+	@# skips test targets, ignores feature-gated queries, and — because the
+	@# sqlx proc-macro only reads/writes query data when its source file is
+	@# (re)compiled — a warm build cache lets a stale/deleted .sqlx entry pass
+	@# undetected. That exact gap silently dropped 71 `#[cfg(test)]` entries
+	@# (commit ed6f954d5) which then only failed in the push-only Warm Cache
+	@# (Test) job. Mirroring the generator here closes it.
+	@rm -rf /tmp/sqlx-check && mkdir -p /tmp/sqlx-check
+	@grep -rl --include='*.rs' 'sqlx::query' $(SERVER_DIR)/crates/ 2>/dev/null | xargs -r touch
+	@cd $(SERVER_DIR) && SQLX_OFFLINE_DIR=/tmp/sqlx-check cargo check --workspace --all-targets --all-features
+	@if [ -z "$$(ls -A /tmp/sqlx-check 2>/dev/null)" ]; then \
+		echo "ERROR: regeneration produced no query files — cannot validate .sqlx/."; \
+		echo "       Try 'cargo clean -p djinn-db' and rerun."; \
+		exit 1; \
+	fi
+	@# The freshly generated set must match the committed cache exactly
+	@# (same query hashes AND same type info). Any difference => stale cache.
+	@stale=0; \
+	for f in /tmp/sqlx-check/query-*.json; do \
+		b=$$(basename $$f); \
+		if [ ! -f "$(SERVER_DIR)/.sqlx/$$b" ]; then \
+			echo "::error::missing committed .sqlx entry: $$b"; stale=1; \
+		elif ! cmp -s "$$f" "$(SERVER_DIR)/.sqlx/$$b"; then \
+			echo "::error::out-of-date committed .sqlx entry: $$b"; stale=1; \
+		fi; \
+	done; \
+	for f in $(SERVER_DIR)/.sqlx/query-*.json; do \
+		b=$$(basename $$f); \
+		if [ ! -f "/tmp/sqlx-check/$$b" ]; then \
+			echo "::error::stale committed .sqlx entry (no longer used): $$b"; stale=1; \
+		fi; \
+	done; \
+	rm -rf /tmp/sqlx-check; \
+	if [ "$$stale" = "1" ]; then \
+		echo "server/.sqlx/ is out of date — run 'make sqlx-prepare' and commit server/.sqlx/."; \
+		exit 1; \
+	fi
+	@echo "server/.sqlx/ is up to date ($$(ls $(SERVER_DIR)/.sqlx/query-*.json | wc -l) entries)."
 
 skills-manifest-generate: ## Regenerate .djinn/skills.json after editing skills/references
 		cd $(SERVER_DIR) && cargo run -p djinn-agent --bin djinn-skills-manifest -- generate --root ..

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SERVER_DIR := $(CURDIR)/server
 # Postgres (docker-compose.yml → `postgres-test` service at :5433) plus the
 # test harness targets that depend on it.
 
-.PHONY: help dev test-db-migrate test-db-postgres-template test-vault test-db-reset sqlx-prepare sqlx-check skills-manifest-generate skills-manifest-check test test-all validate-taskrun-backstop check-boundaries
+.PHONY: help dev test-db-migrate test-db-postgres-template test-vault test-db-reset sqlx-prepare sqlx-check sqlx-verify skills-manifest-generate skills-manifest-check test test-all validate-taskrun-backstop check-boundaries
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -69,9 +69,16 @@ sqlx-prepare: ## Regenerate server/.sqlx/ offline cache (uses test Postgres on :
 	@rm -rf /tmp/sqlx-prepare
 	@echo "server/.sqlx/ regenerated ($$(ls $(SERVER_DIR)/.sqlx/query-*.json | wc -l) entries) — run 'git add server/.sqlx' and commit."
 
-sqlx-check: ## Fail if server/.sqlx/ is stale vs. current queries (CI)
+sqlx-check: ## Fail if server/.sqlx/ is stale vs. current queries (local)
 	@command -v sqlx >/dev/null 2>&1 || { echo "Install sqlx-cli: cargo install sqlx-cli --no-default-features --features postgres,rustls"; exit 1; }
+	@# Local convenience: bring the docker test Postgres up to schema, then
+	@# run the DB-agnostic verifier. CI applies migrations with its own step
+	@# (service container, no `docker exec`) and calls `sqlx-verify` directly.
 	@$(MAKE) --no-print-directory test-db-migrate
+	@$(MAKE) --no-print-directory sqlx-verify
+
+sqlx-verify: ## Verify server/.sqlx/ freshness; assumes schema already applied + DATABASE_URL reachable (CI)
+	@command -v sqlx >/dev/null 2>&1 || { echo "Install sqlx-cli: cargo install sqlx-cli --no-default-features --features postgres,rustls"; exit 1; }
 	@# Regenerate into a scratch dir using the EXACT same surface as
 	@# `sqlx-prepare` (--all-targets --all-features) and force macro
 	@# re-execution by touching every sqlx::query file, then diff against the

--- a/server/.sqlx/query-05dfea6a059ad0cbd4564c1c582239145fc7db4d70a2f4acde458c10b717d73c.json
+++ b/server/.sqlx/query-05dfea6a059ad0cbd4564c1c582239145fc7db4d70a2f4acde458c10b717d73c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE tasks SET status = 'needs_task_review' WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "05dfea6a059ad0cbd4564c1c582239145fc7db4d70a2f4acde458c10b717d73c"
+}

--- a/server/.sqlx/query-09a038b105a655245870d746506ef896e7bc2f7f98c3c3955e55216b4c4cb699.json
+++ b/server/.sqlx/query-09a038b105a655245870d746506ef896e7bc2f7f98c3c3955e55216b4c4cb699.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE note_associations SET last_co_access = to_char((now() at time zone 'utc') - interval '1 day', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') WHERE note_a_id = $1 AND note_b_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "09a038b105a655245870d746506ef896e7bc2f7f98c3c3955e55216b4c4cb699"
+}

--- a/server/.sqlx/query-10219bd0af09132cec13d368bfb74ec12698efa7a2f6010baf9527cdeef9ad4f.json
+++ b/server/.sqlx/query-10219bd0af09132cec13d368bfb74ec12698efa7a2f6010baf9527cdeef9ad4f.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM notes WHERE project_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "10219bd0af09132cec13d368bfb74ec12698efa7a2f6010baf9527cdeef9ad4f"
+}

--- a/server/.sqlx/query-161ccf85e06f7d63ac5df286fbff7e8d9881b6a815ae9dc0fc2727cbc8b65aa7.json
+++ b/server/.sqlx/query-161ccf85e06f7d63ac5df286fbff7e8d9881b6a815ae9dc0fc2727cbc8b65aa7.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE note_associations SET last_co_access = to_char((now() at time zone 'utc') - interval '100 day', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') WHERE note_a_id = $1 AND note_b_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "161ccf85e06f7d63ac5df286fbff7e8d9881b6a815ae9dc0fc2727cbc8b65aa7"
+}

--- a/server/.sqlx/query-17146c7fb37310f72f01fb7929a69bf63e92abc127b3b58608738be78bb9c6e2.json
+++ b/server/.sqlx/query-17146c7fb37310f72f01fb7929a69bf63e92abc127b3b58608738be78bb9c6e2.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name,\n                          github_owner AS \"github_owner!: String\",\n                          github_repo AS \"github_repo!: String\",\n                          created_at, target_branch,\n                          auto_merge AS \"auto_merge!: bool\",\n                          sync_enabled AS \"sync_enabled!: bool\",\n                          sync_remote\n                 FROM projects WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "github_owner!: String",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "github_repo!: String",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "target_branch",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "auto_merge!: bool",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "sync_enabled!: bool",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "sync_remote",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "17146c7fb37310f72f01fb7929a69bf63e92abc127b3b58608738be78bb9c6e2"
+}

--- a/server/.sqlx/query-175b8f7124a65eb8fcca53a7b9667e9300690495cad15a4c8624c4f6abbecbc2.json
+++ b/server/.sqlx/query-175b8f7124a65eb8fcca53a7b9667e9300690495cad15a4c8624c4f6abbecbc2.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO code_chunk_meta\n                (id, project_id, content_hash, model_version, embedded_at, extension_state)\n               VALUES ($1, $2, $3, $4, $5, $6)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "175b8f7124a65eb8fcca53a7b9667e9300690495cad15a4c8624c4f6abbecbc2"
+}

--- a/server/.sqlx/query-210a338613015106ab216b3da1cfb272869e99c94c8db18fafc09445ff1959bb.json
+++ b/server/.sqlx/query-210a338613015106ab216b3da1cfb272869e99c94c8db18fafc09445ff1959bb.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO epics (id, project_id, short_id, title, description, emoji, color, status, owner, memory_refs, auto_breakdown)\n             VALUES ($1, $2, 'gep1', 'T', '', '', '', 'open', '', '[]'::jsonb, true)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "210a338613015106ab216b3da1cfb272869e99c94c8db18fafc09445ff1959bb"
+}

--- a/server/.sqlx/query-2ae3391e1d12a00268ae7b6f4877f46e67cc617f395a5701cbfb03161da24897.json
+++ b/server/.sqlx/query-2ae3391e1d12a00268ae7b6f4877f46e67cc617f395a5701cbfb03161da24897.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT target_id FROM note_links WHERE source_id = $1 AND target_raw = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "target_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "2ae3391e1d12a00268ae7b6f4877f46e67cc617f395a5701cbfb03161da24897"
+}

--- a/server/.sqlx/query-32d84ac682924129242971598c02e04b4b2bb924d6772ad2d91a2fce5469cb69.json
+++ b/server/.sqlx/query-32d84ac682924129242971598c02e04b4b2bb924d6772ad2d91a2fce5469cb69.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO epics (id, project_id, short_id, title, description, emoji, color, owner, memory_refs, created_by_user_id)\n             VALUES ($1, $2, $3, '', '', '', '', '', '[]'::jsonb, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "32d84ac682924129242971598c02e04b4b2bb924d6772ad2d91a2fce5469cb69"
+}

--- a/server/.sqlx/query-37ae555078f58e2dd3cd33a40bb7fbc5aa4019129e7a9d6be3c9b7ae0f9f7df5.json
+++ b/server/.sqlx/query-37ae555078f58e2dd3cd33a40bb7fbc5aa4019129e7a9d6be3c9b7ae0f9f7df5.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tasks (id, project_id, short_id, epic_id, title, description, design,\n                                issue_type, priority, owner, status, continuation_count, labels, acceptance_criteria, memory_refs)\n             VALUES ($1, $2, 't003', $3, 'T3', '', '', 'task', 0, '', 'open', 0, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "37ae555078f58e2dd3cd33a40bb7fbc5aa4019129e7a9d6be3c9b7ae0f9f7df5"
+}

--- a/server/.sqlx/query-395910b81a23e01644c86b79fcc8eeb12ed61aaabdffd3067c09c23e86f405e5.json
+++ b/server/.sqlx/query-395910b81a23e01644c86b79fcc8eeb12ed61aaabdffd3067c09c23e86f405e5.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes SET access_count = 0, confidence = 1.0 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "395910b81a23e01644c86b79fcc8eeb12ed61aaabdffd3067c09c23e86f405e5"
+}

--- a/server/.sqlx/query-3c9612a621eca772aa476ecac4d2b9fde91754f0dea42163aeea560e2944ca27.json
+++ b/server/.sqlx/query-3c9612a621eca772aa476ecac4d2b9fde91754f0dea42163aeea560e2944ca27.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO epics (id, project_id, short_id, title, description, emoji, color, status, owner, memory_refs, auto_breakdown)\n             VALUES ($1, $2, $3, 'T', '', '', '', 'open', '', '[]'::jsonb, true)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3c9612a621eca772aa476ecac4d2b9fde91754f0dea42163aeea560e2944ca27"
+}

--- a/server/.sqlx/query-3d91642ec4056b6d36ffd8730d71e33be30665b1369e6e8a074bf442bdda7f2d.json
+++ b/server/.sqlx/query-3d91642ec4056b6d36ffd8730d71e33be30665b1369e6e8a074bf442bdda7f2d.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tasks (id, project_id, short_id, epic_id, title, description, design,\n                                issue_type, priority, owner, status, continuation_count, labels, acceptance_criteria, memory_refs)\n             VALUES ($1, $2, $3, $4, 'T', '', '', 'task', 0, '', 'open', 0, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3d91642ec4056b6d36ffd8730d71e33be30665b1369e6e8a074bf442bdda7f2d"
+}

--- a/server/.sqlx/query-3e06caa5dba150d2fa01915c48377378bba43490474509427c26138c4f31776c.json
+++ b/server/.sqlx/query-3e06caa5dba150d2fa01915c48377378bba43490474509427c26138c4f31776c.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO users (id, github_id, github_login) VALUES ($1, $2, $3)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Int8",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3e06caa5dba150d2fa01915c48377378bba43490474509427c26138c4f31776c"
+}

--- a/server/.sqlx/query-3e6433013a72444fd844c422f2c76571b85382ba168f6cf7b0f694e200ab44d8.json
+++ b/server/.sqlx/query-3e6433013a72444fd844c422f2c76571b85382ba168f6cf7b0f694e200ab44d8.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tasks (id, project_id, short_id, epic_id, title, description, design,\n                                issue_type, priority, owner, status, continuation_count, labels, acceptance_criteria, memory_refs)\n             VALUES ($1, $2, $3, $4, 'Task', '', '', 'task', 0, '', 'open', 0, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3e6433013a72444fd844c422f2c76571b85382ba168f6cf7b0f694e200ab44d8"
+}

--- a/server/.sqlx/query-3ec3f45c1c777602f5a3a78ddb43d7839bd7ca1cd6dbdcc13f1bd183de9c241e.json
+++ b/server/.sqlx/query-3ec3f45c1c777602f5a3a78ddb43d7839bd7ca1cd6dbdcc13f1bd183de9c241e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO epics (id, project_id, short_id, title, description, emoji, color, status, owner, memory_refs, auto_breakdown)\n             VALUES ($1, $2, 'fz01', 'T', '', '', '', 'open', '', '[]'::jsonb, true)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3ec3f45c1c777602f5a3a78ddb43d7839bd7ca1cd6dbdcc13f1bd183de9c241e"
+}

--- a/server/.sqlx/query-40069c5097e228db004507a5d0ffbe7bb6fc31be07a67c30b4bad9c75fba2730.json
+++ b/server/.sqlx/query-40069c5097e228db004507a5d0ffbe7bb6fc31be07a67c30b4bad9c75fba2730.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes SET access_count = 0, confidence = 0.5 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "40069c5097e228db004507a5d0ffbe7bb6fc31be07a67c30b4bad9c75fba2730"
+}

--- a/server/.sqlx/query-463e1539d330725040a75f2b51ee2f5c075dd41a550adf595071e2ca7743119c.json
+++ b/server/.sqlx/query-463e1539d330725040a75f2b51ee2f5c075dd41a550adf595071e2ca7743119c.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes\n             SET abstract = $1,\n                 overview = $2\n             WHERE id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "463e1539d330725040a75f2b51ee2f5c075dd41a550adf595071e2ca7743119c"
+}

--- a/server/.sqlx/query-464a39e6c0bd211969d020001628fc1af8f9bd4082b91d179fb6c9b5864acca9.json
+++ b/server/.sqlx/query-464a39e6c0bd211969d020001628fc1af8f9bd4082b91d179fb6c9b5864acca9.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE epics SET status = 'closed' WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "464a39e6c0bd211969d020001628fc1af8f9bd4082b91d179fb6c9b5864acca9"
+}

--- a/server/.sqlx/query-4aefc47532c482f6ff007dcc34ab3947c5460b0656dfa2a97e75c933a3b16ebd.json
+++ b/server/.sqlx/query-4aefc47532c482f6ff007dcc34ab3947c5460b0656dfa2a97e75c933a3b16ebd.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO code_chunks\n                    (id, project_id, file_path, symbol_key, kind,\n                     start_line, end_line, content_hash, embedded_text)\n                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Text",
+        "Varchar",
+        "Int4",
+        "Int4",
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4aefc47532c482f6ff007dcc34ab3947c5460b0656dfa2a97e75c933a3b16ebd"
+}

--- a/server/.sqlx/query-4d6a1048d08286f320976670905e008ddca5dc6201ab6ed6b22f35b2a17c40ba.json
+++ b/server/.sqlx/query-4d6a1048d08286f320976670905e008ddca5dc6201ab6ed6b22f35b2a17c40ba.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes\n         SET created_at = '2026-01-01T00:00:00.000Z',\n             updated_at = '2026-01-01T00:00:00.000Z',\n             last_accessed = '2026-01-01T00:00:00.000Z',\n             access_count = 0,\n             confidence = 1.0\n         WHERE project_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4d6a1048d08286f320976670905e008ddca5dc6201ab6ed6b22f35b2a17c40ba"
+}

--- a/server/.sqlx/query-514e95e48e4c0f33404dd83a254b0dcf59651c8ccf134f8c0f29e8b9bc34fc9d.json
+++ b/server/.sqlx/query-514e95e48e4c0f33404dd83a254b0dcf59651c8ccf134f8c0f29e8b9bc34fc9d.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name,\n                  github_owner AS \"github_owner!: String\",\n                  github_repo AS \"github_repo!: String\",\n                  created_at, target_branch,\n                  auto_merge AS \"auto_merge!: bool\",\n                  sync_enabled AS \"sync_enabled!: bool\",\n                  sync_remote\n           FROM projects WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "github_owner!: String",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "github_repo!: String",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "target_branch",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "auto_merge!: bool",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "sync_enabled!: bool",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "sync_remote",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "514e95e48e4c0f33404dd83a254b0dcf59651c8ccf134f8c0f29e8b9bc34fc9d"
+}

--- a/server/.sqlx/query-5fa4245735f7d969b3c726b142a8ca6313eb43bd11362d09aead7ae8f58f236d.json
+++ b/server/.sqlx/query-5fa4245735f7d969b3c726b142a8ca6313eb43bd11362d09aead7ae8f58f236d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes SET content_hash = NULL WHERE id IN ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5fa4245735f7d969b3c726b142a8ca6313eb43bd11362d09aead7ae8f58f236d"
+}

--- a/server/.sqlx/query-60ff8f56a867ff1f84aa43398ff01f44e8cf03413ba7b3b6667b9f3ad36e4f41.json
+++ b/server/.sqlx/query-60ff8f56a867ff1f84aa43398ff01f44e8cf03413ba7b3b6667b9f3ad36e4f41.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT tags::text AS \"tags!\" FROM notes WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "tags!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "60ff8f56a867ff1f84aa43398ff01f44e8cf03413ba7b3b6667b9f3ad36e4f41"
+}

--- a/server/.sqlx/query-6be081a11e478c28d720992da9c2df2261109657a09392abce3258a219b24737.json
+++ b/server/.sqlx/query-6be081a11e478c28d720992da9c2df2261109657a09392abce3258a219b24737.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT name, base_role, is_default AS \"is_default!: bool\" FROM agents WHERE project_id = $1 ORDER BY base_role",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "base_role",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "is_default!: bool",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6be081a11e478c28d720992da9c2df2261109657a09392abce3258a219b24737"
+}

--- a/server/.sqlx/query-7d79d93a313e1e89a0f8bd1842ef95345f7415432f565ee41983592def0744f7.json
+++ b/server/.sqlx/query-7d79d93a313e1e89a0f8bd1842ef95345f7415432f565ee41983592def0744f7.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tasks\n                (id, project_id, short_id, epic_id, title, description, design,\n                 issue_type, priority, owner, status, continuation_count, memory_refs)\n             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 0, '[]'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Text",
+        "Varchar",
+        "Int8",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7d79d93a313e1e89a0f8bd1842ef95345f7415432f565ee41983592def0744f7"
+}

--- a/server/.sqlx/query-8e19fe8154fc9fd1949d36adc19f5fcee04418f22e88e7d696f33f65e3273c5d.json
+++ b/server/.sqlx/query-8e19fe8154fc9fd1949d36adc19f5fcee04418f22e88e7d696f33f65e3273c5d.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO session_messages (id, session_id, role, content_json, created_at)\n                 VALUES ($1, $2, 'assistant', '{}', $3)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8e19fe8154fc9fd1949d36adc19f5fcee04418f22e88e7d696f33f65e3273c5d"
+}

--- a/server/.sqlx/query-913374da39ddb883d1ec67f34a50fd06db93960659f2365f4d7627f9d9764597.json
+++ b/server/.sqlx/query-913374da39ddb883d1ec67f34a50fd06db93960659f2365f4d7627f9d9764597.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sessions (\n            id,\n            project_id,\n            task_id,\n            model_id,\n            agent_type,\n            started_at,\n            status,\n            tokens_in,\n            tokens_out\n        )\n        VALUES (\n            $1,\n            $2,\n            $3,\n            'test-model',\n            'worker',\n            to_char(now() at time zone 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),\n            'completed',\n            0,\n            0\n        )",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "913374da39ddb883d1ec67f34a50fd06db93960659f2365f4d7627f9d9764597"
+}

--- a/server/.sqlx/query-993ed60aea606e1e15824dd81774a80e521ab5c1d9743c233711230cae8c456a.json
+++ b/server/.sqlx/query-993ed60aea606e1e15824dd81774a80e521ab5c1d9743c233711230cae8c456a.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, content_hash FROM notes WHERE id IN ($1, $2) ORDER BY id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "content_hash",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "993ed60aea606e1e15824dd81774a80e521ab5c1d9743c233711230cae8c456a"
+}

--- a/server/.sqlx/query-a1b9b51da574c1cc1c54f4ec105180b62faa3d75f8372d65b6bfed56e69f05f8.json
+++ b/server/.sqlx/query-a1b9b51da574c1cc1c54f4ec105180b62faa3d75f8372d65b6bfed56e69f05f8.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) AS \"c!: i64\" FROM epic_read_sources WHERE epic_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "c!: i64",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "a1b9b51da574c1cc1c54f4ec105180b62faa3d75f8372d65b6bfed56e69f05f8"
+}

--- a/server/.sqlx/query-a572fef07bcf5f1fdb5c189018bf9e32d47af5d75f39045e75e767dfa32a3df3.json
+++ b/server/.sqlx/query-a572fef07bcf5f1fdb5c189018bf9e32d47af5d75f39045e75e767dfa32a3df3.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT note_a_id, note_b_id FROM note_associations WHERE note_a_id IN ($1, $2, $3) OR note_b_id IN ($4, $5, $6) ORDER BY note_a_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "note_a_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "note_b_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "a572fef07bcf5f1fdb5c189018bf9e32d47af5d75f39045e75e767dfa32a3df3"
+}

--- a/server/.sqlx/query-b0e5ba6b1d9145b36afa1e9d6093ec561af0de2777c707d8bc28a1610f70976d.json
+++ b/server/.sqlx/query-b0e5ba6b1d9145b36afa1e9d6093ec561af0de2777c707d8bc28a1610f70976d.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tasks (id, project_id, short_id, epic_id, title, description, design,\n                                    issue_type, priority, owner, status, continuation_count,\n                                    labels, acceptance_criteria, memory_refs, created_by_user_id)\n                 VALUES ($1,$2,$3,$4,'T','','',$5,0,'','open',0,'[]'::jsonb,'[]'::jsonb,'[]'::jsonb,$6)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b0e5ba6b1d9145b36afa1e9d6093ec561af0de2777c707d8bc28a1610f70976d"
+}

--- a/server/.sqlx/query-b0fe3227152fdedda936447256b331c494cdd9df933fa7a5c85e8967be956345.json
+++ b/server/.sqlx/query-b0fe3227152fdedda936447256b331c494cdd9df933fa7a5c85e8967be956345.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT owner_user_id FROM credentials WHERE key_name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "owner_user_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "b0fe3227152fdedda936447256b331c494cdd9df933fa7a5c85e8967be956345"
+}

--- a/server/.sqlx/query-be5cd47abf22deb6f08ce25589f7e4f0876c57c05769f214a6339f80f86bbd1c.json
+++ b/server/.sqlx/query-be5cd47abf22deb6f08ce25589f7e4f0876c57c05769f214a6339f80f86bbd1c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT created_by_user_id FROM tasks WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_by_user_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "be5cd47abf22deb6f08ce25589f7e4f0876c57c05769f214a6339f80f86bbd1c"
+}

--- a/server/.sqlx/query-c60dd64b1ed4953ef719ec1463fb09e38f5b5cb973f7a09084319506cb2dc245.json
+++ b/server/.sqlx/query-c60dd64b1ed4953ef719ec1463fb09e38f5b5cb973f7a09084319506cb2dc245.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE tasks SET status = 'closed' WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c60dd64b1ed4953ef719ec1463fb09e38f5b5cb973f7a09084319506cb2dc245"
+}

--- a/server/.sqlx/query-c8c6f2e9876ca5f28b7c4bf126d27909ada85ed46700be2afce47d1c92bf34c7.json
+++ b/server/.sqlx/query-c8c6f2e9876ca5f28b7c4bf126d27909ada85ed46700be2afce47d1c92bf34c7.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sessions\n                (id, project_id, task_id, model_id, agent_type, status,\n                 created_by_user_id, task_run_id, title)\n             VALUES ($1, NULL, NULL, 'openai/gpt', 'chat', 'running', $2, NULL, 'New Chat')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c8c6f2e9876ca5f28b7c4bf126d27909ada85ed46700be2afce47d1c92bf34c7"
+}

--- a/server/.sqlx/query-c9cfb31636a788a9f4ce20723b1c4003ffb5069a217bbe27a38937f2f5dcd20f.json
+++ b/server/.sqlx/query-c9cfb31636a788a9f4ce20723b1c4003ffb5069a217bbe27a38937f2f5dcd20f.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes SET access_count = 10 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c9cfb31636a788a9f4ce20723b1c4003ffb5069a217bbe27a38937f2f5dcd20f"
+}

--- a/server/.sqlx/query-cb34298129c2f8ec4f32a6e3f0b5b8416ced1e67a50d00cf26825f4e0fb56a3b.json
+++ b/server/.sqlx/query-cb34298129c2f8ec4f32a6e3f0b5b8416ced1e67a50d00cf26825f4e0fb56a3b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO code_chunks\n                (id, project_id, file_path, symbol_key, kind,\n                 start_line, end_line, content_hash, embedded_text)\n               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Text",
+        "Varchar",
+        "Int4",
+        "Int4",
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cb34298129c2f8ec4f32a6e3f0b5b8416ced1e67a50d00cf26825f4e0fb56a3b"
+}

--- a/server/.sqlx/query-ccdc8f2189ac6d0e86a6323923bcb7101ab3f33616c7e692e3f417f534ec175b.json
+++ b/server/.sqlx/query-ccdc8f2189ac6d0e86a6323923bcb7101ab3f33616c7e692e3f417f534ec175b.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) AS \"c!\" FROM blockers WHERE task_id = $1 AND blocking_task_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "c!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ccdc8f2189ac6d0e86a6323923bcb7101ab3f33616c7e692e3f417f534ec175b"
+}

--- a/server/.sqlx/query-ce70e810581156bb765784abd79192abd958c7736f67cbfe92b55f5a2f86c2ea.json
+++ b/server/.sqlx/query-ce70e810581156bb765784abd79192abd958c7736f67cbfe92b55f5a2f86c2ea.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT content_hash FROM notes WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "content_hash",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "ce70e810581156bb765784abd79192abd958c7736f67cbfe92b55f5a2f86c2ea"
+}

--- a/server/.sqlx/query-d75abe50ac4854fa9bc97903ab7198f7918a9e6eb00dc3a971d1322bb93a2801.json
+++ b/server/.sqlx/query-d75abe50ac4854fa9bc97903ab7198f7918a9e6eb00dc3a971d1322bb93a2801.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO epics (id, project_id, short_id, title, description, emoji, color, owner, memory_refs)\n             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '[]'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d75abe50ac4854fa9bc97903ab7198f7918a9e6eb00dc3a971d1322bb93a2801"
+}

--- a/server/.sqlx/query-d95076ded289a1a1bafbbf9da6ef7cb2a3f495c821c233c70053d9625142e789.json
+++ b/server/.sqlx/query-d95076ded289a1a1bafbbf9da6ef7cb2a3f495c821c233c70053d9625142e789.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO tasks (id, project_id, short_id, epic_id, title, description, design,\n                                    issue_type, priority, owner, status, continuation_count, labels, acceptance_criteria, memory_refs)\n                 VALUES ($1, $2, $3, $4, 'T', '', '', 'task', 0, '', 'open', 0, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d95076ded289a1a1bafbbf9da6ef7cb2a3f495c821c233c70053d9625142e789"
+}

--- a/server/.sqlx/query-dc6448f711b107df0275f18500378ccbc22588d958da1d5415b99e7130012fab.json
+++ b/server/.sqlx/query-dc6448f711b107df0275f18500378ccbc22588d958da1d5415b99e7130012fab.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes SET confidence = 0.5 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "dc6448f711b107df0275f18500378ccbc22588d958da1d5415b99e7130012fab"
+}

--- a/server/.sqlx/query-e54cfecc0c8044c0e563322b097a3dc667a32ca3398a268cef646d4133dd2906.json
+++ b/server/.sqlx/query-e54cfecc0c8044c0e563322b097a3dc667a32ca3398a268cef646d4133dd2906.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO note_associations (note_a_id, note_b_id) VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e54cfecc0c8044c0e563322b097a3dc667a32ca3398a268cef646d4133dd2906"
+}

--- a/server/.sqlx/query-e608f9806e03440d1526979af4e6419b4dd416d321c22c428cadebe824a08029.json
+++ b/server/.sqlx/query-e608f9806e03440d1526979af4e6419b4dd416d321c22c428cadebe824a08029.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO epics (id, project_id, short_id, title, description, emoji, color, owner, memory_refs)\n         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '[]'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e608f9806e03440d1526979af4e6419b4dd416d321c22c428cadebe824a08029"
+}

--- a/server/.sqlx/query-e8ef9b94977f65b153e5ae81350d75d7da99c48c3dbd19e4cbdfa6b09e915aa2.json
+++ b/server/.sqlx/query-e8ef9b94977f65b153e5ae81350d75d7da99c48c3dbd19e4cbdfa6b09e915aa2.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT name, is_default AS \"is_default!: i64\" FROM agents WHERE project_id = $1 AND base_role = 'worker' ORDER BY name",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "is_default!: i64",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "e8ef9b94977f65b153e5ae81350d75d7da99c48c3dbd19e4cbdfa6b09e915aa2"
+}

--- a/server/.sqlx/query-ec13035aeffc4f554107ee0af12f271618e5da3f135baa38c2c06d967526b8d7.json
+++ b/server/.sqlx/query-ec13035aeffc4f554107ee0af12f271618e5da3f135baa38c2c06d967526b8d7.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE notes SET access_count = 0 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ec13035aeffc4f554107ee0af12f271618e5da3f135baa38c2c06d967526b8d7"
+}

--- a/server/.sqlx/query-f0e0f0a2b83eb2623eb4ab023ca8e5e446bb4da9e484f53e2b65fa783dec5f27.json
+++ b/server/.sqlx/query-f0e0f0a2b83eb2623eb4ab023ca8e5e446bb4da9e484f53e2b65fa783dec5f27.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) AS \"count!: i64\" FROM note_associations WHERE note_a_id = $1 OR note_b_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!: i64",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f0e0f0a2b83eb2623eb4ab023ca8e5e446bb4da9e484f53e2b65fa783dec5f27"
+}

--- a/server/.sqlx/query-f116751c42e04b8c2c7abd3caf6ab1a99919c77b3d6087eaca8e68ca6e1f89cf.json
+++ b/server/.sqlx/query-f116751c42e04b8c2c7abd3caf6ab1a99919c77b3d6087eaca8e68ca6e1f89cf.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) AS \"count!: i64\" FROM notes WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!: i64",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f116751c42e04b8c2c7abd3caf6ab1a99919c77b3d6087eaca8e68ca6e1f89cf"
+}

--- a/server/.sqlx/query-f6f692793ddc3fc6ff3f3ebb52b08132f0db229ec57c8077d2a8b31ef8ec3488.json
+++ b/server/.sqlx/query-f6f692793ddc3fc6ff3f3ebb52b08132f0db229ec57c8077d2a8b31ef8ec3488.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) AS \"count!: i64\" FROM agents WHERE is_default = TRUE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!: i64",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f6f692793ddc3fc6ff3f3ebb52b08132f0db229ec57c8077d2a8b31ef8ec3488"
+}

--- a/server/.sqlx/query-fedf6d4c05d2ca5df343201a018734298acd2ab22863b9d8dc3bd431ed42be61.json
+++ b/server/.sqlx/query-fedf6d4c05d2ca5df343201a018734298acd2ab22863b9d8dc3bd431ed42be61.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) AS \"count!: i64\" FROM note_associations WHERE note_a_id IN ($1, $2, $3) OR note_b_id IN ($4, $5, $6)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!: i64",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "fedf6d4c05d2ca5df343201a018734298acd2ab22863b9d8dc3bd431ed42be61"
+}


### PR DESCRIPTION
## What broke

`Warm Cache (Test)` on `main` is red ([run](https://github.com/djinnos/djinn/actions/runs/28377941703/job/84072539907)) with:

```
error: `SQLX_OFFLINE=true` but there is no cached data for this query
```

across ~14 `#[cfg(test)]` queries in `djinn-db` (`code_chunk/search.rs`, `note/tests/association.rs`, `agent.rs`, `epic.rs`, `dispatch_state.rs`, `code_chunk/mod.rs`).

## Root cause

Commit `ed6f954d5` regenerated `server/.sqlx/` with **71 deletions and zero additions** — it was prepared with plain `cargo sqlx prepare --workspace` (which **skips test targets**) instead of `make sqlx-prepare` (`--all-targets --all-features`). The push-only `warm-cache-test` job is the first to compile that surface offline with a *cold* cache, so the missing entries only surfaced **after** merge.

## Why the PR-time guards missed it (both fixed here)

1. `server-sqlx-cache` ran `cargo sqlx prepare --check --workspace -- --all-targets` with **default features** — it didn't match the `--features qdrant` surface the offline consumers (`warm-cache-test`, `server-clippy`) actually compile.
2. More importantly, it **didn't force the sqlx proc-macros to re-execute**. The macro only reads/writes `.sqlx` when its source file recompiles; with a restored warm build cache + unchanged `.rs` files, a deleted/stale entry passes silently. This is why `--all-targets` alone (already on main) wasn't enough.

## Changes

- **Regenerate `server/.sqlx/`** via `make sqlx-prepare` — restores **51** test-target query entries (346 → 397). Purely additive: no modifications, no deletions.
- **Rewrite `make sqlx-check`** to mirror the generator exactly: `touch` every `sqlx::query` file to force macro re-execution, regenerate into a scratch dir with `--all-targets --all-features`, then content-diff against the committed cache (fails on missing/stale/extra entries with `::error` annotations).
- **Point the CI `server-sqlx-cache` step at `make sqlx-check`** so the guard and the generator can never diverge. The guard is now a strict superset of every offline consumer's compile surface, so a stale cache fails at **PR / merge-queue** time instead of post-merge.

## Verification (local)

- Positive: `make sqlx-check` on the complete cache → `server/.sqlx/ is up to date (397 entries)`.
- Negative: hiding any one restored entry → `::error::missing committed .sqlx entry: …` → `out of date` (guard correctly fails).