### PR TITLE
feat(coordinator): resume mid-flight refinements across restarts instead of stamping Interrupted

### DIFF
--- a/server/crates/djinn-coordinator/src/refinement_recovery.rs
+++ b/server/crates/djinn-coordinator/src/refinement_recovery.rs
@@ -1,16 +1,173 @@
 // Startup recovery for refinement loops interrupted by a coordinator restart.
 //
 // Split out of `refinement_outcome.rs` to keep that file under the
-// size-guard byte threshold. Owns the restart reconciliation pass: dangling
-// refinements that legitimately converged and parked awaiting the human's
-// accept/reject review are restored from durable lifecycle data; refinements
-// genuinely lost mid-tribunal are stamped `refinement_stop`/`Interrupted`.
+// size-guard byte threshold. Owns the restart reconciliation pass:
+//
+//   1. Dangling refinements that legitimately converged and parked awaiting the
+//      human's accept/reject review are restored from durable lifecycle data.
+//   2. Refinements still mid-tribunal are RESUMED in place — their in-memory
+//      `RefinementLoopState` is rebuilt from durable data (lifecycle events,
+//      debate trail, refinement task rows) and re-inserted into
+//      `active_refinements` so the driver continues the same run.
+//   3. Only genuinely ambiguous/contradictory refinements (no coherent
+//      round/phase can be derived) fall back to the historical behavior:
+//      stamped `refinement_stop`/`Interrupted` and left restartable.
 
-use djinn_db::ProposalRepository;
+use djinn_core::models::ProposalDebateTrail;
+use djinn_db::{ProposalRepository, TaskRepository};
 
 use super::actor::CoordinatorActor;
-use super::refinement::{RefinementLoopState, StopReason};
+use super::refinement::{RefinementConfig, RefinementLoopState, RefinementPhase, StopReason};
 use super::refinement_outcome::entry_in_current_run;
