### PR TITLE
Polish website and README copy for launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 <p align="center">
   <strong>From proposal to pull request.</strong>
   <br />
-  A Kubernetes-native platform where your team proposes and approves work — and AI agents build it.
+  A Kubernetes-native platform where your team proposes and approves work, and AI agents build it.
   On your cluster, with your models, behind your review.
 </p>
 
 <p align="center">
+  <a href="https://youtu.be/f-S3ju-GjCs"><strong>Demo video</strong></a> ·
   <a href="#quick-start-local"><strong>Quick start</strong></a> ·
   <a href="#architecture"><strong>Architecture</strong></a> ·
   <a href="#deploy-kubernetes"><strong>Deploy</strong></a> ·
@@ -20,9 +21,9 @@
 
 <br />
 
-Djinn turns ideas into reviewed, merged code through one governed pipeline. Anyone on the team writes a **proposal** — a living spec, not a chat prompt. Your product folks and engineers discuss it, leave feedback, and sign off. When it graduates, Djinn plans the work, decomposes it into epics and tasks across any number of repositories, and dispatches AI agents — each in its own isolated **Kubernetes Job** — to build it. An AI reviewer checks every result against the acceptance criteria before a pull request is opened. **Nothing ships without your approval.**
+Djinn turns ideas into reviewed, merged code through one governed pipeline. Anyone on the team writes a **proposal**: a living spec, not a chat prompt. Product and engineering discuss it, leave feedback, and sign off. When it graduates, Djinn plans the work, decomposes it into epics and tasks across any number of repositories, and dispatches AI agents to build it, each in its own isolated **Kubernetes Job**. An AI reviewer checks every result against the acceptance criteria before a pull request is opened. **Nothing ships without your approval.**
 
-The `djinn-server` control plane is the single source of truth — the web UI, Claude Code, Cursor, and any MCP client are all just consumers of the same API. And because it all runs on your cluster with your provider credentials, your code and your spend never leave your control.
+The `djinn-server` control plane is the single source of truth: the web UI, Claude Code, Cursor, and any MCP client are all consumers of the same API. And because it all runs on your cluster with your provider credentials, your code and your spend never leave your control.
 
 <br />
 
