### PR TITLE
fix(coordinator): deploy/reap interruptions are environmental — no strikes or cooldowns

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -560,6 +560,51 @@ impl CoordinatorActor {
             .await
     }
 
+    /// True when the newest non-guard attempt for `(task, role)` terminalized as
+    /// an ENVIRONMENTAL interruption (`TaskAttemptOutcome::Interrupted`) — i.e.
+    /// the prior session was killed by infrastructure (a deploy/rollout, a k8s
+    /// pod eviction, or a startup reap of a run that deploy orphaned) rather than
+    /// by any liveness/quality decision.
+    ///
+    /// The dispatch reappearance path uses this to spare an innocent in-flight
+    /// task from a same-role dispatch-failure streak + escalating cooldown after
+    /// a deploy: an environmental interruption is treated "as if the attempt
+    /// never ran". Guard-only rows (`deferred`/`adopted_pr`) are skipped so the
+    /// check reflects the newest REAL attempt. Fail-safe: any lookup error
+    /// returns `false`, preserving the existing failure-counting behavior (never
+    /// silently suppress a genuine failure on a transient DB blip).
+    pub(crate) async fn latest_attempt_was_environmental_interrupt(
+        &self,
+        task_id: &str,
+        role: &str,
+    ) -> bool {
+        let repo = TaskAttemptRepository::new(self.db.clone());
+        let attempts = match repo.list_for_task(task_id).await {
+            Ok(attempts) => attempts,
+            Err(e) => {
+                tracing::warn!(
+                    task_id = %task_id,
+                    role,
+                    error = %e,
+                    "CoordinatorActor: environmental-interrupt attempt lookup failed; \
+                     treating reappearance as a normal failure (fail-safe)"
+                );
+                return false;
+            }
+        };
+        // `list_for_task` is ordered created_at DESC, so the first non-guard row
+        // for this role is the newest real attempt.
+        attempts
+            .iter()
+            .filter(|a| a.role == role)
+            .find(|a| {
+                a.outcome != TaskAttemptOutcome::Deferred.as_str()
+                    && a.outcome != TaskAttemptOutcome::AdoptedPr.as_str()
+            })
+            .and_then(|a| a.outcome_enum().ok())
+            .is_some_and(|o| o.is_environmental_interrupt())
+    }
+
     /// Trigger C: a worker/reviewer run completed degenerate because the
     /// reply-loop guard saw repeated identical behavior. This is not a provider
     /// fault and not a dispatch failure; route it directly to the same Planner
@@ -2576,9 +2621,13 @@ fn outcome_to_reopen_class(outcome: &TaskAttemptOutcome) -> Option<ReopenClass> 
         // park escalation thresholds — while still surfacing in diagnostic
         // park/retry reasons. Sourced from the `7w2i` `task_attempts.outcome`
         // contract; no parallel outcome store is introduced.
+        // `Interrupted` is an environmental infrastructure interruption
+        // (deploy/rollout/reap); classified `Infra` so it never counts as a
+        // worker/task-quality strike or park escalation.
         TaskAttemptOutcome::TimedOut
         | TaskAttemptOutcome::SpawnFailed
