### PR TITLE
fix(coordinator): exclude human-review-hold tasks from planner dispatch

### DIFF
--- a/server/crates/djinn-coordinator/src/roles.rs
+++ b/server/crates/djinn-coordinator/src/roles.rs
@@ -115,9 +115,37 @@ fn architect_dispatch_rule() -> DispatchRule {
     }
 }
 
+/// Label marking a task as a human-only review hold (auto-park terminal
+/// escalation). Tasks carrying it must NEVER be auto-dispatched to any
+/// agent role — they wait for a human. The auto-park mechanism (see
+/// `dispatch/retry.rs`) stamps this label on the `review`-type hold task
+/// it creates to break a CI/rework loop.
+pub(crate) const HUMAN_REVIEW_HOLD_LABEL: &str = "human-review-hold";
+
+/// Returns `true` if `task` carries the `human-review-hold` label.
+///
+/// `labels` is a JSON-array string (e.g. `["human-review-hold"]`); a
+/// substring match is sufficient and is the same shape used by the
+/// dispatch-time hold check in `dispatch/task_dispatch.rs`.
+pub(crate) fn is_human_review_hold(task: &Task) -> bool {
+    task.labels.contains(HUMAN_REVIEW_HOLD_LABEL)
+}
+
 /// Returns `true` if the task is an open/in-progress review task.
