### PR TITLE
fix(refinement): fail fast when starting refinement on a proposal with no targets

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
@@ -147,6 +147,27 @@ impl DjinnMcpServer {
             )));
         }
 
+        // Refinement dispatches tribunal tasks into the proposal's target
+        // project (see create_refinement_task_with_context, which reads
+        // targets[0].project_id). With no target the coordinator silently
+        // fails task creation and terminates with an opaque agent_failure and
+        // zero entries — so reject fast here with an actionable message.
+        match repo.targets(&proposal.id).await {
+            Ok(targets) if !targets.is_empty() => {}
+            Ok(_) => {
+                return Json(err_refinement_start(
+                    "proposal has no target project; add one with proposal_add_target \
+                     before starting refinement"
+                        .to_string(),
+                ));
+            }
+            Err(e) => {
+                return Json(err_refinement_start(format!(
+                    "failed to check proposal targets: {e}"
+                )));
+            }
+        }
+
         // Lifecycle-level duplicate check — fast-path early return before
         // hitting the coordinator channel.
         if refinement_is_active(&repo, &proposal.id).await {
@@ -343,6 +364,35 @@ impl DjinnMcpServer {
                 refinement: Some(current_refinement),
                 error: Some("refinement is already active for this proposal".to_string()),
             });
+        }
+
+        // Same missing-target blind spot as refinement_start: a demanded round
+        // dispatches a fresh tribunal task, which needs a target project. Reject
+        // fast here rather than terminating with an opaque agent_failure. Checked
+        // after the duplicate-active guard so a genuinely-active proposal still
+        // reports "already active" first.
+        match repo.targets(&proposal.id).await {
+            Ok(targets) if !targets.is_empty() => {}
+            Ok(_) => {
+                return Json(DemandRoundResponse {
+                    proposal_id: Some(proposal.id),
+                    accepted: false,
+                    refinement: None,
+                    error: Some(
+                        "proposal has no target project; add one with proposal_add_target \
+                         before demanding a refinement round"
+                            .to_string(),
+                    ),
+                });
+            }
+            Err(e) => {
+                return Json(DemandRoundResponse {
+                    proposal_id: Some(proposal.id),
+                    accepted: false,
+                    refinement: None,
+                    error: Some(format!("failed to check proposal targets: {e}")),
+                });
+            }
         }
 
         // Record the demand-round action as a lifecycle event.

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part1.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part1.inc
@@ -19,6 +19,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         let resp = server
             .dispatch_tool(
@@ -122,6 +123,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         // Start refinement.
         server
@@ -294,6 +296,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         let resp = server
             .dispatch_tool(
@@ -373,6 +376,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         let resp = server
             .dispatch_tool(
@@ -416,6 +420,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         // 1. Start refinement (checkpoint mode).
         let start_resp = server
@@ -554,6 +559,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         // Start refinement.
         server
@@ -609,6 +615,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         server
             .dispatch_tool(
@@ -657,6 +664,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         server
             .dispatch_tool(
@@ -705,6 +713,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         server
             .dispatch_tool(

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part2.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part2.inc
@@ -222,6 +222,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         // Start refinement (always checkpoint-gated).
         server
@@ -291,6 +292,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         // First start succeeds.
         let resp1 = server
@@ -373,6 +375,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         let resp = server
             .dispatch_tool(
@@ -501,6 +504,7 @@
             })
             .await
             .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
 
         repo.record_refinement_lifecycle(&proposal.id, "refinement_start", None)
             .await
@@ -970,5 +974,100 @@
         assert_eq!(
             reopened.get("blocking").and_then(|v| v.as_bool()),
             Some(true)
+        );
+    }
+
+    // ── Missing-target fail-fast at start time ────────────────────────────────
+
+    /// Starting refinement on a proposal with no target project must be
+    /// rejected up front with an actionable message, rather than silently
+    /// terminating the tribunal with an opaque agent_failure once the
+    /// coordinator fails to place the first tribunal task (prod incident,
+    /// proposal t7lh, 2026-07-10). No refinement_start lifecycle entry should
+    /// be recorded.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn refinement_start_rejects_proposal_without_target() {
+        let (server, db) = test_server().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let proposal = repo
+            .create(ProposalCreateInput {
+                title: "No Target Start",
+                body: "body",
+                acceptance_criteria: Some("[]"),
+                status: Some("draft"),
+                body_format: None,
+            })
+            .await
+            .unwrap();
+
+        // Intentionally do NOT link a target project.
+        let resp = server
+            .dispatch_tool(
+                "proposal_refinement_start",
+                serde_json::json!({ "proposal_id": proposal.id }),
+            )
+            .await
+            .expect("tool should be registered");
+
+        let error = resp.get("error").and_then(|v| v.as_str()).unwrap();
+        assert!(
+            error.contains("no target project"),
+            "should mention missing target: {error}"
+        );
+        assert!(
+            error.contains("proposal_add_target"),
+            "should tell the operator how to fix it: {error}"
+        );
+
+        // Fail-fast means no refinement lifecycle entry was written.
+        let revisions = repo.revisions(&proposal.id).await.unwrap();
+        assert_eq!(
+            revisions
+                .iter()
+                .filter(|r| r.event_kind == "refinement_start")
+                .count(),
+            0,
+            "no refinement_start should be recorded when the target check fails"
+        );
+    }
+
+    /// Demanding a refinement round on a proposal with no target project is
+    /// rejected with the same actionable message.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn demand_round_rejects_proposal_without_target() {
+        let (server, db) = test_server().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let proposal = repo
+            .create(ProposalCreateInput {
+                title: "No Target Demand",
+                body: "body",
+                acceptance_criteria: Some("[]"),
+                status: Some("draft"),
+                body_format: None,
+            })
+            .await
+            .unwrap();
+
+        // Intentionally do NOT link a target project.
+        let resp = server
+            .dispatch_tool(
+                "proposal_refinement_demand_round",
+                serde_json::json!({
+                    "proposal_id": proposal.id,
+                    "reason": "another round",
+                }),
+            )
+            .await
+            .expect("tool should be registered");
+
+        assert_eq!(resp.get("accepted").and_then(|v| v.as_bool()), Some(false));
+        let error = resp.get("error").and_then(|v| v.as_str()).unwrap();
+        assert!(
+            error.contains("no target project"),
+            "should mention missing target: {error}"
+        );
+        assert!(
+            error.contains("proposal_add_target"),
+            "should tell the operator how to fix it: {error}"
         );
     }

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -861,7 +861,30 @@ impl CoordinatorActor {
 
         let project_id = match proposal_repo.targets(proposal_id).await {
             Ok(targets) if !targets.is_empty() => targets[0].project_id.clone(),
-            _ => return None,
+            Ok(_) => {
+                // No target project → the refinement task cannot be placed in a
+                // repo and the loop terminates. This is a fail-fast that should
+                // have been caught at start time (proposal_refinement_start);
+                // log it here so a leak past that gate is observable rather than
+                // surfacing only as an opaque agent_failure with zero entries.
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    agent_type,
+                    "Cannot create refinement task: proposal has no target project \
+                     (add one with proposal_add_target); terminating refinement"
+                );
+                return None;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    agent_type,
+                    error = %e,
+                    "Cannot create refinement task: failed to query proposal targets; \
+                     terminating refinement"
+                );
+                return None;
+            }
         };
 
         match task_repo


### PR DESCRIPTION
## Bug

Starting proposal refinement on a proposal with **no target projects** silently killed the tribunal with an opaque `agent_failure`:

1. `proposal_refinement_start` accepted a proposal with an empty target list and started the loop.
2. On first phase dispatch, `create_refinement_task_with_context` (`djinn-coordinator/src/refinement_outcome.rs`) did `_ => return None` when `proposal_repo.targets(...)` returned empty — no log, and it also swallowed DB errors.
3. The caller (`dispatch_next_refinement_phase`) saw `None`, logged only a generic "Failed to create refinement task", and terminated with `StopReason::AgentFailure { error: "task creation failed" }`.

## Operator impact

Refinement instantly stopped with `stop_reason: "agent_failure"`, `total_entries: 0`, and nothing anywhere said "this proposal has no target project". Burned ~an hour of diagnosis in production (proposal t7lh, 2026-07-10).

## Fix

- **Fail fast at start**: `proposal_refinement_start` and `proposal_refinement_demand_round` now validate the proposal has at least one target before starting/resuming the loop, returning an actionable validation error — `"proposal has no target project; add one with proposal_add_target before starting refinement"` — matching the existing draft/in_review and duplicate-active validation style. No refinement lifecycle entry is recorded on rejection. (The demand-round check runs after the duplicate-active guard so a genuinely-active proposal still reports "already active" first.)
- **Log the silent path**: `create_refinement_task_with_context` splits the `_ => return None` arm into empty-targets vs targets-query-error, each logging a `tracing::warn!` that names the proposal (and the error, for the query-failure case). It still returns `None` — terminate-with-AgentFailure is acceptable once observable.

## Tests

- New `refinement_start_rejects_proposal_without_target` and `demand_round_rejects_proposal_without_target` assert the actionable message and that no lifecycle entry is written.
- Existing success-path start/demand tests now link a target project via the shared `link_proposal_to_project` helper.
- `cargo fmt --all`; `cargo clippy -p djinn-control-plane -p djinn-coordinator --all-features` clean; `djinn-control-plane` refinement suite 99 passed, `djinn-coordinator` refinement suite 82 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)