-        | TaskAttemptOutcome::Crashed => Some(ReopenClass::Infra),
+        | TaskAttemptOutcome::Crashed
+        | TaskAttemptOutcome::Interrupted => Some(ReopenClass::Infra),
         // Guard-only or not a submission-triggered terminal.
         TaskAttemptOutcome::Deferred
         | TaskAttemptOutcome::AdoptedPr

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -2585,23 +2585,56 @@ impl CoordinatorActor {
         // non-terminal forever and the respawn guard defers every future
         // dispatch of this (task, role) pair — a permanent wedge.
         //
-        // `advance_to_terminal` is forward-only and idempotent, so duplicate
-        // exit events (or overlap with the recovery-scan terminalizers) are
-        // safe. `KillNoop` means the task is already terminal — leave the
-        // attempt to the terminal-path owners (PR poller / force-close).
+        // Outcome selection distinguishes an ENVIRONMENTAL interruption from a
+        // genuine failure:
+        //
+        //  - `interrupted`  → the pod was killed by infrastructure (a coordinator
+        //    deploy/rollout, a k8s pod eviction/deletion, or a startup reap of a
+        //    run that deploy orphaned) while the task was still nonterminal. This
+        //    is an environmental non-attempt: terminalize as `Interrupted` so
+        //    nothing wedges, but contribute NO quality strike, NO dispatch-failure
+        //    streak, and NO reopen_class penalty (the dispatch reappearance path
+        //    treats a latest `Interrupted` attempt as environmental).
+        //  - `failed`       → a genuine application/provider crash. Stays a
+        //    failure (`Crashed`), which the reappearance path still counts.
+        //
+        // This terminalizer only fires when the attempt is STILL pending/submitted
+        // (`advance_latest_to_terminal` no-ops on an already-terminal row). Every
+        // coordinator liveness path (stall-kill → TimedOut, ceiling → LoopGuard,
+        // no-progress/zombie/hard-runtime → TimedOut/Crashed) terminalizes the
+        // attempt with its own failure outcome BEFORE this event is processed, so
+        // stall / runtime-cap / zombie kills are NEVER reclassified environmental
+        // here — only a pure infra kill that no liveness path claimed reaches this
+        // `Interrupted` branch. Forward-only + idempotent; `KillNoop` means the
+        // task is already terminal — leave the attempt to the terminal-path owners
+        // (PR poller / force-close).
         if matches!(session_status, "failed" | "interrupted")
             && result.outcome != Some(LivenessOutcome::KillNoop)
         {
+            let (attempt_outcome, failure_class, summary) = if session_status == "interrupted" {
+                (
+                    TaskAttemptOutcome::Interrupted,
+                    "environmental_interrupt",
+                    "session interrupted by infrastructure (deploy/rollout/pod-eviction/reap) \
+                     while task nonterminal — environmental non-attempt, no dispatch penalty",
+                )
+            } else {
+                (
+                    TaskAttemptOutcome::Crashed,
+                    "session_exit_nonterminal",
+                    "session exited failed while task nonterminal",
+                )
+            };
             self.terminalize_recovery_attempt(
                 task_id,
                 role,
-                TaskAttemptOutcome::Crashed,
+                attempt_outcome,
                 "session_exit_liveness",
                 Some(session_id),
                 task_run_id,
                 Some(result.verdict.as_str()),
-                Some("session_exit_nonterminal"),
-                Some("session exited failed/interrupted while task nonterminal"),
+                Some(failure_class),
+                Some(summary),
             )
             .await;
         }

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1784,187 +1784,229 @@ impl CoordinatorActor {
                 // in which case the ordinary streak/ladder logic applies
                 // unchanged.
                 let provider_failure = self.health.take_task_provider_failure(&task.id);
-                match classify_reappearing_dispatch(marker, role, current_streak) {
-                    Some(ReappearingDispatch::SameRoleFailure {
-                        next_streak,
-                        cooldown,
-                    }) => {
-                        // A3: a throttle/rate-limit reappearance is a transient
-                        // provider fault, NOT evidence the task is structurally
-                        // undispatchable — so it must not advance the terminal
-                        // `dispatch_failure_streak` toward MAX (which would close a
-                        // perfectly healthy task). The task still backs off (the
-                        // escalating cooldown below still grows with the
-                        // reappearance) and the per-(scope,model) breaker still
-                        // fails over; only the terminal-close counter is spared.
-                        let throttle = provider_failure.is_some_and(|f| f.throttle);
-
-                        // Second-strike Planner escalation for provider-error
-                        // FAILED sessions. A genuine (non-throttle) typed
-                        // provider failure that recurs for the same task is the
-                        // poisoned-transcript-400 / dead-credential / persistent
-                        // server-fault class: redispatch reproduces it
-                        // identically, so riding the backoff ladder toward the
-                        // streak-10 terminal close just burns attempts with
-                        // nobody deciding what to do. The cycling gate (trigger
-                        // B) below excludes provider faults by design, and the
-                        // stall-cancel escalation only covers coordinator stall
-                        // kills — so without this the failure has no Planner
-                        // path. Count consecutive such failures (reset when the
-                        // task's status advances, mirroring the stall streak)
-                        // and hand the task to the Planner on the
-                        // FAILURE_ESCALATION_THRESHOLD-th strike instead of
-                        // another doomed redispatch.
-                        if provider_failure.is_some()
-                            && !throttle
-                            && self
-                                .maybe_escalate_provider_failure_streak(&task, role)
-                                .await
-                        {
-                            // Bump the local cap to reflect the planner session
-                            // the intervention just dispatched (same as trigger
-                            // B and the stuck-task path).
-                            self.bump_local_cap_for_last_planner_admission(
-                                &mut running_by_user_model,
-                            )
-                            .await;
-                            continue;
-                        }
-
-                        // Trigger B: the task keeps reappearing for the SAME
-                        // role with no typed provider failure to blame — its
-                        // runs complete but the task never converges (the
-                        // review-cycle bounce that never passes through `open`,
-                        // so trigger A's reopen_count never arms). Route it to
-                        // a Planner intervention instead of riding the ladder
-                        // to the terminal close at MAX_DISPATCH_FAILURES, which
-                        // would force-close a task whose durable work may be
-                        // fine. Falls through to the ordinary ladder when the
-                        // Planner was already routed for this loop (idempotency
-                        // marker) — the terminal close then remains the final
-                        // backstop.
-                        if should_route_cycling_intervention(
-                            role,
+                let reappearing = classify_reappearing_dispatch(marker, role, current_streak);
+                // Environmental-interrupt exemption. A same-role reappearance is
+                // normally a failed attempt (streak++ + escalating cooldown). But
+                // when the prior session was killed by INFRASTRUCTURE — a
+                // coordinator deploy/rollout, a k8s pod eviction, or a startup
+                // reap of a run that deploy orphaned — the task did nothing wrong:
+                // the classifier/reaper terminalized its attempt as `Interrupted`
+                // (environmental non-attempt). Deploys happen many times a day, so
+                // without this every deploy would march innocent in-flight tasks up
+                // the cooldown ladder toward strikes/interventions/terminal close.
+                // Treat it as if the attempt never ran: clear any backoff state and
+                // dispatch immediately, contributing NO streak and NO cooldown.
+                // Genuine `crashed`/`timed_out` attempts are NOT environmental and
+                // still fall through to the ordinary failure accounting below.
+                if matches!(
+                    reappearing,
+                    Some(ReappearingDispatch::SameRoleFailure { .. })
+                ) && self
+                    .latest_attempt_was_environmental_interrupt(&task.id, role)
+                    .await
+                {
+                    self.dispatch_failure_streak.remove(&task.id);
+                    self.provider_failure_streak.remove(&task.id);
+                    self.dispatch_cooldowns.remove(&task.id);
+                    self.clear_durable_dispatch_backoff_state(
+                        &task.id,
+                        Some(&task.short_id),
+                        "environmental_interrupt_no_dispatch_penalty",
+                    )
+                    .await;
+                    tracing::info!(
+                        task_id = %task.short_id,
+                        role,
+                        "CoordinatorActor: prior session ended in an environmental interruption \
+                         (deploy/rollout/pod-eviction/reap) — reappearance is NOT a dispatch \
+                         failure; dispatching without streak or cooldown"
+                    );
+                    // Fall through to dispatch (deliberately no `continue`).
+                } else {
+                    match reappearing {
+                        Some(ReappearingDispatch::SameRoleFailure {
                             next_streak,
-                            provider_failure.is_some(),
-                        ) && self
-                            .maybe_intervene_on_cycling_task(&task, role, next_streak)
-                            .await
-                        {
-                            self.dispatch_failure_streak.remove(&task.id);
-                            self.provider_failure_streak.remove(&task.id);
-                            self.dispatch_cooldowns.remove(&task.id);
-                            self.clear_durable_dispatch_backoff_state(
-                                &task.id,
-                                Some(&task.short_id),
-                                "cycling_planner_intervention_handoff_clear",
-                            )
-                            .await;
-                            // Bump local cap to reflect the planner session the
-                            // intervention just dispatched (same as Trigger A).
-                            self.bump_local_cap_for_last_planner_admission(
-                                &mut running_by_user_model,
-                            )
-                            .await;
-                            continue;
-                        }
+                            cooldown,
+                        }) => {
+                            // A3: a throttle/rate-limit reappearance is a transient
+                            // provider fault, NOT evidence the task is structurally
+                            // undispatchable — so it must not advance the terminal
+                            // `dispatch_failure_streak` toward MAX (which would close a
+                            // perfectly healthy task). The task still backs off (the
+                            // escalating cooldown below still grows with the
+                            // reappearance) and the per-(scope,model) breaker still
+                            // fails over; only the terminal-close counter is spared.
+                            let throttle = provider_failure.is_some_and(|f| f.throttle);
 
-                        // After MAX consecutive same-role failures the task is
-                        // structurally doomed (e.g. its run can never complete);
-                        // fail it terminally instead of looping forever. Skipped
-                        // for throttles (A3): a transient quota window must never
-                        // terminally close the task.
-                        if !throttle && next_streak >= MAX_DISPATCH_FAILURES {
-                            self.terminally_fail_task(
-                                &task,
+                            // Second-strike Planner escalation for provider-error
+                            // FAILED sessions. A genuine (non-throttle) typed
+                            // provider failure that recurs for the same task is the
+                            // poisoned-transcript-400 / dead-credential / persistent
+                            // server-fault class: redispatch reproduces it
+                            // identically, so riding the backoff ladder toward the
+                            // streak-10 terminal close just burns attempts with
+                            // nobody deciding what to do. The cycling gate (trigger
+                            // B) below excludes provider faults by design, and the
+                            // stall-cancel escalation only covers coordinator stall
+                            // kills — so without this the failure has no Planner
+                            // path. Count consecutive such failures (reset when the
+                            // task's status advances, mirroring the stall streak)
+                            // and hand the task to the Planner on the
+                            // FAILURE_ESCALATION_THRESHOLD-th strike instead of
+                            // another doomed redispatch.
+                            if provider_failure.is_some()
+                                && !throttle
+                                && self
+                                    .maybe_escalate_provider_failure_streak(&task, role)
+                                    .await
+                            {
+                                // Bump the local cap to reflect the planner session
+                                // the intervention just dispatched (same as trigger
+                                // B and the stuck-task path).
+                                self.bump_local_cap_for_last_planner_admission(
+                                    &mut running_by_user_model,
+                                )
+                                .await;
+                                continue;
+                            }
+
+                            // Trigger B: the task keeps reappearing for the SAME
+                            // role with no typed provider failure to blame — its
+                            // runs complete but the task never converges (the
+                            // review-cycle bounce that never passes through `open`,
+                            // so trigger A's reopen_count never arms). Route it to
+                            // a Planner intervention instead of riding the ladder
+                            // to the terminal close at MAX_DISPATCH_FAILURES, which
+                            // would force-close a task whose durable work may be
+                            // fine. Falls through to the ordinary ladder when the
+                            // Planner was already routed for this loop (idempotency
+                            // marker) — the terminal close then remains the final
+                            // backstop.
+                            if should_route_cycling_intervention(
                                 role,
-                                "repeated dispatch failures: the task could not complete after \
+                                next_streak,
+                                provider_failure.is_some(),
+                            ) && self
+                                .maybe_intervene_on_cycling_task(&task, role, next_streak)
+                                .await
+                            {
+                                self.dispatch_failure_streak.remove(&task.id);
+                                self.provider_failure_streak.remove(&task.id);
+                                self.dispatch_cooldowns.remove(&task.id);
+                                self.clear_durable_dispatch_backoff_state(
+                                    &task.id,
+                                    Some(&task.short_id),
+                                    "cycling_planner_intervention_handoff_clear",
+                                )
+                                .await;
+                                // Bump local cap to reflect the planner session the
+                                // intervention just dispatched (same as Trigger A).
+                                self.bump_local_cap_for_last_planner_admission(
+                                    &mut running_by_user_model,
+                                )
+                                .await;
+                                continue;
+                            }
+
+                            // After MAX consecutive same-role failures the task is
+                            // structurally doomed (e.g. its run can never complete);
+                            // fail it terminally instead of looping forever. Skipped
+                            // for throttles (A3): a transient quota window must never
+                            // terminally close the task.
+                            if !throttle && next_streak >= MAX_DISPATCH_FAILURES {
+                                self.terminally_fail_task(
+                                    &task,
+                                    role,
+                                    "repeated dispatch failures: the task could not complete after \
                                  multiple attempts. Resolve the underlying issue and reopen.",
-                            )
-                            .await;
-                            self.dispatch_failure_streak.remove(&task.id);
-                            self.provider_failure_streak.remove(&task.id);
-                            self.dispatch_cooldowns.remove(&task.id);
-                            self.inflight_dispatches.remove(&task.id);
-                            self.clear_durable_dispatch_backoff_state(
-                                &task.id,
-                                Some(&task.short_id),
-                                "same_role_terminal_close_clear",
-                            )
-                            .await;
-                            continue;
-                        }
+                                )
+                                .await;
+                                self.dispatch_failure_streak.remove(&task.id);
+                                self.provider_failure_streak.remove(&task.id);
+                                self.dispatch_cooldowns.remove(&task.id);
+                                self.inflight_dispatches.remove(&task.id);
+                                self.clear_durable_dispatch_backoff_state(
+                                    &task.id,
+                                    Some(&task.short_id),
+                                    "same_role_terminal_close_clear",
+                                )
+                                .await;
+                                continue;
+                            }
 
-                        // A3: leave the terminal streak at its current value on a
-                        // throttle (don't persist the advanced `next_streak`).
-                        let stored_streak =
-                            stored_streak_after_failure(current_streak, next_streak, throttle);
-                        if stored_streak > 0 {
-                            self.dispatch_failure_streak
-                                .insert(task.id.clone(), stored_streak);
-                        } else {
-                            self.dispatch_failure_streak.remove(&task.id);
-                        }
+                            // A3: leave the terminal streak at its current value on a
+                            // throttle (don't persist the advanced `next_streak`).
+                            let stored_streak =
+                                stored_streak_after_failure(current_streak, next_streak, throttle);
+                            if stored_streak > 0 {
+                                self.dispatch_failure_streak
+                                    .insert(task.id.clone(), stored_streak);
+                            } else {
+                                self.dispatch_failure_streak.remove(&task.id);
+                            }
 
-                        // A6: honor a provider-stated reset as a redispatch floor.
-                        // `cooldown` is the escalating ladder value for this
-                        // reappearance; when the provider stated a Retry-After /
-                        // rate-limit-reset that exceeds it, redispatch no earlier
-                        // than that reset (otherwise a 5-hour quota window would be
-                        // probed every ~30 min, burning failover). The provider
-                        // reset is deliberately allowed to EXCEED the ladder's
-                        // 30-min ceiling — that's the whole point — but is clamped
-                        // to a hard safety max so a malformed value can't wedge the
-                        // task forever.
-                        let retry_after_ms = provider_failure.and_then(|f| f.retry_after_ms);
-                        let effective_cooldown =
-                            apply_provider_retry_floor(cooldown, retry_after_ms);
-                        if effective_cooldown > cooldown {
-                            tracing::info!(
+                            // A6: honor a provider-stated reset as a redispatch floor.
+                            // `cooldown` is the escalating ladder value for this
+                            // reappearance; when the provider stated a Retry-After /
+                            // rate-limit-reset that exceeds it, redispatch no earlier
+                            // than that reset (otherwise a 5-hour quota window would be
+                            // probed every ~30 min, burning failover). The provider
+                            // reset is deliberately allowed to EXCEED the ladder's
+                            // 30-min ceiling — that's the whole point — but is clamped
+                            // to a hard safety max so a malformed value can't wedge the
+                            // task forever.
+                            let retry_after_ms = provider_failure.and_then(|f| f.retry_after_ms);
+                            let effective_cooldown =
+                                apply_provider_retry_floor(cooldown, retry_after_ms);
+                            if effective_cooldown > cooldown {
+                                tracing::info!(
+                                    task_id = %task.short_id,
+                                    role,
+                                    ladder_cooldown_secs = cooldown.as_secs(),
+                                    provider_floor_secs = effective_cooldown.as_secs(),
+                                    "CoordinatorActor: applying provider-stated retry-after as redispatch floor"
+                                );
+                            }
+
+                            tracing::warn!(
                                 task_id = %task.short_id,
                                 role,
-                                ladder_cooldown_secs = cooldown.as_secs(),
-                                provider_floor_secs = effective_cooldown.as_secs(),
-                                "CoordinatorActor: applying provider-stated retry-after as redispatch floor"
+                                streak = stored_streak,
+                                throttle,
+                                cooldown_secs = effective_cooldown.as_secs(),
+                                "CoordinatorActor: repeated task failure — backing off dispatch (escalating cooldown)"
                             );
+                            self.dispatch_cooldowns.insert(
+                                task.id.clone(),
+                                SystemClock::new().now_instant() + effective_cooldown,
+                            );
+                            self.persist_durable_dispatch_state_update(
+                                &task.id,
+                                Some(&task.short_id),
+                                "same_role_failure_backoff",
+                                DurableDispatchStateUpdate {
+                                    failure_streak: Some(stored_streak),
+                                    cooldown_until: Some(dispatch_wall_clock_after(
+                                        effective_cooldown,
+                                    )),
+                                    last_dispatched: Some(None),
+                                    ..Default::default()
+                                },
+                            )
+                            .await;
+                            continue;
                         }
-
-                        tracing::warn!(
-                            task_id = %task.short_id,
-                            role,
-                            streak = stored_streak,
-                            throttle,
-                            cooldown_secs = effective_cooldown.as_secs(),
-                            "CoordinatorActor: repeated task failure — backing off dispatch (escalating cooldown)"
-                        );
-                        self.dispatch_cooldowns.insert(
-                            task.id.clone(),
-                            SystemClock::new().now_instant() + effective_cooldown,
-                        );
-                        self.persist_durable_dispatch_state_update(
-                            &task.id,
-                            Some(&task.short_id),
-                            "same_role_failure_backoff",
-                            DurableDispatchStateUpdate {
-                                failure_streak: Some(stored_streak),
-                                cooldown_until: Some(dispatch_wall_clock_after(effective_cooldown)),
-                                last_dispatched: Some(None),
-                                ..Default::default()
-                            },
-                        )
-                        .await;
-                        continue;
-                    }
-                    Some(ReappearingDispatch::RoleTransition) | None => {
-                        self.dispatch_failure_streak.remove(&task.id);
-                        self.provider_failure_streak.remove(&task.id);
-                        self.dispatch_cooldowns.remove(&task.id);
-                        self.clear_durable_dispatch_backoff_state(
-                            &task.id,
-                            Some(&task.short_id),
-                            "role_transition_dispatch_state_clear",
-                        )
-                        .await;
+                        Some(ReappearingDispatch::RoleTransition) | None => {
+                            self.dispatch_failure_streak.remove(&task.id);
+                            self.provider_failure_streak.remove(&task.id);
+                            self.dispatch_cooldowns.remove(&task.id);
+                            self.clear_durable_dispatch_backoff_state(
+                                &task.id,
+                                Some(&task.short_id),
+                                "role_transition_dispatch_state_clear",
+                            )
+                            .await;
+                        }
                     }
                 }
             }

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -1870,26 +1870,49 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
         }
     };
 
+    // Outcome selection by reap reason. A `startup` reap fires immediately after
+    // this coordinator boots: any `pending` attempt with no live task_run and no
+    // running session at boot was orphaned because a DEPLOY/ROLLOUT killed its
+    // pod out from under it — an ENVIRONMENTAL interruption, not a task failure.
+    // Stamp it `Interrupted` so the dispatch reappearance path recognizes it and
+    // skips the failure streak / cooldown escalation ("treat like it never ran").
+    // The `periodic` reap is conservative — a pending attempt still orphaned after
+    // the periodic threshold with no live run is more likely a genuine mid-run
+    // loss, so it stays `Crashed` (both are is_infra ⇒ quality/park exempt; they
+    // differ only in whether the reappearance streak counts them).
+    let (orphan_outcome, orphan_failure_class, orphan_summary) = if reason == "startup" {
+        (
+            djinn_core::models::task_attempt::TaskAttemptOutcome::Interrupted,
+            "environmental_interrupt_startup_reap",
+            "orphaned pending attempt reaped at startup (deploy/rollout interrupted the run): \
+             environmental non-attempt, no dispatch penalty",
+        )
+    } else {
+        (
+            djinn_core::models::task_attempt::TaskAttemptOutcome::Crashed,
+            "orphaned_pending_attempt",
+            "orphaned pending attempt reaped: no live task_run or running session",
+        )
+    };
+
     for orphan in orphans {
         let summary_json = serde_json::json!({
             "recovery_classifier": "orphaned_pending_attempt_reaper",
             "reason": reason,
             "threshold_secs": threshold_secs,
-            "failure_class": "orphaned_pending_attempt",
+            "failure_class": orphan_failure_class,
         })
         .to_string();
         match repo
             .advance_to_terminal(djinn_db::TerminalTaskAttemptParams {
                 id: &orphan.id,
-                outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::Crashed,
+                outcome: orphan_outcome,
                 pr_url: None,
                 submit_ref: None,
                 checkpoint_ref: None,
                 mirror_head_sha: None,
                 github_head_sha: None,
-                summary: Some(
-                    "orphaned pending attempt reaped: no live task_run or running session",
-                ),
+                summary: Some(orphan_summary),
                 summary_json: Some(&summary_json),
                 log_tail: None,
             })

--- a/server/crates/djinn-coordinator/src/tests/deploy_interruptions_environmental.rs
+++ b/server/crates/djinn-coordinator/src/tests/deploy_interruptions_environmental.rs
@@ -1,0 +1,142 @@
+//! Regression coverage for "deploy/reap interruptions are environmental".
+//!
+//! A worker/reviewer session killed by an infrastructure event — a coordinator
+//! deploy/rollout, a k8s pod eviction, or a startup reap of a run that deploy
+//! orphaned — leaves the task dispatch-ready again for the SAME role. The
+//! dispatch reappearance path would normally count that as a same-role failure
+//! (streak++ + escalating cooldown), unfairly pushing an innocent in-flight
+//! task toward strikes/interventions on every deploy. These tests lock the fix:
+//! when the prior attempt terminalized as the environmental `interrupted`
+//! outcome, the reappearance is spared (no streak, no cooldown, dispatched
+//! immediately); a genuine `crashed` attempt still counts as a failure.
+
+use super::*;
+use djinn_core::models::task_attempt::TaskAttemptOutcome;
+use djinn_db::{TaskAttemptRepository, TerminalTaskAttemptParams};
+
+/// Seed a terminal `(task, role)` attempt with the given outcome, exactly as a
+/// dispatch-start + terminalization would leave it.
+async fn seed_terminal_attempt(
+    db: &Database,
+    task_id: &str,
+    role: &str,
+    outcome: TaskAttemptOutcome,
+) {
+    let repo = TaskAttemptRepository::new(db.clone());
+    let id = uuid::Uuid::now_v7().to_string();
+    let dispatch_key = format!("{task_id}:{role}:{id}");
+    repo.create_or_get_pending(djinn_db::CreateTaskAttemptParams {
+        id: &id,
+        task_id,
+        role,
+        dispatch_key: &dispatch_key,
+        session_id: None,
+        attempt_seq: None,
+    })
+    .await
+    .unwrap();
+    repo.advance_to_terminal(TerminalTaskAttemptParams {
+        id: &id,
+        outcome,
+        pr_url: None,
+        submit_ref: None,
+        checkpoint_ref: None,
+        mirror_head_sha: None,
+        github_head_sha: None,
+        summary: Some("seeded terminal attempt"),
+        summary_json: None,
+        log_tail: None,
+    })
+    .await
+    .unwrap();
+}
+
+/// A reviewer task whose prior session ended in an environmental `interrupted`
+/// (deploy/reap) and reappears for the same role must be dispatched immediately
+/// with NO dispatch-failure streak and NO cooldown — the interruption was not a
+/// task failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn environmental_interrupt_reappearance_dispatches_without_streak_or_cooldown() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "reviewer interrupted by deploy").await;
+    let task = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+
+    // The prior reviewer session was killed by infrastructure: its attempt was
+    // terminalized environmental.
+    seed_terminal_attempt(&db, &task.id, "reviewer", TaskAttemptOutcome::Interrupted).await;
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    // Seed the reappearance marker that a pre-deploy dispatch (rehydrated at
+    // boot) would leave: same role, recent.
+    actor.last_dispatched.insert(
+        task.id.clone(),
+        DispatchMarker {
+            instant: StdInstant::now(),
+            role: "reviewer".to_owned(),
+        },
+    );
+
+    actor.dispatch_ready_tasks(None).await;
+
+    assert_eq!(
+        actor.dispatched, 1,
+        "an environmentally-interrupted task must re-dispatch immediately"
+    );
+    assert!(
+        !actor.dispatch_failure_streak.contains_key(&task.id),
+        "an environmental interruption must NOT add a dispatch-failure streak"
+    );
+    assert!(
+        !actor.dispatch_cooldowns.contains_key(&task.id),
+        "an environmental interruption must NOT apply an escalating cooldown"
+    );
+}
+
+/// Control / regression: a reviewer task whose prior session genuinely `crashed`
+/// and reappears for the same role IS counted as a same-role failure — streak
+/// advances to 1 and a cooldown is applied (no dispatch this pass). This proves
+/// the environmental exemption is narrow and genuine failures still back off.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn crashed_reappearance_still_counts_as_failure_with_streak_and_cooldown() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "reviewer crashed for real").await;
+    let task = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+
+    // The prior reviewer session genuinely crashed — a real failure.
+    seed_terminal_attempt(&db, &task.id, "reviewer", TaskAttemptOutcome::Crashed).await;
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.last_dispatched.insert(
+        task.id.clone(),
+        DispatchMarker {
+            instant: StdInstant::now(),
+            role: "reviewer".to_owned(),
+        },
+    );
+
+    actor.dispatch_ready_tasks(None).await;
+
+    assert_eq!(
+        actor.dispatched, 0,
+        "a same-role crash reappearance backs off (cooldown) rather than dispatching this pass"
+    );
+    assert_eq!(
+        actor.dispatch_failure_streak.get(&task.id).copied(),
+        Some(1),
+        "a genuine crash reappearance must advance the dispatch-failure streak"
+    );
+    assert!(
+        actor.dispatch_cooldowns.contains_key(&task.id),
+        "a genuine crash reappearance must apply an escalating cooldown"
+    );
+}

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -1369,6 +1369,7 @@ async fn planner_intervention_markers(
     .collect()
 }
 
+mod deploy_interruptions_environmental;
 mod dispatch_flow;
 mod doctor_zombie_e2e;
 mod intervention;

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -4621,6 +4621,347 @@ async fn stall_timeout_terminalizes_attempt_as_timed_out() {
     cancel.cancel();
 }
 
+// ── Deploy/reap interruptions are environmental (fix/deploy-interruptions) ──
+
+/// A session `interrupted` by INFRASTRUCTURE (deploy/rollout/pod-eviction/reap)
+/// while its task is still nonterminal must terminalize the live attempt as the
+/// environmental `interrupted` outcome — NOT `crashed`. This is what lets the
+/// dispatch reappearance path spare the task from a failure streak / cooldown.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupted_session_terminalizes_attempt_as_environmental_interrupt() {
+    use djinn_core::models::task_attempt::TaskAttemptOutcome;
+    use djinn_db::{CreateSessionParams, SessionRepository, TaskAttemptRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "env-interrupt-attempt").await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let run_id = "run-env-interrupt";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    // A live (pending) dispatch-start attempt exists — nothing has claimed it as
+    // a failure, i.e. a pure infra kill (no stall/ceiling/zombie decision).
+    let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
+
+    let actor = coordinator_actor_for_tests(&db, &tx);
+    actor
+        .classify_session_exit_liveness(
+            &session.id,
+            &task.id,
+            Some(run_id),
+            "interrupted",
+            "worker",
+        )
+        .await;
+
+    let repo = TaskAttemptRepository::new(db.clone());
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "interrupted",
+        "an infrastructure interruption must terminalize the attempt as environmental \
+         `interrupted`, not `crashed`"
+    );
+    assert!(attempt.terminal_at.is_some());
+    let outcome: TaskAttemptOutcome = attempt.outcome.parse().unwrap();
+    assert!(outcome.is_environmental_interrupt());
+    assert!(
+        outcome.is_infra(),
+        "environmental interrupt is infra-classified (quality/park exempt)"
+    );
+    let sj: serde_json::Value =
+        serde_json::from_str(attempt.summary_json.as_deref().unwrap()).unwrap();
+    assert_eq!(sj["failure_class"], "environmental_interrupt");
+    assert_eq!(sj["recovery_classifier"], "session_exit_liveness");
+    // No duplicate row.
+    assert_eq!(repo.list_for_task(&task.id).await.unwrap().len(), 1);
+}
+
+/// Regression: a genuine `failed` session exit (application/provider crash) still
+/// terminalizes the attempt as `crashed` — a real failure the reappearance streak
+/// keeps counting. Only `interrupted` (infra) is treated environmental.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_session_terminalizes_attempt_as_crashed_not_interrupted() {
+    use djinn_core::models::task_attempt::TaskAttemptOutcome;
+    use djinn_db::{CreateSessionParams, SessionRepository, TaskAttemptRepository};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "failed-stays-crashed").await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let run_id = "run-failed-crash";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+    let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
+
+    let actor = coordinator_actor_for_tests(&db, &tx);
+    actor
+        .classify_session_exit_liveness(&session.id, &task.id, Some(run_id), "failed", "worker")
+        .await;
+
+    let repo = TaskAttemptRepository::new(db.clone());
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "crashed",
+        "a genuine failed exit must remain a `crashed` failure"
+    );
+    let outcome: TaskAttemptOutcome = attempt.outcome.parse().unwrap();
+    assert!(!outcome.is_environmental_interrupt());
+}
+
+/// Regression: a stall/ceiling/zombie kill terminalizes the attempt with its own
+/// failure outcome BEFORE the session-interrupt event is processed. The later
+/// `interrupted` event must NOT reclassify that already-terminal failure to
+/// environmental — `advance_latest_to_terminal` no-ops on a terminal attempt, so
+/// stall-killed / runtime-exceeded runs stay failures.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupted_event_does_not_reclassify_already_terminal_failure() {
+    use djinn_db::{
+        CreateSessionParams, SessionRepository, TaskAttemptRepository, TerminalTaskAttemptParams,
+    };
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _note) = create_task_with_note(&db, &tx, "stall-then-interrupt").await;
+    TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "in_progress")
+        .await
+        .unwrap();
+
+    let run_id = "run-stall-then-interrupt";
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: run_id,
+            project_id: &task.project_id,
+            task_id: &task.id,
+            trigger_type: "manual",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+    let session_repo = SessionRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+    let session = session_repo
+        .create(CreateSessionParams {
+            project_id: &task.project_id,
+            task_id: Some(&task.id),
+            model: "openai/gpt-5.5",
+            agent_type: "worker",
+            metadata_json: None,
+            task_run_id: Some(run_id),
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .unwrap();
+
+    // The stall path already terminalized the attempt as `timed_out`.
+    let attempt_id = seed_pending_attempt(&db, &task.id, "worker").await;
+    let repo = TaskAttemptRepository::new(db.clone());
+    repo.advance_to_terminal(TerminalTaskAttemptParams {
+        id: &attempt_id,
+        outcome: djinn_core::models::task_attempt::TaskAttemptOutcome::TimedOut,
+        pr_url: None,
+        submit_ref: None,
+        checkpoint_ref: None,
+        mirror_head_sha: None,
+        github_head_sha: None,
+        summary: Some("stall kill"),
+        summary_json: None,
+        log_tail: None,
+    })
+    .await
+    .unwrap();
+
+    // The session-interrupt event arrives afterward — must be a no-op.
+    let actor = coordinator_actor_for_tests(&db, &tx);
+    actor
+        .classify_session_exit_liveness(
+            &session.id,
+            &task.id,
+            Some(run_id),
+            "interrupted",
+            "worker",
+        )
+        .await;
+
+    let attempt = repo.get(&attempt_id).await.unwrap().unwrap();
+    assert_eq!(
+        attempt.outcome, "timed_out",
+        "an already-terminal stall/timeout attempt must NOT be reclassified environmental"
+    );
+}
+
+/// Fix #3: the STARTUP orphaned-pending reaper stamps `interrupted` (a deploy
+/// killed the run), while the PERIODIC/other reap stays `crashed`. Both are
+/// infra-classified; they differ only in whether the reappearance streak counts
+/// them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_orphan_reap_stamps_interrupted_periodic_stamps_crashed() {
+    use djinn_db::TaskAttemptRepository;
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskAttemptRepository::new(db.clone());
+
+    // A stale orphaned pending attempt (no live run/session). Reap it via the
+    // STARTUP path → environmental `interrupted`. Seed + reap in isolation so the
+    // startup sweep (which reaps every eligible orphan) does not also claim the
+    // periodic fixture below.
+    let (task_startup, _n) = create_task_with_note(&db, &tx, "orphan-startup").await;
+    let startup_attempt = seed_pending_attempt(&db, &task_startup.id, "reviewer").await;
+    backdate_attempt(&db, &startup_attempt).await;
+    crate::health::reap_orphaned_pending_attempts_with_threshold(&db, 15 * 60, "startup").await;
+
+    // A second stale orphan seeded AFTER the startup sweep, reaped via the
+    // PERIODIC path → stays `crashed` (conservative).
+    let (task_periodic, _n) = create_task_with_note(&db, &tx, "orphan-periodic").await;
+    let periodic_attempt = seed_pending_attempt(&db, &task_periodic.id, "reviewer").await;
+    backdate_attempt(&db, &periodic_attempt).await;
+    crate::health::reap_orphaned_pending_attempts_with_threshold(&db, 15 * 60, "periodic").await;
+
+    let startup = repo.get(&startup_attempt).await.unwrap().unwrap();
+    assert_eq!(
+        startup.outcome, "interrupted",
+        "a startup reap (deploy killed the run) must stamp environmental `interrupted`"
+    );
+    let sj: serde_json::Value =
+        serde_json::from_str(startup.summary_json.as_deref().unwrap()).unwrap();
+    assert_eq!(sj["failure_class"], "environmental_interrupt_startup_reap");
+
+    let periodic = repo.get(&periodic_attempt).await.unwrap().unwrap();
+    assert_eq!(
+        periodic.outcome, "crashed",
+        "a periodic reap stays `crashed` (conservative)"
+    );
+}
+
+/// The reappearance helper detects only an environmental `interrupted` latest
+/// attempt — genuine `crashed`/`timed_out` latest attempts are NOT environmental,
+/// guard-only rows are skipped, and no attempt is NOT environmental.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn latest_attempt_environmental_interrupt_helper_detection() {
+    use djinn_core::models::task_attempt::TaskAttemptOutcome;
+    use djinn_db::{TaskAttemptRepository, TerminalTaskAttemptParams};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let actor = coordinator_actor_for_tests(&db, &tx);
+
+    let terminalize = |attempt_id: String, outcome: TaskAttemptOutcome| {
+        let db = db.clone();
+        async move {
+            let repo = TaskAttemptRepository::new(db.clone());
+            repo.advance_to_terminal(TerminalTaskAttemptParams {
+                id: &attempt_id,
+                outcome,
+                pr_url: None,
+                submit_ref: None,
+                checkpoint_ref: None,
+                mirror_head_sha: None,
+                github_head_sha: None,
+                summary: None,
+                summary_json: None,
+                log_tail: None,
+            })
+            .await
+            .unwrap();
+        }
+    };
+
+    // Interrupted latest → environmental.
+    let (t_env, _n) = create_task_with_note(&db, &tx, "helper-env").await;
+    let a = seed_pending_attempt(&db, &t_env.id, "reviewer").await;
+    terminalize(a, TaskAttemptOutcome::Interrupted).await;
+    assert!(
+        actor
+            .latest_attempt_was_environmental_interrupt(&t_env.id, "reviewer")
+            .await
+    );
+    // Wrong role → not environmental for that role.
+    assert!(
+        !actor
+            .latest_attempt_was_environmental_interrupt(&t_env.id, "worker")
+            .await
+    );
+
+    // Crashed latest → NOT environmental (genuine failure still counts).
+    let (t_crash, _n) = create_task_with_note(&db, &tx, "helper-crash").await;
+    let a = seed_pending_attempt(&db, &t_crash.id, "reviewer").await;
+    terminalize(a, TaskAttemptOutcome::Crashed).await;
+    assert!(
+        !actor
+            .latest_attempt_was_environmental_interrupt(&t_crash.id, "reviewer")
+            .await
+    );
+
+    // No attempt at all → NOT environmental.
+    let (t_none, _n) = create_task_with_note(&db, &tx, "helper-none").await;
+    assert!(
+        !actor
+            .latest_attempt_was_environmental_interrupt(&t_none.id, "reviewer")
+            .await
+    );
+}
+
 /// A zombie session reaped past the hard cap with no live worker is a crash:
 /// the matching attempt must be terminalized as `crashed` with a `failure_class`
 /// in its structured context. Running the reaper again must not duplicate the

