### PR TITLE
uv3p: Attempted-remediation park rung + consumed-hold release

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -7,6 +7,25 @@ use djinn_core::models::ReopenClass;
 #[cfg(not(test))]
 use djinn_db::AgentRepository;
 
+/// uv3p Part B: what the fleet actually did after the current intervention (or
+/// after a human released a prior hold), derived from durable sessions +
+/// activity. Drives the attempted-remediation park gate, the forced model
+/// rotation at dispatch, and the truthful park reason.
+#[derive(Debug, Default)]
+pub(crate) struct PostInterventionHistory {
+    /// At least one post-intervention session reached `submit_work` (logged a
+    /// `work_submitted` activity after the evidence floor). When true the
+    /// remediation was genuinely attempted, so a park is legitimate.
+    pub any_submitted: bool,
+    /// Distinct models of post-intervention worker sessions that terminated
+    /// pre-submission, in first-seen (chronological) order. Empty when a submit
+    /// occurred. Excluded from the redispatch model list (forced rotation) and
+    /// counted against [`NON_ATTEMPT_PARK_THRESHOLD`].
+    pub non_attempt_models: Vec<String>,
+    /// `sess <id8> (model)` labels for the truthful park reason.
+    pub non_attempt_session_labels: Vec<String>,
+}
+
 /// Which kind of remediation task to create for a stuck source task.
 ///
 /// Both kinds create a `Planner remediation [<short_id>]: <title>` review task
@@ -565,6 +584,211 @@ impl CoordinatorActor {
             .await
     }
 
+    /// uv3p Part B: what the fleet actually did since the current intervention
+    /// (or since a human released a prior hold), computed from durable sessions
+    /// and activity — the source of both the park-vs-redispatch decision and the
+    /// truthful park reason. Never templated.
+    pub(crate) async fn post_intervention_history(
+        &self,
+        task: &djinn_core::models::Task,
+    ) -> PostInterventionHistory {
+        // Evidence floor: the later of the last intervention and the last
+        // human-review hold resolution. Sessions/strikes before this floor are
+        // pre-intervention (or already-adjudicated pre-release) noise, not
+        // evidence the CURRENT remediation was attempted.
+        let resolved_at = self
+            .task_repo()
+            .human_review_resolved_at(&task.id)
+            .await
+            .ok()
+            .flatten();
+        let floor = [task.last_intervention_at.clone(), resolved_at]
+            .into_iter()
+            .flatten()
+            .max();
+        let Some(floor) = floor else {
+            // No intervention has landed yet — nothing counts as post-intervention.
+            return PostInterventionHistory::default();
+        };
+
+        // Did any post-intervention session reach submit_work?
+        let any_submitted = match self
+            .task_repo()
+            .query_activity(ActivityQuery {
+                task_id: Some(task.id.clone()),
+                event_type: Some("work_submitted".to_string()),
+                actor_role: None,
+                project_id: None,
+                from_time: None,
+                to_time: None,
+                limit: 200,
+                offset: 0,
+            })
+            .await
+        {
+            Ok(entries) => entries
+                .iter()
+                .any(|entry| entry.created_at.as_str() > floor.as_str()),
+            Err(e) => {
+                // Fail safe: without evidence, treat as "attempted" so the caller
+                // parks rather than looping — the conservative direction.
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    error = %e,
+                    "uv3p: post-intervention work_submitted lookup failed; treating as attempted"
+                );
+                return PostInterventionHistory {
+                    any_submitted: true,
+                    ..Default::default()
+                };
+            }
+        };
+
+        if any_submitted {
+            return PostInterventionHistory {
+                any_submitted: true,
+                ..Default::default()
+            };
+        }
+
+        // No submit: enumerate the TERMINATED post-intervention worker sessions
+        // and collect their distinct models (rotation exclusion + non-attempt
+        // bound). `list_for_task` is DESC by started_at; reverse for chronology.
+        let session_repo = djinn_db::SessionRepository::new(
+            self.db.clone(),
+            crate::events::event_bus_for(&self.events_tx),
+        );
+        let sessions = session_repo
+            .list_for_task(&task.id)
+            .await
+            .unwrap_or_default();
+        let mut non_attempt_models: Vec<String> = Vec::new();
+        let mut non_attempt_session_labels: Vec<String> = Vec::new();
+        for session in sessions.iter().rev() {
+            if session.agent_type != "worker" {
+                continue;
+            }
+            if session.started_at.as_str() <= floor.as_str() {
+                continue;
+            }
+            // Still running → an in-flight attempt, not a termination.
+            if session.ended_at.is_none() {
+                continue;
+            }
+            let id8: String = session.id.chars().take(8).collect();
+            non_attempt_session_labels.push(format!("sess {id8} ({})", session.model_id));
+            if !non_attempt_models.contains(&session.model_id) {
+                non_attempt_models.push(session.model_id.clone());
+            }
+        }
+
+        PostInterventionHistory {
+            any_submitted: false,
+            non_attempt_models,
+            non_attempt_session_labels,
+        }
+    }
+
+    /// uv3p Part B: truthful park reason computed from `history`. Never contains
+    /// the templated "same acceptance criteria kept failing" phrasing that five
+    /// of five 2026-07-04 parks asserted falsely.
+    fn compute_park_reason(
+        &self,
+        task: &djinn_core::models::Task,
+        history: &PostInterventionHistory,
+    ) -> String {
+        let detail = if history.any_submitted {
+            "The post-intervention remediation WAS attempted — at least one session submitted \
+             work after the planner reshaped the scope — but the acceptance criteria still did \
+             not pass, so re-dispatching would only loop again."
+                .to_string()
+        } else {
+            format!(
+                "{} post-intervention session(s) terminated pre-submission across models {} — \
+                 the remediation never converged despite forced model rotation, so re-dispatching \
+                 would only loop again.",
+                history.non_attempt_session_labels.len(),
+                history.non_attempt_models.join(", "),
+            )
+        };
+        format!(
+            "Auto-parked for human review after {} planner intervention(s) \
+             (intervention_count={}, total_reopen_count={}). {detail} The task is held (open + \
+             blocked on a human-review remediation task) so it frees the dispatch slot for other \
+             ready tasks while its branch and prior work are preserved. A human must resolve the \
+             remediation task to release it, or close this task if the work is no longer wanted.",
+            MAX_PLANNER_INTERVENTIONS, task.intervention_count, task.total_reopen_count,
+        )
+    }
+
+    /// uv3p Part B: has a park-redispatch marker already recorded this CI
+    /// `fingerprint` as seen for this task? First-occurrence = no such marker.
+    async fn park_fingerprint_seen(
+        &self,
+        task: &djinn_core::models::Task,
+        fingerprint: &str,
+    ) -> djinn_db::Result<bool> {
+        let entries = self
+            .task_repo()
+            .query_activity(ActivityQuery {
+                task_id: Some(task.id.clone()),
+                event_type: Some(PARK_REDISPATCH_MARKER.to_string()),
+                actor_role: Some("system".to_string()),
+                project_id: None,
+                from_time: None,
+                to_time: None,
+                limit: 200,
+                offset: 0,
+            })
+            .await?;
+        Ok(entries.iter().any(|entry| {
+            serde_json::from_str::<serde_json::Value>(&entry.payload)
+                .ok()
+                .and_then(|payload| {
+                    payload
+                        .get("fingerprint")
+                        .and_then(serde_json::Value::as_str)
+                        .map(|seen| seen == fingerprint)
+                })
+                .unwrap_or(false)
+        }))
+    }
+
+    /// uv3p Part B: record that the park rung declined to park and redispatched.
+    /// Non-fatal audit trail (and the durable first-occurrence-fingerprint record).
+    async fn record_park_redispatch_marker(
+        &self,
+        task: &djinn_core::models::Task,
+        kind: &str,
+        fingerprint: Option<&str>,
+        non_attempt_count: usize,
+    ) {
+        let payload = serde_json::json!({
+            "kind": kind,
+            "fingerprint": fingerprint,
+            "non_attempt_count": non_attempt_count,
+            "intervention_count": task.intervention_count,
+        })
+        .to_string();
+        if let Err(e) = self
+            .task_repo()
+            .log_activity(
+                Some(&task.id),
+                "coordinator",
+                "system",
+                PARK_REDISPATCH_MARKER,
+                &payload,
+            )
+            .await
+        {
+            tracing::warn!(
+                task_id = %task.short_id,
+                error = %e,
+                "uv3p: failed to record park-redispatch marker"
+            );
+        }
+    }
+
     /// Shared intervention router behind triggers A and B: second-strike
     /// terminal park, idempotency marker keyed by the task's CURRENT
     /// quality strike count, backoff-state clearing, and the Planner escalation
