### PR TITLE
fix(tripwires): make policy defaults project-agnostic

### DIFF
--- a/server/crates/djinn-coordinator/src/pr_poller/tripwire_hold.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tripwire_hold.rs
@@ -151,6 +151,16 @@ impl CoordinatorActor {
         tripwire_result: &super::tripwire_gate::TripwireGateResult,
         head_sha: &str,
     ) {
+        // TODO(per-project-policy): load the org/project tripwire policy for
+        // `task.project_id` and fall back to `TripwirePolicy::default()` only
+        // when none is published. The SHIPPED default is intentionally
+        // ecosystem-generic (no `Tiltfile`/`Makefile`/`deploy/**`/
+        // boundary-script globs, empty allowlist source) so foreign repos do
+        // not trip false-positive holds. djinn's OWN repo therefore loses its
+        // Tiltfile/deploy/capability-boundary tripwires until this load-with-
+        // fallback lands and an org policy re-adds those repo-specific globs.
+        // No persisted tripwire-policy surface exists yet (org_ai_policy is
+        // model-lane only), so wiring it is a separate epic.
         self.create_tripwire_hold_with_policy(
             task,
             tripwire_result,

--- a/server/crates/djinn-coordinator/src/tripwires/policy.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/policy.rs
@@ -24,7 +24,8 @@
 //! - [`TripwirePolicy::policy_revision`] identifies the org policy revision
 //!   evaluated against the diff. Defaults to `"org-policy:default"`.
 //! - [`TripwirePolicy::allowlist`] carries the boundary allowlist revision
-//!   sourced from `scripts/capability-boundary-allowlist.toml`. If the
+//!   sourced from a project-supplied allowlist file (empty by default — the
+//!   SHIPPED policy assumes no particular repo layout). If the
 //!   allowlist is unavailable the boundary rule enters degraded mode (see
 //!   [`TripwirePolicy::boundary_path`]) and downstream callers must emit a
 //!   warning event.
@@ -56,10 +57,16 @@ pub const DEFAULT_POLICY_REVISION: &str = "org-policy:default";
 /// revision (see [`TripwirePolicy::boundary_path`]).
 pub const MISSING_ALLOWLIST_REVISION: &str = "capability-boundary-allowlist:missing";
 
-/// Source path (relative to repo root) of the boundary allowlist TOML the
-/// boundary-path rule consults at evaluation time. Engine code reads this
-/// file lazily; the policy struct only carries the revision + source.
-pub const DEFAULT_ALLOWLIST_SOURCE: &str = "scripts/capability-boundary-allowlist.toml";
+/// Default boundary-allowlist source path.
+///
+/// Intentionally empty: djinn is a platform that manages arbitrary projects,
+/// so the SHIPPED default MUST NOT assume any particular repo layout. A
+/// project that keeps a capability-boundary allowlist supplies its own source
+/// path via org/project tripwire policy; until then the boundary rule stays in
+/// degraded mode (see [`MISSING_ALLOWLIST_REVISION`]) rather than pointing at a
+/// file that only exists in djinn's own repo. Engine code reads this file
+/// lazily; the policy struct only carries the revision + source.
+pub const DEFAULT_ALLOWLIST_SOURCE: &str = "";
 
 // ─── Policy source label ────────────────────────────────────────────────────
 
@@ -315,9 +322,11 @@ impl Default for UnsafeCodeRuleConfig {
 /// - `match_outside_allowlist`: `true` → any changed file matching the
 ///   boundary category patterns that is NOT in the allowlist trips the rule;
 ///   `false` → only new boundary-category files trip it.
-/// - `category_patterns`: glob patterns identifying boundary-sensitive paths
-///   (e.g. `scripts/capability-boundary-allowlist.toml`, auth/permission
-///   files, secrets, deployment configs).
+/// - `category_patterns`: ecosystem-generic glob patterns identifying
+///   boundary-sensitive paths (auth/permission files, secrets, deployment
+///   configs). Project-specific paths (e.g. a capability-boundary allowlist)
+///   are supplied via org/project policy, never baked into the SHIPPED
+///   default.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BoundaryPathRuleConfig {
     /// Master switch. `false` → rule is skipped entirely.
@@ -333,7 +342,8 @@ pub struct BoundaryPathRuleConfig {
     /// introduced boundary-category files trigger findings.
     pub match_outside_allowlist: bool,
     /// Glob patterns identifying boundary-sensitive paths (auth, permission,
-    /// secrets, deployment, billing, capability-boundary allowlist).
+    /// secrets, deployment, billing). Ecosystem-generic by default; project
+    /// specific paths are added via org/project policy.
     pub category_patterns: Vec<String>,
 }
 
@@ -345,7 +355,6 @@ impl Default for BoundaryPathRuleConfig {
             adjudication: Adjudication::Arbiter,
             match_outside_allowlist: true,
             category_patterns: vec![
-                "scripts/capability-boundary-allowlist.toml".to_owned(),
                 "**/auth/**".to_owned(),
                 "**/authz/**".to_owned(),
                 "**/permissions/**".to_owned(),
@@ -448,16 +457,20 @@ impl Default for CIWorkflowRuleConfig {
             enabled: true,
             report_only: false,
             adjudication: Adjudication::Arbiter,
+            // Ecosystem-generic CI/workflow paths only. djinn manages
+            // arbitrary projects, so the SHIPPED default MUST NOT encode any
+            // single repo's layout (no `Tiltfile`, `Makefile`, `deploy/**`,
+            // `release/**`, or repo-specific boundary scripts). Projects that
+            // want to gate those add them via org/project tripwire policy.
             path_globs: vec![
                 ".github/workflows/**".to_owned(),
                 ".github/actions/**".to_owned(),
                 ".gitlab-ci.yml".to_owned(),
                 ".circleci/**".to_owned(),
-                "deploy/**".to_owned(),
-                "release/**".to_owned(),
-                "Tiltfile".to_owned(),
-                "Makefile".to_owned(),
-                "scripts/check-*-boundary.sh".to_owned(),
+                "azure-pipelines.yml".to_owned(),
+                "bitbucket-pipelines.yml".to_owned(),
+                ".drone.yml".to_owned(),
+                "Jenkinsfile".to_owned(),
             ],
         }
     }
@@ -822,6 +835,55 @@ mod tests {
             p.reason_code_for(TripwireRuleId::CIWorkflowChange),
             REASON_CI_WORKFLOW_CHANGE
         );
+    }
+
+    /// The SHIPPED defaults must be project-agnostic: djinn is a platform
+    /// managing arbitrary repos, so no default glob may encode djinn's own
+    /// layout (`Tiltfile`, `Makefile`, `deploy/**`, `release/**`, the
+    /// capability-boundary allowlist, or repo-specific boundary scripts).
+    /// A foreign repo touching an ordinary `Makefile` or `deploy/` file must
+    /// NOT trip a merge hold under the fallback policy.
+    #[test]
+    fn default_policy_is_project_agnostic() {
+        let p = TripwirePolicy::default();
+
+        // CI-workflow globs: only ecosystem-generic CI paths.
+        for banned in [
+            "Tiltfile",
+            "Makefile",
+            "deploy/**",
+            "release/**",
+            "scripts/check-*-boundary.sh",
+        ] {
+            assert!(
+                !p.ci_workflow.path_globs.iter().any(|g| g == banned),
+                "ci_workflow default must not encode repo-specific glob {banned:?}"
+            );
+        }
+        // At least the universal GitHub-Actions path is still covered.
+        assert!(
+            p.ci_workflow
+                .path_globs
+                .iter()
+                .any(|g| g == ".github/workflows/**"),
+            "ci_workflow default must still cover .github/workflows/**"
+        );
+
+        // Boundary category patterns: no capability-boundary allowlist path.
+        assert!(
+            !p.boundary_path
+                .category_patterns
+                .iter()
+                .any(|g| g.contains("capability-boundary-allowlist")),
+            "boundary default must not reference the djinn capability-boundary allowlist"
+        );
+
+        // Allowlist source is unset by default (project supplies its own).
+        assert_eq!(
+            p.allowlist.source, "",
+            "default allowlist source must be empty (no repo-specific path)"
+        );
+        assert_eq!(DEFAULT_ALLOWLIST_SOURCE, "");
     }
 
     /// Boundary allowlist degraded-mode flag must distinguish "missing"

--- a/server/crates/djinn-coordinator/src/tripwires/rules/mod.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/rules/mod.rs
@@ -563,9 +563,11 @@ pub fn evaluate_large_delete_or_rewrite(
 /// Evaluate CI/workflow/release/deploy/automation change findings.
 ///
 /// Flags any changed file whose path matches the policy's CI workflow
-/// path globs (e.g. `.github/workflows/**`, `.github/actions/**`,
-/// `.gitlab-ci.yml`, `deploy/**`, `release/**`, `Makefile`,
-/// `Tiltfile`). Each matching file produces one file-level finding.
+/// path globs. The SHIPPED default is ecosystem-generic (e.g.
+/// `.github/workflows/**`, `.github/actions/**`, `.gitlab-ci.yml`,
+/// `.circleci/**`, `Jenkinsfile`); repo-specific paths (`Makefile`,
+/// `Tiltfile`, `deploy/**`, `release/**`) are opted into via org/project
+/// policy. Each matching file produces one file-level finding.
 ///
 /// This rule mirrors [`evaluate_migration_changes`] in structure but
 /// targets CI/automation surfaces instead of database migrations.

--- a/server/crates/djinn-coordinator/src/tripwires/rules/tests/imb4_rules.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/rules/tests/imb4_rules.rs
@@ -733,6 +733,26 @@ fn billing_path_change_triggers_boundary_finding() {
 
 #[test]
 fn capability_allowlist_change_triggers_boundary_finding() {
+    // The capability-boundary allowlist path is repo-specific, NOT a SHIPPED
+    // default (djinn manages arbitrary projects). A project that keeps one
+    // adds its path via org/project policy — modelled here.
+    let mut policy = default_policy();
+    policy
+        .boundary_path
+        .category_patterns
+        .push("scripts/capability-boundary-allowlist.toml".to_owned());
+    let files = vec![simple_file(
+        "scripts/capability-boundary-allowlist.toml",
+        ChangedFileStatus::Modified,
+        5,
+        2,
+    )];
+    let findings = evaluate_boundary_path_changes(&policy, &files);
+    assert_eq!(findings.len(), 1);
+}
+
+#[test]
+fn capability_allowlist_path_not_in_default_boundary_patterns() {
     let files = vec![simple_file(
         "scripts/capability-boundary-allowlist.toml",
         ChangedFileStatus::Modified,
@@ -740,7 +760,10 @@ fn capability_allowlist_change_triggers_boundary_finding() {
         2,
     )];
     let findings = evaluate_boundary_path_changes(&default_policy(), &files);
-    assert_eq!(findings.len(), 1);
+    assert!(
+        findings.is_empty(),
+        "repo-specific allowlist path must not be a SHIPPED boundary default"
+    );
 }
 
 #[test]
@@ -827,8 +850,11 @@ fn match_outside_allowlist_false_only_flags_new_files() {
 fn match_outside_allowlist_false_still_flags_allowlist_file() {
     let mut policy = default_policy();
     policy.boundary_path.match_outside_allowlist = false;
+    // A project that keeps a capability-boundary allowlist supplies its path
+    // via org/project policy (empty in the SHIPPED default).
+    policy.allowlist.source = "scripts/capability-boundary-allowlist.toml".to_owned();
 
-    // The allowlist file itself should still trigger even when
+    // The configured allowlist file itself should still trigger even when
     // match_outside_allowlist is false.
     let files = vec![simple_file(
         "scripts/capability-boundary-allowlist.toml",

--- a/server/crates/djinn-coordinator/src/tripwires/rules/tests/na0w_rules.rs
+++ b/server/crates/djinn-coordinator/src/tripwires/rules/tests/na0w_rules.rs
@@ -417,7 +417,24 @@ fn ci_workflow_circleci_triggers() {
     assert_eq!(findings.len(), 1);
 }
 
-/// Deploy directory triggers.
+/// Project-specific globs (deploy/release/Tiltfile/Makefile/boundary scripts)
+/// are NOT in the ecosystem-generic SHIPPED default — a project opts into them
+/// via org/project tripwire policy. This helper models that override so the
+/// matcher tests still exercise those path shapes without baking djinn's own
+/// repo layout into the default.
+fn policy_with_project_ci_globs() -> TripwirePolicy {
+    let mut p = default_policy();
+    p.ci_workflow.path_globs.extend([
+        "deploy/**".to_owned(),
+        "release/**".to_owned(),
+        "Tiltfile".to_owned(),
+        "Makefile".to_owned(),
+        "scripts/check-*-boundary.sh".to_owned(),
+    ]);
+    p
+}
+
+/// Deploy directory triggers when a project configures the glob.
 #[test]
 fn ci_workflow_deploy_directory_triggers() {
     let files = vec![simple_file(
@@ -426,11 +443,27 @@ fn ci_workflow_deploy_directory_triggers() {
         5,
         2,
     )];
-    let findings = evaluate_ci_workflow_changes(&default_policy(), &files);
+    let findings = evaluate_ci_workflow_changes(&policy_with_project_ci_globs(), &files);
     assert_eq!(findings.len(), 1);
 }
 
-/// Release directory triggers.
+/// Deploy directory does NOT trigger under the generic SHIPPED default.
+#[test]
+fn ci_workflow_deploy_directory_not_in_default() {
+    let files = vec![simple_file(
+        "deploy/production/manifest.yaml",
+        ChangedFileStatus::Modified,
+        5,
+        2,
+    )];
+    let findings = evaluate_ci_workflow_changes(&default_policy(), &files);
+    assert!(
+        findings.is_empty(),
+        "deploy/** must not be a SHIPPED default — it is a repo-specific path"
+    );
+}
+
+/// Release directory triggers when a project configures the glob.
 #[test]
 fn ci_workflow_release_directory_triggers() {
     let files = vec![simple_file(
@@ -439,27 +472,27 @@ fn ci_workflow_release_directory_triggers() {
         100,
         0,
     )];
-    let findings = evaluate_ci_workflow_changes(&default_policy(), &files);
+    let findings = evaluate_ci_workflow_changes(&policy_with_project_ci_globs(), &files);
     assert_eq!(findings.len(), 1);
 }
 
-/// Tiltfile triggers.
+/// Tiltfile triggers when a project configures the glob.
 #[test]
 fn ci_workflow_tiltfile_triggers() {
     let files = vec![simple_file("Tiltfile", ChangedFileStatus::Modified, 10, 5)];
-    let findings = evaluate_ci_workflow_changes(&default_policy(), &files);
+    let findings = evaluate_ci_workflow_changes(&policy_with_project_ci_globs(), &files);
     assert_eq!(findings.len(), 1);
 }
 
-/// Makefile triggers.
+/// Makefile triggers when a project configures the glob.
 #[test]
 fn ci_workflow_makefile_triggers() {
     let files = vec![simple_file("Makefile", ChangedFileStatus::Modified, 5, 3)];
-    let findings = evaluate_ci_workflow_changes(&default_policy(), &files);
+    let findings = evaluate_ci_workflow_changes(&policy_with_project_ci_globs(), &files);
     assert_eq!(findings.len(), 1);
 }
 
-/// Boundary check script triggers.
+/// Boundary check script triggers when a project configures the glob.
 #[test]
 fn ci_workflow_boundary_check_script_triggers() {
     let files = vec![simple_file(
@@ -468,7 +501,7 @@ fn ci_workflow_boundary_check_script_triggers() {
         10,
         5,
     )];
-    let findings = evaluate_ci_workflow_changes(&default_policy(), &files);
+    let findings = evaluate_ci_workflow_changes(&policy_with_project_ci_globs(), &files);
     assert_eq!(findings.len(), 1);
 }
 
@@ -490,7 +523,7 @@ fn ci_workflow_multiple_files_multiple_findings() {
         ),
         simple_file("Makefile", ChangedFileStatus::Modified, 3, 1),
     ];
-    let findings = evaluate_ci_workflow_changes(&default_policy(), &files);
+    let findings = evaluate_ci_workflow_changes(&policy_with_project_ci_globs(), &files);
     assert_eq!(findings.len(), 3);
 }
 


### PR DESCRIPTION
## Problem

djinn is a platform that manages arbitrary projects, but the **SHIPPED** tripwire policy defaults encoded djinn's own repo layout. Because per-project policy loading is unfinished — `create_tripwire_hold` always uses `TripwirePolicy::default()` (`pr_poller/tripwire_hold.rs`) — every managed foreign repo inherited these djinn-specific globs. On a foreign repo, touching an ordinary `Makefile` or `deploy/` file tripped a merge-hold escalation to the arbiter.

## What changed (defaults only)

- **`CIWorkflowRuleConfig::default`** — removed `Tiltfile`, `Makefile`, `deploy/**`, `release/**`, `scripts/check-*-boundary.sh`. Kept ecosystem-generic CI paths (`.github/workflows/**`, `.github/actions/**`, `.gitlab-ci.yml`, `.circleci/**`) and added universal ones (`Jenkinsfile`, `azure-pipelines.yml`, `bitbucket-pipelines.yml`, `.drone.yml`).
- **`BoundaryPathRuleConfig::default`** — removed `scripts/capability-boundary-allowlist.toml` from `category_patterns` (auth/authz/secrets/deploy/billing/iam/rbac patterns remain — those are ecosystem-generic).
- **`DEFAULT_ALLOWLIST_SOURCE`** — now empty (was `scripts/capability-boundary-allowlist.toml`). The boundary allowlist was already in degraded mode by default (revision = `MISSING_ALLOWLIST_REVISION`), so behavior is unchanged; this just stops baking a djinn-only path into the default `source`.

## Per-project policy wiring — deliberately NOT built

The audit was correct: no persisted tripwire-policy surface exists. `org_ai_policy` (the only org-policy store) is model-lane only — wiring per-project tripwire policy needs a new DB table + migration + repo + MCP tool + loader, i.e. a separate epic. Per the operator's guidance I did **not** build it. Instead:

- Added a `TODO(per-project-policy)` at the call site documenting the load-with-fallback-to-default that should replace the hardcoded default.
- **Known consequence:** djinn's OWN repo loses its `Tiltfile`/`deploy/`/`release/`/capability-boundary-script tripwires until that per-project policy load lands and an org policy re-adds those repo-specific globs. This is the intended trade — removing foreign-repo false positives is the priority.

## Tests

- New `default_policy_is_project_agnostic` regression test locks the defaults (no `Tiltfile`/`Makefile`/`deploy/**`/`release/**`/boundary-script/allowlist globs; empty allowlist source; `.github/workflows/**` still covered).
- Rule-matcher tests that exercised the repo-specific paths (`na0w_rules`, `imb4_rules`) now configure those globs explicitly via policy, proving the matcher still works when a project opts in, plus new negative tests asserting they are absent from the default.
- `cargo test -p djinn-coordinator tripwire`: 291 passed / 0 failed. clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)