### PR TITLE
chore(i6xq): wire session-recovery attempt terminalization + focused path tests

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -2,6 +2,7 @@
 use super::super::*;
 use crate::pr_poller::pr_cleanup::CloseKind;
 use djinn_core::models::TransitionAction;
+use djinn_core::models::task_attempt::TaskAttemptOutcome;
 use djinn_db::{
     ClaimExtensionRecord, CurrentLivenessState, LivenessEvidenceSnapshot, LivenessRepository,
 };
@@ -323,6 +324,22 @@ impl CoordinatorActor {
                 )
                 .await;
 
+                // Terminalize the matching attempt as a loop-guard trip: a
+                // token/turn ceiling kill is a runaway guard, routed through the
+                // loop-guard planner intervention rather than a stall/timeout.
+                self.terminalize_recovery_attempt(
+                    task_id,
+                    &session.agent_type,
+                    TaskAttemptOutcome::LoopGuardTripped,
+                    "session_recovery_ceiling",
+                    Some(&session.id),
+                    session.task_run_id.as_deref(),
+                    Some("dead"),
+                    Some("ceiling_kill"),
+                    Some(&reason),
+                )
+                .await;
+
                 tracing::warn!(
                     task_id = %task_id,
                     session_id = %session.id,
@@ -465,6 +482,22 @@ impl CoordinatorActor {
                             );
                         }
                     }
+
+                    // Terminalize the matching attempt as a timeout: a
+                    // no-progress controlled exit reclaims a session that stopped
+                    // making durable progress (a stall variant).
+                    self.terminalize_recovery_attempt(
+                        task_id,
+                        &session.agent_type,
+                        TaskAttemptOutcome::TimedOut,
+                        "session_recovery_no_progress",
+                        Some(&session.id),
+                        session.task_run_id.as_deref(),
+                        Some("dead"),
+                        Some("no_progress"),
+                        None,
+                    )
+                    .await;
 
                     tracing::warn!(
                         task_id = %task_id,
@@ -831,6 +864,29 @@ impl CoordinatorActor {
                 scope = ?scope,
                 "CoordinatorActor: killed stalled session"
             );
+
+            // Terminalize the matching attempt as a timeout. A stall kill (idle
+            // past threshold, or a first-call hang) reclaims a live session; the
+            // failure class distinguishes the two so downstream can tell a hung
+            // first call from a productive turn that went quiet.
+            let stall_verdict = classification.as_ref().map(|c| c.verdict.as_str());
+            let stall_failure_class = if never_active {
+                "first_call_hang"
+            } else {
+                "idle_stall"
+            };
+            self.terminalize_recovery_attempt(
+                task_id,
+                &session.agent_type,
+                TaskAttemptOutcome::TimedOut,
+                "session_recovery_stall",
+                Some(&session.id),
+                session.task_run_id.as_deref(),
+                stall_verdict,
+                Some(stall_failure_class),
+                Some(reason),
+            )
+            .await;
 
             // ── Second-strike stall escalation ──────────────────────────────
             // Record this stall cancel against the task. Two CONSECUTIVE stall
@@ -1284,6 +1340,35 @@ impl CoordinatorActor {
                 tracing::warn!(task_id = %task_id, error = %e, "CoordinatorActor: failed to finalize zombie session row");
             }
 
+            // Terminalize the matching attempt for the reclaimed zombie session.
+            // A dead pod past the hard cap with no live worker is a crash; a
+            // hard-runtime-cap breach is a timeout. Carry the liveness verdict
+            // and a failure class into the attempt's structured context.
+            let (zombie_outcome, zombie_failure_class) =
+                match classification.as_ref().and_then(|c| c.reason) {
+                    Some(super::liveness::LivenessReason::HardRuntimeExceeded) => {
+                        (TaskAttemptOutcome::TimedOut, "hard_runtime_exceeded")
+                    }
+                    Some(reason) => (TaskAttemptOutcome::Crashed, reason.as_str()),
+                    None => (TaskAttemptOutcome::Crashed, "zombie_no_live_worker"),
+                };
+            let zombie_verdict = classification
+                .as_ref()
+                .map(|c| c.verdict.as_str())
+                .unwrap_or("dead");
+            self.terminalize_recovery_attempt(
+                task_id,
+                &session.agent_type,
+                zombie_outcome,
+                "session_recovery_zombie_reap",
+                Some(&session.id),
+                session.task_run_id.as_deref(),
+                Some(zombie_verdict),
+                Some(zombie_failure_class),
+                None,
+            )
+            .await;
+
             djinn_telemetry::zombie::increment_reap(djinn_telemetry::zombie::KIND_STALL);
 
             // Release the task from its execution status so dispatch can pick
@@ -1593,6 +1678,25 @@ impl CoordinatorActor {
                                 session_id = %running_session.id,
                                 "CoordinatorActor: finalized stale ready-state running session"
                             );
+                            // Terminalize the matching attempt for the reclaimed
+                            // orphan. The session outlived a reset/release with no
+                            // live pod, so it counts as a crashed attempt.
+                            let orphan_verdict = classification
+                                .as_ref()
+                                .map(|c| c.verdict.as_str())
+                                .unwrap_or("dead");
+                            self.terminalize_recovery_attempt(
+                                &task.id,
+                                &running_session.agent_type,
+                                TaskAttemptOutcome::Crashed,
+                                "session_recovery_stale_ready_state",
+                                Some(&running_session.id),
+                                running_session.task_run_id.as_deref(),
+                                Some(orphan_verdict),
+                                Some("stale_ready_state_orphan"),
+                                None,
+                            )
+                            .await;
                             affected += 1;
                         }
                         Ok(_) => {}
