### PR TITLE
chore: de-flake 4 DB/coordinator tests

### DIFF
--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -566,30 +566,55 @@ async fn clone_postgres_test_template(server_prefix: &str, test_db: &str) -> DbR
     let opts = sqlx::postgres::PgConnectOptions::from_str(&admin_url).map_err(DbError::from)?;
     let mut conn = opts.connect().await.map_err(DbError::from)?;
 
+    // Take the template advisory lock in SHARED mode for the terminate+clone
+    // window. `ensure_test_template` holds the same lock EXCLUSIVELY while it
+    // has a live client connection to the template (migrate/verify), so this
+    // shared acquisition blocks until that bootstrap connection is gone — our
+    // `pg_terminate_backend` below can therefore never kill a live bootstrap
+    // connection (the `57P01 "terminating connection due to administrator
+    // command"` flake). Concurrent clones all take shared, so they never block
+    // each other.
+    sqlx::query("SELECT pg_advisory_lock_shared($1)")
+        .bind(template_bootstrap::TEMPLATE_ADVISORY_LOCK_ID)
+        .execute(&mut conn)
+        .await
+        .map_err(DbError::from)?;
+
     // Boot any stragglers off the template. Without this, parallel tests
     // racing on the template see `ERROR: source database "djinn_test_template"
     // is being accessed by other users`.
     // Non-macro: this is a side-effecting `SELECT pg_terminate_backend(...)`
     // executed for effect only. The `query!` macro types it as a row-returning
     // query (no `.execute()`), so we keep the plain form here.
