### PR TITLE
fix(coordinator): stop counting pod-Pending time against refinement session timeout

### DIFF
--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -31,9 +31,22 @@ use super::refinement::{RefinementPhase, StopReason};
 use super::actor::CoordinatorActor;
 use djinn_core::clock::{Clock, SystemClock};
 
-/// How long to wait for a refinement session to start producing output
-/// before treating it as stalled (conservative — sessions can take 5+ min).
+/// How long a refinement agent session may run (measured from **session
+/// start**, not dispatch) before treating it as stalled (conservative —
+/// sessions can take 5+ min). Time the task-run pod spends Pending in the k8s
+/// scheduler queue before any agent session starts does NOT count against this
+/// budget — see [`REFINEMENT_PENDING_START_TIMEOUT`].
 const REFINEMENT_SESSION_TIMEOUT: Duration = Duration::from_secs(900);
+
+/// How long a dispatched refinement session may sit **without its agent
+/// session ever starting** (e.g. the task-run pod stuck Pending in the k8s
+/// scheduler queue under CPU pressure) before the dispatch is abandoned and
+/// retried. Distinct from [`REFINEMENT_SESSION_TIMEOUT`], which bounds actual
+/// agent execution once a session has started. Expiry is retryable (bounded by
+/// [`REFINEMENT_DISPATCH_RETRY_CAP`]), never terminal on its own — a slow
+/// scheduler must not permanently kill a tribunal that never got to run
+/// (incident 2026-07-12).
+const REFINEMENT_PENDING_START_TIMEOUT: Duration = Duration::from_secs(1200);
 
 /// How many consecutive times a refinement role session may fail to start
 /// before the loop terminates instead of re-dispatching.