--- a/server/crates/djinn-core/src/models/task_attempt.rs
+++ b/server/crates/djinn-core/src/models/task_attempt.rs
@@ -56,6 +56,23 @@ pub enum TaskAttemptOutcome {
     ForceClosed,
     /// Handed off to another task, epic, or human process.
     Handoff,
+    /// The run was interrupted by INFRASTRUCTURE — a coordinator deploy/rollout
+    /// that killed the worker pod, a startup reap of a run orphaned by that
+    /// deploy, or a k8s pod eviction/deletion during a rollout — while the task
+    /// was still nonterminal, and NO liveness path (stall/ceiling/no-progress/
+    /// zombie/hard-runtime) had already claimed the attempt as a failure. This
+    /// is an environmental non-attempt (sibling of
+    /// [`TaskRunOutcome::EnvironmentalNonAttempt`](crate) semantics): the
+    /// attempt is terminalized so nothing wedges, but it must contribute NO
+    /// quality strike, NO dispatch-failure streak, NO cooldown escalation, and
+    /// NO `reopen_class` penalty — it is treated as if the attempt never ran.
+    /// Classified as [`is_infra`](Self::is_infra) so it is excluded from the
+    /// quality/park/intervention counters, and the dispatch reappearance path
+    /// treats a task whose latest attempt is `Interrupted` as environmental
+    /// rather than a same-role failure. Distinct from `Crashed` (a genuine
+    /// application/provider crash, which REMAINS a failure) and `TimedOut`
+    /// (stall / hard-runtime, which REMAINS a failure).
+    Interrupted,
 }
 
 impl TaskAttemptOutcome {
@@ -75,6 +92,7 @@ impl TaskAttemptOutcome {
             Self::AdoptedPr => "adopted_pr",
             Self::ForceClosed => "force_closed",
             Self::Handoff => "handoff",
+            Self::Interrupted => "interrupted",
         }
     }
 
