### PR TITLE
ci: fail fast — cancel the run on first job failure; harden poller for cancelled-job fallout

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -252,6 +252,15 @@ jobs:
           echo "::error::cargo-deny check failed after 3 attempts"
           exit 1
 
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  Server Lint (PR + merge queue)                                  ║
   # ║                                                                  ║
@@ -303,6 +312,15 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --all-targets --features qdrant -- -D warnings
+
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
 
   # Cross-check the Linux sandbox layer for aarch64. Everything else in CI
   # compiles x86_64-only, which let an aarch64-breaking seccomp deny list
@@ -369,6 +387,15 @@ jobs:
       - name: cargo check (aarch64)
         run: cargo check -p djinn-sandbox --all-targets --target aarch64-unknown-linux-gnu
 
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # Pure-shell PR-time guard for Rust source file size; independent from clippy.
   # Runs in changed-file mode (--files-from-stdin) so the job enforces the
   # "new or edited Rust file" regression guard and does not fail on the
@@ -422,6 +449,15 @@ jobs:
           git diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" \
             | ./scripts/check-file-size.sh --files-from-stdin
 
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # Pure-shell PR-time guard: already-applied sqlx migrations are immutable.
   # Editing/renaming/deleting a migration that exists on the base branch breaks
   # the `migrate` init container on every EXISTING database (sqlx checksum
@@ -451,6 +487,15 @@ jobs:
                || '' }}
         run: ./scripts/check-migrations-immutable.sh
 
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # Pure-shell PR-time guard: raw sqlx query usage is confined to djinn-db.
   # Enforces the boundary that all direct sqlx::query / sqlx::query! calls
   # must live inside `server/crates/djinn-db/` and not leak into other crates.
@@ -479,6 +524,15 @@ jobs:
                || github.event.merge_group.base_sha
                || '' }}
         run: ./scripts/check-raw-sql-boundary.sh
+
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
 
   # Pure-shell PR-time guard for the git, HTTP, and Kubernetes capability
   # boundaries.  All direct git usage (git2::, Command::new("git")), outbound
@@ -517,6 +571,15 @@ jobs:
           ./scripts/check-http-boundary.sh
           ./scripts/check-k8s-boundary.sh
 
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # Pure-script PR-time guard: architectural layering boundaries.
   # Enforces the forbidden-edge rules in `server/boundary_rules.toml`
   # against the workspace's declared crate dependencies + a source scan
@@ -534,6 +597,15 @@ jobs:
 
       - name: Check architectural boundaries
         run: python3 scripts/check_boundaries.py
+
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
 
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  Server Tests (merge queue only)                                 ║
@@ -744,6 +816,15 @@ jobs:
         working-directory: .
         run: make sqlx-verify
 
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  Memory-eval Phase 1 PR gate (PR + merge queue)                  ║
   # ║                                                                  ║
@@ -875,6 +956,16 @@ jobs:
             cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # Fail fast — see the note above the Quality Gate job. Placed after the
+      # always() artifact/summary steps so the report still uploads first.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # ╔══════════════════════════════════════════════════════════════════╗
   # ║  UI (PR + merge queue)                                           ║
   # ╚══════════════════════════════════════════════════════════════════╝
@@ -930,7 +1021,30 @@ jobs:
       - name: Production build
         run: pnpm build
 
+      # Fail fast — see the note above the Quality Gate job.
+      - name: Fail fast
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
+            || echo "::warning::Fail-fast cancel failed; letting the run finish."
+
   # ── Quality gate ────────────────────────────────────────────────────
+  # FAIL FAST: most jobs above end with a `Fail fast` step (if: failure())
+  # that cancels this whole run the moment that job fails, instead of letting
+  # the remaining jobs burn runners for minutes before this gate can even
+  # start (a 14s boundary-guard failure used to wait ~7 min for the test
+  # shards). Cancellation semantics make this safe: the failing job keeps its
+  # red conclusion + logs (it fails before issuing the cancel), sibling jobs
+  # flip to `cancelled`, and this gate — `if: always()` — still RUNS after
+  # the cancellation (GitHub re-evaluates job `if` conditions on cancel and
+  # lets true ones proceed), sees the non-success results below, and
+  # concludes `failure` like any other red run. Server Test shards carry no
+  # fail-fast step on purpose: they fail near the END of their runs (after
+  # compile), so cancelling siblings would hide the other shards' failures
+  # and feed the rework loop partial results while saving almost nothing.
+  #
   # If you change this job's name, also update the branch-protection rule
   # (and the merge-queue config) that requires "Quality Gate" as THE
   # single required status check. The individual jobs above must NOT be