@@ -46,8 +59,19 @@ pub(super) struct RefinementSession {
     pub task_id: String,
     /// Which phase this session is executing.
     pub phase: RefinementPhase,
-    /// When the session was dispatched.
+    /// When the session was dispatched (task-run pool dispatch time). Used to
+    /// bound the Pending-in-queue wait before the agent session starts, NOT the
+    /// execution budget — see `session_started_at`.
     pub dispatched_at: StdInstant,
+    /// First tick at which an agent session row was observed for `task_id`,
+    /// i.e. when the agent actually started running. `None` while the task-run
+    /// pod is still Pending / no session row exists yet. The execution timeout
+    /// (`REFINEMENT_SESSION_TIMEOUT`) is measured from this instant so pod
+    /// scheduler-queue time is never charged against the agent's budget. Cached
+    /// so start detection stops re-querying the DB once confirmed. In-memory
+    /// only; a coordinator restart drops in-flight sessions entirely (the loop
+    /// re-dispatches), so this needs no persistence.
+    pub session_started_at: Option<StdInstant>,
     /// The model used for this session.
     #[allow(dead_code)]
     pub model_id: String,
@@ -137,23 +161,86 @@ impl CoordinatorActor {
             let still_running = running_tasks.contains(&session.task_id);
 
             if still_running {
-                if session.dispatched_at.elapsed() > REFINEMENT_SESSION_TIMEOUT {
-                    tracing::warn!(
-                        proposal_id = %proposal_id,
-                        task_id = %session.task_id,
-                        phase = ?session.phase,
-                        "Refinement session timed out"
-                    );
-                    self.close_refinement_task(&session.task_id, "refinement session timed out")
-                        .await;
-                    self.terminate_refinement(
-                        proposal_id,
-                        StopReason::AgentFailure {
-                            role: format!("{:?}", session.phase),
-                            error: "session timeout".into(),
-                        },
-                    )
-                    .await;
+                // Resolve whether the agent session has actually started yet.
+                // The execution budget (`REFINEMENT_SESSION_TIMEOUT`) must be
+                // measured from session start, NOT from dispatch: time the
+                // task-run pod spends Pending in the k8s scheduler queue (before
+                // any session row exists) must not count against it. Otherwise
+                // scheduler back-pressure silently terminates tribunals that
+                // never got to run (incident 2026-07-12). Cache the first
+                // observed start so we stop re-querying the DB every tick.
+                let session_started_at = match session.session_started_at {
+                    Some(started) => Some(started),
+                    None => {
+                        if self.refinement_session_has_started(&session.task_id).await {
+                            let observed = SystemClock::new().now_instant();
+                            if let Some(s) = self.refinement_sessions.get_mut(proposal_id) {
+                                s.session_started_at = Some(observed);
+                            }
+                            Some(observed)
+                        } else {
+                            None
+                        }
+                    }
+                };
+
+                match session_started_at {
+                    Some(started_at) => {
+                        // The agent session has started — bound actual execution
+                        // from session start.
+                        if started_at.elapsed() > REFINEMENT_SESSION_TIMEOUT {
+                            tracing::warn!(
+                                proposal_id = %proposal_id,
+                                task_id = %session.task_id,
+                                phase = ?session.phase,
+                                "Refinement session timed out (execution budget from session start)"
+                            );
+                            self.close_refinement_task(
+                                &session.task_id,
+                                "refinement session timed out",
+                            )
+                            .await;
+                            self.terminate_refinement(
+                                proposal_id,
+                                StopReason::AgentFailure {
+                                    role: format!("{:?}", session.phase),
+                                    error: "session timeout".into(),
+                                },
+                            )
+                            .await;
+                        }
+                    }
+                    None => {
+                        // Dispatched but the agent session has not started — the
+                        // task-run pod is (most likely) still Pending in the
+                        // scheduler queue. Do NOT burn the execution budget, but
+                        // bound the wait so a forever-Pending pod cannot hold the
+                        // tribunal open indefinitely. On expiry, abandon THIS
+                        // dispatch and retry the same phase (bounded by the retry
+                        // cap) rather than terminally kill the tribunal.
+                        if session.dispatched_at.elapsed() > REFINEMENT_PENDING_START_TIMEOUT {
+                            tracing::warn!(
+                                proposal_id = %proposal_id,
+                                task_id = %session.task_id,
+                                phase = ?session.phase,
+                                elapsed_secs = session.dispatched_at.elapsed().as_secs(),
+                                "Refinement session never started (task-run pod Pending past \
+                                 pending-start timeout); abandoning dispatch and retrying"
+                            );
+                            let over_cap_error = format!(
+                                "role session failed to start {REFINEMENT_DISPATCH_RETRY_CAP} times \
+                                 (task-run pod stuck Pending in scheduler queue)"
+                            );
+                            self.retry_or_terminate_unstarted_refinement(
+                                proposal_id,
+                                &session,
+                                "refinement role session never started (task-run pod stuck Pending)",
+                                over_cap_error,
+                                true,
+                            )
+                            .await;
+                        }
+                    }
                 }
                 return;
             }
@@ -167,65 +254,26 @@ impl CoordinatorActor {
             // Treating (b) as a completed-but-"dry" round silently burns rounds
             // on a dispatch outage and can hollow-converge the tribunal. Tell
             // them apart by whether any session row exists for the task.
-            let session_ran = {
-                let event_bus = crate::events::event_bus_for(&self.events_tx);
-                let session_repo = djinn_db::SessionRepository::new(self.db.clone(), event_bus);
-                match session_repo.list_for_task(&session.task_id).await {
-                    Ok(sessions) => !sessions.is_empty(),
-                    // On a DB read error, fail safe toward "it ran" so we don't
-                    // spin forever re-dispatching.
-                    Err(e) => {
-                        tracing::warn!(
-                            proposal_id = %proposal_id,
-                            task_id = %session.task_id,
-                            error = %e,
-                            "Failed to read sessions for refinement task; assuming it ran"
-                        );
-                        true
-                    }
-                }
-            };
+            let session_ran = self.refinement_session_has_started(&session.task_id).await;
 
             if !session_ran {
                 // Dispatch/setup failure: the role never executed. Re-dispatch
                 // the same phase on the next tick, bounded by a retry cap so a
-                // persistently broken runtime escalates instead of looping.
-                self.close_refinement_task(
-                    &session.task_id,
+                // persistently broken runtime escalates instead of looping. The
+                // slot already freed on its own here (the pool no longer reports
+                // the task running), so no pool teardown is needed.
+                let over_cap_error = format!(
+                    "role session failed to start {REFINEMENT_DISPATCH_RETRY_CAP} times \
+                     (runtime/devcontainer setup failure)"
+                );
+                self.retry_or_terminate_unstarted_refinement(
+                    proposal_id,
+                    &session,
                     "refinement role session never started (dispatch/setup failure)",
+                    over_cap_error,
+                    false,
                 )
                 .await;
-                self.refinement_sessions.remove(proposal_id);
-                let over_cap = if let Some(state) = self.active_refinements.get_mut(proposal_id) {
-                    state.dispatch_failures += 1;
-                    state.dispatch_failures >= REFINEMENT_DISPATCH_RETRY_CAP
-                } else {
-                    true
-                };
-                if over_cap {
-                    tracing::warn!(
-                        proposal_id = %proposal_id,
-                        phase = ?session.phase,
-                        "Refinement role session repeatedly failed to start — terminating"
-                    );
-                    self.terminate_refinement(
-                        proposal_id,
-                        StopReason::AgentFailure {
-                            role: format!("{:?}", session.phase),
-                            error: format!(
-                                "role session failed to start {REFINEMENT_DISPATCH_RETRY_CAP} times \
-                                 (runtime/devcontainer setup failure)"
-                            ),
-                        },
-                    )
-                    .await;
-                } else {
-                    tracing::warn!(
-                        proposal_id = %proposal_id,
-                        phase = ?session.phase,
-                        "Refinement role session never started; will re-dispatch (not counted as dry)"
-                    );
-                }
                 return;
             }
 
@@ -244,6 +292,96 @@ impl CoordinatorActor {
 
         // No in-flight session — dispatch the next phase.
         self.dispatch_next_refinement_phase(proposal_id).await;
+    }
+
+    /// Whether an agent session row exists yet for a dispatched refinement
+    /// task. A dispatched task with no session row means the agent has not
+    /// started (e.g. the task-run pod is still Pending in the scheduler queue).
+    /// On a DB read error, fail safe toward "started" so a transient DB blip
+    /// neither burns the pending-start budget nor strands the loop treating a
+    /// possibly-running session as never-started.
+    async fn refinement_session_has_started(&self, task_id: &str) -> bool {
+        let event_bus = crate::events::event_bus_for(&self.events_tx);
+        let session_repo = djinn_db::SessionRepository::new(self.db.clone(), event_bus);
+        match session_repo.list_for_task(task_id).await {
+            Ok(sessions) => !sessions.is_empty(),
+            Err(e) => {
+                tracing::warn!(
+                    task_id = %task_id,
+                    error = %e,
+                    "Failed to read sessions for refinement task; assuming it started"
+                );
+                true
+            }
+        }
+    }
+
+    /// Abandon a dispatched refinement role session that did not execute and
+    /// either re-dispatch the same phase (bounded by
+    /// [`REFINEMENT_DISPATCH_RETRY_CAP`]) or, once the cap is hit, terminate the
+    /// loop. Shared by the two "role never ran" paths: the slot freed with no
+    /// session row (runtime/devcontainer setup failure), and a dispatch that sat
+    /// Pending past [`REFINEMENT_PENDING_START_TIMEOUT`] without the agent
+    /// session ever starting.
+    ///
+    /// `tear_down_slot` kills the pool session and clears the in-flight
+    /// reservation for the still-Pending case, where the pool still holds the
+    /// slot; the slot-already-freed case leaves those to the paths that already
+    /// released them (the in-flight ledger is cleared by the session-start
+    /// reconciler, which never fired because no session started).
+    async fn retry_or_terminate_unstarted_refinement(
+        &mut self,
+        proposal_id: &str,
+        session: &RefinementSession,
+        close_reason: &str,
+        over_cap_error: String,
+        tear_down_slot: bool,
+    ) {
+        if tear_down_slot {
+            // The pool still holds the slot for the Pending task-run. Tear down
+            // the (still-queued) Job and clear the in-flight reservation so the
+            // retry does not leak a slot. Best-effort: a kill error must not
+            // block the retry.
+            if let Err(e) = self.pool.kill_session(&session.task_id).await {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    task_id = %session.task_id,
+                    error = %e,
+                    "Failed to tear down Pending refinement task-run; proceeding with retry"
+                );
+            }
+            self.clear_inflight_dispatch(&session.task_id).await;
+        }
+        self.close_refinement_task(&session.task_id, close_reason)
+            .await;
+        self.refinement_sessions.remove(proposal_id);
+        let over_cap = if let Some(state) = self.active_refinements.get_mut(proposal_id) {
+            state.dispatch_failures += 1;
+            state.dispatch_failures >= REFINEMENT_DISPATCH_RETRY_CAP
+        } else {
+            true
+        };
+        if over_cap {
+            tracing::warn!(
+                proposal_id = %proposal_id,
+                phase = ?session.phase,
+                "Refinement role session repeatedly failed to start — terminating"
+            );
+            self.terminate_refinement(
+                proposal_id,
+                StopReason::AgentFailure {
+                    role: format!("{:?}", session.phase),
+                    error: over_cap_error,
+                },
+            )
+            .await;
+        } else {
+            tracing::warn!(
+                proposal_id = %proposal_id,
+                phase = ?session.phase,
+                "Refinement role session never started; will re-dispatch (not counted as dry)"
+            );
+        }
     }
 
     /// Dispatch the next refinement phase for a proposal.
@@ -634,6 +772,7 @@ impl CoordinatorActor {
                         task_id,
                         phase,
                         dispatched_at: SystemClock::new().now_instant(),
+                        session_started_at: None,
                         model_id,
                     },
                 );

--- a/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_pool_watchdog_tests.rs
@@ -5,22 +5,26 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use std::time::Instant as StdInstant;
+use std::time::{Duration, Instant as StdInstant};
 
-use djinn_core::events::DjinnEventEnvelope;
+use djinn_core::events::{DjinnEventEnvelope, EventBus};
+use djinn_db::{CreateSessionParams, SessionRepository, TaskRepository};
 use djinn_slot::{PoolMessage, PoolStatus, RunningTaskInfo, SlotPoolHandle};
 use tokio::sync::mpsc;
 
 use super::RefinementSession;
 use crate::actor::CoordinatorActor;
 use crate::refinement::{RefinementLoopState, RefinementPhase};
-use crate::refinement_dispatch::refinement_cap_tests::{TEST_MODEL, build_refinement_actor};
+use crate::refinement_dispatch::refinement_cap_tests::{
+    TEST_MODEL, build_refinement_actor, seed_refinement_fixture,
+};
 
 /// Counters for the pool asks a stub pool observed.
 #[derive(Default)]
 struct PoolCallCounts {
     get_status: usize,
     has_session: usize,
+    kill_session: usize,
 }
 
 /// Spawn a stub pool (via `from_raw_sender`) that answers `GetStatus` with the
@@ -62,6 +66,10 @@ fn spawn_counting_pool(running: Vec<String>) -> (SlotPoolHandle, Arc<Mutex<PoolC
                     counts_task.lock().expect("counts").has_session += 1;
                     let _ = respond_to.send(Ok(true));
                 }
+                PoolMessage::KillSession { respond_to, .. } => {
+                    counts_task.lock().expect("counts").kill_session += 1;
+                    let _ = respond_to.send(Ok(()));
+                }
                 _ => {}
             }
         }
@@ -81,6 +89,7 @@ fn seed_running_refinement(actor: &mut CoordinatorActor, proposal_id: &str, task
             task_id: task_id.to_string(),
             phase: RefinementPhase::AdversaryAttack,
             dispatched_at: StdInstant::now(),
+            session_started_at: None,
             model_id: TEST_MODEL.to_owned(),
         },
     );
