### PR TITLE
Route in-pod proposal_update through shared body-format resolution + block validation

### DIFF
--- a/server/crates/djinn-mcp-extension/Cargo.toml
+++ b/server/crates/djinn-mcp-extension/Cargo.toml
@@ -28,6 +28,9 @@ uuid = { version = "1", features = ["v7"] }
 workspace-hack.workspace = true
 
 [dev-dependencies]
+# Activate test-support on djinn-control-plane so handler tests can build a
+# stub McpState (`state::stubs::test_mcp_state`) for the ExtensionContext seam.
+djinn-control-plane = { path = "../djinn-control-plane", features = ["test-support"] }
 insta = { version = "1", features = ["json"] }
 regex = "1"
 tempfile = "3"

--- a/server/crates/djinn-mcp-extension/src/handlers/task_epic.rs
+++ b/server/crates/djinn-mcp-extension/src/handlers/task_epic.rs
@@ -16,8 +16,10 @@ use djinn_control_plane::tools::task_tools::{
     UpdateTaskRequest as SharedUpdateTaskRequest, add_task_comment as shared_add_task_comment,
     create_task as shared_create_task, update_task as shared_update_task,
 };
+use djinn_control_plane::tools::proposal_blocks::validate_question_form_placement;
 use djinn_control_plane::tools::validation::{
-    validate_ac_count, validate_design, validate_mdx_body, validate_proposal_status, validate_title,
+    resolve_body_format_and_validate, validate_ac_count, validate_design,
+    validate_proposal_status, validate_title,
 };
 use djinn_db::repositories::proposal::ProposalAcceptanceCriteriaAmendment;
 use djinn_db::{
@@ -754,6 +756,13 @@ pub(crate) async fn call_proposal_ac_set(
 /// authoring-attribution `event_metadata` is left `None` — the coordinator's
 /// refinement dispatch tags the resulting revision(s) with
 /// `source = "refinement_loop"` after the session.
+///
+/// Body validation IS identical to the server-side tool: the shared
+/// `resolve_body_format_and_validate` cutover auto-upgrades a markdown body
+/// carrying MDX block tags to `mdx`, runs the full block-validation stack
+/// (unknown tags, empty children-based blocks, wireframe safety, empty
+/// diagrams), and the question-form placement gate applies when a new mdx
+/// body is written.
 pub(crate) async fn call_proposal_update(
     ctx: &dyn ExtensionContext,
     arguments: &Option<serde_json::Map<String, serde_json::Value>>,
@@ -770,11 +779,23 @@ pub(crate) async fn call_proposal_update(
     };
     let body = p.body.as_deref().unwrap_or(&existing.body);
     validate_design(body)?;
-    let body_format = p
+    // Effective declared format: explicitly passed, else the proposal's
+    // current format (matches the server-side tool's fallback on update).
+    let declared_format = p
         .body_format
         .as_deref()
         .unwrap_or(existing.body_format.as_str());
-    validate_mdx_body(body, Some(body_format))?;
+    // Resolve the persisted format (auto-upgrading a markdown body that
+    // carries block tags to mdx) and run the full MDX block-validation stack —
+    // the same shared cutover the server-side `proposal_update` uses, so both
+    // write paths validate and persist identically. Previously this handler
+    // only ran `validate_mdx_body` against the DECLARED format, so a markdown
+    // body full of block tags skipped all validation and was stored as
+    // markdown (rendered as raw text in the UI).
+    let body_format = resolve_body_format_and_validate(body, Some(declared_format))?;
+    if p.body.is_some() && body_format == "mdx" {
+        validate_question_form_placement(body)?;
+    }
 
     let ac_json = if let Some(ac) = &p.acceptance_criteria {
         validate_ac_count(ac.len())?;
@@ -804,7 +825,7 @@ pub(crate) async fn call_proposal_update(
                 acceptance_criteria: &ac_json,
                 status,
                 superseded_by: superseded_by.as_deref(),
-                body_format: p.body_format.as_deref(),
+                body_format: Some(body_format),
                 event_metadata: None,
             },
         )

--- a/server/crates/djinn-mcp-extension/src/tests/mod.rs
+++ b/server/crates/djinn-mcp-extension/src/tests/mod.rs
@@ -3,5 +3,6 @@ mod evidence_spike_regression_tests;
 mod fuzzy_tests;
 mod helpers_tests;
 mod lsp_schema_tests;
+mod proposal_update_handler_tests;
 mod schema_tests;
 mod truncate_tests;

--- a/server/crates/djinn-mcp-extension/src/tests/proposal_update_handler_tests.rs
+++ b/server/crates/djinn-mcp-extension/src/tests/proposal_update_handler_tests.rs
@@ -1,0 +1,224 @@
+//! Handler-level tests for the in-pod `proposal_update` write path
+//! (`handlers::task_epic::call_proposal_update`).
+//!
+//! These mirror the server-side tool tests in
+//! `djinn-control-plane/src/tools/proposal_tools/create_tests.rs`
+//! (`mdx_upgrade_and_validation_tests`): the in-pod agent path must resolve
+//! the persisted `body_format` and validate MDX blocks byte-identically to the
+//! server-side `proposal_update` — auto-upgrading a markdown body that carries
+//! block tags to `mdx`, rejecting unknown tags and empty children-based
+//! blocks, and accepting valid children / content-attribute forms.
+
+use std::path::{Path, PathBuf};
+
+use djinn_control_plane::McpState;
+use djinn_control_plane::state::stubs::test_mcp_state;
+use djinn_core::events::EventBus;
+use djinn_db::{Database, ProposalCreateInput, ProposalRepository};
+
+use crate::context::ExtensionContext;
+use crate::handlers::task_epic::call_proposal_update;
+
+/// Minimal [`ExtensionContext`] stub over an in-memory database. Only `db()`
+/// and `event_bus()` are exercised by the proposal handlers; the remaining
+/// capabilities return inert defaults.
+struct StubCtx {
+    db: Database,
+}
+
+#[async_trait::async_trait]
+impl ExtensionContext for StubCtx {
+    fn db(&self) -> Database {
+        self.db.clone()
+    }
+    fn event_bus(&self) -> EventBus {
+        EventBus::noop()
+    }
+    fn mcp_state(&self) -> McpState {
+        test_mcp_state(self.db.clone())
+    }
+    fn lsp(&self) -> djinn_lsp::LspManager {
+        djinn_lsp::LspManager::new()
+    }
+    fn working_root_for(&self, fallback: &Path) -> PathBuf {
+        fallback.to_path_buf()
+    }
+    fn default_project_id(&self) -> Option<&str> {
+        None
+    }
+}
+
+async fn test_ctx() -> StubCtx {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    StubCtx { db }
+}
+
+/// Seed a plain-markdown proposal directly through the repository.
+async fn seed_markdown_proposal(ctx: &StubCtx) -> djinn_core::models::proposal::Proposal {
+    let repo = ProposalRepository::new(ctx.db(), ctx.event_bus());
+    repo.create(ProposalCreateInput {
+        title: "Plain",
+        body: "plain markdown body",
+        acceptance_criteria: Some("[]"),
+        status: None,
+        body_format: Some("markdown"),
+    })
+    .await
+    .unwrap()
+}
+
+fn args(v: serde_json::Value) -> Option<serde_json::Map<String, serde_json::Value>> {
+    Some(v.as_object().cloned().expect("args must be an object"))
+}
+
+/// A valid block-bearing body (children-form callout + trailing question-form,
+/// satisfying the mdx question-form placement gate).
+const VALID_BLOCK_BODY: &str = "# Proposal\n\n<Callout id=\"note\" tone=\"info\">\nImportant context.\n</Callout>\n\n<QuestionForm id=\"q\" title=\"Open Questions\">\nAny concerns?\n</QuestionForm>\n";
+
+/// Omitted body_format + a body carrying known block tags → the stored
+/// body_format is upgraded to "mdx" (previously stored as markdown with all
+/// block validation skipped).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_omitted_format_with_blocks_stores_mdx() {
+    let ctx = test_ctx().await;
+    let existing = seed_markdown_proposal(&ctx).await;
+
+    let result = call_proposal_update(
+        &ctx,
+        &args(serde_json::json!({ "id": existing.id, "body": VALID_BLOCK_BODY })),
+    )
+    .await
+    .expect("update should succeed");
+    assert_eq!(result["ok"], serde_json::json!(true));
+
+    let repo = ProposalRepository::new(ctx.db(), ctx.event_bus());
+    let stored = repo.get(&existing.id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.body_format, "mdx",
+        "a markdown body carrying block tags must be stored as mdx"
+    );
+    assert_eq!(stored.body, VALID_BLOCK_BODY);
+}
+
+/// An unknown block tag in a markdown-declared body is rejected (previously
+/// passed silently because markdown bodies skipped validation).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_unknown_block_tag_rejected() {
+    let ctx = test_ctx().await;
+    let existing = seed_markdown_proposal(&ctx).await;
+
+    let err = call_proposal_update(
+        &ctx,
+        &args(serde_json::json!({
+            "id": existing.id,
+            "body": "# P\n\n<TotallyUnknown id=\"z\" />\n",
+            "body_format": "markdown",
+        })),
+    )
+    .await
+    .expect_err("unknown block tag must be rejected");
+    assert!(err.contains("TotallyUnknown"), "error was: {err}");
+
+    // Nothing was persisted.
+    let repo = ProposalRepository::new(ctx.db(), ctx.event_bus());
+    let stored = repo.get(&existing.id).await.unwrap().unwrap();
+    assert_eq!(stored.body, "plain markdown body");
+    assert_eq!(stored.body_format, "markdown");
+}
+
+/// The exact production failure: a children-based block written in the
+/// self-closing attribute form (`<Decisions id="x" decisions={[…]} />`) is
+/// rejected with an actionable error directing the author to `###`-heading
+/// children markdown.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_self_closing_decisions_attr_form_rejected() {
+    let ctx = test_ctx().await;
+    let existing = seed_markdown_proposal(&ctx).await;
+
+    let body = "# P\n\n<Decisions id=\"choice\" decisions={[{\"decision\":\"JWT\"}]} />\n\n<QuestionForm id=\"q\" title=\"Q\">\nq?\n</QuestionForm>\n";
+    let err = call_proposal_update(
+        &ctx,
+        &args(serde_json::json!({ "id": existing.id, "body": body })),
+    )
+    .await
+    .expect_err("self-closing Decisions must be rejected");
+    assert!(err.contains("Decisions block"), "error was: {err}");
+    assert!(err.contains("`choice`"), "error must name the id: {err}");
+    assert!(
+        err.contains("###"),
+        "error must direct the author to `###` heading children: {err}"
+    );
+}
+
+/// Self-closing file-tree and checklist blocks (children-based, no attribute
+/// alternative) are likewise rejected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_self_closing_children_blocks_rejected() {
+    let ctx = test_ctx().await;
+    let existing = seed_markdown_proposal(&ctx).await;
+
+    for (id, tag_body) in [
+        ("layout", "<FileTree id=\"layout\" root=\"src\" />"),
+        ("acc", "<Checklist id=\"acc\" />"),
+    ] {
+        let body = format!(
+            "# P\n\n{tag_body}\n\n<QuestionForm id=\"q\" title=\"Q\">\nq?\n</QuestionForm>\n"
+        );
+        let result = call_proposal_update(
+            &ctx,
+            &args(serde_json::json!({ "id": existing.id, "body": body })),
+        )
+        .await;
+        let err = match result {
+            Err(e) => e,
+            Ok(v) => panic!("expected rejection for empty block `{id}`, got {v}"),
+        };
+        assert!(
+            err.contains(&format!("`{id}`")),
+            "error must name the block id `{id}`: {err}"
+        );
+        assert!(err.contains("children"), "error was: {err}");
+    }
+}
+
+/// A valid children-form Decisions block plus an annotated-code attribute form
+/// are accepted and stored as mdx.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_valid_children_and_attr_forms_accepted() {
+    let ctx = test_ctx().await;
+    let existing = seed_markdown_proposal(&ctx).await;
+
+    let body = "# P\n\n<Decisions id=\"d\">\n### Use JWT for stateless auth\nStatus: accepted\n\nWe scale horizontally.\n</Decisions>\n\n<AnnotatedCode id=\"code\" language=\"rust\" code={`fn main() {}`} />\n\n<QuestionForm id=\"q\" title=\"Q\">\nq?\n</QuestionForm>\n";
+    let result = call_proposal_update(
+        &ctx,
+        &args(serde_json::json!({ "id": existing.id, "body": body })),
+    )
+    .await
+    .expect("valid children + attribute forms must be accepted");
+    assert_eq!(result["ok"], serde_json::json!(true));
+
+    let repo = ProposalRepository::new(ctx.db(), ctx.event_bus());
+    let stored = repo.get(&existing.id).await.unwrap().unwrap();
+    assert_eq!(stored.body_format, "mdx");
+}
+
+/// A plain markdown body without block tags stays markdown — no upgrade, no
+/// block validation applied.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_plain_markdown_stays_markdown() {
+    let ctx = test_ctx().await;
+    let existing = seed_markdown_proposal(&ctx).await;
+
+    let result = call_proposal_update(
+        &ctx,
+        &args(serde_json::json!({ "id": existing.id, "body": "# Revised\n\nStill prose." })),
+    )
+    .await
+    .expect("plain markdown update should succeed");
+    assert_eq!(result["ok"], serde_json::json!(true));
+
+    let repo = ProposalRepository::new(ctx.db(), ctx.event_bus());
+    let stored = repo.get(&existing.id).await.unwrap().unwrap();
+    assert_eq!(stored.body_format, "markdown");
+}


