### PR TITLE
fix(ui): paginate epic_list in kanban snapshot so newest epics load (fixes "Unknown Epic")

### DIFF
--- a/ui/scripts/generate-mcp-types.ts
+++ b/ui/scripts/generate-mcp-types.ts
@@ -135,6 +135,19 @@ function normalizeSchema(raw: JsonSchema | undefined): JsonSchema {
           continue;
         }
 
+        // schemars 1.x (rmcp 1.x) renders nullable `Option<T>` as a JSON
+        // Schema 2020-12 type array `["T", "null"]` rather than the 0.8
+        // `nullable: true` extension. Strip the `"null"` member so a
+        // nullable-optional field generates `T` (matching the prior
+        // `nullable`-stripping behavior above) instead of `T | null`, which
+        // would otherwise ripple `| null` through every consumer of the
+        // generated types.
+        if (key === "type" && Array.isArray(current)) {
+          const nonNull = (current as unknown[]).filter((t) => t !== "null");
+          next[key] = nonNull.length === 1 ? nonNull[0] : nonNull;
+          continue;
+        }
+
         next[key] = replacer(current);
       }
 

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -999,9 +999,6 @@ export namespace DispatchResumeOutputSchema {
 }
 export type DispatchResumeOutput = DispatchResumeOutputSchema.DispatchResumeOutput;
 export namespace DoctorFixInputSchema {
-  /**
-   * Parameters for `doctor_fix`.
-   */
   export interface DoctorFixInput {
   /**
    * The stable name of the check that owns the finding. Must match the
@@ -1018,9 +1015,6 @@ export namespace DoctorFixInputSchema {
 }
 export type DoctorFixInput = DoctorFixInputSchema.DoctorFixInput;
 export namespace DoctorFixOutputSchema {
-  /**
-   * Response for `doctor_fix`.
-   */
   export interface DoctorFixOutput {
   check_name: string
   error?: string
@@ -1032,23 +1026,6 @@ export namespace DoctorFixOutputSchema {
 }
 export type DoctorFixOutput = DoctorFixOutputSchema.DoctorFixOutput;
 export namespace DoctorListFindingsInputSchema {
-  /**
-   * Parameters for `doctor_list_findings`.
-   * 
-   * All filters are optional; an unset field means "no narrowing on that
-   * dimension". The `check` filter matches `check_name` exactly. The
-   * `since` filter is a lower-bound timestamp — rows with
-   * `created_at < since` are excluded. The value should be a UTC
-   * ISO-8601 string matching the schema's `created_at` template so the
-   * string comparison the repository issues in SQL is also a valid
-   * chronological comparison.
-   * 
-   * `limit` is `i64` (not `usize`) so the generated MCP JSON schema
-   * lands on `format: int64` instead of the nonstandard `uint` pinned
-   * by `tool_schemas::mcp_tools_list_schemas_do_not_use_nonstandard_uint_…`.
-   * The repository's defensive ceiling (`MAX_RECENT_FINDINGS`) still
-   * applies, and any caller value above it is silently clamped.
-   */
   export interface DoctorListFindingsInput {
   /**
    * Optional check name to narrow on (matches `check_name` exactly).
@@ -1074,9 +1051,6 @@ export namespace DoctorListFindingsInputSchema {
 }
 export type DoctorListFindingsInput = DoctorListFindingsInputSchema.DoctorListFindingsInput;
 export namespace DoctorListFindingsOutputSchema {
-  /**
-   * Response for `doctor_list_findings`.
-   */
   export interface DoctorListFindingsOutput {
   error?: string
   /**
@@ -1153,9 +1127,6 @@ export namespace DoctorListFindingsOutputSchema {
 }
 export type DoctorListFindingsOutput = DoctorListFindingsOutputSchema.DoctorListFindingsOutput;
 export namespace DoctorRunInputSchema {
-  /**
-   * Parameters for `doctor_run`.
-   */
   export interface DoctorRunInput {
   /**
    * Optional list of check names to run. When omitted (or empty), all
@@ -1169,9 +1140,6 @@ export namespace DoctorRunInputSchema {
 }
 export type DoctorRunInput = DoctorRunInputSchema.DoctorRunInput;
 export namespace DoctorRunOutputSchema {
-  /**
-   * Response for `doctor_run`.
-   */
   export interface DoctorRunOutput {
   error?: string
   ok: boolean
@@ -1259,9 +1227,6 @@ export namespace EpicAddReadSourceInputSchema {
 }
 export type EpicAddReadSourceInput = EpicAddReadSourceInputSchema.EpicAddReadSourceInput;
 export namespace EpicAddReadSourceOutputSchema {
-  /**
-   * Response for the read-only multi-repo read-source tools.
-   */
   export interface EpicAddReadSourceOutput {
   error?: string
   /**
@@ -1289,9 +1254,6 @@ export namespace EpicBlockedListInputSchema {
 }
 export type EpicBlockedListInput = EpicBlockedListInputSchema.EpicBlockedListInput;
 export namespace EpicBlockedListOutputSchema {
-  /**
-   * Response for the epic-dependency listing tools.
-   */
   export interface EpicBlockedListOutput {
   blockers?: EpicBlockerItem[]
   error?: string
@@ -1326,9 +1288,6 @@ export namespace EpicBlockersListInputSchema {
 }
 export type EpicBlockersListInput = EpicBlockersListInputSchema.EpicBlockersListInput;
 export namespace EpicBlockersListOutputSchema {
-  /**
-   * Response for the epic-dependency listing tools.
-   */
   export interface EpicBlockersListOutput {
   blockers?: EpicBlockerItem[]
   error?: string
@@ -1624,9 +1583,6 @@ export namespace EpicListReadSourcesInputSchema {
 }
 export type EpicListReadSourcesInput = EpicListReadSourcesInputSchema.EpicListReadSourcesInput;
 export namespace EpicListReadSourcesOutputSchema {
-  /**
-   * Response for the read-only multi-repo read-source tools.
-   */
   export interface EpicListReadSourcesOutput {
   error?: string
   /**
@@ -1659,9 +1615,6 @@ export namespace EpicRemoveReadSourceInputSchema {
 }
 export type EpicRemoveReadSourceInput = EpicRemoveReadSourceInputSchema.EpicRemoveReadSourceInput;
 export namespace EpicRemoveReadSourceOutputSchema {
-  /**
-   * Response for the read-only multi-repo read-source tools.
-   */
   export interface EpicRemoveReadSourceOutput {
   error?: string
   /**
@@ -1943,9 +1896,6 @@ export namespace ExecutionKillTaskOutputSchema {
 }
 export type ExecutionKillTaskOutput = ExecutionKillTaskOutputSchema.ExecutionKillTaskOutput;
 export namespace GetBlockCatalogInputSchema {
-  /**
-   * Params for the lean `get_block_catalog` tool (no fields required).
-   */
   export interface GetBlockCatalogInput {
   [k: string]: any
   }
@@ -1953,9 +1903,6 @@ export namespace GetBlockCatalogInputSchema {
 }
 export type GetBlockCatalogInput = GetBlockCatalogInputSchema.GetBlockCatalogInput;
 export namespace GetBlockCatalogOutputSchema {
-  /**
-   * Response envelope for `get_block_catalog`: a lean list of type/tag pairs.
-   */
   export interface GetBlockCatalogOutput {
   blocks: BlockCatalogEntry[]
   [k: string]: any
@@ -1990,10 +1937,6 @@ export namespace GetProjectDevcontainerStatusInputSchema {
 }
 export type GetProjectDevcontainerStatusInput = GetProjectDevcontainerStatusInputSchema.GetProjectDevcontainerStatusInput;
 export namespace GetProjectDevcontainerStatusOutputSchema {
-  /**
-   * Snapshot of a project's image-build state, used by the UI onboarding
-   * banner.
-   */
   export interface GetProjectDevcontainerStatusOutput {
   /**
    * Populated on lookup failures; clients should surface this verbatim.
@@ -4172,12 +4115,6 @@ export namespace MemoryRunEnrichmentInputSchema {
 }
 export type MemoryRunEnrichmentInput = MemoryRunEnrichmentInputSchema.MemoryRunEnrichmentInput;
 export namespace MemoryRunEnrichmentOutputSchema {
-  /**
-   * MCP response for `memory_run_enrichment`. The `report` is present when
-   * `status="completed"` (foreground execution). For
-   * `status="queued"` (background execution) the report is `None`; the pass
-   * emits the structured report through its own `INFO` log line at finish.
-   */
   export interface MemoryRunEnrichmentOutput {
   /**
    * Top-level failure: project not found, enrichment subsystem not
@@ -4629,9 +4566,6 @@ export namespace OrgPolicySetOutputSchema {
 }
 export type OrgPolicySetOutput = OrgPolicySetOutputSchema.OrgPolicySetOutput;
 export namespace PrReviewContextInputSchema {
-  /**
-   * Input parameters for the `pr_review_context` meta-tool.
-   */
   export interface PrReviewContextInput {
   /**
    * Architecture boundary rules. When empty, boundary analysis is
@@ -5637,11 +5571,6 @@ export namespace ProjectGraphExclusionsGetOutputSchema {
 }
 export type ProjectGraphExclusionsGetOutput = ProjectGraphExclusionsGetOutputSchema.ProjectGraphExclusionsGetOutput;
 export namespace ProjectGraphExclusionsSetInputSchema {
-  /**
-   * Partial-update payload. Either field may be `None` — the repository
-   * leaves the corresponding column untouched when the caller only wants
-   * to rewrite one of the two lists.
-   */
   export interface ProjectGraphExclusionsSetInput {
   /**
    * When present, replaces `graph_excluded_paths` wholesale. Empty
@@ -7000,9 +6929,6 @@ export namespace ProposalRefinementDemandRoundInputSchema {
 }
 export type ProposalRefinementDemandRoundInput = ProposalRefinementDemandRoundInputSchema.ProposalRefinementDemandRoundInput;
 export namespace ProposalRefinementDemandRoundOutputSchema {
-  /**
-   * Response for `proposal_refinement_demand_round`.
-   */
   export interface ProposalRefinementDemandRoundOutput {
   /**
    * True when the demand was accepted and a new round started.
@@ -7113,9 +7039,6 @@ export namespace ProposalRefinementResolveInputSchema {
 }
 export type ProposalRefinementResolveInput = ProposalRefinementResolveInputSchema.ProposalRefinementResolveInput;
 export namespace ProposalRefinementResolveOutputSchema {
-  /**
-   * Response for `proposal_refinement_resolve`.
-   */
   export interface ProposalRefinementResolveOutput {
   error?: string
   proposal_id?: string
@@ -7146,9 +7069,6 @@ export namespace ProposalRefinementStartInputSchema {
 }
 export type ProposalRefinementStartInput = ProposalRefinementStartInputSchema.ProposalRefinementStartInput;
 export namespace ProposalRefinementStartOutputSchema {
-  /**
-   * Response for `proposal_refinement_start`.
-   */
   export interface ProposalRefinementStartOutput {
   error?: string
   proposal_id?: string
@@ -7245,9 +7165,6 @@ export namespace ProposalRefinementStatusInputSchema {
 }
 export type ProposalRefinementStatusInput = ProposalRefinementStatusInputSchema.ProposalRefinementStatusInput;
 export namespace ProposalRefinementStatusOutputSchema {
-  /**
-   * Response for `proposal_refinement_status`.
-   */
   export interface ProposalRefinementStatusOutput {
   error?: string
   proposal_id?: string
@@ -8152,9 +8069,6 @@ export namespace ProposalVerdictOverrideInputSchema {
 }
 export type ProposalVerdictOverrideInput = ProposalVerdictOverrideInputSchema.ProposalVerdictOverrideInput;
 export namespace ProposalVerdictOverrideOutputSchema {
-  /**
-   * Response for `proposal_verdict_override`.
-   */
   export interface ProposalVerdictOverrideOutput {
   error?: string
   /**

--- a/ui/src/api/server.ts
+++ b/ui/src/api/server.ts
@@ -408,7 +408,7 @@ export async function fetchKanbanSnapshot(
 
   // Fetch first page of tasks + all epics in parallel
   const PAGE_SIZE = 200;
-  const [firstTaskPage, epicList] = await Promise.all([
+  const [firstTaskPage, firstEpicPage] = await Promise.all([
     callMcpTool("task_list", {
       project: resolvedProjectSlug,
       limit: PAGE_SIZE,
@@ -416,7 +416,7 @@ export async function fetchKanbanSnapshot(
     }),
     callMcpTool("epic_list", {
       project: resolvedProjectSlug,
-      limit: 500,
+      limit: PAGE_SIZE,
       offset: 0,
     }),
   ]);
@@ -438,6 +438,27 @@ export async function fetchKanbanSnapshot(
     }
   }
 
+  // Paginate remaining epics too. The server caps epic_list at ~200 per page
+  // (a higher requested limit is clamped), so without this loop the *newest*
+  // epics fall off the first page — and since the default sort is created-asc,
+  // those are the currently-active ones, whose tasks then render under
+  // "Unknown Epic" once the closed-epic count grows past one page.
+  const allEpics: Epic[] = [...((firstEpicPage.epics ?? []) as unknown as Epic[])];
+  if (firstEpicPage.has_more) {
+    let epicOffset = allEpics.length;
+
+    while (true) {
+      const page = await callMcpTool("epic_list", {
+        project: resolvedProjectSlug,
+        limit: PAGE_SIZE,
+        offset: epicOffset,
+      });
+      allEpics.push(...(page.epics as unknown as Epic[]));
+      if (!page.has_more) break;
+      epicOffset += (page.epics as unknown[]).length;
+    }
+  }
+
   // Stamp each task with the project it belongs to (needed for all-projects view)
   const projectId = projectStore
     .getState()
@@ -447,6 +468,6 @@ export async function fetchKanbanSnapshot(
   return {
     projectSlug: resolvedProjectSlug,
     tasks,
-    epics: (epicList.epics ?? []) as unknown as Epic[],
+    epics: allEpics,
   };
 }


### PR DESCRIPTION
## Symptom

Active epics render as **"Unknown Epic"** on the board (their tasks show, but the epic title can't be resolved), even though the epics exist and are **open** server-side.

## Root cause

`fetchKanbanSnapshot` (`ui/src/api/server.ts`) paginates **tasks** (loops on `has_more`) but fetched **epics** as a single page with `limit: 500`. Two facts combine to drop epics:

1. The server **caps `epic_list` at ~200 per page** — the requested `500` is clamped and `has_more: true` is returned.
2. `epic_list`'s default sort is **`created` (ascending)** — oldest first.

So once the closed-epic count exceeds one page (currently 215 epics: 201 closed / 13 open), the **newest, currently-active** epics fall off the first page. Their tasks still load (tasks paginate fully) but the epic isn't in the client store, so `getEpicTitle` falls through to `"Unknown Epic"`.

Confirmed empirically: `epic_list(limit:500)` returns 200 (`has_more:true`, 192 closed + 8 open); the active epics `lyzr`, `mzdj`, etc. are **absent** from the page — exactly the ones showing "Unknown Epic".

## Fix

Paginate `epic_list` the same way tasks are already paginated (loop on `has_more`). Also drop the misleading `limit: 500` (clamped anyway) in favor of `PAGE_SIZE`.

## Verification
- `pnpm tsc --noEmit` (the CI typecheck) — clean
- `pnpm build` — succeeds
- `useEventSource` snapshot-hydration tests — 11/11 pass

(Pre-existing unrelated `tsc -p tsconfig.test.json` errors in `codeGraphStore.test.ts` / `settingsStore.test.ts` are not touched here and are not in CI's `tsc --noEmit` path.)