### PR TITLE
fix(coordinator): reap unowned submitted attempts, mark wave-dispatch conflict reopens, terminalize control-plane rework transitions

### DIFF
--- a/server/crates/djinn-agent/src/actors/coordinator/mod.rs
+++ b/server/crates/djinn-agent/src/actors/coordinator/mod.rs
@@ -14,7 +14,7 @@ pub use djinn_coordinator::{
     AutoMergeTracker, BackgroundWorkTracker, BreakerDebugEntry, CoordinatorDebugSnapshot,
     CoordinatorError, CoordinatorHandle, CoordinatorStatus, DebugCooldown, DebugDispatchState,
     DebugFailureStreak, DebugInflightEntry, DebugSlot, DebugTotals, DispatchPauseView,
-    PR_REVIEW_FEEDBACK_EVENT, PrCleanupConfig,
+    PR_REVIEW_FEEDBACK_EVENT, PrCleanupConfig, record_supervisor_rework_reopen,
 };
 
 // Re-export public submodules.

--- a/server/crates/djinn-control-plane/src/bridge/coordinator_bridge.rs
+++ b/server/crates/djinn-control-plane/src/bridge/coordinator_bridge.rs
@@ -58,4 +58,22 @@ pub trait CoordinatorOps: Send + Sync {
         accept: bool,
         feedback: Option<String>,
     ) -> Result<(), String>;
+    /// Terminalize the worker's in-flight attempt (and record a durable
+    /// `reopened` marker) for a supervisor-driven rework reopen applied via the
+    /// control-plane `task_transition` tool.
+    ///
+    /// `djinn-control-plane` cannot depend on `djinn-coordinator` (the
+    /// dependency runs the other way), so the attempt-lifecycle chokepoint
+    /// `djinn_coordinator::record_supervisor_rework_reopen` is reached through
+    /// this bridge — the server binary implements it by delegating to that
+    /// function (exactly like `DirectServices::transition_task` does for the
+    /// in-process/RPC transition path). A no-op for non-rework actions and
+    /// best-effort (errors are swallowed inside the chokepoint), so this returns
+    /// unit rather than a `Result`.
+    async fn record_supervisor_rework_reopen(
+        &self,
+        task_id: &str,
+        action: &djinn_core::models::TransitionAction,
+        reason: Option<&str>,
+    );
 }

--- a/server/crates/djinn-control-plane/src/state.rs
+++ b/server/crates/djinn-control-plane/src/state.rs
@@ -394,6 +394,13 @@ pub mod stubs {
         ) -> Result<(), String> {
             Err("coordinator not initialized".into())
         }
+        async fn record_supervisor_rework_reopen(
+            &self,
+            _: &str,
+            _: &djinn_core::models::TransitionAction,
+            _: Option<&str>,
+        ) {
+        }
     }
 
     /// Test-only coordinator stub that accepts refinement starts (returns Ok)
@@ -427,6 +434,13 @@ pub mod stubs {
             _: Option<String>,
         ) -> Result<(), String> {
             Ok(())
+        }
+        async fn record_supervisor_rework_reopen(
+            &self,
+            _: &str,
+            _: &djinn_core::models::TransitionAction,
+            _: Option<&str>,
+        ) {
         }
     }
 

--- a/server/crates/djinn-control-plane/src/test_support.rs
+++ b/server/crates/djinn-control-plane/src/test_support.rs
@@ -94,6 +94,13 @@ impl CoordinatorOps for StubCoordinator {
     ) -> std::result::Result<(), String> {
         Err("stub: CoordinatorOps::resolve_refinement_review not implemented".into())
     }
+    async fn record_supervisor_rework_reopen(
+        &self,
+        _task_id: &str,
+        _action: &djinn_core::models::TransitionAction,
+        _reason: Option<&str>,
+    ) {
+    }
 }
 
 /// SlotPoolOps stub. Queries return empties; mutations (kill_session) error.

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part1.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part1.inc
@@ -253,6 +253,13 @@
             ) -> Result<(), String> {
                 Err("no refinement awaiting review".to_string())
             }
+            async fn record_supervisor_rework_reopen(
+                &self,
+                _: &str,
+                _: &djinn_core::models::TransitionAction,
+                _: Option<&str>,
+            ) {
+            }
         }
 
         let db = Database::open_in_memory().unwrap();

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part2.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part2.inc
@@ -459,6 +459,13 @@
             ) -> Result<(), String> {
                 Err("unexpected resolve call".into())
             }
+            async fn record_supervisor_rework_reopen(
+                &self,
+                _: &str,
+                _: &djinn_core::models::TransitionAction,
+                _: Option<&str>,
+            ) {
+            }
         }
 
         let db = Database::open_in_memory().unwrap();

--- a/server/crates/djinn-control-plane/src/tools/task_tools/ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/ops.rs
@@ -497,6 +497,10 @@ pub async fn transition_task(
         return Json(ErrorOr::Error(not_found(&request.id)));
     };
 