@@ -588,17 +812,81 @@ impl CoordinatorActor {
         // re-escalating (which just resets and loops). Parked to `open`
         // so the dispatch slot is freed; human resolves the remediation.
         if task.intervention_count >= MAX_PLANNER_INTERVENTIONS {
-            let reason = format!(
-                "Auto-parked for human review: {} planner intervention(s) failed to break the \
-                 rework loop (intervention_count={}, total_reopen_count={}). The same acceptance \
-                 criteria kept failing across repeated rounds even after the planner reshaped the \
-                 scope, so re-dispatching would only loop again and hold the dispatch slot. The \
-                 task is held (open + blocked on a human-review remediation task) so it frees the \
-                 dispatch slot for other ready tasks while its branch and prior work are \
-                 preserved. A human must resolve the remediation task to release it, or close \
-                 this task if the work is no longer wanted.",
-                task.intervention_count, task.intervention_count, task.total_reopen_count,
-            );
+            // uv3p Part B: attempted-remediation requirement on the park rung.
+            // A park declares the current intervention's remediation a failure —
+            // but the audits (cgcl/7fj3/nlus) show parks landing 272ms–36s after
+            // a rescope, before ANY post-intervention session was ever dispatched.
+            // Compute what actually happened since the intervention/hold release
+            // and refuse to park on evidence the fleet never tried.
+            let history = self.post_intervention_history(task).await;
+
+            // First-occurrence CI fingerprint (8y3q): a park-triggering strike
+            // whose failure_fingerprint is brand new on this task deserves exactly
+            // one remediation before any park — "re-dispatching would only loop"
+            // is unfounded against a novel failure (8y3q's fix was one token).
+            if let Some(fingerprint) = task
+                .ci_failure_fingerprint
+                .as_deref()
+                .filter(|f| !f.is_empty())
+            {
+                match self.park_fingerprint_seen(task, fingerprint).await {
+                    Ok(false) => {
+                        self.record_park_redispatch_marker(
+                            task,
+                            "first_occurrence_fingerprint",
+                            Some(fingerprint),
+                            history.non_attempt_models.len(),
+                        )
+                        .await;
+                        tracing::warn!(
+                            task_id = %task.short_id,
+                            fingerprint,
+                            "uv3p: human-park rung declined to park — first-occurrence CI fingerprint; dispatching one remediation before any park"
+                        );
+                        return false;
+                    }
+                    Ok(true) => {}
+                    Err(e) => {
+                        // Fail safe toward the (unchanged) attempted-remediation
+                        // gate below rather than silently parking.
+                        tracing::warn!(
+                            task_id = %task.short_id,
+                            error = %e,
+                            "uv3p: park fingerprint-seen check failed; proceeding to attempted-remediation gate"
+                        );
+                    }
+                }
+            }
+
+            // Attempted-remediation gate: park only when the remediation was
+            // actually attempted (a post-intervention submit) OR enough distinct
+            // models have terminated pre-submission to prove rotation won't help.
+            // Below the bound, redispatch with forced model rotation instead of
+            // consuming the final strike (dispatch-time exclusion in
+            // task_dispatch.rs drops the models that just failed).
+            if !history.any_submitted
+                && history.non_attempt_models.len() < NON_ATTEMPT_PARK_THRESHOLD
+            {
+                self.record_park_redispatch_marker(
+                    task,
+                    "no_attempted_remediation",
+                    None,
+                    history.non_attempt_models.len(),
+                )
+                .await;
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    intervention_count = task.intervention_count,
+                    non_attempt_models = ?history.non_attempt_models,
+                    "uv3p: human-park rung declined to park — no post-intervention session reached submit_work yet; redispatching with forced model rotation instead of parking"
+                );
+                return false;
+            }
+
+            // Truthful park reason computed from actual post-intervention
+            // history — never the templated "same acceptance criteria kept
+            // failing" text when zero post-intervention rounds occurred.
+            let reason = self.compute_park_reason(task, &history);
             tracing::warn!(
                 task_id = %task.short_id,
                 intervention_count = task.intervention_count,

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1602,6 +1602,34 @@ impl CoordinatorActor {
                 }
             }
 
+            // uv3p Part B: forced model rotation on the post-intervention retry
+            // path. When the human-park rung declined to park because no session
+            // has reached submit_work yet, it redispatches — but a redispatch to
+            // the SAME model that just terminated pre-submission (loop-guard trip,
+            // infra death) would loop identically (kibj went back to k2p7 twice).
+            // Drop the models whose post-intervention sessions terminated without
+            // submitting, derived from durable session history so no new state is
+            // needed. Degrades to the unfiltered list when exclusion would empty
+            // it (only one viable model → plan-lane retry, then park at the bound).
+            if role == "worker" && task.intervention_count >= 1 {
+                let history = self.post_intervention_history(&task).await;
+                if !history.non_attempt_models.is_empty() {
+                    let filtered: Vec<String> = model_ids
+                        .iter()
+                        .filter(|m| !history.non_attempt_models.contains(m))
+                        .cloned()
+                        .collect();
+                    if !filtered.is_empty() && filtered.len() < model_ids.len() {
+                        tracing::info!(
+                            task_id = %task.short_id,
+                            excluded = ?history.non_attempt_models,
+                            "uv3p: forcing model rotation on post-intervention redispatch — excluding models that terminated pre-submission"
+                        );
+                        model_ids = filtered;
+                    }
+                }
+            }
+
             // Cross-model ("Thorough") review: when this is a reviewer dispatch
             // and the creator has `diverse_review` on, steer the fallback list so
             // the first viable model id differs from the one that implemented the

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -714,6 +714,17 @@ async fn reopen_loop_guard_second_strike_chaos_parks_without_rearming() {
     harness.seed_same_role_redispatch_state("worker", 2).await;
     harness.assert_same_role_backoff_seeded("worker", 2).await;
     harness.seed_running_capacity_occupancy().await;
+    // uv3p Part B: the park rung now requires an attempted remediation. Seed two
+    // post-intervention sessions that terminated pre-submission across distinct
+    // models so the non-attempt bound is reached and the second strike parks
+    // (rather than redispatching with forced rotation).
+    seed_terminated_post_intervention_sessions(
+        &harness.db,
+        &harness.tx,
+        &harness.task_id,
+        &["chaos-model-a", "chaos-model-b"],
+    )
+    .await;
 
     let (second_handled, parked) = harness.route_reopen_intervention().await;
     assert!(
@@ -1005,6 +1016,10 @@ async fn loop_guard_second_strike_parks_task() {
     repo.reset_intervention_counters(&task.id).await.unwrap();
     let task = repo.get(&task.id).await.unwrap().unwrap();
     assert_eq!(task.intervention_count, MAX_PLANNER_INTERVENTIONS);
+
+    // uv3p Part B: seed two distinct-model pre-submission terminations so the
+    // attempted-remediation park gate reaches its non-attempt bound and parks.
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
 
     let handled = actor
         .route_loop_guard_planner_intervention(
@@ -1472,6 +1487,10 @@ async fn second_strike_parks_task_after_prior_intervention() {
     assert_eq!(task.intervention_count, 1, "one prior planner intervention");
     assert_eq!(task.reopen_count, REOPEN_INTERVENTION_THRESHOLD);
 
+    // uv3p Part B: the second strike parks only once the remediation was
+    // actually attempted; seed two distinct-model pre-submission terminations.
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
+
     let handled = actor.maybe_intervene_on_stuck_task(&task).await;
     assert!(
         handled,
@@ -1511,6 +1530,272 @@ async fn second_strike_parks_task_after_prior_intervention() {
         remediation.title.starts_with("Planner remediation ["),
         "remediation keeps the `Planner remediation [<short_id>]: <title>` convention; got {:?}",
         remediation.title
+    );
+}
+
+/// uv3p Part B (AC #2 / cgcl-7fj3-nlus shape): a task at the second-strike
+/// condition (`intervention_count == 1`, quality strikes at threshold) with
+/// ZERO sessions dispatched since the intervention must NOT park — the
+/// remediation was never attempted. The audits showed parks landing 272ms–36s
+/// after a rescope with zero dispatches; the guard now redispatches instead.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn park_rung_redispatches_when_no_post_intervention_submission() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    // One prior intervention (bumps intervention_count, sets last_intervention_at),
+    // then climb back to the reopen threshold — the second-strike condition.
+    let task = make_task_with_reopen_count(&db, &tx, REOPEN_INTERVENTION_THRESHOLD).await;
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    for _ in 0..REOPEN_INTERVENTION_THRESHOLD {
+        repo.set_status(&task.id, "closed").await.unwrap();
+        repo.set_status(&task.id, "open").await.unwrap();
+    }
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(task.intervention_count, 1);
+    assert_eq!(task.reopen_count, REOPEN_INTERVENTION_THRESHOLD);
+    // No sessions were dispatched after the intervention — the cgcl/7fj3/nlus
+    // shape (park within seconds of a rescope, zero dispatches).
+
+    let handled = actor.maybe_intervene_on_stuck_task(&task).await;
+    assert!(
+        !handled,
+        "park rung must NOT handle (park) the task when no post-intervention session was ever dispatched — it must fall through to the redispatch path"
+    );
+
+    // The observable of the redispatch decision: no human-review hold was
+    // created, so the task stays dispatchable, and a park-redispatch marker
+    // documents the decision.
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert!(
+        blockers.is_empty(),
+        "declining to park must NOT create a remediation hold; the task stays dispatchable"
+    );
+    let parked = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(parked.status, "open", "task stays open and dispatchable");
+    let markers = park_redispatch_markers(&repo, &task.id).await;
+    assert_eq!(
+        markers.len(),
+        1,
+        "the redispatch decision records exactly one park-redispatch marker"
+    );
+    assert_eq!(markers[0]["kind"], "no_attempted_remediation");
+}
+
+/// uv3p Part B (AC #2 / 8y3q shape): a park-triggering strike whose CI
+/// `failure_fingerprint` is first-occurrence for the task must dispatch one
+/// remediation session before any park. 8y3q parked on a brand-new merge-queue
+/// failure whose fix was one token. A subsequent strike on the SAME (now-seen)
+/// fingerprint no longer earns a free shot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn park_rung_dispatches_one_remediation_on_first_occurrence_fingerprint() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let task = make_task_with_reopen_count(&db, &tx, REOPEN_INTERVENTION_THRESHOLD).await;
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    let mut task = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(task.intervention_count, 1);
+    // Attach a brand-new CI failure fingerprint (the merge-queue signature 8y3q
+    // parked on). The Task field is read directly by the park rung.
+    task.ci_failure_fingerprint = Some("abc123:Merge Queue".to_string());
+
+    // Even WITH two distinct-model pre-submission terminations already on record
+    // (which would otherwise clear the non-attempt bound and park), a novel
+    // fingerprint takes precedence and buys exactly one remediation.
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
+
+    let handled = actor
+        .route_planner_intervention(&task, "worker", "second strike", None, 5)
+        .await;
+    assert!(
+        !handled,
+        "a first-occurrence CI fingerprint must dispatch one remediation before any park"
+    );
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert!(
+        blockers.is_empty(),
+        "the first-occurrence remediation must not create a human-review hold"
+    );
+    let markers = park_redispatch_markers(&repo, &task.id).await;
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0]["kind"], "first_occurrence_fingerprint");
+    assert_eq!(markers[0]["fingerprint"], "abc123:Merge Queue");
+
+    // The fingerprint is now SEEN. A repeat strike on it falls through to the
+    // attempted-remediation gate, which — with two non-attempt models on record
+    // — parks.
+    let handled_again = actor
+        .route_planner_intervention(&task, "worker", "second strike", None, 5)
+        .await;
+    assert!(
+        handled_again,
+        "a repeat strike on the now-seen fingerprint no longer earns a free shot; it parks on the non-attempt bound"
+    );
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert_eq!(
+        blockers.len(),
+        1,
+        "the repeat strike parks on a single human-review hold"
+    );
+}
+
+/// uv3p Part B (AC #3): after two consecutive non-attempt terminations across
+/// DIFFERENT models the task parks, and the reason names the terminated
+/// sessions/models — never the templated "same acceptance criteria kept
+/// failing" text that five of five 2026-07-04 parks asserted falsely.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn park_rung_parks_after_two_non_attempts_with_truthful_reason() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let task = make_task_with_reopen_count(&db, &tx, REOPEN_INTERVENTION_THRESHOLD).await;
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    for _ in 0..REOPEN_INTERVENTION_THRESHOLD {
+        repo.set_status(&task.id, "closed").await.unwrap();
+        repo.set_status(&task.id, "open").await.unwrap();
+    }
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+
+    // Two post-intervention sessions terminated pre-submission across DIFFERENT
+    // models — the non-attempt bound (default 2) is reached.
+    seed_terminated_post_intervention_sessions(
+        &db,
+        &tx,
+        &task.id,
+        &["anthropic/claude-x", "openai/gpt-y"],
+    )
+    .await;
+
+    let handled = actor.maybe_intervene_on_stuck_task(&task).await;
+    assert!(
+        handled,
+        "two non-attempt terminations reach the bound and park"
+    );
+
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert_eq!(
+        blockers.len(),
+        1,
+        "park holds the source on one remediation"
+    );
+    let remediation = repo.get(&blockers[0].task_id).await.unwrap().unwrap();
+
+    // The park reason (carried in the remediation description) names the models
+    // and never uses the templated phrasing.
+    assert!(
+        remediation.description.contains("anthropic/claude-x")
+            && remediation.description.contains("openai/gpt-y"),
+        "park reason must name the terminated models; got: {}",
+        remediation.description
+    );
+    assert!(
+        remediation
+            .description
+            .contains("terminated pre-submission"),
+        "park reason must describe the pre-submission terminations; got: {}",
+        remediation.description
+    );
+    assert!(
+        !remediation
+            .description
+            .contains("same acceptance criteria kept failing"),
+        "park reason must NEVER contain the templated phrasing when zero submissions occurred; got: {}",
+        remediation.description
+    );
+}
+
+/// uv3p Part C (AC #4 / ygj0 shape): closing a human-review hold records a
+/// consumed-hold marker; the park evaluator ignores pre-release evidence, so
+/// re-running it on UNCHANGED counters does not spawn a duplicate hold. The
+/// original incident spawned a duplicate hold within ~150ms of releasing the
+/// source on the still-stale `intervention_count=1, total_reopen_count=6`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn closing_hold_records_consumed_marker_and_prevents_duplicate_hold() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    // Park the task (second strike with two attempted-then-failed remediations).
+    let task = make_task_with_reopen_count(&db, &tx, REOPEN_INTERVENTION_THRESHOLD).await;
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    for _ in 0..REOPEN_INTERVENTION_THRESHOLD {
+        repo.set_status(&task.id, "closed").await.unwrap();
+        repo.set_status(&task.id, "open").await.unwrap();
+    }
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
+    assert!(
+        actor.maybe_intervene_on_stuck_task(&task).await,
+        "task parks"
+    );
+
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert_eq!(blockers.len(), 1, "one hold blocker after park");
+    let hold_id = blockers[0].task_id.clone();
+
+    let quality_before = repo.quality_reopen_count(&task.id).await.unwrap();
+    assert!(
+        quality_before >= REOPEN_INTERVENTION_THRESHOLD,
+        "pre-release quality strikes are at/above threshold"
+    );
+
+    // A human closes the hold — releases the source and stamps the consumed-hold
+    // marker on it.
+    repo.transition(
+        &hold_id,
+        djinn_core::models::TransitionAction::Close,
+        "human",
+        "user",
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // The marker makes the pre-release strike ledger read as consumed.
+    let resolved_at = repo.human_review_resolved_at(&task.id).await.unwrap();
+    assert!(
+        resolved_at.is_some(),
+        "closing the hold must stamp human_review_resolved_at on the source"
+    );
+    let quality_after = repo.quality_reopen_count(&task.id).await.unwrap();
+    assert_eq!(
+        quality_after, 0,
+        "the park evaluator must ignore pre-release strikes after the hold is consumed"
+    );
+
+    // Re-run the park evaluator on the UNCHANGED counters — it must NOT re-park
+    // or spawn a duplicate hold (the ygj0 fix).
+    let released = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(released.intervention_count, 1, "counters are unchanged");
+    let re_handled = actor.maybe_intervene_on_stuck_task(&released).await;
+    assert!(
+        !re_handled,
+        "the released source must not be re-parked on the pre-release evidence"
+    );
+    let blockers_after = repo.list_blockers(&task.id).await.unwrap();
+    assert!(
+        blockers_after.iter().all(|b| b.status == "closed"),
+        "closing the hold must not spawn a duplicate hold on unchanged counters"
+    );
+    let open_reviews: Vec<_> = repo
+        .list_by_status("open")
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|t| t.issue_type == "review" && t.project_id == released.project_id)
+        .collect();
+    assert!(
+        open_reviews.is_empty(),
+        "no new open human-review remediation must exist after the hold is consumed"
     );
 }
 
