### PR TITLE
Validate + auto-upgrade markdown proposal bodies carrying MDX block tags

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks.rs
@@ -31,8 +31,9 @@ pub use catalog::{
     proposal_block_definition_for_tag, proposal_block_registry, proposal_block_tags,
 };
 pub use parser::{
-    extract_custom_block_tags, parse_mdx_blocks, validate_block_ids, validate_mdx_blocks,
-    validate_question_form_placement, validate_question_form_placement_for_format,
+    extract_custom_block_tags, parse_mdx_blocks, validate_block_content, validate_block_ids,
+    validate_mdx_blocks, validate_question_form_placement,
+    validate_question_form_placement_for_format,
 };
 pub use types::{
     BlockCatalogEntry, BlockError, BlockRegistry, GetBlockCatalogParams, GetBlockCatalogResponse,

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/parser.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/parser.rs
@@ -372,6 +372,104 @@ pub fn extract_custom_block_tags(body: &str) -> Vec<String> {
     tags
 }
 
+/// The content-bearing ATTRIBUTE alternatives for a children-based block type.
+///
+/// `Some(&[...])` marks a block type as content-required: its visible content
+/// comes from its CHILDREN, so a self-closing tag or blank children renders an
+/// empty block. The slice lists attribute names that satisfy the content
+/// requirement in lieu of children (an empty slice means children are the ONLY
+/// content source). `None` means the block is not subject to this empty-content
+/// check — either self-closing is legitimate, or the emptiness is guarded
+/// elsewhere (e.g. `diagram` is covered by the empty-source guard in
+/// [`validate_mdx_blocks`]).
+///
+/// The children-based set and the attribute alternatives are derived from the
+/// catalog grammar in `proposal_blocks/catalog.rs`: `decisions`, `file-tree`,
+/// `checklist`, `diff`, `json-explorer`, `wireframe`, and `callout` are pure
+/// children blocks (`decisions`' `items=` / `file-tree`'s `entries=` prop forms
+/// are NOT rendered by the UI, so children are mandatory); `rich-text` and
+/// `annotated-code` accept a content attribute (`content` / `code`); `tabs` and
+/// `columns` are self-closing containers whose content lives in the `tabs` /
+/// `columns` attribute.
+fn content_required_attrs(block_type: &str) -> Option<&'static [&'static str]> {
+    match block_type {
+        "rich-text" => Some(&["content"]),
+        "annotated-code" => Some(&["code"]),
+        "tabs" => Some(&["tabs"]),
+        "columns" => Some(&["columns"]),
+        "decisions" | "file-tree" | "checklist" | "diff" | "json-explorer" | "wireframe"
+        | "callout" => Some(&[]),
+        _ => None,
+    }
+}
+
+/// Reject content-required blocks that arrive self-closing or with blank
+/// children and no content-bearing attribute.
+///
+/// A children-based block (see [`content_required_attrs`]) that has neither
+/// non-blank children nor a populated content attribute would validate as a
+/// "known tag" yet render empty in the UI — the exact production failure where
+/// `<Decisions id="x" decisions={[…]} />` (a children-based block written in the
+/// unsupported attribute form) silently rendered nothing. The returned error
+/// names the offending tag + id and states the expected grammar, reusing the
+/// catalog description as the source of truth.
+pub fn validate_block_content(blocks: &[ParsedProposalBlock]) -> Result<(), String> {
+    for block in blocks {
+        let Some(content_attrs) = content_required_attrs(&block.block_type) else {
+            continue;
+        };
+        // Satisfied by non-blank children …
+        if !block.raw_content.trim().is_empty() {
+            continue;
+        }
+        // … or by a present, non-empty content-bearing attribute.
+        let has_content_attr = content_attrs.iter().any(|name| {
+            block
+                .attributes
+                .get(*name)
+                .map(|v| !v.trim().is_empty())
+                .unwrap_or(false)
+        });
+        if has_content_attr {
+            continue;
+        }
+        return Err(empty_block_error(block, content_attrs));
+    }
+    Ok(())
+}
+
+/// Build an actionable error for an empty content-required block, naming the
+/// tag/id, listing any attribute alternative, and quoting the catalog grammar.
+fn empty_block_error(block: &ParsedProposalBlock, content_attrs: &[&str]) -> String {
+    let id = if block.id.is_empty() {
+        "<no id>".to_string()
+    } else {
+        format!("`{}`", block.id)
+    };
+    let mut msg = format!(
+        "{} block {id} is empty: its content must be written as block children",
+        block.tag
+    );
+    if !content_attrs.is_empty() {
+        let attrs = content_attrs
+            .iter()
+            .map(|a| format!("`{a}`"))
+            .collect::<Vec<_>>()
+            .join(" or ");
+        msg.push_str(&format!(" (or supplied via the {attrs} attribute)"));
+    }
+    msg.push_str(
+        ", but it arrived self-closing or with blank children and would render empty. ",
+    );
+    if let Some(def) = proposal_block_definition_for_tag(&block.tag)
+        && let Some(desc) = def.description
+    {
+        msg.push_str("Expected grammar — ");
+        msg.push_str(desc);
+    }
+    msg
+}
+
 /// Ensure all parsed blocks have non-empty, unique `id` attributes.
 pub fn validate_block_ids(blocks: &[ParsedProposalBlock]) -> Result<(), String> {
     let mut seen = HashSet::new();

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
@@ -757,3 +757,109 @@ fn registry_tags_match_catalog_tags() {
         "catalog tags must exactly match proposal_block_registry() tag values"
     );
 }