@@ -63,12 +64,12 @@ The `djinn-server` control plane is the single source of truth — the web UI, C
 ```
 
 1. **Propose** — Anyone writes a proposal: a problem, a goal, acceptance criteria. Proposals are global, collaborative specs that can target any number of projects. Use the editor, or open a proposal-scoped chat and let Djinn draft and refine the spec with you.
-2. **Review & sign off** — The team leaves feedback on the spec; the author (or Djinn) addresses it revision by revision. Reviewers sign off — sign-offs go stale if the spec changes after, so approval always means *this* version.
+2. **Review & sign off** — The team leaves feedback on the spec; the author (or Djinn) addresses it revision by revision. Reviewers sign off, and sign-offs go stale if the spec changes after, so approval always means *this* version.
 3. **Build** — Graduating a proposal turns it into epics and tasks. The coordinator dispatches ready tasks by priority and dependency order, gated by each user's per-model concurrency limit. Each task-run executes in its own Kubernetes Job, in a per-project devcontainer image, with an isolated git workspace. Changed your mind mid-build? Freeze or abort, edit the spec, re-sign, re-graduate.
 4. **AI review** — A reviewer agent checks the work against the proposal's acceptance criteria; rejected work loops back for another pass.
 5. **Pull request** — Approved work is pushed and a PR is opened via your GitHub App. You review, you merge.
 
-Prefer to skip the ceremony? Tasks and epics can also be created directly on the board — the proposal layer is governance you opt into, not a gate you can't route around.
+Prefer to skip the ceremony? Tasks and epics can also be created directly on the board: the proposal layer is governance you opt into, not a gate you can't route around.
 
 ## Architecture
 
@@ -185,7 +186,7 @@ run automatically in the server's migrate initContainer.
 
 ### 📋 Proposals: specs, not prompts
 
-Work starts as a written, reviewable spec with acceptance criteria — targeting one project or many. Feedback threads, revision history, and stale-aware sign-offs give product and engineering a shared artifact to argue about *before* tokens are spent. Graduate it to build; freeze or abort mid-build to rework the spec and go again.
+Work starts as a written, reviewable spec with acceptance criteria, targeting one project or many. Feedback threads, revision history, and stale-aware sign-offs give product and engineering a shared artifact to argue about *before* tokens are spent. Graduate it to build; freeze or abort mid-build to rework the spec and go again.
 
 ### ⚡ Parallel execution
 
@@ -217,10 +218,10 @@ AI reviewers check each task against the proposal's acceptance criteria. You rev
 
 ## What's next: see where the tokens go
 
-AI engineering spend is opaque almost everywhere — Djinn's pipeline makes it attributable. Because every session belongs to a task, every task to an epic, and every epic to a proposal under a real user, we're building the visibility layer on top:
+AI engineering spend is opaque almost everywhere; Djinn's pipeline makes it attributable. Because every session belongs to a task, every task to an epic, and every epic to a proposal under a real user, we're building the visibility layer on top:
 
 - **Spend attribution** — tokens and cost per proposal, per project, per model, per user, per role.
-- **Value delivered** — proposals shipped, PRs merged, rework loops, review pass rates — cost next to outcome, not in a separate billing console.
+- **Value delivered** — proposals shipped, PRs merged, rework loops, review pass rates: cost next to outcome, not in a separate billing console.
 - **Tracing built in** — every agent session already streams to [Langfuse](https://langfuse.com); the next step is rolling those traces up into answers a team lead can act on.
 
 ## Connect your tools
@@ -297,4 +298,4 @@ The lifecycle/concurrency regressions for the vjs6 incidents (dispatch-cap races
 
 ## License
 
-[Business Source License 1.1](LICENSE). Free to self-host and use in production — the only restriction is offering Djinn itself as a competing hosted service. Each version converts to Apache 2.0 four years after release. © 2026 Djinn AI, Inc.
+[Business Source License 1.1](LICENSE). Free to self-host and use in production: the only restriction is offering Djinn itself as a competing hosted service. Each version converts to Apache 2.0 four years after release. © 2026 Djinn AI, Inc.

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
     default: "Djinn | From Proposal to Pull Request",
     template: "%s | Djinn",
   },
-  description: "Open-source, Kubernetes-native platform where your team proposes and approves work — and AI agents build it. On your cluster, with your models, behind your review.",
+  description: "Self-hosted, Kubernetes-native platform where your team proposes and approves work, and AI agents build it. On your cluster, with your models, behind your review.",
   keywords: ["AI", "developer tools", "AI coding agents", "Kubernetes", "self-hosted", "agent orchestration", "proposals", "autonomous development", "AI spend visibility"],
   authors: [{ name: "Djinn AI, Inc." }],
   creator: "Djinn AI, Inc.",
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: "https://djinnai.io",
     title: "Djinn | From Proposal to Pull Request",
-    description: "Open-source, Kubernetes-native platform where your team proposes and approves work — and AI agents build it. On your cluster, with your models, behind your review.",
+    description: "Self-hosted, Kubernetes-native platform where your team proposes and approves work, and AI agents build it. On your cluster, with your models, behind your review.",
     siteName: "Djinn",
     images: [
       {
@@ -54,7 +54,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Djinn | From Proposal to Pull Request",
-    description: "Your team proposes and approves the work. AI agents build it — on your cluster, with your models, behind your review.",
+    description: "Your team proposes and approves the work. AI agents build it, on your cluster, with your models, behind your review.",
     images: ["/kanban.jpg"],
     creator: "@djinnos",
   },
@@ -88,7 +88,7 @@ export default function RootLayout({
                 "priceCurrency": "USD",
                 "availability": "https://schema.org/InStock"
               },
-              "description": "Open-source, Kubernetes-native platform where teams propose and approve work and AI agents build it — self-hosted, bring your own models, every change behind human review.",
+              "description": "Kubernetes-native platform where teams propose and approve work and AI agents build it: self-hosted, bring your own models, every change behind human review.",
               "author": {
                 "@type": "Organization",
                 "name": "Djinn AI, Inc.",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -15,19 +15,19 @@ const PIPELINE = [
     n: "01",
     name: "Propose",
     status: { label: "spec written", tone: "pass" },
-    body: "Anyone on the team writes a proposal — a problem, a goal, acceptance criteria. A living spec that can target one repo or many. Djinn helps draft and refine it in a proposal-scoped chat.",
+    body: "Anyone on the team writes a proposal: a problem, a goal, acceptance criteria. A living spec that can target one repo or many. Djinn helps draft and refine it in a proposal-scoped chat.",
   },
   {
     n: "02",
     name: "Review & sign off",
     status: { label: "2 sign-offs", tone: "pass" },
-    body: "Product and engineering leave feedback; the spec evolves revision by revision. Sign-offs go stale if it changes afterward — approval always means this exact version.",
+    body: "Product and engineering leave feedback; the spec evolves revision by revision. Sign-offs go stale if it changes afterward, so approval always means this exact version.",
   },
   {
     n: "03",
     name: "Build",
     status: { label: "agents running", tone: "warn" },
-    body: "Graduation turns the spec into epics and tasks. Agents work in parallel, each in its own isolated Kubernetes Job, in a per-project devcontainer, using the models you configured — per user, per project, per role.",
+    body: "Graduation turns the spec into epics and tasks. Agents work in parallel, each in its own isolated Kubernetes Job, in a per-project devcontainer, using the models you configured: per user, per project, per role.",
     log: [
       ["$", "kubectl get jobs -n djinn"],
       [" ", "djinn-taskrun-9f2c   Running    api: add usage rollup"],
@@ -39,22 +39,22 @@ const PIPELINE = [
     n: "04",
     name: "Merge",
     status: { label: "checks passed", tone: "pass" },
-    body: "An AI reviewer judges every result against the acceptance criteria; weak work loops back. What passes becomes a pull request — you review, you merge. Nothing ships without you.",
+    body: "An AI reviewer judges every result against the acceptance criteria; weak work loops back. What passes becomes a pull request. You review, you merge. Nothing ships without you.",
   },
 ];
 
 const CRITERIA = [
   {
     title: "Specs, not prompts",
-    body: "Feedback threads, revision history, stale-aware sign-offs. The team argues before the tokens burn — and can freeze, rework, and re-graduate mid-build.",
+    body: "Feedback threads, revision history, stale-aware sign-offs. The team argues before the tokens burn, and can freeze, rework, and re-graduate mid-build.",
   },
   {
     title: "Your cloud",
-    body: "Self-hosted on any Kubernetes — a single VPS running k3s is enough. One Helm chart bundles Postgres, Qdrant, and the registry on one box, or plugs into EKS / GKE / AKS.",
+    body: "Self-hosted on any Kubernetes; a single VPS running k3s is enough. One Helm chart bundles Postgres, Qdrant, and the registry on one box, or plugs into EKS / GKE / AKS.",
   },
   {
     title: "Your models",
-    body: "Anthropic, OpenAI, Google, Bedrock, Vertex, Azure, Copilot, Codex — or any OpenAI-compatible endpoint. One model codes, another reviews. Credentials encrypted, per user.",
+    body: "Anthropic, OpenAI, Google, Bedrock, Vertex, Azure, Copilot, Codex, or any OpenAI-compatible endpoint. One model codes, another reviews. Credentials encrypted, per user.",
   },
   {
     title: "Parallel by default",
@@ -66,7 +66,7 @@ const CRITERIA = [
   },
   {
     title: "Review built in",
-    body: "AI reviewers check each change against the proposal's acceptance criteria and send weak work back. You get a clean pull request — and the final say.",
+    body: "AI reviewers check each change against the proposal's acceptance criteria and send weak work back. You get a clean pull request, and the final say.",
   },
 ];
 
@@ -137,7 +137,7 @@ export default function Home() {
             </h1>
 
             <p className="rise rise-3 text-lg md:text-xl text-text-secondary max-w-2xl leading-relaxed mb-10">
-              Your team proposes and approves the work. AI agents build it —
+              Your team proposes and approves the work. AI agents build it,
               on your cluster, with your models, behind your review.
             </p>
 
@@ -159,19 +159,23 @@ export default function Home() {
             </div>
           </div>
 
-          {/* Screenshot as a window */}
+          {/* Demo video as a window */}
           <div className="rise rise-5 mt-20 max-w-5xl mx-auto window">
             <div className="window-bar">
               <span className="dot bg-accent-coral/70" />
               <span className="dot bg-status-warn/70" />
               <span className="dot bg-status-pass/70" />
-              <span className="ml-3">djinn — proposals · specs in review, building, and done</span>
+              <span className="ml-3">djinn — first look · demo</span>
             </div>
-            <LightboxImage
-              src="/proposals.jpg"
-              alt="Djinn — proposals moving from draft through review and sign-off to build"
-              className="w-full"
-            />
+            <div className="aspect-video">
+              <iframe
+                src="https://www.youtube-nocookie.com/embed/f-S3ju-GjCs"
+                title="Djinn — first look demo"
+                className="w-full h-full"
+                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+              />
+            </div>
           </div>
         </section>
 
@@ -231,10 +235,10 @@ export default function Home() {
         <section className="px-6 py-20 border-y border-border-faint bg-bg-surface/50">
           <div className="max-w-6xl mx-auto grid md:grid-cols-5 gap-12 items-center">
             <div className="md:col-span-3 window">
-              <div className="window-bar">fig. 01 — roadmap · epics generated from proposal #0001</div>
+              <div className="window-bar">fig. 01 — board · agents building in parallel across projects</div>
               <LightboxImage
-                src="/roadmap.jpg"
-                alt="Djinn Roadmap — epics and tasks generated from an approved proposal, with dependencies and blockers"
+                src="/kanban.jpg"
+                alt="Djinn board — AI agents working tasks in parallel across multiple projects"
                 className="w-full"
               />
             </div>
@@ -243,10 +247,11 @@ export default function Home() {
                 Approved specs become coordinated work
               </h3>
               <p className="text-text-secondary leading-relaxed">
-                When a proposal graduates, djinn plans the epic, decomposes it into
-                tasks with dependencies and blockers, and dispatches agents wave by
-                wave. Change your mind mid-build? Freeze it, rework the spec,
-                re-sign, and go again — the board reconciles.
+                When a proposal graduates, djinn plans the epics, decomposes them
+                into tasks with dependencies and blockers, and dispatches agents
+                wave by wave, in parallel, across every project the spec touches.
+                Change your mind mid-build? Freeze it, rework the spec, re-sign,
+                and go again; the board reconciles.
               </p>
             </div>
           </div>
@@ -325,14 +330,14 @@ export default function Home() {
               <p className="text-text-secondary text-lg leading-relaxed max-w-2xl mb-10">
                 AI spend is opaque almost everywhere. Djinn&apos;s pipeline makes it
                 attributable: every session belongs to a task, every task to an
-                epic, every epic to a proposal — under a real user. The visibility
-                layer comes next.
+                epic, every epic to a proposal, all under a real user. The
+                visibility layer comes next.
               </p>
 
               <div className="space-y-5 font-mono text-sm">
                 {[
-                  ["spend_attribution", "tokens and cost per proposal, project, model, user, and role — not one blind number on an invoice."],
-                  ["value_delivered", "proposals shipped, PRs merged, rework loops, review pass rates — cost next to outcome."],
+                  ["spend_attribution", "tokens and cost per proposal, project, model, user, and role, not one blind number on an invoice."],
+                  ["value_delivered", "proposals shipped, PRs merged, rework loops, review pass rates: cost next to outcome."],
                   ["tracing_built_in", "every agent session already streams to Langfuse; next, rolled up into answers a lead can act on."],
                 ].map(([k, v], i) => (
                   <div key={i} className="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
@@ -356,8 +361,9 @@ export default function Home() {
               Your backlog, merged.
             </h2>
             <p className="text-text-secondary text-lg mb-10 max-w-xl mx-auto">
-              Open source. One Helm chart. A single VPS with k3s is enough to start —
-              your code and credentials never leave your infrastructure.
+              Source-available and free to self-host. One Helm chart. A single VPS
+              with k3s is enough to start, and your code and credentials never
+              leave your infrastructure.
             </p>
             <HeroActions />
           </div>

--- a/website/components/HeroActions.tsx
+++ b/website/components/HeroActions.tsx
@@ -21,7 +21,7 @@ export default function HeroActions() {
       </div>
 
       <div className="font-mono text-xs text-text-muted">
-        open source · runs on a single VPS (k3s) or EKS / GKE / AKS
+        free to self-host · runs on a single VPS (k3s) or EKS / GKE / AKS
       </div>
     </div>
   );


### PR DESCRIPTION
## What

- **License honesty**: the site said "open source" in five places (CTA, hero tagline, SEO/OG metadata) but Djinn is BSL. Now reads **source-available / free to self-host**. Pre-empts the inevitable "not actually open source" HN comment; README was already correct.
- **Demo video in the hero**: the first-look video (https://youtu.be/f-S3ju-GjCs) is embedded in the hero window chrome (youtube-nocookie). Also linked as the first item in the README header nav.
- **Kanban screenshot featured**: now the fig. 01 band after the pipeline section, with copy matched to what it shows (parallel agents across projects).
- **Copy pass**: prose em-dashes replaced with commas/colons/conjunctions across the site and README marketing sections; a few sentences tightened.

## Notes

- `proposals.jpg` and `roadmap.jpg` no longer appear on the site (displaced by the video and kanban); both still appear in the README.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)