### PR TITLE
fix(coordinator): bound pool asks + pass watchdog — prevent whole-board freeze

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -664,6 +664,56 @@ impl CoordinatorActor {
         }
     }
 
+    /// Watchdog deadline for a single coordinator pass (one API message, one
+    /// domain event, or one safety-net tick).
+    ///
+    /// The coordinator is a single-mailbox actor: [`run`](Self::run) is one
+    /// `select!` loop that services each pass serially. If any pass blocks
+    /// forever (the 2026-07-09 incident: tick 72 blocked on an un-timed
+    /// coordinator→pool ask while the pool was transiently stalled), the whole
+    /// board freezes — dispatch, PR poller, reviewer dispatch, and refinement
+    /// driving all starve at once until a manual restart.
+    ///
+    /// The bounded pool/slot asks (`POOL_ASK_TIMEOUT` / `SLOT_ACK_TIMEOUT`)
+    /// address the known cause; this watchdog is the defense-in-depth backstop
+    /// for any *other* unbounded await a pass might hit. It is generous
+    /// relative to any healthy pass yet far below the multi-minute freeze it
+    /// guards against.
+    const PASS_DEADLINE: StdDuration = StdDuration::from_secs(120);
+
+    /// Run one coordinator pass under the whole-board-freeze watchdog.
+    ///
+    /// On elapse the `pass` future is dropped (cancelled) and a loud ERROR is
+    /// logged; the caller's `select!` loop then continues to the next
+    /// iteration instead of freezing. This is the coordinator analogue of
+    /// session stall-kill.
+    ///
+    /// Cancel-safety: dropping a pass future mid-await cancels whatever async
+    /// operation it was suspended on. Every DB mutation the passes perform is a
+    /// single transactional repository call (sqlx autocommit, or an explicit
+    /// transaction that rolls back on drop), so dropping *between* operations
+    /// leaves earlier committed operations applied and any in-flight one rolled
+    /// back — never a torn write. The passes are sequences of independent,
+    /// idempotent reconcile / dispatch steps that the 30s safety-net tick
+    /// re-derives, so an abandoned partial pass is recovered next tick.
+    /// `handle_message` may drop an API caller's reply oneshot (the caller sees
+    /// an error rather than a hang) and `handle_event_result` may drop a
+    /// mid-processed event (the tick re-drives any missed dispatch) — both
+    /// strictly better than freezing the entire board.
+    pub(super) async fn run_pass_with_watchdog(
+        pass_kind: &'static str,
+        pass: impl std::future::Future<Output = ()>,
+    ) {
+        if time::timeout(Self::PASS_DEADLINE, pass).await.is_err() {
+            tracing::error!(
+                pass_kind,
+                deadline_secs = Self::PASS_DEADLINE.as_secs(),
+                "CoordinatorActor: pass exceeded watchdog deadline; abandoning it and \
+                 continuing the loop (whole-board-freeze backstop)"
+            );
+        }
+    }
+
     pub(super) async fn run(mut self) {
         tracing::info!("CoordinatorActor started");
 
@@ -723,19 +773,19 @@ impl CoordinatorActor {
                         tracing::debug!("CoordinatorActor: message channel closed");
                         break;
                     };
-                    self.handle_message(msg).await;
+                    Self::run_pass_with_watchdog("message", self.handle_message(msg)).await;
                 }
 
                 // 3. Domain events from repositories.
                 event = self.events.recv() => {
-                    self.handle_event_result(event).await;
+                    Self::run_pass_with_watchdog("event", self.handle_event_result(event)).await;
                 }
 
                 // 4. 30s safety-net tick — stuck detection + dispatch pass for
                 //    any tasks that missed an event (e.g. needs_lead_intervention
                 //    tasks surviving a server restart).
                 _ = self.tick.tick() => {
-                    self.run_tick().await;
+                    Self::run_pass_with_watchdog("tick", self.run_tick()).await;
                 }
             }
         }

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -22,6 +22,7 @@
 //     `ProposalRepository::add_debate_trail_entry()` with `kind = "verdict"`.
 //   - Stop metadata: persisted via `record_refinement_lifecycle`.
 
+use std::collections::HashSet;
 use std::time::{Duration, Instant as StdInstant};
 
 use super::evidence_lifecycle_state::EvidenceLifecycleState;