+    // Preserve the action for the post-transition rework-reopen chokepoint
+    // (`repo.transition` consumes it by value).
+    let action = request.action.clone();
+
     match repo
         .transition(
             &task.id,
@@ -508,7 +512,26 @@ pub async fn transition_task(
         )
         .await
     {
-        Ok(updated) => Json(ErrorOr::Ok(task_to_response(&updated))),
+        Ok(updated) => {
+            // Supervisor-driven rework reopens applied through this tool
+            // (task_review_reject* / lead_approve_conflict) must terminalize the
+            // worker's in-flight `submitted` attempt to `reopened` and record a
+            // durable rework marker — otherwise the transition leaves an
+            // orphaned `submitted` attempt that wedges the respawn guard's
+            // step-2 dedup forever (the ylme bug, previously fixed for the
+            // in-process/RPC path in `DirectServices::transition_task`). The PR
+            // poller's `apply_pr_transition` already owns the
+            // PrCiFailed/PrChangesRequested/PrConflict reopens; the coordinator
+            // chokepoint (reached here via the bridge, since control-plane
+            // cannot depend on djinn-coordinator) is a no-op for every non-rework
+            // action. Best-effort.
+            if let Some(coordinator) = server.state.coordinator().await {
+                coordinator
+                    .record_supervisor_rework_reopen(&task.id, &action, request.reason.as_deref())
+                    .await;
+            }
+            Json(ErrorOr::Ok(task_to_response(&updated)))
+        }
         Err(e) => Json(ErrorOr::Error(ErrorResponse::new(e.to_string()))),
     }
 }

--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard_tests.rs
@@ -1063,3 +1063,102 @@ async fn guard_allows_when_no_pr_url_and_no_pending() {
     let decision = run_respawn_guard(&db, &task.id, "worker", None, None).await;
     assert_eq!(decision, RespawnGuardDecision::Allow);
 }
