### PR TITLE
feat(proposals): Surface tribunal + gate state on the proposals list

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_ops.rs
@@ -127,6 +127,41 @@ pub struct ProposalModel {
     /// When parked for needs-evidence: the named feasibility claim.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub needs_evidence_claim: Option<String>,
+    /// Compact tribunal/readiness summary — populated only on `proposal_list`
+    /// (batched across the page) for non-terminal proposals, so list rows can
+    /// render tribunal/gate chips without opening each proposal. `None` on show
+    /// paths and for terminal proposals (done/rejected/archived/superseded).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub list_summary: Option<ProposalListSummary>,
+}
+
+/// Compact tribunal/readiness state for a single proposal row on the list.
+///
+/// Every field is a cheap, batched approximation of the richer per-proposal
+/// gate/refinement status surfaced by `proposal_show` — enough to drive the
+/// list-row chips (tribunal round / awaiting-review / evidence, and a gate
+/// pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+/// row those full builders cost.
+#[derive(Serialize, Deserialize, Clone, Default, schemars::JsonSchema)]
+pub struct ProposalListSummary {
+    /// A refinement (tribunal) run is active — a round is in flight.
+    pub refinement_active: bool,
+    /// Refinement converged and is parked awaiting human review (the human is
+    /// the bottleneck — the most important state to surface).
+    pub awaiting_review: bool,
+    /// Highest debate round reached (`0` when there is no debate trail yet).
+    pub current_round: i32,
+    /// Parked on an open needs-evidence spike.
+    pub needs_evidence: bool,
+    /// Deterministic Definition-of-Ready passes.
+    pub dor_ready: bool,
+    /// Composed-gate approximation passes: `dor_ready` AND the latest judge
+    /// verdict is not needs-work AND there are no unresolved blocking objections
+    /// AND the proposal is not parked on evidence. (Override lifecycle handling
+    /// is intentionally omitted here; the full check lives in `proposal_show`.)
+    pub gate_ready: bool,
+    /// Count of unresolved blocking (non-verdict) debate objections.
+    pub unresolved_blocking_count: i64,
 }
 
 /// An epic this proposal graduated into.
@@ -174,7 +209,14 @@ impl ProposalModel {
             unresolved_feedback_count,
             linked_spike_task_id: p.linked_spike_task_id.clone(),
             needs_evidence_claim: p.needs_evidence_claim.clone(),
+            list_summary: None,
         }