+
+// ── Empty children-based block rejection (validate_block_content) ────────────
+//
+// A known block whose catalog grammar is CHILDREN-based (decisions, file-tree,
+// checklist, diff, json-explorer, wireframe, callout) that arrives self-closing
+// or with blank children validates as a "known tag" yet renders empty. These
+// tests pin the write-time rejection and the actionable error text, plus the
+// content-attribute escape hatch for the attribute-form blocks.
+
+/// The exact production failure: `<Decisions ... decisions={[…]} />` written in
+/// the unsupported self-closing attribute form is rejected, and the error tells
+/// the author to write children markdown with `###` headings.
+#[test]
+fn block_content_rejects_self_closing_decisions_attr_form() {
+    let body = r#"<Decisions id="auth" title="Auth" decisions={[{"decision":"JWT"}]} />"#;
+    let blocks = parse_mdx_blocks(body).unwrap();
+    let err = validate_block_content(&blocks).unwrap_err();
+    assert!(err.contains("Decisions block"), "error was: {err}");
+    assert!(err.contains("`auth`"), "error must name the block id: {err}");
+    assert!(
+        err.contains("###"),
+        "decisions error must direct the author to `###` heading children: {err}"
+    );
+}
+
+/// A self-closing FileTree (children-only block) is rejected with an
+/// id-naming, grammar-quoting error.
+#[test]
+fn block_content_rejects_self_closing_file_tree() {
+    let body = r#"<FileTree id="layout" root="src" />"#;
+    let blocks = parse_mdx_blocks(body).unwrap();
+    let err = validate_block_content(&blocks).unwrap_err();
+    assert!(err.contains("FileTree block"), "error was: {err}");
+    assert!(err.contains("`layout`"), "error was: {err}");
+    assert!(err.contains("children"), "error was: {err}");
+}
+
+/// A self-closing Checklist (children-only, no attribute alternative) is
+/// rejected.
+#[test]
+fn block_content_rejects_self_closing_checklist() {
+    let body = r#"<Checklist id="acceptance" />"#;
+    let blocks = parse_mdx_blocks(body).unwrap();
+    let err = validate_block_content(&blocks).unwrap_err();
+    assert!(err.contains("Checklist block"), "error was: {err}");
+    assert!(err.contains("`acceptance`"), "error was: {err}");
+}
+
+/// Blank (whitespace-only) children are treated the same as self-closing.
+#[test]
+fn block_content_rejects_blank_children() {
+    let body = "<Callout id=\"c\" tone=\"warning\">\n   \n</Callout>";
+    let blocks = parse_mdx_blocks(body).unwrap();
+    let err = validate_block_content(&blocks).unwrap_err();
+    assert!(err.contains("Callout block"), "error was: {err}");
+}
+
+/// A valid children-form Decisions block is accepted.
+#[test]
+fn block_content_accepts_children_form_decisions() {
+    let body = "<Decisions id=\"auth\">\n### Use JWT for stateless auth\nStatus: accepted\n\nWe scale horizontally.\n</Decisions>";
+    let blocks = parse_mdx_blocks(body).unwrap();
+    assert!(validate_block_content(&blocks).is_ok());
+}
+
+/// The attribute-form blocks are accepted when their content attribute is
+/// present: annotated-code `code=`, rich-text `content=`, tabs `tabs=`,
+/// columns `columns=`.
+#[test]
+fn block_content_accepts_content_attribute_forms() {
+    let ac = r#"<AnnotatedCode id="ex" language="rust" code={`fn main() {}`} />"#;
+    assert!(validate_block_content(&parse_mdx_blocks(ac).unwrap()).is_ok());
+
+    let rt = r#"<RichText id="intro" content="Hello" />"#;
+    assert!(validate_block_content(&parse_mdx_blocks(rt).unwrap()).is_ok());
+
+    let tabs = r#"<Tabs id="t" tabs={[{ "label": "A", "body": "hi" }]} />"#;
+    assert!(validate_block_content(&parse_mdx_blocks(tabs).unwrap()).is_ok());
+
+    let cols = r#"<Columns id="c" columns={[{ "body": "left" }, { "body": "right" }]} />"#;
+    assert!(validate_block_content(&parse_mdx_blocks(cols).unwrap()).is_ok());
+}
+
+/// An attribute-form block with the content attribute MISSING is still rejected
+/// (an empty RichText renders nothing).
+#[test]
+fn block_content_rejects_attribute_form_without_content() {
+    let body = r#"<RichText id="intro" />"#;
+    let blocks = parse_mdx_blocks(body).unwrap();
+    let err = validate_block_content(&blocks).unwrap_err();
+    assert!(err.contains("RichText block"), "error was: {err}");
+    assert!(
+        err.contains("`content`"),
+        "error must mention the content attribute alternative: {err}"
+    );
+}
+
+/// Blocks that are not content-required (e.g. api-endpoint, diagram) are not
+/// subject to the empty-children guard here (diagram emptiness is guarded by
+/// `validate_mdx_blocks`).
+#[test]
+fn block_content_ignores_non_content_required_blocks() {
+    let body = r#"<ApiEndpoint id="get" method="GET" path="/x" />"#;
+    let blocks = parse_mdx_blocks(body).unwrap();
+    assert!(validate_block_content(&blocks).is_ok());
+}

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/create.rs
@@ -36,9 +36,7 @@ use crate::tools::acting_user::acting_caps;
 use crate::tools::list_response::{
     self, ListMeta, NamedListResponse, named_list_response_schema, serialize_named_list_response,
 };
