### PR TITLE
fix(usage): equal-height KPI cards on Overview tab

### DIFF
--- a/ui/src/components/usage/UsageBreakdownsTab.test.tsx
+++ b/ui/src/components/usage/UsageBreakdownsTab.test.tsx
@@ -138,8 +138,11 @@ describe("UsageBreakdownsTab — split cost column labels", () => {
       />,
     );
 
-    // Default sort is desc by actual_spend, so High spend should appear first
-    const rows = screen.getAllByText(/spend/);
+    // Default sort is desc by actual_spend, so High spend should appear first.
+    // Match only the row-name cells (exact "Low spend" / "High spend") so the
+    // intro description and column headers that also contain "spend" don't
+    // shadow the rows in DOM order.
+    const rows = screen.getAllByText(/^(Low|High) spend$/);
     expect(rows[0]).toHaveTextContent("High spend");
   });
 });

--- a/ui/src/components/usage/UsageOverviewTab.tsx
+++ b/ui/src/components/usage/UsageOverviewTab.tsx
@@ -305,7 +305,7 @@ function SimpleKpiCard({
 }) {
   return (
     <div
-      className="min-w-0 rounded-lg border border-border bg-card p-4"
+      className="flex h-full min-w-0 flex-col rounded-lg border border-border bg-card p-4"
       data-testid={testId}
     >
       <p className="truncate text-xs text-muted-foreground">{label}</p>
@@ -314,7 +314,7 @@ function SimpleKpiCard({
       </p>
       {caption && (
         <p
-          className="mt-1 truncate text-[11px] text-muted-foreground"
+          className="mt-auto truncate pt-1 text-[11px] text-muted-foreground"
           title={caption}
         >
           {caption}
@@ -326,7 +326,7 @@ function SimpleKpiCard({
 
 function BreakdownKpiCard({ kpi }: { kpi: UsageKpi }) {
   return (
-    <div className="min-w-0 rounded-lg border border-border bg-card p-4">
+    <div className="flex h-full min-w-0 flex-col rounded-lg border border-border bg-card p-4">
       <p className="truncate text-xs text-muted-foreground">{kpi.label}</p>
       <p className="mt-1 truncate text-2xl font-semibold tabular-nums tracking-tight text-foreground">
         {formatKpiValue(kpi)}
@@ -340,7 +340,7 @@ function BreakdownKpiCard({ kpi }: { kpi: UsageKpi }) {
         </p>
       )}
       {kpi.breakdown && kpi.breakdown.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+        <div className="mt-auto flex flex-wrap gap-x-3 gap-y-1 pt-2">
           {kpi.breakdown.map((part) => (
             <span
               key={part.label}


### PR DESCRIPTION
## Summary

The four KPI summary cards on the usage/cost dashboard **Overview** tab rendered at unequal heights: `BreakdownKpiCard` (Tokens) shows an extra breakdown block, making it taller than the three `SimpleKpiCard`s beside it in the same grid row.

## Change (class-only, no data/content changes)

- Add `h-full flex flex-col` to both card roots (`SimpleKpiCard`, `BreakdownKpiCard`). Grid items stretch by default, so `h-full` fills the row height and the flex column lays out contents top-to-bottom.
- Pin the caption (`SimpleKpiCard`) and the breakdown block (`BreakdownKpiCard`) to the bottom with `mt-auto`, keeping label + value anchored at the top so all cards align.

The loading skeleton (`UsageDashboardPage.tsx`) already uses a fixed `h-24` for all four cards, so no change was needed there.

## Incidental CI unblock

`UsageBreakdownsTab.test.tsx` had a pre-existing brittle assertion: `getAllByText(/spend/)` matched the intro description and column headers (which contain "spend") before the data rows, so the default-sort check inspected the wrong element. It fails deterministically on `main` (since a511364e6, 2026-06-28) and would block the `ui-frontend` job for any PR touching `ui/`. Scoped the selector to the exact row-name cells (`/^(Low|High) spend$/`). Pure test-selector fix, no behavior change.

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm build` — production build succeeds
- `pnpm test src/components/usage` — 33/33 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)