+    }
+
+    /// Attach the batched tribunal/readiness summary (list path only).
+    pub fn with_list_summary(mut self, summary: ProposalListSummary) -> Self {
+        self.list_summary = Some(summary);
+        self
     }
 }
 

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools.rs
@@ -28,8 +28,9 @@ use crate::tools::proposal_blocks::{
 };
 use crate::tools::proposal_ops::{
     ProposalDebateTrailModel, ProposalDeleteResponse, ProposalEpicModel, ProposalFeedbackResponse,
-    ProposalModel, ProposalReconcileObsoleteEpicResponse, ProposalShowResponse,
-    ProposalSignoffModel, ProposalSingleResponse, ProposalTargetModel, ProposalTargetsResponse,
+    ProposalListSummary, ProposalModel, ProposalReconcileObsoleteEpicResponse,
+    ProposalShowResponse, ProposalSignoffModel, ProposalSingleResponse, ProposalTargetModel,
+    ProposalTargetsResponse,
 };
 use crate::tools::proposal_readiness::evaluate_proposal_readiness;
 use crate::tools::validation::{
@@ -38,7 +39,8 @@ use crate::tools::validation::{
     validate_title,
 };
 use djinn_db::{
-    EpicRepository, ProjectRepository, ProposalListQuery, ProposalRepository, TaskRepository,
+    EpicRepository, ProjectRepository, ProposalListQuery, ProposalListSummaryRow,
+    ProposalRepository, TaskRepository,
 };
 
 // ── List response (NamedListResponse boilerplate, mirrors EpicListResponse) ──
@@ -716,6 +718,56 @@ pub struct ProposalStopBuildResponse {
 /// missing, empty, or unparseable.
 fn parse_ac_items(ac_json: &str) -> Vec<AcceptanceCriterionItem> {
     serde_json::from_str::<Vec<AcceptanceCriterionItem>>(ac_json).unwrap_or_default()
+}
+
+/// Whether a proposal status is non-terminal (still moving through scoping /
+/// review). Only these get a batched list summary — terminal proposals never
+/// show tribunal/gate chips. Mirrors the statuses the composed gate cares about
+/// (`draft` and `in_review`).
+fn proposal_status_is_non_terminal(status: &str) -> bool {
+    matches!(status, "draft" | "in_review")
+}
+
+/// Heuristic for a needs-work judge verdict — kept identical to the one in
+/// `build_gate_status` so the list and the detail gate agree.
+fn judge_verdict_is_needs_work(verdict_body: &str) -> bool {
+    let lower = verdict_body.to_lowercase();
+    lower.contains("needs-work") || lower.contains("needs_work") || lower.contains("needs work")
+}
+
+/// Compose the list-row tribunal/readiness summary from a proposal row plus its
+/// batched raw facts. Deterministic and query-free (all data is already loaded):
+/// runs the in-memory DoR evaluator and approximates the composed gate.
+fn build_list_summary(
+    proposal: &djinn_core::models::proposal::Proposal,
+    raw: &ProposalListSummaryRow,
+) -> ProposalListSummary {
+    let ac_items = parse_ac_items(&proposal.acceptance_criteria);
+    let dor_ready =
+        evaluate_proposal_readiness(&proposal.body, &ac_items, raw.target_count as usize).ready;
+
+    let needs_evidence = proposal.linked_spike_task_id.is_some();
+    let judge_needs_work = raw
+        .latest_judge_verdict_body
+        .as_deref()
+        .map(judge_verdict_is_needs_work)
+        .unwrap_or(false);
+
+    // Composed-gate approximation (no override lifecycle handling — see
+    // `ProposalListSummary::gate_ready` docs; the authoritative check with
+    // human-override suppression lives in `build_gate_status`).
+    let gate_ready =
+        dor_ready && !judge_needs_work && raw.unresolved_blocking_count == 0 && !needs_evidence;
+
+    ProposalListSummary {
+        refinement_active: raw.refinement_active,
+        awaiting_review: raw.awaiting_review,
+        current_round: raw.current_round,
+        needs_evidence,
+        dor_ready,
+        gate_ready,
+        unresolved_blocking_count: raw.unresolved_blocking_count,
+    }
 }
 
 /// Convert a `ProposalReadinessResult` into a user-facing error string,
@@ -1555,19 +1607,47 @@ impl DjinnMcpServer {
             limit,
             offset,
         };
-        match repo.list_filtered(query).await {
-            Ok(result) => Json(list_response::success::<ProposalListResponse>(
-                result
-                    .proposals
-                    .iter()
-                    .map(|(p, count)| ProposalModel::from_with_count(p, *count))
-                    .collect(),
-                result.total_count,
-                limit,
-                offset,
-            )),
-            Err(e) => Json(list_response::error::<ProposalListResponse>(e.to_string())),
-        }
+        let result = match repo.list_filtered(query).await {
+            Ok(result) => result,
+            Err(e) => return Json(list_response::error::<ProposalListResponse>(e.to_string())),
+        };
+
+        // Batch the tribunal/readiness summary across only the non-terminal
+        // proposals on this page (draft/in_review). Terminal proposals
+        // (done/rejected/archived/superseded, and any non-active status) keep
+        // `list_summary = None` so the list stays cheap and the UI shows no chips
+        // for them. A summary-query failure is non-fatal: the list still renders
+        // (rows just lack chips).
+        let summary_ids: Vec<String> = result
+            .proposals
+            .iter()
+            .filter(|(p, _)| proposal_status_is_non_terminal(&p.status))
+            .map(|(p, _)| p.id.clone())
+            .collect();
+        let summaries = if summary_ids.is_empty() {
+            std::collections::HashMap::new()
+        } else {
+            repo.list_summaries(&summary_ids).await.unwrap_or_default()
+        };
+
+        let rows: Vec<ProposalModel> = result
+            .proposals
+            .iter()
+            .map(|(p, count)| {
+                let model = ProposalModel::from_with_count(p, *count);
+                match summaries.get(&p.id) {
+                    Some(raw) => model.with_list_summary(build_list_summary(p, raw)),
+                    None => model,
+                }
+            })
+            .collect();
+
+        Json(list_response::success::<ProposalListResponse>(
+            rows,
+            result.total_count,
+            limit,
+            offset,
+        ))
     }
 
     /// Update a proposal's editable fields.
@@ -7572,5 +7652,203 @@ The open-questions section collects uncertainties for the team.
         assert!(exported_ids.contains(&"opening"));
         assert!(exported_ids.contains(&"repo-layout"));
         assert!(exported_ids.contains(&"tradeoffs"));
+    }
+}
+
+#[cfg(test)]
+mod list_summary_tests {
+    use crate::server::DjinnMcpServer;
+    use crate::state::stubs::test_mcp_state;
+    use djinn_core::events::EventBus;
+    use djinn_db::{
+        Database, ProjectRepository, ProposalCreateInput, ProposalDebateTrailCreateInput,
+        ProposalRepository,
+    };
+
+    /// A well-formed body that passes all deterministic readiness checks.
+    fn ready_body() -> &'static str {
+        r#"
+# Problem
+Users cannot do X.
+
+# Scope
+In scope: Y. Out of scope: Z.
+
+# Objectives
+- Deliver A
+
+## File map
+```file-map
+    src/main.rs
+```
+
+# Dependencies
+Blocked by service C.
+
+# Open Questions
+What happens if D fails?
+"#
+    }
+
+    async fn test_server() -> (DjinnMcpServer, Database) {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        (DjinnMcpServer::new(test_mcp_state(db.clone())), db)
+    }
+
+    /// Pull the `list_summary` object for a given proposal id out of a
+    /// `proposal_list` response.
+    fn summary_for<'a>(
+        list: &'a serde_json::Value,
+        proposal_id: &str,
+    ) -> Option<&'a serde_json::Value> {
+        list.get("proposals")?
+            .as_array()?
+            .iter()
+            .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(proposal_id))
+            .and_then(|p| p.get("list_summary"))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proposal_list_surfaces_tribunal_and_gate_summary() {
+        let (server, db) = test_server().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let project_repo = ProjectRepository::new(db.clone(), EventBus::noop());
+        let project = project_repo
+            .create("svc-list-sum", "test", "svc-list-sum-repo")
+            .await
+            .unwrap();
+
+        // Messy: empty body (fails DoR), no target, active refinement, one
+        // blocking objection, and a judge needs-work verdict.
+        let messy = repo
+            .create(ProposalCreateInput {
+                title: "Messy",
+                body: "just some text",
+                acceptance_criteria: Some("[]"),
+                status: None,
+                body_format: None,
+            })
+            .await
+            .unwrap();
+        repo.record_refinement_lifecycle(&messy.id, "refinement_start", None)
+            .await
+            .unwrap();
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &messy.id,
+            kind: "objection",
+            body: "unbounded scope",
+            blocking: true,
+            agent_role: "adversary",
+            author_kind: "agent",
+            author_model: Some("m"),
+            source_task_id: None,
+            against_revision_seq: 1,
+            round: 2,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &messy.id,
+            kind: "verdict",
+            body: "verdict: needs-work",
+            blocking: true,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("m"),
+            source_task_id: None,
+            against_revision_seq: 1,
+            round: 2,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+        // Clean: DoR-passing body, a target, refinement converged awaiting
+        // review, an approving verdict, no blocking objections.
+        let clean = repo
+            .create(ProposalCreateInput {
+                title: "Clean",
+                body: ready_body(),
+                acceptance_criteria: Some(r#"[{"criterion":"API returns 200","met":false}]"#),
+                status: None,
+                body_format: None,
+            })
+            .await
+            .unwrap();
+        repo.add_target(&clean.id, &project.id, "primary")
+            .await
+            .unwrap();
+        repo.record_refinement_lifecycle(&clean.id, "refinement_start", None)
+            .await
+            .unwrap();
+        repo.record_refinement_lifecycle(&clean.id, "refinement_awaiting_review", None)
+            .await
+            .unwrap();
+
+        let list = server
+            .dispatch_tool("proposal_list", serde_json::json!({ "limit": 50 }))
+            .await
+            .unwrap();
+        assert!(
+            list.get("error").is_none(),
+            "proposal_list failed: {:?}",
+            list.get("error")
+        );
+
+        let m = summary_for(&list, &messy.id).expect("messy has a list_summary");
+        assert_eq!(m["refinement_active"], serde_json::json!(true));
+        assert_eq!(m["awaiting_review"], serde_json::json!(false));
+        assert_eq!(m["current_round"], serde_json::json!(2));
+        assert_eq!(m["needs_evidence"], serde_json::json!(false));
+        assert_eq!(m["dor_ready"], serde_json::json!(false));
+        assert_eq!(m["gate_ready"], serde_json::json!(false));
+        assert_eq!(
+            m["unresolved_blocking_count"],
+            serde_json::json!(1),
+            "the judge verdict row must be excluded from the objection count"
+        );
+
+        let c = summary_for(&list, &clean.id).expect("clean has a list_summary");
+        assert_eq!(c["refinement_active"], serde_json::json!(true));
+        assert_eq!(c["awaiting_review"], serde_json::json!(true));
+        assert_eq!(c["dor_ready"], serde_json::json!(true));
+        assert_eq!(c["gate_ready"], serde_json::json!(true));
+        assert_eq!(c["unresolved_blocking_count"], serde_json::json!(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proposal_list_omits_summary_for_terminal_proposals() {
+        let (server, db) = test_server().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let done = repo
+            .create(ProposalCreateInput {
+                title: "Shipped",
+                body: ready_body(),
+                acceptance_criteria: Some("[]"),
+                status: None,
+                body_format: None,
+            })
+            .await
+            .unwrap();
+        repo.set_status(&done.id, "done").await.unwrap();
+
+        let list = server
+            .dispatch_tool("proposal_list", serde_json::json!({ "limit": 50 }))
+            .await
+            .unwrap();
+        let entry = list
+            .get("proposals")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| {
+                arr.iter()
+                    .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(done.id.as_str()))
+            })
+            .expect("proposal present in list");
+        assert!(
+            entry.get("list_summary").is_none(),
+            "terminal proposals must not carry a list_summary (chips hidden)"
+        );
     }
 }

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -99,7 +99,8 @@ pub use repositories::{
     proposal::{
         NeedsEvidenceCapStatus, NeedsEvidenceClaimLink, ProposalCreateInput,
         ProposalDebateTrailCreateInput, ProposalFeedbackCreateInput, ProposalListQuery,
-        ProposalListResult, ProposalMemoryRef, ProposalRepository, ProposalUpdateInput,
+        ProposalListResult, ProposalListSummaryRow, ProposalMemoryRef, ProposalRepository,
+        ProposalUpdateInput,
     },
     repo_graph_cache::{CachedRepoGraph, RepoGraphCacheInsert, RepoGraphCacheRepository},
     service::{ServicePreset, ServicePresetRepository},

--- a/server/crates/djinn-db/src/repositories/proposal.rs
+++ b/server/crates/djinn-db/src/repositories/proposal.rs
@@ -86,6 +86,32 @@ struct ProposalListRow {
     unresolved_feedback_count: i64,
 }
 
+/// Batched tribunal/readiness raw facts for one proposal on the list path.
+///
+/// Populated by [`ProposalRepository::list_summaries`], which runs one grouped
+/// (or window) query per fact across the whole listed page — so rendering the
+/// list's tribunal/gate chips costs a handful of queries total instead of the
+/// several-per-row that `build_gate_status` / `build_refinement_status` issue.
+/// Callers derive the deterministic DoR and composed-gate booleans upstream
+/// (they live in the control-plane readiness evaluator).
+#[derive(Debug, Default, Clone)]
+pub struct ProposalListSummaryRow {
+    /// Unresolved blocking, non-verdict debate objections outstanding.
+    pub unresolved_blocking_count: i64,
+    /// Body of the latest judge verdict, if any (for the needs-work heuristic
+    /// applied upstream — kept out of the DB layer so the heuristic stays
+    /// single-sourced with `build_gate_status`).
+    pub latest_judge_verdict_body: Option<String>,
+    /// Highest debate round reached (`0` when there is no debate trail yet).
+    pub current_round: i32,
+    /// A refinement (tribunal) run is active — started with no later stop.
+    pub refinement_active: bool,
+    /// Refinement converged and is parked awaiting human review.
+    pub awaiting_review: bool,
+    /// Number of target projects attached (feeds the DoR target-count check).
+    pub target_count: i64,
+}
+
 pub struct ProposalCreateInput<'a> {
     pub title: &'a str,
     pub body: &'a str,
@@ -3096,6 +3122,160 @@ impl ProposalRepository {
         .await?;
         Ok(count > 0)
     }
+
+    /// Batched tribunal/readiness raw facts for a page of proposals.
+    ///
+    /// One grouped/window query each for: unresolved blocking non-verdict debate
+    /// entries, latest judge verdict, highest debate round, refinement lifecycle
+    /// events, and target counts — keyed by proposal id. This deliberately does
+    /// NOT call the per-proposal `build_gate_status` / `build_refinement_status`
+    /// helpers (each of which issues several queries); it runs a fixed handful of
+    /// queries for the whole page so the proposals list can render tribunal/gate
+    /// chips cheaply. Callers derive `dor_ready` / `gate_ready` upstream.
+    ///
+    /// Proposals with no rows in a given table simply get the default (`0` /
+    /// `false` / `None`) for that fact. Every id in `ids` is present in the map.
+    pub async fn list_summaries(
+        &self,
+        ids: &[String],
+    ) -> Result<HashMap<String, ProposalListSummaryRow>> {
+        self.db.ensure_initialized().await?;
+        let mut out: HashMap<String, ProposalListSummaryRow> = HashMap::new();
+        if ids.is_empty() {
+            return Ok(out);
+        }
+        for id in ids {
+            out.entry(id.clone()).or_default();
+        }
+
+        // 1. Unresolved blocking non-verdict debate objections per proposal.
+        //    Mirrors `list_unresolved_blocking_debate_entries` (blocking +
+        //    unresolved-or-reopened) but excludes judge verdicts
+        //    (`kind <> 'verdict'`) so the count reflects only outstanding
+        //    objections, not the verdict row itself.
+        let blocking_rows = sqlx::query_as::<_, (String, i64)>(
+            r#"SELECT proposal_id, COUNT(*) AS n
+               FROM proposal_debate_trail
+               WHERE proposal_id = ANY($1)
+                 AND blocking = true
+                 AND kind <> 'verdict'
+                 AND (resolved_at IS NULL
+                      OR (resolved_at IS NOT NULL AND reopened_at IS NOT NULL))
+               GROUP BY proposal_id"#,
+        )
+        .bind(ids)
+        .fetch_all(self.db.pool())
+        .await?;
+        for (pid, n) in blocking_rows {
+            if let Some(row) = out.get_mut(&pid) {
+                row.unresolved_blocking_count = n;
+            }
+        }
+
+        // 2. Latest judge verdict body per proposal (window via DISTINCT ON).
+        let verdict_rows = sqlx::query_as::<_, (String, String)>(
+            r#"SELECT DISTINCT ON (proposal_id) proposal_id, body
+               FROM proposal_debate_trail
+               WHERE proposal_id = ANY($1)
+                 AND kind = 'verdict'
+                 AND agent_role = 'judge'
+               ORDER BY proposal_id, created_at DESC, id DESC"#,
+        )
+        .bind(ids)
+        .fetch_all(self.db.pool())
+        .await?;
+        for (pid, body) in verdict_rows {
+            if let Some(row) = out.get_mut(&pid) {
+                row.latest_judge_verdict_body = Some(body);
+            }
+        }
+
+        // 3. Highest debate round per proposal.
+        let round_rows = sqlx::query_as::<_, (String, Option<i32>)>(
+            r#"SELECT proposal_id, MAX(round) AS max_round
+               FROM proposal_debate_trail
+               WHERE proposal_id = ANY($1)
+               GROUP BY proposal_id"#,
+        )
+        .bind(ids)
+        .fetch_all(self.db.pool())
+        .await?;
+        for (pid, max_round) in round_rows {
+            if let Some(row) = out.get_mut(&pid) {
+                row.current_round = max_round.unwrap_or(0);
+            }
+        }
+
+        // 4. Refinement lifecycle events → active / awaiting_review. Mirrors the
+        //    created_at ordering logic in `build_refinement_status`: the latest
+        //    refinement_start defines the active run; a stop after it ends it; an
+        //    awaiting_review after the start (and after any stop) parks it.
+        let refine_rows = sqlx::query_as::<_, (String, String, String)>(
+            r#"SELECT proposal_id, event_kind, created_at
+               FROM proposal_revisions
+               WHERE proposal_id = ANY($1)
+                 AND event_kind IN
+                   ('refinement_start', 'refinement_stop', 'refinement_awaiting_review')
+               ORDER BY proposal_id, created_at, id"#,
+        )
+        .bind(ids)
+        .fetch_all(self.db.pool())
+        .await?;
+        // Rows ascend by created_at, so the last write per (proposal, kind) is
+        // the latest occurrence — matching `revisions().iter().rev().find(..)`.
+        let mut latest_start: HashMap<String, String> = HashMap::new();
+        let mut latest_stop: HashMap<String, String> = HashMap::new();
+        let mut latest_awaiting: HashMap<String, String> = HashMap::new();
+        for (pid, kind, created_at) in refine_rows {
+            match kind.as_str() {
+                "refinement_start" => {
+                    latest_start.insert(pid, created_at);
+                }
+                "refinement_stop" => {
+                    latest_stop.insert(pid, created_at);
+                }
+                "refinement_awaiting_review" => {
+                    latest_awaiting.insert(pid, created_at);
+                }
+                _ => {}
+            }
+        }
+        for (pid, row) in out.iter_mut() {
+            let Some(start) = latest_start.get(pid) else {
+                continue;
+            };
+            let stop = latest_stop.get(pid);
+            let awaiting = latest_awaiting.get(pid);
+            // Active when no stop landed after the latest start.
+            row.refinement_active = match stop {
+                Some(stop) => stop <= start,
+                None => true,
+            };
+            row.awaiting_review = match (awaiting, stop) {
+                (Some(aw), Some(stop)) => start <= aw && stop < aw,
+                (Some(aw), None) => start <= aw,
+                _ => false,
+            };
+        }
+
+        // 5. Target counts per proposal (feeds the DoR target-count check).
+        let target_rows = sqlx::query_as::<_, (String, i64)>(
+            r#"SELECT proposal_id, COUNT(*) AS n
+               FROM proposal_targets
+               WHERE proposal_id = ANY($1)
+               GROUP BY proposal_id"#,
+        )
+        .bind(ids)
+        .fetch_all(self.db.pool())
+        .await?;
+        for (pid, n) in target_rows {
+            if let Some(row) = out.get_mut(&pid) {
+                row.target_count = n;
+            }
+        }
+
+        Ok(out)
+    }
 }
 
 fn evidence_spike_task_is_terminal(status: &str) -> bool {
@@ -3479,6 +3659,116 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(listed.proposals[0].1, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn list_summaries_batches_tribunal_facts() {
+        let db = test_db();
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let proj = insert_project(&db, "svc-sum").await;
+
+        // Messy proposal: active refinement, one blocking objection, a judge
+        // needs-work verdict, no target.
+        let messy = repo.create(create_input("Messy")).await.unwrap();
+        repo.record_refinement_lifecycle(&messy.id, "refinement_start", None)
+            .await
+            .unwrap();
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &messy.id,
+            kind: "objection",
+            body: "this scope is unbounded",
+            blocking: true,
+            agent_role: "adversary",
+            author_kind: "agent",
+            author_model: Some("m"),
+            source_task_id: None,
+            against_revision_seq: 1,
+            round: 2,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+        // A judge verdict — must NOT count toward the blocking objection total
+        // (kind <> 'verdict'), but its body feeds the needs-work heuristic.
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &messy.id,
+            kind: "verdict",
+            body: "verdict: needs-work — tighten the scope",
+            blocking: true,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("m"),
+            source_task_id: None,
+            against_revision_seq: 1,
+            round: 2,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+        // Clean proposal: refinement converged and parked awaiting review, a
+        // non-needs-work verdict, a target attached, no blocking objections.
+        let clean = repo.create(create_input("Clean")).await.unwrap();
+        repo.add_target(&clean.id, &proj, "primary").await.unwrap();
+        repo.record_refinement_lifecycle(&clean.id, "refinement_start", None)
+            .await
+            .unwrap();
+        repo.record_refinement_lifecycle(&clean.id, "refinement_awaiting_review", None)
+            .await
+            .unwrap();
+        repo.add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id: &clean.id,
+            kind: "verdict",
+            body: "verdict: approve — ready to graduate",
+            blocking: false,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: Some("m"),
+            source_task_id: None,
+            against_revision_seq: 1,
+            round: 3,
+            body_metadata: None,
+        })
+        .await
+        .unwrap();
+
+        let ids = vec![messy.id.clone(), clean.id.clone()];
+        let summaries = repo.list_summaries(&ids).await.unwrap();
+        assert_eq!(summaries.len(), 2, "every id present in the map");
+
+        let m = summaries.get(&messy.id).unwrap();
+        assert!(m.refinement_active, "messy has an active refinement run");
+        assert!(!m.awaiting_review);
+        assert_eq!(m.current_round, 2);
+        assert_eq!(
+            m.unresolved_blocking_count, 1,
+            "the verdict row must be excluded from the objection count"
+        );
+        assert!(m.target_count == 0);
+        assert!(
+            m.latest_judge_verdict_body
+                .as_deref()
+                .is_some_and(|b| b.contains("needs-work"))
+        );
+
+        let c = summaries.get(&clean.id).unwrap();
+        assert!(c.refinement_active, "no stop after start → still active");
+        assert!(c.awaiting_review, "awaiting_review after start parks it");
+        assert_eq!(c.current_round, 3);
+        assert_eq!(c.unresolved_blocking_count, 0);
+        assert_eq!(c.target_count, 1);
+        assert!(
+            c.latest_judge_verdict_body
+                .as_deref()
+                .is_some_and(|b| b.contains("approve"))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn list_summaries_empty_ids_is_empty() {
+        let repo = ProposalRepository::new(test_db(), EventBus::noop());
+        let summaries = repo.list_summaries(&[]).await.unwrap();
+        assert!(summaries.is_empty());
     }
 
     fn update_input<'a>(

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -12474,6 +12474,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -12542,6 +12587,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
@@ -12804,6 +12860,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -12872,6 +12973,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
@@ -13665,6 +13777,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -13733,6 +13890,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
@@ -14099,6 +14267,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -14167,6 +14380,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
@@ -14261,6 +14485,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -14329,6 +14598,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
@@ -14465,6 +14745,51 @@ expression: signatures
           ],
           "type": "object"
         },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
+        },
         "ProposalModel": {
           "properties": {
             "acceptance_criteria": {
@@ -14525,6 +14850,17 @@ expression: signatures
                 "string",
                 "null"
               ]
+            },
+            "list_summary": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ProposalListSummary"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
             },
             "needs_evidence_claim": {
               "description": "When parked for needs-evidence: the named feasibility claim.",
@@ -16391,6 +16727,51 @@ expression: signatures
           ],
           "type": "object"
         },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
