### PR TITLE
Prod-validated resource defaults + longer worker connect budget

### DIFF
--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -70,7 +70,12 @@ service:
 resources:
   server:
     requests:
-      cpu: "500m"
+      # CPU requests are the CFS weight under contention. At 250m-500m the
+      # server lost enough CPU during compile storms (a full worker fleet
+      # linking at once) to fail its readiness probe — transient 521s observed
+      # in production. Pin the request to 1 full core so the long-lived
+      # controller keeps a guaranteed share while task-run pods burst.
+      cpu: "1"
       memory: "512Mi"
     limits:
       cpu: "2"
@@ -94,7 +99,13 @@ resources:
       cpu: "1"
       memory: "2Gi"
     limits:
-      cpu: "6"
+      # CARGO_BUILD_JOBS / NEXTEST_TEST_THREADS derive from this CPU limit
+      # (PR #1896), so it bounds per-pod compile parallelism. At limit 6 a full
+      # fleet of 8 workers compiling simultaneously drove load 55-68 on 12
+      # cores and starved the readiness probes; at limit 4 the plateau is ~39,
+      # which the node tolerates. Keep memory high — a cargo link burst still
+      # needs the headroom.
+      cpu: "4"
       memory: "22Gi"
     # Pod scheduling for both task-run and warm Jobs. Warm Pods pre-warm the
     # graph cache that task-runs later adopt, so they MUST land on the same
@@ -131,7 +142,12 @@ resources:
       cpu: "2"
       memory: "2Gi"
     limits:
-      cpu: "6"
+      # Same per-pod compile-parallelism bound as `taskrun` above: warm passes
+      # compile the workspace too, and CARGO_BUILD_JOBS / NEXTEST_TEST_THREADS
+      # derive from this limit (PR #1896). Limit 4 keeps a warm-plus-worker
+      # fleet under the ~39 plateau the 12-core node tolerates instead of the
+      # 55-68 spike seen at limit 6.
+      cpu: "4"
       memory: "16Gi"
     # Max wall-clock seconds a warm Job may run before the kubelet terminates
     # it (activeDeadlineSeconds), surfaced as DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS.
@@ -294,7 +310,11 @@ postgres:
     maxConnections: 200
   resources:
     requests:
-      cpu: "500m"
+      # CPU request is the CFS weight under contention. At 500m the bundled
+      # Postgres lost CPU during compile storms and pg_isready probes timed
+      # out; pin to 1 full core so SQL stays responsive while task-run pods
+      # burst. Keep limits as-is.
+      cpu: "1"
       memory: "2Gi"
     limits:
       cpu: "2"

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -28,12 +28,19 @@ const STARTUP_TASK_RUN_THRESHOLD_SECS: i64 = 10;
 /// (`starting`/`running`) `task_run` and no `running` session for its task —
 /// before the orphaned-attempt reaper finalizes it to `crashed`.
 ///
-/// Conservative: dispatch-start → session/run creation is seconds, so a
-/// 15-minute-old pending attempt with nothing executing behind it can never
-/// be advanced by the normal lifecycle paths. Left un-reaped it hard-blocks
-/// the respawn guard for its (task, role) pair forever (the guard defers any
-/// dispatch while a `pending`/`submitted` attempt exists).
-const ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS: i64 = 15 * 60;
+/// Conservative but responsive: dispatch-start → session/run creation is
+/// seconds, and even across a server rolling restart the worker's connect
+/// budget (`CONNECT_BACKOFF_MS` in djinn-supervisor, ~90s) means a
+/// legitimately-starting attempt registers a live `task_run`/session well
+/// within 2 minutes. The reaper is already gated on there being no live
+/// (`starting`/`running`) `task_run` and no `running` session for the task,
+/// so a 5-minute-old `pending` attempt with nothing executing behind it can
+/// never be advanced by the normal lifecycle paths. Left un-reaped it
+/// hard-blocks the respawn guard for its (task, role) pair (the guard defers
+/// any dispatch while a `pending`/`submitted` attempt exists), so a 5-minute
+/// threshold cuts the worst-case post-deploy dispatch wedge from 15 min to 5
+/// while staying safely clear of any real starting attempt.
+const ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS: i64 = 5 * 60;
 
 const CARGO_TARGET_RUNS_ROOT: &str = djinn_supervisor::CARGO_TARGET_RUNS_ROOT;
 

--- a/server/crates/djinn-supervisor/src/services/rpc.rs
+++ b/server/crates/djinn-supervisor/src/services/rpc.rs
@@ -89,6 +89,24 @@ fn io_other(msg: impl Into<String>) -> io::Error {
     io::Error::other(msg.into())
 }
 
