### PR TITLE
Render proposal block content from schema attributes, not just children

### DIFF
--- a/server/crates/djinn-agent/src/native_assets/visual-spec/SKILL.md
+++ b/server/crates/djinn-agent/src/native_assets/visual-spec/SKILL.md
@@ -79,6 +79,25 @@ flowchart LR
 - NEVER emit an empty `<Diagram>`. If you cannot express a concrete diagram,
   use prose or a list instead.
 
+## Code blocks
+
+Put the code in the `code` attribute as a template-literal expression — NOT
+between the tags. Real code contains `<` and `{`, which the MDX parser rejects
+as malformed JSX when it appears in block children:
+
+```
+<AnnotatedCode id="handler" language="rust" filename="src/handler.rs" code={`fn handle(req: Request) -> Option<Response> {
+    respond(req)
+}`} annotations={[{"line":"1","note":"Entry point."}]} />
+```
+
+- `annotations` is strict JSON (double quotes only); `line` is a single line
+  (`"3"`) or a range (`"3-5"`).
+- The code inside the template literal must not itself contain backticks or
+  unbalanced `{` / `}` — for such snippets, simplify or trim the excerpt.
+- Only trivially simple snippets with no `<` or braces (e.g. a shell command)
+  may be authored as children between `<AnnotatedCode>` … `</AnnotatedCode>`.
+
 ## Bare `<` / `>` backtick constraint
 
 When you write literal angle brackets in markdown — for example `<div>`,

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/catalog.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/catalog.rs
@@ -24,6 +24,20 @@ define_blocks! {
         },
 
     AnnotatedCode => "annotated-code", "AnnotatedCode",
