### PR TITLE
fix(coordinator): merge-queue failures block adoption handoff — stop requeue loops

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/attempt_lifecycle.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/attempt_lifecycle.rs
@@ -279,12 +279,21 @@ pub fn rework_marker_dispatch_key(task_id: &str, role: &str) -> String {
 /// 1. If an in-flight `pending`/`submitted` attempt still exists, the caller's
 ///    normal terminalization owns the `reopened` signal — no marker needed.
 /// 2. Else if the latest non-guard attempt for the pair is already `reopened`
-///    (an in-flight attempt was just terminalized, or a marker already exists),
-///    this is an idempotent no-op.
-/// 3. Else insert a synthetic terminal `reopened` marker row so the respawn
-///    guard's latest-attempt gate treats the task as rework and dispatches a
-///    worker instead of adopting the still-open PR.  This closes the kv6i
-///    invisible-reopen gap (reopens that leave no live attempt behind).
+///    (an in-flight attempt was just terminalized, or a marker already exists
+///    AND is still the newest attempt — rework is already pending), this is an
+///    idempotent no-op.
+/// 3. Else insert OR re-assert a synthetic terminal `reopened` marker row so the
+///    respawn guard's latest-attempt gate treats the task as rework and
+///    dispatches a worker instead of adopting the still-open PR.  This closes
+///    the kv6i invisible-reopen gap (reopens that leave no live attempt behind)
+///    AND the incident-gton merge-queue requeue loop: when a NEWER non-reopened
+///    attempt has landed since the marker was first written (e.g. a rework
+///    worker ran and `completed`, then the merge queue rejected the PR again),
+///    the latest non-guard attempt is that non-reopened row, so this branch
+///    fires and [`TaskAttemptRepository::insert_rework_marker`] REFRESHES the
+///    fixed-key marker's `created_at` to make it the newest attempt again.
+///    Without the refresh the stale marker stayed pinned behind the
+///    `completed` row and the guard re-adopted the open PR forever.
 pub async fn ensure_rework_marker(
     db: &djinn_db::Database,
     task_id: &str,

--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
@@ -511,3 +511,7 @@ pub async fn handoff_adopted_pr_to_poller(
 #[cfg(test)]
 #[path = "respawn_guard_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "respawn_guard_mergequeue_tests.rs"]
+mod mergequeue_tests;

--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard_mergequeue_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard_mergequeue_tests.rs
@@ -1,0 +1,231 @@
+//! Merge-queue requeue-loop regression tests for the respawn guard (incident
+//! gton).  Split into its own `#[path]` sibling (like `respawn_guard_tests.rs`)
+//! to keep each test file under the size guard; `use super::*` semantics and
+//! private-item access are unchanged.
+//!
+//! Task gton (adopted PR #1765, no live worker session) entered a 13-cycle
+//! merge-queue requeue loop: GitHub dequeued the PR for `failed_checks` (a
+//! merge_group-only test failure — PR-level CI stays green, so the task-row
+//! `PrReworkSignal` is blind), the poller reopened the task via `PrCiFailed`,
+//! but the respawn guard re-adopted the open PR and handed it back to
+//! `pr_review` every pass, so the poller re-enqueued and the same failure
+//! recurred — strike-free, no worker, no intervention.
+//!
+//! Root cause: the durable `reopened` rework marker uses a fixed dispatch key.
+//! Once a rework worker had run and left a NEWER non-reopened terminal attempt
+//! (`completed`), a later merge-queue reopen with no live attempt to
+//! terminalize could not re-assert the signal (the old `ON CONFLICT DO
+//! NOTHING`), so the stale marker stayed pinned behind the `completed` row in
+//! `created_at` order and the guard saw a non-reopened latest attempt → it
+//! re-adopted the PR.  The fix makes `insert_rework_marker` REFRESH the marker
+//! so it is the newest attempt again after every reopen, forcing the guard down
+//! the rework-dispatch path (which reaches the reopen-count intervention gate,
+//! since a merge-queue reopen is a `merge_queue_failed` quality strike).
+
+use super::*;
+use djinn_core::events::EventBus;
+use djinn_core::models::task_attempt::TaskAttemptOutcome;
+use djinn_db::{Database, EpicRepository, TaskAttemptRepository, TaskRepository};
+
+fn test_db() -> Database {
+    Database::open_in_memory().unwrap()
+}
+
+async fn create_task(db: &Database) -> djinn_core::models::Task {
+    let event_bus = EventBus::noop();
+    let epic_repo = EpicRepository::new(db.clone(), event_bus.clone());
+    let epic = epic_repo
+        .create("Epic", "", "", "", "", None)
+        .await
+        .unwrap();
+    let task_repo = TaskRepository::new(db.clone(), event_bus);
+    task_repo
+        .create(&epic.id, "Test task", "", "", "task", 0, "", None)
+        .await
+        .unwrap()
+}
+
+const PR: &str = "https://github.example/owner/repo/pull/1765";
+
+/// Simulate a merge-queue dequeue reopen exactly as
+/// `terminalize_for_pr_outcome` does: terminalize any live attempt to
+/// `reopened` and ensure a durable rework marker.
+async fn merge_queue_reopen(db: &Database, task_id: &str, cycle: u32) {
+    super::super::attempt_lifecycle::record_rework_reopen(
+        db,
+        task_id,
+        "worker",
+        Some(PR),
+        Some(&format!(
+            "merge queue rejected PR (reason: failed_checks) — cycle {cycle}"
+        )),
+        None,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mergequeue_reopen_after_completed_worker_re_asserts_rework_not_adopt() {
+    let db = test_db();
+    let task = create_task(&db).await;
+
+    // First merge-queue dequeue reopens for rework; no live attempt to
+    // terminalize, so a durable `reopened` marker is written.
+    merge_queue_reopen(&db, &task.id, 1).await;
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", Some(PR), None).await,
+        RespawnGuardDecision::Allow,
+        "fresh rework marker must bypass adoption"
+    );
+
+    // A rework worker dispatches and finishes: a NEWER non-reopened terminal
+    // attempt than the marker (the masking row).
+    let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+    super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+        .await
+        .expect("record_dispatch_start should succeed");
+    super::super::attempt_lifecycle::advance_latest_to_terminal(
+        &db,
+        super::super::attempt_lifecycle::TerminalAdvancementParams {
+            task_id: &task.id,
+            role: "worker",
+            outcome: TaskAttemptOutcome::Completed,
+            pr_url: Some(PR),
+            submit_ref: None,
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: Some("rework worker completed"),
+            summary_json: None,
+            log_tail: None,
+        },
+    )
+    .await;
+
+    // The SECOND merge-queue dequeue: still no live attempt to terminalize.
+    // Pre-fix this was a no-op and the guard adopted; post-fix the marker is
+    // re-asserted as the newest attempt.
+    merge_queue_reopen(&db, &task.id, 2).await;
+
+    // No handoff, no adoption: the guard must take the rework-dispatch path.
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", Some(PR), None).await,
+        RespawnGuardDecision::Allow,
+        "a merge-queue reopen after a completed worker must re-assert rework, \
+         not re-adopt the open PR (incident gton requeue loop)"
+    );
+
+    // Exactly one marker row exists (re-assert refreshes it, never stacks).
+    let repo = TaskAttemptRepository::new(db.clone());
+    let markers = repo
+        .list_for_task(&task.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|a| {
+            a.dispatch_key
+                == super::super::attempt_lifecycle::rework_marker_dispatch_key(&task.id, "worker")
+        })
+        .count();
+    assert_eq!(markers, 1, "marker re-assert must not stack duplicate rows");
+}
+
+/// Full incident replay: adopt a healthy open PR → hand it to the poller →
+/// merge-queue reopen after a completed rework worker → the guard must NOT
+/// re-adopt/handoff but bypass to the rework-dispatch path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn adopt_then_handoff_then_mergequeue_loop_bypasses_adoption() {
+    let db = test_db();
+    let task = create_task(&db).await; // open, retains pr_url
+    let task_repo = TaskRepository::new(db.clone(), EventBus::noop());
+
+    // Healthy adoption on the first ready pass (#1785 handoff preserved).
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", Some(PR), None).await,
+        RespawnGuardDecision::Adopted {
+            pr_url: PR.to_owned()
+        },
+        "a healthy open PR is still adopted"
+    );
+    record_adopted_pr_attempt(&db, &task.id, "worker", PR, Some("adopted")).await;
+    assert!(handoff_adopted_pr_to_poller(&task_repo, &task.id, &task.status, PR).await);
+
+    // Poller enqueues, merge_group fails, reopens (cycle 1) → back to open.
+    merge_queue_reopen(&db, &task.id, 1).await;
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", Some(PR), None).await,
+        RespawnGuardDecision::Allow,
+        "cycle 1: marker present → bypass adoption"
+    );
+
+    // A rework worker runs and completes (masking row lands).
+    let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+    super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+        .await
+        .expect("record_dispatch_start should succeed");
+    super::super::attempt_lifecycle::advance_latest_to_terminal(
+        &db,
+        super::super::attempt_lifecycle::TerminalAdvancementParams {
+            task_id: &task.id,
+            role: "worker",
+            outcome: TaskAttemptOutcome::Completed,
+            pr_url: Some(PR),
+            submit_ref: None,
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: Some("rework completed"),
+            summary_json: None,
+            log_tail: None,
+        },
+    )
+    .await;
+
+    // Cycle 2 merge-queue reopen: the guard must still bypass adoption despite
+    // the newer `completed` attempt (this was the wedge).
+    merge_queue_reopen(&db, &task.id, 2).await;
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", Some(PR), None).await,
+        RespawnGuardDecision::Allow,
+        "cycle 2: re-asserted marker → bypass adoption, no requeue loop"
+    );
+}
+
+/// A genuinely healthy adopted PR (no rework reopen) with a stale prior
+/// `completed` attempt must STILL adopt — the re-assert must not fire without a
+/// reopen, so #1785 healthy-adoption behavior is preserved.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn healthy_adopted_pr_with_completed_attempt_still_adopts() {
+    let db = test_db();
+    let task = create_task(&db).await;
+
+    let dk = super::super::attempt_lifecycle::make_dispatch_key(&task.id, "worker");
+    super::super::attempt_lifecycle::record_dispatch_start(&db, &task.id, "worker", None, &dk)
+        .await
+        .expect("record_dispatch_start should succeed");
+    super::super::attempt_lifecycle::advance_latest_to_terminal(
+        &db,
+        super::super::attempt_lifecycle::TerminalAdvancementParams {
+            task_id: &task.id,
+            role: "worker",
+            outcome: TaskAttemptOutcome::Completed,
+            pr_url: Some(PR),
+            submit_ref: None,
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: Some("work landed, PR healthy in review"),
+            summary_json: None,
+            log_tail: None,
+        },
+    )
+    .await;
+
+    assert_eq!(
+        run_respawn_guard(&db, &task.id, "worker", Some(PR), None).await,
+        RespawnGuardDecision::Adopted {
+            pr_url: PR.to_owned()
+        },
+        "no reopen → no marker → healthy PR is adopted (no false rework bypass)"
+    );
+}

