### PR TITLE
gn1e: Migrate safe internal slot helper consumers (Wave 3)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "djinn-graph",
  "djinn-provider",
  "djinn-runtime",
+ "djinn-slot",
  "djinn-stack",
  "djinn-supervisor",
  "djinn-telemetry",

--- a/server/crates/djinn-agent-worker/Cargo.toml
+++ b/server/crates/djinn-agent-worker/Cargo.toml
@@ -19,6 +19,7 @@ djinn-db = { path = "../djinn-db" }
 djinn-graph = { path = "../djinn-graph" }
 djinn-provider = { path = "../djinn-provider" }
 djinn-runtime = { path = "../djinn-runtime" }
+djinn-slot = { path = "../djinn-slot" }
 djinn-stack = { path = "../djinn-stack" }
 djinn-supervisor = { path = "../djinn-supervisor" }
 djinn-telemetry = { path = "../djinn-telemetry" }

--- a/server/crates/djinn-agent-worker/src/worker_services.rs
+++ b/server/crates/djinn-agent-worker/src/worker_services.rs
@@ -38,10 +38,10 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use djinn_agent::actors::slot::helpers::{
-    OAuthConfigWire, auth_method_for_provider, capabilities_for_provider, default_base_url,
-    format_family_for_provider, parse_model_id,
-};
+// `OAuthConfigWire` is a host-specific wire type (worker Secret serialization) that
+// stays in `djinn-agent`; the pure provider-identification helpers are consumed from
+// their canonical home in `djinn-slot`.
+use djinn_agent::actors::slot::helpers::OAuthConfigWire;
 use djinn_agent::context::AgentContext;
 use djinn_agent::supervisor::worker_execute_stage;
 use djinn_core::models::{SessionRecord, SessionStatus, Task, TaskRunStatus};
@@ -51,6 +51,10 @@ use djinn_provider::provider::{
     default_reasoning_effort_for_model,
 };
 use djinn_runtime::{ResolvedCredentials, RoleKind, SerializableCredential};
