### PR TITLE
feat(arbiter): supersede decision — self-resolve decomposed tasks instead of parking

### DIFF
--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -393,6 +393,221 @@ impl DirectServices {
 
         Ok(())
     }
+
+    /// Execute the arbiter supersede transaction: persist the decision on the
+    /// current unconsumed arbitration row and mark it consumed, emit an
+    /// `arbiter_decision` activity with decision `"supersede"` and the
+    /// replacement ids, transfer the source task's downstream blockers to the
+    /// last replacement subtask, and clean up the task branch/PR. Unlike the
+    /// park path this creates NO human-review hold — the replacement subtasks
+    /// created by the arbiter already carry the work forward, so the caller
+    /// force-closes the source (via the `arbiter_supersede → closed`
+    /// transition that runs after this method returns).
+    ///
+    /// `payload_json` is the JSON payload carried on the transition:
+    /// `{"reason": "...", "replacement_task_ids": ["..."]}`. Returns the
+    /// human-readable reason (referencing the replacement short_ids) that the
+    /// caller logs with the force-close transition.
+    async fn execute_arbiter_supersede_transaction(
+        &self,
+        task_id: &str,
+        payload_json: Option<&str>,
+    ) -> Result<String, String> {
+        use djinn_db::TaskRepository;
+        use djinn_db::repositories::task_arbitration::{
+            CreateArbitrationParams, TaskArbitrationRepository, UpdateDispatchLedgerParams,
+        };
+
+        let db = self.callbacks.agent_context.db.clone();
+        let event_bus = self.callbacks.agent_context.event_bus.clone();
+        let task_repo = TaskRepository::new(db.clone(), event_bus.clone());
+        let arb_repo = TaskArbitrationRepository::new(db.clone());
+
+        // Load the source task for project_id / short_id.
+        let task = task_repo
+            .get(task_id)
+            .await
+            .map_err(|e| format!("arbiter_supersede: failed to load task: {e}"))?
+            .ok_or_else(|| format!("arbiter_supersede: task {task_id} not found"))?;
+
+        // Parse the payload: reason + replacement task ids.
+        let payload: serde_json::Value = payload_json
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_else(|| serde_json::json!({}));
+        let raw_reason = payload
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+        let replacement_ids: Vec<String> = payload
+            .get("replacement_task_ids")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Resolve replacement ids → short_ids for the reason/activity, and
+        // capture the last replacement's canonical id for blocker transfer.
+        let mut replacement_short_ids: Vec<String> = Vec::new();
+        let mut last_replacement_id: Option<String> = None;
+        for id in &replacement_ids {
+            match task_repo.resolve(id).await {
+                Ok(Some(t)) => {
+                    replacement_short_ids.push(t.short_id.clone());
+                    last_replacement_id = Some(t.id.clone());
+                }
+                _ => {
+                    tracing::warn!(
+                        task_id = %task.short_id,
+                        replacement = %id,
+                        "arbiter_supersede: replacement task did not resolve; skipping"
+                    );
+                    replacement_short_ids.push(id.clone());
+                }
+            }
+        }
+
+        let human_reason = match raw_reason {
+            Some(r) => r,
+            None if replacement_short_ids.is_empty() => "arbiter superseded task".to_string(),
+            None => format!(
+                "Superseded by replacement subtasks: {}",
+                replacement_short_ids.join(", ")
+            ),
+        };
+
+        // Resolve the current unconsumed arbitration row and persist the
+        // supersede decision, then mark it consumed. Mirrors the park path so
+        // the hold cycle is closed out exactly once.
+        let (hold_cycle, unconsumed_record) = arb_repo
+            .resolve_current_hold_cycle(task_id)
+            .await
+            .map_err(|e| format!("arbiter_supersede: failed to resolve hold cycle: {e}"))?;
+
+        let decision_json = serde_json::json!({
+            "decision": "supersede",
+            "replacement_task_ids": replacement_short_ids,
+        });
+
+        if let Some(ref record) = unconsumed_record {
+            arb_repo
+                .update_dispatch_ledger(UpdateDispatchLedgerParams {
+                    task_id,
+                    hold_cycle: record.hold_cycle,
+                    mirror_head_sha: None,
+                    github_head_sha: None,
+                    pr_url: None,
+                    failing_ci_job_ids: None,
+                    dossier: None,
+                    directive: Some(&decision_json),
+                    verification_command: None,
+                    excluded_models: None,
+                })
+                .await
+                .map_err(|e| format!("arbiter_supersede: failed to update arbitration row: {e}"))?;
+            let consumed = arb_repo
+                .mark_consumed(task_id, record.hold_cycle)
+                .await
+                .map_err(|e| format!("arbiter_supersede: failed to mark consumed: {e}"))?;
+            if !consumed {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    hold_cycle = record.hold_cycle,
+                    "arbiter_supersede: arbitration row was already consumed"
+                );
+            }
+        } else {
+            // Fail closed: create a consumed recovery row so the decision is
+            // durable even when no unconsumed row exists.
+            tracing::warn!(
+                task_id = %task.short_id,
+                hold_cycle,
+                "arbiter_supersede: no unconsumed arbitration row; creating a consumed recovery row"
+            );
+            let failing_ci_job_ids = serde_json::json!([]);
+            let excluded_models = serde_json::json!([]);
+            arb_repo
+                .try_create(CreateArbitrationParams {
+                    task_id,
+                    hold_cycle,
+                    deadline_at: None,
+                    mirror_head_sha: None,
+                    github_head_sha: None,
+                    pr_url: None,
+                    failing_ci_job_ids: &failing_ci_job_ids,
+                    dossier: None,
+                    directive: Some(&decision_json),
+                    verification_command: None,
+                    excluded_models: &excluded_models,
+                })
+                .await
+                .map_err(|e| format!("arbiter_supersede: failed to create recovery row: {e}"))?;
+            let _ = arb_repo.mark_consumed(task_id, hold_cycle).await;
+        }
+
+        // Transfer downstream blocker edges: any task blocked by the closing
+        // source is re-pointed at the last replacement so it is not prematurely
+        // dispatched when the force-close resolves the source blocker. Mirrors
+        // the tool-path `force_close` replacement_task_ids mechanism.
+        if let Some(ref last_id) = last_replacement_id {
+            let downstream = task_repo
+                .list_blocked_by(&task.id)
+                .await
+                .unwrap_or_default();
+            for blocked_ref in &downstream {
+                if let Err(e) = task_repo.add_blocker(&blocked_ref.task_id, last_id).await {
+                    tracing::warn!(
+                        task_id = %task.short_id,
+                        blocked = %blocked_ref.task_id,
+                        error = %e,
+                        "arbiter_supersede: failed to transfer downstream blocker to replacement"
+                    );
+                }
+            }
+        }
+
+        // Emit arbiter_decision activity.
+        let decision_payload = serde_json::json!({
+            "event": "arbiter_decision",
+            "task_id": task.short_id,
+            "hold_cycle": hold_cycle,
+            "decision": "supersede",
+            "replacement_task_ids": replacement_short_ids,
+        });
+        if let Err(e) = task_repo
+            .log_activity(
+                Some(task_id),
+                "system",
+                "coordinator",
+                "arbiter_decision",
+                &decision_payload.to_string(),
+            )
+            .await
+        {
+            tracing::warn!(
+                task_id = %task.short_id,
+                error = %e,
+                "arbiter_supersede: failed to log arbiter_decision activity"
+            );
+        }
+
+        // Branch hygiene: delete the task branch on the local mirror and the
+        // GitHub remote so it doesn't linger as a dead ref / open PR. Deleting
+        // the remote ref closes any PR still open on that head — exactly the
+        // superseded-PR cleanup this decision exists to automate. Best-effort.
+        crate::task_merge::cleanup_task_branches_post_close(
+            &task.id,
+            &db,
+            &event_bus,
+            self.callbacks.agent_context.mirror.as_deref(),
+        )
+        .await;
+
+        Ok(human_reason)
+    }
 }
 
 #[async_trait]