-    sqlx::query(
-        "SELECT pg_terminate_backend(pid) \
-           FROM pg_stat_activity \
-          WHERE datname = 'djinn_test_template' \
-            AND pid <> pg_backend_pid()",
-    )
-    .execute(&mut conn)
-    .await
-    .map_err(DbError::from)?;
-
-    let stmt = format!(r#"CREATE DATABASE "{test_db}" TEMPLATE djinn_test_template"#);
-    sqlx::query(stmt.as_str())
+    let clone_result = async {
+        sqlx::query(
+            "SELECT pg_terminate_backend(pid) \
+               FROM pg_stat_activity \
+              WHERE datname = 'djinn_test_template' \
+                AND pid <> pg_backend_pid()",
+        )
         .execute(&mut conn)
         .await
         .map_err(DbError::from)?;
 
+        let stmt = format!(r#"CREATE DATABASE "{test_db}" TEMPLATE djinn_test_template"#);
+        sqlx::query(stmt.as_str())
+            .execute(&mut conn)
+            .await
+            .map_err(DbError::from)?;
+        Ok::<(), DbError>(())
+    }
+    .await;
+
+    // Always release the shared advisory lock, even if the clone failed, so a
+    // failed clone never wedges a bootstrap waiting on the exclusive lock.
+    let _ = sqlx::query("SELECT pg_advisory_unlock_shared($1)")
+        .bind(template_bootstrap::TEMPLATE_ADVISORY_LOCK_ID)
+        .execute(&mut conn)
+        .await;
+
     drop(conn);
-    Ok(())
+    clone_result
 }
 
 fn is_safe_database_identifier(name: &str) -> bool {

--- a/server/crates/djinn-db/src/template_bootstrap.rs
+++ b/server/crates/djinn-db/src/template_bootstrap.rs
@@ -34,6 +34,17 @@ use crate::error::{DbError, DbResult};
 static TEMPLATE_BOOTSTRAP_SEMAPHORE: std::sync::OnceLock<Arc<Semaphore>> =
     std::sync::OnceLock::new();
 
+/// Process-wide latch: set once the template has been created/verified in this
+/// process so every later `ensure_test_template` call short-circuits. Without
+/// this, bootstrap opens a fresh client connection to `djinn_test_template` on
+/// *every* test's first query (to verify migrations), and that connection is
+/// what a concurrent `clone_postgres_test_template` `pg_terminate_backend`
+/// races with — the `57P01 "terminating connection due to administrator
+/// command"` flake. Verifying once per process removes almost all of those
+/// template connections; the advisory lock (below) closes the remaining window
+/// for the single first-test bootstrap.
+static TEMPLATE_READY: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+
 fn bootstrap_semaphore() -> Arc<Semaphore> {
     TEMPLATE_BOOTSTRAP_SEMAPHORE
         .get_or_init(|| Arc::new(Semaphore::new(1)))
@@ -43,7 +54,14 @@ fn bootstrap_semaphore() -> Arc<Semaphore> {
 /// Advisory lock id used while creating/migrating `djinn_test_template`.
 ///
 /// Chosen as a deterministic 64-bit hash of the string "djinn_test_template".
-const TEMPLATE_ADVISORY_LOCK_ID: i64 = 0x6a5b4c3d2e1f0a9b;
+///
+/// `ensure_test_template` holds this in **exclusive** mode for the entire
+/// maintenance window (including the template-connected migrate/verify);
+/// `clone_postgres_test_template` takes it in **shared** mode around its
+/// `pg_terminate_backend`. Exclusive⇄shared conflict means a clone can never
+/// terminate a live bootstrap template connection, while concurrent clones
+/// (all shared) never block each other.
+pub(crate) const TEMPLATE_ADVISORY_LOCK_ID: i64 = 0x6a5b4c3d2e1f0a9b;
 
 /// Ensure the `djinn_test_template` database exists and is migrated.
 ///
@@ -54,31 +72,65 @@ const TEMPLATE_ADVISORY_LOCK_ID: i64 = 0x6a5b4c3d2e1f0a9b;
 /// Uses both a local semaphore (per-process) and a Postgres advisory lock
 /// (cross-process) so parallel tests / worker pods don't collide.
 pub(crate) async fn ensure_test_template(server_prefix: &str) -> DbResult<()> {
+    // Fast path: the template was already created/verified in this process.
+    if TEMPLATE_READY.get().is_some() {
+        return Ok(());
+    }
+
     let _permit = acquire_bootstrap_permit().await;
+
+    // Re-check under the local permit: a peer thread may have completed the
+    // bootstrap while we waited on the semaphore.
+    if TEMPLATE_READY.get().is_some() {
+        return Ok(());
+    }
 
     let admin_url = format!("{server_prefix}/postgres");
     let opts = sqlx::postgres::PgConnectOptions::from_str(&admin_url).map_err(DbError::from)?;
     let mut conn = opts.connect().await.map_err(DbError::from)?;
 
-    // Cross-process serialization: take an advisory lock for the duration of
-    // our maintenance work on the template. This makes multi-pod races safe.
+    // Cross-process serialization: take an EXCLUSIVE advisory lock for the
+    // duration of our maintenance work on the template — including the
+    // template-connected migrate/verify below. `clone_postgres_test_template`
+    // takes the same lock in SHARED mode around its `pg_terminate_backend`, so
+    // a concurrent clone can never terminate our live template connection
+    // (the `57P01` "terminating connection due to administrator command" flake).
     sqlx::query("SELECT pg_advisory_lock($1)")
         .bind(TEMPLATE_ADVISORY_LOCK_ID)
         .execute(&mut conn)
         .await
         .map_err(DbError::from)?;
 
+    // Do the maintenance work under the lock, then always release it — even on
+    // error — so a failed bootstrap never wedges peers waiting on the lock.
+    let result = ensure_test_template_locked(server_prefix, &mut conn).await;
+    let _ = unlock_template_bootstrap(&mut conn).await;
+    drop(conn);
+    result?;
+
+    // Only latch success: a failed bootstrap must be retried by the next test.
+    let _ = TEMPLATE_READY.set(());
+    Ok(())
+}
+
+/// Body of [`ensure_test_template`], run while the exclusive advisory lock is
+/// held on `conn`. Any template-connected work (migrate on create, verify on
+/// pre-existing) is therefore protected from a concurrent clone's
+/// `pg_terminate_backend`.
+async fn ensure_test_template_locked(
+    server_prefix: &str,
+    conn: &mut sqlx::postgres::PgConnection,
+) -> DbResult<()> {
     // Does the template exist?
     let exists: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM pg_database WHERE datname = 'djinn_test_template'",
     )
-    .fetch_one(&mut conn)
+    .fetch_one(&mut *conn)
     .await
     .map_err(DbError::from)?;
 
     if exists == 0 {
-        create_and_migrate_template(server_prefix, &mut conn).await?;
-        unlock_template_bootstrap(&mut conn).await?;
+        create_and_migrate_template(server_prefix, conn).await?;
         return Ok(());
     }
 
@@ -87,12 +139,12 @@ pub(crate) async fn ensure_test_template(server_prefix: &str) -> DbResult<()> {
     sqlx::query(
         "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'djinn_test_template'",
     )
-    .execute(&mut conn)
+    .execute(&mut *conn)
     .await
     .map_err(DbError::from)?;
 
-    unlock_template_bootstrap(&mut conn).await?;
-    drop(conn);
+    // The exclusive advisory lock is still held on `conn`, so verify's own
+    // connection to the template cannot be terminated by a racing clone.
     verify_template_migrations(server_prefix).await?;
 
     Ok(())


### PR DESCRIPTION
## Summary

The 4 tests reported \`FLAKY 2/3\` in the recent merge_group run are **not per-test logic bugs** — all four failed inside their *setup* (\`create_test_db\`/\`test_db\`, first query) with:

\`\`\`
57P01 terminating connection due to administrator command
\`\`\`

This is the same signature that cascaded ~25 unrelated tests in that run. Root cause is a race in the **shared test-DB harness**, reproduced deterministically against an isolated Postgres (no OOM involved):

- \`clone_postgres_test_template\` (per-test DB clone) runs \`pg_terminate_backend(...)\` on every backend connected to \`djinn_test_template\`, so \`CREATE DATABASE ... TEMPLATE\` doesn't fail with *"is being accessed by other users"*.
- But \`ensure_test_template\` also opens a **live client connection to the template** for its migrate/verify step, and it released the advisory lock **before** that verify ran.
- Under parallelism, one test's clone \`pg_terminate_backend\` killed another test's live bootstrap connection → \`57P01\` → panic in the victim's setup.

The 4 "flaky" tests were just whichever tests happened to be bootstrapping when a peer's clone fired. Their own logic is sound (edges written in-tx; isolated per-test DBs; atomic blocker swap under READ COMMITTED).

## Per-test verdict

| Test | Verdict | Root cause |
|---|---|---|
| \`djinn-coordinator … submit_advancement_moves_pending_to_submitted\` | infra-collateral of the harness race — fixed by the harness fix | 57P01 in setup |
| \`djinn-db … wikilink_graph::wikilink_resolves_on_create\` | same | 57P01 in setup (edges are written synchronously in-tx, so no logic flake) |
| \`djinn-db … project::tests::get_stack_unknown_project_returns_none\` | same | 57P01 in setup (isolated DB, plain SELECT — no logic flake) |
| \`djinn-db (task_tests) … blocker_swap_atomic_no_race_concurrent\` | same | 57P01 in setup (swap is atomic under READ COMMITTED; \`claim()\` never grabbed the task) |

## Fix (test harness only, no per-test changes)

- Hold the template advisory lock **exclusively** across the entire \`ensure_test_template\` body (including migrate/verify), and always release it, even on error.
- Latch a process-wide \`TEMPLATE_READY\` \`OnceLock\` so verify connects to the template at most once per process instead of on every test's first query.
- \`clone_postgres_test_template\` now takes the same advisory lock in **shared** mode around its \`pg_terminate_backend\` + \`CREATE DATABASE\`, so it can never terminate a live bootstrap connection; concurrent clones (all shared) never block each other.

## Verification (isolated Postgres, under concurrent load)

- \`blocker_swap_atomic_no_race_concurrent\`: **2/30 failing under load → 60/60** where it previously reproduced the 57P01 in ~10 iters.
- All 4 target tests: **30/30 each** under concurrent load.
- 9× full-suite concurrent runs (684 \`djinn-db\` lib tests + 126 \`task_tests\` at \`--test-threads 12\`): **zero \`57P01\`, zero failures.**
- \`cargo clippy -p djinn-coordinator -p djinn-db --lib --tests --all-features -- -D warnings\`: clean.
- \`rustfmt --edition 2024 --check\` on changed files: clean.
- No \`sqlx::query!\` macros changed (plain \`sqlx::query\` used for advisory locks), so no \`.sqlx\` regeneration needed.