### PR TITLE
fix(coordinator): terminalize task attempts on failed session exit + reap orphaned pending attempts

### DIFF
--- a/server/.sqlx/query-1ef1c2334602fed5226b04e609fd4598586d1ad482ee396b09bdd3c008505758.json
+++ b/server/.sqlx/query-1ef1c2334602fed5226b04e609fd4598586d1ad482ee396b09bdd3c008505758.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT ta.id AS \"id!\", ta.task_id AS \"task_id!\", ta.role AS \"role!\",\n                ta.dispatch_key AS \"dispatch_key!\", ta.created_at AS \"created_at!\"\n             FROM task_attempts ta\n             WHERE ta.outcome = 'pending'\n               AND ta.created_at < $1\n               AND NOT EXISTS (\n                   SELECT 1 FROM task_runs tr\n                   WHERE tr.task_id = ta.task_id\n                     AND tr.status IN ('starting', 'running')\n                     AND tr.ended_at IS NULL\n               )\n               AND NOT EXISTS (\n                   SELECT 1 FROM sessions s\n                   WHERE s.task_id = ta.task_id\n                     AND s.status = 'running'\n               )\n             ORDER BY ta.created_at ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "task_id!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "role!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "dispatch_key!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at!",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1ef1c2334602fed5226b04e609fd4598586d1ad482ee396b09bdd3c008505758"
+}

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -699,6 +699,10 @@ impl CoordinatorActor {
         // same sweep the 15-min tick uses so the dev UI / queries don't show
         // weeks-old stale rows after every restart.
         health::reap_stale_task_runs_for_startup(&self.db).await;
+        // Reap pending task_attempts orphaned while this coordinator was down
+        // (or wedged from before the reaper existed) so the respawn guard
+        // unblocks those (task, role) pairs immediately after a deploy.
+        health::reap_orphaned_pending_attempts_for_startup(&self.db).await;
         let startup_context = self.maintenance_context();
         health::reap_orphaned_taskrun_jobs_for_startup(&self.db, &startup_context).await;
         self.rehydrate_durable_dispatch_state().await;
@@ -1217,6 +1221,10 @@ impl CoordinatorActor {
                 // ensures protocol violations are recorded and count as
                 // failed attempts. Slow extensions never reach this path
                 // (they extend the claim without ending the session).
+                // For failed/interrupted exits on a nonterminal task this
+                // also terminalizes the live task_attempts row (crashed) so
+                // the respawn guard does not defer the (task, role) pair
+                // forever on an orphaned pending attempt.
                 if let Some(task_id) = session.task_id.as_deref() {
                     let _ = self
                         .classify_session_exit_liveness(
@@ -1224,6 +1232,7 @@ impl CoordinatorActor {
                             task_id,
                             session.task_run_id.as_deref(),
                             &session.status,
+                            &session.agent_type,
                         )
                         .await;
                 }

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -2383,6 +2383,10 @@ impl CoordinatorActor {
     /// accounting (protocol violations increment attempts; slow extensions
     /// do not — but slow extensions never reach this path because they never
     /// end the session).
+    ///
+    /// `role` is the session's `agent_type`: for `failed`/`interrupted` exits
+    /// on a nonterminal task this function also terminalizes the live
+    /// `task_attempts` row for the (task, role) pair (see step 6 below).
     #[tracing::instrument(
         name = "djinn.session_recovery.classify_exit",
         skip(self),
@@ -2394,6 +2398,7 @@ impl CoordinatorActor {
         task_id: &str,
         task_run_id: Option<&str>,
         session_status: &str,
+        role: &str,
     ) -> Option<ClassificationResult> {
         tracing::Span::current().record("task_id", task_id);
         tracing::Span::current().record("session_id", session_id);
@@ -2506,6 +2511,35 @@ impl CoordinatorActor {
                 "classify_session_exit_liveness: protocol violation detected — \
                  session exited while task is nonterminal; counts as failed attempt"
             );
+        }
+
+        // ── 6. Terminalize the live attempt for failed/interrupted exits ──
+        // A cleanly-failed run (e.g. provider error → TaskRunOutcome::Failed)
+        // self-finalizes its session, so none of the session-recovery /
+        // zombie-reap terminalizers ever fires for it. Without this step the
+        // `pending` task_attempts row created at dispatch-start stays
+        // non-terminal forever and the respawn guard defers every future
+        // dispatch of this (task, role) pair — a permanent wedge.
+        //
+        // `advance_to_terminal` is forward-only and idempotent, so duplicate
+        // exit events (or overlap with the recovery-scan terminalizers) are
+        // safe. `KillNoop` means the task is already terminal — leave the
+        // attempt to the terminal-path owners (PR poller / force-close).
+        if matches!(session_status, "failed" | "interrupted")
+            && result.outcome != Some(LivenessOutcome::KillNoop)
+        {
+            self.terminalize_recovery_attempt(
+                task_id,
+                role,
+                TaskAttemptOutcome::Crashed,
+                "session_exit_liveness",
+                Some(session_id),
+                task_run_id,
+                Some(result.verdict.as_str()),
+                Some("session_exit_nonterminal"),
+                Some("session exited failed/interrupted while task nonterminal"),
+            )
+            .await;
         }
 
         Some(result)

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -23,6 +23,17 @@ const STALE_TASK_RUN_THRESHOLD_SECS: i64 = 4 * 60 * 60;
 /// start (we know our previous self is gone).
 const STARTUP_TASK_RUN_THRESHOLD_SECS: i64 = 10;
 
+/// How long a `task_attempts` row may stay `pending` — with no live
+/// (`starting`/`running`) `task_run` and no `running` session for its task —
+/// before the orphaned-attempt reaper finalizes it to `crashed`.
+///
+/// Conservative: dispatch-start → session/run creation is seconds, so a
+/// 15-minute-old pending attempt with nothing executing behind it can never
+/// be advanced by the normal lifecycle paths. Left un-reaped it hard-blocks
+/// the respawn guard for its (task, role) pair forever (the guard defers any
+/// dispatch while a `pending`/`submitted` attempt exists).
+const ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS: i64 = 15 * 60;
+
 const CARGO_TARGET_RUNS_ROOT: &str = djinn_supervisor::CARGO_TARGET_RUNS_ROOT;
 
 /// Default durable output-stash retention window for coordinator maintenance.
@@ -47,6 +58,7 @@ pub(super) async fn sweep_stale_resources(
     app_state: &crate::context::CoordinatorContext,
 ) {
     reap_stale_task_runs(db).await;
+    reap_orphaned_pending_attempts(db).await;
     reap_orphaned_taskrun_jobs(db, app_state, "periodic").await;
     sweep_orphan_worker_sessions(db).await;
     sweep_orphaned_cargo_target_run_dirs(db, app_state.cargo_target_runs_root.as_deref()).await;
@@ -1748,6 +1760,128 @@ async fn reap_stale_task_runs_with_threshold(
         Ok(_) => {}
         Err(e) => {
             tracing::warn!(error = %e, reason = reason, "CoordinatorActor: reap_stale_task_runs failed");
+        }
+    }
+}
+
+// ─── Orphaned pending task_attempt sweep ─────────────────────────────────────
+
+/// Finalize to `crashed` any `pending` `task_attempts` row older than
+/// [`ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS`] whose task has no live
+/// (`starting`/`running`) `task_run` and no `running` session.
+///
+/// Defense-in-depth backstop for the event-path terminalization in
+/// `classify_session_exit_liveness`: a run that fails without ever emitting a
+/// terminal session event (host crash mid-dispatch, session left unfinalized
+/// by an early stage error, missed event during a coordinator restart) leaves
+/// its dispatch-start `pending` attempt orphaned, and the respawn guard then
+/// defers every future dispatch of that (task, role) pair — a permanent wedge.
+///
+/// State-driven off DB truth and idempotent: `advance_to_terminal` is
+/// forward-only, so a row concurrently advanced by the normal lifecycle is
+/// left untouched. Deliberately restricted to `pending` rows — `submitted`
+/// rows are owned by the PR poller's adoption/terminalization flow.
+async fn reap_orphaned_pending_attempts(db: &djinn_db::Database) {
+    reap_orphaned_pending_attempts_with_threshold(
+        db,
+        ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS,
+        "periodic",
+    )
+    .await;
+}
+
+/// Startup variant of [`reap_orphaned_pending_attempts`]. Runs with the same
+/// conservative threshold (a fresh boot proves nothing about a minutes-old
+/// dispatch on another coordinator instance behind the same DB), but firing
+/// at boot means long-orphaned rows self-heal immediately after a deploy
+/// instead of waiting for the first periodic stale sweep.
+pub(super) async fn reap_orphaned_pending_attempts_for_startup(db: &djinn_db::Database) {
+    reap_orphaned_pending_attempts_with_threshold(
+        db,
+        ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS,
+        "startup",
+    )
+    .await;
+}
+
+pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
+    db: &djinn_db::Database,
+    threshold_secs: i64,
+    reason: &'static str,
+) {
+    let cutoff = time::OffsetDateTime::now_utc() - time::Duration::seconds(threshold_secs);
+    let format = time::macros::format_description!(
+        "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z"
+    );
+    let threshold_iso = match cutoff.format(&format) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "reap_orphaned_pending_attempts: failed to format threshold");
+            return;
+        }
+    };
+
+    let repo = djinn_db::TaskAttemptRepository::new(db.clone());
+    let orphans = match repo.list_orphaned_pending(&threshold_iso).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                reason = reason,
+                "CoordinatorActor: reap_orphaned_pending_attempts lookup failed"
+            );
+            return;
+        }
+    };
+
+    for orphan in orphans {
+        let summary_json = serde_json::json!({
+            "recovery_classifier": "orphaned_pending_attempt_reaper",
+            "reason": reason,
+            "threshold_secs": threshold_secs,
+            "failure_class": "orphaned_pending_attempt",
+        })
+        .to_string();
+        match repo
+            .advance_to_terminal(djinn_db::TerminalTaskAttemptParams {
+                id: &orphan.id,
+                outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::Crashed,
+                pr_url: None,
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary: Some(
+                    "orphaned pending attempt reaped: no live task_run or running session",
+                ),
+                summary_json: Some(&summary_json),
+                log_tail: None,
+            })
+            .await
+        {
+            Ok(updated) => {
+                tracing::warn!(
+                    attempt_id = %orphan.id,
+                    task_id = %orphan.task_id,
+                    role = %orphan.role,
+                    dispatch_key = %orphan.dispatch_key,
+                    attempt_created_at = %orphan.created_at,
+                    threshold = %threshold_iso,
+                    outcome = %updated.outcome,
+                    reason = reason,
+                    "CoordinatorActor: reaped orphaned pending task_attempt"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    attempt_id = %orphan.id,
+                    task_id = %orphan.task_id,
+                    role = %orphan.role,
+                    error = %e,
+                    reason = reason,
+                    "CoordinatorActor: failed to reap orphaned pending task_attempt"
+                );
+            }
         }
     }
 }

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -3327,7 +3327,7 @@ async fn protocol_violation_clean_exit_classified_as_failed_attempt() {
 
     let actor = coordinator_actor_for_tests(&db, &tx);
     let result = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed", "worker")
         .await;
 
     let result = result.expect("classification must succeed");
@@ -3419,7 +3419,7 @@ async fn nonzero_exit_is_crash_outcome_distinct_from_clean_violation() {
 
     let actor = coordinator_actor_for_tests(&db, &tx);
     let result = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "failed")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "failed", "worker")
         .await;
 
     let result = result.expect("classification must succeed");