+
+/// Outcome of deriving a resumable phase/round for a mid-flight refinement from
+/// durable data. `Resume` carries the reconstructed phase and 1-based round the
+/// driver should continue at; `Ambiguous` means the durable trail could not be
+/// mapped to a coherent tribunal position and the caller must fall back to the
+/// historical `Interrupted` stamp rather than guess into a corrupt run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResumePlan {
+    Resume {
+        phase: RefinementPhase,
+        round: i32,
+    },
+    Ambiguous(&'static str),
+}
+
+/// Derive the phase/round a mid-flight refinement should resume at, purely from
+/// durable data. No I/O — every input is pre-resolved so this is unit-testable.
+///
+/// The derivation mirrors the tribunal state machine (`Adversary → Advocate →
+/// Judge` per round):
+///
+///   - A linked evidence spike ⇒ the run is parked awaiting evidence; restore
+///     `AwaitingEvidence` so the evidence-completion path can resume it.
+///   - Within the latest current-run round `R`:
+///       * a Judge `needs_evidence` demand ⇒ `AwaitingEvidence`;
+///       * a Judge verdict already ruled ⇒ a blocking verdict below the round
+///         cap advances to round `R+1` `AdversaryAttack`; a ready verdict, or a
+///         blocking verdict at the cap, is AMBIGUOUS (those should have written
+///         a durable awaiting-review park — restored by the sibling path — so
+///         reaching here means the process died mid-transition and we cannot
+///         reconstruct the snapshot revision);
+///       * Adversary objections filed, no verdict yet ⇒ `AdvocateRevision` when
+///         any is blocking, else `JudgeAdjudication` (dry round);
+///       * round opened but the Adversary never filed ⇒ `AdversaryAttack`.
+///   - No current-run debate entries at all ⇒ round 1 `AdversaryAttack` (the
+///     run had just (re)started; the opener never filed).
+///
+/// Re-dispatching the derived phase is idempotent from the tribunal's
+/// perspective: only the Judge advances the round, entry reads are set-based
+/// (not append-counted), and `process_advocate_outcome` guards double-applying a
+/// revision with `new_revision_seq > current_revision_seq`.
+pub(crate) fn derive_resume_plan(
+    entries: &[ProposalDebateTrail],
+    run_start: Option<&str>,
+    head_revision_seq: i32,
+    linked_spike: bool,
+    max_rounds: i32,
+) -> ResumePlan {
+    let max_current_run_round = entries
+        .iter()
+        .filter(|e| entry_in_current_run(e, run_start))
+        .map(|e| e.round)
+        .max();
+
+    // A linked evidence spike parks the whole run awaiting evidence, regardless
+    // of the per-round trail. Restore the park so the evidence-completion path
+    // (which looks the run up in `active_refinements`) can resume it.
+    if linked_spike {
+        let round = max_current_run_round.unwrap_or(1).max(1);
+        return ResumePlan::Resume {
+            phase: RefinementPhase::AwaitingEvidence,
+            round,
+        };
+    }
+
+    let Some(round) = max_current_run_round else {
+        return ResumePlan::Resume {
+            phase: RefinementPhase::AdversaryAttack,
+            round: 1,
+        };
+    };
+    let round = round.max(1);
+
+    // Current-run entries for the latest round.
+    let round_entries: Vec<&ProposalDebateTrail> = entries
+        .iter()
+        .filter(|e| e.round == round && entry_in_current_run(e, run_start))
+        .collect();
+
+    // 1. Judge demanded evidence this round → parked awaiting evidence.
+    if round_entries.iter().any(|e| {
+        e.kind == "needs_evidence" && e.agent_role == "judge" && e.body_metadata.is_some()
+    }) {
+        return ResumePlan::Resume {
+            phase: RefinementPhase::AwaitingEvidence,
+            round,
+        };
+    }
+
+    // 2. Judge already ruled this round. Prefer the latest verdict written
+    //    against the current head revision, else the latest verdict overall
+    //    (mirrors `select_current_run_verdict`).
+    let is_verdict = |e: &&ProposalDebateTrail| e.kind == "verdict" && e.agent_role == "judge";
+    let verdict = round_entries
+        .iter()
+        .copied()
+        .filter(is_verdict)
+        .filter(|e| e.against_revision_seq == head_revision_seq)
+        .max_by(|a, b| a.created_at.cmp(&b.created_at))
+        .or_else(|| {
+            round_entries
+                .iter()
+                .copied()
+                .filter(is_verdict)
+                .max_by(|a, b| a.created_at.cmp(&b.created_at))
+        });
+
+    if let Some(verdict) = verdict {
+        if !verdict.blocking {
+            // A ready verdict should have written a durable awaiting-review park
+            // (restored by `try_restore_awaiting_review` before we get here).
+            // Reaching this branch means the process died between the verdict
+            // and the park write — we can't fabricate the snapshot revision.
+            return ResumePlan::Ambiguous("ready judge verdict without awaiting-review park");
+        }
+        if round >= max_rounds {
+            // A blocking verdict at the round cap escalates to a human-review
+            // park; without that durable park we can't resume coherently.
+            return ResumePlan::Ambiguous("blocking judge verdict at round cap without park");
+        }
+        // Blocking verdict below the cap → advance to the next Adversary round.
+        return ResumePlan::Resume {
+            phase: RefinementPhase::AdversaryAttack,
+            round: round + 1,
+        };
+    }
+
+    // 3. Adversary opened this round; Judge hasn't ruled yet.
+    let adversary_objections: Vec<&ProposalDebateTrail> = round_entries
+        .iter()
+        .copied()
+        .filter(|e| e.kind == "objection" && e.agent_role == "adversary")
+        .collect();
+    if !adversary_objections.is_empty() {
+        let phase = if adversary_objections.iter().any(|e| e.blocking) {
+            RefinementPhase::AdvocateRevision
+        } else {
+            RefinementPhase::JudgeAdjudication
+        };
+        return ResumePlan::Resume { phase, round };
+    }
+
+    // 4. Round started (some non-adversary entry exists) but the Adversary
+    //    never filed → resume at the Adversary opener for this round.
+    ResumePlan::Resume {
+        phase: RefinementPhase::AdversaryAttack,
+        round,
+    }
+}
 
 impl CoordinatorActor {
     /// Startup reconciliation for refinements interrupted by a restart.
@@ -52,16 +209,263 @@ impl CoordinatorActor {
             if self.active_refinements.contains_key(&proposal_id) {
                 continue;
             }
+            // A legitimately-converged park is restored to AwaitingHumanReview.
             if self.try_restore_awaiting_review(&proposal_id).await {
                 continue;
             }
+            // A mid-tribunal run is resumed in place from durable data so it
+            // keeps running across the restart.
+            if self.try_resume_mid_flight(&proposal_id).await {
+                continue;
+            }
+            // Only genuinely ambiguous/contradictory runs are stamped
+            // interrupted (restartable) — never guess into a corrupt tribunal.
             self.persist_refinement_stop(&proposal_id, &StopReason::Interrupted)
                 .await;
             tracing::info!(
                 proposal_id = %proposal_id,
-                "Stopped interrupted refinement (lost across restart); proposal is restartable"
+                "Stopped interrupted refinement (could not reconstruct a coherent \
+                 round/phase across restart); proposal is restartable"
             );
         }
+    }
+
+    /// Attempt to resume a dangling refinement that was mid-tribunal when the
+    /// process died. Rebuilds the in-memory [`RefinementLoopState`] from durable
+    /// data (lifecycle events, debate trail, refinement task rows) and inserts
+    /// it into `active_refinements` so `drive_active_refinements` continues the
+    /// SAME run. Returns `true` when resumed, `false` when the state was
+    /// ambiguous/contradictory or a required read failed (caller then falls back
+    /// to the `Interrupted` stamp).
+    ///
+    /// Reconstruction sources:
+    ///   - **phase / round**: [`derive_resume_plan`] over the current-run debate
+    ///     trail (scoped by the latest `refinement_start` boundary), plus the
+    ///     proposal's linked evidence spike.
+    ///   - **current revision**: the proposal head (`latest_revision_seq`).
+    ///   - **snapshot revision** (revert-on-reject baseline): the `seq` stamped
+    ///     on the latest `refinement_start` lifecycle row.
+    ///   - **attribution**: the most recent this-run refinement task's
+    ///     `created_by_user_id`, falling back to the proposal author (same as
+    ///     `resolve_refinement_attributed_user`).
+    ///   - **spawn budget**: the count of this run's refinement task rows, so the
+    ///     spawn cap still binds across the restart (conservative — includes a
+    ///     re-dispatched orphan, which only tightens the cap).
+    ///
+    /// Any orphaned OPEN refinement task from this run (a role session that was
+    /// running at kill time, whose slot the pool no longer tracks) is closed via
+    /// the existing `close_refinement_task` machinery. The driver then
+    /// re-dispatches the reconstructed phase on the next tick; re-running the
+    /// phase is idempotent (see [`derive_resume_plan`]).
+    async fn try_resume_mid_flight(&mut self, proposal_id: &str) -> bool {
+        let event_bus = crate::events::event_bus_for(&self.events_tx);
+        let proposal_repo = ProposalRepository::new(self.db.clone(), event_bus);
+
+        let proposal = match proposal_repo.get(proposal_id).await {
+            Ok(Some(p)) => p,
+            Ok(None) => return false,
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    error = %e,
+                    "Failed to load proposal for mid-flight refinement resume; \
+                     falling back to interrupted stamp"
+                );
+                return false;
+            }
+        };
+
+        // One revisions read supplies the run boundary, the snapshot seq, and
+        // the converged-park guard below.
+        let revisions = match proposal_repo.revisions(proposal_id).await {
+            Ok(revisions) => revisions,
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    error = %e,
+                    "Failed to read revisions for resume; falling back to interrupted stamp"
+                );
+                return false;
+            }
+        };
+
+        // Current-run boundary = the latest `refinement_start`. A dangling
+        // refinement always has one; `None` is treated as "all in-run".
+        let latest_start = revisions
+            .iter()
+            .rev()
+            .find(|r| r.event_kind == "refinement_start");
+        let run_start = latest_start.map(|r| r.created_at.clone());
+
+        // Converged-park guard. A `refinement_awaiting_review` row in the current
+        // run means the tribunal already converged/escalated and the park is
+        // owned by `try_restore_awaiting_review`. Reaching here means that path
+        // DECLINED to restore it (stale spec, or missing snapshot/refined seqs),
+        // so we preserve the historical `Interrupted` stamp rather than
+        // auto-starting a fresh tribunal over a spec the human may have edited.
+        if let Some(start) = latest_start
+            && revisions.iter().any(|r| {
+                r.event_kind == "refinement_awaiting_review" && r.created_at >= start.created_at
+            })
+        {
+            tracing::info!(
+                proposal_id = %proposal_id,
+                "Converged awaiting-review park present but not restorable; \
+                 preserving interrupted stamp (no mid-flight resume)"
+            );
+            return false;
+        }
+
+        // Snapshot revision seq = the head at the moment refinement started,
+        // recorded as the `seq` of the latest `refinement_start` lifecycle row.
+        // Falls back to the current head (a reject-revert then no-ops).
+        let snapshot_revision_seq = latest_start
+            .map(|r| r.seq)
+            .unwrap_or(proposal.latest_revision_seq);
+
+        let entries = match proposal_repo.debate_trail(proposal_id).await {
+            Ok(entries) => entries,
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    error = %e,
+                    "Failed to read debate trail for resume; \
+                     falling back to interrupted stamp"
+                );
+                return false;
+            }
+        };
+
+        let config = RefinementConfig::default();
+        let head_revision_seq = proposal.latest_revision_seq;
+        let linked_spike = proposal.linked_spike_task_id.is_some();
+
+        let (phase, round) = match derive_resume_plan(
+            &entries,
+            run_start.as_deref(),
+            head_revision_seq,
+            linked_spike,
+            config.max_rounds,
+        ) {
+            ResumePlan::Resume { phase, round } => (phase, round),
+            ResumePlan::Ambiguous(reason) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    reason,
+                    "Mid-flight refinement reconstruction ambiguous; \
+                     falling back to interrupted stamp"
+                );
+                return false;
+            }
+        };
+
+        // Reconstruct attribution, spawn budget, and orphaned open tasks from
+        // this run's refinement task rows.
+        let (task_attributed_user, run_task_count, orphaned_open_task_ids) = self
+            .reconstruct_run_refinement_tasks(proposal_id, run_start.as_deref())
+            .await;
+        let attributed_user_id = task_attributed_user.or_else(|| proposal.author_user_id.clone());
+
+        let mut state = RefinementLoopState::with_config(proposal_id, head_revision_seq, config)
+            .with_attributed_user(attributed_user_id);
+        state.phase = phase;
+        state.current_round = round.max(1);
+        state.snapshot_revision_seq = snapshot_revision_seq;
+        // Conservative: pre-restart dispatched tasks count against the spawn cap
+        // so it still binds. record_spawn on re-dispatch only tightens it.
+        state.total_spawns = run_task_count;
+
+        self.active_refinements
+            .insert(proposal_id.to_string(), state);
+
+        // Reconcile orphaned in-flight work: close any open refinement task from
+        // this run so it does not linger on the board; the reconstructed phase
+        // is re-dispatched by the driver on the next tick (idempotent).
+        for task_id in &orphaned_open_task_ids {
+            self.close_refinement_task(
+                task_id,
+                "refinement role session orphaned by coordinator restart; phase re-dispatched",
+            )
+            .await;
+        }
+
+        tracing::info!(
+            proposal_id = %proposal_id,
+            phase = ?phase,
+            round,
+            snapshot_revision_seq,
+            total_spawns = run_task_count,
+            orphaned_open_tasks = orphaned_open_task_ids.len(),
+            "Resumed mid-flight refinement across restart (in-place, same run)"
+        );
+        true
+    }
+
+    /// Scan this run's refinement task rows to reconstruct: the attributed user
+    /// (most recent task's `created_by_user_id`), the spawn count (all this-run
+    /// refinement tasks), and the ids of any still-OPEN (orphaned) tasks.
+    ///
+    /// Refinement tasks carry no structured proposal-id column; they are matched
+    /// by the durable `for proposal {id},` marker their description always
+    /// carries (see `create_refinement_task_with_context`) and scoped to the
+    /// current run by `created_at > run_start`.
+    async fn reconstruct_run_refinement_tasks(
+        &self,
+        proposal_id: &str,
+        run_start: Option<&str>,
+    ) -> (Option<String>, i32, Vec<String>) {
+        let event_bus = crate::events::event_bus_for(&self.events_tx);
+        let proposal_repo = ProposalRepository::new(self.db.clone(), event_bus);
+        let targets = proposal_repo.targets(proposal_id).await.unwrap_or_default();
+
+        let event_bus2 = crate::events::event_bus_for(&self.events_tx);
+        let task_repo = TaskRepository::new(self.db.clone(), event_bus2);
+
+        let marker = format!("for proposal {proposal_id},");
+        let mut count = 0i32;
+        let mut open_ids: Vec<String> = Vec::new();
+        // (created_at, user_id) of the most recent this-run task with a user.
+        let mut latest_user: Option<(String, String)> = None;
+
+        for target in &targets {
+            let tasks = match task_repo.list_by_project(&target.project_id).await {
+                Ok(tasks) => tasks,
+                Err(e) => {
+                    tracing::warn!(
+                        proposal_id = %proposal_id,
+                        project_id = %target.project_id,
+                        error = %e,
+                        "Failed to list tasks for refinement resume reconstruction; skipping project"
+                    );
+                    continue;
+                }
+            };
+            for task in tasks {
+                if task.issue_type != "refinement" || !task.description.contains(&marker) {
+                    continue;
+                }
+                if let Some(start) = run_start
+                    && task.created_at.as_str() <= start
+                {
+                    continue;
+                }
+                count += 1;
+                if task.status != "closed" {
+                    open_ids.push(task.id.clone());
+                }
+                if let Some(uid) = task.created_by_user_id.clone() {
+                    let is_newer = latest_user
+                        .as_ref()
+                        .map(|(at, _)| task.created_at > *at)
+                        .unwrap_or(true);
+                    if is_newer {
+                        latest_user = Some((task.created_at.clone(), uid));
+                    }
+                }
+            }
+        }
+
+        (latest_user.map(|(_, uid)| uid), count, open_ids)
     }
 
     /// Attempt to restore a dangling refinement that was parked awaiting the

