### PR TITLE
fix(coordinator): respawn-guard adoption hands task to PR poller instead of wedging

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
@@ -53,8 +53,10 @@
 
 use djinn_core::models::CiStatus;
 use djinn_core::models::task_attempt::{GuardDecision, GuardReason, TaskAttemptOutcome};
+use djinn_core::models::{TaskStatus, TransitionAction};
 use djinn_db::{
     GuardAdoptedPrTaskAttemptParams, GuardDeferTaskAttemptParams, TaskAttemptRepository,
+    TaskRepository,
 };
 
 use super::attempt_lifecycle::make_dispatch_key;
@@ -404,6 +406,104 @@ pub async fn record_adopted_pr_attempt(
                 "respawn_guard: failed to record adopted-PR audit row (best-effort)"
             );
             None
+        }
+    }
+}
+
+// ─── Adoption → PR-poller handoff ────────────────────────────────────────────
+
+/// Actor id recorded on the adoption-handoff transition. The handoff is a
+/// system bookkeeping move (no user), mirroring the PR poller's own
+/// `("system", "pr_poller")` board transitions.
+const HANDOFF_ACTOR_ID: &str = "system";
+/// Actor role recorded on the adoption-handoff transition.
+const HANDOFF_ACTOR_ROLE: &str = "respawn_guard";
+
+/// Hand an adopted open PR off to the PR poller by transitioning the task from
+/// the dispatchable `open` column into the poller-owned `pr_review` column.
+///
+/// This closes the wedge in incident gton: a worker task reopened to `open`
+/// while retaining its `pr_url` (e.g. by the startup reaper after a deploy) was
+/// adopted (skip-dispatch) on every ready pass but polled by NOBODY — the PR
+/// poller only polls `pr_draft`/`pr_review`. Moving the task to `pr_review`
+/// makes the poller advance it to merge, and the task leaves the `open` ready
+/// set so the adoption never re-fires (the 470x/night adoption-log spam stops).
+///
+/// Handoff targets `pr_review` unconditionally rather than calling GitHub to
+/// discover the PR's draft flag: the `pr_review` poller advances a ready PR to
+/// merge, while the `pr_draft` poller's undraft (`mark_pr_ready_for_review`)
+/// errors on an already-ready PR — which is the exact gton shape (open, green,
+/// already undrafted) — so `pr_review` is both simplest and correct for the
+/// incident. A genuinely-still-draft adopted PR degrades to a normal merge-gate
+/// hold in the review poller rather than the adoption-spam wedge.
+///
+/// Idempotent: when the task is already in a poller-owned status
+/// (`pr_draft`/`pr_review`) this is a no-op — the handoff already happened.
+/// Only `open` tasks are handed off; any other status is unexpected for an
+/// adopted worker task and is left untouched with a warning rather than forced
+/// into a status the state machine would reject.
+///
+/// Best-effort: transition errors are logged and never propagated. Returns
+/// `true` when the task was moved to `pr_review`, `false` on no-op/error.
+pub async fn handoff_adopted_pr_to_poller(
+    task_repo: &TaskRepository,
+    task_id: &str,
+    current_status: &str,
+    pr_url: &str,
+) -> bool {
+    // Idempotent no-op: already poller-owned.
+    if current_status == TaskStatus::PrDraft.as_str()
+        || current_status == TaskStatus::PrReview.as_str()
+    {
+        tracing::debug!(
+            task_id = %task_id,
+            current_status = %current_status,
+            "respawn_guard: adopted task already poller-owned — handoff is a no-op"
+        );
+        return false;
+    }
+    // The handoff transition is only legal from `open` (the adoption path only
+    // fires for dispatchable `open` worker tasks). Anything else is unexpected;
+    // don't force a status the state machine would reject.
+    if current_status != TaskStatus::Open.as_str() {
+        tracing::warn!(
+            task_id = %task_id,
+            current_status = %current_status,
+            pr_url = %pr_url,
+            "respawn_guard: adopted task in unexpected status — skipping poller handoff"
+        );
+        return false;
+    }
+    let reason =
+        format!("respawn_guard: adopted open PR {pr_url} — handing off to PR poller (pr_review)");
+    match task_repo
+        .transition(
+            task_id,
+            TransitionAction::AdoptionHandoff,
+            HANDOFF_ACTOR_ID,
+            HANDOFF_ACTOR_ROLE,
+            Some(&reason),
+            None,
+        )
+        .await
+    {
+        Ok(task) => {
+            tracing::info!(
+                task_id = %task_id,
+                pr_url = %pr_url,
+                to_status = %task.status,
+                "respawn_guard: adopted open PR handed off to PR poller (open → pr_review)"
+            );
+            true
+        }
+        Err(e) => {
+            tracing::warn!(
+                task_id = %task_id,
+                pr_url = %pr_url,
+                error = %e,
+                "respawn_guard: failed to hand adopted PR off to PR poller (best-effort)"
+            );
+            false
         }
     }
 }

