### PR TITLE
fix(coordinator): stop false stall-kills of live workers + second-strike escalation

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/host_callbacks.rs
+++ b/server/crates/djinn-agent/src/actors/slot/host_callbacks.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::context::AgentContext;
+use djinn_supervisor::SupervisorServices;
 
 /// Construct a [`djinn_slot::host::SlotContext`] from an [`AgentContext`] for
 /// the dispatch pathway.
@@ -39,9 +40,48 @@ pub(crate) fn agent_to_dispatch_slot_context(
         runtime_ops: agent.runtime_ops.clone(),
         repo_graph_ops: agent.repo_graph_ops.clone(),
         clock: Arc::new(djinn_core::clock::SystemClock::new()),
-        callbacks: Arc::new(AgentDispatchCallbacks(agent.clone())),
+        callbacks: Arc::new(AgentDispatchCallbacks {
+            agent: agent.clone(),
+            services: None,
+        }),
         tool_dispatcher: None,
     }
+}
+
+/// Construct a reply-loop [`djinn_slot::host::SlotContext`] whose callbacks
+/// carry a live [`SupervisorServices`] handle.
+///
+/// The canonical reply loop (djinn-slot) emits liveness (`touch_activity_rpc`)
+/// and mid-flight token (`flush_session_tokens_rpc`) heartbeats through
+/// `SlotHostCallbacks`. In the dispatch-only [`agent_to_dispatch_slot_context`]
+/// those are inert stubs, but the reply loop MUST route them to the host:
+///
+/// - host (in-process): `DirectServices` writes the host's shared
+///   `ActivityTracker` / session row directly.
+/// - K8s worker pod: `WorkerSupervisorServices` forwards them over RPC to the
+///   host, where `DirectServices` applies them.
+///
+/// Wiring these through `services` restores the pre-slot-extraction contract
+/// (see `SupervisorServices::touch_activity` docs). Without it the worker's
+/// heartbeats were dropped on the floor and the coordinator's stall poller —
+/// reading its own untouched tracker — false-killed every worker session that
+/// ran past the 30-minute idle threshold.
+pub(crate) fn agent_to_reply_loop_slot_context(
+    agent: &AgentContext,
+    services: &dyn SupervisorServices,
+) -> djinn_slot::host::SlotContext {
+    let mut ctx = agent_to_dispatch_slot_context(agent);
+    // SAFETY: mirrors `AgentToolDispatcher::new`'s lifetime discipline — the
+    // reply loop awaits every callback future before returning, so this erased
+    // `'static` reference never outlives the borrow it was created from.
+    let services_static = unsafe {
+        std::mem::transmute::<&dyn SupervisorServices, &'static dyn SupervisorServices>(services)
+    };
+    ctx.callbacks = Arc::new(AgentDispatchCallbacks {
+        agent: agent.clone(),
+        services: Some(services_static),
+    });
+    ctx
 }
 
 /// Host callback implementation for the dispatch pathway.
