### PR TITLE
Sanitize dangling tool calls on replay + escalate provider-error failure streaks

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -234,6 +234,19 @@ pub(super) struct CoordinatorActor {
     /// Planner intervention instead of blindly redispatching a third time.
     /// Reset when the task's status advances or it leaves execution.
     pub(super) stall_cancel_streak: HashMap<String, StallCancelStreak>,
+    /// Restart-safe-to-lose: consecutive provider-error FAILED sessions per TASK
+    /// id with no durable task-status progress between them. A task whose
+    /// session dies on a terminal provider error (e.g. a poisoned transcript
+    /// 400, an auth/server fault) is redispatched and fails the same way,
+    /// burning attempts in the escalating backoff ladder with nobody deciding
+    /// what to do — the cycling-intervention gate (trigger B) deliberately
+    /// excludes provider faults, and the stall-cancel escalation only covers
+    /// coordinator-initiated stall kills. On the Nth consecutive strike we route
+    /// the task to a Planner intervention instead of another doomed redispatch.
+    /// Reset when the task's status advances or it leaves execution. Sibling of
+    /// `stall_cancel_streak` (see [`STALL_CANCEL_ESCALATION_THRESHOLD`] /
+    /// [`FAILURE_ESCALATION_THRESHOLD`]).
+    pub(super) provider_failure_streak: HashMap<String, StallCancelStreak>,
     /// Timestamp of the last completed idle-time consolidation sweep (ADR-048 §3A).
     pub(super) last_idle_consolidation: Option<StdInstant>,
     /// Cancellation token for an in-flight idle consolidation sweep.
@@ -450,6 +463,7 @@ impl CoordinatorActor {
             stall_killed: HashSet::new(),
             stall_progress_watermark: HashMap::new(),
             stall_cancel_streak: HashMap::new(),
+            provider_failure_streak: HashMap::new(),
             last_idle_consolidation: None,
             idle_consolidation_cancel: None,
             idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/consolidation.rs
+++ b/server/crates/djinn-coordinator/src/consolidation.rs
@@ -486,6 +486,7 @@ mod tests {
             stall_killed: std::collections::HashSet::new(),
             stall_progress_watermark: std::collections::HashMap::new(),
             stall_cancel_streak: std::collections::HashMap::new(),
+            provider_failure_streak: std::collections::HashMap::new(),
             last_idle_consolidation: None,
             idle_consolidation_cancel: None,
             idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -421,6 +421,90 @@ impl CoordinatorActor {
             .await
     }
 
+    /// Trigger D: consecutive provider-error FAILED sessions without progress.
+    ///
+    /// A session that dies on a terminal provider/session error — the
+    /// poisoned-transcript 400 (an assistant `tool_calls` message replayed
+    /// without its tool results), a dead credential, a persistent server fault —
+    /// is redispatched and fails identically, riding the escalating cooldown
+    /// ladder toward the terminal close at [`MAX_DISPATCH_FAILURES`] with nobody
+    /// deciding what to do. The cycling gate (trigger B) excludes provider
+    /// faults by design and the stall-cancel escalation only covers
+    /// coordinator-initiated stall kills, so these failures had no Planner path.
+    ///
+    /// Advances the per-task `provider_failure_streak` — sibling of the
+    /// stall-cancel streak, reset when the task's status advances (durable
+    /// progress) between strikes — and on the
+    /// [`FAILURE_ESCALATION_THRESHOLD`]-th consecutive strike routes the task to
+    /// a Planner intervention (decompose / rescope / close), clearing its
+    /// backoff state so a post-intervention run starts fresh. Returns `true`
+    /// when an intervention was routed (the caller skips the ordinary backoff
+    /// ladder for this reappearance); `false` while still below threshold.
+    ///
+    /// Callers gate this on a genuine, non-throttle typed provider failure — a
+    /// transient throttle must decay on the cooldown ladder, not escalate.
+    pub(crate) async fn maybe_escalate_provider_failure_streak(
+        &mut self,
+        task: &djinn_core::models::Task,
+        role: &'static str,
+    ) -> bool {
+        let strike_count = {
+            let streak = self
+                .provider_failure_streak
+                .entry(task.id.clone())
+                .and_modify(|s| {
+                    if s.last_status == task.status {
+                        s.count += 1;
+                    } else {
+                        // Durable status progress between strikes — reset.
+                        s.count = 1;
+                        s.last_status = task.status.clone();
+                    }
+                })
+                .or_insert_with(|| StallCancelStreak {
+                    count: 1,
+                    last_status: task.status.clone(),
+                });
+            streak.count
+        };
+
+        if strike_count < FAILURE_ESCALATION_THRESHOLD {
+            return false;
+        }
+
+        tracing::warn!(
+            task_id = %task.short_id,
+            role,
+            strike_count,
+            status = %task.status,
+            "CoordinatorActor: consecutive provider-error session failures without status progress — routing to Planner intervention instead of redispatch"
+        );
+        let intervention_reason = format!(
+            "Task failed on {strike_count} consecutive sessions with a terminal \
+             provider/session error and no durable status progress between them (status \
+             `{}`). The redispatched worker reproduces the same failure each time (e.g. a \
+             poisoned resume transcript that the provider rejects, or an unusable \
+             credential), so it is being handed to the Planner to decompose, rescope, or \
+             close rather than redispatched again.",
+            task.status
+        );
+
+        // Clear the streak and backoff state so a post-intervention run starts
+        // fresh and a re-armed intervention is not double-counted.
+        self.provider_failure_streak.remove(&task.id);
+        self.dispatch_failure_streak.remove(&task.id);
+        self.dispatch_cooldowns.remove(&task.id);
+        self.clear_durable_dispatch_backoff_state(
+            &task.id,
+            Some(&task.short_id),
+            "failure_streak_planner_intervention_handoff_clear",
+        )
+        .await;
+
+        self.route_loop_guard_planner_intervention(&task.id, role, &intervention_reason)
+            .await
+    }
+
     /// Trigger C: a worker/reviewer run completed degenerate because the
     /// reply-loop guard saw repeated identical behavior. This is not a provider
     /// fault and not a dispatch failure; route it directly to the same Planner

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -490,6 +490,7 @@ impl CoordinatorActor {
         // continuation dispatch so they cannot advance Trigger-B or terminal
         // close accounting during recovery/refactor paths.
         self.dispatch_failure_streak.remove(task_id);
+        self.provider_failure_streak.remove(task_id);
         self.dispatch_cooldowns.remove(task_id);
         self.last_dispatched.remove(task_id);
         self.inflight_dispatches.remove(task_id);
@@ -1185,6 +1186,38 @@ impl CoordinatorActor {
                         // fails over; only the terminal-close counter is spared.
                         let throttle = provider_failure.is_some_and(|f| f.throttle);
 
+                        // Second-strike Planner escalation for provider-error
+                        // FAILED sessions. A genuine (non-throttle) typed
+                        // provider failure that recurs for the same task is the
+                        // poisoned-transcript-400 / dead-credential / persistent
+                        // server-fault class: redispatch reproduces it
+                        // identically, so riding the backoff ladder toward the
+                        // streak-10 terminal close just burns attempts with
+                        // nobody deciding what to do. The cycling gate (trigger
+                        // B) below excludes provider faults by design, and the
+                        // stall-cancel escalation only covers coordinator stall
+                        // kills — so without this the failure has no Planner
+                        // path. Count consecutive such failures (reset when the
+                        // task's status advances, mirroring the stall streak)
+                        // and hand the task to the Planner on the
+                        // FAILURE_ESCALATION_THRESHOLD-th strike instead of
+                        // another doomed redispatch.
+                        if provider_failure.is_some()
+                            && !throttle
+                            && self
+                                .maybe_escalate_provider_failure_streak(&task, role)
+                                .await
+                        {
+                            // Bump the local cap to reflect the planner session
+                            // the intervention just dispatched (same as trigger
+                            // B and the stuck-task path).
+                            self.bump_local_cap_for_last_planner_admission(
+                                &mut running_by_user_model,
+                            )
+                            .await;
+                            continue;
+                        }
+
                         // Trigger B: the task keeps reappearing for the SAME
                         // role with no typed provider failure to blame — its
                         // runs complete but the task never converges (the
@@ -1206,6 +1239,7 @@ impl CoordinatorActor {
                             .await
                         {
                             self.dispatch_failure_streak.remove(&task.id);
+                            self.provider_failure_streak.remove(&task.id);
                             self.dispatch_cooldowns.remove(&task.id);
                             self.clear_durable_dispatch_backoff_state(
                                 &task.id,
@@ -1236,6 +1270,7 @@ impl CoordinatorActor {
                             )
                             .await;
                             self.dispatch_failure_streak.remove(&task.id);
+                            self.provider_failure_streak.remove(&task.id);
                             self.dispatch_cooldowns.remove(&task.id);
                             self.inflight_dispatches.remove(&task.id);
                             self.clear_durable_dispatch_backoff_state(
@@ -1309,6 +1344,7 @@ impl CoordinatorActor {
                     }
                     Some(ReappearingDispatch::RoleTransition) | None => {
                         self.dispatch_failure_streak.remove(&task.id);
+                        self.provider_failure_streak.remove(&task.id);
                         self.dispatch_cooldowns.remove(&task.id);
                         self.clear_durable_dispatch_backoff_state(
                             &task.id,
@@ -2025,6 +2061,7 @@ mod inflight_ledger_tests {
             stall_killed: HashSet::new(),
             stall_progress_watermark: HashMap::new(),
             stall_cancel_streak: HashMap::new(),
+            provider_failure_streak: HashMap::new(),
             last_idle_consolidation: None,
             idle_consolidation_cancel: None,
             idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
@@ -141,6 +141,7 @@ pub(super) fn build_refinement_actor(
         stall_killed: HashSet::new(),
         stall_progress_watermark: HashMap::new(),
         stall_cancel_streak: HashMap::new(),
+        provider_failure_streak: HashMap::new(),
         last_idle_consolidation: None,
         idle_consolidation_cancel: None,
         idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -2075,3 +2075,167 @@ async fn normal_blocker_release_via_transition_fires_unblocked_event() {
         "source must be ready after the normal blocker is closed via transition(Close)"
     );
 }
+
+// ── Trigger D: provider-error failure-streak escalation ───────────────────────
+
+/// The escalation thresholds form one family: the stall-cancel second strike
+/// (2) and the provider-error failure strike (3) are distinct, and the failure
+/// threshold sits one rung higher so the cooldown ladder absorbs a transient
+/// provider blip at streaks 1-2 before the Planner is involved.
+#[test]
+fn failure_and_stall_escalation_thresholds_are_distinct() {
+    assert_eq!(
+        STALL_CANCEL_ESCALATION_THRESHOLD, 2,
+        "stall-cancel second-strike threshold is unchanged (PR #1429)"
+    );
+    assert_eq!(
+        FAILURE_ESCALATION_THRESHOLD, 3,
+        "provider-error failure escalation fires on the third consecutive strike"
+    );
+    assert!(
+        FAILURE_ESCALATION_THRESHOLD > STALL_CANCEL_ESCALATION_THRESHOLD,
+        "failure streak escalates one rung later than the stall streak"
+    );
+}
+
+/// Three consecutive provider-error FAILED sessions without durable status
+/// progress route the task to a Planner intervention (the second-strike PARK
+/// path here, since the task is already at MAX_PLANNER_INTERVENTIONS) instead
+/// of another backoff+redispatch cycle. The first two strikes only advance the
+/// streak; the third escalates and clears the task's backoff state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn third_provider_failure_without_progress_routes_to_planner() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = make_task_with_reopen_count(&db, &tx, 0).await;
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(task.intervention_count, MAX_PLANNER_INTERVENTIONS);
+
+    // Seed stale backoff state to prove the escalation clears it.
+    actor
+        .dispatch_failure_streak
+        .insert(task.id.clone(), MAX_DISPATCH_FAILURES - 1);
+    actor.dispatch_cooldowns.insert(
+        task.id.clone(),
+        StdInstant::now() + std::time::Duration::from_secs(300),
+    );
+
+    // Strike 1 and 2: below threshold, no routing, streak advances.
+    for expected_count in 1..FAILURE_ESCALATION_THRESHOLD {
+        let routed = actor
+            .maybe_escalate_provider_failure_streak(&task, "worker")
+            .await;
+        assert!(
+            !routed,
+            "strike {expected_count} is below FAILURE_ESCALATION_THRESHOLD and must not escalate"
+        );
+        assert_eq!(
+            actor.provider_failure_streak.get(&task.id).map(|s| s.count),
+            Some(expected_count),
+            "streak advances by one per consecutive failure"
+        );
+    }
+
+    // Strike 3: escalates.
+    let routed = actor
+        .maybe_escalate_provider_failure_streak(&task, "worker")
+        .await;
+    assert!(
+        routed,
+        "the third consecutive provider-error failure routes to a Planner intervention"
+    );
+
+    // The task is HELD (parked open + blocked on a human-review remediation),
+    // the second-strike behavior of the shared loop-guard machinery.
+    let parked = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        parked.status, "open",
+        "escalated task is parked, not redispatched"
+    );
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert_eq!(
+        blockers.len(),
+        1,
+        "escalation blocks the task on a single human-review remediation"
+    );
+
+    // Escalation clears the streak and the stale backoff state.
+    assert!(
+        !actor.provider_failure_streak.contains_key(&task.id),
+        "the streak is cleared on escalation so a post-intervention run starts fresh"
+    );
+    assert!(
+        !actor.dispatch_failure_streak.contains_key(&task.id),
+        "escalation clears the terminal dispatch-failure streak"
+    );
+    assert!(
+        !actor.dispatch_cooldowns.contains_key(&task.id),
+        "escalation clears the dispatch cooldown"
+    );
+}
+
+/// Durable task-status progress between strikes resets the failure streak, so a
+/// task that keeps advancing never escalates.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn status_progress_resets_provider_failure_streak() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let task = make_task_with_reopen_count(&db, &tx, 0).await;
+
+    // Two consecutive failures at the same status → streak reaches 2.
+    for _ in 0..2 {
+        assert!(
+            !actor
+                .maybe_escalate_provider_failure_streak(&task, "worker")
+                .await
+        );
+    }
+    assert_eq!(
+        actor.provider_failure_streak.get(&task.id).map(|s| s.count),
+        Some(2),
+        "two same-status failures accumulate a streak of two"
+    );
+
+    // The task then makes durable progress (status advances). The next failure
+    // observes a different status and resets the streak to one — no escalation.
+    let mut progressed = task.clone();
+    progressed.status = "in_progress".to_string();
+    let routed = actor
+        .maybe_escalate_provider_failure_streak(&progressed, "worker")
+        .await;
+    assert!(!routed, "a failure after status progress must not escalate");
+    assert_eq!(
+        actor.provider_failure_streak.get(&task.id).map(|s| s.count),
+        Some(1),
+        "durable status progress between strikes resets the streak to one"
+    );
+}
+
+/// A successful settlement (`clear_planned_dispatch_completion`) drops the
+/// provider-error failure streak so a recovered task starts fresh.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn planned_completion_clears_provider_failure_streak() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let task = make_task_with_reopen_count(&db, &tx, 0).await;
+
+    assert!(
+        !actor
+            .maybe_escalate_provider_failure_streak(&task, "worker")
+            .await
+    );
+    assert!(actor.provider_failure_streak.contains_key(&task.id));
+
+    actor
+        .clear_planned_dispatch_completion(&task.id, "test_planned_completion_clear")
+        .await;
+    assert!(
+        !actor.provider_failure_streak.contains_key(&task.id),
+        "a planned completion clears the provider-error failure streak"
+    );
+}

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -477,6 +477,7 @@ fn coordinator_actor_for_tests(
         stall_killed: HashSet::new(),
         stall_progress_watermark: HashMap::new(),
         stall_cancel_streak: HashMap::new(),
+        provider_failure_streak: HashMap::new(),
         last_idle_consolidation: None,
         idle_consolidation_cancel: None,
         idle_consolidation_handle: None,

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -311,16 +311,38 @@ pub(super) const MAX_PLANNER_INTERVENTIONS: i64 = 1;
 /// than dispatch a third doomed session.
 pub(super) const STALL_CANCEL_ESCALATION_THRESHOLD: u32 = 2;
 
-/// Per-task record of consecutive stall cancellations without durable
-/// task-status progress, driving the second-strike Planner escalation
-/// (see [`STALL_CANCEL_ESCALATION_THRESHOLD`]).
+/// Number of CONSECUTIVE provider-error FAILED sessions (with no durable
+/// task-status progress between them) after which the coordinator routes the
+/// task to a Planner intervention instead of another backoff+redispatch cycle.
+///
+/// A session that dies on a terminal provider error — the poisoned-transcript
+/// 400 (an assistant `tool_calls` message replayed without its tool results),
+/// a dead credential, a persistent server fault — is redispatched and fails
+/// identically, riding the escalating cooldown ladder toward the terminal close
+/// at [`MAX_DISPATCH_FAILURES`] (10) with nobody deciding what to do. The
+/// cycling-intervention gate (trigger B) deliberately excludes provider faults
+/// (`!had_provider_failure`), and the stall-cancel escalation only covers
+/// coordinator-initiated stall kills — so provider-error failures had no
+/// planner path at all. Mirroring the stall second-strike, on the THIRD
+/// consecutive failed session we hand the task to the Planner (decompose /
+/// rescope / close) rather than dispatch a fourth doomed run. Set to `3` (one
+/// higher than the stall threshold of 2): the escalating backoff already gives
+/// breathing room at streaks 1-2, so a transient provider blip decays without
+/// escalating, while a genuinely poisoned/undispatchable task is caught well
+/// before the streak-10 terminal close.
+pub(super) const FAILURE_ESCALATION_THRESHOLD: u32 = 3;
+
+/// Per-task record of consecutive same-class session failures without durable
+/// task-status progress, driving a second-strike Planner escalation. Shared by
+/// the stall-cancel streak (see [`STALL_CANCEL_ESCALATION_THRESHOLD`]) and the
+/// provider-error failure streak (see [`FAILURE_ESCALATION_THRESHOLD`]).
 #[derive(Debug, Clone)]
 pub(super) struct StallCancelStreak {
-    /// Consecutive stall-cancelled sessions with no status change between them.
+    /// Consecutive same-class failures with no status change between them.
     pub(super) count: u32,
-    /// Task status observed at the most recent stall cancel. A different status
-    /// on the next cancel means the task made durable progress in between, so
-    /// the streak resets rather than escalating.
+    /// Task status observed at the most recent failure. A different status on
+    /// the next failure means the task made durable progress in between, so the
+    /// streak resets rather than escalating.
     pub(super) last_status: String,
 }
 

--- a/server/crates/djinn-core/src/message.rs
+++ b/server/crates/djinn-core/src/message.rs
@@ -764,7 +764,116 @@ impl Conversation {
 
         (instructions, input_items)
     }
+
+    // ─── Dangling tool-call sanitization ─────────────────────────────────────
+
+    /// Return a view of this conversation with a synthesized tool result for
+    /// every assistant `ToolUse` whose `tool_use_id` has no matching
+    /// `ToolResult` anywhere in the history.
+    ///
+    /// Strict OpenAI-compatible and Anthropic APIs reject a request whose
+    /// assistant `tool_calls` / `tool_use` message is not answered by a tool
+    /// message for every `tool_call_id` (HTTP 400 `invalid_request_error`). A
+    /// session cancelled or killed *between* emitting the assistant tool-call
+    /// message and persisting the corresponding tool results leaves such
+    /// dangling ids at the tail of the stored transcript. Replaying that history
+    /// verbatim on resume/redispatch 400s the whole request, so the session
+    /// fails instantly on every retry and the task wedges in dispatch backoff.
+    ///
+    /// Synthesizing a placeholder result — rather than dropping the assistant
+    /// turn — preserves the model's context of what it was doing while
+    /// satisfying the tool-call/tool-result pairing invariant. Because this
+    /// operates on the provider-agnostic [`Conversation`], a single pass repairs
+    /// every wire format (OpenAI chat, OpenAI Responses, Anthropic, Google);
+    /// the downstream serializers just see a well-formed history.
+    ///
+    /// The repaired history is a transient view used only for request
+    /// serialization: this borrows the receiver unchanged when the transcript is
+    /// already well-formed, and never mutates stored history.
+    pub fn with_synthesized_tool_results(&self) -> std::borrow::Cow<'_, Conversation> {
+        use std::collections::HashSet;
+
+        // Every tool_use_id that already has a result somewhere in the history.
+        let mut answered: HashSet<&str> = HashSet::new();
+        for msg in &self.messages {
+            for block in &msg.content {
+                if let ContentBlock::ToolResult { tool_use_id, .. } = block {
+                    answered.insert(tool_use_id.as_str());
+                }
+            }
+        }
+
+        let is_dangling = |block: &ContentBlock| matches!(block, ContentBlock::ToolUse { id, .. } if !answered.contains(id.as_str()));
+        let has_dangling = self
+            .messages
+            .iter()
+            .any(|m| m.role == Role::Assistant && m.content.iter().any(is_dangling));
+        if !has_dangling {
+            return std::borrow::Cow::Borrowed(self);
+        }
+
+        let mut repaired: Vec<Message> = Vec::with_capacity(self.messages.len() + 1);
+        let mut i = 0;
+        while i < self.messages.len() {
+            let msg = &self.messages[i];
+            repaired.push(msg.clone());
+
+            if msg.role == Role::Assistant {
+                let synth_blocks: Vec<ContentBlock> = msg
+                    .content
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::ToolUse { id, .. } if !answered.contains(id.as_str()) => {
+                            Some(ContentBlock::ToolResult {
+                                tool_use_id: id.clone(),
+                                content: vec![ContentBlock::text(INTERRUPTED_TOOL_RESULT)],
+                                is_error: true,
+                            })
+                        }
+                        _ => None,
+                    })
+                    .collect();
+
+                if !synth_blocks.is_empty() {
+                    // Merge the synthesized results into the immediately
+                    // following user message when one exists (a partial-result
+                    // turn, or a resume nudge). This preserves Anthropic's
+                    // strict user/assistant alternation — two consecutive user
+                    // messages would themselves be rejected. Tool results lead
+                    // the user turn, as Anthropic requires. Otherwise insert a
+                    // fresh user turn carrying only the synthesized results.
+                    match self.messages.get(i + 1) {
+                        Some(next) if next.role == Role::User => {
+                            let mut merged = next.clone();
+                            let mut content = synth_blocks;
+                            content.extend(merged.content);
+                            merged.content = content;
+                            repaired.push(merged);
+                            i += 2;
+                            continue;
+                        }
+                        _ => {
+                            repaired.push(Message {
+                                role: Role::User,
+                                content: synth_blocks,
+                                metadata: None,
+                            });
+                        }
+                    }
+                }
+            }
+            i += 1;
+        }
+
+        std::borrow::Cow::Owned(Conversation { messages: repaired })
+    }
 }
+
+/// Placeholder content synthesized for a tool call whose result was never
+/// persisted because the session was cancelled/killed mid-tool-execution.
+/// See [`Conversation::with_synthesized_tool_results`].
+const INTERRUPTED_TOOL_RESULT: &str = "[tool execution interrupted before completion — the \
+     session was cancelled; re-run the tool if the result is still needed]";
 
 // ─── Anthropic content-block helpers ─────────────────────────────────────────
 
@@ -1568,5 +1677,218 @@ Second rule."
         let mut c = Conversation::new();
         c.push(Message::user("This is a test message."));
         assert!(c.token_estimate() > 0);
+    }
+
+    // ── Dangling tool-call sanitization ───────────────────────────────────────
+
+    fn assistant_tool_use(id: &str, name: &str) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: id.into(),
+                name: name.into(),
+                input: json!({}),
+            }],
+            metadata: None,
+        }
+    }
+
+    fn user_tool_result(id: &str) -> Message {
+        Message {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: id.into(),
+                content: vec![ContentBlock::text("ok")],
+                is_error: false,
+            }],
+            metadata: None,
+        }
+    }
+
+    /// Collect `(tool_use_id, is_synthesized)` for every `ToolResult` block.
+    fn tool_results(c: &Conversation) -> Vec<(String, bool)> {
+        c.messages
+            .iter()
+            .flat_map(|m| &m.content)
+            .filter_map(|b| match b {
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } => {
+                    let synth = content
+                        .iter()
+                        .filter_map(|c| c.as_text())
+                        .any(|t| t.contains("tool execution interrupted"));
+                    Some((tool_use_id.clone(), synth))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn sanitize_dangling_tail_synthesizes_result() {
+        // Transcript ending in an unanswered tool call (session killed mid-tool).
+        let convo = Conversation {
+            messages: vec![
+                Message::user("do it"),
+                assistant_tool_use("read:37", "read"),
+            ],
+        };
+
+        let repaired = convo.with_synthesized_tool_results();
+        assert!(matches!(repaired, std::borrow::Cow::Owned(_)));
+
+        // A synthesized result now answers the dangling id...
+        let results = tool_results(&repaired);
+        assert_eq!(results, vec![("read:37".to_string(), true)]);
+
+        // ...carried by a user turn immediately after the assistant tool call,
+        // so the pairing invariant holds for every wire format.
+        let msgs = &repaired.messages;
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[1].role, Role::Assistant);
+        assert_eq!(msgs[2].role, Role::User);
+        assert!(matches!(
+            msgs[2].content[0],
+            ContentBlock::ToolResult { .. }
+        ));
+
+        // The OpenAI chat serialization is now well-formed: the tool_calls
+        // message is followed by a tool message for its id.
+        let openai = repaired.to_openai_messages();
+        let tool_msg = openai
+            .iter()
+            .find(|m| m["role"] == "tool")
+            .expect("a tool message answers the call");
+        assert_eq!(tool_msg["tool_call_id"], "read:37");
+    }
+
+    #[test]
+    fn sanitize_leaves_well_formed_history_untouched() {
+        let convo = Conversation {
+            messages: vec![
+                Message::user("do it"),
+                assistant_tool_use("call_1", "read"),
+                user_tool_result("call_1"),
+                Message::assistant("done"),
+            ],
+        };
+
+        let repaired = convo.with_synthesized_tool_results();
+        // Borrowed (no allocation) — nothing to repair.
+        assert!(matches!(repaired, std::borrow::Cow::Borrowed(_)));
+        // No synthesized results were added.
+        assert!(tool_results(&repaired).iter().all(|(_, synth)| !synth));
+    }
+
+    #[test]
+    fn sanitize_multiple_dangling_ids_in_one_message() {
+        let convo = Conversation {
+            messages: vec![
+                Message::user("do them"),
+                Message {
+                    role: Role::Assistant,
+                    content: vec![
+                        ContentBlock::text("running two tools"),
+                        ContentBlock::ToolUse {
+                            id: "code_search:24".into(),
+                            name: "code_search".into(),
+                            input: json!({}),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "read:37".into(),
+                            name: "read".into(),
+                            input: json!({}),
+                        },
+                    ],
+                    metadata: None,
+                },
+            ],
+        };
+
+        let repaired = convo.with_synthesized_tool_results();
+        let mut results = tool_results(&repaired);
+        results.sort();
+        assert_eq!(
+            results,
+            vec![
+                ("code_search:24".to_string(), true),
+                ("read:37".to_string(), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn sanitize_partial_results_only_fills_missing() {
+        // Assistant issued two calls; only one result was persisted before the
+        // kill. The following user turn already carries the answered result.
+        let convo = Conversation {
+            messages: vec![
+                Message::user("do them"),
+                Message {
+                    role: Role::Assistant,
+                    content: vec![
+                        ContentBlock::ToolUse {
+                            id: "answered".into(),
+                            name: "read".into(),
+                            input: json!({}),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "dangling".into(),
+                            name: "code_search".into(),
+                            input: json!({}),
+                        },
+                    ],
+                    metadata: None,
+                },
+                user_tool_result("answered"),
+            ],
+        };
+
+        let repaired = convo.with_synthesized_tool_results();
+        let mut results = tool_results(&repaired);
+        results.sort();
+        assert_eq!(
+            results,
+            vec![
+                ("answered".to_string(), false),
+                ("dangling".to_string(), true),
+            ]
+        );
+        // Merged into the existing user turn — no extra message inserted, so
+        // Anthropic's user/assistant alternation is preserved.
+        assert_eq!(repaired.messages.len(), 3);
+        assert_eq!(repaired.messages[2].role, Role::User);
+    }
+
+    #[test]
+    fn sanitize_merges_into_following_user_turn_for_anthropic() {
+        // Dangling call followed by a resume nudge (plain user text). The synth
+        // result must fold into that same user turn, not create a second
+        // consecutive user message (which Anthropic rejects).
+        let convo = Conversation {
+            messages: vec![
+                assistant_tool_use("read:37", "read"),
+                Message::user("Continue with the task."),
+            ],
+        };
+
+        let repaired = convo.with_synthesized_tool_results();
+        assert_eq!(repaired.messages.len(), 2);
+        assert_eq!(repaired.messages[0].role, Role::Assistant);
+        assert_eq!(repaired.messages[1].role, Role::User);
+        // Tool result leads the user turn (Anthropic requirement), text follows.
+        assert!(matches!(
+            repaired.messages[1].content[0],
+            ContentBlock::ToolResult { .. }
+        ));
+
+        // Anthropic serialization: exactly one user message, tool_result first.
+        let (_system, msgs) = repaired.to_anthropic_messages();
+        let user_turns: Vec<_> = msgs.iter().filter(|m| m["role"] == "user").collect();
+        assert_eq!(user_turns.len(), 1);
+        assert_eq!(user_turns[0]["content"][0]["type"], "tool_result");
     }
 }

--- a/server/crates/djinn-provider/src/error_classify.rs
+++ b/server/crates/djinn-provider/src/error_classify.rs
@@ -42,6 +42,12 @@ pub fn is_orphaned_tool_call_error_str(msg: &str) -> bool {
     msg.contains("no tool call found for function call output")
         || msg.contains("no tool output found for function call")
         || msg.contains("no function call found")
+        // OpenAI-compatible Chat Completions variant (e.g. kimi-for-coding):
+        // "an assistant message with 'tool_calls' must be followed by tool
+        //  messages responding to each 'tool_call_id'. The following
+        //  tool_call_ids did not have response messages: ...".
+        || msg.contains("must be followed by tool messages")
+        || msg.contains("did not have response messages")
 }
 
 /// Whether `e` is an orphaned tool-call / tool-result reference error.
@@ -65,6 +71,14 @@ mod tests {
             "provider stream event failed: display=provider API error 400 Bad Request: { \
              \"error\": { \"message\": \"No tool output found for function call \
              call_GTQn9uVLax1RG4uWvMNrl3Sq.\", \"type\": \"invalid_request_error\" } }"
+        ));
+        // The OpenAI-compatible Chat Completions variant (kimi-for-coding, 2026-07-02).
+        assert!(is_orphaned_tool_call_error_str(
+            "provider stream event failed: provider API error 400 Bad Request: {\"error\":\
+             {\"type\":\"invalid_request_error\",\"message\":\"an assistant message with \
+             'tool_calls' must be followed by tool messages responding to each \
+             'tool_call_id'. The following tool_call_ids did not have response messages: \
+             code_search:24\"}}"
         ));
         // Negative cases.
         assert!(!is_orphaned_tool_call_error_str("rate limited"));

--- a/server/crates/djinn-slot/src/reply_loop/tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tests.rs
@@ -2406,3 +2406,146 @@ async fn hard_budget_wind_down_ignored_returns_typed_budget_error() {
         "ignored wind-down must not write a misleading summary activity: {entries:?}"
     );
 }
+
+/// Regression (incident 2026-07-02): a conversation whose stored transcript
+/// ends with an assistant `tool_calls` message that was never answered — a
+/// prior session terminated at/after submission or was killed mid-tool-call —
+/// must NOT be replayed verbatim to the provider. `run_reply_loop` sanitizes
+/// every request at the provider seam, so the dangling call is answered by a
+/// synthesized tool result before it can 400 ("tool_call_ids did not have
+/// response messages"). This covers all replay flows (redispatch, retry,
+/// rework-after-review continuation) since every turn passes through the seam.
+#[tokio::test]
+async fn dangling_tool_call_is_sanitized_before_reaching_provider() {
+    use std::sync::Mutex;
+
+    let tools = vec![dummy_tool_schema("submit_work")];
+
+    /// Captures the conversation of the first stream call, then defers to a
+    /// MockProvider that finalizes so the loop terminates.
+    struct CapturingProvider {
+        first_conversation: Arc<Mutex<Option<Conversation>>>,
+        inner: MockProvider,
+    }
+
+    impl LlmProvider for CapturingProvider {
+        fn name(&self) -> &str {
+            "capturing"
+        }
+        fn stream<'a>(
+            &'a self,
+            conversation: &'a Conversation,
+            tools: &'a [serde_json::Value],
+            tool_choice: Option<ToolChoice>,
+        ) -> Pin<
+            Box<
+                dyn futures::Future<
+                        Output = anyhow::Result<
+                            Pin<
+                                Box<dyn futures::Stream<Item = anyhow::Result<StreamEvent>> + Send>,
+                            >,
+                        >,
+                    > + Send
+                    + 'a,
+            >,
+        > {
+            {
+                let mut slot = self.first_conversation.lock().unwrap();
+                if slot.is_none() {
+                    *slot = Some(conversation.clone());
+                }
+            }
+            self.inner.stream(conversation, tools, tool_choice)
+        }
+    }
+
+    let inner = MockProvider::new(vec![MockResponse {
+        text: None,
+        tool_calls: vec![ContentBlock::ToolUse {
+            id: "fin1".to_string(),
+            name: "submit_work".to_string(),
+            input: serde_json::json!({"task_id": "t1", "summary": "done"}),
+        }],
+        input_tokens: 50,
+        output_tokens: 10,
+    }]);
+    let first_conversation = Arc::new(Mutex::new(None));
+    let provider = CapturingProvider {
+        first_conversation: Arc::clone(&first_conversation),
+        inner,
+    };
+
+    let (slot_ctx, project_path, task_id, session_id, cancel) = make_context().await;
+    let worktree_path = std::path::PathBuf::from("/tmp");
+
+    // Seed a transcript ending in an UNANSWERED assistant tool call, exactly as
+    // a prior session's persisted history would on a rework continuation.
+    let mut conv = Conversation::new();
+    conv.push(Message::system("You are a worker."));
+    conv.push(Message::user("Do the task."));
+    conv.push(Message {
+        role: Role::Assistant,
+        content: vec![ContentBlock::ToolUse {
+            id: "apply_patch:45".to_string(),
+            name: "apply_patch".to_string(),
+            input: serde_json::json!({"patch": "..."}),
+        }],
+        metadata: None,
+    });
+
+    let (result, _output, _, _, _, _) = run_reply_loop(
+        ReplyLoopContext {
+            provider: &provider,
+            tools: &tools,
+            task_id: &task_id,
+            task_short_id: "t1",
+            session_id: &session_id,
+            project_path: &project_path,
+            worktree_path: &worktree_path,
+            role_name: "worker",
+            finalize_tool_names: &["submit_work", "request_lead"],
+            context_window: 10_000,
+            model_id: "openai/gpt-5.4",
+            cancel: &cancel,
+            global_cancel: &cancel,
+            ctx: &slot_ctx,
+            active_skill_names: &[],
+            active_mcp_server_names: &[],
+            max_turns_override: None,
+        },
+        &mut conv,
+        false,
+    )
+    .await;
+
+    assert!(result.is_ok(), "expected ok, got: {result:?}");
+
+    // The provider must have received a synthesized tool result answering the
+    // dangling id — the original assistant call is preserved (context intact).
+    let captured = first_conversation
+        .lock()
+        .unwrap()
+        .take()
+        .expect("provider was called at least once");
+    let answered_ids: Vec<&str> = captured
+        .messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .filter_map(|b| match b {
+            ContentBlock::ToolResult { tool_use_id, .. } => Some(tool_use_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        answered_ids.contains(&"apply_patch:45"),
+        "the dangling tool call must be answered by a synthesized result before dispatch; \
+         got tool results for {answered_ids:?}"
+    );
+    assert!(
+        captured.messages.iter().any(|m| m
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "apply_patch:45"))),
+        "the original assistant tool call is preserved (context of what it was doing)"
+    );
+}

--- a/server/crates/djinn-slot/src/reply_loop/turn.rs
+++ b/server/crates/djinn-slot/src/reply_loop/turn.rs
@@ -547,7 +547,17 @@ pub async fn run_reply_loop(
             });
 
             let tool_choice = tool_choice_for_turn(model_id, tools);
-            let stream_result = provider.stream(conversation, tools, tool_choice).await;
+            // Repair any dangling tool calls (assistant tool_use ids with no
+            // persisted result) left by a prior session that was cancelled
+            // mid-tool-execution. Replaying such a transcript verbatim 400s the
+            // whole request on strict OpenAI/Anthropic-compatible APIs, wedging
+            // the task on every redispatch. Sanitizing here — one pass on the
+            // provider-agnostic conversation — covers all wire formats without
+            // mutating stored history.
+            let request_conversation = conversation.with_synthesized_tool_results();
+            let stream_result = provider
+                .stream(request_conversation.as_ref(), tools, tool_choice)
+                .await;
             let stream = match stream_result {
                 Ok(s) => s,
                 Err(e) if (is_context_length_error(&e) || is_orphaned_tool_call_error(&e))


### PR DESCRIPTION
## Incident (production, 2026-07-02, v0.6.68)

Yesterday's stall-kill wave left ~88 sessions terminated mid-tool-execution. Today, tasks whose prior session ended with an unanswered assistant `tool_calls` message failed instantly on redispatch with a provider 400:

> provider API error 400 Bad Request: `an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: code_search:24`

The session dies ~2 min in, gets "Recovered by coordinator", is redispatched, fails identically, and lands in escalating dispatch backoff — the board wedges. Observed on both OpenAI-family and kimi (Anthropic-family) requests. Later evidence (task `019f2293…`) showed even a **cleanly completed** worker session's transcript can end with an unanswered tool call, which the rework-after-review continuation then replays.

## Fix 1 — sanitize dangling tool calls in replayed transcripts

`Conversation::with_synthesized_tool_results` synthesizes a placeholder tool result for every assistant tool call whose `tool_call_id` has no result anywhere in the history:

> `[tool execution interrupted before completion — the session was cancelled; re-run the tool if the result is still needed]`

- Runs on the **provider-agnostic `Conversation`** at the single per-turn provider seam in `run_reply_loop` (`turn.rs`), so one pass repairs **every wire format** (OpenAI chat, OpenAI Responses, Anthropic, Google) and **every replay flow** (redispatch, retry, rework-after-review continuation — each turn's request passes through the seam).
- **Synthesizes** (rather than dropping the assistant turn) to preserve the model's context of what it was doing. Merges synthesized results into the following user turn when present, preserving Anthropic's strict user/assistant alternation; otherwise inserts a fresh user turn.
- **Read-time only** — stored history is never mutated (borrows via `Cow` when already well-formed).
- Extends the orphaned-tool-call error classifier to also match the Chat Completions wording, so the existing reactive compaction backstop covers this variant too.

## Fix 2 — escalate repeated provider-error session failures to the planner

Provider-error session failures never escalated: the cycling-intervention gate (trigger B) excludes provider faults by design, and the stall-cancel second-strike (#1429) only covers coordinator-initiated stall kills. A task could burn every attempt in backoff with nobody deciding what to do.

Adds `provider_failure_streak` (sibling of `stall_cancel_streak`, reset on durable task-status progress) and `maybe_escalate_provider_failure_streak`: on the **third** consecutive genuine provider-error FAILED session (throttles excluded) without status progress, the task routes to a **Planner intervention** via the existing `route_loop_guard_planner_intervention` path instead of another backoff+redispatch cycle. `FAILURE_ESCALATION_THRESHOLD = 3` sits one rung above the stall threshold (2) so the cooldown ladder absorbs transient blips first.

## Tests

- `djinn-core`: `sanitize_dangling_tail_synthesizes_result`, `sanitize_leaves_well_formed_history_untouched`, `sanitize_multiple_dangling_ids_in_one_message`, `sanitize_partial_results_only_fills_missing`, `sanitize_merges_into_following_user_turn_for_anthropic`
- `djinn-slot`: `dangling_tool_call_is_sanitized_before_reaching_provider` (reply-loop level: provider receives synthesized results, original call preserved)
- `djinn-provider`: extended `detects_orphaned_tool_call_variants` with the incident 400
- `djinn-coordinator`: `third_provider_failure_without_progress_routes_to_planner`, `status_progress_resets_provider_failure_streak`, `planned_completion_clears_provider_failure_streak`, `failure_and_stall_escalation_thresholds_are_distinct`

## Verification

- `cargo clippy --all-targets --features qdrant -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo nextest` for djinn-core (message), djinn-provider (error_classify), djinn-slot (reply_loop, 52 tests), djinn-coordinator (intervention/dispatch_flow/task_dispatch/session_recovery/pause) — all green
- No SQL queries or prompts/tool schemas touched (no sqlx-prepare / snapshot regen needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)