### PR TITLE
fix(coordinator): bypass open-PR adoption when required CI checks are failing

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
@@ -6,6 +6,10 @@
 //! 1. **Open-PR adoption**: when the task already has an open PR
 //!    (`task.pr_url`), adopt it and record an `adopted_pr` audit row.  This
 //!    prevents spawning a duplicate worker when a PR is already in review.
+//!    Adoption is **bypassed** when the task's required-CI gate is failing
+//!    (`ci_status == "failing"`): the PrCiFailed remediation flow reopens the
+//!    task precisely so a worker can be dispatched to fix the failing PR, so
+//!    the guard must fall through to step 2 instead of adopting.
 //! 2. **Non-terminal attempt**: when a `pending` or `submitted` attempt already
 //!    exists for the task+role, defer dispatch and record a `deferred` audit
 //!    row.
@@ -23,6 +27,7 @@
 //! should the existing `try_dispatch_to_pool` + `record_dispatch_start` path
 //! proceed.
 
+use djinn_core::models::CiStatus;
 use djinn_core::models::task_attempt::{GuardDecision, GuardReason};
 use djinn_db::{
     GuardAdoptedPrTaskAttemptParams, GuardDeferTaskAttemptParams, TaskAttemptRepository,
@@ -53,11 +58,20 @@ pub enum RespawnGuardDecision {
 /// Guard ordering:
 /// 1. **Open-PR adoption** — when `pr_url` is `Some`, an existing open PR is
 ///    detected.  Returns [`RespawnGuardDecision::Adopted`] so the caller can
-///    record an `adopted_pr` audit row and skip dispatch.
+///    record an `adopted_pr` audit row and skip dispatch.  Adoption is
+///    **bypassed** when `ci_status` is `failing` (a required check is red on
+///    the PR head): the PrCiFailed remediation flow reopened the task so a
+///    worker can fix the failing PR, and adopting here would starve that
+///    remediation forever.  The guard falls through to step 2 instead, so a
+///    remediation worker dispatches exactly once.
 /// 2. **Non-terminal attempt** — consults
 ///    [`TaskAttemptRepository::latest_pending_or_submitted`] for the task/role
 ///    pair.  If a non-terminal attempt already exists the dispatch is deferred
 ///    with [`GuardReason::RespawnGuard`].
+///
+/// `ci_status` is the task's promoted required-CI gate state (the wire string
+/// of [`CiStatus`], e.g. `task.ci_status`).  `None` or any non-`failing` value
+/// (green / pending / unknown) preserves the adoption behavior.
 ///
 /// Returns [`RespawnGuardDecision::Allow`] when neither guard fires.
 ///
@@ -68,22 +82,37 @@ pub async fn run_respawn_guard(
     task_id: &str,
     role: &str,
     pr_url: Option<&str>,
+    ci_status: Option<&str>,
 ) -> RespawnGuardDecision {
     // 1. Open-PR adoption: when the task already has an open PR, adopt it
     //    and skip dispatch.  This prevents spawning a duplicate worker when
-    //    a PR is already in review.
+    //    a PR is already in review — unless required CI is failing on the PR
+    //    head, in which case the task was reopened for remediation and a
+    //    worker MUST be dispatched to fix the PR (step 2 still prevents
+    //    duplicate remediation workers).
     if let Some(url) = pr_url
         && !url.is_empty()
     {
-        tracing::info!(
-            task_id = %task_id,
-            role = %role,
-            pr_url = %url,
-            "respawn_guard: existing open PR detected — adopting"
-        );
-        return RespawnGuardDecision::Adopted {
-            pr_url: url.to_owned(),
-        };
+        if ci_status == Some(CiStatus::Failing.as_str()) {
+            tracing::info!(
+                task_id = %task_id,
+                role = %role,
+                pr_url = %url,
+                ci_status = %CiStatus::Failing,
+                "respawn_guard: open PR has failing required CI — bypassing adoption so a \
+                 remediation worker can dispatch"
+            );
+        } else {
+            tracing::info!(
+                task_id = %task_id,
+                role = %role,
+                pr_url = %url,
+                "respawn_guard: existing open PR detected — adopting"
+            );
+            return RespawnGuardDecision::Adopted {
+                pr_url: url.to_owned(),
+            };
+        }
     }
 
     // 2. Non-terminal attempt: when a pending or submitted attempt already
@@ -259,7 +288,7 @@ mod tests {
         let db = test_db();
         let task = create_task(&db).await;
 
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(decision, RespawnGuardDecision::Allow);
     }
 
@@ -274,7 +303,7 @@ mod tests {
             .await
             .expect("record_dispatch_start should succeed");
 
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(
             decision,
             RespawnGuardDecision::Defer(GuardReason::RespawnGuard)
@@ -307,7 +336,7 @@ mod tests {
         )
         .await;
 
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(
             decision,
             RespawnGuardDecision::Defer(GuardReason::RespawnGuard)
@@ -343,7 +372,7 @@ mod tests {
         )
         .await;
 
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(decision, RespawnGuardDecision::Allow);
     }
 
@@ -361,7 +390,7 @@ mod tests {
         .expect("record_dispatch_start should succeed");
 
         // Guard for "worker" role should allow (different role).
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(decision, RespawnGuardDecision::Allow);
     }
 
@@ -383,7 +412,7 @@ mod tests {
 
         // The guard should allow because `deferred` is not in
         // ('pending', 'submitted').
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(decision, RespawnGuardDecision::Allow);
     }
 
@@ -529,7 +558,7 @@ mod tests {
             .unwrap();
 
         // Guard must defer (pending exists).
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(
             decision,
             RespawnGuardDecision::Defer(GuardReason::RespawnGuard)
@@ -548,6 +577,7 @@ mod tests {
             &task.id,
             "worker",
             Some("https://github.example/owner/repo/pull/42"),
+            None,
         )
         .await;
         assert_eq!(
@@ -564,7 +594,7 @@ mod tests {
         let task = create_task(&db).await;
 
         // An empty pr_url should not trigger adoption.
-        let decision = run_respawn_guard(&db, &task.id, "worker", Some("")).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", Some(""), None).await;
         assert_eq!(decision, RespawnGuardDecision::Allow);
     }
 
@@ -585,6 +615,7 @@ mod tests {
             &task.id,
             "worker",
             Some("https://github.example/owner/repo/pull/42"),
+            None,
         )
         .await;
         assert_eq!(
@@ -593,6 +624,85 @@ mod tests {
                 pr_url: "https://github.example/owner/repo/pull/42".to_owned(),
             }
         );
+    }
+
+    // ─── CI-remediation adoption bypass tests ───────────────────────────
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_does_not_adopt_when_ci_gate_failing() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // Open PR + failing required CI (PrCiFailed remediation reopen): the
+        // guard must NOT adopt.  With no pending attempt it must Allow so a
+        // remediation worker dispatches.
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            Some(CiStatus::Failing.as_str()),
+        )
+        .await;
+        assert_eq!(decision, RespawnGuardDecision::Allow);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_defers_when_ci_gate_failing_and_pending_attempt_exists() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // A remediation worker is already in flight (pending attempt).
+        let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+        super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+            .await
+            .expect("record_dispatch_start should succeed");
+
+        // Open PR + failing required CI: adoption is bypassed, but step 2
+        // still defers so no duplicate remediation worker is dispatched.
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            Some(CiStatus::Failing.as_str()),
+        )
+        .await;
+        assert_eq!(
+            decision,
+            RespawnGuardDecision::Defer(GuardReason::RespawnGuard)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_adopts_when_ci_gate_green_pending_or_absent() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // Any non-failing CI gate state preserves the adoption behavior: the
+        // PR is merely awaiting review/merge, so no duplicate worker spawns.
+        for ci_status in [
+            Some(CiStatus::Passing.as_str()),
+            Some(CiStatus::Pending.as_str()),
+            Some(CiStatus::Unknown.as_str()),
+            None,
+        ] {
+            let decision = run_respawn_guard(
+                &db,
+                &task.id,
+                "worker",
+                Some("https://github.example/owner/repo/pull/42"),
+                ci_status,
+            )
+            .await;
+            assert_eq!(
+                decision,
+                RespawnGuardDecision::Adopted {
+                    pr_url: "https://github.example/owner/repo/pull/42".to_owned(),
+                },
+                "ci_status={ci_status:?} must still adopt"
+            );
+        }
     }
 
     // ─── record_adopted_pr_attempt tests ────────────────────────────────
@@ -710,7 +820,7 @@ mod tests {
         // Simulates the case where the 422 backstop in supervisor_pr_open
         // would handle a race: the task has no pr_url yet and no pending
         // attempt, so the guard allows and the spawn path proceeds.
-        let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+        let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
         assert_eq!(decision, RespawnGuardDecision::Allow);
     }
 }

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1390,6 +1390,10 @@ impl CoordinatorActor {
             // fresh spawn/admission side-effects.  Guard ordering:
             // 1. Open-PR adoption: when the task has an existing open PR
             //    (task.pr_url), adopt it and record an adopted_pr audit row.
+            //    Adoption is bypassed when the task's required-CI gate is
+            //    failing (task.ci_status == "failing"): the PrCiFailed
+            //    remediation flow reopened the task so a worker can fix the
+            //    failing PR, and adopting would starve that remediation.
             // 2. Non-terminal attempt: if a pending or submitted attempt
             //    already exists for this task+role, defer dispatch and record
             //    a guard-only audit row.  No dispatch / provider / reopen
@@ -1399,6 +1403,7 @@ impl CoordinatorActor {
                 &task.id,
                 role,
                 task.pr_url.as_deref(),
+                Some(task.ci_status.as_str()),
             )
             .await
             {

--- a/server/crates/djinn-coordinator/src/tests/i3mv_regression_tests.rs
+++ b/server/crates/djinn-coordinator/src/tests/i3mv_regression_tests.rs
@@ -509,7 +509,7 @@ async fn i3mv_pending_attempt_causes_guard_defer() {
         .expect("dispatch start should succeed");
 
     // The guard defers because a pending attempt exists.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Defer(GuardReason::RespawnGuard),
@@ -577,7 +577,7 @@ async fn i3mv_guard_delegates_to_attempt_repository() {
     let task = make_task_with_reopen_count(&db, &tx, 0).await;
 
     // Before any attempt: guard allows.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(decision, RespawnGuardDecision::Allow);
 
     // Insert a pending attempt via the repository.
@@ -588,7 +588,7 @@ async fn i3mv_guard_delegates_to_attempt_repository() {
 
     // After the attempt exists: guard defers.  This can only happen if the
     // guard is reading the repository API, not duplicating the lookup.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Defer(GuardReason::RespawnGuard),
@@ -616,7 +616,7 @@ async fn i3mv_guard_delegates_to_attempt_repository() {
         .await
         .unwrap();
 
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Allow,
@@ -957,7 +957,7 @@ async fn audit_guard_defer_records_decision_and_reason_with_counter_proof() {
         .expect("dispatch start should succeed");
 
     // Run the guard — it should defer.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Defer(GuardReason::RespawnGuard),
@@ -1036,7 +1036,7 @@ async fn audit_guard_defer_leaves_actor_counters_unchanged() {
 
     // Guard defers and writes an audit row — same code path as
     // dispatch_ready_tasks.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Defer(GuardReason::RespawnGuard)
@@ -1099,7 +1099,7 @@ async fn audit_submitted_attempt_defer_audited_without_counter_ticks() {
     seed_submitted_attempt(&db, &task.id, "worker", Some("in-flight submit")).await;
 
     // Guard defers because a non-terminal submitted attempt exists.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Defer(GuardReason::RespawnGuard),
@@ -1287,7 +1287,7 @@ async fn audit_adopted_pr_in_attempt_history_with_idempotent_guard_evaluation() 
     );
 
     // ── Assert: guard still adopts on re-evaluation ─────────────────────
-    let decision = run_respawn_guard(&db, &task.id, "worker", Some(pr_url)).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", Some(pr_url), None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Adopted {
@@ -1322,7 +1322,7 @@ async fn audit_genuine_dispatch_delegates_attempt_creation_to_lifecycle_api() {
     let task = make_task_with_reopen_count(&db, &tx, 0).await;
 
     // Guard allows: no prior attempts and no open PR.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Allow,
@@ -1361,7 +1361,7 @@ async fn audit_genuine_dispatch_delegates_attempt_creation_to_lifecycle_api() {
     );
 
     // ── Assert: subsequent guard defers (non-terminal pending exists) ───
-    let decision2 = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision2 = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision2,
         RespawnGuardDecision::Defer(GuardReason::RespawnGuard),

--- a/server/crates/djinn-coordinator/src/tests/operator_explanation_tests.rs
+++ b/server/crates/djinn-coordinator/src/tests/operator_explanation_tests.rs
@@ -792,7 +792,7 @@ async fn zps8_pending_head_in_ledger_is_inflight_not_strike() {
     assert!(ledger[0].terminal_at.is_none());
 
     // Guard defers for this task+role.
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Defer(GuardReason::RespawnGuard),

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -5764,7 +5764,7 @@ async fn failed_session_exit_terminalizes_pending_attempt_and_unblocks_respawn_g
     );
 
     // ── The respawn guard no longer wedges the (task, role) pair ──
-    let decision = run_respawn_guard(&db, &task.id, "worker", None).await;
+    let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(
         decision,
         RespawnGuardDecision::Allow,
@@ -5894,13 +5894,13 @@ async fn orphaned_pending_attempt_reaper_finalizes_stale_rows_only() {
 
     // The reaped tasks' respawn guards unblock; the live one still defers.
     assert_eq!(
-        run_respawn_guard(&db, &task_a.id, "worker", None).await,
+        run_respawn_guard(&db, &task_a.id, "worker", None, None).await,
         RespawnGuardDecision::Allow,
         "guard must allow dispatch for a reaped task"
     );
     assert!(
         matches!(
-            run_respawn_guard(&db, &task_d.id, "worker", None).await,
+            run_respawn_guard(&db, &task_d.id, "worker", None, None).await,
             RespawnGuardDecision::Defer(_)
         ),
         "guard must still defer while a live run backs the pending attempt"


### PR DESCRIPTION
## Problem — CI remediation starved by adoption loop

Tasks reopened by the **PrCiFailed** flow (status `open`, `pr_url` retained, required checks failing) never get their remediation worker. Production right now: `q8r6` (PR #1700, Quality Gate failing) and `egu8` (PR #1695, Quality Gate + Clippy + Size Guard failing) loop `respawn guard adopting existing open PR — skipping dispatch` on **every ready pass (~52×/20min)** with no session ever dispatched. On the board they look stuck with an open failing PR.

## Root cause

#1645's `run_respawn_guard` step 1 returns `Adopted` (→ skip dispatch) for **any** non-empty `pr_url`, without considering *why* the task is back in the ready pool. The PrCiFailed reopen exists precisely to dispatch a worker onto the existing PR to fix CI — unconditional adoption defeats it permanently.

## Fix

`run_respawn_guard` now takes the task's promoted `ci_status`. When it equals `CiStatus::Failing` (the exact state that drives the PrCiFailed reopen), adoption is **bypassed** and the guard falls through to the step-2 pending/submitted-attempt check — so a remediation worker dispatches exactly once (step 2 still dedupes). Green/pending/unknown/`None` keep the adoption behavior (correctly prevents duplicate workers for PRs merely awaiting review/merge). Call site passes `task.ci_status` (already on the Task model). Explicit tracing when adoption is bypassed.

Also audited the adoption audit-row path for per-pass spam: `insert_guard_adopted_pr` already uses deterministic key `{task}:{role}:open_pr_adoption` with `ON CONFLICT DO NOTHING` — no fix needed.

## Tests

- New: failing CI + no pending attempt → `Allow`; failing CI + pending attempt → `Defer`; passing/pending/unknown/None CI → `Adopted`.
- `respawn_guard`: 22/22 passed (DB-backed, dedicated test Postgres). Touched suites: `i3mv` 22/22, `operator_explanation` 16/16, `session_reaping` 78/78.
- Pre-existing flake `wnd1_dispatch_race_harness…` fails identically on unmodified baseline; unrelated.
- Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)