### PR TITLE
fix(coordinator): bypass open-PR adoption for any PR-rework reopen (conflicts, not just failing CI)

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
@@ -6,10 +6,25 @@
 //! 1. **Open-PR adoption**: when the task already has an open PR
 //!    (`task.pr_url`), adopt it and record an `adopted_pr` audit row.  This
 //!    prevents spawning a duplicate worker when a PR is already in review.
-//!    Adoption is **bypassed** when the task's required-CI gate is failing
-//!    (`ci_status == "failing"`): the PrCiFailed remediation flow reopens the
-//!    task precisely so a worker can be dispatched to fix the failing PR, so
-//!    the guard must fall through to step 2 instead of adopting.
+//!    Adoption is **bypassed** when the PR needs rework — any reopen-for-PR-
+//!    rework flow (PrCiFailed, PrConflict, PrChangesRequested, merge-queue
+//!    dequeue) returns the task to `open` precisely so a worker can be
+//!    dispatched to fix the PR, so the guard must fall through to step 2
+//!    instead of adopting.  The rework signals, in evaluation order:
+//!    - [`PrReworkSignal::FailingCi`]: `task.ci_status == "failing"` (the
+//!      promoted required-CI gate is red on the PR head — PrCiFailed flow).
+//!    - [`PrReworkSignal::MergeConflict`]: `task.merge_conflict_metadata` is
+//!      populated (PrConflict / task_review_reject_conflict /
+//!      lead_approve_conflict set it; `submit_task_review`, `close`,
+//!      `force_close`, and `user_override` clear it, so a populated value
+//!      always describes the *current* unresolved conflict).
+//!    - Latest-attempt fallback: when neither task-row signal is present but
+//!      the newest non-guard `task_attempts` row for this task+role is
+//!      terminal with outcome `reopened`, the task was reopened for PR rework
+//!      by a path that leaves no task-row column (PrChangesRequested, a
+//!      merge-queue dequeue whose PR-head checks are green because the full
+//!      suite only runs on `merge_group`).  The window is self-closing: the
+//!      very next dispatch inserts a newer `pending` attempt row.
 //! 2. **Non-terminal attempt**: when a `pending` or `submitted` attempt already
 //!    exists for the task+role, defer dispatch and record a `deferred` audit
 //!    row.
@@ -28,12 +43,66 @@
 //! proceed.
 
 use djinn_core::models::CiStatus;
-use djinn_core::models::task_attempt::{GuardDecision, GuardReason};
+use djinn_core::models::task_attempt::{GuardDecision, GuardReason, TaskAttemptOutcome};
 use djinn_db::{
     GuardAdoptedPrTaskAttemptParams, GuardDeferTaskAttemptParams, TaskAttemptRepository,
 };
 
 use super::attempt_lifecycle::make_dispatch_key;
+
+// ─── PR-rework signal ───────────────────────────────────────────────────────
+
+/// Durable "this PR needs a worker" signal derived from the task row at the
+/// dispatch call site (which holds the full task row — no extra DB reads).
+///
+/// When present, open-PR adoption is bypassed so the rework worker the reopen
+/// flow asked for can actually dispatch (step-2 pending/submitted dedup still
+/// prevents duplicates).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PrReworkSignal {
+    /// The promoted required-CI gate is failing on the PR head
+    /// (`task.ci_status == "failing"` — PrCiFailed remediation flow).
+    FailingCi,
+    /// The task carries populated `merge_conflict_metadata` (PrConflict /
+    /// task_review_reject_conflict / lead_approve_conflict reopen flows).
+    /// The column is cleared on `submit_task_review` / `close` /
+    /// `force_close` / `user_override`, so a populated value describes the
+    /// current unresolved conflict, not a stale one.
+    MergeConflict,
+}
+
+impl PrReworkSignal {
+    /// Derive the rework signal from the task-row facts available at the
+    /// dispatch call site.
+    ///
+    /// Precedence: a failing required-CI gate wins over conflict metadata
+    /// (either one alone already bypasses adoption; the ordering only affects
+    /// which signal is named in tracing).  Empty/whitespace conflict metadata
+    /// is treated as absent.
+    pub fn from_task_row(ci_status: &str, merge_conflict_metadata: Option<&str>) -> Option<Self> {
+        if ci_status == CiStatus::Failing.as_str() {
+            return Some(Self::FailingCi);
+        }
+        if merge_conflict_metadata.is_some_and(|m| !m.trim().is_empty()) {
+            return Some(Self::MergeConflict);
+        }
+        None
+    }
+
+    /// Stable snake_case name for tracing/audit output.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::FailingCi => "failing_ci",
+            Self::MergeConflict => "merge_conflict",
+        }
+    }
+}
+
+impl std::fmt::Display for PrReworkSignal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 // ─── Public decision type ───────────────────────────────────────────────────
 