+        desc = "A line-numbered, syntax-highlighted code block with optional \
+                line-anchored annotations. Put the CODE in the `code` attribute \
+                as a template-literal expression: `code={`…`}`. Real code \
+                routinely contains `<` and `{` characters that are rejected as \
+                malformed JSX when placed between the tags, so the attribute \
+                form is the reliable one; children are accepted only for simple \
+                snippets with no `<`, unbalanced braces, or backticks. Set \
+                `language` (e.g. `rust`, `ts`) and optionally `filename`. \
+                `annotations` is a strict-JSON array expression of \
+                `{\"line\": \"3\", \"note\": \"…\"}` entries — double-quoted \
+                JSON only; `line` accepts a single line `\"3\"` or a range \
+                `\"3-5\"`. Example: `<AnnotatedCode id=\"x\" language=\"rust\" \
+                code={`fn main() {}`} annotations={[{\"line\":\"1\",\
+                \"note\":\"entry point\"}]} />`.",
         fields {
             "language" => string,
             "code" => string,

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
@@ -30,6 +30,14 @@ fn registry_contains_v1_blocks() {
             .is_some_and(|d| d.contains("unified diff")),
         "diff block must advertise unified-diff authoring guidance"
     );
+    // The annotated-code block documents its `code`-attribute authoring format
+    // (code with `<`/`{` cannot sit in children; the renderer reads the attr).
+    assert!(
+        registry["annotated-code"]
+            .description
+            .is_some_and(|d| d.contains("code={") && d.contains("annotations")),
+        "annotated-code block must advertise its code-attribute authoring format"
+    );
     // The tabs block documents its JSON-array `tabs` authoring format.
     assert_eq!(registry["tabs"].fields["tabs"].field_type, "string");
     assert!(

--- a/ui/src/components/proposals/blocks/AnnotatedCode.test.tsx
+++ b/ui/src/components/proposals/blocks/AnnotatedCode.test.tsx
@@ -75,6 +75,57 @@ describe("AnnotatedCode", () => {
     expect(screen.queryByText(/could not be parsed/i)).not.toBeInTheDocument();
   });
 
+  it("renders code from the `code` expression attribute when authored self-closing (no children)", () => {
+    // Regression: agents author `<AnnotatedCode code={`…`} />` (the block
+    // catalog's `code` field — code with `<`/`{` cannot sit in children), and
+    // the renderer read children only, so the block rendered empty.
+    render(
+      <AnnotatedCode
+        id="c6"
+        attributes={{
+          language: "rust",
+          code: "`pub struct Config {\n    pub url: Option<String>,\n}`",
+        }}
+      >
+        {""}
+      </AnnotatedCode>,
+    );
+    expect(screen.getByText(/pub struct Config/)).toBeInTheDocument();
+    // The template-literal delimiters are stripped, not rendered.
+    expect(screen.queryByText(/^`/)).not.toBeInTheDocument();
+  });
+
+  it("resolves annotations against attribute-sourced code lines", () => {
+    render(
+      <AnnotatedCode
+        id="c7"
+        attributes={{
+          language: "ts",
+          code: "`const a = 1;\nconst b = 2;\nreturn a + b;`",
+          annotations: JSON.stringify([
+            { line: "3", note: "the sum is returned here" },
+          ]),
+        }}
+      >
+        {""}
+      </AnnotatedCode>,
+    );
+    expect(screen.getByText("Line 3")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("the sum is returned here").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("prefers the `code` attribute over children when both are present", () => {
+    render(
+      <AnnotatedCode id="c8" attributes={{ lang: "ts", code: '"from attr"' }}>
+        {"from children"}
+      </AnnotatedCode>,
+    );
+    expect(screen.getByText(/from attr/)).toBeInTheDocument();
+    expect(screen.queryByText(/from children/)).not.toBeInTheDocument();
+  });
+
   it("clips the code surface vertically so overflow-x never promotes a stray vertical scrollbar", () => {
     // Regression: the surface used only `overflow-x-auto` in its expanded
     // state, which the browser promotes the *other* axis to `auto`, rendering a

--- a/ui/src/components/proposals/blocks/AnnotatedCode.tsx
+++ b/ui/src/components/proposals/blocks/AnnotatedCode.tsx
@@ -16,6 +16,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/utils";
 
 import type { BlockProps } from "./types";
+import { unwrapExprValue } from "./exprAttr";
 import { BlockShell } from "./BlockShell";
 import { splitFilename } from "./diff";
 import {
@@ -65,10 +66,26 @@ const CodeBlock = lazy(() => import("./CodeBlock"));
  * Robust: invalid `annotations` JSON renders the code WITHOUT annotations plus a
  * quiet warning (never crashes, never silently swallows). The app is DARK-ONLY.
  */
+/** The code comes from the `code` schema field (preferred) or the block
+ *  children. The `code` attribute is the form agents author with
+ *  (`<AnnotatedCode language="rust" code={`…`} />`) — real code routinely
+ *  carries `<` / `{` that the MDX grammar would reject as malformed JSX if it
+ *  sat between the tags. Reading children only — as this did before — dropped
+ *  that code entirely and rendered an empty block (same bug and fix as
+ *  Diagram's `source`). */
+function codeContent(
+  code: string | undefined,
+  children: BlockProps["children"],
+): string {
+  if (typeof code === "string" && code.trim().length > 0) {
+    return unwrapExprValue(code).replace(/^\n/, "").replace(/\s+$/, "");
+  }
+  return typeof children === "string" ? children.replace(/\s+$/, "") : "";
+}
+
 export function AnnotatedCode({ attributes, children }: BlockProps) {
   const filename = attributes.filename?.trim() || undefined;
-  const content =
-    typeof children === "string" ? children.replace(/\s+$/, "") : "";
+  const content = codeContent(attributes.code, children);
 
   // The active language can be re-picked via the switcher; it seeds from the
   // authored `lang`/`language` attr (or filename inference), with "" meaning Auto.

--- a/ui/src/components/proposals/blocks/Diagram.tsx
+++ b/ui/src/components/proposals/blocks/Diagram.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from "react";
 
 import type { BlockProps } from "./types";
+import { unwrapExprValue } from "./exprAttr";
 import { DiagramFallback } from "./DiagramFallback";
 import { SandboxedHtmlFrame } from "./SandboxedHtmlFrame";
 
@@ -22,26 +23,6 @@ const MermaidDiagram = lazy(() =>
  *   - anything else (e.g. `plantuml`, for which we have no client renderer):
  *     routed to the same graceful copy-source fallback instead of dumping raw.
  */
-/** Unwrap an MDX expression-attribute value that the parser stores verbatim:
- *  `source={`…`}` / `source={"…"}` arrive here as a template-literal or quoted
- *  string (delimiters included). Strip a single matching pair so mermaid sees
- *  the raw source, not a leading backtick. */
-function unwrapExprValue(s: string): string {
-  const t = s.trim();
-  if (t.length >= 2) {
-    const open = t[0];
-    const close = t[t.length - 1];
-    if (
-      (open === "`" && close === "`") ||
-      (open === '"' && close === '"') ||
-      (open === "'" && close === "'")
-    ) {
-      return t.slice(1, -1);
-    }
-  }
-  return s;
-}
-
 /** A diagram's source comes from the `source` schema field (preferred) or the
  *  block children. The `source` attribute is the form agents author with
  *  (`<Diagram type="mermaid" source={`…`} />`); reading children only — as this

--- a/ui/src/components/proposals/blocks/RichText.tsx
+++ b/ui/src/components/proposals/blocks/RichText.tsx
@@ -1,11 +1,22 @@
 import type { BlockProps } from "./types";
 import { BlockMarkdown } from "./BlockShell";
+import { unwrapExprValue } from "./exprAttr";
 
 /**
  * RichText — plain document prose. This is the proposal's connective tissue, so
  * it renders with no card or type label (a "Rich Text" badge over a real "##"
  * heading is just noise); the markdown headings carry the structure.
+ *
+ * The prose comes from the `content` schema field (the registry's authored
+ * form, e.g. `<RichText content="…" />`) or the block children — reading
+ * children only dropped attribute-authored prose entirely (same class of bug
+ * as Diagram `source` / AnnotatedCode `code`).
  */
-export function RichText({ children }: BlockProps) {
-  return <BlockMarkdown>{children}</BlockMarkdown>;
+export function RichText({ attributes, children }: BlockProps) {
+  const attr = attributes.content;
+  const content =
+    typeof attr === "string" && attr.trim().length > 0
+      ? unwrapExprValue(attr)
+      : children;
+  return <BlockMarkdown>{content}</BlockMarkdown>;
 }

--- a/ui/src/components/proposals/blocks/exprAttr.ts
+++ b/ui/src/components/proposals/blocks/exprAttr.ts
@@ -1,0 +1,21 @@
+/** Unwrap an MDX expression-attribute value that the parser stores verbatim:
+ *  `attr={`…`}` / `attr={"…"}` arrive as a template-literal or quoted string
+ *  (delimiters included). Strip a single matching pair so the consumer sees
+ *  the raw value, not a leading backtick. Shared by the blocks whose primary
+ *  content ships in a schema attribute (`Diagram source`, `AnnotatedCode
+ *  code`). */
+export function unwrapExprValue(s: string): string {
+  const t = s.trim();
+  if (t.length >= 2) {
+    const open = t[0];
+    const close = t[t.length - 1];
+    if (
+      (open === "`" && close === "`") ||
+      (open === '"' && close === '"') ||
+      (open === "'" && close === "'")
+    ) {
+      return t.slice(1, -1);
+    }
+  }
+  return s;
+}


### PR DESCRIPTION
## Problem

Proposal https://code.djinnai.io/proposals/019f1f92-9159-7452-841c-ddb6aa5db27c (and others authored by the tribunal with the visual-spec skill) rendered its code blocks as empty shells.

The block catalog advertises string content fields (`AnnotatedCode.code`, `RichText.content`), so agents author self-closing blocks with the content in the attribute: `<AnnotatedCode code={`…`} />`. That is also the only *parseable* form for real code — `<` and `{` between the tags are rejected as malformed JSX by the MDX grammar (`Option<String>` in children ⇒ parse error/UnknownBlock). But the renderers read only block **children**, silently dropping attribute-authored content. `Diagram` had this exact bug and was fixed earlier (`diagramSource()` prefers the `source` attr); `AnnotatedCode` and `RichText` never got the same fix.

## Fix

- **UI**: `AnnotatedCode` sources code from `attributes.code` (children fallback), so annotations resolve too; `RichText` same for `content`; shared `unwrapExprValue` extracted from `Diagram` into `exprAttr.ts` (strips the verbatim-stored template-literal/quote delimiters).
- **Catalog**: `annotated-code` now ships an authoring description (it had none, unlike diff/tabs/columns/wireframe) documenting the template-literal `code` form and strict-JSON `annotations`; guarded by a registry test.
- **Skill**: visual-spec gains a "Code blocks" section with the canonical example — it mandated `<AnnotatedCode>` but never showed the authoring shape.

Existing proposals need no migration: their bodies already carry the code in the attribute, so they render correctly with this change.

## Verification

- 3 new regression tests mirror the broken proposal's exact shape (self-closing, template-literal `code`, JSON `annotations`); all 318 block tests pass, `tsc`/`eslint` clean.
- Ran the real proposal body through `parseMdxBody` end-to-end: both AnnotatedCode blocks yield non-empty, delimiter-free code and parseable annotations.
- `proposal_blocks` + `native_skills` nextest suites pass (SQLX_OFFLINE), `cargo fmt --check`/`clippy` clean, skills manifest up to date.

Open gap (not addressed): `ApiEndpoint` ignores `request_schema`/`response_schema` attrs, but its children fallback keeps it non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)