--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard_tests.rs
@@ -1160,3 +1160,194 @@ async fn supervisor_rework_reopen_is_noop_for_non_rework_action() {
         "non-rework action must leave the submitted attempt untouched"
     );
 }
+
+// ─── Adoption → PR-poller handoff tests (incident gton) ──────────────
+//
+// The respawn guard's open-PR adoption used to skip dispatch WITHOUT
+// transferring ownership: a worker task reopened to `open` while retaining its
+// `pr_url` (e.g. by the startup reaper after a deploy) was adopted on every
+// ready pass — 470x overnight for task gton — but the PR poller only polls
+// `pr_draft`/`pr_review`, so NOBODY advanced it and it wedged for 9h. The
+// handoff moves the adopted task into the poller-owned `pr_review` column so
+// the poller advances it, and the task leaves the `open` ready set so adoption
+// never re-fires.
+
+/// A `TaskRepository` over the in-memory test DB (noop event bus).
+fn test_task_repo(db: &Database) -> TaskRepository {
+    TaskRepository::new(db.clone(), EventBus::noop())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_moves_open_task_to_pr_review_with_audit_and_activity() {
+    let db = test_db();
+    let task = create_task(&db).await; // status: open
+    let pr = "https://github.example/owner/repo/pull/1765";
+
+    // Full adoption path as the caller runs it: audit row + handoff.
+    record_adopted_pr_attempt(
+        &db,
+        &task.id,
+        "worker",
+        pr,
+        Some("adopted existing open PR"),
+    )
+    .await
+    .expect("adopted_pr audit row inserts");
+    let moved =
+        handoff_adopted_pr_to_poller(&test_task_repo(&db), &task.id, &task.status, pr).await;
+    assert!(
+        moved,
+        "an open adopted task must be handed off to the poller"
+    );
+
+    // Task now lives in the poller-owned column.
+    let repo = test_task_repo(&db);
+    let updated = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        updated.status, "pr_review",
+        "adopted task must land in the poller-owned pr_review column"
+    );
+
+    // The adopted-PR audit row is still recorded (adoption is auditable).
+    let attempts = TaskAttemptRepository::new(db.clone())
+        .list_for_task(&task.id)
+        .await
+        .unwrap();
+    assert!(
+        attempts.iter().any(|a| a.outcome == "adopted_pr"),
+        "adopted_pr audit row must be recorded alongside the handoff"
+    );
+
+    // The handoff emits an auditable activity entry naming the actor and PR.
+    let activity = repo.list_activity(&task.id).await.unwrap();
+    let handoff = activity
+        .iter()
+        .find(|e| e.event_type == "adoption_handoff")
+        .expect("an adoption_handoff activity entry must be recorded");
+    assert_eq!(
+        handoff.actor_role, "respawn_guard",
+        "handoff activity names the respawn-guard system actor"
+    );
+    assert_eq!(handoff.actor_id, "system");
+    assert!(
+        handoff.payload.contains(pr),
+        "handoff activity payload must name the adopted PR url"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_is_one_shot_and_idempotent() {
+    let db = test_db();
+    let task = create_task(&db).await;
+    let pr = "https://github.example/owner/repo/pull/9";
+    let repo = test_task_repo(&db);
+
+    // First handoff moves open → pr_review.
+    assert!(handoff_adopted_pr_to_poller(&repo, &task.id, "open", pr).await);
+    let s1 = repo.get(&task.id).await.unwrap().unwrap().status;
+    assert_eq!(s1, "pr_review");
+
+    // Second call with the now-current (poller-owned) status is a no-op — the
+    // task already left `open`, so adoption cannot re-fire and re-hand it off.
+    assert!(
+        !handoff_adopted_pr_to_poller(&repo, &task.id, &s1, pr).await,
+        "handoff must be one-shot: no re-handoff once the task is poller-owned"
+    );
+    assert_eq!(
+        repo.get(&task.id).await.unwrap().unwrap().status,
+        "pr_review"
+    );
+
+    // Exactly one handoff activity entry exists (the 470x/night spam is gone).
+    let count = repo
+        .list_activity(&task.id)
+        .await
+        .unwrap()
+        .iter()
+        .filter(|e| e.event_type == "adoption_handoff")
+        .count();
+    assert_eq!(
+        count, 1,
+        "exactly one handoff activity entry — no repeated adoption spam"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reopened_task_with_retained_pr_url_is_handed_to_poller_not_wedged() {
+    // Incident gton shape: the startup reaper reopened a task to `open` while
+    // retaining its `pr_url` (open, green PR). Prior behavior: adopted
+    // (skip-dispatch) on every ready pass, polled by nobody, wedged 9h. Now the
+    // guard adopts AND the task is handed to the PR poller.
+    let db = test_db();
+    let task = create_task(&db).await; // open, as the reaper left it
+    let pr = "https://github.example/owner/repo/pull/1765";
+
+    // A healthy open PR (no rework signal) is still adopted by the guard.
+    let decision = run_respawn_guard(&db, &task.id, "worker", Some(pr), None).await;
+    assert_eq!(
+        decision,
+        RespawnGuardDecision::Adopted {
+            pr_url: pr.to_owned()
+        }
+    );
+
+    // The caller records the audit row and hands the task off instead of just
+    // skipping dispatch.
+    record_adopted_pr_attempt(&db, &task.id, "worker", pr, Some("adopted"))
+        .await
+        .expect("audit row inserts");
+    assert!(handoff_adopted_pr_to_poller(&test_task_repo(&db), &task.id, &task.status, pr).await);
+
+    let updated = test_task_repo(&db).get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        updated.status, "pr_review",
+        "reopened-with-pr_url task must be handed to the poller, not left wedged in open"
+    );
+
+    // A subsequent ready pass no longer sees it in `open`, so the handoff is a
+    // no-op and adoption cannot re-fire.
+    assert!(
+        !handoff_adopted_pr_to_poller(&test_task_repo(&db), &updated.id, &updated.status, pr).await
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_is_noop_for_already_poller_owned_status() {
+    // Idempotency: a task already in a poller-owned status must be left alone
+    // (no illegal transition, no duplicate activity).
+    let db = test_db();
+    let task = create_task(&db).await;
+    let repo = test_task_repo(&db);
+    for status in ["pr_draft", "pr_review"] {
+        assert!(
+            !handoff_adopted_pr_to_poller(&repo, &task.id, status, "https://x/pull/1").await,
+            "handoff must no-op for already-poller-owned status {status}"
+        );
+    }
+    // The task itself was never transitioned (still open).
+    assert_eq!(repo.get(&task.id).await.unwrap().unwrap().status, "open");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handoff_is_noop_for_unexpected_non_open_status() {
+    // Defensive: an adopted task observed in a non-open, non-poller status must
+    // not be forced into pr_review (the state machine only permits open →
+    // pr_review); the handoff returns false and leaves the task untouched.
+    let db = test_db();
+    let task = create_task(&db).await;
+    let repo = test_task_repo(&db);
+    // Move to an unexpected status directly (bypass the state machine's Start
+    // AC/blocker gate, which is irrelevant to this handoff no-op assertion).
+    repo.set_status(&task.id, "in_progress")
+        .await
+        .expect("set_status moves the task to in_progress");
+
+    assert!(
+        !handoff_adopted_pr_to_poller(&repo, &task.id, "in_progress", "https://x/pull/1").await
+    );
+    assert_eq!(
+        repo.get(&task.id).await.unwrap().unwrap().status,
+        "in_progress",
+        "unexpected-status task must be left untouched"
+    );
+}

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1703,7 +1703,7 @@ impl CoordinatorActor {
                         task_id = %task.short_id,
                         role,
                         pr_url = %pr_url,
-                        "CoordinatorActor: respawn guard adopting existing open PR — skipping dispatch"
+                        "CoordinatorActor: respawn guard adopting existing open PR — handing off to PR poller"
                     );
                     super::respawn_guard::record_adopted_pr_attempt(
                         &self.db,
@@ -1711,6 +1711,18 @@ impl CoordinatorActor {
                         role,
                         &pr_url,
                         Some("respawn_guard: adopted existing open PR"),
+                    )
+                    .await;
+                    // Adoption must imply ownership: move the task out of the
+                    // dispatchable `open` column into the poller-owned
+                    // `pr_review` column so the PR poller advances it (incident
+                    // gton — an adopted `open` task was polled by nobody and
+                    // wedged 9h). Idempotent: a no-op if already poller-owned.
+                    super::respawn_guard::handoff_adopted_pr_to_poller(
+                        &self.task_repo(),
+                        &task.id,
+                        &task.status,
+                        &pr_url,
                     )
                     .await;
                     continue;

--- a/server/crates/djinn-core/src/models/task.rs
+++ b/server/crates/djinn-core/src/models/task.rs
@@ -624,6 +624,20 @@ pub enum TransitionAction {
     /// supervisor-side supersede transaction before this terminal move; no
     /// human-review hold is created. Terminal, like `ForceClose`.
     ArbiterSupersede,
+    /// Respawn-guard open-PR adoption handoff. When the pre-dispatch respawn
+    /// guard adopts an existing open PR for a dispatch-eligible worker task
+    /// (task carries `pr_url`, healthy PR, no rework signal), the task is moved
+    /// out of the dispatchable `open` column into the poller-owned `pr_review`
+    /// column so the PR poller advances it to merge. Without this, a task
+    /// reopened to `open` while retaining its `pr_url` (e.g. by the startup
+    /// reaper after a deploy) is adopted on every ready pass — skipping
+    /// dispatch — but polled by NOBODY (the PR poller only polls
+    /// `pr_draft`/`pr_review`), so it wedges (incident gton: 470 adoptions
+    /// overnight, 9h wedge). Only legal from `open`. Strike-free: it does NOT
+    /// bump `reopen_count`, carries no `reopen_class`, and records no
+    /// intervention — the PR already exists, this is a bookkeeping handoff, not
+    /// a rework. Applied by the coordinator with a `system` actor (no user).
+    AdoptionHandoff,
 }
 
 impl TransitionAction {
@@ -678,6 +692,7 @@ impl TransitionAction {
             "preapproval_verify_rejected" => Ok(Self::PreApprovalVerifyRejected),
             "arbiter_park" => Ok(Self::ArbiterPark),
             "arbiter_supersede" => Ok(Self::ArbiterSupersede),
+            "adoption_handoff" => Ok(Self::AdoptionHandoff),
             other => Err(Error::Internal(format!(
                 "unknown transition action: {other}"
             ))),
@@ -1179,6 +1194,26 @@ pub fn compute_transition(
                 ..Default::default()
             }
         }
+
+        TransitionAction::AdoptionHandoff => {
+            // Respawn-guard open-PR adoption handoff: the guard adopted an
+            // existing open PR for a dispatch-eligible worker task, so move the
+            // task out of the dispatchable `open` column into the poller-owned
+            // `pr_review` column. Only legal from `open` — the adoption path
+            // only fires for `open` worker tasks, and a task already in a
+            // poller-owned status needs no handoff (the caller no-ops before
+            // reaching here). Strike-free, like `ParkForRemediation`: no
+            // `reopen_count` bump, no `reopen_class`, no intervention. The PR
+            // already exists; this is a bookkeeping handoff, not a rework.
+            if *from != TaskStatus::Open {
+                return bad("adoption_handoff is only valid from open");
+            }
+            TransitionApply {
+                to_status: Some(TaskStatus::PrReview),
+                activity_type: "adoption_handoff",
+                ..Default::default()
+            }
+        }
     })
 }
 
@@ -1255,7 +1290,7 @@ mod tests {
         TaskStatus::Closed,
     ];
 
-    const ACTIONS: [TransitionAction; 30] = [
+    const ACTIONS: [TransitionAction; 31] = [
         TransitionAction::Start,
         TransitionAction::ResumeWorker,
         TransitionAction::SubmitTaskReview,
@@ -1286,6 +1321,7 @@ mod tests {
         TransitionAction::PreApprovalVerifyRejected,
         TransitionAction::ArbiterPark,
         TransitionAction::ArbiterSupersede,
+        TransitionAction::AdoptionHandoff,
     ];
 
     fn expected_status(action: &TransitionAction, from: &TaskStatus) -> Option<TaskStatus> {
@@ -1380,6 +1416,7 @@ mod tests {
             (TransitionAction::ArbiterSupersede, TaskStatus::InLeadIntervention) => {
                 Some(TaskStatus::Closed)
             }
+            (TransitionAction::AdoptionHandoff, TaskStatus::Open) => Some(TaskStatus::PrReview),
             (TransitionAction::SubmitForMerge, TaskStatus::InProgress) => {
                 Some(TaskStatus::Approved)
             }
@@ -1419,6 +1456,66 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn adoption_handoff_moves_open_to_pr_review_strike_free() {
+        // Respawn-guard adoption handoff (incident gton): a worker task reopened
+        // to `open` while retaining its `pr_url` must be handed to the PR poller
+        // by moving it into the poller-owned `pr_review` column, so it advances
+        // to merge instead of being adopted (skip-dispatch) on every ready pass
+        // and polled by nobody.
+        let apply = compute_transition(&TransitionAction::AdoptionHandoff, &TaskStatus::Open, None)
+            .expect("adoption_handoff from open is valid");
+        assert_eq!(apply.to_status, Some(TaskStatus::PrReview));
+        // Strike-free: the PR already exists, this is a bookkeeping handoff.
+        assert!(
+            !apply.increment_reopen,
+            "handoff must not bump reopen_count"
+        );
+        assert!(
+            apply.reopen_class.is_none(),
+            "handoff carries no reopen_class"
+        );
+        assert!(
+            !apply.record_intervention,
+            "handoff records no intervention"
+        );
+        assert!(!apply.set_closed_at);
+        // Auditable activity type names the handoff so the actor/reason are
+        // legible in the activity log.
+        assert_eq!(apply.activity_type, "adoption_handoff");
+    }
+
+    #[test]
+    fn adoption_handoff_invalid_outside_open() {
+        // The handoff is only legal from `open` — the adoption path only fires
+        // for dispatchable `open` worker tasks, and a task already in a
+        // poller-owned status must not be re-handed (the caller no-ops first).
+        for from in [
+            TaskStatus::InProgress,
+            TaskStatus::NeedsTaskReview,
+            TaskStatus::InTaskReview,
+            TaskStatus::Approved,
+            TaskStatus::PrDraft,
+            TaskStatus::PrReview,
+            TaskStatus::NeedsLeadIntervention,
+            TaskStatus::InLeadIntervention,
+            TaskStatus::Closed,
+        ] {
+            assert!(
+                compute_transition(&TransitionAction::AdoptionHandoff, &from, None).is_err(),
+                "adoption_handoff must be invalid from {from:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn adoption_handoff_parses_from_wire() {
+        assert_eq!(
+            TransitionAction::parse("adoption_handoff").unwrap(),
+            TransitionAction::AdoptionHandoff
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Incident (gton, this morning)

Task **gton** was reopened to `open` by the coordinator's startup reaper after a deploy interrupted its session, while retaining its `pr_url` (PR #1765, open and green). The respawn guard then **adopted** the open PR on every ready pass — **470 times overnight** — each time skipping dispatch so no duplicate worker spawned. But adoption never transferred ownership: the PR poller only polls tasks in `pr_draft`/`pr_review`, so a task in `open` with an adopted PR was advanced by **NOBODY**. It sat wedged for **9 hours** until a human ran `user_override → pr_review`. Task **kv6i** needed the same manual nudge two nights prior — a recurring class.

## Invariant

**Adoption must imply ownership.** When the respawn guard adopts a healthy existing open PR for a dispatch-eligible worker task, it now also transitions the task into the poller-owned column so the PR poller advances it from there. Skip-dispatch-only adoption of an `open`-status task is no longer possible. Because the task leaves the `open` ready set, the adoption never re-fires and the 470x/night adoption-log spam disappears naturally.

## Design choices

**New `AdoptionHandoff` transition (open → pr_review).** Wired into the state-machine matrix, `parse`, and matrix tests exactly like last night's `ArbiterSupersede` (PR #1770). Strike-free — no `reopen_count` bump, no `reopen_class`, no intervention (the PR already exists; this is a bookkeeping handoff, not a rework). It carries a dedicated `adoption_handoff` activity type so the actor (`system`/`respawn_guard`) and the adopted `pr_url` are auditable in the activity log. Applied with a **system actor (no user)**, and it does **not** fire for the rework-bypass path (that path returns `Allow`, not `Adopted`, so failing-CI / merge-conflict PRs still dispatch a rework worker unchanged).

**Handoff target = `pr_review`, unconditionally** (the guard must not call GitHub). What I found in the poller:
- The `pr_review` poller advances a ready PR straight to merge (CI-gated on the durable snapshot). It does **not** reconcile `pr_review → pr_draft`.
- The `pr_draft` poller undrafts via `mark_pr_ready_for_review`, which **errors on an already-ready PR** — the exact gton shape (open, green, already undrafted). Handing gton to `pr_draft` would re-wedge it in a "failed to undraft, will retry" loop.

So `pr_review` is both the **simplest** and the **correct** target for the incident. A genuinely-still-draft adopted PR (rare — the reaper would normally have left such a task in `pr_draft`) degrades to a normal merge-gate hold in the review poller rather than the adoption-spam wedge.

**Idempotent:** already-poller-owned tasks (`pr_draft`/`pr_review`) are a no-op; any unexpected non-`open` status is left untouched (not forced into a status the state machine would reject).

## Rework interaction

An adopted+handed-off task that later gets a failing-CI signal still takes the normal `pr_review` rework path (`PrCiFailed`: `pr_review → open`, increments `reopen_count`) — the handoff does not disturb that. Covered by the existing rework-bypass tests (unchanged) plus the new regression.

## Tests

- `respawn_guard` (djinn-coordinator): handoff moves `open → pr_review` with the `adopted_pr` audit row + an `adoption_handoff` activity entry naming the PR; one-shot / idempotent (exactly one handoff entry, no re-fire); incident-shape regression (reopened-with-retained-`pr_url` → handed to poller, not wedged); no-op for already-poller-owned and for unexpected non-`open` statuses. Rework-bypass and non-worker-role paths unchanged.
- state-machine matrix (djinn-core): `adoption_handoff` valid only from `open` → `pr_review`, strike-free, correct `activity_type`; parse round-trip; full `compute_transition` matrix.

## Verification

- `cargo test -p djinn-coordinator --lib dispatch::respawn_guard` — 39 passed (against a throwaway `postgres:16`, not the shared `:5433`).
- `cargo test -p djinn-core --lib models::task` — 57 passed.
- `cargo clippy -p djinn-core -p djinn-coordinator --lib --all-features -- -D warnings` — clean.
- File-size guard on changed files — OK.
- `cargo fmt` on touched crates.

Note: `cargo clippy --workspace --all-targets` surfaces pre-existing 1.96 lints in **untouched** test files (`task_attempt.rs`, note `graph_scoring.rs`, the unchanged `only_escalate` test) — not from this diff; lib-only clippy on the affected crates is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)