### PR TITLE
fix(helm): wire dead task-run/warm resource knobs to DJINN_K8S_* env

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -246,6 +246,35 @@ spec:
                         (include "djinn.fullname" .)
                         (include "djinn.namespace" .)
                         (.Values.service.rpcPort | int) | quote }}
+            # Resource sizing the controller stamps onto the task-run + warm
+            # Job PodSpecs it dispatches. These size the EPHEMERAL worker/warm
+            # Pods djinn-server spawns, NOT this long-lived server Pod (that's
+            # `resources.server` on the container below). Sourced from
+            # `resources.taskrun` / `resources.warm` in values.yaml.
+            #
+            # Emitted BEFORE the `extraEnv` include at the end of this env list
+            # on purpose: Kubernetes resolves a duplicate env name to the LAST
+            # entry, so an operator who also sets any of these via `extraEnv`
+            # still wins. Keep new sizing vars above the `extraEnv` block to
+            # preserve that override property.
+            - name: DJINN_K8S_CPU_REQUEST
+              value: {{ .Values.resources.taskrun.requests.cpu | quote }}
+            - name: DJINN_K8S_CPU_LIMIT
+              value: {{ .Values.resources.taskrun.limits.cpu | quote }}
+            - name: DJINN_K8S_MEMORY_REQUEST
+              value: {{ .Values.resources.taskrun.requests.memory | quote }}
+            - name: DJINN_K8S_MEMORY_LIMIT
+              value: {{ .Values.resources.taskrun.limits.memory | quote }}
+            - name: DJINN_K8S_WARM_CPU_REQUEST
+              value: {{ .Values.resources.warm.requests.cpu | quote }}
+            - name: DJINN_K8S_WARM_CPU_LIMIT
+              value: {{ .Values.resources.warm.limits.cpu | quote }}
+            - name: DJINN_K8S_WARM_MEMORY_REQUEST
+              value: {{ .Values.resources.warm.requests.memory | quote }}
+            - name: DJINN_K8S_WARM_MEMORY_LIMIT
+              value: {{ .Values.resources.warm.limits.memory | quote }}
+            - name: DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS
+              value: {{ .Values.resources.warm.jobTimeoutSeconds | quote }}
             # Pod scheduling for task-run + warm Jobs. JSON-encoded so the
             # controller can deserialize directly into k8s_openapi types
             # without bringing a YAML parser into the dispatch path. The

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -75,16 +75,27 @@ resources:
     limits:
       cpu: "2"
       memory: "2Gi"
-  # Defaults the controller will apply to Job PodSpecs when dispatching
-  # task-run workloads. Surfaced here so operators can tune without editing
-  # controller env directly. djinn-server reads these via env.
+  # Resource sizing the controller stamps onto the task-run Job PodSpecs it
+  # dispatches. These size the EPHEMERAL worker Pods djinn-server spawns, NOT
+  # the long-lived server Deployment above (that's `resources.server`). They
+  # reach the running server as the DJINN_K8S_CPU/MEMORY_{REQUEST,LIMIT} env
+  # vars emitted by templates/deployment-server.yaml, and the k8s runtime
+  # stamps them onto every task-run Pod it creates.
+  #
+  # Rationale for low requests / high limits (proven on a single 12-CPU/47Gi
+  # VPS node running several concurrent workers): keep requests small so many
+  # Pods schedule onto one node, and set limits high so a cargo build/link
+  # burst can spike into the node's idle headroom. Workers idle-wait on the
+  # LLM most of the time, so their steady-state footprint sits far below the
+  # limit — over-committing the node is safe and lets more work run in
+  # parallel.
   taskrun:
     requests:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "1"
+      memory: "2Gi"
     limits:
-      cpu: "2"
-      memory: "4Gi"
+      cpu: "6"
+      memory: "22Gi"
     # Pod scheduling for both task-run and warm Jobs. Warm Pods pre-warm the
     # graph cache that task-runs later adopt, so they MUST land on the same
     # NodePool — that's why one set of hints covers both.