@@ -98,7 +116,21 @@ impl TaskAttemptOutcome {
     /// `task_attempts.outcome` contract; matches the set mapped by
     /// `outcome_to_reopen_class`.
     pub fn is_infra(&self) -> bool {
-        matches!(self, Self::TimedOut | Self::SpawnFailed | Self::Crashed)
+        matches!(
+            self,
+            Self::TimedOut | Self::SpawnFailed | Self::Crashed | Self::Interrupted
+        )
+    }
+
+    /// True if this terminal outcome is an ENVIRONMENTAL interruption — the run
+    /// was killed by infrastructure (deploy/rollout/reap/pod-eviction) before
+    /// any liveness path judged it a failure, so it must be treated as if the
+    /// attempt never ran: no dispatch-failure streak, no cooldown escalation,
+    /// no quality/park penalty. Narrower than [`is_infra`](Self::is_infra),
+    /// which also covers genuine crashes/timeouts that DO remain failures for
+    /// the dispatch reappearance streak.
+    pub fn is_environmental_interrupt(&self) -> bool {
+        matches!(self, Self::Interrupted)
     }
 
     /// Lifecycle rank used for forward-only ordering.
@@ -121,6 +153,11 @@ impl TaskAttemptOutcome {
             Self::AdoptedPr => 38,
             Self::ForceClosed => 39,
             Self::Handoff => 40,
+            // Ranked ABOVE the failure outcomes (Crashed 32 / TimedOut 33) so a
+            // recorded environmental interruption is never clobbered backward to
+            // a failure outcome by a racing terminalizer (forward-only advance):
+            // once environmental, it stays environmental.
+            Self::Interrupted => 41,
         }
     }
 