@@ -54,7 +94,16 @@ pub(crate) fn agent_to_dispatch_slot_context(
 /// Other `SlotHostCallbacks` methods are stubs: the host-side dispatch path
 /// uses `AgentContext` directly (not through callbacks) for MCP resolution,
 /// prompt rendering, provider credentials, etc.
-struct AgentDispatchCallbacks(AgentContext);
+///
+/// `services` is `Some` only on the reply-loop path (built via
+/// [`agent_to_reply_loop_slot_context`]); there `touch_activity_rpc` and
+/// `flush_session_tokens_rpc` route through it to the host. On the dispatch
+/// path it is `None` and those heartbeats stay inert stubs (they are never
+/// invoked there).
+struct AgentDispatchCallbacks {
+    agent: AgentContext,
+    services: Option<&'static dyn SupervisorServices>,
+}
 
 impl djinn_slot::host::SlotHostCallbacks for AgentDispatchCallbacks {
     fn interrupt_paused_worker_session<'a>(
@@ -151,7 +200,7 @@ impl djinn_slot::host::SlotHostCallbacks for AgentDispatchCallbacks {
         kill: CancellationToken,
         pause: CancellationToken,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
-        let app_state = self.0.clone();
+        let app_state = self.agent.clone();
         Box::pin(async move {
             super::supervisor_runner::dispatch_task_runtime(
                 task_id,
@@ -167,19 +216,41 @@ impl djinn_slot::host::SlotHostCallbacks for AgentDispatchCallbacks {
 
     fn touch_activity_rpc<'a>(
         &'a self,
-        _task_id: String,
+        task_id: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
+        // Reply-loop path: route the liveness heartbeat to the host so the
+        // coordinator's stall poller sees the session is alive. Dispatch path
+        // (`services == None`): inert — never invoked there.
+        match self.services {
+            Some(services) => Box::pin(async move { services.touch_activity(task_id).await }),
+            None => Box::pin(async { Ok(()) }),
+        }
     }
 
     fn flush_session_tokens_rpc<'a>(
         &'a self,
-        _session_id: String,
-        _tokens_in: i64,
-        _tokens_out: i64,
-        _cache_read: i64,
-        _cache_write: i64,
+        session_id: String,
+        tokens_in: i64,
+        tokens_out: i64,
+        cache_read: i64,
+        cache_write: i64,
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
-        Box::pin(async { Ok(()) })
+        // Reply-loop path: persist mid-flight token counters to the session row
+        // so long-running sessions expose real progress (also feeds the stall
+        // backstop's DB-visible-progress signal). Dispatch path: inert.
+        match self.services {
+            Some(services) => Box::pin(async move {
+                services
+                    .flush_session_tokens(
+                        session_id,
+                        tokens_in,
+                        tokens_out,
+                        cache_read,
+                        cache_write,
+                    )
+                    .await
+            }),
+            None => Box::pin(async { Ok(()) }),
+        }
     }
 }

--- a/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
+++ b/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
@@ -185,7 +185,7 @@ pub(crate) async fn run_reply_loop(
         max_turns_override,
     } = ctx;
 
-    let mut slot_ctx = super::host_callbacks::agent_to_dispatch_slot_context(app_state);
+    let mut slot_ctx = super::host_callbacks::agent_to_reply_loop_slot_context(app_state, services);
     slot_ctx.tool_dispatcher = Some(Arc::new(AgentToolDispatcher::new(
         app_state,
         services,

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -216,6 +216,24 @@ pub(super) struct CoordinatorActor {
     /// dead predecessor's entry — see `enforce_session_stall_timeout`.
     // Restart-safe-to-lose: records already-issued stall kills; repeated kill attempts on the next sweep are harmless terminal-state no-ops.
     pub(super) stall_killed: HashSet<String>,
+    /// Restart-safe-to-lose: per-session watermark of DB-visible progress
+    /// (`tokens_in + tokens_out + cache_read + cache_write` from the session
+    /// row) observed on the previous stall sweep. The stall backstop compares
+    /// the live row against this watermark: if the counters advanced, the
+    /// session is demonstrably making progress even though the in-memory
+    /// activity tracker is silent (a remote worker whose `touch_activity`
+    /// bridge drifted), so it is spared the idle kill and the watermark is
+    /// bumped. Keyed by session id; pruned alongside `stall_killed` when the
+    /// session leaves `list_active()`.
+    pub(super) stall_progress_watermark: HashMap<String, u64>,
+    /// Restart-safe-to-lose: consecutive stall-cancelled sessions per TASK id
+    /// with no durable task-status progress between them. A task stall-killed
+    /// on two back-to-back sessions without advancing its status is caught in a
+    /// redispatch loop the reopen-count escalation never observes (the loop
+    /// never passes through `open`), so on the second strike we route it to
+    /// Planner intervention instead of blindly redispatching a third time.
+    /// Reset when the task's status advances or it leaves execution.
+    pub(super) stall_cancel_streak: HashMap<String, StallCancelStreak>,
     /// Timestamp of the last completed idle-time consolidation sweep (ADR-048 §3A).
     pub(super) last_idle_consolidation: Option<StdInstant>,
     /// Cancellation token for an in-flight idle consolidation sweep.
@@ -430,6 +448,8 @@ impl CoordinatorActor {
             conversations_resolved: HashMap::new(),
             handled_dequeues: HashMap::new(),
             stall_killed: HashSet::new(),
+            stall_progress_watermark: HashMap::new(),
+            stall_cancel_streak: HashMap::new(),
             last_idle_consolidation: None,
             idle_consolidation_cancel: None,
             idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/consolidation.rs
+++ b/server/crates/djinn-coordinator/src/consolidation.rs
@@ -484,6 +484,8 @@ mod tests {
             conversations_resolved: std::collections::HashMap::new(),
             handled_dequeues: std::collections::HashMap::new(),
             stall_killed: std::collections::HashSet::new(),
+            stall_progress_watermark: std::collections::HashMap::new(),
+            stall_cancel_streak: std::collections::HashMap::new(),
             last_idle_consolidation: None,
             idle_consolidation_cancel: None,
             idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -73,6 +73,11 @@ impl CoordinatorActor {
         let active_session_ids: HashSet<String> = active.iter().map(|s| s.id.clone()).collect();
         self.stall_killed
             .retain(|id| active_session_ids.contains(id));
+        // Prune the DB-progress watermarks the same way — a session that has
+        // left `list_active()` will never be evaluated again, so its watermark
+        // is dead weight (and a redispatched successor gets a fresh session id).
+        self.stall_progress_watermark
+            .retain(|id, _| active_session_ids.contains(id));
 
         /// First-call short-circuit: a session that has never shown a sign of
         /// life (the host's `ActivityTracker` has no entry — see
@@ -408,7 +413,49 @@ impl CoordinatorActor {
                 }
             }
 
+            // ── DB-truth liveness backstop ──────────────────────────────────
+            // The idle measurement above comes from the in-memory
+            // `ActivityTracker`, which for a remote worker pod is fed only by
+            // the worker's `touch_activity` RPC bridge. When that bridge drifts
+            // (or breaks) the host tracker goes silent even though the pod is
+            // busy — the exact failure that stall-killed 88 productive sessions
+            // overnight. Before killing, consult a signal the drift cannot
+            // touch: the session ROW's own token counters, persisted mid-flight
+            // by `flush_session_tokens_rpc`. Compare the live total against the
+            // watermark from the previous sweep; if it advanced, the worker is
+            // demonstrably producing output, so spare it and roll the watermark
+            // forward. A genuinely dead session's counters are frozen — its
+            // watermark never advances and it is still killed at threshold. This
+            // mirrors the tool-run-heartbeat precedent that stopped false reaps
+            // of long clippy runs (~v0.4.7).
+            let db_progress = session.tokens_in.max(0) as u64
+                + session.tokens_out.max(0) as u64
+                + session.cache_read_tokens.max(0) as u64
+                + session.cache_write_tokens.max(0) as u64;
+            let prev_watermark = self
+                .stall_progress_watermark
+                .insert(session.id.clone(), db_progress);
+
             if idle <= applied_threshold {
+                continue;
+            }
+
+            // Over the idle threshold, but if the session row shows token
+            // progress since the last sweep the in-memory idle clock is lying —
+            // never cancel a session for "idle" while there is independent DB
+            // evidence of progress.
+            if let Some(prev) = prev_watermark
+                && db_progress > prev
+            {
+                tracing::info!(
+                    task_id = %task_id,
+                    session_id = %session.id,
+                    idle_seconds = idle,
+                    threshold_secs = applied_threshold,
+                    db_progress,
+                    prev_watermark = prev,
+                    "CoordinatorActor: stall backstop spared session — DB token progress advanced despite silent activity tracker"
+                );
                 continue;
             }
 
@@ -485,12 +532,12 @@ impl CoordinatorActor {
             // (most acutely the per-account ChatGPT Codex backend), so a global
             // trip would disable the model for everyone on one user's bad luck.
             let task_repo = self.task_repo();
-            let scope = task_repo
-                .get(task_id)
-                .await
-                .ok()
-                .flatten()
-                .and_then(|t| t.created_by_user_id);
+            let task_row = task_repo.get(task_id).await.ok().flatten();
+            let scope = task_row.as_ref().and_then(|t| t.created_by_user_id.clone());
+            let current_status = task_row
+                .as_ref()
+                .map(|t| t.status.clone())
+                .unwrap_or_default();
 
             // Feed the model circuit-breaker so dispatch fails over to the next
             // model in the creator's ordered list on redispatch. A first-call
@@ -542,6 +589,65 @@ impl CoordinatorActor {
                 scope = ?scope,
                 "CoordinatorActor: killed stalled session"
             );
+
+            // ── Second-strike stall escalation ──────────────────────────────
+            // Record this stall cancel against the task. Two CONSECUTIVE stall
+            // cancels with no durable task-status progress between them means the
+            // task is looping without converging — a loop the reopen-count
+            // escalation (triggers A/B) never observes, because a stall kill
+            // releases the task straight back into execution without passing
+            // through `open` (reopen_count stays flat). On the second strike,
+            // route it to the Planner instead of letting dispatch send a third
+            // doomed session (the overnight incident stall-killed one task 14
+            // times behind a single slot).
+            let strike_count = {
+                let streak = self
+                    .stall_cancel_streak
+                    .entry(task_id.to_owned())
+                    .and_modify(|s| {
+                        if s.last_status == current_status {
+                            s.count += 1;
+                        } else {
+                            // Durable status progress between strikes — reset.
+                            s.count = 1;
+                            s.last_status = current_status.clone();
+                        }
+                    })
+                    .or_insert_with(|| StallCancelStreak {
+                        count: 1,
+                        last_status: current_status.clone(),
+                    });
+                streak.count
+            };
+
+            if strike_count >= STALL_CANCEL_ESCALATION_THRESHOLD {
+                tracing::warn!(
+                    task_id = %task_id,
+                    session_id = %session.id,
+                    strike_count,
+                    status = %current_status,
+                    "CoordinatorActor: consecutive stall cancels without status progress — routing to Planner intervention instead of redispatch"
+                );
+                let intervention_reason = format!(
+                    "Task stall-cancelled on {strike_count} consecutive sessions with no durable \
+                     status progress between them (status `{current_status}`). A stall kill \
+                     releases the task straight back into execution without passing through \
+                     `open`, so the reopen-based escalation never saw this loop — each redispatch \
+                     just stalls again and holds the dispatch slot. Decide how to unstick it: \
+                     DECOMPOSE into focused subtasks, RESCOPE/clarify the acceptance criteria and \
+                     re-dispatch, or CLOSE if the durable work on the task branch is already \
+                     sufficient or the task is moot/duplicate."
+                );
+                // Clear the streak so a post-intervention run starts fresh (and a
+                // re-armed intervention is not double-counted).
+                self.stall_cancel_streak.remove(task_id);
+                self.route_loop_guard_planner_intervention(
+                    task_id,
+                    "coordinator",
+                    &intervention_reason,
+                )
+                .await;
+            }
         }
     }
 

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -2023,6 +2023,8 @@ mod inflight_ledger_tests {
             conversations_resolved: HashMap::new(),
             handled_dequeues: HashMap::new(),
             stall_killed: HashSet::new(),
+            stall_progress_watermark: HashMap::new(),
+            stall_cancel_streak: HashMap::new(),
             last_idle_consolidation: None,
             idle_consolidation_cancel: None,
             idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
@@ -139,6 +139,8 @@ fn build_refinement_actor(
         conversations_resolved: HashMap::new(),
         handled_dequeues: HashMap::new(),
         stall_killed: HashSet::new(),
+        stall_progress_watermark: HashMap::new(),
+        stall_cancel_streak: HashMap::new(),
         last_idle_consolidation: None,
         idle_consolidation_cancel: None,
         idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -475,6 +475,8 @@ fn coordinator_actor_for_tests(
         conversations_resolved: HashMap::new(),
         handled_dequeues: HashMap::new(),
         stall_killed: HashSet::new(),
+        stall_progress_watermark: HashMap::new(),
+        stall_cancel_streak: HashMap::new(),
         last_idle_consolidation: None,
         idle_consolidation_cancel: None,
         idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -2074,3 +2074,360 @@ fn failed_outcome_blocks_with_block_policy() {
         "Failed should block with Block policy"
     );
 }
+
+// ── Fix 1: DB-truth liveness backstop for the stall killer ───────────────
+//
+// The coordinator's idle measurement comes from an in-memory ActivityTracker
+// fed only by a remote worker's `touch_activity` RPC bridge. When that bridge
+// drifts the tracker goes silent and the stall killer false-flags a busy
+// worker as idle (the overnight incident: 88 productive sessions killed at the
+// 30-minute mark). The backstop consults a signal the drift cannot touch — the
+// session ROW's token counters, persisted mid-flight — and spares any session
+// whose counters advanced since the previous sweep.
+
+/// A session that is well past the idle threshold with a SILENT activity
+/// tracker is NOT stall-killed when its DB token counters advanced since the
+/// last stall sweep — DB-visible progress is independent evidence of liveness.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stall_backstop_spares_session_with_advancing_db_tokens() {
+    use djinn_db::{CreateSessionParams, SessionRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "stall-backstop-spare").await;
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+    // Backdate well past every idle threshold; with no pool slot the stall
+    // check falls back to wall-clock-from-started_at and reads the tracker as
+    // silent (`activity_tracked == false`).
+    session_repo
+        .backdate_started_at(&session.id, "40 minutes")
+        .await
+        .unwrap();
+    // The session row shows real token progress (mid-flight flush).
+    session_repo
+        .flush_tokens(&session.id, 2000, 500, 0, 0)
+        .await
+        .unwrap();
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    // Seed the watermark from a prior sweep BELOW the live total so the current
+    // sweep observes an advance.
+    actor
+        .stall_progress_watermark
+        .insert(session.id.clone(), 1000);
+
+    actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        !actor.stall_killed.contains(&session.id),
+        "a session whose DB token counters advanced since the last sweep must be spared the idle kill"
+    );
+    assert_eq!(
+        actor.stall_progress_watermark.get(&session.id).copied(),
+        Some(2500),
+        "the backstop must roll the watermark forward to the observed DB total"
+    );
+}
+
+/// A truly-dead session — silent activity tracker AND frozen DB token counters
+/// (no advance since the last sweep) — is still stall-killed at threshold. The
+/// backstop only spares demonstrable progress; it must not become a blanket
+/// amnesty that wedges genuinely hung sessions.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stall_kill_still_fires_without_db_progress() {
+    use djinn_db::{CreateSessionParams, SessionRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "stall-backstop-dead").await;
+    let run_id = "run-stall-dead";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+    session_repo
+        .backdate_started_at(&session.id, "40 minutes")
+        .await
+        .unwrap();
+    // Frozen counters: the row shows tokens, but the watermark below already
+    // matches them, so no advance is observed.
+    session_repo
+        .flush_tokens(&session.id, 3000, 0, 0, 0)
+        .await
+        .unwrap();
+
+    let runtime = RecordingRuntimeOps::new(true);
+    let mut app_state = test_helpers::agent_context_from_db(db.clone(), CancellationToken::new());
+    app_state.runtime_ops = Some(std::sync::Arc::new(runtime.clone()));
+    let active_tasks = app_state.active_tasks.clone();
+    let cancel = CancellationToken::new();
+    let pool = SlotPoolHandle::spawn_with_factory(
+        app_state,
+        cancel.clone(),
+        SlotPoolConfig {
+            models: vec![ModelSlotConfig {
+                model_id: "openai/gpt-5.5".to_string(),
+                max_slots: 1,
+                roles: ["worker"].into_iter().map(ToOwned::to_owned).collect(),
+            }],
+            role_priorities: HashMap::new(),
+        },
+        std::sync::Arc::new(|slot_id, model_id, event_tx, app_state, cancel| {
+            let runner: djinn_slot::TestLifecycleRunner = std::sync::Arc::new(
+                |_task_id, _project_path, _model_id, _app_state, kill, _pause| {
+                    Box::pin(async move {
+                        kill.cancelled().await;
+                        Ok(())
+                    })
+                },
+            );
+            SlotHandle::spawn_with_test_runner(
+                slot_id, model_id, event_tx, app_state, cancel, runner,
+            )
+        }),
+    );
+    pool.dispatch(&task.id, "test-project", "openai/gpt-5.5")
+        .await
+        .expect("dispatch should create a slot mapping");
+    // Age the activity timestamp so the idle measurement is over threshold.
+    let old = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs().saturating_sub(40 * 60))
+        .unwrap_or(0);
+    {
+        let guard = active_tasks.lock().expect("active_tasks mutex");
+        if let Some(ts) = guard.get(&task.id) {
+            ts.store(old, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.pool = pool;
+    // Watermark already equals the live DB total → no progress observed.
+    actor
+        .stall_progress_watermark
+        .insert(session.id.clone(), 3000);
+
+    actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        actor.stall_killed.contains(&session.id),
+        "a session with no DB progress and a silent activity tracker must still be stall-killed"
+    );
+    cancel.cancel();
+}
+
+// ── Fix 2: second-strike stall escalation ────────────────────────────────
+//
+// A task stall-killed on two consecutive sessions without durable status
+// progress is caught in a redispatch loop the reopen-count escalation never
+// sees (a stall kill never passes through `open`). On the second strike the
+// coordinator routes it to the Planner instead of dispatching a third session.
+
+/// Helper: stand up a running worker session for `task` on a live slot pool
+/// whose activity is aged past the idle threshold, ready for a stall kill.
+async fn dispatch_stalled_worker_session(
+    db: &Database,
+    tx: &broadcast::Sender<DjinnEventEnvelope>,
+    task: &djinn_core::models::Task,
+    run_id: &str,
+) -> (
+    SlotPoolHandle,
+    CancellationToken,
+    djinn_core::models::SessionRecord,
+) {
+    use djinn_db::{CreateSessionParams, SessionRepository};
+
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+    session_repo
+        .backdate_started_at(&session.id, "40 minutes")
+        .await
+        .unwrap();
+
+    let mut app_state = test_helpers::agent_context_from_db(db.clone(), CancellationToken::new());
+    app_state.runtime_ops = Some(std::sync::Arc::new(RecordingRuntimeOps::new(true)));
+    let active_tasks = app_state.active_tasks.clone();
+    let cancel = CancellationToken::new();
+    let pool = SlotPoolHandle::spawn_with_factory(
+        app_state,
+        cancel.clone(),
+        SlotPoolConfig {
+            models: vec![ModelSlotConfig {
+                model_id: "openai/gpt-5.5".to_string(),
+                max_slots: 1,
+                roles: ["worker"].into_iter().map(ToOwned::to_owned).collect(),
+            }],
+            role_priorities: HashMap::new(),
+        },
+        std::sync::Arc::new(|slot_id, model_id, event_tx, app_state, cancel| {
+            let runner: djinn_slot::TestLifecycleRunner = std::sync::Arc::new(
+                |_task_id, _project_path, _model_id, _app_state, kill, _pause| {
+                    Box::pin(async move {
+                        kill.cancelled().await;
+                        Ok(())
+                    })
+                },
+            );
+            SlotHandle::spawn_with_test_runner(
+                slot_id, model_id, event_tx, app_state, cancel, runner,
+            )
+        }),
+    );
+    pool.dispatch(&task.id, "test-project", "openai/gpt-5.5")
+        .await
+        .expect("dispatch should create a slot mapping");
+    let old = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs().saturating_sub(40 * 60))
+        .unwrap_or(0);
+    {
+        let guard = active_tasks.lock().expect("active_tasks mutex");
+        if let Some(ts) = guard.get(&task.id) {
+            ts.store(old, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    (pool, cancel, session)
+}
+
+/// The FIRST stall cancel of a task does not escalate — it just kills and
+/// releases for redispatch (one stall is not yet a loop).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn first_stall_cancel_does_not_escalate_to_planner() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "stall-strike-one").await;
+    let (pool, cancel, session) =
+        dispatch_stalled_worker_session(&db, &tx, &task, "run-strike-one").await;
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.pool = pool;
+    actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        actor.stall_killed.contains(&session.id),
+        "the stalled session is killed"
+    );
+    let streak = actor
+        .stall_cancel_streak
+        .get(&task.id)
+        .expect("first strike records a streak");
+    assert_eq!(streak.count, 1, "first strike is count 1");
+    let markers = planner_intervention_markers(&actor.task_repo(), &task.id).await;
+    assert!(
+        markers.is_empty(),
+        "a single stall cancel must not escalate to the Planner"
+    );
+    cancel.cancel();
+}
+
+/// Two CONSECUTIVE stall cancels with no durable status progress between them
+/// escalate to a Planner intervention BEFORE a third dispatch. The first strike
+/// is pre-seeded (a prior session already stall-cancelled at this status); the
+/// second real kill crosses the threshold.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn second_consecutive_stall_cancel_escalates_to_planner() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "stall-strike-two").await;
+    let (pool, cancel, session) =
+        dispatch_stalled_worker_session(&db, &tx, &task, "run-strike-two").await;
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.pool = pool;
+    // Pre-seed the first strike at the task's current status: a prior session
+    // already stall-cancelled and the status has not advanced since.
+    let current = actor
+        .task_repo()
+        .get(&task.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .status;
+    actor.stall_cancel_streak.insert(
+        task.id.clone(),
+        StallCancelStreak {
+            count: 1,
+            last_status: current,
+        },
+    );
+
+    actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        actor.stall_killed.contains(&session.id),
+        "the second stalled session is killed"
+    );
+    let markers = planner_intervention_markers(&actor.task_repo(), &task.id).await;
+    assert!(
+        !markers.is_empty(),
+        "the second consecutive stall cancel without status progress must route to a Planner intervention"
+    );
+    assert!(
+        !actor.stall_cancel_streak.contains_key(&task.id),
+        "the streak is cleared once the escalation fires"
+    );
+    cancel.cancel();
+}

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -297,6 +297,33 @@ pub(super) const REOPEN_INTERVENTION_THRESHOLD: i64 = 3;
 /// scoped task against the existing branch) can finish it.
 pub(super) const MAX_PLANNER_INTERVENTIONS: i64 = 1;
 
+/// Number of CONSECUTIVE stall-cancelled sessions (with no durable task-status
+/// progress between them) after which the coordinator routes the task to a
+/// Planner intervention instead of blindly redispatching it again.
+///
+/// A worker task stall-killed twice in a row without its status advancing is
+/// caught in a redispatch loop that the reopen-count escalation (trigger A/B)
+/// never observes: a stall kill releases the task straight back into execution
+/// without passing through `open`, so `reopen_count` stays flat and the loop is
+/// invisible to the reopen threshold. Left alone it can burn a dispatch slot
+/// for hours (the overnight incident: one task stall-killed 14 times). On the
+/// SECOND strike we hand it to the Planner (decompose / rescope / close) rather
+/// than dispatch a third doomed session.
+pub(super) const STALL_CANCEL_ESCALATION_THRESHOLD: u32 = 2;
+
+/// Per-task record of consecutive stall cancellations without durable
+/// task-status progress, driving the second-strike Planner escalation
+/// (see [`STALL_CANCEL_ESCALATION_THRESHOLD`]).
+#[derive(Debug, Clone)]
+pub(super) struct StallCancelStreak {
+    /// Consecutive stall-cancelled sessions with no status change between them.
+    pub(super) count: u32,
+    /// Task status observed at the most recent stall cancel. A different status
+    /// on the next cancel means the task made durable progress in between, so
+    /// the streak resets rather than escalating.
+    pub(super) last_status: String,
+}
+
 /// Per-session total-token ceiling.  A session that has consumed more than
 /// this many tokens across all turns has likely entered a runaway loop
 /// (repeated identical tool calls, circular reasoning, or broken self-correction).


### PR DESCRIPTION
## Incident

Overnight the coordinator stall-killed **88 worker sessions** between 23:00–11:00 UTC, almost all at exactly the 30-minute mark, with:

> Coordinator stall timeout: worker session idle for 1829s/1830s (threshold 1800s, idle). Session was cancelled for redispatch.

None were idle:
- `019f2273…` (remote K8s pod): DB row read `tokens_in=0/tokens_out=0` while the pod was on reply-loop turn 29, running tools, rust-analyzer active, pushing periodic checkpoints minutes before its sibling was killed.
- `019f20dd…` (gpt-5.5): DB row showed `tokens_in=3,991,665` yet was still killed as "idle for 1829s" — the coordinator's in-memory activity signal never updated once in the session's 30-minute life.

Sessions under 30 min completed fine; anything longer was murdered and redispatched, so large tasks cycled forever (one task stall-killed 14×, another 13×).

## Root cause (Fix 1)

The recent slot-extraction cutover (#1346) moved the reply loop's liveness/token heartbeats onto the `SlotHostCallbacks` seam — `touch_activity_rpc` and `flush_session_tokens_rpc`. The only agent implementation, `AgentDispatchCallbacks`, **stubbed both to no-ops** (`Ok(())`). On a remote K8s worker this dropped every `touch_activity` on the floor:

- the worker's reply loop called `callbacks.touch_activity_rpc(...)` → no-op → nothing sent to the host;
- the host coordinator's in-memory `ActivityTracker` never updated;
- the stall poller read its own untouched tracker (`idle_seconds` climbing from `started_at`) and killed every session past the 30-minute threshold.

`flush_session_tokens_rpc` was no-op'd the same way, so mid-flight token counters weren't persisted either (the 3.9M total only landed at session end via the terminal report).

**Fix:** thread the live `SupervisorServices` handle into the reply loop's slot callbacks (`agent_to_reply_loop_slot_context`) so touch/flush route to the host again — in-process via `DirectServices` (local `ActivityTracker` write), on a worker via `WorkerSupervisorServices` → RPC → host `DirectServices`. This restores the pre-extraction contract documented on `SupervisorServices::touch_activity`.

### DB-truth backstop (Fix 1, part 2)

Independent of the in-memory feed (which can silently drift for remote pods), the stall killer now consults a signal the drift cannot touch: the session **row's** token counters (`tokens_in + tokens_out + cache_read + cache_write`), now persisted mid-flight by the restored flush. Before an idle kill it compares the live total to a per-session watermark from the previous sweep; if it advanced, the worker is demonstrably productive → spare it and roll the watermark forward. A frozen-counter session's watermark never advances, so a genuinely-dead session is still killed at threshold. Mirrors the tool-run-heartbeat precedent (~v0.4.7).

## Second-strike stall escalation (Fix 2)

A task stall-killed on **two consecutive sessions with no durable status progress** between them is caught in a redispatch loop the reopen-count escalation never observes — a stall kill releases the task straight back into execution without passing through `open`, so `reopen_count` stays flat. On the second strike the coordinator now routes the task to the existing Planner loop-guard intervention (`route_loop_guard_planner_intervention`) instead of dispatching a third doomed session.

## Tests

- `stall_backstop_spares_session_with_advancing_db_tokens` — advancing DB tokens + silent tracker → **not** killed.
- `stall_kill_still_fires_without_db_progress` — silent tracker + frozen counters → still killed at threshold.
- `first_stall_cancel_does_not_escalate_to_planner` — one stall → kill, no escalation.
- `second_consecutive_stall_cancel_escalates_to_planner` — two consecutive stalls, no status change → Planner intervention fires before the third dispatch.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy -p djinn-agent -p djinn-coordinator --all-features --all-targets` ✅ (one pre-existing unrelated warning in `session_extraction.rs`)
- `cargo test -p djinn-coordinator --lib` — new tests + `session_reaping`/`intervention` suites green (63 + 4).
- `cargo test -p djinn-agent --lib` — 657 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)