+        },
         "ProposalMemoryRefModel": {
           "description": "A memory note linked to a proposal via its graduated epics/tasks.",
           "properties": {
@@ -16481,6 +16862,17 @@ expression: signatures
                 "string",
                 "null"
               ]
+            },
+            "list_summary": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ProposalListSummary"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
             },
             "needs_evidence_claim": {
               "description": "When parked for needs-evidence: the named feasibility claim.",
@@ -16902,6 +17294,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -16970,6 +17407,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
@@ -17069,6 +17517,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -17137,6 +17630,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",
@@ -17399,6 +17903,51 @@ expression: signatures
             "criterion"
           ],
           "type": "object"
+        },
+        "ProposalListSummary": {
+          "description": "Compact tribunal/readiness state for a single proposal row on the list.\n\nEvery field is a cheap, batched approximation of the richer per-proposal\ngate/refinement status surfaced by `proposal_show` — enough to drive the\nlist-row chips (tribunal round / awaiting-review / evidence, and a gate\npass/fail dot with a \"why blocked\" tooltip) without the several-queries-per-\nrow those full builders cost.",
+          "properties": {
+            "awaiting_review": {
+              "description": "Refinement converged and is parked awaiting human review (the human is\nthe bottleneck — the most important state to surface).",
+              "type": "boolean"
+            },
+            "current_round": {
+              "description": "Highest debate round reached (`0` when there is no debate trail yet).",
+              "format": "int32",
+              "type": "integer"
+            },
+            "dor_ready": {
+              "description": "Deterministic Definition-of-Ready passes.",
+              "type": "boolean"
+            },
+            "gate_ready": {
+              "description": "Composed-gate approximation passes: `dor_ready` AND the latest judge\nverdict is not needs-work AND there are no unresolved blocking objections\nAND the proposal is not parked on evidence. (Override lifecycle handling\nis intentionally omitted here; the full check lives in `proposal_show`.)",
+              "type": "boolean"
+            },
+            "needs_evidence": {
+              "description": "Parked on an open needs-evidence spike.",
+              "type": "boolean"
+            },
+            "refinement_active": {
+              "description": "A refinement (tribunal) run is active — a round is in flight.",
+              "type": "boolean"
+            },
+            "unresolved_blocking_count": {
+              "description": "Count of unresolved blocking (non-verdict) debate objections.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "refinement_active",
+            "awaiting_review",
+            "current_round",
+            "needs_evidence",
+            "dor_ready",
+            "gate_ready",
+            "unresolved_blocking_count"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -17467,6 +18016,17 @@ expression: signatures
             "string",
             "null"
           ]
+        },
+        "list_summary": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProposalListSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Compact tribunal/readiness summary — populated only on `proposal_list`\n(batched across the page) for non-terminal proposals, so list rows can\nrender tribunal/gate chips without opening each proposal. `None` on show\npaths and for terminal proposals (done/rejected/archived/superseded)."
         },
         "mdx": {
           "description": "Portable proposal.mdx representation (populated by `proposal_export`).",

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -5845,6 +5845,13 @@ export namespace ProposalBlockPatchOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -5875,6 +5882,50 @@ export namespace ProposalBlockPatchOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -6004,6 +6055,13 @@ export namespace ProposalCreateOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -6034,6 +6092,50 @@ export namespace ProposalCreateOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -6434,6 +6536,13 @@ export namespace ProposalExportOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -6464,6 +6573,50 @@ export namespace ProposalExportOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -6631,6 +6784,13 @@ export namespace ProposalGraduateOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -6661,6 +6821,50 @@ export namespace ProposalGraduateOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -6713,6 +6917,13 @@ export namespace ProposalImportOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -6743,6 +6954,50 @@ export namespace ProposalImportOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -6818,6 +7073,13 @@ export namespace ProposalListOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * When parked for needs-evidence: the named feasibility claim.
    */
   needs_evidence_claim?: string
@@ -6844,6 +7106,50 @@ export namespace ProposalListOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -7881,6 +8187,13 @@ export namespace ProposalShowOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * When parked for needs-evidence: the named feasibility claim.
    */
   needs_evidence_claim?: string
@@ -7907,6 +8220,50 @@ export namespace ProposalShowOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
   /**
@@ -8077,6 +8434,13 @@ export namespace ProposalSignoffOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -8107,6 +8471,50 @@ export namespace ProposalSignoffOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -8163,6 +8571,13 @@ export namespace ProposalSignoffClearOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -8193,6 +8608,50 @@ export namespace ProposalSignoffClearOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 
@@ -8329,6 +8788,13 @@ export namespace ProposalUpdateOutputSchema {
    */
   linked_spike_task_id?: string
   /**
+   * Compact tribunal/readiness summary — populated only on `proposal_list`
+   * (batched across the page) for non-terminal proposals, so list rows can
+   * render tribunal/gate chips without opening each proposal. `None` on show
+   * paths and for terminal proposals (done/rejected/archived/superseded).
+   */
+  list_summary?: (ProposalListSummary | null)
+  /**
    * Portable proposal.mdx representation (populated by `proposal_export`).
    */
   mdx?: string
@@ -8359,6 +8825,50 @@ export namespace ProposalUpdateOutputSchema {
   export interface AcceptanceCriterionStatus {
   criterion: string
   met?: boolean
+  [k: string]: any
+  }
+  /**
+   * Compact tribunal/readiness state for a single proposal row on the list.
+   * 
+   * Every field is a cheap, batched approximation of the richer per-proposal
+   * gate/refinement status surfaced by `proposal_show` — enough to drive the
+   * list-row chips (tribunal round / awaiting-review / evidence, and a gate
+   * pass/fail dot with a "why blocked" tooltip) without the several-queries-per-
+   * row those full builders cost.
+   */
+  export interface ProposalListSummary {
+  /**
+   * Refinement converged and is parked awaiting human review (the human is
+   * the bottleneck — the most important state to surface).
+   */
+  awaiting_review: boolean
+  /**
+   * Highest debate round reached (`0` when there is no debate trail yet).
+   */
+  current_round: number
+  /**
+   * Deterministic Definition-of-Ready passes.
+   */
+  dor_ready: boolean
+  /**
+   * Composed-gate approximation passes: `dor_ready` AND the latest judge
+   * verdict is not needs-work AND there are no unresolved blocking objections
+   * AND the proposal is not parked on evidence. (Override lifecycle handling
+   * is intentionally omitted here; the full check lives in `proposal_show`.)
+   */
+  gate_ready: boolean
+  /**
+   * Parked on an open needs-evidence spike.
+   */
+  needs_evidence: boolean
+  /**
+   * A refinement (tribunal) run is active — a round is in flight.
+   */
+  refinement_active: boolean
+  /**
+   * Count of unresolved blocking (non-verdict) debate objections.
+   */
+  unresolved_blocking_count: number
   [k: string]: any
   }
 

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -71,6 +71,12 @@ export type Proposal = ProposalShowOutputSchema.ProposalModel & {
   /** Body format: 'markdown' (legacy default) or 'mdx' (block-aware). */
   body_format?: "markdown" | "mdx" | string | null;
 };
+/**
+ * Compact tribunal/readiness summary for a proposal list row. Present only on
+ * `proposal_list` (batched across the page) for non-terminal proposals; drives
+ * the list-row tribunal/gate chips.
+ */
+export type ProposalListSummary = ProposalShowOutputSchema.ProposalListSummary;
 export type ProposalFeedback = ProposalShowOutputSchema.ProposalFeedbackModel;
 export type ProposalTarget = ProposalShowOutputSchema.ProposalTargetModel;
 export type ProposalRevision = ProposalShowOutputSchema.ProposalRevisionModel;

--- a/ui/src/pages/ProposalsPage.test.tsx
+++ b/ui/src/pages/ProposalsPage.test.tsx
@@ -281,6 +281,124 @@ describe("ProposalsPage", () => {
     });
   });
 