-use crate::tools::proposal_blocks::{
-    parse_mdx_blocks, validate_mdx_blocks, validate_question_form_placement,
-};
+use crate::tools::proposal_blocks::{parse_mdx_blocks, validate_question_form_placement};
 use crate::tools::proposal_ops::{
     ProposalDebateTrailModel, ProposalDeleteResponse, ProposalEpicModel, ProposalListRow,
     ProposalListSummary, ProposalModel, ProposalShowResponse, ProposalSignoffModel,
@@ -47,8 +45,9 @@ use crate::tools::proposal_ops::{
 };
 use crate::tools::proposal_readiness::evaluate_proposal_readiness;
 use crate::tools::validation::{
-    validate_ac_count, validate_design, validate_limit, validate_mdx_body, validate_offset,
-    validate_proposal_create_status, validate_proposal_status, validate_sort, validate_title,
+    resolve_body_format_and_validate, validate_ac_count, validate_design, validate_limit,
+    validate_offset, validate_proposal_create_status, validate_proposal_status, validate_sort,
+    validate_title,
 };
 use djinn_db::{
     EpicRepository, ProjectRepository, ProposalListQuery, ProposalListSummaryRow,
@@ -277,10 +276,12 @@ impl DjinnMcpServer {
         if let Err(e) = validate_design(body) {
             return Json(err_single(e));
         }
-        if let Err(e) = validate_mdx_body(body, p.body_format.as_deref()) {
-            return Json(err_single(e));
-        }
-        let body_format = p.body_format.as_deref().unwrap_or("markdown");
+        // Resolve the persisted body_format (auto-upgrading a markdown body that
+        // carries block tags to mdx) and run the full MDX block-validation stack.
+        let body_format = match resolve_body_format_and_validate(body, p.body_format.as_deref()) {
+            Ok(f) => f,
+            Err(e) => return Json(err_single(e)),
+        };
         if body_format == "mdx"
             && let Err(e) = validate_question_form_placement(body)
         {
@@ -335,7 +336,7 @@ impl DjinnMcpServer {
                 body,
                 acceptance_criteria: Some(&ac_json),
                 status,
-                body_format: p.body_format.as_deref(),
+                body_format: Some(body_format),
             })
             .await
         {
@@ -406,16 +407,13 @@ impl DjinnMcpServer {
         if let Err(e) = validate_design(imported.body) {
             return Json(err_single(e));
         }
-        if imported.body_format == "mdx"
-            && let Err(e) = validate_mdx_blocks(imported.body)
-        {
-            return Json(err_single(e.to_string()));
-        }
-        if imported.body_format == "mdx"
-            && let Err(e) = parse_mdx_blocks(imported.body)
-        {
-            return Json(err_single(e.to_string()));
-        }
+        // Resolve the persisted format — a markdown-frontmatter body that carries
+        // block tags is upgraded to mdx — and validate the full block stack.
+        let body_format =
+            match resolve_body_format_and_validate(imported.body, Some(&imported.body_format)) {
+                Ok(f) => f,
+                Err(e) => return Json(err_single(e)),
+            };
 
         let repo = ProposalRepository::new(self.state.db().clone(), self.state.event_bus());
         let proposal = if let Some(id) = imported.id.as_deref() {
@@ -457,7 +455,7 @@ impl DjinnMcpServer {
                         acceptance_criteria: &imported.acceptance_criteria_json,
                         status: &existing.status,
                         superseded_by: existing.superseded_by.as_deref(),
-                        body_format: Some(&imported.body_format),
+                        body_format: Some(body_format),
                         // Imported proposals restore historical state — they
                         // are not authoring operations and carry no
                         // block-patch / native-skill attribution.
@@ -476,7 +474,7 @@ impl DjinnMcpServer {
                     body: imported.body,
                     acceptance_criteria: Some(&imported.acceptance_criteria_json),
                     status: None,
-                    body_format: Some(&imported.body_format),
+                    body_format: Some(body_format),
                 })
                 .await
             {
@@ -951,15 +949,18 @@ impl DjinnMcpServer {
         if let Err(e) = validate_design(body) {
             return Json(err_single(e));
         }
-        // Effective body_format: explicitly passed, else the proposal's current
-        // format (matches the repository's own fallback on update).
-        let body_format = p
+        // Effective declared format: explicitly passed, else the proposal's
+        // current format (matches the repository's own fallback on update).
+        let declared_format = p
             .body_format
             .as_deref()
             .unwrap_or(existing.body_format.as_str());
-        if let Err(e) = validate_mdx_body(body, Some(body_format)) {
-            return Json(err_single(e));
-        }
+        // Resolve the persisted format (auto-upgrading a markdown body that
+        // carries block tags) and run the full MDX block-validation stack.
+        let body_format = match resolve_body_format_and_validate(body, Some(declared_format)) {
+            Ok(f) => f,
+            Err(e) => return Json(err_single(e)),
+        };
         if p.body.is_some()
             && body_format == "mdx"
             && let Err(e) = validate_question_form_placement(body)
@@ -1015,7 +1016,7 @@ impl DjinnMcpServer {
                     acceptance_criteria: &ac_json,
                     status,
                     superseded_by: superseded_by.as_deref(),
-                    body_format: p.body_format.as_deref(),
+                    body_format: Some(body_format),
                     // Plain `proposal_update` writes carry no authoring
                     // attribution metadata — block-patch / native-skill tagging
                     // is reserved for the targeted patch primitive.

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/create_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/create_tests.rs
@@ -950,3 +950,189 @@ mod schema_lean_tests {
         assert_schema_excludes_terms(&json, FORBIDDEN_BLOCK_TERMS, "ProposalUpdateParams");
     }
 }
+
+// ── MDX auto-upgrade + block validation on the create/update write paths ─────
+//
+// A proposal body can carry MDX block tags while its declared/omitted
+// body_format is "markdown"; before the cutover that skipped ALL block
+// validation and stored the tags as raw markdown (rendered as literal text in
+// the UI). These tests pin the cutover: any full-body write with block tags is
+// upgraded to "mdx" and validated identically to a declared-mdx body.
+
+#[cfg(test)]
+mod mdx_upgrade_and_validation_tests {
+    use crate::server::DjinnMcpServer;
+    use crate::state::stubs::test_mcp_state;
+    use djinn_core::events::EventBus;
+    use djinn_db::{Database, ProposalCreateInput, ProposalRepository};
+
+    async fn test_server() -> (DjinnMcpServer, Database) {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        (DjinnMcpServer::new(test_mcp_state(db.clone())), db)
+    }
+
+    /// A valid block body (children-form blocks + a trailing question-form).
+    const VALID_BLOCK_BODY: &str = "# Proposal\n\n<Callout id=\"note\" tone=\"info\">\nImportant context.\n</Callout>\n\n<QuestionForm id=\"q\" title=\"Open Questions\">\nAny concerns?\n</QuestionForm>\n";
+
+    /// create with omitted body_format + a body containing known block tags →
+    /// stored body_format is upgraded to "mdx".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_omitted_format_with_blocks_stores_mdx() {
+        let (server, _db) = test_server().await;
+        let resp = server
+            .dispatch_tool(
+                "proposal_create",
+                serde_json::json!({ "title": "Blocks", "body": VALID_BLOCK_BODY }),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.get("error").is_none(),
+            "create should succeed: {:?}",
+            resp.get("error")
+        );
+        assert_eq!(
+            resp.get("body_format").and_then(|v| v.as_str()),
+            Some("mdx"),
+            "a markdown body carrying block tags must be stored as mdx"
+        );
+    }
+
+    /// create with body_format="markdown" + an UNKNOWN block tag is rejected
+    /// (this passed silently before the cutover).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_markdown_format_with_unknown_block_rejected() {
+        let (server, _db) = test_server().await;
+        let resp = server
+            .dispatch_tool(
+                "proposal_create",
+                serde_json::json!({
+                    "title": "Bad",
+                    "body": "# P\n\n<FancyUnknown id=\"x\" />\n",
+                    "body_format": "markdown",
+                }),
+            )
+            .await
+            .unwrap();
+        let err = resp.get("error").and_then(|v| v.as_str()).expect("error");
+        assert!(err.contains("FancyUnknown"), "error was: {err}");
+    }
+
+    /// The exact production failure: `<Decisions id="x" decisions={[…]} />` in a
+    /// markdown body is rejected with an actionable error telling the author to
+    /// write children markdown with `###` headings.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_self_closing_decisions_attr_form_rejected() {
+        let (server, _db) = test_server().await;
+        let body = "# P\n\n<Decisions id=\"choice\" decisions={[{\"decision\":\"JWT\"}]} />\n\n<QuestionForm id=\"q\" title=\"Q\">\nq?\n</QuestionForm>\n";
+        let resp = server
+            .dispatch_tool(
+                "proposal_create",
+                serde_json::json!({ "title": "Decisions attr form", "body": body }),
+            )
+            .await
+            .unwrap();
+        let err = resp.get("error").and_then(|v| v.as_str()).expect("error");
+        assert!(err.contains("Decisions block"), "error was: {err}");
+        assert!(err.contains("`choice`"), "error was: {err}");
+        assert!(err.contains("###"), "error was: {err}");
+    }
+
+    /// Self-closing file-tree and checklist blocks are likewise rejected on the
+    /// create path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_self_closing_children_blocks_rejected() {
+        let (server, _db) = test_server().await;
+        for (id, tag_body) in [
+            ("layout", "<FileTree id=\"layout\" root=\"src\" />"),
+            ("acc", "<Checklist id=\"acc\" />"),
+        ] {
+            let body = format!(
+                "# P\n\n{tag_body}\n\n<QuestionForm id=\"q\" title=\"Q\">\nq?\n</QuestionForm>\n"
+            );
+            let resp = server
+                .dispatch_tool(
+                    "proposal_create",
+                    serde_json::json!({ "title": "empty block", "body": body }),
+                )
+                .await
+                .unwrap();
+            let err = resp
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| panic!("expected error for id {id}"));
+            assert!(err.contains(&format!("`{id}`")), "error was: {err}");
+        }
+    }
+
+    /// A valid children-form Decisions block plus an annotated-code attribute
+    /// form are accepted, and the proposal is stored as mdx.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_valid_children_and_attr_forms_accepted() {
+        let (server, _db) = test_server().await;
+        let body = "# P\n\n<Decisions id=\"d\">\n### Use JWT for stateless auth\nStatus: accepted\n\nWe scale horizontally.\n</Decisions>\n\n<AnnotatedCode id=\"code\" language=\"rust\" code={`fn main() {}`} />\n\n<QuestionForm id=\"q\" title=\"Q\">\nq?\n</QuestionForm>\n";
+        let resp = server
+            .dispatch_tool(
+                "proposal_create",
+                serde_json::json!({ "title": "Valid blocks", "body": body }),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.get("error").is_none(),
+            "create should succeed: {:?}",
+            resp.get("error")
+        );
+        assert_eq!(resp.get("body_format").and_then(|v| v.as_str()), Some("mdx"));
+    }
+
+    /// update path: a markdown proposal updated with a body carrying block tags
+    /// is upgraded to mdx; an unknown block tag on update is rejected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_upgrades_and_validates_blocks() {
+        let (server, db) = test_server().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let existing = repo
+            .create(ProposalCreateInput {
+                title: "Plain",
+                body: "plain markdown",
+                acceptance_criteria: Some("[]"),
+                status: None,
+                body_format: Some("markdown"),
+            })
+            .await
+            .unwrap();
+
+        // Upgrade: update the body with block tags → stored as mdx.
+        let ok = server
+            .dispatch_tool(
+                "proposal_update",
+                serde_json::json!({ "id": existing.id, "body": VALID_BLOCK_BODY }),
+            )
+            .await
+            .unwrap();
+        assert!(
+            ok.get("error").is_none(),
+            "update should succeed: {:?}",
+            ok.get("error")
+        );
+        assert_eq!(ok.get("body_format").and_then(|v| v.as_str()), Some("mdx"));
+        let stored = repo.get(&existing.id).await.unwrap().unwrap();
+        assert_eq!(stored.body_format, "mdx");
+
+        // Reject: update with an unknown block tag.
+        let bad = server
+            .dispatch_tool(
+                "proposal_update",
+                serde_json::json!({
+                    "id": existing.id,
+                    "body": "# P\n\n<TotallyUnknown id=\"z\" />\n",
+                }),
+            )
+            .await
+            .unwrap();
+        let err = bad.get("error").and_then(|v| v.as_str()).expect("error");
+        assert!(err.contains("TotallyUnknown"), "error was: {err}");
+    }
+}

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/end_to_end_planner_tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/end_to_end_planner_tests.rs
@@ -198,7 +198,7 @@ The open-questions section collects uncertainties for the team.
             ),
             (
                 "The approach section describes the high-level plan in prose.",
-                "<FileTree id=\"repo-layout\" name=\"repo\" />",
+                "<FileTree id=\"repo-layout\" name=\"repo\">\nsrc/\n</FileTree>",
                 "second patch: approach -> FileTree",
             ),
             (
@@ -303,7 +303,7 @@ The open-questions section collects uncertainties for the team.
             ),
             (
                 "The approach section describes the high-level plan in prose.",
-                "<FileTree id=\"repo\" name=\"repo\" />",
+                "<FileTree id=\"repo\" name=\"repo\">\nsrc/\n</FileTree>",
             ),
         ] {
             let response = server
@@ -422,7 +422,7 @@ The open-questions section collects uncertainties for the team.
             ),
             (
                 "The approach section describes the high-level plan in prose.",
-                "<FileTree id=\"repo-layout\" name=\"repo\" />",
+                "<FileTree id=\"repo-layout\" name=\"repo\">\nsrc/\n</FileTree>",
             ),
             (
                 "The tradeoffs section enumerates the costs of the chosen approach.",
@@ -638,7 +638,7 @@ The open-questions section collects uncertainties for the team.
             ),
             (
                 "The approach section describes the high-level plan in prose.",
-                "<FileTree id=\"repo-layout\" name=\"repo\" />",
+                "<FileTree id=\"repo-layout\" name=\"repo\">\nsrc/\n</FileTree>",
             ),
             (
                 "The tradeoffs section enumerates the costs of the chosen approach.",

--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/mdx.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/mdx.rs
@@ -21,10 +21,9 @@ use rmcp::schemars;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
-use crate::tools::proposal_blocks::{
-    extract_custom_block_tags, parse_mdx_blocks, validate_mdx_blocks,
+use crate::tools::validation::{
+    resolve_body_format_and_validate, validate_ac_count, validate_design,
 };
-use crate::tools::validation::{validate_ac_count, validate_design};
 
 // ── MDX frontmatter parsing (import path) ───────────────────────────────────
 
@@ -420,19 +419,12 @@ pub fn apply_block_patch(
         _ => unreachable!(),
     };
 
-    // Determine body_format: if the proposal is markdown and the patch
-    // introduces MDX block tags, upgrade to mdx.
-    let has_mdx_blocks = !extract_custom_block_tags(&new_body).is_empty();
-    let new_body_format = if existing_body_format == "mdx" || has_mdx_blocks {
-        "mdx"
-    } else {
-        "markdown"
-    };
-
-    if new_body_format == "mdx" {
-        validate_mdx_blocks(&new_body).map_err(|e| format!("resulting MDX is invalid: {e}"))?;
-        parse_mdx_blocks(&new_body).map_err(|e| format!("resulting MDX parse error: {e}"))?;
-    }
+    // Resolve the persisted body_format (upgrading markdown→mdx when the patch
+    // introduces block tags) and run the shared MDX block-validation stack — the
+    // same resolution + validation the create/update/import write paths use, so
+    // all four paths reject unknown tags and empty children-based blocks
+    // identically.
+    let new_body_format = resolve_body_format_and_validate(&new_body, Some(existing_body_format))?;
     validate_design(&new_body)?;
 
     let mut event_metadata = serde_json::json!({
@@ -571,6 +563,51 @@ mod import_tests {
             serde_json::from_str::<JsonValue>(&stored.acceptance_criteria).unwrap(),
             serde_json::json!([])
         );
+    }
+
+    /// A `proposal.mdx` whose frontmatter declares `body_format: markdown` but
+    /// whose body carries block tags is upgraded to mdx and validated on import
+    /// (previously the blocks were stored unvalidated as raw markdown).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proposal_import_markdown_frontmatter_with_blocks_upgrades_to_mdx() {
+        let (server, db) = test_server().await;
+        let mdx = "---\ntitle: Imported blocks\nbody_format: markdown\n---\nIntro\n\n<Callout id=\"c\" tone=\"info\">\nNote.\n</Callout>\n";
+
+        let response = server
+            .dispatch_tool("proposal_import", serde_json::json!({ "mdx": mdx }))
+            .await
+            .unwrap();
+        assert!(
+            response.get("error").is_none(),
+            "import should succeed: {:?}",
+            response.get("error")
+        );
+        let id = response.get("id").and_then(|v| v.as_str()).unwrap();
+        let repo = ProposalRepository::new(db, EventBus::noop());
+        let stored = repo.get(id).await.unwrap().unwrap();
+        assert_eq!(
+            stored.body_format, "mdx",
+            "markdown frontmatter + block tags must be stored as mdx"
+        );
+    }
+
+    /// Import likewise rejects an empty children-based block written in the
+    /// self-closing attribute form, even when the frontmatter says markdown.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn proposal_import_rejects_self_closing_children_block() {
+        let (server, _db) = test_server().await;
+        let mdx = "---\ntitle: Bad decisions\nbody_format: markdown\n---\n<Decisions id=\"d\" decisions={[{\"decision\":\"x\"}]} />\n";
+
+        let response = server
+            .dispatch_tool("proposal_import", serde_json::json!({ "mdx": mdx }))
+            .await
+            .unwrap();
+        let err = response
+            .get("error")
+            .and_then(|v| v.as_str())
+            .expect("error");
+        assert!(err.contains("Decisions block"), "error was: {err}");
+        assert!(err.contains("###"), "error was: {err}");
     }
 }
 

