### PR TITLE
feat(ui): Redesign proposal tribunal + readiness sections

### DIFF
--- a/ui/src/components/proposals/ProposalDebateTrail.test.tsx
+++ b/ui/src/components/proposals/ProposalDebateTrail.test.tsx
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, userEvent } from "@/test/test-utils";
+import type { ProposalDebateTrailRow } from "@/api/types";
+import { ProposalDebateTrail } from "./ProposalDebateTrail";
+import { verdictOutcome } from "./debateTrailUtils";
+
+function row(overrides: Partial<ProposalDebateTrailRow> = {}): ProposalDebateTrailRow {
+  return {
+    id: `e-${Math.random().toString(36).slice(2)}`,
+    proposal_id: "p-1",
+    kind: "objection",
+    body: "An objection body.",
+    blocking: false,
+    agent_role: "adversary",
+    author_kind: "agent",
+    author_user_id: null,
+    author_model: "gpt",
+    source_task_id: null,
+    against_revision_seq: 1,
+    round: 1,
+    resolved_at: null,
+    resolved_by_user_id: null,
+    reopened_at: null,
+    reopened_by_user_id: null,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("verdictOutcome", () => {
+  it("parses an approve verdict from the body", () => {
+    expect(
+      verdictOutcome(row({ kind: "verdict", body: "Verdict: approve — ready" })),
+    ).toEqual({ label: "approve", positive: true });
+  });
+
+  it("parses a reject/needs-work verdict from the body", () => {
+    expect(
+      verdictOutcome(
+        row({ kind: "verdict", body: "Verdict: needs-work on scope" }),
+      ).positive,
+    ).toBe(false);
+  });
+
+  it("falls back to the blocking flag when no marker is present", () => {
+    expect(
+      verdictOutcome(row({ kind: "verdict", body: "no marker", blocking: true }))
+        .positive,
+    ).toBe(false);
+    expect(
+      verdictOutcome(row({ kind: "verdict", body: "no marker", blocking: false }))
+        .positive,
+    ).toBe(true);
+  });
+});
+
+describe("ProposalDebateTrail", () => {
+  it("renders an empty message when there are no entries", () => {
+    render(<ProposalDebateTrail trail={[]} />);
+    expect(screen.getByText("No debate entries yet.")).toBeInTheDocument();
+  });
+
+  it("groups by round with the latest round expanded and earlier ones collapsed", () => {
+    render(
+      <ProposalDebateTrail
+        trail={[
+          row({
+            id: "r1-o1",
+            round: 1,
+            against_revision_seq: 1,
+            blocking: true,
+            resolved_at: "2026-06-01T01:00:00Z",
+            body: "Round 1 objection.",
+          }),
+          row({
+            id: "r1-v",
+            round: 1,
+            kind: "verdict",
+            agent_role: "judge",
+            against_revision_seq: 1,
+            body: "Verdict: reject",
+          }),
+          row({
+            id: "r2-o1",
+            round: 2,
+            against_revision_seq: 2,
+            body: "Round 2 objection.",
+          }),
+          row({
+            id: "r2-v",
+            round: 2,
+            kind: "verdict",
+            agent_role: "judge",
+            against_revision_seq: 2,
+            body: "Verdict: approve",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Round 1")).toBeInTheDocument();
+    expect(screen.getByText("Round 2")).toBeInTheDocument();
+
+    // Round summaries carry the objection + verdict outcome.
+    expect(screen.getByText(/1 objection \(1 ✓ resolved\)/)).toBeInTheDocument();
+
+    // Latest round (2) is expanded by default → its entry body is visible.
+    expect(screen.getByText("Round 2 objection.")).toBeInTheDocument();
+    // Round 1 is collapsed → its entry body is not visible yet.
+    expect(screen.queryByText("Round 1 objection.")).not.toBeInTheDocument();
+  });
+
+  it("expands a collapsed round on click", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProposalDebateTrail
+        trail={[
+          row({ id: "r1", round: 1, body: "Round 1 objection." }),
+          row({ id: "r2", round: 2, body: "Round 2 objection." }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("Round 1 objection.")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Round 1/ }));
+    expect(screen.getByText("Round 1 objection.")).toBeInTheDocument();
+  });
+
+  it("shows a rev range when entries span multiple revisions", () => {
+    render(
+      <ProposalDebateTrail
+        trail={[
+          row({ id: "a", round: 3, against_revision_seq: 3 }),
+          row({ id: "b", round: 3, against_revision_seq: 4 }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("vs rev 3→4")).toBeInTheDocument();
+  });
+
+  it("expands a long entry body to full markdown", async () => {
+    const user = userEvent.setup();
+    const longBody =
+      "## Objection\n\n" + "This is a very long objection body. ".repeat(10);
+    render(
+      <ProposalDebateTrail
+        trail={[row({ id: "long", round: 1, body: longBody })]}
+      />,
+    );
+
+    // The round is latest → expanded; the entry offers an Expand control.
+    const expand = screen.getByRole("button", { name: "Expand" });
+    await user.click(expand);
+    expect(
+      screen.getByRole("heading", { name: "Objection" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/proposals/ProposalDebateTrail.tsx
+++ b/ui/src/components/proposals/ProposalDebateTrail.tsx
@@ -1,0 +1,247 @@
+import { useMemo, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Alert02Icon,
+  ArrowDown01Icon,
+  CancelCircleIcon,
+  CheckmarkCircle02Icon,
+  Comment01Icon,
+  JusticeScale01Icon,
+} from "@hugeicons/core-free-icons";
+import { Badge } from "@/components/ui/badge";
+import { relativeTime } from "@/components/memory/memoryUtils";
+import { cn } from "@/lib/utils";
+import type { ProposalDebateTrailRow } from "@/api/types";
+import { BlockMarkdown } from "./blocks/BlockShell";
+import { verdictOutcome } from "./debateTrailUtils";
+
+/** Icon for a debate entry by kind. */
+function entryIcon(row: ProposalDebateTrailRow) {
+  if (row.kind === "verdict") return JusticeScale01Icon;
+  if (row.blocking) return Alert02Icon;
+  return Comment01Icon;
+}
+
+interface RoundGroup {
+  round: number;
+  entries: ProposalDebateTrailRow[];
+  objections: number;
+  resolvedObjections: number;
+  verdict: ProposalDebateTrailRow | null;
+  fromRev: number;
+  toRev: number;
+}
+
+function groupByRound(trail: ProposalDebateTrailRow[]): RoundGroup[] {
+  const byRound = new Map<number, ProposalDebateTrailRow[]>();
+  for (const row of trail) {
+    const list = byRound.get(row.round) ?? [];
+    list.push(row);
+    byRound.set(row.round, list);
+  }
+
+  return [...byRound.entries()]
+    .map(([round, rows]) => {
+      const entries = [...rows].sort(
+        (a, b) =>
+          a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id),
+      );
+      const objections = entries.filter((e) => e.kind === "objection");
+      const verdicts = entries.filter((e) => e.kind === "verdict");
+      const revs = entries.map((e) => e.against_revision_seq);
+      return {
+        round,
+        entries,
+        objections: objections.length,
+        resolvedObjections: objections.filter((e) => e.resolved_at != null)
+          .length,
+        verdict: verdicts.length ? verdicts[verdicts.length - 1] : null,
+        fromRev: Math.min(...revs),
+        toRev: Math.max(...revs),
+      };
+    })
+    .sort((a, b) => a.round - b.round);
+}
+
+function EntryRow({ row }: { row: ProposalDebateTrailRow }) {
+  const [open, setOpen] = useState(false);
+  const outcome = row.kind === "verdict" ? verdictOutcome(row) : null;
+  const excerpt = row.body.replace(/\s+/g, " ").trim();
+  const isLong = excerpt.length > 160 || row.body.trim().includes("\n");
+
+  return (
+    <li className="rounded-md border bg-background/60 px-2.5 py-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <HugeiconsIcon
+          icon={entryIcon(row)}
+          size={13}
+          className={cn(
+            "shrink-0",
+            row.blocking ? "text-destructive" : "text-muted-foreground",
+          )}
+        />
+        <span className="font-medium uppercase tracking-wide text-foreground">
+          {row.agent_role || row.kind}
+        </span>
+        {outcome && (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1",
+              outcome.positive
+                ? "text-green-600 dark:text-green-400"
+                : "text-destructive",
+            )}
+          >
+            <HugeiconsIcon
+              icon={outcome.positive ? CheckmarkCircle02Icon : CancelCircleIcon}
+              size={12}
+            />
+            verdict: {outcome.label}
+          </span>
+        )}
+        {row.blocking && (
+          <Badge variant="destructive" className="text-[10px]">
+            blocking
+          </Badge>
+        )}
+        {row.resolved_at && (
+          <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
+            <HugeiconsIcon icon={CheckmarkCircle02Icon} size={12} />
+            resolved {relativeTime(row.resolved_at)}
+          </span>
+        )}
+        {row.reopened_at && (
+          <Badge variant="outline" className="text-[10px]">
+            reopened {relativeTime(row.reopened_at)}
+          </Badge>
+        )}
+        <span className="ml-auto shrink-0 text-muted-foreground">
+          {relativeTime(row.created_at)}
+        </span>
+      </div>
+
+      {open ? (
+        <div className="mt-1.5">
+          <BlockMarkdown>{row.body}</BlockMarkdown>
+        </div>
+      ) : (
+        <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+          {excerpt || "(no content)"}
+        </p>
+      )}
+      {isLong && (
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className="mt-1 text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        >
+          {open ? "Collapse" : "Expand"}
+        </button>
+      )}
+    </li>
+  );
+}
+
+function RoundBlock({
+  group,
+  defaultOpen,
+}: {
+  group: RoundGroup;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const revLabel =
+    group.fromRev === group.toRev
+      ? `rev ${group.fromRev}`
+      : `rev ${group.fromRev}→${group.toRev}`;
+  const outcome = group.verdict ? verdictOutcome(group.verdict) : null;
+
+  return (
+    <li>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full flex-wrap items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        <HugeiconsIcon
+          icon={ArrowDown01Icon}
+          size={14}
+          className={cn(
+            "shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+        <span className="font-medium">Round {group.round}</span>
+        <span className="font-mono text-xs text-muted-foreground">
+          vs {revLabel}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {group.objections} {group.objections === 1 ? "objection" : "objections"}
+          {group.objections > 0 &&
+            ` (${group.resolvedObjections} ✓ resolved)`}
+        </span>
+        {outcome && (
+          <span
+            className={cn(
+              "ml-auto inline-flex items-center gap-1 text-xs",
+              outcome.positive
+                ? "text-green-600 dark:text-green-400"
+                : "text-destructive",
+            )}
+          >
+            <HugeiconsIcon
+              icon={outcome.positive ? CheckmarkCircle02Icon : CancelCircleIcon}
+              size={13}
+            />
+            verdict: {outcome.label}
+          </span>
+        )}
+      </button>
+      {open && (
+        <ul className="space-y-1.5 px-3 pb-3">
+          {group.entries.map((e) => (
+            <EntryRow key={e.id} row={e} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Round-by-round debate timeline for a proposal's tribunal. Groups the raw
+ * `debate_trail` by round (objections, rebuttals, verdicts), summarising each
+ * round on one line and expanding to the individual entries. Rounds are
+ * collapsed by default except the latest, which starts open.
+ */
+export function ProposalDebateTrail({
+  trail,
+}: {
+  trail: ProposalDebateTrailRow[];
+}) {
+  const groups = useMemo(() => groupByRound(trail), [trail]);
+
+  if (groups.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No debate entries yet.
+      </p>
+    );
+  }
+
+  const latestRound = groups[groups.length - 1].round;
+
+  return (
+    <ul className="divide-y rounded-md border">
+      {groups.map((group) => (
+        <RoundBlock
+          key={group.round}
+          group={group}
+          defaultOpen={group.round === latestRound}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/ui/src/components/proposals/ProposalRefinement.test.tsx
+++ b/ui/src/components/proposals/ProposalRefinement.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "@/test/test-utils";
-import type { ProposalRefinementStatus } from "@/api/types";
+import type {
+  ProposalDebateTrailRow,
+  ProposalRefinementStatus,
+} from "@/api/types";
+import type { ProposalHistoryEntry } from "@/lib/proposalQueries";
 import { ProposalRefinement } from "./ProposalRefinement";
 import { callMcpTool } from "@/api/mcpClient";
 import { showToast } from "@/lib/toast";
@@ -44,7 +48,7 @@ describe("ProposalRefinement", () => {
     expect(screen.getByText("Start refinement")).toBeInTheDocument();
   });
 
-  it("renders active in-progress status panel", () => {
+  it("renders active in-progress status panel with ribbon and metrics", () => {
     const status: ProposalRefinementStatus = {
       active: true,
       current_round: 3,
@@ -61,7 +65,9 @@ describe("ProposalRefinement", () => {
         onChanged={vi.fn()}
       />,
     );
+    expect(screen.getByText("Tribunal")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Tribunal running — round 3")).toBeInTheDocument();
     expect(screen.getByText("Refinement in progress")).toBeInTheDocument();
     expect(screen.getAllByText("Entries").length).toBeGreaterThan(0);
     expect(screen.getByText("7")).toBeInTheDocument();
@@ -71,7 +77,41 @@ describe("ProposalRefinement", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders stopped status panel with stop reason", () => {
+  it("renders a Blocked gate chip alongside the ribbon", () => {
+    const status: ProposalRefinementStatus = {
+      active: true,
+      current_round: 2,
+      dry_rounds: 0,
+      total_entries: 4,
+      stop_reason: null,
+      awaiting_review: false,
+    };
+    render(
+      <ProposalRefinement
+        proposalId={proposalId}
+        status={status}
+        gateStatus={{
+          ready: false,
+          dor_ready: true,
+          dor_failures: [],
+          judge_verdict_body: null,
+          judge_verdict_id: null,
+          judge_needs_work: false,
+          adversary_dry_count: 0,
+          unresolved_blocking_count: 1,
+          unresolved_blocking_ids: ["e-1"],
+          needs_evidence: null,
+          human_override_active: false,
+          blocked_explanations: [],
+        }}
+        canStart={false}
+        onChanged={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+  });
+
+  it("renders stopped status panel with stop reason ribbon", () => {
     const status: ProposalRefinementStatus = {
       active: false,
       current_round: 5,
@@ -92,8 +132,6 @@ describe("ProposalRefinement", () => {
   });
 
   it("offers a restart button for an interrupted refinement", () => {
-    // A stopped refinement must offer a way forward — otherwise an
-    // interrupted run (e.g. one lost across a deploy) is a dead end in the UI.
     const status: ProposalRefinementStatus = {
       active: false,
       current_round: 1,
@@ -133,9 +171,7 @@ describe("ProposalRefinement", () => {
     expect(
       screen.getByText(/best-effort cross-model diversity/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/falls back to the same model/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/falls back to the same model/)).toBeInTheDocument();
   });
 
   it("explains the autonomous review flow in the kickoff affordance", () => {
@@ -155,17 +191,16 @@ describe("ProposalRefinement", () => {
   // ── All stop reasons ─────────────────────────────────────────────────────
 
   it("renders round_cap stop reason label", () => {
-    const status: ProposalRefinementStatus = {
-      active: false,
-      current_round: 5,
-      dry_rounds: 0,
-      total_entries: 15,
-      stop_reason: "round_cap",
-    };
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: false,
+          current_round: 5,
+          dry_rounds: 0,
+          total_entries: 15,
+          stop_reason: "round_cap",
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
@@ -175,17 +210,16 @@ describe("ProposalRefinement", () => {
   });
 
   it("renders spawn_cap stop reason label", () => {
-    const status: ProposalRefinementStatus = {
-      active: false,
-      current_round: 3,
-      dry_rounds: 0,
-      total_entries: 8,
-      stop_reason: "spawn_cap",
-    };
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: false,
+          current_round: 3,
+          dry_rounds: 0,
+          total_entries: 8,
+          stop_reason: "spawn_cap",
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
@@ -195,17 +229,16 @@ describe("ProposalRefinement", () => {
   });
 
   it("renders repeated_objection stop reason label", () => {
-    const status: ProposalRefinementStatus = {
-      active: false,
-      current_round: 4,
-      dry_rounds: 0,
-      total_entries: 10,
-      stop_reason: "repeated_objection",
-    };
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: false,
+          current_round: 4,
+          dry_rounds: 0,
+          total_entries: 10,
+          stop_reason: "repeated_objection",
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
@@ -215,17 +248,16 @@ describe("ProposalRefinement", () => {
   });
 
   it("renders agent_failure stop reason label", () => {
-    const status: ProposalRefinementStatus = {
-      active: false,
-      current_round: 2,
-      dry_rounds: 0,
-      total_entries: 3,
-      stop_reason: "agent_failure",
-    };
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: false,
+          current_round: 2,
+          dry_rounds: 0,
+          total_entries: 3,
+          stop_reason: "agent_failure",
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
@@ -235,17 +267,16 @@ describe("ProposalRefinement", () => {
   });
 
   it("renders unknown stop reason as-is", () => {
-    const status: ProposalRefinementStatus = {
-      active: false,
-      current_round: 1,
-      dry_rounds: 0,
-      total_entries: 1,
-      stop_reason: "some_future_reason",
-    };
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: false,
+          current_round: 1,
+          dry_rounds: 0,
+          total_entries: 1,
+          stop_reason: "some_future_reason",
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
@@ -300,18 +331,14 @@ describe("ProposalRefinement", () => {
 
     await user.click(screen.getByText("Start refinement"));
 
-    expect(showToast.error).toHaveBeenCalledWith(
-      "Failed to start refinement",
-      { description: "proposal not found" },
-    );
+    expect(showToast.error).toHaveBeenCalledWith("Failed to start refinement", {
+      description: "proposal not found",
+    });
     expect(onChanged).not.toHaveBeenCalled();
   });
 
   // ── Autonomous review flow (awaiting_review) ─────────────────────────────
 
-  // Shared factory for the converged/awaiting-review state so the three-choice
-  // panel tests don't repeat the same status object on every test. Override
-  // individual fields per test when needed.
   function reviewStatus(
     overrides: Partial<ProposalRefinementStatus> = {},
   ): ProposalRefinementStatus {
@@ -327,7 +354,44 @@ describe("ProposalRefinement", () => {
     };
   }
 
-  it("renders the three-choice review panel with distinct accessible action labels", () => {
+  function specRevision(seq: number, body: string): ProposalHistoryEntry {
+    return {
+      id: `rev-${seq}`,
+      seq,
+      title: "Spec",
+      body,
+      body_format: "markdown",
+      acceptance_criteria: [],
+      event_kind: "spec_revision",
+      created_at: "2026-06-01T00:00:00Z",
+      edited_by_user_id: "user-1",
+    } as ProposalHistoryEntry;
+  }
+
+  function verdictRow(): ProposalDebateTrailRow {
+    return {
+      id: "v-1",
+      proposal_id: proposalId,
+      kind: "verdict",
+      body: "Verdict: approve — the spec is ready.",
+      blocking: false,
+      agent_role: "judge",
+      author_kind: "agent",
+      author_user_id: null,
+      author_model: "gpt",
+      source_task_id: null,
+      against_revision_seq: 4,
+      round: 4,
+      resolved_at: null,
+      resolved_by_user_id: null,
+      reopened_at: null,
+      reopened_by_user_id: null,
+      created_at: "2026-06-01T00:00:00Z",
+      updated_at: "2026-06-01T00:00:00Z",
+    };
+  }
+
+  it("renders the converged review card with a ribbon, tabs and three actions", () => {
     render(
       <ProposalRefinement
         proposalId={proposalId}
@@ -336,15 +400,24 @@ describe("ProposalRefinement", () => {
         onChanged={vi.fn()}
       />,
     );
+    expect(screen.getByText("Awaiting review")).toBeInTheDocument();
     expect(
-      screen.getByText("Tribunal converged — review the result"),
+      screen.getByText("Converged after 4 rounds — awaiting your review"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Review the result")).toBeInTheDocument();
+
+    // Tabs.
+    expect(screen.getByRole("tab", { name: "Verdict" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Spec diff/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Debate trail" }),
+    ).toBeInTheDocument();
+
+    // Verdict tab (default) shows the judge summary.
     expect(
       screen.getByText("The spec was tightened and ambiguities resolved."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/the diff from your original is in the revision history/),
-    ).toBeInTheDocument();
+
     // Three unambiguous human choices with distinct accessible names.
     expect(
       screen.getByRole("button", { name: "Accept refined spec" }),
@@ -355,22 +428,17 @@ describe("ProposalRefinement", () => {
     expect(
       screen.getByRole("button", { name: "Reject and revert" }),
     ).toBeInTheDocument();
-    // The consequences of each choice are surfaced to the reviewer.
-    expect(
-      screen.getByText(/Accept keeps the refined spec/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Accept keeps the refined spec/)).toBeInTheDocument();
     expect(
       screen.getByText(/Reject reverts to your original spec/),
     ).toBeInTheDocument();
-    // The feedback-to-another-round action is disabled until feedback is
-    // entered — verified together with the panel layout to avoid a separate
-    // render with duplicate setup.
+    // The feedback-to-another-round action is disabled until feedback exists.
     expect(
       screen.getByRole("button", { name: /Send feedback for another round/ }),
     ).toBeDisabled();
   });
 
-  it("renders judge_summary markdown semantically", () => {
+  it("renders judge_summary markdown semantically in the verdict tab", () => {
     const { container } = render(
       <ProposalRefinement
         proposalId={proposalId}
@@ -384,10 +452,38 @@ describe("ProposalRefinement", () => {
     );
 
     expect(screen.getByText("Approved").tagName).toBe("STRONG");
-    expect(screen.getByRole("list")).toBeInTheDocument();
     expect(screen.getByText("Tightened scope").tagName).toBe("LI");
     expect(screen.getByText("Resolved ambiguity").tagName).toBe("LI");
     expect(container.querySelector(".prose")).toBeInTheDocument();
+  });
+
+  it("prefers the gate judge verdict body over the summary in the verdict tab", () => {
+    render(
+      <ProposalRefinement
+        proposalId={proposalId}
+        status={reviewStatus({ judge_summary: "fallback summary" })}
+        gateStatus={{
+          ready: true,
+          dor_ready: true,
+          dor_failures: [],
+          judge_verdict_body: "Authoritative judge reasoning from the gate.",
+          judge_verdict_id: "v-1",
+          judge_needs_work: false,
+          adversary_dry_count: 0,
+          unresolved_blocking_count: 0,
+          unresolved_blocking_ids: [],
+          needs_evidence: null,
+          human_override_active: false,
+          blocked_explanations: [],
+        }}
+        canStart={false}
+        onChanged={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText("Authoritative judge reasoning from the gate."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("fallback summary")).not.toBeInTheDocument();
   });
 
   it("falls back to a default summary when judge_summary is blank", () => {
@@ -400,6 +496,31 @@ describe("ProposalRefinement", () => {
       />,
     );
     expect(screen.getByText("The tribunal converged.")).toBeInTheDocument();
+  });
+
+  it("shows the spec diff and debate trail on their tabs", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProposalRefinement
+        proposalId={proposalId}
+        status={reviewStatus({ snapshot_revision_seq: 1 })}
+        revisions={[
+          specRevision(1, "Original spec."),
+          specRevision(2, "Original spec.\nAdded a concrete rollout plan."),
+        ]}
+        debateTrail={[verdictRow()]}
+        canStart={false}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: /Spec diff/ }));
+    expect(
+      screen.getByText("Added a concrete rollout plan."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Debate trail" }));
+    expect(screen.getByText("Round 4")).toBeInTheDocument();
   });
 
   it("calls proposal_refinement_resolve with accept on Accept click", async () => {
@@ -416,9 +537,7 @@ describe("ProposalRefinement", () => {
       />,
     );
 
-    await user.click(
-      screen.getByRole("button", { name: "Accept refined spec" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Accept refined spec" }));
 
     expect(callMcpTool).toHaveBeenCalledWith("proposal_refinement_resolve", {
       proposal_id: proposalId,
@@ -443,9 +562,7 @@ describe("ProposalRefinement", () => {
       />,
     );
 
-    await user.click(
-      screen.getByRole("button", { name: "Reject and revert" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Reject and revert" }));
 
     expect(callMcpTool).toHaveBeenCalledWith("proposal_refinement_resolve", {
       proposal_id: proposalId,
@@ -533,10 +650,7 @@ describe("ProposalRefinement", () => {
       />,
     );
 
-    await user.type(
-      screen.getByLabelText(/Feedback/),
-      "Another round please.",
-    );
+    await user.type(screen.getByLabelText(/Feedback/), "Another round please.");
     await user.click(
       screen.getByRole("button", { name: /Send feedback for another round/ }),
     );
@@ -548,7 +662,7 @@ describe("ProposalRefinement", () => {
     expect(onChanged).not.toHaveBeenCalled();
   });
 
-  it("does not render the review panel while in progress", () => {
+  it("does not render the review card while in progress", () => {
     render(
       <ProposalRefinement
         proposalId={proposalId}
@@ -562,26 +676,23 @@ describe("ProposalRefinement", () => {
         onChanged={vi.fn()}
       />,
     );
-    expect(
-      screen.queryByText("Tribunal converged — review the result"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Review the result")).not.toBeInTheDocument();
     expect(screen.getByText("Refinement in progress")).toBeInTheDocument();
   });
 
   // ── Status panel does not show dry rounds when zero ──────────────────────
 
   it("hides dry rounds count when zero", () => {
-    const status: ProposalRefinementStatus = {
-      active: true,
-      current_round: 1,
-      dry_rounds: 0,
-      total_entries: 2,
-      stop_reason: null,
-    };
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: true,
+          current_round: 1,
+          dry_rounds: 0,
+          total_entries: 2,
+          stop_reason: null,
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
@@ -592,74 +703,41 @@ describe("ProposalRefinement", () => {
   // ── canStart gating ──────────────────────────────────────────────────────
 
   it("does not render kickoff when canStart is false and status is active", () => {
-    const status: ProposalRefinementStatus = {
-      active: true,
-      current_round: 1,
-      dry_rounds: null as unknown as number,
-      total_entries: 0,
-      stop_reason: null,
-    };
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: true,
+          current_round: 1,
+          dry_rounds: null as unknown as number,
+          total_entries: 0,
+          stop_reason: null,
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
     );
-    // Should show the status panel, not the kickoff button.
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.queryByText("Start refinement")).not.toBeInTheDocument();
   });
 
-  // ── Tribunal debate-trail visibility (integration with DebateTrail) ──────
-
-  it("status panel and debate trail are independent components", () => {
-    // Verify that the refinement status panel renders independently of
-    // the debate trail — they are separate UI surfaces that share data
-    // from the same proposal_show response.
-    const status: ProposalRefinementStatus = {
-      active: true,
-      current_round: 3,
-      dry_rounds: 1,
-      total_entries: 7,
-      stop_reason: null,
-    };
+  it("does not render debate-trail entries in the in-progress panel", () => {
     render(
       <ProposalRefinement
         proposalId={proposalId}
-        status={status}
+        status={{
+          active: true,
+          current_round: 3,
+          dry_rounds: 1,
+          total_entries: 7,
+          stop_reason: null,
+        }}
         canStart={false}
         onChanged={vi.fn()}
       />,
     );
-    // The refinement panel shows its own data (entries, dry rounds).
     expect(screen.getAllByText("Entries").length).toBeGreaterThan(0);
-    expect(screen.getByText("7")).toBeInTheDocument();
-    // The refinement panel does NOT render debate trail entries itself.
-    // Debate trail is rendered by the separate <DebateTrail> component.
+    // The debate trail is only surfaced in the converged review card's tab.
     expect(screen.queryByText("Debate trail")).not.toBeInTheDocument();
-    expect(screen.queryByText("objection")).not.toBeInTheDocument();
-    expect(screen.queryByText("verdict")).not.toBeInTheDocument();
-  });
-
-  it("renders demand round explanation in stopped status", () => {
-    const status: ProposalRefinementStatus = {
-      active: false,
-      current_round: 3,
-      dry_rounds: 1,
-      total_entries: 8,
-      stop_reason: "adversary_dry",
-    };
-    render(
-      <ProposalRefinement
-        proposalId={proposalId}
-        status={status}
-        canStart={false}
-        onChanged={vi.fn()}
-      />,
-    );
-    expect(screen.getByText("Stopped")).toBeInTheDocument();
-    expect(screen.getByText(/Adversary exhausted/)).toBeInTheDocument();
   });
 });

--- a/ui/src/components/proposals/ProposalRefinement.tsx
+++ b/ui/src/components/proposals/ProposalRefinement.tsx
@@ -1,5 +1,10 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  CancelCircleIcon,
+  CheckmarkCircle02Icon,
+} from "@hugeicons/core-free-icons";
 import { callMcpTool } from "@/api/mcpClient";
 import { usersQueryOptions } from "@/api/queryOptions";
 import { userDisplayName, type OrgUser } from "@/api/users";
@@ -15,9 +20,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { showToast } from "@/lib/toast";
-import type { ProposalRefinementStatus } from "@/api/types";
+import type {
+  ProposalDebateTrailRow,
+  ProposalGateStatus,
+  ProposalRefinementStatus,
+} from "@/api/types";
+import type { ProposalHistoryEntry } from "@/lib/proposalQueries";
 import { BlockMarkdown } from "./blocks/BlockShell";
+import { DiffView } from "./DiffView";
+import { ProposalDebateTrail } from "./ProposalDebateTrail";
+import { refinementDiffBodies } from "./refinementDiff";
 
 /**
  * Human-readable label for the stop reason.
@@ -44,9 +58,11 @@ function judgeSummaryText(summary: string | null | undefined): string {
 }
 
 /**
- * Proposal refinement kickoff and status component.
- *
- * Shows a "Start refinement" button when refinement hasn't been started.
+ * Unified Tribunal section: refinement kickoff, a status ribbon reconciling the
+ * tribunal state with the readiness gate, and — once the autonomous tribunal
+ * converges — a single review card with the verdict, the spec diff, and the
+ * round-by-round debate trail behind tabs, plus the human accept / another-round
+ * / reject actions.
  *
  * Refinement runs as an autonomous tribunal (Adversary → Advocate → Judge,
  * looping). The human is no longer a per-revision approver: when the tribunal
@@ -56,11 +72,17 @@ function judgeSummaryText(summary: string | null | undefined): string {
 export function ProposalRefinement({
   proposalId,
   status,
+  gateStatus,
+  debateTrail = [],
+  revisions = [],
   canStart,
   onChanged,
 }: {
   proposalId: string;
   status: ProposalRefinementStatus | null;
+  gateStatus?: ProposalGateStatus | null;
+  debateTrail?: ProposalDebateTrailRow[];
+  revisions?: ProposalHistoryEntry[];
   canStart: boolean;
   onChanged: () => void;
 }) {
@@ -87,6 +109,11 @@ export function ProposalRefinement({
   // Required to demand another tribunal round (sent as the request reason).
   const [feedback, setFeedback] = useState<string>("");
   const feedbackBlank = !feedback.trim();
+
+  const diff = useMemo(
+    () => refinementDiffBodies(revisions, status?.snapshot_revision_seq),
+    [revisions, status?.snapshot_revision_seq],
+  );
 
   const handleResolve = useCallback(
     async (decision: "accept" | "reject") => {
@@ -164,11 +191,22 @@ export function ProposalRefinement({
 
   // Active or stopped refinement status panel.
   if (status && (status.active || status.stop_reason)) {
+    const round = status.current_round ?? undefined;
+    const headSeq = diff?.headSeq;
+
+    // Status ribbon: one line reconciling the tribunal state.
+    const ribbon =
+      status.active && status.awaiting_review
+        ? `Converged${round ? ` after ${round} ${round === 1 ? "round" : "rounds"}` : ""} — awaiting your review`
+        : status.active
+          ? `Tribunal running${round ? ` — round ${round}` : ""}`
+          : `Stopped — ${stopReasonLabel(status.stop_reason ?? "")}`;
+
     return (
-      <div className="space-y-2 rounded-md border p-3">
+      <div className="space-y-3 rounded-md border p-3">
         <div className="flex items-center justify-between">
           <Label className="text-xs uppercase text-muted-foreground">
-            Refinement
+            Tribunal
           </Label>
           <div className="flex items-center gap-2">
             {status.active && status.awaiting_review ? (
@@ -184,26 +222,33 @@ export function ProposalRefinement({
                 Stopped
               </Badge>
             )}
+            {gateStatus &&
+              (gateStatus.ready ? (
+                <Badge variant="default" className="gap-1 text-xs">
+                  <HugeiconsIcon icon={CheckmarkCircle02Icon} size={12} />
+                  Ready
+                </Badge>
+              ) : (
+                <Badge variant="destructive" className="gap-1 text-xs">
+                  <HugeiconsIcon icon={CancelCircleIcon} size={12} />
+                  Blocked
+                </Badge>
+              ))}
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-3 text-sm">
-          {status.current_round != null && (
-            <span className="text-muted-foreground">
-              Round{" "}
-              <span className="font-mono font-medium text-foreground">
-                {status.current_round}
-              </span>
-            </span>
-          )}
-          <span className="text-muted-foreground">
+        {/* Status ribbon */}
+        <p className="text-sm font-medium text-foreground">{ribbon}</p>
+
+        <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+          <span>
             Entries{" "}
             <span className="font-mono font-medium text-foreground">
               {status.total_entries}
             </span>
           </span>
           {status.dry_rounds > 0 && (
-            <span className="text-muted-foreground">
+            <span>
               Dry rounds{" "}
               <span className="font-mono font-medium text-foreground">
                 {status.dry_rounds}
@@ -212,15 +257,7 @@ export function ProposalRefinement({
           )}
         </div>
 
-        {status.stop_reason && (
-          <p className="text-xs text-muted-foreground">
-            Stopped: {stopReasonLabel(status.stop_reason)}
-          </p>
-        )}
-
-        {/* Stopped — let the user run a fresh tribunal from here. Without this
-            a stopped/interrupted refinement is a dead end (e.g. a run lost
-            across a deploy leaves nothing actionable in the UI). */}
+        {/* Stopped — let the user run a fresh tribunal from here. */}
         {!status.active && (
           <div className="space-y-1 border-t pt-2">
             <Button size="sm" disabled={busy} onClick={handleStart}>
@@ -233,19 +270,60 @@ export function ProposalRefinement({
           </div>
         )}
 
-        {/* Converged — single human review of the full refined result. */}
+        {/* Converged — single human review of the full refined result, with the
+            verdict, the spec diff, and the debate trail behind tabs. */}
         {status.active && status.awaiting_review && (
           <div className="space-y-3 rounded-md border border-primary/40 bg-primary/5 p-3">
-            <Label className="text-sm font-medium">
-              Tribunal converged — review the result
-            </Label>
-            <div className="rounded-md bg-muted/40 p-2 text-sm text-foreground">
-              <BlockMarkdown>{judgeSummaryText(status.judge_summary)}</BlockMarkdown>
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <Label className="text-sm font-medium">Review the result</Label>
+              <span className="text-xs text-muted-foreground">
+                {round ? `round ${round}` : null}
+                {round && headSeq != null ? " · " : null}
+                {headSeq != null ? `revision ${headSeq}` : null}
+              </span>
             </div>
-            <p className="text-xs text-muted-foreground">
-              The full refined spec is shown in the proposal above; the diff from
-              your original is in the revision history.
-            </p>
+
+            <Tabs defaultValue="verdict" className="gap-3">
+              <TabsList className="w-fit">
+                <TabsTrigger value="verdict">Verdict</TabsTrigger>
+                <TabsTrigger value="diff">
+                  Spec diff
+                  {diff?.fromSeq != null && diff.headSeq != null
+                    ? ` rev ${diff.fromSeq} → ${diff.headSeq}`
+                    : ""}
+                </TabsTrigger>
+                <TabsTrigger value="trail">Debate trail</TabsTrigger>
+              </TabsList>
+
+              {/* Verdict — the judge's reasoning markdown, rendered ONCE on the
+                  whole page (the readiness checklist only references it). */}
+              <TabsContent value="verdict">
+                <div className="rounded-md bg-muted/40 p-2 text-sm text-foreground">
+                  <BlockMarkdown>
+                    {judgeSummaryText(
+                      gateStatus?.judge_verdict_body || status.judge_summary,
+                    )}
+                  </BlockMarkdown>
+                </div>
+              </TabsContent>
+
+              {/* Spec diff — pre-refinement snapshot → converged head. */}
+              <TabsContent value="diff">
+                {diff ? (
+                  <DiffView before={diff.before} after={diff.after} />
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No spec diff available.
+                  </p>
+                )}
+              </TabsContent>
+
+              {/* Debate trail — round-by-round objections/rebuttals/verdicts. */}
+              <TabsContent value="trail">
+                <ProposalDebateTrail trail={debateTrail} />
+              </TabsContent>
+            </Tabs>
+
             <div className="space-y-1">
               <Label
                 htmlFor="refinement-feedback"
@@ -308,14 +386,6 @@ export function ProposalRefinement({
             <Label className="text-xs uppercase text-muted-foreground">
               Refinement in progress
             </Label>
-            {status.current_round != null && (
-              <p className="text-xs text-muted-foreground">
-                Round{" "}
-                <span className="font-mono font-medium text-foreground">
-                  {status.current_round}
-                </span>
-              </p>
-            )}
             <p className="text-xs text-muted-foreground">
               Adversary → Advocate → Judge running autonomously; you'll review the
               result when it converges.

--- a/ui/src/components/proposals/ReadinessPanel.test.tsx
+++ b/ui/src/components/proposals/ReadinessPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import type {
+  ProposalDebateTrailRow,
   ProposalGateStatus,
   ProposalRefinementStatus,
 } from "@/api/types";
@@ -52,6 +53,32 @@ function refinement(
   };
 }
 
+function debateRow(
+  overrides: Partial<ProposalDebateTrailRow> = {},
+): ProposalDebateTrailRow {
+  return {
+    id: "e-1",
+    proposal_id: "p-1",
+    kind: "objection",
+    body: "This is a blocking objection about missing scope.",
+    blocking: true,
+    agent_role: "adversary",
+    author_kind: "agent",
+    author_user_id: null,
+    author_model: "gpt",
+    source_task_id: null,
+    against_revision_seq: 3,
+    round: 2,
+    resolved_at: null,
+    resolved_by_user_id: null,
+    reopened_at: null,
+    reopened_by_user_id: null,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
 describe("ReadinessPanel", () => {
   beforeEach(() => {
     vi.mocked(callMcpTool).mockReset();
@@ -68,9 +95,13 @@ describe("ReadinessPanel", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders Ready badge when gate passes", () => {
-    render(<ReadinessPanel gateStatus={gateStatus()} refinement={refinement()} />);
+  it("renders Ready badge and the checklist footer when gate passes", () => {
+    render(
+      <ReadinessPanel gateStatus={gateStatus()} refinement={refinement()} />,
+    );
+    expect(screen.getByText("Readiness gate")).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Ready when every row clears.")).toBeInTheDocument();
   });
 
   it("renders Blocked badge when gate is blocked", () => {
@@ -78,7 +109,10 @@ describe("ReadinessPanel", () => {
       <ReadinessPanel
         gateStatus={gateStatus({
           ready: false,
-          blocked_explanations: ["Missing problem section"],
+          dor_ready: false,
+          dor_failures: [
+            { check: "problem_coverage", message: "Missing problem section" },
+          ],
         })}
         refinement={refinement()}
       />,
@@ -86,47 +120,51 @@ describe("ReadinessPanel", () => {
     expect(screen.getByText("Blocked")).toBeInTheDocument();
   });
 
-  // ── DoR status ──────────────────────────────────────────────────────────
+  // ── DoR row ─────────────────────────────────────────────────────────────
 
-  it("renders DoR pass when dor_ready is true", () => {
+  it("renders DoR row as passing when dor_ready is true", () => {
     render(
       <ReadinessPanel
         gateStatus={gateStatus({ dor_ready: true })}
         refinement={refinement()}
       />,
     );
-    expect(screen.getByText(/Definition of Ready: Pass/)).toBeInTheDocument();
+    expect(screen.getByText("Definition of Ready")).toBeInTheDocument();
+    expect(screen.getByText("all checks pass")).toBeInTheDocument();
   });
 
-  it("renders DoR failures with check names when dor_ready is false", () => {
+  it("lists DoR failures with check names when dor_ready is false", () => {
     render(
       <ReadinessPanel
         gateStatus={gateStatus({
+          ready: false,
           dor_ready: false,
           dor_failures: [
-            { check: "problem_coverage", message: "Missing required coverage: problem" },
-            { check: "grounding", message: "Missing grounding: add entry points" },
+            {
+              check: "problem_coverage",
+              message: "Missing required coverage: problem",
+            },
+            {
+              check: "grounding",
+              message: "Missing grounding: add entry points",
+            },
           ],
-          blocked_explanations: [
-            "Missing required coverage: problem",
-            "Missing grounding: add entry points",
-          ],
-          ready: false,
         })}
         refinement={refinement()}
       />,
     );
-    expect(screen.getByText(/Definition of Ready: Fail/)).toBeInTheDocument();
+    expect(screen.getByText("Definition of Ready")).toBeInTheDocument();
+    expect(screen.getByText("2 checks failing")).toBeInTheDocument();
     expect(screen.getByText(/Problem coverage/)).toBeInTheDocument();
     expect(
-      screen.getAllByText(/Missing required coverage: problem/).length,
-    ).toBeGreaterThan(0);
+      screen.getByText(/Missing required coverage: problem/),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Grounding/)).toBeInTheDocument();
   });
 
-  // ── Judge verdict ───────────────────────────────────────────────────────
+  // ── Judge verdict row ─────────────────────────────────────────────────────
 
-  it("renders judge verdict badge as Ready when judge is not needs-work", () => {
+  it("renders judge row as approve/ready when judge is not needs-work", () => {
     render(
       <ReadinessPanel
         gateStatus={gateStatus({
@@ -138,11 +176,10 @@ describe("ReadinessPanel", () => {
       />,
     );
     expect(screen.getByText("Judge verdict")).toBeInTheDocument();
-    // "Ready" appears both as the header readiness badge and the judge badge.
-    expect(screen.getAllByText("Ready").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/approve \/ ready/)).toBeInTheDocument();
   });
 
-  it("renders judge verdict badge as Needs-work when judge_needs_work is true", () => {
+  it("renders judge row as needs-work with the round from the trail", () => {
     render(
       <ReadinessPanel
         gateStatus={gateStatus({
@@ -150,23 +187,29 @@ describe("ReadinessPanel", () => {
           judge_verdict_id: "v-2",
           judge_needs_work: true,
           ready: false,
-          blocked_explanations: [
-            "Judge returned needs-work (verdict v-2); no current human override",
-          ],
         })}
         refinement={refinement()}
+        debateTrail={[
+          debateRow({
+            id: "v-2",
+            kind: "verdict",
+            body: "Verdict: needs-work",
+            round: 4,
+            against_revision_seq: 4,
+          }),
+        ]}
       />,
     );
     expect(screen.getByText("Judge verdict")).toBeInTheDocument();
-    expect(screen.getAllByText("Needs-work").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("needs-work (round 4)")).toBeInTheDocument();
   });
 
-  it("renders judge verdict body as markdown reasoning", () => {
+  it("does not render the judge reasoning markdown body (rendered in the tribunal card)", () => {
     render(
       <ReadinessPanel
         gateStatus={gateStatus({
           judge_verdict_body:
-            "## Verdict\n\nNeeds **scope** before graduation.\n\n- Add target services",
+            "## Verdict\n\nNeeds **scope** before graduation.",
           judge_verdict_id: "v-3",
           judge_needs_work: true,
           ready: false,
@@ -174,62 +217,148 @@ describe("ReadinessPanel", () => {
         refinement={refinement()}
       />,
     );
-
-    expect(screen.getByText("Judge reasoning")).toBeInTheDocument();
+    // The full reasoning heading must NOT appear here — it lives in the
+    // Tribunal review card so it renders only once on the page.
     expect(
-      screen.getByRole("heading", { name: "Verdict", level: 2 }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("scope").tagName).toBe("STRONG");
-    expect(screen.getByText("Add target services")).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Verdict", level: 2 }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Judge reasoning")).not.toBeInTheDocument();
   });
 
-  // ── Adversary dry count ─────────────────────────────────────────────────
+  // ── Blocking debate entries row ──────────────────────────────────────────
 
-  it("renders adversary dry count when > 0", () => {
+  it("renders blocking entries row and expands to real entry cards", async () => {
+    const user = userEvent.setup();
     render(
       <ReadinessPanel
-        gateStatus={gateStatus({ adversary_dry_count: 2 })}
-        refinement={refinement()}
-      />,
-    );
-    expect(screen.getByText(/Adversary dry:/)).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
-  });
-
-  // ── Unresolved blocking rows ────────────────────────────────────────────
-
-  it("renders unresolved blocking count when > 0", () => {
-    render(
-      <ReadinessPanel
+        proposalId="p-1"
         gateStatus={gateStatus({
-          unresolved_blocking_count: 3,
-          unresolved_blocking_ids: ["e-1", "e-2", "e-3"],
           ready: false,
-          blocked_explanations: ["Unresolved blocking debate entries: e-1, e-2, e-3"],
+          unresolved_blocking_count: 1,
+          unresolved_blocking_ids: ["e-1"],
         })}
         refinement={refinement()}
+        debateTrail={[debateRow({ id: "e-1" })]}
       />,
     );
-    expect(screen.getByText(/Blocking rows:/)).toBeInTheDocument();
-    expect(screen.getByText("3")).toBeInTheDocument();
+
+    expect(screen.getByText("Blocking debate entries")).toBeInTheDocument();
+    expect(screen.getByText("1 unresolved")).toBeInTheDocument();
+    // Collapsed by default — no entry body until expanded.
+    expect(
+      screen.queryByText(/This is a blocking objection/),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /show/ }));
+
+    expect(screen.getByText("adversary")).toBeInTheDocument();
+    expect(screen.getByText("round 2")).toBeInTheDocument();
+    expect(screen.getByText("vs rev 3")).toBeInTheDocument();
+    expect(screen.getByText(/This is a blocking objection/)).toBeInTheDocument();
   });
 
-  // ── Needs-evidence spike ────────────────────────────────────────────────
+  it("resolves a blocking entry through proposal_debate_resolve", async () => {
+    const onChanged = vi.fn();
+    vi.mocked(callMcpTool).mockResolvedValue({ ok: true } as never);
+    const user = userEvent.setup();
 
-  it("renders needs-evidence spike parking state", () => {
+    render(
+      <ReadinessPanel
+        proposalId="p-1"
+        gateStatus={gateStatus({
+          ready: false,
+          unresolved_blocking_count: 1,
+          unresolved_blocking_ids: ["e-1"],
+        })}
+        refinement={refinement()}
+        debateTrail={[debateRow({ id: "e-1" })]}
+        onChanged={onChanged}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /show/ }));
+    await user.click(screen.getByRole("button", { name: "Resolve" }));
+    // ConfirmButton opens a dialog; confirm the action.
+    await user.click(screen.getByRole("button", { name: "Resolve entry" }));
+
+    await waitFor(() => {
+      expect(callMcpTool).toHaveBeenCalledWith("proposal_debate_resolve", {
+        id: "e-1",
+      });
+    });
+    expect(showToast.success).toHaveBeenCalledWith("Blocking entry resolved");
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it("falls back to the raw id when a blocking id is not in the trail", async () => {
+    const user = userEvent.setup();
     render(
       <ReadinessPanel
         gateStatus={gateStatus({
+          ready: false,
+          unresolved_blocking_count: 1,
+          unresolved_blocking_ids: ["missing-uuid"],
+        })}
+        refinement={refinement()}
+        debateTrail={[]}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /show/ }));
+    expect(screen.getByText("missing-uuid")).toBeInTheDocument();
+  });
+
+  it("labels a superseded blocking verdict", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReadinessPanel
+        gateStatus={gateStatus({
+          ready: false,
+          unresolved_blocking_count: 1,
+          unresolved_blocking_ids: ["v-old"],
+        })}
+        refinement={refinement()}
+        debateTrail={[
+          debateRow({
+            id: "v-old",
+            kind: "verdict",
+            body: "Verdict: needs-work",
+            against_revision_seq: 2,
+          }),
+          debateRow({
+            id: "v-new",
+            kind: "verdict",
+            body: "Verdict: approve",
+            against_revision_seq: 4,
+            blocking: false,
+          }),
+        ]}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /show/ }));
+    expect(screen.getByText("superseded")).toBeInTheDocument();
+  });
+
+  // ── Evidence spike row ────────────────────────────────────────────────────
+
+  it("renders evidence row as none required when there is no spike", () => {
+    render(
+      <ReadinessPanel gateStatus={gateStatus()} refinement={refinement()} />,
+    );
+    expect(screen.getByText("Evidence spike")).toBeInTheDocument();
+    expect(screen.getByText("none required")).toBeInTheDocument();
+  });
+
+  it("renders needs-evidence spike details when parked", () => {
+    render(
+      <ReadinessPanel
+        gateStatus={gateStatus({
+          ready: false,
           needs_evidence: {
             claim: "X is load-bearing",
             spike_task_id: "uuid-spike",
             spike_short_id: "ab12",
             spike_status: "open",
           },
-          ready: false,
-          blocked_explanations: [
-            "Proposal parked on needs-evidence spike ab12 (claim: X is load-bearing)",
-          ],
         })}
         refinement={refinement()}
       />,
@@ -237,48 +366,32 @@ describe("ReadinessPanel", () => {
     expect(screen.getByText("Parked: needs-evidence spike")).toBeInTheDocument();
     expect(screen.getAllByText(/X is load-bearing/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/ab12/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/open/)).toBeInTheDocument();
+    expect(screen.getAllByText(/open/).length).toBeGreaterThan(0);
   });
 
-  // ── Blocked explanations ────────────────────────────────────────────────
+  // ── Human override ────────────────────────────────────────────────────────
 
-  it("renders blocked explanations naming exact failures", () => {
-    render(
-      <ReadinessPanel
-        gateStatus={gateStatus({
-          ready: false,
-          blocked_explanations: [
-            "Missing required coverage: problem",
-            "Judge returned needs-work (verdict v-1); no current human override",
-          ],
-        })}
-        refinement={refinement()}
-      />,
-    );
-    expect(screen.getByText("Blocked because")).toBeInTheDocument();
-    expect(screen.getByText(/Missing required coverage: problem/)).toBeInTheDocument();
-    expect(screen.getByText(/Judge returned needs-work/)).toBeInTheDocument();
-  });
-
-  // ── Human override badge ────────────────────────────────────────────────
-
-  it("renders Human override badge and active state when human_override_active is true", () => {
+  it("collapses the override behind a link and expands to the reason box", async () => {
+    const user = userEvent.setup();
     render(
       <ReadinessPanel
         proposalId="p-1"
         gateStatus={gateStatus({
           ready: false,
-          human_override_active: true,
-          blocked_explanations: ["Judge returned needs-work"],
+          judge_needs_work: true,
+          judge_verdict_id: "v-1",
         })}
         refinement={refinement()}
       />,
     );
-    expect(screen.getByText("Human override")).toBeInTheDocument();
-    expect(screen.getByText(/A human override is active/)).toBeInTheDocument();
+    // Reason box hidden until the link is clicked.
     expect(
-      screen.queryByRole("button", { name: /Override DoR and proceed/ }),
+      screen.queryByLabelText("Human override audit reason"),
     ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Record override/ }));
+    expect(
+      screen.getByLabelText("Human override audit reason"),
+    ).toBeInTheDocument();
   });
 
   it("records a human override with an audit reason and refreshes", async () => {
@@ -293,12 +406,13 @@ describe("ReadinessPanel", () => {
           ready: false,
           judge_verdict_id: "v-override",
           judge_needs_work: true,
-          blocked_explanations: ["Judge returned needs-work"],
         })}
         refinement={refinement()}
         onChanged={onChanged}
       />,
     );
+
+    await user.click(screen.getByRole("button", { name: /Record override/ }));
 
     const button = screen.getByRole("button", {
       name: /Override DoR and proceed/,
@@ -323,7 +437,26 @@ describe("ReadinessPanel", () => {
     expect(onChanged).toHaveBeenCalledTimes(1);
   });
 
-  it("does not render Human override badge when human_override_active is false", () => {
+  it("shows the Human override badge and active note, and no override link", () => {
+    render(
+      <ReadinessPanel
+        proposalId="p-1"
+        gateStatus={gateStatus({
+          ready: false,
+          human_override_active: true,
+          judge_needs_work: true,
+        })}
+        refinement={refinement()}
+      />,
+    );
+    expect(screen.getByText("Human override")).toBeInTheDocument();
+    expect(screen.getByText(/A human override is active/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Record override/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the Human override badge when human_override_active is false", () => {
     render(
       <ReadinessPanel
         gateStatus={gateStatus({ human_override_active: false })}
@@ -337,7 +470,10 @@ describe("ReadinessPanel", () => {
 
   it("renders the autonomous-tribunal note when refinement is active", () => {
     render(
-      <ReadinessPanel gateStatus={gateStatus()} refinement={refinement({ active: true })} />,
+      <ReadinessPanel
+        gateStatus={gateStatus()}
+        refinement={refinement({ active: true })}
+      />,
     );
     expect(
       screen.getByText(/Autonomous tribunal in progress/),
@@ -349,86 +485,5 @@ describe("ReadinessPanel", () => {
     expect(
       screen.getByText(/Autonomous tribunal in progress/),
     ).toBeInTheDocument();
-  });
-
-  // ── P4 regression: needs-evidence with closed spike ──────────────────
-
-  it("renders needs-evidence with closed spike status", () => {
-    render(
-      <ReadinessPanel
-        gateStatus={gateStatus({
-          needs_evidence: {
-            claim: "Y handles 10k rps",
-            spike_task_id: "uuid-spike-2",
-            spike_short_id: "cd34",
-            spike_status: "done",
-          },
-          ready: false,
-          blocked_explanations: [
-            "Proposal parked on needs-evidence spike cd34 (claim: Y handles 10k rps)",
-          ],
-        })}
-        refinement={refinement()}
-      />,
-    );
-    expect(screen.getByText("Parked: needs-evidence spike")).toBeInTheDocument();
-    expect(screen.getAllByText(/Y handles 10k rps/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/cd34/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/done/)).toBeInTheDocument();
-  });
-
-  // ── P4 regression: multiple blocked explanations ─────────────────────
-
-  it("renders multiple blocked explanations simultaneously", () => {
-    render(
-      <ReadinessPanel
-        gateStatus={gateStatus({
-          ready: false,
-          dor_ready: false,
-          dor_failures: [
-            { check: "problem_coverage", message: "Missing required coverage: problem" },
-            { check: "grounding", message: "Missing grounding: add entry points" },
-          ],
-          judge_needs_work: true,
-          unresolved_blocking_count: 1,
-          unresolved_blocking_ids: ["e-1"],
-          blocked_explanations: [
-            "Missing required coverage: problem",
-            "Missing grounding: add entry points",
-            "Judge returned needs-work (verdict v-1); no current human override",
-            "Unresolved blocking debate entries: e-1",
-          ],
-        })}
-        refinement={refinement()}
-      />,
-    );
-    expect(screen.getByText("Blocked because")).toBeInTheDocument();
-    expect(
-      screen.getAllByText(/Missing required coverage: problem/).length,
-    ).toBeGreaterThan(0);
-    expect(screen.getByText(/Judge returned needs-work/)).toBeInTheDocument();
-    expect(screen.getByText(/Unresolved blocking debate entries/)).toBeInTheDocument();
-  });
-
-  // ── P4 regression: pending checkpoint badge ──────────────────────────
-
-  // ── P4 regression: Judge Ready verdict with override ─────────────────
-
-  it("shows both judge Ready verdict and human override badge", () => {
-    render(
-      <ReadinessPanel
-        gateStatus={gateStatus({
-          judge_verdict_body: "Looks good",
-          judge_verdict_id: "v-3",
-          judge_needs_work: false,
-          human_override_active: true,
-        })}
-        refinement={refinement()}
-      />,
-    );
-    expect(screen.getByText("Judge verdict")).toBeInTheDocument();
-    // "Ready" appears as both the header readiness badge and the judge badge.
-    expect(screen.getAllByText("Ready").length).toBeGreaterThanOrEqual(2);
-    expect(screen.getByText("Human override")).toBeInTheDocument();
   });
 });

--- a/ui/src/components/proposals/ReadinessPanel.tsx
+++ b/ui/src/components/proposals/ReadinessPanel.tsx
@@ -1,20 +1,27 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   Alert02Icon,
   AlertCircleIcon,
-  CheckmarkCircle02Icon,
+  ArrowDown01Icon,
   CancelCircleIcon,
+  CheckmarkCircle02Icon,
+  Comment01Icon,
+  JusticeScale01Icon,
+  MinusSignIcon,
   Shield01Icon,
 } from "@hugeicons/core-free-icons";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ConfirmButton } from "@/components/ConfirmButton";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { relativeTime } from "@/components/memory/memoryUtils";
 import { callMcpTool } from "@/api/mcpClient";
 import { showToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import type {
+  ProposalDebateTrailRow,
   ProposalGateStatus,
   ProposalRefinementStatus,
 } from "@/api/types";
@@ -38,38 +45,195 @@ function checkLabel(check: string): string {
   return map[check] ?? check;
 }
 
+type RowState = "pass" | "fail" | "na";
+
+const ROW_MARKER: Record<
+  RowState,
+  { icon: typeof CheckmarkCircle02Icon; cls: string }
+> = {
+  pass: {
+    icon: CheckmarkCircle02Icon,
+    cls: "text-green-600 dark:text-green-400",
+  },
+  fail: { icon: CancelCircleIcon, cls: "text-destructive" },
+  na: { icon: MinusSignIcon, cls: "text-muted-foreground" },
+};
+
+function GateRow({
+  state,
+  label,
+  detail,
+  action,
+  children,
+}: {
+  state: RowState;
+  label: string;
+  detail: React.ReactNode;
+  action?: React.ReactNode;
+  children?: React.ReactNode;
+}) {
+  const marker = ROW_MARKER[state];
+  return (
+    <div className="space-y-1">
+      <div className="flex items-start gap-2 text-sm">
+        <HugeiconsIcon
+          icon={marker.icon}
+          size={15}
+          className={cn("mt-0.5 shrink-0", marker.cls)}
+          aria-hidden
+        />
+        <span className="w-40 shrink-0 font-medium">{label}</span>
+        <span className="min-w-0 flex-1 text-muted-foreground">{detail}</span>
+        {action}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/** One unresolved blocking debate entry, resolved against the trail. */
+function BlockingEntryCard({
+  row,
+  superseded,
+  onResolve,
+  resolving,
+}: {
+  row: ProposalDebateTrailRow;
+  superseded: boolean;
+  onResolve: (id: string) => void;
+  resolving: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const icon = row.kind === "verdict" ? JusticeScale01Icon : Comment01Icon;
+  return (
+    <li className="rounded-md border bg-background/60 p-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <HugeiconsIcon
+          icon={icon}
+          size={13}
+          className="shrink-0 text-destructive"
+        />
+        <span className="font-medium uppercase tracking-wide text-foreground">
+          {row.agent_role || row.kind}
+        </span>
+        <span className="text-muted-foreground">round {row.round}</span>
+        <span className="font-mono text-muted-foreground">
+          vs rev {row.against_revision_seq}
+        </span>
+        {row.blocking && (
+          <Badge variant="destructive" className="text-[10px]">
+            blocking
+          </Badge>
+        )}
+        {superseded && (
+          <Badge variant="outline" className="text-[10px]">
+            superseded
+          </Badge>
+        )}
+        {row.resolved_at && (
+          <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
+            <HugeiconsIcon icon={CheckmarkCircle02Icon} size={12} />
+            resolved
+          </span>
+        )}
+        <span className="ml-auto shrink-0 text-muted-foreground">
+          {relativeTime(row.created_at)}
+        </span>
+      </div>
+      {open ? (
+        <div className="mt-1.5">
+          <BlockMarkdown>{row.body}</BlockMarkdown>
+        </div>
+      ) : (
+        <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+          {row.body.replace(/\s+/g, " ").trim() || "(no content)"}
+        </p>
+      )}
+      <div className="mt-1.5 flex items-center gap-2">
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          className="text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        >
+          {open ? "Collapse" : "Expand"}
+        </button>
+        {!row.resolved_at && (
+          <ConfirmButton
+            title="Resolve blocking entry?"
+            description="Mark this debate entry resolved so it no longer blocks readiness. This is an audited action."
+            confirmLabel="Resolve entry"
+            variant="outline"
+            size="sm"
+            disabled={resolving}
+            onConfirm={() => onResolve(row.id)}
+          >
+            {resolving ? "Resolving…" : "Resolve"}
+          </ConfirmButton>
+        )}
+      </div>
+    </li>
+  );
+}
+
 /**
- * Readiness panel for a proposal.
+ * Readiness gate for a proposal, rendered as a per-condition checklist.
  *
- * Displays deterministic DoR status, latest Judge verdict, adversary dry count,
- * unresolved blocking debate rows, needs-evidence parked spike state, and
- * disabled/blocked gate explanations naming exact failures.
- *
- * The component renders backend-provided status only — it does NOT recompute
- * readiness logic client-side. The autonomous tribunal's converged result and
- * the single human accept/reject review live in `ProposalRefinement`.
+ * Each backend gate condition (Definition of Ready, judge verdict, unresolved
+ * blocking debate entries, needs-evidence spike) is one row with a pass/fail/na
+ * marker; the overall badge comes straight from `gate_status.ready`. The panel
+ * renders backend-provided status only — it does NOT recompute readiness logic
+ * client-side. The judge's full reasoning markdown is rendered once, in the
+ * Tribunal review card; this checklist only references the verdict outcome.
  */
 export function ReadinessPanel({
   proposalId,
   gateStatus,
   refinement,
+  debateTrail = [],
   onChanged,
 }: {
   proposalId?: string;
   gateStatus: ProposalGateStatus | null;
   refinement: ProposalRefinementStatus | null;
+  debateTrail?: ProposalDebateTrailRow[];
   onChanged?: () => void;
 }) {
   const [overrideReason, setOverrideReason] = useState("");
   const [overrideBusy, setOverrideBusy] = useState(false);
+  const [showOverride, setShowOverride] = useState(false);
+  const [showBlocking, setShowBlocking] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
 
   const isReady = gateStatus?.ready ?? true;
-  const hasBlockedReasons =
-    gateStatus && gateStatus.blocked_explanations.length > 0;
-  const judgeVerdictBody = gateStatus?.judge_verdict_body?.trim();
   const showOverrideControls = Boolean(
-    proposalId && gateStatus && !gateStatus.ready && !gateStatus.human_override_active,
+    proposalId &&
+      gateStatus &&
+      !gateStatus.ready &&
+      !gateStatus.human_override_active,
   );
+
+  // Latest judge verdict (highest revision it was written against) for the
+  // round/revision metadata the judge row references.
+  const latestVerdict = useMemo(() => {
+    const verdicts = debateTrail.filter((r) => r.kind === "verdict");
+    if (verdicts.length === 0) return null;
+    return [...verdicts].sort(
+      (a, b) =>
+        a.against_revision_seq - b.against_revision_seq ||
+        a.created_at.localeCompare(b.created_at),
+    )[verdicts.length - 1];
+  }, [debateTrail]);
+  const maxVerdictRev = latestVerdict?.against_revision_seq ?? -1;
+
+  // Resolve the gate's unresolved blocking ids to real trail rows. Ids that
+  // aren't present in the trail fall back to a raw line so we never render worse
+  // than the old uuid list.
+  const blockingRows = useMemo(() => {
+    const ids = gateStatus?.unresolved_blocking_ids ?? [];
+    const byId = new Map(debateTrail.map((r) => [r.id, r] as const));
+    return ids.map((id) => ({ id, row: byId.get(id) ?? null }));
+  }, [gateStatus?.unresolved_blocking_ids, debateTrail]);
 
   const handleOverride = useCallback(async () => {
     const reason = overrideReason.trim();
@@ -85,6 +249,7 @@ export function ReadinessPanel({
       if (res.error) throw new Error(res.error);
       showToast.success("Human override recorded");
       setOverrideReason("");
+      setShowOverride(false);
       onChanged?.();
     } catch (e) {
       showToast.error("Failed to record human override", {
@@ -95,15 +260,59 @@ export function ReadinessPanel({
     }
   }, [gateStatus, proposalId, overrideReason, onChanged]);
 
+  const handleResolve = useCallback(
+    async (id: string) => {
+      setResolvingId(id);
+      try {
+        const res = await callMcpTool("proposal_debate_resolve", { id });
+        if (res.error) throw new Error(res.error);
+        showToast.success("Blocking entry resolved");
+        onChanged?.();
+      } catch (e) {
+        showToast.error("Failed to resolve entry", {
+          description: (e as Error).message,
+        });
+      } finally {
+        setResolvingId(null);
+      }
+    },
+    [onChanged],
+  );
+
   // If there's no gate status and no refinement, don't render anything.
   if (!gateStatus && !refinement) return null;
+
+  // Judge row state + detail.
+  const judgeHasVerdict = Boolean(gateStatus?.judge_verdict_body || latestVerdict);
+  const judgeState: RowState = !gateStatus
+    ? "na"
+    : gateStatus.judge_needs_work
+      ? "fail"
+      : judgeHasVerdict
+        ? "pass"
+        : "na";
+  const judgeRound = latestVerdict?.round;
+  const judgeDetail = !gateStatus
+    ? "no verdict yet"
+    : gateStatus.judge_needs_work
+      ? `needs-work${judgeRound ? ` (round ${judgeRound})` : ""}`
+      : judgeHasVerdict
+        ? `approve / ready${judgeRound ? ` (round ${judgeRound})` : ""}`
+        : "no verdict yet";
+
+  // Blocking-entries row.
+  const blockingCount = gateStatus?.unresolved_blocking_count ?? 0;
+  const blockingState: RowState = blockingCount > 0 ? "fail" : "pass";
+
+  // Evidence-spike row.
+  const evidence = gateStatus?.needs_evidence ?? null;
 
   return (
     <div className="space-y-3 rounded-md border p-3">
       {/* Header */}
       <div className="flex items-center justify-between">
         <Label className="text-xs uppercase text-muted-foreground">
-          Readiness
+          Readiness gate
         </Label>
         <div className="flex items-center gap-2">
           {isReady ? (
@@ -126,94 +335,121 @@ export function ReadinessPanel({
         </div>
       </div>
 
-      {/* DoR status */}
       {gateStatus && (
-        <div className="space-y-1">
-          <div className="flex items-center gap-2 text-sm">
-            <HugeiconsIcon
-              icon={
-                gateStatus.dor_ready
-                  ? CheckmarkCircle02Icon
-                  : CancelCircleIcon
-              }
-              size={14}
-              className={
-                gateStatus.dor_ready ? "text-green-600" : "text-destructive"
-              }
-            />
-            <span
-              className={cn(
-                "font-medium",
-                gateStatus.dor_ready
-                  ? "text-green-700 dark:text-green-400"
-                  : "text-destructive",
-              )}
-            >
-              Definition of Ready: {gateStatus.dor_ready ? "Pass" : "Fail"}
-            </span>
-          </div>
-          {gateStatus.dor_failures.length > 0 && (
-            <ul className="ml-5 space-y-0.5 text-xs text-muted-foreground">
-              {gateStatus.dor_failures.map((f, i) => (
-                <li key={i}>
-                  <span className="font-medium">{checkLabel(f.check)}</span>:{" "}
-                  {f.message}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
+        <div className="space-y-2">
+          {/* Definition of Ready */}
+          <GateRow
+            state={gateStatus.dor_ready ? "pass" : "fail"}
+            label="Definition of Ready"
+            detail={
+              gateStatus.dor_ready
+                ? "all checks pass"
+                : `${gateStatus.dor_failures.length} check${
+                    gateStatus.dor_failures.length === 1 ? "" : "s"
+                  } failing`
+            }
+          >
+            {gateStatus.dor_failures.length > 0 && (
+              <ul className="ml-[26px] space-y-0.5 text-xs text-muted-foreground">
+                {gateStatus.dor_failures.map((f, i) => (
+                  <li key={i}>
+                    <span className="font-medium">{checkLabel(f.check)}</span>:{" "}
+                    {f.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </GateRow>
 
-      {/* Tribunal metrics */}
-      {gateStatus && (
-        <div className="flex flex-wrap gap-3 text-sm">
-          {judgeVerdictBody && (
-            <div className="space-y-0.5">
-              <span className="text-muted-foreground">Judge verdict</span>
-              <Badge
-                variant={
-                  gateStatus.judge_needs_work ? "destructive" : "default"
-                }
-                className="ml-1 text-xs"
-              >
-                {gateStatus.judge_needs_work ? "Needs-work" : "Ready"}
-              </Badge>
-            </div>
-          )}
-          {gateStatus.adversary_dry_count > 0 && (
-            <span className="text-muted-foreground">
-              Adversary dry:{" "}
-              <span className="font-mono font-medium text-foreground">
-                {gateStatus.adversary_dry_count}
-              </span>
-            </span>
-          )}
-          {gateStatus.unresolved_blocking_count > 0 && (
-            <span className="text-muted-foreground">
-              Blocking rows:{" "}
-              <span className="font-mono font-medium text-destructive">
-                {gateStatus.unresolved_blocking_count}
-              </span>
-            </span>
-          )}
-        </div>
-      )}
+          {/* Judge verdict */}
+          <GateRow
+            state={judgeState}
+            label="Judge verdict"
+            detail={judgeDetail}
+          />
 
-      {judgeVerdictBody && (
-        <div className="space-y-2 rounded-md border bg-muted/30 p-3">
-          <div className="flex items-center justify-between gap-2">
-            <Label className="text-xs uppercase text-muted-foreground">
-              Judge reasoning
-            </Label>
-            <Badge
-              variant={gateStatus?.judge_needs_work ? "destructive" : "default"}
-              className="text-xs"
-            >
-              {gateStatus?.judge_needs_work ? "Needs-work" : "Ready"}
-            </Badge>
-          </div>
-          <BlockMarkdown>{judgeVerdictBody}</BlockMarkdown>
+          {/* Blocking debate entries */}
+          <GateRow
+            state={blockingState}
+            label="Blocking debate entries"
+            detail={
+              blockingCount > 0
+                ? `${blockingCount} unresolved`
+                : "none unresolved"
+            }
+            action={
+              blockingCount > 0 ? (
+                <button
+                  type="button"
+                  aria-expanded={showBlocking}
+                  onClick={() => setShowBlocking((v) => !v)}
+                  className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  {showBlocking ? "hide" : "show"}
+                  <HugeiconsIcon
+                    icon={ArrowDown01Icon}
+                    size={12}
+                    className={cn(
+                      "transition-transform",
+                      showBlocking && "rotate-180",
+                    )}
+                  />
+                </button>
+              ) : undefined
+            }
+          >
+            {showBlocking && blockingCount > 0 && (
+              <ul className="ml-[26px] space-y-1.5">
+                {blockingRows.map(({ id, row }) =>
+                  row ? (
+                    <BlockingEntryCard
+                      key={id}
+                      row={row}
+                      superseded={
+                        row.kind === "verdict" &&
+                        row.against_revision_seq < maxVerdictRev
+                      }
+                      onResolve={handleResolve}
+                      resolving={resolvingId === id}
+                    />
+                  ) : (
+                    <li
+                      key={id}
+                      className="flex items-start gap-1.5 rounded-md border bg-background/60 p-2 text-xs text-destructive"
+                    >
+                      <HugeiconsIcon
+                        icon={Alert02Icon}
+                        size={12}
+                        className="mt-0.5 shrink-0"
+                      />
+                      <span className="break-all font-mono">{id}</span>
+                    </li>
+                  ),
+                )}
+              </ul>
+            )}
+          </GateRow>
+
+          {/* Evidence spike */}
+          <GateRow
+            state={evidence ? "fail" : "na"}
+            label="Evidence spike"
+            detail={
+              evidence
+                ? `spike ${evidence.spike_short_id} — ${evidence.spike_status}`
+                : "none required"
+            }
+          >
+            {evidence && (
+              <p className="ml-[26px] text-xs text-muted-foreground">
+                Claim: {evidence.claim}
+              </p>
+            )}
+          </GateRow>
+
+          <p className="border-t pt-2 text-xs text-muted-foreground">
+            Ready when every row clears.
+          </p>
         </div>
       )}
 
@@ -232,7 +468,19 @@ export function ReadinessPanel({
         </div>
       )}
 
-      {showOverrideControls && (
+      {/* Override — collapsed to a quiet link; only when blocked and no
+          override is already active. */}
+      {showOverrideControls && !showOverride && (
+        <button
+          type="button"
+          onClick={() => setShowOverride(true)}
+          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        >
+          Something wrong with the gate itself? Record override…
+        </button>
+      )}
+
+      {showOverrideControls && showOverride && (
         <div className="space-y-2 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950/30">
           <div className="space-y-1">
             <Label
@@ -256,19 +504,30 @@ export function ReadinessPanel({
             disabled={overrideBusy}
             className="min-h-[72px] bg-background"
           />
-          <Button
-            size="sm"
-            variant="destructive"
-            disabled={overrideBusy || !overrideReason.trim()}
-            onClick={handleOverride}
-          >
-            {overrideBusy ? "Recording…" : "Override DoR and proceed"}
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={overrideBusy || !overrideReason.trim()}
+              onClick={handleOverride}
+            >
+              {overrideBusy ? "Recording…" : "Override DoR and proceed"}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={overrideBusy}
+              onClick={() => setShowOverride(false)}
+            >
+              Cancel
+            </Button>
+          </div>
         </div>
       )}
 
-      {/* Needs-evidence spike parking */}
-      {gateStatus?.needs_evidence && (
+      {/* Needs-evidence spike parking note (kept for parity with the old
+          affordance; the row above summarises it inline). */}
+      {evidence && (
         <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-2 dark:border-amber-800 dark:bg-amber-950/30">
           <HugeiconsIcon
             icon={AlertCircleIcon}
@@ -279,45 +538,15 @@ export function ReadinessPanel({
             <p className="font-medium text-amber-800 dark:text-amber-200">
               Parked: needs-evidence spike
             </p>
+            <p className="text-muted-foreground">Claim: {evidence.claim}</p>
             <p className="text-muted-foreground">
-              Claim: {gateStatus.needs_evidence.claim}
-            </p>
-            <p className="text-muted-foreground">
-              Spike task: {gateStatus.needs_evidence.spike_short_id} —{" "}
-              {gateStatus.needs_evidence.spike_status}
+              Spike task: {evidence.spike_short_id} — {evidence.spike_status}
             </p>
           </div>
         </div>
       )}
 
-      {/* Blocked explanations */}
-      {hasBlockedReasons && (
-        <div className="space-y-1">
-          <Label className="text-xs uppercase text-muted-foreground">
-            Blocked because
-          </Label>
-          <ul className="space-y-1">
-            {gateStatus!.blocked_explanations.map((explanation, i) => (
-              <li
-                key={i}
-                className="flex items-start gap-1.5 text-xs text-destructive"
-              >
-                <HugeiconsIcon
-                  icon={Alert02Icon}
-                  size={12}
-                  className="mt-0.5 shrink-0"
-                />
-                <span>{explanation}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {/* Active-refinement note — only while the tribunal is still running.
-          Once it converges (awaiting_review) the refinement panel above shows
-          the verdict + accept/reject, so this "in progress" line would be
-          stale/contradictory. */}
+      {/* Active-refinement note — only while the tribunal is still running. */}
       {refinement?.active && !refinement?.awaiting_review && (
         <p className="text-xs text-muted-foreground">
           Autonomous tribunal in progress: Adversary, Advocate, and Judge refine

--- a/ui/src/components/proposals/debateTrailUtils.ts
+++ b/ui/src/components/proposals/debateTrailUtils.ts
@@ -1,0 +1,30 @@
+import type { ProposalDebateTrailRow } from "@/api/types";
+
+/** Parsed verdict outcome for a `verdict` debate-trail row. */
+export interface VerdictOutcome {
+  label: string;
+  positive: boolean;
+}
+
+/**
+ * Derive a verdict's outcome. Prefers a leading `Verdict: approve/reject/…`
+ * marker in the body; falls back to the `blocking` flag (a blocking verdict
+ * reads as reject/needs-work, a non-blocking one as approve).
+ */
+export function verdictOutcome(row: ProposalDebateTrailRow): VerdictOutcome {
+  const match = row.body.match(/verdict:?\s*([a-z][a-z -]*)/i);
+  if (match) {
+    const word = match[1].trim().toLowerCase();
+    if (/^(approve|approved|ready|pass|passed|accept)/.test(word)) {
+      return { label: word, positive: true };
+    }
+    if (/^(reject|rejected|needs?[ -]?work|block|blocked|fail)/.test(word)) {
+      return { label: word, positive: false };
+    }
+    return { label: word, positive: !row.blocking };
+  }
+  return {
+    label: row.blocking ? "needs-work" : "approve",
+    positive: !row.blocking,
+  };
+}

--- a/ui/src/components/proposals/refinementDiff.ts
+++ b/ui/src/components/proposals/refinementDiff.ts
@@ -1,0 +1,38 @@
+import type { ProposalHistoryEntry } from "@/lib/proposalQueries";
+
+/**
+ * Compute the pre-refinement snapshot → head spec bodies for the tribunal
+ * review diff. Mirrors {@link ProposalHistory}'s refinement-run diff (base
+ * body → converged head body) but keyed off the refinement session's recorded
+ * `snapshot_revision_seq` rather than a contiguous run of `refinement_loop`
+ * revisions, so it stays correct even after the run is collapsed/accepted.
+ *
+ * Returns `null` when there are no spec revisions to diff.
+ */
+export function refinementDiffBodies(
+  revisions: ProposalHistoryEntry[],
+  snapshotSeq: number | null | undefined,
+): {
+  before: string;
+  after: string;
+  fromSeq: number | null;
+  headSeq: number;
+} | null {
+  const specs = revisions.filter((r) => r.event_kind === "spec_revision");
+  if (specs.length === 0) return null;
+
+  const head = specs.reduce((a, b) => (b.seq > a.seq ? b : a));
+  // Base = the snapshot the tribunal ran against, else the revision immediately
+  // before the head (a sensible fallback for older payloads without a snapshot).
+  const base =
+    (snapshotSeq != null
+      ? specs.find((r) => r.seq === snapshotSeq)
+      : undefined) ?? specs.find((r) => r.seq === head.seq - 1);
+
+  return {
+    before: base?.body ?? "",
+    after: head.body,
+    fromSeq: base?.seq ?? null,
+    headSeq: head.seq,
+  };
+}

--- a/ui/src/pages/ProposalsPage.tsx
+++ b/ui/src/pages/ProposalsPage.tsx
@@ -599,15 +599,15 @@ function ProposalDetailView({
           )}
         </div>
 
-        <ProposalHistory detail={detail} />
-
-        <Separator />
-
-        <ProposalSignoffs detail={detail} onChanged={onChanged} />
-
+        {/* Tribunal: refinement kickoff / status ribbon, and — once converged —
+            the review card (verdict / spec diff / debate trail tabs plus the
+            human accept / another-round / reject actions). */}
         <ProposalRefinement
           proposalId={proposal.id}
           status={detail.refinement}
+          gateStatus={detail.gate_status}
+          debateTrail={detail.debate_trail}
+          revisions={detail.revisions}
           canStart={
             (proposal.status === "draft" || proposal.status === "in_review") &&
             !detail.refinement?.active
@@ -615,23 +615,32 @@ function ProposalDetailView({
           onChanged={onChanged}
         />
 
-        {/* Readiness panel: DoR status, tribunal metrics, blocked explanations,
-            and needs-evidence spike parking. */}
+        {/* Readiness gate: per-condition checklist (DoR, judge verdict,
+            unresolved blocking debate entries, evidence spike) rendered
+            straight from gate_status — no client-side recomputation. */}
         <ReadinessPanel
           proposalId={proposal.id}
           gateStatus={detail.gate_status}
           refinement={detail.refinement}
+          debateTrail={detail.debate_trail}
           onChanged={onChanged}
         />
+
+        <Separator />
+
+        <ProposalSignoffs detail={detail} onChanged={onChanged} />
 
         <ProposalKickoff detail={detail} onChanged={onChanged} />
 
         <Separator />
 
+        <ProposalHistory detail={detail} />
+
+        <Separator />
+
         {/* Human feedback thread. The tribunal debate trail (objections /
-            rebuttals / verdicts) is intentionally NOT rendered here — the
-            judge's verdict in the refinement panel above is the human-facing
-            summary; the raw trail is audit data available via the API. */}
+            rebuttals / verdicts) now lives in the Tribunal review card above;
+            this thread is for human discussion only. */}
         <FeedbackThread
           proposal={proposal}
           feedback={feedback}


### PR DESCRIPTION
## What & why

The proposal detail page's **Refinement + Readiness** sections had UX problems on real proposals: the judge's reasoning markdown was rendered twice, the readiness panel printed contradiction-prone raw signals + raw blocking uuids, the full debate trail was never surfaced, the override form sat permanently expanded in alarming orange, and the accept/reject decision was far from the diff it concerned.

This is a UI-only restructure (no backend changes) implementing the agreed wireframes.

## Before → after

**1. Tribunal section** (`ProposalRefinement.tsx`)
- Before: a "Refinement" card that re-rendered the judge summary verbatim and pointed elsewhere for the diff.
- After: a **status ribbon** reconciling tribunal state ("Converged after N rounds — awaiting your review") + gate chip (Ready/Blocked), and a converged **review card** with `[ Verdict ] [ Spec diff rev X → Y ] [ Debate trail ]` tabs above the accept / another-round / reject actions. Judge reasoning renders **once** (Verdict tab). Spec-diff tab uses the pre-refinement snapshot → head diff. All existing actions/preconditions preserved.

**2. Readiness gate** (`ReadinessPanel.tsx`, rewritten)
- Before: raw side-by-side signals ("DoR: Pass", "Judge verdict: Ready", "Blocking rows: 3", "BLOCKED BECAUSE: <uuid>…") + a duplicate judge-reasoning block + a permanently-expanded orange override box.
- After: a **per-condition checklist** (Definition of Ready · Judge verdict · Blocking debate entries · Evidence spike) with pass/fail/na markers and the overall badge straight from `gate_status.ready`. Blocking entries expand to **real entry cards** (kind, role, round, vs-rev, blocking/superseded chip, expandable body) each with an inline **Resolve** action (`proposal_debate_resolve`); ids missing from the trail fall back to the raw id. Override is collapsed behind a "Something wrong with the gate itself?" link. Still renders `gate_status` as-is (no client-side recompute).

**3. Round-timeline** (`ProposalDebateTrail.tsx`, new)
- The `debate_trail` grouped by round (collapsed except the latest), each round summarising objection/resolved counts + verdict outcome, entries expandable to full markdown with blocking/resolved/reopened state.

**4. Section order**: Tribunal → Readiness gate → Sign-offs → Kickoff → History → Feedback.

Helpers `refinementDiff.ts` and `debateTrailUtils.ts` extracted. List rendering and `proposal_list` types untouched (concurrent PR).

## Tests
- Rewrote `ReadinessPanel.test.tsx`, `ProposalRefinement.test.tsx`; added `ProposalDebateTrail.test.tsx`.
- All 385 `src/components/proposals/` tests pass; app typecheck (`tsc -b`) clean; eslint clean on changed files (one pre-existing `as any` in ProposalRefinement retained — present on main).
- Note: the full `ProposalsPage.test.tsx` is order-dependent/flaky under local vmThreads and fails identically on `main` — unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