+  it("renders tribunal and gate chips from each row's list summary", async () => {
+    const proposals = [
+      makeProposal({
+        id: "p-review",
+        short_id: "rvw1",
+        title: "Awaiting review proposal",
+        status: "in_review",
+        list_summary: {
+          refinement_active: true,
+          awaiting_review: true,
+          current_round: 4,
+          needs_evidence: false,
+          dor_ready: true,
+          gate_ready: true,
+          unresolved_blocking_count: 0,
+        },
+      }),
+      makeProposal({
+        id: "p-running",
+        short_id: "rvw2",
+        title: "Refinement running proposal",
+        status: "in_review",
+        list_summary: {
+          refinement_active: true,
+          awaiting_review: false,
+          current_round: 3,
+          needs_evidence: false,
+          dor_ready: false,
+          gate_ready: false,
+          unresolved_blocking_count: 0,
+        },
+      }),
+      makeProposal({
+        id: "p-evidence",
+        short_id: "rvw3",
+        title: "Evidence parked proposal",
+        status: "in_review",
+        list_summary: {
+          refinement_active: true,
+          awaiting_review: false,
+          current_round: 2,
+          needs_evidence: true,
+          dor_ready: true,
+          gate_ready: false,
+          unresolved_blocking_count: 0,
+        },
+      }),
+      makeProposal({
+        id: "p-blocked",
+        short_id: "rvw4",
+        title: "Blocked by objections proposal",
+        status: "in_review",
+        list_summary: {
+          refinement_active: false,
+          awaiting_review: false,
+          current_round: 1,
+          needs_evidence: false,
+          dor_ready: true,
+          gate_ready: false,
+          unresolved_blocking_count: 2,
+        },
+      }),
+    ];
+
+    vi.mocked(callMcpTool).mockImplementation(async (toolName) => {
+      if (toolName === "proposal_list") {
+        return { proposals } as never;
+      }
+      return {} as never;
+    });
+
+    renderProposalsRoute("/proposals");
+
+    const reviewSection = (await screen.findByText("In Review")).closest(
+      "section",
+    );
+    expect(reviewSection).not.toBeNull();
+    const section = within(reviewSection!);
+
+    // Tribunal chip variants.
+    expect(section.getByText("Review")).toBeInTheDocument();
+    expect(section.getByText("R3")).toBeInTheDocument();
+    expect(section.getByText("evidence")).toBeInTheDocument();
+
+    // Gate chip: DoR blocker (running row) + objection blocker + ready dot.
+    expect(section.getByText("DoR ✗")).toBeInTheDocument();
+    expect(section.getByText("⛔2")).toBeInTheDocument();
+    expect(
+      section.getByTitle("2 unresolved blocking objections"),
+    ).toBeInTheDocument();
+    expect(section.getByTitle("Gate ready")).toBeInTheDocument();
+    expect(section.getByTitle("Parked on evidence")).toBeInTheDocument();
+  });
+
+  it("renders no chips for a row without a list summary", async () => {
+    const proposals = [
+      makeProposal({
+        id: "p-nosummary",
+        short_id: "nos1",
+        title: "No summary proposal",
+        status: "in_review",
+      }),
+    ];
+
+    vi.mocked(callMcpTool).mockImplementation(async (toolName) => {
+      if (toolName === "proposal_list") {
+        return { proposals } as never;
+      }
+      return {} as never;
+    });
+
+    renderProposalsRoute("/proposals");
+
+    expect(await screen.findByText("No summary proposal")).toBeInTheDocument();
+    expect(screen.queryByTitle("Gate ready")).not.toBeInTheDocument();
+    expect(screen.queryByText("DoR ✗")).not.toBeInTheDocument();
+  });
+
   it("defaults terminal proposal groups collapsed and active groups expanded with counts visible", async () => {
     const proposals = [
       makeProposal({

--- a/ui/src/pages/ProposalsPage.tsx
+++ b/ui/src/pages/ProposalsPage.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft01Icon, Comment01Icon, Robot01Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowLeft01Icon,
+  Comment01Icon,
+  JusticeScale01Icon,
+  Robot01Icon,
+  TestTube01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { callMcpTool } from "@/api/mcpClient";
 import { usersQueryOptions } from "@/api/queryOptions";
@@ -59,8 +65,129 @@ import {
   proposalDetailQueryOptions,
   proposalListQueryOptions,
 } from "@/lib/proposalQueries";
+import { cn } from "@/lib/utils";
 import type { Project } from "@/api/server";
-import type { Proposal, ProposalFeedback } from "@/api/types";
+import type {
+  Proposal,
+  ProposalFeedback,
+  ProposalListSummary,
+} from "@/api/types";
+
+/**
+ * Compact tribunal + gate chips for a proposal list row.
+ *
+ * `summary` is populated by `proposal_list` only for non-terminal proposals
+ * (draft/in_review), so absence of a summary means "no chips". Renders at most
+ * two chips, right-aligned before the short id, each with a `title` tooltip:
+ *
+ * - Tribunal chip (one variant, by priority): accent `⚖ Review` when the
+ *   tribunal has converged and a human is the bottleneck; `🧪 evidence` when
+ *   parked on a needs-evidence spike; a pulsing `⚖ R{n}` while a refinement
+ *   round is running. Absent when the tribunal is idle.
+ * - Gate chip: a green/red dot. When blocked it also shows the leading reason
+ *   textually — `DoR ✗` when Definition-of-Ready fails, `⛔{n}` for unresolved
+ *   blocking objections — and always names the reason in the tooltip.
+ */
+function ProposalListChips({
+  summary,
+}: {
+  summary?: ProposalListSummary | null;
+}) {
+  if (!summary) return null;
+  const {
+    refinement_active,
+    awaiting_review,
+    current_round,
+    needs_evidence,
+    dor_ready,
+    gate_ready,
+    unresolved_blocking_count,
+  } = summary;
+  const round = current_round || 1;
+
+  let tribunal: ReactNode = null;
+  if (awaiting_review) {
+    tribunal = (
+      <span
+        className="flex shrink-0 items-center gap-0.5 text-xs font-medium text-amber-500"
+        title="Tribunal converged — awaiting your review"
+      >
+        <HugeiconsIcon icon={JusticeScale01Icon} size={13} />
+        Review
+      </span>
+    );
+  } else if (needs_evidence) {
+    tribunal = (
+      <span
+        className="flex shrink-0 items-center gap-0.5 text-xs text-muted-foreground"
+        title="Parked on a needs-evidence spike"
+      >
+        <HugeiconsIcon icon={TestTube01Icon} size={13} />
+        evidence
+      </span>
+    );
+  } else if (refinement_active) {
+    tribunal = (
+      <span
+        className="flex shrink-0 items-center gap-0.5 text-xs text-muted-foreground"
+        title={`Tribunal refinement running (round ${round})`}
+      >
+        <HugeiconsIcon
+          icon={JusticeScale01Icon}
+          size={13}
+          className="animate-pulse"
+        />
+        R{round}
+      </span>
+    );
+  }
+
+  // A blocked gate with DoR passing, no blocking objections, and no evidence
+  // park can only mean the latest judge verdict is needs-work.
+  const judgeNeedsWork =
+    !gate_ready &&
+    dor_ready &&
+    unresolved_blocking_count === 0 &&
+    !needs_evidence;
+  let gateText: string | null = null;
+  let gateTitle: string;
+  if (gate_ready) {
+    gateTitle = "Gate ready";
+  } else if (!dor_ready) {
+    gateText = "DoR ✗";
+    gateTitle = "DoR failing";
+  } else if (unresolved_blocking_count > 0) {
+    gateText = `⛔${unresolved_blocking_count}`;
+    gateTitle = `${unresolved_blocking_count} unresolved blocking objection${
+      unresolved_blocking_count === 1 ? "" : "s"
+    }`;
+  } else if (needs_evidence) {
+    gateTitle = "Parked on evidence";
+  } else if (judgeNeedsWork) {
+    gateTitle = "Judge needs work";
+  } else {
+    gateTitle = "Gate blocked";
+  }
+
+  return (
+    <>
+      {tribunal}
+      <span
+        className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
+        title={gateTitle}
+      >
+        <span
+          className={cn(
+            "inline-block size-2 rounded-full",
+            gate_ready ? "bg-green-500" : "bg-red-500",
+          )}
+          aria-hidden="true"
+        />
+        {gateText}
+      </span>
+    </>
+  );
+}
 
 /** Render a full proposal as markdown — title + spec + acceptance criteria —
  * so it can be copied into an AI to discuss. */
@@ -281,6 +408,7 @@ function ProposalsListView() {
                               criteria={p.acceptance_criteria}
                               className="shrink-0"
                             />
+                            <ProposalListChips summary={p.list_summary} />
                             <span className="hidden shrink-0 font-mono text-xs text-muted-foreground sm:inline">
                               {p.short_id}
                             </span>


### PR DESCRIPTION
## What

Surface tribunal/readiness state on the proposals **list** so users can see at a glance which proposals have an active tribunal, are awaiting review, are parked on evidence, and whether DoR/gate pass — without opening each proposal.

## Backend

- **`ProposalListSummary`** (new nested optional on `ProposalModel`), populated only on `proposal_list` for **non-terminal** proposals (`draft`/`in_review`); `None` on show paths and terminal proposals so the list stays cheap and the UI shows no chips for them. Fields: `refinement_active`, `awaiting_review`, `current_round`, `needs_evidence`, `dor_ready`, `gate_ready`, `unresolved_blocking_count`.
- **`ProposalRepository::list_summaries(ids)`** batches the facts across the whole page — a fixed handful of queries instead of the several-per-row that `build_gate_status` / `build_refinement_status` cost:
  - one grouped count of unresolved blocking **non-verdict** objections (`kind <> 'verdict'`, mirroring `list_unresolved_blocking_debate_entries`),
  - one `DISTINCT ON (proposal_id)` for the latest judge verdict → needs-work heuristic,
  - one refinement-lifecycle-event query deriving `active` / `awaiting_review` (same `created_at` ordering as `build_refinement_status`),
  - one `MAX(round)` per proposal for `current_round`,
  - one target-count-per-proposal query for the DoR target check.
- `dor_ready` runs the in-memory `evaluate_proposal_readiness`; `gate_ready = dor_ready && !judge_needs_work && unresolved_blocking_count == 0 && !needs_evidence` (override lifecycle intentionally omitted for the list — the authoritative check stays in `proposal_show`). A summary-query failure is non-fatal (rows just lack chips).
- All queries are runtime `sqlx::query_as` (no macros) so no `.sqlx` regeneration is needed. Regenerated the MCP tool-schema insta snapshot + the generated TS types (`mcp-tools.gen.ts`) via the existing snapshot pipeline.

## UI

- List rows render up to two compact chips before the short id (truncation-safe, `title` tooltips), only when meaningful:
  - **Tribunal chip**: accent `⚖ Review` when awaiting human review (bottleneck), `🧪 evidence` when parked on evidence, pulsing `⚖ R{n}` while a refinement round runs.
  - **Gate chip**: green/red dot with a "why blocked" tooltip — `DoR ✗` when DoR fails, `⛔{n}` for unresolved blocking objections, plus judge-needs-work / evidence reasons.
- No "needs your review" virtual group (per the explicit rejection) — relies on existing status grouping.

## Tests

- **djinn-db**: `list_summaries_batches_tribunal_facts` (active refinement + blocking objection + judge needs-work verdict vs a clean converged one; verdict excluded from the objection count) + empty-ids case.
- **djinn-control-plane**: `proposal_list_surfaces_tribunal_and_gate_summary` (end-to-end via `dispatch_tool`, asserts dor_ready/gate_ready/round/counts) + terminal-proposals-omit-summary.
- **UI**: chip rendering cases + a no-summary/no-chips case in `ProposalsPage.test.tsx`.

All 250 proposal Rust tests + the tool-schema snapshot pass; `tsc` and `eslint` clean; new UI tests pass. (Two pre-existing detail-pane test failures exist on the branch base, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)