### PR TITLE
perf(kanban): active-first board load with paginated Merged column

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
@@ -133,6 +133,8 @@ pub struct TaskShowParams {
 pub struct TaskListParams {
     /// Absolute project path.
     pub project: String,
+    /// Positive ("open") or negative ("!closed") status filter. A leading "!"
+    /// matches every task whose status differs from the given value.
     pub status: Option<String>,
     /// Positive ("task") or negative ("!epic") issue_type filter.
     pub issue_type: Option<String>,

--- a/server/crates/djinn-control-plane/tests/task_tools.rs
+++ b/server/crates/djinn-control-plane/tests/task_tools.rs
@@ -344,6 +344,35 @@ async fn task_list_filters_and_pagination() {
         .expect("task_list by_status should dispatch");
     assert!(!by_status["tasks"].as_array().unwrap().is_empty());
 
+    // Negated status filter ("!<status>") excludes matching tasks. Only t1 is
+    // in_progress, so "!closed" returns all three tasks and "!in_progress"
+    // returns the two still-open ones.
+    let not_closed = harness
+        .call_tool(
+            "task_list",
+            json!({"project": project.slug(), "status": "!closed"}),
+        )
+        .await
+        .expect("task_list status=!closed should dispatch");
+    assert_eq!(not_closed["total_count"], 3);
+    assert_eq!(not_closed["tasks"].as_array().unwrap().len(), 3);
+
+    let not_in_progress = harness
+        .call_tool(
+            "task_list",
+            json!({"project": project.slug(), "status": "!in_progress"}),
+        )
+        .await
+        .expect("task_list status=!in_progress should dispatch");
+    assert_eq!(not_in_progress["total_count"], 2);
+    assert!(
+        not_in_progress["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|t| t["status"] != "in_progress"),
+    );
+
     let by_text = harness
         .call_tool(
             "task_list",

--- a/server/crates/djinn-db/src/repositories/task/queries.rs
+++ b/server/crates/djinn-db/src/repositories/task/queries.rs
@@ -702,9 +702,15 @@ pub(super) fn build_where(
     }
 
     if let Some(s) = status {
-        let ph = format!("${}", param_offset + params.len() + 1);
-        clauses.push(format!("status = {ph}"));
-        params.push(SqlParam::Text(s.clone()));
+        if let Some(neg) = s.strip_prefix('!') {
+            let ph = format!("${}", param_offset + params.len() + 1);
+            clauses.push(format!("status != {ph}"));
+            params.push(SqlParam::Text(neg.to_owned()));
+        } else {
+            let ph = format!("${}", param_offset + params.len() + 1);
+            clauses.push(format!("status = {ph}"));
+            params.push(SqlParam::Text(s.clone()));
+        }
     }
 
     if let Some(it) = issue_type {

--- a/server/crates/djinn-db/tests/task_tests/filter_matrices.rs
+++ b/server/crates/djinn-db/tests/task_tests/filter_matrices.rs
@@ -268,6 +268,7 @@ async fn task_count_group_by(#[case] group_by: &str) {
 
 #[rstest]
 #[case("status")]
+#[case("status_negated")]
 #[case("priority")]
 #[case("label")]
 #[case("text")]
@@ -307,6 +308,12 @@ async fn task_list_filter(#[case] filter_kind: &str) {
     let query = match filter_kind {
         "status" => ListQuery {
             status: Some("in_progress".to_owned()),
+            ..Default::default()
+        },
+        // A leading "!" negates the status filter: "!open" matches every task
+        // whose status is not `open`, i.e. only the in_progress `beta` task.
+        "status_negated" => ListQuery {
+            status: Some("!open".to_owned()),
             ..Default::default()
         },
         "priority" => ListQuery {

--- a/server/crates/djinn-mcp-extension/src/shared_schemas.rs
+++ b/server/crates/djinn-mcp-extension/src/shared_schemas.rs
@@ -526,13 +526,13 @@ pub fn tool_task_list() -> RmcpTool {
         object!({
             "type": "object",
             "properties": {
-                "status": {"type": "string"},
+                "status": {"type": "string", "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."},
                 "issue_type": {"type": "string"},
                 "priority": {"type": "integer"},
                 "text": {"type": "string", "description": "Free-text search in title/description"},
                 "label": {"type": "string"},
                 "parent": {"type": "string", "description": "Epic ID to filter by"},
-                "sort": {"type": "string"},
+                "sort": {"type": "string", "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."},
                 "limit": {"type": "integer"},
                 "offset": {"type": "integer"}
             }

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__adversary_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__adversary_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_adversary()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_adversary()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__advocate_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__advocate_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_advocate()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_advocate()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__architect_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__architect_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_architect()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_architect()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__judge_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__judge_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_judge()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_judge()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__lead_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__lead_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_lead()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_lead()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__planner_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__planner_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_planner()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_planner()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__reviewer_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__reviewer_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_reviewer()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_reviewer()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__worker_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__worker_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_worker()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_worker()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -20937,6 +20937,7 @@ expression: signatures
           ]
         },
         "status": {
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\"\nmatches every task whose status differs from the given value.",
           "type": [
             "string",
             "null"

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -51,9 +51,7 @@ export namespace AgentCreateOutputSchema {
   is_default?: boolean
   /**
    * Machine-managed prompt learning state. Derived from active
-   * learned_prompt_history amendments. Read-only in public surfaces;
-   * mutations flow through agent_amend_prompt (Planner) and the
-   * evaluator/confirmation loop.
+   * learned_prompt_history amendments. Read-only in public surfaces.
    */
   learned_prompt?: string
   mcp_servers?: AnyJson[]
@@ -105,9 +103,7 @@ export namespace AgentListOutputSchema {
   is_default: boolean
   /**
    * Machine-managed prompt learning state. Derived from active
-   * learned_prompt_history amendments. Read-only in public surfaces;
-   * mutations flow through agent_amend_prompt (Planner) and the
-   * evaluator/confirmation loop.
+   * learned_prompt_history amendments. Read-only in public surfaces.
    */
   learned_prompt?: string
   mcp_servers: AnyJson[]
@@ -191,9 +187,7 @@ export namespace AgentShowOutputSchema {
   is_default?: boolean
   /**
    * Machine-managed prompt learning state. Derived from active
-   * learned_prompt_history amendments. Read-only in public surfaces;
-   * mutations flow through agent_amend_prompt (Planner) and the
-   * evaluator/confirmation loop.
+   * learned_prompt_history amendments. Read-only in public surfaces.
    */
   learned_prompt?: string
   mcp_servers?: AnyJson[]
@@ -214,8 +208,7 @@ export namespace AgentUpdateInputSchema {
   export interface AgentUpdateInput {
   /**
    * Set to true to clear machine-managed learned_prompt back to NULL.
-   * Admin/operator reset path; learned_prompt is otherwise managed through
-   * agent_amend_prompt and the evaluator loop.
+   * Admin/operator reset path.
    */
   clear_learned_prompt?: boolean
   description?: string
@@ -249,9 +242,7 @@ export namespace AgentUpdateOutputSchema {
   is_default?: boolean
   /**
    * Machine-managed prompt learning state. Derived from active
-   * learned_prompt_history amendments. Read-only in public surfaces;
-   * mutations flow through agent_amend_prompt (Planner) and the
-   * evaluator/confirmation loop.
+   * learned_prompt_history amendments. Read-only in public surfaces.
    */
   learned_prompt?: string
   mcp_servers?: AnyJson[]
@@ -3778,10 +3769,30 @@ export namespace MemoryHealthInputSchema {
 export type MemoryHealthInput = MemoryHealthInputSchema.MemoryHealthInput;
 export namespace MemoryHealthOutputSchema {
   export interface MemoryHealthOutput {
+  /**
+   * Notes with zero inbound authored wikilink or explicit authored
+   * association edges.  Machine-minted edges do *not* hide authored-link
+   * debt.
+   */
+  authored_orphan_count?: number
   broken_link_count?: number
   error?: string
+  /**
+   * Notes with no retrieval-effective edges at all — the strictest
+   * connectivity metric.
+   */
+  isolated_count?: number
+  /**
+   * `isolated_count` as a percentage of non-singleton notes.
+   */
+  isolated_pct?: number
   lifecycle?: (LifecycleHealth | null)
   low_confidence_note_count?: number
+  /**
+   * Authored-orphan notes that are *not* graph-isolated because at
+   * least one non-authored retrieval edge connects them.
+   */
+  machine_connected_orphan_count?: number
   orphan_note_count?: number
   recent_sweep?: (RecentSweepMetrics | null)
   stale_note_count?: number
@@ -10283,6 +10294,10 @@ export namespace TaskListInputSchema {
    * "updated", "updated_desc", "closed".
    */
   sort?: string
+  /**
+   * Positive ("open") or negative ("!closed") status filter. A leading "!"
+   * matches every task whose status differs from the given value.
+   */
   status?: string
   /**
    * Full-text search on title and description.

--- a/ui/src/api/server.ts
+++ b/ui/src/api/server.ts
@@ -3,6 +3,8 @@ import type { McpToolOutput, ProjectListOutputSchema } from "@/api/generated/mcp
 import { getServerBaseUrl } from "@/api/serverUrl";
 import type { Epic, Task } from "@/api/types";
 import { projectStore } from "@/stores/projectStore";
+import { taskStore } from "@/stores/taskStore";
+import { mergedColumnStore } from "@/stores/mergedColumnStore";
 
 async function getBaseUrl(): Promise<string> {
   return getServerBaseUrl();
@@ -377,97 +379,188 @@ export async function removeProject(projectId: string): Promise<void> {
   });
 }
 
-export interface KanbanSnapshot {
-  projectSlug: string | null;
+const KANBAN_PAGE_SIZE = 200;
+
+/** Resolve a project slug (`owner/repo`) to its stable project id. */
+function projectIdForSlug(slug: string): string | null {
+  return (
+    projectStore
+      .getState()
+      .projects.find((p) => `${p.github_owner}/${p.github_repo}` === slug)?.id ??
+    null
+  );
+}
+
+/**
+ * Fetch every page of `task_list` for a project honoring the given filters.
+ *
+ * The first page is fetched serially; if the server reports more, the remaining
+ * pages are fetched in parallel using `total_count` (rather than the old serial
+ * `has_more` walk) so a large backlog paints in one round-trip's worth of
+ * latency instead of N.
+ */
+async function fetchAllTaskPages(
+  slug: string,
+  params: Record<string, unknown>,
+): Promise<Task[]> {
+  const first = await callMcpTool("task_list", {
+    project: slug,
+    limit: KANBAN_PAGE_SIZE,
+    offset: 0,
+    ...params,
+  });
+  const tasks: Task[] = [...(first.tasks as unknown as Task[])];
+  if (first.has_more) {
+    const total = first.total_count;
+    const offsets: number[] = [];
+    for (let o = tasks.length; o < total; o += KANBAN_PAGE_SIZE) offsets.push(o);
+    const rest = await Promise.all(
+      offsets.map((offset) =>
+        callMcpTool("task_list", {
+          project: slug,
+          limit: KANBAN_PAGE_SIZE,
+          offset,
+          ...params,
+        }),
+      ),
+    );
+    for (const page of rest) tasks.push(...(page.tasks as unknown as Task[]));
+  }
+  return tasks;
+}
+
+/**
+ * Fetch every page of `epic_list` for a project. The server caps epic_list at
+ * ~200 per page (a higher requested limit is clamped), so without this walk the
+ * *newest* epics fall off the first page — and since the default sort is
+ * created-asc, those are the currently-active ones, whose tasks then render
+ * under "Unknown Epic" once the closed-epic count grows past one page.
+ *
+ * Kept as a serial `has_more` walk (unlike the parallel task pagination): the
+ * epic_list schema types `total_count` as optional, so a `total`-driven
+ * parallel fan-out has no reliable page bound.
+ */
+async function fetchAllEpicPages(slug: string): Promise<Epic[]> {
+  const first = await callMcpTool("epic_list", {
+    project: slug,
+    limit: KANBAN_PAGE_SIZE,
+    offset: 0,
+  });
+  const epics: Epic[] = [...((first.epics ?? []) as unknown as Epic[])];
+  if (first.has_more) {
+    let offset = epics.length;
+    while (true) {
+      const page = await callMcpTool("epic_list", {
+        project: slug,
+        limit: KANBAN_PAGE_SIZE,
+        offset,
+      });
+      epics.push(...(page.epics as unknown as Epic[]));
+      if (!page.has_more) break;
+      offset += (page.epics as unknown[]).length;
+    }
+  }
+  return epics;
+}
+
+export interface ActiveSnapshot {
+  /** Non-closed tasks (Open / In Progress / PR Ready columns). */
   tasks: Task[];
   epics: Epic[];
 }
 
-/** Fetch tasks + epics for a single project, or aggregate across all projects. */
-export async function fetchKanbanSnapshot(
-  projectSlug?: string | null,
-  allProjectSlugs?: string[],
-): Promise<KanbanSnapshot> {
-  // All-projects mode: fetch from every project and merge
-  if (allProjectSlugs && allProjectSlugs.length > 0) {
-    const snapshots = await Promise.all(
-      allProjectSlugs.map((slug) => fetchKanbanSnapshot(slug))
-    );
-    return {
-      projectSlug: null,
-      tasks: snapshots.flatMap((s) => s.tasks),
-      epics: snapshots.flatMap((s) => s.epics),
-    };
-  }
-
-  const resolvedProjectSlug = projectSlug ?? null;
-
-  if (!resolvedProjectSlug) {
-    return { projectSlug: null, tasks: [], epics: [] };
-  }
-
-  // Fetch first page of tasks + all epics in parallel
-  const PAGE_SIZE = 200;
-  const [firstTaskPage, firstEpicPage] = await Promise.all([
-    callMcpTool("task_list", {
-      project: resolvedProjectSlug,
-      limit: PAGE_SIZE,
-      offset: 0,
+/**
+ * Phase 1 of Kanban hydration: fetch the ACTIVE (non-closed) tasks plus all
+ * epics across the given projects. This is the fast paint — active tasks are
+ * few (~dozens) so the board renders without waiting on the (potentially
+ * thousands of) closed/merged rows.
+ */
+export async function fetchActiveSnapshot(
+  slugs: string[],
+): Promise<ActiveSnapshot> {
+  if (slugs.length === 0) return { tasks: [], epics: [] };
+  const perProject = await Promise.all(
+    slugs.map(async (slug) => {
+      const projectId = projectIdForSlug(slug);
+      const [tasks, epics] = await Promise.all([
+        fetchAllTaskPages(slug, { status: "!closed" }),
+        fetchAllEpicPages(slug),
+      ]);
+      return {
+        tasks: tasks.map((t) => ({ ...t, project_id: projectId })),
+        epics,
+      };
     }),
-    callMcpTool("epic_list", {
-      project: resolvedProjectSlug,
-      limit: PAGE_SIZE,
-      offset: 0,
-    }),
-  ]);
-
-  // Paginate remaining tasks if the server has more (server caps at ~200 per page)
-  const allTasks: Task[] = [...(firstTaskPage.tasks as unknown as Task[])];
-  if (firstTaskPage.has_more) {
-    let offset = allTasks.length;
-
-    while (true) {
-      const page = await callMcpTool("task_list", {
-        project: resolvedProjectSlug,
-        limit: PAGE_SIZE,
-        offset,
-      });
-      allTasks.push(...(page.tasks as unknown as Task[]));
-      if (!page.has_more) break;
-      offset += (page.tasks as unknown[]).length;
-    }
-  }
-
-  // Paginate remaining epics too. The server caps epic_list at ~200 per page
-  // (a higher requested limit is clamped), so without this loop the *newest*
-  // epics fall off the first page — and since the default sort is created-asc,
-  // those are the currently-active ones, whose tasks then render under
-  // "Unknown Epic" once the closed-epic count grows past one page.
-  const allEpics: Epic[] = [...((firstEpicPage.epics ?? []) as unknown as Epic[])];
-  if (firstEpicPage.has_more) {
-    let epicOffset = allEpics.length;
-
-    while (true) {
-      const page = await callMcpTool("epic_list", {
-        project: resolvedProjectSlug,
-        limit: PAGE_SIZE,
-        offset: epicOffset,
-      });
-      allEpics.push(...(page.epics as unknown as Epic[]));
-      if (!page.has_more) break;
-      epicOffset += (page.epics as unknown[]).length;
-    }
-  }
-
-  // Stamp each task with the project it belongs to (needed for all-projects view)
-  const projectId = projectStore
-    .getState()
-    .projects.find((p) => `${p.github_owner}/${p.github_repo}` === resolvedProjectSlug)?.id ?? null;
-  const tasks = allTasks.map((t) => ({ ...t, project_id: projectId }));
-
+  );
   return {
-    projectSlug: resolvedProjectSlug,
-    tasks,
-    epics: allEpics,
+    tasks: perProject.flatMap((p) => p.tasks),
+    epics: perProject.flatMap((p) => p.epics),
   };
+}
+
+/**
+ * Fetch a single page of closed tasks for a project (sorted newest-closed
+ * first) and record the pagination cursor in {@link mergedColumnStore}.
+ */
+async function fetchClosedPageForProject(
+  slug: string,
+  offset: number,
+): Promise<Task[]> {
+  const projectId = projectIdForSlug(slug);
+  const page = await callMcpTool("task_list", {
+    project: slug,
+    status: "closed",
+    sort: "closed",
+    limit: KANBAN_PAGE_SIZE,
+    offset,
+  });
+  const tasks = (page.tasks as unknown as Task[]).map((t) => ({
+    ...t,
+    project_id: projectId,
+  }));
+  mergedColumnStore.getState().setProjectPage({
+    slug,
+    projectId,
+    loaded: offset + tasks.length,
+    hasMore: page.has_more,
+    totalClosed: page.total_count,
+  });
+  return tasks;
+}
+
+/**
+ * Phase 2 of Kanban hydration: fetch the FIRST page of closed/merged tasks for
+ * every project. Resets the merged-column pagination cursors first, so a
+ * reconnect re-hydration cleanly drops any extra pages that were previously
+ * loaded (the task store is keyed by id, so re-adding page 1 is idempotent).
+ */
+export async function fetchClosedFirstPage(slugs: string[]): Promise<Task[]> {
+  mergedColumnStore.getState().reset();
+  if (slugs.length === 0) return [];
+  const perProject = await Promise.all(
+    slugs.map((slug) => fetchClosedPageForProject(slug, 0)),
+  );
+  return perProject.flatMap((tasks) => tasks);
+}
+
+/**
+ * "Load more" for the Merged column: fetch the next closed page for every
+ * project that still has more, append the rows into the task store, and return
+ * the newly-loaded tasks. Idempotent and safe to call repeatedly; a no-op when
+ * nothing is left to load.
+ */
+export async function loadMoreClosedTasks(): Promise<Task[]> {
+  const pending = mergedColumnStore.getState().projectsWithMore();
+  if (pending.length === 0) return [];
+  mergedColumnStore.getState().setLoadingMore(true);
+  try {
+    const results = await Promise.all(
+      pending.map((p) => fetchClosedPageForProject(p.slug, p.loaded)),
+    );
+    const tasks = results.flatMap((t) => t);
+    taskStore.getState().upsertTasks(tasks);
+    return tasks;
+  } finally {
+    mergedColumnStore.getState().setLoadingMore(false);
+  }
 }

--- a/ui/src/components/KanbanBoard.test.tsx
+++ b/ui/src/components/KanbanBoard.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor, within } from "@/test/test-utils";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { KanbanBoard } from "@/components/KanbanBoard";
+import { mergedColumnStore } from "@/stores/mergedColumnStore";
+import { loadMoreClosedTasks } from "@/api/server";
 import type { Epic, Task } from "@/api/types";
 
 vi.mock("@/electron/commands", () => ({
@@ -10,6 +12,10 @@ vi.mock("@/electron/commands", () => ({
 
 vi.mock("@/api/mcpClient", () => ({
   callMcpTool: vi.fn(),
+}));
+
+vi.mock("@/api/server", () => ({
+  loadMoreClosedTasks: vi.fn().mockResolvedValue([]),
 }));
 
 const epicA: Epic = {
@@ -66,6 +72,13 @@ const makeTask = (
 });
 
 describe("KanbanBoard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The Merged-column pagination state is a global store; reset it so tests
+    // that don't opt into "Load more" see no affordance.
+    mergedColumnStore.getState().reset();
+  });
+
   it("renders status columns with tasks in correct columns and header counts", () => {
     const tasks: Task[] = [
       makeTask({
@@ -274,6 +287,66 @@ describe("KanbanBoard", () => {
     render(<KanbanBoard tasks={[]} epics={new Map()} />);
 
     expect(screen.getAllByText("No tasks")).toHaveLength(4);
+  });
+
+  it("suffixes the Merged count with '+' and shows Load more when more closed pages exist", async () => {
+    // Simulate the first closed page having been loaded with more remaining.
+    mergedColumnStore.getState().setProjectPage({
+      slug: "owner/repo",
+      projectId: "p1",
+      loaded: 200,
+      hasMore: true,
+      totalClosed: 1231,
+    });
+
+    const tasks: Task[] = [
+      makeTask({
+        id: "t-done",
+        title: "Merged task",
+        status: "closed",
+        epic_id: epicA.id,
+        merge_commit_sha: "abc123merged",
+      }),
+    ];
+
+    render(<KanbanBoard tasks={tasks} epics={new Map([[epicA.id, epicA]])} />);
+
+    // One merged task loaded, but the server has more → "1+".
+    const doneCol = screen.getByText("Merged").closest(".flex.flex-col");
+    expect(doneCol).toHaveTextContent("1+");
+
+    const loadMore = screen.getByRole("button", { name: "Load more" });
+    await userEvent.click(loadMore);
+    expect(loadMoreClosedTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show Load more or a '+' suffix when all closed pages are loaded", () => {
+    mergedColumnStore.getState().setProjectPage({
+      slug: "owner/repo",
+      projectId: "p1",
+      loaded: 1,
+      hasMore: false,
+      totalClosed: 1,
+    });
+
+    const tasks: Task[] = [
+      makeTask({
+        id: "t-done",
+        title: "Merged task",
+        status: "closed",
+        epic_id: epicA.id,
+        merge_commit_sha: "abc123merged",
+      }),
+    ];
+
+    render(<KanbanBoard tasks={tasks} epics={new Map([[epicA.id, epicA]])} />);
+
+    const doneCol = screen.getByText("Merged").closest(".flex.flex-col");
+    expect(doneCol).toHaveTextContent("1");
+    expect(doneCol).not.toHaveTextContent("1+");
+    expect(
+      screen.queryByRole("button", { name: "Load more" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows empty open epics in the Open column when they have no tasks", () => {

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -4,6 +4,8 @@ import { useTaskStore } from "@/stores/useTaskStore";
 import { useEpicStore } from "@/stores/useEpicStore";
 import { useProjects } from "@/stores/useProjectStore";
 import { taskStore } from "@/stores/taskStore";
+import { useMergedColumnStore } from "@/stores/useMergedColumnStore";
+import { loadMoreClosedTasks } from "@/api/server";
 import type { Epic, Task } from "@/api/types";
 import { TaskCard, DoneTaskRow } from "@/components/TaskCard";
 import { TaskDetailPanel } from "@/components/TaskDetailPanel";
@@ -121,6 +123,17 @@ export function KanbanBoard({
   const storeTasks = useTaskStore((state) => Array.from(state.tasks.values()));
   const storeEpics = useEpicStore((state) => state.epics);
   const projects = useProjects();
+
+  // Merged-column pagination: the board loads active tasks first, then the
+  // closed/merged tasks page-by-page. `hasMoreClosed` drives the "Load more"
+  // affordance and the "+" suffix on the Merged header count. When the board is
+  // rendered in controlled mode (`tasksProp`) the store is empty, so both stay
+  // falsy and the affordance is hidden.
+  const hasMoreClosed = useMergedColumnStore((state) => state.hasMore());
+  const loadingMoreClosed = useMergedColumnStore((state) => state.loadingMore);
+  const handleLoadMoreClosed = () => {
+    void loadMoreClosedTasks();
+  };
 
   // Filter values come from the shared header via the URL search params.
   const { projectFilters, epicFilters, ownerFilters, issueTypeFilters, search } =
@@ -319,6 +332,7 @@ export function KanbanBoard({
                       <span className="leading-none">{column.label}</span>
                       <span className="text-xs leading-none text-muted-foreground">
                         {taskCount}
+                        {column.key === "done" && hasMoreClosed ? "+" : ""}
                       </span>
                     </div>
                   </div>
@@ -334,7 +348,8 @@ export function KanbanBoard({
                 </div>
 
                 <CardContent className="relative z-10 flex-1 overflow-y-auto px-3 pt-4">
-                  {!hasContent ? (
+                  {!hasContent &&
+                  !(column.key === "done" && hasMoreClosed) ? (
                     <p className="px-1 text-xs text-muted-foreground/50">
                       No tasks
                     </p>
@@ -426,6 +441,19 @@ export function KanbanBoard({
                           </Card>
                         );
                       })}
+                    </div>
+                  )}
+
+                  {column.key === "done" && hasMoreClosed && (
+                    <div className="px-1 pt-3">
+                      <button
+                        type="button"
+                        onClick={handleLoadMoreClosed}
+                        disabled={loadingMoreClosed}
+                        className="w-full rounded-md border border-white/[0.06] bg-zinc-900/60 px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {loadingMoreClosed ? "Loading…" : "Load more"}
+                      </button>
                     </div>
                   )}
                 </CardContent>

--- a/ui/src/hooks/useEventSource.test.ts
+++ b/ui/src/hooks/useEventSource.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { projectStore } from "@/stores/projectStore";
 import { sseStore, type SSEEvent } from "@/stores/sseStore";
 import { resetMcpClient } from "@/api/mcpClient";
-import { fetchKanbanSnapshot } from "@/api/server";
+import { fetchActiveSnapshot, fetchClosedFirstPage } from "@/api/server";
 import {
   getReconnectDelay,
   INITIAL_RECONNECT_DELAY,
@@ -26,7 +26,8 @@ vi.mock("@/api/serverUrl", () => ({
 }));
 
 vi.mock("@/api/server", () => ({
-  fetchKanbanSnapshot: vi.fn().mockResolvedValue({ tasks: [], epics: [] }),
+  fetchActiveSnapshot: vi.fn().mockResolvedValue({ tasks: [], epics: [] }),
+  fetchClosedFirstPage: vi.fn().mockResolvedValue([]),
   fetchProjects: vi.fn().mockResolvedValue([]),
 }));
 
@@ -172,7 +173,8 @@ describe("useEventSource", () => {
     const hook = await mountEventSourceHook();
     const first = latestEventSource();
     expect(first.url).toBe("http://djinn.test/events");
-    expect(fetchKanbanSnapshot).toHaveBeenCalledWith(null, ["djinnos/djinn"]);
+    expect(fetchActiveSnapshot).toHaveBeenCalledWith(["djinnos/djinn"]);
+    expect(fetchClosedFirstPage).toHaveBeenCalledWith(["djinnos/djinn"]);
 
     act(() => first.onopen?.());
     await advanceTimersBy(SILENCE_TIMEOUT_MS);

--- a/ui/src/hooks/useEventSource.ts
+++ b/ui/src/hooks/useEventSource.ts
@@ -20,7 +20,7 @@ import { useEffect, useRef } from "react";
 import { sseStore, type SSEEvent } from "../stores/sseStore";
 import { getServerBaseUrl } from "@/api/serverUrl";
 import { initSSEEventHandlers } from "../stores/sseEventHandlers";
-import { fetchKanbanSnapshot } from "@/api/server";
+import { fetchActiveSnapshot, fetchClosedFirstPage } from "@/api/server";
 import { useProjects } from "@/stores/useProjectStore";
 import { projectStore } from "@/stores/projectStore";
 import { taskStore } from "@/stores/taskStore";
@@ -91,10 +91,21 @@ export function useEventSource() {
         return;
       }
       try {
-        const snapshot = await fetchKanbanSnapshot(null, slugs);
+        // Phase 1 — active-first paint: fetch the non-closed tasks + epics and
+        // render the Open / In Progress / PR Ready columns immediately, without
+        // waiting on the (potentially thousands of) closed/merged rows.
+        const active = await fetchActiveSnapshot(slugs);
         if (!isActive) return;
-        taskStore.getState().setTasks(snapshot.tasks);
-        epicStore.getState().setEpics(snapshot.epics);
+        taskStore.getState().setTasks(active.tasks);
+        epicStore.getState().setEpics(active.epics);
+
+        // Phase 2 — paginated Merged column: append the first page of closed
+        // tasks. `upsertTasks` merges additively so the active columns painted
+        // above are preserved. On reconnect/lag this resets the merged
+        // pagination cursors and drops any previously-loaded extra pages.
+        const closed = await fetchClosedFirstPage(slugs);
+        if (!isActive) return;
+        taskStore.getState().upsertTasks(closed);
       } catch (error) {
         console.error("Failed to hydrate Kanban snapshot:", error);
       }

--- a/ui/src/stores/mergedColumnStore.ts
+++ b/ui/src/stores/mergedColumnStore.ts
@@ -1,0 +1,75 @@
+/**
+ * Merged-column pagination store.
+ *
+ * The Kanban board paints its active columns (Open / In Progress / PR Ready)
+ * first, then lazily pages the closed/merged tasks into the Merged column. This
+ * store tracks per-project pagination cursors (how many closed rows are loaded,
+ * whether the server has more, and the server-reported closed total) so the
+ * "Load more" affordance can advance every project that still has more.
+ *
+ * All-projects mode aggregates every project, so the cursor is kept per project
+ * slug. On reconnect / lag re-hydration the whole map is reset and the first
+ * closed page is re-fetched (see `fetchClosedFirstPage`).
+ */
+
+import { createStore } from "zustand/vanilla";
+import { subscribeWithSelector } from "zustand/middleware";
+
+export interface MergedProjectPage {
+  slug: string;
+  projectId: string | null;
+  /** Number of closed rows loaded so far for this project (= next offset). */
+  loaded: number;
+  /** Server has additional closed pages beyond what we've loaded. */
+  hasMore: boolean;
+  /**
+   * Server-reported total for `status=closed`. This OVERCOUNTS the Merged
+   * column: it includes force-closed / review / spike tasks that never merged
+   * and are hidden by `taskToColumnKey`. Used only for a rough "~N" hint.
+   */
+  totalClosed: number;
+}
+
+export interface MergedColumnState {
+  /** Per-project pagination state, keyed by project slug. */
+  projects: Record<string, MergedProjectPage>;
+  /** A "Load more" fetch is in flight. */
+  loadingMore: boolean;
+
+  reset: () => void;
+  setProjectPage: (page: MergedProjectPage) => void;
+  setLoadingMore: (loading: boolean) => void;
+
+  /** Projects that still have unloaded closed pages. */
+  projectsWithMore: () => MergedProjectPage[];
+  /** True when any project still has unloaded closed pages. */
+  hasMore: () => boolean;
+  /** Sum of server-reported closed totals across all projects (rough hint). */
+  totalClosed: () => number;
+}
+
+export const mergedColumnStore = createStore<MergedColumnState>()(
+  subscribeWithSelector((set, get) => ({
+    projects: {},
+    loadingMore: false,
+
+    reset: () => set({ projects: {}, loadingMore: false }),
+
+    setProjectPage: (page) =>
+      set((state) => ({
+        projects: { ...state.projects, [page.slug]: page },
+      })),
+
+    setLoadingMore: (loading) => set({ loadingMore: loading }),
+
+    projectsWithMore: () =>
+      Object.values(get().projects).filter((p) => p.hasMore),
+
+    hasMore: () => Object.values(get().projects).some((p) => p.hasMore),
+
+    totalClosed: () =>
+      Object.values(get().projects).reduce((sum, p) => sum + p.totalClosed, 0),
+  })),
+);
+
+export { useMergedColumnStore } from "./useMergedColumnStore";

--- a/ui/src/stores/taskStore.test.ts
+++ b/ui/src/stores/taskStore.test.ts
@@ -40,6 +40,37 @@ describe("taskStore", () => {
     expect(taskStore.getState().getTask(mockTaskB.id)).toEqual(mockTaskB);
   });
 
+  it("upsertTasks merges additively without dropping existing tasks", () => {
+    taskStore.getState().setTasks([mockTaskA]);
+
+    taskStore.getState().upsertTasks([mockTaskB, mockTaskC]);
+
+    // Unlike setTasks, the previously-present task survives the merge.
+    expect(taskStore.getState().getAllTasks()).toHaveLength(3);
+    expect(taskStore.getState().getTask(mockTaskA.id)).toEqual(mockTaskA);
+    expect(taskStore.getState().getTask(mockTaskB.id)).toEqual(mockTaskB);
+    expect(taskStore.getState().getTask(mockTaskC.id)).toEqual(mockTaskC);
+  });
+
+  it("upsertTasks overwrites tasks with the same id (idempotent)", () => {
+    taskStore.getState().setTasks([mockTaskA]);
+    const updated = { ...mockTaskA, title: "Upserted" };
+
+    taskStore.getState().upsertTasks([updated]);
+
+    expect(taskStore.getState().getAllTasks()).toHaveLength(1);
+    expect(taskStore.getState().getTask(mockTaskA.id)?.title).toBe("Upserted");
+  });
+
+  it("upsertTasks is a no-op for an empty list and preserves the map reference", () => {
+    taskStore.getState().setTasks([mockTaskA]);
+    const before = taskStore.getState().tasks;
+
+    taskStore.getState().upsertTasks([]);
+
+    expect(taskStore.getState().tasks).toBe(before);
+  });
+
   it("clearTasks empties the task map", () => {
     taskStore.getState().setTasks([mockTaskA, mockTaskB]);
 

--- a/ui/src/stores/taskStore.ts
+++ b/ui/src/stores/taskStore.ts
@@ -23,6 +23,14 @@ export interface TaskState {
   clearTasks: () => void;
 
   setTasks: (tasks: Task[]) => void;
+  /**
+   * Additively merge tasks into the existing map (keyed by id). Unlike
+   * {@link setTasks} it does NOT drop tasks already present, so the Kanban can
+   * paint the active columns first and then append paginated Merged-column
+   * pages without clobbering what is already on screen. Idempotent: re-adding
+   * the same id overwrites its entry.
+   */
+  upsertTasks: (tasks: Task[]) => void;
 }
 
 export const taskStore = createStore<TaskState>()(
@@ -80,6 +88,15 @@ export const taskStore = createStore<TaskState>()(
     setTasks: (tasks) => {
       set({
         tasks: new Map(tasks.map((task) => [task.id, task])),
+      });
+    },
+
+    upsertTasks: (tasks) => {
+      if (tasks.length === 0) return;
+      set((state) => {
+        const newTasks = new Map(state.tasks);
+        for (const task of tasks) newTasks.set(task.id, task);
+        return { tasks: newTasks };
       });
     },
   }))

--- a/ui/src/stores/useMergedColumnStore.ts
+++ b/ui/src/stores/useMergedColumnStore.ts
@@ -1,0 +1,21 @@
+/**
+ * useMergedColumnStore - React hook for Merged-column pagination state.
+ *
+ * Uses subscribeWithSelector for granular, performant subscriptions so the
+ * Kanban's "Load more" affordance re-renders only when its slice changes.
+ */
+
+import { useStoreWithSelector } from "./useStoreWithSelector";
+import { mergedColumnStore, type MergedColumnState } from "./mergedColumnStore";
+
+export { mergedColumnStore } from "./mergedColumnStore";
+
+export function useMergedColumnStore(): MergedColumnState;
+export function useMergedColumnStore<T>(
+  selector: (state: MergedColumnState) => T,
+): T;
+export function useMergedColumnStore<T>(
+  selector?: (state: MergedColumnState) => T,
+): MergedColumnState | T {
+  return useStoreWithSelector(mergedColumnStore, selector);
+}


### PR DESCRIPTION
## Problem

The Kanban board hydrated **all** tasks of **all** projects before painting anything. One project has ~1231 closed/merged tasks, so the ~14 active tasks waited on 7+ serial `task_list` round trips (200/page, no status filter, single terminal `setTasks`).

## Approach

**Phase 1 — active-first paint.** Fetch `task_list` with `status: "!closed"` + epics and paint the Open / In Progress / PR Ready columns immediately.

**Phase 2 — paginated Merged column.** Fetch the first page of `status: "closed"` (`sort: "closed"`) and append it. A "Load more" button at the bottom of the Merged column fetches the next closed page for every project that still has more.

### Backend
- `build_where` (`djinn-db`): add `!` negation to the `status` filter, mirroring the existing `issue_type` negation, so `!closed` returns every non-closed task in one query. Dynamic runtime SQL — no `.sqlx` regeneration needed.
- Document `status` (`!closed`) and `sort` (`closed`) in the `task_list` tool schema; regenerated role schema snapshots.

### UI
- `taskStore`: additive `upsertTasks` (`setTasks` still replaces).
- New `mergedColumnStore` + `useMergedColumnStore`: per-project closed-page cursors (`loaded` / `hasMore` / `totalClosed`) for all-projects aggregation.
- `server.ts`: `fetchKanbanSnapshot` → `fetchActiveSnapshot`, `fetchClosedFirstPage`, `loadMoreClosedTasks`; active/task pages fan out in parallel via `total_count` instead of the serial `has_more` walk (epic pagination kept as the serial walk — its `total_count` is schema-optional).
- `useEventSource`: two-phase hydrate; reconnect/lag resets to active + first closed page (id-keyed store makes upserts idempotent, dropping stale extra pages).
- Merged header count: loaded count with a **`+`** suffix when more closed pages remain. The server's `status=closed` total overcounts "Merged" (force-closed / review / spike tasks that never merged and are hidden by `taskToColumnKey`), so an exact total would mislead.

## Merged-count display
Shows the client-side loaded merged count (tasks passing `taskToColumnKey` → `done`) with a trailing `+` while any project still has unloaded closed pages — honest and cheap, no new count endpoint.

## Deferred
Client-side search still matches only loaded merged tasks. Moving search to the backend is left to a follow-up (unchanged scope).

## Test evidence
- `cargo clippy --workspace --all-features`: clean.
- `djinn-db` `task_list_filter` (adds `status_negated` case): 5/5 pass.
- `djinn-control-plane` `task_list_filters_and_pagination` (adds `!closed` / `!in_progress` assertions): pass.
- `djinn-mcp-extension` schema snapshot tests: 42 pass (snapshots updated).
- UI vitest for `taskStore` (new `upsertTasks` tests), `KanbanBoard` (Load more + `+` count), `useEventSource` (two-phase mocks): 30/30 pass; full suite otherwise green (two pre-existing local-only timeout failures in `ProposalsPage`/`DiffBlock` reproduce on `main` and are unrelated).
- `tsc -b` and ESLint on touched/new files: clean.