@@ -942,6 +1056,10 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && github.event_name != 'push'
     needs:
+      # `changes` is listed so a paths-filter failure cannot silently skip
+      # every gated job (skipped needs read as success below) and let the
+      # gate go green on a run where no CI actually executed.
+      - changes
       - server-cargo-deny
       - server-clippy
       - server-aarch64-check
@@ -958,6 +1076,7 @@ jobs:
       - name: Check results
         run: |
           results=(
+            "${{ needs.changes.result }}"
             "${{ needs.server-cargo-deny.result }}"
             "${{ needs.server-clippy.result }}"
             "${{ needs.server-aarch64-check.result }}"

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
@@ -987,6 +987,26 @@ pub(crate) fn is_failing_conclusion(conclusion: Option<&str>) -> bool {
     )
 }
 
+/// True when a conclusion is a *hard* failure — the work itself broke, as
+/// opposed to `cancelled`, which under fail-fast semantics (GitHub's native
+/// `fail-fast: true` matrices, or jobs that cancel the run on first failure)
+/// usually just means a sibling job failed first.
+pub(crate) fn is_hard_failure_conclusion(conclusion: Option<&str>) -> bool {
+    matches!(conclusion, Some("failure") | Some("timed_out"))
+}
+
+/// True when the job — or any of its steps — hard-failed. Step-level
+/// detection matters under fail-fast: a job that cancels its own run after a
+/// step fails can end up `cancelled` at the job level (the cancel signal
+/// races its post steps), while the failed step's conclusion is sealed first.
+pub(crate) fn job_hard_failed(job: &ActionsJob) -> bool {
+    is_hard_failure_conclusion(job.conclusion.as_deref())
+        || job
+            .steps
+            .iter()
+            .any(|step| is_hard_failure_conclusion(step.conclusion.as_deref()))
+}
+
 /// Build the human-readable `sections` and the structured `ci_jobs` payload for
 /// a CI-failure rework comment from the *union* of failing jobs across one or
 /// more workflow runs.
@@ -1018,10 +1038,21 @@ pub(crate) fn build_ci_failure_sections(
                 }
             }
 
