### PR TITLE
feat(kanban): back the board search box with the server

### DIFF
--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_lead()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_lead()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_planner()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_planner()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__worker_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__worker_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_worker()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_worker()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-db/src/repositories/task/queries.rs
+++ b/server/crates/djinn-db/src/repositories/task/queries.rs
@@ -741,7 +741,11 @@ pub(super) fn build_where(
     if let Some(t) = text {
         let ph_a = format!("${}", param_offset + params.len() + 1);
         let ph_b = format!("${}", param_offset + params.len() + 2);
-        clauses.push(format!("(title LIKE {ph_a} OR description LIKE {ph_b})"));
+        // ILIKE (not LIKE): case-insensitive substring match. This filter backs
+        // the Kanban board's search box (which fetches unloaded merged tasks via
+        // task_list?text=…), where a case-sensitive match is surprising — a
+        // search for "auth" should find "Auth" and "AUTHZ" alike.
+        clauses.push(format!("(title ILIKE {ph_a} OR description ILIKE {ph_b})"));
         let pattern = format!("%{t}%");
         params.push(SqlParam::Text(pattern.clone()));
         params.push(SqlParam::Text(pattern));

--- a/server/crates/djinn-db/tests/task_tests/filter_matrices.rs
+++ b/server/crates/djinn-db/tests/task_tests/filter_matrices.rs
@@ -272,6 +272,7 @@ async fn task_count_group_by(#[case] group_by: &str) {
 #[case("priority")]
 #[case("label")]
 #[case("text")]
+#[case("text_case_insensitive")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn task_list_filter(#[case] filter_kind: &str) {
     let db = create_test_db();
@@ -326,6 +327,13 @@ async fn task_list_filter(#[case] filter_kind: &str) {
         },
         "text" => ListQuery {
             text: Some("beta".to_owned()),
+            ..Default::default()
+        },
+        // The `text` filter is case-insensitive (ILIKE): an all-caps query still
+        // matches the lower-case "beta feature" title. This backs the Kanban
+        // search box, where matching should not depend on letter case.
+        "text_case_insensitive" => ListQuery {
+            text: Some("BETA".to_owned()),
             ..Default::default()
         },
         _ => unreachable!(),

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -21052,6 +21052,7 @@
           "type": "string"
         },
         "status": {
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\"\nmatches every task whose status differs from the given value.",
           "type": [
             "string",
             "null"

--- a/ui/src/api/server.test.ts
+++ b/ui/src/api/server.test.ts
@@ -8,8 +8,13 @@ import {
   getGithubInstallUrl,
   invalidateProviderCatalogCache,
   listGithubRepos,
+  searchTasksAcrossProjects,
+  SEARCH_RESULT_CAP,
   startProviderOAuth,
 } from "@/api/server";
+import { projectStore } from "@/stores/projectStore";
+import { taskStore } from "@/stores/taskStore";
+import { mergedColumnStore } from "@/stores/mergedColumnStore";
 
 vi.mock("@/api/mcpClient", () => ({
   callMcpTool: vi.fn(),
@@ -208,6 +213,58 @@ describe("server API helpers", () => {
         success: false,
         error: "MCP unavailable",
       });
+    });
+  });
+
+  describe("searchTasksAcrossProjects", () => {
+    beforeEach(() => {
+      taskStore.getState().clearTasks();
+      mergedColumnStore.getState().reset();
+      projectStore.getState().setProjects([
+        {
+          id: "proj-1",
+          name: "One",
+          github_owner: "acme",
+          github_repo: "one",
+        },
+        {
+          id: "proj-2",
+          name: "Two",
+          github_owner: "acme",
+          github_repo: "two",
+        },
+      ] as never);
+    });
+
+    it("queries every project with the case-insensitive text filter and upserts matches", async () => {
+      callMcpToolMock.mockImplementation((async (_tool: string, params: { project: string }) => {
+        if (params.project === "acme/one") {
+          return { tasks: [{ id: "t-1", title: "Auth login", status: "closed" }] };
+        }
+        return { tasks: [{ id: "t-2", title: "AUTHZ policy", status: "closed" }] };
+      }) as never);
+
+      const result = await searchTasksAcrossProjects(["acme/one", "acme/two"], "  auth  ");
+
+      expect(result).toHaveLength(2);
+      // Each project queried once with the trimmed text and the result cap.
+      expect(callMcpToolMock).toHaveBeenCalledWith("task_list", {
+        project: "acme/one",
+        text: "auth",
+        limit: SEARCH_RESULT_CAP,
+        offset: 0,
+      });
+      // Matches are stamped with their project id and merged into the store.
+      expect(taskStore.getState().getTask("t-1")?.project_id).toBe("proj-1");
+      expect(taskStore.getState().getTask("t-2")?.project_id).toBe("proj-2");
+      // The Merged-column pagination cursors are left untouched by search.
+      expect(mergedColumnStore.getState().hasMore()).toBe(false);
+      expect(Object.keys(mergedColumnStore.getState().projects)).toHaveLength(0);
+    });
+
+    it("short-circuits on an empty query without calling the backend", async () => {
+      await expect(searchTasksAcrossProjects(["acme/one"], "   ")).resolves.toEqual([]);
+      expect(callMcpToolMock).not.toHaveBeenCalled();
     });
   });
 

--- a/ui/src/api/server.ts
+++ b/ui/src/api/server.ts
@@ -564,3 +564,54 @@ export async function loadMoreClosedTasks(): Promise<Task[]> {
     mergedColumnStore.getState().setLoadingMore(false);
   }
 }
+
+/**
+ * Cap on server-side search results per project. The board's search box only
+ * needs to *surface* matches that aren't already loaded (chiefly old merged
+ * tasks): one page of matches per project is plenty, and we deliberately do NOT
+ * paginate exhaustively — an unbounded fan-out over a project with thousands of
+ * closed tasks would defeat the whole active-first load. A query specific enough
+ * to matter matches far fewer than this.
+ */
+export const SEARCH_RESULT_CAP = 200;
+
+/**
+ * Backend-backed board search: for every project, run `task_list` with the
+ * case-insensitive `text` filter and additively merge the matches into the task
+ * store. This is what lets the search box match tasks the board never loaded
+ * (e.g. merged tasks beyond the first Merged-column page).
+ *
+ * Notes:
+ * - All statuses are searched (not just closed). Active tasks are already
+ *   loaded, but the store is keyed by id so re-upserting them is a cheap no-op;
+ *   searching everything keeps the semantics simple ("find any matching task").
+ * - The Merged-column pagination cursors ({@link mergedColumnStore}) are left
+ *   untouched: search-surfaced closed tasks render in the Merged column out of
+ *   cursor order (fine), while "Load more" keeps advancing from its own offsets.
+ * - Results are capped at {@link SEARCH_RESULT_CAP} per project (single page).
+ */
+export async function searchTasksAcrossProjects(
+  slugs: string[],
+  query: string,
+): Promise<Task[]> {
+  const trimmed = query.trim();
+  if (slugs.length === 0 || trimmed.length === 0) return [];
+  const perProject = await Promise.all(
+    slugs.map(async (slug) => {
+      const projectId = projectIdForSlug(slug);
+      const page = await callMcpTool("task_list", {
+        project: slug,
+        text: trimmed,
+        limit: SEARCH_RESULT_CAP,
+        offset: 0,
+      });
+      return (page.tasks as unknown as Task[]).map((t) => ({
+        ...t,
+        project_id: projectId,
+      }));
+    }),
+  );
+  const tasks = perProject.flatMap((t) => t);
+  taskStore.getState().upsertTasks(tasks);
+  return tasks;
+}

--- a/ui/src/components/KanbanBoard.test.tsx
+++ b/ui/src/components/KanbanBoard.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/api/mcpClient", () => ({
 
 vi.mock("@/api/server", () => ({
   loadMoreClosedTasks: vi.fn().mockResolvedValue([]),
+  searchTasksAcrossProjects: vi.fn().mockResolvedValue([]),
 }));
 
 const epicA: Epic = {

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -30,6 +30,7 @@ import {
   matchesStructuredFilters,
   useBoardFilters,
 } from "@/components/board/boardFilters";
+import { useBoardServerSearch } from "@/components/board/useBoardServerSearch";
 
 type ColumnKey = "open" | "in_progress" | "pr_ready" | "done";
 
@@ -139,6 +140,11 @@ export function KanbanBoard({
   const { projectFilters, epicFilters, ownerFilters, issueTypeFilters, search } =
     useBoardFilters();
 
+  // Backend-backed search: when the query is non-empty, fetch matching tasks
+  // (including old merged ones the board never loaded) into the store. Disabled
+  // in controlled mode (`tasksProp`, used by tests) where the store is unused.
+  useBoardServerSearch({ enabled: !tasksProp });
+
   const tasks = tasksProp ?? storeTasks;
   const epics = epicsProp ?? storeEpics;
   const [collapsedEpics, setCollapsedEpics] = useState<Record<string, boolean>>(
@@ -219,7 +225,14 @@ export function KanbanBoard({
     };
     return tasks.filter((task) => {
       if (!matchesStructuredFilters(task, filters)) return false;
-      if (q && !task.title.toLowerCase().includes(q)) return false;
+      // Match title OR description, case-insensitive — mirrors the server's
+      // `text` filter (ILIKE over title/description) so tasks surfaced by the
+      // backend search aren't hidden by a narrower client-side predicate.
+      if (q) {
+        const title = (task.title ?? "").toLowerCase();
+        const description = (task.description ?? "").toLowerCase();
+        if (!title.includes(q) && !description.includes(q)) return false;
+      }
       return true;
     });
   }, [

--- a/ui/src/components/board/BoardFilterHeader.tsx
+++ b/ui/src/components/board/BoardFilterHeader.tsx
@@ -14,9 +14,11 @@ import { useProjects } from "@/stores/useProjectStore";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   KanbanIcon,
+  Loading02Icon,
   Search01Icon,
   WorkflowSquare06Icon,
 } from "@hugeicons/core-free-icons";
+import { useBoardSearchStore } from "@/stores/useBoardSearchStore";
 import { cn } from "@/lib/utils";
 import {
   Combobox,
@@ -127,6 +129,9 @@ export function BoardFilterHeader() {
     setSearch,
   } = useBoardFilters();
 
+  // A subtle spinner replaces the search glyph while a backend search runs.
+  const searching = useBoardSearchStore((state) => state.searching);
+
   const epicOptions = useMemo(
     () =>
       Array.from(epics.values()).sort((a, b) =>
@@ -231,7 +236,15 @@ export function BoardFilterHeader() {
       <div className="ml-auto flex items-center gap-2">
         <InputGroup className="w-56">
           <InputGroupAddon>
-            <HugeiconsIcon icon={Search01Icon} className="size-3.5" />
+            {searching ? (
+              <HugeiconsIcon
+                icon={Loading02Icon}
+                className="size-3.5 animate-spin text-muted-foreground"
+                aria-label="Searching"
+              />
+            ) : (
+              <HugeiconsIcon icon={Search01Icon} className="size-3.5" />
+            )}
           </InputGroupAddon>
           <InputGroupInput
             value={searchInput}

--- a/ui/src/components/board/useBoardServerSearch.test.tsx
+++ b/ui/src/components/board/useBoardServerSearch.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import {
+  SEARCH_DEBOUNCE_MS,
+  useBoardServerSearch,
+} from "./useBoardServerSearch";
+import { searchTasksAcrossProjects } from "@/api/server";
+import { projectStore } from "@/stores/projectStore";
+import { boardSearchStore } from "@/stores/boardSearchStore";
+
+vi.mock("@/api/server", () => ({
+  searchTasksAcrossProjects: vi.fn().mockResolvedValue([]),
+}));
+
+const searchMock = vi.mocked(searchTasksAcrossProjects);
+
+function wrapperFor(search: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[`/tasks?q=${encodeURIComponent(search)}`]}>
+        {children}
+      </MemoryRouter>
+    );
+  };
+}
+
+describe("useBoardServerSearch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    searchMock.mockClear();
+    boardSearchStore.getState().setSearching(false);
+    projectStore.getState().setProjects([
+      { id: "p1", name: "One", github_owner: "acme", github_repo: "one" },
+    ] as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("debounces before calling the backend search", () => {
+    renderHook(() => useBoardServerSearch(), { wrapper: wrapperFor("auth") });
+
+    // Nothing fires before the debounce window elapses.
+    vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS - 1);
+    expect(searchMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(searchMock).toHaveBeenCalledTimes(1);
+    expect(searchMock).toHaveBeenCalledWith(["acme/one"], "auth");
+  });
+
+  it("does not search for an empty query", () => {
+    renderHook(() => useBoardServerSearch(), { wrapper: wrapperFor("") });
+    vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS * 2);
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when disabled (controlled board mode)", () => {
+    renderHook(() => useBoardServerSearch({ enabled: false }), {
+      wrapper: wrapperFor("auth"),
+    });
+    vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS * 2);
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/board/useBoardServerSearch.ts
+++ b/ui/src/components/board/useBoardServerSearch.ts
@@ -1,0 +1,61 @@
+/**
+ * Debounced backend search for the Kanban board.
+ *
+ * The board only loads active tasks plus the first page of merged tasks, so a
+ * purely client-side search box can never match old merged tasks that were
+ * never loaded. This hook closes that gap: while the search query is non-empty
+ * it debounces, calls `task_list` with the case-insensitive `text` filter for
+ * every project, and additively merges the matches into the task store. The
+ * existing client-side predicate then displays them.
+ *
+ * The fetch is idempotent (id-keyed store) and never touches the Merged-column
+ * pagination cursors, so "Load more" keeps working independently.
+ */
+
+import { useEffect } from "react";
+import { useProjects } from "@/stores/useProjectStore";
+import { searchTasksAcrossProjects } from "@/api/server";
+import { boardSearchStore } from "@/stores/boardSearchStore";
+import { useBoardFilters } from "./boardFilters";
+
+/** Debounce window before a keystroke triggers a backend search. */
+export const SEARCH_DEBOUNCE_MS = 300;
+
+export function useBoardServerSearch(options?: { enabled?: boolean }): void {
+  const enabled = options?.enabled ?? true;
+  const { search } = useBoardFilters();
+  const projects = useProjects();
+  // Re-run only when the *set* of projects changes, not on every metadata edit.
+  const slugKey = projects
+    .map((p) => `${p.github_owner}/${p.github_repo}`)
+    .sort()
+    .join(",");
+
+  useEffect(() => {
+    if (!enabled) return;
+    const query = search.trim();
+    if (query.length === 0) {
+      boardSearchStore.getState().setSearching(false);
+      return;
+    }
+    const slugs = slugKey ? slugKey.split(",") : [];
+    if (slugs.length === 0) return;
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      boardSearchStore.getState().setSearching(true);
+      try {
+        await searchTasksAcrossProjects(slugs, query);
+      } catch (error) {
+        console.error("Board search failed:", error);
+      } finally {
+        if (!cancelled) boardSearchStore.getState().setSearching(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [enabled, search, slugKey]);
+}

--- a/ui/src/stores/boardSearchStore.ts
+++ b/ui/src/stores/boardSearchStore.ts
@@ -1,0 +1,27 @@
+/**
+ * Board search store.
+ *
+ * The Kanban board's search box is backed by the server (so it matches tasks
+ * that were never loaded client-side — chiefly old merged tasks). Because the
+ * search input lives in the shared `BoardFilterHeader` but the fetch is driven
+ * from the board, this tiny store is the channel that lets the header render a
+ * subtle in-flight spinner while a server search runs.
+ */
+
+import { createStore } from "zustand/vanilla";
+import { subscribeWithSelector } from "zustand/middleware";
+
+export interface BoardSearchState {
+  /** A backend search fetch is currently in flight. */
+  searching: boolean;
+  setSearching: (searching: boolean) => void;
+}
+
+export const boardSearchStore = createStore<BoardSearchState>()(
+  subscribeWithSelector((set) => ({
+    searching: false,
+    setSearching: (searching) => set({ searching }),
+  })),
+);
+
+export { useBoardSearchStore } from "./useBoardSearchStore";

--- a/ui/src/stores/useBoardSearchStore.ts
+++ b/ui/src/stores/useBoardSearchStore.ts
@@ -1,0 +1,18 @@
+/**
+ * useBoardSearchStore - React hook for the board search in-flight state.
+ */
+
+import { useStoreWithSelector } from "./useStoreWithSelector";
+import { boardSearchStore, type BoardSearchState } from "./boardSearchStore";
+
+export { boardSearchStore } from "./boardSearchStore";
+
+export function useBoardSearchStore(): BoardSearchState;
+export function useBoardSearchStore<T>(
+  selector: (state: BoardSearchState) => T,
+): T;
+export function useBoardSearchStore<T>(
+  selector?: (state: BoardSearchState) => T,
+): BoardSearchState | T {
+  return useStoreWithSelector(boardSearchStore, selector);
+}


### PR DESCRIPTION
## Problem

PR #1790 changed the board to load only **active** (non-closed) tasks plus the **first page (200)** of closed/merged tasks per project, with a "Load more" button on the Merged column. But the search box still filtered **client-side only** (`task.title.toLowerCase().includes(q)` over the loaded store), so old merged tasks that were never hydrated could never match.

## Approach

**Frontend — backend-backed search**
- `server.ts` — `searchTasksAcrossProjects(slugs, query)` runs `task_list` with the `text` filter per project, capped at **200 results/project** (single page, no exhaustive pagination — `SEARCH_RESULT_CAP`), and **additively upserts** matches into the id-keyed task store. It does **not** touch the Merged-column pagination cursors, so "Load more" keeps advancing from its own offsets.
- `useBoardServerSearch` — **debounces the query 300ms** and drives the fetch; a no-op in controlled board mode (`tasksProp`).
- `boardSearchStore` — in-flight flag so the header shows a **subtle spinner** in the search box while a server search runs.
- `KanbanBoard` — the client display predicate now matches **title OR description, case-insensitive**, mirroring the server filter so backend matches aren't hidden.

**Backend — LIKE → ILIKE**
- `build_where`'s `text` filter now uses `ILIKE` (was case-sensitive `LIKE`), so a search for `auth` finds `Auth`/`AUTHZ`. This is a runtime-SQL change with **no schema/doc impact** — the MCP schema and generated types are untouched, so there's no generated-type churn (and no golden-file collision with concurrent PRs). Filter matrix extended with a case-insensitive regression.

**Incidental fix — stale #1790 golden files**
- #1790 added `status`/`sort` descriptions to `TaskListParams`/`shared_schemas.rs` but only regenerated *some* derived goldens. The `djinn-agent` role snapshots (lead/planner/worker) and the `DjinnMcpServer` corpus fixture were left stale on `main`, so the full merge-queue suite fails for **every** PR. Regenerated them; the diffs contain only #1790's descriptions.

## Test evidence
- `cargo clippy --workspace --all-features` clean. `filter_matrices::task_list_filter` (incl. new case-insensitive case) 6/6 pass on Postgres :5433. Role-snapshot + corpus-fixture asserts pass.
- `tsc -b` + ESLint clean. New vitest for `searchTasksAcrossProjects` and the debounce hook; board/store suites pass.
- Pre-existing env flake `ProposalsPage.test.tsx` (jsdom canvas `getContext`) fails identically on base — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)