### PR TITLE
Park planner-blocked epics via durable blocker + event-driven wake

### DIFF
--- a/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__planner_tools_section_snapshot.snap
+++ b/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__planner_tools_section_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/djinn-agent/src/prompts/tests.rs
-assertion_line: 757
 expression: section
 ---
 - `task_show(id)` — Show details of a work item including recent activity and blockers.
@@ -51,4 +50,4 @@ expression: section
 - `task_reset_counters(id)` — Reset reopen_count and continuation_count to zero. Use when the task has been meaningfully rescoped and old retry history is no longer relevant.
 - `task_kill_session(id)` — Kill the paused worker session and delete its saved conversation. The next dispatch will start a fresh session. Unlike task_delete_branch, this preserves the branch and any committed code.
 - `agent_amend_prompt(agent_id, amendment, metrics_snapshot?, project?)` — Planner-owned, evidence-based amendment path for machine-managed learned_prompt updates; not a general prompt editor. Use only after agent-effectiveness evidence (agent_metrics, repeated reviewer/lead feedback, or repeated task failures) shows a stable specialist-agent pattern; this is audited in learned_prompt_history and is not a substitute for human/project system_prompt_extensions. Only specialist worker/reviewer agents are eligible; default roles and non-worker/reviewer roles must not be amended. Append concise observed-pattern + behavioral-correction text; provide metrics_snapshot when available so the evaluator can compare before/after outcomes.
-- `submit_grooming(decision?, summary?, tasks_reviewed?)` — Signal that the grooming session is complete. Report per-task actions taken. Your session ends after this call.
+- `submit_grooming(blocked_on?, decision?, summary?, tasks_reviewed?)` — Signal that the grooming session is complete. Report per-task actions taken. Your session ends after this call.

--- a/server/crates/djinn-coordinator/src/reentrance.rs
+++ b/server/crates/djinn-coordinator/src/reentrance.rs
@@ -79,12 +79,28 @@ pub(super) async fn should_auto_dispatch_planner(db: &Database, event: DispatchE
         return false;
     }
 
-    // 2b. Epic-blocker gate (EpicCreated only). A proposal-decomposition
-    // planner can sequence the epics it creates via epic-level `blocked_by`;
-    // suppress wave-1 until every blocking epic closes. The close path
-    // (`EpicRepository::emit_unblocked_epics`) re-emits `epic.updated` for the
-    // dependents, which re-drives this check once the blockers are gone.
-    if let DispatchEvent::EpicCreated { .. } = event {
+    // 2b. Epic-blocker gate (ALL dispatch paths). A parked epic must never
+    // receive a planning task while a blocking epic is still open — whether
+    // the trigger is wave-1 (`EpicCreated`), next-wave batch completion, a
+    // post-planner recheck, or the periodic stale-sweep (all `TaskClosed`).
+    //
+    // Two sources feed this gate:
+    //   • A proposal-decomposition planner sequencing the epics it creates via
+    //     epic-level `blocked_by`.
+    //   • A grooming planner that concluded "blocked on epic X, no tasks
+    //     created" and durably recorded the edge through `submit_grooming`
+    //     (`blocked_on`) — see `finalize_handlers::handle_submit_grooming`.
+    //     Before this gate applied on `TaskClosed` and before the planner
+    //     recorded the edge, a blocked epic re-derived "blocked" via a fresh
+    //     LLM session every 15-min sweep (epic `mygq`, 2026-07-01 — dozens of
+    //     no-op planner generations overnight, each appending a near-identical
+    //     stale-sweep entry to the roadmap note).
+    //
+    // The close path (`EpicRepository::emit_unblocked_epics`) re-emits
+    // `epic.updated` for the dependents, which re-drives this check once the
+    // blockers are gone; the periodic sweep is a DB-truth backstop so a missed
+    // event cannot strand a parked epic forever.
+    {
         let epic_repo = EpicRepository::new(db.clone(), EventBus::noop());
         match epic_repo.has_unresolved_blockers(epic_id).await {
             Ok(true) => {
@@ -543,6 +559,53 @@ mod tests {
             )
             .await,
             "P2 must dispatch after P1 closes"
+        );
+    }
+
+    /// Regression (epic `mygq`, 2026-07-01): the blocker gate must also apply
+    /// on the `TaskClosed` dispatch path (next-wave batch completion,
+    /// post-planner recheck, and the periodic stale-sweep all fire as
+    /// `TaskClosed`). Previously the gate was `EpicCreated`-only, so a parked
+    /// epic re-derived "blocked" via a fresh LLM session every 15-min sweep.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unresolved_epic_blocker_skips_task_closed_dispatch() {
+        let db = test_helpers::create_test_db();
+        let project = test_helpers::create_test_project(&db).await;
+        let epic_repo = EpicRepository::new(db.clone(), EventBus::noop());
+
+        let blocker = make_epic(&db, &project.id).await;
+        let parked = make_epic(&db, &project.id).await;
+        epic_repo
+            .add_blocker(&parked.id, &blocker.id)
+            .await
+            .unwrap();
+
+        // The stale-sweep / next-wave path fires as `TaskClosed`. While the
+        // blocker is open, it must NOT dispatch a planning task.
+        assert!(
+            !should_auto_dispatch_planner(
+                &db,
+                DispatchEvent::TaskClosed {
+                    epic_id: &parked.id,
+                    close_reason: None,
+                },
+            )
+            .await,
+            "TaskClosed dispatch must be suppressed while an epic blocker is open"
+        );
+
+        // Closing the blocker unblocks the parked epic on the same path.
+        epic_repo.close(&blocker.id).await.unwrap();
+        assert!(
+            should_auto_dispatch_planner(
+                &db,
+                DispatchEvent::TaskClosed {
+                    epic_id: &parked.id,
+                    close_reason: None,
+                },
+            )
+            .await,
+            "closing the blocker must allow the TaskClosed dispatch path"
         );
     }
 }

