### PR TITLE
fix(coordinator): grace-period young task-run Jobs in orphan backstop reap

### DIFF
--- a/server/crates/djinn-control-plane/src/bridge/runtime_bridge.rs
+++ b/server/crates/djinn-control-plane/src/bridge/runtime_bridge.rs
@@ -11,6 +11,12 @@ use super::graph_data::SemanticQueryEmbedding;
 pub struct TaskrunJobRef {
     pub job_name: String,
     pub task_run_id: String,
+    /// The Job's `metadata.creation_timestamp`, as a std wall-clock instant.
+    /// Mirrors [`djinn_runtime::TaskrunJobRef::created_at`]; the coordinator's
+    /// backstop reaper uses it to grace-period young Jobs whose DB owner rows
+    /// may simply not exist yet (the worker creates them from inside the pod
+    /// after boot). `None` is treated as old/eligible for reaping.
+    pub created_at: Option<std::time::SystemTime>,
 }
 
 /// Structured error returned from runtime dispatch calls so callers can

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -1499,6 +1499,8 @@ pub(super) async fn reap_orphaned_taskrun_jobs(
 
     let task_run_repo = djinn_db::repositories::task_run::TaskRunRepository::new(db.clone());
 
+    let now = SystemClock::new().now();
+
     for job in jobs {
         let task_run_id = job.task_run_id.trim();
         if task_run_id.is_empty() {
@@ -1548,6 +1550,29 @@ pub(super) async fn reap_orphaned_taskrun_jobs(
                 db_classification = classification.db_classification,
                 reason,
                 "CoordinatorActor: task-run Job backstop preserved live task-run Job"
+            );
+            continue;
+        }
+
+        // Boot-race grace: the worker inserts the task_runs row (and later the
+        // session row) from INSIDE the pod via the create_task_run RPC, i.e.
+        // only after pod scheduling + image pull + worker boot — which can take
+        // minutes. Every new Job therefore has a legitimate window where its DB
+        // owner rows are still "absent" (or the run row exists but no session
+        // yet). Reaping in that window kills sessions before they start, so we
+        // skip young Jobs in the boot-race classes. Terminal task_run statuses
+        // and interrupted/completed sessions are genuinely dead and reaped
+        // regardless of age (handled by the eligibility check below).
+        if is_boot_race_classification(classification.db_classification)
+            && job_within_reap_grace(job.created_at, now, TASKRUN_JOB_REAP_GRACE)
+        {
+            tracing::debug!(
+                job_name = %job.job_name,
+                task_run_id = %task_run_id,
+                db_classification = "young_job_grace",
+                original_classification = classification.db_classification,
+                reason,
+                "CoordinatorActor: task-run Job backstop skipped young Job within boot-race grace window"
             );
             continue;
         }
@@ -1651,6 +1676,44 @@ fn classify_taskrun_job_owner(
     }
 }
 
+/// Grace window before the backstop will reap a task-run Job whose DB owner
+/// rows are still absent. Sized generously (pod scheduling + image pull +
+/// worker boot can take minutes) because the worker only inserts the
+/// `task_runs` row from inside the pod after boot; reaping sooner races the
+/// worker and kills the session before it starts.
+const TASKRUN_JOB_REAP_GRACE: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+/// The classifications that can legitimately appear during pod boot, before the
+/// worker has inserted its DB owner rows: no `task_runs` row at all
+/// (`"absent"`), or a running `task_runs` row whose session row hasn't been
+/// created yet (`"task_run_running_without_session"`). Only these classes are
+/// age-gated; every other non-`keep_job` class is a genuinely dead owner.
+fn is_boot_race_classification(db_classification: &str) -> bool {
+    matches!(
+        db_classification,
+        "absent" | "task_run_running_without_session"
+    )
+}
+
+/// True when a Job is younger than `grace` and therefore still inside the
+/// boot-race window. A missing `created_at` is treated as old (not within
+/// grace) so the backstop still reaps Jobs it cannot age — preserving the
+/// cleanup guarantee. A `created_at` in the future (clock skew) is treated as
+/// within grace, since such a Job cannot yet have aged out.
+fn job_within_reap_grace(
+    created_at: Option<std::time::SystemTime>,
+    now: std::time::SystemTime,
+    grace: std::time::Duration,
+) -> bool {
+    match created_at {
+        Some(created) => match now.duration_since(created) {
+            Ok(age) => age < grace,
+            Err(_) => true,
+        },
+        None => false,
+    }
+}
+
 fn taskrun_status_classification(status: &str) -> &'static str {
     match status {
         "completed" => "task_run_completed",
@@ -1658,6 +1721,115 @@ fn taskrun_status_classification(status: &str) -> &'static str {
         "interrupted" => "task_run_interrupted",
         "running" => "task_run_running_without_live_session",
         _ => "task_run_unknown_status",
+    }
+}
+
+#[cfg(test)]
+mod taskrun_backstop_grace_tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    /// Mirror of the loop's skip decision: a Job is spared only when its DB
+    /// classification is a boot-race class AND it is still within the grace
+    /// window.
+    fn would_skip_reap(
+        db_classification: &str,
+        created_at: Option<SystemTime>,
+        now: SystemTime,
+        grace: Duration,
+    ) -> bool {
+        is_boot_race_classification(db_classification)
+            && job_within_reap_grace(created_at, now, grace)
+    }
+
+    fn base() -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
+    }
+
+    #[test]
+    fn young_absent_job_is_kept() {
+        let now = base();
+        let created = now - Duration::from_secs(30);
+        assert!(
+            would_skip_reap("absent", Some(created), now, TASKRUN_JOB_REAP_GRACE),
+            "a 30s-old Job with no task_runs row must be spared during boot"
+        );
+    }
+
+    #[test]
+    fn young_running_without_session_job_is_kept() {
+        let now = base();
+        let created = now - Duration::from_secs(60);
+        assert!(
+            would_skip_reap(
+                "task_run_running_without_session",
+                Some(created),
+                now,
+                TASKRUN_JOB_REAP_GRACE
+            ),
+            "a running task_run whose session row is not yet inserted must be spared during boot"
+        );
+    }
+
+    #[test]
+    fn old_absent_job_is_reaped() {
+        let now = base();
+        let created = now - (TASKRUN_JOB_REAP_GRACE + Duration::from_secs(1));
+        assert!(
+            !would_skip_reap("absent", Some(created), now, TASKRUN_JOB_REAP_GRACE),
+            "an aged-out Job with no DB owner is genuinely orphaned and must be reaped"
+        );
+    }
+
+    #[test]
+    fn young_terminal_task_run_job_is_reaped() {
+        let now = base();
+        let created = now - Duration::from_secs(5);
+        // Terminal task_run statuses are dead regardless of age.
+        for class in [
+            "task_run_completed",
+            "task_run_failed",
+            "task_run_interrupted",
+            "session_interrupted",
+            "session_completed",
+        ] {
+            assert!(
+                !would_skip_reap(class, Some(created), now, TASKRUN_JOB_REAP_GRACE),
+                "terminal classification {class} must be reaped even for a young Job"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_timestamp_is_treated_as_old() {
+        let now = base();
+        assert!(
+            !job_within_reap_grace(None, now, TASKRUN_JOB_REAP_GRACE),
+            "a Job with no creation timestamp must be eligible for reaping"
+        );
+    }
+
+    #[test]
+    fn future_timestamp_is_treated_as_young() {
+        let now = base();
+        let created = now + Duration::from_secs(120);
+        assert!(
+            job_within_reap_grace(Some(created), now, TASKRUN_JOB_REAP_GRACE),
+            "clock skew (future creation time) must not make a Job eligible for reaping"
+        );
+    }
+
+    #[test]
+    fn boot_race_classification_membership() {
+        assert!(is_boot_race_classification("absent"));
+        assert!(is_boot_race_classification(
+            "task_run_running_without_session"
+        ));
+        assert!(!is_boot_race_classification("task_run_completed"));
+        assert!(!is_boot_race_classification(
+            "task_run_running_without_live_session"
+        ));
+        assert!(!is_boot_race_classification("live_running"));
     }
 }
 

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -107,10 +107,12 @@ async fn taskrun_job_backstop_skips_empty_task_run_id_inventory_entry() {
         djinn_control_plane::bridge::TaskrunJobRef {
             job_name: "djinn-taskrun-empty".to_string(),
             task_run_id: "".to_string(),
+            created_at: None,
         },
         djinn_control_plane::bridge::TaskrunJobRef {
             job_name: "djinn-taskrun-whitespace".to_string(),
             task_run_id: "   ".to_string(),
+            created_at: None,
         },
     ]);
     let mut app_state =
@@ -742,6 +744,9 @@ fn taskrun_job_ref(task_run_id: &str) -> djinn_control_plane::bridge::TaskrunJob
     djinn_control_plane::bridge::TaskrunJobRef {
         job_name: format!("djinn-taskrun-{task_run_id}"),
         task_run_id: task_run_id.to_string(),
+        // `None` is treated as an old Job (past the boot-race grace window), so
+        // these existing reaping assertions keep exercising the delete path.
+        created_at: None,
     }
 }
 

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -102,9 +102,21 @@ pub fn taskrun_job_ref_from_job(job: &Job) -> Option<djinn_runtime::TaskrunJobRe
         return None;
     };
 