--- a/server/crates/djinn-control-plane/src/tools/validation.rs
+++ b/server/crates/djinn-control-plane/src/tools/validation.rs
@@ -4,7 +4,8 @@
 // message suitable for returning as a JSON `{ "error": ... }` response.
 
 use crate::tools::proposal_blocks::{
-    extract_custom_block_tags, parse_mdx_blocks, proposal_block_tags,
+    extract_custom_block_tags, parse_mdx_blocks, proposal_block_tags, validate_block_content,
+    validate_mdx_blocks,
 };
 
 /// Decode the handful of HTML entities that LLM-authored plain text routinely
@@ -189,6 +190,51 @@ pub fn validate_mdx_body(body: &str, body_format: Option<&str>) -> Result<(), St
     }
     validate_html_block_safety(body)?;
     Ok(())
+}
+
+/// Resolve the effective `body_format` for a full-body proposal write and run
+/// the full MDX block-validation stack on it.
+///
+/// This is the shared cutover that closes the "markdown body full of block tags"
+/// hole: a `markdown` body that carries any custom (PascalCase) block tag is
+/// upgraded to `mdx` and validated, exactly like [`apply_block_patch`] already
+/// does for targeted patches. A body that is already `mdx`, or has no block
+/// tags, keeps its declared format. When the effective format is `mdx` the body
+/// must pass the whole stack: unknown-tag rejection + wireframe HTML-safety
+/// ([`validate_mdx_body`]), the empty-diagram guard and unknown-tag walk
+/// ([`validate_mdx_blocks`]), a structural parse ([`parse_mdx_blocks`]), and the
+/// empty-children guard ([`validate_block_content`]).
+///
+/// All four full-body write paths — `proposal_create`, `proposal_update`,
+/// `proposal_import`, and `apply_block_patch` (block-patch) — call this so they
+/// resolve the persisted format and validate identically. It deliberately does
+/// NOT enforce question-form placement: that is an authoring-gate concern layered
+/// on top by `proposal_create` / `proposal_update` (and intentionally skipped by
+/// the block-patch and import restore paths).
+///
+/// Returns the `&'static str` format to persist (`"markdown"` or `"mdx"`).
+pub fn resolve_body_format_and_validate(
+    body: &str,
+    declared_format: Option<&str>,
+) -> Result<&'static str, String> {
+    let has_block_tags = !extract_custom_block_tags(body).is_empty();
+    let effective = if declared_format == Some("mdx") || has_block_tags {
+        "mdx"
+    } else {
+        "markdown"
+    };
+
+    if effective == "mdx" {
+        // Unknown-tag rejection + wireframe active-markup backstop.
+        validate_mdx_body(body, Some("mdx"))?;
+        // Unknown-tag walk (descends nested blocks) + empty-diagram guard.
+        validate_mdx_blocks(body).map_err(|e| e.to_string())?;
+        // Structural parse, then reject empty children-based blocks.
+        let blocks = parse_mdx_blocks(body).map_err(|e| e.to_string())?;
+        validate_block_content(&blocks)?;
+    }
+
+    Ok(effective)
 }
 
 /// Server-side backstop for the sandboxed `html` and `wireframe` blocks (defense
