### PR TITLE
ivek: gs37-shaped rework-loop regression test

### DIFF
--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -2886,3 +2886,118 @@ async fn mixed_reopen_ledger_park_uses_quality_count_and_emits_telemetry_breakdo
         .expect("metric value parses");
     assert!(value >= 1.0, "parked counter should be >= 1.0, got {value}");
 }
+
+// ── gs37-shaped park-guard regression (proposal ivek) ────────────────────────
+
+/// gs37-shaped rework-loop park-guard regression (proposal `ivek`).
+///
+/// This is the coordinator-side half of the gs37 acceptance criterion; the
+/// slot-side half (the fabricated no-edit submit is bounced/typed-finalized
+/// without consuming a quality strike, and the redispatch prompt carries the
+/// newest rejection verbatim + the reopen ledger) lives in the djinn-slot test
+/// `gs37_no_edit_submit_after_rejection_keeps_one_quality_strike_and_prompt_carries_rejection`.
+///
+/// Scenario: a genuine reviewer rejection (the sole quality strike), a
+/// fabricated no-edit submit settled as a typed `no_progress_submission`
+/// (recorded, but NOT a reopen), then repeated merge-conflict holds. Each
+/// merge-conflict is a real reopen EVENT — it bounces the task back to `open`
+/// and lands in the reopen ledger — so the raw reopen-event count advances
+/// past `REOPEN_INTERVENTION_THRESHOLD`. But `merge_conflict` is excluded from
+/// the quality strike count, which stays at 1. Trigger A
+/// (`maybe_intervene_on_stuck_task`) reads the QUALITY count, so the task is
+/// NOT parked to human review and no Planner intervention is armed — proving
+/// the acceptance criterion's "does not reach the human-review park threshold"
+/// clause despite the raw reopen counter having advanced.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn gs37_park_guard_not_triggered_below_quality_threshold_despite_raw_reopen_advance() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let task = make_task_with_reopen_count(&db, &tx, 0).await;
+
+    // 1. One genuine reviewer rejection — the sole quality strike.
+    walk_review_reject_cycle(
+        &repo,
+        &task.id,
+        djinn_core::models::TransitionAction::TaskReviewReject,
+        "AC-2 unmet: handler not registered",
+    )
+    .await;
+
+    // 2. A fabricated no-edit submit settled as a typed no_progress_submission.
+    //    The live settlement lives in djinn-slot; here we assert the
+    //    coordinator-visible invariant — the activity is recorded but does NOT
+    //    perturb the quality ledger (it is not a reopen).
+    repo.log_activity(
+        Some(&task.id),
+        "worker",
+        "system",
+        "no_progress_submission",
+        &serde_json::json!({ "reason": "no_progress_submission" }).to_string(),
+    )
+    .await
+    .unwrap();
+
+    // 3. Repeated merge-conflict holds — each a real reopen event, excluded
+    //    from quality strikes. This drives the raw reopen-event count past the
+    //    park threshold while the quality count stays put.
+    for _ in 0..3 {
+        walk_review_reject_cycle(
+            &repo,
+            &task.id,
+            djinn_core::models::TransitionAction::TaskReviewRejectConflict,
+            "merge_conflict: base branch advanced",
+        )
+        .await;
+    }
+
+    let t = repo.get(&task.id).await.unwrap().unwrap();
+
+    // Raw reopen-event count (the untyped ledger) has advanced to 4 — past the
+    // park threshold of 3.
+    let ledger = repo.recent_reopen_ledger(&task.id, 10).await.unwrap();
+    assert_eq!(
+        ledger.len(),
+        4,
+        "one reviewer rejection + three merge-conflict reopen events"
+    );
+    assert!(
+        (ledger.len() as i64) >= REOPEN_INTERVENTION_THRESHOLD,
+        "raw reopen-event count must have advanced to/past the park threshold"
+    );
+
+    // But the QUALITY strike count excludes the merge_conflict reopens.
+    let quality = repo.quality_reopen_count(&task.id).await.unwrap();
+    assert_eq!(
+        quality, 1,
+        "only the genuine reviewer rejection is a quality strike"
+    );
+    assert!(
+        quality < REOPEN_INTERVENTION_THRESHOLD,
+        "quality strike count must stay below the park threshold"
+    );
+
+    // Trigger A reads the quality count → the park guard does NOT fire.
+    let intervened = actor.maybe_intervene_on_stuck_task(&t).await;
+    assert!(
+        !intervened,
+        "park guard must NOT trigger while quality strikes stay below threshold, \
+         despite the raw reopen counter having advanced"
+    );
+    assert!(
+        planner_intervention_markers(&repo, &task.id)
+            .await
+            .is_empty(),
+        "no planner-intervention marker may be written below the quality threshold"
+    );
+
+    // And no Planner intervention (review) task was spawned.
+    let reviews = repo.list_by_status("open").await.unwrap();
+    assert!(
+        !reviews
+            .iter()
+            .any(|r| r.issue_type == "review" && r.project_id == t.project_id),
+        "no Planner intervention (review) task may be created below the park threshold"
+    );
+}