@@ -105,6 +116,29 @@ resources:
     # constraints allow is eligible (preserves the pre-feature behavior).
     nodeSelector: {}
     tolerations: []
+  # Resource sizing for graph-warm Jobs — the short-lived Pods that populate
+  # the canonical graph cache a later task-run adopts. These reach the running
+  # server as the DJINN_K8S_WARM_* env vars emitted by
+  # templates/deployment-server.yaml and are stamped onto every warm Pod.
+  #
+  # Same low-request / high-limit rationale as `taskrun` above: SCIP indexer
+  # subprocesses (rust-analyzer, scip-go, ...) spike CPU/memory during a warm
+  # pass but idle otherwise, so a small request packs Pods onto a node while a
+  # high limit lets a burst use the idle headroom. Warm Jobs run in the
+  # background and don't gate worker latency, so over-committing is safe.
+  warm:
+    requests:
+      cpu: "2"
+      memory: "2Gi"
+    limits:
+      cpu: "6"
+      memory: "16Gi"
+    # Max wall-clock seconds a warm Job may run before the kubelet terminates
+    # it (activeDeadlineSeconds), surfaced as DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS.
+    # 3600s (60 min) covers a cold single-pass warm of a ~12-crate workspace
+    # (~20-25 min observed) with ample margin. Raise it if a larger workspace
+    # consistently hits the deadline.
+    jobTimeoutSeconds: 3600
 
 # -----------------------------------------------------------------------------
 # Storage


### PR DESCRIPTION
The Helm chart documented `resources.taskrun` in `values.yaml`, but `templates/deployment-server.yaml` never emitted the `DJINN_K8S_CPU/MEMORY_{REQUEST,LIMIT}` (nor the `DJINN_K8S_WARM_*`) env vars the server runtime actually reads (`server/crates/djinn-k8s/src/config.rs`). The knobs were silently dead, so real deployments worked around it by stuffing every sizing value into `extraEnv` — a footgun, since Helm REPLACES list values from later `-f` files, forcing the whole `extraEnv` list to live in one file.

## What this does
- **Emit the sizing env vars** from chart values in `deployment-server.yaml`: task-run CPU/memory request+limit (`DJINN_K8S_CPU_REQUEST`/`CPU_LIMIT`/`MEMORY_REQUEST`/`MEMORY_LIMIT`), warm CPU/memory request+limit (`DJINN_K8S_WARM_*`), and warm job timeout (`DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS`). Env names verified against `config.rs`, not guessed.
- **Override-safe ordering**: the new vars are placed BEFORE the `extraEnv` include in the env list. K8s resolves a duplicate env name to the last entry, and `extraEnv` is appended last, so an operator who still sets any of these via `extraEnv` continues to win. Documented in a comment.
- **Production-proven defaults** (from the live single-node VPS, a 12-CPU/47Gi node): task-run requests `cpu "1"` / `memory "2Gi"`, limits `cpu "6"` / `memory "22Gi"`; warm requests `cpu "2"` / `memory "2Gi"`, limits `cpu "6"` / `memory "16Gi"`; warm job timeout `3600`. Added a `resources.warm` block. Rationale comments kept: low requests so several Pods schedule on one node, high limits so cargo bursts into idle headroom; workers idle-wait on the LLM most of the time.
- **Fixed the misleading `values.yaml` comments** so operators know these values now actually flow to the task-run/warm Jobs the server spawns (they size those ephemeral Pods, not the server Pod itself).

## Follow-up
Once this ships, the VPS deploy overrides `eks-application-platform` used to stuff these DJINN_K8S sizing values into `extraEnv` become redundant and can be dropped — the chart defaults now match them.

## Validation
- `helm lint deploy/helm/djinn` → 0 failures.
- `helm template deploy/helm/djinn` (default values) renders all nine env vars with the new defaults.
- `helm template` with an override file that sets `DJINN_K8S_CPU_LIMIT`/`DJINN_K8S_WARM_MEMORY_LIMIT` via `extraEnv`: the chart default renders first and the `extraEnv` entry renders last, confirming the operator override wins.