### PR TITLE
fix(warm): align SCIP indexer CPU budget and stop OOM-as-timeout mislabel

### DIFF
--- a/server/crates/djinn-graph/src/process.rs
+++ b/server/crates/djinn-graph/src/process.rs
@@ -44,23 +44,43 @@ pub async fn output(mut cmd: Command) -> io::Result<Output> {
 }
 
 /// Like [`output`], but aborts if the command does not finish within `timeout`.
-/// Returns `io::ErrorKind::TimedOut` on expiry.
+/// Returns `io::ErrorKind::TimedOut` **only** when the deadline actually expired.
 ///
 /// Unlike the old implementation (which wrapped [`output`] in
 /// `tokio::time::timeout` and leaked the still-running child + blocking thread
 /// on expiry), this delegates to [`output_with_kill`], which performs the
 /// timeout *inside* the blocking closure and actually reaps the child's process
 /// group before returning.
+///
+/// The `TimedOut` classification is driven by the in-closure "did we fire the
+/// deadline kill?" flag, NOT by inspecting the child's exit signal. Re-deriving
+/// it from `SIGTERM`/`SIGKILL` conflated our own timeout kill with an EXTERNAL
+/// signal — most dangerously the kernel OOM killer's `SIGKILL`, which can reap
+/// the child *before* the deadline. Reporting an OOM as `TimedOut` makes the
+/// `timed_out` status untrustworthy for callers that treat "the tool hung"
+/// differently from "the tool died". A child killed by a signal we did not send
+/// (before the deadline) instead surfaces as a distinct non-timeout failure.
 pub async fn output_with_timeout(cmd: Command, timeout: Duration) -> io::Result<Output> {
-    let out = output_with_kill(cmd, timeout).await?;
-    // Preserve the historical contract: a timed-out command surfaces as
-    // `TimedOut` rather than a non-zero exit status, so callers that
-    // distinguish "the tool failed" from "the tool hung" keep working.
     #[cfg(unix)]
-    if timed_out_status(&out.status) {
-        return Err(io::Error::new(io::ErrorKind::TimedOut, "process timed out"));
+    {
+        let (out, deadline_fired) = output_with_kill_inner(cmd, timeout).await?;
+        if deadline_fired {
+            return Err(io::Error::new(io::ErrorKind::TimedOut, "process timed out"));
+        }
+        // Deadline did NOT fire, so we never signalled the child ourselves. Any
+        // signal death here is external (e.g. OOM killer) — surface it as a
+        // distinct failure so it is never miscounted as a timeout.
+        if let Some(sig) = killed_by_signal(&out.status) {
+            return Err(io::Error::other(format!(
+                "process killed by signal {sig} before its deadline"
+            )));
+        }
+        Ok(out)
     }
-    Ok(out)
+    #[cfg(not(unix))]
+    {
+        output_with_kill(cmd, timeout).await
+    }
 }
 
 /// Run a pre-configured `std::process::Command` on a blocking thread and return
@@ -72,12 +92,14 @@ pub async fn status(mut cmd: Command) -> io::Result<std::process::ExitStatus> {
         .map_err(io::Error::other)?
 }
 
-/// True if `status` reflects a process killed by SIGTERM/SIGKILL (i.e. the
-/// timeout path fired) rather than a normal exit.
+/// The signal number that killed the process, if it was terminated by a signal
+/// rather than exiting normally. Used to distinguish an externally-signalled
+/// death (e.g. the OOM killer) from a clean exit; the caller separately tracks
+/// whether *our* deadline kill fired.
 #[cfg(unix)]
-fn timed_out_status(status: &std::process::ExitStatus) -> bool {
+fn killed_by_signal(status: &std::process::ExitStatus) -> Option<i32> {
     use std::os::unix::process::ExitStatusExt;
-    matches!(status.signal(), Some(libc::SIGTERM) | Some(libc::SIGKILL))
+    status.signal()
 }
 
 #[cfg(unix)]
@@ -148,7 +170,20 @@ fn signal_process_group(pgid: i32, signal: libc::c_int) -> io::Result<()> {
 /// blocking-pool thread always returns rather than leaking when the caller's
 /// future is dropped.
 #[cfg(unix)]
-pub async fn output_with_kill(mut cmd: Command, timeout: Duration) -> io::Result<Output> {
+pub async fn output_with_kill(cmd: Command, timeout: Duration) -> io::Result<Output> {
+    output_with_kill_inner(cmd, timeout)
+        .await
+        .map(|(out, _timed_out)| out)
+}
+
+/// Inner form of [`output_with_kill`] that also reports whether *our* deadline
+/// kill fired. `true` means the timeout expired and we signalled the child's
+/// process group; `false` means the child exited (cleanly or via an external
+/// signal) on its own. [`output_with_timeout`] relies on this flag rather than
+/// on the child's exit signal so an OOM-killer `SIGKILL` before the deadline is
+/// not misreported as a timeout.
+#[cfg(unix)]
+async fn output_with_kill_inner(mut cmd: Command, timeout: Duration) -> io::Result<(Output, bool)> {
     // The caller's `Command` may not have piped stdio (e.g. SCIP indexer plans
     // build a bare `Command`).  We take the pipes ourselves, so force them.
     cmd.stdout(std::process::Stdio::piped())
@@ -201,11 +236,14 @@ pub async fn output_with_kill(mut cmd: Command, timeout: Duration) -> io::Result
         let stdout_bytes = join_with_timeout(stdout_handle, drain_deadline);
         let stderr_bytes = join_with_timeout(stderr_handle, drain_deadline);
 
-        Ok(Output {
-            status,
-            stdout: stdout_bytes,
-            stderr: stderr_bytes,
-        })
+        Ok((
+            Output {
+                status,
+                stdout: stdout_bytes,
+                stderr: stderr_bytes,
+            },
+            timed_out,
+        ))
     })
     .await
     .map_err(io::Error::other)?
@@ -261,7 +299,7 @@ mod tests {
 
         // Killed by signal => not a clean success.
         assert!(!out.status.success());
-        assert!(timed_out_status(&out.status));
+        assert!(killed_by_signal(&out.status).is_some());
 
         let pgid: i32 = String::from_utf8_lossy(&out.stdout)
             .lines()
@@ -283,6 +321,32 @@ mod tests {
             io::Error::last_os_error().raw_os_error(),
             Some(libc::ESRCH),
             "expected the killed process group to be fully gone"
+        );
+    }
+
+    /// A child killed by an EXTERNAL signal (modelling the kernel OOM killer)
+    /// *before* the deadline must NOT be reported as a timeout — otherwise the
+    /// `timed_out` status becomes untrustworthy. It surfaces as a distinct
+    /// non-timeout failure instead.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn external_signal_before_deadline_is_not_a_timeout() {
+        // The shell SIGKILLs itself immediately, well within the generous
+        // 30s deadline, so our timeout-kill path never fires.
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("kill -9 $$");
+
+        let err = output_with_timeout(cmd, Duration::from_secs(30))
+            .await
+            .expect_err("a signal-killed child must surface as an error");
+
+        assert_ne!(
+            err.kind(),
+            io::ErrorKind::TimedOut,
+            "an external SIGKILL before the deadline must not be reported as a timeout"
+        );
+        assert!(
+            err.to_string().contains("signal"),
+            "expected a distinct signal-death message, got: {err}"
         );
     }
 

--- a/server/crates/djinn-graph/src/scip_indexer/mod.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/mod.rs
@@ -246,19 +246,49 @@ pub struct PlannedIndexerCommand {
     pub output_path: PathBuf,
 }
 
+/// Ceiling on `CARGO_BUILD_JOBS` for a SCIP indexer subprocess. Preserves the
+/// historical ADR-050 §3 cap of 4 so a large host can never fan `cargo check`
+/// out past what the warm pipeline was tuned for.
+const MAX_CARGO_BUILD_JOBS: usize = 4;
+
+/// Derive the `CARGO_BUILD_JOBS` value for a SCIP indexer subprocess.
+///
+/// SCIP indexers (notably `rust-analyzer scip`) invoke `cargo check`, which
+/// fans out into a parallel `cc` build for native deps (openssl-sys et al).
+/// The warm Pod is CPU-capped (`warm_cpu_limit`), runs its indexers at
+/// `nice 10`, and runs the Rust indexer concurrently with the scip-typescript
+/// indexers, so hardcoding 4 build jobs on a 2-CPU pod *oversubscribed* the
+/// budget: 4 jobs fighting over 2 throttled CPUs is slower than 2 jobs, and
+/// that contention is one of the causes of the Rust workspace hitting its
+/// wall-clock cap on every warm.
+///
+/// `std::thread::available_parallelism()` reads the process's cgroup CPU quota
+/// on Linux (stable since Rust 1.64; the pinned toolchain is `stable`), so
+/// inside the warm Pod it reflects the container's `warm_cpu_limit` rather than
+/// the node's core count. We cap the result at [`MAX_CARGO_BUILD_JOBS`] to keep
+/// the historical ceiling and fall back to it when detection fails, and floor
+/// at 1 so a mis-detected 0 can never disable parallelism entirely.
+fn cargo_build_jobs() -> String {
+    let jobs = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(MAX_CARGO_BUILD_JOBS)
+        .clamp(1, MAX_CARGO_BUILD_JOBS);
+    jobs.to_string()
+}
+
 impl PlannedIndexerCommand {
     fn build_command(&self) -> Command {
         let mut command = Command::new(&self.binary_path);
         command.current_dir(&self.working_directory);
         command.args(&self.args);
-        // ADR-050 §3 non-negotiable cap: SCIP indexers commonly invoke
-        // `cargo check` which fans out into a parallel `cc` build for
-        // native deps (openssl-sys et al).  Two simultaneous indexer
-        // runs are already serialized by `IndexerLock`, but a single
-        // run can still saturate the host without this cap.  4 jobs is
-        // empirically sufficient to keep `rust-analyzer scip` warm
-        // without melting the box.
-        command.env("CARGO_BUILD_JOBS", "4");
+        // ADR-050 §3 cap: SCIP indexers commonly invoke `cargo check` which
+        // fans out into a parallel `cc` build for native deps (openssl-sys
+        // et al). Two simultaneous indexer runs are already serialized by
+        // `IndexerLock`, but a single run can still saturate the host without
+        // a cap. Derive the job count from the CPU actually available to this
+        // process (cgroup-aware) rather than hardcoding 4 — on the CPU-capped
+        // warm Pod, 4 jobs oversubscribed the quota and made warms slower.
+        command.env("CARGO_BUILD_JOBS", cargo_build_jobs());
         // NOTE: do NOT force `RUSTUP_TOOLCHAIN=stable` here. The image's
         // install-rust.sh installs the `rust-analyzer` component into the
         // project's *pinned* toolchain (derived from rust-toolchain.toml
@@ -310,4 +340,54 @@ pub struct IndexingRun {
     pub commands: Vec<ExecutedIndexerCommand>,
     pub artifacts: Vec<ScipArtifact>,
     pub workspace_statuses: Vec<WorkspaceWarmStatus>,
+}
+
+#[cfg(test)]
+mod build_command_tests {
+    use super::*;
+
+    /// `CARGO_BUILD_JOBS` is derived from available parallelism, floored at 1
+    /// and capped at the historical ADR-050 §3 ceiling of 4. It must always be
+    /// a parseable positive integer within that band so the value passed to
+    /// cargo is never `0`, negative, or over the cap regardless of host CPU.
+    #[test]
+    fn cargo_build_jobs_is_bounded_and_parseable() {
+        let jobs: usize = cargo_build_jobs()
+            .parse()
+            .expect("CARGO_BUILD_JOBS must be a positive integer");
+        assert!(
+            (1..=MAX_CARGO_BUILD_JOBS).contains(&jobs),
+            "expected 1..={MAX_CARGO_BUILD_JOBS} build jobs, got {jobs}"
+        );
+        // It should also match the cgroup-aware detection clamped to the band,
+        // so on the CPU-capped warm Pod it tracks the CPU limit rather than the
+        // node core count.
+        let expected = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(MAX_CARGO_BUILD_JOBS)
+            .clamp(1, MAX_CARGO_BUILD_JOBS);
+        assert_eq!(jobs, expected);
+    }
+
+    /// The built command carries the derived `CARGO_BUILD_JOBS` env override.
+    #[test]
+    fn build_command_sets_cargo_build_jobs_env() {
+        let plan = PlannedIndexerCommand {
+            indexer: SupportedIndexer::RustAnalyzer,
+            binary_path: PathBuf::from("rust-analyzer"),
+            args: vec!["scip".into()],
+            working_directory: PathBuf::from("/tmp"),
+            workspace_root: PathBuf::from("/tmp"),
+            workspace_rel_root: PathBuf::new(),
+            workspace_slug: "root".into(),
+            output_path: PathBuf::from("/tmp/out.scip"),
+        };
+        let command = plan.build_command();
+        let jobs = command
+            .get_envs()
+            .find(|(k, _)| *k == OsStr::new("CARGO_BUILD_JOBS"))
+            .and_then(|(_, v)| v)
+            .map(|v| v.to_string_lossy().into_owned());
+        assert_eq!(jobs.as_deref(), Some(cargo_build_jobs().as_str()));
+    }
 }

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -92,7 +92,14 @@ pub struct KubernetesConfig {
     /// signal and the Pod can be evicted under contention. Default `1`.
     pub warm_cpu_request: String,
     /// CPU limit on the warm Pod container. Caps the indexer subprocesses
-    /// so they don't starve neighbours on the same node. Default `2`.
+    /// so they don't starve neighbours on the same node. Default `4`.
+    ///
+    /// Bumped `2` → `4`: `rust-analyzer scip` derives `CARGO_BUILD_JOBS` from
+    /// the cgroup-visible CPU quota (see djinn-graph `cargo_build_jobs`), and
+    /// runs concurrently with the scip-typescript indexers. A `2` limit
+    /// throttled the Rust workspace so hard it hit its wall-clock cap on every
+    /// warm; `4` gives the derived job count room to match without letting a
+    /// single warm Pod monopolise a node.
     pub warm_cpu_limit: String,
     /// Memory request on the warm Pod container. SCIP index buffers for a
     /// medium-sized Rust workspace already crest 1 GiB; reserving 2 GiB
@@ -139,7 +146,10 @@ impl KubernetesConfig {
             task_run_active_deadline_seconds: 10800,
             task_run_termination_grace_period_seconds: 60,
             warm_cpu_request: "1".into(),
-            warm_cpu_limit: "2".into(),
+            // Bumped limit 2 → 4 so the cgroup-aware `CARGO_BUILD_JOBS` in the
+            // Rust SCIP indexer has real CPU to use; a 2-CPU cap starved the
+            // warm and timed the Rust workspace out on every run.
+            warm_cpu_limit: "4".into(),
             // Bumped limit 4Gi → 6Gi: compiling test binaries with --all-targets
             // links more codegen units at once than clippy alone.
             warm_memory_request: "2Gi".into(),
@@ -177,7 +187,7 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_TASK_RUN_ACTIVE_DEADLINE_SECONDS` | `task_run_active_deadline_seconds` | `10800` (parsed as `u64`) |
     /// | `DJINN_K8S_TASK_RUN_TERMINATION_GRACE_PERIOD_SECONDS` | `task_run_termination_grace_period_seconds` | `60` (parsed as `i64`) |
     /// | `DJINN_K8S_WARM_CPU_REQUEST` | `warm_cpu_request` | `1` |
-    /// | `DJINN_K8S_WARM_CPU_LIMIT` | `warm_cpu_limit` | `2` |
+    /// | `DJINN_K8S_WARM_CPU_LIMIT` | `warm_cpu_limit` | `4` |
     /// | `DJINN_K8S_WARM_MEMORY_REQUEST` | `warm_memory_request` | `2Gi` |
     /// | `DJINN_K8S_WARM_MEMORY_LIMIT` | `warm_memory_limit` | `6Gi` |
     /// | `DJINN_K8S_NODE_SELECTOR` | `node_selector` | `{}` (parsed as a JSON object of string→string) |

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -616,7 +616,7 @@ mod tests {
         // Defaults pin the documented values. Memory limit bumped 4Gi → 6Gi to
         // cover the added test-compile warm pass (--all-targets test codegen).
         assert_eq!(cfg.warm_cpu_request, "1");
-        assert_eq!(cfg.warm_cpu_limit, "2");
+        assert_eq!(cfg.warm_cpu_limit, "4");
         assert_eq!(cfg.warm_memory_request, "2Gi");
         assert_eq!(cfg.warm_memory_limit, "6Gi");
     }


### PR DESCRIPTION
## Root cause

The graph-warm Job times the Rust `server` workspace out at its 1200s cap on **every** warm. Three CPU-budget / observability defects contribute (a sibling PR handles the larger `CARGO_TARGET_DIR` cache-bypass fix):

1. **`rust-analyzer scip` hardcoded `CARGO_BUILD_JOBS=4`** while the warm Pod is CPU-capped at `2`, runs at `nice 10`, and runs concurrently with two scip-typescript indexers via `join_all`. 4 build jobs contending for 2 throttled CPUs is *slower* than 2.
2. **`warm_cpu_limit` defaulted to `2`**, starving the Rust indexer.
3. **`output_with_timeout` mislabeled OOM kills as timeouts.** It re-derived its `TimedOut` classification from the child's exit signal (`SIGTERM`/`SIGKILL`), conflating our own deadline kill with an *external* signal — most dangerously the kernel OOM killer's `SIGKILL`, which reaps the child *before* the deadline. An OOM booked as `timed_out`, making that status untrustworthy.

## Fix

**1 — derive `CARGO_BUILD_JOBS` from the cgroup CPU quota** (`scip_indexer/mod.rs`). `std::thread::available_parallelism()` reads the process cgroup CPU quota on Linux (stable since Rust 1.64; pinned toolchain is `stable`/1.96), so inside the warm Pod it reflects `warm_cpu_limit` rather than the node core count. Clamped to `[1, 4]` — floor at 1, cap at the historical ADR-050 §3 ceiling of 4, fall back to 4 if detection fails.

**2 — raise default `warm_cpu_limit` `2` → `4`** (`djinn-k8s/config.rs`) so the derived job count has real CPU. Env doc table + the `warm_job` spec test updated. **`warm_memory_limit` left at `6Gi`**: no OOM history justifies a further bump (the existing code comment already documents the prior `4Gi → 6Gi` test-compile bump), and doubling CPU without doubling memory is the intended axis.

**3 — trust the in-closure deadline flag** (`djinn-graph/process.rs`). `output_with_kill` now reports whether *our* deadline kill fired; `output_with_timeout` maps `TimedOut` off that flag only. A child killed by a signal we did not send surfaces as a distinct non-timeout failure, so `timed_out` statuses stay trustworthy (an OOM is now classified `failed`, not `timed_out`).

## Test evidence

- New `cargo_build_jobs` tests: value is a positive integer in `[1, 4]` and tracks cgroup detection; `build_command` wires the derived value into `CARGO_BUILD_JOBS`.
- New `external_signal_before_deadline_is_not_a_timeout`: a self-`SIGKILL` well within a 30s deadline must surface as a non-`TimedOut` failure whose message mentions the signal. Fails under the old signal-derived logic.
- `warm_job` spec test updated to assert the new `4` default.
- `cargo test -p djinn-graph` (555 passed) + `-p djinn-k8s` (127 passed); `cargo fmt --check` + `cargo clippy --all-features` clean for both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)