### PR TITLE
fix(tripwires): emit tripwire.hold.released on human hold-task close

### DIFF
--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_lead()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_lead()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__planner_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_planner()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_planner()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__worker_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__worker_tool_schemas.snap
@@ -31,7 +31,8 @@ expression: tool_schemas_worker()
       "type": "object",
       "properties": {
         "status": {
-          "type": "string"
+          "type": "string",
+          "description": "Positive (\"open\") or negative (\"!closed\") status filter. A leading \"!\" matches every task whose status differs from the given value."
         },
         "issue_type": {
           "type": "string"
@@ -51,7 +52,8 @@ expression: tool_schemas_worker()
           "description": "Epic ID to filter by"
         },
         "sort": {
-          "type": "string"
+          "type": "string",
+          "description": "priority (default), created, created_desc, updated, updated_desc, closed (closed_at DESC then created_at DESC)."
         },
         "limit": {
           "type": "integer"

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -1278,6 +1278,12 @@ impl CoordinatorActor {
                     }
                     self.persist_terminal_linked_spike_evidence_from_closed_task(&task)
                         .await;
+                    // Tripwire: a closed `human-review-hold` task means a human
+                    // resolved the hold — emit `tripwire.hold.released` on each
+                    // held source so the merge-boundary gate can clear for the
+                    // current head (no release producer existed before; hold
+                    // task `yynd` never cleared its gate on close).
+                    self.emit_tripwire_release_on_hold_close(&task).await;
                     // Fire epic completion rules (spike/batch).
                     self.on_task_closed(&task).await;
                 }

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -137,6 +137,7 @@ mod refinement_e2e_evidence_regression_tests;
 mod refinement_outcome;
 mod refinement_recovery;
 pub mod rules;
+mod tripwire_hold_release;
 mod types;
 mod wave;
 mod worker_lifecycle;

--- a/server/crates/djinn-coordinator/src/tripwire_hold_release.rs
+++ b/server/crates/djinn-coordinator/src/tripwire_hold_release.rs
@@ -1,0 +1,187 @@
+//! Coordinator wiring for emitting `tripwire.hold.released` events when a
+//! human closes a `human-review-hold` remediation task.
+//!
+//! ## The gap this closes
+//!
+//! The active-hold interpreter ([`crate::tripwires::active_hold`]) clears a
+//! tripwire hold only when it sees a `tripwire.hold.released` event covering
+//! the held findings for the current head. Historically **no code emitted
+//! that event**: closing a `human-review-hold` task stamped
+//! `human_review_resolved_at` and unparked the source (via
+//! `mark_human_review_resolved`) but never wrote the release. The merge-time
+//! tripwire gate (`reconcile_tripwire_hold`) therefore stayed held for the
+//! current head until a new commit superseded it — incident: hold task
+//! `yynd` was closed by a human yet the gate never cleared.
+//!
+//! ## What this does
+//!
+//! When the coordinator observes a closed task carrying the
+//! `human-review-hold` label, for every source task it was blocking it:
+//!
+//! 1. Loads the source and takes its current PR head SHA
+//!    (`ci_github_head_sha`, the poller-maintained head).
+//! 2. Recomputes the active-hold state over the source's activity entries
+//!    ([`compute_active_hold_state`]).
+//! 3. If a hold is active for the current head, emits one
+//!    `tripwire.hold.released` event covering **all** currently-held finding
+//!    keys, with `released_by = "human"` and rationale = the hold task's
+//!    close reason (falling back to a fixed non-empty string).
+//!
+//! If no hold is active for the current head (already superseded / released),
+//! emission is skipped — no spurious event. The producer is idempotent: the
+//! release idempotency key is stable, and the interpreter tolerates duplicate
+//! releases.
+
+use super::*;
+
+use crate::tripwires::{
+    ActivityEntryRef, HUMAN_RELEASE_ACTOR, HUMAN_RELEASE_ROLE, TRIPWIRE_EVENT_HOLD_RELEASED,
+    build_hold_released_payload, compute_active_hold_state,
+};
+
+impl CoordinatorActor {
+    /// Emit `tripwire.hold.released` on each source task held by a just-closed
+    /// `human-review-hold` remediation task. Best-effort and fail-open on the
+    /// emission side: a failure to write a release must not wedge the close.
+    pub(super) async fn emit_tripwire_release_on_hold_close(
+        &self,
+        hold_task: &djinn_core::models::Task,
+    ) {
+        if !crate::roles::is_human_review_hold(hold_task) {
+            return;
+        }
+
+        let task_repo = self.task_repo();
+
+        let blocked = match task_repo.list_blocked_by(&hold_task.id).await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    hold_task_id = %hold_task.short_id,
+                    error = %e,
+                    "tripwire release: failed to list source tasks held by closed hold task"
+                );
+                return;
+            }
+        };
+        if blocked.is_empty() {
+            return;
+        }
+
+        // Rationale = the hold task's close reason; the pure builder applies a
+        // non-empty fallback when it is absent/blank (payload validator rejects
+        // an empty rationale).
+        let rationale = hold_task.close_reason.clone().unwrap_or_default();
+        let now = ::time::OffsetDateTime::now_utc()
+            .format(&::time::format_description::well_known::Rfc3339)
+            .unwrap_or_default();
+
+        for blocked_ref in blocked {
+            let source = match task_repo.get(&blocked_ref.task_id).await {
+                Ok(Some(t)) => t,
+                Ok(None) => continue,
+                Err(e) => {
+                    tracing::warn!(
+                        hold_task_id = %hold_task.short_id,
+                        source_task_id = %blocked_ref.task_id,
+                        error = %e,
+                        "tripwire release: failed to load source task"
+                    );
+                    continue;
+                }
+            };
+
+            // The current head is the poller-maintained GitHub head SHA. With
+            // no known head there is nothing to release against.
+            let Some(head_sha) = source
+                .ci_github_head_sha
+                .as_deref()
+                .filter(|s| !s.is_empty())
+            else {
+                continue;
+            };
+
+            let entries = match task_repo.list_activity(&source.id).await {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!(
+                        source_task_id = %source.short_id,
+                        error = %e,
+                        "tripwire release: failed to query source activity"
+                    );
+                    continue;
+                }
+            };
+            let entry_refs: Vec<ActivityEntryRef> =
+                entries.iter().map(ActivityEntryRef::from_entry).collect();
+
+            let state = compute_active_hold_state(&entry_refs, head_sha);
+            if !state.held {
+                // No active hold for the current head (superseded or already
+                // released) — skip emission.
+                tracing::info!(
+                    source_task_id = %source.short_id,
+                    head_sha = %head_sha,
+                    "tripwire release: no active hold for current head on hold-task close — skipping"
+                );
+                continue;
+            }
+
+            let pr_number = source
+                .pr_url
+                .as_deref()
+                .and_then(|url| crate::pr_poller::parse_pr_url(url).map(|(_, _, n)| n));
+
+            let payload = match build_hold_released_payload(
+                &state,
+                &source.id,
+                &source.project_id,
+                pr_number,
+                HUMAN_RELEASE_ACTOR,
+                HUMAN_RELEASE_ROLE,
+                &rationale,
+                &now,
+            ) {
+                Ok(Some(p)) => p,
+                Ok(None) => continue,
+                Err(e) => {
+                    tracing::warn!(
+                        source_task_id = %source.short_id,
+                        error = %e,
+                        "tripwire release: failed to build hold-released payload"
+                    );
+                    continue;
+                }
+            };
+
+            let payload_json = serde_json::to_string(&payload).unwrap_or_default();
+            match task_repo
+                .log_activity(
+                    Some(&source.id),
+                    HUMAN_RELEASE_ACTOR,
+                    HUMAN_RELEASE_ROLE,
+                    TRIPWIRE_EVENT_HOLD_RELEASED,
+                    &payload_json,
+                )
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!(
+                        source_task_id = %source.short_id,
+                        hold_task_id = %hold_task.short_id,
+                        head_sha = %head_sha,
+                        released_findings = payload.released_findings.len(),
+                        "tripwire release: emitted tripwire.hold.released on human hold-task close"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        source_task_id = %source.short_id,
+                        error = %e,
+                        "tripwire release: failed to log tripwire.hold.released event"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/server/crates/djinn-coordinator/src/tripwires/hold_release.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/hold_release.rs
@@ -1,0 +1,433 @@
+//! Producer helpers for `tripwire.hold.released` activity events.
+//!
+//! The active-hold interpreter ([`crate::tripwires::active_hold`]) clears a
+//! hold only when it observes a [`TRIPWIRE_EVENT_HOLD_RELEASED`] event whose
+//! `head_sha` matches the current head and whose released finding
+//! idempotency keys cover the held findings. Until this module landed there
+//! was **no producer** of that event anywhere in the coordinator — a human
+//! closing a `human-review-hold` remediation task unparked the source (via
+//! `mark_human_review_resolved`) but never wrote the release event, so the
+//! merge-boundary tripwire gate could never clear for the current head short
+//! of pushing a new commit (incident: hold task `yynd`).
+//!
+//! This module is **pure** — no DB, GitHub, or LLM calls. It builds and
+//! validates a [`TripwireHoldReleasedPayload`] from a computed
+//! [`ActiveHoldState`]; the actual activity-log write is the caller's
+//! responsibility (see `CoordinatorActor::emit_tripwire_release_on_hold_close`).
+
+use sha2::{Digest, Sha256};
+
+use crate::tripwires::active_hold::ActiveHoldState;
+use crate::tripwires::activity_payloads::{
+    TRIPWIRE_EVENT_HOLD_RELEASED, TripwireHoldReleasedPayload,
+};
+
+/// Fallback rationale stamped on a release when the closing hold task carries
+/// no close reason. The payload validator rejects an empty rationale, so a
+/// non-empty fallback is required for the fail-closed close path.
+pub const DEFAULT_HOLD_RELEASE_RATIONALE: &str = "human review hold closed";
+
+/// Actor id stamped on a release emitted by the human hold-task-close path.
+/// The close is driven by a human resolving the `human-review-hold`
+/// remediation task; the specific GitHub login is not resolvable at the
+/// coordinator event boundary, so a stable `"human"` sentinel is used.
+pub const HUMAN_RELEASE_ACTOR: &str = "human";
+
+/// Role stamped on a release emitted by the human hold-task-close path.
+pub const HUMAN_RELEASE_ROLE: &str = "human_reviewer";
+
+/// Build a deterministic idempotency key for a hold-release event.
+///
+/// The key is a SHA-256 hex digest of:
+///
+/// ```text
+/// release:{task_id}:{pr_number}:{head_sha}:{released_by}:{policy_revision}
+/// ```
+///
+/// This mirrors the release-key derivation documented on
+/// [`TripwireHoldReleasedPayload`] (`(task_id, pr_number, head_sha,
+/// released_by, policy_revision)`) so the same logical release recorded twice
+/// collapses to one stable key, while a different head SHA produces a
+/// distinct key (stale-release protection).
+pub fn build_hold_release_key(
+    task_id: &str,
+    pr_number: Option<u64>,
+    head_sha: &str,
+    released_by: &str,
+    policy_revision: &str,
+) -> String {
+    let pr = pr_number.map(|n| n.to_string()).unwrap_or_default();
+    let payload = format!("release:{task_id}:{pr}:{head_sha}:{released_by}:{policy_revision}");
+    let hash = Sha256::digest(payload.as_bytes());
+    format!("sha256:{}", hex::encode(hash))
+}
+
+/// Build a validated [`TripwireHoldReleasedPayload`] that releases **every**
+/// finding currently active in `state` for the state's head SHA.
+///
+/// Returns:
+///
+/// - `Ok(None)` when the state carries no active hold — nothing to release,
+///   the caller should skip emission (no spurious event).
+/// - `Ok(Some(payload))` with a validated payload covering all active
+///   findings when a hold exists.
+/// - `Err(msg)` when the constructed payload fails validation (empty
+///   actor / role after the rationale fallback is applied).
+///
+/// The `head_sha` of the release is taken from `state.head_sha`, so a release
+/// built from a hold computed against head A can never clear a hold on head B
+/// (the active-hold interpreter keys releases on `head_sha`).
+#[allow(clippy::too_many_arguments)]
+pub fn build_hold_released_payload(
+    state: &ActiveHoldState,
+    task_id: &str,
+    project_id: &str,
+    pr_number: Option<u64>,
+    released_by: &str,
+    released_by_role: &str,
+    rationale: &str,
+    released_at: &str,
+) -> Result<Option<TripwireHoldReleasedPayload>, String> {
+    if !state.held {
+        return Ok(None);
+    }
+
+    // The payload validator rejects an empty rationale; fall back to a fixed
+    // string when the closing hold task carried no close reason.
+    let rationale = if rationale.trim().is_empty() {
+        DEFAULT_HOLD_RELEASE_RATIONALE
+    } else {
+        rationale
+    };
+
+    let policy_revision = state.policy_revision.clone().unwrap_or_default();
+    let idempotency_key = build_hold_release_key(
+        task_id,
+        pr_number,
+        &state.head_sha,
+        released_by,
+        &policy_revision,
+    );
+
+    let payload = TripwireHoldReleasedPayload {
+        event_type: TRIPWIRE_EVENT_HOLD_RELEASED.to_owned(),
+        task_id: task_id.to_owned(),
+        project_id: project_id.to_owned(),
+        pr_number,
+        head_sha: state.head_sha.clone(),
+        policy_revision,
+        released_by: released_by.to_owned(),
+        released_by_role: released_by_role.to_owned(),
+        rationale: rationale.to_owned(),
+        released_findings: state.active_findings.clone(),
+        idempotency_key,
+        released_at: Some(released_at.to_owned()),
+    };
+
+    payload.validate()?;
+    Ok(Some(payload))
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tripwires::active_hold::{ActivityEntryRef, compute_active_hold_state};
+    use crate::tripwires::activity_payloads::{
+        TRIPWIRE_EVENT_GATE_HELD, TripwireEvidenceSpan, TripwireFindingSummary,
+        TripwireGateDecisionPayload, TripwireSeverity,
+    };
+
+    const TASK_ID: &str = "task-001";
+    const PROJECT_ID: &str = "proj-001";
+    const PR_NUMBER: u64 = 42;
+    const POLICY_REV: &str = "org-policy:17";
+
+    fn enforcement_finding(rule_id: &str, path: &str, key: &str) -> TripwireFindingSummary {
+        TripwireFindingSummary {
+            rule_id: rule_id.to_owned(),
+            reason_code: format!("tripwire.{rule_id}.changed"),
+            severity: TripwireSeverity::HumanReviewRequired,
+            evidence: TripwireEvidenceSpan::file(path),
+            idempotency_key: key.to_owned(),
+        }
+    }
+
+    fn gate_held_entry(
+        head_sha: &str,
+        findings: Vec<TripwireFindingSummary>,
+        created_at: &str,
+    ) -> ActivityEntryRef {
+        let enforcement_count = findings
+            .iter()
+            .filter(|f| f.severity == TripwireSeverity::HumanReviewRequired)
+            .count() as u32;
+        let payload = TripwireGateDecisionPayload {
+            event_type: TRIPWIRE_EVENT_GATE_HELD.to_owned(),
+            task_id: TASK_ID.to_owned(),
+            project_id: PROJECT_ID.to_owned(),
+            pr_number: Some(PR_NUMBER),
+            head_sha: head_sha.to_owned(),
+            base_sha: None,
+            policy_revision: POLICY_REV.to_owned(),
+            allowlist_revision: None,
+            findings,
+            enforcement_finding_count: enforcement_count,
+            report_only_finding_count: 0,
+            idempotency_key: format!("sha256:gate:{head_sha}"),
+            decided_at: Some(created_at.to_owned()),
+        };
+        ActivityEntryRef {
+            event_type: TRIPWIRE_EVENT_GATE_HELD.to_owned(),
+            payload: serde_json::to_string(&payload).unwrap_or_default(),
+            created_at: created_at.to_owned(),
+        }
+    }
+
+    /// A release built from an active single-finding hold must validate and
+    /// carry the held finding, and — fed back into the interpreter as an
+    /// activity entry — must clear the hold for the same head (end-to-end
+    /// producer→interpreter round-trip).
+    #[test]
+    fn release_from_active_hold_clears_same_head() {
+        let f1 = enforcement_finding("migration_change", "migrations/001.sql", "key-mig");
+        let held = vec![gate_held_entry("sha-aaa", vec![f1], "2026-01-01T00:00:00Z")];
+        let state = compute_active_hold_state(&held, "sha-aaa");
+        assert!(state.held);
+
+        let payload = build_hold_released_payload(
+            &state,
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR_NUMBER),
+            HUMAN_RELEASE_ACTOR,
+            HUMAN_RELEASE_ROLE,
+            "resolved after manual review",
+            "2026-01-02T00:00:00Z",
+        )
+        .expect("payload builds")
+        .expect("hold is active so a payload is produced");
+
+        payload.validate().expect("payload validates");
+        assert_eq!(payload.head_sha, "sha-aaa");
+        assert_eq!(payload.released_findings.len(), 1);
+        assert_eq!(payload.released_findings[0].idempotency_key, "key-mig");
+        assert_eq!(payload.released_by, HUMAN_RELEASE_ACTOR);
+
+        // Feed the release back into the interpreter alongside the held event.
+        let release_entry = ActivityEntryRef {
+            event_type: TRIPWIRE_EVENT_HOLD_RELEASED.to_owned(),
+            payload: serde_json::to_string(&payload).unwrap_or_default(),
+            created_at: "2026-01-02T00:00:00Z".to_owned(),
+        };
+        let mut entries = held.clone();
+        entries.push(release_entry);
+        let cleared = compute_active_hold_state(&entries, "sha-aaa");
+        assert!(
+            !cleared.held,
+            "release must clear the hold for the same head"
+        );
+        assert!(cleared.released_finding_keys.contains("key-mig"));
+    }
+
+    /// A multi-finding hold must be fully covered by the human-close release
+    /// (partial coverage regression — all held findings released at once).
+    #[test]
+    fn release_covers_all_multi_findings() {
+        let f1 = enforcement_finding("migration_change", "migrations/001.sql", "key-mig");
+        let f2 = enforcement_finding("unsafe_code_change", "src/native.rs", "key-unsafe");
+        let held = vec![gate_held_entry(
+            "sha-aaa",
+            vec![f1, f2],
+            "2026-01-01T00:00:00Z",
+        )];
+        let state = compute_active_hold_state(&held, "sha-aaa");
+        assert_eq!(state.active_findings.len(), 2);
+
+        let payload = build_hold_released_payload(
+            &state,
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR_NUMBER),
+            HUMAN_RELEASE_ACTOR,
+            HUMAN_RELEASE_ROLE,
+            "reviewed",
+            "2026-01-02T00:00:00Z",
+        )
+        .expect("payload builds")
+        .expect("hold active");
+        assert_eq!(payload.released_findings.len(), 2);
+
+        let release_entry = ActivityEntryRef {
+            event_type: TRIPWIRE_EVENT_HOLD_RELEASED.to_owned(),
+            payload: serde_json::to_string(&payload).unwrap_or_default(),
+            created_at: "2026-01-02T00:00:00Z".to_owned(),
+        };
+        let mut entries = held.clone();
+        entries.push(release_entry);
+        let cleared = compute_active_hold_state(&entries, "sha-aaa");
+        assert!(!cleared.held, "multi-finding hold fully cleared");
+        assert_eq!(cleared.active_findings.len(), 0);
+    }
+
+    /// A release built for head A must NOT clear a hold on head B
+    /// (stale-release protection preserved through the producer).
+    #[test]
+    fn release_for_old_head_does_not_clear_new_head() {
+        let old_f = enforcement_finding("migration_change", "migrations/001.sql", "key-old");
+        let held_old = vec![gate_held_entry(
+            "sha-old",
+            vec![old_f],
+            "2026-01-01T00:00:00Z",
+        )];
+        let state_old = compute_active_hold_state(&held_old, "sha-old");
+
+        let payload = build_hold_released_payload(
+            &state_old,
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR_NUMBER),
+            HUMAN_RELEASE_ACTOR,
+            HUMAN_RELEASE_ROLE,
+            "reviewed",
+            "2026-01-02T00:00:00Z",
+        )
+        .expect("payload builds")
+        .expect("hold active");
+        assert_eq!(payload.head_sha, "sha-old");
+
+        // A new head is held (fresh push). The old-head release must not leak.
+        let new_f = enforcement_finding("migration_change", "migrations/001.sql", "key-new");
+        let release_entry = ActivityEntryRef {
+            event_type: TRIPWIRE_EVENT_HOLD_RELEASED.to_owned(),
+            payload: serde_json::to_string(&payload).unwrap_or_default(),
+            created_at: "2026-01-02T00:00:00Z".to_owned(),
+        };
+        let entries = vec![
+            gate_held_entry("sha-new", vec![new_f], "2026-01-03T00:00:00Z"),
+            release_entry,
+        ];
+        let state_new = compute_active_hold_state(&entries, "sha-new");
+        assert!(
+            state_new.held,
+            "old-head release must not clear the new-head hold"
+        );
+        assert!(state_new.released_finding_keys.is_empty());
+    }
+
+    /// A clear state (no active hold) must produce no payload — the close
+    /// path skips emission (no spurious event).
+    #[test]
+    fn no_payload_when_not_held() {
+        let state = compute_active_hold_state::<&[ActivityEntryRef]>(&[], "sha-none");
+        assert!(!state.held);
+        let out = build_hold_released_payload(
+            &state,
+            TASK_ID,
+            PROJECT_ID,
+            None,
+            HUMAN_RELEASE_ACTOR,
+            HUMAN_RELEASE_ROLE,
+            "irrelevant",
+            "2026-01-02T00:00:00Z",
+        )
+        .expect("build ok");
+        assert!(out.is_none(), "no hold → no release payload");
+    }
+
+    /// An empty close reason must fall back to the fixed rationale so the
+    /// payload validator (which rejects empty rationale) accepts it.
+    #[test]
+    fn empty_rationale_falls_back() {
+        let f1 = enforcement_finding("migration_change", "migrations/001.sql", "key-mig");
+        let held = vec![gate_held_entry("sha-aaa", vec![f1], "2026-01-01T00:00:00Z")];
+        let state = compute_active_hold_state(&held, "sha-aaa");
+
+        let payload = build_hold_released_payload(
+            &state,
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR_NUMBER),
+            HUMAN_RELEASE_ACTOR,
+            HUMAN_RELEASE_ROLE,
+            "   ", // whitespace-only close reason
+            "2026-01-02T00:00:00Z",
+        )
+        .expect("build ok")
+        .expect("hold active");
+        assert_eq!(payload.rationale, DEFAULT_HOLD_RELEASE_RATIONALE);
+        payload.validate().expect("fallback rationale validates");
+    }
+
+    /// The release idempotency key is stable for identical inputs and
+    /// changes with the head SHA (double-close does not corrupt state; a new
+    /// head produces a distinct key).
+    #[test]
+    fn release_key_stable_and_head_sensitive() {
+        let k1 = build_hold_release_key(
+            TASK_ID,
+            Some(PR_NUMBER),
+            "sha-a",
+            HUMAN_RELEASE_ACTOR,
+            POLICY_REV,
+        );
+        let k2 = build_hold_release_key(
+            TASK_ID,
+            Some(PR_NUMBER),
+            "sha-a",
+            HUMAN_RELEASE_ACTOR,
+            POLICY_REV,
+        );
+        assert_eq!(k1, k2, "same inputs → same key");
+        let k3 = build_hold_release_key(
+            TASK_ID,
+            Some(PR_NUMBER),
+            "sha-b",
+            HUMAN_RELEASE_ACTOR,
+            POLICY_REV,
+        );
+        assert_ne!(k1, k3, "different head → different key");
+        assert!(k1.starts_with("sha256:"));
+    }
+
+    /// Idempotency: building the release payload twice from the same state
+    /// yields byte-identical payloads (stable key + deterministic fields), so
+    /// a double/re-close cannot produce a diverging release row.
+    #[test]
+    fn double_build_is_idempotent() {
+        let f1 = enforcement_finding("migration_change", "migrations/001.sql", "key-mig");
+        let held = vec![gate_held_entry("sha-aaa", vec![f1], "2026-01-01T00:00:00Z")];
+        let state = compute_active_hold_state(&held, "sha-aaa");
+
+        let p1 = build_hold_released_payload(
+            &state,
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR_NUMBER),
+            HUMAN_RELEASE_ACTOR,
+            HUMAN_RELEASE_ROLE,
+            "reviewed",
+            "2026-01-02T00:00:00Z",
+        )
+        .unwrap()
+        .unwrap();
+        let p2 = build_hold_released_payload(
+            &state,
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR_NUMBER),
+            HUMAN_RELEASE_ACTOR,
+            HUMAN_RELEASE_ROLE,
+            "reviewed",
+            "2026-01-02T00:00:00Z",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(p1.idempotency_key, p2.idempotency_key);
+        assert_eq!(
+            serde_json::to_string(&p1).unwrap(),
+            serde_json::to_string(&p2).unwrap()
+        );
+    }
+}

