### PR TITLE
nlus: Compaction critical-section guard around slot reply-loop compaction

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
+++ b/server/crates/djinn-agent/src/actors/slot/reply_loop/mod.rs
@@ -199,6 +199,10 @@ pub(crate) async fn run_reply_loop(
         mcp_registry,
         allowed_for_dispatch,
     )));
+    // Shared compaction critical section for this reply-loop session; the slot
+    // reply loop enters it around every context rotation and releases it on
+    // every exit path.
+    let compaction_cs = djinn_slot::reply_loop::CompactionCriticalSection::new();
     let (result, output, tokens_in, tokens_out, cache_read, cache_write) =
         djinn_slot::reply_loop::run_reply_loop(
             djinn_slot::reply_loop::ReplyLoopContext {
@@ -219,6 +223,7 @@ pub(crate) async fn run_reply_loop(
                 active_skill_names,
                 active_mcp_server_names,
                 max_turns_override,
+                compaction_cs: &compaction_cs,
             },
             conversation,
             is_resumed_session,

--- a/server/crates/djinn-slot/src/lib.rs
+++ b/server/crates/djinn-slot/src/lib.rs
@@ -101,7 +101,7 @@ pub use supervisor_runner::run_supervisor_dispatch;
 // Re-export the public surface so callers can use
 // `djinn_slot::reply_loop::{ReplyLoopContext, run_reply_loop}`.
 
-pub use reply_loop::{ReplyLoopContext, run_reply_loop};
+pub use reply_loop::{CompactionCriticalSection, ReplyLoopContext, run_reply_loop};
 
 #[derive(Debug, Clone)]
 pub enum SlotEvent {

--- a/server/crates/djinn-slot/src/reply_loop/compaction_guard.rs
+++ b/server/crates/djinn-slot/src/reply_loop/compaction_guard.rs
@@ -1,0 +1,114 @@
+//! Internal compaction coordination primitive for the slot reply loop.
+//!
+//! Provides a scoped guard that marks a slot lifecycle as "compaction in
+//! flight" so entry/exit cleanup around context rotation is centralized and so
+//! actor/pool command routing can observe whether the reply loop is mid-rotation
+//! (a later slice consumes that signal to defer/demote work that would otherwise
+//! apply to the pre-rotation transcript). The guard is released on every exit
+//! path — success, summarizer failure, early return, or panic unwinding — via
+//! RAII `Drop`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Shared state that tracks whether a compaction critical section is active.
+///
+/// A single instance is intended to live for the lifetime of a slot/reply-loop
+/// session; the actor/pool can observe the same instance to decide whether to
+/// defer/demote commands. This is intentionally a simple boolean flag; it does
+/// not serialize concurrent callers (the reply loop itself is single-tasked).
+#[derive(Debug, Clone, Default)]
+pub struct CompactionCriticalSection {
+    active: Arc<AtomicBool>,
+}
+
+impl CompactionCriticalSection {
+    /// Create a new, released critical section.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns true if the critical section is currently entered.
+    pub fn is_compacting(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+
+    /// Enter the critical section. Panics if already entered (single-tasked
+    /// contract violation).
+    #[allow(clippy::panic)]
+    fn enter(&self) {
+        if self.active.swap(true, Ordering::AcqRel) {
+            panic!("compaction critical section entered while already active");
+        }
+    }
+
+    /// Release the critical section. Idempotent.
+    fn release(&self) {
+        self.active.store(false, Ordering::Release);
+    }
+
+    /// Acquire a scoped guard that releases the section when dropped.
+    pub fn guard(&self) -> CompactionGuard<'_> {
+        self.enter();
+        CompactionGuard { section: self }
+    }
+}
+
+/// RAII guard for the compaction critical section. The section is released when
+/// the guard is dropped, covering success, error, early-return, and panic paths.
+#[derive(Debug)]
+pub struct CompactionGuard<'a> {
+    section: &'a CompactionCriticalSection,
+}
+
+impl CompactionGuard<'_> {
+    /// Explicitly release the guard before the end of its scope by dropping it.
+    /// Equivalent to letting the guard fall out of scope; provided for call
+    /// sites that want to make the release point explicit.
+    pub fn release(self) {
+        // Dropping `self` here runs the `Drop` impl, which releases the section.
+    }
+}
+
+impl Drop for CompactionGuard<'_> {
+    fn drop(&mut self) {
+        self.section.release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_releases_on_explicit_release() {
+        let section = CompactionCriticalSection::new();
+        assert!(!section.is_compacting());
+        {
+            let guard = section.guard();
+            assert!(section.is_compacting());
+            guard.release();
+            // After explicit release the section is no longer active.
+            assert!(!section.is_compacting());
+        }
+        assert!(!section.is_compacting());
+    }
+
+    #[test]
+    fn guard_releases_on_implicit_drop() {
+        let section = CompactionCriticalSection::new();
+        {
+            let _guard = section.guard();
+            assert!(section.is_compacting());
+        }
+        assert!(!section.is_compacting());
+    }
+
+    #[test]
+    #[should_panic(expected = "compaction critical section entered while already active")]
+    fn guard_panics_on_reentry() {
+        let section = CompactionCriticalSection::new();
+        let _guard1 = section.guard();
+        let _guard2 = section.guard(); // should panic: single-tasked contract
+    }
+}

--- a/server/crates/djinn-slot/src/reply_loop/mod.rs
+++ b/server/crates/djinn-slot/src/reply_loop/mod.rs
@@ -10,6 +10,7 @@
 //! directly; and `djinn-agent` is never imported.
 
 pub(crate) mod budget;
+pub mod compaction_guard;
 pub mod error_handling;
 pub mod loop_guard;
 mod persistence;
@@ -17,6 +18,7 @@ mod streaming;
 mod tool_dispatch;
 mod turn;
 
+pub use compaction_guard::CompactionCriticalSection;
 pub use turn::{ReplyLoopContext, run_reply_loop};
 
 // Soft-budget tests hold `SESSION_BUDGET_ENV_LOCK` across `.await` on

--- a/server/crates/djinn-slot/src/reply_loop/tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tests.rs
@@ -297,6 +297,7 @@ impl ReplyLoopHarness {
         let worktree_path = std::path::PathBuf::from("/tmp");
         run_reply_loop(
             ReplyLoopContext {
+                compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
                 provider,
                 tools,
                 task_id: &self.task_id,
@@ -391,6 +392,7 @@ async fn proactive_compaction_fires_when_current_context_exceeds_threshold() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[],
             task_id: &task_id,
@@ -472,6 +474,7 @@ async fn no_compaction_when_sum_large_but_current_context_small() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[],
             task_id: &task_id,
@@ -598,6 +601,7 @@ async fn reactive_compaction_on_context_length_error() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[],
             task_id: &task_id,
@@ -837,6 +841,7 @@ async fn run_scripted_reply_loop_with_dispatcher(
     conv.push(Message::user("Do the task."));
     let (result, output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider,
             tools,
             task_id: &task_id,
@@ -1011,6 +1016,7 @@ async fn tool_choice_required_for_supported_providers() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
             task_id: &task_id,
@@ -1128,6 +1134,7 @@ async fn max_step_cap_injects_wind_down_and_ends_gracefully() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
             task_id: &task_id,
@@ -1231,6 +1238,7 @@ async fn max_step_wind_down_ignored_falls_back_to_hard_error() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
             task_id: &task_id,
@@ -1803,6 +1811,7 @@ async fn soft_budget_threshold_triggers_one_shot_converge_reminder() {
     conv.push(Message::user("Do the task."));
     let (result, _output, _tokens_in, _tokens_out, _cr, _cw) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
             task_id: &task_id,
@@ -2227,6 +2236,7 @@ async fn dangling_tool_call_is_sanitized_before_reaching_provider() {
     });
     let (result, _output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &tools,
             task_id: &task_id,
@@ -2355,6 +2365,7 @@ async fn first_no_progress_submit_intercepted_returns_corrective_and_continues()
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",
@@ -2437,6 +2448,7 @@ async fn missing_rejected_fingerprint_skips_comparison_and_allows_finalize() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",
@@ -2509,6 +2521,7 @@ async fn non_worker_role_bypasses_guard() {
     conv.push(Message::user("Plan the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",
@@ -2576,6 +2589,7 @@ async fn different_fingerprint_allows_finalize() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",
@@ -2672,6 +2686,7 @@ async fn empty_worktree_skips_guard_and_allows_finalize() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",
@@ -2768,6 +2783,7 @@ async fn second_strike_no_progress_submission_settles_session() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",
@@ -2981,6 +2997,7 @@ async fn gs37_no_edit_submit_after_rejection_keeps_one_quality_strike_and_prompt
     conv.push(Message::user("Do the task."));
     let (_result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",
@@ -3141,6 +3158,7 @@ async fn changed_diff_fingerprint_does_not_trigger_no_progress_submission() {
     conv.push(Message::user("Do the task."));
     let (result, output, _, _, _, _) = run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider: &provider,
             tools: &[serde_json::json!({
                 "type": "function",

--- a/server/crates/djinn-slot/src/reply_loop/turn.rs
+++ b/server/crates/djinn-slot/src/reply_loop/turn.rs
@@ -24,6 +24,7 @@ use crate::lifecycle::teardown::settle_no_progress_submission;
 use super::budget::{
     SessionBudgetPolicy, hard_budget_threshold_exceeded, soft_budget_threshold_exceeded,
 };
+use super::compaction_guard::CompactionCriticalSection;
 use super::error_handling::{
     BudgetWindDownIgnored, MAX_COMPACTION_RETRIES, empty_start_streak_feeds_breaker,
     empty_turn_backoff, empty_turn_is_reasoning_only, is_context_length_error,
@@ -440,6 +441,13 @@ pub struct ReplyLoopContext<'a> {
     pub active_skill_names: &'a [String],
     pub active_mcp_server_names: &'a [String],
     pub max_turns_override: Option<u32>,
+    /// Shared compaction critical section for this slot/reply-loop session.
+    ///
+    /// The reply loop enters it around every `compact_conversation` call and
+    /// releases it on every exit path. Actor/pool command routing can observe
+    /// the same instance to decide whether to defer or demote work that would
+    /// otherwise apply to the pre-rotation transcript.
+    pub compaction_cs: &'a CompactionCriticalSection,
 }
 
 /// Djinn-native reply loop. Drives an `LlmProvider` stream, dispatches tool
@@ -468,6 +476,7 @@ pub async fn run_reply_loop(
         active_skill_names,
         active_mcp_server_names,
         max_turns_override,
+        compaction_cs,
     } = ctx;
     let tool_dispatcher = match slot_ctx.tool_dispatcher.as_ref() {
         Some(d) => d.as_ref(),
@@ -734,29 +743,17 @@ pub async fn run_reply_loop(
                     if let Some(llm) = otel_llm {
                         llm.end_error("context_length_exceeded");
                     }
-                    let boundary_repo = SessionCompactionBoundaryRepository::new(slot_ctx.db.clone());
-                    let boundary_id = record_compaction_started(
-                        &boundary_repo, session_id, conversation,
-                    ).await;
-                    let compacted = compact_conversation(
-                        provider, conversation, session_id, task_id,
-                        CompactionContext::MidSession(role_name.to_string()),
+                    let compacted = compact_conversation_in_critical_section(
+                        provider,
+                        conversation,
+                        session_id,
+                        task_id,
+                        role_name,
                         context_window,
-                    ).await;
-                    if compacted {
-                        let summary = conversation
-                            .messages
-                            .iter()
-                            .find(|m| {
-                                m.role == Role::User
-                                    && m.text_content().contains(COMPACTION_SUMMARY_END_MARKER)
-                            })
-                            .map(|m| strip_compaction_markers(&m.text_content()))
-                            .unwrap_or_default();
-                        complete_compaction_boundary(
-                            &boundary_repo, boundary_id.as_deref(), conversation, &summary,
-                        ).await;
-                    }
+                        compaction_cs,
+                        slot_ctx,
+                    )
+                    .await;
                     if compacted {
                         total_tokens_in = 0;
                         total_tokens_out = 0;
@@ -873,29 +870,17 @@ pub async fn run_reply_loop(
                     compaction_attempts,
                     "ReplyLoop: context_length_exceeded mid-stream; compacting reactively"
                 );
-                let boundary_repo = SessionCompactionBoundaryRepository::new(slot_ctx.db.clone());
-                let boundary_id = record_compaction_started(
-                    &boundary_repo, session_id, conversation,
-                ).await;
-                let compacted = compact_conversation(
-                    provider, conversation, session_id, task_id,
-                    CompactionContext::MidSession(role_name.to_string()),
+                let compacted = compact_conversation_in_critical_section(
+                    provider,
+                    conversation,
+                    session_id,
+                    task_id,
+                    role_name,
                     context_window,
-                ).await;
-                if compacted {
-                    let summary = conversation
-                        .messages
-                        .iter()
-                        .find(|m| {
-                            m.role == Role::User
-                                && m.text_content().contains(COMPACTION_SUMMARY_END_MARKER)
-                        })
-                        .map(|m| strip_compaction_markers(&m.text_content()))
-                        .unwrap_or_default();
-                    complete_compaction_boundary(
-                        &boundary_repo, boundary_id.as_deref(), conversation, &summary,
-                    ).await;
-                }
+                    compaction_cs,
+                    slot_ctx,
+                )
+                .await;
                 if compacted {
                     total_tokens_in = 0;
                     total_tokens_out = 0;
@@ -1069,33 +1054,17 @@ pub async fn run_reply_loop(
                     usage_pct = current_context_tokens as f64 / context_window as f64,
                     "ReplyLoop: compaction threshold reached, compacting"
                 );
-                let boundary_repo = SessionCompactionBoundaryRepository::new(slot_ctx.db.clone());
-                let boundary_id = record_compaction_started(
-                    &boundary_repo, session_id, conversation,
-                ).await;
-                let compacted = compact_conversation(
+                let compacted = compact_conversation_in_critical_section(
                     provider,
                     conversation,
                     session_id,
                     task_id,
-                    CompactionContext::MidSession(role_name.to_string()),
+                    role_name,
                     context_window,
+                    compaction_cs,
+                    slot_ctx,
                 )
                 .await;
-                if compacted {
-                    let summary = conversation
-                        .messages
-                        .iter()
-                        .find(|m| {
-                            m.role == Role::User
-                                && m.text_content().contains(COMPACTION_SUMMARY_END_MARKER)
-                        })
-                        .map(|m| strip_compaction_markers(&m.text_content()))
-                        .unwrap_or_default();
-                    complete_compaction_boundary(
-                        &boundary_repo, boundary_id.as_deref(), conversation, &summary,
-                    ).await;
-                }
                 if compacted {
                     total_tokens_in = 0;
                     total_tokens_out = 0;
@@ -1444,6 +1413,63 @@ pub async fn run_reply_loop(
     )
 }
 
+/// Run `compact_conversation` inside the shared compaction critical section.
+///
+/// Enters the critical section (via the RAII [`CompactionGuard`]), records a
+/// `Started` boundary, invokes the compaction, and — only when compaction is
+/// accepted — completes the boundary. The guard releases the critical section
+/// on every exit path (success, summarizer failure, early return, panic
+/// unwinding); retry/backoff decisions stay with the caller so this helper does
+/// not alter loop semantics.
+#[allow(clippy::too_many_arguments)]
+async fn compact_conversation_in_critical_section(
+    provider: &dyn LlmProvider,
+    conversation: &mut Conversation,
+    session_id: &str,
+    task_id: &str,
+    role_name: &str,
+    context_window: i64,
+    compaction_cs: &CompactionCriticalSection,
+    slot_ctx: &SlotContext,
+) -> bool {
+    // Held for the whole record -> compact -> complete sequence; `Drop` releases
+    // the section on any exit path below.
+    let _guard = compaction_cs.guard();
+
+    let boundary_repo = SessionCompactionBoundaryRepository::new(slot_ctx.db.clone());
+    let boundary_id = record_compaction_started(&boundary_repo, session_id, conversation).await;
+
+    let compacted = compact_conversation(
+        provider,
+        conversation,
+        session_id,
+        task_id,
+        CompactionContext::MidSession(role_name.to_string()),
+        context_window,
+    )
+    .await;
+
+    if compacted {
+        let summary = conversation
+            .messages
+            .iter()
+            .find(|m| {
+                m.role == Role::User && m.text_content().contains(COMPACTION_SUMMARY_END_MARKER)
+            })
+            .map(|m| strip_compaction_markers(&m.text_content()))
+            .unwrap_or_default();
+        complete_compaction_boundary(
+            &boundary_repo,
+            boundary_id.as_deref(),
+            conversation,
+            &summary,
+        )
+        .await;
+    }
+
+    compacted
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1475,5 +1501,206 @@ mod tests {
                 .expect("Codex empty-turn error must carry EmptyCompletion");
             assert_eq!(*typed, ProviderError::EmptyCompletion);
         }
+    }
+
+    // ---- compaction critical-section guard (nlus) -------------------------
+    //
+    // These tests exercise the real `compact_conversation_in_critical_section`
+    // helper (not a hand-rolled mimic) and assert the shared critical section is
+    // released after every outcome of the underlying compaction: a successful
+    // compaction, a benign no-op that returns false, a summarizer error, and an
+    // abnormal early exit (a summarizer panic that unwinds through the helper).
+
+    use crate::test_helpers::{
+        FailingProvider, FakeProvider, agent_context_from_db, create_test_db,
+    };
+    use djinn_provider::provider::StreamEvent;
+
+    fn guard_test_slot_ctx() -> SlotContext {
+        agent_context_from_db(create_test_db(), tokio_util::sync::CancellationToken::new())
+    }
+
+    /// A conversation whose old tool-result turns can be micro-compacted, so
+    /// `compact_conversation` reports a real (`true`) compaction without ever
+    /// invoking the summarizer provider.
+    fn micro_compactable_conversation(num_turns: usize) -> Conversation {
+        let mut conversation = Conversation::new();
+        conversation.push(Message::system("You are a coding agent."));
+        conversation.push(Message::user("Do the task."));
+        for i in 0..num_turns {
+            let call_id = format!("call_{i}");
+            conversation.push(Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: call_id.clone(),
+                    name: "bash".into(),
+                    input: serde_json::json!({ "command": format!("echo turn {i}") }),
+                }],
+                metadata: None,
+            });
+            conversation.push(Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: call_id,
+                    content: vec![ContentBlock::text(format!(
+                        "verbose tool result from turn {i}: {}",
+                        "x".repeat(400)
+                    ))],
+                    is_error: false,
+                }],
+                metadata: None,
+            });
+            conversation.push(Message::assistant(format!("Processed turn {i}.")));
+        }
+        conversation
+    }
+
+    fn tiny_conversation() -> Conversation {
+        let mut conversation = Conversation::new();
+        conversation.push(Message::system("You are a worker."));
+        conversation.push(Message::user("Do the task."));
+        conversation
+    }
+
+    /// Successful compaction: the guard releases and the helper returns `true`.
+    #[tokio::test]
+    async fn helper_releases_guard_on_successful_compaction() {
+        let section = CompactionCriticalSection::new();
+        // A provider that would panic if the summarizer were ever called — this
+        // path succeeds via micro-compaction, before any LLM round-trip.
+        let provider = FailingProvider::new("summarizer must not be called on the micro path");
+        let mut conversation = micro_compactable_conversation(12);
+        let slot_ctx = guard_test_slot_ctx();
+
+        let compacted = compact_conversation_in_critical_section(
+            &provider,
+            &mut conversation,
+            "s-success",
+            "t-success",
+            "worker",
+            1_000_000,
+            &section,
+            &slot_ctx,
+        )
+        .await;
+
+        assert!(
+            compacted,
+            "micro-compaction should report a successful compaction"
+        );
+        assert!(
+            !section.is_compacting(),
+            "guard must release after a successful compaction"
+        );
+    }
+
+    /// False / no-compaction: the summarizer yields nothing usable and the
+    /// conversation is too small to truncate, so the helper returns `false`.
+    /// Distinct from the summarizer-error case: here the provider does not error,
+    /// it simply produces empty summaries.
+    #[tokio::test]
+    async fn helper_releases_guard_when_compaction_is_a_noop() {
+        let section = CompactionCriticalSection::new();
+        // Empty summaries across every removal-percentage attempt: a benign
+        // no-op, not an error. Extra scripted turns are harmless if unused.
+        let provider = FakeProvider::script(vec![
+            vec![StreamEvent::Done],
+            vec![StreamEvent::Done],
+            vec![StreamEvent::Done],
+            vec![StreamEvent::Done],
+            vec![StreamEvent::Done],
+            vec![StreamEvent::Done],
+        ]);
+        let mut conversation = tiny_conversation();
+        let slot_ctx = guard_test_slot_ctx();
+
+        let compacted = compact_conversation_in_critical_section(
+            &provider,
+            &mut conversation,
+            "s-noop",
+            "t-noop",
+            "worker",
+            10_000,
+            &section,
+            &slot_ctx,
+        )
+        .await;
+
+        assert!(!compacted, "an empty-summary no-op yields no compaction");
+        assert!(
+            !section.is_compacting(),
+            "guard must release after a no-op compaction"
+        );
+    }
+
+    /// Summarizer error / `compact_conversation` error path: the provider stream
+    /// errors, so no compaction happens; the guard must still release. This is a
+    /// distinct test (and a distinct provider/failure mode) from the no-op case.
+    #[tokio::test]
+    async fn helper_releases_guard_on_summarizer_error() {
+        let section = CompactionCriticalSection::new();
+        let provider = FailingProvider::new("summarizer boom");
+        let mut conversation = tiny_conversation();
+        let slot_ctx = guard_test_slot_ctx();
+
+        let compacted = compact_conversation_in_critical_section(
+            &provider,
+            &mut conversation,
+            "s-error",
+            "t-error",
+            "worker",
+            10_000,
+            &section,
+            &slot_ctx,
+        )
+        .await;
+
+        assert!(!compacted, "a summarizer error yields no compaction");
+        assert!(
+            !section.is_compacting(),
+            "guard must release after a summarizer error"
+        );
+    }
+
+    /// Early / abnormal exit: the summarizer panics mid-compaction and the panic
+    /// unwinds *through* the real helper. The RAII guard must still release the
+    /// critical section during unwinding.
+    #[tokio::test]
+    async fn helper_releases_guard_on_panic_early_exit() {
+        use futures::FutureExt;
+
+        let section = CompactionCriticalSection::new();
+        // An exhausted script: the first `stream()` call panics, standing in for
+        // a summarizer that blows up mid-compaction.
+        let provider = FakeProvider::script(vec![]);
+        let mut conversation = tiny_conversation();
+        // Enough turns that micro-compaction is skipped and the provider is
+        // actually invoked (and thus panics).
+        conversation.push(Message::assistant("first"));
+        conversation.push(Message::user("second"));
+        conversation.push(Message::assistant("third"));
+        let slot_ctx = guard_test_slot_ctx();
+
+        let outcome = std::panic::AssertUnwindSafe(compact_conversation_in_critical_section(
+            &provider,
+            &mut conversation,
+            "s-panic",
+            "t-panic",
+            "worker",
+            10_000,
+            &section,
+            &slot_ctx,
+        ))
+        .catch_unwind()
+        .await;
+
+        assert!(
+            outcome.is_err(),
+            "the summarizer panic must unwind out of the helper"
+        );
+        assert!(
+            !section.is_compacting(),
+            "guard must release on a panic / early-exit unwinding through the helper"
+        );
     }
 }

--- a/server/crates/djinn-slot/src/reply_loop_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop_tests.rs
@@ -82,6 +82,7 @@ async fn run_with_provider(
     let worktree_path = worktree.as_path();
     run_reply_loop(
         ReplyLoopContext {
+            compaction_cs: &crate::reply_loop::CompactionCriticalSection::new(),
             provider,
             tools,
             task_id,


### PR DESCRIPTION
## Rescoped acceptance criteria

1. All `compact_conversation` call sites in `server/crates/djinn-slot/src/reply_loop/turn.rs` enter a shared internal compaction critical section before recording the Started boundary and release it after completion/failure without changing retry/backoff semantics.
2. Boundary persistence still uses `record_compaction_started` before compaction and `complete_compaction_boundary` only after accepted compaction; no duplicate compaction boundary schema or load projection code is introduced.
3. The task branch contains no tracked scratch artifacts, including `turn.rs.temp` and `turn.rs.tests.tail`.
4. Focused tests demonstrate guard release on all four required paths: successful compaction, false/no-compaction, summarizer-error/`compact_conversation`-error, and early-return/error; the summarizer-error case is a distinct test from the false/no-compaction case.

## What changed

- **New `reply_loop/compaction_guard.rs`** — `CompactionCriticalSection` + RAII `CompactionGuard`. The section is released on every exit path (explicit release, implicit drop, and panic unwinding). `enter()` panics on re-entry to enforce the single-tasked contract.
- **New private helper `compact_conversation_in_critical_section` in `turn.rs`** — enters the section (RAII guard), records the Started boundary, runs `compact_conversation`, and completes the boundary only on accepted compaction. All three reply-loop call sites (recoverable stream-init error, reactive mid-stream, proactive threshold) now route through it. Retry/backoff bookkeeping (`compaction_attempts`, `clear_stash()`, continuation messages, `should_retry_after_tool_call_compaction`) stays in the callers, so loop semantics are unchanged. **[AC1, AC2]**
- **Threaded `compaction_cs` through `ReplyLoopContext`** and constructed the section at the djinn-agent production call site (`actors/slot/reply_loop/mod.rs`) so the production path compiles and shares one instance per session. The type/field are `pub` for cross-crate construction.
- **Tests** — four focused helper tests exercising the *real* helper: successful (micro-)compaction returning `true`; a benign no-op returning `false` (empty summaries); a distinct summarizer-error path (`FailingProvider` stream error); and a summarizer panic that unwinds through the helper (`catch_unwind`), proving RAII release on abnormal early exit. Plus three primitive-level tests. **[AC4]**
- **No scratch artifacts** — the branch was rebuilt cleanly; `git ls-files | grep -E '\.temp$|\.tail$'` is empty. **[AC3]**

## Verification (from `server/`, `SQLX_OFFLINE=true`)

- `cargo fmt --check -p djinn-slot -p djinn-agent` → exit 0
- `cargo clippy -p djinn-slot -p djinn-agent --all-targets --all-features -- -D warnings` → exit 0
- `cargo test -p djinn-slot guard` → 19 passed, 0 failed (all four guard-release paths + primitives), against a Postgres 16 test template
- Size guard (`scripts/check-file-size.sh --files-from-stdin` on changed files) → exit 0 (`compaction_guard.rs` 114 lines / 3899 bytes; `turn.rs`/`tests.rs` oversize allowed by pre-existing `djinn:allow-oversize` markers, not introduced here)