@@ -802,5 +848,58 @@ Bind it with `el.onclick = fn` in the handler.
         assert!(validate_epic_create_status(Some("drafting")).is_err());
         assert!(validate_epic_create_status(Some("proposed")).is_err());
         assert!(validate_epic_create_status(Some("closed")).is_err());
+    }
+
+    // ── resolve_body_format_and_validate ─────────────────────────────────────
+
+    #[test]
+    fn resolve_plain_markdown_stays_markdown() {
+        // No block tags → stays markdown, no validation applied.
+        assert_eq!(
+            resolve_body_format_and_validate("# Title\n\nPlain prose.", Some("markdown")).unwrap(),
+            "markdown"
+        );
+        assert_eq!(
+            resolve_body_format_and_validate("just text", None).unwrap(),
+            "markdown"
+        );
+    }
+
+    #[test]
+    fn resolve_markdown_with_block_tags_upgrades_to_mdx() {
+        // A markdown-declared body carrying a known block tag is upgraded and
+        // validated — this is the core cutover that closes the storage hole.
+        let body = "<Callout id=\"c\" tone=\"info\">\nNote.\n</Callout>";
+        assert_eq!(
+            resolve_body_format_and_validate(body, Some("markdown")).unwrap(),
+            "mdx"
+        );
+        // Omitted format upgrades the same way.
+        assert_eq!(resolve_body_format_and_validate(body, None).unwrap(), "mdx");
+    }
+
+    #[test]
+    fn resolve_markdown_with_unknown_block_tag_is_rejected() {
+        // Previously passed silently (markdown skipped all validation).
+        let body = "<FooBar id=\"x\" />";
+        let err = resolve_body_format_and_validate(body, Some("markdown")).unwrap_err();
+        assert!(err.contains("FooBar"), "error was: {err}");
+    }
+
+    #[test]
+    fn resolve_rejects_empty_children_based_block() {
+        // The production failure: a self-closing children-based block.
+        let body = r#"<Decisions id="d" decisions={[{"decision":"x"}]} />"#;
+        let err = resolve_body_format_and_validate(body, Some("markdown")).unwrap_err();
+        assert!(err.contains("Decisions block"), "error was: {err}");
+        assert!(err.contains("###"), "error was: {err}");
+    }
+
+    #[test]
+    fn resolve_mdx_declared_empty_body_ok() {
+        assert_eq!(
+            resolve_body_format_and_validate("", Some("mdx")).unwrap(),
+            "mdx"
+        );
     }
 }