+
+// ── Hole C: supervisor rework-reopen chokepoint (control-plane path) ──────
+//
+// The control-plane `task_transition` MCP tool cannot terminalize the worker
+// attempt itself (`djinn-control-plane` cannot depend on `djinn-coordinator`);
+// it delegates to `crate::record_supervisor_rework_reopen` through the
+// `CoordinatorOps` bridge, which in tests is stubbed to a no-op. This test
+// exercises that exact chokepoint directly — with the same `TransitionAction`
+// values the tool passes — proving a rework action terminalizes an in-flight
+// `submitted` worker attempt to `reopened`, while a non-rework action is a
+// no-op. (Per the task spec, the coordinator-level test stands in for the
+// control-plane path because the bridge stub makes an end-to-end tool test
+// impossible.)
+
+/// Seed a `submitted` worker attempt (pending → submitted) for a task.
+async fn seed_submitted_attempt(db: &Database, task_id: &str) {
+    let dk = super::super::attempt_lifecycle::make_dispatch_key(task_id, "worker");
+    super::super::attempt_lifecycle::record_dispatch_start(db, task_id, "worker", None, &dk)
+        .await
+        .expect("record_dispatch_start should succeed");
+    super::super::attempt_lifecycle::advance_to_submitted(
+        db,
+        super::super::attempt_lifecycle::SubmitAdvancementParams {
+            task_id,
+            role: "worker",
+            submit_ref: Some("ref-1"),
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: Some("submitted"),
+            summary_json: None,
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn supervisor_rework_reopen_terminalizes_submitted_attempt_to_reopened() {
+    use djinn_core::models::TransitionAction;
+
+    let db = test_db();
+    let task = create_task(&db).await;
+    seed_submitted_attempt(&db, &task.id).await;
+
+    // A rework action (as passed by the control-plane task_transition tool)
+    // terminalizes the in-flight submitted attempt to `reopened`.
+    crate::record_supervisor_rework_reopen(
+        &db,
+        &task.id,
+        &TransitionAction::TaskReviewReject,
+        Some("reviewer rejected"),
+    )
+    .await;
+
+    let repo = TaskAttemptRepository::new(db.clone());
+    let latest = repo
+        .list_for_task(&task.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|a| a.role == "worker")
+        .expect("worker attempt exists");
+    assert_eq!(
+        latest.outcome, "reopened",
+        "rework transition must advance the submitted attempt to reopened"
+    );
+
+    // And the guard now allows a fresh rework worker (no live attempt remains).
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", None, None).await,
+        RespawnGuardDecision::Allow,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn supervisor_rework_reopen_is_noop_for_non_rework_action() {
+    use djinn_core::models::TransitionAction;
+
+    let db = test_db();
+    let task = create_task(&db).await;
+    seed_submitted_attempt(&db, &task.id).await;
+
+    // A non-rework action must NOT touch the in-flight submitted attempt.
+    crate::record_supervisor_rework_reopen(
+        &db,
+        &task.id,
+        &TransitionAction::Start,
+        Some("started"),
+    )
+    .await;
+
+    let repo = TaskAttemptRepository::new(db.clone());
+    let attempts = repo.list_for_task(&task.id).await.unwrap();
+    assert_eq!(attempts.len(), 1, "no marker rows for non-rework actions");
+    assert_eq!(
+        attempts[0].outcome, "submitted",
+        "non-rework action must leave the submitted attempt untouched"
+    );
+}

--- a/server/crates/djinn-coordinator/src/dispatch/wave_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/wave_dispatch.rs
@@ -1,5 +1,7 @@
 use super::super::*;
-use super::attempt_lifecycle::{TerminalAdvancementParams, advance_latest_to_terminal};
+use super::attempt_lifecycle::{
+    TerminalAdvancementParams, advance_latest_to_terminal, ensure_rework_marker,
+};
 use crate::pr_poller::pr_cleanup::CloseKind;
 use djinn_core::models::TransitionAction;
 use djinn_core::models::task::IssueType;
@@ -33,6 +35,14 @@ pub(super) enum WaveDispatchAttemptOutcome<'a> {
         reason: &'a str,
         replacement: &'a str,
     },
+    /// A rework reopen owned by wave dispatch: the task is re-queued to `open`
+    /// via a `PrConflict` transition (e.g. an approved task whose `task_branch`
+    /// never reached the mirror), so a fresh worker must redo the work. Unlike
+    /// [`Handoff`], this MUST leave a durable `reopened` latest attempt to honor
+    /// the rework-marker invariant the respawn guard's `latest_attempt_is_reopened`
+    /// check relies on — terminalizing any live attempt to `reopened` AND
+    /// inserting a marker when nothing was in-flight.
+    Reopened { reason: &'a str },
     /// Dispatch-owned ForceClose (oversized blob in branch history, etc.).
     ForceClosed {
         reason: &'a str,
@@ -397,17 +407,18 @@ impl CoordinatorActor {
                         }
                         self.pr_errors.remove(&task.project_id);
                         self.publish_status();
-                        // Attempt lifecycle: the current worker attempt stops
-                        // here and another worker process takes over (the task
-                        // is re-queued to `open` for a fresh worker run that
-                        // recreates and pushes the missing branch). Terminalize
-                        // as `handoff`. Best-effort.
+                        // Attempt lifecycle: this is a rework reopen — the
+                        // `PrConflict` transition re-queued the task to `open`
+                        // for a fresh worker run that recreates and pushes the
+                        // missing branch. Terminalize as `reopened` (NOT
+                        // `handoff`) and record a durable rework marker so the
+                        // respawn guard's `latest_attempt_is_reopened` gate sees
+                        // this reopen — honoring #1719's invariant that every
+                        // rework reopen leaves a `reopened` latest attempt.
+                        // Best-effort.
                         self.terminalize_wave_dispatch_attempt(
                             &task,
-                            WaveDispatchAttemptOutcome::Handoff {
-                                reason: &reason,
-                                replacement: "requeued_missing_branch",
-                            },
+                            WaveDispatchAttemptOutcome::Reopened { reason: &reason },
                         )
                         .await;
                     } else if task.pr_url.is_some() {
@@ -650,6 +661,27 @@ pub(super) fn build_wave_dispatch_terminal_params<'a>(
                 submit_ref,
             }
         }
+        WaveDispatchAttemptOutcome::Reopened { reason } => {
+            let summary =
+                format!("wave_dispatch: current worker attempt reopened for rework: {reason}");
+            let summary_json = serde_json::json!({
+                "source": "wave_dispatch",
+                "path": "reopened",
+                "reason": reason,
+                "submit_ref": submit_ref,
+                "pr_url": task.pr_url,
+                "task_branch": task_branch,
+            })
+            .to_string();
+            WaveDispatchTerminalParams {
+                outcome: TaskAttemptOutcome::Reopened,
+                pr_url: task.pr_url.as_deref(),
+                github_head_sha: task.ci_head_sha.as_deref(),
+                summary,
+                summary_json,
+                submit_ref,
+            }
+        }
         WaveDispatchAttemptOutcome::ForceClosed {
             reason,
             close_reason,
@@ -702,6 +734,7 @@ pub(super) async fn terminalize_wave_dispatch_attempt_on_db(
     outcome: WaveDispatchAttemptOutcome<'_>,
 ) {
     let params = build_wave_dispatch_terminal_params(task, outcome);
+    let is_rework_reopen = params.outcome == TaskAttemptOutcome::Reopened;
     advance_latest_to_terminal(
         db,
         TerminalAdvancementParams {
@@ -719,4 +752,12 @@ pub(super) async fn terminalize_wave_dispatch_attempt_on_db(
         },
     )
     .await;
+    // Rework-marker invariant (#1719): a `reopened` wave-dispatch outcome MUST
+    // leave a durable `reopened` latest attempt even when no live attempt
+    // existed to terminalize above. `ensure_rework_marker` is a no-op when a
+    // live attempt was just advanced or the latest attempt is already
+    // `reopened`, so this is idempotent.
+    if is_rework_reopen {
+        ensure_rework_marker(db, &task.id, "worker", Some(&params.summary)).await;
+    }
 }

--- a/server/crates/djinn-coordinator/src/dispatch/wave_dispatch_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/wave_dispatch_tests.rs
@@ -689,3 +689,116 @@ async fn wiring_already_terminal_attempt_is_not_moved_backward() {
         "must not overwrite terminal summary_json"
     );
 }
+
+// ── Hole B: branch-missing PrConflict reopens (NOT handoffs) ─────────────
+
+/// Newest non-guard worker attempt outcome for a task (mirrors the respawn
+/// guard's `latest_attempt_is_reopened` filter): skips guard-only audit rows.
+async fn newest_non_guard_worker_outcome(db: &Database, task_id: &str) -> Option<String> {
+    TaskAttemptRepository::new(db.clone())
+        .list_for_task(task_id)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|a| a.role == "worker")
+        .find(|a| {
+            a.outcome != TaskAttemptOutcome::Deferred.as_str()
+                && a.outcome != TaskAttemptOutcome::AdoptedPr.as_str()
+        })
+        .map(|a| a.outcome)
+}
+
+/// Pure-logic: the `Reopened` outcome maps to `TaskAttemptOutcome::Reopened`
+/// and records the `reopened` summary_json path with task PR / branch context.
+#[test]
+fn build_terminal_params_reopened_records_reopen_path_and_branch() {
+    let mut task = test_task("t-reopen");
+    task.pr_url = Some("https://github.example/owner/repo/pull/7".into());
+    task.ci_head_sha = Some("cafef00d".into());
+    let params = build_wave_dispatch_terminal_params(
+        &task,
+        WaveDispatchAttemptOutcome::Reopened {
+            reason: "approved with no pushed task_branch",
+        },
+    );
+    assert_eq!(params.outcome, TaskAttemptOutcome::Reopened);
+    assert_eq!(
+        params.pr_url,
+        Some("https://github.example/owner/repo/pull/7")
+    );
+    assert_eq!(params.github_head_sha, Some("cafef00d"));
+    assert_eq!(params.submit_ref, "refs/heads/task/t-reopen");
+    let ctx: serde_json::Value = serde_json::from_str(&params.summary_json).unwrap();
+    assert_eq!(ctx["source"], "wave_dispatch");
+    assert_eq!(ctx["path"], "reopened");
+    assert_eq!(ctx["reason"], "approved with no pushed task_branch");
+    assert_eq!(ctx["task_branch"], "task/t-reopen");
+}
+
+/// Wiring: a branch-missing PrConflict reopen terminalizes the live `submitted`
+/// worker attempt to `reopened` (NOT `handoff`), so the respawn guard's
+/// latest-attempt-is-reopened gate sees the rework reopen (#1719 invariant).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wiring_reopened_terminalizes_live_submitted_attempt_to_reopened() {
+    let db = lifecycle_test_db();
+    let (task, attempt_id) = setup_pending_attempt(&db).await;
+    let repo = TaskAttemptRepository::new(db.clone());
+    // Advance to `submitted` to mirror the real branch-missing approved task
+    // (the worker already submitted before the PR-open push found no branch).
+    repo.advance_to_submitted(djinn_db::SubmitTaskAttemptParams {
+        id: &attempt_id,
+        submit_ref: Some("ref-1"),
+        checkpoint_ref: None,
+        mirror_head_sha: None,
+        github_head_sha: None,
+        summary: Some("submitted"),
+        summary_json: None,
+        log_tail: None,
+    })
+    .await
+    .unwrap();
+
+    terminalize_wave_dispatch_attempt_on_db(
+        &db,
+        &task,
+        WaveDispatchAttemptOutcome::Reopened {
+            reason: "approved with no pushed task_branch; re-running worker",
+        },
+    )
+    .await;
+
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "reopened",
+        "branch-missing PrConflict must terminalize as reopened, not handoff"
+    );
+    assert_eq!(
+        newest_non_guard_worker_outcome(&db, &task.id).await.as_deref(),
+        Some("reopened"),
+        "newest non-guard worker attempt must be reopened"
+    );
+}
+
+/// Wiring: with NO live attempt, the `Reopened` outcome still leaves a durable
+/// `reopened` marker (via ensure_rework_marker), preserving #1719's invariant
+/// that every rework reopen leaves a `reopened` latest attempt.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wiring_reopened_with_no_live_attempt_records_durable_marker() {
+    let db = lifecycle_test_db();
+    let task = lifecycle_create_task(&db).await;
+
+    terminalize_wave_dispatch_attempt_on_db(
+        &db,
+        &task,
+        WaveDispatchAttemptOutcome::Reopened {
+            reason: "approved with no pushed task_branch",
+        },
+    )
+    .await;
+
+    assert_eq!(
+        newest_non_guard_worker_outcome(&db, &task.id).await.as_deref(),
+        Some("reopened"),
+        "a durable reopened marker must exist even with no live attempt to terminalize"
+    );
+}

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -1887,23 +1887,32 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
         }
     }
 
