### PR TITLE
Fix local Tilt/kind dev loop and arm64 multi-arch support

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -270,6 +270,56 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --features qdrant -- -D warnings
 
+  # Cross-check the Linux sandbox layer for aarch64. Everything else in CI
+  # compiles x86_64-only, which let an aarch64-breaking seccomp deny list
+  # (x86_64-only legacy syscall constants in djinn-sandbox) ship to main —
+  # local dev on Apple Silicon (kind node = linux/arm64) then failed to
+  # build. Check-only (no link), scoped to the crate that owns the
+  # arch-conditional syscall/landlock code.
+  server-aarch64-check:
+    name: Server aarch64 Check
+    needs: changes
+    if: needs.changes.outputs.server == 'true' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    env:
+      SQLX_OFFLINE: "true"
+      # Cross C compiler for any cc-built dep reached through the crate's
+      # tree (e.g. via workspace-hack); `check` doesn't link, but build
+      # scripts still compile target-arch C.
+      CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      # workspace-hack activates openssl-sys's `vendored` feature for the whole
+      # workspace, but server/.cargo/config.toml pins OPENSSL_NO_VENDOR=1 to
+      # link the *host* system OpenSSL (there is no aarch64 system libssl here,
+      # and pkg-config isn't set up for cross). Override it back to 0 so
+      # openssl-sys compiles the vendored copy from source with the cross C
+      # toolchain installed below. (config.toml's [env] isn't force=true, so a
+      # real env var wins.)
+      OPENSSL_NO_VENDOR: "0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: rustup toolchain install
+        working-directory: server
+      - run: rustup target add aarch64-unknown-linux-gnu
+        working-directory: server
+
+      - name: Install cross C toolchain
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+          shared-key: server-aarch64-check
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: cargo check (aarch64)
+        run: cargo check -p djinn-sandbox --all-targets --target aarch64-unknown-linux-gnu
+
   # Pure-shell PR-time guard for Rust source file size; independent from clippy.
   # Runs in changed-file mode (--files-from-stdin) so the job enforces the
   # "new or edited Rust file" regression guard and does not fail on the
@@ -653,6 +703,7 @@ jobs:
     needs:
       - server-cargo-deny
       - server-clippy
+      - server-aarch64-check
       - server-size-guard
       - server-migrations-guard
       - server-raw-sql-boundary