### PR DESCRIPTION
## The bug

A proposal body could be stored with MDX block tags while its `body_format` stayed `"markdown"`. That had two consequences:

1. **Validation skipped.** `validate_mdx_body` returns `Ok(())` immediately when `body_format != "mdx"`, so a markdown-format body full of block tags was never checked — `proposal_create`/`proposal_update`/`proposal_import` all had this hole.
2. **Rendered as raw text.** The UI only routes a body through the block renderer when `body_format === "mdx"` (`ui/src/pages/ProposalsPage.tsx`), so those blocks displayed as literal `<Decisions .../>` text.

A secondary defect: a children-based block written in a self-closing/attribute-only form (the production case `<Decisions id="x" decisions={[…]} />` — `Decisions` is children-based; the `items=`/`decisions=` prop form is not rendered) validated as a known tag yet rendered empty. Nothing rejected it.

Real-world trigger: proposal `019f2f0c-0a3b-78b3-995d-e4b30aecc0b6` was created `body_format="markdown"` but contained `<Decisions>`, `<FileTree>`, `<AnnotatedCode>`, `<Diagram>` blocks.

## The fix (clean cutover, no compat shim)

- **`resolve_body_format_and_validate`** (validation.rs): a shared helper used by all four full-body write paths (`proposal_create`, `proposal_update`, `proposal_import`, and `apply_block_patch`). It resolves the effective `body_format` — **auto-upgrading a markdown body that carries custom block tags to `mdx`** — and runs the full MDX validation stack (unknown-tag rejection + wireframe HTML-safety, empty-diagram guard, structural parse, and the new empty-children guard). This mirrors what `apply_block_patch` already did for targeted patches; now every path resolves + validates identically.
- **`validate_block_content`** (proposal_blocks/parser.rs): rejects children-based blocks (`decisions`, `file-tree`, `checklist`, `diff`, `json-explorer`, `wireframe`, `callout`) that arrive self-closing or with blank children, with an actionable error that names the block id/tag and quotes the catalog grammar (source of truth). Attribute-form blocks (`annotated-code` `code=`, `rich-text` `content=`, `tabs`/`columns`) are accepted when their content attribute is present. The exact production failure `<Decisions id="x" decisions={[…]} />` is now rejected, directing the author to write `###`-heading children.

