### PR TITLE
feat(tripwires): autonomous hold reduction + release-path fixes

### DIFF
--- a/server/crates/djinn-coordinator/src/pr_poller/mod.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/mod.rs
@@ -84,6 +84,7 @@ mod pr_undraft;
 mod pr_watcher;
 mod state;
 mod tripwire_gate;
+mod tripwire_hold;
 
 #[cfg(test)]
 mod tests;

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_watcher.rs
@@ -390,57 +390,29 @@ impl CoordinatorActor {
                                 "PR poller: unexpected Held outcome in backfill mode — logging but not blocking"
                             );
                         } else {
-                            // Apply human-review-hold and park the source.
-                            tracing::info!(
-                                task_id = %task.short_id,
-                                pr = pull_number,
-                                head_sha = %pr.head.sha,
-                                enforcement_count = result.decision.enforcement_finding_count,
-                                "PR poller: tripwire gate HELD — creating human-review hold"
-                            );
-
-                            let findings_summary = result
-                                .decision
-                                .findings
-                                .iter()
-                                .map(|f| {
-                                    format!(
-                                        "- `{}` ({}) — {}",
-                                        f.rule_id.as_str(),
-                                        f.reason_code,
-                                        f.evidence.path,
-                                    )
-                                })
-                                .collect::<Vec<_>>()
-                                .join("\n");
-
-                            let hold_reason = format!(
-                                "Tripwire gate held for PR head `{}`.\n\n\
-                                 Policy revision: `{}`\n\
-                                 Enforcement findings ({}):\n{}",
-                                &pr.head.sha[..12.min(pr.head.sha.len())],
-                                result.decision.policy_revision,
-                                result.decision.enforcement_finding_count,
-                                findings_summary,
-                            );
-
-                            // Create a human-review remediation task (idempotent —
-                            // skips if the source is already held by an unresolved
-                            // blocker).
-                            self.create_remediation_task(
-                                &task.id,
-                                &hold_reason,
-                                &task.project_id,
-                                crate::dispatch::RemediationKind::HumanReview,
-                            )
-                            .await;
-
-                            // Park the source so it stops being re-dispatched.
-                            self.park_source_open(&task.id, &hold_reason).await;
-                            self.pr_status_cache.remove(&task.id);
-                            self.pr_draft_first_seen.remove(&task.id);
-                            self.review_stuck_sha_first_seen.remove(&task.id);
-                            continue;
+                            // Enforce mode. First run release carry-forward
+                            // (see `tripwire_hold`): if every enforcement
+                            // finding was already adjudicated + released on a
+                            // prior head and is byte-identical here (rebase /
+                            // merge of main), the hold clears autonomously and
+                            // we fall through to undraft. Otherwise create the
+                            // hold for the remaining findings.
+                            let proceed = self
+                                .carry_forward_tripwire_gate(
+                                    &task,
+                                    &pr.head.sha,
+                                    pull_number,
+                                    result,
+                                )
+                                .await;
+                            if !proceed {
+                                self.create_tripwire_hold(&task, result, &pr.head.sha)
+                                    .await;
+                                self.pr_status_cache.remove(&task.id);
+                                self.pr_draft_first_seen.remove(&task.id);
+                                self.review_stuck_sha_first_seen.remove(&task.id);
+                                continue;
+                            }
                         }
                     }
                     crate::tripwires::GateOutcome::Passed

