### PR TITLE
ci: make PR-head CI representative of the merge queue (+ aarch64 cache priming)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -354,7 +354,17 @@ jobs:
           workspaces: server
           shared-key: server-aarch64-check
           cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # This job is gated OFF `push` (it runs only on pull_request /
+          # merge_group / workflow_dispatch), so a `github.ref == 'refs/heads/main'`
+          # save-if is NEVER true here and the aarch64 cache was permanently cold
+          # — every sandbox-touching run paid the full ~400s cross-compile from
+          # scratch (PR #1590 finding). Unlike the x86 jobs, there is no
+          # main-push warm-cache job priming this key, so the authoritative place
+          # to SAVE is the merge_group run: it is the last build of the change
+          # before it lands, and its saved cache warms the NEXT sandbox-touching
+          # PR/queue run. pull_request runs still read-only (save-if false) so a
+          # cold PR build never overwrites the good queue-primed cache.
+          save-if: ${{ github.event_name == 'merge_group' }}
 
       - name: cargo check (aarch64)
         run: cargo check -p djinn-sandbox --all-targets --target aarch64-unknown-linux-gnu
@@ -543,8 +553,21 @@ jobs:
     # rarely fails on the rebase, so the far more common case is paying that
     # 112s for nothing. A red clippy still fails the Quality Gate; the only
     # cost of parallelizing is occasionally burning shards on a doomed run.
+    #
+    # PR-HEAD REPRESENTATIVENESS: this DB-backed suite now runs on `pull_request`
+    # as well, not just the merge queue. When it was merge_group-only, a PR went
+    # green on lint alone while the authoritative test suite ran for the first
+    # time inside the merge queue — so a test that would reject the change only
+    # surfaced AFTER the PR looked mergeable, ejecting it from the queue and
+    # forcing rework. The draft-PR-gated agent flow reads the PR-head checks as
+    # the readiness signal, so the suite that can reject in the queue must also
+    # execute on the PR head. The `server` change-filter still short-circuits
+    # docs-only PRs (they skip here AND in the queue, so no queue rejection is
+    # possible), preserving that economy. Cache is still saved on main only
+    # (save-if below), so PR/merge_group runs read the warm cache without
+    # writing divergent entries.
     needs: changes
-    if: needs.changes.outputs.server == 'true' && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+    if: needs.changes.outputs.server == 'true' && github.event_name != 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why

A production audit found ~45% of agent-task rework came from PRs that looked
green but got ejected in the merge queue, because the authoritative DB-backed
test suite ran **only** on `merge_group`. Under the incoming draft-PR-gated flow
the PR-head check results are the readiness signal, so the PR head must catch
what the queue catches.

## Goal 1 — PR-head CI is now representative of the merge queue

I audited every job in `quality-gate.yml` (the sole workflow feeding the single
required **Quality Gate** check; `cla.yml` is `pull_request_target` CLA only,
`release.yml` is tags-only, `stale-branches.yml` is scheduled — none gate PR
code). A required check that is *skipped* on a PR reports **success**, which is
what masked the gap.

### Gap table (job → PR-head vs merge_group behavior)

| Job (required-check name) | Before — PR head | Before — merge_group | After — PR head |
|---|---|---|---|
| **Server Test** (4 shards) | **SKIPPED → reported success** | runs full DB suite | **runs full DB suite (same as queue)** |
| **Server aarch64 Check** | ran if `sandbox` changed, but cache **always cold** | ran, cache **always cold** | runs; cache **primed by merge_group save** |
| Server sqlx Cache | runs (`make sqlx-verify` + PG) | runs | unchanged — already representative |
| Server Size Guard | runs (changed-file scan) | runs | unchanged — already representative |
| Server Migrations Guard | runs (immutability scan) | runs | unchanged — already representative |
| Quality Gate (summary) | ran, but green with Server Test **skipped** | ran | now gates on the **real** Server Test result |

The single skip-gap that let green PRs get rejected in the queue was
**Server Test** (`if:` was `merge_group || workflow_dispatch`). It is the job
that runs the full `cargo nextest --workspace` suite — i.e. the DB-backed tests,
lifecycle/concurrency regressions, and the tool-schema snapshot guards — so a
race or a schema-golden drift only surfaced *after* a PR looked mergeable. It
now runs on `pull_request` too. The listed sqlx-cache / size-guard /
migrations-guard checks already execute the identical logic on the PR head; I
confirmed and left them unchanged.