@@ -2389,6 +2493,59 @@ impl CoordinatorActor {
         }
 
         Some(result)
+    }
+
+    /// Best-effort terminalization of the live `task_attempts` row for a
+    /// session-recovery outcome.
+    ///
+    /// Wraps [`super::attempt_lifecycle::advance_latest_to_terminal`] with a
+    /// structured `summary_json` capturing the recovery classifier, the
+    /// session/task-run identity, the liveness verdict, and a failure class.
+    /// The underlying repo helper is forward-only and idempotent, so duplicate
+    /// recovery scans, duplicate terminal handlers, and late terminal reports
+    /// never create a duplicate row and never move a terminal attempt backward.
+    ///
+    /// Best-effort: lookup/write failures are logged inside the helper and
+    /// never propagate, so they cannot fail the surrounding recovery
+    /// transition.
+    #[allow(clippy::too_many_arguments)]
+    async fn terminalize_recovery_attempt(
+        &self,
+        task_id: &str,
+        role: &str,
+        outcome: TaskAttemptOutcome,
+        classifier: &str,
+        session_id: Option<&str>,
+        task_run_id: Option<&str>,
+        liveness_verdict: Option<&str>,
+        failure_class: Option<&str>,
+        summary: Option<&str>,
+    ) {
+        let summary_json = serde_json::json!({
+            "recovery_classifier": classifier,
+            "session_id": session_id,
+            "task_run_id": task_run_id,
+            "liveness_verdict": liveness_verdict,
+            "failure_class": failure_class,
+        })
+        .to_string();
+        super::attempt_lifecycle::advance_latest_to_terminal(
+            &self.db,
+            super::attempt_lifecycle::TerminalAdvancementParams {
+                task_id,
+                role,
+                outcome,
+                pr_url: None,
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary,
+                summary_json: Some(&summary_json),
+                log_tail: None,
+            },
+        )
+        .await;
     }
 }
 

--- a/server/crates/djinn-coordinator/src/test_helpers.rs
+++ b/server/crates/djinn-coordinator/src/test_helpers.rs
@@ -30,7 +30,18 @@ pub fn create_test_db() -> Database {
     Database::open_in_memory().expect("open in-memory test database")
 }
 
