### PR TITLE
fix(proposal-gate): stop double-counting judge verdicts as blocking rows

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
@@ -839,21 +839,17 @@ async fn evaluate_composed_gate(
     let override_is_current = current_explicit_verdict_override(repo, proposal).await;
 
     // 2b. Unresolved blocking debate-trail entries.
-    // When a current override exists, judge verdict entries are excluded —
-    // the override explicitly supersedes the judge's needs-work verdict.
+    // Judge verdict rows are excluded at the query level — verdicts gate solely
+    // through the latest-verdict channel below (2c), so they must not also count
+    // as unresolved blocking rows (a stale reject verdict superseded by a later
+    // approve verdict has nothing that resolves it, and would block forever).
     match repo
         .list_unresolved_blocking_debate_entries(proposal_id)
         .await
     {
         Ok(entries) => {
-            let remaining: Vec<_> = entries
-                .iter()
-                .filter(|e| {
-                    !(override_is_current && e.kind == "verdict" && e.agent_role == "judge")
-                })
-                .collect();
-            if !remaining.is_empty() {
-                let ids: Vec<String> = remaining.iter().map(|e| e.id.clone()).collect();
+            if !entries.is_empty() {
+                let ids: Vec<String> = entries.iter().map(|e| e.id.clone()).collect();
                 failures.push(format!(
                     "unresolved blocking debate entries: {}",
                     ids.join(", ")
@@ -967,25 +963,22 @@ async fn build_gate_status(
         }
     }
 
-    // 2b. Unresolved blocking debate entries
+    // 2b. Unresolved blocking debate entries. Judge verdict rows are excluded at
+    // the query level — verdicts gate solely through the latest-verdict channel
+    // below (2c), never as unresolved blocking rows.
     let (unresolved_blocking_ids, unresolved_count) = match repo
         .list_unresolved_blocking_debate_entries(proposal_id)
         .await
     {
         Ok(entries) => {
-            let remaining: Vec<_> = entries
-                .iter()
-                .filter(|e| {
-                    !(override_is_current && e.kind == "verdict" && e.agent_role == "judge")
-                })
-                .collect();
-            if !remaining.is_empty() {
-                let ids: Vec<String> = remaining.iter().map(|e| e.id.clone()).collect();
+            if !entries.is_empty() {
+                let ids: Vec<String> = entries.iter().map(|e| e.id.clone()).collect();
                 blocked_explanations.push(format!(
                     "Unresolved blocking debate entries: {}",
                     ids.join(", ")
                 ));
-                (ids, remaining.len() as i32)
+                let count = ids.len() as i32;
+                (ids, count)
             } else {
                 (vec![], 0)
             }
@@ -5562,6 +5555,142 @@ What happens if D fails?
         // Proposal should still be draft — no sign-off recorded.
         let stored = repo.get(&proposal.id).await.unwrap().unwrap();
         assert_eq!(stored.status, "draft");
+    }
+
+    /// Regression (gate-verdict-supersession): stale reject verdicts from
+    /// earlier tribunal rounds must never count as unresolved blocking rows.
+    /// Once a later approve verdict supersedes them, the gate is ready — the
+    /// reject verdicts have nothing that resolves them and would otherwise
+    /// block the proposal forever ("blocking rows: N" with "Judge verdict:
+    /// Ready").
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn superseded_reject_verdicts_do_not_block_gate() {
+        let (server, db, user_id) = setup_test_server_and_user().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+
+        let proposal =
+            create_ready_proposal(&repo, &project_repo, &user_id, "Superseded Verdicts").await;
+
+        // Three rounds of blocking reject verdicts (the judge's own REJECTs).
+        for (round, body) in [
+            (1, "needs-work: round 1"),
+            (2, "needs-work: round 2"),
+            (3, "needs-work: round 3"),
+        ] {
+            repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+                proposal_id: &proposal.id,
+                kind: "verdict",
+                body,
+                blocking: true,
+                agent_role: "judge",
+                author_kind: "agent",
+                author_model: Some("test-judge"),
+                source_task_id: None,
+                against_revision_seq: proposal.latest_revision_seq,
+                round,
+                body_metadata: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        // Latest verdict is an approve — it supersedes the rejects.
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &proposal.id,
+            kind: "verdict",
+            body: "Ready",
+            blocking: false,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("test-judge"),
+            source_task_id: None,
+            against_revision_seq: proposal.latest_revision_seq,
+            round: 4,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+        let gate = show_gate_status(&server, &user_id, &proposal.id).await;
+        assert_eq!(
+            gate.get("unresolved_blocking_count")
+                .and_then(|v| v.as_i64()),
+            Some(0),
+            "superseded reject verdicts must not count as unresolved blocking: {gate:?}"
+        );
+        assert_eq!(
+            gate.get("judge_needs_work").and_then(|v| v.as_bool()),
+            Some(false),
+            "latest verdict is approve, so judge_needs_work is false: {gate:?}"
+        );
+        assert_eq!(
+            gate.get("ready").and_then(|v| v.as_bool()),
+            Some(true),
+            "gate should be ready once the latest verdict approves: {gate:?}"
+        );
+    }
+
+    /// The latest-verdict channel still gates: when the newest verdict is a
+    /// reject, `judge_needs_work` is true and the gate is not ready — even
+    /// though verdict rows no longer count as unresolved blocking entries.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn latest_reject_verdict_still_blocks_via_needs_work_channel() {
+        let (server, db, user_id) = setup_test_server_and_user().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+
+        let proposal = create_ready_proposal(&repo, &project_repo, &user_id, "Latest Reject").await;
+
+        // An earlier approve, then a later reject — latest wins.
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &proposal.id,
+            kind: "verdict",
+            body: "Ready",
+            blocking: false,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("test-judge"),
+            source_task_id: None,
+            against_revision_seq: proposal.latest_revision_seq,
+            round: 1,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &proposal.id,
+            kind: "verdict",
+            body: "needs-work: regression found",
+            blocking: true,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("test-judge"),
+            source_task_id: None,
+            against_revision_seq: proposal.latest_revision_seq,
+            round: 2,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+        let gate = show_gate_status(&server, &user_id, &proposal.id).await;
+        assert_eq!(
+            gate.get("unresolved_blocking_count")
+                .and_then(|v| v.as_i64()),
+            Some(0),
+            "verdict rows never count as unresolved blocking: {gate:?}"
+        );
+        assert_eq!(
+            gate.get("judge_needs_work").and_then(|v| v.as_bool()),
+            Some(true),
+            "latest verdict is a reject — judge_needs_work must be true: {gate:?}"
+        );
+        assert_eq!(
+            gate.get("ready").and_then(|v| v.as_bool()),
+            Some(false),
+            "gate must not be ready with a latest reject verdict: {gate:?}"
+        );
     }
 
     /// A needs-evidence spike blocks graduation with a deterministic

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -244,6 +244,27 @@ impl CoordinatorActor {
                 "Failed to persist refinement_awaiting_review lifecycle metadata"
             );
         }
+
+        // Surface converged-awaiting-review proposals in the standard status
+        // grouping: a `draft` proposal that the tribunal parks for human review
+        // advances to `in_review`. Idempotent and status-scoped (draft-only);
+        // any other status is left untouched.
+        match proposal_repo.advance_draft_to_in_review(proposal_id).await {
+            Ok(true) => {
+                tracing::info!(
+                    proposal_id = %proposal_id,
+                    "Tribunal converged — advanced draft proposal to in_review"
+                );
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    error = %e,
+                    "Failed to advance draft proposal to in_review on awaiting-review park"
+                );
+            }
+        }
     }
 
     /// Process a judge session outcome: read the verdict from the debate

--- a/server/crates/djinn-db/src/repositories/proposal.rs
+++ b/server/crates/djinn-db/src/repositories/proposal.rs
@@ -2574,6 +2574,50 @@ impl ProposalRepository {
         Ok(())
     }
 
+    /// Advance a `draft` proposal to `in_review` when the tribunal converges
+    /// and parks it awaiting human review. Idempotent and status-scoped: only
+    /// `draft → in_review` transitions; any other status is left untouched.
+    ///
+    /// Emits a `status_change` revision event (matching the sign-off-driven
+    /// promotion path) so the transition appears in revision history, and
+    /// publishes a `proposal_updated` event. Returns `true` when a transition
+    /// occurred.
+    pub async fn advance_draft_to_in_review(&self, proposal_id: &str) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        let Some(proposal) = self.get(proposal_id).await? else {
+            return Ok(false);
+        };
+        if proposal.status != "draft" {
+            return Ok(false);
+        }
+        sqlx::query(
+            r#"UPDATE proposals SET status = 'in_review',
+                    updated_at = to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+             WHERE id = $1 AND status = 'draft'"#,
+        )
+        .bind(proposal_id)
+        .execute(self.db.pool())
+        .await?;
+        let acceptance_criteria: serde_json::Value =
+            serde_json::from_str(&proposal.acceptance_criteria).unwrap_or(serde_json::json!([]));
+        self.insert_status_event(ProposalStatusEvent {
+            proposal_id,
+            seq: proposal.latest_revision_seq,
+            title: &proposal.title,
+            body: &proposal.body,
+            body_format: &proposal.body_format,
+            acceptance_criteria: &acceptance_criteria,
+            edited_by: None,
+            status_from: "draft",
+            status_to: "in_review",
+        })
+        .await?;
+        let updated = self.get_required(proposal_id).await?;
+        self.events
+            .send(DjinnEventEnvelope::proposal_updated(&updated));
+        Ok(true)
+    }
+
     pub async fn set_done(&self, proposal_id: &str) -> Result<Proposal> {
         self.db.ensure_initialized().await?;
         let proposal = self.get_required(proposal_id).await?;
@@ -3028,6 +3072,12 @@ impl ProposalRepository {
     /// An entry is "unresolved" when `resolved_at IS NULL` OR
     /// (`resolved_at IS NOT NULL AND reopened_at IS NOT NULL`).
     /// Only `blocking = true` entries are returned.
+    ///
+    /// Judge `kind = 'verdict'` rows are excluded: verdicts gate through their
+    /// own channel (`latest_judge_verdict` → `judge_needs_work`), where a later
+    /// approve verdict supersedes an earlier reject. Nothing ever resolves the
+    /// stale reject-verdict rows, so counting them here double-counts a signal
+    /// that can never be cleared (see gate-verdict-supersession fix).
     pub async fn list_unresolved_blocking_debate_entries(
         &self,
         proposal_id: &str,
@@ -3044,6 +3094,7 @@ impl ProposalRepository {
              FROM proposal_debate_trail
              WHERE proposal_id = $1
                AND blocking = true
+               AND kind <> 'verdict'
                AND (resolved_at IS NULL
                     OR (resolved_at IS NOT NULL AND reopened_at IS NOT NULL))
              ORDER BY round, created_at"#,
@@ -5063,6 +5114,142 @@ mod tests {
             events
                 .iter()
                 .all(|e| e.entity_type == "proposal_debate_trail")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn judge_verdicts_never_count_as_unresolved_blocking() {
+        // Regression (gate-verdict-supersession): a judge's blocking reject
+        // verdict is never "resolved" — nothing clears it when a later approve
+        // verdict supersedes it. Counting verdict rows as unresolved blocking
+        // double-counts a signal that already gates through `latest_judge_verdict`
+        // and would block the gate forever. Verdict rows must be excluded from
+        // the unresolved-blocking set regardless of resolution/reopen state.
+        let repo = ProposalRepository::new(test_db(), EventBus::noop());
+        let p = repo
+            .create(create_input("Verdict supersession"))
+            .await
+            .unwrap();
+
+        for (round, body) in [
+            (1, "needs-work: unclear on X"),
+            (2, "needs-work: still unclear"),
+            (3, "needs-work: one more round"),
+        ] {
+            repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+                proposal_id: &p.id,
+                kind: "verdict",
+                body,
+                blocking: true,
+                agent_role: "judge",
+                author_kind: "agent",
+                author_model: Some("test-judge"),
+                source_task_id: None,
+                against_revision_seq: 1,
+                round,
+                body_metadata: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        // Even with three blocking reject verdicts and no resolution, the
+        // unresolved-blocking set excludes verdict rows entirely.
+        let unresolved = repo
+            .list_unresolved_blocking_debate_entries(&p.id)
+            .await
+            .unwrap();
+        assert!(
+            unresolved.is_empty(),
+            "judge verdict rows must not appear in unresolved-blocking set: {unresolved:?}"
+        );
+
+        // A later approve verdict is the latest verdict, superseding the rejects.
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &p.id,
+            kind: "verdict",
+            body: "Ready",
+            blocking: false,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("test-judge"),
+            source_task_id: None,
+            against_revision_seq: 1,
+            round: 4,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+        let latest = repo.latest_judge_verdict(&p.id).await.unwrap().unwrap();
+        assert_eq!(latest.body, "Ready");
+
+        // A non-verdict blocking objection still counts (verdict exclusion is
+        // narrow to `kind = 'verdict'`).
+        let objection = repo
+            .add_debate_trail_entry(ProposalDebateTrailCreateInput {
+                proposal_id: &p.id,
+                kind: "objection",
+                body: "Missing error handling",
+                blocking: true,
+                agent_role: "adversary",
+                author_kind: "agent",
+                author_model: None,
+                source_task_id: None,
+                against_revision_seq: 1,
+                round: 4,
+                body_metadata: None,
+            })
+            .await
+            .unwrap();
+        let unresolved = repo
+            .list_unresolved_blocking_debate_entries(&p.id)
+            .await
+            .unwrap();
+        assert_eq!(unresolved.len(), 1, "objection must still count");
+        assert_eq!(unresolved[0].id, objection.id);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn advance_draft_to_in_review_is_idempotent_and_status_scoped() {
+        let repo = ProposalRepository::new(test_db(), EventBus::noop());
+        let p = repo.create(create_input("Park draft")).await.unwrap();
+        assert_eq!(p.status, "draft");
+
+        // First call transitions draft → in_review and records a status_change.
+        let changed = repo.advance_draft_to_in_review(&p.id).await.unwrap();
+        assert!(changed, "draft should advance to in_review");
+        let after = repo.get(&p.id).await.unwrap().unwrap();
+        assert_eq!(after.status, "in_review");
+
+        let revisions = repo.revisions(&p.id).await.unwrap();
+        let status_event = revisions
+            .iter()
+            .find(|r| r.event_kind == "status_change")
+            .expect("a status_change revision event should be recorded");
+        assert_eq!(status_event.status_from.as_deref(), Some("draft"));
+        assert_eq!(status_event.status_to.as_deref(), Some("in_review"));
+
+        // Second call is a no-op (idempotent): no transition, no extra event.
+        let changed_again = repo.advance_draft_to_in_review(&p.id).await.unwrap();
+        assert!(!changed_again, "already in_review — no transition");
+        let status_events = repo
+            .revisions(&p.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.event_kind == "status_change")
+            .count();
+        assert_eq!(status_events, 1, "no duplicate status_change event");
+
+        // A non-draft proposal is left untouched (status-scoped).
+        let other = repo.create(create_input("Approved already")).await.unwrap();
+        repo.set_status(&other.id, "approved").await.unwrap();
+        let changed_other = repo.advance_draft_to_in_review(&other.id).await.unwrap();
+        assert!(!changed_other, "approved proposal must not be touched");
+        assert_eq!(
+            repo.get(&other.id).await.unwrap().unwrap().status,
+            "approved"
         );
     }
 


### PR DESCRIPTION
## Problem

Proposal readiness could show "Blocked, blocking rows: N" while "Judge verdict: Ready" and "DoR: Pass". The unresolved blocking rows were the judge's own REJECT verdicts (`kind='verdict'`, `blocking=true`, `resolved_at IS NULL`) from earlier tribunal rounds. Nothing ever resolves an old reject verdict when a later approve verdict supersedes it, so those rows lingered in the unresolved-blocking set and blocked the gate forever. Verdicts already gate through their own channel (`latest_judge_verdict` → `judge_needs_work`), so counting verdict rows as blocking entries was double-counting a signal that could never clear.

## Fix

- `list_unresolved_blocking_debate_entries` now excludes `kind = 'verdict'` rows at the query level.
- Removed the now-dead override-scoped verdict filtering in both gate consumers (`evaluate_composed_gate`, `build_gate_status`). The `judge_needs_work` / latest-verdict channel and its needs-work override suppression are untouched — that channel is now the sole place verdict state gates.
- Auto-transition `draft → in_review` when the tribunal converges and parks a proposal awaiting human review (`persist_awaiting_review`). Idempotent and status-scoped (draft-only); emits a `status_change` revision event so it shows in revision history.

## Tests

- `djinn-db`: `judge_verdicts_never_count_as_unresolved_blocking` (verdicts excluded regardless of resolution; non-verdict objections still count) and `advance_draft_to_in_review_is_idempotent_and_status_scoped`.
- `djinn-control-plane`: `superseded_reject_verdicts_do_not_block_gate` (later approve ⇒ gate ready, count 0, `judge_needs_work=false`) and `latest_reject_verdict_still_blocks_via_needs_work_channel` (latest reject ⇒ not ready via needs-work channel, count still 0).

All 4 pass; `cargo clippy --all-features` clean on touched crates. No `.sqlx` regen needed (both changed queries use the runtime-checked non-macro API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)