**Remaining, intentional PR-vs-queue differences** (cannot cause queue
rejection): docs-only PRs still skip the `server` change-filter (they skip in
the queue too); `cargo hakari` + skills-manifest verification run only on the PR
head (the queue skips them — the PR does strictly *more*); Warm-Cache jobs stay
push-only. Cache stays `save-if` main-only for the shared keys, so PR /
merge_group runs read the warm cache without writing divergent entries.

### aarch64 cold-cache fix (PR #1590 finding)

`server-aarch64-check` had `save-if: github.ref == 'refs/heads/main'`, but the
job is gated **off** `push`, so that condition is never true and the aarch64
cache never saved — every sandbox-touching run paid the full ~400s cold
cross-compile. There is no main-push warm job priming this key, so I moved the
save to `merge_group` (`save-if: github.event_name == 'merge_group'`): the last
build before the change lands, whose cache warms the next sandbox run.
`pull_request` stays read-only so a cold PR build never clobbers the good cache.

## Goal 2 — today's merge-queue flakes: root-caused; already resolved on `main`

I pulled `--log-failed` for runs 29150825914 / 29149812589 / 29149947514 /
29147929404 / 29147234028 and reproduced each failing test locally against
current `main` (Postgres 16 on :5433). **All three are deterministic/green on
current `main`** — the queue failures were the Goal-1 representativeness gap
plus one race that a sibling PR already fixed:

1. **`djinn-telemetry … cache_cleanup_registered_labels_render_at_zero_on_init`**
   (`lib.rs`, "missing sample"; hard-failed all 3 retries in run 29150825914 @
   11:22). Root cause is registration completeness of a process-global metrics
   recorder. The recorder is **process-isolated per test under nextest** and
   `register_metrics()` deterministically pre-touches every
   `component × outcome × mode` combo with `.absolute(0)`. It **passed 270/270**
   locally (nextest process-per-test 30×, shared-process threaded libtest 40×,
   single-test 100×, +100×). The test was on `main` since #1862 (02:08 UTC) and
   *passed* in the 09:09 run while failing the 11:22 run on the same telemetry
   code → an environmental/load-induced blip on the 2-core queue runner, not a
   `main` code defect. No change: it is already maximally serialized/isolated,
   and `#[ignore]`-ing a passing registration-completeness guard would drop real
   coverage. Goal 1 additionally surfaces any recurrence on the PR head (with
   nextest `ci` retries) instead of ejecting from the queue.

2. **`djinn-coordinator rules::tests::batch_completion_does_not_fire_for_closed_epic`**
   (`InvalidTransition("task is already closed")`; failed 3 runs 09:00–11:00).
   **Fixed by #1875** (`chore(mf0b): Apply parent disposition transactionally
   during epic close`), merged 11:41 UTC — *after* the failing runs. Its diff
   removed the racy `close_task(&t1.id)` call from this very test: the test
   closes the epic (which cascades-closes the child), then the old code *also*
   transitioned the child to Close — a race between the cascade and the explicit
   close that panicked whenever the cascade won. #1875 makes epic-close
   transactional and the test now asserts the child is already `parent_closed`.
   **0/40** on current `main`.

3. **Tool-schema snapshots** — `djinn-control-plane server_tests::…::djinn_mcp_server_corpus_fixture_is_current`
   (run 29147234028) and the sibling `djinn-server …::mcp_tools_schema_snapshot`
   failed **together** in one batch. Schema generation is deterministic
   (schemars 1.x preserves field-declaration order for both `properties` and
   `required`; `annotate_server_tool_schema_safety` inserts fixed keys), so this
   is not a nondeterministic flake — it is **golden drift**: a batched PR changed
   a tool's params and regenerated only some of the schema goldens (the known
   "tool-schema golden fanout" — a schema edit fans out to multiple committed
   fixtures). The corpus test is **0/40** on current `main`. This class is
   exactly what Goal 1 closes: these snapshot tests live inside **Server Test**,
   which was merge_group-only, so a partial-regen PR went green on the PR head
   and only drifted in the queue. With Server Test on the PR head, the offending
   PR now fails on its own PR head.

**Net:** the unifying root cause of the rework and of flakes #2/#3 is the
PR-head representativeness gap fixed here; flake #2's specific race was
independently fixed by #1875; flake #1 is not reproducible on `main`. No test
code changes were warranted (quarantining green, valuable guards would only
reduce coverage).

## Validation

- `quality-gate.yml`: valid YAML; required-check names unchanged.
- Local repro loops on current `main`: telemetry 270/270 green; coordinator
  closed-epic 40/40 green; MCP corpus snapshot 40/40 green (Postgres 16 :5433).
- This PR edits `quality-gate.yml`, which is in every change-filter glob, so its
  own PR-head run exercises the **full** suite including the now-PR-gated Server
  Test — dogfooding the change.