-    // Also finalize orphaned `submitted` attempts whose task carries no open PR.
-    // The PR poller can only own `submitted` attempts that HAVE a PR (it drives
-    // adoption/terminalization off `tasks.pr_url`); a `submitted` attempt with
-    // NO PR — e.g. an internal task-review rejection that reopened the task
-    // without terminalizing the worker's `submitted` row (the ylme orphan) —
-    // can never be advanced by the poller and hard-blocks the respawn guard's
-    // step-2 dedup forever. Finalize it to `reopened` (submitted work existed):
-    // that also makes the guard's latest-attempt gate treat the task as rework,
-    // so a fresh worker dispatches to redo it. `submitted`-with-PR rows are
-    // strictly untouched (excluded by the query). Forward-only + idempotent.
-    let submitted_orphans = match repo.list_orphaned_submitted_no_pr(&threshold_iso).await {
+    // Also finalize orphaned `submitted` attempts the PR poller can never own.
+    // The poller drives adoption/terminalization ONLY for the statuses it polls
+    // (`pr_draft`/`pr_review`), keyed off `tasks.pr_url`. The old assumption
+    // "has pr_url ⟹ poller owns it" is FALSE for `open` tasks: the true rule is
+    // "the poller owns a `submitted` attempt only when the task is in a
+    // poller-polled status". Two poller-blind classes are reaped here, each of
+    // which otherwise hard-blocks the respawn guard's step-2 dedup forever:
+    //   1. PR-less tasks — e.g. an internal task-review rejection that reopened
+    //      the task without terminalizing the worker's `submitted` row (the
+    //      ylme orphan); the poller never sees a PR-less task.
+    //   2. `open` tasks (the sole dispatchable status) that RETAINED a stale
+    //      `pr_url` across a `PrConflict` reopen — never polled, so nothing
+    //      advances the `submitted` attempt and the task is permanently stuck
+    //      `open` yet un-dispatchable behind the guard.
+    // Finalize each to `reopened` (submitted work existed): that also makes the
+    // guard's latest-attempt gate treat the task as rework, so a fresh worker
+    // dispatches to redo it. `submitted` rows for poller-polled statuses
+    // (`pr_draft`/`pr_review`) with a PR are strictly untouched (excluded by the
+    // query). Forward-only + idempotent.
+    let submitted_orphans = match repo.list_orphaned_submitted_unowned(&threshold_iso).await {
         Ok(rows) => rows,
         Err(e) => {
             tracing::warn!(
                 error = %e,
                 reason = reason,
-                "CoordinatorActor: reap_orphaned_submitted_no_pr lookup failed"
+                "CoordinatorActor: reap_orphaned_submitted_unowned lookup failed"
             );
             return;
         }
@@ -1911,10 +1920,10 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
 
     for orphan in submitted_orphans {
         let summary_json = serde_json::json!({
-            "recovery_classifier": "orphaned_submitted_no_pr_reaper",
+            "recovery_classifier": "orphaned_submitted_unowned_reaper",
             "reason": reason,
             "threshold_secs": threshold_secs,
-            "failure_class": "orphaned_submitted_no_pr",
+            "failure_class": "orphaned_submitted_unowned",
         })
         .to_string();
         match repo
@@ -1927,7 +1936,7 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
                 mirror_head_sha: None,
                 github_head_sha: None,
                 summary: Some(
-                    "orphaned submitted attempt (no PR) reaped: reopened for a fresh worker",
+                    "orphaned submitted attempt (poller-unowned: no PR, or retained-PR open task) reaped: reopened for a fresh worker",
                 ),
                 summary_json: Some(&summary_json),
                 log_tail: None,
@@ -1944,7 +1953,7 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
                     threshold = %threshold_iso,
                     outcome = %updated.outcome,
                     reason = reason,
-                    "CoordinatorActor: reaped orphaned no-PR submitted task_attempt to reopened"
+                    "CoordinatorActor: reaped poller-unowned submitted task_attempt to reopened"
                 );
             }
             Err(e) => {
@@ -1954,7 +1963,7 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
                     role = %orphan.role,
                     error = %e,
                     reason = reason,
-                    "CoordinatorActor: failed to reap orphaned no-PR submitted task_attempt"
+                    "CoordinatorActor: failed to reap poller-unowned submitted task_attempt"
                 );
             }
         }

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -5924,8 +5924,9 @@ async fn orphaned_pending_attempt_reaper_finalizes_stale_rows_only() {
 /// Reaper backstop for the ylme orphan: a stale `submitted` attempt whose task
 /// has NO open PR is finalized to `reopened` (submitted work existed, and the
 /// reopened marker lets a fresh worker dispatch); a `submitted` attempt whose
-/// task HAS a PR (owned by the PR poller) and a fresh `submitted`-no-PR row are
-/// left untouched; the sweep is idempotent.
+/// task is in a poller-polled status (`pr_review`) with a PR — genuinely owned
+/// by the PR poller — and a fresh `submitted`-no-PR row are left untouched; the
+/// sweep is idempotent.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn orphaned_submitted_no_pr_reaper_finalizes_stale_rows_only() {
     use crate::dispatch::respawn_guard::{RespawnGuardDecision, run_respawn_guard};
@@ -5966,14 +5967,19 @@ async fn orphaned_submitted_no_pr_reaper_finalizes_stale_rows_only() {
     let attempt_a = seed_submitted(task_a.id.clone()).await;
     backdate_attempt(&db, &attempt_a).await;
 
-    // B: stale submitted + task HAS a pr_url → untouched (PR poller owns it).
+    // B: stale submitted + task in `pr_review` with a PR → untouched (the PR
+    // poller genuinely owns it — poller-ownership requires a poller-polled
+    // status, NOT merely a retained pr_url; a retained pr_url on an `open` task
+    // is reaped, see `orphaned_submitted_open_retained_pr_reaper_reaps_only_unpolled`).
     let (task_b, _n) = create_task_with_note(&db, &tx, "submitted-reaper-with-pr").await;
     let attempt_b = seed_submitted(task_b.id.clone()).await;
     backdate_attempt(&db, &attempt_b).await;
-    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+    let task_b_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    task_b_repo
         .set_pr_url(&task_b.id, "https://github.example/owner/repo/pull/11")
         .await
         .unwrap();
+    task_b_repo.set_status(&task_b.id, "pr_review").await.unwrap();
 
     // C: FRESH submitted-no-PR (younger than threshold) → untouched.
     let (task_c, _n) = create_task_with_note(&db, &tx, "submitted-reaper-fresh").await;
@@ -6033,5 +6039,151 @@ async fn orphaned_submitted_no_pr_reaper_finalizes_stale_rows_only() {
     assert_eq!(
         attempt_repo.get(&attempt_b).await.unwrap().unwrap().outcome,
         "submitted"
+    );
+}
+
+/// Seed a `submitted` worker attempt (pending → submitted) for a task.
+async fn seed_submitted_worker_attempt(db: &Database, task_id: &str) -> String {
+    let dk = crate::dispatch::attempt_lifecycle::make_dispatch_key(task_id, "worker");
+    let id =
+        crate::dispatch::attempt_lifecycle::record_dispatch_start(db, task_id, "worker", None, &dk)
+            .await
+            .expect("pending attempt must insert");
+    TaskAttemptRepository::new(db.clone())
+        .advance_to_submitted(djinn_db::SubmitTaskAttemptParams {
+            id: &id,
+            submit_ref: Some("ref-1"),
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: Some("submitted for internal review"),
+            summary_json: None,
+            log_tail: None,
+        })
+        .await
+        .expect("advance to submitted");
+    id
+}
+
+/// Hole A backstop: a stale `submitted` worker attempt on an `open` task that
+/// RETAINED a `pr_url` across a `PrConflict` reopen is finalized to `reopened`.
+/// `open` is the sole dispatchable status and the PR poller never polls it, so
+/// nothing else can advance the attempt and the task is otherwise permanently
+/// stuck behind the respawn guard's step-2 dedup. A same-shape task left in
+/// `pr_review` — which the poller DOES own — is untouched, as is a fresh
+/// `open`+PR row. The sweep is idempotent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn orphaned_submitted_open_retained_pr_reaper_reaps_only_unpolled() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let attempt_repo = TaskAttemptRepository::new(db.clone());
+    let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    const PR: &str = "https://github.example/owner/repo/pull/42";
+
+    // A: `open` + retained pr_url + stale submitted → reaped to `reopened`.
+    // (Tasks are created `open`; the retained PR simulates the PrConflict reopen
+    // that does NOT clear tasks.pr_url.)
+    let (task_a, _n) = create_task_with_note(&db, &tx, "open-retained-pr-stale").await;
+    let attempt_a = seed_submitted_worker_attempt(&db, &task_a.id).await;
+    backdate_attempt(&db, &attempt_a).await;
+    task_repo.set_pr_url(&task_a.id, PR).await.unwrap();
+
+    // B: `pr_review` + pr_url + stale submitted → UNTOUCHED (poller owns it).
+    let (task_b, _n) = create_task_with_note(&db, &tx, "pr-review-stale").await;
+    let attempt_b = seed_submitted_worker_attempt(&db, &task_b.id).await;
+    backdate_attempt(&db, &attempt_b).await;
+    task_repo.set_pr_url(&task_b.id, PR).await.unwrap();
+    task_repo.set_status(&task_b.id, "pr_review").await.unwrap();
+
+    // C: `open` + pr_url + FRESH submitted → UNTOUCHED (younger than threshold).
+    let (task_c, _n) = create_task_with_note(&db, &tx, "open-retained-pr-fresh").await;
+    let attempt_c = seed_submitted_worker_attempt(&db, &task_c.id).await;
+    task_repo.set_pr_url(&task_c.id, PR).await.unwrap();
+
+    crate::health::reap_orphaned_pending_attempts_with_threshold(&db, 15 * 60, "test").await;
+
+    let a = attempt_repo.get(&attempt_a).await.unwrap().unwrap();
+    assert_eq!(
+        a.outcome, "reopened",
+        "open retained-PR stale submitted must reap to reopened"
+    );
+    assert!(a.terminal_at.is_some(), "terminal_at must be stamped");
+
+    for (attempt_id, label) in [(&attempt_b, "pr_review"), (&attempt_c, "fresh-open")] {
+        let attempt = attempt_repo.get(attempt_id).await.unwrap().unwrap();
+        assert_eq!(attempt.outcome, "submitted", "{label}: must NOT be reaped");
+        assert!(attempt.terminal_at.is_none(), "{label}: must stay live");
+    }
+
+    // Idempotency: a second sweep changes nothing and creates no rows.
+    crate::health::reap_orphaned_pending_attempts_with_threshold(&db, 15 * 60, "test").await;
+    for task in [&task_a, &task_b, &task_c] {
+        assert_eq!(
+            attempt_repo.list_for_task(&task.id).await.unwrap().len(),
+            1,
+            "sweep must never create attempt rows"
+        );
+    }
+    assert_eq!(
+        attempt_repo.get(&attempt_a).await.unwrap().unwrap().outcome,
+        "reopened"
+    );
+    assert_eq!(
+        attempt_repo.get(&attempt_b).await.unwrap().unwrap().outcome,
+        "submitted"
+    );
+}
+
+/// Hole A end-to-end: the respawn guard DEFERS an `open`+retained-PR task with
+/// an in-flight `submitted` attempt (step 2 dedup, reached because the retained
+/// `PrConflict` conflict signal bypasses adoption), and only ALLOWS a fresh
+/// worker after the reaper finalizes the orphaned attempt to `reopened`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn guard_defers_open_retained_pr_submitted_until_reaped_then_allows() {
+    use crate::dispatch::respawn_guard::{PrReworkSignal, RespawnGuardDecision, run_respawn_guard};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let attempt_repo = TaskAttemptRepository::new(db.clone());
+    let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    const PR: &str = "https://github.example/owner/repo/pull/43";
+
+    let (task, _n) = create_task_with_note(&db, &tx, "open-retained-pr-guard").await;
+    let attempt = seed_submitted_worker_attempt(&db, &task.id).await;
+    backdate_attempt(&db, &attempt).await;
+    task_repo.set_pr_url(&task.id, PR).await.unwrap();
+
+    // Before reap: the PrConflict rework signal bypasses PR adoption (step 1),
+    // and the live `submitted` attempt makes step 2 defer.
+    assert!(
+        matches!(
+            run_respawn_guard(
+                &db,
+                &task.id,
+                "worker",
+                Some(PR),
+                Some(PrReworkSignal::MergeConflict),
+            )
+            .await,
+            RespawnGuardDecision::Defer(_)
+        ),
+        "guard must defer while a stale submitted attempt is in flight"
+    );
+
+    crate::health::reap_orphaned_pending_attempts_with_threshold(&db, 15 * 60, "test").await;
+    assert_eq!(
+        attempt_repo.get(&attempt).await.unwrap().unwrap().outcome,
+        "reopened",
+        "reaper must finalize the orphaned submitted attempt"
+    );
+
+    // After reap: no live attempt remains, and the `reopened` latest attempt
+    // bypasses adoption, so a rework worker is allowed to dispatch.
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", Some(PR), None).await,
+        RespawnGuardDecision::Allow,
+        "guard must allow a fresh worker once the orphan is reaped"
     );
 }