--- a/server/crates/djinn-coordinator/src/refinement_recovery_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_recovery_tests.rs
@@ -6,11 +6,84 @@
 // size-guard line threshold; shares its fixture helpers.
 
 use super::refinement_cap_tests::{
-    build_refinement_actor, seed_refinement_fixture, spawn_test_pool,
+    TEST_MODEL, build_refinement_actor, seed_refinement_fixture, spawn_test_pool,
 };
-use crate::refinement::StopReason;
+use crate::refinement::{RefinementPhase, StopReason};
 use djinn_core::events::{DjinnEventEnvelope, EventBus};
-use djinn_db::ProposalRepository;
+use djinn_db::{ProposalDebateTrailCreateInput, ProposalRepository, TaskRepository};
+
+/// Record a `refinement_start` boundary, then sleep so subsequent debate/task
+/// `created_at` timestamps strictly advance past it (current-run scoping uses a
+/// strict `>` comparison).
+async fn seed_refinement_start(db: &djinn_db::Database, proposal_id: &str) {
+    ProposalRepository::new(db.clone(), EventBus::noop())
+        .record_refinement_lifecycle(proposal_id, "refinement_start", None)
+        .await
+        .expect("record refinement_start");
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+}
+
+/// Append an adversary objection debate-trail entry at `round`.
+async fn add_objection(
+    db: &djinn_db::Database,
+    proposal_id: &str,
+    round: i32,
+    blocking: bool,
+    against_revision_seq: i32,
+) {
+    ProposalRepository::new(db.clone(), EventBus::noop())
+        .add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id,
+            kind: "objection",
+            body: "Adversary objection seeded for restart-resume test",
+            blocking,
+            agent_role: "adversary",
+            author_kind: "agent",
+            author_model: None,
+            source_task_id: None,
+            against_revision_seq,
+            round,
+            body_metadata: None,
+        })
+        .await
+        .expect("append objection");
+}
+
+/// Append a judge verdict debate-trail entry at `round`.
+async fn add_verdict(
+    db: &djinn_db::Database,
+    proposal_id: &str,
+    round: i32,
+    blocking: bool,
+    against_revision_seq: i32,
+) {
+    ProposalRepository::new(db.clone(), EventBus::noop())
+        .add_debate_trail_entry(ProposalDebateTrailCreateInput {
+            proposal_id,
+            kind: "verdict",
+            body: if blocking { "needs work" } else { "ready" },
+            blocking,
+            agent_role: "judge",
+            author_kind: "agent",
+            author_model: None,
+            source_task_id: None,
+            against_revision_seq,
+            round,
+            body_metadata: None,
+        })
+        .await
+        .expect("append verdict");
+}
+
+/// Read the proposal's current head revision seq.
+async fn head_seq(db: &djinn_db::Database, proposal_id: &str) -> i32 {
+    ProposalRepository::new(db.clone(), EventBus::noop())
+        .get(proposal_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .latest_revision_seq
+}
 
 /// Record a `refinement_start` followed by a `refinement_awaiting_review`
 /// lifecycle row, simulating a tribunal that converged and parked for human
@@ -109,33 +182,255 @@ async fn recover_restores_awaiting_review_park_and_does_not_stamp_interrupted() 
     );
 }
 
