### PR TITLE
fix(dispatch): escalate persistent throttles and deprioritize throttle-cooling models

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -2179,6 +2179,20 @@ impl CoordinatorActor {
                     .await;
             }
 
+            // Dispatch-time throttle deprioritization: move any model that is
+            // currently inside a throttle cooldown window to the BACK of the
+            // ordered list so a healthy lane-mate is attempted first. A model
+            // whose token plan just 429'd is likely still quota-dead; retrying
+            // it head-of-line wastes a session spawn + a <10s crash + the
+            // ~30-minute task redispatch cooldown before failover finally
+            // happens. This is a pure reorder (not a filter): a throttle-cooling
+            // model stays in the list as a last-resort candidate, so if every
+            // lane model is cooling the existing all-unavailable path still
+            // applies (the dispatch loop's `is_available` gate + escalating
+            // backoff), and a half-open (cooldown-expired) throttle model is
+            // still tried when it is the only option.
+            deprioritize_throttle_cooling(&self.health, creator.as_deref(), &mut model_ids);
+
             // Structured observability: emit one log record per candidate in
             // the final ordered list so post-apply / post-rollback model order
             // can be inspected without production-only tooling.
@@ -2603,6 +2617,38 @@ impl CoordinatorActor {
         }
         self.publish_status();
     }
+}
+
+/// Reorder `model_ids` in place so that models currently inside a **throttle
+/// cooldown window** are moved to the back, preserving relative order within
+/// each group (healthy/available first, throttle-cooling last).
+///
+/// This is a pure reorder, not a filter: a throttle-cooling model stays in the
+/// list as a last-resort candidate. Its purpose is to prefer a healthy lane-mate
+/// over a model whose token plan just 429'd — avoiding a wasted session spawn +
+/// <10s crash + task-redispatch cooldown on a model known to be cooling — while
+/// keeping the all-cooling / only-candidate case sane: the dispatch loop's
+/// `is_available` gate still skips a model in an *active* cooldown, and a
+/// half-open (cooldown-expired) throttle model is still attempted when it is the
+/// only option. A list shorter than two candidates is left untouched.
+fn deprioritize_throttle_cooling(
+    health: &djinn_provider::catalog::HealthTracker,
+    scope: Option<&str>,
+    model_ids: &mut Vec<String>,
+) {
+    if model_ids.len() < 2 {
+        return;
+    }
+    let mut cooling: Vec<String> = Vec::new();
+    model_ids.retain(|m| {
+        if health.is_throttle_cooling(scope, m) {
+            cooling.push(m.clone());
+            false
+        } else {
+            true
+        }
+    });
+    model_ids.extend(cooling);
 }
 
 /// E6 regression tests.
@@ -6765,5 +6811,84 @@ mod monitored_reopen_no_eligible_model_tests {
         );
 
         cancel.cancel();