--- a/server/crates/djinn-coordinator/src/wave.rs
+++ b/server/crates/djinn-coordinator/src/wave.rs
@@ -127,9 +127,15 @@ impl CoordinatorActor {
              2. Review any previous wave results (closed tasks, session reflections).\n\
              3. Decide: is the epic's goal fully met? If YES → call `epic_close({})`, \
              then `submit_grooming`. Do NOT create new tasks.\n\
-             4. If NO → write or update the epic roadmap design note, \
+             4. If the epic is BLOCKED on another epic (a foundation/ownership \
+             gate that is still open) and you can create no useful work yet, \
+             create NO tasks and call \
+             `submit_grooming(decision=\"escalate\", blocked_on=[<blocking epic short_id(s)>])`. \
+             This parks the epic until the blocker closes — the coordinator \
+             wakes it automatically. Do NOT restate a known block on every run.\n\
+             5. Otherwise → write or update the epic roadmap design note, \
              create 3–5 worker tasks (or a spike if uncertainty is high).\n\
-             5. Call `submit_grooming` when done.",
+             6. Call `submit_grooming` when done.",
             epic.title, epic.short_id, epic.short_id
         );
         let originating_adr_section = match epic.originating_adr_id.as_deref() {

--- a/server/crates/djinn-mcp-extension/src/finalize_tools.rs
+++ b/server/crates/djinn-mcp-extension/src/finalize_tools.rs
@@ -126,6 +126,11 @@ pub fn tool_submit_grooming() -> RmcpTool {
                     "type": "string",
                     "enum": ["execute", "close", "escalate"],
                     "description": "Outcome decision: 'execute' = wave was created or board work continues (coordinator dispatches the new tasks); 'close' = epic is complete and the planning task should close (set `reason` in summary); 'escalate' = board state needs human attention. Optional — defaults to 'execute' when omitted."
+                },
+                "blocked_on": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Epics (UUID or short_id) that block this epic. If you conclude the epic cannot proceed until another epic closes and you therefore created NO worker tasks, list the blocking epic(s) here (use decision='escalate'). This durably parks this epic's planning until every listed epic closes — the coordinator wakes it automatically then. Reference the blocking EPIC, not a task (if a task blocks you, reference the epic that owns it). Do NOT re-run planning to restate a known block: declare it here once."
                 }
             }
         }),

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__planner_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__planner_tool_schemas.snap
@@ -1597,6 +1597,13 @@ expression: tool_schemas_planner()
             "escalate"
           ],
           "description": "Outcome decision: 'execute' = wave was created or board work continues (coordinator dispatches the new tasks); 'close' = epic is complete and the planning task should close (set `reason` in summary); 'escalate' = board state needs human attention. Optional — defaults to 'execute' when omitted."
+        },
+        "blocked_on": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Epics (UUID or short_id) that block this epic. If you conclude the epic cannot proceed until another epic closes and you therefore created NO worker tasks, list the blocking epic(s) here (use decision='escalate'). This durably parks this epic's planning until every listed epic closes — the coordinator wakes it automatically then. Reference the blocking EPIC, not a task (if a task blocks you, reference the epic that owns it). Do NOT re-run planning to restate a known block: declare it here once."
         }
       }
     },

