### PR TITLE
docs(djinn-db): mark template_bootstrap as djinn-specific dogfooding

### DIFF
--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -504,6 +504,10 @@ impl Database {
                         // template is bootstrapped automatically (idempotent,
                         // advisory-locked) so DB-backed tests can run without
                         // a CI-only provisioning step.
+                        // This template bootstrap is djinn-repo-specific
+                        // scaffolding (djinn's own schema/migrations); it only
+                        // runs for djinn's own test suite, not for arbitrary
+                        // target repos.
                         template_bootstrap::ensure_test_template(&init.server_prefix).await?;
                         clone_postgres_test_template(&init.server_prefix, &init.test_db).await?;
                     }

--- a/server/crates/djinn-db/src/template_bootstrap.rs
+++ b/server/crates/djinn-db/src/template_bootstrap.rs
@@ -1,3 +1,21 @@
+//! djinn-repo-specific test scaffolding ("dogfooding").
+//!
+//! This module bootstraps djinn's OWN `djinn_test_template` database by running
+//! djinn's OWN sqlx migrations, so that djinn agents editing the djinn repo can
+//! run djinn's DB-backed tests inside a worker pod whose image provides a bare
+//! Postgres sidecar. It is intrinsically coupled to djinn's schema/migrations.
+//!
+//! It is NOT a general mechanism for making arbitrary target repos' test
+//! databases work in the pod, and must not be generalized in place — hardcoding
+//! the `djinn_test_template` name and djinn's migrations is intentional.
+//!
+//! The generic, reusable half of this capability lives in `djinn-k8s`: service
+//! preset injection (`sidecar::resolve_image_services_with_metadata`) stands up
+//! the sidecar and exposes an injected connection env var. The intended reusable
+//! path for a non-djinn target repo to bootstrap its own test DB is a
+//! project-declared lifecycle / pre-task bootstrap command run against that
+//! injected connection env var — NOT code here in `djinn-db`.
+
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;


### PR DESCRIPTION
## What

Documentation-only change (no runtime behavior touched) clarifying that `server/crates/djinn-db/src/template_bootstrap.rs` is **djinn-repo-specific test scaffolding**, not general infrastructure.

## Why

The 2vxr work (#1568) made the worker-pod Postgres sidecar reliable for djinn's own DB tests. It has two halves with opposite reusability profiles:

- **Generic / reusable** — service-preset injection observability in `djinn-k8s` (`resolve_image_services_with_metadata`, `task_run_services_resolved`). Works for any target repo. Untouched.
- **djinn-specific** — `template_bootstrap.rs` hardcodes `djinn_test_template` and runs djinn's own sqlx migrations. It can only ever serve the djinn repo.

The risk: a future reader mistakes the djinn-db-internal helper for general test-DB infra and tries to generalize it in place. This adds a module-level doc + call-site comment stating it is intentional dogfooding, must not be generalized here, and points at the genuinely reusable path — a project-declared pre-task lifecycle bootstrap command run against the injected connection env var.

## Verification

`cargo check -p djinn-db` passes. Doc-only; no logic change.