+///
+/// Excludes `human-review-hold` tasks: those are a terminal,
+/// human-only escalation and must never be claimed by the Planner.
+/// Without this guard a Planner session would claim the hold task,
+/// choose "escalate"/"skip", and close it — which fires the
+/// unblocked-tasks release and flips the parked source task back to
+/// `open`, defeating the auto-park safety mechanism (the exact loop the
+/// hold exists to break). Epic `pdn6` already excluded the blocked
+/// *source* task from worker dispatch; this closes the gap of the HOLD
+/// task itself being claimed by the Planner.
 fn planner_review_claims(task: &Task, _ctx: &DispatchContext) -> bool {
-    matches!(task.status.as_str(), "open" | "in_progress") && task.issue_type.as_str() == "review"
+    matches!(task.status.as_str(), "open" | "in_progress")
+        && task.issue_type.as_str() == "review"
+        && !is_human_review_hold(task)
 }
 
 fn planner_review_dispatch_rule() -> DispatchRule {
@@ -192,5 +220,111 @@ fn planner_dispatch_rule() -> DispatchRule {
     DispatchRule {
         role_name: "planner",
         claims: planner_claims,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal `Task` for dispatch-rule unit tests.
+    fn task(issue_type: &str, status: &str, labels: &str) -> Task {
+        Task {
+            id: "task-id".to_owned(),
+            project_id: "project-id".to_owned(),
+            short_id: "task".to_owned(),
+            epic_id: None,
+            title: "Task".to_owned(),
+            description: String::new(),
+            design: String::new(),
+            issue_type: issue_type.to_owned(),
+            status: status.to_owned(),
+            priority: 2,
+            owner: String::new(),
+            labels: labels.to_owned(),
+            acceptance_criteria: "[]".to_owned(),
+            reopen_count: 0,
+            continuation_count: 0,
+            total_reopen_count: 0,
+            intervention_count: 0,
+            last_intervention_at: None,
+            created_at: "2026-06-30T00:00:00.000Z".to_owned(),
+            updated_at: "2026-06-30T00:00:00.000Z".to_owned(),
+            closed_at: None,
+            close_reason: None,
+            merge_commit_sha: None,
+            pr_url: None,
+            merge_conflict_metadata: None,
+            memory_refs: "[]".to_owned(),
+            agent_type: None,
+            created_by_user_id: None,
+            ci_status: "unknown".to_owned(),
+            ci_head_sha: None,
+            ci_pr_number: None,
+            ci_blocking_required_check_names: "[]".to_owned(),
+            ci_failure_fingerprint: None,
+            ci_first_seen_at: None,
+            ci_last_seen_at: None,
+            ci_same_signature_count: 0,
+            ci_last_remediation_base_sha: None,
+            unresolved_blocker_count: 0,
+        }
+    }
+
+    /// A normal `review` task (no hold label) is still Planner-owned —
+    /// the human-review-hold exclusion must not regress the escalation/
+    /// intervention review dispatch path (ADR-051 §1 + §8).
+    #[test]
+    fn plain_review_task_is_claimed_by_planner() {
+        let registry = RoleRegistry::new();
+        let ctx = DispatchContext;
+        for status in ["open", "in_progress"] {
+            let t = task("review", status, "[]");
+            assert!(planner_review_claims(&t, &ctx));
+            assert_eq!(
+                registry.role_for_task(&t, &ctx),
+                Some("planner"),
+                "plain review task ({status}) must route to the planner"
+            );
+        }
+    }
+
+    /// Regression (this fix): a `human-review-hold`-labeled `review` task
+    /// must NOT be claimed by ANY dispatch rule — not planner, worker,
+    /// architect, reviewer, or lead. It is a human-only terminal hold and
+    /// must wait for a human; auto-dispatching + auto-closing it releases
+    /// the parked source task, defeating the auto-park safety mechanism.
+    #[test]
+    fn human_review_hold_task_is_claimed_by_no_role() {
+        let registry = RoleRegistry::new();
+        let ctx = DispatchContext;
+        let labels = r#"["human-review-hold"]"#;
+
+        for status in ["open", "in_progress"] {
+            let t = task("review", status, labels);
+
+            assert!(
+                is_human_review_hold(&t),
+                "fixture must carry the human-review-hold label"
+            );
+            // The planner review rule must reject it.
+            assert!(
+                !planner_review_claims(&t, &ctx),
+                "planner must not claim a human-review-hold task ({status})"
+            );
+            // No dispatch rule at all may claim it.
+            assert_eq!(
+                registry.role_for_task(&t, &ctx),
+                None,
+                "no role may claim a human-review-hold task ({status})"
+            );
+            // Defense check: each individual claims predicate is false.
+            assert!(!architect_claims(&t, &ctx));
+            assert!(!planning_claims(&t, &ctx));
+            assert!(!worker_claims(&t, &ctx));
+            assert!(!reviewer_claims(&t, &ctx));
+            assert!(!lead_claims(&t, &ctx));
+            assert!(!planner_claims(&t, &ctx));
+        }
     }
 }

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -31,7 +31,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use djinn_core::clock::{Clock, SystemClock};
-use djinn_core::models::{TaskRunStatus, TaskRunTrigger};
+use djinn_core::models::{Task, TaskRunStatus, TaskRunTrigger};
 use djinn_workspace::{
     EphemeralWorkspaceError, GitIdentity, MergeOutcome, MergeParentOutcome, MirrorError,
     MirrorManager,
@@ -293,6 +293,32 @@ fn emit_stage_outcome_event(
         task_run_id = %task_run_id,
         "supervisor: stage outcome observed"
     );
+}
+
+/// Label marking a task as a human-only review hold — the auto-park
+/// terminal escalation. A task carrying it must NEVER be auto-closed by
+/// an agent decision; only a human (or an explicit human-driven API)
+/// closes it.
+const HUMAN_REVIEW_HOLD_LABEL: &str = "human-review-hold";
+
+/// Board transition a planner *terminal* outcome (execute / close /
+/// escalate) should fire for `task`, or `None` to fire no transition.
+///
+/// Defense in depth behind the coordinator dispatch-rule exclusion
+/// (`planner_review_claims`, which already stops the Planner from
+/// claiming the hold): a `human-review-hold` task is a human-only
+/// terminal hold and must NEVER be auto-closed by a planner decision —
+/// closing it fires the unblocked-tasks release that flips the parked
+/// source task back to `open`, defeating the auto-park safety mechanism.
+/// For every other planning-type issue the action is `close`.
+fn planner_terminal_close_action(task: &Task) -> Option<&'static str> {
+    if task.labels.contains(HUMAN_REVIEW_HOLD_LABEL) {
+        return None;
+    }
+    match task.issue_type.as_str() {
+        "planning" | "decomposition" | "review" | "epic_breakdown" => Some("close"),
+        _ => None,
+    }
 }
 
 /// Routing decision for [`apply_planner_escalate_route`].
@@ -1232,12 +1258,11 @@ impl TaskRunSupervisor {
                         //   planning|decomposition|review → close
                         //   other                         → no transition
                         if role_kind == RoleKind::Planner {
-                            let action = match task.issue_type.as_str() {
-                                "planning" | "decomposition" | "review" | "epic_breakdown" => {
-                                    Some("close")
-                                }
-                                _ => None,
-                            };
+                            // `planner_terminal_close_action` returns `None`
+                            // for a `human-review-hold` task so it is never
+                            // auto-closed here (defense in depth behind the
+                            // coordinator dispatch-rule exclusion).
+                            let action = planner_terminal_close_action(&task);
                             if let Some(action) = action
                                 && let Err(e) = self
                                     .services
@@ -1263,12 +1288,10 @@ impl TaskRunSupervisor {
                         // matches the run outcome. Same issue-type-aware
                         // routing as PlannerExecute.
                         if role_kind == RoleKind::Planner {
-                            let action = match task.issue_type.as_str() {
-                                "planning" | "decomposition" | "review" | "epic_breakdown" => {
-                                    Some("close")
-                                }
-                                _ => None,
-                            };
+                            // A `human-review-hold` task is never auto-closed
+                            // here — `planner_terminal_close_action` returns
+                            // `None` for it (defense in depth).
+                            let action = planner_terminal_close_action(&task);
                             if let Some(action) = action
                                 && let Err(e) = self
                                     .services
@@ -1327,6 +1350,22 @@ impl TaskRunSupervisor {
                         //     returned by the helper uses the same
                         //     surfaced reason so host/UI reporting
                         //     matches the persisted close reason.
+                        // Defense in depth: a `human-review-hold` task is a
+                        // human-only terminal hold — never auto-close it on a
+                        // planner escalate. Closing it would fire the
+                        // unblocked-tasks release and flip the parked source
+                        // task back to `open` (the exact loop the hold breaks).
+                        // Leave it parked (Escalated, no transition) for a human.
+                        if task.labels.contains(HUMAN_REVIEW_HOLD_LABEL) {
+                            tracing::warn!(
+                                task_run_id = %run_id,
+                                task_id = %spec.task_id,
+                                issue_type = %task.issue_type,
+                                "supervisor: planner escalate on human-review-hold task — NOT closing; parking for human",
+                            );
+                            result = Some(TaskRunOutcome::Escalated { reason });
+                            break;
+                        }
                         let outcome = apply_planner_escalate_route(
                             role_kind,
                             &task.issue_type,
@@ -2690,6 +2729,44 @@ mod tests {
                 "planner escalate on non-planning issue {issue_type:?} must keep the legacy Escalated outcome"
             );
         }
+    }
+
+    /// Defense in depth: `planner_terminal_close_action` returns `None`
+    /// for a `human-review-hold` task regardless of its `issue_type`, so
+    /// the planner execute/close/escalate paths never auto-close the
+    /// human-only hold (closing it would release the parked source task).
+    /// Every other planning-type issue still maps to `close`.
+    #[test]
+    fn planner_terminal_close_action_never_closes_human_review_hold() {
+        // Hold label present → no transition, for ALL planning issue types.
+        for issue_type in PLANNING_ISSUE_TYPES {
+            let mut task = fixture_task("t1", "p1");
+            task.issue_type = (*issue_type).into();
+            task.labels = r#"["human-review-hold"]"#.into();
+            assert_eq!(
+                planner_terminal_close_action(&task),
+                None,
+                "a human-review-hold {issue_type} task must never be auto-closed"
+            );
+        }
+
+        // No hold label → planning-type issues still close.
+        for issue_type in PLANNING_ISSUE_TYPES {
+            let mut task = fixture_task("t2", "p1");
+            task.issue_type = (*issue_type).into();
+            task.labels = "[]".into();
+            assert_eq!(
+                planner_terminal_close_action(&task),
+                Some("close"),
+                "a plain {issue_type} task must still close on a planner terminal outcome"
+            );
+        }
+
+        // Non-planning issue → no transition (unchanged behavior).
+        let mut task = fixture_task("t3", "p1");
+        task.issue_type = "task".into();
+        task.labels = "[]".into();
+        assert_eq!(planner_terminal_close_action(&task), None);
     }
 
     /// The headline regression test for `ep1i`: planner + `planning`


### PR DESCRIPTION
## Problem

Human-review-hold tasks were being auto-dispatched to the **planner** and then auto-closed, releasing the parked source task back into the dispatch pool — defeating the entire auto-park safety mechanism.

### Concrete trace (2026-06-30)
Source task `nlr8` looped on CI and got auto-parked behind a `review`-type hold task (`3dcu`, `issue_type=review`, `owner=system`, label `human-review-hold`). A **planner** session then claimed `3dcu`, chose "escalate/skip", and that path transitioned `3dcu` to `closed` — which fired the unblocked-tasks release and flipped `nlr8` back to `open`. The exact loop the hold exists to break.

## Root cause

`server/crates/djinn-coordinator/src/roles.rs` — `planner_review_claims` claimed **every** `issue_type == "review"` task with no exclusion for the `human-review-hold` label.

Epic **pdn6** already fixed the *source* task not being dispatched to a worker while blocked by the hold (`task/mod.rs`, test `review_human_hold_blocks_source_from_all_dispatch_paths`). The scope gap was the **HOLD task itself** being claimed by the planner — this PR closes that gap.

## Changes

**Primary fix — claims path** (`djinn-coordinator/src/roles.rs`):
- `planner_review_claims` now excludes `human-review-hold` tasks via `is_human_review_hold()`. A hold task is now claimed by **no** dispatch rule (planner/worker/architect/reviewer/lead) and waits for a human.
- Regression tests: `human_review_hold_task_is_claimed_by_no_role` (asserts every rule rejects it) and `plain_review_task_is_claimed_by_planner` (guards against regressing the normal review/escalation dispatch path).

**Defense in depth — close path** (`djinn-supervisor/src/lib.rs`):
- New `planner_terminal_close_action(task)` returns `None` for a `human-review-hold` task, so the planner **execute** and **close** outcomes never auto-close the human-only hold.
- The planner **escalate** outcome likewise refuses to close a hold task and parks it (Escalated, no transition) for a human.
- Focused unit test `planner_terminal_close_action_never_closes_human_review_hold`.

## Tests

- `cargo test -p djinn-coordinator --lib roles::` — 2 passed
- `cargo test -p djinn-supervisor --lib planner_terminal_close_action` / `route_planner_escalate` — passed (existing route tests unchanged)
- `cargo clippy -p djinn-coordinator -p djinn-supervisor --all-targets` — clean

No SQL changes.