### PR TITLE
fix(coordinator): attribute refinement task owner to the resolved user instead of "system"

### DIFF
--- a/server/crates/djinn-coordinator/src/refinement_dor_status_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dor_status_tests.rs
@@ -115,3 +115,93 @@ async fn structured_acs_added_mid_refinement_clear_missing_ac_dor_status() {
         task.description
     );
 }
+
+/// Regression: refinement tribunal tasks must be attributed to the resolved
+/// user in the legacy `owner` column (their GitHub login), not the hardcoded
+/// "system" placeholder. The coordinator already fail-closed-validates the
+/// attributed user before dispatch, so a real login is always available —
+/// leaving `owner: "system"` made the Kanban board render tribunal tasks as
+/// unassigned and dropped them from owner-based filters (`task_ready owner=…`).
+/// `created_by_user_id` (the authoritative ownership field) is unaffected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refinement_task_owner_is_attributed_user_login_not_system() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    let task_id = actor
+        .create_refinement_task_with_context(
+            &fixture.proposal_id,
+            "adversary",
+            1,
+            1,
+            "Proposal currently meets all DoR checks.",
+            None,
+            Some(&fixture.user_id),
+        )
+        .await
+        .expect("create adversary refinement task");
+
+    let task = TaskRepository::new(db.clone(), EventBus::noop())
+        .get(&task_id)
+        .await
+        .expect("read task")
+        .expect("task exists");
+
+    // `owner` (legacy display/filter column) is now the user's GitHub login.
+    assert_eq!(
+        task.owner, "refinement-cap-user",
+        "refinement task owner must be the attributed user's login, not \"system\""
+    );
+    assert_ne!(
+        task.owner, "system",
+        "refinement task owner must not fall back to the \"system\" placeholder \
+         when a real attributed user is in scope"
+    );
+    // Authoritative ownership field is still stamped with the user id.
+    assert_eq!(
+        task.created_by_user_id.as_deref(),
+        Some(fixture.user_id.as_str()),
+        "created_by_user_id must remain the authoritative ownership field"
+    );
+}
+
+/// The owner resolution fails closed to the prior "system" behavior when the
+/// attributed user id cannot be resolved to a row (e.g. a deleted user), rather
+/// than failing task creation. `created_by_user_id` is still stamped with the
+/// supplied id — the fallback only affects the legacy display `owner` column.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn refinement_task_owner_falls_back_to_system_when_user_unresolvable() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    let missing_user_id = "00000000-0000-0000-0000-000000000000";
+    let task_id = actor
+        .create_refinement_task_with_context(
+            &fixture.proposal_id,
+            "judge",
+            1,
+            1,
+            "Proposal currently meets all DoR checks.",
+            None,
+            Some(missing_user_id),
+        )
+        .await
+        .expect("task creation must not fail when the user row is unresolvable");
+
+    let task = TaskRepository::new(db.clone(), EventBus::noop())
+        .get(&task_id)
+        .await
+        .expect("read task")
+        .expect("task exists");
+
+    assert_eq!(
+        task.owner, "system",
+        "owner must fall back to \"system\" when the attributed user cannot be resolved"
+    );
+}

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -744,6 +744,30 @@ impl CoordinatorActor {
             .and_then(|p| p.author_user_id)
     }
 
+    /// Resolve a user id to the display identity used for the legacy `owner`
+    /// column (their GitHub login). Returns `None` when the user can't be
+    /// resolved (missing row or lookup error) so callers fall back to the prior
+    /// "system" owner rather than failing task creation. `created_by_user_id`
+    /// remains the authoritative ownership field — this is display/filter only.
+    pub(super) async fn resolve_owner_identity(&self, user_id: &str) -> Option<String> {
+        match djinn_db::UserRepository::new(self.db.clone())
+            .get_by_id(user_id)
+            .await
+        {
+            Ok(Some(user)) => Some(user.github_login),
+            Ok(None) => None,
+            Err(e) => {
+                tracing::warn!(
+                    user_id = %user_id,
+                    error = %e,
+                    "Failed to resolve owner identity for refinement task; \
+                     falling back to system owner"
+                );
+                None
+            }
+        }
+    }
+
     /// Force-close a finished refinement task. Best-effort.
     pub(super) async fn close_refinement_task(&self, task_id: &str, reason: &str) {
         let event_bus = crate::events::event_bus_for(&self.events_tx);
@@ -887,6 +911,21 @@ impl CoordinatorActor {
             }
         };
 