+use djinn_slot::helpers::{
+    auth_method_for_provider, capabilities_for_provider, default_base_url,
+    format_family_for_provider, parse_model_id,
+};
 use djinn_stack::environment::EnvironmentConfig;
 use djinn_supervisor::services::{
     SerializableCreateSessionParams, SerializableCreateTaskRunParams, SerializableDjinnEvent,

--- a/server/docs/slot-cutover/wave3-reduction-ledger.md
+++ b/server/docs/slot-cutover/wave3-reduction-ledger.md
@@ -859,3 +859,89 @@ Environment limitations:
 - `OPENSSL_NO_VENDOR=1` is required because the container lacks `make` for vendored OpenSSL.
 
 ---
+
+## Slice: gn1e — migrate safe internal slot helper consumers (Wave 3 post-spike, final)
+
+Task: `019f26bd-bd95-7833-bf03-0efd4b07e5a2` (gn1e) — Migrate safe internal/workspace consumers away from unnecessary `djinn-agent::actors::slot` helper imports to canonical `djinn-slot` imports where compile-safe, preserving all public compatibility shims, and record the final measured state.
+
+> **AC note.** The planner formally rescoped this task on 2026-07-04 (`intervention_count=1`). The original hard `−150 net lines relative to post-6ad0 baseline` gate was ruled *invalid* for this final cleanup slice: parallel `main` growth in the scoped trees offset honest reductions, and the remaining agent-side code is functional host wiring that cannot shrink without deleting behavior or narrowing the public API. This slice therefore measures the exact delta, reconciles the ledger/plan to reality, and does **not** chase the superseded numeric target.
+
+### Line-count proof (three scoped commands)
+
+```sh
+find server/crates/djinn-agent/src/actors/slot -name '*.rs' -type f -print0 | xargs -0 cat | wc -l
+find server/crates/djinn-slot/src -name '*.rs' -type f -print0 | xargs -0 cat | wc -l
+find server/crates/djinn-agent/src/actors/slot server/crates/djinn-slot/src -name '*.rs' -type f -print0 | xargs -0 cat | wc -l
+```
+
+Documented post-`6ad0` baseline (from the `6ad0` slice above):
+
+| Tree | Post-6ad0 baseline |
+|---|---:|
+| `server/crates/djinn-agent/src/actors/slot` | 7,285 |
+| `server/crates/djinn-slot/src` | 30,028 |
+| **Combined** | **37,313** |
+
+gn1e starting point (this task's merge-base = current `origin/main`, measured verbatim):
+
+| Tree | Count |
+|---|---:|
+| `server/crates/djinn-agent/src/actors/slot` | 7,463 |
+| `server/crates/djinn-slot/src` | 30,281 |
+| **Combined** | **37,744** |
+
+After the gn1e slice (measured verbatim on this branch HEAD):
+
+| Tree | Count | Delta vs gn1e start | Delta vs post-6ad0 baseline |
+|---|---:|---:|---:|
+| `server/crates/djinn-agent/src/actors/slot` | **7,463** | **0** | **+178** |
+| `server/crates/djinn-slot/src` | **30,281** | **0** | **+253** |
+| **Combined** | **37,744** | **0** | **+431** |
+
+The scoped combined count is unchanged by this slice, and is **+431 above** the post-6ad0 baseline. That `+431` is entirely `main` growth in the two scoped trees between the `6ad0` merge and this task's merge-base — **not** a regression introduced here. The migration performed by this slice lands in `server/crates/djinn-agent-worker/`, which is deliberately **outside** the two scoped count trees, so honest consumer migration cannot and does not move the scoped raw count. This is exactly the structural mismatch the planner cited when invalidating the `−150` gate.
+
+### What changed (migration)
+
+- **`server/crates/djinn-agent-worker/src/worker_services.rs`** — migrated the five pure provider-identification helpers (`auth_method_for_provider`, `capabilities_for_provider`, `default_base_url`, `format_family_for_provider`, `parse_model_id`) from the re-export facade `djinn_agent::actors::slot::helpers::{…}` to their canonical home `djinn_slot::helpers::{…}`. The host-specific wire type `OAuthConfigWire` (worker Secret serialization) stays imported from `djinn_agent`.
+- **`server/crates/djinn-agent-worker/Cargo.toml`** — added `djinn-slot = { path = "../djinn-slot" }`. `djinn-slot` was already transitively present via `djinn-agent`; the direct dependency lets the worker consume the pure helpers from their canonical crate.
+
+### Consumers intentionally NOT migrated (rationale / remaining shims)
+
+- **`server/crates/djinn-control-plane/tests/execution_tools.rs`** — imports agent-local slot-actor types (`ModelSlotConfig`, `SlotFactory`, `SlotHandle`, `SlotPoolConfig`, `SlotPoolHandle`, `TestLifecycleRunner`). These live in the `djinn-agent` actor system, not in `djinn-slot`, and `djinn-control-plane` carries no `djinn-slot` dependency. Not migratable without relocating the actor system — out of scope.
+- **`server/crates/djinn-agent/src/supervisor_impl/stage.rs`** and **`server/crates/djinn-agent/src/direct_services.rs`** — their pure-helper references (`default_base_url`, …) already resolve to the canonical `djinn-slot` functions through the agent facade's `pub use djinn_slot::helpers::provider_resolution::{…}` re-export, so repointing the import path would be pure churn with zero behavioral or line effect. Their remaining helper calls (`load_task`, `conflict_context_for_dispatch`, `build_provider_from_resolved`, `build_telemetry_meta_with_attribution`, `resolved_needs_base_url`, and the `lifecycle::*` / `reply_loop::*` types) are agent-local: they are either `pub(crate)`-only in `djinn-slot`, or take the agent-owned `ResolvedModelCredential` type, or belong to the agent-only actor lifecycle. They correctly stay on the facade.
+- **`ProviderCredential` consolidation — explicitly rejected.** `djinn_slot::helpers::ProviderCredential` is structurally identical to the agent-local enum but lacks the host-specific `to_serializable()` inherent method (it depends on the agent-local `OAuthConfigWire`). Re-exporting the `djinn-slot` type in place of the agent enum would remove a public inherent method from `djinn_agent::actors::slot::helpers::ProviderCredential` — a violation of this task's safety boundary (no removing/narrowing public `djinn_agent::actors::slot` symbols) and precisely the metric-gaming relocation the planner forbade. Left as-is.
+
+### Public compatibility preservation
+
+No public `djinn_agent::actors::slot` symbol was removed, renamed, relocated, visibility-narrowed, or signature-changed. This slice edits only an external consumer's import path plus a `Cargo.toml` dependency line; `slot/mod.rs`, `helpers/mod.rs`, and all `pub`/`pub use` exports are byte-for-byte identical to `origin/main`.
+
+### Cumulative Wave 3 post-spike summary (final, measured)
+
+| Metric | Value |
+|---|---:|
+| Original ttlg / Wave 3 baseline | **45,312** |
+| Final combined count (this branch HEAD) | **37,744** |
+| **Total reduction from 45,312** | **7,568** |
+| Raw target | **≤ 30,312** |
+| **Remaining shortfall to 30,312** | **7,432** |
+
+The remaining 37,744 combined lines are `djinn-slot/src` (30,281 — the canonical extraction destination) plus `djinn-agent/src/actors/slot` (7,463 — host-only `AgentContext`→`SlotContext` adapter/lifecycle wiring, actor plumbing, and test infrastructure). Neither block contains removable duplication reachable under the non-destructive / no-public-API-removal boundary, so the raw `≤ 30,312` target remains structurally unmet by honest cleanup. See the Wave 4 plan for the next-planner recommendation.
+
+### Validation
+
+All from `server/`, `SQLX_OFFLINE=true OPENSSL_NO_VENDOR=1`:
+
+```sh
+cargo check   -p djinn-agent-worker                                  # clean
+cargo clippy  -p djinn-agent-worker --all-targets --all-features -- -D warnings
+cargo fmt     --check -p djinn-agent-worker                          # clean
+cargo test    -p djinn-agent-worker --bins -- worker_services        # 4 passed / 0 failed
+cargo test    -p djinn-slot --lib -- helpers::provider_resolution    # 5 passed / 0 failed
+```
+
+- `cargo check` / `cargo test`: clean; `worker_services` 4/4 pass and `djinn-slot` `provider_resolution` 5/5 pass with the migrated imports.
+- `cargo clippy -D warnings`: the only findings are two **pre-existing** `clippy::needless_borrow` lints at `djinn-agent-worker/src/main.rs:1838` (identical on `origin/main`, a file this slice does not touch). The touched file `worker_services.rs` is clippy-clean.
+- `cargo fmt --check`: clean after formatting the new import block.
+- Environment limitation: DB-backed tests still require `djinn_test_template`; none were disabled or weakened.
+
+---

--- a/server/docs/slot-cutover/wave4-host-contract-reduction-plan.md
+++ b/server/docs/slot-cutover/wave4-host-contract-reduction-plan.md
@@ -30,11 +30,11 @@ Outputs:
 |---|---|
 | Original combined baseline (q7y6 / abi6 proof) | **45,312** |
 | Required target (≤ 30,312) | **30,312** |
-| Current combined count | **37,731** |
-| Reduction so far | **7,581** lines (45,312 − 37,731) |
-| Required remaining reduction | **7,419** lines (37,731 − 30,312) |
+| Current combined count (gn1e final — see §8) | **37,744** |
+| Reduction so far | **7,568** lines (45,312 − 37,744) |
+| Required remaining reduction | **7,432** lines (37,744 − 30,312) |
 
-The 15,000-line reduction target is **not met**. The remaining shortfall is **7,419 lines**.
+The 15,000-line reduction target is **not met**. The remaining shortfall is **7,432 lines**. (The §1 table above is the Wave-4-planning-time snapshot of **37,731**; the current combined count of **37,744** is the gn1e-final measurement — the +13 is `main` growth in the scoped trees since that snapshot. See §8 for the final measured state.)
 
 ## 2. Largest remaining files
 
@@ -142,7 +142,7 @@ Any future Wave 4 cleanup must preserve the following known consumers (identifie
 | Consumer | Symbols / paths used | Why protected |
 |---|---|---|
 | `djinn-control-plane/tests/execution_tools.rs` | `SlotFactory`, `SlotHandle`, `SlotPoolConfig`, `SlotPoolHandle`, `TestLifecycleRunner` | External crate imports; no `djinn-slot` equivalents |
-| `djinn-agent-worker/src/worker_services.rs` | `OAuthConfigWire` and related helpers | Agent-local types; crate lacks direct `djinn-slot` dependency |
+| `djinn-agent-worker/src/worker_services.rs` | `OAuthConfigWire` (host-only wire type) | Agent-local serialization type; stays on the `djinn_agent` facade. Its five pure provider helpers were migrated to `djinn_slot::helpers` in gn1e (crate now has a direct `djinn-slot` dependency). |
 | `djinn-agent/src/supervisor_impl/stage.rs` | `build_telemetry_meta_with_attribution` | Internal caller migrated in Wave 3 |
 | `djinn-agent/src/direct_services.rs` | `build_telemetry_meta_with_attribution` | Internal caller migrated in Wave 3 |
 | `djinn-agent/src/lib.rs` | Public facade re-exports | Compatibility contract |
@@ -154,10 +154,38 @@ Any future Wave 4 cleanup must preserve the following known consumers (identifie
 |---|---|
 | Fresh scoped line counts recorded | ✅ §1 |
 | Top largest files listed | ✅ §2 |
-| 7,419-line remaining shortfall made explicit | ✅ §1.1 |
+| 7,432-line remaining shortfall made explicit | ✅ §1.1, §8 |
 | Spike conclusion that full raw target is structurally unlikely without spec reconciliation | ✅ §5 |
 | Allowed cleanup categories listed | ✅ §3 |
 | Non-solutions explicitly rejected | ✅ §4 |
+| Final measured state + next-planner recommendation | ✅ §8 |
+
+## 8. Final measured state (gn1e) and next-planner recommendation
+
+gn1e was the final serialized post-spike cleanup slice for epic `ttlg`. Its `−150 net lines` gate was formally invalidated by the planner (2026-07-04): parallel `main` growth in the scoped trees offset honest reductions, and the safety boundary forbids public-API removal, so the numeric gate was structurally unachievable. gn1e was rescoped to exact measurement + accurate ledger/plan reconciliation + safe consumer migration only.
+
+### Final measured state (this branch HEAD, three scoped commands, verbatim)
+
+| Tree | Lines |
+|---|---:|
+| `server/crates/djinn-agent/src/actors/slot` | **7,463** |
+| `server/crates/djinn-slot/src` | **30,281** |
+| **Combined** | **37,744** |
+
+| Metric | Value |
+|---|---:|
+| Original baseline | **45,312** |
+| Total reduction achieved | **7,568** (45,312 − 37,744) |
+| Raw target | **≤ 30,312** |
+| **Remaining shortfall** | **7,432** (37,744 − 30,312) |
+
+gn1e itself made **0** net change to the scoped combined count: its only code migration (`worker_services.rs` five pure helpers → `djinn_slot::helpers`, plus a `djinn-slot` dependency on `djinn-agent-worker`) lands in `djinn-agent-worker/`, which is outside the two scoped count trees by design. Honest consumer migration cannot move the scoped raw count.
+
+### Recommendation to the next planner
+
+The raw `≤ 30,312` combined-line target is **not met** (37,744; shortfall 7,432) and is **not reachable** through honest, non-destructive cleanup. The remaining mass is canonical `djinn-slot` implementation/tests (30,281 — the intended extraction destination) plus host-only `AgentContext`→`SlotContext` adapter/lifecycle/actor wiring and test infrastructure in the facade (7,463) — neither contains removable duplication under the public-compatibility boundary.
+
+**Do NOT** close epic `ttlg` as if the raw target were met, and **do NOT** spawn deletion-only follow-up tasks (they would either delete host behavior/tests or narrow the public API — both out of scope and previously rejected). **Instead, reconcile/amend the raw line-count criterion** in the governing proposal (`flpe`): replace the raw combined line-count gate with a duplicate-code / facade-thinness gate, or exclude canonical `djinn-slot` implementation/tests that were legitimately added during the extraction. Only then can the epic be closed against a criterion that reflects the actual architecture.
 
 ---
 


### PR DESCRIPTION
Final serialized post-spike cleanup slice for epic `ttlg` (task `gn1e`). The original `−150 net lines relative to post-6ad0 baseline` gate was **formally invalidated by the planner** (2026-07-04, `intervention_count=1`) as "an invalid hard numeric gate": parallel `main` growth in the scoped trees offset honest reductions, and the safety boundary forbids public-API deletion. This PR works against the **amended** acceptance criteria — exact measurement, accurate ledger/plan reconciliation, safe consumer migration, no deletion-only chase.

## Amended acceptance criteria (worked against verbatim)

1. *"Internal/workspace consumers that can safely use canonical `djinn-slot` imports are migrated, while all public `djinn_agent::actors::slot` compatibility exports remain available and any unresolved shims are documented with rationale."* — **Met.** `worker_services.rs` migrated (5 pure helpers → `djinn_slot::helpers`); `execution_tools.rs`, `stage.rs`, `direct_services.rs`, and the rejected `ProviderCredential` consolidation documented with rationale (ledger gn1e slice). All public facade exports byte-for-byte unchanged.

2. *"The combined scoped Rust line count is measured exactly relative to the post-`6ad0` baseline using the three scoped `find ... wc -l` commands, the ledger/plan record the actual delta without requiring the superseded `-150` target, and the implementation avoids public destructive changes or metric-gaming relocation."* — **Met.** Measured verbatim (below); no public destructive changes; no relocation to game the metric.

3. *"`wave3-reduction-ledger.md` contains a cumulative Wave 3 post-spike summary with accurate per-task deltas, final combined count, total reduction from 45,312, remaining shortfall to 30,312, caller-impact notes, validation outcomes, and explicit rationale for any remaining shims/shortfall."* — **Met.** New gn1e cumulative section.

4. *"`wave4-host-contract-reduction-plan.md` is updated with the final measured state and a next-planner recommendation to close the epic only if the raw target is met, otherwise reconcile/amend the raw line-count criterion rather than create deletion-only follow-ups."* — **Met.** New §8 + §1.1/§6/§7 reconciled.

5. *"Focused compile/tests covering migrated call sites, or the strongest local fallback if environment services are unavailable, complete and their outcomes are recorded in the ledger."* — **Met.** Recorded below and in the ledger.

## Measured line counts (three scoped commands, verbatim)

```sh
find server/crates/djinn-agent/src/actors/slot -name '*.rs' -type f -print0 | xargs -0 cat | wc -l   # 7463
find server/crates/djinn-slot/src -name '*.rs' -type f -print0 | xargs -0 cat | wc -l                # 30281
find server/crates/djinn-agent/src/actors/slot server/crates/djinn-slot/src -name '*.rs' -type f -print0 | xargs -0 cat | wc -l  # 37744
```

| Tree | post-6ad0 baseline | gn1e HEAD | Δ vs baseline |
|---|---:|---:|---:|
| `djinn-agent/src/actors/slot` | 7,285 | 7,463 | +178 |
| `djinn-slot/src` | 30,028 | 30,281 | +253 |
| **Combined** | **37,313** | **37,744** | **+431** |

The scoped combined delta introduced by this slice is **0** — the migration lands in `djinn-agent-worker/` (outside the scoped trees), so honest consumer migration cannot move the scoped raw count. The +431 vs post-6ad0 is entirely `main` growth in the scoped trees since the 6ad0 merge, not this task. Total reduction from 45,312 = **7,568**; remaining shortfall to ≤30,312 = **7,432**.

## Changes

- `djinn-agent-worker/src/worker_services.rs` — 5 pure helpers (`auth_method_for_provider`, `capabilities_for_provider`, `default_base_url`, `format_family_for_provider`, `parse_model_id`) migrated to `djinn_slot::helpers`; `OAuthConfigWire` (host wire type) stays on the `djinn_agent` facade.
- `djinn-agent-worker/Cargo.toml` + `Cargo.lock` — direct `djinn-slot` path dependency (already transitively present).
- `wave3-reduction-ledger.md`, `wave4-host-contract-reduction-plan.md` — reconciled to measured reality + next-planner recommendation.

**Explicitly rejected:** re-exporting `djinn_slot::ProviderCredential` (it lacks the host-specific `to_serializable()` method) — would remove a public inherent method, violating the safety boundary. Not done.

## Verification (from `server/`, `SQLX_OFFLINE=true OPENSSL_NO_VENDOR=1`)

- `cargo check -p djinn-agent-worker` — clean.
- `cargo clippy -p djinn-agent-worker --all-targets --all-features -- -D warnings` — only 2 **pre-existing** `needless_borrow` lints at `main.rs:1838` (identical on `origin/main`, untouched); the touched `worker_services.rs` is clean.
- `cargo fmt --check -p djinn-agent-worker` — clean.
- `cargo test -p djinn-agent-worker --bins -- worker_services` — **4 passed / 0 failed**.
- `cargo test -p djinn-slot --lib -- helpers::provider_resolution` — **5 passed / 0 failed**.