### PR TITLE
feat(graph): adapt SCIP indexer timeout from persisted per-workspace timings

### DIFF
--- a/server/crates/djinn-db/migrations_postgres/106_scip_indexer_timing.sql
+++ b/server/crates/djinn-db/migrations_postgres/106_scip_indexer_timing.sql
@@ -1,0 +1,35 @@
+-- Per-(project, workspace, indexer) SCIP indexer timing feedback.
+--
+-- Each warm run records the wall-clock elapsed and outcome of every SCIP
+-- indexer invocation so the NEXT warm can size its per-invocation timeout to
+-- observed reality instead of a hand-tuned static cap. The static cap history
+-- (120 -> 600 -> 1200s, bumped by hand each time a heavy workspace like the
+-- `server` Rust crate timed out and silently dropped from the graph) shows a
+-- fixed cap never fits every workspace. This table feeds the adaptive budget
+-- model in `djinn-graph::scip_indexer::budget`.
+--
+-- One row per key (latest observation + rolling evidence), not an unbounded
+-- append log:
+--   * `last_status` / `last_elapsed_ms` / `observed_at` — the most recent run.
+--   * `success_elapsed_ms` — elapsed of the last SUCCESSFUL run. Feeds the
+--     existing prior-timing hook (raise the budget for slow-but-passing runs,
+--     still clamped by the per-indexer static max). Cleared when a later run of
+--     any non-success outcome does NOT overwrite it; reset to the fresh value
+--     on every success.
+--   * `timed_out_elapsed_ms` — high-water elapsed of TIMED-OUT runs. A
+--     workspace that keeps timing out grows headroom (next budget ~1.5x this
+--     value) instead of retrying at the identical cap. Reset to NULL on the
+--     next success, since a success proves the current cap was sufficient.
+CREATE TABLE IF NOT EXISTS scip_indexer_timing (
+    project_id           VARCHAR(36)  NOT NULL,
+    workspace_slug       VARCHAR(255) NOT NULL,
+    indexer              VARCHAR(64)  NOT NULL,
+    last_status          VARCHAR(32)  NOT NULL,
+    last_elapsed_ms      BIGINT       NOT NULL,
+    success_elapsed_ms   BIGINT,
+    timed_out_elapsed_ms BIGINT,
+    observed_at          VARCHAR(64)  NOT NULL DEFAULT to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+    PRIMARY KEY (project_id, workspace_slug, indexer),
+    CONSTRAINT fk_scip_indexer_timing_project
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -120,6 +120,10 @@ pub use repositories::{
         ProposalUpdateInput,
     },
     repo_graph_cache::{CachedRepoGraph, RepoGraphCacheInsert, RepoGraphCacheRepository},
+    scip_indexer_timing::{
+        ScipIndexerTiming, ScipIndexerTimingObservation, ScipIndexerTimingRepository,
+        TIMING_STATUS_FAILED, TIMING_STATUS_SUCCESS, TIMING_STATUS_TIMED_OUT,
+    },
     service::{ServicePreset, ServicePresetRepository},
     session::{
         CreateSessionParams, ExtractionBackfillCandidate, OrphanSessionCandidate,

--- a/server/crates/djinn-db/src/repositories/mod.rs
+++ b/server/crates/djinn-db/src/repositories/mod.rs
@@ -23,6 +23,7 @@ pub mod repo_graph_cache;
 pub mod retrieval_trace;
 #[cfg(test)]
 pub mod retrieval_trace_tests;
+pub mod scip_indexer_timing;
 pub mod service;
 pub mod session;
 pub mod session_auth;

--- a/server/crates/djinn-db/src/repositories/scip_indexer_timing.rs
+++ b/server/crates/djinn-db/src/repositories/scip_indexer_timing.rs
@@ -1,0 +1,360 @@
+//! Persistence for per-(project, workspace, indexer) SCIP indexer timings.
+//!
+//! Each warm run records the outcome and wall-clock elapsed of every indexer
+//! invocation here; the next warm reads it back to adapt the per-invocation
+//! timeout budget (see `djinn-graph::scip_indexer::budget`). Storage is a
+//! single row per key (latest observation + rolling evidence), not an
+//! append-only log — see `migrations_postgres/106_scip_indexer_timing.sql`.
+
+use crate::Result;
+use crate::database::Database;
+
+/// Recorded status of a single indexer invocation. Stored verbatim in
+/// `last_status`. Only these three values are written by the warm path.
+pub const TIMING_STATUS_SUCCESS: &str = "success";
+pub const TIMING_STATUS_FAILED: &str = "failed";
+pub const TIMING_STATUS_TIMED_OUT: &str = "timed_out";
+
+/// A persisted timing row for one (project, workspace, indexer) key.
+#[derive(Clone, Debug, PartialEq, Eq, sqlx::FromRow)]
+pub struct ScipIndexerTiming {
+    pub project_id: String,
+    pub workspace_slug: String,
+    /// Stable indexer key (e.g. `rust`, `typescript`) — matches
+    /// `SupportedIndexer::language()` on the graph side.
+    pub indexer: String,
+    pub last_status: String,
+    pub last_elapsed_ms: i64,
+    /// Elapsed of the last SUCCESSFUL run, if any.
+    pub success_elapsed_ms: Option<i64>,
+    /// High-water elapsed of TIMED-OUT runs since the last success, if any.
+    pub timed_out_elapsed_ms: Option<i64>,
+    pub observed_at: String,
+}
+
+/// A single observation to persist. `elapsed_ms` is the wall-clock duration of
+/// the invocation; `status` must be one of the `TIMING_STATUS_*` constants.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScipIndexerTimingObservation<'a> {
+    pub project_id: &'a str,
+    pub workspace_slug: &'a str,
+    pub indexer: &'a str,
+    pub status: &'a str,
+    pub elapsed_ms: i64,
+}
+
+pub struct ScipIndexerTimingRepository {
+    db: Database,
+}
+
+impl ScipIndexerTimingRepository {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Record (upsert) a single invocation's timing.
+    ///
+    /// The rolling evidence columns follow these rules so the budget only ever
+    /// relaxes and repeated timeouts grow headroom:
+    ///   * on `success`  — refresh `success_elapsed_ms`; clear
+    ///     `timed_out_elapsed_ms` (the current cap sufficed).
+    ///   * on `timed_out` — raise `timed_out_elapsed_ms` to the high-water of
+    ///     itself and the new elapsed; leave `success_elapsed_ms` untouched.
+    ///   * on `failed`   — record the latest status/elapsed only; a hard
+    ///     indexer error is not evidence about the timeout size either way.
+    pub async fn record(&self, obs: ScipIndexerTimingObservation<'_>) -> Result<()> {
+        self.db.ensure_initialized().await?;
+        self.record_initialized(obs).await
+    }
+
+    /// Record many observations. Each is upserted independently; a single bad
+    /// row does not roll back the rest (best-effort telemetry).
+    pub async fn record_many(&self, rows: &[ScipIndexerTimingObservation<'_>]) -> Result<()> {
+        self.db.ensure_initialized().await?;
+        for row in rows {
+            self.record_initialized(row.clone()).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn get(
+        &self,
+        project_id: &str,
+        workspace_slug: &str,
+        indexer: &str,
+    ) -> Result<Option<ScipIndexerTiming>> {
+        self.db.ensure_initialized().await?;
+        Ok(sqlx::query_as::<_, ScipIndexerTiming>(
+            r#"SELECT project_id, workspace_slug, indexer, last_status, last_elapsed_ms,
+                      success_elapsed_ms, timed_out_elapsed_ms, observed_at
+                 FROM scip_indexer_timing
+                WHERE project_id = $1 AND workspace_slug = $2 AND indexer = $3"#,
+        )
+        .bind(project_id)
+        .bind(workspace_slug)
+        .bind(indexer)
+        .fetch_optional(self.db.pool())
+        .await?)
+    }
+
+    pub async fn list_for_project(&self, project_id: &str) -> Result<Vec<ScipIndexerTiming>> {
+        self.db.ensure_initialized().await?;
+        Ok(sqlx::query_as::<_, ScipIndexerTiming>(
+            r#"SELECT project_id, workspace_slug, indexer, last_status, last_elapsed_ms,
+                      success_elapsed_ms, timed_out_elapsed_ms, observed_at
+                 FROM scip_indexer_timing
+                WHERE project_id = $1
+                ORDER BY workspace_slug ASC, indexer ASC"#,
+        )
+        .bind(project_id)
+        .fetch_all(self.db.pool())
+        .await?)
+    }
+
+    async fn record_initialized(&self, obs: ScipIndexerTimingObservation<'_>) -> Result<()> {
+        // `$4` = status, `$5` = elapsed_ms. The CASE expressions in both the
+        // INSERT and the ON CONFLICT UPDATE derive the rolling evidence columns
+        // so timed-out headroom only grows and a success clears it.
+        sqlx::query(
+            r#"INSERT INTO scip_indexer_timing
+                   (project_id, workspace_slug, indexer, last_status, last_elapsed_ms,
+                    success_elapsed_ms, timed_out_elapsed_ms, observed_at)
+               VALUES
+                   ($1, $2, $3, $4, $5,
+                    CASE WHEN $4 = 'success'   THEN $5 ELSE NULL END,
+                    CASE WHEN $4 = 'timed_out' THEN $5 ELSE NULL END,
+                    to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'))
+               ON CONFLICT (project_id, workspace_slug, indexer) DO UPDATE SET
+                   last_status = $4,
+                   last_elapsed_ms = $5,
+                   observed_at = to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+                   success_elapsed_ms = CASE
+                       WHEN $4 = 'success' THEN $5
+                       ELSE scip_indexer_timing.success_elapsed_ms
+                   END,
+                   timed_out_elapsed_ms = CASE
+                       WHEN $4 = 'success'   THEN NULL
+                       WHEN $4 = 'timed_out' THEN GREATEST(
+                           COALESCE(scip_indexer_timing.timed_out_elapsed_ms, 0), $5)
+                       ELSE scip_indexer_timing.timed_out_elapsed_ms
+                   END"#,
+        )
+        .bind(obs.project_id)
+        .bind(obs.workspace_slug)
+        .bind(obs.indexer)
+        .bind(obs.status)
+        .bind(obs.elapsed_ms)
+        .execute(self.db.pool())
+        .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn fresh() -> ScipIndexerTimingRepository {
+        let db = Database::open_in_memory().expect("in-memory db");
+        ScipIndexerTimingRepository::new(db)
+    }
+
+    async fn seed_project(repo: &ScipIndexerTimingRepository, project_id: &str) {
+        repo.db.ensure_initialized().await.expect("init db");
+        sqlx::query(
+            "INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1, $2, $3, $4)",
+        )
+        .bind(project_id)
+        .bind(project_id)
+        .bind("test")
+        .bind(format!("repo-{project_id}"))
+        .execute(repo.db.pool())
+        .await
+        .expect("seed project");
+    }
+
+    fn obs<'a>(
+        project_id: &'a str,
+        workspace_slug: &'a str,
+        indexer: &'a str,
+        status: &'a str,
+        elapsed_ms: i64,
+    ) -> ScipIndexerTimingObservation<'a> {
+        ScipIndexerTimingObservation {
+            project_id,
+            workspace_slug,
+            indexer,
+            status,
+            elapsed_ms,
+        }
+    }
+
+    #[tokio::test]
+    async fn success_records_success_elapsed_and_no_timeout_evidence() {
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        repo.record(obs("p1", "server", "rust", TIMING_STATUS_SUCCESS, 900_000))
+            .await
+            .expect("record");
+
+        let row = repo
+            .get("p1", "server", "rust")
+            .await
+            .expect("get")
+            .expect("hit");
+        assert_eq!(row.last_status, "success");
+        assert_eq!(row.last_elapsed_ms, 900_000);
+        assert_eq!(row.success_elapsed_ms, Some(900_000));
+        assert_eq!(row.timed_out_elapsed_ms, None);
+        assert!(!row.observed_at.is_empty());
+    }
+
+    #[tokio::test]
+    async fn timed_out_grows_high_water_evidence() {
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        // First timeout at the 1200s cap.
+        repo.record(obs(
+            "p1",
+            "server",
+            "rust",
+            TIMING_STATUS_TIMED_OUT,
+            1_200_000,
+        ))
+        .await
+        .expect("record 1");
+        // A later timeout at a larger cap raises the high-water.
+        repo.record(obs(
+            "p1",
+            "server",
+            "rust",
+            TIMING_STATUS_TIMED_OUT,
+            1_800_000,
+        ))
+        .await
+        .expect("record 2");
+        // A smaller timeout must NOT lower the high-water.
+        repo.record(obs(
+            "p1",
+            "server",
+            "rust",
+            TIMING_STATUS_TIMED_OUT,
+            1_500_000,
+        ))
+        .await
+        .expect("record 3");
+
+        let row = repo
+            .get("p1", "server", "rust")
+            .await
+            .expect("get")
+            .expect("hit");
+        assert_eq!(row.last_status, "timed_out");
+        assert_eq!(row.last_elapsed_ms, 1_500_000);
+        assert_eq!(row.timed_out_elapsed_ms, Some(1_800_000));
+        assert_eq!(row.success_elapsed_ms, None);
+    }
+
+    #[tokio::test]
+    async fn success_after_timeouts_clears_timeout_evidence() {
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        repo.record(obs(
+            "p1",
+            "server",
+            "rust",
+            TIMING_STATUS_TIMED_OUT,
+            1_800_000,
+        ))
+        .await
+        .expect("record timeout");
+        repo.record(obs(
+            "p1",
+            "server",
+            "rust",
+            TIMING_STATUS_SUCCESS,
+            1_400_000,
+        ))
+        .await
+        .expect("record success");
+
+        let row = repo
+            .get("p1", "server", "rust")
+            .await
+            .expect("get")
+            .expect("hit");
+        assert_eq!(row.success_elapsed_ms, Some(1_400_000));
+        assert_eq!(
+            row.timed_out_elapsed_ms, None,
+            "a success proves the cap sufficed — timeout evidence must reset"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_preserves_prior_evidence() {
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        repo.record(obs("p1", "server", "rust", TIMING_STATUS_SUCCESS, 500_000))
+            .await
+            .expect("record success");
+        repo.record(obs("p1", "server", "rust", TIMING_STATUS_FAILED, 3_000))
+            .await
+            .expect("record failed");
+
+        let row = repo
+            .get("p1", "server", "rust")
+            .await
+            .expect("get")
+            .expect("hit");
+        assert_eq!(row.last_status, "failed");
+        assert_eq!(row.last_elapsed_ms, 3_000);
+        assert_eq!(
+            row.success_elapsed_ms,
+            Some(500_000),
+            "a hard failure is not evidence — prior success elapsed survives"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_many_and_list_for_project() {
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        repo.record_many(&[
+            obs("p1", "server", "rust", TIMING_STATUS_SUCCESS, 900_000),
+            obs("p1", "web", "typescript", TIMING_STATUS_SUCCESS, 60_000),
+        ])
+        .await
+        .expect("record many");
+
+        let rows = repo.list_for_project("p1").await.expect("list");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].workspace_slug, "server");
+        assert_eq!(rows[0].indexer, "rust");
+        assert_eq!(rows[1].workspace_slug, "web");
+        assert_eq!(rows[1].indexer, "typescript");
+    }
+
+    #[tokio::test]
+    async fn deleting_project_cascades_timing_rows() {
+        let repo = fresh().await;
+        seed_project(&repo, "p1").await;
+
+        repo.record(obs("p1", "server", "rust", TIMING_STATUS_SUCCESS, 900_000))
+            .await
+            .expect("record");
+
+        sqlx::query("DELETE FROM projects WHERE id = $1")
+            .bind("p1")
+            .execute(repo.db.pool())
+            .await
+            .expect("delete project");
+
+        let rows = repo.list_for_project("p1").await.expect("list");
+        assert!(rows.is_empty());
+    }
+}

--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -608,6 +608,11 @@ pub async fn ensure_canonical_graph<C: WarmContext>(
     let stack_filter = resolve_stack_indexer_filter(ctx, project_id).await;
     let declared_workspaces = resolve_declared_workspaces(ctx, project_id).await;
 
+    // Feed persisted per-(workspace, indexer) timings into the budget so heavy
+    // workspaces that timed out on a prior warm get an adapted (larger) cap
+    // this time instead of timing out identically and dropping from the graph.
+    let timing_priors = load_indexer_timing_priors(ctx, project_id).await;
+
     let clock = SystemClock::new();
     let t_indexers = clock.now_instant();
     let run = crate::scip_indexer::run_indexers_already_locked(
@@ -616,10 +621,14 @@ pub async fn ensure_canonical_graph<C: WarmContext>(
         Some(&target_dir),
         stack_filter.as_deref(),
         declared_workspaces.as_deref(),
+        Some(&timing_priors),
     )
     .await
     .map_err(|e| format!("run_indexers: {e}"))?;
     let indexers_ms = t_indexers.elapsed().as_millis() as u64;
+
+    // Record this run's elapsed timings for the next warm's adaptive budget.
+    persist_indexer_timings_best_effort(ctx, project_id, &run.timings).await;
 
     let output_dir_for_blocking = output_dir.clone();
     let artifacts = run.artifacts;
@@ -1103,6 +1112,82 @@ async fn ingest_coupling_best_effort<C: WarmContext>(
             project_id = %project_id,
             error = %e,
             "ensure_canonical_graph: coupling ingest failed"
+        );
+    }
+}
+
+/// Load persisted per-(workspace, indexer) timing evidence for this project
+/// into the budget's prior-timing map. Best-effort: a DB error yields an empty
+/// map, so the warm falls back to the static-cap budget (today's behaviour).
+async fn load_indexer_timing_priors<C: WarmContext>(
+    ctx: &C,
+    project_id: &str,
+) -> crate::scip_indexer::PriorTimingMap {
+    use djinn_db::ScipIndexerTimingRepository;
+
+    let mut map = crate::scip_indexer::PriorTimingMap::new();
+    let repo = ScipIndexerTimingRepository::new(ctx.db().clone());
+    match repo.list_for_project(project_id).await {
+        Ok(rows) => {
+            for row in rows {
+                // Ignore rows for retired / unknown indexer keys.
+                let Some(indexer) =
+                    crate::scip_indexer::SupportedIndexer::from_language_key(&row.indexer)
+                else {
+                    continue;
+                };
+                map.insert(
+                    (row.workspace_slug, indexer),
+                    crate::scip_indexer::IndexerPriorTiming {
+                        last_success_ms: row.success_elapsed_ms.and_then(|v| u64::try_from(v).ok()),
+                        last_timed_out_ms: row
+                            .timed_out_elapsed_ms
+                            .and_then(|v| u64::try_from(v).ok()),
+                    },
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                project_id = %project_id,
+                error = %e,
+                "ensure_canonical_graph: failed to load scip_indexer_timing priors; using static budget"
+            );
+        }
+    }
+    map
+}
+
+/// Persist this run's per-invocation timings so the NEXT warm can adapt its
+/// budget. Best-effort telemetry — a failure never fails the warm.
+async fn persist_indexer_timings_best_effort<C: WarmContext>(
+    ctx: &C,
+    project_id: &str,
+    timings: &[crate::scip_indexer::IndexerTimingObservation],
+) {
+    if timings.is_empty() {
+        return;
+    }
+    use djinn_db::{ScipIndexerTimingObservation, ScipIndexerTimingRepository};
+
+    let rows: Vec<ScipIndexerTimingObservation<'_>> = timings
+        .iter()
+        .map(|t| ScipIndexerTimingObservation {
+            project_id,
+            workspace_slug: &t.workspace_slug,
+            indexer: t.indexer.language(),
+            status: t.outcome.as_str(),
+            elapsed_ms: i64::try_from(t.elapsed_ms).unwrap_or(i64::MAX),
+        })
+        .collect();
+
+    let repo = ScipIndexerTimingRepository::new(ctx.db().clone());
+    if let Err(e) = repo.record_many(&rows).await {
+        tracing::warn!(
+            project_id = %project_id,
+            row_count = rows.len(),
+            error = %e,
+            "ensure_canonical_graph: failed to persist scip_indexer_timing observations"
         );
     }
 }
@@ -2604,6 +2689,7 @@ edition = "2024"
             None,
             None,
             Some(&declared),
+            None,
         )
         .await;
         // An empty tree with no indexers on PATH plans zero indexers
@@ -2727,6 +2813,7 @@ edition = "2024"
             None,
             None,
             Some(&declared),
+            None,
         )
         .await;
         assert!(

--- a/server/crates/djinn-graph/src/scip_indexer/budget.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/budget.rs
@@ -40,6 +40,22 @@ const SOURCE_BYTES_STEP_DURATION: Duration = Duration::from_secs(30);
 /// Minimum per-partition budget for partition-capable indexers.
 const MIN_PER_PARTITION: Duration = Duration::from_secs(10);
 
+/// Multiplier applied to a timed-out run's observed elapsed to derive the next
+/// invocation's headroom. A workspace killed at its cap gets ~1.5x the killed
+/// elapsed next time, so it grows toward "enough" instead of retrying at the
+/// identical too-small cap.
+const TIMEOUT_HEADROOM_NUMERATOR: u32 = 3;
+const TIMEOUT_HEADROOM_DENOMINATOR: u32 = 2;
+
+/// Absolute ceiling multiplier for the ADAPTIVE (prior-timing-driven) path,
+/// applied to the per-indexer static `max_cap`. Normal size-scaling and
+/// success/p95 prior scaling stay clamped by `max_cap`; only the timed-out
+/// headroom path is allowed to climb above `max_cap`, and never past
+/// `max_cap * ADAPTIVE_CEILING_MULTIPLIER`. For rust-analyzer (max_cap 1200s)
+/// this is a hard 3600s (1h) ceiling — comfortably enough for a heavy Rust
+/// workspace's first cold warm while still bounding a genuinely hung indexer.
+const ADAPTIVE_CEILING_MULTIPLIER: u32 = 3;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -88,6 +104,13 @@ pub(crate) struct PriorIndexerTiming {
     pub p50_ms: Option<u64>,
     pub p95_ms: Option<u64>,
     pub last_success_ms: Option<u64>,
+    /// High-water elapsed (ms) of the most recent TIMED-OUT run(s) since the
+    /// last success. Distinct from the p95/last-success fields because a
+    /// timeout is evidence the cap itself was too small: it feeds the
+    /// [`ADAPTIVE_CEILING_MULTIPLIER`] headroom path, which may raise the
+    /// budget *above* the static `max_cap` (unlike the success-derived hooks,
+    /// which stay clamped by `max_cap`).
+    pub last_timed_out_ms: Option<u64>,
 }
 
 /// A computed indexer budget with a human-readable reason.
@@ -135,6 +158,15 @@ fn max_cap(indexer: SupportedIndexer) -> Duration {
         | SupportedIndexer::Ruby
         | SupportedIndexer::DotNet => Duration::from_secs(300),
     }
+}
+
+/// Absolute ceiling for the adaptive (timed-out headroom) path.
+///
+/// `max_cap(indexer) * ADAPTIVE_CEILING_MULTIPLIER`. The static size-scaling
+/// and success-prior paths never exceed `max_cap`; only repeated-timeout
+/// headroom growth may climb here, and never past this value.
+fn adaptive_ceiling(indexer: SupportedIndexer) -> Duration {
+    max_cap(indexer).saturating_mul(ADAPTIVE_CEILING_MULTIPLIER)
 }
 
 /// File extensions that count as "source" for each indexer's size estimation
@@ -244,6 +276,22 @@ fn prior_based_budget(prior: &PriorIndexerTiming, cap: Duration) -> Duration {
     prior_max.min(cap)
 }
 
+/// Headroom budget derived from a timed-out run's observed elapsed, clamped by
+/// the adaptive ceiling. Returns `Duration::ZERO` when there is no timeout
+/// evidence. Unlike [`prior_based_budget`], this may exceed the static
+/// `max_cap` (up to [`adaptive_ceiling`]) — a timeout means the cap itself was
+/// too small, so identical retries are pointless.
+fn timeout_headroom_budget(prior: &PriorIndexerTiming, ceiling: Duration) -> Duration {
+    match prior.last_timed_out_ms {
+        Some(ms) if ms > 0 => {
+            Duration::from_millis(ms).saturating_mul(TIMEOUT_HEADROOM_NUMERATOR)
+                / TIMEOUT_HEADROOM_DENOMINATOR
+        }
+        _ => Duration::ZERO,
+    }
+    .min(ceiling)
+}
+
 /// Formula-based budget (baseline + size scaling), capped by the indexer max.
 fn scaled_budget(indexer: SupportedIndexer, size: &WorkspaceSizeHint) -> (Duration, usize, u64) {
     let base = baseline(indexer);
@@ -285,10 +333,25 @@ fn budget_for_indexer_at(
 
     // Step 3: prior-timing scaling.
     if let Some(prior) = prior {
+        // 3a: success/p95 prior scaling — raises within the static `max_cap`.
         let prior_budget = prior_based_budget(prior, cap);
         if prior_budget > total {
             total = prior_budget;
             reason_parts.push(format!("prior timing raised to {:?}", prior_budget));
+        }
+
+        // 3b: timed-out headroom — a run killed at its cap is evidence the cap
+        // was too small, so grow toward "enough" (≈1.5x the killed elapsed)
+        // rather than retrying identically. This is the ONLY path allowed to
+        // climb above `max_cap`, bounded by the adaptive ceiling.
+        let ceiling = adaptive_ceiling(indexer);
+        let headroom = timeout_headroom_budget(prior, ceiling);
+        if headroom > total {
+            total = headroom;
+            reason_parts.push(format!(
+                "timed-out headroom raised to {:?} (ceiling {:?})",
+                headroom, ceiling
+            ));
         }
     }
 
@@ -541,6 +604,147 @@ mod tests {
         let budget = budget_for_indexer(SupportedIndexer::RustAnalyzer, &size, Some(&prior), None);
         assert_eq!(budget.total, Duration::from_secs(420));
         assert!(!budget.reason.contains("prior timing raised"));
+    }
+
+    // --- Timed-out headroom (adaptive ceiling) ----------------------------
+
+    #[test]
+    fn timed_out_headroom_raises_above_static_max_cap() {
+        // The whole point: rust-analyzer keeps timing out at its 1200s cap.
+        // Next warm should get ~1.5x the killed elapsed (1800s), ABOVE the
+        // static 1200s max_cap, so it stops retrying at a too-small cap.
+        let size = WorkspaceSizeHint::default();
+        let prior = PriorIndexerTiming {
+            last_timed_out_ms: Some(1_200_000),
+            ..Default::default()
+        };
+        let budget = budget_for_indexer(SupportedIndexer::RustAnalyzer, &size, Some(&prior), None);
+        assert_eq!(budget.total, Duration::from_secs(1800));
+        assert_eq!(budget.per_invocation, Duration::from_secs(1800));
+        assert!(budget.total > max_cap(SupportedIndexer::RustAnalyzer));
+        assert!(budget.reason.contains("timed-out headroom raised"));
+    }
+
+    #[test]
+    fn timed_out_headroom_bounded_by_adaptive_ceiling() {
+        // Even a huge timed-out elapsed can't exceed max_cap * 3 (Rust 3600s).
+        let size = WorkspaceSizeHint::default();
+        let prior = PriorIndexerTiming {
+            last_timed_out_ms: Some(10_000_000), // 1.5x = 15000s, way over ceiling
+            ..Default::default()
+        };
+        let budget = budget_for_indexer(SupportedIndexer::RustAnalyzer, &size, Some(&prior), None);
+        assert_eq!(budget.total, Duration::from_secs(3600));
+        assert_eq!(
+            budget.total,
+            adaptive_ceiling(SupportedIndexer::RustAnalyzer)
+        );
+    }
+
+    #[test]
+    fn adaptive_ceiling_is_three_times_max_cap() {
+        for indexer in SupportedIndexer::ALL {
+            assert_eq!(
+                adaptive_ceiling(indexer),
+                max_cap(indexer) * 3,
+                "{indexer:?}: adaptive ceiling must be 3x static max_cap"
+            );
+        }
+    }
+
+    #[test]
+    fn timed_out_headroom_grows_across_successive_timeouts() {
+        // Model the intended escalation: 1200s cap -> killed -> 1800s cap ->
+        // killed -> 2700s cap -> killed -> 3600s (ceiling) and then flat.
+        let size = WorkspaceSizeHint::default();
+        let step = |timed_out_ms: u64| {
+            let prior = PriorIndexerTiming {
+                last_timed_out_ms: Some(timed_out_ms),
+                ..Default::default()
+            };
+            budget_for_indexer(SupportedIndexer::RustAnalyzer, &size, Some(&prior), None).total
+        };
+        assert_eq!(step(1_200_000), Duration::from_secs(1800));
+        assert_eq!(step(1_800_000), Duration::from_secs(2700));
+        assert_eq!(step(2_700_000), Duration::from_secs(3600)); // hits ceiling
+        assert_eq!(step(3_600_000), Duration::from_secs(3600)); // stays at ceiling
+    }
+
+    #[test]
+    fn timed_out_headroom_never_lowers_formula_budget() {
+        // A tiny timed-out elapsed must not shrink a larger size-scaled budget.
+        let size = WorkspaceSizeHint {
+            source_file_count: 1000, // 4 steps → 300 + 120 = 420s for Rust
+            source_bytes: 0,
+            partition_count: 1,
+        };
+        let prior = PriorIndexerTiming {
+            last_timed_out_ms: Some(60_000), // 1.5x = 90s < 420s
+            ..Default::default()
+        };
+        let budget = budget_for_indexer(SupportedIndexer::RustAnalyzer, &size, Some(&prior), None);
+        assert_eq!(budget.total, Duration::from_secs(420));
+        assert!(!budget.reason.contains("timed-out headroom raised"));
+    }
+
+    #[test]
+    fn timed_out_headroom_wins_over_success_prior_when_larger() {
+        // Both signals present: success p95 caps at max_cap (1200s) while the
+        // timeout headroom climbs above it. The larger (headroom) wins.
+        let size = WorkspaceSizeHint::default();
+        let prior = PriorIndexerTiming {
+            p95_ms: Some(700_000),              // 2x = 1400 → capped to 1200s
+            last_success_ms: Some(500_000),     // 2x = 1000s
+            last_timed_out_ms: Some(1_400_000), // 1.5x = 2100s
+            ..Default::default()
+        };
+        let budget = budget_for_indexer(SupportedIndexer::RustAnalyzer, &size, Some(&prior), None);
+        assert_eq!(budget.total, Duration::from_secs(2100));
+        assert!(budget.reason.contains("prior timing raised"));
+        assert!(budget.reason.contains("timed-out headroom raised"));
+    }
+
+    #[test]
+    fn timed_out_headroom_still_clamped_by_active_deadline() {
+        // The adaptive headroom raises the budget, but an active deadline still
+        // clamps it — the pod's activeDeadline is the hard ceiling.
+        let (deadline, now) = fresh_deadline(1060, 60); // remaining = 1000s
+        let size = WorkspaceSizeHint::default();
+        let prior = PriorIndexerTiming {
+            last_timed_out_ms: Some(1_200_000), // 1.5x = 1800s
+            ..Default::default()
+        };
+        let budget = budget_for_indexer_at(
+            SupportedIndexer::RustAnalyzer,
+            &size,
+            Some(&prior),
+            Some(&deadline),
+            now,
+        );
+        assert_eq!(budget.total, Duration::from_secs(1000));
+        assert!(budget.reason.contains("timed-out headroom raised"));
+        assert!(budget.reason.contains("clamped"));
+    }
+
+    #[test]
+    fn no_timeout_evidence_is_byte_identical_to_no_prior() {
+        // A prior with only the (default) None timeout field must produce the
+        // same budget as passing no prior at all — no-history behaviour is
+        // preserved exactly.
+        let size = WorkspaceSizeHint {
+            source_file_count: 500,
+            source_bytes: 10 * 1024 * 1024,
+            partition_count: 1,
+        };
+        let empty_prior = PriorIndexerTiming::default();
+        for indexer in SupportedIndexer::ALL {
+            let with_none = budget_for_indexer(indexer, &size, None, None);
+            let with_empty = budget_for_indexer(indexer, &size, Some(&empty_prior), None);
+            assert_eq!(
+                with_none, with_empty,
+                "{indexer:?}: empty prior must equal no prior"
+            );
+        }
     }
 
     // --- Active-deadline clamp --------------------------------------------

--- a/server/crates/djinn-graph/src/scip_indexer/indexing.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/indexing.rs
@@ -255,6 +255,7 @@ pub(crate) async fn run_indexers_already_locked(
     target_dir: Option<&Path>,
     language_filter: Option<&[SupportedIndexer]>,
     declared_workspaces: Option<&[djinn_stack::Workspace]>,
+    priors: Option<&super::PriorTimingMap>,
 ) -> Result<IndexingRun> {
     let _guard = target_dir.map(CargoTargetDirGuard::new);
     run_indexers(
@@ -262,28 +263,65 @@ pub(crate) async fn run_indexers_already_locked(
         output_root,
         language_filter,
         declared_workspaces,
+        priors,
     )
     .await
 }
 
 /// Compute the wall-clock timeout for a planned indexer command.
 ///
-/// In the default production path (no active deadline, no prior timing), the
-/// budget model yields the indexer baseline which is combined with the legacy
-/// `SupportedIndexer::timeout()` cap via `max()`. This guarantees the shipped
-/// fixed-cap behavior is preserved exactly — the budget model only *raises*
-/// timeouts when workspace size / prior timing warrant it, and only *lowers*
-/// them when an active deadline is supplied (which the current flow does not
-/// do yet; the deadline/prior inputs are hooks for later integration tasks).
-fn budgeted_timeout_for_plan(plan: &PlannedIndexerCommand) -> std::time::Duration {
+/// When no prior timing exists (a project's first-ever warm), the budget model
+/// yields the size-scaled baseline, combined with the legacy
+/// `SupportedIndexer::timeout()` cap via `max()` — byte-identical to the
+/// shipped fixed-cap behavior. When prior timings ARE supplied (fed from
+/// persisted `scip_indexer_timing` rows), the budget adapts: a slow-but-passing
+/// run raises the timeout within `max_cap`, and a run that keeps TIMING OUT
+/// grows headroom above `max_cap` up to the adaptive ceiling (`max_cap * 3`),
+/// so a heavy workspace stops silently dropping out of the graph on every warm.
+/// The `max(..., timeout())` floor guarantees the adaptive value never dips
+/// below today's static cap.
+fn budgeted_timeout_for_plan(
+    plan: &PlannedIndexerCommand,
+    prior: Option<&super::IndexerPriorTiming>,
+) -> std::time::Duration {
     let size = super::budget::estimate_workspace_size(&plan.working_directory, plan.indexer);
-    let budget = super::budget::budget_for_indexer(plan.indexer, &size, None, None);
+    let prior_timing = prior.map(|p| super::budget::PriorIndexerTiming {
+        last_success_ms: p.last_success_ms,
+        last_timed_out_ms: p.last_timed_out_ms,
+        ..Default::default()
+    });
+    let budget =
+        super::budget::budget_for_indexer(plan.indexer, &size, prior_timing.as_ref(), None);
 
-    // Preserve the legacy fixed cap: `max(budget.per_invocation, timeout())`.
-    // This ensures equivalent behavior when no deadline/prior timing exists:
-    // the budget model may raise the timeout above the fixed cap (for large
-    // workspaces) but never lowers it below the shipped cap.
+    // Preserve the legacy fixed cap as a floor: `max(budget, timeout())`. The
+    // budget model may raise the timeout above the fixed cap (large workspaces
+    // or timeout headroom) but never lowers it below the shipped cap.
     budget.per_invocation.max(plan.indexer.timeout())
+}
+
+/// Classify a completed plan execution into the outcome recorded for the
+/// adaptive budget. Cache hits and deadline-skipped plans never invoked the
+/// indexer, so they yield no observation (`None`).
+fn timing_outcome_for(execution: &PlanExecution) -> Option<super::IndexerRunOutcome> {
+    use super::IndexerRunOutcome;
+    match execution {
+        PlanExecution::CachedHit | PlanExecution::DeadlineExhausted(_) => None,
+        PlanExecution::Ran(Ok(output)) if output.status.success() => {
+            Some(IndexerRunOutcome::Success)
+        }
+        PlanExecution::Ran(Ok(_)) => Some(IndexerRunOutcome::Failed),
+        PlanExecution::Ran(Err(err)) if err.kind() == std::io::ErrorKind::TimedOut => {
+            Some(IndexerRunOutcome::TimedOut)
+        }
+        PlanExecution::Ran(Err(_)) => Some(IndexerRunOutcome::Failed),
+        PlanExecution::Partitioned(summary) => match summary.status.as_str() {
+            "timed_out" => Some(IndexerRunOutcome::TimedOut),
+            "failed" => Some(IndexerRunOutcome::Failed),
+            // "artifact_pending" / "ready" / "ready_with_quarantine": at least
+            // one partition produced an index → treat as a successful run.
+            _ => Some(IndexerRunOutcome::Success),
+        },
+    }
 }
 
 /// Result of running a single planned indexer command (with optional cache
@@ -389,9 +427,10 @@ impl GoPackageLister for CommandGoPackageLister {
 async fn execute_plan_with_cache(
     plan: PlannedIndexerCommand,
     timeout: std::time::Duration,
+    prior: Option<&super::IndexerPriorTiming>,
 ) -> PlanExecution {
     if matches!(plan.indexer, SupportedIndexer::Go | SupportedIndexer::Clang) {
-        return execute_partitioned_plan(plan).await;
+        return execute_partitioned_plan(plan, prior).await;
     }
     // Attempt cache lookup. Any error is a non-fatal miss — we fall through
     // to running the indexer.
@@ -452,11 +491,14 @@ async fn execute_plan_with_cache(
     PlanExecution::Ran(result)
 }
 
-async fn execute_partitioned_plan(plan: PlannedIndexerCommand) -> PlanExecution {
+async fn execute_partitioned_plan(
+    plan: PlannedIndexerCommand,
+    prior: Option<&super::IndexerPriorTiming>,
+) -> PlanExecution {
     let units = match partition_units_for_plan(&plan, &CommandGoPackageLister) {
         Ok(units) if !units.is_empty() => units,
         Ok(_) | Err(_) => {
-            let timeout = budgeted_timeout_for_plan(&plan);
+            let timeout = budgeted_timeout_for_plan(&plan, prior);
             return execute_workspace_plan_with_cache(plan, timeout).await;
         }
     };
@@ -1006,6 +1048,7 @@ pub(crate) async fn run_indexers(
     output_root: impl AsRef<Path>,
     language_filter: Option<&[SupportedIndexer]>,
     declared_workspaces: Option<&[djinn_stack::Workspace]>,
+    priors: Option<&super::PriorTimingMap>,
 ) -> Result<IndexingRun> {
     let project_root = project_root.as_ref().to_path_buf();
     let output_root = output_root.as_ref().to_path_buf();
@@ -1045,22 +1088,44 @@ pub(crate) async fn run_indexers(
     let futures: Vec<_> = plans
         .into_iter()
         .map(|plan| {
-            // Compute a scaled budget for this workspace/indexer. When no
-            // active deadline or prior timing is available (the current
-            // production path), the budget is combined with the legacy
-            // `SupportedIndexer::timeout()` cap so runtime behavior stays
-            // equivalent — the budget model never shortens a timeout below
-            // the shipped fixed cap in the default case.
-            let timeout = budgeted_timeout_for_plan(&plan);
+            // Size the timeout from persisted prior timings for this
+            // (workspace, indexer). With no history the budget resolves to the
+            // size-scaled baseline floored by the legacy `timeout()` cap —
+            // byte-identical to the shipped behaviour. With history it adapts:
+            // slow-but-passing runs raise within `max_cap`; repeated timeouts
+            // grow headroom above it (up to the adaptive ceiling).
+            let prior = priors.and_then(|m| m.get(&(plan.workspace_slug.clone(), plan.indexer)));
+            let timeout = budgeted_timeout_for_plan(&plan, prior);
+            let prior = prior.copied();
             let plan_for_future = plan.clone();
             async move {
-                let outcome = execute_plan_with_cache(plan_for_future, timeout).await;
-                (plan, outcome)
+                use djinn_core::clock::{Clock, SystemClock};
+                let started = SystemClock::new().now_instant();
+                let outcome =
+                    execute_plan_with_cache(plan_for_future, timeout, prior.as_ref()).await;
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                (plan, outcome, elapsed_ms)
             }
         })
         .collect();
 
-    let results = futures::future::join_all(futures).await;
+    let raw_results = futures::future::join_all(futures).await;
+
+    // Split the timing observations off before tally consumes the executions.
+    // Only actual invocations (not cache hits / deadline skips) yield a row.
+    let mut timings: Vec<super::IndexerTimingObservation> = Vec::with_capacity(raw_results.len());
+    let mut results = Vec::with_capacity(raw_results.len());
+    for (plan, outcome, elapsed_ms) in raw_results {
+        if let Some(run_outcome) = timing_outcome_for(&outcome) {
+            timings.push(super::IndexerTimingObservation {
+                workspace_slug: plan.workspace_slug.clone(),
+                indexer: plan.indexer,
+                outcome: run_outcome,
+                elapsed_ms,
+            });
+        }
+        results.push((plan, outcome));
+    }
 
     let mut tally = tally_indexer_results(results)?;
 
@@ -1081,6 +1146,7 @@ pub(crate) async fn run_indexers(
         commands: tally.commands,
         artifacts,
         workspace_statuses: tally.workspace_statuses,
+        timings,
     })
 }
 
@@ -1900,7 +1966,7 @@ mod tests {
         let output_root = tmp.path().join("scip-out");
 
         let result =
-            run_indexers_already_locked(&project_root, &output_root, None, None, None).await;
+            run_indexers_already_locked(&project_root, &output_root, None, None, None, None).await;
         assert!(result.is_ok(), "expected Ok, got {result:?}");
         assert!(std::env::var_os("CARGO_TARGET_DIR").is_none());
     }

--- a/server/crates/djinn-graph/src/scip_indexer/mod.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/mod.rs
@@ -96,6 +96,16 @@ impl SupportedIndexer {
         }
     }
 
+    /// Parse the stable per-language storage key produced by [`Self::language`]
+    /// back into a [`SupportedIndexer`]. Used to reload persisted timing rows
+    /// (`scip_indexer_timing.indexer`) into the budget's prior-timing map.
+    /// Returns `None` for unknown / retired keys so stale rows are ignored.
+    pub fn from_language_key(key: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|indexer| indexer.language() == key)
+    }
+
     /// Wall-clock cap for a single invocation of this indexer.
     ///
     /// `rust-analyzer scip` drives a full `cargo metadata` + analysis pass.
@@ -303,6 +313,54 @@ pub struct WorkspaceWarmStatus {
     pub detail: Option<String>,
 }
 
+/// Outcome class of a single indexer invocation, as recorded for the adaptive
+/// timeout budget. Only actual invocations produce one — cache hits and
+/// deadline-skipped plans never ran, so they yield no observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexerRunOutcome {
+    Success,
+    Failed,
+    TimedOut,
+}
+
+impl IndexerRunOutcome {
+    /// Stable string key persisted in `scip_indexer_timing.last_status`; must
+    /// match the `djinn_db::TIMING_STATUS_*` constants.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::TimedOut => "timed_out",
+        }
+    }
+}
+
+/// One indexer invocation's timing, surfaced on [`IndexingRun`] so the warm
+/// caller can persist it (keyed by workspace slug + indexer) for the next
+/// warm's adaptive budget.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexerTimingObservation {
+    pub workspace_slug: String,
+    pub indexer: SupportedIndexer,
+    pub outcome: IndexerRunOutcome,
+    pub elapsed_ms: u64,
+}
+
+/// Prior-timing evidence for one (workspace, indexer) key, loaded from
+/// persisted [`IndexerTimingObservation`]s and fed back into the budget model.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IndexerPriorTiming {
+    /// Elapsed (ms) of the last successful run.
+    pub last_success_ms: Option<u64>,
+    /// High-water elapsed (ms) of timed-out runs since the last success.
+    pub last_timed_out_ms: Option<u64>,
+}
+
+/// Map of prior timings keyed by `(workspace_slug, indexer)`, passed into the
+/// warm run so each plan can size its timeout from history.
+pub type PriorTimingMap = std::collections::HashMap<(String, SupportedIndexer), IndexerPriorTiming>;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexingRun {
     pub project_root: PathBuf,
@@ -310,4 +368,8 @@ pub struct IndexingRun {
     pub commands: Vec<ExecutedIndexerCommand>,
     pub artifacts: Vec<ScipArtifact>,
     pub workspace_statuses: Vec<WorkspaceWarmStatus>,
+    /// Per-invocation timings from THIS run, for persistence into the adaptive
+    /// budget history. Empty when no indexer actually executed (all cache hits
+    /// / deadline-skipped / no indexers on PATH).
+    pub timings: Vec<IndexerTimingObservation>,
 }


### PR DESCRIPTION
## Motivation

djinn warms a per-project code graph by running SCIP indexers per workspace inside a K8s warm-Job Pod. The Rust `server` workspace repeatedly times out at its per-invocation cap and silently drops out of the graph. The cap history — 120 → 600 → 1200s, hand-bumped each time it bit — shows a **static** cap never fits every workspace: too low starves a heavy workspace's cold warm, too high lets a genuinely hung indexer pin the Job.

`budget.rs` already had prior-timing hooks (`PriorIndexerTiming` p95 / last-success) but they were **wired but never fed** by the production path — every run used the static default. This PR feeds them from real, persisted timings and adds a repeated-timeout headroom path.

## Design

**Storage** — new `scip_indexer_timing` table (migration `106`), keyed by `(project_id, workspace_slug, indexer)`. One row per key (not an append log), carrying the latest observation plus rolling evidence:
- `success_elapsed_ms` — elapsed of the last successful run (feeds the existing prior hook).
- `timed_out_elapsed_ms` — high-water of timed-out elapsed **since the last success**; reset to NULL on the next success (a success proves the current cap sufficed).
- `failed` outcomes record latest status only — a hard indexer error is not evidence about timeout size.

Uses runtime `sqlx::query`/`query_as` like the neighbouring `project_workspace_graph` repo, so **no `.sqlx` offline metadata** is required (CI's `SQLX_OFFLINE` is unaffected).

**Flow** — `ensure_canonical_graph` now:
1. loads persisted priors into a `PriorTimingMap` before the warm (best-effort; DB error → empty map → today's static budget),
2. passes them through `run_indexers_already_locked` → `budget_for_indexer`, where each plan sizes its own timeout from history,
3. times every actual invocation (cache hits / deadline-skips produce no row) and persists the outcomes for the next warm (best-effort).

**Adaptation rule** (in `budget.rs`, follows the existing hook semantics):
- success/p95 priors raise the budget within the static `max_cap` — unchanged existing behaviour, existing tests intact.
- a **timed-out** run grows the next budget to ≈`1.5 × killed_elapsed`. This is the **only** path allowed to climb above `max_cap`, so a workspace that keeps timing out escalates (1200s → 1800s → 2700s → ceiling) instead of retrying identically.
- The legacy `SupportedIndexer::timeout()` floor (`max(budget, timeout())`) guarantees the adaptive value **never dips below today's static cap** — behaviour only ever relaxes.

**Ceiling** — the adaptive path is bounded by an absolute ceiling of **`max_cap × 3`** per indexer: **rust-analyzer 1200s → 3600s (1h)**, TypeScript 900s → 2700s, Java 600s → 1800s, others 300s → 900s. 1h is comfortably enough for a heavy Rust workspace's first cold warm while still bounding a genuinely hung indexer, and stays a hard stop regardless of how large a timed-out elapsed grows. An active warm-Job deadline (when supplied) still clamps on top of this.

**No-history behaviour is byte-identical to today** — asserted by a unit test that compares "no prior" vs "empty prior" across all indexers.

## Tests

- `budget.rs`: adaptive-path unit tests — headroom raises above `max_cap`, bounded by the ceiling, grows across successive timeouts then flattens, never lowers a larger formula budget, wins over success-prior when larger, still clamped by an active deadline, and the no-history equivalence check. Existing budget tests unchanged and passing (34 total).
- `scip_indexer_timing.rs`: repository tests — success records + clears timeout evidence, timeouts grow the high-water (and never lower it), success after timeouts resets evidence, failed preserves prior evidence, `record_many` + `list_for_project`, and FK cascade on project delete (6 total, all passing against Postgres :5433).
- `cargo fmt --check`, `cargo clippy --all-features --all-targets` clean on both touched crates; `cargo check --workspace` green.

### Note on parallel-agent boundaries
Additive only: new columns/table + new repo, new `IndexingRun.timings` field, new optional `priors` param threaded through the indexer entrypoints. Did not reshape `project_workspace_graph::upsert_many` or the CARGO_TARGET_DIR region (sibling-owned). A pre-existing flaky parity test (`canonical_graph::tests::out_of_core_*`, global env-var mutation + real rust-analyzer on PATH) flakes on `main` too in this environment — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)