### PR TITLE
build(djinn-k8s): link warm/task-run pods with mold

### DIFF
--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -649,6 +649,36 @@ fn common_cache_env_vars(project_id: &str) -> Vec<EnvVar> {
         // trying — and failing — to connect. Local dev keeps online validation
         // because it never sources cache_env_vars.
         env_var("SQLX_OFFLINE", "true"),
+        // Fast-linker default for every build-in-pod cargo invocation. The
+        // per-project devcontainer image already installs mold (see
+        // image-builder scripts/install-rust.sh, which apt-installs
+        // `clang lld mold` whenever a Rust toolchain is requested), but nothing
+        // WIRED it in — so warm/task-run pods linked djinn-server + every test
+        // binary with the default `ld` and paid full link time on every
+        // iterative edit→clippy/test loop (measured 6-22min/invocation).
+        //
+        // `CARGO_BUILD_RUSTFLAGS` (the env form of `build.rustflags`) is the
+        // LOWEST-priority rustflags source: a repo that pins its own
+        // `[build]`/`[target.*] rustflags` in `.cargo/config.toml` keeps its
+        // flags untouched, and a project on a custom base image without mold is
+        // unaffected on the (rare) crates that override. It degrades gracefully
+        // rather than clobbering, unlike `RUSTFLAGS`.
+        //
+        // Set HERE, in the shared helper both warm_cache_env_vars and
+        // task_run_cache_env_vars flow through, ON PURPOSE: cargo folds
+        // rustflags into its compile fingerprint (and the warm base is seeded
+        // into task-run target dirs), so warm and worker MUST resolve the
+        // identical flag or the warm seed fingerprint-mismatches and every
+        // task-run cold-rebuilds. Single-sourcing it here makes that drift
+        // impossible — the same class of guarantee the SCCACHE_DIR/CARGO_HOME
+        // routing above relies on. Mirrors the local-docker path, where
+        // djinn-agent-runtime-base.Dockerfile bakes the identical
+        // `CARGO_BUILD_RUSTFLAGS=-Clink-arg=-fuse-ld=mold` as an image ENV.
+        //
+        // Shipping this is a ONE-TIME warm-base invalidation (the effective
+        // rustflags change → fingerprints change → the first warm after deploy
+        // rebuilds the per-project base); steady state is fast links thereafter.
+        env_var("CARGO_BUILD_RUSTFLAGS", "-Clink-arg=-fuse-ld=mold"),
     ]
 }
 
@@ -1242,6 +1272,11 @@ mod tests {
             Some(""),
             "task-runs disable the sccache wrapper (sccache forbids incremental)"
         );
+        assert_eq!(
+            envs.get("CARGO_BUILD_RUSTFLAGS").copied(),
+            Some("-Clink-arg=-fuse-ld=mold"),
+            "task-runs default to the mold fast linker (installed in the devcontainer image)"
+        );
     }
 
     /// Regression guard: warm and task-run must resolve the same shared cache
@@ -1360,6 +1395,19 @@ mod tests {
             worker_env.get("RUSTC_WRAPPER").copied(),
             Some(""),
             "worker must clear RUSTC_WRAPPER so incremental works"
+        );
+
+        // The fast-linker rustflag is part of the compile fingerprint, so it
+        // MUST match between warm and worker or the warm seed is wasted (every
+        // task-run cold-rebuilds against a fingerprint-mismatched base).
+        assert_eq!(
+            warm_env.get("CARGO_BUILD_RUSTFLAGS"),
+            worker_env.get("CARGO_BUILD_RUSTFLAGS"),
+            "warm and worker CARGO_BUILD_RUSTFLAGS must match (fingerprint parity)"
+        );
+        assert_eq!(
+            warm_env.get("CARGO_BUILD_RUSTFLAGS").copied(),
+            Some("-Clink-arg=-fuse-ld=mold"),
         );
     }
 

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -528,6 +528,13 @@ mod tests {
         );
         assert_eq!(envs.get("SCCACHE_CACHE_SIZE").copied(), Some("20G"));
         assert_eq!(envs.get("SQLX_OFFLINE").copied(), Some("true"));