@@ -164,4 +173,249 @@ async fn watchdog_abandons_a_wedged_pass_and_runs_the_next() {
     })
     .await;
     assert!(*ran.lock().expect("ran"), "fast pass should have completed");
+}
+
+// ─── Pending-time-vs-execution-budget watchdog (incident 2026-07-12) ────────
+//
+// The 900s execution timeout must measure actual agent session runtime, not
+// the time the task-run pod spends Pending in the k8s scheduler queue before
+// any agent session starts. A separate, longer pending-start timeout bounds a
+// forever-Pending pod, and its expiry is retryable (not a terminal kill of the
+// whole tribunal).
+
+/// A monotonic instant `d` in the past (saturating).
+fn ago(d: Duration) -> StdInstant {
+    StdInstant::now()
+        .checked_sub(d)
+        .expect("instant within representable range")
+}
+
+/// Seed a running refinement whose in-flight session was dispatched at a
+/// caller-controlled instant, with no observed session start yet.
+fn seed_running_refinement_dispatched_at(
+    actor: &mut CoordinatorActor,
+    proposal_id: &str,
+    task_id: &str,
+    dispatched_at: StdInstant,
+) {
+    actor.active_refinements.insert(
+        proposal_id.to_string(),
+        RefinementLoopState::new(proposal_id, 1),
+    );
+    actor.refinement_sessions.insert(
+        proposal_id.to_string(),
+        RefinementSession {
+            task_id: task_id.to_string(),
+            phase: RefinementPhase::AdversaryAttack,
+            dispatched_at,
+            session_started_at: None,
+            model_id: TEST_MODEL.to_owned(),
+        },
+    );
+}
+
+/// Create a refinement task row owned by `user_id` in `project_id`.
+async fn seed_refinement_task_row(
+    db: &djinn_db::Database,
+    project_id: &str,
+    user_id: &str,
+) -> String {
+    djinn_core::auth_context::SESSION_USER_ID
+        .scope(Some(user_id.to_owned()), async {
+            TaskRepository::new(db.clone(), EventBus::noop())
+                .create_in_project(
+                    project_id,
+                    None,
+                    "Refinement watchdog task",
+                    "watchdog test task",
+                    "",
+                    "refinement",
+                    0,
+                    "adversary",
+                    Some("open"),
+                    Some("[]"),
+                )
+                .await
+                .expect("seed refinement task")
+                .id
+        })
+        .await
+}
+
+/// (a) A dispatched-but-not-yet-started session whose dispatch is already older
+/// than the *execution* timeout is NOT terminated: pod-Pending queue time must
+/// not burn the agent's execution budget. No session row exists for the task,
+/// so the agent has not started.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pending_queue_time_does_not_burn_execution_budget() {
+    let db = crate::test_helpers::create_test_db();
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    let task_id = "refine-pending-task";
+    let (pool, _counts) = spawn_counting_pool(vec![task_id.to_string()]);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+
+    // Dispatched longer ago than the execution timeout, but within the
+    // pending-start timeout — and no session row exists (pod still Pending).
+    seed_running_refinement_dispatched_at(
+        &mut actor,
+        "proposal-pending",
+        task_id,
+        ago(super::REFINEMENT_SESSION_TIMEOUT + Duration::from_secs(60)),
+    );
+
+    actor.drive_active_refinements().await;
+
+    assert!(
+        actor.active_refinements.contains_key("proposal-pending"),
+        "a Pending-in-queue session must NOT be terminated by the execution timeout"
+    );
+    let session = actor
+        .refinement_sessions
+        .get("proposal-pending")
+        .expect("session must still be in-flight (execution budget not burned)");
+    assert!(
+        session.session_started_at.is_none(),
+        "session start must not be recorded while no session row exists"
+    );
+}
+
+/// (b) A session that starts late (long after dispatch) still gets the full
+/// execution budget measured from session start, not from dispatch. Even though
+/// dispatch is older than the execution timeout, a just-created session row
+/// resets the clock to session start, so the loop is not terminated.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn late_starting_session_gets_full_budget_from_start() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    let task_id = seed_refinement_task_row(&db, &fixture.project_id, &fixture.user_id).await;
+
+    // Materialize a session row NOW — i.e. the agent just started, long after
+    // dispatch. `started_at` defaults to the insert time.
+    SessionRepository::new(db.clone(), EventBus::noop())
+        .create(CreateSessionParams {
+            project_id: &fixture.project_id,
+            task_id: Some(&task_id),
+            model: TEST_MODEL,
+            agent_type: "adversary",
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .expect("materialize just-started session");
+
+    let (pool, _counts) = spawn_counting_pool(vec![task_id.clone()]);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+
+    // Dispatched longer ago than the execution timeout — but the session only
+    // just started, so the budget (from start) is nowhere near exhausted.
+    seed_running_refinement_dispatched_at(
+        &mut actor,
+        &fixture.proposal_id,
+        &task_id,
+        ago(super::REFINEMENT_SESSION_TIMEOUT + Duration::from_secs(120)),
+    );
+
+    actor.drive_active_refinements().await;
+
+    assert!(
+        actor.active_refinements.contains_key(&fixture.proposal_id),
+        "a session that just started must not be terminated despite an old dispatch time"
+    );
+    let session = actor
+        .refinement_sessions
+        .get(&fixture.proposal_id)
+        .expect("session must still be in-flight");
+    assert!(
+        session.session_started_at.is_some(),
+        "observed session start must be cached once a session row exists"
+    );
+}
+
+/// (c) A dispatch that sits Pending past the pending-start timeout without ever
+/// starting a session is abandoned and retried (bounded by the retry cap), NOT
+/// terminated: the tribunal survives, the in-flight session is cleared, the
+/// dispatch-failure counter increments, and the still-Pending slot is torn down.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pending_start_timeout_retries_without_terminating() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    let task_id = seed_refinement_task_row(&db, &fixture.project_id, &fixture.user_id).await;
+
+    let (pool, counts) = spawn_counting_pool(vec![task_id.clone()]);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+
+    // No session row was ever created; dispatched longer ago than the
+    // pending-start timeout (pod stuck Pending in the scheduler queue).
+    seed_running_refinement_dispatched_at(
+        &mut actor,
+        &fixture.proposal_id,
+        &task_id,
+        ago(super::REFINEMENT_PENDING_START_TIMEOUT + Duration::from_secs(60)),
+    );
+
+    actor.drive_active_refinements().await;
+
+    assert!(
+        actor.active_refinements.contains_key(&fixture.proposal_id),
+        "pending-start timeout must be RETRYABLE — the tribunal must not be terminated"
+    );
+    assert!(
+        !actor.refinement_sessions.contains_key(&fixture.proposal_id),
+        "the abandoned in-flight session must be cleared so the phase re-dispatches"
+    );
+    assert_eq!(
+        actor.active_refinements[&fixture.proposal_id].dispatch_failures, 1,
+        "the dispatch-failure counter must increment on a pending-start abandonment"
+    );
+    assert_eq!(
+        counts.lock().expect("counts").kill_session,
+        1,
+        "the still-Pending slot must be torn down via kill_session"
+    );
+}
+
+/// (d) Once the dispatch-failure retry cap is reached, a further pending-start
+/// abandonment escalates to termination (the tribunal is stopped).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pending_start_timeout_escalates_to_termination_at_retry_cap() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+
+    let task_id = seed_refinement_task_row(&db, &fixture.project_id, &fixture.user_id).await;
+
+    let (pool, _counts) = spawn_counting_pool(vec![task_id.clone()]);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool);
+
+    seed_running_refinement_dispatched_at(
+        &mut actor,
+        &fixture.proposal_id,
+        &task_id,
+        ago(super::REFINEMENT_PENDING_START_TIMEOUT + Duration::from_secs(60)),
+    );
+    // Pre-load the failure counter to one below the cap so this abandonment
+    // reaches it.
+    actor
+        .active_refinements
+        .get_mut(&fixture.proposal_id)
+        .expect("seeded refinement")
+        .dispatch_failures = super::REFINEMENT_DISPATCH_RETRY_CAP - 1;
+
+    actor.drive_active_refinements().await;
+
+    assert!(
+        !actor.active_refinements.contains_key(&fixture.proposal_id),
+        "reaching the retry cap must terminate the refinement (removed after retain)"
+    );
+    assert!(
+        !actor.refinement_sessions.contains_key(&fixture.proposal_id),
+        "in-flight session must be cleared on terminal escalation"
+    );
 }


