### PR TITLE
fix(refinement): recompute DoR status from structured ACs at dispatch

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/epic_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/epic_ops.rs
@@ -225,7 +225,16 @@ fn parse_string_array(raw: &str) -> Vec<String> {
     serde_json::from_str(raw).unwrap_or_default()
 }
 
-fn parse_acceptance_criteria_array(raw: &str) -> Vec<AcceptanceCriterionItem> {
+/// Parse a JSON acceptance-criteria array string into typed items.
+///
+/// Tolerant of both plain-string ACs (`["do X", ...]`) and structured
+/// `{ "criterion": "...", "met": bool }` objects, falling back to a `Text`
+/// item for anything that does not deserialize cleanly. This is the canonical
+/// parser every read path (proposal_show, DoR readiness, epic breakdown) must
+/// use so structured ACs are never silently dropped — unlike
+/// `djinn_core::models::parse_json_array`, which deserializes to `Vec<String>`
+/// and therefore fails wholesale (returning an empty vec) on structured ACs.
+pub fn parse_acceptance_criteria_array(raw: &str) -> Vec<AcceptanceCriterionItem> {
     let parsed = serde_json::from_str::<serde_json::Value>(raw)
         .ok()
         .and_then(|v| v.as_array().cloned())

--- a/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
@@ -2,7 +2,7 @@
 // `epic_ops.rs`: thin serializable views over the `djinn-core` models with
 // JSON-array fields expanded to `Vec<String>`.
 
-use crate::tools::epic_ops::AcceptanceCriterionItem;
+use crate::tools::epic_ops::{AcceptanceCriterionItem, parse_acceptance_criteria_array};
 use djinn_core::models::{
     Proposal, ProposalFeedback, ProposalRevision, ProposalSignoff, ProposalTarget,
 };
@@ -745,17 +745,7 @@ pub struct GateFailureModel {
 /// accepting both plain strings and `{criterion, met}` objects (same
 /// tolerance as the task layer).
 fn parse_acceptance_criteria(raw: &str) -> Vec<AcceptanceCriterionItem> {
-    let parsed = serde_json::from_str::<serde_json::Value>(raw)
-        .ok()
-        .and_then(|v| v.as_array().cloned())
-        .unwrap_or_default();
-    parsed
-        .into_iter()
-        .map(|item| {
-            serde_json::from_value::<AcceptanceCriterionItem>(item.clone())
-                .unwrap_or_else(|_| AcceptanceCriterionItem::Text(item.to_string()))
-        })
-        .collect()
+    parse_acceptance_criteria_array(raw)
 }
 
 // ── Human authority control responses ──────────────────────────────────────

--- a/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
@@ -23,17 +23,17 @@ const TEST_MODEL: &str = DEFAULT_MODEL_ID; // "test/mock"
 
 // ── Fixture ──────────────────────────────────────────────────────────
 
-struct RefinementFixture {
+pub(super) struct RefinementFixture {
     #[allow(dead_code)]
     db: djinn_db::Database,
     project_id: String,
-    user_id: String,
-    proposal_id: String,
+    pub(super) user_id: String,
+    pub(super) proposal_id: String,
 }
 
 /// Create a project, user, and proposal (with a project target) ready
 /// for refinement dispatch.
-async fn seed_refinement_fixture(db: &djinn_db::Database) -> RefinementFixture {
+pub(super) async fn seed_refinement_fixture(db: &djinn_db::Database) -> RefinementFixture {
     let event_bus = EventBus::noop();
     let project = crate::test_helpers::create_test_project(db).await;
     let user = UserRepository::new(db.clone())
@@ -81,7 +81,7 @@ async fn seed_refinement_fixture(db: &djinn_db::Database) -> RefinementFixture {
 // ── Actor construction ───────────────────────────────────────────────
 
 /// Build a `CoordinatorActor` wired to the given pool and DB.
-fn build_refinement_actor(
+pub(super) fn build_refinement_actor(
     db: &djinn_db::Database,
     events_tx: &tokio::sync::broadcast::Sender<DjinnEventEnvelope>,
     pool: djinn_slot::SlotPoolHandle,
@@ -152,7 +152,10 @@ fn build_refinement_actor(
 }
 
 /// Create a slot pool with the test model configured.
-fn spawn_test_pool(db: &djinn_db::Database, max_slots: u32) -> djinn_slot::SlotPoolHandle {
+pub(super) fn spawn_test_pool(
+    db: &djinn_db::Database,
+    max_slots: u32,
+) -> djinn_slot::SlotPoolHandle {
     let cancel = CancellationToken::new();
     djinn_slot::SlotPoolHandle::spawn(
         crate::test_helpers::agent_context_from_db(db.clone(), cancel.clone()),
@@ -1323,111 +1326,5 @@ async fn evidence_lifecycle_terminal_skips_dispatch() {
     assert!(
         refinement_tasks.is_empty(),
         "no refinement task should be created when Terminal"
-    );
-}
-
-/// Regression (proposal 019f0c32): structured acceptance criteria added
-/// mid-refinement must be reflected in the DoR readiness evaluation, and
-/// therefore in the "Current DoR status" string injected into the next
-/// tribunal task.
-///
-/// The advocate added nine structured `{ "criterion", "met" }` ACs in a
-/// revision, but the DoR path parsed the stored JSON with
-/// `parse_json_array` (which deserializes to `Vec<String>` and fails
-/// wholesale on structured objects), so the injected status kept reporting
-/// "At least one acceptance criterion is required". The Judge treats any
-/// non-clean injected DoR status as a blocking readiness failure, so it
-/// filed reject verdicts for rounds 1–3 against a proposal that already had
-/// nine visible ACs. This test drives the real injection path
-/// (`evaluate_proposal_readiness` → `create_refinement_task_with_context`)
-/// and asserts the missing-AC failure does not survive structured ACs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn structured_acs_added_mid_refinement_clear_missing_ac_dor_status() {
-    use djinn_control_plane::tools::proposal_readiness::ReadinessCheck;
-
-    let db = crate::test_helpers::create_test_db();
-    let fixture = seed_refinement_fixture(&db).await;
-    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
-    let pool = spawn_test_pool(&db, 4);
-    let actor = build_refinement_actor(&db, &events_tx, pool.clone());
-
-    // Baseline: the fixture proposal is created with empty ACs (`"[]"`), so
-    // the DoR evaluator must report the missing-AC failure.
-    let baseline = actor
-        .evaluate_proposal_readiness(&fixture.proposal_id)
-        .await
-        .expect("baseline readiness");
-    assert!(
-        baseline
-            .failures
-            .iter()
-            .any(|f| f.check == ReadinessCheck::AcceptanceCriteriaCount),
-        "empty ACs must trip the missing-AC DoR check (baseline sanity)"
-    );
-
-    // The advocate adds nine *structured* acceptance criteria mid-refinement,
-    // exactly as recorded on the real proposal.
-    let structured_acs = serde_json::json!([
-        {"criterion": "Injected DoR status is recomputed against the live head", "met": false},
-        {"criterion": "Structured ACs are counted by the readiness evaluator", "met": false},
-        {"criterion": "Judge no longer rejects on a stale missing-AC status", "met": false},
-        {"criterion": "proposal_show and DoR readiness agree on AC count", "met": false},
-        {"criterion": "Regression test reproduces the round 1-3 failure", "met": false},
-        {"criterion": "parse_json_array is not used on structured ACs", "met": false},
-        {"criterion": "Shared tolerant parser is reused across read paths", "met": false},
-        {"criterion": "sqlx offline data regenerated if SQL changed", "met": false},
-        {"criterion": "clippy and nextest pass on touched crates", "met": false},
-    ])
-    .to_string();
-    ProposalRepository::new(db.clone(), EventBus::noop())
-        .set_acceptance_criteria(&fixture.proposal_id, &structured_acs)
-        .await
-        .expect("attach structured ACs mid-refinement");
-
-    // The readiness evaluator must now see the nine ACs and NOT report the
-    // missing-AC failure.
-    let refreshed = actor
-        .evaluate_proposal_readiness(&fixture.proposal_id)
-        .await
-        .expect("refreshed readiness");
-    assert!(
-        !refreshed
-            .failures
-            .iter()
-            .any(|f| f.check == ReadinessCheck::AcceptanceCriteriaCount),
-        "structured ACs added mid-refinement must clear the missing-AC DoR check; \
-         failures were: {:?}",
-        refreshed.failures
-    );
-
-    // Drive the real injection path used at dispatch: fold the readiness into
-    // the "Current DoR status" string and create the tribunal task.
-    let readiness_context = refreshed
-        .to_error_string()
-        .unwrap_or_else(|| "Proposal currently meets all DoR checks.".to_string());
-    let task_id = actor
-        .create_refinement_task_with_context(
-            &fixture.proposal_id,
-            "judge",
-            2,
-            2,
-            &readiness_context,
-            None,
-            Some(&fixture.user_id),
-        )
-        .await
-        .expect("create judge refinement task");
-
-    let task = TaskRepository::new(db.clone(), EventBus::noop())
-        .get(&task_id)
-        .await
-        .expect("read task")
-        .expect("task exists");
-    assert!(
-        !task
-            .description
-            .contains("At least one acceptance criterion is required"),
-        "injected DoR status must not claim ACs are missing once structured ACs exist:\n{}",
-        task.description
     );
 }

--- a/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
@@ -1325,3 +1325,109 @@ async fn evidence_lifecycle_terminal_skips_dispatch() {
         "no refinement task should be created when Terminal"
     );
 }
+
+/// Regression (proposal 019f0c32): structured acceptance criteria added
+/// mid-refinement must be reflected in the DoR readiness evaluation, and
+/// therefore in the "Current DoR status" string injected into the next
+/// tribunal task.
+///
+/// The advocate added nine structured `{ "criterion", "met" }` ACs in a
+/// revision, but the DoR path parsed the stored JSON with
+/// `parse_json_array` (which deserializes to `Vec<String>` and fails
+/// wholesale on structured objects), so the injected status kept reporting
+/// "At least one acceptance criterion is required". The Judge treats any
+/// non-clean injected DoR status as a blocking readiness failure, so it
+/// filed reject verdicts for rounds 1–3 against a proposal that already had
+/// nine visible ACs. This test drives the real injection path
+/// (`evaluate_proposal_readiness` → `create_refinement_task_with_context`)
+/// and asserts the missing-AC failure does not survive structured ACs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn structured_acs_added_mid_refinement_clear_missing_ac_dor_status() {
+    use djinn_control_plane::tools::proposal_readiness::ReadinessCheck;
+
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    // Baseline: the fixture proposal is created with empty ACs (`"[]"`), so
+    // the DoR evaluator must report the missing-AC failure.
+    let baseline = actor
+        .evaluate_proposal_readiness(&fixture.proposal_id)
+        .await
+        .expect("baseline readiness");
+    assert!(
+        baseline
+            .failures
+            .iter()
+            .any(|f| f.check == ReadinessCheck::AcceptanceCriteriaCount),
+        "empty ACs must trip the missing-AC DoR check (baseline sanity)"
+    );
+
+    // The advocate adds nine *structured* acceptance criteria mid-refinement,
+    // exactly as recorded on the real proposal.
+    let structured_acs = serde_json::json!([
+        {"criterion": "Injected DoR status is recomputed against the live head", "met": false},
+        {"criterion": "Structured ACs are counted by the readiness evaluator", "met": false},
+        {"criterion": "Judge no longer rejects on a stale missing-AC status", "met": false},
+        {"criterion": "proposal_show and DoR readiness agree on AC count", "met": false},
+        {"criterion": "Regression test reproduces the round 1-3 failure", "met": false},
+        {"criterion": "parse_json_array is not used on structured ACs", "met": false},
+        {"criterion": "Shared tolerant parser is reused across read paths", "met": false},
+        {"criterion": "sqlx offline data regenerated if SQL changed", "met": false},
+        {"criterion": "clippy and nextest pass on touched crates", "met": false},
+    ])
+    .to_string();
+    ProposalRepository::new(db.clone(), EventBus::noop())
+        .set_acceptance_criteria(&fixture.proposal_id, &structured_acs)
+        .await
+        .expect("attach structured ACs mid-refinement");
+
+    // The readiness evaluator must now see the nine ACs and NOT report the
+    // missing-AC failure.
+    let refreshed = actor
+        .evaluate_proposal_readiness(&fixture.proposal_id)
+        .await
+        .expect("refreshed readiness");
+    assert!(
+        !refreshed
+            .failures
+            .iter()
+            .any(|f| f.check == ReadinessCheck::AcceptanceCriteriaCount),
+        "structured ACs added mid-refinement must clear the missing-AC DoR check; \
+         failures were: {:?}",
+        refreshed.failures
+    );
+
+    // Drive the real injection path used at dispatch: fold the readiness into
+    // the "Current DoR status" string and create the tribunal task.
+    let readiness_context = refreshed
+        .to_error_string()
+        .unwrap_or_else(|| "Proposal currently meets all DoR checks.".to_string());
+    let task_id = actor
+        .create_refinement_task_with_context(
+            &fixture.proposal_id,
+            "judge",
+            2,
+            2,
+            &readiness_context,
+            None,
+            Some(&fixture.user_id),
+        )
+        .await
+        .expect("create judge refinement task");
+
+    let task = TaskRepository::new(db.clone(), EventBus::noop())
+        .get(&task_id)
+        .await
+        .expect("read task")
+        .expect("task exists");
+    assert!(
+        !task
+            .description
+            .contains("At least one acceptance criterion is required"),
+        "injected DoR status must not claim ACs are missing once structured ACs exist:\n{}",
+        task.description
+    );
+}

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -614,3 +614,7 @@ impl CoordinatorActor {
 #[cfg(test)]
 #[path = "refinement_cap_tests.rs"]
 mod refinement_cap_tests;
+
+#[cfg(test)]
+#[path = "refinement_dor_status_tests.rs"]
+mod refinement_dor_status_tests;

--- a/server/crates/djinn-coordinator/src/refinement_dor_status_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dor_status_tests.rs
@@ -1,0 +1,117 @@
+// Regression tests for the "Current DoR status" string injected into
+// tribunal refinement task descriptions.
+//
+// Split out of `refinement_cap_tests.rs` to keep that file under the
+// size-guard byte threshold; shares its fixture helpers.
+
+use super::refinement_cap_tests::{
+    build_refinement_actor, seed_refinement_fixture, spawn_test_pool,
+};
+use djinn_core::events::{DjinnEventEnvelope, EventBus};
+use djinn_db::{ProposalRepository, TaskRepository};
+
+/// Regression (proposal 019f0c32): structured acceptance criteria added
+/// mid-refinement must be reflected in the DoR readiness evaluation, and
+/// therefore in the "Current DoR status" string injected into the next
+/// tribunal task.
+///
+/// The advocate added nine structured `{ "criterion", "met" }` ACs in a
+/// revision, but the DoR path parsed the stored JSON with
+/// `parse_json_array` (which deserializes to `Vec<String>` and fails
+/// wholesale on structured objects), so the injected status kept reporting
+/// "At least one acceptance criterion is required". The Judge treats any
+/// non-clean injected DoR status as a blocking readiness failure, so it
+/// filed reject verdicts for rounds 1–3 against a proposal that already had
+/// nine visible ACs. This test drives the real injection path
+/// (`evaluate_proposal_readiness` → `create_refinement_task_with_context`)
+/// and asserts the missing-AC failure does not survive structured ACs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn structured_acs_added_mid_refinement_clear_missing_ac_dor_status() {
+    use djinn_control_plane::tools::proposal_readiness::ReadinessCheck;
+
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    // Baseline: the fixture proposal is created with empty ACs (`"[]"`), so
+    // the DoR evaluator must report the missing-AC failure.
+    let baseline = actor
+        .evaluate_proposal_readiness(&fixture.proposal_id)
+        .await
+        .expect("baseline readiness");
+    assert!(
+        baseline
+            .failures
+            .iter()
+            .any(|f| f.check == ReadinessCheck::AcceptanceCriteriaCount),
+        "empty ACs must trip the missing-AC DoR check (baseline sanity)"
+    );
+
+    // The advocate adds nine *structured* acceptance criteria mid-refinement,
+    // exactly as recorded on the real proposal.
+    let structured_acs = serde_json::json!([
+        {"criterion": "Injected DoR status is recomputed against the live head", "met": false},
+        {"criterion": "Structured ACs are counted by the readiness evaluator", "met": false},
+        {"criterion": "Judge no longer rejects on a stale missing-AC status", "met": false},
+        {"criterion": "proposal_show and DoR readiness agree on AC count", "met": false},
+        {"criterion": "Regression test reproduces the round 1-3 failure", "met": false},
+        {"criterion": "parse_json_array is not used on structured ACs", "met": false},
+        {"criterion": "Shared tolerant parser is reused across read paths", "met": false},
+        {"criterion": "sqlx offline data regenerated if SQL changed", "met": false},
+        {"criterion": "clippy and nextest pass on touched crates", "met": false},
+    ])
+    .to_string();
+    ProposalRepository::new(db.clone(), EventBus::noop())
+        .set_acceptance_criteria(&fixture.proposal_id, &structured_acs)
+        .await
+        .expect("attach structured ACs mid-refinement");
+
+    // The readiness evaluator must now see the nine ACs and NOT report the
+    // missing-AC failure.
+    let refreshed = actor
+        .evaluate_proposal_readiness(&fixture.proposal_id)
+        .await
+        .expect("refreshed readiness");
+    assert!(
+        !refreshed
+            .failures
+            .iter()
+            .any(|f| f.check == ReadinessCheck::AcceptanceCriteriaCount),
+        "structured ACs added mid-refinement must clear the missing-AC DoR check; \
+         failures were: {:?}",
+        refreshed.failures
+    );
+
+    // Drive the real injection path used at dispatch: fold the readiness into
+    // the "Current DoR status" string and create the tribunal task.
+    let readiness_context = refreshed
+        .to_error_string()
+        .unwrap_or_else(|| "Proposal currently meets all DoR checks.".to_string());
+    let task_id = actor
+        .create_refinement_task_with_context(
+            &fixture.proposal_id,
+            "judge",
+            2,
+            2,
+            &readiness_context,
+            None,
+            Some(&fixture.user_id),
+        )
+        .await
+        .expect("create judge refinement task");
+
+    let task = TaskRepository::new(db.clone(), EventBus::noop())
+        .get(&task_id)
+        .await
+        .expect("read task")
+        .expect("task exists");
+    assert!(
+        !task
+            .description
+            .contains("At least one acceptance criterion is required"),
+        "injected DoR status must not claim ACs are missing once structured ACs exist:\n{}",
+        task.description
+    );
+}

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -5,7 +5,9 @@
 // per-user/model cap admission. Split to keep both files under the
 // size-guard threshold.
 
-use djinn_control_plane::tools::epic_ops::AcceptanceCriterionItem;
+use djinn_control_plane::tools::epic_ops::{
+    AcceptanceCriterionItem, parse_acceptance_criteria_array,
+};
 use djinn_control_plane::tools::proposal_readiness::evaluate_proposal_readiness;
 use djinn_core::models::TransitionAction;
 use djinn_db::{ProposalRepository, TaskRepository, UserSettingsRepository};
@@ -831,11 +833,15 @@ impl CoordinatorActor {
             _ => 0,
         };
 
+        // Parse ACs with the tolerant, structure-aware parser that every read
+        // path uses (proposal_show et al.). `djinn_core::models::parse_json_array`
+        // deserializes to `Vec<String>` and therefore fails wholesale on
+        // structured `{ "criterion", "met" }` ACs, silently yielding an empty
+        // vec — which made the injected "Current DoR status" report "At least
+        // one acceptance criterion is required" even when the live proposal head
+        // already had structured ACs attached (proposal 019f0c32 rounds 1–3).
         let ac_items: Vec<AcceptanceCriterionItem> =
-            djinn_core::models::parse_json_array(&proposal.acceptance_criteria)
-                .into_iter()
-                .map(AcceptanceCriterionItem::Text)
-                .collect();
+            parse_acceptance_criteria_array(&proposal.acceptance_criteria);
 
         Some(evaluate_proposal_readiness(
             &proposal.body,


### PR DESCRIPTION
## Root cause

The **Current DoR status** injected into adversary/judge refinement task prompts is composed in `refinement_dispatch.rs` from `CoordinatorActor::evaluate_proposal_readiness` (`refinement_outcome.rs`). That method read the *live* proposal head via `proposal_repo.get()`, so staleness was **not** a snapshot/caching problem — the bug was in **how the ACs were parsed**.

`evaluate_proposal_readiness` parsed `proposal.acceptance_criteria` with `djinn_core::models::parse_json_array`, which does `serde_json::from_str::<Vec<String>>`. ACs are commonly stored as **structured** `{ "criterion": "...", "met": bool }` objects (`AcceptanceCriterionItem::Structured`), and deserializing an array containing objects into `Vec<String>` **fails wholesale**, returning an empty vec. The deterministic DoR evaluator (`proposal_readiness.rs`) then emitted `AcceptanceCriteriaCount` → "At least one acceptance criterion is required".

Meanwhile `proposal_show` uses the tolerant `parse_acceptance_criteria` (untagged `AcceptanceCriterionItem`), so it rendered all nine ACs. That divergence is why proposal `019f0c32` showed 9 ACs while rounds 1–3 kept getting an injected status claiming ACs were missing; the Judge treats any non-clean injected DoR status as a blocking readiness failure and correctly filed rejects until the status finally read clean at round 4.

- Broken parse: `server/crates/djinn-coordinator/src/refinement_outcome.rs:834` (old `parse_json_array(...).map(Text)`)
- Tolerant parse used by reads: `server/crates/djinn-control-plane/src/tools/proposal_ops.rs:747`
- Injection site: `server/crates/djinn-coordinator/src/refinement_dispatch.rs:467` / `refinement_outcome.rs:746`

## Fix

Promote the tolerant, structure-aware parser to `parse_acceptance_criteria_array` in `epic_ops.rs` and reuse it from both `proposal_ops::parse_acceptance_criteria` and the coordinator's `evaluate_proposal_readiness`. Structured ACs are now counted when readiness is recomputed against the live head at each refinement dispatch, so the injected DoR status is accurate.

## Regression test

`structured_acs_added_mid_refinement_clear_missing_ac_dor_status` (in `refinement_cap_tests.rs`) seeds a proposal with empty ACs (baseline asserts the missing-AC failure fires), adds nine **structured** ACs mid-refinement via `set_acceptance_criteria`, then drives the real injection path (`evaluate_proposal_readiness` → `create_refinement_task_with_context`) and asserts the injected description no longer claims ACs are missing. Fails without the fix, passes with it.

## Verification

- `cargo fmt`, `cargo clippy --all-features` clean on `djinn-control-plane` + `djinn-coordinator`
- `cargo nextest run` — new test + full `refinement_cap_tests` (15) + proposal_show/AC parse tests all green
- No SQL query strings changed (reused existing `set_acceptance_criteria`), so no sqlx-prepare needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)