-pub fn agent_context_from_db(db: Database, _cancel: CancellationToken) -> SlotContext {
+pub fn agent_context_from_db(db: Database, cancel: CancellationToken) -> SlotContext {
+    agent_context_from_db_with_clock(db, cancel, Arc::new(djinn_core::clock::SystemClock::new()))
+}
+
+/// Like [`agent_context_from_db`] but with an injectable [`djinn_core::clock::Clock`]
+/// so tests can advance monotonic time deterministically (e.g. to drive the
+/// stall-timeout recovery path without sleeping).
+pub fn agent_context_from_db_with_clock(
+    db: Database,
+    _cancel: CancellationToken,
+    clock: Arc<dyn djinn_core::clock::Clock>,
+) -> SlotContext {
     let event_bus = EventBus::noop();
     let catalog = CatalogService::new();
     let health_tracker = HealthTracker::default();
@@ -162,7 +173,7 @@ pub fn agent_context_from_db(db: Database, _cancel: CancellationToken) -> SlotCo
         coordinator_trigger: None,
         runtime_ops: None,
         repo_graph_ops: None,
-        clock: Arc::new(djinn_core::clock::SystemClock::new()),
+        clock,
         callbacks: Arc::new(NoopCallbacks),
         tool_dispatcher: None,
         compaction_cs: CompactionCriticalSection::new(),

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -2711,3 +2711,426 @@ async fn zombie_reap_terminal_task_race_records_kill_noop() {
         "zombie session must still be finalized even in the terminal-task race"
     );
 }
+
+// ── Attempt-lifecycle terminalization in the session-recovery lane (i6xq) ──
+//
+// These path-level tests drive the real recovery functions
+// (`enforce_session_stall_timeout`, `reap_zombie_sessions`) and assert that the
+// matching `task_attempts` row is advanced to the correct terminal outcome with
+// structured recovery context, and that duplicate/late terminal handling stays
+// idempotent (no backward move, no duplicate row).
+
+/// Seed a `pending` attempt for `(task_id, role)` exactly as the dispatch-start
+/// path would, and return its id.
+async fn seed_pending_attempt(db: &Database, task_id: &str, role: &str) -> String {
+    let repo = djinn_db::TaskAttemptRepository::new(db.clone());
+    let id = uuid::Uuid::now_v7().to_string();
+    let dispatch_key = format!("{task_id}:{role}:{id}");
+    repo.create_or_get_pending(djinn_db::CreateTaskAttemptParams {
+        id: &id,
+        task_id,
+        role,
+        dispatch_key: &dispatch_key,
+        session_id: None,
+        attempt_seq: None,
+    })
+    .await
+    .unwrap();
+    id
+}
+
+/// A per-session token/turn ceiling kill routes through the loop-guard planner
+/// intervention, and must terminalize the matching attempt as
+/// `loop_guard_tripped` with structured recovery context.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ceiling_kill_terminalizes_attempt_as_loop_guard_tripped() {
+    use djinn_db::{CreateSessionParams, SessionRepository, TaskAttemptRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "ceiling-attempt").await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
+
+    let cancel = CancellationToken::new();
+    let app_state = test_helpers::agent_context_from_db(db.clone(), cancel.clone());
+    let activity = app_state.register_activity(&task.id);
+    activity.store(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    let pool = SlotPoolHandle::spawn_with_factory(
+        app_state,
+        cancel.clone(),
+        SlotPoolConfig {
+            models: vec![ModelSlotConfig {
+                model_id: "openai/gpt-5.5".to_string(),
+                max_slots: 1,
+                roles: ["worker"].into_iter().map(ToOwned::to_owned).collect(),
+            }],
+            role_priorities: HashMap::new(),
+        },
+        Arc::new(|slot_id, model_id, event_tx, app_state, cancel| {
+            let runner: djinn_slot::TestLifecycleRunner = Arc::new(
+                |_task_id,
+                 _project_path,
+                 _model_id,
+                 _app_state,
+                 kill,
+                 _pause,
+                 _resume_lifecycle_metadata| {
+                    Box::pin(async move {
+                        kill.cancelled().await;
+                        Ok(())
+                    })
+                },
+            );
+            SlotHandle::spawn_with_test_runner(
+                slot_id, model_id, event_tx, app_state, cancel, runner,
+            )
+        }),
+    );
+    pool.dispatch(&task.id, "test-project", "openai/gpt-5.5")
+        .await
+        .expect("dispatch should create a slot mapping");
+    pool.test_set_token_override(&task.id, 3_000_000, 10).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.pool = pool.clone();
+    actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        actor.stall_killed.contains(&session.id),
+        "ceiling-tripped session must be killed"
+    );
+
+    let repo = TaskAttemptRepository::new(db.clone());
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "loop_guard_tripped",
+        "ceiling kill (runaway guard) must terminalize the attempt as loop_guard_tripped"
+    );
+    assert!(attempt.terminal_at.is_some());
+    let sj: serde_json::Value =
+        serde_json::from_str(attempt.summary_json.as_deref().unwrap()).unwrap();
+    assert_eq!(sj["recovery_classifier"], "session_recovery_ceiling");
+    assert_eq!(sj["failure_class"], "ceiling_kill");
+    assert_eq!(sj["session_id"], session.id);
+    assert_eq!(sj["liveness_verdict"], "dead");
+    // Exactly one attempt row — no duplicate.
+    assert_eq!(repo.list_for_task(&task.id).await.unwrap().len(), 1);
+
+    cancel.cancel();
+}
+
+/// A stall timeout (session idle past the 30-minute threshold) must terminalize
+/// the matching attempt as `timed_out` with structured recovery context. Uses a
+/// deterministic [`djinn_core::clock::TestClock`] to advance idle time without
+/// sleeping, and disables slow-extension so the stall path is deterministic.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stall_timeout_terminalizes_attempt_as_timed_out() {
+    use djinn_db::{CreateSessionParams, SessionRepository, TaskAttemptRepository};
+    use std::time::{Duration, Instant, SystemTime};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "stall-attempt").await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: DEFAULT_MODEL_ID,
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
+
+    // Deterministic clock so we can push monotonic idle time past the 300s
+    // first-call cap without sleeping.
+    let clock = Arc::new(djinn_core::clock::TestClock::new(
+        SystemTime::now(),
+        Instant::now(),
+    ));
+    let cancel = CancellationToken::new();
+    let app_state =
+        test_helpers::agent_context_from_db_with_clock(db.clone(), cancel.clone(), clock.clone());
+    let pool = SlotPoolHandle::spawn_with_factory(
+        app_state,
+        cancel.clone(),
+        SlotPoolConfig {
+            models: vec![ModelSlotConfig {
+                model_id: DEFAULT_MODEL_ID.to_owned(),
+                max_slots: 1,
+                roles: ["worker"].into_iter().map(ToOwned::to_owned).collect(),
+            }],
+            role_priorities: HashMap::new(),
+        },
+        Arc::new(|slot_id, model_id, event_tx, app_state, cancel| {
+            let runner: djinn_slot::TestLifecycleRunner = Arc::new(
+                |_task_id,
+                 _project_path,
+                 _model_id,
+                 _app_state,
+                 kill,
+                 _pause,
+                 _resume_lifecycle_metadata| {
+                    Box::pin(async move {
+                        kill.cancelled().await;
+                        Ok(())
+                    })
+                },
+            );
+            SlotHandle::spawn_with_test_runner(
+                slot_id, model_id, event_tx, app_state, cancel, runner,
+            )
+        }),
+    );
+    pool.dispatch(&task.id, "test-project", DEFAULT_MODEL_ID)
+        .await
+        .expect("dispatch should create a slot mapping");
+    // Let the slot's registration event populate the pool's slot-model map so
+    // `session_for_task` returns live info rather than falling back to the DB row.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Push both clocks past the 30-minute stall timeout: monotonic drives the
+    // slot's wall-clock duration; wall drives the activity tracker's idle
+    // reading. The session then reads as idle well beyond the stall threshold.
+    clock.advance_mono(Duration::from_secs(2000));
+    clock.advance_wall(Duration::from_secs(2000));
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.pool = pool.clone();
+    // Skip the slow-extension classifier gate so the stall path is deterministic.
+    actor.worker_lifecycle_config.slow_extension.enabled = false;
+    actor.enforce_session_stall_timeout().await;
+
+    assert!(
+        actor.stall_killed.contains(&session.id),
+        "idle-stalled session must be killed"
+    );
+
+    let repo = TaskAttemptRepository::new(db.clone());
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "timed_out",
+        "stall kill must terminalize the attempt as timed_out"
+    );
+    assert!(attempt.terminal_at.is_some());
+    let sj: serde_json::Value =
+        serde_json::from_str(attempt.summary_json.as_deref().unwrap()).unwrap();
+    assert_eq!(sj["recovery_classifier"], "session_recovery_stall");
+    assert_eq!(sj["failure_class"], "idle_stall");
+    assert_eq!(sj["session_id"], session.id);
+    assert_eq!(repo.list_for_task(&task.id).await.unwrap().len(), 1);
+
+    cancel.cancel();
+}
+
+/// A zombie session reaped past the hard cap with no live worker is a crash:
+/// the matching attempt must be terminalized as `crashed` with a `failure_class`
+/// in its structured context. Running the reaper again must not duplicate the
+/// row or move it — duplicate recovery scans are idempotent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zombie_reap_terminalizes_attempt_as_crashed_with_failure_class() {
+    use djinn_db::{CreateSessionParams, SessionRepository, TaskAttemptRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "zombie-attempt").await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let run_id = "run-zombie-attempt";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+    session_repo
+        .backdate_started_at(&session.id, "20 minutes")
+        .await
+        .unwrap();
+
+    let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.reap_zombie_sessions().await;
+
+    let repo = TaskAttemptRepository::new(db.clone());
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "crashed",
+        "a dead zombie (no live worker past hard cap) must terminalize the attempt as crashed"
+    );
+    assert!(attempt.terminal_at.is_some());
+    let sj: serde_json::Value =
+        serde_json::from_str(attempt.summary_json.as_deref().unwrap()).unwrap();
+    assert_eq!(sj["recovery_classifier"], "session_recovery_zombie_reap");
+    assert!(
+        sj["failure_class"].as_str().is_some_and(|s| !s.is_empty()),
+        "crashed attempt must carry a non-empty failure_class, got {:?}",
+        sj["failure_class"]
+    );
+    assert_eq!(sj["session_id"], session.id);
+
+    // Duplicate scan idempotency: reaping again must not duplicate or move.
+    actor.reap_zombie_sessions().await;
+    let after = repo.list_for_task(&task.id).await.unwrap();
+    assert_eq!(
+        after.len(),
+        1,
+        "duplicate reap must not create a second row"
+    );
+    assert_eq!(
+        after[0].outcome, "crashed",
+        "duplicate reap must not move the terminal attempt"
+    );
+}
+
+/// A late recovery terminalization must never move an attempt that already
+/// reached a terminal outcome backward, nor create a duplicate row. Seeds an
+/// attempt that already `completed`, then drives the zombie reaper (which would
+/// otherwise terminalize as `crashed`) and asserts the attempt stays completed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_terminalization_does_not_move_terminal_attempt_backward() {
+    use djinn_db::{
+        CreateSessionParams, SessionRepository, TaskAttemptRepository, TerminalTaskAttemptParams,
+    };
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "late-terminal").await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let run_id = "run-late-terminal";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+    session_repo
+        .backdate_started_at(&session.id, "20 minutes")
+        .await
+        .unwrap();
+
+    // Seed an attempt that has already reached a terminal `completed` outcome.
+    let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
+    let repo = TaskAttemptRepository::new(db.clone());
+    repo.advance_to_terminal(TerminalTaskAttemptParams {
+        id: &attempt_id,
+        outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::Completed,
+        pr_url: Some("https://github.example/pr/1"),
+        submit_ref: None,
+        checkpoint_ref: None,
+        mirror_head_sha: None,
+        github_head_sha: None,
+        summary: Some("already done"),
+        summary_json: None,
+        log_tail: None,
+    })
+    .await
+    .unwrap();
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.reap_zombie_sessions().await;
+
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "completed",
+        "a late recovery crash must NOT move an already-terminal (completed) attempt backward"
+    );
+    assert_eq!(
+        attempt.summary.as_deref(),
+        Some("already done"),
+        "terminal summary must be preserved"
+    );
+    assert_eq!(
+        repo.list_for_task(&task.id).await.unwrap().len(),
+        1,
+        "late terminalization must not create a duplicate row"
+    );
+}