--- a/server/crates/djinn-db/src/repositories/task_attempt.rs
+++ b/server/crates/djinn-db/src/repositories/task_attempt.rs
@@ -116,7 +116,10 @@ pub struct GuardAdoptedPrTaskAttemptParams<'a> {
 /// the respawn guard's latest-attempt gate a durable "this PR needs a worker"
 /// signal even for reopens that leave no live attempt behind (the kv6i
 /// invisible-reopen gap). Idempotent on `dispatch_key`
-/// (`{task_id}:{role}:rework_marker`) via `ON CONFLICT DO NOTHING`.
+/// (`{task_id}:{role}:rework_marker`): on conflict the marker is re-asserted
+/// (its `created_at` refreshed to now) so it becomes the newest attempt again
+/// after a later non-reopened attempt landed — the incident-gton merge-queue
+/// requeue-loop fix.
 #[derive(Clone, Debug)]
 pub struct ReworkMarkerTaskAttemptParams<'a> {
     pub id: &'a str,
@@ -485,8 +488,8 @@ impl TaskAttemptRepository {
         })
     }
 
-    /// Insert a durable `reopened` rework-marker attempt row.  Idempotent on
-    /// `dispatch_key`.
+    /// Insert (or re-assert) a durable `reopened` rework-marker attempt row.
+    /// Idempotent on `dispatch_key` — one marker row per (task, role).
     ///
     /// The row is terminal (`reopened` outcome) with a NULL `session_id` and no
     /// guard decision — it is a synthetic marker, not a real dispatch.  It is