--- a/server/crates/djinn-coordinator/src/tripwires/mod.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/mod.rs
@@ -24,6 +24,7 @@
 pub mod active_hold;
 pub mod activity_payloads;
 pub mod engine;
+pub mod hold_release;
 pub mod policy;
 pub mod reason_codes;
 pub mod rules;
@@ -55,6 +56,11 @@ pub use engine::{
     ChangedFile, ChangedFileStatus, DiffHunk, EvidenceSpan, GateOutcome, RawFinding,
     TripwireEvaluationInput, TripwireFinding, TripwireFindingSeverity, TripwireGateDecision,
     build_finding_idempotency_key, build_gate_idempotency_key, evaluate, sort_findings,
+};
+#[allow(unused_imports)]
+pub use hold_release::{
+    DEFAULT_HOLD_RELEASE_RATIONALE, HUMAN_RELEASE_ACTOR, HUMAN_RELEASE_ROLE,
+    build_hold_release_key, build_hold_released_payload,
 };
 #[allow(unused_imports)]
 pub use policy::{


### PR DESCRIPTION
## The gap

The tripwire active-hold interpreter (`compute_active_hold_state`) clears a hold **only** when it observes a `tripwire.hold.released` activity event whose `head_sha` matches the current PR head and whose released finding idempotency keys cover the held findings. But **nothing in the codebase emitted that event** — a grep confirmed zero producers of `TRIPWIRE_EVENT_HOLD_RELEASED` outside the contract module (`activity_payloads.rs`) and tests.

When a human closes a `human-review-hold` remediation task, the close path calls `mark_human_review_resolved` (stamps `human_review_resolved_at`, unparks the source) — but **no release event is written**. Consequence: the merge-boundary tripwire gate (`reconcile_tripwire_hold` in `pr_watcher.rs`) could **never** clear for the current head except by pushing a new commit.

**Real incident:** hold task `yynd` was closed by a human; only the pre-undraft unpark ran and the release event was never emitted, so the gate stayed held.

## The fix (Slice 1)

1. **Pure producer** `tripwires::hold_release`:
   - `build_hold_released_payload(...)` — builds + validates a `TripwireHoldReleasedPayload` from a computed `ActiveHoldState`, releasing **every** currently-held finding for the state's `head_sha`. Returns `Ok(None)` when no hold is active (caller skips emission — no spurious event). Falls back to a fixed rationale (`"human review hold closed"`) when the close reason is blank, since the payload validator rejects an empty rationale.
   - `build_hold_release_key(...)` — stable SHA-256 idempotency key over `(task_id, pr_number, head_sha, released_by, policy_revision)`; head-sensitive so a re-close cannot corrupt state and an old-head release cannot masquerade as a new-head one.

2. **Human-close wiring** `CoordinatorActor::emit_tripwire_release_on_hold_close`, invoked from the closed-task event arm in `actor.rs` (the same flow that reaches `mark_human_review_resolved`). For each source task held by the closed `human-review-hold` task, it recomputes the active-hold state over the source's activity entries for its current PR head (`ci_github_head_sha`, the poller-maintained head) and — when a hold is active — emits one `tripwire.hold.released` covering all held finding keys with `released_by = "human"` and rationale = the hold task's close reason.

## Home choice

The producer lives in **djinn-coordinator**, not `djinn-agent`. The human-close event is observed by `CoordinatorActor` (which already handles the closed-task arm), and both `compute_active_hold_state` and the task repository are reachable there without circular deps. The DB `status.rs` close path cannot host it because `djinn-db` cannot depend on `djinn-coordinator`. This also **avoids touching `pr_review_watcher.rs`** (PR #1794 / ufsh conflict surface) — the producer + close wiring do not need it.

## Behavior guarantees (pure producer↔interpreter round-trip tests)

- Closing the hold task → release emitted → `compute_active_hold_state` reports no active hold for the same head.
- Stale-release protection: a release for head A does not clear a hold on head B.
- Partial coverage: multi-finding holds are fully released in one event.
- Close without an active hold (head already superseded) → no event emitted (skip + log info).
- Idempotency: stable key; double-build is byte-identical.

## Verification

- `SQLX_OFFLINE=true cargo clippy -p djinn-coordinator -p djinn-agent --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p djinn-coordinator --lib tripwires::hold_release` — 7 passed.
- `cargo fmt`; size guard passes (`hold_release.rs` 433 lines / 16.7 KB, `tripwire_hold_release.rs` 187 lines / 7.4 KB — both under 1500 lines / 51200 bytes).
- No new migrations; all activity writes go through `TaskRepository::log_activity`.

**Verification gap:** the actor-level glue (`emit_tripwire_release_on_hold_close`) is compile- and clippy-checked but not covered by a DB-backed integration test; the semantics it composes are covered by the pure producer↔interpreter tests.