@@ -59,19 +128,25 @@ pub enum RespawnGuardDecision {
 /// 1. **Open-PR adoption** — when `pr_url` is `Some`, an existing open PR is
 ///    detected.  Returns [`RespawnGuardDecision::Adopted`] so the caller can
 ///    record an `adopted_pr` audit row and skip dispatch.  Adoption is
-///    **bypassed** when `ci_status` is `failing` (a required check is red on
-///    the PR head): the PrCiFailed remediation flow reopened the task so a
-///    worker can fix the failing PR, and adopting here would starve that
-///    remediation forever.  The guard falls through to step 2 instead, so a
-///    remediation worker dispatches exactly once.
+///    **bypassed** when the PR needs rework: any reopen-for-PR-rework flow
+///    (PrCiFailed, PrConflict, PrChangesRequested, merge-queue dequeue)
+///    reopened the task so a worker can fix the PR, and adopting here would
+///    starve that rework forever.  The guard falls through to step 2 instead,
+///    so a rework worker dispatches exactly once.  Rework is detected via:
+///    - `rework_signal` (built by the caller from the task row with
+///      [`PrReworkSignal::from_task_row`]): failing required CI or an
+///      unresolved merge conflict; or
+///    - the latest-attempt fallback for paths that leave no task-row column
+///      (PrChangesRequested, merge-queue dequeues whose PR-head checks are
+///      green): the newest non-guard attempt row for this task+role is
+///      terminal with outcome `reopened`.
 /// 2. **Non-terminal attempt** — consults
 ///    [`TaskAttemptRepository::latest_pending_or_submitted`] for the task/role
 ///    pair.  If a non-terminal attempt already exists the dispatch is deferred
 ///    with [`GuardReason::RespawnGuard`].
 ///
-/// `ci_status` is the task's promoted required-CI gate state (the wire string
-/// of [`CiStatus`], e.g. `task.ci_status`).  `None` or any non-`failing` value
-/// (green / pending / unknown) preserves the adoption behavior.
+/// A healthy open PR (CI green/pending/unknown, no conflict metadata, no
+/// reopened-latest attempt) preserves the adoption behavior.
 ///
 /// Returns [`RespawnGuardDecision::Allow`] when neither guard fires.
 ///
@@ -82,25 +157,34 @@ pub async fn run_respawn_guard(
     task_id: &str,
     role: &str,
     pr_url: Option<&str>,
-    ci_status: Option<&str>,
+    rework_signal: Option<PrReworkSignal>,
 ) -> RespawnGuardDecision {
     // 1. Open-PR adoption: when the task already has an open PR, adopt it
     //    and skip dispatch.  This prevents spawning a duplicate worker when
-    //    a PR is already in review — unless required CI is failing on the PR
-    //    head, in which case the task was reopened for remediation and a
-    //    worker MUST be dispatched to fix the PR (step 2 still prevents
-    //    duplicate remediation workers).
+    //    a PR is already in review — unless the PR needs rework, in which
+    //    case the task was reopened so a worker MUST be dispatched to fix
+    //    the PR (step 2 still prevents duplicate rework workers).
     if let Some(url) = pr_url
         && !url.is_empty()
     {
-        if ci_status == Some(CiStatus::Failing.as_str()) {
+        if let Some(signal) = rework_signal {
             tracing::info!(
                 task_id = %task_id,
                 role = %role,
                 pr_url = %url,
-                ci_status = %CiStatus::Failing,
-                "respawn_guard: open PR has failing required CI — bypassing adoption so a \
-                 remediation worker can dispatch"
+                rework_signal = %signal,
+                "respawn_guard: open PR needs rework — bypassing adoption so a \
+                 rework worker can dispatch"
+            );
+        } else if latest_attempt_is_reopened(db, task_id, role).await {
+            tracing::info!(
+                task_id = %task_id,
+                role = %role,
+                pr_url = %url,
+                rework_signal = "latest_attempt_reopened",
+                "respawn_guard: open PR needs rework (latest attempt terminalized as \
+                 reopened; e.g. changes requested or merge-queue dequeue) — bypassing \
+                 adoption so a rework worker can dispatch"
             );
         } else {
             tracing::info!(
@@ -141,6 +225,49 @@ pub async fn run_respawn_guard(
                 "respawn_guard: attempt-history lookup failed (fail-open); allowing dispatch"
             );
             RespawnGuardDecision::Allow
+        }
+    }
+}
+
+/// Latest-attempt rework fallback: `true` when the newest non-guard
+/// `task_attempts` row for this task+role is terminal with outcome
+/// `reopened`.
+///
+/// The PR poller terminalizes the in-flight worker attempt as `reopened`
+/// for every reopen-for-PR-rework transition (PrCiFailed,
+/// PrChangesRequested, PrConflict, task_review_reject*, merge-queue
+/// dequeue via PrCiFailed) *before* applying the board transition, so a
+/// `reopened`-latest attempt means "reopened for rework, no new attempt
+/// dispatched yet".  Guard-only audit rows (`deferred`, `adopted_pr`) are
+/// skipped: prior guard ticks must not mask the rework signal.
+///
+/// The bypass window is self-closing (no permanent adoption bypass): the
+/// moment a rework worker dispatches, `record_dispatch_start` inserts a
+/// newer `pending` row, which becomes the latest attempt and step 2 defers
+/// any further dispatch; on submit/merge it advances to
+/// `submitted`/`completed`, restoring adoption for the then-healthy PR.
+///
+/// Fail-closed on DB errors: a lookup failure preserves the pre-existing
+/// adoption behavior rather than spawning a possibly-duplicate worker.
+async fn latest_attempt_is_reopened(db: &djinn_db::Database, task_id: &str, role: &str) -> bool {
+    let repo = TaskAttemptRepository::new(db.clone());
+    match repo.list_for_task(task_id).await {
+        Ok(attempts) => attempts
+            .iter()
+            .filter(|a| a.role == role)
+            .find(|a| {
+                a.outcome != TaskAttemptOutcome::Deferred.as_str()
+                    && a.outcome != TaskAttemptOutcome::AdoptedPr.as_str()
+            })
+            .is_some_and(|latest| latest.outcome == TaskAttemptOutcome::Reopened.as_str()),
+        Err(e) => {
+            tracing::warn!(
+                task_id = %task_id,
+                role = %role,
+                error = %e,
+                "respawn_guard: latest-attempt rework lookup failed; preserving adoption"
+            );
+            false
         }
     }
 }
@@ -626,6 +753,42 @@ mod tests {
         );
     }
 
+    // ─── PrReworkSignal derivation tests ─────────────────────────────────
+
+    const CONFLICT_METADATA: &str = r#"{"conflicting_files":["src/note/mod.rs"],"base_branch":"main","merge_target":"main"}"#;
+
+    #[test]
+    fn rework_signal_from_task_row_mapping() {
+        // Failing required CI wins regardless of conflict metadata.
+        assert_eq!(
+            PrReworkSignal::from_task_row(CiStatus::Failing.as_str(), None),
+            Some(PrReworkSignal::FailingCi)
+        );
+        assert_eq!(
+            PrReworkSignal::from_task_row(CiStatus::Failing.as_str(), Some(CONFLICT_METADATA)),
+            Some(PrReworkSignal::FailingCi)
+        );
+        // Populated conflict metadata signals rework even with green CI.
+        assert_eq!(
+            PrReworkSignal::from_task_row(CiStatus::Passing.as_str(), Some(CONFLICT_METADATA)),
+            Some(PrReworkSignal::MergeConflict)
+        );
+        assert_eq!(
+            PrReworkSignal::from_task_row(CiStatus::Pending.as_str(), Some(CONFLICT_METADATA)),
+            Some(PrReworkSignal::MergeConflict)
+        );
+        // Healthy: green/pending/unknown CI and no (or blank) metadata.
+        for ci in [
+            CiStatus::Passing.as_str(),
+            CiStatus::Pending.as_str(),
+            CiStatus::Unknown.as_str(),
+        ] {
+            assert_eq!(PrReworkSignal::from_task_row(ci, None), None);
+            assert_eq!(PrReworkSignal::from_task_row(ci, Some("")), None);
+            assert_eq!(PrReworkSignal::from_task_row(ci, Some("   ")), None);
+        }
+    }
+
     // ─── CI-remediation adoption bypass tests ───────────────────────────
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -641,7 +804,7 @@ mod tests {
             &task.id,
             "worker",
             Some("https://github.example/owner/repo/pull/42"),
-            Some(CiStatus::Failing.as_str()),
+            PrReworkSignal::from_task_row(CiStatus::Failing.as_str(), None),
         )
         .await;
         assert_eq!(decision, RespawnGuardDecision::Allow);
@@ -665,7 +828,7 @@ mod tests {
             &task.id,
             "worker",
             Some("https://github.example/owner/repo/pull/42"),
-            Some(CiStatus::Failing.as_str()),
+            PrReworkSignal::from_task_row(CiStatus::Failing.as_str(), None),
         )
         .await;
         assert_eq!(
@@ -679,20 +842,20 @@ mod tests {
         let db = test_db();
         let task = create_task(&db).await;
 
-        // Any non-failing CI gate state preserves the adoption behavior: the
-        // PR is merely awaiting review/merge, so no duplicate worker spawns.
+        // Any non-failing CI gate state (and no conflict metadata) preserves
+        // the adoption behavior: the PR is merely awaiting review/merge, so
+        // no duplicate worker spawns.
         for ci_status in [
-            Some(CiStatus::Passing.as_str()),
-            Some(CiStatus::Pending.as_str()),
-            Some(CiStatus::Unknown.as_str()),
-            None,
+            CiStatus::Passing.as_str(),
+            CiStatus::Pending.as_str(),
+            CiStatus::Unknown.as_str(),
         ] {
             let decision = run_respawn_guard(
                 &db,
                 &task.id,
                 "worker",
                 Some("https://github.example/owner/repo/pull/42"),
-                ci_status,
+                PrReworkSignal::from_task_row(ci_status, None),
             )
             .await;
             assert_eq!(
@@ -703,6 +866,253 @@ mod tests {
                 "ci_status={ci_status:?} must still adopt"
             );
         }
+    }
+
+    // ─── Merge-conflict adoption bypass tests (PrConflict reopen) ────────
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_does_not_adopt_when_merge_conflict_metadata_present() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // Open PR + populated merge_conflict_metadata + green CI (PrConflict
+        // reopen: the PR conflicts with main while its own checks pass): the
+        // guard must NOT adopt.  With no pending attempt it must Allow so a
+        // conflict-resolution worker dispatches.
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            PrReworkSignal::from_task_row(CiStatus::Passing.as_str(), Some(CONFLICT_METADATA)),
+        )
+        .await;
+        assert_eq!(decision, RespawnGuardDecision::Allow);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_defers_when_merge_conflict_and_pending_attempt_exists() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // A conflict-resolution worker is already in flight (pending attempt).
+        let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+        super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+            .await
+            .expect("record_dispatch_start should succeed");
+
+        // Open PR + merge conflict: adoption is bypassed, but step 2 still
+        // defers so no duplicate conflict-resolution worker is dispatched.
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            PrReworkSignal::from_task_row(CiStatus::Passing.as_str(), Some(CONFLICT_METADATA)),
+        )
+        .await;
+        assert_eq!(
+            decision,
+            RespawnGuardDecision::Defer(GuardReason::RespawnGuard)
+        );
+    }
+
+    // ─── Latest-attempt rework fallback tests ────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_does_not_adopt_when_latest_attempt_reopened() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // Simulate the PrChangesRequested / merge-queue-dequeue flow: the PR
+        // poller terminalizes the in-flight worker attempt as `reopened`
+        // before reopening the task.  No task-row rework column exists for
+        // these paths, so the guard's latest-attempt fallback must bypass
+        // adoption and Allow a rework worker.
+        let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+        super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+            .await
+            .expect("record_dispatch_start should succeed");
+        super::super::attempt_lifecycle::advance_latest_to_terminal(
+            &db,
+            super::super::attempt_lifecycle::TerminalAdvancementParams {
+                task_id: &task.id,
+                role: "worker",
+                outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::Reopened,
+                pr_url: Some("https://github.example/owner/repo/pull/42"),
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary: Some("Reviewer requested changes on PR"),
+                summary_json: None,
+                log_tail: None,
+            },
+        )
+        .await;
+
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            None,
+        )
+        .await;
+        assert_eq!(decision, RespawnGuardDecision::Allow);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_reopened_fallback_ignores_guard_only_audit_rows() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // A `reopened` attempt followed by guard-only audit rows from earlier
+        // wedged ticks (adopted_pr / deferred, exactly what the starved
+        // production tasks accumulated) must still bypass adoption: guard
+        // rows must not mask the rework signal.
+        let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+        super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+            .await
+            .expect("record_dispatch_start should succeed");
+        super::super::attempt_lifecycle::advance_latest_to_terminal(
+            &db,
+            super::super::attempt_lifecycle::TerminalAdvancementParams {
+                task_id: &task.id,
+                role: "worker",
+                outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::Reopened,
+                pr_url: Some("https://github.example/owner/repo/pull/42"),
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary: Some("reopened for rework"),
+                summary_json: None,
+                log_tail: None,
+            },
+        )
+        .await;
+        record_adopted_pr_attempt(
+            &db,
+            &task.id,
+            "worker",
+            "https://github.example/owner/repo/pull/42",
+            Some("stale adoption from a wedged tick"),
+        )
+        .await
+        .expect("adopted_pr audit row should insert");
+        record_guard_deferred_attempt(
+            &db,
+            &task.id,
+            "worker",
+            GuardReason::RespawnGuard,
+            Some("stale deferral"),
+        )
+        .await
+        .expect("deferred audit row should insert");
+
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            None,
+        )
+        .await;
+        assert_eq!(decision, RespawnGuardDecision::Allow);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_adopts_when_latest_attempt_completed() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // A `completed`-latest attempt means the PR is healthy work-in-review
+        // (e.g. the 422-adopt backstop): adoption must be preserved even
+        // though an older attempt cycle could have been reopened before.
+        let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+        super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+            .await
+            .expect("record_dispatch_start should succeed");
+        super::super::attempt_lifecycle::advance_latest_to_terminal(
+            &db,
+            super::super::attempt_lifecycle::TerminalAdvancementParams {
+                task_id: &task.id,
+                role: "worker",
+                outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::Completed,
+                pr_url: Some("https://github.example/owner/repo/pull/42"),
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary: Some("done"),
+                summary_json: None,
+                log_tail: None,
+            },
+        )
+        .await;
+
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            None,
+        )
+        .await;
+        assert_eq!(
+            decision,
+            RespawnGuardDecision::Adopted {
+                pr_url: "https://github.example/owner/repo/pull/42".to_owned(),
+            }
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn guard_reopened_fallback_is_role_scoped() {
+        let db = test_db();
+        let task = create_task(&db).await;
+
+        // A `reopened` attempt for a DIFFERENT role must not bypass adoption
+        // for this role.
+        let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "reviewer");
+        super::super::attempt_lifecycle::record_dispatch_start(
+            &db, &task.id, "reviewer", None, &dk,
+        )
+        .await
+        .expect("record_dispatch_start should succeed");
+        super::super::attempt_lifecycle::advance_latest_to_terminal(
+            &db,
+            super::super::attempt_lifecycle::TerminalAdvancementParams {
+                task_id: &task.id,
+                role: "reviewer",
+                outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::Reopened,
+                pr_url: None,
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary: Some("reviewer attempt reopened"),
+                summary_json: None,
+                log_tail: None,
+            },
+        )
+        .await;
+
+        let decision = run_respawn_guard(
+            &db,
+            &task.id,
+            "worker",
+            Some("https://github.example/owner/repo/pull/42"),
+            None,
+        )
+        .await;
+        assert_eq!(
+            decision,
+            RespawnGuardDecision::Adopted {
+                pr_url: "https://github.example/owner/repo/pull/42".to_owned(),
+            }
+        );
     }
 
     // ─── record_adopted_pr_attempt tests ────────────────────────────────

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1390,20 +1390,28 @@ impl CoordinatorActor {
             // fresh spawn/admission side-effects.  Guard ordering:
             // 1. Open-PR adoption: when the task has an existing open PR
             //    (task.pr_url), adopt it and record an adopted_pr audit row.
-            //    Adoption is bypassed when the task's required-CI gate is
-            //    failing (task.ci_status == "failing"): the PrCiFailed
-            //    remediation flow reopened the task so a worker can fix the
-            //    failing PR, and adopting would starve that remediation.
+            //    Adoption is bypassed when the PR needs rework — the reopen
+            //    flow returned the task to open so a worker can fix the PR,
+            //    and adopting would starve that rework: failing required CI
+            //    (task.ci_status == "failing", PrCiFailed flow), an
+            //    unresolved merge conflict (task.merge_conflict_metadata,
+            //    PrConflict flow), or a reopened-latest attempt (paths with
+            //    no task-row column, e.g. PrChangesRequested / merge-queue
+            //    dequeue with green PR-head checks).
             // 2. Non-terminal attempt: if a pending or submitted attempt
             //    already exists for this task+role, defer dispatch and record
             //    a guard-only audit row.  No dispatch / provider / reopen
             //    counters are incremented for the deferral.
+            let pr_rework_signal = super::respawn_guard::PrReworkSignal::from_task_row(
+                task.ci_status.as_str(),
+                task.merge_conflict_metadata.as_deref(),
+            );
             match super::respawn_guard::run_respawn_guard(
                 &self.db,
                 &task.id,
                 role,
                 task.pr_url.as_deref(),
-                Some(task.ci_status.as_str()),
+                pr_rework_signal,
             )
             .await
             {


### PR DESCRIPTION
## Problem — #1706 under-fixed the adoption starvation

#1706 bypassed open-PR adoption only when `ci_status == failing`. But the **PrConflict** flow reopens tasks with green CI and an unmergeable PR — those fall straight back into the unconditional adoption loop. Production right now: `4tl2` (PR #1707, conflict in `note/mod.rs`) and `q8r6` (PR #1700, conflicts in 8 files) each log `adopting existing open PR — skipping dispatch` ~55×/25min; their conflict-resolution workers never dispatch.

## Full rework-signal audit (so there is no fourth variant)

`pr_url` is never cleared, so every reopen-with-PR path re-enters the adoption gate:

| Reopen path | Durable task-row signal |
|---|---|
| PrCiFailed (PR-head CI) | `ci_status == failing` (covered by #1706) |
| PrConflict / task_review_reject_conflict / lead_approve_conflict | `merge_conflict_metadata` set |
| PrCiFailed via **merge-queue dequeue** | often **none** (PR-head checks stay green; full suite runs only on merge_group) |
| PrChangesRequested | **none** (only a `task_attempts` row terminalized `reopened`) |

## Fix

- New `PrReworkSignal` enum (`FailingCi`, `MergeConflict`) derived at the dispatch call site from task-row facts (no new queries).
- Adoption is bypassed on either signal, falling through to the step-2 pending/submitted dedup (remediation dispatches exactly once).
- **Fallback for the signal-less paths:** when the latest non-guard attempt row for (task, role) is terminalized `reopened` (skipping guard-only `deferred`/`adopted_pr` audit rows — the exact production masking shape), adoption is also bypassed. Self-closing: the first rework dispatch inserts a newer `pending` row that supersedes it. DB errors fail closed (preserve adoption). Reuses the existing prepared query — sqlx offline cache unchanged.
- Staleness safe: `merge_conflict_metadata` is cleared on `submit_task_review`/`close`/`force_close`/`user_override`, so a populated value always describes the current conflict; no permanent-bypass inverse bug.
- Tracing names the exact signal that bypassed adoption (`failing_ci` / `merge_conflict` / `latest_attempt_reopened`).

## Tests

`respawn_guard`: **29 passed** (+7 new: conflict→Allow, conflict+pending→Defer, healthy→Adopted, from_task_row mapping/precedence, reopened-latest→Allow, reopened-masked-by-guard-rows→Allow, completed→Adopted, role-scoping). Touched suites `i3mv` 22/22, `operator_explanation` 16/16. `dispatch` filter 279/280 — the 1 failure is the known pre-existing `wnd1` parallel-run flake (fails identically on unmodified base; passes 3/3 in isolation). Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)