### PR TITLE
test(graph): de-flake canonical-graph indexer/env tests via a single pipeline env lock

### DIFF
--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -1705,8 +1705,16 @@ mod tests {
     use djinn_core::events::EventBus;
     use djinn_db::{ProjectRepository, RepoGraphCacheInsert, RepoGraphCacheRepository};
 
-    static OUT_OF_CORE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    static CACHE_REUSE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // All four env-mutating pipeline tests below (out-of-core parity,
+    // out-of-core warm, cache-reuse warm) share ONE process-global lock.
+    // They each mutate overlapping process-wide env vars — the two warm
+    // tests both rewrite `PATH` + `DJINN_TEST_SCIP_FIXTURE` to point at the
+    // fake `rust-analyzer`, and the out-of-core tests share
+    // `DJINN_GRAPH_OUT_OF_CORE*`. Separate per-family locks let them run
+    // concurrently on Cargo's test threads and clobber each other's env,
+    // which is the root cause of the intermittent "no index produced"
+    // flake. Route every one through `test_helpers::lock_pipeline_env`.
+    use crate::test_helpers::lock_pipeline_env;
 
     struct EnvVarGuard {
         key: &'static str,
@@ -2018,7 +2026,7 @@ edition = "2024"
 
     #[test]
     fn test_out_of_core_graph_parity_with_in_memory() {
-        let _guard = OUT_OF_CORE_ENV_LOCK.lock().unwrap();
+        let _env_lock = lock_pipeline_env();
         let tmp = workspace_tempdir("ooc-graph-parity-");
         let store_path = tmp.path().join("store");
 
@@ -2051,7 +2059,7 @@ edition = "2024"
 
     #[test]
     fn test_out_of_core_graph_diverges_on_file_change() {
-        let _guard = OUT_OF_CORE_ENV_LOCK.lock().unwrap();
+        let _env_lock = lock_pipeline_env();
         let tmp = workspace_tempdir("ooc-graph-diverge-");
         let store_path = tmp.path().join("store");
 
@@ -2988,7 +2996,7 @@ cp "$DJINN_TEST_SCIP_FIXTURE" "$out"
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn out_of_core_warm_produces_identical_graph_blob() {
-        let _env_lock = OUT_OF_CORE_ENV_LOCK.lock().unwrap();
+        let _env_lock = lock_pipeline_env();
         let _ooc_flag = EnvVarGuard::remove("DJINN_GRAPH_OUT_OF_CORE");
         let _ooc_min_nodes = EnvVarGuard::remove("DJINN_GRAPH_OUT_OF_CORE_MIN_NODES");
         let _ooc_path = EnvVarGuard::remove("DJINN_GRAPH_OUT_OF_CORE_PATH");
@@ -3127,7 +3135,7 @@ cp "$DJINN_TEST_SCIP_FIXTURE" "$out"
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn cache_reuse_produces_identical_graph_blob() {
-        let _env_lock = CACHE_REUSE_ENV_LOCK.lock().unwrap();
+        let _env_lock = lock_pipeline_env();
 
         // Remove any pre-existing cache-reuse env var.
         unsafe {

--- a/server/crates/djinn-graph/src/graph_parity.rs
+++ b/server/crates/djinn-graph/src/graph_parity.rs
@@ -914,6 +914,10 @@ mod tests {
     ///    real SCIP binaries, no network, no credentials).
     #[test]
     fn canonical_warm_cache_reuse_toggle_reaches_parity_seam() {
+        // Serialize against the canonical-graph cache-reuse warm test, which
+        // mutates the same `*CACHE_REUSE_ENABLED` toggles and
+        // `DJINN_SCIP_CACHE_DIR` on Cargo's shared test threads.
+        let _env_lock = crate::test_helpers::lock_pipeline_env();
         // SAFETY: this test manipulates env vars for the duration of the
         // test. `std::env::set_var` / `remove_var` are marked unsafe in
         // Rust 2024 because they race with concurrent getenv readers. This

--- a/server/crates/djinn-graph/src/out_of_core.rs
+++ b/server/crates/djinn-graph/src/out_of_core.rs
@@ -675,6 +675,9 @@ mod tests {
 
     #[test]
     fn test_out_of_core_disabled_by_default() {
+        // Shared with the canonical-graph out-of-core tests, which read the
+        // same `DJINN_GRAPH_OUT_OF_CORE*` process env. Serialize them all.
+        let _env_lock = crate::test_helpers::lock_pipeline_env();
         // Ensure the env var is not set.
         // SAFETY: tests run single-threaded for env var mutation.
         unsafe {
@@ -693,6 +696,7 @@ mod tests {
 
     #[test]
     fn test_out_of_core_disabled_for_truthy_variants() {
+        let _env_lock = crate::test_helpers::lock_pipeline_env();
         // All the truthy variants should enable.
         for val in &["1", "true", "TRUE", "True", "yes", "YES", "on", "ON"] {
             unsafe {
@@ -722,6 +726,7 @@ mod tests {
 
     #[test]
     fn test_threshold_gating_small_repo() {
+        let _env_lock = crate::test_helpers::lock_pipeline_env();
         unsafe {
             std::env::set_var("DJINN_GRAPH_OUT_OF_CORE", "1");
             std::env::set_var("DJINN_GRAPH_OUT_OF_CORE_MIN_NODES", "100000");
@@ -839,6 +844,7 @@ mod tests {
 
     #[test]
     fn test_lru_capacity_is_configurable() {
+        let _env_lock = crate::test_helpers::lock_pipeline_env();
         unsafe {
             std::env::set_var("DJINN_GRAPH_OUT_OF_CORE", "1");
             std::env::set_var("DJINN_GRAPH_OUT_OF_CORE_MIN_NODES", "100");

--- a/server/crates/djinn-graph/src/test_helpers.rs
+++ b/server/crates/djinn-graph/src/test_helpers.rs
@@ -24,6 +24,31 @@ use crate::repo_graph::{
     edge_confidence_floor, edge_weight_for,
 };
 
+/// Process-global lock serializing every test that mutates process-wide
+/// environment variables consumed by the SCIP indexer / canonical-graph
+/// pipeline — `PATH`, `DJINN_TEST_SCIP_FIXTURE`, `DJINN_GRAPH_OUT_OF_CORE*`,
+/// the `*CACHE_REUSE_ENABLED` toggles, and `DJINN_SCIP_CACHE_DIR`.
+///
+/// `std::env::{set_var,remove_var}` mutate shared process state, and the
+/// indexer spawns subprocesses that inherit `PATH`. Under Cargo's parallel
+/// test threads, two such tests can clobber each other's env mid-flight:
+/// one test's `PATH` restore drops the fake-`rust-analyzer` bin dir while a
+/// sibling's indexer is still resolving it, so the spawn falls back to the
+/// real (or missing) binary and the pipeline reports "no index produced".
+/// Every test that touches any of these vars MUST hold this single lock for
+/// its whole body so the mutations are fully serialized (a per-var or
+/// per-module lock is NOT enough — the vars are shared across modules).
+pub(crate) static PIPELINE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire [`PIPELINE_ENV_LOCK`], transparently recovering from a poisoned
+/// mutex so one panicking env-mutating test does not cascade into spurious
+/// failures across every other test that shares the lock.
+pub(crate) fn lock_pipeline_env() -> std::sync::MutexGuard<'static, ()> {
+    PIPELINE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Open a fresh test database (isolated Dolt branch via
 /// `Database::open_in_memory`).
 pub(crate) fn create_test_db() -> Database {


### PR DESCRIPTION
## Problem

The `djinn-graph` canonical-graph parity tests intermittently fail under machine load — biting multiple agents and merge-queue runs. Failure mode: `"no index produced"` → empty parsed SCIP set → graph-artifact parity mismatch.

## Inventory of affected tests (all in `server/crates/djinn-graph`)

| Test | File | Env it mutates |
|------|------|----------------|
| `out_of_core_warm_produces_identical_graph_blob` | canonical_graph.rs | `PATH`, `DJINN_TEST_SCIP_FIXTURE`, `DJINN_GRAPH_OUT_OF_CORE*` |
| `cache_reuse_produces_identical_graph_blob` | canonical_graph.rs | `PATH`, `DJINN_TEST_SCIP_FIXTURE`, `*CACHE_REUSE_ENABLED` |
| `test_out_of_core_graph_parity_with_in_memory` | canonical_graph.rs | `DJINN_GRAPH_OUT_OF_CORE*` |
| `test_out_of_core_graph_diverges_on_file_change` | canonical_graph.rs | `DJINN_GRAPH_OUT_OF_CORE*` |
| `test_out_of_core_disabled_by_default` / `_truthy_variants` / `test_threshold_gating_small_repo` / `test_lru_capacity_is_configurable` | out_of_core.rs | `DJINN_GRAPH_OUT_OF_CORE*` (previously **no lock**) |
| `canonical_warm_cache_reuse_toggle_reaches_parity_seam` | graph_parity.rs | `*CACHE_REUSE_ENABLED`, `DJINN_SCIP_CACHE_DIR` (previously **no lock**) |

## Root cause

These tests mutate **process-global** env consumed by the SCIP indexer / canonical-graph pipeline. `cargo test` runs them as parallel threads in **one process**, but they were guarded by *separate* per-family locks (`OUT_OF_CORE_ENV_LOCK` vs `CACHE_REUSE_ENV_LOCK`) or **no lock at all**. So they run concurrently and clobber each other:

- The two warm tests both rewrite `PATH` to prepend a fake `rust-analyzer` bin and set `DJINN_TEST_SCIP_FIXTURE`. When one test's `PATH` guard restores mid-flight of the other, the sibling's indexer spawn no longer finds the fake bin → it falls back to the **real** `rust-analyzer` (which, starved under load, times out) or nothing → `"no index produced"`.
- The `out_of_core.rs` and `graph_parity.rs` env tests shared `DJINN_GRAPH_OUT_OF_CORE*` / `*CACHE_REUSE_ENABLED` with the canonical tests across module boundaries with no common lock.

nextest hides this (process-per-test isolation); `cargo test` / merge_group does not.

## Fix (root, not `#[ignore]`)

A single process-global `PIPELINE_ENV_LOCK` + `lock_pipeline_env()` helper in `test_helpers` (`#![cfg(test)]`, `pub(crate)`, poison-tolerant so one panicking test can't cascade). Every env-mutating pipeline test now holds this **one** lock for its whole body:

- canonical_graph.rs: removed the two per-family locks; all four tests route through the shared lock.
- out_of_core.rs: added the lock to the four previously-unlocked env tests.
- graph_parity.rs: added the lock to the cache-reuse toggle test.

No assertions weakened, nothing ignored, no product code touched (test-side only). The fake-`rust-analyzer` hermetic fixture already in place is now reliably reachable because `PATH` no longer races.

## Stability proof

`cargo test -p djinn-graph --lib canonical_graph::tests`, run under 14 busy cores of CPU load, 12 iterations each:

```
before (per-family locks): 9 PASS / 3 FAIL   (out-of-core parity + warm tests)
after  (single lock):     12 PASS / 0 FAIL
```

Full `cargo test -p djinn-graph --lib` under the same load: **4/4 PASS**. `cargo fmt --check` + `cargo clippy --all-features --tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)