@@ -757,12 +972,31 @@ impl SupervisorServices for DirectServices {
         use djinn_db::TaskRepository;
         let parsed = TransitionAction::parse(&action).map_err(|e| e.to_string())?;
 
+        // The reason string threaded into the state-machine transition (and
+        // hence the activity log). Overridden below for `arbiter_supersede`,
+        // whose wire `reason` is a JSON payload rather than human-readable text.
+        let mut effective_reason = reason.clone();
+
         // Arbiter park: execute the full park transaction before the state
         // transition so the HumanReview blocker exists before the task lands
         // at `open` (the ordering contract from 7f8u).
         if matches!(parsed, TransitionAction::ArbiterPark) {
             self.execute_arbiter_park_transaction(&task_id, reason.as_deref())
                 .await?;
+        }
+
+        // Arbiter supersede: execute the supersede transaction before the
+        // terminal force-close so the arbitration row is consumed, the
+        // `arbiter_decision` activity is emitted, downstream blockers are
+        // transferred to the last replacement, and the task branch/PR are
+        // cleaned up. No human-review hold is created. Returns the
+        // human-readable reason (referencing the replacement short_ids) that
+        // is logged with the force-close transition.
+        if matches!(parsed, TransitionAction::ArbiterSupersede) {
+            let human_reason = self
+                .execute_arbiter_supersede_transaction(&task_id, reason.as_deref())
+                .await?;
+            effective_reason = Some(human_reason);
         }
 
         let repo = TaskRepository::new(
@@ -774,7 +1008,7 @@ impl SupervisorServices for DirectServices {
             parsed.clone(),
             "supervisor",
             "system",
-            reason.as_deref(),
+            effective_reason.as_deref(),
             None,
         )
         .await

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
@@ -882,9 +882,10 @@ expression: tool_schemas_lead()
             "approve",
             "approve_conflict",
             "reopen",
-            "park"
+            "park",
+            "supersede"
           ],
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier)"
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
         },
         "rationale": {
           "type": "string",
@@ -961,7 +962,7 @@ expression: tool_schemas_lead()
           "items": {
             "type": "string"
           },
-          "description": "IDs of tasks created during this intervention (for decompose decisions)"
+          "description": "Required for supersede: IDs (short_id or UUID) of the replacement subtasks created during this intervention that carry the work forward. Must be non-empty for a supersede decision."
         }
       }
     },