--- a/server/crates/djinn-slot/src/finalize_handlers.rs
+++ b/server/crates/djinn-slot/src/finalize_handlers.rs
@@ -48,7 +48,7 @@ pub async fn process_finalize_payload_with_outcome(
             true
         }
         "submit_grooming" => {
-            handle_submit_grooming(payload, app_state).await;
+            handle_submit_grooming(payload, task_id, app_state).await;
             true
         }
         other => {
@@ -362,11 +362,17 @@ async fn handle_submit_decision(
     }
 }
 
-/// Log per-task planning activity entries.
+/// Log per-task planning activity entries and durably record any blocker the
+/// planner declared.
 ///
-/// The planner is project-scoped, so `task_id` is a synthetic project identifier.
-/// Each `tasks_reviewed` entry references a real task by its own `task_id` field.
-async fn handle_submit_grooming(payload: &serde_json::Value, app_state: &SlotContext) {
+/// `finalize_task_id` is the planning task the session ran on; its epic owns
+/// any `blocked_on` edges. Each `tasks_reviewed` entry references a real task
+/// by its own `task_id` field.
+async fn handle_submit_grooming(
+    payload: &serde_json::Value,
+    finalize_task_id: &str,
+    app_state: &SlotContext,
+) {
     let grooming = match serde_json::from_value::<SubmitGrooming>(payload.clone()) {
         Ok(g) => g,
         Err(e) => {
@@ -401,6 +407,99 @@ async fn handle_submit_grooming(payload: &serde_json::Value, app_state: &SlotCon
                 error = %e,
                 "finalize_handlers: failed to log planning_entry activity"
             );
+        }
+    }
+
+    // Durably record a planner's "blocked on epic X" conclusion as an epic
+    // blocker edge, so the coordinator parks this epic's planning until X
+    // closes rather than re-deriving "blocked" via a fresh LLM session on every
+    // stale-sweep (epic `mygq`, 2026-07-01). Idempotent: `add_blocker` no-ops
+    // on a duplicate edge and rejects self-loops / cycles.
+    if !grooming.blocked_on.is_empty() {
+        record_declared_epic_blockers(finalize_task_id, &grooming.blocked_on, app_state).await;
+    }
+}
+
+/// Resolve the planning task's epic and wire each declared blocker as an
+/// epic-blocker edge. Best-effort: unresolvable refs are logged and skipped;
+/// a lookup/DB error never crashes the finalize path.
+async fn record_declared_epic_blockers(
+    finalize_task_id: &str,
+    blocked_on: &[String],
+    app_state: &SlotContext,
+) {
+    let task_repo = TaskRepository::new(app_state.db.clone(), app_state.event_bus.clone());
+    let task = match task_repo.get(finalize_task_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            tracing::warn!(
+                task_id = %finalize_task_id,
+                "finalize_handlers: submit_grooming blocked_on — planning task not found"
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(
+                task_id = %finalize_task_id,
+                error = %e,
+                "finalize_handlers: submit_grooming blocked_on — failed to load planning task"
+            );
+            return;
+        }
+    };
+    let Some(epic_id) = task.epic_id.as_deref() else {
+        tracing::warn!(
+            task_id = %finalize_task_id,
+            "finalize_handlers: submit_grooming blocked_on — planning task has no epic; ignoring"
+        );
+        return;
+    };
+
+    let epic_repo =
+        djinn_db::EpicRepository::new(app_state.db.clone(), app_state.event_bus.clone());
+    for blocker_ref in blocked_on {
+        let blocker_ref = blocker_ref.trim();
+        if blocker_ref.is_empty() {
+            continue;
+        }
+        let blocking = match epic_repo
+            .resolve_in_project(&task.project_id, blocker_ref)
+            .await
+        {
+            Ok(Some(e)) => e,
+            Ok(None) => {
+                tracing::warn!(
+                    epic_id,
+                    blocker_ref,
+                    "finalize_handlers: submit_grooming blocked_on — no epic matches ref in \
+                     project; skipping (reference the blocking EPIC, not a task)"
+                );
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    epic_id,
+                    blocker_ref,
+                    error = %e,
+                    "finalize_handlers: submit_grooming blocked_on — epic resolve failed"
+                );
+                continue;
+            }
+        };
+        match epic_repo.add_blocker(epic_id, &blocking.id).await {
+            Ok(()) => tracing::info!(
+                epic_id,
+                blocking_epic_id = %blocking.id,
+                blocking_short_id = %blocking.short_id,
+                "finalize_handlers: parked epic on planner-declared blocker"
+            ),
+            Err(e) => tracing::warn!(
+                epic_id,
+                blocking_epic_id = %blocking.id,
+                error = %e,
+                "finalize_handlers: submit_grooming blocked_on — add_blocker failed \
+                 (self-loop or cycle?)"
+            ),
         }
     }
 }