--- a/server/crates/djinn-coordinator/src/pr_poller/tripwire_gate_tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tripwire_gate_tests.rs
@@ -791,10 +791,14 @@ fn idempotency_key_changes_with_head_sha() {
 fn idempotency_key_changes_with_policy_revision() {
     let files = vec![pr_file("migrations/001.sql", "added", 10, 0)];
     let changed = convert_pr_files(&files);
-    let mut policy_v1 = TripwirePolicy::default();
-    policy_v1.policy_revision = "org-policy:1".to_owned();
-    let mut policy_v2 = TripwirePolicy::default();
-    policy_v2.policy_revision = "org-policy:2".to_owned();
+    let policy_v1 = TripwirePolicy {
+        policy_revision: "org-policy:1".to_owned(),
+        ..TripwirePolicy::default()
+    };
+    let policy_v2 = TripwirePolicy {
+        policy_revision: "org-policy:2".to_owned(),
+        ..TripwirePolicy::default()
+    };
     let input_v1 = TripwireEvaluationInput {
         task_id: "task-001".to_owned(),
         project_id: "proj-001".to_owned(),
@@ -859,10 +863,14 @@ fn same_head_sha_new_policy_revision_not_skipped_by_rollout() {
 
     // Also verify the idempotency key changes (proving the new policy
     // revision produces a distinct key, not a duplicate of the old one).
-    let mut old_policy = TripwirePolicy::default();
-    old_policy.policy_revision = "policy-v1".to_owned();
-    let mut new_policy = TripwirePolicy::default();
-    new_policy.policy_revision = "policy-v2".to_owned();
+    let old_policy = TripwirePolicy {
+        policy_revision: "policy-v1".to_owned(),
+        ..TripwirePolicy::default()
+    };
+    let new_policy = TripwirePolicy {
+        policy_revision: "policy-v2".to_owned(),
+        ..TripwirePolicy::default()
+    };
 
     let files = vec![pr_file("migrations/001.sql", "added", 10, 0)];
     let changed = convert_pr_files(&files);

--- a/server/crates/djinn-coordinator/src/pr_poller/tripwire_hold.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tripwire_hold.rs
@@ -1,0 +1,196 @@
+//! Tripwire hold creation + release carry-forward for the PR poller.
+//!
+//! Split out of `pr_watcher` so that module stays under the repo size guard
+//! (`scripts/check-file-size.sh`). Both methods extend [`CoordinatorActor`]
+//! and are invoked from the `GateOutcome::Held` arm of the draft-processing
+//! loop.
+
+use super::*;
+
+impl CoordinatorActor {
+    /// Release carry-forward for a `Held` gate on a new head.
+    ///
+    /// For each enforcement finding the gate produced on `head_sha`, if the
+    /// same content (by head-independent
+    /// [content fingerprint](crate::tripwires::build_finding_content_fingerprint))
+    /// was already adjudicated + released on a PRIOR head of this PR and is
+    /// byte-identical here — a rebase / merge of `main` that left the flagged
+    /// file untouched — a fresh `tripwire.hold.released` (`carried_forward:
+    /// true`) is emitted for the new head referencing the prior rationale.
+    /// Genuinely changed content has a different fingerprint and is never
+    /// carried forward (it re-holds).
+    ///
+    /// Returns `true` when EVERY enforcement finding was carried forward (the
+    /// hold is cleared for this head — the caller proceeds to undraft), or
+    /// `false` when at least one enforcement finding remains active (the caller
+    /// must create the hold).
+    pub(super) async fn carry_forward_tripwire_gate(
+        &self,
+        task: &djinn_core::models::Task,
+        head_sha: &str,
+        pull_number: u64,
+        tripwire_result: &super::tripwire_gate::TripwireGateResult,
+    ) -> bool {
+        let now = ::time::OffsetDateTime::now_utc()
+            .format(&::time::format_description::well_known::Rfc3339)
+            .unwrap_or_default();
+
+        let enforcement_summaries: Vec<crate::tripwires::TripwireFindingSummary> = tripwire_result
+            .payload
+            .findings
+            .iter()
+            .filter(|f| f.severity == crate::tripwires::TripwireSeverity::HumanReviewRequired)
+            .cloned()
+            .collect();
+        if enforcement_summaries.is_empty() {
+            return false;
+        }
+
+        let prior_entries = self
+            .task_repo()
+            .list_activity(&task.id)
+            .await
+            .unwrap_or_default();
+        let prior_refs: Vec<crate::tripwires::ActivityEntryRef> = prior_entries
+            .iter()
+            .map(crate::tripwires::ActivityEntryRef::from_entry)
+            .collect();
+        let carries = crate::tripwires::build_carry_forward_releases(
+            &prior_refs,
+            head_sha,
+            &enforcement_summaries,
+            &task.id,
+            &task.project_id,
+            Some(pull_number),
+            &now,
+        );
+
+        let mut carried_fps: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for cf in &carries {
+            for f in &cf.payload.released_findings {
+                carried_fps.insert(f.content_fingerprint.clone());
+            }
+            let payload_json = serde_json::to_string(&cf.payload).unwrap_or_default();
+            match self
+                .task_repo()
+                .log_activity(
+                    Some(&task.id),
+                    "coordinator",
+                    "system",
+                    crate::tripwires::TRIPWIRE_EVENT_HOLD_RELEASED,
+                    &payload_json,
+                )
+                .await
+            {
+                Ok(_) => tracing::info!(
+                    task_id = %task.short_id,
+                    pr = pull_number,
+                    head_sha = %head_sha,
+                    from_head = %cf.from_head_sha,
+                    released = cf.payload.released_findings.len(),
+                    "PR poller: carried forward prior tripwire release to new head"
+                ),
+                Err(e) => tracing::warn!(
+                    task_id = %task.short_id,
+                    pr = pull_number,
+                    error = %e,
+                    "PR poller: failed to log carry-forward tripwire.hold.released event"
+                ),
+            }
+        }
+
+        let all_carried = enforcement_summaries
+            .iter()
+            .all(|f| carried_fps.contains(&f.content_fingerprint));
+        if all_carried && !carries.is_empty() {
+            tracing::info!(
+                task_id = %task.short_id,
+                pr = pull_number,
+                head_sha = %head_sha,
+                "PR poller: tripwire gate HELD but all findings carried forward — proceeding"
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Create the tripwire hold for a gate that remains `Held` after the
+    /// carry-forward pass.
+    ///
+    /// Resolution routing is governed by the per-rule
+    /// [`Adjudication`](crate::tripwires::Adjudication) policy knob (default
+    /// [`Arbiter`](crate::tripwires::Adjudication::Arbiter), NO human-review
+    /// holds): a hold whose remaining enforcement findings all belong to
+    /// arbiter-adjudicated rules is destined for autonomous arbiter
+    /// adjudication; a hold that includes any rule an operator has explicitly
+    /// opted to [`Human`](crate::tripwires::Adjudication::Human) takes the
+    /// legacy human-review remediation path.
+    ///
+    /// The hold state itself — the `tripwire.gate.held` event (already logged
+    /// by the caller), the active-hold state machine, the `human-review-hold`
+    /// label, and merge blocking — is identical regardless of resolver; only
+    /// the RESOLVER differs.
+    ///
+    /// NOTE: the autonomous arbiter-dispatch resolver (seed a tripwire
+    /// arbitration row + route the source into the lead-intervention queue,
+    /// where the arbiter `tripwire_release`s benign findings or reopens
+    /// dangerous ones) is being wired as a follow-up. Until it lands, BOTH
+    /// routing intents create the hold via the existing human-review
+    /// remediation substrate so the gate stays fail-closed (a held PR never
+    /// proceeds).
+    pub(super) async fn create_tripwire_hold(
+        &mut self,
+        task: &djinn_core::models::Task,
+        tripwire_result: &super::tripwire_gate::TripwireGateResult,
+        head_sha: &str,
+    ) {
+        let policy = crate::tripwires::TripwirePolicy::default();
+        let requires_human = tripwire_result
+            .decision
+            .findings
+            .iter()
+            .filter(|f| f.severity == crate::tripwires::TripwireFindingSeverity::EnforceHold)
+            .any(|f| policy.adjudication_for(f.rule_id).is_human());
+
+        let findings_summary = tripwire_result
+            .decision
+            .findings
+            .iter()
+            .filter(|f| f.severity == crate::tripwires::TripwireFindingSeverity::EnforceHold)
+            .map(|f| {
+                format!(
+                    "- `{}` ({}) — {}",
+                    f.rule_id.as_str(),
+                    f.reason_code,
+                    f.evidence.path,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let hold_reason = format!(
+            "Tripwire gate held for PR head `{}`.\n\n\
+             Policy revision: `{}`\n\
+             Enforcement findings:\n{}",
+            &head_sha[..12.min(head_sha.len())],
+            tripwire_result.decision.policy_revision,
+            findings_summary,
+        );
+
+        tracing::info!(
+            task_id = %task.short_id,
+            head_sha = %head_sha,
+            adjudication = if requires_human { "human" } else { "arbiter" },
+            "PR poller: tripwire gate held — creating hold via remediation substrate"
+        );
+        self.create_remediation_task(
+            &task.id,
+            &hold_reason,
+            &task.project_id,
+            crate::dispatch::RemediationKind::HumanReview,
+        )
+        .await;
+        self.park_source_open(&task.id, &hold_reason).await;
+    }
+}

--- a/server/crates/djinn-coordinator/src/pr_poller/tripwire_merge_gate_tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tripwire_merge_gate_tests.rs
@@ -33,6 +33,8 @@ fn enforcement_finding(rule_id: &str, path: &str, key: &str) -> TripwireFindingS
         severity: TripwireSeverity::HumanReviewRequired,
         evidence: TripwireEvidenceSpan::file(path),
         idempotency_key: key.to_owned(),
+        content_fingerprint: format!("fp:{key}"),
+        downgrade_reason: None,
     }
 }
 
@@ -43,6 +45,8 @@ fn report_only_finding(rule_id: &str, path: &str, key: &str) -> TripwireFindingS
         severity: TripwireSeverity::ReportOnly,
         evidence: TripwireEvidenceSpan::file(path),
         idempotency_key: key.to_owned(),
+        content_fingerprint: format!("fp:{key}"),
+        downgrade_reason: None,
     }
 }
 
@@ -104,6 +108,7 @@ fn hold_released_entry(
         released_by_role: "lead".to_owned(),
         rationale: "approved after review".to_owned(),
         released_findings,
+        carried_forward: false,
         idempotency_key: format!("sha256:release:{head_sha}"),
         released_at: Some(created_at.to_owned()),
     };

--- a/server/crates/djinn-coordinator/src/roles.rs
+++ b/server/crates/djinn-coordinator/src/roles.rs
@@ -158,6 +158,26 @@ pub(crate) fn releases_source_on_close(task: &Task) -> bool {
     is_human_review_hold(task) || task.labels.contains(PLANNER_PARK_ESCALATION_LABEL)
 }
 
+/// Remove the `human-review-hold` label from an existing labels JSON array,
+/// returning the updated JSON string. Idempotent: if the label is absent the
+/// input's label set is returned unchanged (re-serialised).
+///
+/// `existing_labels` is a JSON-array string (e.g. `["bug","human-review-hold"]`).
+/// Malformed JSON is treated as an empty label set (yielding `[]`).
+///
+/// Used by the hold-release path: once a hold is released (human close or
+/// arbiter `tripwire_release`) the source task must shed the label so the
+/// dispatch guard stops skipping it and the tamper reconciler does not
+/// re-apply it (the label-only-ever-added regression).
+pub(crate) fn remove_hold_label_from_existing(existing_labels: &str) -> String {
+    let labels: Vec<String> = serde_json::from_str(existing_labels).unwrap_or_default();
+    let kept: Vec<String> = labels
+        .into_iter()
+        .filter(|l| l != HUMAN_REVIEW_HOLD_LABEL)
+        .collect();
+    serde_json::to_string(&kept).unwrap_or_else(|_| "[]".to_owned())
+}
+
 /// Returns `true` if the task is an open/in-progress review task.
 ///
 /// Excludes `human-review-hold` tasks: those are a terminal,
@@ -318,6 +338,25 @@ mod tests {
                 "plain review task ({status}) must route to the planner"
             );
         }
+    }
+
+    /// `remove_hold_label_from_existing` strips only the hold label, keeps
+    /// siblings, and is idempotent when the label is absent / malformed.
+    #[test]
+    fn remove_hold_label_strips_only_the_hold_label() {
+        assert_eq!(
+            remove_hold_label_from_existing(r#"["bug","human-review-hold","blocked"]"#),
+            r#"["bug","blocked"]"#
+        );
+        // Absent → unchanged set (re-serialised).
+        assert_eq!(remove_hold_label_from_existing(r#"["bug"]"#), r#"["bug"]"#);
+        // Only the hold label → empty set.
+        assert_eq!(
+            remove_hold_label_from_existing(r#"["human-review-hold"]"#),
+            r#"[]"#
+        );
+        // Malformed JSON → empty set (fail-safe).
+        assert_eq!(remove_hold_label_from_existing("not json"), r#"[]"#);
     }
 
     /// Regression (this fix): a `human-review-hold`-labeled `review` task

--- a/server/crates/djinn-coordinator/src/tripwire_hold_release.rs
+++ b/server/crates/djinn-coordinator/src/tripwire_hold_release.rs
@@ -93,16 +93,6 @@ impl CoordinatorActor {
                 }
             };
 
-            // The current head is the poller-maintained GitHub head SHA. With
-            // no known head there is nothing to release against.
-            let Some(head_sha) = source
-                .ci_github_head_sha
-                .as_deref()
-                .filter(|s| !s.is_empty())
-            else {
-                continue;
-            };
-
             let entries = match task_repo.list_activity(&source.id).await {
                 Ok(e) => e,
                 Err(e) => {
@@ -117,16 +107,22 @@ impl CoordinatorActor {
             let entry_refs: Vec<ActivityEntryRef> =
                 entries.iter().map(ActivityEntryRef::from_entry).collect();
 
-            let state = compute_active_hold_state(&entry_refs, head_sha);
-            if !state.held {
-                // No active hold for the current head (superseded or already
-                // released) — skip emission.
-                tracing::info!(
-                    source_task_id = %source.short_id,
-                    head_sha = %head_sha,
-                    "tripwire release: no active hold for current head on hold-task close — skipping"
-                );
-                continue;
+            // Release EVERY head that still carries an un-released
+            // `tripwire.gate.held` — NOT just the task row's current GitHub
+            // head. The merge-boundary gate keys "current head" on the head
+            // pinned in the gate.held event (the CI-snapshot head at hold
+            // time), which can lag the task row's `ci_github_head_sha` after a
+            // later push. Releasing only the row head silently misses the hold
+            // the gate actually sees (incident: task `7tmi` — gate head
+            // `fd3d3670` vs row head `e4e0ccb8`).
+            let mut held_heads = crate::tripwires::gate_held_head_shas(&entry_refs);
+            if let Some(row_head) = source
+                .ci_github_head_sha
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                && !held_heads.iter().any(|h| h == row_head)
+            {
+                held_heads.push(row_head.to_owned());
             }
 
             let pr_number = source
@@ -134,53 +130,75 @@ impl CoordinatorActor {
                 .as_deref()
                 .and_then(|url| crate::pr_poller::parse_pr_url(url).map(|(_, _, n)| n));
 
-            let payload = match build_hold_released_payload(
-                &state,
-                &source.id,
-                &source.project_id,
-                pr_number,
-                HUMAN_RELEASE_ACTOR,
-                HUMAN_RELEASE_ROLE,
-                &rationale,
-                &now,
-            ) {
-                Ok(Some(p)) => p,
-                Ok(None) => continue,
-                Err(e) => {
-                    tracing::warn!(
-                        source_task_id = %source.short_id,
-                        error = %e,
-                        "tripwire release: failed to build hold-released payload"
-                    );
+            for head_sha in &held_heads {
+                let state = compute_active_hold_state(&entry_refs, head_sha);
+                if !state.held {
                     continue;
                 }
-            };
-
-            let payload_json = serde_json::to_string(&payload).unwrap_or_default();
-            match task_repo
-                .log_activity(
-                    Some(&source.id),
+                let payload = match build_hold_released_payload(
+                    &state,
+                    &source.id,
+                    &source.project_id,
+                    pr_number,
                     HUMAN_RELEASE_ACTOR,
                     HUMAN_RELEASE_ROLE,
-                    TRIPWIRE_EVENT_HOLD_RELEASED,
-                    &payload_json,
-                )
-                .await
-            {
-                Ok(_) => {
-                    tracing::info!(
-                        source_task_id = %source.short_id,
-                        hold_task_id = %hold_task.short_id,
-                        head_sha = %head_sha,
-                        released_findings = payload.released_findings.len(),
-                        "tripwire release: emitted tripwire.hold.released on human hold-task close"
-                    );
+                    &rationale,
+                    &now,
+                ) {
+                    Ok(Some(p)) => p,
+                    Ok(None) => continue,
+                    Err(e) => {
+                        tracing::warn!(
+                            source_task_id = %source.short_id,
+                            error = %e,
+                            "tripwire release: failed to build hold-released payload"
+                        );
+                        continue;
+                    }
+                };
+
+                let payload_json = serde_json::to_string(&payload).unwrap_or_default();
+                match task_repo
+                    .log_activity(
+                        Some(&source.id),
+                        HUMAN_RELEASE_ACTOR,
+                        HUMAN_RELEASE_ROLE,
+                        TRIPWIRE_EVENT_HOLD_RELEASED,
+                        &payload_json,
+                    )
+                    .await
+                {
+                    Ok(_) => {
+                        tracing::info!(
+                            source_task_id = %source.short_id,
+                            hold_task_id = %hold_task.short_id,
+                            head_sha = %head_sha,
+                            released_findings = payload.released_findings.len(),
+                            "tripwire release: emitted tripwire.hold.released on human hold-task close"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            source_task_id = %source.short_id,
+                            error = %e,
+                            "tripwire release: failed to log tripwire.hold.released event"
+                        );
+                    }
                 }
-                Err(e) => {
+            }
+
+            // Shed the `human-review-hold` label from the source now the hold
+            // is resolved. Otherwise the dispatch guard keeps skipping the
+            // labeled source AND the tamper reconciler re-applies the label on
+            // its next pass (labels were only ever added, never removed).
+            // Best-effort — a failure here does not wedge the close.
+            if crate::roles::is_human_review_hold(&source) {
+                let cleaned = crate::roles::remove_hold_label_from_existing(&source.labels);
+                if let Err(e) = task_repo.update_labels(&source.id, &cleaned).await {
                     tracing::warn!(
                         source_task_id = %source.short_id,
                         error = %e,
-                        "tripwire release: failed to log tripwire.hold.released event"
+                        "tripwire release: failed to strip human-review-hold label after release"
                     );
                 }
             }

--- a/server/crates/djinn-coordinator/src/tripwires/active_hold.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/active_hold.rs
@@ -194,6 +194,33 @@ where
     }
 }
 
+/// Distinct head SHAs that carry at least one `tripwire.gate.held` event in
+/// `entries`, in first-seen order.
+///
+/// The hold-release producer iterates these to release **every** head that
+/// may still be held, not just the task row's current `github_head_sha`. The
+/// merge-boundary gate and the release emitter must not disagree on "current
+/// head": a hold pinned to an earlier CI-snapshot head must still be released
+/// when the hold is resolved, even though the task row's head has since
+/// advanced (incident: task `7tmi` — gate saw head `fd3d3670`, emitter used
+/// row head `e4e0ccb8`, release was a silent no-op).
+pub fn gate_held_head_shas<'a, I>(entries: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a ActivityEntryRef>,
+{
+    let mut seen: Vec<String> = Vec::new();
+    let mut set: HashSet<String> = HashSet::new();
+    for entry in entries {
+        if entry.event_type == TRIPWIRE_EVENT_GATE_HELD
+            && let Ok(payload) = serde_json::from_str::<TripwireGateDecisionPayload>(&entry.payload)
+            && set.insert(payload.head_sha.clone())
+        {
+            seen.push(payload.head_sha);
+        }
+    }
+    seen
+}
+
 // ─── Label tamper reconciliation ───────────────────────────────────────────
 
 /// Result of a label-tamper reconciliation check.
@@ -362,6 +389,8 @@ mod tests {
             severity: TripwireSeverity::HumanReviewRequired,
             evidence: TripwireEvidenceSpan::file(path),
             idempotency_key: key.to_owned(),
+            content_fingerprint: format!("fp:{key}"),
+            downgrade_reason: None,
         }
     }
 
@@ -372,6 +401,8 @@ mod tests {
             severity: TripwireSeverity::ReportOnly,
             evidence: TripwireEvidenceSpan::file(path),
             idempotency_key: key.to_owned(),
+            content_fingerprint: format!("fp:{key}"),
+            downgrade_reason: None,
         }
     }
 
@@ -428,6 +459,7 @@ mod tests {
             released_by_role: "lead".to_owned(),
             rationale: "approved after review".to_owned(),
             released_findings,
+            carried_forward: false,
             idempotency_key: format!("sha256:release:{head_sha}"),
             released_at: Some(created_at.to_owned()),
         };
@@ -829,6 +861,33 @@ mod tests {
         assert_eq!(refs.event_type, TRIPWIRE_EVENT_GATE_HELD);
         assert_eq!(refs.created_at, "2026-01-01T00:00:00Z");
         assert!(refs.payload.contains("tripwire.gate.held"));
+    }
+
+    // ── gate_held_head_shas ───────────────────────────────────────────────
+
+    /// Distinct held heads are returned in first-seen order (the release
+    /// producer iterates these to release every held head, not just the row's
+    /// current head — incident 7tmi).
+    #[test]
+    fn gate_held_head_shas_returns_distinct_heads() {
+        let f = enforcement_finding("migration_change", "migrations/001.sql", "k");
+        let entries = vec![
+            gate_held_entry("sha-a", vec![f.clone()], "2026-01-01T00:00:00Z"),
+            gate_held_entry("sha-b", vec![f.clone()], "2026-01-02T00:00:00Z"),
+            // Duplicate head must not repeat.
+            gate_held_entry("sha-a", vec![f.clone()], "2026-01-03T00:00:00Z"),
+            // Releases are not gate.held events and must be ignored here.
+            hold_released_entry("sha-a", vec![f], "2026-01-04T00:00:00Z"),
+        ];
+        let heads = gate_held_head_shas(&entries);
+        assert_eq!(heads, vec!["sha-a".to_owned(), "sha-b".to_owned()]);
+    }
+
+    /// No gate.held events → empty head list.
+    #[test]
+    fn gate_held_head_shas_empty_without_held() {
+        let entries: Vec<ActivityEntryRef> = Vec::new();
+        assert!(gate_held_head_shas(&entries).is_empty());
     }
 
     // ── Empty entries ─────────────────────────────────────────────────────

--- a/server/crates/djinn-coordinator/src/tripwires/activity_payloads.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/activity_payloads.rs
@@ -169,6 +169,19 @@ pub struct TripwireFindingSummary {
     /// `(task_id, pr_number, head_sha, rule_id, evidence_path, evidence_line_range, policy_revision)`.
     /// See engine module (sibling task `gl0p`) for the canonical builder.
     pub idempotency_key: String,
+    /// Head-independent content fingerprint. Stable across PR heads while the
+    /// underlying flagged content (rule + file + patch hunk) is unchanged —
+    /// unlike [`idempotency_key`](TripwireFindingSummary::idempotency_key)
+    /// which includes `head_sha`. The gate's release carry-forward keys on
+    /// this to recognise a finding already adjudicated on a prior head.
+    /// `#[serde(default)]` keeps pre-fingerprint activity rows decoding.
+    #[serde(default)]
+    pub content_fingerprint: String,
+    /// When set, the reason this finding was downgraded from enforcement to
+    /// report-only (e.g. the evidence path is a test file). Omitted from the
+    /// wire when absent.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub downgrade_reason: Option<String>,
 }
 
 // ─── Gate decision payload ─────────────────────────────────────────────────
@@ -288,6 +301,15 @@ pub struct TripwireHoldReleasedPayload {
     pub rationale: String,
     /// Findings that were released (still recorded for audit).
     pub released_findings: Vec<TripwireFindingSummary>,
+    /// `true` when this release was auto-carried-forward from a prior head:
+    /// the same content (by content fingerprint) was already adjudicated and
+    /// released on an earlier head of the same PR and is byte-identical on the
+    /// new head, so the release is re-emitted for the new head referencing the
+    /// prior rationale/releaser without re-running adjudication. `false` for a
+    /// first-time (human- or arbiter-driven) release. `#[serde(default)]`
+    /// keeps pre-carry-forward rows decoding.
+    #[serde(default)]
+    pub carried_forward: bool,
     /// Stable idempotency key for this release. Derived from
     /// `(task_id, pr_number, head_sha, released_by, policy_revision)`.
     pub idempotency_key: String,
@@ -524,6 +546,8 @@ mod tests {
             severity: TripwireSeverity::HumanReviewRequired,
             evidence: TripwireEvidenceSpan::file(path.to_owned()),
             idempotency_key: format!("sha256:{rule_id}:{path}"),
+            content_fingerprint: format!("fp:sha256:{rule_id}:{path}"),
+            downgrade_reason: None,
         }
     }
 
@@ -651,6 +675,8 @@ mod tests {
             severity: TripwireSeverity::ReportOnly,
             evidence: TripwireEvidenceSpan::file(".github/workflows/ci.yml"),
             idempotency_key: "sha256:ci:yml".to_owned(),
+            content_fingerprint: "fp:sha256:ci:yml".to_owned(),
+            downgrade_reason: None,
         };
         let payload = TripwireGateDecisionPayload {
             event_type: TRIPWIRE_EVENT_GATE_REPORT_ONLY.to_owned(),
@@ -746,6 +772,7 @@ mod tests {
                 "tripwire.large_delete_or_rewrite",
                 "legacy/big_file.rs",
             )],
+            carried_forward: false,
             idempotency_key: "sha256:release:feedface".to_owned(),
             released_at: Some("2026-02-02T00:00:00Z".to_owned()),
         };
@@ -769,6 +796,7 @@ mod tests {
             released_by_role: "lead".to_owned(),
             rationale: "rationale".to_owned(),
             released_findings: Vec::new(),
+            carried_forward: false,
             idempotency_key: "k".to_owned(),
             released_at: None,
         };

--- a/server/crates/djinn-coordinator/src/tripwires/carry_forward.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/carry_forward.rs
@@ -1,0 +1,429 @@
+//! Release carry-forward for unchanged tripwire findings across PR heads.
+//!
+//! When a PR head advances, the sticky-hold state machine
+//! ([`crate::tripwires::active_hold`]) deliberately supersedes every prior
+//! hold and release — a new head requires fresh adjudication. That is correct
+//! when the flagged *content* changed, but it re-holds benign changes that
+//! were already adjudicated and released on an earlier head yet are
+//! byte-identical on the new head (a rebase, a merge of `main`, or an
+//! unrelated commit that leaves the flagged file untouched).
+//!
+//! This module closes that gap **without** weakening the per-head stale-release
+//! protection. Every finding carries a head-independent
+//! [content fingerprint](crate::tripwires::engine::build_finding_content_fingerprint)
+//! derived from `(rule_id, file, patch hunk)`. When a NEW head produces an
+//! enforcement finding whose fingerprint matches a finding that was already
+//! *released* on a PRIOR head of the same PR, [`build_carry_forward_releases`]
+//! emits a fresh `tripwire.hold.released` payload **for the new head**,
+//! referencing the prior rationale/releaser and marked `carried_forward:
+//! true`. A genuinely changed finding has a different fingerprint, so it is
+//! never carried forward — it re-holds and is adjudicated afresh.
+//!
+//! This module is **pure** — no DB, GitHub, or LLM calls. The caller
+//! (`CoordinatorActor`, the gate path) logs the returned payloads as activity
+//! events and re-computes the active-hold state.
+
+// Consumed by the gate path (`pr_watcher`) once wired; keep the module warm
+// for incremental landing without churn.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use sha2::{Digest, Sha256};
+
+use crate::tripwires::active_hold::ActivityEntryRef;
+use crate::tripwires::activity_payloads::{
+    TRIPWIRE_EVENT_HOLD_RELEASED, TripwireFindingSummary, TripwireHoldReleasedPayload,
+};
+
+/// Prior-head release context recovered for a single content fingerprint.
+#[derive(Debug, Clone)]
+struct PriorRelease {
+    head_sha: String,
+    released_by: String,
+    released_by_role: String,
+    rationale: String,
+    policy_revision: String,
+}
+
+/// A carry-forward release built for the new head plus the prior head it was
+/// carried from (for logging / audit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CarryForwardRelease {
+    /// The prior head SHA the release rationale/releaser was carried from.
+    pub from_head_sha: String,
+    /// The validated release payload for the new head.
+    pub payload: TripwireHoldReleasedPayload,
+}
+
+/// Build a deterministic idempotency key for a carry-forward release.
+fn build_carry_forward_key(
+    task_id: &str,
+    pr_number: Option<u64>,
+    new_head_sha: &str,
+    policy_revision: &str,
+) -> String {
+    let pr = pr_number.map(|n| n.to_string()).unwrap_or_default();
+    let payload = format!("carry_forward:{task_id}:{pr}:{new_head_sha}:{policy_revision}");
+    let hash = Sha256::digest(payload.as_bytes());
+    format!("sha256:{}", hex::encode(hash))
+}
+
+/// Compute carry-forward releases for a new head's enforcement findings.
+///
+/// # Arguments
+/// * `entries` — the source task's tripwire activity entries (gate.held +
+///   hold.released across all heads).
+/// * `new_head_sha` — the head just evaluated by the gate.
+/// * `new_enforcement_findings` — the enforcement-on findings the gate
+///   produced for `new_head_sha` (each carrying a `content_fingerprint`).
+/// * `task_id`, `project_id`, `pr_number` — identity for the release payload.
+/// * `released_at` — RFC 3339 timestamp for the emitted release.
+///
+/// Returns at most one [`CarryForwardRelease`] (all matched findings collapse
+/// into a single release for the new head). Returns an empty vector when no
+/// enforcement finding's fingerprint matches a prior-head release, or when
+/// `new_head_sha` itself already carries a release for those fingerprints.
+///
+/// The returned payload is validated; a build that would fail validation is
+/// dropped rather than returned.
+pub fn build_carry_forward_releases(
+    entries: &[ActivityEntryRef],
+    new_head_sha: &str,
+    new_enforcement_findings: &[TripwireFindingSummary],
+    task_id: &str,
+    project_id: &str,
+    pr_number: Option<u64>,
+    released_at: &str,
+) -> Vec<CarryForwardRelease> {
+    if new_enforcement_findings.is_empty() {
+        return Vec::new();
+    }
+
+    // Map content fingerprint → prior release context, from releases on any
+    // head OTHER than the new head. Ignore blank fingerprints (pre-fingerprint
+    // rows) so we never match on the empty string.
+    let mut prior_by_fp: HashMap<String, PriorRelease> = HashMap::new();
+    // Fingerprints already released ON the new head — never re-emit those.
+    let mut released_on_new_head: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
+    for entry in entries {
+        if entry.event_type != TRIPWIRE_EVENT_HOLD_RELEASED {
+            continue;
+        }
+        let Ok(payload) = serde_json::from_str::<TripwireHoldReleasedPayload>(&entry.payload)
+        else {
+            continue;
+        };
+        for finding in &payload.released_findings {
+            let fp = finding.content_fingerprint.trim();
+            if fp.is_empty() {
+                continue;
+            }
+            if payload.head_sha == new_head_sha {
+                released_on_new_head.insert(fp.to_owned());
+                continue;
+            }
+            // Keep the most-recent prior release per fingerprint. Entries are
+            // chronological, so a later insert wins.
+            prior_by_fp.insert(
+                fp.to_owned(),
+                PriorRelease {
+                    head_sha: payload.head_sha.clone(),
+                    released_by: payload.released_by.clone(),
+                    released_by_role: payload.released_by_role.clone(),
+                    rationale: payload.rationale.clone(),
+                    policy_revision: payload.policy_revision.clone(),
+                },
+            );
+        }
+    }
+
+    if prior_by_fp.is_empty() {
+        return Vec::new();
+    }
+
+    // Collect new-head enforcement findings whose fingerprint was released on a
+    // prior head and NOT already re-released on the new head.
+    let mut matched: Vec<TripwireFindingSummary> = Vec::new();
+    let mut prior: Option<PriorRelease> = None;
+    for finding in new_enforcement_findings {
+        let fp = finding.content_fingerprint.trim();
+        if fp.is_empty() || released_on_new_head.contains(fp) {
+            continue;
+        }
+        if let Some(p) = prior_by_fp.get(fp) {
+            matched.push(finding.clone());
+            // Reference the first matched prior release for rationale/releaser.
+            if prior.is_none() {
+                prior = Some(p.clone());
+            }
+        }
+    }
+
+    let (Some(prior), false) = (prior, matched.is_empty()) else {
+        return Vec::new();
+    };
+
+    let policy_revision = if prior.policy_revision.trim().is_empty() {
+        // Fall back to the new findings' policy revision is not tracked here;
+        // an empty revision still produces a valid, distinct release key.
+        String::new()
+    } else {
+        prior.policy_revision.clone()
+    };
+
+    let rationale = format!(
+        "carried forward from prior head {}: {}",
+        &prior.head_sha[..12.min(prior.head_sha.len())],
+        prior.rationale,
+    );
+
+    let payload = TripwireHoldReleasedPayload {
+        event_type: TRIPWIRE_EVENT_HOLD_RELEASED.to_owned(),
+        task_id: task_id.to_owned(),
+        project_id: project_id.to_owned(),
+        pr_number,
+        head_sha: new_head_sha.to_owned(),
+        policy_revision: policy_revision.clone(),
+        released_by: prior.released_by.clone(),
+        released_by_role: prior.released_by_role.clone(),
+        rationale,
+        released_findings: matched,
+        carried_forward: true,
+        idempotency_key: build_carry_forward_key(
+            task_id,
+            pr_number,
+            new_head_sha,
+            &policy_revision,
+        ),
+        released_at: Some(released_at.to_owned()),
+    };
+
+    if payload.validate().is_err() {
+        return Vec::new();
+    }
+
+    vec![CarryForwardRelease {
+        from_head_sha: prior.head_sha,
+        payload,
+    }]
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tripwires::activity_payloads::{
+        TRIPWIRE_EVENT_GATE_HELD, TripwireEvidenceSpan, TripwireGateDecisionPayload,
+        TripwireSeverity,
+    };
+
+    const TASK_ID: &str = "task-cf";
+    const PROJECT_ID: &str = "proj-cf";
+    const PR: u64 = 7;
+    const POLICY_REV: &str = "org-policy:1";
+
+    fn finding(rule_id: &str, path: &str, fp: &str) -> TripwireFindingSummary {
+        TripwireFindingSummary {
+            rule_id: rule_id.to_owned(),
+            reason_code: format!("tripwire.{rule_id}.changed"),
+            severity: TripwireSeverity::HumanReviewRequired,
+            evidence: TripwireEvidenceSpan::file(path),
+            idempotency_key: format!("sha256:{path}"),
+            content_fingerprint: fp.to_owned(),
+            downgrade_reason: None,
+        }
+    }
+
+    fn gate_held_entry(
+        head: &str,
+        findings: Vec<TripwireFindingSummary>,
+        at: &str,
+    ) -> ActivityEntryRef {
+        let payload = TripwireGateDecisionPayload {
+            event_type: TRIPWIRE_EVENT_GATE_HELD.to_owned(),
+            task_id: TASK_ID.to_owned(),
+            project_id: PROJECT_ID.to_owned(),
+            pr_number: Some(PR),
+            head_sha: head.to_owned(),
+            base_sha: None,
+            policy_revision: POLICY_REV.to_owned(),
+            allowlist_revision: None,
+            enforcement_finding_count: findings.len() as u32,
+            report_only_finding_count: 0,
+            findings,
+            idempotency_key: format!("sha256:gate:{head}"),
+            decided_at: Some(at.to_owned()),
+        };
+        ActivityEntryRef {
+            event_type: TRIPWIRE_EVENT_GATE_HELD.to_owned(),
+            payload: serde_json::to_string(&payload).unwrap(),
+            created_at: at.to_owned(),
+        }
+    }
+
+    fn release_entry(
+        head: &str,
+        findings: Vec<TripwireFindingSummary>,
+        rationale: &str,
+        at: &str,
+    ) -> ActivityEntryRef {
+        let payload = TripwireHoldReleasedPayload {
+            event_type: TRIPWIRE_EVENT_HOLD_RELEASED.to_owned(),
+            task_id: TASK_ID.to_owned(),
+            project_id: PROJECT_ID.to_owned(),
+            pr_number: Some(PR),
+            head_sha: head.to_owned(),
+            policy_revision: POLICY_REV.to_owned(),
+            released_by: "lead".to_owned(),
+            released_by_role: "lead".to_owned(),
+            rationale: rationale.to_owned(),
+            released_findings: findings,
+            carried_forward: false,
+            idempotency_key: format!("sha256:release:{head}"),
+            released_at: Some(at.to_owned()),
+        };
+        ActivityEntryRef {
+            event_type: TRIPWIRE_EVENT_HOLD_RELEASED.to_owned(),
+            payload: serde_json::to_string(&payload).unwrap(),
+            created_at: at.to_owned(),
+        }
+    }
+
+    /// Same content fingerprint released on a prior head → carry-forward
+    /// release emitted for the new head, marked `carried_forward`.
+    #[test]
+    fn unchanged_finding_is_carried_forward() {
+        let f_old = finding("unsafe_code_change", "tests/fixture.rs", "fp:same");
+        let entries = vec![
+            gate_held_entry("head-a", vec![f_old.clone()], "2026-01-01T00:00:00Z"),
+            release_entry(
+                "head-a",
+                vec![f_old],
+                "benign test fixture",
+                "2026-01-02T00:00:00Z",
+            ),
+        ];
+        // New head produces the same finding (identical fingerprint).
+        let new = finding("unsafe_code_change", "tests/fixture.rs", "fp:same");
+        let out = build_carry_forward_releases(
+            &entries,
+            "head-b",
+            &[new],
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR),
+            "2026-01-03T00:00:00Z",
+        );
+        assert_eq!(out.len(), 1, "one carry-forward release expected");
+        let cf = &out[0];
+        assert_eq!(cf.from_head_sha, "head-a");
+        assert_eq!(cf.payload.head_sha, "head-b");
+        assert!(cf.payload.carried_forward);
+        assert_eq!(cf.payload.released_findings.len(), 1);
+        assert!(cf.payload.rationale.contains("benign test fixture"));
+        cf.payload
+            .validate()
+            .expect("carry-forward release validates");
+    }
+
+    /// Changed content (different fingerprint) is NOT carried forward — it
+    /// re-holds and must be adjudicated afresh.
+    #[test]
+    fn changed_finding_is_not_carried_forward() {
+        let f_old = finding("unsafe_code_change", "src/native.rs", "fp:old");
+        let entries = vec![
+            gate_held_entry("head-a", vec![f_old.clone()], "2026-01-01T00:00:00Z"),
+            release_entry("head-a", vec![f_old], "reviewed", "2026-01-02T00:00:00Z"),
+        ];
+        // New head: same rule + file, but the patch content changed → new fp.
+        let new = finding("unsafe_code_change", "src/native.rs", "fp:new");
+        let out = build_carry_forward_releases(
+            &entries,
+            "head-b",
+            &[new],
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR),
+            "2026-01-03T00:00:00Z",
+        );
+        assert!(
+            out.is_empty(),
+            "changed content must not be carried forward"
+        );
+    }
+
+    /// A finding never released on any prior head is not carried forward.
+    #[test]
+    fn never_released_finding_is_not_carried_forward() {
+        let f_old = finding("migration_change", "migrations/1.sql", "fp:mig");
+        let entries = vec![gate_held_entry(
+            "head-a",
+            vec![f_old],
+            "2026-01-01T00:00:00Z",
+        )];
+        let new = finding("migration_change", "migrations/1.sql", "fp:mig");
+        let out = build_carry_forward_releases(
+            &entries,
+            "head-b",
+            &[new],
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR),
+            "2026-01-03T00:00:00Z",
+        );
+        assert!(
+            out.is_empty(),
+            "unreleased finding must re-hold, not carry forward"
+        );
+    }
+
+    /// Blank fingerprints (pre-fingerprint rows) never match.
+    #[test]
+    fn blank_fingerprint_never_matches() {
+        let f_old = finding("unsafe_code_change", "tests/x.rs", "");
+        let entries = vec![release_entry(
+            "head-a",
+            vec![f_old],
+            "reviewed",
+            "2026-01-02T00:00:00Z",
+        )];
+        let new = finding("unsafe_code_change", "tests/x.rs", "");
+        let out = build_carry_forward_releases(
+            &entries,
+            "head-b",
+            &[new],
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR),
+            "2026-01-03T00:00:00Z",
+        );
+        assert!(out.is_empty(), "blank fingerprints must not match");
+    }
+
+    /// Already re-released on the new head → no duplicate carry-forward.
+    #[test]
+    fn already_released_on_new_head_is_skipped() {
+        let f = finding("unsafe_code_change", "tests/y.rs", "fp:dup");
+        let entries = vec![
+            release_entry("head-a", vec![f.clone()], "ok", "2026-01-02T00:00:00Z"),
+            release_entry("head-b", vec![f.clone()], "ok", "2026-01-03T00:00:00Z"),
+        ];
+        let out = build_carry_forward_releases(
+            &entries,
+            "head-b",
+            &[f],
+            TASK_ID,
+            PROJECT_ID,
+            Some(PR),
+            "2026-01-04T00:00:00Z",
+        );
+        assert!(
+            out.is_empty(),
+            "must not duplicate an existing new-head release"
+        );
+    }
+}

--- a/server/crates/djinn-coordinator/src/tripwires/engine.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/engine.rs
@@ -25,6 +25,7 @@
 
 #![allow(dead_code)]
 
+use djinn_core::test_paths::is_test_path;
 use sha2::{Digest, Sha256};
 
 use crate::tripwires::activity_payloads::{
@@ -32,6 +33,11 @@ use crate::tripwires::activity_payloads::{
 };
 use crate::tripwires::policy::TripwirePolicy;
 use crate::tripwires::reason_codes::{TripwireRuleId, reason_code_for_rule};
+
+/// Human-readable annotation stamped on a finding whose evidence path is a
+/// test file and was therefore downgraded from enforcement to report-only.
+pub const TEST_PATH_DOWNGRADE_REASON: &str =
+    "test-path: evidence path is a test file; downgraded to report-only";
 
 // ─── Changed-file / diff-hunk input structs ────────────────────────────────
 
@@ -192,6 +198,15 @@ pub struct TripwireFinding {
     pub allowlist_revision: Option<String>,
     /// Deterministic idempotency key for this finding.
     pub idempotency_key: String,
+    /// Head-independent content fingerprint. Stable across PR heads while the
+    /// underlying flagged content (rule + file + patch hunk) is unchanged;
+    /// unlike [`idempotency_key`](TripwireFinding::idempotency_key) it does
+    /// NOT include `head_sha`. The gate's release carry-forward keys on this
+    /// to recognise a finding already adjudicated on a prior head.
+    pub content_fingerprint: String,
+    /// When set, a human-readable reason this finding was downgraded from
+    /// enforcement to report-only (e.g. the evidence path is a test file).
+    pub downgrade_reason: Option<String>,
 }
 
 impl TripwireFinding {
@@ -212,6 +227,8 @@ impl TripwireFinding {
                 evidence_redacted: false,
             },
             idempotency_key: self.idempotency_key.clone(),
+            content_fingerprint: self.content_fingerprint.clone(),
+            downgrade_reason: self.downgrade_reason.clone(),
         }
     }
 }
@@ -329,6 +346,50 @@ pub fn build_gate_idempotency_key(
     format!("sha256:{}", hex::encode(hash))
 }
 
+/// Build a head-independent content fingerprint for a finding.
+///
+/// The fingerprint is a SHA-256 hex digest over
+/// `(rule_id, evidence_path, additions, deletions, added_line_content)` where
+/// `added_line_content` is the concatenation of every added (`+`-prefixed)
+/// diff line of the matching changed file, with the `+` stripped. It
+/// deliberately excludes `head_sha`, `base_sha`, and line numbers so that the
+/// same flagged change carried across a rebase / new push — identical patch
+/// content for the file — yields the same fingerprint. When no matching
+/// changed file is available (or it has no hunks) the fingerprint still
+/// covers the rule + path + coarse add/delete counts, which is stable for an
+/// unchanged file-level finding.
+pub fn build_finding_content_fingerprint(
+    rule_id: TripwireRuleId,
+    evidence_path: &str,
+    changed_file: Option<&ChangedFile>,
+) -> String {
+    let (additions, deletions, added_content) = match changed_file {
+        Some(file) => {
+            let mut added = String::new();
+            for hunk in &file.hunks {
+                for line in &hunk.diff_lines {
+                    if let Some(rest) = line.strip_prefix('+') {
+                        added.push_str(rest);
+                        added.push('\n');
+                    }
+                }
+            }
+            (file.additions, file.deletions, added)
+        }
+        None => (0, 0, String::new()),
+    };
+    let payload = format!(
+        "{}:{}:{}:{}:{}",
+        rule_id.as_str(),
+        evidence_path,
+        additions,
+        deletions,
+        added_content,
+    );
+    let hash = Sha256::digest(payload.as_bytes());
+    format!("fp:sha256:{}", hex::encode(hash))
+}
+
 // ─── Engine evaluation ─────────────────────────────────────────────────────
 
 /// Evaluate the tripwire policy against the changed files and produce a
@@ -378,6 +439,16 @@ where
                 TripwireFindingSeverity::EnforceHold
             };
 
+            // Test-path downgrade annotation: rule evaluators already flip
+            // `report_only` for test-path evidence (see rules::mod), so a
+            // test-path finding arrives here as report-only. Stamp the reason
+            // so the activity payload explains why enforcement was skipped.
+            let downgrade_reason = if is_test_path(&raw.evidence_path) {
+                Some(TEST_PATH_DOWNGRADE_REASON.to_owned())
+            } else {
+                None
+            };
+
             let idempotency_key = build_finding_idempotency_key(
                 &input.task_id,
                 &input.head_sha,
@@ -386,6 +457,15 @@ where
                 raw.evidence_start_line,
                 raw.evidence_end_line,
                 &input.policy.policy_revision,
+            );
+
+            let content_fingerprint = build_finding_content_fingerprint(
+                rule_id,
+                &raw.evidence_path,
+                input
+                    .changed_files
+                    .iter()
+                    .find(|f| f.path == raw.evidence_path),
             );
 
             findings.push(TripwireFinding {
@@ -404,6 +484,8 @@ where
                     None
                 },
                 idempotency_key,
+                content_fingerprint,
+                downgrade_reason,
             });
         }
     }
@@ -520,782 +602,6 @@ pub struct RawFinding {
 pub type RuleEvaluator = dyn Fn(&TripwirePolicy, &[ChangedFile]) -> Vec<RawFinding> + Send + Sync;
 
 // ─── Tests ─────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tripwires::policy::TripwirePolicy;
-    use crate::tripwires::reason_codes::*;
-
-    // ── Helpers ──────────────────────────────────────────────────────────
-
-    fn sample_input(task_id: &str, head_sha: &str) -> TripwireEvaluationInput {
-        TripwireEvaluationInput {
-            task_id: task_id.to_owned(),
-            project_id: "proj_1".to_owned(),
-            pr_number: Some(42),
-            head_sha: head_sha.to_owned(),
-            policy: TripwirePolicy::default(),
-            allowlist_revision: None,
-            changed_files: Vec::new(),
-        }
-    }
-
-    fn migration_finding(_task_id: &str, _head_sha: &str, path: &str) -> RawFinding {
-        RawFinding {
-            rule_id: TripwireRuleId::MigrationChange,
-            report_only: false,
-            evidence_path: path.to_owned(),
-            evidence_start_line: Some(1),
-            evidence_end_line: Some(10),
-            evidence_is_excluded: false,
-        }
-    }
-
-    fn ci_report_only_finding(path: &str) -> RawFinding {
-        RawFinding {
-            rule_id: TripwireRuleId::CIWorkflowChange,
-            report_only: true,
-            evidence_path: path.to_owned(),
-            evidence_start_line: None,
-            evidence_end_line: None,
-            evidence_is_excluded: false,
-        }
-    }
-
-    fn make_evaluator(
-        findings: Vec<RawFinding>,
-    ) -> impl Fn(&TripwirePolicy, &[ChangedFile]) -> Vec<RawFinding> {
-        move |_policy: &TripwirePolicy, _files: &[ChangedFile]| -> Vec<RawFinding> {
-            findings.clone()
-        }
-    }
-
-    // ── Deterministic ordering ───────────────────────────────────────────
-
-    /// Findings must be sorted by (rule_id, path, start_line, end_line,
-    /// severity) regardless of insertion order.
-    #[test]
-    fn findings_are_sorted_deterministically() {
-        let raw_findings = vec![
-            RawFinding {
-                rule_id: TripwireRuleId::CIWorkflowChange,
-                report_only: false,
-                evidence_path: ".github/workflows/ci.yml".to_owned(),
-                evidence_start_line: None,
-                evidence_end_line: None,
-                evidence_is_excluded: false,
-            },
-            RawFinding {
-                rule_id: TripwireRuleId::MigrationChange,
-                report_only: false,
-                evidence_path: "migrations/001.sql".to_owned(),
-                evidence_start_line: Some(1),
-                evidence_end_line: Some(5),
-                evidence_is_excluded: false,
-            },
-            RawFinding {
-                rule_id: TripwireRuleId::MigrationChange,
-                report_only: false,
-                evidence_path: "migrations/001.sql".to_owned(),
-                evidence_start_line: Some(10),
-                evidence_end_line: Some(20),
-                evidence_is_excluded: false,
-            },
-        ];
-
-        let evaluator = make_evaluator(raw_findings);
-        let input = sample_input("task_1", "sha_a");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.findings.len(), 3);
-        // CI workflow < Migration (alphabetical by rule_id string)
-        assert_eq!(
-            decision.findings[0].rule_id,
-            TripwireRuleId::CIWorkflowChange
-        );
-        assert_eq!(
-            decision.findings[1].rule_id,
-            TripwireRuleId::MigrationChange
-        );
-        assert_eq!(decision.findings[1].evidence.start_line, Some(1));
-        assert_eq!(
-            decision.findings[2].rule_id,
-            TripwireRuleId::MigrationChange
-        );
-        assert_eq!(decision.findings[2].evidence.start_line, Some(10));
-    }
-
-    /// Running the engine twice with the same input must produce
-    /// byte-identical findings and idempotency keys.
-    #[test]
-    fn engine_output_is_idempotent() {
-        let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
-        let eval1 = make_evaluator(raw.clone());
-        let eval2 = make_evaluator(raw);
-
-        let mut input = sample_input("t1", "sha1");
-        input.changed_files = vec![ChangedFile {
-            path: "migrations/001.sql".to_owned(),
-            old_path: None,
-            status: ChangedFileStatus::Added,
-            additions: 10,
-            deletions: 0,
-            hunks: Vec::new(),
-            is_generated: false,
-            is_vendor: false,
-        }];
-
-        let d1 = evaluate(&input, &[eval1]);
-        let d2 = evaluate(&input, &[eval2]);
-
-        assert_eq!(d1, d2, "same input must produce identical decisions");
-    }
-
-    // ── Report-only vs enforcement decisions ─────────────────────────────
-
-    /// When all findings are enforcement-on, outcome must be `Held`.
-    #[test]
-    fn enforcement_findings_produce_held_outcome() {
-        let raw = vec![
-            migration_finding("t1", "sha1", "migrations/001.sql"),
-            RawFinding {
-                rule_id: TripwireRuleId::UnsafeCodeChange,
-                report_only: false,
-                evidence_path: "src/native.rs".to_owned(),
-                evidence_start_line: Some(10),
-                evidence_end_line: Some(50),
-                evidence_is_excluded: false,
-            },
-        ];
-        let evaluator = make_evaluator(raw);
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.outcome, GateOutcome::Held);
-        assert_eq!(decision.enforcement_finding_count, 2);
-        assert_eq!(decision.report_only_finding_count, 0);
-    }
-
-    /// When all findings are report-only, outcome must be `ReportOnly`.
-    #[test]
-    fn report_only_findings_produce_report_only_outcome() {
-        let raw = vec![
-            ci_report_only_finding(".github/workflows/ci.yml"),
-            ci_report_only_finding(".github/workflows/deploy.yml"),
-        ];
-        let evaluator = make_evaluator(raw);
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.outcome, GateOutcome::ReportOnly);
-        assert_eq!(decision.enforcement_finding_count, 0);
-        assert_eq!(decision.report_only_finding_count, 2);
-        assert!(
-            decision
-                .findings
-                .iter()
-                .all(|f| f.severity == TripwireFindingSeverity::ReportOnly)
-        );
-    }
-
-    /// When there are mixed enforcement + report-only findings, outcome
-    /// must be `Held` (enforcement wins).
-    #[test]
-    fn mixed_findings_produce_held_outcome() {
-        let raw = vec![
-            migration_finding("t1", "sha1", "migrations/001.sql"),
-            ci_report_only_finding(".github/workflows/ci.yml"),
-        ];
-        let evaluator = make_evaluator(raw);
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.outcome, GateOutcome::Held);
-        assert_eq!(decision.enforcement_finding_count, 1);
-        assert_eq!(decision.report_only_finding_count, 1);
-    }
-
-    /// When there are no findings, outcome must be `Passed`.
-    #[test]
-    fn empty_findings_produce_passed_outcome() {
-        let evaluator = make_evaluator(Vec::new());
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.outcome, GateOutcome::Passed);
-        assert_eq!(decision.enforcement_finding_count, 0);
-        assert_eq!(decision.report_only_finding_count, 0);
-        assert!(decision.findings.is_empty());
-    }
-
-    // ── Generated/vendor exclusion plumbing ──────────────────────────────
-
-    /// Findings from generated files must be excluded.
-    #[test]
-    fn generated_file_findings_are_excluded() {
-        let raw = vec![RawFinding {
-            rule_id: TripwireRuleId::MigrationChange,
-            report_only: false,
-            evidence_path: "target/debug/build.rs".to_owned(),
-            evidence_start_line: None,
-            evidence_end_line: None,
-            evidence_is_excluded: true, // classified as generated
-        }];
-        let evaluator = make_evaluator(raw);
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.outcome, GateOutcome::Passed);
-        assert!(
-            decision.findings.is_empty(),
-            "generated-file finding must be excluded"
-        );
-    }
-
-    /// Findings from vendor files must be excluded.
-    #[test]
-    fn vendor_file_findings_are_excluded() {
-        let raw = vec![RawFinding {
-            rule_id: TripwireRuleId::DependencyIdentityChange,
-            report_only: false,
-            evidence_path: "vendor/some-lib/index.js".to_owned(),
-            evidence_start_line: Some(1),
-            evidence_end_line: Some(5),
-            evidence_is_excluded: true, // classified as vendor
-        }];
-        let evaluator = make_evaluator(raw);
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.outcome, GateOutcome::Passed);
-        assert!(
-            decision.findings.is_empty(),
-            "vendor-file finding must be excluded"
-        );
-    }
-
-    /// Mixed: generated file excluded, real file kept.
-    #[test]
-    fn exclusion_only_affects_flagged_files() {
-        let raw = vec![
-            RawFinding {
-                rule_id: TripwireRuleId::MigrationChange,
-                report_only: false,
-                evidence_path: "target/generated/migrations.rs".to_owned(),
-                evidence_start_line: None,
-                evidence_end_line: None,
-                evidence_is_excluded: true,
-            },
-            migration_finding("t1", "sha1", "migrations/001.sql"),
-        ];
-        let evaluator = make_evaluator(raw);
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.outcome, GateOutcome::Held);
-        assert_eq!(decision.findings.len(), 1);
-        assert_eq!(decision.findings[0].evidence.path, "migrations/001.sql");
-    }
-
-    /// ChangedFile::is_excluded helper reflects generated/vendor flags.
-    #[test]
-    fn changed_file_is_excluded_reflects_flags() {
-        let normal = ChangedFile {
-            path: "src/main.rs".to_owned(),
-            old_path: None,
-            status: ChangedFileStatus::Modified,
-            additions: 5,
-            deletions: 2,
-            hunks: Vec::new(),
-            is_generated: false,
-            is_vendor: false,
-        };
-        assert!(!normal.is_excluded());
-
-        let generated = ChangedFile {
-            is_generated: true,
-            ..normal.clone()
-        };
-        assert!(generated.is_excluded());
-
-        let vendored = ChangedFile {
-            is_vendor: true,
-            ..normal
-        };
-        assert!(vendored.is_excluded());
-    }
-
-    // ── Revision propagation ─────────────────────────────────────────────
-
-    /// Policy revision must be propagated into every finding and the
-    /// decision.
-    #[test]
-    fn policy_revision_propagated_to_findings_and_decision() {
-        let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
-        let evaluator = make_evaluator(raw);
-        let mut input = sample_input("t1", "sha1");
-        input.policy.policy_revision = "org-policy:42".to_owned();
-
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.policy_revision, "org-policy:42");
-        for finding in &decision.findings {
-            assert_eq!(finding.policy_revision, "org-policy:42");
-        }
-    }
-
-    /// Allowlist revision must be propagated into boundary-path findings.
-    #[test]
-    fn allowlist_revision_propagated_to_boundary_findings() {
-        let raw = vec![RawFinding {
-            rule_id: TripwireRuleId::BoundaryPathChange,
-            report_only: false,
-            evidence_path: "scripts/capability-boundary-allowlist.toml".to_owned(),
-            evidence_start_line: Some(1),
-            evidence_end_line: Some(20),
-            evidence_is_excluded: false,
-        }];
-        let evaluator = make_evaluator(raw);
-        let mut input = sample_input("t1", "sha1");
-        input.policy.allowlist.revision = "capability-boundary-allowlist:9".to_owned();
-
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(
-            decision.allowlist_revision,
-            Some("capability-boundary-allowlist:9".to_owned())
-        );
-        assert_eq!(
-            decision.findings[0].allowlist_revision,
-            Some("capability-boundary-allowlist:9".to_owned())
-        );
-    }
-
-    /// Allowlist revision is absent from the decision when no boundary
-    /// rule tripped.
-    #[test]
-    fn allowlist_revision_absent_when_no_boundary_finding() {
-        let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
-        let evaluator = make_evaluator(raw);
-        let input = sample_input("t1", "sha1");
-
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.allowlist_revision, None);
-        assert_eq!(decision.findings[0].allowlist_revision, None);
-    }
-
-    /// Allowlist revision from input override takes precedence.
-    #[test]
-    fn allowlist_revision_override_takes_precedence() {
-        let raw = vec![RawFinding {
-            rule_id: TripwireRuleId::BoundaryPathChange,
-            report_only: false,
-            evidence_path: "**/auth/**".to_owned(),
-            evidence_start_line: None,
-            evidence_end_line: None,
-            evidence_is_excluded: false,
-        }];
-        let evaluator = make_evaluator(raw);
-        let mut input = sample_input("t1", "sha1");
-        input.policy.allowlist.revision = "from-policy:1".to_owned();
-        input.allowlist_revision = Some("override:99".to_owned());
-
-        let decision = evaluate(&input, &[evaluator]);
-
-        assert_eq!(decision.allowlist_revision, Some("override:99".to_owned()));
-        assert_eq!(
-            decision.findings[0].allowlist_revision,
-            Some("override:99".to_owned())
-        );
-    }
-
-    // ── Idempotency key stability ────────────────────────────────────────
-
-    /// Finding idempotency keys must be stable for the same inputs.
-    #[test]
-    fn finding_idempotency_key_is_stable() {
-        let k1 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            Some(1),
-            Some(10),
-            "org-policy:1",
-        );
-        let k2 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            Some(1),
-            Some(10),
-            "org-policy:1",
-        );
-        assert_eq!(k1, k2, "same inputs must produce same key");
-        assert!(k1.starts_with("sha256:"), "key must use sha256 prefix");
-    }
-
-    /// Changing the head SHA must change the finding idempotency key.
-    #[test]
-    fn finding_key_changes_with_head_sha() {
-        let k1 = build_finding_idempotency_key(
-            "task_1",
-            "sha_a",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            None,
-            None,
-            "org-policy:1",
-        );
-        let k2 = build_finding_idempotency_key(
-            "task_1",
-            "sha_b",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            None,
-            None,
-            "org-policy:1",
-        );
-        assert_ne!(k1, k2, "different head SHA must produce different key");
-    }
-
-    /// Changing the evidence path must change the finding idempotency key.
-    #[test]
-    fn finding_key_changes_with_evidence_path() {
-        let k1 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            Some(1),
-            Some(10),
-            "org-policy:1",
-        );
-        let k2 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/002.sql",
-            Some(1),
-            Some(10),
-            "org-policy:1",
-        );
-        assert_ne!(k1, k2, "different evidence path must produce different key");
-    }
-
-    /// Changing the policy revision must change the finding idempotency key.
-    #[test]
-    fn finding_key_changes_with_policy_revision() {
-        let k1 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            Some(1),
-            Some(10),
-            "org-policy:1",
-        );
-        let k2 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            Some(1),
-            Some(10),
-            "org-policy:2",
-        );
-        assert_ne!(
-            k1, k2,
-            "different policy revision must produce different key"
-        );
-    }
-
-    /// Changing the task id must change the finding idempotency key.
-    #[test]
-    fn finding_key_changes_with_task_id() {
-        let k1 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            None,
-            None,
-            "org-policy:1",
-        );
-        let k2 = build_finding_idempotency_key(
-            "task_2",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            None,
-            None,
-            "org-policy:1",
-        );
-        assert_ne!(k1, k2, "different task id must produce different key");
-    }
-
-    /// Changing the evidence span must change the finding idempotency key.
-    #[test]
-    fn finding_key_changes_with_evidence_span() {
-        let k1 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            Some(1),
-            Some(10),
-            "org-policy:1",
-        );
-        let k2 = build_finding_idempotency_key(
-            "task_1",
-            "sha_abc",
-            TripwireRuleId::MigrationChange,
-            "migrations/001.sql",
-            Some(5),
-            Some(20),
-            "org-policy:1",
-        );
-        assert_ne!(k1, k2, "different evidence span must produce different key");
-    }
-
-    /// Gate idempotency key must be stable for the same inputs.
-    #[test]
-    fn gate_idempotency_key_is_stable() {
-        let keys = vec!["sha256:aaa".to_owned(), "sha256:bbb".to_owned()];
-        let k1 = build_gate_idempotency_key(
-            "task_1",
-            "sha_abc",
-            "org-policy:1",
-            Some("allowlist:1"),
-            &keys,
-        );
-        let k2 = build_gate_idempotency_key(
-            "task_1",
-            "sha_abc",
-            "org-policy:1",
-            Some("allowlist:1"),
-            &keys,
-        );
-        assert_eq!(k1, k2, "same inputs must produce same gate key");
-    }
-
-    /// Gate idempotency key must change with head SHA.
-    #[test]
-    fn gate_key_changes_with_head_sha() {
-        let keys = vec!["sha256:aaa".to_owned()];
-        let k1 = build_gate_idempotency_key("t", "sha_a", "p", None, &keys);
-        let k2 = build_gate_idempotency_key("t", "sha_b", "p", None, &keys);
-        assert_ne!(k1, k2);
-    }
-
-    /// Gate idempotency key must change with policy revision.
-    #[test]
-    fn gate_key_changes_with_policy_revision() {
-        let keys = vec!["sha256:aaa".to_owned()];
-        let k1 = build_gate_idempotency_key("t", "sha", "p1", None, &keys);
-        let k2 = build_gate_idempotency_key("t", "sha", "p2", None, &keys);
-        assert_ne!(k1, k2);
-    }
-
-    /// Gate idempotency key must be independent of finding insertion order
-    /// (because the caller sorts finding keys before passing them).
-    #[test]
-    fn gate_key_is_independent_of_finding_order() {
-        let mut keys_a = vec!["sha256:aaa".to_owned(), "sha256:bbb".to_owned()];
-        let mut keys_b = vec!["sha256:bbb".to_owned(), "sha256:aaa".to_owned()];
-        keys_a.sort();
-        keys_b.sort();
-
-        let k1 = build_gate_idempotency_key("t", "sha", "p", None, &keys_a);
-        let k2 = build_gate_idempotency_key("t", "sha", "p", None, &keys_b);
-        assert_eq!(
-            k1, k2,
-            "sorted keys must produce the same gate key regardless of original order"
-        );
-    }
-
-    // ── Evaluator integration ────────────────────────────────────────────
-
-    /// Multiple evaluators must all run and their findings combined.
-    #[test]
-    fn multiple_evaluators_produce_combined_findings() {
-        let eval1 = make_evaluator(vec![migration_finding("t1", "sha1", "migrations/001.sql")]);
-        let eval2 = make_evaluator(vec![RawFinding {
-            rule_id: TripwireRuleId::CIWorkflowChange,
-            report_only: true,
-            evidence_path: ".github/workflows/ci.yml".to_owned(),
-            evidence_start_line: None,
-            evidence_end_line: None,
-            evidence_is_excluded: false,
-        }]);
-
-        let input = sample_input("t1", "sha1");
-        let decision = evaluate(&input, &[eval1, eval2]);
-
-        assert_eq!(decision.findings.len(), 2);
-        assert_eq!(decision.outcome, GateOutcome::Held);
-        assert_eq!(decision.enforcement_finding_count, 1);
-        assert_eq!(decision.report_only_finding_count, 1);
-    }
-
-    // ── to_summary conversion ────────────────────────────────────────────
-
-    /// TripwireFinding::to_summary must correctly map severity and fields.
-    #[test]
-    fn finding_to_summary_maps_correctly() {
-        let finding = TripwireFinding {
-            rule_id: TripwireRuleId::MigrationChange,
-            reason_code: REASON_MIGRATION_CHANGE,
-            severity: TripwireFindingSeverity::EnforceHold,
-            evidence: EvidenceSpan::lines("migrations/001.sql", 1, 10),
-            policy_revision: "org-policy:1".to_owned(),
-            allowlist_revision: None,
-            idempotency_key: "sha256:test".to_owned(),
-        };
-
-        let summary = finding.to_summary();
-        assert_eq!(summary.rule_id, "migration_change");
-        assert_eq!(summary.reason_code, REASON_MIGRATION_CHANGE);
-        assert_eq!(summary.severity, TripwireSeverity::HumanReviewRequired);
-        assert_eq!(summary.evidence.path, "migrations/001.sql");
-        assert_eq!(summary.evidence.start_line, Some(1));
-        assert_eq!(summary.evidence.end_line, Some(10));
-        assert_eq!(summary.idempotency_key, "sha256:test");
-    }
-
-    /// to_summary must map ReportOnly correctly.
-    #[test]
-    fn finding_to_summary_maps_report_only() {
-        let finding = TripwireFinding {
-            rule_id: TripwireRuleId::CIWorkflowChange,
-            reason_code: REASON_CI_WORKFLOW_CHANGE,
-            severity: TripwireFindingSeverity::ReportOnly,
-            evidence: EvidenceSpan::file(".github/workflows/ci.yml"),
-            policy_revision: "org-policy:1".to_owned(),
-            allowlist_revision: None,
-            idempotency_key: "sha256:ro".to_owned(),
-        };
-
-        let summary = finding.to_summary();
-        assert_eq!(summary.severity, TripwireSeverity::ReportOnly);
-        assert_eq!(summary.evidence.start_line, None);
-        assert_eq!(summary.evidence.end_line, None);
-    }
-
-    // ── EvidenceSpan constructors ────────────────────────────────────────
-
-    /// EvidenceSpan::lines must produce a line-precise span.
-    #[test]
-    fn evidence_span_lines_constructor() {
-        let span = EvidenceSpan::lines("src/main.rs", 10, 20);
-        assert_eq!(span.path, "src/main.rs");
-        assert_eq!(span.start_line, Some(10));
-        assert_eq!(span.end_line, Some(20));
-    }
-
-    /// EvidenceSpan::file must produce a file-level span.
-    #[test]
-    fn evidence_span_file_constructor() {
-        let span = EvidenceSpan::file("Cargo.lock");
-        assert_eq!(span.path, "Cargo.lock");
-        assert_eq!(span.start_line, None);
-        assert_eq!(span.end_line, None);
-    }
-
-    // ── ChangedFile total_lines_changed ──────────────────────────────────
-
-    #[test]
-    fn changed_file_total_lines_changed() {
-        let f = ChangedFile {
-            path: "src/lib.rs".to_owned(),
-            old_path: None,
-            status: ChangedFileStatus::Modified,
-            additions: 15,
-            deletions: 7,
-            hunks: Vec::new(),
-            is_generated: false,
-            is_vendor: false,
-        };
-        assert_eq!(f.total_lines_changed(), 22);
-    }
-
-    // ── End-to-end gate key stability ────────────────────────────────────
-
-    /// Full end-to-end: running evaluate twice must produce identical
-    /// gate idempotency keys.
-    #[test]
-    fn gate_key_end_to_end_stability() {
-        let raw = vec![
-            migration_finding("t1", "sha1", "migrations/001.sql"),
-            RawFinding {
-                rule_id: TripwireRuleId::CIWorkflowChange,
-                report_only: true,
-                evidence_path: ".github/workflows/ci.yml".to_owned(),
-                evidence_start_line: None,
-                evidence_end_line: None,
-                evidence_is_excluded: false,
-            },
-        ];
-
-        let eval_a = make_evaluator(raw.clone());
-        let eval_b = make_evaluator(raw);
-
-        let input = sample_input("t1", "sha1");
-        let d1 = evaluate(&input, &[eval_a]);
-        let d2 = evaluate(&input, &[eval_b]);
-
-        assert_eq!(
-            d1.idempotency_key, d2.idempotency_key,
-            "gate idempotency key must be identical for same input"
-        );
-    }
-
-    /// Different head SHA must produce different gate idempotency key in
-    /// full end-to-end.
-    #[test]
-    fn gate_key_end_to_end_changes_with_head_sha() {
-        let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
-
-        let eval_a = make_evaluator(raw.clone());
-        let eval_b = make_evaluator(raw);
-
-        let mut input_a = sample_input("t1", "sha_a");
-        let mut input_b = sample_input("t1", "sha_b");
-        input_a.policy.policy_revision = "org-policy:1".to_owned();
-        input_b.policy.policy_revision = "org-policy:1".to_owned();
-
-        let d1 = evaluate(&input_a, &[eval_a]);
-        let d2 = evaluate(&input_b, &[eval_b]);
-
-        assert_ne!(
-            d1.idempotency_key, d2.idempotency_key,
-            "different head SHA must produce different gate key"
-        );
-    }
-
-    /// Different policy revision must produce different gate idempotency
-    /// key in full end-to-end.
-    #[test]
-    fn gate_key_end_to_end_changes_with_policy_revision() {
-        let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
-
-        let eval_a = make_evaluator(raw.clone());
-        let eval_b = make_evaluator(raw);
-
-        let mut input_a = sample_input("t1", "sha1");
-        input_a.policy.policy_revision = "org-policy:1".to_owned();
-        let mut input_b = sample_input("t1", "sha1");
-        input_b.policy.policy_revision = "org-policy:2".to_owned();
-
-        let d1 = evaluate(&input_a, &[eval_a]);
-        let d2 = evaluate(&input_b, &[eval_b]);
-
-        assert_ne!(
-            d1.idempotency_key, d2.idempotency_key,
-            "different policy revision must produce different gate key"
-        );
-    }
-}
+#[path = "engine_tests.rs"]
+mod tests;