+    // Carry the Job's creation timestamp so the backstop reaper can age-gate
+    // young Jobs: the worker inserts the task_runs row only after pod boot, so
+    // a fresh Job legitimately has no DB owner rows yet. k8s_openapi wraps the
+    // timestamp as `Time(chrono::DateTime<Utc>)`; chrono provides the
+    // `SystemTime: From<DateTime<Utc>>` conversion.
+    let created_at = job
+        .metadata
+        .creation_timestamp
+        .as_ref()
+        .map(|time| std::time::SystemTime::from(time.0));
+
     Some(djinn_runtime::TaskrunJobRef {
         job_name,
         task_run_id,
+        created_at,
     })
 }
 
@@ -790,6 +802,27 @@ mod tests {
             taskrun_job_ref_from_job(&inventory_job(Some(&job_name), Some("not-a-uuid")))
                 .expect("canonical name should recover from malformed label");
         assert_eq!(malformed_label.task_run_id, task_run_id.to_string());
+    }
+
+    #[test]
+    fn carries_creation_timestamp_into_inventory_ref() {
+        let task_run_id = Uuid::now_v7();
+        let job_name = format!("{TASKRUN_JOB_NAME_PREFIX}{task_run_id}");
+        let created = k8s_openapi::chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .expect("valid timestamp");
+
+        let mut job = inventory_job(Some(&job_name), None);
+        job.metadata.creation_timestamp = Some(
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(created),
+        );
+
+        let got = taskrun_job_ref_from_job(&job).expect("canonical name should be extracted");
+        assert_eq!(got.created_at, Some(std::time::SystemTime::from(created)));
+
+        // No creation timestamp → None, which the backstop treats as old.
+        let bare = taskrun_job_ref_from_job(&inventory_job(Some(&job_name), None))
+            .expect("canonical name should be extracted");
+        assert_eq!(bare.created_at, None);
     }
 
     #[test]