+/// Per-attempt backoff (in milliseconds) for [`RpcServices::connect_tcp`]'s
+/// dial-retry loop. There is one sleep entry per retry, so the total connect
+/// budget is `CONNECT_BACKOFF_MS.iter().sum()` and the attempt count is
+/// `CONNECT_BACKOFF_MS.len() + 1` (the initial dial plus one per entry).
+///
+/// Sized to survive a rolling restart of djinn-server. A `helm upgrade` roll
+/// of the server takes ~20-30s, during which its RPC listener is briefly
+/// unreachable. Any task-run pod that starts inside that window must keep
+/// dialing rather than exit 1 — an early exit strands a `pending`
+/// task_attempt that blocks the (task, role) dispatch until the orphan reaper
+/// fires (observed twice in production). The schedule ramps quickly for the
+/// common launcher-boot race (sub-second), then holds at a 10s cap for the
+/// long tail; the entries below sum to ~88.7s, covering a server roll with
+/// comfortable margin.
+const CONNECT_BACKOFF_MS: &[u64] = &[
+    100, 200, 400, 1000, 2000, 5000, 10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000,
+];
+
 // ── Real RPC client ──────────────────────────────────────────────────────────
 
 type PendingMap = Arc<Mutex<HashMap<u64, oneshot::Sender<ServiceRpcResponse>>>>;