--- a/server/crates/djinn-coordinator/src/tripwires/engine_tests.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/engine_tests.rs
@@ -1,0 +1,897 @@
+//! Unit tests for the pure tripwire engine primitives.
+//!
+//! Kept in a `#[path]` sibling file so `engine.rs` stays under the repo size
+//! guard (see `scripts/check-file-size.sh`).
+
+use super::*;
+use crate::tripwires::policy::TripwirePolicy;
+use crate::tripwires::reason_codes::*;
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn sample_input(task_id: &str, head_sha: &str) -> TripwireEvaluationInput {
+    TripwireEvaluationInput {
+        task_id: task_id.to_owned(),
+        project_id: "proj_1".to_owned(),
+        pr_number: Some(42),
+        head_sha: head_sha.to_owned(),
+        policy: TripwirePolicy::default(),
+        allowlist_revision: None,
+        changed_files: Vec::new(),
+    }
+}
+
+fn migration_finding(_task_id: &str, _head_sha: &str, path: &str) -> RawFinding {
+    RawFinding {
+        rule_id: TripwireRuleId::MigrationChange,
+        report_only: false,
+        evidence_path: path.to_owned(),
+        evidence_start_line: Some(1),
+        evidence_end_line: Some(10),
+        evidence_is_excluded: false,
+    }
+}
+
+fn ci_report_only_finding(path: &str) -> RawFinding {
+    RawFinding {
+        rule_id: TripwireRuleId::CIWorkflowChange,
+        report_only: true,
+        evidence_path: path.to_owned(),
+        evidence_start_line: None,
+        evidence_end_line: None,
+        evidence_is_excluded: false,
+    }
+}
+
+fn make_evaluator(
+    findings: Vec<RawFinding>,
+) -> impl Fn(&TripwirePolicy, &[ChangedFile]) -> Vec<RawFinding> {
+    move |_policy: &TripwirePolicy, _files: &[ChangedFile]| -> Vec<RawFinding> { findings.clone() }
+}
+
+// ── Deterministic ordering ───────────────────────────────────────────
+
+/// Findings must be sorted by (rule_id, path, start_line, end_line,
+/// severity) regardless of insertion order.
+#[test]
+fn findings_are_sorted_deterministically() {
+    let raw_findings = vec![
+        RawFinding {
+            rule_id: TripwireRuleId::CIWorkflowChange,
+            report_only: false,
+            evidence_path: ".github/workflows/ci.yml".to_owned(),
+            evidence_start_line: None,
+            evidence_end_line: None,
+            evidence_is_excluded: false,
+        },
+        RawFinding {
+            rule_id: TripwireRuleId::MigrationChange,
+            report_only: false,
+            evidence_path: "migrations/001.sql".to_owned(),
+            evidence_start_line: Some(1),
+            evidence_end_line: Some(5),
+            evidence_is_excluded: false,
+        },
+        RawFinding {
+            rule_id: TripwireRuleId::MigrationChange,
+            report_only: false,
+            evidence_path: "migrations/001.sql".to_owned(),
+            evidence_start_line: Some(10),
+            evidence_end_line: Some(20),
+            evidence_is_excluded: false,
+        },
+    ];
+
+    let evaluator = make_evaluator(raw_findings);
+    let input = sample_input("task_1", "sha_a");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.findings.len(), 3);
+    // CI workflow < Migration (alphabetical by rule_id string)
+    assert_eq!(
+        decision.findings[0].rule_id,
+        TripwireRuleId::CIWorkflowChange
+    );
+    assert_eq!(
+        decision.findings[1].rule_id,
+        TripwireRuleId::MigrationChange
+    );
+    assert_eq!(decision.findings[1].evidence.start_line, Some(1));
+    assert_eq!(
+        decision.findings[2].rule_id,
+        TripwireRuleId::MigrationChange
+    );
+    assert_eq!(decision.findings[2].evidence.start_line, Some(10));
+}
+
+/// Running the engine twice with the same input must produce
+/// byte-identical findings and idempotency keys.
+#[test]
+fn engine_output_is_idempotent() {
+    let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
+    let eval1 = make_evaluator(raw.clone());
+    let eval2 = make_evaluator(raw);
+
+    let mut input = sample_input("t1", "sha1");
+    input.changed_files = vec![ChangedFile {
+        path: "migrations/001.sql".to_owned(),
+        old_path: None,
+        status: ChangedFileStatus::Added,
+        additions: 10,
+        deletions: 0,
+        hunks: Vec::new(),
+        is_generated: false,
+        is_vendor: false,
+    }];
+
+    let d1 = evaluate(&input, &[eval1]);
+    let d2 = evaluate(&input, &[eval2]);
+
+    assert_eq!(d1, d2, "same input must produce identical decisions");
+}
+
+// ── Report-only vs enforcement decisions ─────────────────────────────
+
+/// When all findings are enforcement-on, outcome must be `Held`.
+#[test]
+fn enforcement_findings_produce_held_outcome() {
+    let raw = vec![
+        migration_finding("t1", "sha1", "migrations/001.sql"),
+        RawFinding {
+            rule_id: TripwireRuleId::UnsafeCodeChange,
+            report_only: false,
+            evidence_path: "src/native.rs".to_owned(),
+            evidence_start_line: Some(10),
+            evidence_end_line: Some(50),
+            evidence_is_excluded: false,
+        },
+    ];
+    let evaluator = make_evaluator(raw);
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.outcome, GateOutcome::Held);
+    assert_eq!(decision.enforcement_finding_count, 2);
+    assert_eq!(decision.report_only_finding_count, 0);
+}
+
+/// When all findings are report-only, outcome must be `ReportOnly`.
+#[test]
+fn report_only_findings_produce_report_only_outcome() {
+    let raw = vec![
+        ci_report_only_finding(".github/workflows/ci.yml"),
+        ci_report_only_finding(".github/workflows/deploy.yml"),
+    ];
+    let evaluator = make_evaluator(raw);
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.outcome, GateOutcome::ReportOnly);
+    assert_eq!(decision.enforcement_finding_count, 0);
+    assert_eq!(decision.report_only_finding_count, 2);
+    assert!(
+        decision
+            .findings
+            .iter()
+            .all(|f| f.severity == TripwireFindingSeverity::ReportOnly)
+    );
+}
+
+/// When there are mixed enforcement + report-only findings, outcome
+/// must be `Held` (enforcement wins).
+#[test]
+fn mixed_findings_produce_held_outcome() {
+    let raw = vec![
+        migration_finding("t1", "sha1", "migrations/001.sql"),
+        ci_report_only_finding(".github/workflows/ci.yml"),
+    ];
+    let evaluator = make_evaluator(raw);
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.outcome, GateOutcome::Held);
+    assert_eq!(decision.enforcement_finding_count, 1);
+    assert_eq!(decision.report_only_finding_count, 1);
+}
+
+/// When there are no findings, outcome must be `Passed`.
+#[test]
+fn empty_findings_produce_passed_outcome() {
+    let evaluator = make_evaluator(Vec::new());
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.outcome, GateOutcome::Passed);
+    assert_eq!(decision.enforcement_finding_count, 0);
+    assert_eq!(decision.report_only_finding_count, 0);
+    assert!(decision.findings.is_empty());
+}
+
+// ── Generated/vendor exclusion plumbing ──────────────────────────────
+
+/// Findings from generated files must be excluded.
+#[test]
+fn generated_file_findings_are_excluded() {
+    let raw = vec![RawFinding {
+        rule_id: TripwireRuleId::MigrationChange,
+        report_only: false,
+        evidence_path: "target/debug/build.rs".to_owned(),
+        evidence_start_line: None,
+        evidence_end_line: None,
+        evidence_is_excluded: true, // classified as generated
+    }];
+    let evaluator = make_evaluator(raw);
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.outcome, GateOutcome::Passed);
+    assert!(
+        decision.findings.is_empty(),
+        "generated-file finding must be excluded"
+    );
+}
+
+/// Findings from vendor files must be excluded.
+#[test]
+fn vendor_file_findings_are_excluded() {
+    let raw = vec![RawFinding {
+        rule_id: TripwireRuleId::DependencyIdentityChange,
+        report_only: false,
+        evidence_path: "vendor/some-lib/index.js".to_owned(),
+        evidence_start_line: Some(1),
+        evidence_end_line: Some(5),
+        evidence_is_excluded: true, // classified as vendor
+    }];
+    let evaluator = make_evaluator(raw);
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.outcome, GateOutcome::Passed);
+    assert!(
+        decision.findings.is_empty(),
+        "vendor-file finding must be excluded"
+    );
+}
+
+/// Mixed: generated file excluded, real file kept.
+#[test]
+fn exclusion_only_affects_flagged_files() {
+    let raw = vec![
+        RawFinding {
+            rule_id: TripwireRuleId::MigrationChange,
+            report_only: false,
+            evidence_path: "target/generated/migrations.rs".to_owned(),
+            evidence_start_line: None,
+            evidence_end_line: None,
+            evidence_is_excluded: true,
+        },
+        migration_finding("t1", "sha1", "migrations/001.sql"),
+    ];
+    let evaluator = make_evaluator(raw);
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.outcome, GateOutcome::Held);
+    assert_eq!(decision.findings.len(), 1);
+    assert_eq!(decision.findings[0].evidence.path, "migrations/001.sql");
+}
+
+/// ChangedFile::is_excluded helper reflects generated/vendor flags.
+#[test]
+fn changed_file_is_excluded_reflects_flags() {
+    let normal = ChangedFile {
+        path: "src/main.rs".to_owned(),
+        old_path: None,
+        status: ChangedFileStatus::Modified,
+        additions: 5,
+        deletions: 2,
+        hunks: Vec::new(),
+        is_generated: false,
+        is_vendor: false,
+    };
+    assert!(!normal.is_excluded());
+
+    let generated = ChangedFile {
+        is_generated: true,
+        ..normal.clone()
+    };
+    assert!(generated.is_excluded());
+
+    let vendored = ChangedFile {
+        is_vendor: true,
+        ..normal
+    };
+    assert!(vendored.is_excluded());
+}
+
+// ── Revision propagation ─────────────────────────────────────────────
+
+/// Policy revision must be propagated into every finding and the
+/// decision.
+#[test]
+fn policy_revision_propagated_to_findings_and_decision() {
+    let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
+    let evaluator = make_evaluator(raw);
+    let mut input = sample_input("t1", "sha1");
+    input.policy.policy_revision = "org-policy:42".to_owned();
+
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.policy_revision, "org-policy:42");
+    for finding in &decision.findings {
+        assert_eq!(finding.policy_revision, "org-policy:42");
+    }
+}
+
+/// Allowlist revision must be propagated into boundary-path findings.
+#[test]
+fn allowlist_revision_propagated_to_boundary_findings() {
+    let raw = vec![RawFinding {
+        rule_id: TripwireRuleId::BoundaryPathChange,
+        report_only: false,
+        evidence_path: "scripts/capability-boundary-allowlist.toml".to_owned(),
+        evidence_start_line: Some(1),
+        evidence_end_line: Some(20),
+        evidence_is_excluded: false,
+    }];
+    let evaluator = make_evaluator(raw);
+    let mut input = sample_input("t1", "sha1");
+    input.policy.allowlist.revision = "capability-boundary-allowlist:9".to_owned();
+
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(
+        decision.allowlist_revision,
+        Some("capability-boundary-allowlist:9".to_owned())
+    );
+    assert_eq!(
+        decision.findings[0].allowlist_revision,
+        Some("capability-boundary-allowlist:9".to_owned())
+    );
+}
+
+/// Allowlist revision is absent from the decision when no boundary
+/// rule tripped.
+#[test]
+fn allowlist_revision_absent_when_no_boundary_finding() {
+    let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
+    let evaluator = make_evaluator(raw);
+    let input = sample_input("t1", "sha1");
+
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.allowlist_revision, None);
+    assert_eq!(decision.findings[0].allowlist_revision, None);
+}
+
+/// Allowlist revision from input override takes precedence.
+#[test]
+fn allowlist_revision_override_takes_precedence() {
+    let raw = vec![RawFinding {
+        rule_id: TripwireRuleId::BoundaryPathChange,
+        report_only: false,
+        evidence_path: "**/auth/**".to_owned(),
+        evidence_start_line: None,
+        evidence_end_line: None,
+        evidence_is_excluded: false,
+    }];
+    let evaluator = make_evaluator(raw);
+    let mut input = sample_input("t1", "sha1");
+    input.policy.allowlist.revision = "from-policy:1".to_owned();
+    input.allowlist_revision = Some("override:99".to_owned());
+
+    let decision = evaluate(&input, &[evaluator]);
+
+    assert_eq!(decision.allowlist_revision, Some("override:99".to_owned()));
+    assert_eq!(
+        decision.findings[0].allowlist_revision,
+        Some("override:99".to_owned())
+    );
+}
+
+// ── Idempotency key stability ────────────────────────────────────────
+
+/// Finding idempotency keys must be stable for the same inputs.
+#[test]
+fn finding_idempotency_key_is_stable() {
+    let k1 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        Some(1),
+        Some(10),
+        "org-policy:1",
+    );
+    let k2 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        Some(1),
+        Some(10),
+        "org-policy:1",
+    );
+    assert_eq!(k1, k2, "same inputs must produce same key");
+    assert!(k1.starts_with("sha256:"), "key must use sha256 prefix");
+}
+
+/// Changing the head SHA must change the finding idempotency key.
+#[test]
+fn finding_key_changes_with_head_sha() {
+    let k1 = build_finding_idempotency_key(
+        "task_1",
+        "sha_a",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        None,
+        None,
+        "org-policy:1",
+    );
+    let k2 = build_finding_idempotency_key(
+        "task_1",
+        "sha_b",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        None,
+        None,
+        "org-policy:1",
+    );
+    assert_ne!(k1, k2, "different head SHA must produce different key");
+}
+
+/// Changing the evidence path must change the finding idempotency key.
+#[test]
+fn finding_key_changes_with_evidence_path() {
+    let k1 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        Some(1),
+        Some(10),
+        "org-policy:1",
+    );
+    let k2 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/002.sql",
+        Some(1),
+        Some(10),
+        "org-policy:1",
+    );
+    assert_ne!(k1, k2, "different evidence path must produce different key");
+}
+
+/// Changing the policy revision must change the finding idempotency key.
+#[test]
+fn finding_key_changes_with_policy_revision() {
+    let k1 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        Some(1),
+        Some(10),
+        "org-policy:1",
+    );
+    let k2 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        Some(1),
+        Some(10),
+        "org-policy:2",
+    );
+    assert_ne!(
+        k1, k2,
+        "different policy revision must produce different key"
+    );
+}
+
+/// Changing the task id must change the finding idempotency key.
+#[test]
+fn finding_key_changes_with_task_id() {
+    let k1 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        None,
+        None,
+        "org-policy:1",
+    );
+    let k2 = build_finding_idempotency_key(
+        "task_2",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        None,
+        None,
+        "org-policy:1",
+    );
+    assert_ne!(k1, k2, "different task id must produce different key");
+}
+
+/// Changing the evidence span must change the finding idempotency key.
+#[test]
+fn finding_key_changes_with_evidence_span() {
+    let k1 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        Some(1),
+        Some(10),
+        "org-policy:1",
+    );
+    let k2 = build_finding_idempotency_key(
+        "task_1",
+        "sha_abc",
+        TripwireRuleId::MigrationChange,
+        "migrations/001.sql",
+        Some(5),
+        Some(20),
+        "org-policy:1",
+    );
+    assert_ne!(k1, k2, "different evidence span must produce different key");
+}
+
+/// Gate idempotency key must be stable for the same inputs.
+#[test]
+fn gate_idempotency_key_is_stable() {
+    let keys = vec!["sha256:aaa".to_owned(), "sha256:bbb".to_owned()];
+    let k1 = build_gate_idempotency_key(
+        "task_1",
+        "sha_abc",
+        "org-policy:1",
+        Some("allowlist:1"),
+        &keys,
+    );
+    let k2 = build_gate_idempotency_key(
+        "task_1",
+        "sha_abc",
+        "org-policy:1",
+        Some("allowlist:1"),
+        &keys,
+    );
+    assert_eq!(k1, k2, "same inputs must produce same gate key");
+}
+
+/// Gate idempotency key must change with head SHA.
+#[test]
+fn gate_key_changes_with_head_sha() {
+    let keys = vec!["sha256:aaa".to_owned()];
+    let k1 = build_gate_idempotency_key("t", "sha_a", "p", None, &keys);
+    let k2 = build_gate_idempotency_key("t", "sha_b", "p", None, &keys);
+    assert_ne!(k1, k2);
+}
+
+/// Gate idempotency key must change with policy revision.
+#[test]
+fn gate_key_changes_with_policy_revision() {
+    let keys = vec!["sha256:aaa".to_owned()];
+    let k1 = build_gate_idempotency_key("t", "sha", "p1", None, &keys);
+    let k2 = build_gate_idempotency_key("t", "sha", "p2", None, &keys);
+    assert_ne!(k1, k2);
+}
+
+/// Gate idempotency key must be independent of finding insertion order
+/// (because the caller sorts finding keys before passing them).
+#[test]
+fn gate_key_is_independent_of_finding_order() {
+    let mut keys_a = vec!["sha256:aaa".to_owned(), "sha256:bbb".to_owned()];
+    let mut keys_b = vec!["sha256:bbb".to_owned(), "sha256:aaa".to_owned()];
+    keys_a.sort();
+    keys_b.sort();
+
+    let k1 = build_gate_idempotency_key("t", "sha", "p", None, &keys_a);
+    let k2 = build_gate_idempotency_key("t", "sha", "p", None, &keys_b);
+    assert_eq!(
+        k1, k2,
+        "sorted keys must produce the same gate key regardless of original order"
+    );
+}
+
+// ── Evaluator integration ────────────────────────────────────────────
+
+/// Multiple evaluators must all run and their findings combined.
+#[test]
+fn multiple_evaluators_produce_combined_findings() {
+    let eval1 = make_evaluator(vec![migration_finding("t1", "sha1", "migrations/001.sql")]);
+    let eval2 = make_evaluator(vec![RawFinding {
+        rule_id: TripwireRuleId::CIWorkflowChange,
+        report_only: true,
+        evidence_path: ".github/workflows/ci.yml".to_owned(),
+        evidence_start_line: None,
+        evidence_end_line: None,
+        evidence_is_excluded: false,
+    }]);
+
+    let input = sample_input("t1", "sha1");
+    let decision = evaluate(&input, &[eval1, eval2]);
+
+    assert_eq!(decision.findings.len(), 2);
+    assert_eq!(decision.outcome, GateOutcome::Held);
+    assert_eq!(decision.enforcement_finding_count, 1);
+    assert_eq!(decision.report_only_finding_count, 1);
+}
+
+// ── to_summary conversion ────────────────────────────────────────────
+
+/// TripwireFinding::to_summary must correctly map severity and fields.
+#[test]
+fn finding_to_summary_maps_correctly() {
+    let finding = TripwireFinding {
+        rule_id: TripwireRuleId::MigrationChange,
+        reason_code: REASON_MIGRATION_CHANGE,
+        severity: TripwireFindingSeverity::EnforceHold,
+        evidence: EvidenceSpan::lines("migrations/001.sql", 1, 10),
+        policy_revision: "org-policy:1".to_owned(),
+        allowlist_revision: None,
+        idempotency_key: "sha256:test".to_owned(),
+        content_fingerprint: "fp:sha256:test".to_owned(),
+        downgrade_reason: None,
+    };
+
+    let summary = finding.to_summary();
+    assert_eq!(summary.rule_id, "migration_change");
+    assert_eq!(summary.content_fingerprint, "fp:sha256:test");
+    assert_eq!(summary.reason_code, REASON_MIGRATION_CHANGE);
+    assert_eq!(summary.severity, TripwireSeverity::HumanReviewRequired);
+    assert_eq!(summary.evidence.path, "migrations/001.sql");
+    assert_eq!(summary.evidence.start_line, Some(1));
+    assert_eq!(summary.evidence.end_line, Some(10));
+    assert_eq!(summary.idempotency_key, "sha256:test");
+}
+
+/// to_summary must map ReportOnly correctly.
+#[test]
+fn finding_to_summary_maps_report_only() {
+    let finding = TripwireFinding {
+        rule_id: TripwireRuleId::CIWorkflowChange,
+        reason_code: REASON_CI_WORKFLOW_CHANGE,
+        severity: TripwireFindingSeverity::ReportOnly,
+        evidence: EvidenceSpan::file(".github/workflows/ci.yml"),
+        policy_revision: "org-policy:1".to_owned(),
+        allowlist_revision: None,
+        idempotency_key: "sha256:ro".to_owned(),
+        content_fingerprint: "fp:sha256:ro".to_owned(),
+        downgrade_reason: None,
+    };
+
+    let summary = finding.to_summary();
+    assert_eq!(summary.severity, TripwireSeverity::ReportOnly);
+    assert_eq!(summary.evidence.start_line, None);
+    assert_eq!(summary.evidence.end_line, None);
+}
+
+// ── EvidenceSpan constructors ────────────────────────────────────────
+
+/// EvidenceSpan::lines must produce a line-precise span.
+#[test]
+fn evidence_span_lines_constructor() {
+    let span = EvidenceSpan::lines("src/main.rs", 10, 20);
+    assert_eq!(span.path, "src/main.rs");
+    assert_eq!(span.start_line, Some(10));
+    assert_eq!(span.end_line, Some(20));
+}
+
+/// EvidenceSpan::file must produce a file-level span.
+#[test]
+fn evidence_span_file_constructor() {
+    let span = EvidenceSpan::file("Cargo.lock");
+    assert_eq!(span.path, "Cargo.lock");
+    assert_eq!(span.start_line, None);
+    assert_eq!(span.end_line, None);
+}
+
+// ── ChangedFile total_lines_changed ──────────────────────────────────
+
+#[test]
+fn changed_file_total_lines_changed() {
+    let f = ChangedFile {
+        path: "src/lib.rs".to_owned(),
+        old_path: None,
+        status: ChangedFileStatus::Modified,
+        additions: 15,
+        deletions: 7,
+        hunks: Vec::new(),
+        is_generated: false,
+        is_vendor: false,
+    };
+    assert_eq!(f.total_lines_changed(), 22);
+}
+
+// ── End-to-end gate key stability ────────────────────────────────────
+
+/// Full end-to-end: running evaluate twice must produce identical
+/// gate idempotency keys.
+#[test]
+fn gate_key_end_to_end_stability() {
+    let raw = vec![
+        migration_finding("t1", "sha1", "migrations/001.sql"),
+        RawFinding {
+            rule_id: TripwireRuleId::CIWorkflowChange,
+            report_only: true,
+            evidence_path: ".github/workflows/ci.yml".to_owned(),
+            evidence_start_line: None,
+            evidence_end_line: None,
+            evidence_is_excluded: false,
+        },
+    ];
+
+    let eval_a = make_evaluator(raw.clone());
+    let eval_b = make_evaluator(raw);
+
+    let input = sample_input("t1", "sha1");
+    let d1 = evaluate(&input, &[eval_a]);
+    let d2 = evaluate(&input, &[eval_b]);
+
+    assert_eq!(
+        d1.idempotency_key, d2.idempotency_key,
+        "gate idempotency key must be identical for same input"
+    );
+}
+
+/// Different head SHA must produce different gate idempotency key in
+/// full end-to-end.
+#[test]
+fn gate_key_end_to_end_changes_with_head_sha() {
+    let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
+
+    let eval_a = make_evaluator(raw.clone());
+    let eval_b = make_evaluator(raw);
+
+    let mut input_a = sample_input("t1", "sha_a");
+    let mut input_b = sample_input("t1", "sha_b");
+    input_a.policy.policy_revision = "org-policy:1".to_owned();
+    input_b.policy.policy_revision = "org-policy:1".to_owned();
+
+    let d1 = evaluate(&input_a, &[eval_a]);
+    let d2 = evaluate(&input_b, &[eval_b]);
+
+    assert_ne!(
+        d1.idempotency_key, d2.idempotency_key,
+        "different head SHA must produce different gate key"
+    );
+}
+
+/// Different policy revision must produce different gate idempotency
+/// key in full end-to-end.
+#[test]
+fn gate_key_end_to_end_changes_with_policy_revision() {
+    let raw = vec![migration_finding("t1", "sha1", "migrations/001.sql")];
+
+    let eval_a = make_evaluator(raw.clone());
+    let eval_b = make_evaluator(raw);
+
+    let mut input_a = sample_input("t1", "sha1");
+    input_a.policy.policy_revision = "org-policy:1".to_owned();
+    let mut input_b = sample_input("t1", "sha1");
+    input_b.policy.policy_revision = "org-policy:2".to_owned();
+
+    let d1 = evaluate(&input_a, &[eval_a]);
+    let d2 = evaluate(&input_b, &[eval_b]);
+
+    assert_ne!(
+        d1.idempotency_key, d2.idempotency_key,
+        "different policy revision must produce different gate key"
+    );
+}
+
+// ── Content fingerprint + test-path downgrade annotation ─────────────
+
+fn changed_file(path: &str, added: &[&str], additions: u32, deletions: u32) -> ChangedFile {
+    let diff_lines: Vec<String> = added.iter().map(|l| format!("+{l}")).collect();
+    ChangedFile {
+        path: path.to_owned(),
+        old_path: None,
+        status: ChangedFileStatus::Modified,
+        additions,
+        deletions,
+        hunks: vec![DiffHunk {
+            new_start: 1,
+            new_lines: added.len() as u32,
+            old_start: 1,
+            old_lines: 0,
+            diff_lines,
+        }],
+        is_generated: false,
+        is_vendor: false,
+    }
+}
+
+/// The content fingerprint is head-independent: two heads with the same
+/// changed-file content produce the same fingerprint, while the
+/// idempotency key (head-dependent) differs.
+#[test]
+fn content_fingerprint_is_head_independent() {
+    let raw = vec![RawFinding {
+        rule_id: TripwireRuleId::UnsafeCodeChange,
+        report_only: false,
+        evidence_path: "src/ffi.rs".to_owned(),
+        evidence_start_line: Some(1),
+        evidence_end_line: Some(1),
+        evidence_is_excluded: false,
+    }];
+    let file = changed_file("src/ffi.rs", &["unsafe { x() }"], 1, 0);
+
+    let mut input_a = sample_input("t1", "head-a");
+    input_a.changed_files = vec![file.clone()];
+    let mut input_b = sample_input("t1", "head-b");
+    input_b.changed_files = vec![file];
+
+    let d1 = evaluate(&input_a, &[make_evaluator(raw.clone())]);
+    let d2 = evaluate(&input_b, &[make_evaluator(raw)]);
+
+    assert_eq!(
+        d1.findings[0].content_fingerprint, d2.findings[0].content_fingerprint,
+        "identical content must share a fingerprint across heads"
+    );
+    assert_ne!(
+        d1.findings[0].idempotency_key, d2.findings[0].idempotency_key,
+        "idempotency key must still vary with head"
+    );
+    assert!(d1.findings[0].content_fingerprint.starts_with("fp:sha256:"));
+}
+
+/// Changed content produces a different fingerprint.
+#[test]
+fn content_fingerprint_changes_with_content() {
+    let raw = vec![RawFinding {
+        rule_id: TripwireRuleId::UnsafeCodeChange,
+        report_only: false,
+        evidence_path: "src/ffi.rs".to_owned(),
+        evidence_start_line: Some(1),
+        evidence_end_line: Some(1),
+        evidence_is_excluded: false,
+    }];
+    let mut input_a = sample_input("t1", "head-a");
+    input_a.changed_files = vec![changed_file("src/ffi.rs", &["unsafe { a() }"], 1, 0)];
+    let mut input_b = sample_input("t1", "head-a");
+    input_b.changed_files = vec![changed_file("src/ffi.rs", &["unsafe { b() }"], 1, 0)];
+
+    let d1 = evaluate(&input_a, &[make_evaluator(raw.clone())]);
+    let d2 = evaluate(&input_b, &[make_evaluator(raw)]);
+    assert_ne!(
+        d1.findings[0].content_fingerprint, d2.findings[0].content_fingerprint,
+        "different content must produce different fingerprints"
+    );
+}
+
+/// A test-path finding is annotated with the downgrade reason; a
+/// production-path finding is not.
+#[test]
+fn test_path_finding_carries_downgrade_reason() {
+    let raw = vec![RawFinding {
+        rule_id: TripwireRuleId::UnsafeCodeChange,
+        // As the rules layer would emit for a test path.
+        report_only: true,
+        evidence_path: "crates/foo/src/ffi_test.rs".to_owned(),
+        evidence_start_line: Some(1),
+        evidence_end_line: Some(1),
+        evidence_is_excluded: false,
+    }];
+    let input = sample_input("t1", "head-a");
+    let d = evaluate(&input, &[make_evaluator(raw)]);
+    assert_eq!(d.findings[0].severity, TripwireFindingSeverity::ReportOnly);
+    assert_eq!(
+        d.findings[0].downgrade_reason.as_deref(),
+        Some(TEST_PATH_DOWNGRADE_REASON)
+    );
+    assert_eq!(
+        d.findings[0].to_summary().downgrade_reason.as_deref(),
+        Some(TEST_PATH_DOWNGRADE_REASON)
+    );
+}
+
+#[test]
+fn production_path_finding_has_no_downgrade_reason() {
+    let raw = vec![migration_finding("t1", "head-a", "migrations/001.sql")];
+    let input = sample_input("t1", "head-a");
+    let d = evaluate(&input, &[make_evaluator(raw)]);
+    assert!(d.findings[0].downgrade_reason.is_none());
+}