--- a/server/crates/djinn-runtime/src/warmer.rs
+++ b/server/crates/djinn-runtime/src/warmer.rs
@@ -22,6 +22,14 @@ use async_trait::async_trait;
 pub struct TaskrunJobRef {
     pub job_name: String,
     pub task_run_id: String,
+    /// The Job's `metadata.creation_timestamp`, as a std wall-clock instant.
+    /// The backstop reaper age-gates young Jobs against this: the worker
+    /// inserts the `task_runs` row from INSIDE the pod (only after pod
+    /// scheduling + image pull + worker boot), so a freshly-created Job
+    /// legitimately has no DB owner rows yet. `None` when the Job carries no
+    /// timestamp (shouldn't happen for live Jobs); callers treat `None` as
+    /// old/eligible so the backstop's cleanup guarantee is preserved.
+    pub created_at: Option<std::time::SystemTime>,
 }
 
 /// Server-wide canonical-graph warmer.

--- a/server/src/mcp_bridge/mod.rs
+++ b/server/src/mcp_bridge/mod.rs
@@ -87,6 +87,7 @@ impl RuntimeOps for AppState {
             .map(|job| TaskrunJobRef {
                 job_name: job.job_name,
                 task_run_id: job.task_run_id,
+                created_at: job.created_at,
             })
             .collect())
     }