@@ -782,6 +881,89 @@ mod tests {
         assert!(e2.is_some(), "expected planning_entry for task2");
         let b2: serde_json::Value = serde_json::from_str(&e2.unwrap().payload).unwrap();
         assert_eq!(b2["action"], "skipped");
+    }
+
+    /// A planner concluding "blocked on epic X, no tasks created" must durably
+    /// record the epic-blocker edge, so the coordinator parks this epic instead
+    /// of re-planning every stale-sweep (epic `mygq`, 2026-07-01).
+    #[tokio::test]
+    async fn submit_grooming_blocked_on_records_epic_blocker_durably() {
+        let db = test_helpers::create_test_db();
+        let ctx = test_helpers::agent_context_from_db(
+            db.clone(),
+            tokio_util::sync::CancellationToken::new(),
+        );
+        let project = test_helpers::create_test_project(&db).await;
+        let parked = test_helpers::create_test_epic(&db, &project.id).await;
+        let blocker = test_helpers::create_test_epic(&db, &project.id).await;
+        // The planning session runs on a real planning task under the parked epic.
+        let planning_task = test_helpers::create_test_task(&db, &project.id, &parked.id).await;
+
+        let epic_repo = djinn_db::EpicRepository::new(db.clone(), ctx.event_bus.clone());
+        assert!(
+            !epic_repo.has_unresolved_blockers(&parked.id).await.unwrap(),
+            "precondition: parked epic starts with no blockers"
+        );
+
+        // Declare the blocker by short_id and create no tasks.
+        let payload = Some(serde_json::json!({
+            "tasks_reviewed": [],
+            "summary": "blocked on foundation epic; no work created",
+            "decision": "escalate",
+            "blocked_on": [blocker.short_id],
+        }));
+        process_finalize_payload(&payload, "submit_grooming", &planning_task.id, &ctx).await;
+
+        // The durable edge must exist and the gate must see an open blocker.
+        assert!(
+            epic_repo.has_unresolved_blockers(&parked.id).await.unwrap(),
+            "blocked_on must durably record an epic-blocker edge"
+        );
+        let blockers = epic_repo.list_blockers(&parked.id).await.unwrap();
+        assert_eq!(blockers.len(), 1);
+        assert_eq!(blockers[0].epic_id, blocker.id);
+
+        // Idempotent: re-declaring the same blocker must not error or duplicate.
+        process_finalize_payload(&payload, "submit_grooming", &planning_task.id, &ctx).await;
+        let blockers_again = epic_repo.list_blockers(&parked.id).await.unwrap();
+        assert_eq!(
+            blockers_again.len(),
+            1,
+            "re-declaring the same blocker must be idempotent"
+        );
+
+        // Closing the blocker clears the gate (event-driven wake path).
+        epic_repo.close(&blocker.id).await.unwrap();
+        assert!(
+            !epic_repo.has_unresolved_blockers(&parked.id).await.unwrap(),
+            "closing the blocker must clear the park gate"
+        );
+    }
+
+    /// An unresolvable `blocked_on` ref (e.g. a task short_id, not an epic) must
+    /// be skipped without crashing and without recording a bogus edge.
+    #[tokio::test]
+    async fn submit_grooming_blocked_on_unresolvable_ref_is_skipped() {
+        let db = test_helpers::create_test_db();
+        let ctx = test_helpers::agent_context_from_db(
+            db.clone(),
+            tokio_util::sync::CancellationToken::new(),
+        );
+        let project = test_helpers::create_test_project(&db).await;
+        let parked = test_helpers::create_test_epic(&db, &project.id).await;
+        let planning_task = test_helpers::create_test_task(&db, &project.id, &parked.id).await;
+
+        let payload = Some(serde_json::json!({
+            "tasks_reviewed": [],
+            "blocked_on": ["does-not-exist"],
+        }));
+        process_finalize_payload(&payload, "submit_grooming", &planning_task.id, &ctx).await;
+
+        let epic_repo = djinn_db::EpicRepository::new(db.clone(), ctx.event_bus.clone());
+        assert!(
+            !epic_repo.has_unresolved_blockers(&parked.id).await.unwrap(),
+            "unresolvable blocked_on ref must not record a blocker"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/djinn-slot/src/finalize_types.rs
+++ b/server/crates/djinn-slot/src/finalize_types.rs
@@ -76,4 +76,11 @@ pub struct SubmitGrooming {
     pub tasks_reviewed: Vec<TaskGroomingEntry>,
     pub summary: Option<String>,
     pub decision: Option<String>,
+    /// Epics (UUID or short_id) that block this planning epic. When the planner
+    /// concludes "blocked on epic X, no tasks created", listing X here durably
+    /// records the epic-blocker edge so the coordinator parks this epic's
+    /// planning until X closes — instead of re-deriving "blocked" via a fresh
+    /// LLM session on every stale-sweep. Idempotent; ignored when empty.
+    #[serde(default)]
+    pub blocked_on: Vec<String>,
 }


### PR DESCRIPTION
## Incident

Epic `mygq` re-dispatched a planning task every ~10–15 min **all night** (2026-07-01). Every session concluded the same thing — quoting the planning entries: *"Created no worker tasks because 0ecv remains open and owns t9i0 supervisor-dispatch collapse"* / *"the flpe/0ecv canonical ownership gate remains unsatisfied"* — and each appended another near-identical "stale-sweep" entry to the `reference/mygq-roadmap` note (bloating it). Dozens of no-op planner sessions burned tokens and planner slots for zero work.

## Root cause

The periodic re-plan is `sweep_stale_auto_dispatches` on the 15-min `AUTO_DISPATCH_SWEEP_INTERVAL`. The planner's "blocked on X" conclusion was **not recorded durably** — `submit_grooming`'s `decision` field was parsed and dropped — so every sweep re-derived "blocked" via a fresh LLM session. The epic-blocker gate that already existed (`should_auto_dispatch_planner` → `has_unresolved_blockers`) had no edge to enforce, and it only ran on the `EpicCreated` dispatch path.

## Fix (design option A: epic-level blocked-by + event-driven wake)

Reuses the existing epic-dependency machinery — `epic_blockers` table, `EpicRepository::add_blocker` / `has_unresolved_blockers` / `emit_unblocked_epics`. **No new table or migration.**

1. **Gate on all dispatch paths** (`reentrance.rs`): the epic-blocker gate now applies to both `EpicCreated` and `TaskClosed`, so wave-1, next-wave batch completion, post-planner recheck, and the periodic stale-sweep all skip a parked epic. Evaluated against **DB truth** on every tick, so a missed event cannot strand an epic; a parked epic whose blocker is already closed dispatches normally.
2. **Durable park from the planning outcome** (`submit_grooming`): new `blocked_on` field. When the planner concludes "blocked on epic X, no tasks created", the finalize handler resolves the planning task's epic and records the epic-blocker edge via `add_blocker` (idempotent; unresolvable refs are logged and skipped, never crashes the finalize path).
3. **Event-driven wake**: closing the blocker fires `emit_unblocked_epics` → `epic.updated` → the parked epic becomes eligible on the next coordinator tick. No polling, no fixed re-check interval.
4. **Prompt** (`wave.rs`): the planner is told to declare `blocked_on` once (decision=`escalate`, no tasks) instead of restating a known block every run.

Task blockers (e.g. `t9i0`) are modeled by referencing the owning **epic** (`0ecv`), which is exactly the incident's `flpe/0ecv` ownership gate — no epic→task relation needed.

## Tests

- `reentrance::unresolved_epic_blocker_skips_task_closed_dispatch` — gate now covers the sweep/next-wave path; closing the blocker re-enables it.
- `finalize_handlers::submit_grooming_blocked_on_records_epic_blocker_durably` — declaration records the edge, is idempotent, and closing the blocker clears the gate.
- `finalize_handlers::submit_grooming_blocked_on_unresolvable_ref_is_skipped` — bad ref never records a bogus edge.
- Existing blocker/wave regressions still pass (34 targeted tests green).

## Verification

- `cargo clippy --all-targets --features qdrant -- -D warnings` (exact CI command): clean.
- `cargo fmt --check`: clean.
- Targeted `cargo nextest` (djinn-slot + djinn-coordinator blocker/wave/grooming): 34 passed.
- Schema snapshot regenerated for the new `blocked_on` property.

## Scope

Changes are confined to planner dispatch gating / epic-dependency evaluation / planning-outcome handling. Does not touch the stall-detector/worker-event-bridge or model circuit-breaker areas owned by concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)