### PR TITLE
Close the pre-session "setting up" gap: track runs from dispatch + pre-session liveness deadline (c2xb)

### DIFF
--- a/server/.sqlx/query-8f11b51708c05352a2eb45d10a3744a5be099b79d174c9a306d15e54adfe69f7.json
+++ b/server/.sqlx/query-8f11b51708c05352a2eb45d10a3744a5be099b79d174c9a306d15e54adfe69f7.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, project_id, task_id, trigger_type,\n                status AS \"status!\", started_at, ended_at,\n                workspace_path, mirror_ref\n             FROM task_runs\n             WHERE task_id = $1 AND status = 'starting' AND ended_at IS NULL\n             ORDER BY started_at DESC LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "project_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "task_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "trigger_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "started_at",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "ended_at",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "workspace_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "mirror_ref",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "8f11b51708c05352a2eb45d10a3744a5be099b79d174c9a306d15e54adfe69f7"
+}

--- a/server/.sqlx/query-a0de1e98dc76e7f001978bb89298963e7d07a64d8beefb7e745ca32995fb538d.json
+++ b/server/.sqlx/query-a0de1e98dc76e7f001978bb89298963e7d07a64d8beefb7e745ca32995fb538d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE task_runs SET status = 'running', ended_at = NULL\n                 WHERE id = $1 AND status = 'starting'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a0de1e98dc76e7f001978bb89298963e7d07a64d8beefb7e745ca32995fb538d"
+}

--- a/server/.sqlx/query-bc1296ed628e954ae1a99edea6609450e1066f3afc6f22e4d4d792dac12fb236.json
+++ b/server/.sqlx/query-bc1296ed628e954ae1a99edea6609450e1066f3afc6f22e4d4d792dac12fb236.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT ON (task_id)\n                id, project_id, task_id, trigger_type,\n                status AS \"status!\", started_at, ended_at,\n                workspace_path, mirror_ref\n             FROM task_runs\n             WHERE task_id = ANY($1) AND status = 'starting' AND ended_at IS NULL\n             ORDER BY task_id, started_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "project_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "task_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "trigger_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "started_at",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "ended_at",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "workspace_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "mirror_ref",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "bc1296ed628e954ae1a99edea6609450e1066f3afc6f22e4d4d792dac12fb236"
+}

--- a/server/.sqlx/query-cdf494e3052af23d4b9082f1dc44f3eb51bf90d0c88da767c0a3dc7f2fdd9efe.json
+++ b/server/.sqlx/query-cdf494e3052af23d4b9082f1dc44f3eb51bf90d0c88da767c0a3dc7f2fdd9efe.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id FROM task_runs\n             WHERE task_id = $1 AND status = 'running' AND ended_at IS NULL\n             ORDER BY started_at DESC LIMIT 1",
+  "query": "SELECT id FROM task_runs\n             WHERE status IN ('starting', 'running')\n               AND ended_at IS NULL\n               AND started_at < $1",
   "describe": {
     "columns": [
       {
@@ -18,5 +18,5 @@
       false
     ]
   },
-  "hash": "3b6bf0e5d447a50fa48ac21bd8a60f1f4e4f4fd8133713b388b7af8ff003bed1"
+  "hash": "cdf494e3052af23d4b9082f1dc44f3eb51bf90d0c88da767c0a3dc7f2fdd9efe"
 }

--- a/server/.sqlx/query-f63df7e925561f6e6fae432e3c7996e0498c7b27323348d68d71b0e38de3dc91.json
+++ b/server/.sqlx/query-f63df7e925561f6e6fae432e3c7996e0498c7b27323348d68d71b0e38de3dc91.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id FROM task_runs\n             WHERE status = 'running'\n               AND ended_at IS NULL\n               AND started_at < $1",
+  "query": "SELECT id FROM task_runs\n             WHERE task_id = $1 AND status IN ('starting', 'running') AND ended_at IS NULL\n             ORDER BY started_at DESC LIMIT 1",
   "describe": {
     "columns": [
       {
@@ -18,5 +18,5 @@
       false
     ]
   },
-  "hash": "7b84f6687319bafb6a1b232b27afd8738e395321af0290cc526fb9f2f205281f"
+  "hash": "f63df7e925561f6e6fae432e3c7996e0498c7b27323348d68d71b0e38de3dc91"
 }

--- a/server/crates/djinn-agent-worker/src/worker_services.rs
+++ b/server/crates/djinn-agent-worker/src/worker_services.rs
@@ -201,6 +201,10 @@ impl SupervisorServices for WorkerSupervisorServices {
         &self.cancel
     }
 
+    async fn report_stage_step(&self, step: &'static str) -> Result<(), String> {
+        self.rpc.report_stage_step(step).await
+    }
+
     async fn load_task(&self, task_id: String) -> Result<Task, String> {
         self.rpc.load_task(task_id).await
     }

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -60,6 +60,53 @@ fn supervisor_rpc_span(op: &'static str, session_id: &str, task_id: &str) -> tra
     )
 }
 
+/// Default pre-session liveness deadline: how long stage init has to reach the
+/// first reply-loop session/turn before the run is failed fast.
+///
+/// 8 minutes — comfortably above a legitimately slow setup (a cold cargo target
+/// seed can take ~2 min, plus workspace clone + context/prompt assembly) but
+/// far under the orphan reaper's ~15-min catch and the 3h in-pod soft deadline.
+/// Overridable via `DJINN_PRESESSION_DEADLINE_SECS` (0 / unparseable → default).
+const PRE_SESSION_DEADLINE_SECS_DEFAULT: u64 = 480;
+
+/// Initial step label used before the worker emits its first stage marker —
+/// the window right after the handshake while the in-pod supervisor creates the
+/// `task_runs` row and begins setup.
+const PRE_SESSION_INITIAL_STEP: &str = "run_create";
+
+/// How often the pre-session watchdog re-checks the DB for a session row when
+/// the deadline fires (the DB is the authoritative disarm signal; the stream
+/// markers only name the step).
+fn pre_session_deadline() -> std::time::Duration {
+    let secs = std::env::var("DJINN_PRESESSION_DEADLINE_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .unwrap_or(PRE_SESSION_DEADLINE_SECS_DEFAULT);
+    std::time::Duration::from_secs(secs)
+}
+
+/// Typed error surfaced when stage init never reaches the first reply-loop turn
+/// within the pre-session liveness deadline. Names the in-pod step the run hung
+/// on so the failure is diagnosable straight from host logs.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error(
+    "pre-session stage-init deadline exceeded: no session / first provider turn after \
+     {elapsed_secs}s (hung at step '{step}')"
+)]
+pub struct PreSessionTimeout {
+    pub step: String,
+    pub elapsed_secs: u64,
+}
+
+/// Outcome of awaiting the worker's report stream: either a terminal report
+/// (or `None` when the stream closed / was cancelled) or a pre-session deadline
+/// breach.
+enum ReportAwait {
+    Report(Option<TaskRunReport>),
+    PreSessionTimeout(PreSessionTimeout),
+}
+
 /// Persist and surface a credential revocation after a run hit a 401.
 ///
 /// Marks the stored credential for the run's provider revoked (the F5-safe
@@ -365,6 +412,32 @@ pub(super) async fn dispatch_task_runtime(
         commit_author_email,
     };
 
+    // ── Announce dispatch live (pre-session UI tracking) ──────────────────
+    //
+    // Emit `session.dispatched` the instant the run is dispatched — before the
+    // pod even boots — so the UI shows the task as "starting" immediately,
+    // instead of the old derived "setting up" pseudo-status. The in-pod
+    // supervisor creates the `task_runs` row as `starting` shortly after; this
+    // event is the live nudge (F5 refetch resolves the same state from
+    // `task_show`/`task_list`, which surface the `starting` run). The first
+    // reply-loop `session.started` upgrades it to `running`.
+    {
+        let agent_type = spec
+            .flow
+            .role_sequence()
+            .first()
+            .map(|role| role.as_str())
+            .unwrap_or("worker");
+        app_state
+            .event_bus
+            .send(djinn_core::events::DjinnEventEnvelope::session_dispatched(
+                &spec.project_id,
+                &spec.task_id,
+                &model_id,
+                agent_type,
+            ));
+    }
+
     // ── Resolve per-role provider credentials (Phase 7a) ──────────────────
     //
     // The host pulls every role's credential from the vault (or OAuth token