@@ -3503,7 +3503,7 @@ async fn already_terminal_task_exit_preserves_kill_noop() {
 
     let actor = coordinator_actor_for_tests(&db, &tx);
     let result = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed", "worker")
         .await;
 
     let result = result.expect("classification must succeed");
@@ -3688,7 +3688,7 @@ async fn interrupted_session_nonterminal_is_crash_protocol_violation() {
 
     let actor = coordinator_actor_for_tests(&db, &tx);
     let result = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "interrupted")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "interrupted", "worker")
         .await;
 
     let result = result.expect("classification must succeed");
@@ -5363,7 +5363,7 @@ async fn classify_session_exit_clean_nonterminal_vs_terminal_are_distinct_and_id
 
     // ── Path A: clean exit on nonterminal task → ProtocolViolation ──
     let r1 = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed", "worker")
         .await
         .expect("first classification must succeed");
     assert_eq!(
@@ -5379,7 +5379,7 @@ async fn classify_session_exit_clean_nonterminal_vs_terminal_are_distinct_and_id
 
     // ── Idempotency on the nonterminal path: second call sees same task state ──
     let r1_again = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed", "worker")
         .await
         .expect("repeat classification must succeed");
     assert_eq!(
@@ -5413,7 +5413,7 @@ async fn classify_session_exit_clean_nonterminal_vs_terminal_are_distinct_and_id
         .unwrap();
 
     let r2 = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed", "worker")
         .await
         .expect("terminal classification must succeed");
     assert_eq!(
@@ -5455,7 +5455,7 @@ async fn classify_session_exit_clean_nonterminal_vs_terminal_are_distinct_and_id
     //  idempotency here means the verdict/outcome are stable, not that the
     //  evidence row count is fixed. The append-only chain is the audit trail.)
     let r3 = actor
-        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed")
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "completed", "worker")
         .await
         .expect("repeat terminal classification must succeed");
     assert_eq!(
@@ -5658,4 +5658,258 @@ async fn repeated_recovery_ticks_do_not_duplicate_terminalization_or_release() {
         dead_after_tick3, dead_after_tick1,
         "tick 2 and tick 3 must NOT append additional dead_reclaimed rows"
     );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orphaned pending task_attempt terminalization (event path + reaper backstop).
+//
+// Regression: dispatch-start creates a `pending` task_attempts row, but a
+// cleanly-failed run (e.g. provider error → TaskRunOutcome::Failed) finalizes
+// its own session, so no recovery/zombie terminalizer ever fires and the row
+// stayed `pending` forever — `run_respawn_guard` then deferred every future
+// dispatch of that (task, role) pair (permanent wedge; 5 production tasks).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Event path: a session "failed" event for a nonterminal task must
+/// terminalize the dispatch-start `pending` attempt to `crashed` and unblock
+/// the respawn guard.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_session_exit_terminalizes_pending_attempt_and_unblocks_respawn_guard() {
+    use crate::dispatch::respawn_guard::{RespawnGuardDecision, run_respawn_guard};
+    use djinn_core::models::SessionStatus;
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "failed-exit-terminalize").await;
+
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    // ── Dispatch-start: pending attempt row (as task_dispatch records it) ──
+    let dk = crate::dispatch::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+    let attempt_id =
+        crate::dispatch::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+            .await
+            .expect("dispatch-start must create a pending attempt");
+
+    // ── A run + session that self-finalizes as failed (provider error) ──
+    let run_id = "run-failed-exit-terminalize";
+    let run_repo = TaskRunRepository::new(db.clone());
+    run_repo
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+    let session = session_repo
+        .update(&session.id, SessionStatus::Failed, 0, 0, 0, 0, None)
+        .await
+        .unwrap();
+    run_repo
+        .update_status(run_id, djinn_core::models::TaskRunStatus::Failed)
+        .await
+        .unwrap();
+
+    // ── Deliver the session "failed" event through the real handler ──
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor
+        .handle_event(DjinnEventEnvelope {
+            entity_type: "session",
+            action: "failed",
+            payload: serde_json::to_value(&session).unwrap(),
+            id: None,
+            project_id: None,
+            from_sync: false,
+        })
+        .await;
+
+    // ── The pending attempt is terminal (crashed) ──
+    let attempt_repo = TaskAttemptRepository::new(db.clone());
+    let in_flight = attempt_repo
+        .latest_pending_or_submitted(&task.id, Some("worker"))
+        .await
+        .unwrap();
+    assert!(
+        in_flight.is_none(),
+        "no pending/submitted attempt may survive a failed session exit"
+    );
+    let attempt = attempt_repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(attempt.outcome, "crashed");
+    assert!(
+        attempt.terminal_at.is_some(),
+        "terminal_at must be stamped on the crashed attempt"
+    );
+
+    // ── The respawn guard no longer wedges the (task, role) pair ──
+    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    assert_eq!(
+        decision,
+        RespawnGuardDecision::Allow,
+        "respawn guard must allow dispatch after the attempt is terminalized"
+    );
+
+    // ── Idempotency: a duplicate failed event is a no-op ──
+    actor
+        .handle_event(DjinnEventEnvelope {
+            entity_type: "session",
+            action: "failed",
+            payload: serde_json::to_value(&session).unwrap(),
+            id: None,
+            project_id: None,
+            from_sync: false,
+        })
+        .await;
+    let all = attempt_repo.list_for_task(&task.id).await.unwrap();
+    assert_eq!(all.len(), 1, "duplicate exit events must not create rows");
+    assert_eq!(all[0].outcome, "crashed");
+}
+
+/// Backdate a task_attempt's `created_at` so the orphan reaper's threshold
+/// comparison sees it as old (well past the 15-minute threshold).
+async fn backdate_attempt(db: &Database, attempt_id: &str) {
+    djinn_db::test_support::backdate_task_attempt_created_at(db, attempt_id, "1 hour").await;
+}
+
+/// Reaper backstop: a stale `pending` attempt whose task has a terminal (or
+/// absent) task_run is finalized to `crashed`; a fresh pending row and one
+/// backed by a live task_run are left untouched.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn orphaned_pending_attempt_reaper_finalizes_stale_rows_only() {
+    use crate::dispatch::respawn_guard::{RespawnGuardDecision, run_respawn_guard};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+
+    let run_repo = TaskRunRepository::new(db.clone());
+    let attempt_repo = TaskAttemptRepository::new(db.clone());
+
+    let seed_attempt = |task_id: String| {
+        let db = db.clone();
+        async move {
+            let dk = crate::dispatch::attempt_lifecycle::make_dispatch_key(&task_id, "worker");
+            crate::dispatch::attempt_lifecycle::record_dispatch_start(
+                &db, &task_id, "worker", None, &dk,
+            )
+            .await
+            .expect("pending attempt must insert")
+        }
+    };
+
+    // A: stale attempt + terminal task_run → reaped.
+    let (task_a, _n) = create_task_with_note(&db, &tx, "reaper-terminal-run").await;
+    let attempt_a = seed_attempt(task_a.id.clone()).await;
+    backdate_attempt(&db, &attempt_a).await;
+    run_repo
+        .create(CreateTaskRunParams {
+            id: "run-reaper-a",
+            project_id: &task_a.project_id,
+            task_id: &task_a.id,
+            trigger_type: "manual",
+            status: Some("failed"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    // B: stale attempt + NO task_run at all → reaped.
+    let (task_b, _n) = create_task_with_note(&db, &tx, "reaper-absent-run").await;
+    let attempt_b = seed_attempt(task_b.id.clone()).await;
+    backdate_attempt(&db, &attempt_b).await;
+
+    // C: FRESH attempt (younger than threshold) + terminal task_run → kept.
+    let (task_c, _n) = create_task_with_note(&db, &tx, "reaper-fresh-attempt").await;
+    let attempt_c = seed_attempt(task_c.id.clone()).await;
+    run_repo
+        .create(CreateTaskRunParams {
+            id: "run-reaper-c",
+            project_id: &task_c.project_id,
+            task_id: &task_c.id,
+            trigger_type: "manual",
+            status: Some("failed"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    // D: stale attempt + LIVE (running) task_run → kept.
+    let (task_d, _n) = create_task_with_note(&db, &tx, "reaper-live-run").await;
+    let attempt_d = seed_attempt(task_d.id.clone()).await;
+    backdate_attempt(&db, &attempt_d).await;
+    run_repo
+        .create(CreateTaskRunParams {
+            id: "run-reaper-d",
+            project_id: &task_d.project_id,
+            task_id: &task_d.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    crate::health::reap_orphaned_pending_attempts_with_threshold(&db, 15 * 60, "test").await;
+
+    // A and B reaped to crashed with terminal_at stamped.
+    for (attempt_id, label) in [(&attempt_a, "terminal-run"), (&attempt_b, "absent-run")] {
+        let attempt = attempt_repo.get(attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.outcome, "crashed", "{label}: must be reaped");
+        assert!(
+            attempt.terminal_at.is_some(),
+            "{label}: terminal_at must be stamped"
+        );
+    }
+
+    // C (fresh) and D (live run) untouched.
+    for (attempt_id, label) in [(&attempt_c, "fresh-attempt"), (&attempt_d, "live-run")] {
+        let attempt = attempt_repo.get(attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.outcome, "pending", "{label}: must NOT be reaped");
+        assert!(attempt.terminal_at.is_none(), "{label}: must stay live");
+    }
+
+    // The reaped tasks' respawn guards unblock; the live one still defers.
+    assert_eq!(
+        run_respawn_guard(&db, &task_a.id, "worker", None).await,
+        RespawnGuardDecision::Allow,
+        "guard must allow dispatch for a reaped task"
+    );
+    assert!(
+        matches!(
+            run_respawn_guard(&db, &task_d.id, "worker", None).await,
+            RespawnGuardDecision::Defer(_)
+        ),
+        "guard must still defer while a live run backs the pending attempt"
+    );
+
+    // Idempotency: a second sweep changes nothing and creates no rows.
+    crate::health::reap_orphaned_pending_attempts_with_threshold(&db, 15 * 60, "test").await;
+    for task in [&task_a, &task_b, &task_c, &task_d] {
+        let all = attempt_repo.list_for_task(&task.id).await.unwrap();
+        assert_eq!(all.len(), 1, "sweep must never create attempt rows");
+    }
 }

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -12,7 +12,8 @@ mod template_bootstrap;
 pub mod test_support {
     pub use crate::repositories::test_support::{
         HousekeepingFixture, HousekeepingFixtureExpectedCounts, HousekeepingFixtureProject,
-        UsageTestSessionSeed, UsageTestTaskSeed, add_blocker_edge, backdate_task_updated_at,
+        UsageTestSessionSeed, UsageTestTaskSeed, add_blocker_edge,
+        backdate_task_attempt_created_at, backdate_task_updated_at,
         build_multi_project_housekeeping_fixture, close_task_at,
         corrupt_credential_encrypted_value, drop_table_for_test, ensure_doctor_findings_schema,
         event_bus_for, make_project, override_debate_trail_body_metadata, seed_chat_session_row,
@@ -134,8 +135,8 @@ pub use repositories::{
     },
     task_attempt::{
         CompletedParentSummary, CreateTaskAttemptParams, FillTaskAttemptParams,
-        GuardAdoptedPrTaskAttemptParams, GuardDeferTaskAttemptParams, SubmitTaskAttemptParams,
-        TaskAttemptRepository, TerminalTaskAttemptParams,
+        GuardAdoptedPrTaskAttemptParams, GuardDeferTaskAttemptParams, OrphanedPendingAttempt,
+        SubmitTaskAttemptParams, TaskAttemptRepository, TerminalTaskAttemptParams,
     },
     task_run::{CreateTaskRunParams, TaskRunRepository},
     usage_analytics::{

--- a/server/crates/djinn-db/src/repositories/task_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/task_attempt.rs
@@ -25,6 +25,18 @@ pub struct TaskAttemptRepository {
     db: Database,
 }
 
+/// A `pending` attempt row identified as orphaned by
+/// [`TaskAttemptRepository::list_orphaned_pending`]: older than the caller's
+/// threshold with no live `task_run` and no `running` session for its task.
+#[derive(Clone, Debug)]
+pub struct OrphanedPendingAttempt {
+    pub id: String,
+    pub task_id: String,
+    pub role: String,
+    pub dispatch_key: String,
+    pub created_at: String,
+}
+
 /// Parameters for creating or idempotently returning a pending attempt row.
 #[derive(Clone, Debug)]
 pub struct CreateTaskAttemptParams<'a> {
@@ -594,6 +606,52 @@ impl TaskAttemptRepository {
             .await?
         };
         Ok(row)
+    }
+
+    /// List `pending` attempt rows that look orphaned: created before
+    /// `created_before_iso` (lexicographic compare over the ISO-8601 UTC text
+    /// timestamps, same convention as `TaskRunRepository::reap_stale_running`)
+    /// with no live (`starting`/`running`, NULL `ended_at`) `task_run` and no
+    /// `running` session for their task.
+    ///
+    /// `task_attempts` rows do not carry a `task_run` FK (the session link is
+    /// NULL for fresh dispatches), so "linked task_run is terminal or absent"
+    /// is evaluated at task granularity: any live run or running session for
+    /// the task keeps every one of its pending attempts out of the result
+    /// (conservative — a later sweep re-evaluates).
+    ///
+    /// Used by the coordinator's orphaned-attempt reaper: a `pending` row with
+    /// nothing executing behind it can never be advanced by the normal
+    /// lifecycle paths, yet it hard-blocks the respawn guard for its
+    /// (task, role) pair forever.
+    pub async fn list_orphaned_pending(
+        &self,
+        created_before_iso: &str,
+    ) -> Result<Vec<OrphanedPendingAttempt>> {
+        self.db.ensure_initialized().await?;
+        Ok(sqlx::query_as!(
+            OrphanedPendingAttempt,
+            r#"SELECT ta.id AS "id!", ta.task_id AS "task_id!", ta.role AS "role!",
+                ta.dispatch_key AS "dispatch_key!", ta.created_at AS "created_at!"
+             FROM task_attempts ta
+             WHERE ta.outcome = 'pending'
+               AND ta.created_at < $1
+               AND NOT EXISTS (
+                   SELECT 1 FROM task_runs tr
+                   WHERE tr.task_id = ta.task_id
+                     AND tr.status IN ('starting', 'running')
+                     AND tr.ended_at IS NULL
+               )
+               AND NOT EXISTS (
+                   SELECT 1 FROM sessions s
+                   WHERE s.task_id = ta.task_id
+                     AND s.status = 'running'
+               )
+             ORDER BY ta.created_at ASC"#,
+            created_before_iso
+        )
+        .fetch_all(self.db.pool())
+        .await?)
     }
 
     /// Latest `submitted` attempt for a task, optionally filtered by role.

--- a/server/crates/djinn-db/src/repositories/test_support.rs
+++ b/server/crates/djinn-db/src/repositories/test_support.rs
@@ -198,6 +198,26 @@ pub async fn backdate_task_updated_at(db: &Database, task_id: &str, interval: &s
     .unwrap();
 }
 
+/// Backdate a `task_attempts` row's `created_at` by a PostgreSQL `interval`
+/// string (e.g. `'1 hour'`).
+///
+/// Test-fixture helper for the coordinator's orphaned-pending-attempt reaper,
+/// whose age threshold compares against `created_at`.
+pub async fn backdate_task_attempt_created_at(db: &Database, attempt_id: &str, interval: &str) {
+    db.ensure_initialized().await.unwrap();
+    sqlx::query(
+        "UPDATE task_attempts SET created_at = to_char(
+             now() AT TIME ZONE 'utc' - $1::interval,
+             'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')
+         WHERE id = $2",
+    )
+    .bind(interval)
+    .bind(attempt_id)
+    .execute(db.pool())
+    .await
+    .unwrap();
+}
+
 /// Close a task at an explicit timestamp. Test-fixture helper: production
 /// `closed_at` is stamped automatically by terminal status transitions.
 pub async fn close_task_at(db: &Database, task_id: &str, closed_at: &str) {


### PR DESCRIPTION
## Problem — 5 production tasks permanently wedged

Since v0.6.73, a task-run that fails **cleanly** (e.g. provider error → `TaskRunOutcome::Failed`) leaves its `task_attempts` row at `outcome="pending"` forever, and #1645's respawn guard then defers **every** future dispatch of that (task, role) with `non-terminal attempt already exists`. The doctor's `stranded_ready` check flags the tasks but has no fix; `board_reconcile` / `execution_kill_task` no-op because nothing is live. 5 tasks (`jbqf, 8kna, mdia, q8r6, tx23`) are stuck this way in production right now.

## Root cause — missing wiring, no backstop

Dispatch-start records the pending row (#1630), but **no path terminalizes it for a cleanly-failed run**:
- PR poller → needs a submitted PR (worker never submitted)
- Wave dispatch → only `AdoptedPr | Handoff | ForceClosed`
- Session-recovery terminalizers → only fire when **reclaiming a still-live/zombie session**; a cleanly-failed run already finalized itself
- The session-exit handler (`actor.rs`) calls `classify_session_exit_liveness`, which persists evidence and logs "counts as failed" — but **never advances the attempt row**, and its result was discarded (`let _ =`)
- No TTL/reaper exists for orphaned pending attempts

## Fix (two complementary layers)

**1. Event path:** `classify_session_exit_liveness` now takes the session role and, on `failed`/`interrupted` exits with a nonterminal task, advances the live attempt to `crashed` via the existing forward-only, idempotent `advance_to_terminal`. (Traced: the stage-settlement path reliably marks the session `failed` for provider-error failures; early stage-setup deaths that never emit `session.failed` are covered by layer 2.)

**2. Reaper backstop (state-driven, DB-truth):** startup + periodic sweep finalizes to `crashed` any `pending` attempt older than 15 min whose task has **no live task_run and no running session**. Deliberately restricted to `pending` — `submitted` rows stay owned by the PR poller. One structured log line per reaped row. **The startup pass self-heals the 5 wedged production rows immediately after deploy** — no manual DB surgery — and gives the `stranded_ready` doctor finding a real resolution path.

## Tests

- New: failed-session-exit event → attempt `crashed`, `terminal_at` set, `run_respawn_guard` returns `Allow`, duplicate event no-op.
- New: reaper — stale+terminal-run and stale+absent-run reaped; fresh row and live-run row untouched; second sweep idempotent.
- DB-backed suites ran against the dedicated test Postgres: `attempt` 51/51, `respawn_guard` 19/19, `session_reaping` 78/78, `djinn-db` full suite green. Full `djinn-coordinator`: 1042 passed, 1 pre-existing flake (`wnd1_dispatch_race_harness…`) confirmed failing on clean HEAD too.
- Clippy clean on both touched crates. New sqlx offline metadata included (all other entries byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)