### PR DESCRIPTION
## What

Wires attempt-terminalization into the **session-recovery lane** (part of epic 7w2i, attempt-lifecycle instrumentation). When a session is classified/reaped as a terminal recovery outcome, the matching `task_attempts` row is now advanced to the correct terminal `TaskAttemptOutcome` with structured `summary_json` context. Reconstructed from `origin/main` (prior sessions' branch never reached GitHub).

The original AC1 compile error (`provider_failure_class_for_report`) was already resolved on main; the genuinely-missing wiring was the session-recovery terminalization, which is what this PR adds.

## Wiring (session-recovery lane only — PR-poller / wave-dispatch / task-admin untouched)

New best-effort helper `CoordinatorActor::terminalize_recovery_attempt` wraps the existing forward-only, idempotent `attempt_lifecycle::advance_latest_to_terminal`. `summary_json` carries: `recovery_classifier`, `session_id`, `task_run_id`, `liveness_verdict`, `failure_class`.

Insertion points in `dispatch/session_recovery.rs`:
- **ceiling (token/turn) kill** → `loop_guard_tripped` (runaway guard, routed as loop guard)
- **no-progress controlled exit** → `timed_out`
- **idle / first-call stall kill** → `timed_out` (`failure_class` = `idle_stall` / `first_call_hang`)
- **zombie reap dead-reclaim** → `crashed` (or `timed_out` when the liveness reason is `hard_runtime_exceeded`), with `failure_class`
- **stale ready-state orphan reclaim** → `crashed`

Best-effort: attempt-write failures are logged (`tracing::warn`) inside the helper and never fail the existing recovery transition. Monotonicity + idempotency come from the existing repo semantics — duplicate scans, duplicate handlers, and late terminal reports never dup a row or move a terminal attempt backward. Additive only; no schema/migration/sqlx changes; no public API removed/renamed.

## Tests

Focused path-level tests in `tests/session_reaping.rs` that drive the real recovery functions:
- `ceiling_kill_terminalizes_attempt_as_loop_guard_tripped`
- `stall_timeout_terminalizes_attempt_as_timed_out` (uses a deterministic `TestClock` via a new test-only `agent_context_from_db_with_clock` helper)
- `zombie_reap_terminalizes_attempt_as_crashed_with_failure_class` (also asserts duplicate-scan idempotency)
- `recovery_terminalization_does_not_move_terminal_attempt_backward` (late/duplicate terminal stays put, no dup row)

## Verification (from `server/`, Postgres-backed test DB)

- `cargo clippy -p djinn-coordinator --lib --tests --all-features -- -D warnings` → **clean**
- `cargo test -p djinn-coordinator --lib` → **888 passed; 0 failed** (incl. the 4 new tests + full `session_reaping`/`attempt_lifecycle` modules)
- `rustfmt --edition 2024 --check` on the 3 changed files → **clean**
- `scripts/check_boundaries.py` → **no violations**
- File-size guard → changed files OK (the two large coordinator files carry the `djinn:allow-oversize` marker; `test_helpers.rs` is 289 lines)
- No new `sqlx::query!` — only existing repo methods used, so no `.sqlx` regeneration needed.

Note: local clippy 1.96 flags a pre-existing `Instant::now()` in `djinn-agent`'s `fuzzy_tests.rs` (unmodified on this branch, byte-identical to main) — an environment/toolchain discrepancy, not introduced here.