### PR DESCRIPTION
## Incident (prod, 2026-07-12)

Four proposal refinements (tribunals) were started via MCP. The coordinator dispatched two adversary sessions whose k8s task-run pods sat **Pending for ~12 minutes** because the node's CPU requests were at 98% ("Insufficient cpu"). They only survived because an operator manually freed CPU. Had the pods stayed Pending ~3 more minutes, the watchdog would have **permanently terminated the tribunals** as `AgentFailure("session timeout")` — and even after they scheduled, the agents had only ~3 min of the 900s budget left.

## Root cause

`REFINEMENT_SESSION_TIMEOUT` (900s) was measured from **pool-dispatch time** (`RefinementSession::dispatched_at`). Time a task-run pod spends Pending in the k8s scheduler queue — before any agent session row exists — was therefore charged against the agent's execution budget. Under scheduler back-pressure this kills tribunals that never got to run.

## Fix

Measure the execution timeout from **actual session start**, not dispatch:

- `RefinementSession` gains `session_started_at`, detected via the sessions table (`SessionRepository::list_for_task`) and **cached** so start detection stops re-querying the DB every tick once confirmed.
- While the pool reports the task running but **no session has started**, the execution budget is not burned.
- A separate `REFINEMENT_PENDING_START_TIMEOUT` (20 min) bounds a forever-Pending pod. On expiry the dispatch is abandoned and the **same phase is retried** (bounded by the existing `REFINEMENT_DISPATCH_RETRY_CAP`), tearing down the still-Pending slot via `kill_session` and clearing the in-flight reservation — **retryable, not a terminal kill** of the tribunal. Only at the retry cap does it escalate to termination.
- The retry/terminate tail is shared with the existing "slot freed with no session row" (runtime/devcontainer setup-failure) path via `retry_or_terminate_unstarted_refinement` — a behavior-preserving refactor of that path.

