### PR TITLE
fix(graph): converge served canonical graph after out-of-pod warm Job

### DIFF
--- a/server/.sqlx/query-aca6b9e7f6b70b8d204389363f68aeb7279c6721170ee90154afd0d8f14c2c47.json
+++ b/server/.sqlx/query-aca6b9e7f6b70b8d204389363f68aeb7279c6721170ee90154afd0d8f14c2c47.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT commit_sha\n             FROM repo_graph_cache\n             WHERE project_id = $1\n             ORDER BY built_at DESC\n             LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "commit_sha",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "aca6b9e7f6b70b8d204389363f68aeb7279c6721170ee90154afd0d8f14c2c47"
+}

--- a/server/crates/djinn-db/src/repositories/repo_graph_cache.rs
+++ b/server/crates/djinn-db/src/repositories/repo_graph_cache.rs
@@ -69,6 +69,28 @@ impl RepoGraphCacheRepository {
         .await?)
     }
 
+    /// Return only the `commit_sha` of the most recently warmed entry for
+    /// `project_id`, without fetching the (potentially multi-MB) graph blob.
+    ///
+    /// Used by the server-side read path's commit-aware revalidation backstop
+    /// (`load_canonical_graph`): a cached in-memory graph is only trusted while
+    /// its pinned commit still matches the latest persisted row. Fetching the
+    /// full blob on every revalidation probe would defeat the point of the
+    /// in-RAM cache, so this projection keeps the periodic check cheap.
+    pub async fn latest_commit_for_project(&self, project_id: &str) -> Result<Option<String>> {
+        self.db.ensure_initialized().await?;
+        Ok(sqlx::query_scalar!(
+            "SELECT commit_sha
+             FROM repo_graph_cache
+             WHERE project_id = $1
+             ORDER BY built_at DESC
+             LIMIT 1",
+            project_id,
+        )
+        .fetch_optional(self.db.pool())
+        .await?)
+    }
+
     pub async fn upsert(&self, entry: RepoGraphCacheInsert<'_>) -> Result<()> {
         self.db.ensure_initialized().await?;
         // `built_at` defaults to "" in the schema; stamp it explicitly so the

--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -1,6 +1,7 @@
 // djinn:allow-oversize — legacy module over size-guard threshold; split when touched substantively.
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::RwLock;
 
@@ -160,6 +161,89 @@ pub fn git_head_is_strictly_stale(caller_head: &str, git_head: &str) -> bool {
 
 pub static GRAPH_CACHE: std::sync::LazyLock<RwLock<Option<CachedGraph>>> =
     std::sync::LazyLock::new(|| RwLock::new(None));
+
+/// Instant at which the in-memory [`GRAPH_CACHE`] slot was last confirmed to
+/// still match the latest persisted `repo_graph_cache` row. `None` means the
+/// slot has never been validated (or was explicitly invalidated) and the next
+/// read MUST revalidate before trusting it.
+///
+/// This is the state behind the commit-aware revalidation backstop in
+/// [`load_canonical_graph`]: the process-global RAM slot is kept fresh by this
+/// process's own warm path (`install_as_canonical`), but an *out-of-band*
+/// writer — the K8s graph-warm Job pod — rewrites `repo_graph_cache` without
+/// touching our RAM slot. Left unchecked, every `code_graph` query serves the
+/// pre-warm blob until the server restarts. Re-probing the persisted commit on
+/// every query would negate the cache; instead we re-check at most once per
+/// [`CACHE_REVALIDATION_TTL`] window, bounding staleness for ANY out-of-band
+/// writer while keeping steady-state per-query overhead at zero DB round-trips.
+static CACHE_LAST_VALIDATED: std::sync::LazyLock<RwLock<Option<std::time::Instant>>> =
+    std::sync::LazyLock::new(|| RwLock::new(None));
+
+/// Maximum time the in-memory canonical-graph slot may be served without
+/// re-confirming its pinned commit against the persisted `repo_graph_cache`
+/// row. Bounds worst-case read-path staleness from an out-of-band warm writer
+/// to this window (the event-driven [`invalidate_canonical_graph_cache`] hook
+/// converges within seconds; this TTL is the safety net if that hook is absent
+/// or missed).
+const CACHE_REVALIDATION_TTL: Duration = Duration::from_secs(20);
+
+/// True when the in-memory slot is due for a commit revalidation against the
+/// DB — i.e. it has never been validated, or the TTL window has elapsed.
+async fn revalidation_due() -> bool {
+    let guard = CACHE_LAST_VALIDATED.read().await;
+    match *guard {
+        None => true,
+        // `Instant::elapsed` is the monotonic-clock read our clippy config
+        // steers away from at the `Instant::now` call site; go through the
+        // injected `SystemClock` so this stays the single sanctioned monotonic
+        // read and remains consistent with the timestamps written below.
+        Some(stamped) => {
+            SystemClock::new()
+                .now_instant()
+                .saturating_duration_since(stamped)
+                >= CACHE_REVALIDATION_TTL
+        }
+    }
+}
+
+/// Stamp the in-memory slot as validated "now", opening a fresh
+/// [`CACHE_REVALIDATION_TTL`] window before the next DB revalidation probe.
+async fn mark_cache_validated() {
+    let mut guard = CACHE_LAST_VALIDATED.write().await;
+    *guard = Some(SystemClock::new().now_instant());
+}
+
+/// Clear the in-memory canonical-graph slot and its revalidation stamp so the
+/// very next [`load_canonical_graph`] call reloads the latest persisted blob.
+///
+/// This is the event-driven convergence seam for the *out-of-pod* warm path:
+/// the canonical-graph warm runs in a separate K8s Job pod that rewrites
+/// `repo_graph_cache` but cannot reach this process's RAM slot. The server's
+/// in-process warm watcher (`djinn_k8s::K8sGraphWarmer`) calls this on warm-Job
+/// success, so `code_graph` queries converge to the fresh graph within seconds
+/// instead of serving the stale slot until a restart. The
+/// [`CACHE_REVALIDATION_TTL`] backstop covers the case where this hook is never
+/// invoked (e.g. non-K8s runtime, or a missed terminal observation).
+///
+/// The slot is single-tenant (one project at a time), so clearing it may cost
+/// an unrelated project one reload from the persisted blob — cheap and correct.
+pub async fn invalidate_canonical_graph_cache() {
+    {
+        let mut cache = GRAPH_CACHE.write().await;
+        *cache = None;
+    }
+    let mut validated = CACHE_LAST_VALIDATED.write().await;
+    *validated = None;
+}
+
+/// Test-only: force the next read to treat the slot as revalidation-due
+/// without disturbing the cached graph itself, so tests can exercise the
+/// out-of-band-staleness reload path deterministically (no wall-clock wait).
+#[cfg(test)]
+pub(crate) async fn force_revalidation_due_for_test() {
+    let mut guard = CACHE_LAST_VALIDATED.write().await;
+    *guard = None;
+}
 
 pub fn derive_graph_caches(
     graph: &crate::repo_graph::RepoDependencyGraph,
@@ -1327,16 +1411,24 @@ async fn install_as_canonical(
     layout_positions: Arc<std::collections::BTreeMap<String, crate::layout::GraphLayoutPosition>>,
     crate_map: Arc<std::collections::BTreeMap<PathBuf, String>>,
 ) {
-    let mut cache = GRAPH_CACHE.write().await;
-    *cache = Some(CachedGraph {
-        graph,
-        project_path,
-        git_head,
-        pagerank,
-        sccs,
-        layout_positions,
-        crate_map,
-    });
+    {
+        let mut cache = GRAPH_CACHE.write().await;
+        *cache = Some(CachedGraph {
+            graph,
+            project_path,
+            git_head,
+            pagerank,
+            sccs,
+            layout_positions,
+            crate_map,
+        });
+    }
+    // Whenever we (re)install the slot it reflects the freshest graph this
+    // process knows — from the in-process warm path or a DB reload — so open a
+    // fresh revalidation window. This keeps the in-process warm path's
+    // behaviour unchanged (its just-warmed slot is trusted for the full TTL)
+    // while the read-path backstop bounds staleness from out-of-band writers.
+    mark_cache_validated().await;
 }
 
 async fn load_cached_artifact(
@@ -1389,18 +1481,67 @@ pub async fn load_canonical_graph<C: WarmContext>(
 
     let (_project_root, index_tree_path) = normalize_graph_query_paths(project_path);
 
-    {
+    // Fast path: serve the in-memory slot — but only after a commit-aware
+    // revalidation backstop confirms it hasn't been superseded out-of-band.
+    // The K8s warm Job pod rewrites `repo_graph_cache` without touching this
+    // process's RAM slot; without this check every query serves the pre-warm
+    // blob until the server restarts. We re-probe the persisted commit at most
+    // once per `CACHE_REVALIDATION_TTL` window (see `revalidation_due`), so the
+    // steady-state cost stays at zero DB round-trips.
+    let cached_head = {
         let cache = GRAPH_CACHE.read().await;
-        if let Some(cached) = cache.as_ref().filter(|c| c.project_path == index_tree_path) {
-            return Ok((
-                cached.graph.clone(),
-                cached.pagerank.clone(),
-                cached.sccs.clone(),
-            ));
+        cache
+            .as_ref()
+            .filter(|c| c.project_path == index_tree_path)
+            .map(|c| c.git_head.clone())
+    };
+
+    let cache_repo = RepoGraphCacheRepository::new(ctx.db().clone());
+
+    if let Some(cached_head) = cached_head {
+        let serve_from_ram = if !revalidation_due().await {
+            // Within the TTL window: trust the slot without a DB round-trip.
+            true
+        } else {
+            // TTL elapsed: cheap commit-only probe (no blob fetch).
+            match cache_repo.latest_commit_for_project(project_id).await {
+                Ok(Some(latest)) => {
+                    // `git_head_is_strictly_stale(caller, cached)` is true when
+                    // `cached` is blank or differs from `caller`; the slot is
+                    // still current exactly when that is false. (Both args are
+                    // trimmed inside the helper.)
+                    let still_current = !git_head_is_strictly_stale(&latest, &cached_head);
+                    if still_current {
+                        // Slot matches the latest persisted commit → reopen the
+                        // TTL window and keep serving from RAM.
+                        mark_cache_validated().await;
+                    }
+                    // Commit advanced out-of-band (still_current == false) → do
+                    // NOT stamp; fall through to the reload path below.
+                    still_current
+                }
+                // No persisted row (unexpected while a slot is populated) or a
+                // transient DB error: keep serving the RAM slot rather than
+                // failing an otherwise-answerable query. We deliberately do NOT
+                // stamp validation, so the next query re-probes.
+                Ok(None) | Err(_) => true,
+            }
+        };
+
+        if serve_from_ram {
+            let cache = GRAPH_CACHE.read().await;
+            if let Some(cached) = cache.as_ref().filter(|c| c.project_path == index_tree_path) {
+                return Ok((
+                    cached.graph.clone(),
+                    cached.pagerank.clone(),
+                    cached.sccs.clone(),
+                ));
+            }
+            // Slot was cleared/replaced between our peek and here → fall
+            // through to the DB load path below.
         }
     }
 
-    let cache_repo = RepoGraphCacheRepository::new(ctx.db().clone());
     let row = cache_repo
         .latest_for_project(project_id)
         .await
@@ -1432,6 +1573,8 @@ pub async fn load_canonical_graph<C: WarmContext>(
         crate_map.clone(),
     )
     .await;
+    // `install_as_canonical` stamps the revalidation window, so subsequent
+    // reads within the TTL serve this freshly loaded blob without a DB probe.
     Ok((graph, pagerank, sccs))
 }
 
@@ -2402,6 +2545,10 @@ edition = "2024"
 
     #[tokio::test]
     async fn ensure_canonical_graph_serves_cache_hit_without_running_indexer() {
+        // Mutates the process-global GRAPH_CACHE; serialize with the other
+        // slot-touching tests (incl. the revalidation-backstop tests) so
+        // concurrent installs/clears can't clobber the single shared slot.
+        let _env_lock = lock_pipeline_env();
         let tmp = workspace_tempdir("canonical-graph-");
         let project_root = make_project(tmp.path()).await;
         let db = create_test_db();
@@ -2443,6 +2590,7 @@ edition = "2024"
 
     #[tokio::test]
     async fn ensure_canonical_graph_treats_stale_blob_as_cache_miss() {
+        let _env_lock = lock_pipeline_env();
         let tmp = workspace_tempdir("canonical-graph-");
         let project_root = make_project(tmp.path()).await;
         let db = create_test_db();
@@ -2485,6 +2633,7 @@ edition = "2024"
 
     #[tokio::test]
     async fn cache_only_readers_serve_cached_graph_and_caches() {
+        let _env_lock = lock_pipeline_env();
         let tmp = workspace_tempdir("canonical-graph-");
         let project_root = make_project(tmp.path()).await;
         let db = create_test_db();
@@ -2534,6 +2683,160 @@ edition = "2024"
         assert_eq!(graph_only.node_count(), expected_node_count);
         assert_eq!(graph_with_caches.node_count(), expected_node_count);
         assert_eq!(pagerank.nodes.len(), expected_node_count);
+    }
+
+    /// Commit-aware revalidation backstop (out-of-pod staleness fix): when the
+    /// in-memory slot is pinned to a commit that no longer matches the latest
+    /// persisted `repo_graph_cache` row — the exact situation the K8s warm Job
+    /// pod creates by rewriting the row without touching this process's RAM
+    /// slot — a read after the TTL window must reload the fresh blob instead of
+    /// serving the stale one.
+    #[tokio::test]
+    async fn load_canonical_graph_reloads_when_slot_commit_is_stale() {
+        // Serialize against every other test that mutates the process-global
+        // GRAPH_CACHE / revalidation stamp (see `lock_pipeline_env` note).
+        let _env_lock = lock_pipeline_env();
+        let tmp = workspace_tempdir("canonical-graph-reval-stale-");
+        let project_root = make_project(tmp.path()).await;
+        let db = create_test_db();
+        let ctx = TestWarmContext::new(db.clone());
+        let project = ProjectRepository::new(db.clone(), EventBus::noop())
+            .create("reval-stale", "test", "reval-stale")
+            .await
+            .expect("create project");
+        let project_root_str = project_root.to_string_lossy().into_owned();
+        let (_pr, index_tree_path) = normalize_graph_query_paths(&project_root_str);
+
+        // DB holds the FRESH graph, pinned at a NEW commit (out-of-band warm).
+        let fresh_graph = build_test_graph_fixture();
+        let fresh_count = fresh_graph.node_count();
+        let fresh_blob = bincode::serialize(&fresh_graph.to_artifact()).expect("serialize fresh");
+        RepoGraphCacheRepository::new(db.clone())
+            .upsert(RepoGraphCacheInsert {
+                project_id: &project.id,
+                commit_sha: "fresh-sha",
+                graph_blob: &fresh_blob,
+            })
+            .await
+            .expect("seed fresh row");
+
+        // RAM slot holds a DIFFERENT (stale) graph, pinned at an OLD commit.
+        let stale_graph = crate::repo_graph::RepoDependencyGraph::build(&[]);
+        assert_ne!(
+            stale_graph.node_count(),
+            fresh_count,
+            "stale and fresh fixtures must differ to distinguish a reload"
+        );
+        let (pagerank, sccs, layout_positions, crate_map) =
+            derive_graph_caches(&stale_graph, &project_root);
+        install_as_canonical(
+            index_tree_path.clone(),
+            "stale-sha".to_string(),
+            stale_graph,
+            pagerank,
+            sccs,
+            layout_positions,
+            crate_map,
+        )
+        .await;
+
+        // Simulate the TTL window elapsing so the read path revalidates.
+        force_revalidation_due_for_test().await;
+
+        let (graph, _pr, _sccs) = load_canonical_graph(&ctx, &project.id, &project_root_str)
+            .await
+            .expect("load must succeed");
+        assert_eq!(
+            graph.node_count(),
+            fresh_count,
+            "a stale-commit slot must reload the fresh persisted blob after the TTL window"
+        );
+        // The slot is now re-pinned to the fresh commit.
+        assert_eq!(
+            canonical_graph_cache_pinned_commit_for(&index_tree_path)
+                .await
+                .as_deref(),
+            Some("fresh-sha"),
+            "reload must re-pin the in-memory slot to the fresh commit"
+        );
+        clear_test_caches().await;
+    }
+
+    /// Within the revalidation TTL window the in-memory slot is served without
+    /// any DB round-trip — proving steady-state per-query overhead stays at
+    /// zero — even when a newer row exists; once the window elapses the newer
+    /// blob is picked up. This pins the "cheap staleness check" contract.
+    #[tokio::test]
+    async fn load_canonical_graph_serves_slot_within_ttl_then_reloads_after_expiry() {
+        let _env_lock = lock_pipeline_env();
+        let tmp = workspace_tempdir("canonical-graph-reval-ttl-");
+        let project_root = make_project(tmp.path()).await;
+        let db = create_test_db();
+        let ctx = TestWarmContext::new(db.clone());
+        let project = ProjectRepository::new(db.clone(), EventBus::noop())
+            .create("reval-ttl", "test", "reval-ttl")
+            .await
+            .expect("create project");
+        let project_root_str = project_root.to_string_lossy().into_owned();
+        let (_pr, index_tree_path) = normalize_graph_query_paths(&project_root_str);
+
+        // RAM slot: the fixture graph pinned at "slot-sha". `install_as_canonical`
+        // stamps the revalidation window, so the slot starts inside the TTL.
+        let ram_graph = build_test_graph_fixture();
+        let ram_count = ram_graph.node_count();
+        let (pagerank, sccs, layout_positions, crate_map) =
+            derive_graph_caches(&ram_graph, &project_root);
+        install_as_canonical(
+            index_tree_path.clone(),
+            "slot-sha".to_string(),
+            ram_graph,
+            pagerank,
+            sccs,
+            layout_positions,
+            crate_map,
+        )
+        .await;
+
+        // DB holds a DIFFERENT graph at a NEWER commit — the out-of-band warm.
+        let db_graph = crate::repo_graph::RepoDependencyGraph::build(&[]);
+        let db_count = db_graph.node_count();
+        assert_ne!(
+            db_count, ram_count,
+            "RAM and DB fixtures must differ to distinguish serve-from-RAM vs reload"
+        );
+        let db_blob = bincode::serialize(&db_graph.to_artifact()).expect("serialize db graph");
+        RepoGraphCacheRepository::new(db.clone())
+            .upsert(RepoGraphCacheInsert {
+                project_id: &project.id,
+                commit_sha: "newer-sha",
+                graph_blob: &db_blob,
+            })
+            .await
+            .expect("seed newer row");
+
+        // Within the TTL window: served from RAM without revalidating. If the
+        // read path had queried the DB it would see "newer-sha" != "slot-sha"
+        // and reload `db_count`; asserting `ram_count` proves it did NOT.
+        let (within, _p, _s) = load_canonical_graph(&ctx, &project.id, &project_root_str)
+            .await
+            .expect("load within ttl");
+        assert_eq!(
+            within.node_count(),
+            ram_count,
+            "within the TTL window the RAM slot must be served, ignoring the newer DB row"
+        );
+
+        // Now the window elapses: revalidate, observe the newer commit, reload.
+        force_revalidation_due_for_test().await;
+        let (after, _p, _s) = load_canonical_graph(&ctx, &project.id, &project_root_str)
+            .await
+            .expect("load after ttl");
+        assert_eq!(
+            after.node_count(),
+            db_count,
+            "after the TTL window the newer persisted blob must be reloaded"
+        );
+        clear_test_caches().await;
     }
 
     #[tokio::test]
@@ -2852,6 +3155,7 @@ edition = "2024"
     /// for the same commit must pass `assert_graph_artifact_blob_parity`.
     #[tokio::test]
     async fn incremental_full_equivalence_same_commit() {
+        let _env_lock = lock_pipeline_env();
         let tmp = workspace_tempdir("incremental-equiv-");
         let project_root = make_project(tmp.path()).await;
         let db = create_test_db();

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -88,6 +88,22 @@ impl WarmJobDispatcher for KubeClientDispatcher {
     }
 }
 
+/// Terminal outcome reported by a [`WarmJobWatcher`]. Drives the in-process
+/// convergence hook: on [`WarmTerminalOutcome::Succeeded`] the warm Job pod has
+/// already rewritten `repo_graph_cache`, so the server invalidates its RAM slot
+/// (see [`WarmCompletionSink`]); on [`WarmTerminalOutcome::Failed`] the row is
+/// unchanged and no convergence is needed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WarmTerminalOutcome {
+    /// The warm Job reported `.status.succeeded > 0` (or completed and was
+    /// reaped before we observed it — see the 404 branch), meaning a fresh
+    /// blob was persisted.
+    Succeeded,
+    /// The warm Job reported `.status.failed > 0`, or the watcher gave up at
+    /// its deadline without observing success. No fresh blob was persisted.
+    Failed,
+}
+
 /// Optional Job-terminal watcher. Production uses
 /// [`KubeClientJobWatcher`]; tests pass [`NoopJobWatcher`] to keep the
 /// unit tests free of any apiserver dependency.
@@ -95,8 +111,10 @@ impl WarmJobDispatcher for KubeClientDispatcher {
 pub trait WarmJobWatcher: Send + Sync {
     /// Poll the Job `job_name` in `namespace` until it reaches a terminal
     /// state (succeeded OR failed) or the watcher's internal deadline
-    /// elapses. Implementations MUST NOT block forever.
-    async fn wait_terminal(&self, namespace: &str, job_name: &str);
+    /// elapses. Implementations MUST NOT block forever. The returned
+    /// [`WarmTerminalOutcome`] tells the caller whether a fresh graph blob was
+    /// persisted (→ trigger in-process cache convergence).
+    async fn wait_terminal(&self, namespace: &str, job_name: &str) -> WarmTerminalOutcome;
 }
 
 /// Production watcher backed by `kube::Api::<Job>::get`. Polls on
@@ -113,7 +131,7 @@ impl KubeClientJobWatcher {
 
 #[async_trait]
 impl WarmJobWatcher for KubeClientJobWatcher {
-    async fn wait_terminal(&self, namespace: &str, job_name: &str) {
+    async fn wait_terminal(&self, namespace: &str, job_name: &str) -> WarmTerminalOutcome {
         let api: Api<Job> = Api::namespaced(self.client.clone(), namespace);
         let deadline = SystemClock::new().now_instant() + WATCH_DEADLINE;
         loop {
@@ -122,17 +140,24 @@ impl WarmJobWatcher for KubeClientJobWatcher {
                     if let Some(status) = job.status.as_ref() {
                         if status.succeeded.unwrap_or(0) > 0 {
                             debug!(job = %job_name, "K8sGraphWarmer watcher: succeeded");
-                            return;
+                            return WarmTerminalOutcome::Succeeded;
                         }
                         if status.failed.unwrap_or(0) > 0 {
                             warn!(job = %job_name, "K8sGraphWarmer watcher: failed");
-                            return;
+                            return WarmTerminalOutcome::Failed;
                         }
                     }
                 }
                 Err(kube::Error::Api(resp)) if resp.code == 404 => {
-                    debug!(job = %job_name, "K8sGraphWarmer watcher: job gone (treating as done)");
-                    return;
+                    // The Job is gone. `ttlSecondsAfterFinished` only reaps
+                    // *finished* Jobs, and a Job that ran to completion so fast
+                    // it was reaped before our first poll is overwhelmingly a
+                    // success, so we treat "gone" as Succeeded and let the
+                    // server converge its RAM slot. A needless reload on the
+                    // rare reaped-failure is harmless (it re-reads the same
+                    // latest persisted row).
+                    debug!(job = %job_name, "K8sGraphWarmer watcher: job gone (treating as succeeded)");
+                    return WarmTerminalOutcome::Succeeded;
                 }
                 Err(e) => {
                     warn!(
@@ -147,19 +172,45 @@ impl WarmJobWatcher for KubeClientJobWatcher {
                     job = %job_name,
                     "K8sGraphWarmer watcher: deadline exceeded, notifying anyway"
                 );
-                return;
+                // Unknown terminal state → treat as Failed so we don't churn
+                // the cache; the read-path revalidation TTL still converges.
+                return WarmTerminalOutcome::Failed;
             }
             tokio::time::sleep(WATCH_POLL_INTERVAL).await;
         }
     }
 }
 
-/// No-op watcher used by unit tests.
+/// No-op watcher used by unit tests. Reports success so the in-flight slot is
+/// released and the completion hook (if any) fires, matching the common
+/// "warm completed" path the tests exercise.
 pub struct NoopJobWatcher;
 
 #[async_trait]
 impl WarmJobWatcher for NoopJobWatcher {
-    async fn wait_terminal(&self, _namespace: &str, _job_name: &str) {}
+    async fn wait_terminal(&self, _namespace: &str, _job_name: &str) -> WarmTerminalOutcome {
+        WarmTerminalOutcome::Succeeded
+    }
+}
+
+/// In-process convergence hook invoked when a warm Job reaches terminal
+/// success. The canonical-graph warm runs in a *separate* K8s Job pod that
+/// rewrites `repo_graph_cache` but cannot reach the server process's in-memory
+/// graph slot; without this hook every `code_graph` query serves the pre-warm
+/// blob until the server restarts (or the read-path revalidation TTL elapses).
+///
+/// `djinn-k8s` intentionally does not depend on `djinn-graph`, so the concrete
+/// sink that clears `djinn_graph`'s `GRAPH_CACHE` is wired at the composition
+/// root (`AppState`) where both crates are in scope, and injected via
+/// [`K8sGraphWarmer::with_completion_sink`]. Kept as a trait (not a bare
+/// closure) so unit tests can supply a recording mock with the existing
+/// dispatcher/watcher patterns.
+#[async_trait]
+pub trait WarmCompletionSink: Send + Sync {
+    /// Invoked once, in-process, after the warm Job for `project_id` reaches
+    /// terminal success and its fresh blob is persisted. Implementations
+    /// converge process-local caches (e.g. the canonical-graph RAM slot).
+    async fn on_warm_succeeded(&self, project_id: &str);
 }
 
 /// Abstraction used by [`K8sGraphWarmer`] to discover warm Jobs that are
@@ -275,6 +326,11 @@ pub struct K8sGraphWarmer {
     /// parallel pod). `None` only under the test/mock path that injects
     /// a dispatcher without a live apiserver.
     lister: Option<Arc<dyn WarmJobLister>>,
+    /// In-process hook fired after a warm Job succeeds so the server can
+    /// converge its canonical-graph RAM slot to the freshly persisted blob
+    /// without a restart. `None` under the test/mock path and for non-K8s
+    /// wiring; production sets it via [`Self::with_completion_sink`].
+    completion_sink: Option<Arc<dyn WarmCompletionSink>>,
     in_flight: Arc<Mutex<HashMap<String, Arc<Notify>>>>,
     /// Live kube client for Pod/Service/Job ops that the (Job-only) dispatcher
     /// abstraction doesn't cover — e.g. backing-service provisioning. `None`
@@ -324,9 +380,20 @@ impl K8sGraphWarmer {
             dispatcher,
             watcher,
             lister,
+            completion_sink: None,
             in_flight: Arc::new(Mutex::new(HashMap::new())),
             client: None,
         }
+    }
+
+    /// Attach the in-process warm-completion sink (builder style). Production
+    /// wires a sink that clears `djinn_graph`'s canonical-graph RAM slot; tests
+    /// inject a recording mock. Returns `self` for chaining off
+    /// [`Self::new`]/[`Self::with_dispatcher`].
+    #[must_use]
+    pub fn with_completion_sink(mut self, sink: Arc<dyn WarmCompletionSink>) -> Self {
+        self.completion_sink = Some(sink);
+        self
     }
 
     /// Resolve the image the warm Job should run in, honouring catalog-image
@@ -614,12 +681,13 @@ impl GraphWarmerService for K8sGraphWarmer {
 
         let watcher = self.watcher.clone();
         let in_flight = self.in_flight.clone();
+        let completion_sink = self.completion_sink.clone();
         let project_id_owned = project_id.to_string();
         let namespace_owned = namespace.clone();
         let job_name_owned = job_name.clone();
         let notify_owned = notify.clone();
         tokio::spawn(async move {
-            watcher
+            let outcome = watcher
                 .wait_terminal(&namespace_owned, &job_name_owned)
                 .await;
             let mut guard = in_flight.lock().await;
@@ -631,8 +699,18 @@ impl GraphWarmerService for K8sGraphWarmer {
             // the map still holds (in case a re-trigger happened mid-flight
             // and reassigned the slot).
             notify_owned.notify_waiters();
+            // Event-driven convergence: on success the warm pod has already
+            // rewritten `repo_graph_cache`, so invalidate the server's RAM slot
+            // now (fast path). The read-path revalidation TTL is the backstop
+            // if this hook is absent or the outcome was ambiguous.
+            if outcome == WarmTerminalOutcome::Succeeded
+                && let Some(sink) = completion_sink.as_ref()
+            {
+                sink.on_warm_succeeded(&project_id_owned).await;
+            }
             debug!(
                 project_id = %project_id_owned,
+                outcome = ?outcome,
                 "K8sGraphWarmer: warm watcher complete, waiters notified"
             );
         });

--- a/server/crates/djinn-k8s/src/graph_warmer_tests.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_tests.rs
@@ -58,8 +58,48 @@ struct ControlledWatcher {
 
 #[async_trait]
 impl WarmJobWatcher for ControlledWatcher {
-    async fn wait_terminal(&self, _namespace: &str, _job_name: &str) {
+    async fn wait_terminal(&self, _namespace: &str, _job_name: &str) -> WarmTerminalOutcome {
         self.release.notified().await;
+        WarmTerminalOutcome::Succeeded
+    }
+}
+
+/// A watcher that returns a caller-chosen terminal outcome immediately.
+/// Used to exercise the completion-sink hook on both success and failure.
+struct ImmediateWatcher {
+    outcome: WarmTerminalOutcome,
+}
+
+#[async_trait]
+impl WarmJobWatcher for ImmediateWatcher {
+    async fn wait_terminal(&self, _namespace: &str, _job_name: &str) -> WarmTerminalOutcome {
+        self.outcome
+    }
+}
+
+/// Recording [`WarmCompletionSink`] that captures the `project_id`s it was
+/// invoked with, so tests can assert the event-driven invalidation hook fired
+/// exactly on warm-Job success.
+struct RecordingSink {
+    calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordingSink {
+    fn new() -> (Self, Arc<Mutex<Vec<String>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                calls: calls.clone(),
+            },
+            calls,
+        )
+    }
+}
+
+#[async_trait]
+impl WarmCompletionSink for RecordingSink {
+    async fn on_warm_succeeded(&self, project_id: &str) {
+        self.calls.lock().await.push(project_id.to_string());
     }
 }
 
@@ -602,5 +642,69 @@ async fn trigger_consults_lister_before_dispatching_with_empty_cluster() {
     assert!(
         !calls.lock().await.is_empty(),
         "lister must be consulted even when the cluster is empty (to keep the dedupe path exercised)"
+    );
+}
+
+/// Event-driven convergence: when a warm Job completes successfully the
+/// in-process completion sink must fire with the warmed `project_id`, so the
+/// server can invalidate its canonical-graph RAM slot without a restart.
+#[tokio::test]
+async fn trigger_fires_completion_sink_on_warm_success() {
+    let db = Database::open_in_memory().expect("in-memory db");
+    let project_id = seed_project_with_ready_image(&db, "proj-sink-success").await;
+
+    let (dispatcher, _captured, _count) = RecordingDispatcher::new("warm");
+    let (sink, calls) = RecordingSink::new();
+
+    let warmer = K8sGraphWarmer::with_dispatcher(
+        test_config(),
+        db,
+        Arc::new(dispatcher),
+        Arc::new(ImmediateWatcher {
+            outcome: WarmTerminalOutcome::Succeeded,
+        }),
+    )
+    .with_completion_sink(Arc::new(sink));
+
+    warmer.trigger(&project_id).await;
+    // The watcher runs in a spawned task; give it room to fire the sink.
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let calls = calls.lock().await;
+    assert_eq!(
+        &*calls,
+        &[project_id],
+        "completion sink must fire exactly once with the warmed project id on success"
+    );
+}
+
+/// The completion sink must NOT fire when the warm Job ends in failure —
+/// no fresh blob was persisted, so there is nothing to converge to.
+#[tokio::test]
+async fn trigger_skips_completion_sink_on_warm_failure() {
+    let db = Database::open_in_memory().expect("in-memory db");
+    let project_id = seed_project_with_ready_image(&db, "proj-sink-failure").await;
+
+    let (dispatcher, _captured, _count) = RecordingDispatcher::new("warm");
+    let (sink, calls) = RecordingSink::new();
+
+    let warmer = K8sGraphWarmer::with_dispatcher(
+        test_config(),
+        db,
+        Arc::new(dispatcher),
+        Arc::new(ImmediateWatcher {
+            outcome: WarmTerminalOutcome::Failed,
+        }),
+    )
+    .with_completion_sink(Arc::new(sink));
+
+    warmer.trigger(&project_id).await;
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    assert!(
+        calls.lock().await.is_empty(),
+        "completion sink must not fire on warm-Job failure"
     );
 }

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -24,7 +24,8 @@ pub use env_config::{
 };
 pub use graph_warmer::{
     K8sGraphWarmer, KubeClientDispatcher, KubeClientJobWatcher, KubeClientWarmJobLister,
-    NoopJobWatcher, NoopWarmJobLister, WarmJobDispatcher, WarmJobLister, WarmJobWatcher,
+    NoopJobWatcher, NoopWarmJobLister, WarmCompletionSink, WarmJobDispatcher, WarmJobLister,
+    WarmJobWatcher, WarmTerminalOutcome,
 };
 pub use runtime::KubernetesRuntime;
 pub use token_review::TokenReviewer;

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -21,7 +21,7 @@ use djinn_db::{
 };
 use djinn_git::{GitActorHandle, GitError};
 use djinn_image_controller::{ImageBuildWatcher, ImageController, ImageControllerConfig};
-use djinn_k8s::{K8sGraphWarmer, KubernetesConfig, TokenReviewer};
+use djinn_k8s::{K8sGraphWarmer, KubernetesConfig, TokenReviewer, WarmCompletionSink};
 use djinn_provider::catalog::{CatalogService, HealthTracker};
 use djinn_provider::embeddings::{EmbeddingService, default_embedding_cache_dir};
 use djinn_provider::github_app::AppConfig as GitHubAppConfig;
@@ -43,6 +43,30 @@ use canonical_graph_refresh_planner::{
 const EVENT_CHANNEL_CAPACITY: usize = 1024;
 const SETTINGS_RAW_KEY: &str = "settings.raw";
 const MODEL_HEALTH_STATE_KEY: &str = "model_health.state";
+
+/// Production [`WarmCompletionSink`]: converge the server's in-memory
+/// canonical-graph slot after an *out-of-pod* warm Job succeeds.
+///
+/// The K8s warm Job writes a fresh blob to `repo_graph_cache` from a separate
+/// pod and cannot reach this process's `djinn_graph::canonical_graph::GRAPH_CACHE`
+/// slot, so `code_graph` queries would keep serving the pre-warm graph until a
+/// restart. Clearing the slot here makes the next query reload the fresh blob
+/// within seconds of the warm completing. Wired at this composition root
+/// because it is the only place both `djinn-k8s` (the warmer) and `djinn-graph`
+/// (the cache) are in scope — `djinn-k8s` deliberately does not depend on
+/// `djinn-graph`.
+struct CanonicalGraphInvalidationSink;
+
+#[async_trait::async_trait]
+impl WarmCompletionSink for CanonicalGraphInvalidationSink {
+    async fn on_warm_succeeded(&self, project_id: &str) {
+        djinn_graph::canonical_graph::invalidate_canonical_graph_cache().await;
+        tracing::info!(
+            project_id,
+            "graph_warmer: warm Job succeeded; invalidated in-memory canonical-graph slot for reload"
+        );
+    }
+}
 
 /// Default startup grace window (ms) used for the reconnectability probe.
 /// During this window the measurement checks whether a running session's
@@ -544,8 +568,9 @@ impl AppState {
                         namespace = %config.namespace,
                         "graph_warmer: wiring K8sGraphWarmer"
                     );
-                    Arc::new(K8sGraphWarmer::new(client, config, self.db().clone()))
-                        as Arc<dyn GraphWarmerService>
+                    let warmer = K8sGraphWarmer::new(client, config, self.db().clone())
+                        .with_completion_sink(Arc::new(CanonicalGraphInvalidationSink));
+                    Arc::new(warmer) as Arc<dyn GraphWarmerService>
                 }
                 Err(e) => {
                     tracing::info!(


### PR DESCRIPTION
## Problem (verified live in production)

`djinn-graph`'s `load_canonical_graph` serves the process-global single-slot `GRAPH_CACHE` filtered **only** by `project_path`, never by commit. In production the canonical-graph warm runs in a **separate K8s Job pod** (`K8sGraphWarmer`) that writes a fresh blob to `repo_graph_cache` — but the `djinn-server` process's in-memory slot is never invalidated, so every `code_graph` MCP query serves the stale graph until the server restarts.

Observed today: the warm Job completed with `node_count=58867`, the `repo_graph_cache` row and workspace-freshness rows all advanced to the new commit, and `status` (which reads the DB) showed the new pinned commit — yet `search`/`ranked` kept returning the **old** blob (old node counts, `workspace_hint` missing the new `server` slug). The in-process warm path was already fine (`ensure_canonical_graph` → `install_as_canonical` updates the slot); only the **out-of-pod** warm path left the server stale.

## Fix — both mechanisms, in-process behavior unchanged

**1. Event-driven invalidation (fast path, seconds).** `K8sGraphWarmer`'s in-process Job watcher now returns a `WarmTerminalOutcome`; on `Succeeded` it fires a new `WarmCompletionSink`. The production sink clears `djinn_graph`'s RAM slot so the next query reloads the fresh blob. `djinn-k8s` keeps **no** dependency on `djinn-graph` — the concrete sink is wired at the `AppState` composition root (the only place both crates are in scope) and injected via `K8sGraphWarmer::with_completion_sink`.

**2. Commit-aware revalidation backstop (safety net, ≤20s).** `load_canonical_graph` now trusts the cached slot only while its pinned commit still matches the latest persisted row, re-checking the DB **at most once per 20s TTL** (`revalidation_due` / `mark_cache_validated`). The check uses a new cheap commit-only projection `RepoGraphCacheRepository::latest_commit_for_project` (no blob fetch), so steady-state per-query overhead stays at zero DB round-trips while staleness is bounded for **any** out-of-band writer. `install_as_canonical` stamps the window, so the in-process warm path serves its just-warmed slot for the full TTL unchanged.

## Tests
- `load_canonical_graph_reloads_when_slot_commit_is_stale` — stale commit in slot + newer row → reload.
- `load_canonical_graph_serves_slot_within_ttl_then_reloads_after_expiry` — same commit served from RAM with no DB read inside the TTL; newer blob picked up after expiry.
- `trigger_fires_completion_sink_on_warm_success` / `trigger_skips_completion_sink_on_warm_failure` — watcher-side hook.
- All global-`GRAPH_CACHE`-mutating tests now share the one existing `lock_pipeline_env()` guard so the single slot can't be clobbered across threads.

Verified: `cargo fmt --check`, `cargo clippy --all-features -p djinn-graph -p djinn-k8s -p djinn-db` clean; `cargo test -p djinn-graph` (571) + `-p djinn-k8s` (131) green; `djinn-server` builds. sqlx offline cache extended with the single new query only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