+        // Resolve the attributed user's display identity (their GitHub login)
+        // for the legacy `owner` column so the Kanban board and owner-based
+        // filters (`task_ready owner=…`) render refinement tasks under the real
+        // user instead of "system". `created_by_user_id` (set below) remains the
+        // authoritative ownership field; `tasks.owner` is legacy display/filter
+        // only. Falls back to "system" when the user row can't be resolved so
+        // task creation never fails on the lookup.
+        let owner = match attributed_user_id {
+            Some(uid) => self
+                .resolve_owner_identity(uid)
+                .await
+                .unwrap_or_else(|| "system".to_string()),
+            None => "system".to_string(),
+        };
+
         match task_repo
             .create_in_project(
                 &project_id,
@@ -896,7 +935,7 @@ impl CoordinatorActor {
                 "",
                 "refinement",
                 0,
-                "system",
+                &owner,
                 None,
                 None,
             )


### PR DESCRIPTION
## Defect

Refinement (tribunal) tasks were created with a hardcoded `owner: "system"` even though the coordinator has already resolved and fail-closed-validated a real attributed user at that point. `create_refinement_task_with_context` (in `refinement_outcome.rs`) called `create_in_project(..., "system", ...)` and only afterwards stamped the real attribution via `set_created_by_user_id`.

Effect: the legacy `tasks.owner` column stayed `"system"`, so owner-based filtering — e.g. `task_ready(owner=…)`, which compares against `t.owner` — missed refinement tasks, and any `owner`-derived display rendered them as system-owned/unassigned. Verified live: adversary tasks r4va/e35t showed `owner: "system"` with a correct `created_by_user_id`.

## Fix

- Added `resolve_owner_identity(user_id)` on `CoordinatorActor`, which looks up the user row (`djinn_db::UserRepository::get_by_id`) and returns their `github_login` — the identity convention used across the codebase for the free-form `owner` display/filter column (the `users` table has no email column; `github_login` is the human-facing identity).
- In `create_refinement_task_with_context`, when `attributed_user_id` is `Some`, the resolved login is passed as the `owner` argument to `create_in_project` instead of `"system"`. If the user row can't be resolved (missing row or lookup error), it falls back to the prior `"system"` behavior rather than failing task creation.
- `set_created_by_user_id` is unchanged — `created_by_user_id` remains the authoritative ownership field; `tasks.owner` is legacy display/filter only.

### What `owner` is now set to
The attributed user's **GitHub login** (e.g. `refinement-cap-user` in tests), falling back to `"system"` only when the user cannot be resolved or no user is in scope.

### Sibling paths swept
- The only refinement-flow coordinator spawn path hardcoding `owner: "system"` while a resolved user is in scope was `create_refinement_task_with_context` — now fixed.
- The evidence-spike creation for refinement demand rounds (`proposal_refinement_demand_evidence` in `djinn-control-plane`) already follows the standard MCP task-creation convention: `owner: ""` plus `created_by_user_id` stamped from the attributed MCP session via `auth_context` — it does not use the `"system"` placeholder, so it is intentionally left as-is (matching every other MCP-created task).
- Other coordinator `create_in_project(..., "system", ...)` paths (e.g. planner-escalation review tasks) belong to unrelated subsystems, attribute via `SESSION_USER_ID` scope, and deliberately keep `owner` as a role label; out of scope for this refinement-attribution fix.

## Tests

Extended `refinement_dor_status_tests.rs`:
- `refinement_task_owner_is_attributed_user_login_not_system` — asserts the created task's `owner` is the attributed user's login (not `"system"`) and that `created_by_user_id` still holds the user id.
- `refinement_task_owner_falls_back_to_system_when_user_unresolvable` — asserts an unresolvable user id falls back to `owner: "system"` without failing task creation.

## Verification

- `cargo clippy -p djinn-coordinator --all-features` — clean (the one remaining `redundant_closure` warning is pre-existing in `pr_poller/merged_change_projection.rs`, untouched here).
- `cargo test -p djinn-coordinator refinement` — 89 passed, 0 failed (including the 2 new tests).