-/// A dangling refinement genuinely interrupted mid-tribunal (a
-/// `refinement_start` with no subsequent `refinement_awaiting_review`) still
-/// gets the interrupted `refinement_stop` stamp and is not restored.
+/// A dangling refinement started but with no durable debate artifacts yet (the
+/// opener never filed) RESUMES at the round-1 Adversary opener across the
+/// restart instead of being stamped interrupted. This is the core behavior
+/// change: a mid-flight run keeps running.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn recover_stamps_interrupted_for_mid_tribunal_refinement() {
+async fn recover_resumes_bare_started_refinement_at_round_one_adversary() {
     let db = crate::test_helpers::create_test_db();
     let fixture = seed_refinement_fixture(&db).await;
     let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
     let pool = spawn_test_pool(&db, 4);
     let mut actor = build_refinement_actor(&db, &events_tx, pool.clone());
 
-    // Started but never parked awaiting review — a real interruption.
-    ProposalRepository::new(db.clone(), EventBus::noop())
-        .record_refinement_lifecycle(&fixture.proposal_id, "refinement_start", None)
+    seed_refinement_start(&db, &fixture.proposal_id).await;
+
+    actor.recover_interrupted_refinements().await;
+
+    let resumed = actor
+        .active_refinements
+        .get(&fixture.proposal_id)
+        .expect("bare-started refinement must resume, not be stamped interrupted");
+    assert_eq!(resumed.phase, RefinementPhase::AdversaryAttack);
+    assert_eq!(resumed.current_round, 1);
+    assert_eq!(
+        interrupted_stop_count(&db, &fixture.proposal_id).await,
+        0,
+        "a resumed refinement must NOT be stamped interrupted"
+    );
+}
+
+/// (a) A tribunal interrupted mid-round — the round-1 Adversary filed blocking
+/// objections but the Judge never ruled — resumes at the Advocate for round 1
+/// (blocking objections route to the Advocate), NOT stamped interrupted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recover_resumes_mid_round_at_advocate_after_blocking_objections() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    let seq = head_seq(&db, &fixture.proposal_id).await;
+    seed_refinement_start(&db, &fixture.proposal_id).await;
+    add_objection(&db, &fixture.proposal_id, 1, true, seq).await;
+    add_objection(&db, &fixture.proposal_id, 1, true, seq).await;
+
+    actor.recover_interrupted_refinements().await;
+
+    let resumed = actor
+        .active_refinements
+        .get(&fixture.proposal_id)
+        .expect("mid-round tribunal must resume");
+    assert_eq!(
+        resumed.phase,
+        RefinementPhase::AdvocateRevision,
+        "blocking round-1 objections resume at the Advocate"
+    );
+    assert_eq!(resumed.current_round, 1);
+    assert_eq!(
+        interrupted_stop_count(&db, &fixture.proposal_id).await,
+        0
+    );
+}
+
+/// (a′) A round advanced by a blocking Judge verdict resumes at the NEXT round's
+/// Adversary — the reconstruction mirrors the state machine's round advance.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recover_resumes_after_blocking_verdict_at_next_round_adversary() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    let seq = head_seq(&db, &fixture.proposal_id).await;
+    seed_refinement_start(&db, &fixture.proposal_id).await;
+    add_objection(&db, &fixture.proposal_id, 1, true, seq).await;
+    // Judge ruled round 1 not-ready (blocking) → the loop had advanced to round 2.
+    add_verdict(&db, &fixture.proposal_id, 1, true, seq).await;
+
+    actor.recover_interrupted_refinements().await;
+
+    let resumed = actor
+        .active_refinements
+        .get(&fixture.proposal_id)
+        .expect("post-verdict tribunal must resume");
+    assert_eq!(resumed.phase, RefinementPhase::AdversaryAttack);
+    assert_eq!(
+        resumed.current_round, 2,
+        "a blocking verdict below the cap advances to the next round"
+    );
+}
+
+/// (b) An orphaned OPEN refinement task (a role session that was running at kill
+/// time) is closed by recovery, and the reconstructed phase is re-dispatched by
+/// the driver on the next tick WITHOUT burning a round.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recover_closes_orphaned_open_task_and_redispatches_same_round() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    let seq = head_seq(&db, &fixture.proposal_id).await;
+    seed_refinement_start(&db, &fixture.proposal_id).await;
+    // Round-1 Adversary filed blocking objections → resume phase is Advocate.
+    add_objection(&db, &fixture.proposal_id, 1, true, seq).await;
+
+    // Orphaned in-flight Advocate task, left OPEN by the kill. Created through
+    // the real task builder so it carries the durable `for proposal {id},`
+    // description marker and the attribution the reconstruction reads back.
+    let orphan_task_id = actor
+        .create_refinement_task_with_context(
+            &fixture.proposal_id,
+            "advocate",
+            1,
+            seq,
+            "Proposal currently meets all DoR checks.",
+            None,
+            Some(&fixture.user_id),
+        )
         .await