--- a/server/crates/djinn-slot/src/reply_loop/tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tests.rs
@@ -2852,6 +2852,259 @@ async fn second_strike_no_progress_submission_settles_session() {
     assert_eq!(provider.remaining(), 0);
 }
 
+/// gs37-shaped end-to-end rework-loop regression (proposal `ivek`).
+///
+/// Walks the full gs37 scenario at the highest fidelity the djinn-slot harness
+/// allows — a fabricated no-edit submit after a genuine rejection, then a
+/// merge-conflict hold, then the redispatch prompt build — and asserts the two
+/// slot-side halves of the acceptance criterion:
+///
+///   1. Seed a genuine reviewer rejection round: a real `TaskReviewReject`
+///      transition (`reopen_class=review_rejected`) plus a structured
+///      `review_submitted` rejection activity carrying the newest rejection
+///      text, and persist the rejected diff fingerprint.
+///   2. Fabricated no-edit submit (worktree fingerprint identical to the
+///      rejected fingerprint): the guard bounces the first identical submit
+///      and typed-finalizes the second as `no_progress_submission` — WITHOUT
+///      consuming a quality reopen strike.
+///   3. Merge-conflict reopen (`TaskReviewRejectConflict` →
+///      `reopen_class=merge_conflict`): a real reopen event that is excluded
+///      from the quality strike count.
+///   4. The redispatch prompt (`initial_user_message_for_task`) includes the
+///      newest reviewer rejection verbatim and renders the bounded reopen
+///      ledger.
+///
+/// Across the whole scenario exactly ONE quality reopen strike is consumed (the
+/// genuine rejection), well below the coordinator's
+/// `REOPEN_INTERVENTION_THRESHOLD` (3). The park-guard half of the acceptance
+/// criterion — that Trigger A does NOT reach the human-review park threshold —
+/// lives in djinn-coordinator (the threshold constant and
+/// `maybe_intervene_on_stuck_task` are not visible from this crate) and is
+/// asserted authoritatively in the sibling coordinator test
+/// `gs37_park_guard_not_triggered_below_quality_threshold_despite_raw_reopen_advance`.
+#[tokio::test]
+async fn gs37_no_edit_submit_after_rejection_keeps_one_quality_strike_and_prompt_carries_rejection()
+{
+    // The verbatim reviewer rejection the redispatch prompt must carry forward.
+    const NEWEST_REJECTION: &str = "AC-2 unmet: the handler is implemented but never registered with the \
+         service. Wire it into `build_router` before resubmitting.";
+
+    let worktree = init_git_repo_with_dirty_file();
+    let worktree_path = worktree.path().to_path_buf();
+    let fp = djinn_git::compute_submission_diff_fingerprint(&worktree_path)
+        .await
+        .expect("compute fingerprint");
+    let fingerprint = fp.fingerprint().expect("must be a Diff").to_string();
+    let (slot_ctx, project_path, task_id, session_id, cancel) = make_context().await;
+    let repo = TaskRepository::new(slot_ctx.db.clone(), slot_ctx.event_bus.clone());
+    // The review lifecycle (SubmitTaskReview) requires acceptance criteria.
+    repo.set_acceptance_criteria(&task_id, r#"[{"title":"AC-1"},{"title":"AC-2"}]"#)
+        .await
+        .expect("set acceptance criteria");
+
+    // ── Step 1: seed a genuine reviewer rejection round ──────────────────────
+    // open → in_progress → needs_task_review → in_task_review, then reject.
+    for (action, actor_role) in [
+        (djinn_core::models::TransitionAction::Start, "worker"),
+        (
+            djinn_core::models::TransitionAction::SubmitTaskReview,
+            "worker",
+        ),
+        (
+            djinn_core::models::TransitionAction::TaskReviewStart,
+            "reviewer",
+        ),
+    ] {
+        repo.transition(&task_id, action, actor_role, actor_role, None, None)
+            .await
+            .expect("valid setup transition");
+    }
+    repo.transition(
+        &task_id,
+        djinn_core::models::TransitionAction::TaskReviewReject,
+        "reviewer",
+        "reviewer",
+        Some(NEWEST_REJECTION),
+        None,
+    )
+    .await
+    .expect("reviewer rejection transition");
+    // Structured reviewer rejection activity — `recent_feedback` surfaces this
+    // verbatim into the redispatch prompt (0kws).
+    repo.log_activity(
+        Some(&task_id),
+        "reviewer",
+        "reviewer",
+        "review_submitted",
+        &serde_json::json!({ "verdict": "rejected", "feedback": NEWEST_REJECTION }).to_string(),
+    )
+    .await
+    .expect("log review_submitted");
+    // Persist the rejected diff fingerprint — the submission-integrity anchor
+    // the no-progress guard compares against.
+    record_rejected_integrity_entry(
+        &task_id,
+        &slot_ctx,
+        djinn_core::models::RejectedVerdictKind::ReviewerReject.as_str(),
+        None,
+        None,
+        &fingerprint,
+    )
+    .await;
+
+    assert_eq!(
+        repo.quality_reopen_count(&task_id).await.unwrap(),
+        1,
+        "the genuine reviewer rejection is exactly one quality strike"
+    );
+
+    // ── Step 2: fabricated no-edit submit → first bounce, second-strike settle ─
+    // Turn 1 submit_work (identical fingerprint) is bounced; turn 3 submit_work
+    // (still identical) settles the session as a typed no_progress_submission.
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call_with_input(
+            "submit-1",
+            "submit_work",
+            serde_json::json!({"task_id": task_id, "summary": "done", "files_changed": []}),
+            100,
+        ),
+        MockResponse::text_only("I'll try resubmitting anyway.", 100),
+        MockResponse::tool_call_with_input(
+            "submit-2",
+            "submit_work",
+            serde_json::json!({"task_id": task_id, "summary": "done again", "files_changed": []}),
+            100,
+        ),
+    ]);
+    let mut conv = Conversation::new();
+    conv.push(Message::system("You are a worker."));
+    conv.push(Message::user("Do the task."));
+    let (_result, output, _, _, _, _) = run_reply_loop(
+        ReplyLoopContext {
+            provider: &provider,
+            tools: &[serde_json::json!({
+                "type": "function",
+                "function": { "name": "submit_work", "description": "submit", "parameters": {"type": "object"} },
+                "concurrent_safe": false
+            })],
+            task_id: &task_id,
+            task_short_id: "t1",
+            session_id: &session_id,
+            project_path: &project_path,
+            worktree_path: &worktree_path,
+            role_name: "worker",
+            finalize_tool_names: &["submit_work", "request_lead"],
+            context_window: 10_000,
+            model_id: "test/mock-model",
+            cancel: &cancel,
+            global_cancel: &cancel,
+            ctx: &slot_ctx,
+            active_skill_names: &[],
+            active_mcp_server_names: &[],
+            max_turns_override: None,
+        },
+        &mut conv,
+        false,
+    )
+    .await;
+    assert!(
+        output.no_progress_submission,
+        "second identical no-edit submit must settle as no_progress_submission"
+    );
+    assert!(
+        output.finalize_payload.is_none(),
+        "the fabricated no-edit submit must NOT be accepted as a finalize"
+    );
+    // The typed no_progress_submission was logged, and it consumed NO quality
+    // reopen strike — the count is unchanged from step 1.
+    let np_entries = repo
+        .query_activity(djinn_db::repositories::task::ActivityQuery {
+            task_id: Some(task_id.clone()),
+            event_type: Some("no_progress_submission".to_string()),
+            actor_role: None,
+            project_id: None,
+            from_time: None,
+            to_time: None,
+            limit: 10,
+            offset: 0,
+        })
+        .await
+        .expect("query activity");
+    assert!(
+        !np_entries.is_empty(),
+        "a typed no_progress_submission activity must be logged"
+    );
+    assert_eq!(
+        repo.quality_reopen_count(&task_id).await.unwrap(),
+        1,
+        "the no-edit submit bounce + settlement must NOT consume a quality reopen strike"
+    );
+
+    // ── Step 3: merge-conflict hold → reopen excluded from quality strikes ────
+    // The task is back at `open` after the rejection; walk another review round
+    // and reject it as a merge conflict.
+    for (action, actor_role) in [
+        (djinn_core::models::TransitionAction::Start, "worker"),
+        (
+            djinn_core::models::TransitionAction::SubmitTaskReview,
+            "worker",
+        ),
+        (
+            djinn_core::models::TransitionAction::TaskReviewStart,
+            "reviewer",
+        ),
+    ] {
+        repo.transition(&task_id, action, actor_role, actor_role, None, None)
+            .await
+            .expect("valid setup transition");
+    }
+    repo.transition(
+        &task_id,
+        djinn_core::models::TransitionAction::TaskReviewRejectConflict,
+        "reviewer",
+        "reviewer",
+        Some("merge_conflict: base branch advanced under the PR"),
+        None,
+    )
+    .await
+    .expect("merge-conflict reject transition");
+    assert_eq!(
+        repo.quality_reopen_count(&task_id).await.unwrap(),
+        1,
+        "the merge_conflict reopen is excluded from the quality strike count"
+    );
+    let ledger = repo.recent_reopen_ledger(&task_id, 6).await.unwrap();
+    assert_eq!(
+        ledger.len(),
+        2,
+        "two reopen events: the reviewer rejection and the merge conflict"
+    );
+    // Newest first.
+    assert_eq!(
+        ledger[0].reopen_class,
+        djinn_core::models::ReopenClass::MergeConflict
+    );
+    assert_eq!(
+        ledger[1].reopen_class,
+        djinn_core::models::ReopenClass::ReviewRejected
+    );
+
+    // ── Step 4: redispatch prompt carries the newest rejection + reopen ledger ─
+    let prompt = crate::helpers::initial_user_message_for_task(&task_id, &slot_ctx).await;
+    assert!(
+        prompt.contains(NEWEST_REJECTION),
+        "redispatch prompt must include the newest reviewer rejection verbatim; got: {prompt}"
+    );
+    assert!(
+        prompt.contains("Reopen history"),
+        "redispatch prompt must render the reopen ledger; got: {prompt}"
+    );
+    assert!(
+        prompt.contains("review_rejected") && prompt.contains("merge_conflict"),
+        "reopen ledger must render both reopen classes; got: {prompt}"
+    );
+}
+
 /// Regression: when a worker submits a changed (non-matching) fingerprint,
 /// the guard allows the finalize to proceed. The `no_progress_submission`
 /// flag must remain false.