--- a/server/crates/djinn-db/src/repositories/task_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/task_attempt.rs
@@ -722,20 +722,35 @@ impl TaskAttemptRepository {
         .await?)
     }
 
-    /// List `submitted` attempt rows that look orphaned AND whose task carries
-    /// no open PR: created before `created_before_iso`, whose task has no
-    /// `pr_url` (and the attempt itself no `pr_url`), no live
-    /// (`starting`/`running`) `task_run`, and no `running` session.
+    /// List `submitted` attempt rows that look orphaned AND that the PR poller
+    /// can never own: created before `created_before_iso`, with no live
+    /// (`starting`/`running`) `task_run` and no `running` session, and whose
+    /// task falls in the poller's blind spot.
     ///
-    /// Companion to [`list_orphaned_pending`] for the reaper.  `submitted` rows
-    /// that HAVE a PR are deliberately excluded — the PR poller owns their
-    /// adoption/terminalization flow.  But a `submitted` attempt with NO PR
-    /// (e.g. an internal task-review rejection that reopened the task without
-    /// terminalizing the worker's `submitted` row — the ylme orphan) can never
-    /// be advanced by the poller and hard-blocks the respawn guard's step-2
-    /// dedup forever, so the reaper finalizes it to `reopened` (submitted work
-    /// existed, and the reopened marker lets a rework worker dispatch).
-    pub async fn list_orphaned_submitted_no_pr(
+    /// Companion to [`list_orphaned_pending`] for the reaper. The PR poller
+    /// drives adoption/terminalization ONLY for the statuses it polls
+    /// (`pr_draft`/`pr_review`), keyed off `tasks.pr_url`. A `submitted` attempt
+    /// is therefore "unowned" — and reapable — in exactly two poller-blind
+    /// cases, both of which otherwise hard-block the respawn guard's step-2
+    /// dedup forever:
+    ///
+    ///   1. The task carries NO PR (and the attempt itself no `pr_url`) — e.g.
+    ///      an internal task-review rejection that reopened the task without
+    ///      terminalizing the worker's `submitted` row (the ylme orphan). The
+    ///      poller never sees a PR-less task.
+    ///   2. The task sits in `open` — the sole dispatchable status
+    ///      (`list_ready` / `build_ready_where` require `status = 'open'`), which
+    ///      the poller never polls even when a stale `pr_url` was RETAINED across
+    ///      a `PrConflict` reopen (`task` transition logic does not clear it).
+    ///      Here the pr_url gate is bypassed entirely: no `open`-status task is
+    ///      ever poller-owned, so the retained PR link is irrelevant.
+    ///
+    /// The old assumption "has pr_url ⟹ poller owns it" is FALSE for `open`
+    /// tasks; the true rule is "the poller owns `submitted` attempts only for
+    /// tasks in poller-polled statuses (`pr_draft`/`pr_review`)". The reaper
+    /// finalizes every match to `reopened` (submitted work existed, and the
+    /// reopened marker lets a rework worker dispatch).
+    pub async fn list_orphaned_submitted_unowned(
         &self,
         created_before_iso: &str,
     ) -> Result<Vec<OrphanedPendingAttempt>> {
@@ -749,8 +764,16 @@ impl TaskAttemptRepository {
              JOIN tasks t ON t.id = ta.task_id
              WHERE ta.outcome = 'submitted'
                AND ta.created_at < $1
-               AND (t.pr_url IS NULL OR t.pr_url = '')
-               AND (ta.pr_url IS NULL OR ta.pr_url = '')
+               AND (
+                   -- Case 2: `open` is the sole dispatchable status and is never
+                   -- polled — reap regardless of a retained (task or attempt) PR.
+                   t.status = 'open'
+                   -- Case 1: PR-less task the poller never sees (the ylme orphan).
+                   OR (
+                       (t.pr_url IS NULL OR t.pr_url = '')
+                       AND (ta.pr_url IS NULL OR ta.pr_url = '')
+                   )
+               )
                AND NOT EXISTS (
                    SELECT 1 FROM task_runs tr
                    WHERE tr.task_id = ta.task_id

--- a/server/src/mcp_bridge/bridges.rs
+++ b/server/src/mcp_bridge/bridges.rs
@@ -9,7 +9,13 @@ use djinn_control_plane::bridge::{
 
 // ── Newtype wrappers ───────────────────────────────────────────────────────────
 
-pub(super) struct CoordinatorBridge(pub CoordinatorHandle);
+pub(super) struct CoordinatorBridge {
+    pub handle: CoordinatorHandle,
+    /// Needed by `record_supervisor_rework_reopen`, which delegates to the
+    /// free-function attempt-lifecycle chokepoint that operates on the DB
+    /// directly (the coordinator actor is not involved).
+    pub db: djinn_db::Database,
+}
 pub(super) struct SlotPoolBridge(pub SlotPoolHandle);
 pub(super) struct LspBridge(pub LspManager);
 
@@ -18,7 +24,7 @@ pub(super) struct LspBridge(pub LspManager);
 #[async_trait]
 impl CoordinatorOps for CoordinatorBridge {
     fn get_status(&self) -> Result<CoordinatorStatus, String> {
-        let s = self.0.get_status().map_err(|e| e.to_string())?;
+        let s = self.handle.get_status().map_err(|e| e.to_string())?;
         Ok(CoordinatorStatus {
             tasks_dispatched: s.tasks_dispatched,
             sessions_recovered: s.sessions_recovered,
@@ -28,7 +34,7 @@ impl CoordinatorOps for CoordinatorBridge {
     }
 
     async fn trigger_dispatch_for_project(&self, project_id: &str) -> Result<(), String> {
-        self.0
+        self.handle
             .trigger_dispatch_for_project(project_id)
             .await
             .map_err(|e| e.to_string())
@@ -38,7 +44,7 @@ impl CoordinatorOps for CoordinatorBridge {
         &self,
         request: ProposalRefinementStartRequest,
     ) -> Result<(), String> {
-        self.0
+        self.handle
             .start_proposal_refinement(
                 request.proposal_id,
                 request.current_revision_seq,
@@ -52,7 +58,7 @@ impl CoordinatorOps for CoordinatorBridge {
         &self,
         request: ProposalRefinementStartRequest,
     ) -> Result<(), String> {
-        self.0
+        self.handle
             .demand_proposal_refinement_round(request.proposal_id, request.current_revision_seq)
             .await
             .map_err(|e| e.to_string())
@@ -64,10 +70,25 @@ impl CoordinatorOps for CoordinatorBridge {
         accept: bool,
         feedback: Option<String>,
     ) -> Result<(), String> {
-        self.0
+        self.handle
             .resolve_refinement_review(proposal_id, accept, feedback)
             .await
             .map_err(|e| e.to_string())
+    }
+
+    async fn record_supervisor_rework_reopen(
+        &self,
+        task_id: &str,
+        action: &djinn_core::models::TransitionAction,
+        reason: Option<&str>,
+    ) {
+        // Delegate to the same attempt-lifecycle chokepoint the in-process/RPC
+        // transition path uses (`DirectServices::transition_task`). It no-ops
+        // for non-rework actions and swallows its own errors (best-effort).
+        djinn_agent::actors::coordinator::record_supervisor_rework_reopen(
+            &self.db, task_id, action, reason,
+        )
+        .await;
     }
 }
 

--- a/server/src/mcp_bridge/snapshot.rs
+++ b/server/src/mcp_bridge/snapshot.rs
@@ -80,9 +80,12 @@ impl AppState {
     /// In production this is called after `initialize_agents()`, so both are
     /// populated. In tests neither is initialised; tools return graceful errors.
     pub fn mcp_state(&self) -> djinn_control_plane::McpState {
-        let coordinator = self
-            .coordinator_sync()
-            .map(|c| Arc::new(CoordinatorBridge(c)) as Arc<dyn CoordinatorOps>);
+        let coordinator = self.coordinator_sync().map(|c| {
+            Arc::new(CoordinatorBridge {
+                handle: c,
+                db: self.db().clone(),
+            }) as Arc<dyn CoordinatorOps>
+        });
         let pool = self
             .pool_sync()
             .map(|p| Arc::new(SlotPoolBridge(p)) as Arc<dyn SlotPoolOps>);


### PR DESCRIPTION
## Three residual attempt-lifecycle holes (code-verified audit after #1719)

A full coverage audit of every rework-apply site confirmed the poller and supervisor paths are wired, and found three remaining holes:

**Hole A (primary — caused a production task to stick permanently):** a `submitted` worker attempt on an `open` task that retained its `pr_url` is unrecoverable: the respawn guard defers (step-2), the PR poller only iterates `pr_draft`/`pr_review` (never `open`), and the submitted-reaper excluded anything with a `pr_url` on the false assumption "has PR ⟹ poller owns it". Fix: `list_orphaned_submitted_no_pr` → `list_orphaned_submitted_unowned`; for `open`-status tasks the pr_url gate is bypassed entirely (`open` is the sole dispatchable status — `build_ready_where` hardcodes it — and is never poller-polled). Finalized to `reopened` so a worker redispatches. Also covers PRs closed externally while the task sits at `open`.

**Hole B:** the wave-dispatch branch-missing PrConflict terminalized as `Handoff` and skipped the rework marker, violating #1719's "every rework reopen leaves a `reopened` latest attempt" invariant. Now maps to `Reopened` + `ensure_rework_marker` via the shared helpers.

**Hole C:** the control-plane `task_transition` MCP tool applied rework actions (PrConflict, TaskReviewReject*, LeadApproveConflict, Reopen) with no attempt terminalization — same class as the ylme bug fixed for the supervisor path. Wired through a new `CoordinatorOps` bridge method delegating to the existing `record_supervisor_rework_reopen` chokepoint (control-plane can't depend on coordinator directly; bridge carries a db handle). No-ops for non-rework actions.

## Tests
7 new DB-backed tests: reaper (open+retained-PR reaped; `pr_review` untouched — poller-owned; fresh untouched; idempotent), guard Defer→Allow across the reap, wave-dispatch reopen marker (live + no-live-attempt), chokepoint rework/non-rework. One pre-existing test updated (it encoded the exact false assumption this fixes). Full `djinn-coordinator`: **1068 passed** (only the 2 known parallel-run flakes, both pass serially). Control-plane: 769+ pass. Clippy clean; no `.sqlx` changes; all files within size guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)