@@ -494,6 +497,22 @@ impl TaskAttemptRepository {
     /// attempt existed to terminalize, so the respawn guard's latest-attempt
     /// gate still sees a `reopened` newest attempt and dispatches a rework
     /// worker instead of adopting the open PR (the kv6i invisible-reopen gap).
+    ///
+    /// **Re-assertable (incident gton):** on conflict the marker is REFRESHED
+    /// (`created_at`/`terminal_at`/`updated_at` bumped to now, summary replaced)
+    /// rather than left untouched.  The fixed dispatch key with the old
+    /// `ON CONFLICT DO NOTHING` could not re-assert the signal after a NEWER
+    /// non-reopened attempt landed (e.g. a rework worker ran and `completed`,
+    /// then the merge queue rejected the PR again with no live attempt to
+    /// terminalize): the stale marker stayed pinned behind the `completed` row
+    /// in `created_at` order, so the respawn guard saw a non-reopened latest
+    /// attempt and re-adopted the open PR — the 13-cycle merge-queue requeue
+    /// loop.  Refreshing `created_at` makes the marker the newest attempt again
+    /// so the guard bypasses adoption and dispatches a rework worker (which then
+    /// reaches the reopen-count intervention gate).  The caller
+    /// (`ensure_rework_marker`) only reaches this insert when the latest
+    /// non-guard attempt is NOT already `reopened`, so a still-pending rework
+    /// never triggers a needless refresh.
     pub async fn insert_rework_marker(
         &self,
         params: ReworkMarkerTaskAttemptParams<'_>,
@@ -514,7 +533,13 @@ impl TaskAttemptRepository {
                  summary, summary_json, terminal_at)
              VALUES ($1, $2, $3, $4, $5, NULL, $6, $7, $8::text::jsonb,
                      to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
-             ON CONFLICT (dispatch_key) DO NOTHING"#,
+             ON CONFLICT (dispatch_key) DO UPDATE SET
+                 outcome = EXCLUDED.outcome,
+                 summary = EXCLUDED.summary,
+                 summary_json = EXCLUDED.summary_json,
+                 created_at = to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+                 terminal_at = to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+                 updated_at = to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')"#,
         )
         .bind(params.id)
         .bind(params.task_id)
@@ -2032,5 +2057,97 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert!(rows[0].log_tail_present);
         assert_eq!(rows[0].log_tail_error_class.as_deref(), Some("timeout"));
+    }
+
+    /// Incident gton: a re-asserted rework marker must refresh its `created_at`
+    /// (so it sorts as the newest attempt again) without stacking a duplicate
+    /// row. Pre-fix the fixed-key `ON CONFLICT DO NOTHING` left the marker
+    /// pinned behind a newer non-reopened attempt, wedging the respawn guard
+    /// into a merge-queue requeue loop.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn insert_rework_marker_re_asserts_created_at_on_conflict() {
+        let db = test_db();
+        let (_pid, task_id) = create_task(&db).await;
+        let repo = TaskAttemptRepository::new(db);
+        let dispatch_key = format!("{task_id}:worker:rework_marker");
+
+        // First insert.
+        let first = repo
+            .insert_rework_marker(ReworkMarkerTaskAttemptParams {
+                id: &new_attempt_id(),
+                task_id: &task_id,
+                role: "worker",
+                dispatch_key: &dispatch_key,
+                summary: Some("cycle 1"),
+                summary_json: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(first.outcome, "reopened");
+
+        // A newer non-reopened terminal attempt lands (a rework worker that ran
+        // and completed).
+        let worker_id = new_attempt_id();
+        repo.create_or_get_pending(CreateTaskAttemptParams {
+            id: &worker_id,
+            task_id: &task_id,
+            role: "worker",
+            dispatch_key: &format!("{task_id}:worker:dispatch-1"),
+            session_id: None,
+            attempt_seq: None,
+        })
+        .await
+        .unwrap();
+        repo.advance_to_terminal(TerminalTaskAttemptParams {
+            id: &worker_id,
+            outcome: TaskAttemptOutcome::Completed,
+            pr_url: None,
+            submit_ref: None,
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: Some("completed"),
+            summary_json: None,
+            log_tail: None,
+        })
+        .await
+        .unwrap();
+        let completed = repo.get(&worker_id).await.unwrap().unwrap();
+
+        // Re-assert the marker (second merge-queue reopen, same dispatch key).
+        let second = repo
+            .insert_rework_marker(ReworkMarkerTaskAttemptParams {
+                id: &new_attempt_id(),
+                task_id: &task_id,
+                role: "worker",
+                dispatch_key: &dispatch_key,
+                summary: Some("cycle 2"),
+                summary_json: None,
+            })
+            .await
+            .unwrap();
+
+        // Same row (idempotent id), refreshed summary, and `created_at` advanced
+        // to be strictly newer than the completed attempt so it sorts first.
+        assert_eq!(second.id, first.id, "re-assert must reuse the marker row");
+        assert_eq!(second.outcome, "reopened");
+        assert_eq!(second.summary.as_deref(), Some("cycle 2"));
+        assert!(
+            second.created_at >= completed.created_at,
+            "re-asserted marker created_at ({}) must be >= the newer completed \
+             attempt ({}) so the guard sees it as the latest attempt",
+            second.created_at,
+            completed.created_at,
+        );
+
+        // No duplicate marker rows.
+        let markers = repo
+            .list_for_task(&task_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|a| a.dispatch_key == dispatch_key)
+            .count();
+        assert_eq!(markers, 1, "re-assert must not stack marker rows");
     }
 }


### PR DESCRIPTION
## The incident (gton, v0.6.81, 2026-07-09 14:07–16:05 UTC)

Task **gton** (adopted PR #1765, no live worker session) entered a **13-cycle merge-queue requeue loop** over ~2 hours. GitHub dequeued the PR for `failed_checks` — a deterministic **merge_group-only** test failure (the unit/integration stages only run on `merge_group`, so PR-level CI stays green). The poller reopened the task via `PrCiFailed` (`reopen_count` 2→13), but on the next ready pass the respawn guard **re-adopted the open PR and handed it back to `pr_review`** (the #1785 `AdoptionHandoff`), the poller saw green PR-level CI + approval and **re-enqueued**, and the same failure recurred — strike-free, no worker, no planner intervention. A human had to draft the PR to break it.

## Verified root cause

The durable `reopened` rework marker (#1719, kv6i) uses a **fixed `dispatch_key` with `ON CONFLICT DO NOTHING`**. On the first reopen the marker is the newest attempt, so the guard bypasses adoption and dispatches a rework worker. But once that worker ran and left a **newer non-reopened terminal attempt** (`completed`), a later merge-queue reopen with no live attempt to terminalize **could not re-assert the signal** — the stale marker stayed pinned behind the `completed` row in `created_at` order, so the guard's latest-attempt gate saw a non-reopened newest attempt and **re-adopted** the still-open PR.

Compounding factors, both confirmed:
- **Hypothesis 1 (blind primary signal):** `PrReworkSignal::from_task_row` keys off `ci_status`, which is `"passing"` for merge_group-only failures, so the primary rework signal never fires — the whole bypass rests on the fragile marker.
- **Hypothesis 2 (masking):** confirmed in spirit, but the masking row is **not** the adopted_pr audit row (the guard already filters that) — it's a stale non-reopened *worker* attempt newer than the marker. Reproduced with a failing test (`Adopted` where `Allow` is required); the adopted_pr-newer-than-marker case (scenario C) already passes.
- **Strike-free:** merge-queue reopens **already** count as `merge_queue_failed` quality strikes, but the guard adopts and `continue`s *before* the `maybe_intervene_on_stuck_task` gate, so 13 accrued strikes were never checked.

## Fix

Make `insert_rework_marker` **re-assertable**: on conflict it now REFRESHES the marker (`created_at`/`terminal_at`/`updated_at` bumped to now, summary replaced) instead of doing nothing, so every merge-queue reopen makes the marker the newest attempt again. The guard then takes the rework-bypass branch (no adoption, no handoff) and dispatches a rework worker — which reaches `maybe_intervene_on_stuck_task`, so the **existing planner intervention now fires at the 3-strike threshold** instead of looping forever.

`ensure_rework_marker` only reaches the refresh when the latest non-guard attempt is **not** already `reopened`, so a still-pending rework never triggers a needless refresh, and a genuinely healthy adopted PR (no reopen → no marker) still adopts/hands off — **#1785 preserved**.

## Follow-up (not in this PR)

Record merge_group check-run failures into the task's CI snapshot (`ci_failure_fingerprint`/`ci_same_signature_count`) on dequeue so repeated identical failures are visible on the task row. Those columns are **read-only projections** from `task_pr_ci_snapshots`, so feeding them requires snapshot-table work beyond this fix (and no migrations are permitted here). The merge-group failing checks are already surfaced to the worker via `log_ci_failure_comment`.

## Tests

- New `respawn_guard_mergequeue_tests.rs` `#[path]` sibling (keeps files under the size guard): re-assert after a completed worker; full `adopt → handoff → merge-queue-loop` replay; healthy adopted PR still adopts.
- DB-level re-assert test in `task_attempt.rs` (refreshes `created_at`, never stacks a duplicate marker row).
- Existing respawn_guard / attempt_lifecycle / pr_poller and the `merge_queue_failed` quality-strike tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)