@@ -536,16 +609,30 @@ pub(super) async fn dispatch_task_runtime(
     // the Test runtime) so a terminally dead Job/Pod is detected within ~15s,
     // its real death reason captured, and the slot freed promptly.
     let mut infra_death: Option<String> = None;
+    // Pre-session liveness deadline: a stage-init hang that never reaches the
+    // first reply-loop session must fail FAST (minutes, not the orphan reaper's
+    // ~15-min catch or the 3h in-pod soft deadline), naming the in-pod step it
+    // hung on. Set when `await_report_from_stream` breaches the deadline before
+    // any session appears; handled below like a handshake timeout (fail over +
+    // spare the terminal streak) but with a typed, step-named error.
+    let mut presession_timeout: Option<PreSessionTimeout> = None;
     let report_result: anyhow::Result<Option<TaskRunReport>> = match bistream_result {
         Ok(bistream) => {
-            tokio::select! {
+            let await_outcome = tokio::select! {
                 biased;
                 // The report stream is authoritative for a *clean* exit — a
                 // worker that exits normally flushes its TerminalReport here.
                 // Prefer it (biased) so a Job that flips Failed in the same
                 // instant the worker delivered a report doesn't shadow the
-                // real outcome.
-                res = await_report_from_stream(bistream, &kill, &spec.task_run_id, &spec.task_id) => res,
+                // real outcome. Also enforces the pre-session deadline.
+                res = await_report_from_stream(
+                    bistream,
+                    &kill,
+                    app_state.db.clone(),
+                    &spec.task_run_id,
+                    &spec.task_id,
+                    pre_session_deadline(),
+                ) => res,
                 reason = runtime.watch_infra_death(&handle) => {
                     tracing::warn!(
                         task_id = %task.short_id,
@@ -555,8 +642,16 @@ pub(super) async fn dispatch_task_runtime(
                          (OOM / eviction / Job failure); finalizing run as interrupted"
                     );
                     infra_death = Some(reason);
+                    Ok(ReportAwait::Report(None))
+                }
+            };
+            match await_outcome {
+                Ok(ReportAwait::Report(report)) => Ok(report),
+                Ok(ReportAwait::PreSessionTimeout(timeout)) => {
+                    presession_timeout = Some(timeout);
                     Ok(None)
                 }
+                Err(e) => Err(e),
             }
         }
         Err(e) => Err(anyhow::anyhow!("runtime.attach_stdio failed: {e}")),
@@ -575,11 +670,18 @@ pub(super) async fn dispatch_task_runtime(
     // synthesized — defaulting to `Interrupted` when the report is missing.
     // Slot serialization means at most one in-flight run per task, so
     // reaping by `task_id` finds exactly the right row.
-    let reap_status = teardown
-        .as_ref()
-        .ok()
-        .map(report_to_terminal_status)
-        .unwrap_or(TaskRunStatus::Interrupted);
+    let reap_status = if presession_timeout.is_some() {
+        // A stage-init hang is a definite failure of THIS run — mark it Failed
+        // (not the generic Interrupted stub) so the `starting` row is flipped
+        // terminal and the coordinator redispatches promptly.
+        TaskRunStatus::Failed
+    } else {
+        teardown
+            .as_ref()
+            .ok()
+            .map(report_to_terminal_status)
+            .unwrap_or(TaskRunStatus::Interrupted)
+    };
     reap_orphan_task_run(&app_state, &task.id, reap_status).await;
 
     // Deterministic teardown backstop: remove the worker's private Cargo target
@@ -683,6 +785,55 @@ pub(super) async fn dispatch_task_runtime(
                 "supervisor dispatch: failed to finalize session row after infra death"
             ),
         }
+    }
+
+    // Pre-session stage-init deadline breached: the run never reached its first
+    // reply-loop turn within the bounded window. The Job was torn down above
+    // and the `starting` task_run row reaped as Failed. Surface the typed,
+    // step-named failure where operators look, feed the breaker as a stall so
+    // dispatch fails over and the coordinator spares the terminal
+    // MAX_DISPATCH_FAILURES streak (this is an infra/setup wedge, not the
+    // task's fault), and return the typed error so host logs name the step.
+    if let Some(timeout) = presession_timeout {
+        let PreSessionTimeout { step, elapsed_secs } = &timeout;
+        tracing::error!(
+            task_id = %task.short_id,
+            task_run_id = %spec.task_run_id,
+            %model_id,
+            stage_step = %step,
+            elapsed_secs,
+            "supervisor dispatch: pre-session stage-init deadline exceeded before first \
+             provider turn; failing run fast"
+        );
+        app_state
+            .health_tracker
+            .record_stall(creator_scope.as_deref(), &model_id, true);
+        app_state.health_tracker.note_task_provider_failure(
+            &task.id,
+            djinn_provider::catalog::health::TaskFailureSignal {
+                throttle: true,
+                retry_after_ms: None,
+            },
+        );
+        let _ = task_repo
+            .log_activity(
+                Some(&task.id),
+                "agent-supervisor",
+                "system",
+                "stage_init_timeout",
+                &serde_json::json!({
+                    "body": format!(
+                        "Stage init hung at step '{step}' — no session / first provider \
+                         turn within {elapsed_secs}s (pre-session liveness deadline). \
+                         Tore down the Job and failed over off model {model_id}."
+                    ),
+                    "stage_step": step,
+                    "elapsed_secs": elapsed_secs,
+                })
+                .to_string(),
+            )
+            .await;
+        return Err(anyhow::Error::new(timeout));
     }
 
     match (report_result, teardown) {
@@ -1249,18 +1400,31 @@ async fn teardown_cargo_target_run_dir(app_state: &AgentContext, task_run_id: &s
 async fn await_report_from_stream(
     mut stream: BiStream,
     kill: &CancellationToken,
-    session_id: &str,
+    db: djinn_db::Database,
+    task_run_id: &str,
     task_id: &str,
-) -> anyhow::Result<Option<TaskRunReport>> {
+    pre_session_deadline: std::time::Duration,
+) -> anyhow::Result<ReportAwait> {
+    let started = tokio::time::Instant::now();
+    // Pre-session watchdog: fires once at the deadline; the `if !session_reached`
+    // guard disables the arm as soon as we observe the first turn, so a normal
+    // (even slow) setup is never killed. Pinned so the already-elapsed future is
+    // not polled again after disarm.
+    let deadline = tokio::time::sleep(pre_session_deadline);
+    tokio::pin!(deadline);
+
+    let mut last_step = PRE_SESSION_INITIAL_STEP.to_string();
+    let mut session_reached = false;
+
     loop {
         tokio::select! {
             biased;
             _ = kill.cancelled() => {
-                let rpc_span = supervisor_rpc_span("kill", session_id, task_id);
+                let rpc_span = supervisor_rpc_span("kill", task_run_id, task_id);
                 async move {
                     tracing::debug!(
                         op = "kill",
-                        session_id = %session_id,
+                        session_id = %task_run_id,
                         task_id = %task_id,
                         "supervisor dispatch: kill fired while awaiting terminal report; \
                          proceeding to teardown"
@@ -1268,33 +1432,90 @@ async fn await_report_from_stream(
                 }
                 .instrument(rpc_span)
                 .await;
-                return Ok(None);
+                return Ok(ReportAwait::Report(None));
+            }
+            _ = &mut deadline, if !session_reached => {
+                // Authoritative DB double-check before failing: the worker may
+                // have created the session without us seeing a stream marker
+                // (older image, dropped frame). Only a genuine no-session hang
+                // trips the deadline.
+                let session_repo =
+                    djinn_db::SessionRepository::new(db.clone(), djinn_core::events::EventBus::new(|_| {}));
+                match session_repo.exists_for_task_run(task_run_id).await {
+                    Ok(true) => {
+                        // A session exists — first turn was reached; disarm and
+                        // keep awaiting the terminal report.
+                        session_reached = true;
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        // Fail open on a DB error: don't kill a possibly-live run
+                        // just because the backstop query flaked. Disarm and let
+                        // the coarse reapers handle any genuine hang.
+                        tracing::warn!(
+                            task_id = %task_id,
+                            task_run_id = %task_run_id,
+                            error = %e,
+                            "supervisor dispatch: pre-session deadline DB check failed; \
+                             disarming watchdog (falling back to coarse reapers)"
+                        );
+                        session_reached = true;
+                        continue;
+                    }
+                }
+                let elapsed_secs = started.elapsed().as_secs();
+                tracing::warn!(
+                    task_id = %task_id,
+                    task_run_id = %task_run_id,
+                    stage_step = %last_step,
+                    elapsed_secs,
+                    "supervisor dispatch: pre-session liveness deadline breached before first turn"
+                );
+                return Ok(ReportAwait::PreSessionTimeout(PreSessionTimeout {
+                    step: last_step.clone(),
+                    elapsed_secs,
+                }));
             }
             frame = stream.events_rx.recv() => {
                 match frame {
                     Some(StreamEvent::Report(report)) => {
-                        let rpc_span = supervisor_rpc_span("terminal_report", session_id, task_id);
+                        let rpc_span = supervisor_rpc_span("terminal_report", task_run_id, task_id);
                         let report_task_run_id = report.task_run_id.clone();
                         async move {
                             tracing::info!(
                                 event = "supervisor.rpc.terminal_report",
                                 op = "terminal_report",
-                                session_id = %session_id,
+                                session_id = %task_run_id,
                                 task_id = %task_id,
                                 task_run_id = %report_task_run_id,
                             );
                         }
                         .instrument(rpc_span)
                         .await;
-                        return Ok(Some(report));
+                        return Ok(ReportAwait::Report(Some(report)));
                     }
-                    Some(other) => {
-                        tracing::trace!(event = ?other, "supervisor dispatch: dropping non-terminal frame");
+                    Some(StreamEvent::StageStep { step }) => {
+                        // The reply-loop marker (or any reply-loop activity)
+                        // means the first turn is reached — disarm the deadline.
+                        if step == djinn_runtime::STAGE_STEP_FIRST_TURN {
+                            session_reached = true;
+                        }
+                        last_step = step;
+                    }
+                    Some(
+                        StreamEvent::AssistantDelta { .. }
+                        | StreamEvent::ToolCall { .. }
+                        | StreamEvent::FinalizePayload { .. }
+                        | StreamEvent::StageOutcome { .. },
+                    ) => {
+                        // Any reply-loop event proves the session is live.
+                        session_reached = true;
                     }
                     // Channel closed without a terminal report — the supervisor
                     // path persists state as a side effect; the caller uses the
                     // teardown stub for the terminal status.
-                    None => return Ok(None),
+                    None => return Ok(ReportAwait::Report(None)),
                 }
             }
         }
@@ -1609,6 +1830,29 @@ mod tests {
         }
     }
 
+    /// Lazy (unconnected) Postgres handle for the await tests below. The pool
+    /// is `connect_lazy_with`, so this never touches the network unless a query
+    /// runs — and with `no_deadline()` the pre-session watchdog never fires, so
+    /// none of these tests query the DB.
+    fn lazy_db() -> djinn_db::Database {
+        djinn_db::Database::open_in_memory().expect("lazy in-memory db handle")
+    }
+
+    /// A deadline far beyond any test's wall-clock so the pre-session watchdog
+    /// arm never fires — isolates the report/kill/close behaviour.
+    fn no_deadline() -> std::time::Duration {
+        std::time::Duration::from_secs(3600)
+    }
+
+    /// Unwrap the terminal-report arm, panicking on an unexpected pre-session
+    /// timeout.
+    fn expect_report(outcome: ReportAwait) -> Option<TaskRunReport> {
+        match outcome {
+            ReportAwait::Report(report) => report,
+            ReportAwait::PreSessionTimeout(t) => panic!("unexpected pre-session timeout: {t:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn await_report_returns_streamed_report() {
         let (bistream, events_tx, _requests_rx) = BiStream::new_in_memory(8);
@@ -1625,9 +1869,18 @@ mod tests {
             .await
             .expect("send report");
 
-        let got = await_report_from_stream(bistream, &kill, "session-id-b", "task-id-b")
+        let got = expect_report(
+            await_report_from_stream(
+                bistream,
+                &kill,
+                lazy_db(),
+                "session-id-b",
+                "task-id-b",
+                no_deadline(),
+            )
             .await
-            .expect("await ok");
+            .expect("await ok"),
+        );
         assert_eq!(got.expect("some report").task_run_id, "id-B");
     }
 
@@ -1648,9 +1901,18 @@ mod tests {
             .await
             .unwrap();
 
-        let got = await_report_from_stream(bistream, &kill, "session-terminal", "task-terminal")
+        let got = expect_report(
+            await_report_from_stream(
+                bistream,
+                &kill,
+                lazy_db(),
+                "session-terminal",
+                "task-terminal",
+                no_deadline(),
+            )
             .await
-            .expect("await ok");
+            .expect("await ok"),
+        );
 
         assert!(got.is_some());
         let span = layer
@@ -1692,9 +1954,18 @@ mod tests {
             .await
             .unwrap();
 
-        let got = await_report_from_stream(bistream, &kill, "session-id-b", "task-id-b")
+        let got = expect_report(
+            await_report_from_stream(
+                bistream,
+                &kill,
+                lazy_db(),
+                "session-id-b",
+                "task-id-b",
+                no_deadline(),
+            )
             .await
-            .expect("await ok");
+            .expect("await ok"),
+        );
         assert_eq!(got.expect("some report").task_run_id, "id-B");
     }
 
@@ -1705,9 +1976,18 @@ mod tests {
         let (bistream, _events_tx, _requests_rx) = BiStream::new_in_memory(8);
         let kill = CancellationToken::new();
         kill.cancel();
-        let got = await_report_from_stream(bistream, &kill, "session-kill", "task-kill")
+        let got = expect_report(
+            await_report_from_stream(
+                bistream,
+                &kill,
+                lazy_db(),
+                "session-kill",
+                "task-kill",
+                no_deadline(),
+            )
             .await
-            .expect("await ok");
+            .expect("await ok"),
+        );
         assert!(got.is_none());
     }
 
@@ -1721,9 +2001,18 @@ mod tests {
         let kill = CancellationToken::new();
         kill.cancel();
 
-        let got = await_report_from_stream(bistream, &kill, "session-kill", "task-kill")
+        let got = expect_report(
+            await_report_from_stream(
+                bistream,
+                &kill,
+                lazy_db(),
+                "session-kill",
+                "task-kill",
+                no_deadline(),
+            )
             .await
-            .expect("await ok");
+            .expect("await ok"),
+        );
 
         assert!(got.is_none());
         let span = layer
@@ -1747,9 +2036,111 @@ mod tests {
         let (bistream, events_tx, _requests_rx) = BiStream::new_in_memory(8);
         let kill = CancellationToken::new();
         drop(events_tx);
-        let got = await_report_from_stream(bistream, &kill, "session-closed", "task-closed")
+        let got = expect_report(
+            await_report_from_stream(
+                bistream,
+                &kill,
+                lazy_db(),
+                "session-closed",
+                "task-closed",
+                no_deadline(),
+            )
             .await
-            .expect("await ok");
+            .expect("await ok"),
+        );
         assert!(got.is_none());
+    }
+
+    /// Pre-session deadline (DB-backed): with no session row for the run and no
+    /// `reply_loop` marker, the watchdog fires a typed `PreSessionTimeout`
+    /// naming the last stage step seen — here `context_build`. Tiny deadline;
+    /// the event sender is kept alive so `recv()` would otherwise pend forever
+    /// (proving the deadline, not the stream close, is what bounds the wait).
+    #[tokio::test]
+    async fn await_report_pre_session_deadline_fires_naming_last_step() {
+        let db = lazy_db();
+        // Materialise the schema so `exists_for_task_run` returns Ok(false)
+        // (real query, no matching session) rather than fail-open on a DB error.
+        db.ensure_initialized().await.expect("schema ready");
+
+        let (bistream, events_tx, _requests_rx) = BiStream::new_in_memory(8);
+        let kill = CancellationToken::new();
+        events_tx
+            .send(StreamEvent::StageStep {
+                step: djinn_runtime::stage_step::WORKSPACE_ATTACH.to_string(),
+            })
+            .await
+            .unwrap();
+        events_tx
+            .send(StreamEvent::StageStep {
+                step: djinn_runtime::stage_step::CONTEXT_BUILD.to_string(),
+            })
+            .await
+            .unwrap();
+
+        let outcome = await_report_from_stream(
+            bistream,
+            &kill,
+            db,
+            "run-hang-no-session",
+            "task-hang",
+            std::time::Duration::from_millis(150),
+        )
+        .await
+        .expect("await ok");
+
+        match outcome {
+            ReportAwait::PreSessionTimeout(t) => {
+                assert_eq!(
+                    t.step,
+                    djinn_runtime::stage_step::CONTEXT_BUILD,
+                    "timeout names the last stage step reached"
+                );
+            }
+            ReportAwait::Report(_) => panic!("expected pre-session timeout, got a report"),
+        }
+        drop(events_tx);
+    }
+
+    /// A `reply_loop` marker disarms the deadline even when it is tiny, and the
+    /// subsequent terminal report is still returned — proving a normal (even
+    /// slow) setup is never spuriously killed once the first turn is reached.
+    #[tokio::test]
+    async fn await_report_first_turn_marker_disarms_tiny_deadline() {
+        let (bistream, events_tx, _requests_rx) = BiStream::new_in_memory(8);
+        let kill = CancellationToken::new();
+        events_tx
+            .send(StreamEvent::StageStep {
+                step: djinn_runtime::STAGE_STEP_FIRST_TURN.to_string(),
+            })
+            .await
+            .unwrap();
+        events_tx
+            .send(StreamEvent::Report(report(
+                "run-live",
+                vec![RoleKind::Worker],
+                TaskRunOutcome::Closed {
+                    reason: "done".into(),
+                },
+            )))
+            .await
+            .unwrap();
+
+        let got = expect_report(
+            await_report_from_stream(
+                bistream,
+                &kill,
+                lazy_db(),
+                "run-live",
+                "task-live",
+                std::time::Duration::from_millis(50),
+            )
+            .await
+            .expect("await ok"),
+        );
+        assert_eq!(
+            got.expect("report after first turn").task_run_id,
+            "run-live"
+        );
     }
 }

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -645,6 +645,12 @@ pub(crate) async fn execute_stage(
     // projects so the prompt can advertise them (and check out their files
     // read-only for direct inspection during a migration).
     let read_sources = advertise_read_sources(spec, agent_context).await;
+    // Coarse pre-session progress marker for the host-side liveness deadline:
+    // model/credential/MCP/skill resolution and prompt assembly happen here,
+    // before any session row exists.
+    let _ = services
+        .report_stage_step(djinn_runtime::stage_step::CONTEXT_BUILD)
+        .await;
     let PromptContext { system_prompt, .. } = assemble_prompt_context(PromptContextInputs {
         task,
         runtime_role: runtime_role.as_ref(),
@@ -684,6 +690,9 @@ pub(crate) async fn execute_stage(
     });
     let cost_basis_hint = billing_signal.map(|(hint, _)| hint);
     let billing_source = billing_signal.map(|(_, source)| source);
+    let _ = services
+        .report_stage_step(djinn_runtime::stage_step::SESSION_CREATE)
+        .await;
     let session_record = services
         .create_session(
             djinn_supervisor::services::SerializableCreateSessionParams {
@@ -700,6 +709,13 @@ pub(crate) async fn execute_stage(
         .await
         .map_err(StageError::SessionCreate)?;
     let session_id = session_record.id.clone();
+    // The session row now exists — the first reply-loop turn is reached. This
+    // marker (and the `sessions` row itself) disarms the host-side pre-session
+    // liveness deadline; from here liveness is owned by the coordinator's
+    // session stall detector / zombie reaper.
+    let _ = services
+        .report_stage_step(djinn_runtime::stage_step::FIRST_TURN)
+        .await;
 
     // ── Build the LLM provider ───────────────────────────────────────────────
     // Soft fallback: a missing catalog entry surfaces as `Err`, which we map to

--- a/server/crates/djinn-control-plane/src/tools/task_tools/mod.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/mod.rs
@@ -264,6 +264,36 @@ impl DjinnMcpServer {
                     }
                     None => None,
                 };
+                // Pre-session surfacing: when no reply-loop session exists yet
+                // but the run is dispatched and setting up (`task_run` status
+                // `starting`), surface that live state so the UI renders a real
+                // "starting" status instead of deriving a "setting up"
+                // pseudo-status from the absent session. Model/agent are not yet
+                // known at this stage, so they are left blank; the UI keys off
+                // `status == "starting"`.
+                let active_session = match active_session {
+                    Some(s) => Some(s),
+                    None => match task_run_repo.latest_starting_for_task(&t.id).await {
+                        Ok(Some(run)) => Some(SessionRecordResponse {
+                            id: run.id,
+                            project_id: Some(run.project_id),
+                            task_id: run.task_id,
+                            model_id: String::new(),
+                            agent_type: String::new(),
+                            started_at: run.started_at,
+                            ended_at: None,
+                            status: djinn_core::models::TaskRunStatus::Starting
+                                .as_str()
+                                .to_string(),
+                            tokens_in: 0,
+                            tokens_out: 0,
+                            cache_read_tokens: 0,
+                            cache_write_tokens: 0,
+                            workspace_path: run.workspace_path,
+                        }),
+                        _ => None,
+                    },
+                };
                 Json(ErrorOr::Ok(TaskShowResponse {
                     task: task_to_response(&t),
                     session_count,
@@ -373,17 +403,44 @@ impl DjinnMcpServer {
                     .await
                     .unwrap_or_default();
 
+                // Pre-session surfacing (batch): tasks dispatched but not yet at
+                // their first reply-loop session hold a `starting` task_run and
+                // have no active session — surface that live state so the UI
+                // renders "starting" rather than deriving "setting up".
+                let task_run_repo = djinn_db::repositories::task_run::TaskRunRepository::new(
+                    self.state.db().clone(),
+                );
+                let mut starting_by_task = task_run_repo
+                    .latest_starting_by_tasks(&task_ids)
+                    .await
+                    .unwrap_or_default();
+
                 let tasks = result
                     .tasks
                     .iter()
                     .map(|t| {
-                        let active = session_by_task.remove(&t.id).map(|s| ActiveSessionSummary {
-                            session_id: s.id,
-                            agent_type: s.agent_type,
-                            model_id: s.model_id,
-                            started_at: s.started_at,
-                            status: s.status,
-                        });
+                        let active = match session_by_task.remove(&t.id) {
+                            Some(s) => Some(ActiveSessionSummary {
+                                session_id: s.id,
+                                agent_type: s.agent_type,
+                                model_id: s.model_id,
+                                started_at: s.started_at,
+                                status: s.status,
+                            }),
+                            None => {
+                                starting_by_task
+                                    .remove(&t.id)
+                                    .map(|run| ActiveSessionSummary {
+                                        session_id: run.id,
+                                        agent_type: String::new(),
+                                        model_id: String::new(),
+                                        started_at: run.started_at,
+                                        status: djinn_core::models::TaskRunStatus::Starting
+                                            .as_str()
+                                            .to_string(),
+                                    })
+                            }
+                        };
                         let count = session_counts.get(&t.id).copied().unwrap_or(0);
                         task_to_list_item(t, active, count)
                     })

--- a/server/crates/djinn-core/src/models/task_run.rs
+++ b/server/crates/djinn-core/src/models/task_run.rs
@@ -7,10 +7,22 @@ use serde::{Deserialize, Serialize};
 ///
 /// Wire strings are the lowercase variant names; the DB stores them as
 /// VARCHAR(64).  Terminal statuses (Completed, Failed, Interrupted) cause the
-/// run's `ended_at` to be stamped; `Running` leaves it NULL.
+/// run's `ended_at` to be stamped; `Starting` / `Running` leave it NULL.
+///
+/// `Starting` is the pre-session tracking state: a dispatched run holds it from
+/// the moment the in-pod supervisor creates the `task_runs` row until the first
+/// reply-loop session is created (see `SessionRepository::create`, which flips
+/// `starting → running`). It exists so the UI and the host-side pre-session
+/// liveness deadline can see a dispatched run BEFORE any `sessions` row exists,
+/// closing the invisible "setting up" gap. Both `Starting` and `Running` are
+/// "live" (non-terminal) states and are treated identically by the task_run
+/// reapers (`reap_running_for_task`, `reap_stale_running`, `running_ids`).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskRunStatus {
+    /// Dispatched, pre-first-session. Set when the run row is created; flipped
+    /// to `Running` at the first reply-loop session.
+    Starting,
     Running,
     Completed,
     Failed,
@@ -20,6 +32,7 @@ pub enum TaskRunStatus {
 impl TaskRunStatus {
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::Starting => "starting",
             Self::Running => "running",
             Self::Completed => "completed",
             Self::Failed => "failed",
@@ -30,6 +43,12 @@ impl TaskRunStatus {
     /// True for statuses that close out a run (i.e. should set `ended_at`).
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Completed | Self::Failed | Self::Interrupted)
+    }
+
+    /// True for the live (non-terminal) states a dispatched run occupies while
+    /// the pod is running — `Starting` (pre-session) or `Running`.
+    pub fn is_live(&self) -> bool {
+        matches!(self, Self::Starting | Self::Running)
     }
 }
 
@@ -44,6 +63,7 @@ impl FromStr for TaskRunStatus {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "starting" => Ok(Self::Starting),
             "running" => Ok(Self::Running),
             "completed" => Ok(Self::Completed),
             "failed" => Ok(Self::Failed),

--- a/server/crates/djinn-db/src/repositories/session.rs
+++ b/server/crates/djinn-db/src/repositories/session.rs
@@ -83,6 +83,25 @@ impl SessionRepository {
         .execute(self.db.pool())
         .await?;
 
+        // Pre-session tracking transition: a dispatched `task_run` holds
+        // `starting` from creation (in-pod supervisor) until its first
+        // reply-loop session is created — this is that first turn, so flip it
+        // to `running`. Guarded on `status = 'starting'` so it is a no-op for
+        // subsequent per-stage sessions (already `running`), terminal runs
+        // (post-session extraction), and chat sessions (`task_run_id` NULL).
+        // This transition is what flips the UI off its "starting" badge; the
+        // host-side pre-session liveness deadline disarms on the `sessions`
+        // row itself.
+        if let Some(run_id) = params.task_run_id {
+            sqlx::query!(
+                "UPDATE task_runs SET status = 'running', ended_at = NULL
+                 WHERE id = $1 AND status = 'starting'",
+                run_id,
+            )
+            .execute(self.db.pool())
+            .await?;
+        }
+
         let session = sqlx::query_as!(
             SessionRecord,
             r#"SELECT id, project_id, task_id, model_id, agent_type, started_at, ended_at,
@@ -1296,6 +1315,22 @@ impl SessionRepository {
         .await?)
     }
 
+    /// True when at least one `sessions` row references the given task_run.
+    ///
+    /// Used by the host-side pre-session liveness deadline as its DB-truth
+    /// disarm signal: once any session exists for the run, the first reply-loop
+    /// turn has been reached and liveness is owned by the coordinator's session
+    /// stall detector / zombie reaper, so the pre-session deadline stands down.
+    pub async fn exists_for_task_run(&self, task_run_id: &str) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        let found: Option<i32> =
+            sqlx::query_scalar("SELECT 1 FROM sessions WHERE task_run_id = $1 LIMIT 1")
+                .bind(task_run_id)
+                .fetch_optional(self.db.pool())
+                .await?;
+        Ok(found.is_some())
+    }
+
     /// Backdate a session's `started_at` by a PostgreSQL `interval` string
     /// (e.g. `'20 minutes'`, `'30 seconds'`).
     ///
@@ -1444,6 +1479,125 @@ mod tests {
         .unwrap();
 
         (epic.project_id, task_id)
+    }
+
+    /// Creating the first reply-loop session flips its `starting` task_run to
+    /// `running`, and a subsequent session on the same run is a no-op (stays
+    /// `running`) — the pre-session tracking transition. A session with no
+    /// task_run, or one whose run is already terminal, leaves the run untouched.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_session_flips_starting_task_run_to_running() {
+        use crate::repositories::task_run::{CreateTaskRunParams, TaskRunRepository};
+
+        let db = test_db();
+        let (bus, _captured) = capturing_bus();
+        db.ensure_initialized().await.unwrap();
+        let (project_id, task_id) = create_task(&db, bus.clone()).await;
+
+        let run_repo = TaskRunRepository::new(db.clone());
+        let run_id = uuid::Uuid::now_v7().to_string();
+        run_repo
+            .create(CreateTaskRunParams {
+                id: &run_id,
+                project_id: &project_id,
+                task_id: &task_id,
+                trigger_type: "new_task",
+                status: Some("starting"),
+                workspace_path: None,
+                mirror_ref: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            run_repo.get(&run_id).await.unwrap().unwrap().status,
+            "starting"
+        );
+
+        let repo = SessionRepository::new(db.clone(), bus.clone());
+        repo.create(CreateSessionParams {
+            project_id: &project_id,
+            task_id: Some(&task_id),
+            model: "openai/gpt-a",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(&run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            run_repo.get(&run_id).await.unwrap().unwrap().status,
+            "running",
+            "first session flips starting → running"
+        );
+
+        // Mark the run terminal, then a late (extraction) session must NOT
+        // resurrect it back to running.
+        run_repo
+            .update_status(&run_id, djinn_core::models::TaskRunStatus::Completed)
+            .await
+            .unwrap();
+        repo.create(CreateSessionParams {
+            project_id: &project_id,
+            task_id: Some(&task_id),
+            model: "openai/gpt-a",
+            agent_type: "reviewer",
+            metadata_json: None,
+            task_run_id: Some(&run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            run_repo.get(&run_id).await.unwrap().unwrap().status,
+            "completed",
+            "guarded flip is a no-op for a non-starting run"
+        );
+    }
+
+    /// `exists_for_task_run` is the pre-session deadline's disarm probe: false
+    /// before any session exists, true once one does.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exists_for_task_run_tracks_session_presence() {
+        use crate::repositories::task_run::{CreateTaskRunParams, TaskRunRepository};
+
+        let db = test_db();
+        let (bus, _captured) = capturing_bus();
+        db.ensure_initialized().await.unwrap();
+        let (project_id, task_id) = create_task(&db, bus.clone()).await;
+        let repo = SessionRepository::new(db.clone(), bus.clone());
+
+        let run_repo = TaskRunRepository::new(db.clone());
+        let run_id = uuid::Uuid::now_v7().to_string();
+        run_repo
+            .create(CreateTaskRunParams {
+                id: &run_id,
+                project_id: &project_id,
+                task_id: &task_id,
+                trigger_type: "new_task",
+                status: Some("starting"),
+                workspace_path: None,
+                mirror_ref: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(!repo.exists_for_task_run(&run_id).await.unwrap());
+        repo.create(CreateSessionParams {
+            project_id: &project_id,
+            task_id: Some(&task_id),
+            model: "openai/gpt-a",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(&run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+        assert!(repo.exists_for_task_run(&run_id).await.unwrap());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-db/src/repositories/task_run.rs
+++ b/server/crates/djinn-db/src/repositories/task_run.rs
@@ -138,9 +138,12 @@ impl TaskRunRepository {
         }
         self.db.ensure_initialized().await?;
 
+        // Both live states (`starting` pre-session, `running` post-session)
+        // are reapable: a run wedged in stage-init before its first session
+        // must be flipped terminal too, not just a `running` one.
         let row: Option<String> = sqlx::query_scalar!(
             "SELECT id FROM task_runs
-             WHERE task_id = $1 AND status = 'running' AND ended_at IS NULL
+             WHERE task_id = $1 AND status IN ('starting', 'running') AND ended_at IS NULL
              ORDER BY started_at DESC LIMIT 1",
             task_id
         )
@@ -168,7 +171,7 @@ impl TaskRunRepository {
 
         let ids: Vec<String> = sqlx::query_scalar!(
             "SELECT id FROM task_runs
-             WHERE status = 'running'
+             WHERE status IN ('starting', 'running')
                AND ended_at IS NULL
                AND started_at < $1",
             stale_threshold_iso
@@ -201,6 +204,59 @@ impl TaskRunRepository {
         Ok(row.flatten())
     }
 
+    /// Latest live `starting` (pre-session) run for a task, if any.
+    ///
+    /// A run holds `starting` from dispatch until its first reply-loop session
+    /// is created (which flips it to `running`). `task_show`/`task_list` surface
+    /// this as the task's active state so the UI renders the real "starting"
+    /// status instead of inferring a "setting up" pseudo-status from a missing
+    /// session.
+    pub async fn latest_starting_for_task(&self, task_id: &str) -> Result<Option<TaskRunRecord>> {
+        self.db.ensure_initialized().await?;
+        Ok(sqlx::query_as!(
+            TaskRunRecord,
+            r#"SELECT id, project_id, task_id, trigger_type,
+                status AS "status!", started_at, ended_at,
+                workspace_path, mirror_ref
+             FROM task_runs
+             WHERE task_id = $1 AND status = 'starting' AND ended_at IS NULL
+             ORDER BY started_at DESC LIMIT 1"#,
+            task_id
+        )
+        .fetch_optional(self.db.pool())
+        .await?)
+    }
+
+    /// Batch variant of [`latest_starting_for_task`]: the latest live
+    /// `starting` run per task id, keyed by task id. Tasks with no starting run
+    /// are absent from the map. Used by `task_list` to avoid an N+1 query.
+    pub async fn latest_starting_by_tasks(
+        &self,
+        task_ids: &[&str],
+    ) -> Result<std::collections::HashMap<String, TaskRunRecord>> {
+        if task_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        self.db.ensure_initialized().await?;
+        let owned: Vec<String> = task_ids.iter().map(|s| (*s).to_string()).collect();
+        // DISTINCT ON (task_id) with the ORDER BY picks the newest starting run
+        // for each task in one pass.
+        let rows = sqlx::query_as!(
+            TaskRunRecord,
+            r#"SELECT DISTINCT ON (task_id)
+                id, project_id, task_id, trigger_type,
+                status AS "status!", started_at, ended_at,
+                workspace_path, mirror_ref
+             FROM task_runs
+             WHERE task_id = ANY($1) AND status = 'starting' AND ended_at IS NULL
+             ORDER BY task_id, started_at DESC"#,
+            &owned
+        )
+        .fetch_all(self.db.pool())
+        .await?;
+        Ok(rows.into_iter().map(|r| (r.task_id.clone(), r)).collect())
+    }
+
     /// Return IDs of task-runs that are still `running` with `ended_at IS NULL`.
     ///
     /// Used by the coordinator's cargo-target-run-dir sweep to build the set
@@ -208,7 +264,7 @@ impl TaskRunRepository {
     pub async fn running_ids(&self) -> Result<Vec<String>> {
         self.db.ensure_initialized().await?;
         Ok(sqlx::query_scalar(
-            "SELECT id FROM task_runs WHERE status = 'running' AND ended_at IS NULL",
+            "SELECT id FROM task_runs WHERE status IN ('starting', 'running') AND ended_at IS NULL",
         )
         .fetch_all(self.db.pool())
         .await?)

--- a/server/crates/djinn-runtime/src/lib.rs
+++ b/server/crates/djinn-runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub use spec::{
     LoopGuardKind, LoopGuardTrip, ProviderFailureClass, RoleKind, SupervisorFlow, TaskRunOutcome,
     TaskRunReport, TaskRunSpec, role_sequence,
 };
-pub use stream::{BiStream, StreamEvent, StreamFrame};
+pub use stream::{BiStream, STAGE_STEP_FIRST_TURN, StreamEvent, StreamFrame, stage_step};
 pub use warmer::{GraphWarmerService, TaskrunJobRef, WarmerError};
 pub use wire::{ControlMsg, MAX_FRAME_BYTES, WorkerEvent, WorkspaceRef, read_frame, write_frame};
 

--- a/server/crates/djinn-runtime/src/stream.rs
+++ b/server/crates/djinn-runtime/src/stream.rs
@@ -38,9 +38,39 @@ pub enum StreamEvent {
     },
     /// One stage finished — advances the supervisor's role sequence.
     StageOutcome { role: RoleKind, outcome_tag: String },
+    /// Coarse stage-init progress marker emitted while the run is setting up,
+    /// BEFORE the first reply-loop session exists. Lets the host name the
+    /// in-pod step a hung run is stuck on (workspace attach, cargo seed,
+    /// context build, ...) and detect when the first turn is reached (the
+    /// [`STAGE_STEP_FIRST_TURN`] marker). Diagnostic-only: dropped by the
+    /// normal report drain.
+    StageStep { step: String },
     /// Terminal: the whole task-run finished.  Always the last frame.
     Report(TaskRunReport),
 }
+
+/// Stage-init step markers emitted as [`StreamEvent::StageStep`] /
+/// [`crate::WorkerEvent::StageStep`] so the host can name the step a
+/// pre-session hang is stuck on. The values are stable wire strings shared by
+/// the worker (emitter) and the host (pre-session liveness deadline).
+pub mod stage_step {
+    /// Attaching/cloning the ephemeral workspace from the mirror.
+    pub const WORKSPACE_ATTACH: &str = "workspace_attach";
+    /// Seeding the per-run private cargo target dir from the base snapshot.
+    pub const CARGO_SEED: &str = "cargo_seed";
+    /// Resolving model/credentials, MCP, skills, and assembling the prompt.
+    pub const CONTEXT_BUILD: &str = "context_build";
+    /// Creating the session row (immediately precedes the reply loop).
+    pub const SESSION_CREATE: &str = "session_create";
+    /// The reply loop has started — the first provider turn is reached. Seeing
+    /// this (or any reply-loop event, or a `sessions` row) disarms the
+    /// host-side pre-session liveness deadline.
+    pub const FIRST_TURN: &str = "reply_loop";
+}
+
+/// Marker step signalling the first reply-loop turn has been reached. Re-export
+/// of [`stage_step::FIRST_TURN`] for the host's deadline check.
+pub const STAGE_STEP_FIRST_TURN: &str = stage_step::FIRST_TURN;
 
 /// Requests flowing downstream from the coordinator to the worker.
 ///

--- a/server/crates/djinn-runtime/src/wire.rs
+++ b/server/crates/djinn-runtime/src/wire.rs
@@ -95,6 +95,11 @@ pub enum WorkerEvent {
     /// connection's event stream looking for this variant to extract the
     /// real terminal report instead of synthesising one from Job status.
     TerminalReport(TaskRunReport),
+    /// Coarse stage-init progress marker (see
+    /// [`crate::StreamEvent::StageStep`]). Appended last to preserve the
+    /// wire layout of the earlier variants. Emitted while the run is setting
+    /// up so the host can name the step a pre-session hang is stuck on.
+    StageStep { step: String },
 }
 
 /// Write `payload` as a length-prefixed bincode frame.

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -552,7 +552,15 @@ impl TaskRunSupervisor {
                 project_id: spec.project_id.clone(),
                 task_id: spec.task_id.clone(),
                 trigger_type: trigger_str.clone(),
-                status: None,
+                // Pre-session tracking state: the run is visible to the UI and
+                // the host-side pre-session liveness deadline from dispatch,
+                // and flips to `running` when the first reply-loop session is
+                // created (`SessionRepository::create`). See `TaskRunStatus`.
+                status: Some(
+                    djinn_core::models::TaskRunStatus::Starting
+                        .as_str()
+                        .to_string(),
+                ),
                 workspace_path: None,
                 mirror_ref: None,
             })
@@ -568,6 +576,14 @@ impl TaskRunSupervisor {
             }
             return Err(SupervisorError::CreateTaskRun(e));
         }
+
+        // Coarse pre-session progress marker: the host-side liveness deadline
+        // names this step if the ephemeral clone hangs (the biggest suspect
+        // for a stage-init wedge). Best-effort — never blocks the run.
+        let _ = self
+            .services
+            .report_stage_step(djinn_runtime::stage_step::WORKSPACE_ATTACH)
+            .await;
 
         // Try to clone on task_branch first (preserves prior cycle's commits
         // in the mirror — workspace.push_to_origin writes them back after

--- a/server/crates/djinn-supervisor/src/services.rs
+++ b/server/crates/djinn-supervisor/src/services.rs
@@ -271,6 +271,21 @@ pub trait SupervisorServices: Send + Sync + 'static {
     /// trackers so the host's poller stays accurate.
     async fn touch_activity(&self, task_id: String) -> Result<(), String>;
 
+    /// Emit a coarse stage-init progress marker (see
+    /// [`djinn_runtime::StreamEvent::StageStep`]) so the host-side pre-session
+    /// liveness deadline can name the in-pod step a hung setup is stuck on
+    /// (workspace attach, cargo seed, context build, ...) and detect when the
+    /// first reply-loop turn is reached ([`djinn_runtime::STAGE_STEP_FIRST_TURN`]).
+    ///
+    /// Fire-and-forget and diagnostic-only: the default impl is a no-op, so
+    /// only the in-pod worker transport (which forwards it on the shared frame
+    /// channel as a [`djinn_runtime::WorkerEvent::StageStep`]) needs to
+    /// override it. Host-side / test service impls that drive the run in-process
+    /// leave it a no-op — the deadline's DB-truth backstop covers those paths.
+    async fn report_stage_step(&self, _step: &'static str) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Apply a [`djinn_core::models::TransitionAction`] to the given task
     /// on the host. The supervisor stage loop calls this at every stage
     /// boundary so the task walks its full status machine

--- a/server/crates/djinn-supervisor/src/services/rpc.rs
+++ b/server/crates/djinn-supervisor/src/services/rpc.rs
@@ -379,6 +379,16 @@ impl SupervisorServices for RpcServices {
         &self.cancel
     }
 
+    async fn report_stage_step(&self, step: &'static str) -> Result<(), String> {
+        // Ship the marker out-of-band on the shared frame channel; the host's
+        // reader_loop lowers it to a `StreamEvent::StageStep`. Best-effort —
+        // a dropped writer just means the connection is already gone.
+        self.emit_event(djinn_runtime::WorkerEvent::StageStep {
+            step: step.to_string(),
+        })
+        .await
+    }
+
     async fn load_task(&self, task_id: String) -> Result<Task, String> {
         match self
             .roundtrip(ServiceRpcRequest::LoadTask { task_id })

--- a/server/crates/djinn-supervisor/src/services/server.rs
+++ b/server/crates/djinn-supervisor/src/services/server.rs
@@ -578,6 +578,7 @@ struct AttachedSlot {
 fn worker_event_to_stream_event(event: WorkerEvent) -> Option<StreamEvent> {
     match event {
         WorkerEvent::TerminalReport(report) => Some(StreamEvent::Report(report)),
+        WorkerEvent::StageStep { step } => Some(StreamEvent::StageStep { step }),
         WorkerEvent::Placeholder => None,
     }
 }

--- a/ui/src/components/TaskCard.test.tsx
+++ b/ui/src/components/TaskCard.test.tsx
@@ -18,30 +18,61 @@ describe("TaskCard", () => {
         { criterion: "second", met: true },
       ],
       unresolved_blocker_count: 1,
+      active_session: {
+        session_id: "run-starting-1",
+        agent_type: "",
+        model_id: "",
+        started_at: new Date().toISOString(),
+        status: "starting",
+      },
     };
 
     render(<TaskCard task={task} />);
 
     expect(screen.getByText(task.title)).toBeInTheDocument();
     expect(screen.getByText(task.short_id)).toBeInTheDocument();
-    expect(screen.getByText("setting up")).toBeInTheDocument();
+    expect(screen.getByText("starting")).toBeInTheDocument();
     expect(screen.getByLabelText(`Priority P${task.priority}`)).toBeInTheDocument();
     expect(screen.getByText("1/2")).toBeInTheDocument();
     expect(screen.getByText(/frontend/i)).toBeInTheDocument();
   });
 
-  it("renders setting up badge for in-progress tasks without an active session", () => {
+  it("renders the real 'starting' status (not a derived 'setting up') for a dispatched, pre-session run", () => {
     const task = {
       ...mockTaskA,
       id: "task-setup-step",
       short_id: "s1",
       status: "in_progress",
       title: "Setup task",
+      active_session: {
+        session_id: "run-starting-2",
+        agent_type: "",
+        model_id: "",
+        started_at: new Date().toISOString(),
+        status: "starting",
+      },
     };
 
     render(<TaskCard task={task} />);
 
-    expect(screen.getByText("setting up")).toBeInTheDocument();
+    expect(screen.getByText("starting")).toBeInTheDocument();
+    expect(screen.queryByText("setting up")).not.toBeInTheDocument();
+  });
+
+  it("never derives a 'setting up' pseudo-status from a missing session", () => {
+    const task = {
+      ...mockTaskA,
+      id: "task-no-session",
+      short_id: "s2",
+      status: "in_progress",
+      title: "In progress, no session yet",
+      active_session: undefined,
+    };
+
+    render(<TaskCard task={task} />);
+
+    expect(screen.queryByText("setting up")).not.toBeInTheDocument();
+    expect(screen.queryByText("starting")).not.toBeInTheDocument();
   });
 
   it("renders CI: passing badge when ci status is passing", () => {

--- a/ui/src/components/TaskCard.tsx
+++ b/ui/src/components/TaskCard.tsx
@@ -96,18 +96,29 @@ function hasHumanReviewHold(task: Task): boolean {
   return task.labels?.includes(HUMAN_REVIEW_HOLD_LABEL) ?? false;
 }
 
-function getStatusBadge(status: string, hasSession: boolean, allAcMet: boolean): { label: string; className: string } | null {
-  if ((status === "needs_task_review" || status === "in_task_review") && !hasSession && allAcMet) {
+// The pre-first-turn tracking state a dispatched run reports (via
+// `active_session.status`) until its first reply-loop session upgrades it to
+// `running`. Matches the backend `TaskRunStatus::Starting` wire string.
+const STARTING_SESSION_STATUS = "starting";
+
+function getStatusBadge(
+  status: string,
+  sessionStatus: string | undefined,
+  allAcMet: boolean,
+): { label: string; className: string } | null {
+  if ((status === "needs_task_review" || status === "in_task_review") && !sessionStatus && allAcMet) {
     return { label: "merging", className: "text-green-400 animate-pulse" };
   }
-  if (status === "in_progress" && !hasSession) {
-    return { label: "setting up", className: "text-blue-400 animate-pulse" };
+  // Real dispatched-but-pre-session state, surfaced from the tracked run —
+  // NOT a "setting up" pseudo-status inferred from a missing session.
+  if (status === "in_progress" && sessionStatus === STARTING_SESSION_STATUS) {
+    return { label: "starting", className: "text-blue-400 animate-pulse" };
   }
   return null;
 }
 
-function StatusBadge({ status, hasSession, allAcMet }: { status: string; hasSession: boolean; allAcMet: boolean }) {
-  const badge = getStatusBadge(status, hasSession, allAcMet);
+function StatusBadge({ status, sessionStatus, allAcMet }: { status: string; sessionStatus: string | undefined; allAcMet: boolean }) {
+  const badge = getStatusBadge(status, sessionStatus, allAcMet);
   if (!badge) return null;
   return (
     <span className={cn("text-[10px] font-medium", badge.className)}>
@@ -238,7 +249,11 @@ export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
   const acMet = ac.filter((c: { met?: boolean }) => c.met).length;
   const cardTint = getCardTint(task);
   const needsReview = hasHumanReviewHold(task);
-  const isSettingUp = task.status === "in_progress" && !task.active_session;
+  // Dispatched but not yet at its first reply-loop turn: the tracked run
+  // reports `starting` via `active_session.status`. Suppress duration/model/
+  // avatar until the session is really running (model/agent are unknown while
+  // starting).
+  const isStarting = task.active_session?.status === STARTING_SESSION_STATUS;
 
   return (
     <Card
@@ -324,7 +339,7 @@ export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
           {/* Status badge for in-flight */}
           {isInFlight && (
             <span className="inline-flex items-center gap-1" data-testid="taskcard-status-badge">
-              <StatusBadge status={task.status} hasSession={!!task.active_session} allAcMet={acTotal > 0 && acMet === acTotal} />
+              <StatusBadge status={task.status} sessionStatus={task.active_session?.status} allAcMet={acTotal > 0 && acMet === acTotal} />
             </span>
           )}
 
@@ -340,10 +355,10 @@ export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
           )}
 
           {/* Duration & model for in-flight / done (hidden during setup — shown in tooltip) */}
-          {shouldShowDuration && !isSettingUp && (
+          {shouldShowDuration && !isStarting && (
             <span className="text-[10px]">{formatCompactDuration(totalTrackedSeconds)}</span>
           )}
-          {task.active_session?.model_id && !isSettingUp && (
+          {task.active_session?.model_id && !isStarting && (
             <span className="min-w-0 shrink truncate text-[10px]" title={task.active_session.model_id}>
               {task.active_session.model_id}
             </span>
@@ -377,7 +392,7 @@ export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
         )}
 
         {/* Agent avatar – shown when task has an active session (hidden during setup) */}
-        {task.active_session && !isSettingUp && (
+        {task.active_session && !isStarting && (
           <img
             src={agentAvatar(task.active_session.agent_type)}
             alt={task.active_session.agent_type ?? "agent"}

--- a/ui/src/stores/sseEventHandlers.ts
+++ b/ui/src/stores/sseEventHandlers.ts
@@ -234,7 +234,11 @@ export function initSSEEventHandlers(): () => void {
         agent_type: payload.agent_type,
         model_id: payload.model_id,
         started_at: new Date().toISOString(),
-        status: "dispatched",
+        // Live pre-session tracking state (matches the backend
+        // `TaskRunStatus::Starting` wire string and what `task_show`/
+        // `task_list` surface on refetch) so the card renders a real
+        // "starting" status instead of the old derived "setting up" label.
+        status: "starting",
       },
     });
   });


### PR DESCRIPTION
Implements djinn proposal `c2xb`.

## Problem (production evidence, 2026-07-02, v0.6.68)
Between task dispatch and a worker's first reply-loop turn there was **no session row and no liveness tracking**. The coordinator stall detector watches `sessions`, so a stage-init hang was invisible.

Task **1f9u** (`019f2240-a63c-7c82-8704-95ac810cac92`), run `019f22f6-5dbb`: pod booted 13:13:32, "Supervisor stage: starting" 13:13:37, then **zero progress** — no session row, no provider turn. The orphan reaper finally caught it at 13:28:39 (`Interrupted`, `stages_completed=[]`), burning ~15 min and one attempt from the retry budget invisibly. The UI showed a derived **"setting up"** pseudo-status the whole time.

## The fix (three parts)

**1. Tracked from dispatch.** New `TaskRunStatus::Starting` (VARCHAR — no migration). The in-pod supervisor creates the `task_runs` row as `starting`; the first reply-loop `SessionRepository::create` flips it to `running` (guarded — later per-stage / extraction / chat sessions are no-ops). `task_show`/`task_list` surface a live `starting` run as the task's `active_session` (F5-safe), and `session.dispatched` is emitted at dispatch for the live nudge. The task_run reapers (`reap_running_for_task`, `reap_stale_running`, `running_ids`) treat `starting` as live so a pre-session wedge is still reaped and its cargo dir protected. **The session stall detector / zombie reaper (PR #1429) are untouched** — they key on `sessions`, invisible to `task_runs`.

**2. Pre-session liveness deadline** (default **8 min**, `DJINN_PRESESSION_DEADLINE_SECS`). Enforced host-side in the supervisor-dispatch seam (`await_report_from_stream`): if no session appears before the deadline, the run fails fast with a **typed `PreSessionTimeout` naming the in-pod step** it hung on. The worker emits coarse `StageStep` markers (`workspace_attach` → `context_build` → `session_create` → `reply_loop`) over the existing frame channel; the host tracks the last step and disarms on the first-turn marker, any reply-loop event, or a DB-truth session-exists check (fail-open on DB error). Cargo seed runs pre-handshake and stays covered by the existing 600s handshake timeout.

**3. UI renders the real state.** `TaskCard` no longer derives "setting up" from a missing session — it renders the tracked `starting`/`running` status. The `session.dispatched` SSE handler sets status `starting`.

## Scope
Does **not** touch the resume/replay path, failure-streak escalation, or the terminal-error recording seam (concurrent work #1438/#1439, rebased over cleanly). No MCP schema change (reused `active_session`), so no `mcp-tools.gen.ts` / insta snapshot churn.

## Tests
- `djinn-db`: `create_session_flips_starting_task_run_to_running` (flip + guarded no-op for terminal/late sessions), `exists_for_task_run_tracks_session_presence`.
- host: `await_report_pre_session_deadline_fires_naming_last_step` (typed timeout names `context_build`), `await_report_first_turn_marker_disarms_tiny_deadline` (normal setup, no spurious kill).
- UI: `TaskCard` renders `starting`, never derives `setting up` (incl. a missing-session case).

## Verification
`cargo fmt --check`, CI-exact `cargo clippy --all-targets --features qdrant -D warnings` (offline), `cargo nextest` for djinn-db / djinn-agent / djinn-supervisor / djinn-agent-worker / djinn-control-plane / djinn-coordinator + tool-schema snapshots (incl. `planner_tools_section_snapshot`) all green. `sqlx` offline cache regenerated. UI `tsc --noEmit`, `mcp:types:check`, TaskCard + sseEventHandlers vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)