-        .expect("record refinement_start");
+        .expect("create orphaned open refinement task");
+
+    actor.recover_interrupted_refinements().await;
+
+    // The reconstructed state is present at round 1 / Advocate — round NOT burned.
+    let resumed = actor
+        .active_refinements
+        .get(&fixture.proposal_id)
+        .expect("must resume");
+    assert_eq!(resumed.phase, RefinementPhase::AdvocateRevision);
+    assert_eq!(resumed.current_round, 1);
+    assert_eq!(
+        resumed.total_spawns, 1,
+        "the one pre-restart refinement task counts against the spawn budget"
+    );
+
+    // The orphaned task was force-closed by recovery.
+    let orphan = TaskRepository::new(db.clone(), EventBus::noop())
+        .get(&orphan_task_id)
+        .await
+        .expect("read orphan task")
+        .expect("orphan task exists");
+    assert_eq!(
+        orphan.status, "closed",
+        "orphaned open refinement task must be closed by recovery"
+    );
+
+    // Next tick: the driver re-dispatches the SAME phase at the SAME round.
+    actor.drive_active_refinements().await;
+    let session = actor
+        .refinement_sessions
+        .get(&fixture.proposal_id)
+        .expect("reconstructed phase must be re-dispatched on the next tick");
+    assert_eq!(session.phase, RefinementPhase::AdvocateRevision);
+    assert_eq!(session.model_id, TEST_MODEL);
+    let state = &actor.active_refinements[&fixture.proposal_id];
+    assert_eq!(
+        state.current_round, 1,
+        "re-dispatch must not burn a round"
+    );
+    assert_eq!(
+        state.total_spawns, 2,
+        "re-dispatch consumes one more spawn on top of the reconstructed count"
+    );
+}
+
+/// (c) A ready (non-blocking) Judge verdict with NO durable awaiting-review park
+/// is contradictory (a ready verdict must persist a park). Recovery cannot
+/// fabricate the snapshot revision, so it falls back to the interrupted stamp.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recover_stamps_interrupted_for_ready_verdict_without_park() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    let seq = head_seq(&db, &fixture.proposal_id).await;
+    seed_refinement_start(&db, &fixture.proposal_id).await;
+    add_objection(&db, &fixture.proposal_id, 1, false, seq).await;
+    // Ready verdict, but no `refinement_awaiting_review` park was written.
+    add_verdict(&db, &fixture.proposal_id, 1, false, seq).await;
 
     actor.recover_interrupted_refinements().await;
 
     assert!(
         !actor.active_refinements.contains_key(&fixture.proposal_id),
-        "a mid-tribunal refinement must not be restored"
+        "an ambiguous ready-verdict-without-park run must not be resumed"
     );
     assert_eq!(
         interrupted_stop_count(&db, &fixture.proposal_id).await,
         1,
-        "a mid-tribunal refinement must be stamped interrupted"
+        "ambiguous reconstruction falls back to the interrupted stamp"
+    );
+}
+
+/// (e) The resumed run reconstructs the spawn budget from this run's refinement
+/// task rows, so the spawn cap still binds across the restart.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recover_reconstructs_spawn_budget_from_run_tasks() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_test_pool(&db, 4);
+    let mut actor = build_refinement_actor(&db, &events_tx, pool.clone());
+
+    let seq = head_seq(&db, &fixture.proposal_id).await;
+    seed_refinement_start(&db, &fixture.proposal_id).await;
+    add_objection(&db, &fixture.proposal_id, 1, true, seq).await;
+
+    // Three pre-restart refinement tasks for this run — two already closed, one
+    // still open (orphaned). All three count toward the spawn budget.
+    for agent_type in ["adversary", "advocate", "judge"] {
+        let task_id = actor
+            .create_refinement_task_with_context(
+                &fixture.proposal_id,
+                agent_type,
+                1,
+                seq,
+                "Proposal currently meets all DoR checks.",
+                None,
+                Some(&fixture.user_id),
+            )
+            .await
+            .expect("create run refinement task");
+        if agent_type != "judge" {
+            actor
+                .close_refinement_task(&task_id, "pre-restart phase complete")
+                .await;
+        }
+    }
+
+    actor.recover_interrupted_refinements().await;
+
+    let resumed = actor
+        .active_refinements
+        .get(&fixture.proposal_id)
+        .expect("must resume");
+    assert_eq!(
+        resumed.total_spawns, 3,
+        "all three this-run refinement tasks count against the reconstructed spawn budget"
+    );
+    // Attribution was reconstructed from the run's task rows.
+    assert_eq!(
+        resumed.attributed_user_id.as_deref(),
+        Some(fixture.user_id.as_str()),
+        "attribution is reconstructed from this run's refinement task rows"
     );
 }
 