### PR DESCRIPTION
## The bug (follow-up to #1684)

#1684 closed the "markdown body carrying MDX block tags skips validation and renders as raw text" hole on the server-side write paths (`proposal_create` / `proposal_update` / `proposal_import` / `apply_block_patch`). The **in-pod agent path** had the identical hole: `djinn-mcp-extension::handlers::task_epic::call_proposal_update` — the Advocate's primary refinement action, and the write path in-pod agents use — validated the body with `validate_mdx_body(body, Some(declared_format))` (a no-op for markdown) and persisted `p.body_format.as_deref()` straight through `ProposalRepository::update`. This is very likely the path that authored the broken production proposal (`019f2f0c-…` — markdown format, `<Decisions/>`/`<FileTree>`/… blocks stored unvalidated).

## The fix (cutover, no compat path)

- `call_proposal_update` now routes through the shared **`resolve_body_format_and_validate`** helper introduced in #1684 — the same crate-boundary precedent as the sibling `call_proposal_block_patch`, which already reuses `apply_block_patch` from `djinn-control-plane` (and therefore picked up #1684 automatically).
- The persisted `body_format` auto-upgrades markdown→mdx when the body carries custom block tags; unknown tags, empty children-based blocks (`<Decisions decisions={…} />`, self-closing `<FileTree/>`/`<Checklist/>`, …), wireframe active-markup, and empty diagrams are rejected with the **same actionable errors** as the server-side `proposal_update` — byte-identical validation semantics.
- The **question-form placement gate** the server-side tool applies when a new mdx body is written (`exactly one question-form, last`) is also applied here. The in-pod handler had silently drifted by omitting it; now both paths match. (The `in_review` composed DoR gate remains intentionally NOT applied in-pod — that divergence is documented and unchanged.)