@@ -159,6 +196,7 @@ impl FromStr for TaskAttemptOutcome {
             "adopted_pr" => Ok(Self::AdoptedPr),
             "force_closed" => Ok(Self::ForceClosed),
             "handoff" => Ok(Self::Handoff),
+            "interrupted" => Ok(Self::Interrupted),
             other => Err(format!("unknown task_attempt outcome: {other}")),
         }
     }
@@ -566,6 +604,7 @@ mod tests {
             TaskAttemptOutcome::AdoptedPr,
             TaskAttemptOutcome::ForceClosed,
             TaskAttemptOutcome::Handoff,
+            TaskAttemptOutcome::Interrupted,
         ] {
             let s = outcome.as_str();
             let parsed: TaskAttemptOutcome = s.parse().unwrap();
@@ -598,6 +637,7 @@ mod tests {
             TaskAttemptOutcome::AdoptedPr,
             TaskAttemptOutcome::ForceClosed,
             TaskAttemptOutcome::Handoff,
+            TaskAttemptOutcome::Interrupted,
         ] {
             assert!(terminal.is_terminal(), "{terminal} should be terminal");
             assert!(
@@ -646,6 +686,28 @@ mod tests {
             assert!(rank >= prev, "ranks must be non-decreasing after submitted");
             prev = rank;
         }
+    }
+
+    #[test]
+    fn interrupted_is_environmental_infra_and_terminal() {
+        let o = TaskAttemptOutcome::Interrupted;
+        assert!(o.is_terminal());
+        assert!(!o.is_non_terminal());
+        // Environmental interrupts are infra-classified (quality/park exempt)…
+        assert!(o.is_infra());
+        // …and are the ONLY environmental-interrupt outcome.
+        assert!(o.is_environmental_interrupt());
+        // Genuine crashes / timeouts remain failures — infra, but NOT
+        // environmental interrupts (they still feed the dispatch streak).
+        assert!(TaskAttemptOutcome::Crashed.is_infra());
+        assert!(!TaskAttemptOutcome::Crashed.is_environmental_interrupt());
+        assert!(!TaskAttemptOutcome::TimedOut.is_environmental_interrupt());
+        assert!(!TaskAttemptOutcome::SpawnFailed.is_environmental_interrupt());
+        // Ranked above the failure outcomes so it is never rolled back to a
+        // failure by a racing forward-only terminalizer.
+        assert!(o.is_forward_from(TaskAttemptOutcome::Crashed));
+        assert!(o.is_forward_from(TaskAttemptOutcome::TimedOut));
+        assert!(!TaskAttemptOutcome::Crashed.is_forward_from(o));
     }
 
     #[test]

--- a/server/crates/djinn-db/migrations_postgres/100_task_attempt_interrupted_outcome.sql
+++ b/server/crates/djinn-db/migrations_postgres/100_task_attempt_interrupted_outcome.sql
@@ -1,0 +1,25 @@
+-- Deploy/reap interruptions are environmental: widen task_attempts.outcome to
+-- accept the new terminal `interrupted` value.
+--
+-- An infrastructure interruption (a coordinator deploy/rollout that kills the
+-- worker pod, a startup reap of a run orphaned by that deploy, or a k8s pod
+-- eviction during a rollout) that lands while the task is still nonterminal is
+-- an ENVIRONMENTAL non-attempt — it must not count as a task failure. The
+-- session-exit classifier and the startup orphaned-pending reaper now stamp
+-- such attempts `interrupted` (instead of `crashed`) so the dispatch
+-- reappearance path can recognize them and skip the failure streak / cooldown
+-- escalation, while genuine `crashed` / `timed_out` attempts remain failures.
+--
+-- Applied idempotently: DROP the pre-existing constraint of the same name
+-- before re-ADDing it (migration 94 created it) so re-running is safe.
+ALTER TABLE task_attempts
+    DROP CONSTRAINT IF EXISTS task_attempts_outcome_check;
+
+ALTER TABLE task_attempts
+    ADD CONSTRAINT task_attempts_outcome_check
+        CHECK (outcome IN (
+            'pending', 'submitted',
+            'completed', 'reopened', 'crashed', 'timed_out', 'cancelled',
+            'loop_guard_tripped', 'spawn_failed', 'deferred',
+            'adopted_pr', 'force_closed', 'handoff', 'interrupted'
+        ));


### PR DESCRIPTION
## The bug (incident: task xij7, v0.6.83)

A reviewer session started and was killed 15s later by a server-deploy rollout (session `interrupted`; startup reaper logged "reaped stale 'running' task_runs reason=startup" + "reaped orphaned pending task_attempt ... outcome=crashed"). The dispatch retry machinery then counted that reappearance toward the task's failure streak, producing "repeated task failure — backing off dispatch (escalating cooldown)". We deploy many times a day, so **every deploy unfairly pushes innocent in-flight tasks toward cooldowns/strikes/interventions.**

## What actually fed xij7's streak (evidence)

The streak came **solely** from the dispatch *reappearance* mechanism in `task_dispatch.rs`, **not** from the catalog-image-rebuild window:

- The image-not-ready deferral (`"dispatch deferred — project devcontainer image not ready"`) `continue`s **before** the reappearance logic and touches no fault state — it does not increment the streak.
- The streak is incremented when a task with a `last_dispatched` marker (persisted to durable dispatch state and **rehydrated at boot**) becomes dispatch-ready again for the **same role** within the 35-min `FAILURE_DETECTION_WINDOW`. Across the deploy: reviewer dispatched → marker persisted → pod killed → new coordinator boots, rehydrates the marker → task reappears for the reviewer role → `classify_reappearing_dispatch` returns `SameRoleFailure` → `dispatch_failure_streak`++ + escalating cooldown. Repeated deploys accumulate the persisted streak.

The interrupted session's attempt was terminalized `crashed` by the startup orphaned-pending reaper. `crashed` is already `is_infra()` (quality/park exempt), so **quality strikes were never the problem** — the dispatch-failure streak + cooldown was. Fix #1 (classifier) alone would not have stopped it; the reappearance path is where the penalty lands.

## The fix

Extend the existing environmental-non-attempt concept (`TaskRunOutcome::EnvironmentalNonAttempt`, task c9l4) to deploy/reap interruptions via a new terminal **`TaskAttemptOutcome::Interrupted`** — `is_infra` + `is_environmental_interrupt`, `ReopenClass::Infra`, ranked above the failure outcomes so a recorded environmental interrupt is never clobbered backward to a failure:

1. **`session_recovery::classify_session_exit_liveness`** — an `interrupted` exit terminalizes the live attempt as `Interrupted` (environmental); a `failed` exit stays `Crashed`. This only fires when the attempt is still pending/submitted (`advance_latest_to_terminal` no-ops on a terminal row), so **stall-kill / ceiling / no-progress / zombie / hard-runtime** paths — which terminalize their own attempt first (TimedOut/LoopGuard/Crashed) — remain failures.
2. **`health::reap_orphaned_pending_attempts`** — a `reason="startup"` reap (a deploy killed the run) stamps `Interrupted`; periodic reaps stay `Crashed` (conservative).
3. **`task_dispatch` reappearance** — when the latest non-guard attempt for `(task, role)` is environmental `Interrupted`, spare the reappearance: clear backoff state and dispatch immediately with **no streak and no cooldown**. Genuine `crashed`/`timed_out` attempts still count (control test proves this).

Migration `100_task_attempt_interrupted_outcome.sql` widens the `task_attempts.outcome` CHECK constraint. `TaskAttemptOutcome` is a DB/serde string enum (not bincode), so appending the variant is wire-safe; no bincode enum was touched.

Respawn guard is unchanged: an `Interrupted` attempt is terminal and not `reopened`, so the guard treats it exactly like a `crashed` attempt (no rework/adoption confusion — "as if it never ran").

## Tests

- `deploy_interruptions_environmental`: incident shape (interrupted reappearance → dispatched immediately, no streak, no cooldown) + control (crashed reappearance → streak=1 + cooldown).
- `session_reaping`: interrupted→`interrupted` attempt; failed→`crashed` (regression); interrupted event does not reclassify an already-terminal `timed_out` (stall regression); startup reap→`interrupted` / periodic→`crashed`; reappearance helper detection.
- `djinn-core`: `TaskAttemptOutcome::Interrupted` round-trip / is_infra / is_environmental_interrupt / rank.

Verified: `cargo clippy -p djinn-coordinator -p djinn-runtime --all-targets --all-features -D warnings` clean (djinn-core clean; djinn-db only pre-existing graph_scoring.rs lints); full workspace builds; new + regression tests pass against throwaway postgres:16; fmt clean; size-guard clean.