### PR TITLE
README: cut the noise for launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://youtu.be/f-S3ju-GjCs"><strong>Demo video</strong></a> ·
-  <a href="#quick-start-local"><strong>Quick start</strong></a> ·
+  <a href="#how-it-works"><strong>How it works</strong></a> ·
   <a href="#architecture"><strong>Architecture</strong></a> ·
   <a href="#deploy"><strong>Deploy</strong></a> ·
   <a href="https://djinnai.io"><strong>Website</strong></a>
@@ -63,13 +63,13 @@ The `djinn-server` control plane is the single source of truth: the web UI, Clau
   it            sign off       parallel        rejects loop back
 ```
 
-1. **Propose** — Anyone writes a proposal: a problem, a goal, acceptance criteria. Proposals are global, collaborative specs that can target any number of projects. Use the editor, or open a proposal-scoped chat and let Djinn draft and refine the spec with you.
-2. **Review & sign off** — The team leaves feedback on the spec; the author (or Djinn) addresses it revision by revision. Reviewers sign off, and sign-offs go stale if the spec changes after, so approval always means *this* version.
-3. **Build** — Graduating a proposal turns it into epics and tasks. The coordinator dispatches ready tasks by priority and dependency order, gated by each user's per-model concurrency limit. Each task-run executes in its own Kubernetes Job, in a per-project devcontainer image, with an isolated git workspace. Changed your mind mid-build? Freeze or abort, edit the spec, re-sign, re-graduate.
-4. **AI review** — A reviewer agent checks the work against the proposal's acceptance criteria; rejected work loops back for another pass.
-5. **Pull request** — Approved work is pushed and a PR is opened via your GitHub App. You review, you merge.
+1. **Propose** — anyone writes a spec: a problem, a goal, acceptance criteria. In the editor, or by letting Djinn draft it with you in chat.
+2. **Review & sign off** — feedback lands revision by revision; sign-offs go stale if the spec changes after, so approval always means *this* version.
+3. **Build** — graduation decomposes the proposal into epics and tasks, dispatched by priority and dependency order, each in its own Kubernetes Job. Freeze or abort mid-build to rework the spec and go again.
+4. **AI review** — a reviewer agent checks the work against the acceptance criteria; rejections loop back.
+5. **Pull request** — approved work opens a PR via your GitHub App. You review, you merge.
 
-Prefer to skip the ceremony? Tasks and epics can also be created directly on the board: the proposal layer is governance you opt into, not a gate you can't route around.
+Prefer to skip the ceremony? Tasks and epics can also be created directly on the board — the proposal layer is governance you opt into, not a gate you can't route around.
 
 ## Architecture
 
@@ -99,59 +99,7 @@ Djinn is a Rust control plane (`djinn-server`) that acts as a Kubernetes control
    └───────────────────────────────────────────────────┘
 ```
 
