### PR TITLE
Regenerate stale MCP UI types (NeedsEvidence demand doc-comments)

### DIFF
--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -6974,8 +6974,10 @@ export namespace ProposalRefinementDemandEvidenceOutputSchema {
    * Accepted demand result for `proposal_refinement_demand_evidence`.
    * 
    * Returned inside [`NeedsEvidenceDemandResponse`] when the Judge's demand
-   * passes validation and is recorded. Spike creation is wired in a later
-   * task — until then `spike_task_id` is `None` and the proposal is parked.
+   * passes validation. The accepted-demand mutation atomically creates the
+   * evidence spike task, links it to the proposal, writes a `needs_evidence`
+   * debate entry, and records a `refinement_awaiting_evidence_started`
+   * lifecycle event.
    */
   export interface NeedsEvidenceDemandResult {
   /**
@@ -6991,8 +6993,8 @@ export namespace ProposalRefinementDemandEvidenceOutputSchema {
    */
   round: number
   /**
-   * The spike task id (UUID) once linked. `None` until spike creation is
-   * wired in a subsequent task.
+   * The spike task id (UUID) created for this demand. Present when the
+   * demand was accepted and the spike was successfully linked.
    */
   spike_task_id?: string
   [k: string]: any


### PR DESCRIPTION
## What
Regenerate `ui/src/api/generated/mcp-tools.gen.ts` — it drifted from the Rust MCP tool doc-comments.

## Why
`clbz` #1388 updated the `proposal_refinement_demand_evidence` "NeedsEvidence" wording without regenerating the UI snapshot, so `UI Frontend → mcp:types:check` fails on the stale generated file. This surfaced during a `workflow_dispatch` validation run. Pure regen (`pnpm mcp:types:snapshot`); no behavior change.

## Verification
- `pnpm mcp:types:check` → exit 0
- Only `mcp-tools.gen.ts` changed (6+/4-), matching the clbz doc-comment update