## Tests

New handler-level suite `djinn-mcp-extension/src/tests/proposal_update_handler_tests.rs` (stub `ExtensionContext` over an in-memory DB), mirroring the server-side tool tests:

- omitted body_format + block-bearing body → stored `body_format = "mdx"`, body byte-preserved
- unknown block tag in a markdown-declared body → rejected, nothing persisted
- `<Decisions id="choice" decisions={[…]} />` → rejected with error naming the id and directing to `###`-heading children
- self-closing `<FileTree/>` and `<Checklist/>` → rejected naming the block id + children grammar
- valid children-form `<Decisions>` + annotated-code `code={…}` attribute form → accepted, stored as mdx
- plain markdown without block tags → stays markdown

Adds a `djinn-control-plane = { features = ["test-support"] }` dev-dependency for the stub `McpState` (`cargo hakari verify` passes). Full crate suite green (233 tests), `cargo clippy --all-features --all-targets` clean.

## Other direct repository body writes checked while in here

- `djinn-mcp-extension::call_proposal_block_patch` — goes through shared `apply_block_patch`; already covered by #1684.
- `djinn-coordinator/src/refinement_outcome.rs` (refinement reject-revert) — restores an already-persisted historical revision verbatim (body_format from the stored revision), not new authoring; benign, left alone.
- `djinn-mcp-extension::call_proposal_ac_set` — mutates acceptance criteria only via `set_acceptance_criteria`, never the body/format; not affected.
- Everything else touching `ProposalUpdateInput`/`ProposalCreateInput` outside the tools layer is test fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)