@@ -202,14 +220,20 @@ impl RpcServices {
         cancel: CancellationToken,
     ) -> Result<(Arc<Self>, RpcBackgroundTasks), ConnectTcpError> {
         // Retry the TCP dial with exponential backoff so the worker tolerates
-        // launcher races: the dispatch path can create the worker Job within
-        // milliseconds of the launcher boot, before the launcher's TCP
-        // listener on :8443 has bound. Without retry, a single
-        // "Connection refused" kills the task-run (Job backoff_limit=0 means
-        // no K8s-level retry). Total budget: ~30s across 7 attempts at
-        // 100ms / 200ms / 400ms / 1s / 2s / 5s / 10s.
+        // launcher races AND a server rolling restart: the dispatch path can
+        // create the worker Job within milliseconds of the launcher boot,
+        // before the launcher's TCP listener on :8443 has bound, and a
+        // `helm upgrade` roll of djinn-server (~20-30s) makes the RPC listener
+        // transiently unreachable for any pod that starts inside that window.
+        // Without a budget that spans the roll, a single "Connection refused"
+        // kills the task-run (Job backoff_limit=0 means no K8s-level retry)
+        // and strands a `pending` task_attempt that blocks (task, role)
+        // dispatch until the orphan reaper fires. See [`CONNECT_BACKOFF_MS`]
+        // for the schedule and the ~88.7s total budget.
         let mut stream = {
-            let backoff_ms: [u64; 7] = [100, 200, 400, 1000, 2000, 5000, 10000];
+            let backoff_ms = CONNECT_BACKOFF_MS;
+            let total_attempts = backoff_ms.len() + 1;
+            let budget_secs = backoff_ms.iter().sum::<u64>() / 1000;
             let mut attempt = 0usize;
             loop {
                 tokio::select! {
@@ -227,9 +251,7 @@ impl RpcServices {
                             => {
                             if attempt >= backoff_ms.len() {
                                 return Err(ConnectTcpError::Io(io_other(format!(
-                                    "connect_tcp: launcher unreachable after {} attempts ({}s budget): {e}",
-                                    backoff_ms.len() + 1,
-                                    backoff_ms.iter().sum::<u64>() / 1000,
+                                    "connect_tcp: launcher unreachable after {total_attempts} attempts ({budget_secs}s budget): {e}",
                                 ))));
                             }
                             let delay = backoff_ms[attempt];
@@ -237,9 +259,11 @@ impl RpcServices {
                             tracing::warn!(
                                 %addr,
                                 attempt,
+                                total_attempts,
+                                budget_secs,
                                 next_retry_ms = delay,
                                 error = %e,
-                                "connect_tcp: launcher not yet listening; retrying",
+                                "connect_tcp: launcher not yet listening; retrying (tolerates a server roll)",
                             );
                             tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
                         }
@@ -1318,6 +1342,33 @@ impl SupervisorServices for UnimplementedRpcServices {
 mod tests {
     use super::*;
     use std::sync::Arc;
+
+    /// The connect-retry budget must span a server rolling restart. A
+    /// `helm upgrade` roll of djinn-server takes ~20-30s during which its RPC
+    /// listener is unreachable; a task-run pod that starts in that window has
+    /// to keep dialing rather than exit and strand a `pending` attempt. Assert
+    /// the total budget clears the roll with margin and that the tail holds at
+    /// a 10s cap (fast ramp for the launcher-boot race, patient tail for a
+    /// roll).
+    #[test]
+    fn connect_backoff_budget_covers_a_server_roll() {
+        let total_ms: u64 = CONNECT_BACKOFF_MS.iter().sum();
+        // A server roll is ~20-30s; require >=60s so a pod that starts at the
+        // very beginning of the roll still outlasts it comfortably.
+        assert!(
+            total_ms >= 60_000,
+            "connect budget {total_ms}ms must exceed a ~30s server roll with margin",
+        );
+        // The tail must be capped so we keep retrying at a steady cadence
+        // instead of ballooning to minute-long sleeps.
+        let cap = *CONNECT_BACKOFF_MS.iter().max().expect("non-empty schedule");
+        assert_eq!(cap, 10_000, "backoff tail should hold at a 10s cap");
+        assert_eq!(
+            *CONNECT_BACKOFF_MS.last().expect("non-empty schedule"),
+            10_000,
+            "final backoff entry should sit at the 10s cap",
+        );
+    }
 
     /// The stub satisfies the trait (compile-time) and can be stored behind
     /// `Arc<dyn SupervisorServices>` (the supervisor's dispatch shape).


### PR DESCRIPTION
## Story

Today's single-node (12-core / 47Gi) load testing surfaced three coupled failure modes and their fixes:

1. **Load 103.** A full fleet of 8 workers compiling at once with `taskrun.limits.cpu: 6` (from which `CARGO_BUILD_JOBS`/`NEXTEST_TEST_THREADS` derive, PR #1896) drove node load to 55-68 on 12 cores, timing out liveness/readiness probes. PR #1896 wired the per-pod parallelism to the CPU limit; this PR sets that limit to the value that behaves.
2. **Limit-4 plateau ~39.** Dropping `taskrun`/`warm` `limits.cpu` to `4` bounds per-pod compile parallelism so a full fleet plateaus at load ~39, which the node tolerates.
3. **Probe starvation at 250m/500m requests.** CPU *requests* are the CFS weight under contention. At 250m-500m the server lost enough CPU during compile storms to fail readiness (transient 521s in production) and the bundled Postgres's `pg_isready` timed out. Pinning `server` and `postgres` requests to `1` core keeps them responsive while task-run pods burst.
4. **Deploy-window orphans.** The worker→server `connect_tcp` retry budget was ~18s across 8 attempts. A `helm upgrade` roll of djinn-server takes ~20-30s, so any task-run pod that started inside that window exhausted the budget, exited 1, and stranded a `pending` `task_attempt` that blocked its (task, role) dispatch for up to 15 min (observed twice today).

## Changes

### 1. Helm resource defaults (`deploy/helm/djinn/values.yaml`)
- `resources.taskrun.limits.cpu`: `6` → `4`
- `resources.warm.limits.cpu`: `6` → `4`
- `resources.server.requests.cpu`: `500m` → `1`
- `postgres.resources.requests.cpu`: `500m` → `1`
- All memory values and all limits (except the two `taskrun`/`warm` CPU limits) unchanged. Comments carry the rationale.

### 2. Worker→server connect budget (`djinn-supervisor` `services/rpc.rs`)
- Extracted the retry schedule into a module const `CONNECT_BACKOFF_MS` and extended it to span a server roll with margin:
  `[100, 200, 400, 1000, 2000, 5000, 10000×8]` ms — **15 attempts, ~88.7s total budget**, ramping fast for the launcher-boot race then holding at a 10s cap for the long tail.
- Log lines now carry `attempt` / `total_attempts` / `budget_secs`.
- New unit test `connect_backoff_budget_covers_a_server_roll` asserts the budget clears a ~30s roll (≥60s) and the tail holds at the 10s cap.

### 3. Orphaned-pending-attempt reaper threshold (`djinn-coordinator` `health.rs`)
- `ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS`: `15*60` → `5*60`. **Included** — judged safe: the reaper (`list_orphaned_pending`) only reaps `pending` attempts whose task has no live (`starting`/`running`) `task_run` and no `running` session, and with change #2 a legitimately-starting attempt registers a run/session well within ~2 min even across a server roll. 5 min cuts the worst-case post-deploy dispatch wedge from 15 min to 5 while staying clear of any real starting attempt. The periodic stale-sweep INTERVAL stays 15 min (unchanged), so this mainly helps the startup pass and mid-window sweeps.

## Test evidence
- `helm lint deploy/helm/djinn` → 0 charts failed. `helm template` renders `DJINN_K8S_CPU_LIMIT=4`, `DJINN_K8S_WARM_CPU_LIMIT=4`, server/postgres `requests.cpu: "1"`.
- `SQLX_OFFLINE=true cargo test -p djinn-supervisor -p djinn-coordinator health` → ok (38 coordinator + supervisor). New `connect_backoff_budget_covers_a_server_roll` → ok.
- `cargo fmt --check` clean on both crates. `cargo clippy` on the touched crates surfaces only pre-existing warnings in files this PR does not touch (`lib.rs`, `merged_change_projection.rs`); the edited files (`rpc.rs`, `health.rs`) are warning-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)