-**Components**
-
-| Component | Role |
-|-----------|------|
-| `djinn-server` | Control plane: HTTP API, embedded UI, MCP endpoint, OAuth server, proposal pipeline, task coordinator, slot pool, repo mirror fetcher, per-project image controller, worker RPC listener. |
-| `djinn-agent-worker` | Runs inside each task-run pod. Drives the agent role sequence stage-by-stage against an isolated `/workspace`, streaming results back over RPC. |
-| Postgres 16 | All state — proposals, tasks, epics, sessions, notes, users, encrypted credentials, code-graph cache (JSONB throughout). |
-| Qdrant | Vector store for code-chunk and note embeddings (semantic + hybrid search). |
-| BuildKit + registry | Builds a per-project devcontainer image (from detected stack) that every task-run for that project runs in. |
-
-**Agent roles** — Each task is routed to a role based on its type:
-
-- **Architect** — read-only consultant for spikes; deep structural reasoning, no board changes.
-- **Planner** — owns planning, decomposition, and review-grooming tasks.
-- **Developer** — does the code change, commits, and pushes to the project mirror.
-- **Reviewer** — judges the work against acceptance criteria; approves or sends it back.
-- **Lead** — handles escalations and interventions.
-
-**Model routing** — Djinn runs its own LLM agent loop (no external runtime). Models are resolved per task with precedence **user → project → global**, drawn from a live [models.dev](https://models.dev) catalog. The slot pool is elastic; the sole admission control is each user's per-model concurrency cap.
-
-## Quick start (local)
-
-The full stack runs in a local [kind](https://kind.sigs.k8s.io) cluster, orchestrated by [Tilt](https://tilt.dev). One command brings up the cluster, registry, server, Postgres, Qdrant, the image pipeline, and a self-hosted Langfuse for tracing.
-
-**Prerequisites:** Docker, [kind](https://kind.sigs.k8s.io), `kubectl`, [Helm](https://helm.sh), [Tilt](https://tilt.dev), [pnpm](https://pnpm.io) (Node), and `openssl`.
-
-The image pipeline runs BuildKit rootless via user namespaces. On the host (kind inherits host sysctls):
-
-```sh
-sudo sysctl -w kernel.unprivileged_userns_clone=1
-sudo sysctl -w user.max_user_namespaces=28633   # or higher
-```
-
-Then, from the repo root:
-
-```bash
-tilt up
-```
-
-Tilt bootstraps the kind cluster (`djinn`) + a local registry, builds `djinn-server` and `djinn-agent-worker`, embeds the freshly built UI, installs the Helm chart, and port-forwards:
-
-| Port | Service |
-|------|---------|
-| `:3000` | djinn API + web UI |
-| `:8443` | worker RPC |
-| `:5432` | Postgres |
-| `:6333` / `:6334` | Qdrant (HTTP / gRPC) |
-| `:5000` | Langfuse dashboard |
-| `:9091` | MinIO console |
-
-Open the UI at **http://127.0.0.1:3000**. `tilt down` removes the Helm release but leaves the cluster up; `kind delete cluster --name djinn` tears it down completely.
-
-> The heavy build steps (`djinn-binaries`, `djinn-ui-dist`, runtime base image) are **manual** triggers in the Tilt UI — hit refresh on `djinn-binaries` to recompile after Rust changes; the server image and pod roll follow automatically.
+Each task routes to an **agent role** by type — Architect (read-only spikes), Planner, Developer, Reviewer, Lead — and Djinn runs its own LLM agent loop (no external runtime), resolving the model per task with precedence **user → project → global** from a live [models.dev](https://models.dev) catalog. The only admission control is each user's per-model concurrency cap.
 
 ## Deploy
 
@@ -191,6 +139,10 @@ The agent interviews you (VPS or existing cluster, domain, keys), runs the
 install phase by phase with verification checkpoints, and hands you a working
 URL. `helm upgrade --install` handles fresh installs and upgrades alike —
 migrations run automatically in the server's migrate initContainer.
+
+Just want a quick local test (or to hack on Djinn itself)? `tilt up` brings
+the whole stack up in a local kind cluster, built from source — see
+[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Beyond the pipeline
 
@@ -253,7 +205,7 @@ claude mcp add --transport http djinn https://<your-host>/mcp
 
 ## Development
 
-Rust workspace in `server/`, React UI in `ui/`, embedded into the server binary. `tilt up` is the whole dev loop ([Quick start](#quick-start-local)); workspace layout, test setup, and CI notes are in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+Rust workspace in `server/`, React UI in `ui/`, embedded into the server binary. `tilt up` is the whole dev loop; the local stack, workspace layout, test setup, and CI notes are in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -192,47 +192,13 @@ install phase by phase with verification checkpoints, and hands you a working
 URL. `helm upgrade --install` handles fresh installs and upgrades alike —
 migrations run automatically in the server's migrate initContainer.
 
-## Features
+## Beyond the pipeline
 
-### 📋 Proposals: specs, not prompts
-
-Work starts as a written, reviewable spec with acceptance criteria, targeting one project or many. Feedback threads, revision history, and stale-aware sign-offs give product and engineering a shared artifact to argue about *before* tokens are spent. Graduate it to build; freeze or abort mid-build to rework the spec and go again.
-
-### ⚡ Parallel execution
-
-Each task-run is an isolated Kubernetes Job in its own workspace. Run many agents at once across many repos; scale by adding nodes, not terminal tabs.
-
-### 📁 Multi-project
-
-Microservices, monorepos, many repositories — Djinn manages them all. Each project gets its own devcontainer image (built from auto-detected stack), task board, code graph, and knowledge base. A single proposal can drive changes across several of them.
-
-### 🔀 Your models, mixed & matched
-
-Djinn owns its own agent loop and talks to providers directly: Anthropic, OpenAI, Google, Fireworks, ChatGPT/Codex and GitHub Copilot (OAuth), Vertex AI, Bedrock, Azure OpenAI, plus any OpenAI-compatible endpoint from the models.dev catalog. Use one model for coding, another for reviews, another for research — configured per user, per project, and per role.
-
-### 🧠 Persistent memory
-
-Decisions, patterns, and architectural rules live in a searchable, DB-backed knowledge base of linked notes (`[[wikilinks]]`). Agents extract what they learn from each task and carry it into the next. Hybrid lexical + semantic search keeps the right context in front of every agent.
-
-### 🔍 Code intelligence
-
-A per-project **code graph** built from SCIP indexers across 8 languages powers impact analysis, dependency cycles, coupling hubs, dead-symbol detection, and complexity metrics (cognitive + cyclomatic). Agents query it over MCP; you explore it visually in the UI.
-
-### 👥 Multi-user
-
-Self-hosted for your whole team. Each user logs in via GitHub, brings their own provider credentials (encrypted at rest, with org-shared fallback), and has private chat — over a shared board. Every task runs under a real user with their model limits. Admins can manage users and act on their behalf.
-
-### ✅ Built-in review
-
-AI reviewers check each task against the proposal's acceptance criteria. You review the finished work and decide when to merge.
-
-## What's next: see where the tokens go
-
-AI engineering spend is opaque almost everywhere; Djinn's pipeline makes it attributable. Because every session belongs to a task, every task to an epic, and every epic to a proposal under a real user, we're building the visibility layer on top:
-
-- **Spend attribution** — tokens and cost per proposal, per project, per model, per user, per role.
-- **Value delivered** — proposals shipped, PRs merged, rework loops, review pass rates: cost next to outcome, not in a separate billing console.
-- **Tracing built in** — every agent session already streams to [Langfuse](https://langfuse.com); the next step is rolling those traces up into answers a team lead can act on.
+- **Multi-project** — microservices, monorepos, many repositories. Each project gets its own devcontainer image (auto-detected stack), task board, code graph, and knowledge base; one proposal can drive changes across several.
+- **Your models, mixed & matched** — Anthropic, OpenAI, Google, Vertex, Bedrock, Azure, Fireworks, ChatGPT/Codex and Copilot via OAuth, plus any OpenAI-compatible endpoint from the models.dev catalog. One model for coding, another for review — per user, per project, per role.
+- **Persistent memory** — a searchable, DB-backed knowledge base of linked notes. Agents extract what they learn from each task and carry it into the next.
+- **Code intelligence** — a per-project code graph (SCIP, 8 languages): impact analysis, dependency cycles, coupling hubs, dead symbols, complexity. Queryable over MCP, explorable in the UI.
+- **Multi-user** — GitHub login, per-user encrypted provider credentials with org-shared fallback, private chat over a shared board, per-user concurrency caps, admin role.
 
 ## Connect your tools
 
@@ -287,20 +253,7 @@ claude mcp add --transport http djinn https://<your-host>/mcp
 
 ## Development
 
-The Rust workspace lives in `server/` (binary `djinn-server` plus ~16 crates under `server/crates/`); the web client is in `ui/` (React + Vite + TypeScript, pnpm). The UI is compiled into the server binary via `rust-embed`, and the TypeScript MCP types are generated from the server's live tool schemas (`pnpm --dir ui mcp:types`).
-
-Tests run against a dedicated throwaway Postgres (not the dev cluster), started via Docker Compose on `:5433`:
-
-```bash
-docker compose up -d postgres-test   # test-only Postgres
-make test                            # djinn-db tests
-make test-all                        # whole workspace (cargo nextest)
-make sqlx-check                      # fail if the offline sqlx cache is stale
-```
-
-The workspace `.cargo/config.toml` defaults `DATABASE_URL` and `DJINN_TEST_DATABASE_URL` to the `:5433` instance. `make test-all` rebuilds the `djinn_test_template` database and then mirrors the merge-queue/full-suite nextest command: `cd server && cargo nextest run --workspace --all-targets --all-features --profile ci`. The PR-time fast gate is intentionally cheaper (`cargo nextest ... --no-run` plus clippy); DB-backed test execution runs in the merge queue/manual workflow.
-
-The lifecycle/concurrency regressions for the vjs6 incidents (dispatch-cap races, slot-pool lifecycle event races, `execution_kill_task` kill/cancel settlement, and reopen/intervention chaos) are part of that unfiltered `profile ci` full-suite path and must remain enabled. They use in-process TestRuntime/template-Postgres or in-memory helpers, not kind/k8s; stripped-down worker pods without Postgres/template setup may be unable to run them locally. See [`docs/LIFECYCLE_CONCURRENCY_TEST_INVENTORY.md`](docs/LIFECYCLE_CONCURRENCY_TEST_INVENTORY.md) for the focused filters and rationale.
+Rust workspace in `server/`, React UI in `ui/`, embedded into the server binary. `tilt up` is the whole dev loop ([Quick start](#quick-start-local)); workspace layout, test setup, and CI notes are in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Community
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,9 +6,52 @@ TypeScript, pnpm). The UI is compiled into the server binary via `rust-embed`,
 and the TypeScript MCP types are generated from the server's live tool schemas
 (`pnpm --dir ui mcp:types`).
 
-`tilt up` is the dev loop — it brings up the full stack in a local kind
-cluster and hot-reloads binaries and UI from your working tree. See
-[Quick start (local)](../README.md#quick-start-local).
+## Local stack (Tilt + kind)
+
+The full stack runs in a local [kind](https://kind.sigs.k8s.io) cluster,
+orchestrated by [Tilt](https://tilt.dev). One command brings up the cluster,
+registry, server, Postgres, Qdrant, the image pipeline, and a self-hosted
+Langfuse for tracing — built from your working tree.
+
+**Prerequisites:** Docker, [kind](https://kind.sigs.k8s.io), `kubectl`,
+[Helm](https://helm.sh), [Tilt](https://tilt.dev), [pnpm](https://pnpm.io)
+(Node), and `openssl`.
+
+The image pipeline runs BuildKit rootless via user namespaces. On the host
+(kind inherits host sysctls):
+
+```sh
+sudo sysctl -w kernel.unprivileged_userns_clone=1
+sudo sysctl -w user.max_user_namespaces=28633   # or higher
+```
+
+Then, from the repo root:
+
+```bash
+tilt up
+```
+
+Tilt bootstraps the kind cluster (`djinn`) + a local registry, builds
+`djinn-server` and `djinn-agent-worker`, embeds the freshly built UI, installs
+the Helm chart, and port-forwards:
+
+| Port | Service |
+|------|---------|
+| `:3000` | djinn API + web UI |
+| `:8443` | worker RPC |
+| `:5432` | Postgres |
+| `:6333` / `:6334` | Qdrant (HTTP / gRPC) |
+| `:5000` | Langfuse dashboard |
+| `:9091` | MinIO console |
+
+Open the UI at **http://127.0.0.1:3000**. `tilt down` removes the Helm release
+but leaves the cluster up; `kind delete cluster --name djinn` tears it down
+completely.
+
+> The heavy build steps (`djinn-binaries`, `djinn-ui-dist`, runtime base
+> image) are **manual** triggers in the Tilt UI — hit refresh on
+> `djinn-binaries` to recompile after Rust changes; the server image and pod
+> roll follow automatically.
 
 ## Tests
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,41 @@
+# Development
+
+The Rust workspace lives in `server/` (binary `djinn-server` plus ~16 crates
+under `server/crates/`); the web client is in `ui/` (React + Vite +
+TypeScript, pnpm). The UI is compiled into the server binary via `rust-embed`,
+and the TypeScript MCP types are generated from the server's live tool schemas
+(`pnpm --dir ui mcp:types`).
+
+`tilt up` is the dev loop — it brings up the full stack in a local kind
+cluster and hot-reloads binaries and UI from your working tree. See
+[Quick start (local)](../README.md#quick-start-local).
+
+## Tests
+
+Tests run against a dedicated throwaway Postgres (not the dev cluster),
+started via Docker Compose on `:5433`:
+
+```bash
+docker compose up -d postgres-test   # test-only Postgres
+make test                            # djinn-db tests
+make test-all                        # whole workspace (cargo nextest)
+make sqlx-check                      # fail if the offline sqlx cache is stale
+```
+
+The workspace `.cargo/config.toml` defaults `DATABASE_URL` and
+`DJINN_TEST_DATABASE_URL` to the `:5433` instance. `make test-all` rebuilds the
+`djinn_test_template` database and then mirrors the merge-queue/full-suite
+nextest command: `cd server && cargo nextest run --workspace --all-targets
+--all-features --profile ci`. The PR-time fast gate is intentionally cheaper
+(`cargo nextest ... --no-run` plus clippy); DB-backed test execution runs in
+the merge queue/manual workflow.
+
+The lifecycle/concurrency regressions for the vjs6 incidents (dispatch-cap
+races, slot-pool lifecycle event races, `execution_kill_task` kill/cancel
+settlement, and reopen/intervention chaos) are part of that unfiltered
+`profile ci` full-suite path and must remain enabled. They use in-process
+TestRuntime/template-Postgres or in-memory helpers, not kind/k8s;
+stripped-down worker pods without Postgres/template setup may be unable to run
+them locally. See
+[`LIFECYCLE_CONCURRENCY_TEST_INVENTORY.md`](LIFECYCLE_CONCURRENCY_TEST_INVENTORY.md)
+for the focused filters and rationale.

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -16,7 +16,7 @@ pointed at managed equivalents. Everything is just different `values`.
 
 | You have | Guide | What you get |
 |----------|-------|--------------|
-| A laptop, want to try it | [Quick start (local)](../../README.md#quick-start-local) | Full stack in kind via `tilt up`, built from source |
+| A laptop, want to hack on Djinn | [Local stack (Tilt + kind)](../DEVELOPMENT.md#local-stack-tilt--kind) | Full stack in kind via `tilt up`, built from source |
 | A VPS (or want to rent one) | **[Single VPS with k3s](vps.md)** | Everything bundled on one box: Postgres, Qdrant, in-cluster registry, TLS via Let's Encrypt |
 | A managed / production cluster | **[Managed Kubernetes (EKS / GKE / AKS)](kubernetes.md)** | External Postgres (RDS / Cloud SQL), managed registry (ECR / GAR / ACR), cloud identity, GitOps |
 | An AI agent with a shell | **[AI-assisted install](AGENT.md)** | Paste one prompt; the agent interviews you and runs the deploy |


### PR DESCRIPTION
Follow-up to #1500, trimming the README sections that repeat or over-explain:

- **Features** → 5-bullet "Beyond the pipeline" list. Keeps only what the rest of the README doesn't already say (multi-project, model mixing, memory, code graph, multi-user); drops the proposals/parallel-execution/built-in-review blocks that duplicate "How it works".
- **"What's next: see where the tokens go"** → removed.
- **Development** → two-line pointer; the full workspace/test/CI content (including the vjs6 lifecycle-test guard) moves verbatim to `docs/DEVELOPMENT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)