@@ -58,9 +59,48 @@ impl CoordinatorActor {
     /// Drive all active refinement loops. Called from `run_tick()`.
     pub(super) async fn drive_active_refinements(&mut self) {
         let proposal_ids: Vec<String> = self.active_refinements.keys().cloned().collect();
+        if proposal_ids.is_empty() {
+            return;
+        }
+
+        // Fetch the pool's running-task set ONCE per tick and check membership
+        // in memory, instead of issuing one `pool.has_session(...)` ask per
+        // active refinement. During the 2026-07-09 freeze ~12 active refinements
+        // meant ~12 un-timed pool round-trips every tick, amplifying the single
+        // stalled ask into a per-tick pile-up on the coordinator's mailbox. One
+        // `get_status()` (already the primitive used by the in-flight-ledger
+        // reconciler) is O(1) in pool round-trips regardless of refinement count.
+        //
+        // On a pool error (including the new `PoolError::Timeout`) liveness is
+        // unknown this tick → `None`. `drive_one_refinement` then DEFERS only the
+        // in-flight liveness check (it must not misclassify a possibly-running
+        // session as finished and prematurely process its outcome / burn a
+        // round) while still driving refinements that have no in-flight session,
+        // where `dispatch_next_refinement_phase` already handles pool failures.
+        // This preserves the pre-existing per-refinement behavior for the
+        // no-session path while staying conservative for the stall case.
+        let running_tasks: Option<HashSet<String>> = match self.pool.get_status().await {
+            Ok(status) => Some(
+                status
+                    .running_tasks
+                    .into_iter()
+                    .map(|t| t.task_id)
+                    .collect(),
+            ),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "CoordinatorActor: pool get_status failed while driving refinements; \
+                     in-flight liveness unknown this tick (those refinements deferred; \
+                     new dispatches still attempted)"
+                );
+                None
+            }
+        };
 
         for proposal_id in proposal_ids {
-            self.drive_one_refinement(&proposal_id).await;
+            self.drive_one_refinement(&proposal_id, running_tasks.as_ref())
+                .await;
         }
 
         // Clean up completed refinements.
@@ -68,8 +108,17 @@ impl CoordinatorActor {
             .retain(|_, state| !state.is_complete());
     }
 
