### PR TITLE
fix(graph): prune vanished workspace freshness rows on each warm

### DIFF
--- a/server/crates/djinn-db/src/repositories/project_workspace_graph.rs
+++ b/server/crates/djinn-db/src/repositories/project_workspace_graph.rs
@@ -77,6 +77,62 @@ impl ProjectWorkspaceGraphRepository {
         Ok(())
     }
 
+    /// Persist a warm run's freshness rows as a *replace-set*: upsert every
+    /// row in `rows` and, in the same transaction, delete any existing row for
+    /// `project_id` whose `workspace_slug` is not among them.
+    ///
+    /// Plain [`Self::upsert_many`] only ever writes — it can never retire a
+    /// workspace that no longer exists. When workspace discovery stops emitting
+    /// a slug (e.g. a `root` row from before per-workspace discovery, or a
+    /// folder that was deleted/renamed), that slug's last stamp survives forever
+    /// and the `code_graph workspaces` op keeps returning a ghost row. Warm runs
+    /// call this so each run's persisted set exactly mirrors the workspaces it
+    /// actually indexed (ready) plus the ones it explicitly marked
+    /// failed/timed_out — a timed-out workspace is in `rows`, so it keeps its
+    /// row; only truly-vanished slugs are pruned.
+    ///
+    /// Upsert and delete run in one transaction so a crash can never leave a
+    /// half-applied set (some new rows written, stale rows not yet pruned).
+    ///
+    /// All `rows` must share the same `project_id` as the `project_id`
+    /// argument; the delete is scoped to that project.
+    pub async fn replace_for_project(
+        &self,
+        project_id: &str,
+        rows: &[ProjectWorkspaceGraphUpsert<'_>],
+    ) -> Result<()> {
+        self.db.ensure_initialized().await?;
+        let keep: Vec<&str> = rows.iter().map(|row| row.workspace_slug).collect();
+
+        let mut tx = self.db.pool().begin().await?;
+        for row in rows {
+            sqlx::query(r#"INSERT INTO project_workspace_graph
+                       (project_id, workspace_slug, commit_sha, warmed_at, status)
+                   VALUES
+                       ($1, $2, $3, to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'), $4)
+                   ON CONFLICT (project_id, workspace_slug) DO UPDATE SET
+                       commit_sha = EXCLUDED.commit_sha,
+                       warmed_at = EXCLUDED.warmed_at,
+                       status = EXCLUDED.status"#)
+            .bind(row.project_id)
+            .bind(row.workspace_slug)
+            .bind(row.commit_sha)
+            .bind(row.status)
+            .execute(&mut *tx)
+            .await?;
+        }
+        sqlx::query(
+            "DELETE FROM project_workspace_graph
+              WHERE project_id = $1 AND workspace_slug <> ALL($2)",
+        )
+        .bind(project_id)
+        .bind(&keep)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
     /// Remove a single workspace freshness row. Used to retire the
     /// [`CODELESS_WORKSPACE_SLUG`] sentinel once a real warm succeeds — a
     /// project can't simultaneously be "code-less" and have indexed
@@ -395,6 +451,185 @@ mod tests {
             .expect("state");
         assert_eq!(state.warmed_at, latest.warmed_at);
         assert_eq!(state.status, "ready");
+    }
+
+    #[tokio::test]
+    async fn replace_for_project_prunes_vanished_slugs_and_keeps_timed_out() {
+        // Pins the live djinnos/djinn scenario: prior rows {root, server, ui,
+        // website}; a new warm emits ready {ui, website} and marks {server}
+        // timed_out. The `root` slug no longer exists, so its stale row must be
+        // deleted; `server` is in the replace-set (timed_out), so it must keep
+        // its row; `ui`/`website` are re-stamped ready at the new commit.
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        repo.upsert_many(&[
+            ProjectWorkspaceGraphUpsert {
+                project_id: "p1",
+                workspace_slug: "root",
+                commit_sha: "old",
+                status: "ready",
+            },
+            ProjectWorkspaceGraphUpsert {
+                project_id: "p1",
+                workspace_slug: "server",
+                commit_sha: "old",
+                status: "ready",
+            },
+            ProjectWorkspaceGraphUpsert {
+                project_id: "p1",
+                workspace_slug: "ui",
+                commit_sha: "old",
+                status: "ready",
+            },
+            ProjectWorkspaceGraphUpsert {
+                project_id: "p1",
+                workspace_slug: "website",
+                commit_sha: "old",
+                status: "ready",
+            },
+        ])
+        .await
+        .expect("seed prior rows");
+
+        repo.replace_for_project(
+            "p1",
+            &[
+                ProjectWorkspaceGraphUpsert {
+                    project_id: "p1",
+                    workspace_slug: "ui",
+                    commit_sha: "new",
+                    status: "ready",
+                },
+                ProjectWorkspaceGraphUpsert {
+                    project_id: "p1",
+                    workspace_slug: "website",
+                    commit_sha: "new",
+                    status: "ready",
+                },
+                ProjectWorkspaceGraphUpsert {
+                    project_id: "p1",
+                    workspace_slug: "server",
+                    commit_sha: "new",
+                    status: "timed_out",
+                },
+            ],
+        )
+        .await
+        .expect("replace");
+
+        // `root` vanished → pruned.
+        assert!(repo.get("p1", "root").await.expect("get root").is_none());
+
+        // `server` timed out but is in the set → kept, re-stamped.
+        let server = repo
+            .get("p1", "server")
+            .await
+            .expect("get server")
+            .expect("server row kept");
+        assert_eq!(server.status, "timed_out");
+        assert_eq!(server.commit_sha, "new");
+
+        // `ui`/`website` re-stamped ready at the new commit.
+        for slug in ["ui", "website"] {
+            let row = repo
+                .get("p1", slug)
+                .await
+                .expect("get")
+                .unwrap_or_else(|| panic!("{slug} row"));
+            assert_eq!(row.status, "ready");
+            assert_eq!(row.commit_sha, "new");
+        }
+
+        let slugs: Vec<_> = repo
+            .list_for_project("p1")
+            .await
+            .expect("list")
+            .into_iter()
+            .map(|r| r.workspace_slug)
+            .collect();
+        assert_eq!(slugs, vec!["server", "ui", "website"]);
+    }
+
+    #[tokio::test]
+    async fn replace_for_project_is_scoped_to_the_project() {
+        // Pruning must never touch another project's rows even though the new
+        // set omits that project's slugs.
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+        seed_project(&repo, "p2").await;
+
+        repo.upsert(ProjectWorkspaceGraphUpsert {
+            project_id: "p2",
+            workspace_slug: "root",
+            commit_sha: "abc",
+            status: "ready",
+        })
+        .await
+        .expect("seed p2");
+        repo.upsert(ProjectWorkspaceGraphUpsert {
+            project_id: "p1",
+            workspace_slug: "old",
+            commit_sha: "abc",
+            status: "ready",
+        })
+        .await
+        .expect("seed p1");
+
+        repo.replace_for_project(
+            "p1",
+            &[ProjectWorkspaceGraphUpsert {
+                project_id: "p1",
+                workspace_slug: "server",
+                commit_sha: "new",
+                status: "ready",
+            }],
+        )
+        .await
+        .expect("replace p1");
+
+        // p1's stale `old` pruned, `server` present.
+        assert!(repo.get("p1", "old").await.expect("get").is_none());
+        assert!(repo.get("p1", "server").await.expect("get").is_some());
+        // p2 untouched.
+        assert!(repo.get("p2", "root").await.expect("get").is_some());
+    }
+
+    #[tokio::test]
+    async fn replace_for_project_retires_codeless_sentinel() {
+        // A prior code-less sentinel row is not in a real warm's replace-set, so
+        // it is pruned automatically — no separate delete call needed.
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        repo.upsert(ProjectWorkspaceGraphUpsert {
+            project_id: "p1",
+            workspace_slug: CODELESS_WORKSPACE_SLUG,
+            commit_sha: "abc",
+            status: "ready",
+        })
+        .await
+        .expect("seed sentinel");
+
+        repo.replace_for_project(
+            "p1",
+            &[ProjectWorkspaceGraphUpsert {
+                project_id: "p1",
+                workspace_slug: "server",
+                commit_sha: "new",
+                status: "ready",
+            }],
+        )
+        .await
+        .expect("replace");
+
+        assert!(
+            repo.get("p1", CODELESS_WORKSPACE_SLUG)
+                .await
+                .expect("get sentinel")
+                .is_none()
+        );
+        assert!(repo.get("p1", "server").await.expect("get").is_some());
     }
 
     #[tokio::test]

--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -1137,9 +1137,7 @@ async fn persist_workspace_graph_freshness_best_effort<C: WarmContext>(
     graph: &crate::repo_graph::RepoDependencyGraph,
     workspace_statuses: &[crate::scip_indexer::WorkspaceWarmStatus],
 ) {
-    use djinn_db::{
-        CODELESS_WORKSPACE_SLUG, ProjectWorkspaceGraphRepository, ProjectWorkspaceGraphUpsert,
-    };
+    use djinn_db::{ProjectWorkspaceGraphRepository, ProjectWorkspaceGraphUpsert};
 
     let workspaces = distinct_workspace_slugs(graph);
     if workspaces.is_empty() {
@@ -1187,24 +1185,21 @@ async fn persist_workspace_graph_freshness_best_effort<C: WarmContext>(
 
     let workspace_count = rows.len();
     let repo = ProjectWorkspaceGraphRepository::new(ctx.db().clone());
-    if let Err(e) = repo.upsert_many(&rows).await {
+    // Persist as a *replace-set*, not a blind upsert: this run's rows are the
+    // full truth for the project, so any slug it no longer emits (a vanished
+    // folder, a pre-per-workspace `root` stamp, or the code-less sentinel — none
+    // of which are in `rows`) is pruned in the same transaction. Plain
+    // `upsert_many` could only ever write, leaving ghost rows that the
+    // `code_graph workspaces` op kept surfacing forever. Timed-out/failed
+    // workspaces are already in `rows`, so they keep their row and are not
+    // pruned.
+    if let Err(e) = repo.replace_for_project(project_id, &rows).await {
         tracing::warn!(
             project_id = %project_id,
             commit_sha = %commit_sha,
             workspace_count,
             error = %e,
             "ensure_canonical_graph: failed to persist project_workspace_graph freshness rows"
-        );
-    }
-
-    // A successful warm with real workspaces contradicts any lingering
-    // code-less sentinel (e.g. stamped while the warm gate misfired on a
-    // catalog-image project). Retire it so freshness derives from real rows.
-    if let Err(e) = repo.delete(project_id, CODELESS_WORKSPACE_SLUG).await {
-        tracing::warn!(
-            project_id = %project_id,
-            error = %e,
-            "ensure_canonical_graph: failed to delete code-less sentinel row"
         );
     }
 }


### PR DESCRIPTION
## Live bug

djinn persists per-workspace code-graph freshness rows (slug, commit_sha, warmed_at, status) via `persist_workspace_graph_freshness_best_effort` → `ProjectWorkspaceGraphRepository::upsert_many`. That path only ever **writes** rows: it stamps (a) slugs present in the freshly-built graph as `ready` and (b) slugs reported `failed`/`timed_out`. Rows for slugs that no longer exist are never deleted.

Consequence on `djinnos/djinn`: a stale `root` row (node_count 0, status `ready`, commit pinned to `2e1a292` from 2026-07-07) persists forever because workspace discovery now emits only `server`/`ui`/`website` — the MCP `code_graph workspaces` op keeps returning the ghost row.

## Fix

Make each warm run's persistence a **replace-set** rather than upsert-only. Add `ProjectWorkspaceGraphRepository::replace_for_project(project_id, rows)` which, in a single transaction:

- upserts every row in the current (ready ∪ failed/timed_out) set, then
- deletes that project's rows whose `workspace_slug` is not in that set (`workspace_slug <> ALL($keep)`).

One transaction means a crash can't leave a half-applied set. A workspace that **timed out is in the row set**, so it keeps its row — only truly-vanished slugs are pruned. The replace also subsumes the explicit code-less-sentinel delete (the sentinel is never in a real warm's set), so that separate call is removed. Best-effort semantics are preserved: persistence failure is logged via `tracing::warn!` and never fails the warm.

The change is additive/localized — `upsert_many` keeps its signature; the new method sits alongside it.

## Test evidence

New djinn-db repository tests (each on its own template-cloned Postgres test DB):
- `replace_for_project_prunes_vanished_slugs_and_keeps_timed_out` — pins the live scenario: prior rows `{root, server, ui, website}`; new warm ready `{ui, website}` + timed_out `{server}` → `root` deleted, `server` kept as `timed_out` at the new commit, `ui`/`website` re-stamped `ready`.
- `replace_for_project_is_scoped_to_the_project` — another project's rows are never touched.
- `replace_for_project_retires_codeless_sentinel` — the code-less sentinel is pruned automatically.

```
cargo test -p djinn-db --lib project_workspace_graph → 11 passed
cargo test -p djinn-graph --lib persist_freshness → 1 passed (existing test still green)
cargo fmt --check + cargo clippy --all-features -p djinn-db -p djinn-graph → clean
```

Queries use runtime `sqlx::query` (not the `query!` macro), so no `.sqlx` offline metadata changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)