### PR DESCRIPTION
## Root cause

The coordinator's periodic task-run Job backstop (`reap_orphaned_taskrun_jobs` in `djinn-coordinator/src/health.rs`) classifies each Kubernetes Job against DB truth and foreground-deletes Jobs whose classification is `absent` (no `task_runs` row, no live session). But the `task_runs` row is inserted by the worker **inside the pod** via the `create_task_run` RPC — i.e. only after pod scheduling + image pull + worker boot. Every freshly-created Job therefore has a legitimate window where it looks like an orphan. The same race applies to `task_run_running_without_session` (run row inserted, session row not yet).

## Evidence (prod logs, 2026-07-10)

- `00:23:38.5Z` — coordinator dispatched two proposal-refinement (tribunal) sessions; k8s Jobs `djinn-taskrun-019f4968-9511-...` and `djinn-taskrun-019f4968-955d-...` created ("kubernetes_runtime: task-run resources created").
- `00:23:42.4Z` — same coordinator tick (cycle 36), the periodic backstop logged "CoordinatorActor: backstop reaped orphaned task-run Job" with `db_classification: "absent"`, `reason: "periodic"` for **both** Jobs — 4 seconds after creation.
- Result: pods never booted, no session rows were created, the slot actors hung waiting on deleted Jobs, and all pending tribunal refinements starved behind the per-user model cap.

## Fix

- Plumb the Job's `metadata.creation_timestamp` through `TaskrunJobRef` (`djinn-runtime` + `djinn-control-plane` bridge, populated in `djinn-k8s`'s `taskrun_job_ref_from_job`, forwarded by the server's `RuntimeOps` bridge).
- In `reap_orphaned_taskrun_jobs`, skip deletion (debug log with `db_classification = "young_job_grace"`) when the Job is younger than a 10-minute grace window **and** its classification is a boot-race class (`absent` or `task_run_running_without_session`). The window is sized generously because pod scheduling + image pull can take minutes.
- Terminal `task_run` statuses (completed/failed/interrupted) and interrupted/completed sessions are still reaped regardless of age — those are genuinely dead.
- A missing creation timestamp is treated as old (eligible to reap) so the backstop's cleanup guarantee is preserved. The startup pass uses the same grace uniformly — it is idempotent and the periodic pass picks aged-out Jobs up later.

## Tests

- New unit tests in `health.rs` (`taskrun_backstop_grace_tests`): young+absent kept, young running-without-session kept, old+absent reaped, young+terminal reaped, missing timestamp treated as old, future timestamp (clock skew) treated as young, boot-race class membership.
- New test in `djinn-k8s/src/job.rs` asserting `creation_timestamp` is carried into the inventory ref (and `None` when absent).
- `cargo fmt` clean; `cargo clippy --all-features --all-targets` clean for `djinn-runtime`, `djinn-control-plane`, `djinn-k8s`, `djinn-coordinator`, `djinn-slot`, `djinn-server` (one pre-existing `useless_vec` warning in untouched `sidecar.rs`).
- `cargo test -p djinn-coordinator --lib health::` (19 passed) and `cargo test -p djinn-k8s --lib job::` (29 passed). Pre-existing `graph_warmer` DB-backed test failures are environmental (stale local test-DB template, reproduced on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)