+        // Fast linker: mold is installed in the devcontainer image; wire it in
+        // for the warm build so the warm base is linked (and fingerprinted)
+        // identically to the task-run pods that seed from it.
+        assert_eq!(
+            envs.get("CARGO_BUILD_RUSTFLAGS").copied(),
+            Some("-Clink-arg=-fuse-ld=mold"),
+        );
 
         let mounts = container.volume_mounts.as_ref().expect("mounts");
         assert_eq!(mounts.len(), 4, "mirror + workspace + cache + env-config");


### PR DESCRIPTION
## Problem

Worker agent sessions are dominated by cargo builds (audited 6-22 min/invocation). Warm and task-run pods run on the **per-project devcontainer image**, whose build (`image-builder/scripts/install-rust.sh`) already apt-installs `clang lld mold` for every Rust stack — but **nothing ever wired mold in**. So production K8s pods linked `djinn-server` (20 workspace deps) plus every per-crate test binary with the default `ld`, paying full link time on each iterative edit → clippy/test loop.

(The local-docker/Tilt path was already covered: `djinn-agent-runtime-base.Dockerfile` bakes `CARGO_BUILD_RUSTFLAGS=-Clink-arg=-fuse-ld=mold` as an image ENV. `release.yml` already installs+uses mold for the binary/image builds. This PR closes the remaining gap — the K8s warm/worker pods.)

## Change

Default `CARGO_BUILD_RUSTFLAGS=-Clink-arg=-fuse-ld=mold` in `common_cache_env_vars` — the **single** helper both `warm_cache_env_vars` and `task_run_cache_env_vars` flow through.

## Fingerprint coherence (the critical constraint)

Task-run target dirs are seeded from the shared per-project warm base. Cargo folds rustflags into its compile fingerprint, so if warm and worker resolved different linker flags the seed would fingerprint-bust and every task-run would cold-rebuild. Setting the flag in the **one shared helper** makes warm == worker coherent by construction — the same single-sourcing guarantee the existing `CARGO_HOME` / `SCCACHE_DIR` routing relies on. A parity test asserts `warm_env["CARGO_BUILD_RUSTFLAGS"] == worker_env["CARGO_BUILD_RUSTFLAGS"]`.

## Why the env approach (not `.cargo/config.toml`)

- **Pods are where the pain is**, and both pod types share this env → coherent by construction.
- `CARGO_BUILD_RUSTFLAGS` is the **lowest-priority** rustflags source (env form of `build.rustflags`): a repo pinning its own `[build]`/`[target.*] rustflags` keeps its flags, and a project on a custom base image without mold is unaffected on any crate that overrides. It **degrades gracefully** rather than clobbering, unlike `RUSTFLAGS`.
- Editing `server/.cargo/config.toml` would break local dev machines without mold and is a no-op for CI (which pins its own `RUSTFLAGS`), so it was rejected.
- **CI (`quality-gate.yml`) intentionally out of scope**: it's a separate GitHub Actions cache namespace (no coherence coupling to the pods), and `release.yml` already links the shipped binaries with mold. Adding mold to the PR gate is a clean follow-up (it would require folding the flag into the single workflow-level `RUSTFLAGS` + an install step per compile job, and vetting the aarch64 cross-check job).

## Expected one-time warm-base invalidation

Shipping changes the effective rustflags → cargo fingerprints change → the first warm after deploy rebuilds each per-project base once. Steady state is fast links thereafter. Explicitly acceptable per the design constraint.

## Verification

- Mechanism validated against the exact toolchain (rustc 1.96 stable): `rustc -C link-arg=-fuse-ld=mold` links, and the output binary's `.comment` carries `mold 2.41.0 (... compatible with GNU ld)`. Same confirmed on a real `cargo build -p djinn-agent-worker` (binary `.comment` = mold).
- `cargo fmt -p djinn-k8s`, `cargo clippy -p djinn-k8s --all-targets` clean (one pre-existing `useless_vec` warning in `sidecar.rs` tests, a local-toolchain-version artifact, untouched here).
- `cargo test -p djinn-k8s`: **127 passed**, including the new `CARGO_BUILD_RUSTFLAGS` assertions in the task-run spec test, the warm-pod spec test, and the warm/worker parity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)