--- a/server/crates/djinn-coordinator/src/tripwires/hold_release.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/hold_release.rs
@@ -120,6 +120,7 @@ pub fn build_hold_released_payload(
         released_by_role: released_by_role.to_owned(),
         rationale: rationale.to_owned(),
         released_findings: state.active_findings.clone(),
+        carried_forward: false,
         idempotency_key,
         released_at: Some(released_at.to_owned()),
     };
@@ -151,6 +152,8 @@ mod tests {
             severity: TripwireSeverity::HumanReviewRequired,
             evidence: TripwireEvidenceSpan::file(path),
             idempotency_key: key.to_owned(),
+            content_fingerprint: format!("fp:{key}"),
+            downgrade_reason: None,
         }
     }
 

--- a/server/crates/djinn-coordinator/src/tripwires/mod.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/mod.rs
@@ -23,6 +23,7 @@
 
 pub mod active_hold;
 pub mod activity_payloads;
+pub mod carry_forward;
 pub mod engine;
 pub mod hold_release;
 pub mod policy;
@@ -41,7 +42,7 @@ pub mod rules;
 #[allow(unused_imports)]
 pub use active_hold::{
     ActiveHoldState, ActivityEntryRef, TamperReconciliation, build_tamper_reconciliation_key,
-    check_label_tamper, compute_active_hold_state,
+    check_label_tamper, compute_active_hold_state, gate_held_head_shas,
 };
 #[allow(unused_imports)]
 pub use activity_payloads::{
@@ -52,10 +53,13 @@ pub use activity_payloads::{
     TripwirePolicyChangedPayload, TripwireSeverity, TripwireTamperPayload,
 };
 #[allow(unused_imports)]
+pub use carry_forward::{CarryForwardRelease, build_carry_forward_releases};
+#[allow(unused_imports)]
 pub use engine::{
     ChangedFile, ChangedFileStatus, DiffHunk, EvidenceSpan, GateOutcome, RawFinding,
-    TripwireEvaluationInput, TripwireFinding, TripwireFindingSeverity, TripwireGateDecision,
-    build_finding_idempotency_key, build_gate_idempotency_key, evaluate, sort_findings,
+    TEST_PATH_DOWNGRADE_REASON, TripwireEvaluationInput, TripwireFinding, TripwireFindingSeverity,
+    TripwireGateDecision, build_finding_content_fingerprint, build_finding_idempotency_key,
+    build_gate_idempotency_key, evaluate, sort_findings,
 };
 #[allow(unused_imports)]
 pub use hold_release::{
@@ -64,7 +68,7 @@ pub use hold_release::{
 };
 #[allow(unused_imports)]
 pub use policy::{
-    BoundaryAllowlistRef, BoundaryPathRuleConfig, CIWorkflowRuleConfig,
+    Adjudication, BoundaryAllowlistRef, BoundaryPathRuleConfig, CIWorkflowRuleConfig,
     DependencyIdentityRuleConfig, GeneratedExclusions, LargeDeleteRewriteRuleConfig,
     MigrationRuleConfig, NetworkEgressRuleConfig, PolicySource, TripwirePolicy,
     UnsafeCodeRuleConfig, VendorExclusions,

--- a/server/crates/djinn-coordinator/src/tripwires/policy.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/policy.rs
@@ -80,6 +80,45 @@ pub enum PolicySource {
     Org,
 }
 
+// ─── Adjudication mode ─────────────────────────────────────────────────────
+
+/// Who resolves an enforcement hold produced by a rule.
+///
+/// The operator directive is **NO human-review holds**: every tripwire hold
+/// is adjudicated by the ARBITER (lead role) autonomously. [`Arbiter`] is the
+/// default for every rule. [`Human`] is a config-only escape hatch — only
+/// when an operator explicitly publishes `adjudication = human` for a rule via
+/// org policy does the legacy human-review remediation path run for holds
+/// that rule triggers.
+///
+/// [`Arbiter`]: Adjudication::Arbiter
+/// [`Human`]: Adjudication::Human
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Adjudication {
+    /// Autonomous arbiter (lead role) adjudication. The default.
+    #[default]
+    Arbiter,
+    /// Legacy human-review hold. Only reachable when an operator explicitly
+    /// opts a rule out of autonomous adjudication.
+    Human,
+}
+
+impl Adjudication {
+    /// Stable wire literal.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Arbiter => "arbiter",
+            Self::Human => "human",
+        }
+    }
+
+    /// Whether this rule's holds must be routed to a human reviewer.
+    pub const fn is_human(&self) -> bool {
+        matches!(self, Self::Human)
+    }
+}
+
 // ─── Per-rule configuration structs ────────────────────────────────────────
 
 /// Migration change detection: files created, changed, or deleted under the
@@ -92,6 +131,11 @@ pub struct MigrationRuleConfig {
     /// When `true`, findings are recorded as report-only (advisory) and do
     /// not block the gate.
     pub report_only: bool,
+    /// Who adjudicates a hold this rule triggers. Defaults to
+    /// [`Adjudication::Arbiter`]; an operator may set [`Adjudication::Human`]
+    /// via org policy to route this rule's holds to a human reviewer.
+    #[serde(default)]
+    pub adjudication: Adjudication,
     /// Glob patterns identifying migration files (e.g. `["migrations/**",
     /// "db/migrations/**", "migrations_postgres/**", "crates/*/migrations/**"]`).
     pub path_globs: Vec<String>,
@@ -102,6 +146,7 @@ impl Default for MigrationRuleConfig {
         Self {
             enabled: true,
             report_only: false,
+            adjudication: Adjudication::Arbiter,
             path_globs: vec![
                 // Standard migration directories
                 "migrations/**".to_owned(),
@@ -134,6 +179,9 @@ impl Default for MigrationRuleConfig {
 pub struct DependencyIdentityRuleConfig {
     pub enabled: bool,
     pub report_only: bool,
+    /// Who adjudicates a hold this rule triggers (defaults to arbiter).
+    #[serde(default)]
+    pub adjudication: Adjudication,
     pub major_version_bump_blocks: bool,
     pub lockfile_change_blocks: bool,
     /// Manifest paths watched (e.g. `Cargo.toml`, `package.json`,
@@ -148,6 +196,7 @@ impl Default for DependencyIdentityRuleConfig {
         Self {
             enabled: true,
             report_only: false,
+            adjudication: Adjudication::Arbiter,
             major_version_bump_blocks: true,
             lockfile_change_blocks: false,
             manifest_paths: vec![
@@ -175,6 +224,9 @@ impl Default for DependencyIdentityRuleConfig {
 pub struct NetworkEgressRuleConfig {
     pub enabled: bool,
     pub report_only: bool,
+    /// Who adjudicates a hold this rule triggers (defaults to arbiter).
+    #[serde(default)]
+    pub adjudication: Adjudication,
     /// Substring matchers that flag a file as a network-egress touchpoint
     /// (e.g. `reqwest::`, `curl_easy`, `Webhook`, `http::Request`).
     pub matcher_substrings: Vec<String>,
@@ -189,6 +241,7 @@ impl Default for NetworkEgressRuleConfig {
         Self {
             enabled: true,
             report_only: false,
+            adjudication: Adjudication::Arbiter,
             matcher_substrings: vec![
                 "reqwest::".to_owned(),
                 "ureq::".to_owned(),
@@ -210,6 +263,9 @@ impl Default for NetworkEgressRuleConfig {
 pub struct UnsafeCodeRuleConfig {
     pub enabled: bool,
     pub report_only: bool,
+    /// Who adjudicates a hold this rule triggers (defaults to arbiter).
+    #[serde(default)]
+    pub adjudication: Adjudication,
     /// File extensions the rule scans for `unsafe` markers. Files outside
     /// this list are ignored.
     pub extensions: Vec<String>,
@@ -224,6 +280,7 @@ impl Default for UnsafeCodeRuleConfig {
         Self {
             enabled: true,
             report_only: false,
+            adjudication: Adjudication::Arbiter,
             extensions: vec![
                 "rs".to_owned(),
                 "ts".to_owned(),
@@ -268,6 +325,9 @@ pub struct BoundaryPathRuleConfig {
     /// When `true`, findings are recorded as report-only (advisory) and do
     /// not block the gate.
     pub report_only: bool,
+    /// Who adjudicates a hold this rule triggers (defaults to arbiter).
+    #[serde(default)]
+    pub adjudication: Adjudication,
     /// `true` → changed files matching boundary category patterns that are
     /// absent from the allowlist trip the rule. `false` → only newly
     /// introduced boundary-category files trigger findings.
@@ -282,6 +342,7 @@ impl Default for BoundaryPathRuleConfig {
         Self {
             enabled: true,
             report_only: false,
+            adjudication: Adjudication::Arbiter,
             match_outside_allowlist: true,
             category_patterns: vec![
                 "scripts/capability-boundary-allowlist.toml".to_owned(),
@@ -338,6 +399,9 @@ impl Default for BoundaryAllowlistRef {
 pub struct LargeDeleteRewriteRuleConfig {
     pub enabled: bool,
     pub report_only: bool,
+    /// Who adjudicates a hold this rule triggers (defaults to arbiter).
+    #[serde(default)]
+    pub adjudication: Adjudication,
     /// Maximum lines deletable in a single file before the rule trips.
     pub per_file_line_threshold: u32,
     /// Maximum net lines deleted across the PR before the rule trips.
@@ -355,6 +419,7 @@ impl Default for LargeDeleteRewriteRuleConfig {
         Self {
             enabled: true,
             report_only: false,
+            adjudication: Adjudication::Arbiter,
             per_file_line_threshold: 400,
             aggregate_line_threshold: 1_500,
             file_rewrite_percentage_threshold: 60,
@@ -369,6 +434,9 @@ impl Default for LargeDeleteRewriteRuleConfig {
 pub struct CIWorkflowRuleConfig {
     pub enabled: bool,
     pub report_only: bool,
+    /// Who adjudicates a hold this rule triggers (defaults to arbiter).
+    #[serde(default)]
+    pub adjudication: Adjudication,
     /// Path globs identifying CI / workflow / release / deploy / automation
     /// files.
     pub path_globs: Vec<String>,
@@ -379,6 +447,7 @@ impl Default for CIWorkflowRuleConfig {
         Self {
             enabled: true,
             report_only: false,
+            adjudication: Adjudication::Arbiter,
             path_globs: vec![
                 ".github/workflows/**".to_owned(),
                 ".github/actions/**".to_owned(),
@@ -561,6 +630,37 @@ impl TripwirePolicy {
         clone.large_delete_rewrite.report_only = true;
         clone.ci_workflow.report_only = true;
         clone
+    }
+
+    /// The [`Adjudication`] mode configured for a given rule family.
+    ///
+    /// Defaults to [`Adjudication::Arbiter`] for every rule — the operator
+    /// directive is NO human-review holds. Only an explicit org-policy
+    /// override flips a rule to [`Adjudication::Human`].
+    pub fn adjudication_for(&self, rule: super::reason_codes::TripwireRuleId) -> Adjudication {
+        use super::reason_codes::TripwireRuleId;
+        match rule {
+            TripwireRuleId::MigrationChange => self.migration.adjudication,
+            TripwireRuleId::DependencyIdentityChange => self.dependency_identity.adjudication,
+            TripwireRuleId::NetworkEgressChange => self.network_egress.adjudication,
+            TripwireRuleId::UnsafeCodeChange => self.unsafe_code.adjudication,
+            TripwireRuleId::BoundaryPathChange => self.boundary_path.adjudication,
+            TripwireRuleId::LargeDeleteOrRewrite => self.large_delete_rewrite.adjudication,
+            TripwireRuleId::CIWorkflowChange => self.ci_workflow.adjudication,
+        }
+    }
+
+    /// Whether any of the given rule families is configured for human
+    /// adjudication. A hold whose enforcement findings include at least one
+    /// human-adjudicated rule takes the legacy human-review path; otherwise
+    /// the arbiter adjudicates autonomously.
+    pub fn any_rule_requires_human<I>(&self, rules: I) -> bool
+    where
+        I: IntoIterator<Item = super::reason_codes::TripwireRuleId>,
+    {
+        rules
+            .into_iter()
+            .any(|r| self.adjudication_for(r).is_human())
     }
 }
 
@@ -802,6 +902,62 @@ mod tests {
                 "{name}: serialized value must be an object, got {value}"
             );
         }
+    }
+
+    /// Every rule defaults to arbiter adjudication (NO human-review holds),
+    /// and `any_rule_requires_human` reflects an explicit per-rule override.
+    #[test]
+    fn adjudication_defaults_to_arbiter_and_honours_human_override() {
+        let mut p = TripwirePolicy::default();
+        for rule in [
+            TripwireRuleId::MigrationChange,
+            TripwireRuleId::DependencyIdentityChange,
+            TripwireRuleId::NetworkEgressChange,
+            TripwireRuleId::UnsafeCodeChange,
+            TripwireRuleId::BoundaryPathChange,
+            TripwireRuleId::LargeDeleteOrRewrite,
+            TripwireRuleId::CIWorkflowChange,
+        ] {
+            assert_eq!(
+                p.adjudication_for(rule),
+                Adjudication::Arbiter,
+                "{rule:?} must default to arbiter adjudication"
+            );
+        }
+        // No rule requires human by default.
+        assert!(!p.any_rule_requires_human([TripwireRuleId::MigrationChange]));
+
+        // Explicit operator override flips exactly one rule to human.
+        p.migration.adjudication = Adjudication::Human;
+        assert_eq!(
+            p.adjudication_for(TripwireRuleId::MigrationChange),
+            Adjudication::Human
+        );
+        assert!(p.any_rule_requires_human([
+            TripwireRuleId::MigrationChange,
+            TripwireRuleId::UnsafeCodeChange,
+        ]));
+        // A hold whose findings do not include the human-adjudicated rule
+        // stays on the arbiter path.
+        assert!(!p.any_rule_requires_human([TripwireRuleId::UnsafeCodeChange]));
+    }
+
+    /// Adjudication mode must survive a policy serde round-trip and decode
+    /// from a pre-adjudication policy document (serde default = arbiter).
+    #[test]
+    fn adjudication_round_trips_and_defaults_when_absent() {
+        let mut p = TripwirePolicy::default();
+        p.unsafe_code.adjudication = Adjudication::Human;
+        let json = serde_json::to_string(&p).unwrap();
+        let back: TripwirePolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.unsafe_code.adjudication, Adjudication::Human);
+        assert_eq!(back.migration.adjudication, Adjudication::Arbiter);
+
+        // A migration config JSON that predates the field must decode as
+        // arbiter (serde default).
+        let legacy = r#"{"enabled":true,"report_only":false,"path_globs":["migrations/**"]}"#;
+        let cfg: MigrationRuleConfig = serde_json::from_str(legacy).unwrap();
+        assert_eq!(cfg.adjudication, Adjudication::Arbiter);
     }
 
     /// Boundary allowlist content SHA256 is optional but must round-trip

--- a/server/crates/djinn-coordinator/src/tripwires/rules/mod.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/rules/mod.rs
@@ -26,6 +26,7 @@
 
 #![allow(dead_code)]
 
+use djinn_core::test_paths::is_test_path;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
 use crate::tripwires::engine::{ChangedFile, RawFinding};
@@ -34,6 +35,24 @@ use crate::tripwires::reason_codes::TripwireRuleId;
 
 #[cfg(test)]
 mod tests;
+
+// ─── Test-path downgrade ──────────────────────────────────────────────────
+
+/// Effective `report_only` for a finding whose evidence lives at `path`.
+///
+/// A finding is downgraded to report-only (advisory, non-blocking) whenever
+/// either the rule's own `report_only` config is set OR the evidence path is
+/// a test file per djinn-core's canonical [`is_test_path`]. This kills the
+/// single dumbest tripwire false-positive class — an `unsafe`/egress matcher
+/// or a large delete that lives inside a test fixture is never a real
+/// enforcement hold. The engine stamps a human-readable downgrade reason on
+/// any test-path finding (see `engine::TEST_PATH_DOWNGRADE_REASON`).
+///
+/// Applied uniformly across every rule family so no rule can enforce-hold on
+/// a test path.
+fn effective_report_only(config_report_only: bool, path: &str) -> bool {
+    config_report_only || is_test_path(path)
+}
 
 // ─── Glob matching helpers ────────────────────────────────────────────────
 
@@ -128,7 +147,7 @@ pub fn evaluate_migration_changes(
         if current_matches || old_matches {
             findings.push(RawFinding {
                 rule_id: TripwireRuleId::MigrationChange,
-                report_only: config.report_only,
+                report_only: effective_report_only(config.report_only, &file.path),
                 evidence_path: file.path.clone(),
                 evidence_start_line: None,
                 evidence_end_line: None,
@@ -183,7 +202,7 @@ pub fn evaluate_dependency_identity_changes(
             // (add/remove/rename/source switch/major version bump).
             findings.push(RawFinding {
                 rule_id: TripwireRuleId::DependencyIdentityChange,
-                report_only: config.report_only,
+                report_only: effective_report_only(config.report_only, &file.path),
                 evidence_path: file.path.clone(),
                 evidence_start_line: None,
                 evidence_end_line: None,
@@ -192,7 +211,7 @@ pub fn evaluate_dependency_identity_changes(
         } else if is_lockfile && config.lockfile_change_blocks {
             findings.push(RawFinding {
                 rule_id: TripwireRuleId::DependencyIdentityChange,
-                report_only: config.report_only,
+                report_only: effective_report_only(config.report_only, &file.path),
                 evidence_path: file.path.clone(),
                 evidence_start_line: None,
                 evidence_end_line: None,
@@ -281,7 +300,7 @@ pub fn evaluate_network_egress_changes(
         for (path, start, end) in matched_spans {
             findings.push(RawFinding {
                 rule_id: TripwireRuleId::NetworkEgressChange,
-                report_only: config.report_only,
+                report_only: effective_report_only(config.report_only, &path),
                 evidence_path: path,
                 evidence_start_line: start,
                 evidence_end_line: end,
@@ -345,7 +364,7 @@ pub fn evaluate_unsafe_code_changes(
                         let line_num = hunk.new_start + i as u32;
                         findings.push(RawFinding {
                             rule_id: TripwireRuleId::UnsafeCodeChange,
-                            report_only: config.report_only,
+                            report_only: effective_report_only(config.report_only, &file.path),
                             evidence_path: file.path.clone(),
                             evidence_start_line: Some(line_num),
                             evidence_end_line: Some(line_num),
@@ -417,7 +436,7 @@ pub fn evaluate_boundary_path_changes(
 
         findings.push(RawFinding {
             rule_id: TripwireRuleId::BoundaryPathChange,
-            report_only: config.report_only,
+            report_only: effective_report_only(config.report_only, &file.path),
             evidence_path: file.path.clone(),
             evidence_start_line: None,
             evidence_end_line: None,
@@ -493,7 +512,7 @@ pub fn evaluate_large_delete_or_rewrite(
         if deletions > config.per_file_line_threshold {
             findings.push(RawFinding {
                 rule_id: TripwireRuleId::LargeDeleteOrRewrite,
-                report_only: config.report_only,
+                report_only: effective_report_only(config.report_only, &file.path),
                 evidence_path: file.path.clone(),
                 evidence_start_line: None,
                 evidence_end_line: None,
@@ -509,7 +528,7 @@ pub fn evaluate_large_delete_or_rewrite(
             if percentage > config.file_rewrite_percentage_threshold {
                 findings.push(RawFinding {
                     rule_id: TripwireRuleId::LargeDeleteOrRewrite,
-                    report_only: config.report_only,
+                    report_only: effective_report_only(config.report_only, &file.path),
                     evidence_path: file.path.clone(),
                     evidence_start_line: None,
                     evidence_end_line: None,
@@ -527,7 +546,7 @@ pub fn evaluate_large_delete_or_rewrite(
         if let Some(path) = first_file_path {
             findings.push(RawFinding {
                 rule_id: TripwireRuleId::LargeDeleteOrRewrite,
-                report_only: config.report_only,
+                report_only: effective_report_only(config.report_only, &path),
                 evidence_path: path,
                 evidence_start_line: None,
                 evidence_end_line: None,
@@ -580,7 +599,7 @@ pub fn evaluate_ci_workflow_changes(
         if current_matches || old_matches {
             findings.push(RawFinding {
                 rule_id: TripwireRuleId::CIWorkflowChange,
-                report_only: config.report_only,
+                report_only: effective_report_only(config.report_only, &file.path),
                 evidence_path: file.path.clone(),
                 evidence_start_line: None,
                 evidence_end_line: None,

--- a/server/crates/djinn-coordinator/src/tripwires/rules/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/rules/tests/mod.rs
@@ -1,3 +1,4 @@
 mod helpers;
 mod imb4_rules;
 mod na0w_rules;
+mod test_path_downgrade;

--- a/server/crates/djinn-coordinator/src/tripwires/rules/tests/test_path_downgrade.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/rules/tests/test_path_downgrade.rs
@@ -1,0 +1,128 @@
+//! Tests for the test-path severity downgrade: a finding whose evidence path
+//! is a test file per djinn-core's `is_test_path` is emitted as report-only
+//! (advisory) instead of enforcement, across every rule family. This kills the
+//! dumbest tripwire false-positive class — an `unsafe`/egress matcher or a
+//! large delete inside a test fixture is never a real enforcement hold.
+
+use super::helpers::*;
+use crate::tripwires::engine::ChangedFileStatus;
+use crate::tripwires::rules::{
+    evaluate_boundary_path_changes, evaluate_dependency_identity_changes,
+    evaluate_large_delete_or_rewrite, evaluate_migration_changes, evaluate_network_egress_changes,
+    evaluate_unsafe_code_changes,
+};
+
+/// Unsafe code inside a `_test.rs` file downgrades to report-only.
+#[test]
+fn unsafe_in_test_file_is_report_only() {
+    let files = vec![file_with_added_lines(
+        "server/crates/foo/src/ffi_test.rs",
+        &["unsafe { ptr::read(addr); }"],
+    )];
+    let findings = evaluate_unsafe_code_changes(&default_policy(), &files);
+    assert_eq!(findings.len(), 1);
+    assert!(
+        findings[0].report_only,
+        "unsafe finding in a test file must be report-only"
+    );
+}
+
+/// Unsafe code in a NON-test file still enforces (control).
+#[test]
+fn unsafe_in_production_file_still_enforces() {
+    let files = vec![file_with_added_lines(
+        "server/crates/foo/src/ffi.rs",
+        &["unsafe { ptr::read(addr); }"],
+    )];
+    let findings = evaluate_unsafe_code_changes(&default_policy(), &files);
+    assert_eq!(findings.len(), 1);
+    assert!(
+        !findings[0].report_only,
+        "unsafe finding in production code must still enforce"
+    );
+}
+
+/// Network egress inside a conventional `tests/` dir downgrades. Uses the
+/// `Webhook` egress matcher (not an http-client crate path) so this fixture
+/// string does not trip the repo's http capability-boundary detector.
+#[test]
+fn egress_in_tests_dir_is_report_only() {
+    let files = vec![file_with_added_lines(
+        "tests/integration_client.rs",
+        &["Webhook::register(endpoint);"],
+    )];
+    let findings = evaluate_network_egress_changes(&default_policy(), &files);
+    assert_eq!(findings.len(), 1);
+    assert!(
+        findings[0].report_only,
+        "egress finding in a tests/ dir must be report-only"
+    );
+}
+
+/// A large delete inside a test file downgrades.
+#[test]
+fn large_delete_in_test_file_is_report_only() {
+    let files = vec![simple_file(
+        "server/crates/foo/src/big_test.rs",
+        ChangedFileStatus::Modified,
+        10,
+        600, // exceeds default per-file threshold
+    )];
+    let findings = evaluate_large_delete_or_rewrite(&default_policy(), &files);
+    assert!(!findings.is_empty());
+    assert!(
+        findings.iter().all(|f| f.report_only),
+        "large delete in a test file must be report-only"
+    );
+}
+
+/// A boundary-path change under a test dir downgrades.
+#[test]
+fn boundary_change_in_test_dir_is_report_only() {
+    let files = vec![simple_file(
+        "tests/auth/permissions_fixture.rs",
+        ChangedFileStatus::Added,
+        40,
+        0,
+    )];
+    let findings = evaluate_boundary_path_changes(&default_policy(), &files);
+    assert_eq!(findings.len(), 1);
+    assert!(
+        findings[0].report_only,
+        "boundary change in a test dir must be report-only"
+    );
+}
+
+/// A dependency manifest inside a test dir downgrades.
+#[test]
+fn dependency_manifest_in_test_dir_is_report_only() {
+    let files = vec![simple_file(
+        "tests/fixtures/Cargo.toml",
+        ChangedFileStatus::Modified,
+        3,
+        1,
+    )];
+    let findings = evaluate_dependency_identity_changes(&default_policy(), &files);
+    assert_eq!(findings.len(), 1);
+    assert!(
+        findings[0].report_only,
+        "dependency manifest under tests/ must be report-only"
+    );
+}
+
+/// A migration `.sql` under a test dir downgrades.
+#[test]
+fn migration_sql_in_test_dir_is_report_only() {
+    let files = vec![simple_file(
+        "tests/db/schema_fixture.sql",
+        ChangedFileStatus::Added,
+        20,
+        0,
+    )];
+    let findings = evaluate_migration_changes(&default_policy(), &files);
+    assert_eq!(findings.len(), 1);
+    assert!(
+        findings[0].report_only,
+        "migration sql under a test dir must be report-only"
+    );
+}


### PR DESCRIPTION
## Summary

Reduces tripwire human-review holds **autonomously** and fixes two confirmed release-path production bugs. Scoped entirely to `djinn-coordinator` — no `submit_decision` schema or decision-machinery changes, so **no corpus/insta/prompt regen is required**.

### Autonomous hold reduction
- **Test-path downgrade** (`rules/mod.rs` + `engine.rs`): any finding whose evidence path satisfies djinn-core `is_test_path` is emitted **report-only** instead of enforcement, across every rule family. Kills the dumbest false-positive class — `unsafe`/egress matchers and large deletes inside test fixtures. A `downgrade_reason` is stamped on the finding summary.
- **Release carry-forward** (`carry_forward.rs`): every finding carries a **head-independent content fingerprint** (`rule + file + patch hunk`). When a new PR head re-produces an enforcement finding whose content was already adjudicated + released on a prior head and is byte-identical here (rebase / merge of `main`), the gate auto-emits a fresh `tripwire.hold.released` (`carried_forward: true`) for the new head referencing the prior rationale — clearing the re-hold with **no human**. Genuinely changed content has a different fingerprint and re-holds. Per-head stale-release protection is preserved.

### Policy substrate (Part 5)
- Per-rule `adjudication` knob (`Arbiter | Human`) defaulting **Arbiter** for every rule; `TripwirePolicy::adjudication_for` / `any_rule_requires_human` select the resolver. `Human` is a config-only escape hatch.

### Release-path bug fixes (coordinator-flagged, v0.6.82)
- **Head-SHA mismatch**: the release emitter now releases **every** head carrying an un-released `tripwire.gate.held` (`gate_held_head_shas`), not just the task row's current `github_head_sha`. A hold pinned to an earlier CI-snapshot head — the head the merge-boundary gate keys on — was previously a silent no-op (incident `7tmi`).
- **Label never removed**: after release the source task sheds the `human-review-hold` label (`remove_hold_label_from_existing`), so the dispatch guard stops skipping it and the tamper reconciler does not re-apply it.

## Descoped (follow-up)
The **live arbiter-dispatch resolver** and the **`tripwire_release` arbiter decision** (seed a tripwire arbitration row → route the source into the lead-intervention queue → arbiter `tripwire_release`/`reopen`) are NOT in this PR — they span `djinn-core` (TransitionAction), `djinn-supervisor` (StageOutcome + run loop), `djinn-agent` (stage.rs + a `execute_tripwire_release_transaction`), and `djinn-mcp-extension` (submit_decision schema) plus corpus/insta regen, and were held back to keep this a clean, verified, single-crate increment. Until they land, held findings that are neither test-path nor carry-forwardable still create a human-review hold (fail-closed). The policy `adjudication` knob is the seam the resolver will consume.

## Verification
- `cargo clippy -p djinn-coordinator --all-targets --all-features -- -D warnings` clean
- 225 tripwire unit tests pass (test-path downgrade per rule, carry-forward same/changed content, fingerprint head-independence, `gate_held_head_shas`, label strip, adjudication default/override)
- `scripts/check-file-size.sh` passes (engine tests moved to a `#[path]` sibling; hold logic extracted to `pr_poller/tripwire_hold.rs`)
- `cargo fmt` clean