@@ -1817,6 +2102,11 @@ async fn review_hold_release_lifecycle_proves_dispatch_readiness_recovery() {
     let task = repo.get(&task.id).await.unwrap().unwrap();
     assert_eq!(task.intervention_count, MAX_PLANNER_INTERVENTIONS);
 
+    // uv3p Part B: seed two distinct-model pre-submission terminations so the
+    // attempted-remediation gate reaches its bound and the loop-guard second
+    // strike parks (the behavior the rest of this lifecycle test exercises).
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
+
     // Route to the loop guard second-strike path (the actual pdn6 hold mechanism).
     let handled = actor
         .route_loop_guard_planner_intervention(
@@ -2116,6 +2406,11 @@ async fn third_provider_failure_without_progress_routes_to_planner() {
     repo.reset_intervention_counters(&task.id).await.unwrap();
     let task = repo.get(&task.id).await.unwrap().unwrap();
     assert_eq!(task.intervention_count, MAX_PLANNER_INTERVENTIONS);
+
+    // uv3p Part B: the three provider-error failures are pre-submission
+    // terminations; seed two of them as distinct-model sessions so the park
+    // rung's attempted-remediation bound is reached and the task parks.
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
 
     // Seed stale backoff state to prove the escalation clears it.
     actor
@@ -2836,6 +3131,10 @@ async fn mixed_reopen_ledger_park_uses_quality_count_and_emits_telemetry_breakdo
         superseded_in_ledger, 1,
         "ledger contains one superseded row"
     );
+
+    // uv3p Part B: park requires an attempted remediation; seed two
+    // distinct-model pre-submission terminations so the bound is reached.
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
 
     // The park guard uses the DB-backed quality count, not the in-memory raw
     // counter, so it fires even though the raw count is strictly above the

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -1276,6 +1276,85 @@ async fn make_task_with_reopen_count(
     task
 }
 
+/// uv3p Part B test support: seed terminated post-intervention worker sessions,
+/// one per model in `models`, so the attempted-remediation park gate sees the
+/// remediation was tried (and, at `NON_ATTEMPT_PARK_THRESHOLD` distinct models,
+/// parks). Each session is `failed` with an `ended_at` — a genuine
+/// pre-submission termination with no `work_submitted` logged. A short real
+/// sleep before creation guarantees `started_at` sorts strictly after the
+/// `last_intervention_at`/`human_review_resolved_at` floor (millisecond-format
+/// timestamps), matching the production ordering where a post-intervention
+/// dispatch lands seconds after the intervention.
+#[allow(dead_code)]
+async fn seed_terminated_post_intervention_sessions(
+    db: &Database,
+    tx: &broadcast::Sender<DjinnEventEnvelope>,
+    task_id: &str,
+    models: &[&str],
+) {
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(tx));
+    let project_id = repo
+        .get(task_id)
+        .await
+        .unwrap()
+        .expect("seed task must exist")
+        .project_id;
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(tx));
+    for model in models {
+        // Strictly after the intervention floor; the format truncates to
+        // milliseconds so a few ms of real time guarantees a greater string.
+        tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+        let session = session_repo
+            .create(CreateSessionParams {
+                project_id: &project_id,
+                task_id: Some(task_id),
+                model,
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: None,
+                pricing: None,
+                cost_basis: None,
+            })
+            .await
+            .unwrap();
+        // Terminate it pre-submission (sets ended_at + a non-completed status);
+        // no work_submitted activity is logged for it.
+        session_repo
+            .update(
+                &session.id,
+                djinn_core::models::SessionStatus::Failed,
+                0,
+                0,
+                0,
+                0,
+                None,
+            )
+            .await
+            .unwrap();
+    }
+}
+
+/// uv3p Part B: the `park_attempted_remediation_redispatch` markers recorded
+/// when the park rung declined to park and redispatched.
+#[allow(dead_code)]
+async fn park_redispatch_markers(repo: &TaskRepository, task_id: &str) -> Vec<serde_json::Value> {
+    repo.query_activity(ActivityQuery {
+        task_id: Some(task_id.to_owned()),
+        event_type: Some(PARK_REDISPATCH_MARKER.to_string()),
+        actor_role: Some("system".to_string()),
+        project_id: None,
+        from_time: None,
+        to_time: None,
+        limit: 100,
+        offset: 0,
+    })
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|e| serde_json::from_str::<serde_json::Value>(&e.payload).unwrap())
+    .collect()
+}
+
 async fn planner_intervention_markers(
     repo: &TaskRepository,
     task_id: &str,

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -263,6 +263,28 @@ pub(super) const TASK_OUTCOME_FAILED_CLOSE: &str = "failed_closed";
 /// The marker payload also stores the `quality_strikes` count for audit.
 pub(super) const PLANNER_INTERVENTION_MARKER: &str = "planner_intervention";
 
+/// uv3p Part B: activity marker recording that the human-park rung declined to
+/// park and redispatched instead (no post-intervention remediation was ever
+/// attempted, or a brand-new CI fingerprint deserved one shot). Payload carries
+/// the decision (`kind`), the fingerprint when relevant, and the non-attempt
+/// model count — an audit trail proving the fleet actually tried before a human
+/// is ever paged.
+pub(super) const PARK_REDISPATCH_MARKER: &str = "park_attempted_remediation_redispatch";
+
+/// uv3p Part B: number of CONSECUTIVE post-intervention sessions that terminated
+/// pre-submission (across DIFFERENT models) after which the human-park rung
+/// stops rotating and finally parks. Below this bound the coordinator redispatches
+/// with forced model rotation instead of parking; at/above it the task parks
+/// with a reason that names the terminated sessions/models rather than the
+/// templated "same acceptance criteria kept failing" text.
+///
+/// Rationale for `2`: the first non-attempt termination (loop-guard trip, infra
+/// death, handshake failure) is evidence about that one session/model, not about
+/// the task — a single rotation to a different model is cheap and frequently
+/// succeeds (kibj would have). Two distinct models both terminating pre-submission
+/// is a genuine signal the remediation itself is stuck, so park for a human.
+pub(super) const NON_ATTEMPT_PARK_THRESHOLD: usize = 2;
+
 /// Number of consecutive worker re-attempts (internal review rejections /
 /// reopens) after which the coordinator stops re-dispatching the worker and
 /// instead routes the task to a Planner intervention pass that DECIDES how to

--- a/server/crates/djinn-db/migrations_postgres/93_human_review_resolved_at.sql
+++ b/server/crates/djinn-db/migrations_postgres/93_human_review_resolved_at.sql
@@ -1,0 +1,15 @@
+-- uv3p Part C: consumed-hold marker.
+--
+-- When a human closes a `human-review-hold` remediation task, the source task
+-- it was holding is released back to `open`. Before this marker the park
+-- evaluator re-fired immediately on the still-unchanged strike/intervention
+-- counters and spawned a duplicate hold within ~150ms (the ygj0 incident).
+--
+-- `human_review_resolved_at` records the UTC instant the hold was resolved.
+-- The strike accounting the park guard reads (`quality_reopen_count`) ignores
+-- reopen evidence that predates this marker, so only NEW post-release strikes
+-- can re-park the task. Same ISO-8601 text format as the other timestamp
+-- columns (`last_intervention_at`, `activity_log.created_at`) so lexical
+-- comparison is correct.
+ALTER TABLE tasks
+    ADD COLUMN IF NOT EXISTS human_review_resolved_at VARCHAR(64);

--- a/server/crates/djinn-db/src/repositories/task/activity.rs
+++ b/server/crates/djinn-db/src/repositories/task/activity.rs
@@ -171,6 +171,14 @@ impl TaskRepository {
     /// Reopen-like transitions are identified heuristically from the
     /// activity payload: `to_status = 'open'` from one of the
     /// review/PR/closed source states.
+    ///
+    /// uv3p Part C: reopen events whose `activity_log.created_at` predates the
+    /// task's `human_review_resolved_at` marker are excluded. When a human
+    /// closes a human-review hold the strike ledger it just adjudicated must
+    /// read as consumed — only strikes accrued AFTER the release count, so the
+    /// park evaluator cannot re-park on the stale pre-release counters (ygj0).
+    /// The subquery is NULL for tasks that were never held, in which case every
+    /// reopen counts (`created_at > NULL` is NULL → the OR keeps the row).
     pub async fn quality_reopen_count(&self, task_id: &str) -> Result<i64> {
         self.db.ensure_initialized().await?;
         // NOTE: dynamic SQL with JSONB operators — compile-time check not possible.
@@ -181,12 +189,60 @@ impl TaskRepository {
                AND archived = FALSE
                AND (payload ->> 'to_status') = 'open'
                AND (payload ->> 'from_status') IN ('in_task_review', 'pr_draft', 'pr_review', 'closed', 'approved')
-               AND COALESCE(payload ->> 'reopen_class', 'other') IN ('review_rejected', 'merge_queue_failed', 'other')"#,
+               AND COALESCE(payload ->> 'reopen_class', 'other') IN ('review_rejected', 'merge_queue_failed', 'other')
+               AND (
+                   (SELECT t.human_review_resolved_at FROM tasks t WHERE t.id = $1) IS NULL
+                   OR created_at > (SELECT t.human_review_resolved_at FROM tasks t WHERE t.id = $1)
+               )"#,
         )
         .bind(task_id)
         .fetch_one(self.db.pool())
         .await?;
         Ok(count)
+    }
+
+    /// uv3p Part C: read the consumed-hold marker for a task.
+    ///
+    /// `Some(ts)` is the UTC instant the most recent human-review hold on this
+    /// task was resolved (see [`Self::mark_human_review_resolved`]); `None` when
+    /// the task has never been held. The park guard uses it as the floor for
+    /// "post-release" evidence so it never re-parks on strikes a human already
+    /// adjudicated.
+    pub async fn human_review_resolved_at(&self, task_id: &str) -> Result<Option<String>> {
+        self.db.ensure_initialized().await?;
+        let ts = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT human_review_resolved_at FROM tasks WHERE id = $1",
+        )
+        .bind(task_id)
+        .fetch_optional(self.db.pool())
+        .await?
+        .flatten();
+        Ok(ts)
+    }
+
+    /// uv3p Part C: stamp the consumed-hold marker on every source task that
+    /// `hold_task_id` was blocking.
+    ///
+    /// Called when a `human-review-hold` remediation task closes. Records the
+    /// resolution instant so `quality_reopen_count` (and the park guard's
+    /// evidence floor) discount every strike accrued before the human released
+    /// the source — the ygj0 duplicate-hold fix. Returns the number of source
+    /// tasks stamped. Idempotent by construction: re-closing writes a later
+    /// timestamp, never a duplicate hold.
+    pub async fn mark_human_review_resolved(&self, hold_task_id: &str) -> Result<u64> {
+        self.db.ensure_initialized().await?;
+        let result = sqlx::query(
+            r#"UPDATE tasks SET
+                    human_review_resolved_at =
+                        to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+                    updated_at =
+                        to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                 WHERE id IN (SELECT task_id FROM blockers WHERE blocking_task_id = $1)"#,
+        )
+        .bind(hold_task_id)
+        .execute(self.db.pool())
+        .await?;
+        Ok(result.rows_affected())
     }
 
     /// Return the most recent reopen ledger entries for a task.

--- a/server/crates/djinn-db/src/repositories/task/status.rs
+++ b/server/crates/djinn-db/src/repositories/task/status.rs
@@ -185,6 +185,20 @@ impl TaskRepository {
         // Blocker resolution: when a task reaches post-merge/closed states, notify any tasks
         // it was blocking that are now fully unblocked, so coordinators can dispatch them.
         if task.status == "closed" {
+            // uv3p Part C: closing a human-review hold stamps a consumed-hold
+            // marker on the source task(s) it was holding BEFORE they are
+            // revived, so the park evaluator that runs on the very next
+            // dispatch tick discounts the pre-release strike ledger and cannot
+            // spawn a duplicate hold on unchanged counters (ygj0).
+            if task.labels.contains("human-review-hold")
+                && let Err(e) = self.mark_human_review_resolved(&task.id).await
+            {
+                tracing::warn!(
+                    hold_task_id = %task.id,
+                    error = %e,
+                    "failed to stamp human_review_resolved_at on held source(s)"
+                );
+            }
             self.emit_unblocked_tasks(&task.id).await?;
         }
 


### PR DESCRIPTION
Implements Parts **B** and **C** of proposal `uv3p` (builds on #1538 plan-lane routing).

## AC mapping

| AC | Where |
| --- | --- |
| **B/AC2** human-park rung checks for a post-intervention `submit_work`; when none, redispatch with forced model rotation instead of parking (cgcl/7fj3/nlus) | `dispatch/retry.rs` `route_planner_intervention` second-strike branch + `post_intervention_history`; forced rotation in `dispatch/task_dispatch.rs`. Test `park_rung_redispatches_when_no_post_intervention_submission` |
| **B/AC3** first-occurrence CI `failure_fingerprint` dispatches one remediation before any park (8y3q) | `route_planner_intervention` `park_fingerprint_seen` / `record_park_redispatch_marker`. Test `park_rung_dispatches_one_remediation_on_first_occurrence_fingerprint` |
| **B/AC4** after N=2 non-attempt terminations across models, park with a reason naming the sessions/models, never the templated text | `NON_ATTEMPT_PARK_THRESHOLD` (types.rs) + `compute_park_reason`. Test `park_rung_parks_after_two_non_attempts_with_truthful_reason` |
| **C/AC5** closing a hold records a consumed-hold marker; park evaluator ignores pre-release evidence; no duplicate hold | migration `93_human_review_resolved_at.sql`; `mark_human_review_resolved` stamped in `task/status.rs` transition-close; marker-aware `quality_reopen_count` in `task/activity.rs`. Test `closing_hold_records_consumed_marker_and_prevents_duplicate_hold` |
| **AC6** loop-guard routing + infra-death non-counting unchanged except final park decision | only the second-strike branch changed; existing loop-guard/provider-failure tests pass (updated to seed the now-required attempted remediation) |

## Design notes
- Evidence floor = `max(last_intervention_at, human_review_resolved_at)`; post-intervention history derived from durable sessions + `work_submitted` activity — no new per-task state beyond the Part C marker.
- Forced model rotation composes with #1538's plan-lane routing (drops pre-submission-terminated models, degrades to the unfiltered list when exclusion would empty it).
- `escalate_ci_failure_and_park` (CI-cycle park) is intentionally unchanged — a CI failure means the worker already reached `submit_work`.

## Migration
`93_human_review_resolved_at.sql` — `ALTER TABLE tasks ADD COLUMN human_review_resolved_at VARCHAR(64)`. `.sqlx` offline cache unchanged (all new/modified SQL uses runtime queries; verified 413/413 identical).

## Verification (Postgres :5436, SQLX_OFFLINE=true)
- `cargo fmt` (my crates) clean; pre-existing `djinn-k8s/src/lib.rs` drift is on main, untouched here.
- `cargo clippy -p djinn-coordinator -p djinn-db --all-targets --all-features -- -D warnings` → exit 0.
- `cargo test -p djinn-coordinator --all-features` → 772 passed.
- `cargo test -p djinn-db --lib --all-features` → 649 passed.
- Migration applies cleanly (93/93).