### PR TITLE
fix(proposal): move AC-amendment audit from feedback pane to revision history

### DIFF
--- a/server/crates/djinn-db/migrations_postgres/90_ac_amendment_audit_to_revision_metadata.sql
+++ b/server/crates/djinn-db/migrations_postgres/90_ac_amendment_audit_to_revision_metadata.sql
@@ -1,0 +1,67 @@
+-- AC-amendment audit moves from the FEEDBACK pane to the revision History.
+--
+-- `proposal_ac_amend` used to write the machine-oriented change list as an
+-- `author_kind = 'ai'` `proposal_feedback` row ("Acceptance criteria amended
+-- \nreason: ...\nrevision: N -> M\namendments: <json>"). That surfaced raw
+-- audit JSON as unresolved reviewer feedback with "Address with djinn" /
+-- "Dismiss" buttons — wrong, it is a spec-change audit, not review feedback.
+--
+-- The amendment audit now rides on the bumped spec revision's
+-- `event_metadata` (`{"kind":"ac_amendment","reason":...,"amendments":[...]}`).
+-- This migration (1) best-effort backfills that metadata onto the matching
+-- revision for existing feedback rows, then (2) deletes the feedback rows.
+
+-- (1) Best-effort backfill. Per-row EXCEPTION guard: any row whose body doesn't
+--     parse cleanly (unexpected shape, invalid amendments JSON) is skipped, not
+--     fatal. Only fills revisions that don't already carry event_metadata.
+DO $$
+DECLARE
+    r        RECORD;
+    v_seq    INT;
+    v_reason TEXT;
+    v_amend  TEXT;
+    v_meta   JSONB;
+BEGIN
+    FOR r IN
+        SELECT id, proposal_id, body
+          FROM proposal_feedback
+         WHERE author_kind = 'ai'
+           AND body LIKE 'Acceptance criteria amended%'
+    LOOP
+        BEGIN
+            -- Target revision seq from the "revision: N -> M" line.
+            v_seq := NULLIF((regexp_match(r.body, 'revision:\s*\d+\s*->\s*(\d+)'))[1], '')::INT;
+            -- Reason: text after "reason: " up to the "\nrevision:" line.
+            v_reason := (regexp_match(r.body, 'reason:\s*(.*?)\nrevision:'))[1];
+            -- Amendments: the compact JSON array after "amendments: ".
+            v_amend := (regexp_match(r.body, 'amendments:\s*(.*)$'))[1];
+
+            IF v_seq IS NULL OR v_amend IS NULL THEN
+                CONTINUE;
+            END IF;
+
+            v_meta := jsonb_build_object(
+                'kind', 'ac_amendment',
+                'reason', COALESCE(v_reason, ''),
+                'amendments', v_amend::jsonb
+            );
+
+            UPDATE proposal_revisions
+               SET event_metadata = v_meta
+             WHERE proposal_id = r.proposal_id
+               AND seq = v_seq
+               AND event_kind = 'spec_revision'
+               AND event_metadata IS NULL;
+        EXCEPTION WHEN others THEN
+            -- Unparseable body / invalid JSON — skip this row, keep going.
+            CONTINUE;
+        END;
+    END LOOP;
+END $$;
+
+-- (2) Delete the stale audit-as-feedback rows. proposal_feedback has no FK
+--     children (parent_id has no FK; resolution is columns on the row itself),
+--     so a plain DELETE is safe.
+DELETE FROM proposal_feedback
+ WHERE author_kind = 'ai'
+   AND body LIKE 'Acceptance criteria amended%';

--- a/server/crates/djinn-db/src/repositories/proposal.rs
+++ b/server/crates/djinn-db/src/repositories/proposal.rs
@@ -2746,9 +2746,11 @@ impl ProposalRepository {
     /// Apply Planner-authored acceptance-criteria amendments as real spec edits.
     ///
     /// Unlike [`Self::set_acceptance_criteria`], this bumps the proposal head
-    /// revision and inserts a feedback audit entry. Unlike [`Self::update`], it
-    /// intentionally retains existing sign-offs and does not demote approved
-    /// proposals; the audit event is the mechanism for humans to object.
+    /// revision and stamps the structured change list on the new revision's
+    /// `event_metadata` (`kind = "ac_amendment"`) so it surfaces in the History
+    /// stream. Unlike [`Self::update`], it intentionally retains existing
+    /// sign-offs and does not demote approved proposals; the history audit entry
+    /// is the mechanism for humans to object.
     pub async fn amend_acceptance_criteria(
         &self,
         proposal_id: &str,
@@ -2874,6 +2876,18 @@ impl ProposalRepository {
         .execute(self.db.pool())
         .await?;
         let editor = djinn_core::auth_context::current_user_id();
+        // The structured change list rides on the spec revision itself, under
+        // `event_metadata.kind = "ac_amendment"`. This keeps the amendment audit
+        // in the History stream (where it belongs) rather than the reviewer
+        // FEEDBACK pane, while the revision's `event_kind` stays `spec_revision`
+        // so existing seq/spec-revision lookups keep working.
+        let amendments_json = serde_json::to_value(&audit_entries)
+            .map_err(|e| Error::InvalidData(format!("failed to encode amendment audit: {e}")))?;
+        let event_metadata = serde_json::json!({
+            "kind": "ac_amendment",
+            "reason": reason,
+            "amendments": amendments_json,
+        });
         self.insert_revision(ProposalRevisionSnapshot {
             proposal_id,
             seq: next_revision_seq,
@@ -2882,24 +2896,7 @@ impl ProposalRepository {
             body_format: &current.body_format,
             acceptance_criteria: &acceptance_criteria,
             edited_by: editor.as_deref(),
-            // AC amendments stamp a separate `proposal_feedback` audit entry
-            // that holds the structured change list — no extra metadata needed
-            // on the spec revision itself.
-            event_metadata: None,
-        })
-        .await?;
-
-        let audit_json = serde_json::to_string(&audit_entries)
-            .map_err(|e| Error::InvalidData(format!("failed to encode amendment audit: {e}")))?;
-        let body = format!(
-            "Acceptance criteria amended\nreason: {reason}\nrevision: {old_revision_seq} -> {next_revision_seq}\namendments: {audit_json}"
-        );
-        self.add_feedback(ProposalFeedbackCreateInput {
-            proposal_id,
-            parent_id: None,
-            author_kind: "ai",
-            author_model: None,
-            body: &body,
+            event_metadata: Some(&event_metadata),
         })
         .await?;
 
@@ -4227,25 +4224,25 @@ mod tests {
         assert_eq!(parsed[1]["criterion"], serde_json::json!("waive me"));
         assert_eq!(parsed[1]["waived"], serde_json::json!(true));
 
+        // No feedback row is written on amendment anymore — the audit rides on
+        // the revision's `event_metadata` instead.
         let feedback = repo.feedback(&p.id).await.unwrap();
-        assert_eq!(feedback.len(), 1);
-        let audit = &feedback[0];
-        assert_eq!(audit.author_kind, "ai");
-        assert!(
-            audit
-                .body
-                .contains("reason: criterion 2 cannot be verified by agents")
+        assert!(feedback.is_empty());
+
+        // The bumped spec revision (seq 2) carries the structured amendment audit.
+        let revisions = repo.revisions(&p.id).await.unwrap();
+        let amend_rev = revisions
+            .iter()
+            .find(|r| r.seq == 2 && r.event_kind == "spec_revision")
+            .expect("amendment spec revision at seq 2");
+        let meta: serde_json::Value =
+            serde_json::from_str(amend_rev.event_metadata.as_deref().unwrap()).unwrap();
+        assert_eq!(meta["kind"], serde_json::json!("ac_amendment"));
+        assert_eq!(
+            meta["reason"],
+            serde_json::json!("criterion 2 cannot be verified by agents")
         );
-        assert!(audit.body.contains("revision: 1 -> 2"));
-        let amendments_json = audit
-            .body
-            .strip_prefix(&format!(
-                "Acceptance criteria amended\nreason: {}\nrevision: 1 -> 2\namendments: ",
-                "criterion 2 cannot be verified by agents"
-            ))
-            .unwrap();
-        let audit_entries: serde_json::Value = serde_json::from_str(amendments_json).unwrap();
-        let audit_entries = audit_entries.as_array().unwrap();
+        let audit_entries = meta["amendments"].as_array().unwrap();
         assert_eq!(audit_entries.len(), 3);
         assert_eq!(audit_entries[0]["operation"], serde_json::json!("rewrite"));
         assert_eq!(audit_entries[1]["operation"], serde_json::json!("drop"));
@@ -4259,12 +4256,11 @@ mod tests {
             serde_json::json!({"dropped": true})
         );
 
+        // Only the `proposal updated` event fires — no `proposal_feedback created`.
         let events = captured.lock().unwrap();
-        assert_eq!(events.len(), 2);
-        assert_eq!(events[0].entity_type, "proposal_feedback");
-        assert_eq!(events[0].action, "created");
-        assert_eq!(events[1].entity_type, "proposal");
-        assert_eq!(events[1].action, "updated");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].entity_type, "proposal");
+        assert_eq!(events[0].action, "updated");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/ui/src/components/proposals/ProposalHistory.test.tsx
+++ b/ui/src/components/proposals/ProposalHistory.test.tsx
@@ -298,6 +298,64 @@ describe("ProposalHistory", () => {
     expect(screen.getByText("Status changed")).toBeInTheDocument();
   });
 
+  it("renders an acceptance-criteria amendment revision with reason and operations", () => {
+    render(
+      <ProposalHistory
+        detail={detail([
+          revision(1, { body: "Base body" }),
+          revision(2, {
+            body: "Base body",
+            created_at: "2026-06-02T00:00:00Z",
+            event_metadata: JSON.stringify({
+              kind: "ac_amendment",
+              reason: "criterion 2 cannot be verified by agents",
+              amendments: [
+                {
+                  operation: "rewrite",
+                  index: 0,
+                  old_criterion: "old criterion text",
+                  new_criterion: "rewritten criterion text",
+                },
+                {
+                  operation: "drop",
+                  index: 1,
+                  old_criterion: { criterion: "drop me", met: false },
+                  new_criterion: { dropped: true },
+                },
+                {
+                  operation: "waive",
+                  index: 6,
+                  old_criterion: "waive me",
+                  new_criterion: { criterion: "waive me", waived: true },
+                },
+              ],
+            }),
+          }),
+        ])}
+      />,
+    );
+
+    // Distinct badge and a machine-free collapsed summary (no raw JSON).
+    expect(screen.getByText("AC amendment")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "criterion 1 rewritten, criterion 2 dropped, criterion 7 waived",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/ac_amendment/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /rev 2/ }));
+
+    expect(
+      screen.getByText("criterion 2 cannot be verified by agents"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Criterion 1 rewritten")).toBeInTheDocument();
+    expect(screen.getByText("old criterion text")).toBeInTheDocument();
+    expect(screen.getByText("rewritten criterion text")).toBeInTheDocument();
+    expect(screen.getByText("Criterion 2 dropped")).toBeInTheDocument();
+    expect(screen.getByText("Criterion 7 waived")).toBeInTheDocument();
+  });
+
   it("collapses a tribunal refinement run into a single entry", () => {
     render(
       <ProposalHistory

--- a/ui/src/components/proposals/ProposalHistory.tsx
+++ b/ui/src/components/proposals/ProposalHistory.tsx
@@ -58,10 +58,22 @@ function revisionBodyPreview(revision: ProposalHistoryEntry): string {
   return textPreview ? `${blockSummary} · ${textPreview}` : blockSummary;
 }
 
+/** One entry in an AC-amendment audit list (from `proposal_ac_amend`). */
+type AmendmentEntry = {
+  operation?: string;
+  index?: number;
+  old_criterion?: unknown;
+  new_criterion?: unknown;
+};
+
 /** Parsed `event_metadata` (it arrives as a JSON string on the wire). */
-function parsedMeta(
-  r: ProposalHistoryEntry,
-): { source?: string; round?: number } | null {
+function parsedMeta(r: ProposalHistoryEntry): {
+  source?: string;
+  round?: number;
+  kind?: string;
+  reason?: string;
+  amendments?: AmendmentEntry[];
+} | null {
   const meta = (r as { event_metadata?: unknown }).event_metadata;
   if (!meta) return null;
   try {
@@ -74,6 +86,35 @@ function parsedMeta(
 /** A spec revision produced by the autonomous refinement tribunal. */
 function isRefinementRevision(r: ProposalHistoryEntry): boolean {
   return r.event_kind === "spec_revision" && parsedMeta(r)?.source === "refinement_loop";
+}
+
+/** A spec revision that carries an acceptance-criteria amendment audit. */
+function isAcAmendmentRevision(r: ProposalHistoryEntry): boolean {
+  return r.event_kind === "spec_revision" && parsedMeta(r)?.kind === "ac_amendment";
+}
+
+/** Human-readable criterion text from a criterion value (string or object). */
+function criterionText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const criterion = (value as Record<string, unknown>).criterion;
+    if (typeof criterion === "string") return criterion;
+  }
+  return "";
+}
+
+/** Short verb for an amendment operation ("rewritten" / "waived" / "dropped"). */
+function amendmentVerb(operation: string | undefined): string {
+  switch (operation) {
+    case "rewrite":
+      return "rewritten";
+    case "waive":
+      return "waived";
+    case "drop":
+      return "dropped";
+    default:
+      return operation ?? "changed";
+  }
 }
 
 /**
@@ -253,6 +294,119 @@ export function ProposalHistory({ detail }: { detail: ProposalDetail }) {
           const isSpecRevision = r.event_kind === "spec_revision";
           const bodyFormat = revisionBodyFormat(r);
           const titleChanged = !!prev && prev.title !== r.title;
+
+          // ── Acceptance-criteria amendment ───────────────────────────────
+          // A spec revision whose only change is an AC amendment (via
+          // `proposal_ac_amend`). Its body is unchanged, so render the reason
+          // and a human-readable list of operations instead of a body diff.
+          if (isAcAmendmentRevision(r)) {
+            const meta = parsedMeta(r);
+            const reason = meta?.reason?.trim() ?? "";
+            const amendments = meta?.amendments ?? [];
+            const summary =
+              amendments
+                .map((a) => `criterion ${(a.index ?? 0) + 1} ${amendmentVerb(a.operation)}`)
+                .join(", ") || "acceptance criteria amended";
+            return (
+              <li key={r.id}>
+                <button
+                  onClick={() => toggle(r.id)}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted/40"
+                >
+                  <HugeiconsIcon
+                    icon={ArrowDown01Icon}
+                    size={14}
+                    className={cn(
+                      "shrink-0 text-muted-foreground transition-transform",
+                      isOpen && "rotate-180",
+                    )}
+                  />
+                  <Badge
+                    variant={isHead ? "default" : "outline"}
+                    className="font-mono"
+                  >
+                    rev {r.seq}
+                  </Badge>
+                  <Badge variant="secondary">AC amendment</Badge>
+                  {isHead && (
+                    <span className="text-xs text-muted-foreground">current</span>
+                  )}
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <UserAvatar user={editor} className="size-4" />
+                    <span className="truncate">
+                      {editor
+                        ? userDisplayName(editor)
+                        : r.edited_by_user_id
+                          ? "unknown"
+                          : "—"}
+                    </span>
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                    {summary}
+                  </span>
+                  <time
+                    dateTime={r.created_at}
+                    title={r.created_at}
+                    className="ml-auto shrink-0 text-xs text-muted-foreground"
+                  >
+                    {relativeTime(r.created_at)}
+                  </time>
+                </button>
+                {isOpen && (
+                  <div className="space-y-2 px-3 pb-3">
+                    {reason && (
+                      <p className="text-xs text-muted-foreground">
+                        Reason:{" "}
+                        <span className="text-foreground">{reason}</span>
+                      </p>
+                    )}
+                    {amendments.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">
+                        Acceptance criteria amended.
+                      </p>
+                    ) : (
+                      <ul className="space-y-1 text-xs">
+                        {amendments.map((a, i) => {
+                          const oldText = criterionText(a.old_criterion);
+                          const newText = criterionText(a.new_criterion);
+                          const showNew =
+                            a.operation === "rewrite" && !!newText && newText !== oldText;
+                          return (
+                            <li
+                              key={i}
+                              className="rounded-md border border-border/60 px-2 py-1.5"
+                            >
+                              <span className="font-medium">
+                                Criterion {(a.index ?? 0) + 1} {amendmentVerb(a.operation)}
+                              </span>
+                              {oldText && (
+                                <span className="block text-muted-foreground">
+                                  <span
+                                    className={cn(showNew && "line-through")}
+                                  >
+                                    {oldText}
+                                  </span>
+                                  {showNew && (
+                                    <>
+                                      {" → "}
+                                      <span className="text-foreground">
+                                        {newText}
+                                      </span>
+                                    </>
+                                  )}
+                                </span>
+                              )}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          }
+
           if (!isSpecRevision) {
             // Only genuine status transitions belong in the spec revision
             // history. Refinement lifecycle events (refinement_start/stop) are


### PR DESCRIPTION
## What

When a proposal's acceptance criteria are amended via `proposal_ac_amend`, the
audit trail used to be written as an `author_kind: "ai"` **feedback** row whose
body was raw machine-oriented text (`Acceptance criteria amended\nreason: …\n
revision: N -> M\namendments: <json>`). That surfaced raw audit JSON in the
proposal **Feedback** pane as unresolved AI feedback with "Address with djinn" /
"Dismiss" buttons — it is a spec-change audit, not reviewer feedback.

This moves the amendment audit onto the bumped spec revision itself and renders
it in the **History** tab.

## Changes

- **`amend_acceptance_criteria`** (`djinn-db/src/repositories/proposal.rs`):
  - The revision snapshot now carries structured `event_metadata`
    `{"kind":"ac_amendment","reason":…,"amendments":[…]}`. The revision's
    `event_kind` stays `spec_revision`, so existing seq / spec-revision lookups
    keep working; amendments are distinguished purely by `event_metadata.kind`.
  - Deleted the `add_feedback` call — no feedback row is written on amendment
    anymore. Updated the now-stale doc comment.
- **Migration `90_ac_amendment_audit_to_revision_metadata.sql`**:
  - Best-effort backfill: a per-row `EXCEPTION`-guarded `DO` block parses each
    legacy `Acceptance criteria amended…` feedback body (target seq + reason +
    compact amendments JSON) and copies it onto the matching
    `proposal_revisions.event_metadata` (only where currently NULL). Any row
    that doesn't parse cleanly is skipped, never fatal.
  - Deletes the stale `author_kind='ai'` `Acceptance criteria amended%` feedback
    rows. `proposal_feedback` has no FK children (`parent_id` has no FK;
    resolution is columns on the row), so a plain `DELETE` is safe.
- **UI** (`ProposalHistory.tsx`): amendment revisions render with an
  "AC amendment" badge, a human-readable collapsed summary (e.g. "criterion 1
  rewritten, criterion 2 dropped, criterion 7 waived"), and an expanded list of
  operations showing the reason and old → new criterion text for rewrites. The
  `event_metadata` was already plumbed through `proposal_show` to the frontend.
- **Tests**: the Rust test now asserts the revision carries the structured
  `event_metadata` and that **no** feedback row is created; added a
  `ProposalHistory.test.tsx` case for amendment rendering.

The MCP-extension `call_proposal_ac_amend` handler delegates to the same repo
method (no duplicate feedback write), so no change was needed there.

## Test commands

- `cargo clippy -p djinn-db --all-features` — clean
- `cargo nextest run -p djinn-db proposal` — 106 passed
- `pnpm vitest run ProposalHistory.test.tsx` — 8 passed
- Migration applied cleanly against a fresh postgres:16 template DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