-    /// Drive a single refinement loop.
-    async fn drive_one_refinement(&mut self, proposal_id: &str) {
+    /// Drive a single refinement loop. `running_tasks` is the pool's running
+    /// task-id set, fetched once by the caller so this method issues no
+    /// per-refinement pool round-trip for the liveness check. `None` means the
+    /// pool status was unavailable this tick (see `drive_active_refinements`):
+    /// the in-flight liveness check is deferred, but a refinement with no
+    /// in-flight session is still driven to dispatch.
+    async fn drive_one_refinement(
+        &mut self,
+        proposal_id: &str,
+        running_tasks: Option<&HashSet<String>>,
+    ) {
         let Some(state) = self.active_refinements.get(proposal_id).cloned() else {
             return;
         };
@@ -79,11 +128,13 @@ impl CoordinatorActor {
 
         // Check if there's an in-flight session for this refinement.
         if let Some(session) = self.refinement_sessions.get(proposal_id).cloned() {
-            let still_running = self
-                .pool
-                .has_session(&session.task_id)
-                .await
-                .unwrap_or(false);
+            let Some(running_tasks) = running_tasks else {
+                // Pool liveness unknown this tick (get_status errored). Do NOT
+                // treat a possibly-running session as finished — defer to the
+                // next tick rather than risk prematurely processing its outcome.
+                return;
+            };
+            let still_running = running_tasks.contains(&session.task_id);
 
             if still_running {
                 if session.dispatched_at.elapsed() > REFINEMENT_SESSION_TIMEOUT {
@@ -669,6 +720,10 @@ impl CoordinatorActor {
 #[cfg(test)]
 #[path = "refinement_cap_tests.rs"]
 pub(crate) mod refinement_cap_tests;
+
+#[cfg(test)]
+#[path = "refinement_pool_watchdog_tests.rs"]
+mod refinement_pool_watchdog_tests;
 
 #[cfg(test)]
 #[path = "refinement_dor_status_tests.rs"]

--- a/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
@@ -1,0 +1,167 @@
+//! Regression tests for the 2026-07-09 whole-board freeze fixes as they touch
+//! the coordinator: refinement driving must be O(1) in pool round-trips, the
+//! bounded pool ask must let the coordinator degrade instead of hang, and the
+//! per-pass watchdog must abandon a wedged pass so the loop keeps running.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant as StdInstant;
+
+use djinn_core::events::DjinnEventEnvelope;
+use djinn_slot::{PoolMessage, PoolStatus, RunningTaskInfo, SlotPoolHandle};
+use tokio::sync::mpsc;
+
+use super::RefinementSession;
+use crate::actor::CoordinatorActor;
+use crate::refinement::{RefinementLoopState, RefinementPhase};
+use crate::refinement_dispatch::refinement_cap_tests::{TEST_MODEL, build_refinement_actor};
+
+/// Counters for the pool asks a stub pool observed.
+#[derive(Default)]
+struct PoolCallCounts {
+    get_status: usize,
+    has_session: usize,
+}
+
+/// Spawn a stub pool (via `from_raw_sender`) that answers `GetStatus` with the
+/// given `running` task ids and tallies which asks it received. Any session in
+/// `running` is reported as live so `drive_one_refinement` short-circuits on the
+/// in-memory membership check without any further pool round-trip.
+fn spawn_counting_pool(running: Vec<String>) -> (SlotPoolHandle, Arc<Mutex<PoolCallCounts>>) {
+    let counts = Arc::new(Mutex::new(PoolCallCounts::default()));
+    let counts_task = counts.clone();
+    let (tx, mut rx) = mpsc::channel::<PoolMessage>(64);
+    tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                PoolMessage::GetStatus { respond_to } => {
+                    counts_task.lock().expect("counts").get_status += 1;
+                    let running_tasks = running
+                        .iter()
+                        .map(|id| RunningTaskInfo {
+                            task_id: id.clone(),
+                            model_id: TEST_MODEL.to_owned(),
+                            slot_id: 0,
+                            duration_seconds: 0,
+                            idle_seconds: 0,
+                            activity_tracked: true,
+                            project_id: None,
+                            token_count: 0,
+                            turn_count: 0,
+                            no_progress_streak: 0,
+                        })
+                        .collect();
+                    let _ = respond_to.send(Ok(PoolStatus {
+                        active_slots: running.len(),
+                        total_slots: running.len(),
+                        per_model: HashMap::new(),
+                        running_tasks,
+                    }));
+                }
+                PoolMessage::HasSession { respond_to, .. } => {
+                    counts_task.lock().expect("counts").has_session += 1;
+                    let _ = respond_to.send(Ok(true));
+                }
+                _ => {}
+            }
+        }
+    });
+    (SlotPoolHandle::from_raw_sender(tx), counts)
+}
+
+/// Seed an active refinement whose in-flight session task is `task_id`.
+fn seed_running_refinement(actor: &mut CoordinatorActor, proposal_id: &str, task_id: &str) {
+    actor.active_refinements.insert(
+        proposal_id.to_string(),
+        RefinementLoopState::new(proposal_id, 1),
+    );
+    actor.refinement_sessions.insert(
+        proposal_id.to_string(),
+        RefinementSession {
+            task_id: task_id.to_string(),
+            phase: RefinementPhase::AdversaryAttack,
+            dispatched_at: StdInstant::now(),
+            model_id: TEST_MODEL.to_owned(),
+        },
+    );
+}
+
+/// Item 4: driving N active refinements issues exactly ONE `get_status` and
+/// ZERO `has_session` asks — down from one `has_session` per refinement (the
+/// N× amplification that piled onto the coordinator mailbox during the freeze).
+#[tokio::test]
+async fn drive_active_refinements_issues_one_status_query_for_n_refinements() {
+    let db = crate::test_helpers::create_test_db();
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    const N: usize = 5;
+    let task_ids: Vec<String> = (0..N).map(|i| format!("refine-task-{i}")).collect();
+    let (pool, counts) = spawn_counting_pool(task_ids.clone());
+
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+    for (i, task_id) in task_ids.iter().enumerate() {
+        seed_running_refinement(&mut actor, &format!("proposal-{i}"), task_id);
+    }
+
+    actor.drive_active_refinements().await;
+
+    let counts = counts.lock().expect("counts");
+    assert_eq!(
+        counts.get_status, 1,
+        "expected exactly one get_status for {N} refinements, got {}",
+        counts.get_status
+    );
+    assert_eq!(
+        counts.has_session, 0,
+        "expected zero has_session asks (O(1) via get_status), got {}",
+        counts.has_session
+    );
+}
+
+/// Item 1 + degraded path: when the pool never replies, `drive_active_refinements`
+/// gives up within the bounded `get_status` ask (`PoolError::Timeout`) instead of
+/// hanging, and burns no refinement rounds — the loop stays intact for next tick.
+/// `start_paused` auto-advances past `POOL_ASK_TIMEOUT` so the test is fast.
+#[tokio::test(start_paused = true)]
+async fn drive_active_refinements_degrades_when_pool_never_replies() {
+    let db = crate::test_helpers::create_test_db();
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    // Receiver kept alive but never drained → get_status enqueues then times out.
+    let (tx, _rx) = mpsc::channel::<PoolMessage>(64);
+    let pool = SlotPoolHandle::from_raw_sender(tx);
+
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+    seed_running_refinement(&mut actor, "proposal-a", "refine-task-a");
+
+    // Must return (not hang). If the bound were absent this would block forever.
+    actor.drive_active_refinements().await;
+
+    assert!(
+        actor.active_refinements.contains_key("proposal-a"),
+        "refinement must survive a pool-unresponsive tick (no round burned)"
+    );
+    assert!(
+        actor.refinement_sessions.contains_key("proposal-a"),
+        "in-flight session must be left intact when pool liveness is unknown"
+    );
+    drop(_rx);
+}
+
+/// Item 3: a pass that blocks past the watchdog deadline is abandoned so the
+/// coordinator loop continues, and a fast pass runs to completion normally.
+#[tokio::test(start_paused = true)]
+async fn watchdog_abandons_a_wedged_pass_and_runs_the_next() {
+    // A pass that never completes must not hang the watchdog: it returns once the
+    // deadline elapses (auto-advanced by the paused clock).
+    CoordinatorActor::run_pass_with_watchdog("wedged", std::future::pending::<()>()).await;
+
+    // A normal pass runs to completion (side effect observed).
+    let ran = Arc::new(Mutex::new(false));
+    let ran_inner = ran.clone();
+    CoordinatorActor::run_pass_with_watchdog("fast", async move {
+        *ran_inner.lock().expect("ran") = true;
+    })
+    .await;
+    assert!(*ran.lock().expect("ran"), "fast pass should have completed");
+}

--- a/server/crates/djinn-slot/src/actor.rs
+++ b/server/crates/djinn-slot/src/actor.rs
@@ -346,6 +346,20 @@ impl SlotActor {
     }
 }
 
+/// Upper bound on how long the pool→slot dispatch ask waits for the slot
+/// actor to ACK a `RunTask`/`RunTaskWithResume` command.
+///
+/// IMPORTANT: the slot ACKs the command *before* running the task lifecycle
+/// (see [`SlotActor::run`] — the ACK is sent at the `respond_to.send(Ok(()))`
+/// immediately after `start_lifecycle`, which only builds the lifecycle future
+/// and does not run it). So this deadline bounds only the *mailbox enqueue +
+/// ACK*, never task execution. It exists so a stalled slot actor (bounded
+/// mailbox backed up, or wedged between commands) cannot in turn wedge the
+/// single-mailbox *pool* actor — which would then wedge the coordinator (the
+/// 2026-07-09 whole-board-freeze chain). The value is generous relative to the
+/// trivial ACK work yet far below any human-visible freeze.
+const SLOT_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+
 #[derive(Debug, Clone)]
 pub struct SlotHandle {
     id: usize,
@@ -495,12 +509,28 @@ impl SlotHandle {
                 respond_to: tx,
             },
         };
-        self.sender
-            .send(cmd)
-            .await
-            .map_err(|_| SlotError::SessionFailed("slot actor channel closed".to_string()))?;
-        rx.await
-            .map_err(|_| SlotError::SessionFailed("slot actor did not ack dispatch".to_string()))?
+        // Bound the mailbox enqueue + ACK wait. The slot ACKs before running
+        // the lifecycle, so this deadline never truncates task execution; it
+        // only prevents a stalled slot actor from wedging the pool→slot ask
+        // (and, transitively, the coordinator). Both `send` and `rx.await` are
+        // cancel-safe, so an elapsed deadline leaves no half-delivered command.
+        match tokio::time::timeout(SLOT_ACK_TIMEOUT, async {
+            self.sender
+                .send(cmd)
+                .await
+                .map_err(|_| SlotError::SessionFailed("slot actor channel closed".to_string()))?;
+            rx.await.map_err(|_| {
+                SlotError::SessionFailed("slot actor did not ack dispatch".to_string())
+            })?
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(SlotError::SessionFailed(format!(
+                "slot actor did not ack dispatch within {}s (slot stalled)",
+                SLOT_ACK_TIMEOUT.as_secs()
+            ))),
+        }
     }
     #[tracing::instrument(
         name = "djinn.slot.kill",
@@ -540,6 +570,38 @@ mod tests {
     use tracing_subscriber::layer::Context;
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::{Layer, registry::LookupSpan};
+
+    /// Pool→slot ACK-timeout regression (2026-07-09 freeze chain). A slot actor
+    /// that never drains its mailbox / never ACKs must not wedge the pool→slot
+    /// dispatch ask forever: `run_task_with_resume` bounds the enqueue + ACK
+    /// wait with `SLOT_ACK_TIMEOUT` and surfaces a `SessionFailed`. The receiver
+    /// is held alive (so `send` sees an open channel) but never read, so the
+    /// oneshot ACK never arrives. `start_paused` auto-advances past the bound.
+    #[tokio::test(start_paused = true)]
+    async fn run_task_ack_times_out_when_slot_never_acks() {
+        let (tx, _rx) = mpsc::channel::<SlotCommand>(16);
+        let handle = SlotHandle {
+            id: 0,
+            model_id: "test/mock".to_string(),
+            sender: tx,
+            compaction_cs: CompactionCriticalSection::new(),
+        };
+
+        let result = handle
+            .run_task_with_resume("task-1".to_string(), "/tmp/proj".to_string(), None)
+            .await;
+
+        match result {
+            Err(SlotError::SessionFailed(msg)) => {
+                assert!(
+                    msg.contains("did not ack dispatch within"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected SlotError::SessionFailed ack timeout, got {other:?}"),
+        }
+        drop(_rx);
+    }
     #[derive(Clone, Debug, Default)]
     struct RecordedSpan {
         name: String,

--- a/server/crates/djinn-slot/src/llm_extraction.rs
+++ b/server/crates/djinn-slot/src/llm_extraction.rs
@@ -70,6 +70,20 @@ const TRANSCRIPT_EXCERPT_CHARS: usize = 12_000;
 /// structured payload while staying well within the model's context window.
 const EXTRACTION_MAX_TOKENS: u32 = 4096;
 
+/// Hard outer bound on the post-session extraction LLM completion.
+///
+/// Post-session knowledge extraction is best-effort background work that runs
+/// on the slot's finalize path. Without an explicit bound it inherits the
+/// provider's own request timeout (up to ~10 minutes for a streaming
+/// completion), which needlessly pins a finalize task and slot-pool resources
+/// on a stalled memory provider — indirect pressure on the same
+/// session-exit→teardown→redispatch window implicated in the 2026-07-09
+/// whole-board freeze. Cap it explicitly and reuse the existing
+/// "LLM completion failed; skipping extraction" degrade path on elapse; the
+/// value sits above the provider's inner per-attempt timeout (plus its one
+/// transient retry) so it only fires when that inner bound is itself defeated.
+const EXTRACTION_LLM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 const NO_LLM_PROVIDER_WARNING: &str =
     "llm_extraction: no LLM provider available; skipping extraction";
 
@@ -821,22 +835,33 @@ async fn run_llm_extraction_inner(
         &transcript,
         &scope_json,
     );
-    let response = match complete(
-        provider.as_ref(),
-        CompletionRequest {
-            system: EXTRACTION_SYSTEM_PROMPT.to_string(),
-            prompt,
-            max_tokens: EXTRACTION_MAX_TOKENS,
-        },
+    let completion = tokio::time::timeout(
+        EXTRACTION_LLM_TIMEOUT,
+        complete(
+            provider.as_ref(),
+            CompletionRequest {
+                system: EXTRACTION_SYSTEM_PROMPT.to_string(),
+                prompt,
+                max_tokens: EXTRACTION_MAX_TOKENS,
+            },
+        ),
     )
-    .await
-    {
-        Ok(r) => r,
-        Err(e) => {
+    .await;
+    let response = match completion {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
             tracing::warn!(
                 session_id = %session_id,
                 error = %e,
                 "llm_extraction: LLM completion failed; skipping extraction"
+            );
+            return;
+        }
+        Err(_) => {
+            tracing::warn!(
+                session_id = %session_id,
+                timeout_secs = EXTRACTION_LLM_TIMEOUT.as_secs(),
+                "llm_extraction: LLM completion timed out; skipping extraction"
             );
             return;
         }

--- a/server/crates/djinn-slot/src/pool/handle.rs
+++ b/server/crates/djinn-slot/src/pool/handle.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
@@ -9,6 +11,22 @@ use super::actor::SlotPool;
 #[cfg(any(test, feature = "test-support"))]
 use super::types::SlotFactory;
 use super::types::{PoolError, PoolMessage, PoolStatus, Reply, RunningTaskInfo};
+
+/// Upper bound on how long a single coordinator→pool ask may block on the
+/// pool actor's mailbox + reply before the caller gives up with
+/// [`PoolError::Timeout`].
+///
+/// The slot pool is a single-mailbox actor: every ask is serviced serially by
+/// one `select!` loop. On 2026-07-09 an un-timed coordinator→pool ask (tick 72)
+/// wedged the *coordinator's* own single-mailbox loop for 11 minutes when the
+/// pool was transiently stalled during a session-exit→teardown→redispatch
+/// window — starving dispatch, the PR poller, reviewer dispatch, and refinement
+/// driving all at once (whole-board freeze, restart-only recovery). Bounding
+/// the ask converts that hang into a fast, tolerated `PoolError` on the caller
+/// side. The value is comfortably longer than any healthy pool handler (which
+/// are in-memory map operations plus at most one short DB read) yet far below
+/// the multi-minute freeze it prevents.
+pub(crate) const POOL_ASK_TIMEOUT: Duration = Duration::from_secs(8);
 
 #[derive(Clone)]
 pub struct SlotPoolHandle {
@@ -58,11 +76,28 @@ impl SlotPoolHandle {
     }
     async fn request<T>(&self, f: impl FnOnce(Reply<T>) -> PoolMessage) -> Result<T, PoolError> {
         let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(f(tx))
-            .await
-            .map_err(|_| PoolError::ActorDead)?;
-        rx.await.map_err(|_| PoolError::NoResponse)?
+        // Bound BOTH the mailbox enqueue and the reply wait under one deadline.
+        // A stalled pool actor can back up its bounded mailbox (so `send` blocks
+        // on a full channel) *or* accept the message and never reply (so
+        // `rx.await` blocks) — either wedges an un-timed caller. `mpsc::send`
+        // and `oneshot::recv` are both cancel-safe: if the deadline fires during
+        // `send` the message is not enqueued; if it fires during `rx.await` the
+        // message was delivered and the pool will still process it (its reply is
+        // simply dropped, which is harmless for the read/idempotent asks).
+        match tokio::time::timeout(POOL_ASK_TIMEOUT, async {
+            self.sender
+                .send(f(tx))
+                .await
+                .map_err(|_| PoolError::ActorDead)?;
+            rx.await.map_err(|_| PoolError::NoResponse)?
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(PoolError::Timeout {
+                timeout_secs: POOL_ASK_TIMEOUT.as_secs(),
+            }),
+        }
     }
     pub async fn dispatch(
         &self,
@@ -213,3 +248,7 @@ impl SlotPoolHandle {
             .await;
     }
 }
+
+#[cfg(test)]
+#[path = "handle_timeout_tests.rs"]
+mod handle_timeout_tests;

--- a/server/crates/djinn-slot/src/pool/handle_timeout_tests.rs
+++ b/server/crates/djinn-slot/src/pool/handle_timeout_tests.rs
@@ -1,0 +1,70 @@
+//! Coordinator→pool ask-timeout regression tests (2026-07-09 whole-board
+//! freeze). A single-mailbox pool actor that stalls must not wedge its
+//! caller: an un-timed `rx.await` on a stalled pool froze the coordinator's
+//! own single `select!` loop for 11 minutes. `SlotPoolHandle::request` now
+//! bounds every ask with [`POOL_ASK_TIMEOUT`], returning `PoolError::Timeout`.
+
+use std::collections::HashMap;
+
+use tokio::sync::mpsc;
+
+use super::POOL_ASK_TIMEOUT;
+use crate::pool::types::{PoolError, PoolMessage, PoolStatus};
+
+/// A pool whose mailbox is never drained (receiver kept alive so the channel
+/// is not `Closed`, but no reply is ever sent) must elapse into
+/// `PoolError::Timeout` rather than hang forever. `start_paused` auto-advances
+/// the clock past the timeout so the test does not sleep for real.
+#[tokio::test(start_paused = true)]
+async fn get_status_times_out_when_pool_never_replies() {
+    let (tx, _rx) = mpsc::channel::<PoolMessage>(64);
+    let handle = super::SlotPoolHandle::from_raw_sender(tx);
+
+    let result = handle.get_status().await;
+
+    match result {
+        Err(PoolError::Timeout { timeout_secs }) => {
+            assert_eq!(timeout_secs, POOL_ASK_TIMEOUT.as_secs());
+        }
+        other => panic!("expected PoolError::Timeout, got {other:?}"),
+    }
+    // Keep the receiver alive to the end so `send` saw an open channel (i.e. the
+    // failure was the reply timeout, not an `ActorDead` from a closed channel).
+    drop(_rx);
+}
+
+#[tokio::test(start_paused = true)]
+async fn has_session_times_out_when_pool_never_replies() {
+    let (tx, _rx) = mpsc::channel::<PoolMessage>(64);
+    let handle = super::SlotPoolHandle::from_raw_sender(tx);
+
+    let result = handle.has_session("task-1").await;
+
+    assert!(
+        matches!(result, Err(PoolError::Timeout { .. })),
+        "expected PoolError::Timeout, got {result:?}"
+    );
+    drop(_rx);
+}
+
+/// Positive control: a pool that replies promptly returns `Ok` and the
+/// watchdog never fires.
+#[tokio::test(start_paused = true)]
+async fn get_status_returns_ok_when_pool_replies_fast() {
+    let (tx, mut rx) = mpsc::channel::<PoolMessage>(64);
+    tokio::spawn(async move {
+        if let Some(PoolMessage::GetStatus { respond_to }) = rx.recv().await {
+            let _ = respond_to.send(Ok(PoolStatus {
+                active_slots: 0,
+                total_slots: 0,
+                per_model: HashMap::new(),
+                running_tasks: Vec::new(),
+            }));
+        }
+    });
+    let handle = super::SlotPoolHandle::from_raw_sender(tx);
+
+    let result = handle.get_status().await;
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+}

--- a/server/crates/djinn-slot/src/pool/types.rs
+++ b/server/crates/djinn-slot/src/pool/types.rs
@@ -28,6 +28,17 @@ pub enum PoolError {
     ActorDead,
     #[error("no response from actor")]
     NoResponse,
+    /// The coordinator→pool ask exceeded [`super::handle::POOL_ASK_TIMEOUT`]
+    /// without the single-mailbox pool actor replying. Introduced after the
+    /// 2026-07-09 whole-board freeze: an un-timed coordinator→pool ask on
+    /// tick 72 blocked the coordinator's single `select!` loop for 11 minutes
+    /// while the pool was transiently stalled in a
+    /// session-exit→teardown→redispatch window. Callers already tolerate
+    /// `PoolError`, so `Timeout` degrades the same way (ledger preserved,
+    /// session treated as not-running, dispatch retried next tick) rather than
+    /// wedging the whole coordinator.
+    #[error("pool ask timed out after {timeout_secs}s (pool actor stalled)")]
+    Timeout { timeout_secs: u64 },
     #[error("task {task_id} already has an active slot")]
     SessionAlreadyActive { task_id: String },
     #[error("task {task_id} has no active slot")]


### PR DESCRIPTION
## Incident

On **2026-07-09** the `CoordinatorActor` froze for **11 minutes** (restart-only recovery). The coordinator is a single-mailbox actor: `CoordinatorActor::run` is one `tokio::select!` loop that serially awaits `handle_message` / `handle_event` / `run_tick`. **Tick 72 blocked forever on an un-timed ask to the SlotPool actor** while the pool/slot was transiently stalled during a session-exit→teardown→redispatch window.

With that single pass wedged, the whole board froze at once: dispatch, PR poller, reviewer dispatch, and refinement/tribunal driving all starved. Refinement driving **amplified** it — one un-timed `pool.has_session` ask per active refinement (~12/tick during the incident) piled onto the coordinator mailbox.

`handle.rs` already documented the circular-wait risk and defended the pool→coordinator direction with `try_send`; the **coordinator→pool direction was unbounded**. This PR bounds it and adds a defense-in-depth watchdog.

## Fixes

1. **Bound coordinator→pool asks.** `SlotPoolHandle::request` wraps the mailbox enqueue + oneshot reply in `tokio::time::timeout` (`POOL_ASK_TIMEOUT`, 8s), returning a new `PoolError::Timeout`. Both `send` and `recv` are cancel-safe, so an elapsed deadline leaves no half-delivered message. Every existing caller already tolerates `PoolError` (log+continue / keep the in-flight ledger / treat as not-running), so `Timeout` degrades identically — audited all callers; the only ones that special-case are `ActorDead` (abort) and the catch-all `Err(e)` arms.

2. **Bound pool→slot ACK wait.** `SlotHandle::run_task_with_resume` wraps its enqueue + ACK oneshot in `SLOT_ACK_TIMEOUT` (8s). The slot ACKs **before** running the lifecycle (`actor.rs` `respond_to.send(Ok(()))` right after `start_lifecycle`), so the bound covers only the ACK, never task execution — documented at the const and call site.

3. **Coordinator-pass watchdog.** Each pass (`handle_message`, `handle_event_result`, `run_tick`) runs under `tokio::time::timeout(PASS_DEADLINE, ...)` (120s) via a small `run_pass_with_watchdog` helper; on elapse the pass future is dropped and a loud ERROR is logged, then the loop continues. Cancel-safety is reasoned about in-code: every DB mutation is a single transactional repo call (sqlx autocommit / explicit txn that rolls back on drop), and the passes are sequences of idempotent reconcile/dispatch steps the 30s safety-net tick re-derives, so an abandoned partial pass is recovered next tick. Coordinator analogue of session stall-kill.

4. **Refinement driving O(1) in pool round-trips.** `drive_active_refinements` fetches the running-task set **once** via `pool.get_status()` (the same primitive the in-flight-ledger reconciler uses) and checks membership in memory instead of one `has_session` ask per refinement. On a pool-status error, liveness is unknown → the in-flight liveness check is **deferred** (never misclassifies a possibly-running session as finished, which could prematurely process its outcome / burn a round), while refinements with **no** in-flight session are still driven to dispatch — preserving the prior per-refinement behavior for that path (`dispatch_next_refinement_phase` already handles pool failures).

5. **Bound post-session extraction (secondary).** The extraction LLM call is wrapped in `EXTRACTION_LLM_TIMEOUT` (120s) as an outer backstop, reusing the existing "LLM completion failed; skipping extraction" degrade path.

`TEARDOWN_POLL_TIMEOUT` / teardown semantics are intentionally untouched (separate concern).

## Tests

- **Pool-ask timeout** (`handle_timeout_tests.rs`): stub pool that never replies → `get_status` / `has_session` return `PoolError::Timeout` within the bound; positive control that a fast-replying pool returns `Ok`.
- **Slot ACK timeout** (`actor.rs`): slot that never ACKs → `SessionFailed` within the bound.
- **Refinement O(1)** (`refinement_pool_watchdog_tests.rs`): with N active refinements, exactly **one** `get_status` and **zero** `has_session` asks.
- **Incident-shaped degraded path**: pool momentarily unresponsive → `drive_active_refinements` returns within the timeout window instead of freezing, and burns no refinement round.
- **Pass watchdog**: a pass that blocks past the deadline is abandoned (returns) and the next pass runs.

New timeout tests use `start_paused` to auto-advance past the deadlines.

### Note on the extraction (#5) test

A dedicated full-path extraction-timeout test is impractical: `start_paused` is incompatible with the sqlx in-memory pool the extraction fixture uses (the paused clock trips `PoolTimedOut` on the fixture's own DB setup), and a real-time test would wait ≥30s on the provider's inner completion timeout. The change is a 6-line timeout wrapper identical to the unit-tested pool/slot bounds. Worth flagging: the provider's `complete()` already bounds each completion at ~30s (×1 transient retry), so the practical pre-fix exposure on the extraction path was already limited; `EXTRACTION_LLM_TIMEOUT` is an outer backstop.

## Verification

- `cargo clippy -p djinn-slot -p djinn-coordinator --all-targets --all-features -- -D warnings` → clean. (Workspace-wide clippy surfaces pre-existing lints in untouched `djinn-db`/`djinn-supervisor` test targets from the local rust-1.96.0 toolchain — not from this change.)
- Full `djinn-slot` and `djinn-coordinator` lib test suites pass (in-memory DB, no Postgres needed). The only red were the two known-flaky merge_group tests (`wnd1_dispatch_race_harness_*`, `preservation_telemetry_counter_increments`), green on re-run.
- Size guard passes (touched oversize files are pre-existing `djinn:allow-oversize`).
- `cargo fmt` applied to touched crates.