**Restart-safe:** `session_started_at` is in-memory only; a coordinator restart drops in-flight sessions and the loop re-dispatches (worst case the timer restarts, which is fine). `refinement_recovery.rs` does not reconstruct in-flight `RefinementSession`s, so nothing else changes there.

## Tests (`refinement_pool_watchdog_tests.rs`)

- `pending_queue_time_does_not_burn_execution_budget` — a dispatch older than the execution timeout, with no session row, is not terminated.
- `late_starting_session_gets_full_budget_from_start` — a session that starts long after dispatch still gets the full 900s from start; the start is cached.
- `pending_start_timeout_retries_without_terminating` — pending-start expiry clears the session, increments `dispatch_failures`, tears down the slot (`kill_session`), and leaves the tribunal active.
- `pending_start_timeout_escalates_to_termination_at_retry_cap` — reaching the cap terminates the loop.

## Verification

- `cargo clippy -p djinn-coordinator --all-features --all-targets` — clean (only a pre-existing unrelated warning in `pr_poller/merged_change_projection.rs`).
- `cargo test -p djinn-coordinator refinement` — 91 passed, 0 failed (run against a local postgres:16 test DB on :5433; not prod).

## Scope note

The secondary Kanban-attribution item from the original brief was dropped by request — attribution is being fixed at the source by a separate change, so no frontend/owner fallback is included here. This PR is watchdog-only.