-            for job in jobs
-                .iter()
-                .filter(|j| is_failing_conclusion(j.conclusion.as_deref()))
-            {
+            // Fail-fast cancellation (GitHub's `fail-fast: true` matrices, or
+            // jobs cancelling the run on first failure) marks every sibling
+            // job `cancelled` alongside the one real failure. Those cancelled
+            // jobs are fallout, not signal — listing them sends the worker
+            // chasing logs of jobs that never finished. Only surface
+            // cancelled jobs when nothing hard-failed.
+            let has_hard_failure = jobs.iter().any(job_hard_failed);
+
+            for job in jobs.iter().filter(|j| {
+                if has_hard_failure {
+                    job_hard_failed(j)
+                } else {
+                    is_failing_conclusion(j.conclusion.as_deref())
+                }
+            }) {
                 let conclusion = job.conclusion.as_deref().unwrap_or("unknown");
                 sections.push(format!("**Failed job:** {} ({})", job.name, conclusion));
 

--- a/server/crates/djinn-coordinator/src/pr_poller/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tests.rs
@@ -1363,6 +1363,71 @@ fn ci_failure_run_cap_bounds_aggregation() {
 }
 
 #[test]
+fn ci_failure_sections_drop_cancelled_jobs_when_a_hard_failure_exists() {
+    // Fail-fast cancellation (native fail-fast matrices or a watchdog job
+    // cancelling the run on first failure) leaves one real `failure` job in a
+    // sea of `cancelled` siblings. Only the real failure is signal.
+    let mut gate = failed_job(30, "aggregate-gate", "CI", vec![]);
+    gate.conclusion = Some("cancelled".to_string());
+    let mut shard = failed_job(31, "test-shard (1)", "CI", vec![]);
+    shard.conclusion = Some("cancelled".to_string());
+    let jobs = vec![
+        failed_job(10, "lint", "CI", vec![failed_step("run lint", 1)]),
+        gate,
+        shard,
+    ];
+    let checks = [check_run("CI / aggregate-gate", 100)];
+    let refs: Vec<&CheckRun> = checks.iter().collect();
+    let (sections, ci_jobs) = build_ci_failure_sections(Some(&jobs), &refs);
+
+    let body = sections.join("\n");
+    assert!(body.contains("**Failed job:** lint"), "{body}");
+    assert!(!body.contains("aggregate-gate (cancelled)"), "{body}");
+    assert!(!body.contains("test-shard (1)"), "{body}");
+    assert_eq!(ci_jobs.len(), 1);
+    assert_eq!(ci_jobs[0]["job_id"].as_u64(), Some(10));
+}
+
+#[test]
+fn ci_failure_sections_treat_cancelled_job_with_failed_step_as_signal() {
+    // A job that cancels its own run after a step fails can race the cancel
+    // signal and end up `cancelled` at the job level while its failed step is
+    // already sealed. That job is the signal; the step-less cancelled sibling
+    // is fallout.
+    let mut source = failed_job(50, "lint", "CI", vec![failed_step("run lint", 1)]);
+    source.conclusion = Some("cancelled".to_string());
+    let mut sibling = failed_job(51, "aggregate-gate", "CI", vec![]);
+    sibling.conclusion = Some("cancelled".to_string());
+    let jobs = vec![source, sibling];
+    let checks = [check_run("CI / aggregate-gate", 100)];
+    let refs: Vec<&CheckRun> = checks.iter().collect();
+    let (sections, ci_jobs) = build_ci_failure_sections(Some(&jobs), &refs);
+
+    let body = sections.join("\n");
+    assert!(body.contains("**Failed job:** lint"), "{body}");
+    assert!(!body.contains("aggregate-gate (cancelled)"), "{body}");
+    assert_eq!(ci_jobs.len(), 1);
+    assert_eq!(ci_jobs[0]["job_id"].as_u64(), Some(50));
+}
+
+#[test]
+fn ci_failure_sections_keep_cancelled_jobs_when_nothing_hard_failed() {
+    // A run where the only red conclusions are cancellations (e.g. a timeout
+    // watchdog never fired and the run was cancelled externally) must still
+    // surface those jobs rather than produce an empty report.
+    let mut job = failed_job(40, "test-shard (2)", "CI", vec![]);
+    job.conclusion = Some("cancelled".to_string());
+    let jobs = vec![job];
+    let checks = [check_run("CI / aggregate-gate", 100)];
+    let refs: Vec<&CheckRun> = checks.iter().collect();
+    let (sections, ci_jobs) = build_ci_failure_sections(Some(&jobs), &refs);
+
+    let body = sections.join("\n");
+    assert!(body.contains("**Failed job:** test-shard (2) (cancelled)"), "{body}");
+    assert_eq!(ci_jobs.len(), 1);
+}
+
+#[test]
 fn ci_failure_sections_fallback_when_no_jobs() {
     // No Actions job data → fall back to listing raw check-run names.
     let checks = [check_run("lint", 100)];

--- a/server/crates/djinn-provider/src/github_api/checks.rs
+++ b/server/crates/djinn-provider/src/github_api/checks.rs
@@ -624,9 +624,17 @@ fn select_actions_job<'a>(
         return Some(job);
     }
 
+    // Prefer the job matching the required check only when it carries a real
+    // failing step. Aggregate-gate setups (a required "gate" job that `needs:`
+    // every real job) combined with fail-fast run cancellation leave the gate
+    // job `cancelled` with no steps — the diagnosable failure lives in the
+    // sibling job that hard-failed before the cancel.
     jobs.iter()
         .filter(|job| is_failing_conclusion(job.conclusion.as_deref()))
-        .find(|job| check_name_matches_job(&request.required_check_name, job))
+        .find(|job| {
+            check_name_matches_job(&request.required_check_name, job) && has_failing_step(job)
+        })
+        .or_else(|| jobs.iter().find(|job| has_hard_failed_step(job)))
         .or_else(|| {
             jobs.iter()
                 .find(|job| check_name_matches_job(&request.required_check_name, job))
@@ -656,6 +664,30 @@ fn is_failing_conclusion(conclusion: Option<&str>) -> bool {
         conclusion,
         Some("failure") | Some("timed_out") | Some("cancelled") | Some("action_required")
     )
+}
+
+/// A *hard* failure — the work itself broke, as opposed to `cancelled`, which
+/// under fail-fast semantics usually means a sibling job failed first.
+fn is_hard_failed_conclusion(conclusion: Option<&str>) -> bool {
+    matches!(conclusion, Some("failure") | Some("timed_out"))
+}
+
+fn has_failing_step(job: &ActionsJob) -> bool {
+    job.steps
+        .iter()
+        .any(|step| is_failing_conclusion(step.conclusion.as_deref()))
+}
+
+/// True when the job contains a step that hard-failed. Detected at step level
+/// on purpose: a job that cancels its own run on failure can end up with a
+/// job-level conclusion of `cancelled` (the cancel signal races its post
+/// steps), but the failed step's conclusion is sealed before that — so this
+/// identifies the real source of failure in a fail-fast-cancelled run
+/// regardless of how the job-level race resolved.
+fn has_hard_failed_step(job: &ActionsJob) -> bool {
+    job.steps
+        .iter()
+        .any(|step| is_hard_failed_conclusion(step.conclusion.as_deref()))
 }
 
 fn workflow_path_from_name(name: &str) -> String {
@@ -814,9 +846,17 @@ impl GitHubApiClient {
         run: &WorkflowRun,
     ) -> std::result::Result<RequiredCheckReproduction, GitHubApiError> {
         let jobs = self.list_run_jobs(owner, repo, run.id).await?;
+        // Same fail-fast-aware preference as `select_actions_job`: an
+        // aggregate required gate cancelled by a fail-fast watchdog has no
+        // failing step, so a check-name match only wins when it can actually
+        // name a failing step; otherwise take the hard-failed sibling job that
+        // caused the cancellation. Without this, every bundle for such a run
+        // comes back Unreproducible (FailingStepNotFound on the gate job).
         let Some(job) = jobs
             .iter()
-            .find(|job| job_matches_check(job, check_run))
+            .find(|job| job_matches_check(job, check_run) && has_failing_step(job))
+            .or_else(|| jobs.iter().find(|job| has_hard_failed_step(job)))
+            .or_else(|| jobs.iter().find(|job| job_matches_check(job, check_run)))
             .or_else(|| {
                 jobs.iter()
                     .find(|job| is_failed_conclusion(job.conclusion.as_deref()))

--- a/server/crates/djinn-provider/src/github_api/tests/checks.rs
+++ b/server/crates/djinn-provider/src/github_api/tests/checks.rs
@@ -196,6 +196,121 @@ async fn required_check_reproduction_context_extracts_command_and_setup() {
     assert!(context.log_tail.contains("assertion failed"));
 }
 
+// Fail-fast run cancellation: the required aggregate gate job is `cancelled`
+// with no steps (it never started — a watchdog cancelled the run when a
+// sibling job failed). The reproduction context must come from the sibling
+// job that hard-failed, not from the step-less gate job (which would make
+// every bundle Unreproducible/FailingStepNotFound and eventually park the
+// task).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn required_check_reproduction_context_prefers_hard_failed_job_over_cancelled_gate() {
+    let server = MockServer::start().await;
+    let install_id = seed_installation_token();
+
+    Mock::given(method("GET"))
+        .and(path("/repos/djinnos/server/commits/head-sha/check-runs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 1,
+            "check_runs": [{
+                "id": 9002,
+                "name": "CI / aggregate-gate",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "html_url": "https://github.com/checks/9002"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/djinnos/server/actions/runs"))
+        .and(query_param("event", "pull_request"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "workflow_runs": [{
+                "id": 5678,
+                "name": "CI",
+                "head_branch": "feature-branch",
+                "head_sha": "head-sha",
+                "status": "completed",
+                "conclusion": "cancelled"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/djinnos/server/actions/runs/5678/jobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "jobs": [
+                {
+                    "id": 90,
+                    "name": "aggregate-gate",
+                    "status": "completed",
+                    "conclusion": "cancelled",
+                    "html_url": "https://github.com/jobs/90",
+                    "workflow_name": "quality-gate.yml",
+                    "steps": []
+                },
+                {
+                    "id": 91,
+                    "name": "boundary-guard",
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "html_url": "https://github.com/jobs/91",
+                    "workflow_name": "quality-gate.yml",
+                    "steps": [
+                        {
+                            "name": "Check boundary",
+                            "status": "completed",
+                            "conclusion": "failure",
+                            "number": 1
+                        }
+                    ]
+                },
+                {
+                    "id": 92,
+                    "name": "test-shard (1)",
+                    "status": "completed",
+                    "conclusion": "cancelled",
+                    "html_url": "https://github.com/jobs/92",
+                    "workflow_name": "quality-gate.yml",
+                    "steps": [{
+                        "name": "Tests",
+                        "status": "completed",
+                        "conclusion": "cancelled",
+                        "number": 1
+                    }]
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/repos/djinnos/server/actions/jobs/91/logs"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "2026-01-01T00:00:00.000Z ##[group]Run ./scripts/check-boundary.sh\n\
+             2026-01-01T00:00:01.000Z boundary violation in crate-a\n",
+        ))
+        .mount(&server)
+        .await;
+
+    let client = GitHubApiClient::for_installation_with_base_url(install_id, server.uri());
+    let result = client
+        .required_check_reproduction_context("djinnos", "server", "head-sha", "CI / aggregate-gate")
+        .await
+        .unwrap();
+
+    let RequiredCheckReproduction::Reproducible(context) = result else {
+        panic!("expected reproducible context from the hard-failed sibling job, got {result:?}");
+    };
+    assert_eq!(context.job.id, 91);
+    assert_eq!(context.job.name, "boundary-guard");
+    assert_eq!(context.failing_step.name, "Check boundary");
+    assert_eq!(context.command, "./scripts/check-boundary.sh");
+    assert!(context.log_tail.contains("boundary violation"));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn required_check_reproduction_context_returns_unreproducible_for_unmappable_check() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Why
Quality Gate can only report after every needed job finishes, so a 14s guard failure (e.g. Raw-SQL Boundary on #1903) waited ~7 min on the test shards before the PR showed a blocking failure — wasted runner minutes and slow feedback for djinn/humans fixing the PR.

## Workflow
- Each fast/medium job ends with a 5-line `Fail fast` step (`if: failure()` → `gh run cancel` on its own run). Zero standing cost — it only executes inside a job that already failed. No native cross-job fail-fast exists; this is the ecosystem-standard pattern.
- The gate goes properly **red**: GitHub re-evaluates job `if` conditions on cancellation and `always()` jobs keep running, so Quality Gate executes post-cancel, sees `cancelled` needs results, and concludes `failure`.
- Server Test shards intentionally carry no fail-fast step: they fail near the end anyway, and cancelling siblings would hide cross-shard failures from the rework loop.
- Gate now also needs `changes`: a paths-filter failure used to skip every job and pass the gate green on zero CI.

## Platform (codebase-agnostic)
A fail-fast-cancelled run — including any repo's native `fail-fast: true` matrix — ends as one hard failure among many `cancelled` jobs:
- `build_ci_failure_sections` drops cancelled fallout when a hard failure exists (still lists cancellations when nothing hard-failed).
- Rework/repro job selection prefers jobs with a **hard-failed step** (step-level, because a self-cancelling job can race its own job conclusion to `cancelled` while the failed step is already sealed). Prevents picking a step-less cancelled aggregate-gate job → "all bundles unreproducible" → parking on a second identical failure. No job names or gate assumptions; repos where the required check is a real job hit the first preference tier unchanged.

## Tests
3 new coordinator section tests + 1 new wiremock repro-context test; 22 targeted tests pass, clippy clean.