`validate_mdx_body`'s contract is unchanged (still mdx-only); the upgrade + always-validate happens in the shared resolver at the tool layer, so the low-level function's tests still hold.

## Tests

- `validate_block_content` unit tests: self-closing decisions (attr form) / file-tree / checklist / blank-children rejected; children-form decisions + attribute-form blocks accepted; missing content attribute rejected; non-content-required blocks ignored.
- `resolve_body_format_and_validate` unit tests: plain markdown stays markdown; markdown + block tags → mdx; unknown tag rejected; empty children-based block rejected; declared-mdx empty body ok.
- Tool-level create/update tests: omitted-format + blocks → stored `mdx`; markdown + unknown tag rejected; `<Decisions … decisions={…} />` rejected with actionable `###` error; self-closing file-tree/checklist rejected; valid children + annotated-code attribute forms accepted; update upgrade + unknown-tag rejection.
- Import tests: markdown-frontmatter body with blocks upgraded to mdx; self-closing children block rejected.
- Updated `end_to_end_planner_tests` fixtures that relied on the old lax behavior (self-closing `<FileTree … />`) to supply children.

## Note (out of scope, not fixed)

`djinn-mcp-extension/src/handlers/task_epic.rs::call_proposal_update` (the in-pod agent `proposal_update`) writes the body through the repository with `body_format: p.body_format.as_deref()` and does **not** run block validation / auto-upgrade — it has the same hole as the server tool did. Its sibling `call_proposal_block_patch` reuses the shared `apply_block_patch`, so it picks up this fix automatically. `djinn-coordinator/refinement_outcome.rs` reverts to an already-persisted historical revision (a restore, not new authoring), so its bypass is benign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)