### PR TITLE
fix(warm): fair CPU share for the warm Pod + no indexer nice in dedicated pods

### DIFF
--- a/server/crates/djinn-graph/src/process.rs
+++ b/server/crates/djinn-graph/src/process.rs
@@ -102,23 +102,68 @@ fn killed_by_signal(status: &std::process::ExitStatus) -> Option<i32> {
     status.signal()
 }
 
+/// Resolve the nice level applied to subprocesses spawned through the
+/// timeout/kill path (in practice: the SCIP indexer fan-out).
+///
+/// `explicit` is the parsed `DJINN_INDEXER_NICE` override, if any operator
+/// set one; `pod_workspace` is whether we're running inside a dedicated warm
+/// Pod (signalled by `DJINN_PROJECT_ROOT`, the same signal `index_tree.rs`
+/// keys off).
+///
+/// - **In-process warmer** (djinn-server on a dev box, `pod_workspace = false`):
+///   the indexers share the server's cgroup and fan out into `cargo check` /
+///   `cc`, so a nice of 10 keeps them from starving interactive request
+///   handling. This is the context the original nice was written for.
+/// - **Dedicated warm Pod** (`pod_workspace = true`): the indexer is the ONLY
+///   workload in the Pod's cgroup — there is nothing intra-pod to yield to, so
+///   the nice buys nothing, and with kernel autogrouping edge cases it can only
+///   cost the throughput graph freshness depends on. Run at normal priority.
+///
+/// An explicit `DJINN_INDEXER_NICE` always wins, for hand-tuning.
+#[cfg(unix)]
+fn resolve_nice_level(explicit: Option<&str>, pod_workspace: bool) -> i32 {
+    if let Some(raw) = explicit
+        && let Ok(n) = raw.trim().parse::<i32>()
+    {
+        return n;
+    }
+    if pod_workspace { 0 } else { 10 }
+}
+
+/// Env-reading wrapper around [`resolve_nice_level`]. Called in the PARENT
+/// (before fork) so the `pre_exec` closure — which must stay
+/// async-signal-safe — never reads the environment itself.
+#[cfg(unix)]
+fn indexer_nice_level() -> i32 {
+    let explicit = std::env::var("DJINN_INDEXER_NICE").ok();
+    let pod_workspace = std::env::var("DJINN_PROJECT_ROOT").is_ok();
+    resolve_nice_level(explicit.as_deref(), pod_workspace)
+}
+
 #[cfg(unix)]
 fn isolate_process_group(cmd: &mut Command) {
+    // Resolve the nice level HERE, in the parent thread before fork, so the
+    // pre_exec closure below stays async-signal-safe (no env reads after fork).
+    let nice = indexer_nice_level();
     // SAFETY: pre_exec runs in the child process right before exec.
     // setpgid(0, 0) places that child in a new process group so the whole
     // group (the indexer/git child plus anything it forks) can be signalled
     // with a single `kill(-pgid, …)`.
     unsafe {
-        cmd.pre_exec(|| {
+        cmd.pre_exec(move || {
             let rc = libc::setpgid(0, 0);
             if rc != 0 {
                 return Err(io::Error::last_os_error());
             }
 
-            // Nice level 10 — well below default 0, but not starved. SCIP
-            // indexers fan out into `cargo check`/`cc`; keep them from
-            // starving interactive applications.  Best-effort.
-            let _ = libc::setpriority(libc::PRIO_PROCESS, 0, 10);
+            // Best-effort renice. `nice == 0` is normal priority (the kernel
+            // default), so skip the syscall entirely there — in a dedicated
+            // warm Pod the indexer owns the whole cgroup and must not yield.
+            // In-process (dev box) `nice == 10` keeps the indexer fan-out from
+            // starving interactive server request handling.
+            if nice != 0 {
+                let _ = libc::setpriority(libc::PRIO_PROCESS, 0, nice);
+            }
 
             Ok(())
         });
@@ -348,6 +393,39 @@ mod tests {
             err.to_string().contains("signal"),
             "expected a distinct signal-death message, got: {err}"
         );
+    }
+
+    /// The in-process warmer (no `DJINN_PROJECT_ROOT`) keeps nice 10 so the
+    /// indexer fan-out can't starve the interactive server it shares a cgroup
+    /// with.
+    #[test]
+    fn nice_level_defaults_to_10_in_process() {
+        assert_eq!(resolve_nice_level(None, false), 10);
+    }
+
+    /// In a dedicated warm Pod the indexer owns the whole cgroup — nothing to
+    /// yield to — so it must run at normal priority (0), not niced. This is the
+    /// core of the starvation fix: niceing a sole-tenant cgroup only costs the
+    /// throughput graph freshness depends on.
+    #[test]
+    fn nice_level_is_zero_in_pod_workspace() {
+        assert_eq!(resolve_nice_level(None, true), 0);
+    }
+
+    /// An explicit `DJINN_INDEXER_NICE` override wins in either context.
+    #[test]
+    fn explicit_nice_override_wins() {
+        assert_eq!(resolve_nice_level(Some("5"), true), 5);
+        assert_eq!(resolve_nice_level(Some("15"), false), 15);
+        assert_eq!(resolve_nice_level(Some(" 3 "), true), 3);
+    }
+
+    /// A malformed override falls back to the context default rather than
+    /// crashing the spawn path.
+    #[test]
+    fn malformed_nice_override_falls_back() {
+        assert_eq!(resolve_nice_level(Some("not-a-number"), true), 0);
+        assert_eq!(resolve_nice_level(Some(""), false), 10);
     }
 
     /// A fast command still returns its real output and a success status.

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -89,7 +89,21 @@ pub struct KubernetesConfig {
     /// CPU request on the warm Pod container. The canonical-graph pipeline
     /// spawns SCIP indexer subprocesses (rust-analyzer, scip-go, etc.) that
     /// can spike CPU; without a request the scheduler has no fairness
-    /// signal and the Pod can be evicted under contention. Default `1`.
+    /// signal and the Pod can be evicted under contention.
+    ///
+    /// Default `4` — deliberately equal to `warm_cpu_limit`. Kubernetes
+    /// derives the container's cgroup `cpu.weight` (CFS share) from the
+    /// REQUEST, not the limit. A `1` request left the warm Pod with a tiny
+    /// share under host contention: on the single-node k3s VPS, six task-run
+    /// Pods (each requesting ~2 cores) drove host load ~20, and the warm
+    /// Pod's `rust-analyzer scip` pass — which finishes the `server`
+    /// workspace in ~257s on an idle 16-core box — was throttled to ~2
+    /// effective cores and blew past its 1202s → 1800s adaptive wall-clock
+    /// caps on every run. Graph freshness is user-facing (task-runs adopt
+    /// the warm's canonical graph), so the warm's cgroup weight must reflect
+    /// its actual need: matching the request to the limit gives it a fair
+    /// CFS share proportional to what it will actually use. Tunable via
+    /// `DJINN_K8S_WARM_CPU_REQUEST`.
     pub warm_cpu_request: String,
     /// CPU limit on the warm Pod container. Caps the indexer subprocesses
     /// so they don't starve neighbours on the same node. Default `4`.
@@ -145,7 +159,13 @@ impl KubernetesConfig {
             database_url: None,
             task_run_active_deadline_seconds: 10800,
             task_run_termination_grace_period_seconds: 60,
-            warm_cpu_request: "1".into(),
+            // Request == limit: cgroup cpu.weight derives from the REQUEST, so
+            // a `1` request starved the warm to ~2 effective cores under host
+            // contention even with a `4` limit, timing the Rust SCIP pass out
+            // on every run. Matching request to limit gives the warm a CFS
+            // share proportional to its real need (graph freshness is
+            // user-facing). See the field doc for the full mechanics.
+            warm_cpu_request: "4".into(),
             // Bumped limit 2 → 4 so the cgroup-aware `CARGO_BUILD_JOBS` in the
             // Rust SCIP indexer has real CPU to use; a 2-CPU cap starved the
             // warm and timed the Rust workspace out on every run.
@@ -186,7 +206,7 @@ impl KubernetesConfig {
     /// | `DJINN_DATABASE_URL` | `database_url` | _(unset → warm Pod has no fallback; helm chart projects this via the `djinn-server` ConfigMap)_ |
     /// | `DJINN_K8S_TASK_RUN_ACTIVE_DEADLINE_SECONDS` | `task_run_active_deadline_seconds` | `10800` (parsed as `u64`) |
     /// | `DJINN_K8S_TASK_RUN_TERMINATION_GRACE_PERIOD_SECONDS` | `task_run_termination_grace_period_seconds` | `60` (parsed as `i64`) |
-    /// | `DJINN_K8S_WARM_CPU_REQUEST` | `warm_cpu_request` | `1` |
+    /// | `DJINN_K8S_WARM_CPU_REQUEST` | `warm_cpu_request` | `4` (== limit; cgroup cpu.weight derives from the request) |
     /// | `DJINN_K8S_WARM_CPU_LIMIT` | `warm_cpu_limit` | `4` |
     /// | `DJINN_K8S_WARM_MEMORY_REQUEST` | `warm_memory_request` | `2Gi` |
     /// | `DJINN_K8S_WARM_MEMORY_LIMIT` | `warm_memory_limit` | `6Gi` |

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -632,8 +632,19 @@ mod tests {
         );
         // Defaults pin the documented values. Memory limit bumped 4Gi → 6Gi to
         // cover the added test-compile warm pass (--all-targets test codegen).
-        assert_eq!(cfg.warm_cpu_request, "1");
+        // CPU request bumped 1 → 4 to match the limit: cgroup cpu.weight
+        // derives from the REQUEST, so a `1` request starved the warm under
+        // host contention and timed the Rust SCIP pass out on every run.
+        assert_eq!(cfg.warm_cpu_request, "4");
         assert_eq!(cfg.warm_cpu_limit, "4");
+        // The warm's CPU request must equal its limit so the kubelet gives it a
+        // cgroup CFS share proportional to what it actually uses — graph
+        // freshness is user-facing and must not be starved by neighbouring
+        // task-run Pods on a contended node.
+        assert_eq!(
+            cfg.warm_cpu_request, cfg.warm_cpu_limit,
+            "warm CPU request must equal limit so cpu.weight reflects real need"
+        );
         assert_eq!(cfg.warm_memory_request, "2Gi");
         assert_eq!(cfg.warm_memory_limit, "6Gi");
     }


### PR DESCRIPTION
## Problem

The per-project code-graph warm runs in a K8s Job Pod on a single-node k3s VPS shared with many task-run Pods. The `server` workspace's `rust-analyzer scip` indexer keeps timing out — 1202s, then 1800s (the adaptive cap escalation from #1891 works: it gets killed at exactly each cap). On an idle 16-CPU box the same command finishes in **~257s**. This is **CPU starvation by scheduling policy, not capability**, and it has two independent causes.

### 1. cgroup `cpu.weight` derives from the REQUEST, not the limit

The warm Pod was Burstable with `requests.cpu = 1` and `limits.cpu = 4`. Kubernetes/cgroup v2 derives the container's CFS share (`cpu.weight`) from the **request**, so under host contention — observed load ~20 from six task-run Pods, each carrying its own ~2-core request — the warm Pod got roughly a 2-core share no matter its 4-core limit. That is exactly the ~2 effective cores that reproduced the >1800s stall, versus 257s at 16 cores idle.

**Fix:** bump the warm CPU request default `1 → 4`, equal to the limit, so the warm's cgroup weight is proportional to what it actually uses. `DJINN_K8S_WARM_CPU_REQUEST` / `DJINN_K8S_WARM_MEMORY_REQUEST` were already wired as config knobs; this changes only the default and its docs. Graph freshness is user-facing (task-runs adopt the warm's canonical graph), so the warm must not be throttled to a token share by its neighbours.

### 2. `nice 10` on indexer subprocesses is pointless (or harmful) in a dedicated Pod

SCIP indexer subprocesses were always spawned at `nice 10` (`isolate_process_group` in `djinn-graph/src/process.rs`). That was written for the **in-process** warmer — djinn-server running the indexer on a dev box, where the indexer shares the server's cgroup and must not starve interactive request handling. In a **dedicated warm Pod** the indexer is the *only* workload in its cgroup — there is nothing intra-pod to yield to — so the nice buys nothing, and with kernel autogrouping edge cases it can only cost the very throughput graph freshness depends on.

**Fix:** run indexers at normal priority (0) when `DJINN_PROJECT_ROOT` is set — the same warm-Pod signal `index_tree.rs` already keys off — and keep `nice 10` for the in-process path. `DJINN_INDEXER_NICE` overrides both for hand-tuning. The nice level is resolved in the parent before fork, so the `pre_exec` closure stays async-signal-safe.

## Scope

Touches only the two mechanisms: `djinn-k8s` config/warm_job (CPU request default + docs + spec test) and the `djinn-graph` indexer spawn path (`process.rs`). No changes to `cargo_target_seed.rs`, `budget.rs`, or `canonical_graph.rs`.

## Tests

- `cargo test -p djinn-k8s` (129 pass): warm-Job spec test now asserts `warm_cpu_request == "4"` and `request == limit`.
- New pure unit tests for `resolve_nice_level` (in-process → 10, pod-workspace → 0, explicit override wins, malformed override falls back).
- `cargo nextest run -p djinn-graph`: 569/569 pass. (Note: `cargo test`'s in-process parallelism intermittently trips a *pre-existing* global-`PATH` env race among the SCIP fake-indexer parity tests — reproduces identically on stock `main`; nextest's process-per-test isolation, which CI uses, is green.)
- `cargo fmt --check` + `cargo clippy --all-features -p djinn-k8s -p djinn-graph` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)