+    }
+}
+
+/// Dispatch-time throttle-deprioritization tests for
+/// [`deprioritize_throttle_cooling`].
+#[cfg(test)]
+mod throttle_deprioritization_tests {
+    use super::deprioritize_throttle_cooling;
+    use djinn_provider::catalog::health::HealthTracker;
+
+    const SCOPE: Option<&str> = Some("user-a");
+
+    fn ids(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn cooling_model_is_moved_behind_healthy_lanemate() {
+        let health = HealthTracker::new();
+        // model-a is throttle-cooling; model-b is healthy.
+        health.record_stall(SCOPE, "model-a", false);
+        assert!(health.is_throttle_cooling(SCOPE, "model-a"));
+
+        let mut model_ids = ids(&["model-a", "model-b"]);
+        deprioritize_throttle_cooling(&health, SCOPE, &mut model_ids);
+        assert_eq!(
+            model_ids,
+            ids(&["model-b", "model-a"]),
+            "a throttle-cooling head-of-line model is moved behind a healthy lane-mate"
+        );
+    }
+
+    #[test]
+    fn healthy_order_is_preserved_when_nothing_is_cooling() {
+        let health = HealthTracker::new();
+        let mut model_ids = ids(&["model-a", "model-b", "model-c"]);
+        deprioritize_throttle_cooling(&health, SCOPE, &mut model_ids);
+        assert_eq!(
+            model_ids,
+            ids(&["model-a", "model-b", "model-c"]),
+            "with no cooling model the priority order is untouched"
+        );
+    }
+
+    #[test]
+    fn relative_order_within_each_group_is_stable() {
+        let health = HealthTracker::new();
+        // a and c cooling; b and d healthy. Expect [b, d, a, c].
+        health.record_stall(SCOPE, "model-a", false);
+        health.record_stall(SCOPE, "model-c", false);
+        let mut model_ids = ids(&["model-a", "model-b", "model-c", "model-d"]);
+        deprioritize_throttle_cooling(&health, SCOPE, &mut model_ids);
+        assert_eq!(
+            model_ids,
+            ids(&["model-b", "model-d", "model-a", "model-c"])
+        );
+    }
+
+    #[test]
+    fn only_candidate_that_is_cooling_is_left_in_place() {
+        let health = HealthTracker::new();
+        health.record_stall(SCOPE, "model-a", false);
+        // A lone cooling candidate is NOT dropped — it stays as the last-resort
+        // candidate so the dispatch loop can still attempt it (half-open) or
+        // defer via the existing all-unavailable path.
+        let mut model_ids = ids(&["model-a"]);
+        deprioritize_throttle_cooling(&health, SCOPE, &mut model_ids);
+        assert_eq!(model_ids, ids(&["model-a"]));
+    }
+
+    #[test]
+    fn all_cooling_keeps_all_candidates() {
+        let health = HealthTracker::new();
+        health.record_stall(SCOPE, "model-a", false);
+        health.record_stall(SCOPE, "model-b", false);
+        let mut model_ids = ids(&["model-a", "model-b"]);
+        deprioritize_throttle_cooling(&health, SCOPE, &mut model_ids);
+        // No candidate is lost; order among the cooling group is preserved.
+        assert_eq!(model_ids, ids(&["model-a", "model-b"]));
     }
 }

--- a/server/crates/djinn-provider/src/catalog/health.rs
+++ b/server/crates/djinn-provider/src/catalog/health.rs
@@ -57,6 +57,39 @@ const TRIP_RATE_CEILING: usize = 8;
 /// Rolling window over which [`TRIP_RATE_CEILING`] trips force a hard-disable.
 const TRIP_RATE_WINDOW: Duration = Duration::from_secs(6 * 60 * 60);
 
+/// Number of *consecutive* throttle trips (`record_stall(escalate=false)`) with
+/// no intervening success after which a throttle stops being treated as a
+/// clock-resetting quota blip and starts escalating like a genuine failure.
+///
+/// A throttle-classified stall normally applies only the fixed
+/// [`STALL_MIN_COOLDOWN`] floor and does NOT advance `disable_ttl_trips` or the
+/// hard-disable trip-rate window, because a quota that resets in minutes is not
+/// a broken model. But a token *plan / subscription* that has been over-quota
+/// for **days** produces the same 429 every session and flaps forever: disable
+/// 5 min → re-enable → grab a slot → crash in <10s → repeat, with a ~30-minute
+/// task-redispatch cooldown between attempts (one production task lost 5.75h to
+/// 8 consecutive 429 crashes). Because the throttle never escalates, the
+/// 8-trips/6h hard-disable backstop ([`TRIP_RATE_CEILING`]) never catches it.
+///
+/// Once a bucket has throttle-cooldowned this many consecutive times with no
+/// success in between, further throttle trips are escalated — they advance
+/// `disable_ttl_trips` (growing the cooldown past the 5-minute floor) AND count
+/// toward the hard-disable ceiling — so a genuinely-dead subscription is
+/// eventually pinned instead of flapping indefinitely. A single successful
+/// session fully resets the streak (the plan's quota came back), returning the
+/// model to the gentle clock-reset treatment. `6` consecutive trips is well
+/// past what a minutes-long quota window produces (which self-heals after one
+/// or two cooldowns and then succeeds) yet reached within ~30 minutes of a
+/// truly-dead plan flapping.
+const PERSISTENT_THROTTLE_TRIP_THRESHOLD: u32 = 6;
+/// Wall-clock companion to [`PERSISTENT_THROTTLE_TRIP_THRESHOLD`]: if a bucket
+/// has been continuously throttle-cooldowning (no intervening success) for at
+/// least this long, escalate even when the consecutive-trip *count* is still
+/// low. Sparse-but-persistent throttling — e.g. a provider-stated multi-minute
+/// `retry-after` producing few, long cooldowns — is just as dead as rapid
+/// flapping, and the wall-clock bound catches it without waiting for the count.
+const PERSISTENT_THROTTLE_WINDOW: Duration = Duration::from_secs(60 * 60);
+
 /// Identifies a single circuit-breaker bucket.
 ///
 /// Health is tracked **per `(scope, model_id)`**, not globally per model. The
@@ -193,8 +226,28 @@ struct ModelState {
     /// Monotonic timestamps of recent breaker trips, pruned to
     /// [`TRIP_RATE_WINDOW`]. When its length reaches [`TRIP_RATE_CEILING`] the
     /// bucket is hard-disabled. Only genuine (escalating) trips are recorded —
-    /// account-quota throttles do not count toward the ceiling.
+    /// account-quota throttles do not count toward the ceiling *unless* they
+    /// have persisted long enough to be escalated (see `record_stall`).
     trip_times: Vec<Instant>,
+    /// Consecutive throttle trips (`record_stall(escalate=false)`) with no
+    /// intervening success. Drives persistent-throttle escalation: once this
+    /// reaches [`PERSISTENT_THROTTLE_TRIP_THRESHOLD`] (or the streak has lasted
+    /// [`PERSISTENT_THROTTLE_WINDOW`]) further throttle trips escalate like
+    /// genuine trips. Reset to 0 by any success. Runtime-only (not persisted):
+    /// the escalation it *produces* — `disable_ttl_trips` / `trip_times` — is
+    /// what survives a restart; an in-progress streak restarting from zero on a
+    /// leader failover is acceptable.
+    consecutive_throttle_trips: u32,
+    /// Monotonic timestamp of the first throttle trip in the current streak,
+    /// for the [`PERSISTENT_THROTTLE_WINDOW`] wall-clock escalation. `None` when
+    /// there is no active throttle streak. Runtime-only (Instants don't persist).
+    throttle_streak_started_at: Option<Instant>,
+    /// Whether the trip that put this bucket into its current cooldown was a
+    /// throttle (`escalate=false`). Consulted at dispatch time
+    /// (`is_throttle_cooling`) so the candidate order can deprioritize a model
+    /// that is currently throttle-cooling in favor of a healthy lane-mate.
+    /// Cleared on success.
+    last_trip_throttle: bool,
 }
 
 impl ModelState {
@@ -443,6 +496,13 @@ impl HealthTracker {
         // isn't reached by ancient, since-recovered trips.
         state.disable_ttl_trips = 0;
         state.trip_times.clear();
+        // A success proves the plan's quota is back — fully reset the
+        // persistent-throttle escalation state so the next throttle starts a
+        // fresh streak with the gentle clock-reset treatment, and clear the
+        // throttle-cooling deprioritization flag.
+        state.consecutive_throttle_trips = 0;
+        state.throttle_streak_started_at = None;
+        state.last_trip_throttle = false;
         if state.auto_disabled && state.is_available(now) {
             state.auto_disabled = false;
             state.cooldown_until = None;
@@ -523,7 +583,16 @@ impl HealthTracker {
     ///   escalating the cooldown cap is wrong: the model isn't getting "more
     ///   broken", the account is merely over quota until its window resets. We
     ///   still apply the `STALL_MIN_COOLDOWN` floor so failover still happens —
-    ///   we just don't ratchet the cap.
+    ///   we just don't ratchet the cap **until the throttle proves persistent**.
+    ///
+    /// Persistent-throttle escalation (see [`PERSISTENT_THROTTLE_TRIP_THRESHOLD`]):
+    /// a subscription that has been over-quota for *days* keeps 429-ing every
+    /// session and, with `escalate=false`, would flap forever without the
+    /// hard-disable backstop ever catching it. Once a bucket has throttle-tripped
+    /// enough consecutive times (or for long enough on the wall clock) with no
+    /// intervening success, this method escalates the throttle *as if* it were a
+    /// genuine trip — ratcheting the cap and counting toward the hard-disable
+    /// ceiling. A single success fully resets that streak.
     pub fn record_stall(&self, scope: Option<&str>, model_id: &str, escalate: bool) {
         let now = SystemClock::new().now_instant();
         let mut map = self.inner.lock().unwrap();
@@ -544,16 +613,43 @@ impl HealthTracker {
             return;
         }
 
+        // Persistent-throttle escalation. A throttle (`escalate=false`) normally
+        // resets on a clock, not on model health, so it does NOT ratchet the
+        // escalating cooldown cap or count toward the hard-disable ceiling — a
+        // quota-limited account is not a broken model. But a plan/subscription
+        // that has been over-quota for *days* keeps flapping (disable 5min →
+        // re-enable → crash in <10s → repeat) and never escalates, so the
+        // hard-disable backstop never catches it. Track consecutive throttle
+        // trips (no intervening success); once the streak is long enough — by
+        // count OR wall-clock — escalate this and every subsequent throttle
+        // trip like a genuine failure so the 8-trips/6h ladder can eventually
+        // pin a dead subscription. A single success fully resets the streak.
+        let effective_escalate = if escalate {
+            // A genuine failure/stall trip breaks any throttle streak — it is
+            // already escalating on its own ladder.
+            state.consecutive_throttle_trips = 0;
+            state.throttle_streak_started_at = None;
+            true
+        } else {
+            state.consecutive_throttle_trips = state.consecutive_throttle_trips.saturating_add(1);
+            let streak_started_at = *state.throttle_streak_started_at.get_or_insert(now);
+            state.consecutive_throttle_trips >= PERSISTENT_THROTTLE_TRIP_THRESHOLD
+                || now.duration_since(streak_started_at) >= PERSISTENT_THROTTLE_WINDOW
+        };
+
         // Trip immediately, cooldown floored at STALL_MIN_COOLDOWN so it
         // outlasts the task's redispatch cooldown and forces failover.
         let cooldown = state.compute_cooldown().max(STALL_MIN_COOLDOWN);
         state.auto_disabled = true;
         state.cooldown_until = Some(now + cooldown);
-        // A throttle resets on a clock, not on model health — don't ratchet the
-        // escalating cooldown cap for it (idea 6), and don't count it toward the
-        // hard-disable ceiling (a quota-limited account is not a broken model).
-        // Genuine failures/stalls do both.
-        let hard_disabled = if escalate {
+        // Remember whether this cooldown was throttle-induced so dispatch can
+        // deprioritize a currently-cooling model in favor of a healthy lane-mate.
+        state.last_trip_throttle = !escalate;
+        // A non-escalated throttle only floors the cooldown; an escalated trip
+        // (genuine failure, OR a throttle that has persisted past the threshold)
+        // also ratchets `disable_ttl_trips` and counts toward the hard-disable
+        // ceiling.
+        let hard_disabled = if effective_escalate {
             state.disable_ttl_trips += 1;
             state.register_trip(now)
         } else {
@@ -589,6 +685,23 @@ impl HealthTracker {
         let map = self.inner.lock().unwrap();
         map.get(&HealthKey::new(scope, model_id))
             .is_none_or(|s| s.is_available(now))
+    }
+
+    /// Returns `true` when the `(scope, model)` bucket is currently demoted by a
+    /// **throttle** cooldown — the breaker tripped on a `record_stall(escalate=
+    /// false)` quota signal and has not yet been cleared by a success.
+    ///
+    /// Unlike [`is_available`], this stays `true` through the *half-open* window
+    /// (cooldown deadline elapsed but no success has re-proven the model): a
+    /// quota that just flapped 5 minutes ago is likely still dead, so dispatch
+    /// deprioritizes it behind healthy lane-mates rather than re-picking it
+    /// head-of-line and burning a session on another <10s 429 crash. A genuine
+    /// (non-throttle) breaker trip is NOT reported here — those are handled by
+    /// the ordinary `is_available` skip and their own escalation ladder.
+    pub fn is_throttle_cooling(&self, scope: Option<&str>, model_id: &str) -> bool {
+        let map = self.inner.lock().unwrap();
+        map.get(&HealthKey::new(scope, model_id))
+            .is_some_and(|s| s.auto_disabled && s.last_trip_throttle)
     }
 
     /// Return health state for all tracked buckets, sorted by `(scope, model)`.
@@ -718,6 +831,9 @@ impl HealthTracker {
                 // the persist boundary, so anchor them at `now`: they age out
                 // naturally over `TRIP_RATE_WINDOW`.
                 trip_times: vec![now; (health.trips_in_window as usize).min(TRIP_RATE_CEILING)],
+                // Persistent-throttle streak counters are runtime-only; a
+                // restart restarts any in-progress streak from zero.
+                ..Default::default()
             };
 
             if health.hard_disabled {

--- a/server/crates/djinn-provider/src/catalog/health_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/health_tests.rs
@@ -222,20 +222,175 @@ fn trip_rate_ceiling_hard_disables_until_manual_enable() {
 }
 
 #[test]
-fn throttle_stalls_never_hit_the_hard_disable_ceiling() {
+fn throttle_stalls_below_persistence_threshold_never_escalate() {
     // A quota throttle (`escalate = false`) resets on a clock, not on model
-    // health, so it must NOT count toward the hard-disable ceiling — even far
-    // more than CEILING throttle trips must keep auto-recovering.
+    // health, so — up to the persistence threshold — it must NOT count toward
+    // the hard-disable ceiling or ratchet the escalating cap, and must keep
+    // auto-recovering. (Persistent throttling past the threshold DOES escalate;
+    // see `persistent_throttle_escalates_after_consecutive_trips`.)
     let ht = HealthTracker::new();
-    for _ in 0..(TRIP_RATE_CEILING * 3) {
+    for _ in 0..(PERSISTENT_THROTTLE_TRIP_THRESHOLD - 1) {
         ht.record_stall(S, TEST_MODEL, false);
         let h = ht.model_health(S, TEST_MODEL);
-        assert!(!h.hard_disabled, "throttles never hard-disable");
-        assert_eq!(h.trips_in_window, 0, "throttles are not counted");
+        assert!(
+            !h.hard_disabled,
+            "sub-threshold throttles never hard-disable"
+        );
+        assert_eq!(
+            h.trips_in_window, 0,
+            "sub-threshold throttles are not counted"
+        );
         assert_eq!(h.disable_ttl_trips, 0);
         expire_cooldown(&ht, S, TEST_MODEL);
         assert!(ht.is_available(S, TEST_MODEL), "throttle always self-heals");
     }
+}
+
+#[test]
+fn persistent_throttle_escalates_after_consecutive_trips() {
+    // Fix (persistent-throttle escalation): a plan/subscription that has been
+    // over-quota for days keeps flapping (throttle-cooldown → re-enable →
+    // crash → repeat) and never escalates. Once a bucket has throttle-tripped
+    // PERSISTENT_THROTTLE_TRIP_THRESHOLD consecutive times with no success,
+    // further throttle trips escalate like genuine failures — advancing
+    // `disable_ttl_trips` AND counting toward the hard-disable ceiling.
+    let ht = HealthTracker::new();
+
+    // Trips below the threshold do not escalate.
+    for _ in 0..(PERSISTENT_THROTTLE_TRIP_THRESHOLD - 1) {
+        ht.record_stall(S, TEST_MODEL, false);
+        let h = ht.model_health(S, TEST_MODEL);
+        assert_eq!(h.disable_ttl_trips, 0);
+        assert_eq!(h.trips_in_window, 0);
+        expire_cooldown(&ht, S, TEST_MODEL);
+    }
+
+    // The threshold-th consecutive throttle trip escalates.
+    ht.record_stall(S, TEST_MODEL, false);
+    let h = ht.model_health(S, TEST_MODEL);
+    assert_eq!(
+        h.disable_ttl_trips, 1,
+        "persistent throttle now ratchets the escalating cap"
+    );
+    assert_eq!(
+        h.trips_in_window, 1,
+        "and now counts toward the hard-disable ceiling"
+    );
+    // The floored stall cooldown still applies (>= the task-redispatch ladder).
+    assert!(!ht.is_available(S, TEST_MODEL));
+}
+
+#[test]
+fn success_resets_persistent_throttle_escalation() {
+    // A single productive session must fully reset the throttle streak: the
+    // plan's quota came back, so the model returns to the gentle clock-reset
+    // treatment and the next throttle starts a fresh streak from trip 1.
+    let ht = HealthTracker::new();
+    for _ in 0..(PERSISTENT_THROTTLE_TRIP_THRESHOLD - 1) {
+        ht.record_stall(S, TEST_MODEL, false);
+        expire_cooldown(&ht, S, TEST_MODEL);
+    }
+    ht.record_success(S, TEST_MODEL);
+
+    // The next throttle trip is treated as trip 1 again — no escalation.
+    ht.record_stall(S, TEST_MODEL, false);
+    let h = ht.model_health(S, TEST_MODEL);
+    assert_eq!(
+        h.disable_ttl_trips, 0,
+        "success reset the streak, so this throttle does not escalate"
+    );
+    assert_eq!(h.trips_in_window, 0);
+    assert!(!h.hard_disabled);
+}
+
+#[test]
+fn persistent_throttle_eventually_hard_disables() {
+    // The end-to-end backstop: a subscription that keeps 429-ing forever with
+    // no success must eventually be hard-disabled (held until a human
+    // re-enables) instead of flapping indefinitely and burning task wall-clock.
+    let ht = HealthTracker::new();
+    for _ in 0..(PERSISTENT_THROTTLE_TRIP_THRESHOLD + TRIP_RATE_CEILING as u32) {
+        ht.record_stall(S, TEST_MODEL, false);
+        expire_cooldown(&ht, S, TEST_MODEL);
+    }
+    let h = ht.model_health(S, TEST_MODEL);
+    assert!(
+        h.hard_disabled,
+        "a plan throttling for days must eventually hard-disable"
+    );
+    assert!(
+        !ht.is_available(S, TEST_MODEL),
+        "a hard-disabled bucket never self-heals on the clock"
+    );
+}
+
+#[test]
+fn persistent_throttle_escalates_on_wall_clock_window() {
+    // The wall-clock companion: even when the consecutive-trip *count* is still
+    // low, a throttle streak that has lasted PERSISTENT_THROTTLE_WINDOW (sparse
+    // but continuous throttling — long provider retry-after windows) escalates.
+    let ht = HealthTracker::new();
+    // First throttle trip starts the streak.
+    ht.record_stall(S, TEST_MODEL, false);
+    assert_eq!(ht.model_health(S, TEST_MODEL).disable_ttl_trips, 0);
+    // Age the streak start past the wall-clock window.
+    {
+        let mut map = ht.inner.lock().unwrap();
+        let state = map.get_mut(&HealthKey::new(S, TEST_MODEL)).unwrap();
+        state.throttle_streak_started_at =
+            Some(Instant::now() - PERSISTENT_THROTTLE_WINDOW - Duration::from_secs(1));
+    }
+    expire_cooldown(&ht, S, TEST_MODEL);
+
+    // The next throttle trip escalates on the wall-clock bound alone.
+    ht.record_stall(S, TEST_MODEL, false);
+    let h = ht.model_health(S, TEST_MODEL);
+    assert_eq!(
+        h.disable_ttl_trips, 1,
+        "a throttle streak older than the window escalates regardless of count"
+    );
+    assert_eq!(h.trips_in_window, 1);
+}
+
+#[test]
+fn is_throttle_cooling_tracks_throttle_cooldown_only() {
+    let ht = HealthTracker::new();
+    assert!(
+        !ht.is_throttle_cooling(S, TEST_MODEL),
+        "an untracked model is not throttle-cooling"
+    );
+
+    // A throttle trip flags the model as throttle-cooling…
+    ht.record_stall(S, TEST_MODEL, false);
+    assert!(ht.is_throttle_cooling(S, TEST_MODEL));
+
+    // …and it stays flagged through the half-open window (cooldown expired but
+    // no success has re-proven it) so dispatch keeps deprioritizing it.
+    expire_cooldown(&ht, S, TEST_MODEL);
+    assert!(
+        ht.is_available(S, TEST_MODEL),
+        "cooldown expired → available (half-open)"
+    );
+    assert!(
+        ht.is_throttle_cooling(S, TEST_MODEL),
+        "still throttle-cooling until a success clears it"
+    );
+
+    // A success clears the flag.
+    ht.record_success(S, TEST_MODEL);
+    assert!(!ht.is_throttle_cooling(S, TEST_MODEL));
+
+    // A GENUINE (non-throttle) breaker trip is not reported as throttle-cooling.
+    ht.reset(S, TEST_MODEL);
+    ht.record_stall(S, TEST_MODEL, true);
+    assert!(
+        !ht.is_available(S, TEST_MODEL),
+        "genuine stall trips the breaker"
+    );
+    assert!(
+        !ht.is_throttle_cooling(S, TEST_MODEL),
+        "a genuine (escalating) trip is not a throttle cooldown"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem (production audit, 2026-07-11)

`minimax-coding-plan/MiniMax-M3`'s token plan has been over-quota for days: every session crashes in <10s with `429 Token Plan usage limit reached (2056)`, yet it kept being dispatched. One task bounced `open -> in_progress -> open` through **8 consecutive 429 crashes with ~30-minute redispatch waits, losing 5.75h of wall-clock**. Its health counters showed 86 consecutive failures with `auto_disabled: false`.

Two gaps let this happen:

1. **429s are Throttle-class stalls that never escalate.** `record_stall(escalate=false)` applies only the fixed 5-minute `STALL_MIN_COOLDOWN` and never advances `disable_ttl_trips` or the trip-rate window, so the 8-trips/6h hard-disable ladder can never catch a plan that's been dead for days. Correct for a quota that resets in minutes; wrong for a dead subscription. The model flaps forever: disable 5min -> re-enable -> grab slot -> crash 10s -> repeat.
2. **Dispatch retried the cooling model head-of-line**, wasting the first attempt + session spawn + crash-recovery + task redispatch cooldown before lane fallback finally kicked in.

## Fix 1 — persistent-throttle escalation (`djinn-provider/src/catalog/health.rs`)

Track consecutive throttle trips with no intervening success per `(scope, model)` bucket. Once the streak reaches **`PERSISTENT_THROTTLE_TRIP_THRESHOLD` (6) consecutive trips**, or has lasted **`PERSISTENT_THROTTLE_WINDOW` (1h)** on the wall clock, further throttle trips escalate exactly like genuine failures: they ratchet `disable_ttl_trips` (growing the cooldown past the 5-minute floor: 5min -> ... -> 4h cap) **and** count toward the existing 8-trips/6h hard-disable ceiling, so a genuinely-dead subscription is eventually pinned until a human re-enables it via `model_health(enable)`.

A **single success fully resets** the streak — an ordinary short quota window that self-heals keeps the gentle clock-reset treatment it has today. A genuine (escalating) trip also breaks the throttle streak, since it escalates on its own ladder. Streak state is runtime-only; the escalation it produces (`disable_ttl_trips` / trip window) persists as before.

## Fix 2 — dispatch-time throttle skip (`djinn-coordinator/src/dispatch/task_dispatch.rs`)

New `HealthTracker::is_throttle_cooling(scope, model)` reports a bucket demoted by a throttle trip (staying `true` through the half-open window until a success re-proves the model). At candidate-order build time, `deprioritize_throttle_cooling` moves throttle-cooling models to the **back** of the ordered lane list (stable reorder, **not a filter**):

- A healthy lane-mate is attempted first — no wasted session spawn on a model known to be cooling.
- A cooling model stays in the list as last resort, so the only-candidate and all-cooling cases behave exactly like today: the in-loop `is_available` gate still skips active cooldowns and the existing chain-exhaustion escalating backoff/deferral applies; a half-open throttle model is still attempted when it's the only option.

## Tests

- `cargo test -p djinn-provider --lib`: **526 passed, 0 failed** (new: persistent-throttle escalation at threshold, reset-on-success, wall-clock escalation, eventual hard-disable, `is_throttle_cooling` semantics; updated the old "throttles never escalate" test to "below the persistence threshold").
- `cargo test -p djinn-coordinator --lib`: **1515 passed**, 2 failed — both failures (`wnd1_dispatch_race_harness_never_exceeds_caps_1_through_5`, `preservation_telemetry_counter_increments`) reproduce identically on unmodified main in this environment and pass in isolation; pre-existing parallel-run flakes, unrelated. New `throttle_deprioritization_tests` (5) cover: cooling model moved behind healthy lane-mate, stable ordering, lone/all-cooling candidates preserved.
- `cargo clippy -p djinn-provider -p djinn-coordinator --all-targets`: no warnings from this diff (one pre-existing `redundant_closure` in `pr_poller/merged_change_projection.rs`, untouched).
- `cargo fmt` clean. No MCP tool schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)