### PR DESCRIPTION
## What this proves

Final acceptance criterion of proposal **ivek**, verbatim:

> A gs37-shaped integration test (fabricated no-edit submit after a rejection, followed by a merge-conflict hold and a redispatch) completes without consuming a quality reopen strike, includes the newest rejection in the prompt, and does not reach the human-review park threshold.

The gs37 scenario spans two crates (the submission-integrity gate + redispatch-prompt builder live in `djinn-slot`; the human-review park guard + threshold live in `djinn-coordinator`, and the slot crate's `test_helpers`/`SlotContext` constructor is `pub(crate)`), so it is covered by a coordinated pair of regression tests — no feature code is changed, only tests.

### `djinn-slot` — `reply_loop::tests::gs37_no_edit_submit_after_rejection_keeps_one_quality_strike_and_prompt_carries_rejection`
Drives the real machinery end-to-end against a Postgres-backed task:
1. **Seed a genuine reviewer rejection round** — real `TaskReviewReject` transition (`reopen_class=review_rejected`) + a structured `review_submitted` rejection activity carrying the newest rejection text; persist the rejected diff fingerprint via `record_rejected_integrity_entry`. Asserts `quality_reopen_count == 1`.
2. **Fabricated no-edit submit** — runs `run_reply_loop` with the worktree fingerprint identical to the rejected one. The guard bounces the first identical `submit_work` and typed-finalizes the second as `no_progress_submission` (`output.no_progress_submission == true`, `finalize_payload == None`, `no_progress_submission` activity logged). Asserts `quality_reopen_count` is **still 1** — the bounce + settlement consume **no** quality reopen strike.
3. **Merge-conflict hold** — real `TaskReviewRejectConflict` transition (`reopen_class=merge_conflict`). Asserts `quality_reopen_count` **still 1** and the reopen ledger has 2 entries (`merge_conflict`, `review_rejected`).
4. **Redispatch prompt** — `initial_user_message_for_task` includes the newest reviewer rejection **verbatim** and renders the reopen ledger ("Reopen history", both classes).

### `djinn-coordinator` — `tests::intervention::gs37_park_guard_not_triggered_below_quality_threshold_despite_raw_reopen_advance`
Asserts the park-guard clause authoritatively: a genuine rejection (1 quality strike) + a recorded `no_progress_submission` + three merge-conflict holds drive the **raw reopen-event count (ledger) to 4 — past `REOPEN_INTERVENTION_THRESHOLD` (3)** while `quality_reopen_count` stays at **1**. `maybe_intervene_on_stuck_task` reads the quality count → returns `false`, writes **no** planner-intervention marker, and spawns **no** Planner review task.

### Scenario-step coverage
All 5 requested steps are asserted. Steps 1–4 in the slot test; steps 3 & 5 (park guard) in the coordinator test. No faked assertions.

**Documented seam boundary** (code comments in both tests): the fabricated-submit *settlement* is exercised live in the slot test; the coordinator test represents it as a recorded `no_progress_submission` activity and asserts the coordinator-visible invariant (it does not perturb the quality ledger), because the live settlement path is `pub(crate)` in `djinn-slot`. "Raw reopen counter" is interpreted as the untyped reopen-event ledger (which merge-conflict holds advance), since no real transition increments the `reopen_count` column without also being a quality strike.

## Verification (from `server/`, `SQLX_OFFLINE=true`, Postgres:16 on :5434)
- `cargo fmt --check -p djinn-slot -p djinn-coordinator` — exit 0
- `cargo clippy -p djinn-slot -p djinn-coordinator --all-targets --all-features -- -D warnings` — exit 0
- Both new tests — pass
- (`cargo fmt --check` flags a pre-existing `pub use` ordering in `djinn-k8s/src/lib.rs`, present on origin/main and untouched here.)