### PR DESCRIPTION
## Problem

When djinn-server was OOMKilled (2Gi limit) on 2026-07-12, `recover_interrupted_refinements` stamped all 4 in-flight tribunals `refinement_stop`/`Interrupted`, destroying live runs (rounds mid-progress, debate entries filed). An operator had to manually `proposal_refinement_start` 13 proposals. Requirement: **refinements must keep running and survive deploys/restarts.**

## Change

In `refinement_recovery.rs`, a DB-dangling refinement that is NOT an awaiting-review park is now **resumed in place** rather than stamped Interrupted. Recovery rebuilds the in-memory `RefinementLoopState` from durable data and re-inserts it into `active_refinements`, so `drive_active_refinements` continues the **same run** (no new run scope, no round reuse — avoids the ic16 stale-verdict and PR#1855 advocate-starvation pitfalls).

### How state is reconstructed
- **phase / round** — `derive_resume_plan` (pure, unit-tested) over the current-run debate trail, scoped by the latest `refinement_start` boundary via the existing `entry_in_current_run`, mirroring the tribunal state machine:
  - linked evidence spike ⇒ `AwaitingEvidence` (so the evidence-completion path can resume it);
  - Judge `needs_evidence` this round ⇒ `AwaitingEvidence`;
  - blocking Judge verdict below the round cap ⇒ next round's `AdversaryAttack`;
  - Adversary objections filed, no verdict ⇒ `AdvocateRevision` (any blocking) or `JudgeAdjudication` (dry);
  - round opened, Adversary hasn't filed / no current-run entries ⇒ `AdversaryAttack`.
- **current revision** — proposal head (`latest_revision_seq`).
- **snapshot revision** (revert-on-reject baseline) — the `seq` stamped on the latest `refinement_start` lifecycle row.
- **attribution** — most recent this-run refinement task's `created_by_user_id`, falling back to the proposal author (same as `resolve_refinement_attributed_user`).
- **spawn budget** — count of this run's refinement task rows, so the spawn cap still binds across the restart (conservative; a re-dispatched orphan only tightens it).

Refinement tasks carry no structured proposal-id column, so this-run tasks are matched by the durable `for proposal {id},` description marker (emitted by `create_refinement_task_with_context`) and scoped by `created_at > run_start`.

### Orphaned in-flight work
An OPEN refinement task from a role session running at kill time is force-closed via the existing `close_refinement_task` helper; the driver re-dispatches the reconstructed phase on the next tick. **Re-running a phase is idempotent** from the tribunal's perspective: only the Judge advances `current_round`; debate/verdict reads are set-based (`select_current_run_verdict` takes the latest current-run verdict; adversary objections are read as a set, not append-counted); and `process_advocate_outcome` guards double-applying a revision with `new_revision_seq > current_revision_seq`.

### Fail-safe (never guess into a corrupt tribunal)
Falls back to the historical `Interrupted` stamp (restartable) when:
- a ready (non-blocking) Judge verdict has no durable awaiting-review park (should have persisted one — died mid-transition; snapshot revision unrecoverable);
- a blocking Judge verdict sits at the round cap with no park;
- a converged `refinement_awaiting_review` row exists in the current run but the awaiting-review restore path declined it (stale spec / missing seqs) — preserves prior behavior, avoids auto-restarting a tribunal over a human-edited spec;
- any required durable read fails.

The existing awaiting-review restore path is unchanged.

## Tests (`refinement_recovery_tests.rs`)
- (a) mid-round tribunal with blocking objections resumes at `AdvocateRevision` round 1; a post-blocking-verdict run resumes at `AdversaryAttack` round 2; a bare-started run resumes at `AdversaryAttack` round 1.
- (b) orphaned open task is force-closed and the phase is re-dispatched on the next tick without burning a round.
- (c) ready-verdict-without-park falls back to Interrupted.
- (d) awaiting-review restore + stale-park→Interrupted unchanged (existing tests still green).
- (e) resumed run reconstructs the spawn budget (and attribution) from this run's task rows.

`cargo clippy -p djinn-coordinator --all-features` clean (one pre-existing unrelated warning in `pr_poller`); all 92 refinement tests + 8 recovery tests pass. Diff is limited to `refinement_recovery.rs` and its test file (disjoint from the sibling watchdog / `create_refinement_task_with_context` owner PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)