@@ -666,6 +717,7 @@ jobs:
           results=(
             "${{ needs.server-cargo-deny.result }}"
             "${{ needs.server-clippy.result }}"
+            "${{ needs.server-aarch64-check.result }}"
             "${{ needs.server-size-guard.result }}"
             "${{ needs.server-migrations-guard.result }}"
             "${{ needs.server-raw-sql-boundary.result }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      # QEMU for the linux/arm64 half of the multi-arch build below.
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -106,7 +108,9 @@ jobs:
         with:
           context: .
           file: server/docker/djinn-buildkitd.Dockerfile
-          platforms: linux/amd64
+          # arm64 keeps the image pullable on kind-on-Apple-Silicon and
+          # Graviton nodes; the Dockerfile resolves helper URLs via TARGETARCH.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Tiltfile
+++ b/Tiltfile
@@ -120,7 +120,11 @@ local_resource(
     'djinn-ui-dist',
     cmd=' && '.join([
         'cd ui',
-        '[ -d node_modules ] || pnpm install --frozen-lockfile',
+        # Unconditional: a `[ -d node_modules ] ||` guard poisons every
+        # later run after a half-failed install (dir exists, postinstalls
+        # never ran). With a warm store + up-to-date lockfile this is a
+        # ~1s no-op.
+        'pnpm install --frozen-lockfile',
         'pnpm build',
     ]),
     deps=[

--- a/deploy/helm/djinn/values.local.yaml
+++ b/deploy/helm/djinn/values.local.yaml
@@ -129,6 +129,12 @@ imagePipeline:
   # anonymous pulls 401 inside kind. Override to the in-cluster registry.
   builderImage: "localhost:5001/djinn-image-builder:dev"
   buildkitd:
+    # The chart default (ghcr.io/djinnos/djinn-buildkitd:latest) only
+    # publishes linux/amd64 — on Apple Silicon the kind node is arm64 and
+    # the pull fails with "no match for platform in manifest". The baked-in
+    # cloud credential helpers are unused locally (Zot auths via htpasswd),
+    # so plain multi-arch moby/buildkit:rootless is the supported fallback.
+    image: docker.io/moby/buildkit:v0.15.2-rootless
     # Local Zot serves plaintext HTTP over ClusterIP — tell buildkitd to
     # not expect TLS. Prod environments that front Zot with an Ingress +
     # TLS should leave this at its chart default (false).

--- a/deploy/langfuse-local/langfuse.yaml
+++ b/deploy/langfuse-local/langfuse.yaml
@@ -351,6 +351,13 @@ spec:
             - secretRef:
                 name: langfuse-init
           env:
+            # Next.js standalone binds to $HOSTNAME, which Kubernetes sets to
+            # the pod name (resolving to the pod IP). That leaves nothing
+            # listening on 127.0.0.1 inside the pod, so `kubectl port-forward`
+            # (and Tilt's :5000 forward) gets connection refused. Pin the
+            # bind address explicitly.
+            - name: HOSTNAME
+              value: "0.0.0.0"
             - name: NODE_ENV
               value: production
             - name: NEXTAUTH_URL

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,10 +15,12 @@ Langfuse for tracing — built from your working tree.
 
 **Prerequisites:** Docker, [kind](https://kind.sigs.k8s.io), `kubectl`,
 [Helm](https://helm.sh), [Tilt](https://tilt.dev), [pnpm](https://pnpm.io)
-(Node), and `openssl`.
+(Node **≥ 22.13** — pnpm 11 needs `node:sqlite`; older Nodes die mid-install
+with `ERR_UNKNOWN_BUILTIN_MODULE`), and `openssl`.
 
-The image pipeline runs BuildKit rootless via user namespaces. On the host
-(kind inherits host sysctls):
+**Linux only:** the image pipeline runs BuildKit rootless via user
+namespaces, which needs host sysctls (kind inherits them). On macOS, Docker
+Desktop's VM already provides this — skip these:
 
 ```sh
 sudo sysctl -w kernel.unprivileged_userns_clone=1
@@ -30,6 +32,14 @@ Then, from the repo root:
 ```bash
 tilt up
 ```
+
+> **First run with a non-kind kubectl context active** (e.g. `staging`):
+> Tilt's production-context guard fires at Tiltfile parse time, *before* the
+> bootstrap gets a chance to create the kind cluster and switch contexts, so
+> `tilt up` aborts with "Refusing to run 'local'…". Bootstrap once by hand —
+> `bash scripts/kind/setup-kind.sh` — which creates the cluster and switches
+> the current context to `kind-djinn`; then `tilt up` works. (Switch back
+> later with `kubectl config use-context <your-context>`.)
 
 Tilt bootstraps the kind cluster (`djinn`) + a local registry, builds
 `djinn-server` and `djinn-agent-worker`, embeds the freshly built UI, installs

--- a/scripts/kind/setup-kind.sh
+++ b/scripts/kind/setup-kind.sh
@@ -15,6 +15,12 @@ KIND_IMAGE_VERSION="${KIND_IMAGE_VERSION:-1.31.0}"
 REG_NAME="${REG_NAME:-kind-registry}"
 REG_PORT="${REG_PORT:-5001}"
 
+# Every kubectl call below pins --context: if the cluster already exists,
+# `kind create cluster` never runs and never switches the active context,
+# so an unpinned apply would land in whatever context the caller happens
+# to be on (staging/prod).
+KUBECTL=(kubectl --context "kind-${CLUSTER_NAME}")
+
 # --- 1. Ensure local registry is running ------------------------------------
 if [ "$(docker inspect -f '{{.State.Running}}' "${REG_NAME}" 2>/dev/null || echo false)" != 'true' ]; then
   echo ">>> starting local registry ${REG_NAME} at 127.0.0.1:${REG_PORT}"
@@ -67,7 +73,7 @@ done
 ZOT_NS="${ZOT_NAMESPACE:-djinn}"
 ZOT_SVC="${ZOT_SERVICE:-djinn-zot}"
 ZOT_HOST="${ZOT_HOST:-${ZOT_SVC}.${ZOT_NS}.svc.cluster.local:5000}"
-ZOT_IP="$(kubectl -n "${ZOT_NS}" get svc "${ZOT_SVC}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+ZOT_IP="$("${KUBECTL[@]}" -n "${ZOT_NS}" get svc "${ZOT_SVC}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
 if [ -n "${ZOT_IP}" ]; then
   echo ">>> wiring kubelet → Zot mirror: ${ZOT_HOST} → http://${ZOT_IP}:5000"
   ZOT_DIR="/etc/containerd/certs.d/${ZOT_HOST}"
@@ -90,7 +96,7 @@ fi
 
 # --- 5. Document the local registry in-cluster -----------------------------
 # See https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
-cat <<EOF | kubectl apply -f -
+cat <<EOF | "${KUBECTL[@]}" apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/server/crates/djinn-sandbox/src/chat_shell.rs
+++ b/server/crates/djinn-sandbox/src/chat_shell.rs
@@ -506,8 +506,11 @@ fn apply_seccomp() -> io::Result<()> {
     // SYS_create_module is marked deprecated in libc but kernels still
     // reserve the number and a rogue LKM could still call it; keep it on
     // the deny list as defense-in-depth. Same for _sysctl.
-    #[allow(deprecated)]
-    let deny: &[i64] = &[
+    // `mut` is used only on x86_64, where the arch-specific `deny.extend(...)`
+    // below runs; on other arches (e.g. aarch64) that block is cfg'd out and
+    // the binding is never mutated, so silence unused_mut there.
+    #[cfg_attr(not(target_arch = "x86_64"), allow(unused_mut))]
+    let mut deny: Vec<i64> = vec![
         libc::SYS_ptrace,
         libc::SYS_mount,
         libc::SYS_umount2,
@@ -516,21 +519,28 @@ fn apply_seccomp() -> io::Result<()> {
         libc::SYS_kexec_file_load,
         libc::SYS_init_module,
         libc::SYS_finit_module,
-        libc::SYS_create_module,
         libc::SYS_delete_module,
         libc::SYS_pivot_root,
         libc::SYS_setns,
         libc::SYS_unshare,
         libc::SYS_perf_event_open,
         libc::SYS_bpf,
+        libc::SYS_swapon,
+        libc::SYS_swapoff,
+    ];
+    // Legacy syscalls that only ever existed in the x86_64 table; aarch64
+    // never allocated numbers for them, so libc has no constants there and
+    // denying them is a no-op anyway.
+    #[cfg(target_arch = "x86_64")]
+    #[allow(deprecated)]
+    deny.extend([
+        libc::SYS_create_module,
         libc::SYS_ioperm,
         libc::SYS_iopl,
         libc::SYS_uselib,
-        libc::SYS_swapon,
-        libc::SYS_swapoff,
         libc::SYS_sysfs,
         libc::SYS__sysctl,
-    ];
+    ]);
 
     let rules = deny.iter().map(|n| (*n, Vec::new())).collect();
 

--- a/server/docker/djinn-buildkitd.Dockerfile
+++ b/server/docker/djinn-buildkitd.Dockerfile
@@ -22,16 +22,20 @@ FROM alpine:3.20 AS helpers
 ARG ECR_CRED_HELPER_VERSION=0.9.0
 ARG GCR_CRED_HELPER_VERSION=2.1.22
 ARG ACR_CRED_HELPER_VERSION=0.7.0
+# amd64 | arm64 — set by BuildKit from --platform; all three helpers publish
+# both. Keeps the image installable on arm64 nodes (e.g. kind on Apple
+# Silicon, Graviton), matching moby/buildkit's own multi-arch manifest.
+ARG TARGETARCH
 
 RUN apk add --no-cache curl ca-certificates tar && mkdir -p /helpers
 
 RUN curl -fsSL -o /helpers/docker-credential-ecr-login \
-      "https://amazon-ecr-credential-helper-releases.s3.amazonaws.com/${ECR_CRED_HELPER_VERSION}/linux-amd64/docker-credential-ecr-login"
+      "https://amazon-ecr-credential-helper-releases.s3.amazonaws.com/${ECR_CRED_HELPER_VERSION}/linux-${TARGETARCH}/docker-credential-ecr-login"
 
-RUN curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_CRED_HELPER_VERSION}/docker-credential-gcr_linux_amd64-${GCR_CRED_HELPER_VERSION}.tar.gz" \
+RUN curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_CRED_HELPER_VERSION}/docker-credential-gcr_linux_${TARGETARCH}-${GCR_CRED_HELPER_VERSION}.tar.gz" \
     | tar -xz -C /helpers docker-credential-gcr
 
-RUN curl -fsSL "https://github.com/chrismellard/docker-credential-acr-env/releases/download/${ACR_CRED_HELPER_VERSION}/docker-credential-acr-env_${ACR_CRED_HELPER_VERSION}_linux_amd64.tar.gz" \
+RUN curl -fsSL "https://github.com/chrismellard/docker-credential-acr-env/releases/download/${ACR_CRED_HELPER_VERSION}/docker-credential-acr-env_${ACR_CRED_HELPER_VERSION}_linux_${TARGETARCH}.tar.gz" \
     | tar -xz -C /helpers docker-credential-acr-env
 
 RUN chmod 0755 /helpers/*

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,0 +1,4 @@
+# Fail install immediately on unsupported Node versions instead of dying
+# later inside pnpm with an opaque "No such built-in module: node:sqlite"
+# (pnpm 11 requires Node >= 22.13 — see "engines" in package.json).
+engine-strict=true

--- a/ui/package.json
+++ b/ui/package.json
@@ -128,5 +128,8 @@
     "vite": "^7.3.1",
     "vitest": "^4.1.2"
   },
-  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26"
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
+  "engines": {
+    "node": ">=22.13"
+  }
 }

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -2,9 +2,9 @@ packages:
   - .
 
 allowBuilds:
-  esbuild: set this to true or false
-  msw: set this to true or false
-  sharp: set this to true or false
+  esbuild: true
+  msw: true
+  sharp: true
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
Local development on Apple Silicon (kind node = `linux/arm64`) hit several breakages. This fixes them and adds CI coverage so an aarch64 regression can't reach `main` again.

## Changes

**Correctness / cross-arch**
- **djinn-sandbox seccomp**: split the deny list so x86_64-only legacy syscall constants (`SYS_create_module`, `ioperm`, `iopl`, `uselib`, `sysfs`, `_sysctl`) are gated behind `cfg(target_arch = "x86_64")` — aarch64 never allocated those numbers, so the previous unconditional list failed to compile there. Added `SYS_swapon`/`SYS_swapoff` to the shared list.
- **CI**: new `server-aarch64-check` job (`cargo check -p djinn-sandbox` for `aarch64-unknown-linux-gnu`) so arch-conditional syscall/landlock breakage is caught before merge.

**Multi-arch images**
- **release.yml**: build `djinn-buildkitd` as `linux/amd64,linux/arm64` (QEMU + `TARGETARCH`-resolved credential-helper URLs in the Dockerfile) so the image stays pullable on arm64 kind / Graviton nodes.
- **values.local.yaml**: fall back to multi-arch `moby/buildkit:*-rootless` locally (the chart default only publishes amd64).

**Local dev loop**
- **langfuse-local**: pin `HOSTNAME=0.0.0.0` so `kubectl port-forward` / Tilt's `:5000` forward reaches the pod (Next.js standalone otherwise binds to the pod IP only).
- **setup-kind.sh**: pin `kubectl --context kind-<cluster>` so re-running against an existing cluster can't apply into staging/prod.
- **Tiltfile**: drop the `[ -d node_modules ]` guard that poisoned every run after a half-failed install.
- **ui**: `engine-strict` + `engines.node >=22.13` (pnpm 11 requirement) and resolve `pnpm-workspace.yaml` `allowBuilds` placeholders.