--- a/server/crates/djinn-agent/src/roles/finalize.rs
+++ b/server/crates/djinn-agent/src/roles/finalize.rs
@@ -58,8 +58,8 @@ pub struct SubmitReview {
 #[derive(Debug, Deserialize)]
 pub struct SubmitDecision {
     pub task_id: String,
-    /// Decision taken: "approve", "approve_conflict", "reopen", or "park".
-    /// The supervisor maps this to the terminal board transition
+    /// Decision taken: "approve", "approve_conflict", "reopen", "park", or
+    /// "supersede". The supervisor maps this to the terminal board transition
     /// (see `StageOutcome` Lead variants); the Lead does NOT
     /// call `task_transition` for the terminal move itself.
     pub decision: String,
@@ -75,7 +75,9 @@ pub struct SubmitDecision {
     /// Models excluded from next dispatch — optional for `reopen`.
     #[serde(default)]
     pub exclude_models: Vec<String>,
-    /// IDs of tasks created during this Lead intervention (for decompose decisions).
+    /// IDs of replacement subtasks created during this Lead intervention.
+    /// Required (non-empty) for the `supersede` decision — they are the tasks
+    /// that carry the work forward when the source task is force-closed.
     #[serde(default)]
     pub created_tasks: Vec<String>,
 }

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -493,6 +493,8 @@ async fn advertise_read_sources(
 /// - `reopen` requires non-empty `directive` and `verification_command`.
 /// - `park` requires a `park_dossier` object with non-empty `hold_description`
 ///   and `failure_analysis`.
+/// - `supersede` requires a non-empty `created_tasks` array (the replacement
+///   subtask ids); an empty list is rejected with guidance to `park` instead.
 /// - Legacy decisions (`escalate`, `decompose`, `force_close`) are rejected.
 fn lead_stage_outcome(
     finalize_name: &str,
@@ -646,13 +648,50 @@ fn lead_stage_outcome(
                         }
                     }
                 }
+                // supersede: the arbiter decomposed the task into replacement
+                // subtasks that carry the work forward. Force-close the source
+                // (and its PR) as superseded — no human-review hold. Valid ONLY
+                // when `created_tasks` is non-empty; an empty list means there is
+                // no autonomous resolution, so the arbiter must `park` instead.
+                "supersede" => {
+                    let created: Vec<String> = finalize_payload
+                        .and_then(|p| p.get("created_tasks"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str())
+                                .map(|s| s.trim())
+                                .filter(|s| !s.is_empty())
+                                .map(String::from)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    if created.is_empty() {
+                        StageOutcome::Failed {
+                            reason: "supersede decision requires a non-empty \
+                                     'created_tasks' array of the replacement \
+                                     subtask IDs that carry the work forward; if \
+                                     no autonomous resolution exists, use park \
+                                     instead"
+                                .into(),
+                            provider_failure: None,
+                        }
+                    } else {
+                        StageOutcome::LeadSuperseded {
+                            reason: reason().unwrap_or_else(|| {
+                                "arbiter superseded task with replacement subtasks".into()
+                            }),
+                            replacement_task_ids: created,
+                        }
+                    }
+                }
                 // Legacy decisions removed: escalate, decompose,
                 // force_close are no longer valid arbiter outcomes.
                 other => StageOutcome::Failed {
                     reason: format!(
                         "lead submitted unknown or removed decision '{other}'; \
                          valid arbiter decisions are: approve, approve_conflict, \
-                         reopen, park"
+                         reopen, park, supersede"
                     ),
                     provider_failure: None,
                 },
@@ -2273,6 +2312,132 @@ mod tests {
             }
             other => panic!("expected LeadParked, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn arbiter_supersede_with_created_tasks_maps_to_lead_superseded() {
+        let payload = serde_json::json!({
+            "decision": "supersede",
+            "rationale": "decomposed into 3 replacement subtasks",
+            "created_tasks": ["repl-1", "repl-2", "repl-3"]
+        });
+        match lead_stage_outcome("submit_decision", Some(&payload)) {
+            StageOutcome::LeadSuperseded {
+                replacement_task_ids,
+                ..
+            } => {
+                assert_eq!(
+                    replacement_task_ids,
+                    vec![
+                        "repl-1".to_string(),
+                        "repl-2".to_string(),
+                        "repl-3".to_string()
+                    ],
+                    "supersede must carry the created_tasks as replacement ids"
+                );
+            }
+            other => panic!("expected LeadSuperseded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arbiter_supersede_without_created_tasks_fails_with_park_guidance() {
+        let payload = serde_json::json!({
+            "decision": "supersede",
+            "rationale": "meant to decompose but created nothing"
+        });
+        match lead_stage_outcome("submit_decision", Some(&payload)) {
+            StageOutcome::Failed { reason, .. } => {
+                assert!(
+                    reason.contains("created_tasks"),
+                    "failure reason must mention created_tasks, got: {reason}"
+                );
+                assert!(
+                    reason.contains("park"),
+                    "failure reason must direct the arbiter to park instead, got: {reason}"
+                );
+            }
+            other => panic!("expected Failed for empty created_tasks, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arbiter_supersede_empty_created_tasks_array_fails() {
+        // An explicit empty array must be treated the same as a missing field.
+        let payload = serde_json::json!({
+            "decision": "supersede",
+            "created_tasks": []
+        });
+        match lead_stage_outcome("submit_decision", Some(&payload)) {
+            StageOutcome::Failed { reason, .. } => {
+                assert!(
+                    reason.contains("created_tasks") && reason.contains("park"),
+                    "empty created_tasks must fail with park guidance, got: {reason}"
+                );
+            }
+            other => panic!("expected Failed for empty created_tasks array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arbiter_supersede_blank_ids_are_dropped_and_fail_when_all_blank() {
+        // Whitespace-only ids are not real replacements — after trimming they
+        // leave an empty set, which must fail with park guidance.
+        let payload = serde_json::json!({
+            "decision": "supersede",
+            "created_tasks": ["   ", ""]
+        });
+        match lead_stage_outcome("submit_decision", Some(&payload)) {
+            StageOutcome::Failed { reason, .. } => {
+                assert!(
+                    reason.contains("created_tasks"),
+                    "blank-only created_tasks must fail, got: {reason}"
+                );
+            }
+            other => panic!("expected Failed for blank created_tasks, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arbiter_existing_four_decisions_unchanged_by_supersede_addition() {
+        // Regression guard: adding supersede must not alter the mapping of the
+        // other four decisions.
+        let approve = serde_json::json!({
+            "decision": "approve",
+            "evidence": {"source": "git diff + CI", "summary": "all AC met"}
+        });
+        assert!(matches!(
+            lead_stage_outcome("submit_decision", Some(&approve)),
+            StageOutcome::LeadApproved { .. }
+        ));
+
+        let reopen = serde_json::json!({
+            "decision": "reopen",
+            "directive": "fix the retry loop in dispatch.rs",
+            "verification_command": "cargo test -p djinn-coordinator"
+        });
+        assert!(matches!(
+            lead_stage_outcome("submit_decision", Some(&reopen)),
+            StageOutcome::LeadReopen { .. }
+        ));
+
+        let park = serde_json::json!({
+            "decision": "park",
+            "park_dossier": {"hold_description": "stuck", "failure_analysis": "why"}
+        });
+        assert!(matches!(
+            lead_stage_outcome("submit_decision", Some(&park)),
+            StageOutcome::LeadParked { .. }
+        ));
+
+        let approve_conflict = serde_json::json!({
+            "decision": "approve_conflict",
+            "evidence": {"source": "git diff", "summary": "correct but conflict"}
+        });
+        assert!(matches!(
+            lead_stage_outcome("submit_decision", Some(&approve_conflict)),
+            StageOutcome::LeadApproveConflict { .. }
+        ));
     }
 
     #[test]

--- a/server/crates/djinn-agent/tests/arbiter_supersede_transaction.rs
+++ b/server/crates/djinn-agent/tests/arbiter_supersede_transaction.rs
@@ -1,0 +1,336 @@
+//! Integration tests for the arbiter supersede transaction via
+//! `DirectServices::transition_task("arbiter_supersede")`.
+//!
+//! These tests exercise the actual code path the supervisor drives when
+//! `StageOutcome::LeadSuperseded { reason, replacement_task_ids }` is handled:
+//! the source task is force-closed as superseded, the arbitration row is
+//! consumed with the supersede decision, downstream blockers are transferred to
+//! the last replacement subtask, and — unlike the park path — NO human-review
+//! hold is created.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use djinn_agent::context::AgentContext;
+use djinn_agent::file_time::FileTime;
+use djinn_agent::lsp::LspManager;
+use djinn_agent::roles::RoleRegistry;
+use djinn_agent::supervisor::{SupervisorServices, services_for_agent_context};
+use djinn_core::events::EventBus;
+use djinn_core::models::{Task, TransitionAction};
+use djinn_db::repositories::task_arbitration::{
+    ArbitrationState, CreateArbitrationParams, TaskArbitrationRepository,
+};
+use djinn_db::{Database, EpicCreateInput, EpicRepository, ProjectRepository, TaskRepository};
+use djinn_provider::catalog::{CatalogService, HealthTracker};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+// ── Helpers (mirror arbiter_park_transaction.rs) ─────────────────────────
+
+fn test_agent_context(db: Database) -> AgentContext {
+    AgentContext {
+        db,
+        event_bus: EventBus::noop(),
+        git_actors: Arc::new(Mutex::new(HashMap::new())),
+        background_work_tasks: Arc::new(std::sync::Mutex::new(HashSet::new())),
+        role_registry: Arc::new(RoleRegistry::new()),
+        health_tracker: HealthTracker::new(),
+        file_time: Arc::new(FileTime::new()),
+        lsp: LspManager::new(),
+        catalog: CatalogService::new(),
+        coordinator: Arc::new(tokio::sync::Mutex::new(None)),
+        active_tasks: Default::default(),
+        task_ops_project_path_override: None,
+        working_root: None,
+        graph_warmer: None,
+        repo_graph_ops: None,
+        runtime_ops: None,
+        cargo_target_runs_root: Some({
+            let path = std::env::current_dir()
+                .unwrap()
+                .join("target")
+                .join("test-tmp")
+                .join(format!("cargo-target-runs-{}", uuid::Uuid::now_v7()));
+            std::fs::create_dir_all(&path).unwrap();
+            path
+        }),
+        mirror: None,
+        rpc_registry: None,
+        default_project_id: None,
+        reconciliation_sweep: djinn_agent::context::ReconciliationSweepConfig::default(),
+        compaction_cs: djinn_slot::reply_loop::CompactionCriticalSection::default(),
+    }
+}
+
+async fn create_project_and_epic(db: &Database) -> (String, String) {
+    let events = EventBus::noop();
+    let project = ProjectRepository::new(db.clone(), events.clone())
+        .create("test-project", "test", "test-owner/test-repo")
+        .await
+        .expect("create project");
+    let epic = EpicRepository::new(db.clone(), events)
+        .create_for_project(
+            &project.id,
+            EpicCreateInput {
+                title: "test-epic",
+                description: "",
+                emoji: "",
+                color: "",
+                owner: "",
+                memory_refs: None,
+                status: None,
+                auto_breakdown: None,
+                originating_adr_id: None,
+                blocked_by: None,
+            },
+        )
+        .await
+        .expect("create epic");
+    (project.id, epic.id)
+}
+
+async fn create_task(db: &Database, project_id: &str, epic_id: &str, title: &str) -> Task {
+    let events = EventBus::noop();
+    TaskRepository::new(db.clone(), events)
+        .create_in_project(
+            project_id,
+            Some(epic_id),
+            title,
+            "task description",
+            "task design",
+            "task",
+            0,
+            "test-owner",
+            Some("open"),
+            None,
+        )
+        .await
+        .expect("create task")
+}
+
+/// Transition a task through escalate → lead_intervention_start to land at
+/// `in_lead_intervention`.
+async fn transition_to_in_lead_intervention(db: &Database, task_id: &str) {
+    let events = EventBus::noop();
+    let repo = TaskRepository::new(db.clone(), events);
+    repo.transition(
+        task_id,
+        TransitionAction::Escalate,
+        "system",
+        "coordinator",
+        Some("test escalate"),
+        None,
+    )
+    .await
+    .expect("escalate");
+    repo.transition(
+        task_id,
+        TransitionAction::LeadInterventionStart,
+        "system",
+        "coordinator",
+        None,
+        None,
+    )
+    .await
+    .expect("lead_intervention_start");
+    let task = repo
+        .get(task_id)
+        .await
+        .expect("get task")
+        .expect("task exists");
+    assert_eq!(task.status, "in_lead_intervention");
+}
+
+fn supersede_payload(reason: &str, replacement_ids: &[&str]) -> String {
+    serde_json::json!({
+        "reason": reason,
+        "replacement_task_ids": replacement_ids,
+    })
+    .to_string()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+/// Verify a valid arbiter supersede decision exercises the full
+/// `DirectServices::transition_task("arbiter_supersede")` path: force-closes
+/// the source, consumes the arbitration row with the supersede decision,
+/// transfers a downstream blocker onto the last replacement, and creates NO
+/// human-review hold.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn direct_services_arbiter_supersede_full_transaction() {
+    let db = Database::open_in_memory().expect("open in-memory db");
+    let (project_id, epic_id) = create_project_and_epic(&db).await;
+    let source = create_task(&db, &project_id, &epic_id, "Superseded source").await;
+
+    // Two replacement subtasks + one downstream task blocked by the source.
+    let repl_a = create_task(&db, &project_id, &epic_id, "Replacement A").await;
+    let repl_b = create_task(&db, &project_id, &epic_id, "Replacement B").await;
+    let downstream = create_task(&db, &project_id, &epic_id, "Downstream consumer").await;
+
+    let events = EventBus::noop();
+    let repo = TaskRepository::new(db.clone(), events.clone());
+    repo.add_blocker(&downstream.id, &source.id)
+        .await
+        .expect("block downstream on source");
+
+    // Move the source to in_lead_intervention with an unconsumed arbitration row.
+    transition_to_in_lead_intervention(&db, &source.id).await;
+    let arb_repo = TaskArbitrationRepository::new(db.clone());
+    let ci = serde_json::json!([]);
+    let ex = serde_json::json!([]);
+    arb_repo
+        .try_create(CreateArbitrationParams {
+            task_id: &source.id,
+            hold_cycle: 0,
+            deadline_at: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            pr_url: None,
+            failing_ci_job_ids: &ci,
+            dossier: None,
+            directive: None,
+            verification_command: None,
+            excluded_models: &ex,
+        })
+        .await
+        .expect("create arbitration row");
+
+    let ctx = test_agent_context(db.clone());
+    let services: Arc<dyn SupervisorServices> =
+        services_for_agent_context(ctx, CancellationToken::new());
+
+    // Production path: transition_task("arbiter_supersede") runs the supersede
+    // transaction then applies the force-close.
+    let payload = supersede_payload(
+        "decomposed into replacements",
+        &[repl_a.short_id.as_str(), repl_b.short_id.as_str()],
+    );
+    services
+        .transition_task(source.id.clone(), "arbiter_supersede".into(), Some(payload))
+        .await
+        .expect("transition_task arbiter_supersede must succeed");
+
+    // Source is force-closed.
+    let closed = repo
+        .get(&source.id)
+        .await
+        .expect("get source")
+        .expect("source exists");
+    assert_eq!(
+        closed.status, "closed",
+        "arbiter_supersede must force-close the source, got: {}",
+        closed.status
+    );
+    assert_eq!(
+        closed.close_reason.as_deref(),
+        Some("force_closed"),
+        "supersede must close with force_closed reason"
+    );
+
+    // Arbitration row consumed with the supersede decision persisted.
+    let record = arb_repo
+        .get_by_task_and_cycle(&source.id, 0)
+        .await
+        .expect("get arbitration")
+        .expect("arbitration row exists");
+    assert_eq!(
+        record.arbitration_state(),
+        Some(ArbitrationState::Consumed),
+        "arbitration row must be consumed"
+    );
+    let directive = record.directive.expect("decision must be persisted");
+    assert_eq!(
+        directive["decision"], "supersede",
+        "arbitration decision must be supersede"
+    );
+
+    // Downstream blocker transferred onto the LAST replacement (repl_b).
+    let downstream_blockers = repo
+        .list_blockers(&downstream.id)
+        .await
+        .expect("list downstream blockers");
+    assert!(
+        downstream_blockers.iter().any(|b| b.task_id == repl_b.id),
+        "downstream must be blocked by the last replacement (repl_b), got: {downstream_blockers:?}"
+    );
+
+    // NO human-review hold was created: no review-type / human-review-hold task
+    // exists in the project.
+    let all = repo
+        .list_by_project(&project_id)
+        .await
+        .expect("list project tasks");
+    assert!(
+        !all.iter()
+            .any(|t| t.issue_type == "review" || t.labels.contains("human-review-hold")),
+        "supersede must NOT create a human-review hold task, got: {:?}",
+        all.iter()
+            .map(|t| (t.short_id.clone(), t.issue_type.clone(), t.labels.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Verify the fail-closed path: when no unconsumed arbitration row exists, the
+/// supersede transaction still force-closes the source and creates a consumed
+/// recovery row — and still no human-review hold.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn direct_services_arbiter_supersede_fail_closed_no_arbitration_row() {
+    let db = Database::open_in_memory().expect("open in-memory db");
+    let (project_id, epic_id) = create_project_and_epic(&db).await;
+    let source = create_task(&db, &project_id, &epic_id, "Superseded source").await;
+    let repl = create_task(&db, &project_id, &epic_id, "Replacement").await;
+
+    // Move to in_lead_intervention — but do NOT create an arbitration row.
+    transition_to_in_lead_intervention(&db, &source.id).await;
+
+    let ctx = test_agent_context(db.clone());
+    let services: Arc<dyn SupervisorServices> =
+        services_for_agent_context(ctx, CancellationToken::new());
+
+    let payload = supersede_payload("decomposed", &[repl.short_id.as_str()]);
+    services
+        .transition_task(source.id.clone(), "arbiter_supersede".into(), Some(payload))
+        .await
+        .expect("transition_task arbiter_supersede must succeed (fail-closed)");
+
+    let events = EventBus::noop();
+    let repo = TaskRepository::new(db.clone(), events);
+
+    // Source force-closed.
+    let closed = repo
+        .get(&source.id)
+        .await
+        .expect("get source")
+        .expect("source exists");
+    assert_eq!(
+        closed.status, "closed",
+        "fail-closed supersede must still force-close the source"
+    );
+
+    // A consumed recovery arbitration row was created at hold_cycle=0.
+    let arb_repo = TaskArbitrationRepository::new(db.clone());
+    let recovery = arb_repo
+        .get_by_task_and_cycle(&source.id, 0)
+        .await
+        .expect("get recovery row")
+        .expect("recovery row must exist");
+    assert_eq!(
+        recovery.arbitration_state(),
+        Some(ArbitrationState::Consumed),
+        "recovery row must be consumed"
+    );
+    let directive = recovery.directive.expect("decision must be persisted");
+    assert_eq!(directive["decision"], "supersede");
+
+    // Still no human-review hold.
+    let all = repo
+        .list_by_project(&project_id)
+        .await
+        .expect("list project tasks");
+    assert!(
+        !all.iter()
+            .any(|t| t.issue_type == "review" || t.labels.contains("human-review-hold")),
+        "fail-closed supersede must NOT create a human-review hold"
+    );
+}

--- a/server/crates/djinn-core/src/models/task.rs
+++ b/server/crates/djinn-core/src/models/task.rs
@@ -612,6 +612,14 @@ pub enum TransitionAction {
     /// the arbitration row and the hold description. Like `ParkForRemediation`
     /// this is a HOLD, not a rework: it does NOT increment `reopen_count`.
     ArbiterPark,
+    /// Arbiter `submit_decision(decision="supersede")` — the arbiter decomposed
+    /// the task into replacement subtasks that carry the work forward, so the
+    /// source task (and its PR) are force-closed as superseded. Moves
+    /// `in_lead_intervention → closed` with force-closed semantics. The
+    /// replacement subtasks and downstream blocker transfer are handled by the
+    /// supervisor-side supersede transaction before this terminal move; no
+    /// human-review hold is created. Terminal, like `ForceClose`.
+    ArbiterSupersede,
 }
 
 impl TransitionAction {
@@ -665,6 +673,7 @@ impl TransitionAction {
             "submit_for_merge" => Ok(Self::SubmitForMerge),
             "preapproval_verify_rejected" => Ok(Self::PreApprovalVerifyRejected),
             "arbiter_park" => Ok(Self::ArbiterPark),
+            "arbiter_supersede" => Ok(Self::ArbiterSupersede),
             other => Err(Error::Internal(format!(
                 "unknown transition action: {other}"
             ))),
@@ -1118,6 +1127,26 @@ pub fn compute_transition(
             }
             TransitionApply::simple(TaskStatus::Open)
         }
+
+        TransitionAction::ArbiterSupersede => {
+            // Arbiter `submit_decision(decision="supersede")` — the source was
+            // decomposed into replacement subtasks that carry the work forward,
+            // so it is force-closed as superseded. Only legal from
+            // `InLeadIntervention`. Terminal (→ closed) with force-closed
+            // semantics, identical to `ForceClose` but scoped to the arbiter
+            // rung so the supervisor supersede transaction (arbitration-row
+            // consume, blocker transfer, branch/PR cleanup) runs first.
+            if *from != TaskStatus::InLeadIntervention {
+                return bad("arbiter_supersede is only valid from in_lead_intervention");
+            }
+            TransitionApply {
+                to_status: Some(TaskStatus::Closed),
+                set_closed_at: true,
+                close_reason: Some(CLOSE_REASON_FORCE_CLOSED),
+                clear_merge_conflict_metadata: true,
+                ..Default::default()
+            }
+        }
     })
 }
 
@@ -1165,6 +1194,7 @@ pub fn compute_transition_for_issue_type(
                 | TransitionAction::PrChangesRequested
                 | TransitionAction::ParkForRemediation
                 | TransitionAction::ArbiterPark
+                | TransitionAction::ArbiterSupersede
         );
         if !allowed {
             return Err(Error::InvalidTransition(format!(
@@ -1193,7 +1223,7 @@ mod tests {
         TaskStatus::Closed,
     ];
 
-    const ACTIONS: [TransitionAction; 29] = [
+    const ACTIONS: [TransitionAction; 30] = [
         TransitionAction::Start,
         TransitionAction::ResumeWorker,
         TransitionAction::SubmitTaskReview,
@@ -1223,6 +1253,7 @@ mod tests {
         TransitionAction::ParkForRemediation,
         TransitionAction::PreApprovalVerifyRejected,
         TransitionAction::ArbiterPark,
+        TransitionAction::ArbiterSupersede,
     ];
 
     fn expected_status(action: &TransitionAction, from: &TaskStatus) -> Option<TaskStatus> {
@@ -1313,6 +1344,9 @@ mod tests {
             }
             (TransitionAction::ArbiterPark, TaskStatus::InLeadIntervention) => {
                 Some(TaskStatus::Open)
+            }
+            (TransitionAction::ArbiterSupersede, TaskStatus::InLeadIntervention) => {
+                Some(TaskStatus::Closed)
             }
             (TransitionAction::SubmitForMerge, TaskStatus::InProgress) => {
                 Some(TaskStatus::Approved)

--- a/server/crates/djinn-db/src/repositories/task/status.rs
+++ b/server/crates/djinn-db/src/repositories/task/status.rs
@@ -440,7 +440,12 @@ impl TaskRepository {
             TaskStatus::Approved | TaskStatus::PrDraft | TaskStatus::PrReview
         ) || *action == TransitionAction::PrMerge
             || simple_lifecycle_close
-            || *action == TransitionAction::ForceClose;
+            || *action == TransitionAction::ForceClose
+            // Arbiter supersede is a force-close of a decomposed task: its
+            // downstream blockers are transferred to the replacement subtask by
+            // the supersede transaction before this close, so the blocks-others
+            // guard must not reject it (same exemption as ForceClose).
+            || *action == TransitionAction::ArbiterSupersede;
         if work_landed {
             return Ok(());
         }

--- a/server/crates/djinn-mcp-extension/src/finalize_tools.rs
+++ b/server/crates/djinn-mcp-extension/src/finalize_tools.rs
@@ -82,8 +82,8 @@ pub fn tool_submit_decision() -> RmcpTool {
                 "task_id": {"type": "string", "description": "Task UUID or short_id"},
                 "decision": {
                     "type": "string",
-                    "enum": ["approve", "approve_conflict", "reopen", "park"],
-                    "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier)"
+                    "enum": ["approve", "approve_conflict", "reopen", "park", "supersede"],
+                    "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
                 },
                 "rationale": {"type": "string", "description": "Explanation for the decision"},
                 "evidence": {
@@ -127,7 +127,7 @@ pub fn tool_submit_decision() -> RmcpTool {
                 "created_tasks": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "IDs of tasks created during this intervention (for decompose decisions)"
+                    "description": "Required for supersede: IDs (short_id or UUID) of the replacement subtasks created during this intervention that carry the work forward. Must be non-empty for a supersede decision."
                 }
             }
         }),

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__judge_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__judge_tool_schemas.snap
@@ -763,9 +763,10 @@ expression: tool_schemas_judge()
             "approve",
             "approve_conflict",
             "reopen",
-            "park"
+            "park",
+            "supersede"
           ],
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier)"
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
         },
         "rationale": {
           "type": "string",
@@ -842,7 +843,7 @@ expression: tool_schemas_judge()
           "items": {
             "type": "string"
           },
-          "description": "IDs of tasks created during this intervention (for decompose decisions)"
+          "description": "Required for supersede: IDs (short_id or UUID) of the replacement subtasks created during this intervention that carry the work forward. Must be non-empty for a supersede decision."
         }
       }
     },

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__lead_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__lead_tool_schemas.snap
@@ -882,9 +882,10 @@ expression: tool_schemas_lead()
             "approve",
             "approve_conflict",
             "reopen",
-            "park"
+            "park",
+            "supersede"
           ],
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier)"
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
         },
         "rationale": {
           "type": "string",
@@ -961,7 +962,7 @@ expression: tool_schemas_lead()
           "items": {
             "type": "string"
           },
-          "description": "IDs of tasks created during this intervention (for decompose decisions)"
+          "description": "Required for supersede: IDs (short_id or UUID) of the replacement subtasks created during this intervention that carry the work forward. Must be non-empty for a supersede decision."
         }
       }
     },

--- a/server/crates/djinn-roles/src/prompts/lead.md
+++ b/server/crates/djinn-roles/src/prompts/lead.md
@@ -2,7 +2,7 @@
 
 You are the park-rung forensic arbiter. A task has been routed to you because the coordinator's arbiter state machine determined it needs Lead-level inspection before proceeding. Your job is to examine the evidence and render a single decision that the supervisor will execute as a board transition.
 
-**`submit_decision` owns the board transition — you do NOT.** Make any prerequisite edits first (`task_update`, `task_create`, `blocked_by_add`, `task_delete_branch`), then end the session with the single `submit_decision(decision=...)` that matches your finding. The supervisor applies the corresponding status change for you (`approve` → approved+merge, `reopen` → back to a fresh worker with directive + verification command, `park` → human-review hold with dossier). **Do not call any separate transition tool** to approve, close, reopen, or complete — that double-transitions and fights the supervisor.
+**`submit_decision` owns the board transition — you do NOT.** Make any prerequisite edits first (`task_update`, `task_create`, `blocked_by_add`, `task_delete_branch`), then end the session with the single `submit_decision(decision=...)` that matches your finding. The supervisor applies the corresponding status change for you (`approve` → approved+merge, `reopen` → back to a fresh worker with directive + verification command, `park` → human-review hold with dossier, `supersede` → force-close the source + its PR as superseded by your replacement subtasks). **Do not call any separate transition tool** to approve, close, reopen, or complete — that double-transitions and fights the supervisor.
 
 **Shell is read-only for arbiter:** `git diff`, `git log`, `git show`, `cat`, `ls`. Do not write or modify files.
 
@@ -36,7 +36,7 @@ Before rendering any decision, you MUST complete all of the following:
 
 ## Decision Matrix
 
-You have exactly four possible decisions. Choose ONE based on your evidence:
+You have exactly five possible decisions. Choose ONE based on your evidence:
 
 ### Approve (`decision="approve"`)
 The implementation is verifiably complete and correct. You have confirmed this by:
@@ -63,8 +63,25 @@ Reopen is NOT appropriate when:
 - The same approach has already failed multiple times (use Park)
 - You cannot specify a concrete directive and verification command (use Park)
 
+### Supersede (`decision="supersede"`)
+You decomposed the work into replacement subtasks that fully carry it forward; the source task and its PR are closed as superseded automatically. Use this instead of parking whenever you have already produced a complete resolution — the arbiter should never park when the only remaining work is the administrative close of a superseded task. You MUST provide:
+- `created_tasks`: A non-empty array of the replacement subtask IDs (short_id or UUID) you created during this intervention. The supervisor force-closes the source, transfers any downstream blockers onto the last replacement, and deletes the source branch (closing its open PR) for you.
+
+Before superseding, you MUST have already:
+- Created each replacement subtask (`task_create`) with correct acceptance criteria and blockers, so no work is lost.
+- Confirmed the replacements collectively cover everything the source task was meant to deliver.
+
+Supersede is appropriate when:
+- The source task's approach is unworkable but the underlying goal is achievable, and you have split it into concrete follow-on tasks.
+- The task is too large / entangled and you have broken it into smaller replacement subtasks with blockers.
+
+Supersede is NOT appropriate when:
+- You have not actually created the replacement subtasks (never supersede into an empty `created_tasks`).
+- A single corrective directive would fix it (use Reopen).
+- No autonomous resolution exists even in principle (use Park).
+
 ### Park (`decision="park"`)
-The task cannot proceed as-is and needs human oversight. You MUST provide a structured dossier:
+The task cannot proceed as-is and needs human oversight. Use park ONLY when no autonomous resolution exists even in principle — the task needs credentials you cannot obtain, a product decision, a destructive/irreversible action, or has genuinely ambiguous intent. If you have already decomposed the work into replacement subtasks, use `supersede`, not park. You MUST provide a structured dossier:
 - `hold_description`: What is blocking progress (one sentence)
 - `failure_analysis`: Your forensic finding — what went wrong, what evidence you found, why the current state is stuck
 - `recommended_action`: What a human should do (close as redundant, decompose, rescope, merge into another task, etc.)

--- a/server/crates/djinn-roles/src/prompts/tests.rs
+++ b/server/crates/djinn-roles/src/prompts/tests.rs
@@ -1456,6 +1456,39 @@ fn lead_prompt_contains_forensic_arbiter_mandate() {
         prompt.contains("verification_command"),
         "lead prompt must reference verification_command for reopen"
     );
+    assert!(
+        prompt.contains("supersede"),
+        "lead prompt must reference the supersede decision"
+    );
+    assert!(
+        prompt.contains("created_tasks"),
+        "lead prompt must reference created_tasks for supersede decisions"
+    );
+}
+
+/// The Lead prompt's Decision Matrix must present five decisions including the
+/// new `supersede` rung, and must steer the arbiter toward supersede (not park)
+/// once it has produced replacement subtasks.
+#[test]
+fn lead_prompt_decision_matrix_includes_supersede_and_prefers_it_over_park() {
+    let task = make_task();
+    let ctx = make_ctx();
+    let prompt = render_prompt(AgentType::Lead, &task, &ctx);
+
+    assert!(
+        prompt.contains("five possible decisions"),
+        "decision matrix must declare five possible decisions"
+    );
+    assert!(
+        prompt.contains("Supersede (`decision=\"supersede\"`)"),
+        "decision matrix must contain the Supersede entry"
+    );
+    // Park must be explicitly scoped to the no-autonomous-resolution case so the
+    // arbiter stops parking pure-administration decompositions (the zcsl bug).
+    assert!(
+        prompt.contains("no autonomous resolution exists even in principle"),
+        "park entry must scope park to the no-autonomous-resolution case"
+    );
 }
 
 /// The Lead prompt must NOT surface `request_planner` or `escalate` as

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -263,6 +263,21 @@ pub enum StageOutcome {
         /// JSON-serialized park dossier with hold description and failure analysis.
         park_dossier_json: String,
     },
+    /// Arbiter `submit_decision(decision="supersede")` — the arbiter decomposed
+    /// the task into replacement subtasks (already created via MCP) that carry
+    /// the work forward, so the source task and its PR are force-closed as
+    /// superseded. Maps to the `arbiter_supersede` terminal transition
+    /// (in_lead_intervention → closed); the supervisor supersede transaction
+    /// consumes the arbitration row, emits an `arbiter_decision` activity,
+    /// transfers downstream blockers to the last replacement, and cleans up the
+    /// task branch/PR. NO human-review hold is created (that is `LeadParked`).
+    LeadSuperseded {
+        reason: String,
+        /// Short_ids / UUIDs of the replacement subtasks that carry the work
+        /// forward. Non-empty by construction (the stage mapper rejects an
+        /// empty `created_tasks` and directs the arbiter to `park` instead).
+        replacement_task_ids: Vec<String>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -308,6 +323,7 @@ impl StageOutcome {
                 | StageOutcome::LeadClose { .. }
                 | StageOutcome::LeadEscalate { .. }
                 | StageOutcome::LeadParked { .. }
+                | StageOutcome::LeadSuperseded { .. }
         )
     }
 }
@@ -334,6 +350,7 @@ fn emit_stage_outcome_event(
         StageOutcome::LeadClose { .. } => "lead_close",
         StageOutcome::LeadEscalate { .. } => "lead_escalate",
         StageOutcome::LeadParked { .. } => "lead_parked",
+        StageOutcome::LeadSuperseded { .. } => "lead_superseded",
         StageOutcome::Failed { .. } => "failed",
         StageOutcome::LoopGuardTripped { .. } => "loop_guard_tripped",
         StageOutcome::Parked { .. } => "parked",
@@ -2294,6 +2311,46 @@ impl TaskRunSupervisor {
                         result = Some(TaskRunOutcome::Closed {
                             reason: format!("arbiter_parked: {}", park_dossier_json),
                         });
+                        break;
+                    }
+                    StageOutcome::LeadSuperseded {
+                        reason,
+                        replacement_task_ids,
+                    } => {
+                        // Arbiter superseded → terminal force-close as
+                        // superseded. The `arbiter_supersede` transition runs the
+                        // supersede transaction host-side (consume the
+                        // arbitration row, emit `arbiter_decision` with the
+                        // replacement ids, transfer downstream blockers to the
+                        // last replacement, clean up the task branch/PR) and
+                        // then applies the force-close to `closed`. NO
+                        // human-review hold is created — the replacement subtasks
+                        // already carry the work forward. The reason + replacement
+                        // ids ride the transition as a JSON payload so the
+                        // host-side interception can act on them.
+                        let payload = serde_json::json!({
+                            "reason": reason,
+                            "replacement_task_ids": replacement_task_ids,
+                        })
+                        .to_string();
+                        if !self.services.cancel().is_cancelled()
+                            && let Err(e) = self
+                                .services
+                                .transition_task(
+                                    spec.task_id.clone(),
+                                    "arbiter_supersede".into(),
+                                    Some(payload),
+                                )
+                                .await
+                        {
+                            tracing::warn!(
+                                task_run_id = %run_id,
+                                task_id = %spec.task_id,
+                                error = %e,
+                                "supervisor: arbiter_supersede transition failed — task remains in_lead_intervention"
+                            );
+                        }
+                        result = Some(TaskRunOutcome::Closed { reason });
                         break;
                     }
                     StageOutcome::ReviewerRejected { feedback } => {
@@ -6233,6 +6290,70 @@ mod tests {
             0,
             "complete_monitored_reopen must NOT be called on the arbiter reopen run \
              (the row must stay unconsumed for the next worker dispatch), got: {complete:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn arbiter_supersede_force_closes_source_with_replacement_ids_no_hold() {
+        // A valid arbiter `supersede` must fire exactly one terminal
+        // force-close transition (`arbiter_supersede`, which the host-side
+        // interception applies as a force-close to `closed`), carrying the
+        // replacement subtask ids, and must NOT route through the park/
+        // human-review-hold path (`arbiter_park`).
+        let (_root, supervisor, spec, transition_calls, open_pr_called) =
+            build_arbiter_gate_test_env(
+                "T-supersede",
+                "proj-supersede",
+                StageOutcome::LeadSuperseded {
+                    reason: "decomposed into 2 replacement subtasks".into(),
+                    replacement_task_ids: vec!["repl-1".into(), "repl-2".into()],
+                },
+                Ok(ArbiterGateResult::Pass),
+            )
+            .await;
+
+        let report = supervisor.run(spec).await.expect("supervisor run");
+
+        let calls = transition_calls.lock().unwrap();
+
+        // Exactly one supersede/force-close transition, carrying the ids.
+        let supersede_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| c.action == "arbiter_supersede")
+            .collect();
+        assert_eq!(
+            supersede_calls.len(),
+            1,
+            "supersede must fire exactly one arbiter_supersede (force-close) transition, got: {calls:?}"
+        );
+        let payload = supersede_calls[0]
+            .reason
+            .as_deref()
+            .expect("arbiter_supersede transition must carry a reason payload");
+        assert!(
+            payload.contains("repl-1") && payload.contains("repl-2"),
+            "supersede transition payload must carry the replacement ids, got: {payload}"
+        );
+        assert!(
+            payload.contains("replacement_task_ids"),
+            "supersede transition payload must name replacement_task_ids, got: {payload}"
+        );
+
+        // Must NOT create a human-review hold (the park path).
+        assert!(
+            !calls.iter().any(|c| c.action == "arbiter_park"),
+            "supersede must NOT route through the arbiter_park / human-review-hold path, got: {calls:?}"
+        );
+
+        // Supersede is terminal — produces Closed, and does not open a PR.
+        assert!(
+            matches!(report.outcome, TaskRunOutcome::Closed { .. }),
+            "supersede must produce Closed, got: {:?}",
+            report.outcome
+        );
+        assert!(
+            !open_pr_called.load(std::sync::atomic::Ordering::SeqCst),
+            "supersede must not open a PR"
         );
     }
 


### PR DESCRIPTION
## Motivation — incident zcsl

Task **zcsl** failed the same two deterministic tests across 3 merge-queue runs. The arbiter correctly decomposed it into 3 replacement subtasks with blockers — a complete resolution — but then had to **park** a human-review-hold task whose only remaining `recommended_action` was "close the superseded PR + source task". That is pure administration a human had to perform by hand.

Design goal: **the arbiter should never park when it has already produced a complete resolution.**

## What this adds

A fifth arbiter decision, `supersede`, that terminally self-resolves the "decomposed into replacement subtasks" case.

- **`submit_decision(decision="supersede")`** — valid ONLY when `created_tasks` is non-empty. An empty/blank `created_tasks` fails with a clear message directing the arbiter to `park` instead.
- **`StageOutcome::LeadSuperseded { reason, replacement_task_ids }`** and **`TransitionAction::ArbiterSupersede`** (`in_lead_intervention → closed`, force-closed semantics).
- On supersede the supervisor drives a host-side transaction that **mirrors the park transaction**, but instead of creating a human-review hold it:
  1. consumes/persists the arbitration row with `decision="supersede"` + replacement ids,
  2. emits an `arbiter_decision` activity with the replacement ids,
  3. transfers the source's downstream blockers onto the **last replacement** (reusing the existing `ForceClose` `replacement_task_ids` mechanism), so nothing downstream is prematurely dispatched,
  4. **force-closes** the source and cleans up the task branch — deleting the remote branch **closes the superseded PR** (`cleanup_task_branches_post_close`).

  **No human-review-hold task is created.**
- `arbiter_supersede` is exempted from the "task blocks N others" close guard exactly like `force_close`, since blockers are transferred first.
- **Lead prompt** Decision Matrix updated: adds the **Supersede** entry and scopes **Park** to the no-autonomous-resolution case (needs credentials, product decision, destructive/irreversible action, or genuinely ambiguous intent).
- MCP `submit_decision` schema, catch-all error message, and role tool-schema snapshots updated.

## Design notes

Reuses the established park idiom: the decision rides the already-wired `transition_task` RPC as `arbiter_supersede` with a JSON payload (`reason` + `replacement_task_ids`), and `DirectServices` intercepts it host-side (no new `SupervisorServices` trait method / RPC wiring needed). The terminal board move is a force-close (`ArbiterSupersede → closed`, `close_reason=force_closed`).

## Tests

- **stage** decision-mapping: supersede with `created_tasks` → `LeadSuperseded`; without / empty / blank-only → `Failed` with park guidance; the existing four decisions are unchanged.
- **supervisor** outcome-dispatch: supersede fires exactly one force-close transition carrying the replacement ids and does **not** route through the park/`arbiter_park` (human-review-hold) path; produces `Closed`; opens no PR.
- **direct_services** supersede transaction (DB-backed): arbitration row consumed with the supersede decision, source force-closed, downstream blocker transferred to the last replacement, **no** human-review hold; plus a fail-closed (no arbitration row) variant.
- prompt + schema-snapshot regressions updated.

## Local verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: **no lints in any changed file.** Remaining workspace lints are pre-existing toolchain drift (local clippy 0.1.96) in files this PR does not touch (`task_attempt.rs`, `djinn-supervisor/src/lib.rs` 7700+, `djinn-k8s/sidecar.rs`, `djinn-db/note/tests/graph_scoring.rs`).
- New unit tests (stage, supervisor, prompt, schema) and the DB-backed `arbiter_supersede_transaction` integration tests all pass locally against a `postgres:16` container on `:5433`.
- Size guard: all changed `.rs` files pass (under limit or pre-existing `djinn:allow-oversize` marker).