### PR TITLE
feat: add secure local GitHub App onboarding

### DIFF
--- a/deploy/helm/djinn/templates/_helpers.tpl
+++ b/deploy/helm/djinn/templates/_helpers.tpl
@@ -118,6 +118,28 @@ that string wins; otherwise we use the chart-local name.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Whether the operator attempted GitHub App Secret configuration.
+
+The distinction between "absent" and "present but incomplete" is part of the
+server credential-source contract:
+  * no existingSecret and no inline value -> omit the Secret, env vars, path,
+    and volume entirely so local self-setup can use persisted credentials;
+  * any inline value or existingSecret -> expose the complete Secret/env
+    surface, allowing the server to reject partial or malformed configuration
+    instead of silently falling through to persisted credentials.
+*/}}
+{{- define "djinn.githubAppConfigAttempted" -}}
+{{- $cfg := .Values.secrets.githubApp -}}
+{{- if or
+      (ne (toString $cfg.existingSecret) "")
+      (ne (toString $cfg.appId) "")
+      (ne (toString $cfg.clientId) "")
+      (ne (toString $cfg.clientSecret) "")
+      (ne (toString $cfg.privateKey) "")
+-}}true{{- end -}}
+{{- end -}}
+
 {{- define "djinn.secretName.vaultKey" -}}
 {{- if .Values.secrets.vaultKey.existingSecret -}}
 {{- .Values.secrets.vaultKey.existingSecret -}}

--- a/deploy/helm/djinn/templates/configmap.yaml
+++ b/deploy/helm/djinn/templates/configmap.yaml
@@ -46,3 +46,6 @@ data:
   DJINN_WEB_URL: {{ . | quote }}
   {{- end }}
   DJINN_ENABLE_SELF_SETUP: {{ .Values.env.enableSelfSetup | quote }}
+  # Local/solo deployments may bind to a personal GitHub account. Production
+  # defaults to organization-only binding; the server owns enforcement.
+  DJINN_ALLOW_USER_INSTALLATIONS: {{ .Values.env.allowUserInstallations | quote }}

--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -1,3 +1,4 @@
+{{- $githubAppConfigAttempted := include "djinn.githubAppConfigAttempted" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -320,6 +321,7 @@ spec:
             {{- end }}
             - name: DJINN_VAULT_KEY_PATH
               value: /var/run/secrets/djinn/vault.key
+            {{- if $githubAppConfigAttempted }}
             - name: GITHUB_APP_PRIVATE_KEY_PATH
               value: /var/run/secrets/djinn/github-app/private-key.pem
             - name: GITHUB_APP_ID
@@ -340,6 +342,7 @@ spec:
                   name: {{ include "djinn.secretName.githubApp" . }}
                   key: client-secret
                   optional: true
+            {{- end }}
             # Provider API keys — read by djinn-provider::bootstrap at startup.
             # Every entry is optional: the Secret is rendered with empty
             # strings for unset keys, and `optional: true` means the pod
@@ -415,9 +418,11 @@ spec:
               mountPath: /var/run/secrets/djinn/vault.key
               subPath: vault.key
               readOnly: true
+            {{- if $githubAppConfigAttempted }}
             - name: github-app
               mountPath: /var/run/secrets/djinn/github-app
               readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources.server | nindent 12 }}
           lifecycle:
@@ -464,6 +469,7 @@ spec:
             # mounted into this Pod, so "world-readable" inside the
             # container is fine.
             defaultMode: 0444
+        {{- if $githubAppConfigAttempted }}
         - name: github-app
           secret:
             secretName: {{ include "djinn.secretName.githubApp" . }}
@@ -473,3 +479,4 @@ spec:
             # mounted into this Pod, so "world-readable" inside the
             # container is fine.
             defaultMode: 0444
+        {{- end }}

--- a/deploy/helm/djinn/templates/secret-github-app.yaml
+++ b/deploy/helm/djinn/templates/secret-github-app.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secrets.githubApp.existingSecret -}}
+{{- if and (not .Values.secrets.githubApp.existingSecret) (include "djinn.githubAppConfigAttempted" .) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/djinn/values.local.yaml
+++ b/deploy/helm/djinn/values.local.yaml
@@ -51,9 +51,10 @@ ingress:
 # manual credential files are needed. The `.tilt/github-app/` path with
 # `helm --set-file` is still supported as an override/fallback for operators
 # who already have credentials, but it is NOT the default local self-serve
-# path. Leave `secrets.githubApp` alone here so the chart's default path
-# (render a Secret from values) stays active; the Tiltfile overrides the
-# fields when the local files exist.
+# path. Leave `secrets.githubApp` empty here so the chart omits the
+# Secret/env/path surface; the Tiltfile overrides fields when local files exist.
+# Supplying only some files still counts as attempted configuration and remains
+# a fatal server-side validation error.
 
 # Tighter resource defaults so the whole stack fits on a laptop.
 # Server limit accounts for the in-process nomic-embed model (~1GB FP32)
@@ -176,3 +177,6 @@ env:
   # `.tilt/github-app/` credential files are needed. Operators who already
   # have credentials can still override via the Tiltfile's --set-file path.
   enableSelfSetup: true
+  # Local contributors commonly install the generated App on their personal
+  # GitHub account. Production values keep this organization-only.
+  allowUserInstallations: true

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -201,9 +201,11 @@ secrets:
     # If non-empty, the Deployment mounts the named Secret instead of a
     # chart-rendered one. The Secret must expose the same keys listed below.
     existingSecret: ""
-    # Literal values — rendered into a chart-managed Secret when
-    # existingSecret is empty. Leave blank in VCS; set via `--set` or
-    # a local -f overrides file.
+    # Literal values. When existingSecret is empty, the chart renders a Secret
+    # only if at least one value below is non-empty. All-empty means the Secret
+    # source is absent (required by manifest self-setup); any partial set means
+    # configuration was attempted and is exposed to the server for fatal
+    # validation. Leave blank in VCS; set via `--set` or a local override file.
     appId: ""
     privateKey: ""
     clientId: ""
@@ -379,6 +381,10 @@ env:
   # load GitHub App credentials from the mounted Secret only. This flag is
   # rendered into the server ConfigMap as DJINN_ENABLE_SELF_SETUP.
   enableSelfSetup: false
+  # Allow binding the deployment to a personal GitHub account (installation
+  # account type `User`) as well as an organization. Intended for local/solo
+  # evaluation; production remains organization-only by default.
+  allowUserInstallations: false
 
 # Arbitrary extra env injected into the server container. Useful for ad-hoc
 # tuning knobs without re-templating.

--- a/docs/GITHUB_APP_SETUP.md
+++ b/docs/GITHUB_APP_SETUP.md
@@ -75,9 +75,72 @@ For local/Tilt, `values.local.yaml` already sets `env.enableSelfSetup: true`:
 env:
   enableSelfSetup: true
   publicUrl: "http://localhost:3000"
+  allowUserInstallations: true
+```
+
+With no `.tilt/github-app/` files, the chart deliberately omits the GitHub App
+Secret, `GITHUB_APP_*` env variables, private-key path, and volume. That is an
+*absent* Secret source, so persisted credentials from the manifest flow can
+hot-load. If any inline credential file/value is present — or
+`secrets.githubApp.existingSecret` is set — the chart renders the whole
+Secret/env surface. A partial or malformed attempted configuration is therefore
+still fatal and never silently falls through to self-setup.
+
+`allowUserInstallations` is a local/solo-development opt-in. Production values
+default it to `false`, preserving organization-only deployment binding.
+
+### Isolated Tilt validation instance
+
+To validate onboarding without touching an existing `kind-djinn` cluster,
+default `.tilt/` state, local registry, or host forwards, use a distinct cluster,
+registry, state directory, and ports. Bootstrap first so Tilt's production-
+context guard sees the new kind context:
+
+```bash
+CLUSTER_NAME=djinn-validation \
+REG_NAME=kind-registry-validation \
+REG_PORT=15001 \
+  bash scripts/kind/setup-kind.sh
+
+TILT_ARGS=(
+  --cluster-name djinn-validation
+  --registry-name kind-registry-validation
+  --registry-port 15001
+  --state-dir /var/tmp/djinn-tilt-validation
+  --api-port 13000
+  --rpc-port 18443
+  --postgres-port 15432
+  --qdrant-http-port 16333
+  --qdrant-grpc-port 16334
+  --langfuse-port 15000
+  --minio-port 19091
+)
+
+tilt up --context kind-djinn-validation --port 11350 -- "${TILT_ARGS[@]}"
+```
+
+The generated GitHub callback and web URLs use `http://localhost:13000`, and
+Langfuse uses `http://localhost:15000`. Teardown must use the same Tiltfile
+arguments; omitting them selects the historical defaults instead:
+
+```bash
+tilt down --context kind-djinn-validation -- "${TILT_ARGS[@]}"
+kind delete cluster --name djinn-validation
+docker rm -f kind-registry-validation
+rm -rf /var/tmp/djinn-tilt-validation
 ```
 
 ### Steps
+
+The current self-setup manifest is a **personal-account local-development
+flow**. It posts to GitHub's personal App-registration endpoint and creates a
+private App, so GitHub permits installation only on the owning personal
+account. Organization-owned self-setup needs an organization-specific manifest
+endpoint and is not implemented yet; pre-create the organization App and use
+the Secret-based configuration path for that deployment shape. The initial
+`org_config` binding must also be provisioned through an operator-controlled
+migration; an uncorrelated public setup callback is deliberately not allowed to
+create the deployment's first binding.
 
 1. **Start the server.** On first boot with self-setup enabled and no usable
    credentials, the server generates a **one-time setup token** and prints a
@@ -85,7 +148,7 @@ env:
 
    ```
    GitHub App not configured. Complete setup at:
-     http://localhost:3000/auth/github/create-app?token=<setup-token>
+     http://localhost:3000/auth/github/create-app?setup_token=<setup-token>
    ```
 
    > **Setup token handling:**
@@ -98,9 +161,10 @@ env:
 
 2. **Open the setup URL in your browser.** The server redirects you to
    GitHub's "Create GitHub App" manifest page with every field pre-filled:
-   app name, callback URL, permissions, webhook target, and events.
+   app name, callback URLs, permissions, visibility, and OAuth-on-install.
+   Webhooks remain disabled and the manifest does not submit a webhook URL.
 
-3. **Click "Create GitHub App for \<account\>".** GitHub creates the App and
+3. **Click "Create GitHub App for \<personal-account\>".** GitHub creates the App and
    redirects back to Djinn's `/auth/github/app-manifest-callback` carrying a
    one-time `code`.
 
@@ -116,8 +180,9 @@ env:
 
 6. **OAuth callback.** GitHub redirects back to Djinn's
    `/auth/github/app-setup-callback`, which completes the install
-   continuation, creates the bootstrap admin user, and lands you on the
-   task board.
+   continuation and creates the bootstrap admin user. A fresh deployment then
+   continues through provider/model setup and repository setup before showing
+   the task board.
 
 The setup-session cookie (`djinn_setup_session`) is invalidated after
 successful credential persistence. If the manifest exchange fails before
@@ -297,7 +362,7 @@ server generates a one-time setup token at boot.
 | **Rotation** | Restart the server to generate a fresh token |
 | **Leak response** | If the token is leaked before use, restart the server to invalidate it |
 
-The token is passed as a query parameter (`?token=<setup-token>`) in the
+The token is passed as a query parameter (`?setup_token=<setup-token>`) in the
 boot-log setup URL. It gates access to `/auth/github/create-app` so that
 only the operator who can read the server logs can initiate the manifest
 flow.
@@ -310,22 +375,30 @@ The manifest flow pre-configures these permissions on the GitHub App:
 
 | Permission | Access level | Rationale |
 |------------|-------------|-----------|
+| **Actions** | Read-only | Read workflow runs, jobs, and logs for CI diagnostics |
+| **Checks** | Read-only | Read check runs, suites, and annotations |
 | **Contents** | Read & write | Clone repos, push branches, create commits |
+| **Members** | Read-only | Verify organization membership and reconcile access |
 | **Metadata** | Read-only | Required by GitHub; always granted automatically |
 | **Pull requests** | Read & write | Open PRs, enable auto-merge, request reviews |
 
-**Account permissions:** Leave all at "No access". The App operates on
-repositories, not account-level settings.
+**Organization permissions:** Members read-only is the sole organization-level
+grant. Djinn uses it to enforce organization membership and reconcile access;
+it is not requested for personal-account installations. No account-level write
+permissions are required.
 
-**Who can install:** "Any account" unless you want to restrict to your own
-organization.
+**Who can install:** The manifest creates a private personal-account App, so
+GitHub restricts installation to the owning account. Organization deployments
+must currently use the manual/Secret path described above.
 
 ### Webhook status
 
-The webhook is configured as **inactive** (the "Active" checkbox is
-unticked). Djinn does not consume webhook events today — the server polls
-or uses on-demand API calls for status updates. Leaving the webhook inactive
-avoids unnecessary event delivery and the need to expose a webhook endpoint.
+The manifest omits `hook_attributes` entirely, so GitHub leaves the webhook
+disabled. Djinn does not consume webhook events today — the server polls or
+uses on-demand API calls for status updates. GitHub validates every webhook URL
+that is included in a manifest even when `active` is false, so submitting a
+`localhost` target breaks local onboarding. [GitHub's webhook guidance](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/using-webhooks-with-github-apps)
+confirms that an App with webhooks turned off does not need a webhook URL.
 
 If you configure the App manually (not via the manifest flow), also leave
 the webhook inactive.
@@ -341,15 +414,17 @@ Complete this checklist after a fresh `tilt up` with no
 
 - [ ] `values.local.yaml` has `env.enableSelfSetup: true`
 - [ ] Server boot log contains a line with the setup URL:
-      `http://localhost:3000/auth/github/create-app?token=<token>`
+      `http://localhost:3000/auth/github/create-app?setup_token=<token>`
 - [ ] Opening the setup URL in a browser redirects to GitHub's
       "Create GitHub App" manifest page
 - [ ] Clicking "Create GitHub App" redirects back to Djinn's
       `/auth/github/app-manifest-callback`
 - [ ] Djinn persists the returned credentials and redirects to the
       GitHub App install/authorize page
-- [ ] After granting repo access, the OAuth callback completes and
-      the user lands on the task board (bootstrap admin created)
+- [ ] After granting repo access, the OAuth callback completes and creates the
+      bootstrap admin
+- [ ] Provider/model setup and first-repository setup complete before the user
+      lands on the task board
 - [ ] Subsequent sign-ins work without re-running setup
 - [ ] `/setup/status` reports `appCredentialsConfigured: true`
 

--- a/scripts/test-helm-github-app-render.sh
+++ b/scripts/test-helm-github-app-render.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# Regression coverage for the Helm <-> GitHub App credential-source contract.
+#
+# Run from any directory:
+#
+#   sh scripts/test-helm-github-app-render.sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+CHART="$REPO_ROOT/deploy/helm/djinn"
+LOCAL_VALUES="$CHART/values.local.yaml"
+
+command -v helm >/dev/null 2>&1 || {
+    printf 'FATAL: helm is required\n' >&2
+    exit 2
+}
+
+umask 077
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/djinn-helm-github-app.XXXXXX")
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+render() {
+    output=$1
+    shift
+    helm template djinn "$CHART" --namespace djinn "$@" > "$output"
+}
+
+assert_contains() {
+    label=$1
+    needle=$2
+    file=$3
+    if ! grep -Fq -- "$needle" "$file"; then
+        printf 'FAIL: %s (missing %s)\n' "$label" "$needle" >&2
+        exit 1
+    fi
+    printf 'ok: %s\n' "$label"
+}
+
+assert_lacks() {
+    label=$1
+    needle=$2
+    file=$3
+    if grep -Fq -- "$needle" "$file"; then
+        printf 'FAIL: %s (unexpected %s)\n' "$label" "$needle" >&2
+        exit 1
+    fi
+    printf 'ok: %s\n' "$label"
+}
+
+fresh="$TMP_DIR/fresh-local.yaml"
+render "$fresh" --values "$LOCAL_VALUES"
+assert_lacks 'fresh local omits chart-managed GitHub App Secret' \
+    '# Source: djinn/templates/secret-github-app.yaml' "$fresh"
+assert_lacks 'fresh local omits GitHub App env variables and private-key path' \
+    'GITHUB_APP_' "$fresh"
+assert_lacks 'fresh local omits GitHub App volume and mount' \
+    'name: github-app' "$fresh"
+assert_contains 'fresh local enables self-setup' \
+    'DJINN_ENABLE_SELF_SETUP: "true"' "$fresh"
+assert_contains 'fresh local allows personal-account installation' \
+    'DJINN_ALLOW_USER_INSTALLATIONS: "true"' "$fresh"
+
+partial="$TMP_DIR/partial-inline.yaml"
+render "$partial" --values "$LOCAL_VALUES" \
+    --set-string secrets.githubApp.appId=12345
+assert_contains 'partial inline config renders the chart-managed Secret' \
+    '# Source: djinn/templates/secret-github-app.yaml' "$partial"
+assert_contains 'partial inline config injects App ID' \
+    'name: GITHUB_APP_ID' "$partial"
+assert_contains 'partial inline config injects client ID' \
+    'name: GITHUB_APP_CLIENT_ID' "$partial"
+assert_contains 'partial inline config injects client secret' \
+    'name: GITHUB_APP_CLIENT_SECRET' "$partial"
+assert_contains 'partial inline config injects private-key path' \
+    'name: GITHUB_APP_PRIVATE_KEY_PATH' "$partial"
+assert_contains 'partial inline config mounts GitHub App Secret' \
+    'mountPath: /var/run/secrets/djinn/github-app' "$partial"
+
+numeric_zero="$TMP_DIR/numeric-zero-app-id.yaml"
+render "$numeric_zero" --values "$LOCAL_VALUES" \
+    --set secrets.githubApp.appId=0
+assert_contains 'numeric zero App ID is still an attempted configuration' \
+    '# Source: djinn/templates/secret-github-app.yaml' "$numeric_zero"
+assert_contains 'numeric zero App ID keeps the fatal-validation env surface' \
+    'name: GITHUB_APP_ID' "$numeric_zero"
+
+existing="$TMP_DIR/existing-secret.yaml"
+render "$existing" --values "$LOCAL_VALUES" \
+    --set-string secrets.githubApp.existingSecret=precreated-github-app
+assert_lacks 'existingSecret bypasses chart-managed Secret rendering' \
+    '# Source: djinn/templates/secret-github-app.yaml' "$existing"
+assert_contains 'existingSecret name is preserved on the Deployment' \
+    'secretName: precreated-github-app' "$existing"
+assert_contains 'existingSecret still injects fatal-validation env surface' \
+    'name: GITHUB_APP_ID' "$existing"
+assert_contains 'existingSecret still mounts private-key path' \
+    'mountPath: /var/run/secrets/djinn/github-app' "$existing"
+
+defaults="$TMP_DIR/defaults.yaml"
+render "$defaults"
+assert_contains 'production default disables self-setup' \
+    'DJINN_ENABLE_SELF_SETUP: "false"' "$defaults"
+assert_contains 'production default remains organization-only' \
+    'DJINN_ALLOW_USER_INSTALLATIONS: "false"' "$defaults"
+
+printf 'all Helm GitHub App render assertions passed\n'

--- a/server/crates/djinn-agent/src/task_merge.rs
+++ b/server/crates/djinn-agent/src/task_merge.rs
@@ -20,17 +20,10 @@ pub(crate) fn build_app_push_url(owner: &str, repo: &str, installation_token: &s
     format!("https://x-access-token:{installation_token}@github.com/{owner}/{repo}.git")
 }
 
-/// Bot identity used when committing/pushing through the GitHub App. The
-/// canonical no-reply email form is `<app-id>+djinn-bot[bot]@users.noreply.github.com`.
+/// Bot identity used when committing/pushing through the active GitHub App.
 #[allow(dead_code)]
 fn bot_identity() -> (String, String) {
-    let app_id = djinn_provider::github_app::app_id()
-        .map(|id| id.to_string())
-        .unwrap_or_else(|_| "0".to_string());
-    (
-        "djinn-bot[bot]".to_string(),
-        format!("{app_id}+djinn-bot[bot]@users.noreply.github.com"),
-    )
+    djinn_provider::github_app::bot_git_identity()
 }
 
 /// Parse `owner` and `repo` from a GitHub remote URL.

--- a/server/crates/djinn-control-plane/src/tools/acting_user.rs
+++ b/server/crates/djinn-control-plane/src/tools/acting_user.rs
@@ -69,8 +69,10 @@ pub(crate) async fn acting_caps(db: &Database) -> Result<Option<ActingCaps>, Str
 
 /// Resolve the effective user for an admin "act-as" operation. `None` target →
 /// the acting user (`current_user_id()`). `Some(t)` → requires the caller to be
-/// admin and returns `t`, letting an admin read/write another user's per-user
-/// config (e.g. another target user that can't self-configure).
+/// admin and verifies that `t` is a real `users.id` before returning it, letting
+/// an admin read/write another user's per-user config (e.g. another target user
+/// that can't self-configure). Rejecting unknown targets here keeps invalid UI
+/// sentinels or stale user IDs from reaching writes guarded by user FKs.
 pub(crate) async fn resolve_effective_user(
     db: &Database,
     target_user_id: Option<&str>,
@@ -79,7 +81,65 @@ pub(crate) async fn resolve_effective_user(
         None => Ok(current_user_id()),
         Some(t) => {
             require_admin(db).await?;
-            Ok(Some(t.to_string()))
+            match UserRepository::new(db.clone()).get_by_id(t).await {
+                Ok(Some(_)) => Ok(Some(t.to_string())),
+                Ok(None) => Err(format!("target user '{t}' was not found")),
+                Err(e) => Err(format!("target user lookup failed: {e}")),
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djinn_core::auth_context::SESSION_USER_ID;
+
+    async fn seed_user(db: &Database, github_id: i64, login: &str) -> String {
+        UserRepository::new(db.clone())
+            .upsert_from_github(github_id, login, None, None)
+            .await
+            .expect("seed user")
+            .id
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_unknown_target_is_rejected_before_fk_backed_writes() {
+        let db = Database::open_in_memory().expect("open in-memory database");
+        let admin_id = seed_user(&db, 90_001, "acting-admin").await;
+        UserRepository::new(db.clone())
+            .set_admin_status(&admin_id, true)
+            .await
+            .expect("promote acting user");
+
+        let result = SESSION_USER_ID
+            .scope(Some(admin_id), async {
+                resolve_effective_user(&db, Some("__self__")).await
+            })
+            .await;
+
+        assert_eq!(
+            result,
+            Err("target user '__self__' was not found".to_string())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_existing_target_is_returned_for_admin() {
+        let db = Database::open_in_memory().expect("open in-memory database");
+        let admin_id = seed_user(&db, 90_002, "acting-admin-existing").await;
+        let target_id = seed_user(&db, 90_003, "oauth-target").await;
+        UserRepository::new(db.clone())
+            .set_admin_status(&admin_id, true)
+            .await
+            .expect("promote acting user");
+
+        let result = SESSION_USER_ID
+            .scope(Some(admin_id), async {
+                resolve_effective_user(&db, Some(&target_id)).await
+            })
+            .await;
+
+        assert_eq!(result, Ok(Some(target_id)));
     }
 }

--- a/server/crates/djinn-control-plane/src/tools/github_app_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/github_app_tools.rs
@@ -91,14 +91,10 @@ impl DjinnMcpServer {
         &self,
         Parameters(_): Parameters<GithubAppInstallationsParams>,
     ) -> Json<GithubAppInstallationsResponse> {
-        // If the App itself isn't provisioned yet (no GITHUB_APP_ID), say so
-        // cleanly instead of bubbling a cryptic JWT-mint error. The UI can
-        // route the user to the manifest flow on this signal.
-        if std::env::var("GITHUB_APP_ID")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .is_none()
-        {
+        // If the App itself isn't provisioned yet, say so cleanly instead of
+        // bubbling a cryptic JWT-mint error. `app_id()` resolves the runtime
+        // persisted snapshot before its pre-initialization env fallback.
+        if djinn_provider::github_app::app_id().is_err() {
             return Json(GithubAppInstallationsResponse {
                 status: "error: GitHub App not configured".into(),
                 installations: vec![],

--- a/server/crates/djinn-control-plane/src/tools/project_tools/github_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/project_tools/github_ops.rs
@@ -58,11 +58,7 @@ impl DjinnMcpServer {
     ) -> Json<GithubListReposResponse> {
         use djinn_provider::github_app::{GitHubAppClient, get_installation_by_id};
 
-        if std::env::var("GITHUB_APP_ID")
-            .ok()
-            .filter(|v| !v.trim().is_empty())
-            .is_none()
-        {
+        if djinn_provider::github_app::app_id().is_err() {
             return Json(GithubListReposResponse {
                 status: "error: GitHub App not configured".into(),
                 repos: vec![],

--- a/server/crates/djinn-control-plane/src/tools/project_tools/lifecycle_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/project_tools/lifecycle_ops.rs
@@ -406,30 +406,21 @@ impl DjinnMcpServer {
             }
         }
 
-        // 5b. Configure git user.name/user.email so any commits created by
-        //     the server/agents are attributed to the App's bot identity
-        //     (`djinn-bot[bot]`). The `<app-id>+djinn-bot[bot]@users.noreply.github.com`
-        //     form is GitHub's canonical no-reply email for apps.
-        if let Ok(app_id) = djinn_provider::github_app::app_id() {
-            let email = format!("{app_id}+djinn-bot[bot]@users.noreply.github.com");
-            for (key, value) in [
-                ("user.name", "djinn-bot[bot]"),
-                ("user.email", email.as_str()),
-            ] {
-                if let Err(e) = crate::tools::git_ops::git_config_set(&clone_path, key, value).await
-                {
-                    tracing::warn!(
-                        path = %clone_path, key, error = %e,
-                        "project_add_from_github: failed to set git config"
-                    );
-                }
+        // 5b. Configure git user.name/user.email so commits created by the
+        //     server/agents use the active App's bot login. Manifest-created
+        //     Apps have unique slugs, so a hard-coded `djinn-bot[bot]` would
+        //     misattribute them.
+        let (bot_name, bot_email) = djinn_provider::github_app::bot_git_identity();
+        for (key, value) in [
+            ("user.name", bot_name.as_str()),
+            ("user.email", bot_email.as_str()),
+        ] {
+            if let Err(e) = crate::tools::git_ops::git_config_set(&clone_path, key, value).await {
+                tracing::warn!(
+                    path = %clone_path, key, error = %e,
+                    "project_add_from_github: failed to set git config"
+                );
             }
-        } else {
-            tracing::warn!(
-                "project_add_from_github: GITHUB_APP_ID unset — skipping \
-                 djinn-bot[bot] identity config on {}",
-                clone_path
-            );
         }
 
         // 6. Seed .djinn/ conveniences and defense-in-depth ignores.

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_cleanup.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_cleanup.rs
@@ -86,11 +86,8 @@ impl PrCleanupPolicyConfig {
 impl Default for PrCleanupPolicyConfig {
     fn default() -> Self {
         let mut bot_logins = HashSet::new();
-        if let Ok(slug) = std::env::var("GITHUB_APP_SLUG") {
-            let slug = slug.trim();
-            if !slug.is_empty() {
-                bot_logins.insert(format!("{slug}[bot]"));
-            }
+        if let Some(slug) = djinn_provider::github_app::app_slug() {
+            bot_logins.insert(format!("{slug}[bot]"));
         }
         bot_logins.insert("djinn-bot[bot]".to_string());
 

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_review_watcher.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_review_watcher.rs
@@ -644,7 +644,7 @@ impl CoordinatorActor {
                 // If creds aren't available we degrade to the legacy
                 // non-refreshable client; a 401 will then hard-evict the
                 // session row and the next UI hit bounces to login.
-                let user_client = match github_app_user::client_credentials_from_env() {
+                let user_client = match github_app_user::client_credentials() {
                     Some((cid, secret)) => GitHubApiClient::for_user_session(
                         session.github_access_token.clone(),
                         DbBackedRefresher::new(self.db.clone(), session.token.clone(), cid, secret)

--- a/server/crates/djinn-coordinator/src/task_merge.rs
+++ b/server/crates/djinn-coordinator/src/task_merge.rs
@@ -23,16 +23,9 @@ pub(crate) fn build_app_push_url(owner: &str, repo: &str, installation_token: &s
     format!("https://x-access-token:{installation_token}@github.com/{owner}/{repo}.git")
 }
 
-/// Bot identity used when committing/pushing through the GitHub App. The
-/// canonical no-reply email form is `<app-id>+djinn-bot[bot]@users.noreply.github.com`.
+/// Bot identity used when committing/pushing through the active GitHub App.
 fn bot_identity() -> (String, String) {
-    let app_id = djinn_provider::github_app::app_id()
-        .map(|id| id.to_string())
-        .unwrap_or_else(|_| "0".to_string());
-    (
-        "djinn-bot[bot]".to_string(),
-        format!("{app_id}+djinn-bot[bot]@users.noreply.github.com"),
-    )
+    djinn_provider::github_app::bot_git_identity()
 }
 
 /// Parse `owner` and `repo` from a GitHub remote URL.

--- a/server/crates/djinn-db/src/repositories/org_config.rs
+++ b/server/crates/djinn-db/src/repositories/org_config.rs
@@ -8,9 +8,10 @@
 //! The row is written by the in-UI installation picker (see
 //! `server/src/server/github_install.rs`) and by the GitHub App-install
 //! redirect callback (`server/src/server/auth.rs::app_setup_callback`),
-//! both of which funnel through the single [`OrgConfigRepository::set`]
-//! writer below. Picking a different installation overwrites the row in
-//! place — there is no env override and no second writer.
+//! both of which use the repository writers below. Bootstrap callers use
+//! [`OrgConfigRepository::create_if_absent`] so concurrent setup requests
+//! cannot replace an established binding. [`OrgConfigRepository::set`] is
+//! retained for explicit operator-controlled replacement paths.
 
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +29,8 @@ pub struct OrgConfig {
     pub created_at: String,
 }
 
-/// Input for [`OrgConfigRepository::set`].
+/// Input for [`OrgConfigRepository::create_if_absent`] and
+/// [`OrgConfigRepository::set`].
 #[derive(Debug, Clone)]
 pub struct NewOrgConfig<'a> {
     pub github_org_id: i64,
@@ -60,14 +62,37 @@ impl OrgConfigRepository {
         .await?)
     }
 
+    /// Create the singleton org binding only when it does not already exist.
+    ///
+    /// Returns `Some(row)` when this call created the binding and `None` when
+    /// another setup request (or an earlier setup) already owns the singleton
+    /// row. The conflict check and insert are one database statement, so two
+    /// concurrent bootstrap requests cannot overwrite each other.
+    pub async fn create_if_absent(&self, cfg: NewOrgConfig<'_>) -> Result<Option<OrgConfig>> {
+        self.db.ensure_initialized().await?;
+
+        let inserted = sqlx::query_as::<_, OrgConfig>(
+            "INSERT INTO org_config
+                (id, github_org_id, github_org_login, app_id, installation_id)
+             VALUES (1, $1, $2, $3, $4)
+             ON CONFLICT (id) DO NOTHING
+             RETURNING id, github_org_id, github_org_login, app_id, installation_id, created_at",
+        )
+        .bind(cfg.github_org_id)
+        .bind(cfg.github_org_login)
+        .bind(cfg.app_id)
+        .bind(cfg.installation_id)
+        .fetch_optional(self.db.pool())
+        .await?;
+
+        Ok(inserted)
+    }
+
     /// Insert or replace the singleton org-binding row.
     ///
-    /// This is the **only** writer for `org_config` — both the in-UI
-    /// installation picker and the GitHub App-install redirect callback
-    /// land here. Re-binding to a different installation is supported by
-    /// design: an operator setting up a fresh deployment may pick the
-    /// wrong installation on the first click and reasonably expect a
-    /// second click to overwrite the binding.
+    /// This explicit replacement API is for operator-controlled repair or
+    /// migration paths. Public bootstrap surfaces must use
+    /// [`Self::create_if_absent`] so they cannot replace a completed binding.
     ///
     /// The `created_at` of an overwriting row reflects the *latest* bind —
     /// callers that need provenance for the original bind should snapshot
@@ -173,5 +198,70 @@ mod tests {
 
         let fetched = repo.get().await.unwrap().unwrap();
         assert_eq!(fetched.github_org_login, "second");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_if_absent_does_not_replace_existing_row() {
+        let repo = OrgConfigRepository::new(test_db());
+
+        let created = repo
+            .create_if_absent(NewOrgConfig {
+                github_org_id: 1,
+                github_org_login: "first",
+                app_id: 10,
+                installation_id: 20,
+            })
+            .await
+            .unwrap();
+        assert_eq!(created.unwrap().github_org_login, "first");
+
+        let conflict = repo
+            .create_if_absent(NewOrgConfig {
+                github_org_id: 2,
+                github_org_login: "second",
+                app_id: 30,
+                installation_id: 40,
+            })
+            .await
+            .unwrap();
+        assert!(conflict.is_none());
+
+        let fetched = repo.get().await.unwrap().unwrap();
+        assert_eq!(fetched.github_org_login, "first");
+        assert_eq!(fetched.installation_id, 20);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_create_if_absent_has_exactly_one_winner() {
+        let repo = OrgConfigRepository::new(test_db());
+        let first_repo = repo.clone();
+        let second_repo = repo.clone();
+
+        let (first, second) = tokio::join!(
+            first_repo.create_if_absent(NewOrgConfig {
+                github_org_id: 1,
+                github_org_login: "first",
+                app_id: 10,
+                installation_id: 20,
+            }),
+            second_repo.create_if_absent(NewOrgConfig {
+                github_org_id: 2,
+                github_org_login: "second",
+                app_id: 30,
+                installation_id: 40,
+            }),
+        );
+
+        let winners = [first.unwrap(), second.unwrap()]
+            .into_iter()
+            .filter(Option::is_some)
+            .count();
+        assert_eq!(winners, 1);
+
+        let fetched = repo.get().await.unwrap().unwrap();
+        assert!(matches!(
+            fetched.github_org_login.as_str(),
+            "first" | "second"
+        ));
     }
 }

--- a/server/crates/djinn-db/src/repositories/user.rs
+++ b/server/crates/djinn-db/src/repositories/user.rs
@@ -160,6 +160,36 @@ impl UserRepository {
         Ok(())
     }
 
+    /// Atomically grant the one-time bootstrap-admin role when no admin exists.
+    ///
+    /// The auth callback can run concurrently for different GitHub users. A
+    /// separate `admin_count()` followed by `set_admin_status()` lets both
+    /// callbacks observe zero and promote both users. The transaction-scoped
+    /// advisory lock serializes only this rare bootstrap decision; normal
+    /// user writes and later manual admin changes remain unaffected.
+    pub async fn grant_bootstrap_admin_if_none(&self, id: &str) -> Result<bool> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+
+        // Stable, process-independent lock key for "bootstrap the first admin".
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(0x444A_494E_4E41_444Di64)
+            .execute(&mut *tx)
+            .await?;
+
+        let result = sqlx::query(
+            "UPDATE users SET is_admin = TRUE \
+             WHERE id = $1 \
+               AND NOT EXISTS (SELECT 1 FROM users WHERE is_admin = TRUE)",
+        )
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(result.rows_affected() == 1)
+    }
+
     /// Set a user's proposal capability `role` (`proposer` | `pm` | `engineer`).
     pub async fn set_role(&self, id: &str, role: &str) -> Result<()> {
         self.db.ensure_initialized().await?;
@@ -313,5 +343,26 @@ mod tests {
 
         repo.set_admin_status(&u.id, false).await.unwrap();
         assert_eq!(repo.admin_count().await.unwrap(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_bootstrap_admin_has_exactly_one_winner() {
+        let repo = UserRepository::new(test_db());
+        let first = repo
+            .upsert_from_github(101, "first", None, None)
+            .await
+            .unwrap();
+        let second = repo
+            .upsert_from_github(202, "second", None, None)
+            .await
+            .unwrap();
+
+        let (first_won, second_won) = tokio::join!(
+            repo.grant_bootstrap_admin_if_none(&first.id),
+            repo.grant_bootstrap_admin_if_none(&second.id),
+        );
+
+        assert_ne!(first_won.unwrap(), second_won.unwrap());
+        assert_eq!(repo.admin_count().await.unwrap(), 1);
     }
 }

--- a/server/crates/djinn-provider/src/github_app/client.rs
+++ b/server/crates/djinn-provider/src/github_app/client.rs
@@ -13,20 +13,17 @@ use serde::Deserialize;
 use super::installations::{
     InstallationToken, get_installation_token, invalidate_cache, list_installations_for_user,
 };
-use super::{ENV_APP_SLUG, app_id};
+use super::{app_id, app_slug};
 
 const GITHUB_API: &str = "https://api.github.com";
 const USER_AGENT: &str = "djinn-server/0.1 (+https://github.com/djinnos/server)";
 
 /// Build the "install this app" URL for the given slug.
 ///
-/// Returns `None` if [`GITHUB_APP_SLUG`](ENV_APP_SLUG) is unset.
+/// Resolves the slug from the runtime credential snapshot, with environment
+/// fallback before server initialization.
 pub fn install_url() -> Option<String> {
-    let slug = std::env::var(ENV_APP_SLUG).ok()?;
-    let slug = slug.trim();
-    if slug.is_empty() {
-        return None;
-    }
+    let slug = app_slug()?;
     Some(format!("https://github.com/apps/{slug}/installations/new"))
 }
 
@@ -259,12 +256,35 @@ mod tests {
 
     #[test]
     fn install_url_respects_env() {
-        unsafe { std::env::set_var(ENV_APP_SLUG, "djinn-bot") };
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
+        unsafe { std::env::set_var(super::super::ENV_APP_SLUG, "djinn-bot") };
         assert_eq!(
             install_url().as_deref(),
             Some("https://github.com/apps/djinn-bot/installations/new")
         );
-        unsafe { std::env::remove_var(ENV_APP_SLUG) };
+        unsafe { std::env::remove_var(super::super::ENV_APP_SLUG) };
         assert_eq!(install_url(), None);
+    }
+
+    #[test]
+    fn install_url_prefers_runtime_slug() {
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
+        unsafe { std::env::remove_var(super::super::ENV_APP_SLUG) };
+        super::super::install_runtime_config(std::sync::Arc::new(super::super::AppConfig {
+            app_id: 1,
+            slug: "runtime-app".into(),
+            client_id: "Iv1.runtime".into(),
+            client_secret: "secret".into(),
+            pem: "pem".into(),
+            webhook_secret: String::new(),
+            public_url: "http://localhost:3000".into(),
+        }));
+        assert_eq!(
+            install_url().as_deref(),
+            Some("https://github.com/apps/runtime-app/installations/new")
+        );
+        super::super::clear_runtime_config();
     }
 }

--- a/server/crates/djinn-provider/src/github_app/config.rs
+++ b/server/crates/djinn-provider/src/github_app/config.rs
@@ -1,25 +1,23 @@
 //! Resolved GitHub App configuration.
 //!
 //! Holds the credentials needed to mint App JWTs and complete user-to-server
-//! OAuth. Loads exclusively from environment variables:
+//! OAuth. The server installs its resolved Secret-or-persisted configuration
+//! into a process-wide runtime cache; callers fall back to environment
+//! variables before server initialization:
 //!
 //! - `GITHUB_APP_ID`, `GITHUB_APP_SLUG`,
 //!   `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`,
 //!   `GITHUB_APP_PRIVATE_KEY` (or `_PATH`),
 //!   `GITHUB_APP_WEBHOOK_SECRET`, `DJINN_PUBLIC_URL`.
 //!
-//! Production deployments mount these via the Helm chart's `djinn-github-app`
-//! Secret (see `server/docker/README.md`). The legacy "in-UI manifest wizard
-//! that wrote a `__GITHUB_APP_CONFIG` row into the encrypted credentials
-//! vault" path was removed once the K8s migration made env-mounted Secrets
-//! the canonical provisioning surface.
-//!
-//! The struct is cloned cheaply via `Arc` and held inside the server
-//! `AppState` behind a `RwLock`. Env vars require a Pod restart to change,
-//! so the in-process cache never needs hot-swapping anymore — `init_app_config`
-//! is the only writer.
+//! Production deployments normally mount these via the Helm chart's
+//! `djinn-github-app` Secret. Self-setup deployments persist the same shape in
+//! the encrypted credential vault and hot-swap this runtime cache after the
+//! manifest exchange, so provider-level JWT and installation-token consumers
+//! do not need environment mirroring.
 
 use serde::{Deserialize, Serialize};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use super::{ENV_PRIVATE_KEY, ENV_PRIVATE_KEY_PATH};
 
@@ -57,13 +55,14 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
-    /// Resolve the active config from environment variables.
+    /// Resolve the active config from the installed runtime snapshot, falling
+    /// back to environment variables before server initialization.
     ///
     /// Returns `None` if any required env var (App ID, OAuth client id/secret,
     /// private key) is missing — the server then surfaces a "GitHub App not
     /// configured" status to the UI.
     pub fn load() -> Option<Self> {
-        load_from_env()
+        runtime_config().as_deref().cloned().or_else(load_from_env)
     }
 
     /// Build the install URL for this App's slug. Returns `None` if `slug`
@@ -77,14 +76,123 @@ impl AppConfig {
     }
 }
 
+fn runtime_config_slot() -> &'static RwLock<Option<Arc<AppConfig>>> {
+    static RUNTIME_CONFIG: OnceLock<RwLock<Option<Arc<AppConfig>>>> = OnceLock::new();
+    RUNTIME_CONFIG.get_or_init(|| RwLock::new(None))
+}
+
+/// Install the server's resolved credential snapshot for all provider-level
+/// GitHub App consumers. Replacing the App invalidates cached installation
+/// tokens, which are scoped to the previous App identity.
+pub fn install_runtime_config(config: Arc<AppConfig>) {
+    if let Ok(mut guard) = runtime_config_slot().write() {
+        *guard = Some(config);
+    }
+    super::installations::invalidate_all_cache();
+}
+
+/// Clear the process-wide credential snapshot. Environment fallback remains
+/// available for callers that run before `AppState::init_app_config`.
+pub fn clear_runtime_config() {
+    if let Ok(mut guard) = runtime_config_slot().write() {
+        *guard = None;
+    }
+    super::installations::invalidate_all_cache();
+}
+
+/// Return the currently installed runtime credential snapshot, if any.
+pub fn runtime_config() -> Option<Arc<AppConfig>> {
+    runtime_config_slot().read().ok()?.clone()
+}
+
+/// Resolve the active App slug from runtime credentials, then env fallback.
+pub fn app_slug() -> Option<String> {
+    if let Some(config) = runtime_config() {
+        let slug = config.slug.trim();
+        return (!slug.is_empty()).then(|| slug.to_string());
+    }
+    std::env::var(super::ENV_APP_SLUG)
+        .ok()
+        .map(|slug| slug.trim().to_string())
+        .filter(|slug| !slug.is_empty())
+}
+
+/// Resolve the GitHub App bot's commit identity from the active App slug.
+///
+/// The numeric GitHub App ID is not the bot account's user ID, so it must not
+/// be used as the numeric prefix of a GitHub no-reply address. Djinn does not
+/// currently persist the bot user ID; the login-only no-reply form is the safe
+/// non-personal fallback until that distinct ID is available.
+pub fn bot_git_identity() -> (String, String) {
+    let login = format!(
+        "{}[bot]",
+        app_slug().unwrap_or_else(|| "djinn-bot".to_string())
+    );
+    let email = format!("{login}@users.noreply.github.com");
+    (login, email)
+}
+
+/// Resolve the callback base URL registered for the active GitHub App.
+///
+/// Before self-setup completes there is no runtime config, so the manifest
+/// flow uses `DJINN_PUBLIC_URL` (or the localhost default). After credentials
+/// are loaded, the persisted provisioning URL wins to keep OAuth redirect URIs
+/// aligned with the callback registered on the App.
+pub fn public_url() -> String {
+    if let Some(config) = runtime_config() {
+        let public_url = config.public_url.trim();
+        if !public_url.is_empty() {
+            return public_url.to_string();
+        }
+    }
+    std::env::var(ENV_PUBLIC_URL)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_PUBLIC_URL.to_string())
+}
+
+/// Resolve OAuth client credentials from runtime credentials, then env
+/// fallback. Background refresh paths use this because they do not carry an
+/// `AppState` handle.
+pub fn oauth_client_credentials() -> Option<(String, String)> {
+    if let Some(config) = runtime_config() {
+        let client_id = config.client_id.trim();
+        let client_secret = config.client_secret.trim();
+        return (!client_id.is_empty() && !client_secret.is_empty())
+            .then(|| (client_id.to_string(), client_secret.to_string()));
+    }
+    let client_id = std::env::var(super::ENV_CLIENT_ID)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())?;
+    let client_secret = std::env::var(super::ENV_CLIENT_SECRET)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())?;
+    Some((client_id, client_secret))
+}
+
+#[cfg(test)]
+pub(crate) fn github_app_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 fn load_from_env() -> Option<AppConfig> {
     use super::{ENV_APP_ID, ENV_APP_SLUG, ENV_CLIENT_ID, ENV_CLIENT_SECRET};
 
     let app_id = std::env::var(ENV_APP_ID).ok()?.trim().parse::<u64>().ok()?;
+    if app_id == 0 {
+        return None;
+    }
     let slug = std::env::var(ENV_APP_SLUG).unwrap_or_default();
     let client_id = std::env::var(ENV_CLIENT_ID).unwrap_or_default();
     let client_secret = std::env::var(ENV_CLIENT_SECRET).unwrap_or_default();
     let pem = read_env_pem()?;
+    if super::jwt::validate_rsa_private_key(&pem).is_err() {
+        return None;
+    }
     let webhook_secret = std::env::var(ENV_WEBHOOK_SECRET).unwrap_or_default();
     let public_url =
         std::env::var(ENV_PUBLIC_URL).unwrap_or_else(|_| DEFAULT_PUBLIC_URL.to_string());
@@ -159,5 +267,70 @@ mod tests {
         let s = serde_json::to_string(&cfg).unwrap();
         let back: AppConfig = serde_json::from_str(&s).unwrap();
         assert_eq!(cfg, back);
+    }
+
+    #[test]
+    fn runtime_config_is_first_class_without_env_and_clear_restores_isolation() {
+        let _lock = github_app_test_lock();
+        clear_runtime_config();
+        for key in [
+            super::super::ENV_APP_ID,
+            super::super::ENV_APP_SLUG,
+            super::super::ENV_CLIENT_ID,
+            super::super::ENV_CLIENT_SECRET,
+            super::super::ENV_PRIVATE_KEY,
+            super::super::ENV_PRIVATE_KEY_PATH,
+        ] {
+            unsafe { std::env::remove_var(key) };
+        }
+
+        let cfg = fixture();
+        install_runtime_config(Arc::new(cfg.clone()));
+        assert_eq!(AppConfig::load(), Some(cfg.clone()));
+        assert_eq!(app_slug().as_deref(), Some("djinn-bot"));
+        assert_eq!(
+            oauth_client_credentials(),
+            Some((cfg.client_id.clone(), cfg.client_secret.clone()))
+        );
+
+        clear_runtime_config();
+        assert!(runtime_config().is_none());
+        assert!(AppConfig::load().is_none());
+        assert!(app_slug().is_none());
+        assert!(oauth_client_credentials().is_none());
+    }
+
+    #[test]
+    fn bot_git_identity_uses_runtime_slug_without_fabricating_a_user_id() {
+        let _lock = github_app_test_lock();
+        clear_runtime_config();
+        unsafe { std::env::remove_var(super::super::ENV_APP_SLUG) };
+
+        install_runtime_config(Arc::new(fixture()));
+        assert_eq!(
+            bot_git_identity(),
+            (
+                "djinn-bot[bot]".to_string(),
+                "djinn-bot[bot]@users.noreply.github.com".to_string(),
+            )
+        );
+
+        clear_runtime_config();
+    }
+
+    #[test]
+    fn public_url_prefers_runtime_provisioning_url() {
+        let _lock = github_app_test_lock();
+        clear_runtime_config();
+        unsafe { std::env::set_var(ENV_PUBLIC_URL, "https://env.example") };
+
+        let mut cfg = fixture();
+        cfg.public_url = "https://provisioned.example".to_string();
+        install_runtime_config(Arc::new(cfg));
+        assert_eq!(public_url(), "https://provisioned.example");
+
+        clear_runtime_config();
+        assert_eq!(public_url(), "https://env.example");
+        unsafe { std::env::remove_var(ENV_PUBLIC_URL) };
     }
 }

--- a/server/crates/djinn-provider/src/github_app/credential_state.rs
+++ b/server/crates/djinn-provider/src/github_app/credential_state.rs
@@ -178,7 +178,9 @@ fn try_load_from_env_detailed() -> EnvLoadResult {
     // At least one core var is set — attempt full load, collecting issues.
     let mut issues: Vec<&'static str> = Vec::new();
 
-    // APP_ID: required, must parse as u64.
+    // APP_ID: required, must parse as a non-zero u64. GitHub App IDs are
+    // positive identifiers; accepting zero only defers the failure to JWT/API
+    // use and incorrectly advertises the Secret as usable.
     let app_id = match std::env::var(ENV_APP_ID) {
         Ok(val) => {
             let trimmed = val.trim();
@@ -187,6 +189,10 @@ fn try_load_from_env_detailed() -> EnvLoadResult {
                 None
             } else {
                 match trimmed.parse::<u64>() {
+                    Ok(0) => {
+                        issues.push("GITHUB_APP_ID must be greater than zero");
+                        None
+                    }
                     Ok(id) => Some(id),
                     Err(_) => {
                         issues.push("GITHUB_APP_ID is not a valid number");
@@ -235,9 +241,17 @@ fn try_load_from_env_detailed() -> EnvLoadResult {
         }
     };
 
-    // PEM: required, must yield non-empty content.
+    // PEM: required, and it must be a usable RSA private key. A non-empty PEM
+    // envelope is not enough: EC keys and structurally malformed RSA key data
+    // cannot sign the RS256 JWT GitHub requires.
     let pem = match read_env_pem_detailed() {
-        Some(p) => Some(p),
+        Some(p) => match super::jwt::validate_rsa_private_key(&p) {
+            Ok(()) => Some(p),
+            Err(_) => {
+                issues.push("GITHUB_APP_PRIVATE_KEY is not a valid RSA private key");
+                None
+            }
+        },
         None => {
             issues.push("GITHUB_APP_PRIVATE_KEY (or _PATH) is not set or empty");
             None
@@ -383,22 +397,32 @@ pub async fn clear_persisted_app_config(repo: &CredentialRepository) -> Result<b
 
 #[cfg(test)]
 mod tests {
+    use super::super::jwt::tests::TEST_RSA_PRIVATE_KEY;
     use super::*;
     use djinn_core::events::EventBus;
     use djinn_db::Database;
 
     // ── helpers ──────────────────────────────────────────────────────────
 
+    const TEST_EC_PRIVATE_KEY: &str = "-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIl4cWgLf9/UBxBiwqKKzrCPdOWOn8DdO8wn7FxCwZ5loAoGCCqGSM49
+AwEHoUQDQgAEhLdpVmG8MBC2uexhGwHjWK0yoX9uLH5PAuTXMBdRSck+C5MGYcp0
+kveFVBYy/01GtT5ymlBeq5yOk/P8wEI62A==
+-----END EC PRIVATE KEY-----";
+
     /// Set env vars for a valid GitHub App configuration.
     /// Returns a guard that clears them on drop.
     struct EnvGuard {
         vars: Vec<(&'static str, String)>,
+        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         /// Clear all GitHub App env vars to ensure a clean slate.
         /// Returns a guard that also clears on drop.
         fn clean() -> Self {
+            let lock = super::super::config::github_app_test_lock();
+            super::super::clear_runtime_config();
             let all_keys = [
                 "GITHUB_APP_ID",
                 "GITHUB_APP_SLUG",
@@ -413,20 +437,21 @@ mod tests {
             for k in &all_keys {
                 unsafe { std::env::remove_var(k) };
             }
-            Self { vars: Vec::new() }
+            Self {
+                vars: Vec::new(),
+                _lock: lock,
+            }
         }
 
         fn set_valid() -> Self {
+            let lock = super::super::config::github_app_test_lock();
+            super::super::clear_runtime_config();
             let vars = vec![
                 ("GITHUB_APP_ID", "12345".to_string()),
                 ("GITHUB_APP_SLUG", "djinn-test".to_string()),
                 ("GITHUB_APP_CLIENT_ID", "Iv1.abc".to_string()),
                 ("GITHUB_APP_CLIENT_SECRET", "shh".to_string()),
-                (
-                    "GITHUB_APP_PRIVATE_KEY",
-                    "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n"
-                        .to_string(),
-                ),
+                ("GITHUB_APP_PRIVATE_KEY", TEST_RSA_PRIVATE_KEY.to_string()),
                 ("GITHUB_APP_WEBHOOK_SECRET", "wsec".to_string()),
                 ("DJINN_PUBLIC_URL", "https://djinn.example.com".to_string()),
             ];
@@ -434,33 +459,33 @@ mod tests {
                 // SAFETY: test env mutation — EnvGuard::drop cleans up.
                 unsafe { std::env::set_var(k, v) };
             }
-            Self { vars }
+            Self { vars, _lock: lock }
         }
 
         fn set_incomplete() -> Self {
+            let lock = super::super::config::github_app_test_lock();
+            super::super::clear_runtime_config();
             // Only set APP_ID but not CLIENT_ID/SECRET/PEM.
             let vars = vec![("GITHUB_APP_ID", "12345".to_string())];
             for &(k, ref v) in &vars {
                 unsafe { std::env::set_var(k, v) };
             }
-            Self { vars }
+            Self { vars, _lock: lock }
         }
 
         fn set_malformed_app_id() -> Self {
+            let lock = super::super::config::github_app_test_lock();
+            super::super::clear_runtime_config();
             let vars = vec![
                 ("GITHUB_APP_ID", "not-a-number".to_string()),
                 ("GITHUB_APP_CLIENT_ID", "Iv1.abc".to_string()),
                 ("GITHUB_APP_CLIENT_SECRET", "shh".to_string()),
-                (
-                    "GITHUB_APP_PRIVATE_KEY",
-                    "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n"
-                        .to_string(),
-                ),
+                ("GITHUB_APP_PRIVATE_KEY", TEST_RSA_PRIVATE_KEY.to_string()),
             ];
             for &(k, ref v) in &vars {
                 unsafe { std::env::set_var(k, v) };
             }
-            Self { vars }
+            Self { vars, _lock: lock }
         }
     }
 
@@ -492,7 +517,7 @@ mod tests {
             slug: "djinn-fixture".into(),
             client_id: "Iv1.fixture".into(),
             client_secret: "fixture-secret".into(),
-            pem: "-----BEGIN RSA PRIVATE KEY-----\nfixture\n-----END RSA PRIVATE KEY-----\n".into(),
+            pem: TEST_RSA_PRIVATE_KEY.into(),
             webhook_secret: "fixture-wh".into(),
             public_url: "https://fixture.example.com".into(),
         }
@@ -501,6 +526,16 @@ mod tests {
     fn cred_repo() -> CredentialRepository {
         let db = Database::open_in_memory().expect("failed to create test database");
         CredentialRepository::new(db, EventBus::noop())
+    }
+
+    fn set_complete_env(app_id: &str, private_key: &str) {
+        // SAFETY: callers hold the module-wide env lock through `EnvGuard`.
+        unsafe {
+            std::env::set_var("GITHUB_APP_ID", app_id);
+            std::env::set_var("GITHUB_APP_CLIENT_ID", "Iv1.abc");
+            std::env::set_var("GITHUB_APP_CLIENT_SECRET", "shh");
+            std::env::set_var("GITHUB_APP_PRIVATE_KEY", private_key);
+        }
     }
 
     // ── AC 1: typed state replaces Option-only ambiguity ─────────────────
@@ -575,6 +610,63 @@ mod tests {
         }
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn zero_app_id_is_fatal_over_persisted() {
+        let repo = cred_repo();
+        persist_app_config(&repo, &fixture_config()).await.unwrap();
+
+        let _env = EnvGuard::clean();
+        set_complete_env("0", TEST_RSA_PRIVATE_KEY);
+
+        let state = resolve_credential_source(Some(&repo)).await;
+        let CredentialSourceState::InvalidSecret(detail) = state else {
+            panic!("zero App ID must be InvalidSecret, not usable or persisted fallback");
+        };
+        assert!(
+            detail
+                .issues
+                .contains(&"GITHUB_APP_ID must be greater than zero")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn malformed_private_key_is_fatal_over_persisted() {
+        let repo = cred_repo();
+        persist_app_config(&repo, &fixture_config()).await.unwrap();
+
+        let _env = EnvGuard::clean();
+        set_complete_env("12345", "not-a-private-key");
+
+        let state = resolve_credential_source(Some(&repo)).await;
+        let CredentialSourceState::InvalidSecret(detail) = state else {
+            panic!("malformed private key must be InvalidSecret, not ValidSecret");
+        };
+        assert!(
+            detail
+                .issues
+                .contains(&"GITHUB_APP_PRIVATE_KEY is not a valid RSA private key")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn non_rsa_private_key_is_fatal_over_persisted() {
+        let repo = cred_repo();
+        persist_app_config(&repo, &fixture_config()).await.unwrap();
+
+        let _env = EnvGuard::clean();
+        set_complete_env("12345", TEST_EC_PRIVATE_KEY);
+
+        let state = resolve_credential_source(Some(&repo)).await;
+        let CredentialSourceState::InvalidSecret(detail) = state else {
+            panic!("EC private key must be InvalidSecret, not ValidSecret");
+        };
+        assert!(
+            detail
+                .issues
+                .contains(&"GITHUB_APP_PRIVATE_KEY is not a valid RSA private key")
+        );
+    }
+
     /// Regression for the credential-source precedence gap: when an operator
     /// sets a required env var to an *empty* value (e.g. `GITHUB_APP_ID=""`)
     /// while persisted credentials exist, the env source must be treated as
@@ -625,12 +717,7 @@ mod tests {
         unsafe { std::env::set_var("GITHUB_APP_ID", "12345") };
         unsafe { std::env::set_var("GITHUB_APP_CLIENT_ID", "") };
         unsafe { std::env::set_var("GITHUB_APP_CLIENT_SECRET", "shh") };
-        unsafe {
-            std::env::set_var(
-                "GITHUB_APP_PRIVATE_KEY",
-                "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
-            )
-        };
+        unsafe { std::env::set_var("GITHUB_APP_PRIVATE_KEY", TEST_RSA_PRIVATE_KEY) };
 
         let state = resolve_credential_source(Some(&repo)).await;
         assert!(
@@ -879,6 +966,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn persist_and_clear_round_trip() {
+        let _env = EnvGuard::clean();
         let repo = cred_repo();
         let config = fixture_config();
 

--- a/server/crates/djinn-provider/src/github_app/installations.rs
+++ b/server/crates/djinn-provider/src/github_app/installations.rs
@@ -118,6 +118,15 @@ pub fn invalidate_cache(installation_id: u64) {
     }
 }
 
+/// Clear every cached installation token after the active GitHub App
+/// credential snapshot changes. Installation ids are not sufficient cache
+/// isolation across different App identities.
+pub(crate) fn invalidate_all_cache() {
+    if let Ok(mut guard) = cache().lock() {
+        guard.clear();
+    }
+}
+
 // ─── API calls ────────────────────────────────────────────────────────────────
 
 /// List all GitHub App installations the user can see via their user token.

--- a/server/crates/djinn-provider/src/github_app/jwt.rs
+++ b/server/crates/djinn-provider/src/github_app/jwt.rs
@@ -12,7 +12,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use std::time::UNIX_EPOCH;
 
-use super::{ENV_APP_ID, ENV_PRIVATE_KEY, ENV_PRIVATE_KEY_PATH};
+use super::{ENV_APP_ID, ENV_PRIVATE_KEY, ENV_PRIVATE_KEY_PATH, runtime_config};
 
 /// Errors produced while minting an App JWT.
 #[derive(Debug, thiserror::Error)]
@@ -21,6 +21,8 @@ pub enum AppJwtError {
     MissingEnv(&'static str),
     #[error("GITHUB_APP_ID must be numeric, got {0:?}")]
     NonNumericAppId(String),
+    #[error("GITHUB_APP_ID must be greater than zero")]
+    ZeroAppId,
     #[error("failed to read {0}: {1}")]
     PrivateKeyRead(String, std::io::Error),
     #[error("invalid RSA private key: {0}")]
@@ -41,22 +43,53 @@ struct Claims {
     exp: u64,
 }
 
-/// Return the configured App ID, or an error if the env var is missing/bad.
+/// Return the configured App ID from the runtime snapshot, falling back to
+/// environment before server initialization.
 pub fn app_id() -> Result<u64, AppJwtError> {
+    if let Some(config) = runtime_config() {
+        return (config.app_id != 0)
+            .then_some(config.app_id)
+            .ok_or(AppJwtError::ZeroAppId);
+    }
     let raw = std::env::var(ENV_APP_ID).map_err(|_| AppJwtError::MissingEnv(ENV_APP_ID))?;
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err(AppJwtError::MissingEnv(ENV_APP_ID));
     }
-    trimmed
+    let app_id = trimmed
         .parse::<u64>()
-        .map_err(|_| AppJwtError::NonNumericAppId(trimmed.to_string()))
+        .map_err(|_| AppJwtError::NonNumericAppId(trimmed.to_string()))?;
+    (app_id != 0)
+        .then_some(app_id)
+        .ok_or(AppJwtError::ZeroAppId)
+}
+
+/// Verify that a PEM contains a usable RSA private key, using the same RS256
+/// signing path as App JWT minting. Parsing alone is insufficient: it can
+/// accept structurally RSA-shaped keys with invalid key parameters that fail
+/// only when the signer is constructed.
+pub(crate) fn validate_rsa_private_key(pem: &str) -> Result<(), AppJwtError> {
+    let key = EncodingKey::from_rsa_pem(pem.as_bytes())?;
+    let header = Header::new(Algorithm::RS256);
+    let validation_claims = Claims {
+        iss: "1".to_owned(),
+        iat: 0,
+        exp: 1,
+    };
+    encode(&header, &validation_claims, &key)?;
+    Ok(())
 }
 
 /// Load the App's RSA private key PEM from either
 /// [`GITHUB_APP_PRIVATE_KEY`](ENV_PRIVATE_KEY) (inline multi-line PEM) or
 /// [`GITHUB_APP_PRIVATE_KEY_PATH`](ENV_PRIVATE_KEY_PATH) (filesystem path).
 pub fn private_key_pem() -> Result<String, AppJwtError> {
+    if let Some(config) = runtime_config() {
+        if config.pem.trim().is_empty() {
+            return Err(AppJwtError::MissingEnv(ENV_PRIVATE_KEY));
+        }
+        return Ok(config.pem.clone());
+    }
     if let Ok(inline) = std::env::var(ENV_PRIVATE_KEY) {
         let inline = inline.trim();
         if !inline.is_empty() {
@@ -104,11 +137,39 @@ pub fn mint_app_jwt_anyhow() -> Result<String> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
-    // A freshly generated 2048-bit RSA key used only for unit tests.
-    const TEST_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----
+    pub(crate) const TEST_RSA_PRIVATE_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAu+kuYBjHip/Xq2lQnPQD9G2f97RMYFwa3Sr7PNrTd4gjEFkg
+OXFA1SCqlImNG/lNLxDK/tIoBSLkRkzEmbRCE/z+lV9pM3xs+UVeWLDzty5nzAMN
+KDh6RAcexrSEf8TMfvmMmBYJ8Cut6Htu8PkgQSehmSMQ4r5k+VcJw80yYSfL6wQK
+R+7p5O9UPRU4lcygOAxmt9PNeTkWHX/IPmLcsKyoi6IDlGxIeUPj9HkWxj8EYSxB
+XtoB22i5QAxAFmClQ3U08yAaENNZtU/liwTxE4igT93Txnai2mUxzKz6Pacf0ibU
+mCPTAiqnIEoOVKJpGOCZSi4LZDKr8yR4KDd2wwIDAQABAoIBAEWdKkARjgLuGoD3
+IBU1VS29WxDyK4VbOdyLqs2tp7/VoF/TFNwS99i9JFSo7KzbW9u+1eU3R/o3Jehh
+Ukg6/mvXQx1lXlzjkJ98MmqbC37mYy+yRbKL0cfX92/Xump3Juc3Xf2N1Jq0I9ZH
+vB7rvCZHH1fTJNNLg67Xrtdp8msJJ75oC13SbrrDedwPGlFJFNZan+cItD54dTTL
+fZ79Eg5UP+C9zZ0hP7fNJUnqPRUtz768l282IUP/C2Eb4ScbXa4gH8UHKmrNdK4d
+7CXaUDklNe79VaruD2mX6D92ztGnp/M49IqkLLtSirnOoOKIIbf2qi4tvoHe9WX3
+wKRvsOkCgYEA3d1jO+AaHqQ/K6JkWwiCDaOuZZud6aNsvaDtudRuVMjh6ygD+wcY
+Z5KqU7kieBShS8xLBI91EG3FBytSloNWu/aeJC9FAwZ7qKk3F3AKIR/wqbQkOTT/
+8ThTxe+1eaewgxXYNpHGC8LaZwCRSgmFkc6EVKMAmFO/9ovIAiTHx4cCgYEA2NJy
+RxAjXNqegFCeePpwhPvPd3M8K9wo0hwrSgkhzoaKYxQ+qInL/OUSiOnegGrVsJq9
+IfzwV2uBmkVR+sZJv1xyigqmR86h+Dlw0FfV2r5s/BmDYQ7V9MVdxdT7/bfbiggZ
+WdyP3o4YlnSLk/qLim7/QdmW8khj3seQWkJm7eUCgYA0jdCHylnlkDp2d40WEznb
+ST5ySx5ozZFgidJGBo/r/XmmXmAzAkdBoXg/RMdpclmSvt22QtUUAyx8ukJh7NKK
+y6xCHgBW6x43oX2vS5baqdo0GLvL4UYPOax+Yn22R4aERpRkuLsU5h8d7wB7bS36
+j9TAx6vIaW47VHkYKOY52QKBgQCht602panKiuDnkbnxP9IGzg466L87c3Ua6Zm8
+Gb2WXbEAH0xwxn5YPL8rUUv8ejKyC2f/3rmganX7C7MOmTDOQvTHUxQcwNj73FPx
+gWHnSlrdWWYtUTRx4XeEo8vjvGtJs6q85I6GD3P1XC3zDE9hzFIk2lcElMuwkSZw
+u9ArpQKBgD0fKZvRNpXaJRUTkZfF/6HrYpBg3risCi0hzA8KD2CYhDN+n41qZhFV
+R68QYTUok1u+1E/zrD8hR66a0YlSbcHfO5IeyfK2UszZyJxZgkrYk91b3vPqAuqu
+B43YjMtfeD03UXwS4GGcof401pHtVBHuukNdH8qhqH1fObcwd9Ot
+-----END RSA PRIVATE KEY-----";
+
+    // Structurally RSA-shaped test data with invalid key parameters.
+    const MALFORMED_RSA_TEST_KEY: &str = "-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAx+tL1UEtvzpkrugQBoH+WmFVHm5tW4IG14UlWJw8mJp8PeNk
 yx0KjLGLE4ETA7tvHZUvrqxzMH4+KkkW44mhZmGzGVdyprQUXmKvt+zHS7T0btkV
 2R8WmMPp6h6x3Lp5+H8O8JgrkbSH2WcS+Kk1O/hcMRyjmc8pBtIHrLAKzMMKYmXG
@@ -160,19 +221,33 @@ n45yWgSqT+EgIykBHFuVuwN2T+X2jOs7JvrWN0iHl76Ej3F7V4Xf77+HqdEvVSRx
 
     #[test]
     fn app_id_requires_numeric_env() {
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
         let _g = EnvGuard::set(&[(ENV_APP_ID, "not-a-number")]);
         assert!(matches!(app_id(), Err(AppJwtError::NonNumericAppId(_))));
     }
 
     #[test]
     fn app_id_rejects_empty() {
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
         let _g = EnvGuard::set(&[(ENV_APP_ID, "  ")]);
         assert!(matches!(app_id(), Err(AppJwtError::MissingEnv(_))));
     }
 
     #[test]
+    fn app_id_rejects_zero() {
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
+        let _g = EnvGuard::set(&[(ENV_APP_ID, "0")]);
+        assert!(matches!(app_id(), Err(AppJwtError::ZeroAppId)));
+    }
+
+    #[test]
     fn private_key_reads_inline_with_escaped_newlines() {
-        let escaped = TEST_KEY.replace('\n', "\\n");
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
+        let escaped = TEST_RSA_PRIVATE_KEY.replace('\n', "\\n");
         let _g = EnvGuard::set(&[(ENV_PRIVATE_KEY, escaped.as_str())]);
         let pem = private_key_pem().unwrap();
         assert!(pem.starts_with("-----BEGIN RSA PRIVATE KEY-----"));
@@ -181,6 +256,8 @@ n45yWgSqT+EgIykBHFuVuwN2T+X2jOs7JvrWN0iHl76Ej3F7V4Xf77+HqdEvVSRx
 
     #[test]
     fn mint_app_jwt_errors_on_invalid_key() {
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
         // The embedded PEM is a well-formed literal but not a real RSA
         // keypair (generating one here would require a dev-dep on `rsa`
         // which bloats the graph). We assert instead that the jsonwebtoken
@@ -188,7 +265,10 @@ n45yWgSqT+EgIykBHFuVuwN2T+X2jOs7JvrWN0iHl76Ej3F7V4Xf77+HqdEvVSRx
         // which is enough to validate the plumbing between env → PEM →
         // EncodingKey. Runtime verification of a real key happens against
         // GitHub during setup (see docs/GITHUB_APP_SETUP.md).
-        let _g = EnvGuard::set(&[(ENV_APP_ID, "123456"), (ENV_PRIVATE_KEY, TEST_KEY)]);
+        let _g = EnvGuard::set(&[
+            (ENV_APP_ID, "123456"),
+            (ENV_PRIVATE_KEY, MALFORMED_RSA_TEST_KEY),
+        ]);
         match mint_app_jwt() {
             Err(AppJwtError::InvalidKey(_)) => {}
             Err(other) => panic!("expected InvalidKey, got {other:?}"),
@@ -198,5 +278,33 @@ n45yWgSqT+EgIykBHFuVuwN2T+X2jOs7JvrWN0iHl76Ej3F7V4Xf77+HqdEvVSRx
                 assert_eq!(tok.split('.').count(), 3);
             }
         }
+    }
+
+    #[test]
+    fn runtime_config_mints_without_github_app_env() {
+        let _lock = super::super::config::github_app_test_lock();
+        super::super::clear_runtime_config();
+        for key in [ENV_APP_ID, ENV_PRIVATE_KEY, ENV_PRIVATE_KEY_PATH] {
+            unsafe { std::env::remove_var(key) };
+        }
+
+        let config = super::super::AppConfig {
+            app_id: 654321,
+            slug: "runtime-app".into(),
+            client_id: "Iv1.runtime".into(),
+            client_secret: "runtime-secret".into(),
+            pem: TEST_RSA_PRIVATE_KEY.into(),
+            webhook_secret: String::new(),
+            public_url: "http://localhost:3000".into(),
+        };
+        super::super::install_runtime_config(std::sync::Arc::new(config));
+
+        assert_eq!(app_id().unwrap(), 654321);
+        assert_eq!(private_key_pem().unwrap(), TEST_RSA_PRIVATE_KEY);
+        let token = mint_app_jwt().expect("valid runtime RSA key should mint an App JWT");
+        assert_eq!(token.split('.').count(), 3);
+
+        super::super::clear_runtime_config();
+        assert!(matches!(app_id(), Err(AppJwtError::MissingEnv(_))));
     }
 }

--- a/server/crates/djinn-provider/src/github_app/mod.rs
+++ b/server/crates/djinn-provider/src/github_app/mod.rs
@@ -30,7 +30,11 @@ pub mod jwt;
 pub mod manifest;
 
 pub use client::{GitHubAppClient, InstallationRepo, find_installation_for_repo, install_url};
-pub use config::{AppConfig, DEFAULT_PUBLIC_URL, ENV_PUBLIC_URL, ENV_WEBHOOK_SECRET};
+pub use config::{
+    AppConfig, DEFAULT_PUBLIC_URL, ENV_PUBLIC_URL, ENV_WEBHOOK_SECRET, app_slug, bot_git_identity,
+    clear_runtime_config, install_runtime_config, oauth_client_credentials, public_url,
+    runtime_config,
+};
 pub use credential_state::{
     CRED_KEY_NAME, CRED_PROVIDER_ID, ConfigSource, CredentialSourceState, InvalidSecretDetail,
     clear_persisted_app_config, persist_app_config, resolve_credential_source,

--- a/server/crates/djinn-provider/src/oauth/github_app_user.rs
+++ b/server/crates/djinn-provider/src/oauth/github_app_user.rs
@@ -26,20 +26,15 @@ use serde::{Deserialize, Serialize};
 /// initial code exchange and refresh-token rotations.
 const GITHUB_TOKEN_ENDPOINT: &str = "https://github.com/login/oauth/access_token";
 
-/// Read the GitHub App OAuth client_id + client_secret from the process
-/// environment, returning `None` if either is missing or empty.
+/// Resolve the GitHub App OAuth client_id + client_secret from the provider's
+/// runtime credential snapshot, with environment fallback before server
+/// initialization.
 ///
 /// Centralised here so that background paths (`pr_poller`'s refresh
 /// hook) and the web layer (`/auth/github/callback`) read the same
 /// pair of env vars without duplicating the trim+empty filtering.
-pub fn client_credentials_from_env() -> Option<(String, String)> {
-    let cid = std::env::var("GITHUB_APP_CLIENT_ID")
-        .ok()
-        .filter(|v| !v.trim().is_empty())?;
-    let secret = std::env::var("GITHUB_APP_CLIENT_SECRET")
-        .ok()
-        .filter(|v| !v.trim().is_empty())?;
-    Some((cid, secret))
+pub fn client_credentials() -> Option<(String, String)> {
+    crate::github_app::oauth_client_credentials()
 }
 
 /// Tokens minted by GitHub for a user-to-server OAuth flow.

--- a/server/src/server/auth/mod.rs
+++ b/server/src/server/auth/mod.rs
@@ -53,7 +53,7 @@ pub(crate) mod boot_token;
 use axum::{
     Json, Router,
     extract::{Query, Request, State},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{HeaderMap, HeaderValue, StatusCode, Uri, header, uri::Authority},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -64,16 +64,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::server::AppState;
 use djinn_db::{
-    CreateUserAuthSession, NewOrgConfig, OrgConfigRepository, SessionAuthRepository, UserRepository,
+    CreateUserAuthSession, NewOrgConfig, OrgConfig, OrgConfigRepository, SessionAuthRepository,
+    UserRepository,
 };
-use djinn_provider::github_app::ManifestConversion;
 use djinn_provider::github_app::jwt::mint_app_jwt_anyhow;
+use djinn_provider::github_app::{CredentialSourceState, ManifestConversion};
 use djinn_provider::github_server::{AppInstallation, GitHubServerClient};
 use djinn_provider::oauth::github_app_user::{self, GithubUserTokens};
 
 pub(super) const SESSION_COOKIE: &str = "djinn_session";
 const OAUTH_STATE_COOKIE: &str = "djinn_oauth_state";
-pub(super) const DEFAULT_PUBLIC_URL: &str = "http://127.0.0.1:8372";
 const SESSION_TTL_SECS: i64 = 60 * 60 * 24 * 30; // 30 days
 const STATE_COOKIE_TTL_SECS: i64 = 60 * 10; // 10 minutes
 /// CSRF state cookie for the GitHub App manifest creation flow.
@@ -86,6 +86,14 @@ pub(crate) const SETUP_SESSION_COOKIE: &str = "djinn_setup_session";
 const SETUP_SESSION_PATH: &str = "/auth/github";
 /// Setup session TTL: 15 minutes.
 const SETUP_SESSION_TTL_SECS: i64 = 60 * 15;
+/// Browser-only capability cookie that gates the explicit setup CTA.
+const SETUP_LAUNCH_COOKIE: &str = "djinn_setup_launch";
+/// Keep the launch capability off every other auth route, including the
+/// manifest callback that receives a cross-site navigation from GitHub.
+const SETUP_LAUNCH_PATH: &str = "/auth/github/setup-start";
+/// The setup CTA should be used promptly. The server independently enforces
+/// the same lifetime; this is not merely a browser cookie hint.
+const SETUP_LAUNCH_TTL_SECS: i64 = 60 * 2;
 /// Query parameter name for the install-continuation nonce appended to the
 /// GitHub install URL after manifest credential persistence.
 const INSTALL_CONTINUATION_PARAM: &str = "djinn_continuation";
@@ -108,6 +116,42 @@ fn read_github_app_oauth_env(primary: &str) -> Option<String> {
     std::env::var(primary).ok().filter(|v| !v.is_empty())
 }
 
+/// Opt-in for GitHub App installations owned by a personal account. Default
+/// remains organization-only for production deployments.
+pub(super) fn allow_user_installations() -> bool {
+    parse_allow_user_installations(
+        std::env::var("DJINN_ALLOW_USER_INSTALLATIONS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn parse_allow_user_installations(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        let value = value.trim();
+        value == "1" || value.eq_ignore_ascii_case("true")
+    })
+}
+
+/// Account types accepted for deployment binding. Unknown GitHub account
+/// types remain rejected even when personal-account support is enabled.
+pub(super) fn installation_account_type_allowed(account_type: &str, allow_users: bool) -> bool {
+    account_type.eq_ignore_ascii_case("Organization")
+        || (allow_users && account_type.eq_ignore_ascii_case("User"))
+}
+
+/// Personal bindings reuse the legacy `org_config` row, so identify them by
+/// matching the immutable GitHub account id plus login to the signed-in user.
+/// GitHub account ids are global across users and organizations.
+pub(super) fn binding_matches_user(
+    binding: &OrgConfig,
+    github_user_id: i64,
+    github_login: &str,
+) -> bool {
+    binding.github_org_id == github_user_id
+        && binding.github_org_login.eq_ignore_ascii_case(github_login)
+}
+
 pub(super) fn router() -> Router<AppState> {
     Router::new()
         .route("/auth/me", get(me))
@@ -117,6 +161,7 @@ pub(super) fn router() -> Router<AppState> {
         .route("/auth/github/app-setup-callback", get(app_setup_callback))
         // Self-setup routes: gated by DJINN_ENABLE_SELF_SETUP + no usable
         // credentials. When the gate is closed these return 404.
+        .route("/auth/github/setup-start", post(setup_start))
         .route("/auth/github/create-app", get(create_app))
         .route(
             "/auth/github/app-manifest-callback",
@@ -148,13 +193,89 @@ struct ConfigResponse {
     /// `DJINN_ENABLE_SELF_SETUP=true` AND no usable credentials exist.
     #[serde(default)]
     self_setup_available: bool,
+    /// Whether this specific browser request can use the local-only setup
+    /// CTA. This is stricter than `self_setup_available`, which continues to
+    /// describe the boot-token fallback for any deployment.
+    #[serde(default)]
+    setup_launch_available: bool,
+    credential_source: Option<&'static str>,
+    setup_state: &'static str,
+    setup_error: Option<String>,
+    setup_retryable: bool,
+    credentials_unrecoverable: bool,
+}
+
+/// Keep the JSON response shape unchanged while attaching a browser-only
+/// launch cookie when this was a verified same-origin config fetch.
+struct ConfigOutput(ConfigResponse, HeaderMap);
+
+impl IntoResponse for ConfigOutput {
+    fn into_response(self) -> Response {
+        (self.1, Json(self.0)).into_response()
+    }
+}
+
+struct CredentialStatusFields {
+    credential_source: Option<&'static str>,
+    setup_state: &'static str,
+    setup_error: Option<String>,
+    setup_retryable: bool,
+    credentials_unrecoverable: bool,
+}
+
+fn credential_status_fields(state: &CredentialSourceState) -> CredentialStatusFields {
+    match state {
+        CredentialSourceState::ValidSecret(_) => CredentialStatusFields {
+            credential_source: Some("secret"),
+            setup_state: "valid_secret",
+            setup_error: None,
+            setup_retryable: false,
+            credentials_unrecoverable: false,
+        },
+        CredentialSourceState::ValidPersisted(_) => CredentialStatusFields {
+            credential_source: Some("persisted"),
+            setup_state: "valid_persisted",
+            setup_error: None,
+            setup_retryable: false,
+            credentials_unrecoverable: false,
+        },
+        CredentialSourceState::InvalidSecret(detail) => CredentialStatusFields {
+            credential_source: None,
+            setup_state: "invalid_secret",
+            setup_error: Some(format!(
+                "GitHub App Secret is invalid or incomplete: {}",
+                detail.issues.join(", ")
+            )),
+            setup_retryable: false,
+            credentials_unrecoverable: false,
+        },
+        CredentialSourceState::UndecryptablePersisted => CredentialStatusFields {
+            credential_source: None,
+            setup_state: "credentials_unrecoverable",
+            setup_error: Some(
+                "Persisted GitHub App credentials cannot be decrypted; restore the vault key, clear the persisted credentials and rerun setup, or mount a valid Secret"
+                    .to_string(),
+            ),
+            setup_retryable: false,
+            credentials_unrecoverable: true,
+        },
+        CredentialSourceState::Unconfigured => CredentialStatusFields {
+            credential_source: None,
+            setup_state: "unconfigured",
+            setup_error: None,
+            setup_retryable: false,
+            credentials_unrecoverable: false,
+        },
+    }
 }
 
 /// Report whether the GitHub App is configured (env-only after the K8s
 /// migration). Used by the UI to decide between sign-in and a static
 /// "App not configured" notice.
-async fn config(State(state): State<AppState>) -> Json<ConfigResponse> {
-    let active = state.app_config().await;
+async fn config(State(state): State<AppState>, headers: HeaderMap) -> ConfigOutput {
+    let credential_state = state.app_credential_state().await;
+    let active = credential_state.app_config().cloned();
+    let status = credential_status_fields(&credential_state);
     let mut missing: Vec<&'static str> = Vec::new();
 
     if active.is_none() {
@@ -178,14 +299,35 @@ async fn config(State(state): State<AppState>) -> Json<ConfigResponse> {
         }
     }
 
-    let self_setup_available = setup_available(active.is_some());
+    let self_setup_available = setup_available(&credential_state);
+    let setup_launch_available =
+        self_setup_available && local_setup_launch_available(&headers, &public_url());
 
-    Json(ConfigResponse {
-        configured: active.is_some(),
-        missing,
-        setup_doc_url: "https://github.com/djinnos/djinn/blob/main/docs/GITHUB_APP_SETUP.md",
-        self_setup_available,
-    })
+    let mut response_headers = HeaderMap::new();
+    if setup_launch_available {
+        let launch_token = state
+            .issue_setup_launch_capability(std::time::Duration::from_secs(
+                SETUP_LAUNCH_TTL_SECS as u64,
+            ))
+            .await;
+        set_setup_launch_cookie(&mut response_headers, &launch_token);
+    }
+
+    ConfigOutput(
+        ConfigResponse {
+            configured: active.is_some(),
+            missing,
+            setup_doc_url: "https://github.com/djinnos/djinn/blob/main/docs/GITHUB_APP_SETUP.md",
+            self_setup_available,
+            setup_launch_available,
+            credential_source: status.credential_source,
+            setup_state: status.setup_state,
+            setup_error: status.setup_error,
+            setup_retryable: status.setup_retryable,
+            credentials_unrecoverable: status.credentials_unrecoverable,
+        },
+        response_headers,
+    )
 }
 
 use std::sync::atomic::{AtomicI8, Ordering};
@@ -202,18 +344,54 @@ static SELF_SETUP_OVERRIDE: AtomicI8 = AtomicI8::new(-1);
 #[cfg(test)]
 static SELF_SETUP_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// Serialises self-setup tests and restores the process-global credential
+/// cache when each test finishes. Manifest callback tests intentionally
+/// exercise the production hot-reload path, so leaving that cache populated
+/// would leak one test's App into unrelated auth tests.
+#[cfg(test)]
+struct SelfSetupTestGuard {
+    _guard: tokio::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl Drop for SelfSetupTestGuard {
+    fn drop(&mut self) {
+        SELF_SETUP_OVERRIDE.store(-1, Ordering::SeqCst);
+        djinn_provider::github_app::clear_runtime_config();
+        if let Ok(mut slot) = EXCHANGE_MANIFEST_RESULT_OVERRIDE.lock() {
+            *slot = None;
+        }
+        if let Ok(mut slot) = OAUTH_EXCHANGE_RESULT_OVERRIDE.lock() {
+            *slot = None;
+        }
+        if let Ok(mut slot) = GITHUB_USER_RESULT_OVERRIDE.lock() {
+            *slot = None;
+        }
+        if let Ok(mut slot) = USER_INSTALLATIONS_RESULT_OVERRIDE.lock() {
+            *slot = None;
+        }
+        if let Ok(mut slot) = APP_INSTALLATION_RESULT_OVERRIDE.lock() {
+            *slot = None;
+        }
+        if let Ok(mut slot) = ORG_CONFIG_RESULT_OVERRIDE.lock() {
+            *slot = None;
+        }
+    }
+}
+
 /// Acquire the async test lock, set the override, and return the guard.
 /// The override stays set until the guard is dropped (end of test).
 #[cfg(test)]
-async fn with_self_setup_override(value: Option<bool>) -> tokio::sync::MutexGuard<'static, ()> {
+async fn with_self_setup_override(value: Option<bool>) -> SelfSetupTestGuard {
     let guard = SELF_SETUP_TEST_LOCK.lock().await;
+    djinn_provider::github_app::clear_runtime_config();
     let v = match value {
         None => -1,
         Some(true) => 1,
         Some(false) => 0,
     };
     SELF_SETUP_OVERRIDE.store(v, Ordering::SeqCst);
-    guard
+    SelfSetupTestGuard { _guard: guard }
 }
 
 /// Whether the `DJINN_ENABLE_SELF_SETUP` environment variable is set to true.
@@ -228,9 +406,11 @@ pub(crate) fn self_setup_enabled() -> bool {
 }
 
 /// Whether the self-setup UI/flow should be offered: the gate is enabled AND
-/// no usable GitHub App credentials exist yet.
-fn setup_available(has_usable_credentials: bool) -> bool {
-    self_setup_enabled() && !has_usable_credentials
+/// the retained state is truly unconfigured. Invalid Secret and
+/// undecryptable-persisted states require explicit recovery and never fall
+/// through to setup.
+fn setup_available(state: &CredentialSourceState) -> bool {
+    self_setup_enabled() && matches!(state, CredentialSourceState::Unconfigured)
 }
 
 /// Set a `djinn_setup_session` cookie scoped to the setup route prefix.
@@ -285,6 +465,161 @@ fn clear_setup_cookie(headers: &mut HeaderMap) {
     }
 }
 
+/// Set the short-lived capability used only by the setup CTA POST.
+///
+/// `SameSite=Strict` keeps the browser from attaching it to a cross-site
+/// form or fetch. The exact path avoids carrying it through the GitHub
+/// redirect/callback flow, and HttpOnly keeps UI JavaScript from turning it
+/// into another exposed boot token.
+fn set_setup_launch_cookie(headers: &mut HeaderMap, value: &str) {
+    let secure = if cookie_secure() { "; Secure" } else { "" };
+    let cookie = format!(
+        "{name}={value}; Path={path}; HttpOnly; SameSite=Strict; Max-Age={max_age}{secure}",
+        name = SETUP_LAUNCH_COOKIE,
+        path = SETUP_LAUNCH_PATH,
+        max_age = SETUP_LAUNCH_TTL_SECS,
+    );
+    if let Ok(hv) = HeaderValue::from_str(&cookie) {
+        headers.append(header::SET_COOKIE, hv);
+    }
+}
+
+fn clear_setup_launch_cookie(headers: &mut HeaderMap) {
+    let secure = if cookie_secure() { "; Secure" } else { "" };
+    let cookie = format!(
+        "{name}=; Path={path}; HttpOnly; SameSite=Strict; Max-Age=0; \
+         Expires=Thu, 01 Jan 1970 00:00:00 GMT{secure}",
+        name = SETUP_LAUNCH_COOKIE,
+        path = SETUP_LAUNCH_PATH,
+    );
+    if let Ok(hv) = HeaderValue::from_str(&cookie) {
+        headers.append(header::SET_COOKIE, hv);
+    }
+}
+
+/// Recover a same-origin operator from a stale setup page without exposing
+/// why capability validation failed. The SPA reload fetches `/auth/config`,
+/// which mints a fresh launch cookie when the local setup gate remains open.
+fn setup_launch_expired_redirect() -> Response {
+    let mut response_headers = HeaderMap::new();
+    clear_setup_launch_cookie(&mut response_headers);
+    response_headers.insert(
+        header::LOCATION,
+        HeaderValue::from_static("/?setup=expired"),
+    );
+    (StatusCode::SEE_OTHER, response_headers).into_response()
+}
+
+fn sec_fetch_site_is_same_origin(headers: &HeaderMap) -> bool {
+    headers
+        .get("sec-fetch-site")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("same-origin"))
+}
+
+#[derive(Debug, Clone)]
+struct SetupLaunchOrigin {
+    scheme: String,
+    authority: Authority,
+}
+
+/// The browser CTA is deliberately local-only. Fetch metadata and Origin are
+/// browser CSRF defenses, not an authorization boundary for arbitrary HTTP
+/// clients; restricting the configured callback origin to the OS loopback
+/// interface gives the direct-client path an explicit local trust boundary.
+fn configured_loopback_setup_origin(public_url: &str) -> Option<SetupLaunchOrigin> {
+    let uri = public_url.parse::<Uri>().ok()?;
+    let scheme = uri.scheme_str()?;
+    if !matches!(scheme, "http" | "https") {
+        return None;
+    }
+    let authority = uri.authority()?.clone();
+    let host = authority
+        .host()
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or_else(|| authority.host());
+    let loopback = host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .ok()
+            .is_some_and(|address| address.is_loopback());
+    loopback.then(|| SetupLaunchOrigin {
+        scheme: scheme.to_ascii_lowercase(),
+        authority,
+    })
+}
+
+fn request_host_matches_configured(headers: &HeaderMap, configured: &SetupLaunchOrigin) -> bool {
+    headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<Authority>().ok())
+        .is_some_and(|authority| {
+            authority
+                .as_str()
+                .eq_ignore_ascii_case(configured.authority.as_str())
+        })
+}
+
+/// Match the browser's serialized `Origin` exactly to `DJINN_PUBLIC_URL`'s
+/// origin. Comparing against configured state (not merely Origin vs Host)
+/// prevents DNS rebinding and catches localhost/127.0.0.1 alias drift before
+/// GitHub sends the callback to a host that lacks the setup cookie.
+fn request_origin_matches_configured(headers: &HeaderMap, configured: &SetupLaunchOrigin) -> bool {
+    let Some(origin) = headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Ok(uri) = origin.parse::<Uri>() else {
+        return false;
+    };
+    if !uri
+        .scheme_str()
+        .is_some_and(|scheme| scheme.eq_ignore_ascii_case(&configured.scheme))
+    {
+        return false;
+    }
+    if uri
+        .path_and_query()
+        .is_some_and(|value| value.as_str() != "/")
+    {
+        return false;
+    }
+    uri.authority().is_some_and(|authority| {
+        authority
+            .as_str()
+            .eq_ignore_ascii_case(configured.authority.as_str())
+    })
+}
+
+/// `/auth/config` is a GET, so browsers normally omit `Origin`. The
+/// browser fetch-metadata header plus exact configured Host are the issuance
+/// gate; if an Origin is present, it must also equal the configured origin.
+fn same_origin_config_fetch(headers: &HeaderMap, configured: &SetupLaunchOrigin) -> bool {
+    sec_fetch_site_is_same_origin(headers)
+        && request_host_matches_configured(headers, configured)
+        && (!headers.contains_key(header::ORIGIN)
+            || request_origin_matches_configured(headers, configured))
+}
+
+fn local_setup_launch_available(headers: &HeaderMap, configured_public_url: &str) -> bool {
+    configured_loopback_setup_origin(configured_public_url)
+        .as_ref()
+        .is_some_and(|configured| same_origin_config_fetch(headers, configured))
+}
+
+/// The form POST has both browser signals. Require both so a same-site page
+/// on another localhost port cannot ride the Strict cookie into setup, and
+/// bind both signals to the configured callback origin.
+fn same_origin_setup_post(headers: &HeaderMap, configured: &SetupLaunchOrigin) -> bool {
+    sec_fetch_site_is_same_origin(headers)
+        && request_host_matches_configured(headers, configured)
+        && request_origin_matches_configured(headers, configured)
+}
+
 /// Set the install-continuation cookie, which carries the manifest-flow
 /// nonce through the cross-domain GitHub install round-trip.
 ///
@@ -321,11 +656,11 @@ fn clear_install_continuation_cookie(headers: &mut HeaderMap) {
 }
 
 /// Guard for setup routes: returns `Some(404 response)` when the self-setup
-/// gate is closed (disabled or usable credentials already exist), or `None`
-/// when setup is available and the handler should proceed.
+/// gate is closed (disabled or state is anything except truly unconfigured),
+/// or `None` when setup is available and the handler should proceed.
 async fn setup_route_guard(state: &AppState) -> Option<Response> {
-    let has_usable = state.app_config().await.is_some();
-    if !setup_available(has_usable) {
+    let credential_state = state.app_credential_state().await;
+    if !setup_available(&credential_state) {
         return Some(StatusCode::NOT_FOUND.into_response());
     }
     None
@@ -557,6 +892,80 @@ struct CallbackQuery {
     setup_action: Option<String>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum OAuthCallbackOrigin {
+    /// OAuth explicitly started by `/auth/github/start`, protected by the
+    /// normal state parameter + HttpOnly state cookie pair.
+    Stateful {
+        want_install: bool,
+        redirect: String,
+    },
+    /// OAuth automatically started by GitHub after App installation. GitHub
+    /// documents this callback as `code`-only, so the pending manifest
+    /// continuation cookie is the CSRF correlation instead.
+    InstallInitiated { continuation: String },
+}
+
+async fn resolve_oauth_callback_origin(
+    state: &AppState,
+    q: &CallbackQuery,
+    headers: &HeaderMap,
+) -> Result<(String, OAuthCallbackOrigin), Response> {
+    let Some(code) = q.code.as_deref().filter(|code| !code.is_empty()) else {
+        return Err((StatusCode::BAD_REQUEST, "missing code").into_response());
+    };
+
+    if let Some(state_param) = q.state.as_deref().filter(|state| !state.is_empty()) {
+        let Some(cookie_raw) = extract_cookie(headers, OAUTH_STATE_COOKIE) else {
+            return Err((StatusCode::BAD_REQUEST, "missing state cookie").into_response());
+        };
+        // Cookie format: `<state>|i0|<redirect>` or
+        // `<state>|i1|<redirect>`. Legacy `<state>|<redirect>` remains valid
+        // for callbacks already in flight during an upgrade.
+        let mut parts = cookie_raw.splitn(3, '|');
+        let cookie_state = parts.next().unwrap_or("");
+        let (want_install, redirect) = match (parts.next(), parts.next()) {
+            (Some("i1"), Some(redirect)) => (true, redirect.to_string()),
+            (Some("i0"), Some(redirect)) => (false, redirect.to_string()),
+            (Some(redirect), None) => (false, redirect.to_string()),
+            _ => (false, "/".to_string()),
+        };
+        if !constant_time_eq(cookie_state.as_bytes(), state_param.as_bytes()) {
+            return Err((StatusCode::BAD_REQUEST, "state mismatch").into_response());
+        }
+        return Ok((
+            code.to_string(),
+            OAuthCallbackOrigin::Stateful {
+                want_install,
+                redirect,
+            },
+        ));
+    }
+
+    let Some(continuation) = extract_cookie(headers, INSTALL_CONTINUATION_COOKIE) else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "missing OAuth state or install continuation cookie",
+        )
+            .into_response());
+    };
+    if !state
+        .validate_pending_install_continuation(&continuation)
+        .await
+    {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "invalid or expired install continuation",
+        )
+            .into_response());
+    }
+
+    Ok((
+        code.to_string(),
+        OAuthCallbackOrigin::InstallInitiated { continuation },
+    ))
+}
+
 async fn github_callback(
     State(state): State<AppState>,
     Query(q): Query<CallbackQuery>,
@@ -569,7 +978,8 @@ async fn github_callback(
     // `installation_id` actually gets captured and `org_config` is written
     // — bouncing straight home (the old behaviour) silently lost the
     // binding and left the deployment half-configured.
-    if let Some(installation_id) = q.installation_id.as_ref()
+    if q.code.as_deref().filter(|code| !code.is_empty()).is_none()
+        && let Some(installation_id) = q.installation_id.as_ref()
         && q.setup_action.as_deref() == Some("install")
     {
         let mut resp_headers = HeaderMap::new();
@@ -600,29 +1010,19 @@ async fn github_callback(
         return (StatusCode::FOUND, resp_headers).into_response();
     }
 
-    let (code, state_param) = match (q.code, q.state) {
-        (Some(c), Some(s)) if !c.is_empty() && !s.is_empty() => (c, s),
-        _ => return (StatusCode::BAD_REQUEST, "missing code or state").into_response(),
+    let (code, callback_origin) = match resolve_oauth_callback_origin(&state, &q, &headers).await {
+        Ok(origin) => origin,
+        Err(response) => return response,
     };
-
-    let Some(cookie_raw) = extract_cookie(&headers, OAUTH_STATE_COOKIE) else {
-        return (StatusCode::BAD_REQUEST, "missing state cookie").into_response();
+    let (want_install, redirect, install_continuation) = match &callback_origin {
+        OAuthCallbackOrigin::Stateful {
+            want_install,
+            redirect,
+        } => (*want_install, redirect.clone(), None),
+        OAuthCallbackOrigin::InstallInitiated { continuation } => {
+            (false, "/".to_string(), Some(continuation.clone()))
+        }
     };
-    // Cookie format: `<state>|i0|<redirect>` or `<state>|i1|<redirect>`.
-    // Legacy format (`<state>|<redirect>`) is accepted for in-flight
-    // sign-ins during the rollout.
-    let mut parts = cookie_raw.splitn(3, '|');
-    let cookie_state = parts.next().unwrap_or("").to_string();
-    let (want_install, redirect) = match (parts.next(), parts.next()) {
-        (Some("i1"), Some(r)) => (true, r.to_string()),
-        (Some("i0"), Some(r)) => (false, r.to_string()),
-        // Legacy 2-part encoding.
-        (Some(r), None) => (false, r.to_string()),
-        _ => (false, "/".to_string()),
-    };
-    if !constant_time_eq(cookie_state.as_bytes(), state_param.as_bytes()) {
-        return (StatusCode::BAD_REQUEST, "state mismatch").into_response();
-    }
 
     let active = state.app_config().await;
     let (client_id, client_secret) = match active.as_ref() {
@@ -645,14 +1045,7 @@ async fn github_callback(
 
     // 1. Exchange code for access token + (optional) refresh token.
     let callback_url = format!("{}/auth/github/callback", public_url());
-    let tokens = match github_app_user::exchange_code(
-        &client_id,
-        &client_secret,
-        &code,
-        &callback_url,
-    )
-    .await
-    {
+    let tokens = match exchange_user_code(&client_id, &client_secret, &code, &callback_url).await {
         Ok(t) => t,
         Err(e) => {
             tracing::error!(error = %e, "auth callback: token exchange failed");
@@ -660,6 +1053,57 @@ async fn github_callback(
         }
     };
     let access_token = tokens.access_token.clone();
+
+    // GitHub's install-triggered OAuth callback is not correlated with
+    // Djinn's normal OAuth `state`, so it must never create a browser session
+    // or bootstrap admin. Use the short-lived user token only to discover the
+    // just-authorized installation, then bind it through the authoritative
+    // App-JWT callback. Session creation happens in a second, stateful OAuth
+    // round-trip after binding.
+    if let Some(continuation) = install_continuation.as_deref() {
+        let installation_id = match list_user_installations(&access_token).await {
+            Ok(installations) => {
+                unique_selectable_installation_id(installations, allow_user_installations())
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "install OAuth callback: user installation discovery failed; using picker",
+                );
+                None
+            }
+        };
+
+        let mut response_headers = HeaderMap::new();
+        let location = if let Some(installation_id) = installation_id {
+            format!(
+                "{}/auth/github/app-setup-callback?installation_id={installation_id}\
+                 &setup_action=install&{param}={nonce}",
+                public_url().trim_end_matches('/'),
+                param = INSTALL_CONTINUATION_PARAM,
+                nonce = urlencode(continuation),
+            )
+        } else {
+            // Zero or multiple installations are ambiguous. The existing
+            // setup picker performs the explicit choice. Keep the correlated
+            // nonce pending and move its browser copy into a cookie scoped to
+            // the picker endpoints. GET/POST validate that bearer capability,
+            // and POST consumes it only after the atomic org binding succeeds.
+            // This preserves the code-only no-session/no-admin invariant
+            // without exposing an unauthenticated first-binding surface.
+            clear_install_continuation_cookie(&mut response_headers);
+            crate::server::github_install::set_picker_capability_cookie(
+                &mut response_headers,
+                continuation,
+            );
+            format!("{}/", web_url().trim_end_matches('/'))
+        };
+        response_headers.insert(
+            header::LOCATION,
+            HeaderValue::from_str(&location).unwrap_or_else(|_| HeaderValue::from_static("/")),
+        );
+        return (StatusCode::FOUND, response_headers).into_response();
+    }
 
     // 2. Fetch /user to build the identity.
     let user = match fetch_github_user(&access_token).await {
@@ -673,24 +1117,12 @@ async fn github_callback(
     // 3. Phase 2: enforce "one deployment = one GitHub org". Look up the
     //    deployment's locked org; if absent the deployment isn't set up.
     //
-    //    Exception: the bootstrap flow (`want_install=true` on a fresh
-    //    deployment) routes through this handler *before* `org_config` can
-    //    possibly exist — the install redirect we emit at the end of this
-    //    function is what lets GitHub invoke `app_setup_callback`, which is
-    //    what writes `org_config`. If we rejected here, the setup flow could
-    //    never complete. So in that case we skip the org checks and create
-    //    the session; `app_setup_callback` still writes the binding on its
-    //    own authority (App JWT against `GET /app/installations/{id}`).
-    let org_repo = OrgConfigRepository::new(state.db().clone());
-    let org_cfg = match org_repo.get().await {
+    //    No OAuth mode may create a session before this binding exists. In
+    //    particular, the public `install=1` convenience flag cannot become a
+    //    bootstrap-admin bypass; the manifest flow binds first, then starts a
+    //    separate stateful OAuth callback.
+    let org_cfg = match load_org_config_for_auth(&state).await {
         Ok(Some(cfg)) => Some(cfg),
-        Ok(None) if want_install => {
-            tracing::info!(
-                user = %user.login,
-                "auth callback: bootstrap flow — skipping org_config/membership checks",
-            );
-            None
-        }
         Ok(None) => {
             tracing::warn!("auth callback: rejecting login — deployment has no org_config yet");
             return (
@@ -711,11 +1143,14 @@ async fn github_callback(
     //    *user* token we just got; it returns `state: "active"|"pending"` on
     //    2xx and 404 for non-members. We treat only `state == "active"` as
     //    a pass; pending invites still count as "not a member".
-    //
-    //    Skipped during bootstrap — there's no org yet to check membership
-    //    against; `app_setup_callback` validates the installation target
-    //    separately.
-    if let Some(cfg) = &org_cfg {
+    // A deployment bound to a personal account has no organization
+    // membership endpoint to consult. With the explicit opt-in enabled, only
+    // the exact bound GitHub identity (immutable id + login) is accepted.
+    let is_bound_personal_account = org_cfg.as_ref().is_some_and(|cfg| {
+        allow_user_installations() && binding_matches_user(cfg, user.id as i64, &user.login)
+    });
+
+    if let Some(cfg) = org_cfg.as_ref().filter(|_| !is_bound_personal_account) {
         match check_org_membership(&access_token, &cfg.github_org_login).await {
             Ok(true) => {}
             Ok(false) => {
@@ -767,20 +1202,18 @@ async fn github_callback(
 
     // Bootstrap admin: the first user to sign in (when no admin exists yet)
     // becomes admin. This is the only automatic admin grant — further changes
-    // are manual `UPDATE users SET is_admin = …`. Best-effort: a failure here
-    // must not block sign-in (the next login retries while admin_count is 0).
+    // are manual `UPDATE users SET is_admin = …`. The repository method uses a
+    // transaction-scoped advisory lock so concurrent first logins cannot both
+    // win. Best-effort: a failure here must not block sign-in (the next login
+    // retries while no admin exists).
     if !user_row.is_admin {
-        match users_repo.admin_count().await {
-            Ok(0) => {
-                if let Err(e) = users_repo.set_admin_status(&user_row.id, true).await {
-                    tracing::warn!(error = %e, user_id = %user_row.id, "auth callback: failed to stamp bootstrap admin");
-                } else {
-                    tracing::info!(user_id = %user_row.id, login = %user.login, "auth callback: stamped first user as admin");
-                }
+        match users_repo.grant_bootstrap_admin_if_none(&user_row.id).await {
+            Ok(true) => {
+                tracing::info!(user_id = %user_row.id, login = %user.login, "auth callback: stamped first user as admin");
             }
-            Ok(_) => {}
+            Ok(false) => {}
             Err(e) => {
-                tracing::warn!(error = %e, "auth callback: admin_count check failed; skipping bootstrap");
+                tracing::warn!(error = %e, user_id = %user_row.id, "auth callback: bootstrap admin grant failed; skipping bootstrap");
             }
         }
     }
@@ -824,10 +1257,7 @@ async fn github_callback(
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
 
-    // 4. Build redirect response with cookies.
-    //    If `?install=1` was passed to /start, we send the user to the App's
-    //    install page instead of the app home. Otherwise, honour the
-    //    site-local redirect.
+    // 7. Build redirect response with cookies.
     let mut resp_headers = HeaderMap::new();
     set_cookie(&mut resp_headers, SESSION_COOKIE, &token, SESSION_TTL_SECS);
     clear_cookie(&mut resp_headers, OAUTH_STATE_COOKIE);
@@ -839,11 +1269,7 @@ async fn github_callback(
             .as_ref()
             .map(|c| c.slug.clone())
             .filter(|s| !s.trim().is_empty())
-            .or_else(|| {
-                std::env::var("GITHUB_APP_SLUG")
-                    .ok()
-                    .filter(|s| !s.trim().is_empty())
-            });
+            .or_else(djinn_provider::github_app::app_slug);
         match slug {
             Some(s) => format!("https://github.com/apps/{}/installations/new", s.trim()),
             None => {
@@ -859,6 +1285,17 @@ async fn github_callback(
         HeaderValue::from_str(&location).unwrap_or_else(|_| HeaderValue::from_static("/")),
     );
     (StatusCode::FOUND, resp_headers).into_response()
+}
+
+fn unique_selectable_installation_id(
+    installations: Vec<djinn_provider::github_app::Installation>,
+    allow_users: bool,
+) -> Option<u64> {
+    let mut selectable = installations.into_iter().filter(|installation| {
+        installation_account_type_allowed(&installation.account_type, allow_users)
+    });
+    let installation = selectable.next()?;
+    selectable.next().is_none().then_some(installation.id)
 }
 
 async fn logout(State(state): State<AppState>, headers: HeaderMap) -> Response {
@@ -905,7 +1342,7 @@ async fn logout(State(state): State<AppState>, headers: HeaderMap) -> Response {
 
 // ─── GitHub API helpers ───────────────────────────────────────────────────────
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 struct GhUser {
     id: u64,
     login: String,
@@ -916,6 +1353,10 @@ struct GhUser {
 }
 
 async fn fetch_github_user(access_token: &str) -> Result<GhUser, String> {
+    #[cfg(test)]
+    if let Some(result) = GITHUB_USER_RESULT_OVERRIDE.lock().unwrap().clone() {
+        return result;
+    }
     let user = GitHubServerClient::new().fetch_user(access_token).await?;
     Ok(GhUser {
         id: user.id,
@@ -923,6 +1364,44 @@ async fn fetch_github_user(access_token: &str) -> Result<GhUser, String> {
         name: user.name,
         avatar_url: user.avatar_url,
     })
+}
+
+async fn exchange_user_code(
+    client_id: &str,
+    client_secret: &str,
+    code: &str,
+    redirect_uri: &str,
+) -> Result<GithubUserTokens, String> {
+    #[cfg(test)]
+    if let Some(result) = OAUTH_EXCHANGE_RESULT_OVERRIDE.lock().unwrap().clone() {
+        return result;
+    }
+    github_app_user::exchange_code(client_id, client_secret, code, redirect_uri)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+async fn list_user_installations(
+    access_token: &str,
+) -> Result<Vec<djinn_provider::github_app::Installation>, String> {
+    #[cfg(test)]
+    if let Some(result) = USER_INSTALLATIONS_RESULT_OVERRIDE.lock().unwrap().clone() {
+        return result;
+    }
+    djinn_provider::github_app::list_installations_for_user(access_token)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+async fn load_org_config_for_auth(state: &AppState) -> Result<Option<OrgConfig>, String> {
+    #[cfg(test)]
+    if let Some(result) = ORG_CONFIG_RESULT_OVERRIDE.lock().unwrap().clone() {
+        return result;
+    }
+    OrgConfigRepository::new(state.db().clone())
+        .get()
+        .await
+        .map_err(|error| error.to_string())
 }
 
 /// Verify `access_token` belongs to an **active** member of `org_login`.
@@ -946,7 +1425,7 @@ async fn check_org_membership(access_token: &str, org_login: &str) -> Result<boo
 // ─── Cookie + misc helpers ────────────────────────────────────────────────────
 
 pub(super) fn public_url() -> String {
-    std::env::var("DJINN_PUBLIC_URL").unwrap_or_else(|_| DEFAULT_PUBLIC_URL.to_string())
+    djinn_provider::github_app::public_url()
 }
 
 /// Where to send the browser after a completed OAuth/install flow.
@@ -1079,12 +1558,10 @@ pub(super) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 
 // ─── GitHub App install flow ──────────────────────────────────────────────────
 //
-// The legacy in-UI manifest auto-provision wizard is gone — App credentials
-// are provisioned exclusively via the `djinn-github-app` Kubernetes Secret
-// (see `server/docker/README.md`). The only endpoint that survives in this
-// section is `GET /auth/github/app-setup-callback` (further down): GitHub
-// posts the user there after they complete an App install on the target
-// org, and we use that callback to bind `org_config`.
+// GitHub sends the browser here after an App installation has been resolved
+// by the OAuth callback or selected through the existing installation picker.
+// This callback authoritatively resolves the installation with the App JWT
+// and binds the selected account to this deployment.
 
 /// Query parameters for `GET /auth/github/app-setup-callback` — GitHub
 /// appends `?installation_id=<N>&setup_action=install` after the user
@@ -1134,9 +1611,11 @@ async fn app_setup_callback(
     let action = q.setup_action.as_deref().unwrap_or("");
 
     // Validate install-continuation state when a manifest flow just completed.
-    // A pending nonce means this callback must carry the matching continuation
-    // nonce. Non-manifest flows (pre-configured credentials) have no pending
-    // nonce, so they pass through unconditionally.
+    // Creating the initial deployment binding always requires the matching
+    // nonce. A no-nonce callback is accepted only as an idempotent replay for
+    // the exact installation already stored in org_config; otherwise this
+    // public callback would bypass the picker capability and let a drive-by
+    // request win the first-binding race.
     //
     // The nonce can arrive via:
     //   1. The `djinn_continuation` query param — set by `github_callback`
@@ -1149,10 +1628,30 @@ async fn app_setup_callback(
         .continuation_state
         .as_deref()
         .or(continuation_cookie.as_deref());
-    if !state
-        .validate_and_consume_install_continuation(continuation_candidate)
-        .await
+    let continuation_pending = state.has_pending_install_continuation().await;
+    let uncorrelated_idempotent_replay = if !continuation_pending
+        && continuation_candidate.is_none()
     {
+        match OrgConfigRepository::new(state.db().clone()).get().await {
+            Ok(Some(existing)) => existing.installation_id as u64 == installation_id,
+            Ok(None) => false,
+            Err(error) => {
+                tracing::error!(%error, "app_setup_callback: org_config read failed during continuation check");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        }
+    } else {
+        false
+    };
+    let continuation_valid = match (continuation_pending, continuation_candidate) {
+        (true, Some(candidate)) => state.validate_pending_install_continuation(candidate).await,
+        (false, None) => uncorrelated_idempotent_replay,
+        // A pending manifest flow always requires the nonce; a nonce with no
+        // pending flow is stale or replayed and must not turn into an
+        // unrestricted non-manifest callback.
+        _ => false,
+    };
+    if !continuation_valid {
         tracing::warn!(
             installation_id,
             "app_setup_callback: install-continuation state mismatch or missing"
@@ -1200,79 +1699,145 @@ async fn app_setup_callback(
         }
     };
 
-    if !installation
-        .account()
-        .account_type
-        .eq_ignore_ascii_case("Organization")
-    {
+    if !installation_account_type_allowed(
+        &installation.account().account_type,
+        allow_user_installations(),
+    ) {
         tracing::warn!(
             installation_id,
             account_type = %installation.account().account_type,
             account_login = %installation.account().login,
-            "app_setup_callback: rejecting non-org installation",
+            "app_setup_callback: rejecting unsupported installation account type",
         );
         return (
             StatusCode::BAD_REQUEST,
             format!(
-                "This deployment requires a GitHub *organization* installation, \
-                 but installation {installation_id} is bound to account '{}' (type={}). \
-                 Reinstall the App on an organization.",
-                installation.account().login,
+                "This deployment does not allow GitHub account type '{}' for installation \
+                 {installation_id}. Organization installations are always supported; User \
+                 installations require DJINN_ALLOW_USER_INSTALLATIONS=true.",
                 installation.account().account_type,
             ),
         )
             .into_response();
     }
 
-    let org_repo = OrgConfigRepository::new(state.db().clone());
-    // Idempotency: if org_config already points at this installation, the
-    // user probably double-clicked or reloaded — don't surface a confusing
-    // 409, just redirect them home.
-    if let Ok(Some(existing)) = org_repo.get().await
-        && existing.installation_id as u64 == installation_id
-        && existing.github_org_id as u64 == installation.account().id
+    if installation
+        .account()
+        .account_type
+        .eq_ignore_ascii_case("User")
     {
         tracing::info!(
             installation_id,
-            action,
-            "app_setup_callback: re-entry for already-bound org, redirecting home",
+            account_login = %installation.account().login,
+            "app_setup_callback: accepting explicitly enabled personal-account installation",
         );
-        let mut resp = redirect_to_web();
-        let mut extra = HeaderMap::new();
-        clear_install_continuation_cookie(&mut extra);
-        merge_set_cookie(&mut resp, &extra);
-        return resp;
     }
 
-    if let Err(e) = org_repo
-        .set(NewOrgConfig {
-            github_org_id: installation.account().id as i64,
-            github_org_login: &installation.account().login,
-            app_id: cfg.app_id as i64,
-            installation_id: installation_id as i64,
-        })
-        .await
-    {
-        tracing::error!(
-            error = %e,
+    // Keep the stored `org_config` shape for compatibility. Personal bindings
+    // are distinguished later by exact account-id/login matching rather than
+    // by pretending GitHub exposes an organization membership roster.
+
+    let org_repo = OrgConfigRepository::new(state.db().clone());
+    let matches_installation = |existing: &OrgConfig| {
+        existing.installation_id as u64 == installation_id
+            && existing.github_org_id as u64 == installation.account().id
+    };
+
+    // Setup callbacks are one-shot. A repeat callback for the exact binding
+    // is idempotent, but a different installation must never replace an
+    // established deployment binding.
+    let already_bound = match org_repo.get().await {
+        Ok(Some(existing)) if matches_installation(&existing) => true,
+        Ok(Some(_)) => {
+            return (
+                StatusCode::CONFLICT,
+                "This deployment is already bound to a different GitHub installation.",
+            )
+                .into_response();
+        }
+        Ok(None) => false,
+        Err(error) => {
+            tracing::error!(error = %error, "app_setup_callback: org_config read failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    if !already_bound {
+        match org_repo
+            .create_if_absent(NewOrgConfig {
+                github_org_id: installation.account().id as i64,
+                github_org_login: &installation.account().login,
+                app_id: cfg.app_id as i64,
+                installation_id: installation_id as i64,
+            })
+            .await
+        {
+            Ok(Some(_)) => {
+                tracing::info!(
+                    installation_id,
+                    account = %installation.account().login,
+                    action,
+                    "app_setup_callback: org_config bound",
+                );
+            }
+            Ok(None) => {
+                // Another callback won the insert race. Treat an identical
+                // winner as an idempotent retry; reject any different binding.
+                match org_repo.get().await {
+                    Ok(Some(existing)) if matches_installation(&existing) => {}
+                    Ok(Some(_)) => {
+                        return (
+                            StatusCode::CONFLICT,
+                            "This deployment was concurrently bound to a different GitHub installation.",
+                        )
+                            .into_response();
+                    }
+                    Ok(None) => {
+                        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                    }
+                    Err(error) => {
+                        tracing::error!(error = %error, "app_setup_callback: org_config race read failed");
+                        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::error!(
+                    error = %error,
+                    installation_id,
+                    account = %installation.account().login,
+                    "app_setup_callback: org_config create failed",
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to persist org binding. Check server logs.",
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    if already_bound {
+        tracing::info!(
             installation_id,
-            account = %installation.account().login,
-            "app_setup_callback: org_config set failed",
+            action,
+            "app_setup_callback: idempotent re-entry for existing binding",
         );
+    }
+    if continuation_pending
+        && !state
+            .consume_pending_install_continuation(
+                continuation_candidate.expect("validated continuation candidate"),
+            )
+            .await
+    {
         return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to persist org binding. Check server logs.",
+            StatusCode::CONFLICT,
+            "install continuation was already consumed — restart setup",
         )
             .into_response();
     }
-
-    tracing::info!(
-        installation_id,
-        account = %installation.account().login,
-        action,
-        "app_setup_callback: org_config bound",
-    );
-    let mut resp = redirect_to_web();
+    let mut resp = redirect_after_install_binding(continuation_pending);
     let mut extra = HeaderMap::new();
     clear_install_continuation_cookie(&mut extra);
     merge_set_cookie(&mut resp, &extra);
@@ -1290,8 +1855,29 @@ fn redirect_to_web() -> Response {
     (StatusCode::FOUND, resp_headers).into_response()
 }
 
+/// A manifest-origin install callback has only the install-continuation CSRF
+/// proof, not an OAuth `state`. Once the authoritative App-JWT binding is
+/// persisted, start the normal stateful OAuth flow; only that later callback
+/// may create a browser session or bootstrap the first admin.
+fn redirect_after_install_binding(manifest_origin: bool) -> Response {
+    if !manifest_origin {
+        return redirect_to_web();
+    }
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::LOCATION,
+        HeaderValue::from_static("/auth/github/start?redirect=%2F"),
+    );
+    (StatusCode::FOUND, headers).into_response()
+}
+
 /// Fetch an installation's account info via the App JWT.
 async fn fetch_installation_for_setup(installation_id: u64) -> Result<AppInstallation, String> {
+    #[cfg(test)]
+    if let Some(result) = APP_INSTALLATION_RESULT_OVERRIDE.lock().unwrap().clone() {
+        return result;
+    }
     let jwt = mint_app_jwt_anyhow().map_err(|e| e.to_string())?;
     GitHubServerClient::new()
         .fetch_app_installation(&jwt, installation_id)
@@ -1322,27 +1908,93 @@ struct SetupStatusResponse {
     /// The org this deployment is locked to, once known. Sourced
     /// exclusively from the `org_config` DB row written by the picker.
     org_login: Option<String>,
+    credential_source: Option<&'static str>,
+    setup_state: &'static str,
+    setup_error: Option<String>,
+    setup_retryable: bool,
+    credentials_unrecoverable: bool,
 }
 
-async fn setup_status(State(state): State<AppState>) -> Json<SetupStatusResponse> {
-    let app_cfg = state.app_config().await;
+async fn setup_status(
+    State(state): State<AppState>,
+) -> Result<Json<SetupStatusResponse>, (StatusCode, &'static str)> {
+    let credential_state = state.app_credential_state().await;
+    let app_cfg = credential_state.app_config();
+    let status = credential_status_fields(&credential_state);
     let org_cfg = OrgConfigRepository::new(state.db().clone())
         .get()
         .await
-        .ok()
-        .flatten();
+        .map_err(|error| {
+            tracing::error!(%error, "setup status: failed to read installation binding");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to read GitHub installation binding",
+            )
+        })?;
     let needs_app_install = app_cfg.is_none() || org_cfg.is_none();
     let app_credentials_configured = app_cfg.is_some();
     let org_login = org_cfg.map(|c| c.github_org_login);
 
-    Json(SetupStatusResponse {
+    Ok(Json(SetupStatusResponse {
         needs_app_install,
         app_credentials_configured,
         org_login,
-    })
+        credential_source: status.credential_source,
+        setup_state: status.setup_state,
+        setup_error: status.setup_error,
+        setup_retryable: status.setup_retryable,
+        credentials_unrecoverable: status.credentials_unrecoverable,
+    }))
 }
 
 // ─── Self-setup create-app + manifest-callback handlers ───────────────────────
+
+/// `POST /auth/github/setup-start` — explicit browser-only entry point for
+/// the local onboarding CTA.
+///
+/// `/auth/config` issues a short-lived HttpOnly, SameSite=Strict capability
+/// only to a same-origin browser fetch. This endpoint requires that cookie,
+/// independently checks the browser's same-origin fetch metadata + Origin,
+/// consumes the capability, and only then establishes the Lax setup session
+/// needed for GitHub's cross-site callback.
+async fn setup_start(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Some(resp) = setup_route_guard(&state).await {
+        return resp;
+    }
+
+    let Some(configured_origin) = configured_loopback_setup_origin(&public_url()) else {
+        // Remote deployments retain the explicit boot-token/operator path,
+        // but never expose the browser-mintable setup authority.
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    // Validate the browser context before looking up or consuming the token.
+    // A cross-site request must not be able to burn the legitimate operator's
+    // one-shot capability as a denial of service.
+    if !same_origin_setup_post(&headers, &configured_origin) {
+        return (
+            StatusCode::FORBIDDEN,
+            "same-origin browser request required",
+        )
+            .into_response();
+    }
+
+    let Some(launch_token) = extract_cookie(&headers, SETUP_LAUNCH_COOKIE) else {
+        return setup_launch_expired_redirect();
+    };
+    if !state.consume_setup_launch_capability(&launch_token).await {
+        return setup_launch_expired_redirect();
+    }
+
+    let existing_setup_cookie = extract_cookie(&headers, SETUP_SESSION_COOKIE);
+    let session_value = state
+        .begin_browser_setup_session(existing_setup_cookie.as_deref())
+        .await;
+    let mut response = render_manifest_form();
+    set_setup_cookie(response.headers_mut(), &session_value);
+    clear_setup_launch_cookie(response.headers_mut());
+    response
+}
 
 /// Query parameters for `GET /auth/github/create-app`.
 ///
@@ -1351,6 +2003,48 @@ async fn setup_status(State(state): State<AppState>) -> Json<SetupStatusResponse
 #[derive(Deserialize)]
 struct CreateAppQuery {
     setup_token: Option<String>,
+}
+
+/// Render the GitHub App manifest form shared by the boot-token fallback and
+/// the browser setup CTA. The form auto-submits on navigation; no Djinn
+/// credential or setup capability is included in the document.
+fn render_manifest_form() -> Response {
+    let public = public_url();
+    // GitHub App names are globally unique. Generate a fresh suffix for every
+    // manifest form so a retry or a second local operator does not collide on
+    // the old deterministic `djinn-localhost` name. This randomness is
+    // independent from the boot/setup token.
+    let manifest = build_manifest_json(&public, &manifest_name_suffix());
+    let manifest_json = manifest.to_string();
+    let csrf = random_token_b64();
+    let manifest_escaped = html_attr_escape(&manifest_json);
+    let csrf_escaped = html_attr_escape(&csrf);
+
+    let html = format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>Create Djinn GitHub App</title></head>\
+         <body><p>Redirecting to GitHub to create the Djinn App…</p>\
+         <form id=\"f\" method=\"post\" action=\"https://github.com/settings/apps/new?state={csrf}\">\
+         <input type=\"hidden\" name=\"manifest\" value=\"{manifest}\" />\
+         <noscript><button type=\"submit\">Continue to GitHub</button></noscript>\
+         </form>\
+         <script>document.getElementById('f').submit();</script>\
+         </body></html>",
+        csrf = csrf_escaped,
+        manifest = manifest_escaped,
+    );
+
+    let mut resp_headers = HeaderMap::new();
+    resp_headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    set_cookie(
+        &mut resp_headers,
+        MANIFEST_STATE_COOKIE,
+        &csrf,
+        STATE_COOKIE_TTL_SECS,
+    );
+    (StatusCode::OK, resp_headers, html).into_response()
 }
 
 /// `GET /auth/github/create-app` — the self-setup entry point.
@@ -1411,41 +2105,7 @@ async fn create_app(
             .into_response();
     }
 
-    // Build the manifest and render an auto-submitting HTML form that
-    // navigates to GitHub's App creation page. The CSRF state cookie
-    // protects the manifest-code callback below.
-    let public = public_url();
-    let manifest = build_manifest_json(&public);
-    let manifest_json = manifest.to_string();
-    let csrf = random_token_b64();
-    let manifest_escaped = html_attr_escape(&manifest_json);
-    let csrf_escaped = html_attr_escape(&csrf);
-
-    let html = format!(
-        "<!doctype html><html><head><meta charset=\"utf-8\"><title>Create Djinn GitHub App</title></head>\
-         <body><p>Redirecting to GitHub to create the Djinn App…</p>\
-         <form id=\"f\" method=\"post\" action=\"https://github.com/settings/apps/new?state={csrf}\">\
-         <input type=\"hidden\" name=\"manifest\" value=\"{manifest}\" />\
-         <noscript><button type=\"submit\">Continue to GitHub</button></noscript>\
-         </form>\
-         <script>document.getElementById('f').submit();</script>\
-         </body></html>",
-        csrf = csrf_escaped,
-        manifest = manifest_escaped,
-    );
-
-    let mut resp_headers = HeaderMap::new();
-    resp_headers.insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("text/html; charset=utf-8"),
-    );
-    set_cookie(
-        &mut resp_headers,
-        MANIFEST_STATE_COOKIE,
-        &csrf,
-        STATE_COOKIE_TTL_SECS,
-    );
-    (StatusCode::OK, resp_headers, html).into_response()
+    render_manifest_form()
 }
 
 /// `GET /auth/github/app-manifest-callback` — handles the callback from
@@ -1592,28 +2252,39 @@ async fn app_manifest_callback(
 /// Pure function so tests can pin its shape. Requirements:
 /// - App name prefix is `djinn-`
 /// - `request_oauth_on_install: true`
-/// - webhook inactive
-/// - permissions exactly `contents: write` and `pull_requests: write`
-pub(crate) fn build_manifest_json(public_url: &str) -> serde_json::Value {
+/// - no webhook configuration (Djinn does not consume GitHub webhooks)
+/// - permissions match the repo, CI-status, and org-membership APIs Djinn uses
+pub(crate) fn build_manifest_json(public_url: &str, name_suffix: &str) -> serde_json::Value {
     // GitHub automatically grants `metadata: read` as a base permission; we
     // only list the permissions we explicitly need.
     let permissions = serde_json::json!({
+        "actions": "read",
+        "checks": "read",
         "contents": "write",
+        "members": "read",
         "pull_requests": "write",
     });
     serde_json::json!({
-        "name": format!("djinn-{}", url_host(public_url).unwrap_or_else(|| "local".to_string())),
+        "name": format!(
+            "djinn-{}-{}",
+            url_host(public_url).unwrap_or_else(|| "local".to_string()),
+            name_suffix
+        ),
         "url": public_url,
-        "hook_attributes": {
-            "url": format!("{}/webhooks/github", public_url),
-            "active": false,
-        },
         "redirect_url": format!("{}/auth/github/app-manifest-callback", public_url),
         "callback_urls": [format!("{}/auth/github/callback", public_url)],
         "request_oauth_on_install": true,
         "public": false,
         "default_permissions": permissions,
     })
+}
+
+fn manifest_name_suffix() -> String {
+    random_token_b64()
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .take(8)
+        .collect()
 }
 
 /// Lightweight URL host parser: strip scheme, take up to first `/` or `:`.
@@ -1669,6 +2340,27 @@ static EXCHANGE_MANIFEST_RESULT_OVERRIDE: std::sync::Mutex<
     Option<Result<ManifestConversion, String>>,
 > = std::sync::Mutex::new(None);
 
+#[cfg(test)]
+static OAUTH_EXCHANGE_RESULT_OVERRIDE: std::sync::Mutex<Option<Result<GithubUserTokens, String>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+static GITHUB_USER_RESULT_OVERRIDE: std::sync::Mutex<Option<Result<GhUser, String>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+static USER_INSTALLATIONS_RESULT_OVERRIDE: std::sync::Mutex<
+    Option<Result<Vec<djinn_provider::github_app::Installation>, String>>,
+> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+static APP_INSTALLATION_RESULT_OVERRIDE: std::sync::Mutex<Option<Result<AppInstallation, String>>> =
+    std::sync::Mutex::new(None);
+
+#[cfg(test)]
+static ORG_CONFIG_RESULT_OVERRIDE: std::sync::Mutex<Option<Result<Option<OrgConfig>, String>>> =
+    std::sync::Mutex::new(None);
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1696,6 +2388,66 @@ mod tests {
             HeaderValue::from_str(&format!("{SETUP_SESSION_COOKIE}={token}")).unwrap(),
         );
         headers
+    }
+
+    fn same_origin_config_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::HOST, HeaderValue::from_static("127.0.0.1:8372"));
+        headers.insert("sec-fetch-site", HeaderValue::from_static("same-origin"));
+        headers
+    }
+
+    fn same_origin_setup_headers(launch_token: &str) -> HeaderMap {
+        let mut headers = same_origin_config_headers();
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("http://127.0.0.1:8372"),
+        );
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{SETUP_LAUNCH_COOKIE}={launch_token}")).unwrap(),
+        );
+        headers
+    }
+
+    fn set_cookie_value(headers: &HeaderMap, cookie_name: &str) -> Option<String> {
+        for value in headers.get_all(header::SET_COOKIE) {
+            let raw = value.to_str().ok()?;
+            let pair = raw.split(';').next()?;
+            let (name, value) = pair.split_once('=')?;
+            if name == cookie_name {
+                return Some(value.to_string());
+            }
+        }
+        None
+    }
+
+    fn assert_setup_expired_recovery(response: &Response) {
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("/?setup=expired")
+        );
+        assert_eq!(
+            set_cookie_value(response.headers(), SETUP_LAUNCH_COOKIE).as_deref(),
+            Some(""),
+            "recovery must clear the stale launch cookie"
+        );
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .any(|cookie| {
+                    cookie.starts_with(&format!("{SETUP_LAUNCH_COOKIE}="))
+                        && cookie.contains("Max-Age=0")
+                }),
+            "recovery must expire the launch cookie"
+        );
     }
 
     #[test]
@@ -1726,6 +2478,399 @@ mod tests {
         assert_eq!(
             urlencode("read:user user:email repo"),
             "read%3Auser%20user%3Aemail%20repo"
+        );
+    }
+
+    #[test]
+    fn personal_installation_policy_is_default_deny_and_user_only() {
+        assert!(!parse_allow_user_installations(None));
+        assert!(!parse_allow_user_installations(Some("false")));
+        assert!(parse_allow_user_installations(Some(" true ")));
+        assert!(parse_allow_user_installations(Some("1")));
+
+        assert!(installation_account_type_allowed("Organization", false));
+        assert!(!installation_account_type_allowed("User", false));
+        assert!(installation_account_type_allowed("User", true));
+        assert!(!installation_account_type_allowed("Bot", true));
+        assert!(!installation_account_type_allowed("Enterprise", true));
+    }
+
+    #[test]
+    fn personal_binding_requires_exact_id_and_login() {
+        let binding = OrgConfig {
+            id: 1,
+            github_org_id: 42,
+            github_org_login: "OctoCat".into(),
+            app_id: 7,
+            installation_id: 9,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        };
+        assert!(binding_matches_user(&binding, 42, "octocat"));
+        assert!(!binding_matches_user(&binding, 43, "octocat"));
+        assert!(!binding_matches_user(&binding, 42, "someone-else"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn install_initiated_code_only_callback_uses_continuation_without_oauth_state_cookie() {
+        use crate::test_helpers;
+
+        let state = test_helpers::test_app_state_in_memory().await;
+        let continuation = "manifest-install-continuation";
+        state
+            .set_pending_install_continuation_for_tests(Some(continuation.to_string()))
+            .await;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{INSTALL_CONTINUATION_COOKIE}={continuation}"))
+                .unwrap(),
+        );
+        assert!(extract_cookie(&headers, OAUTH_STATE_COOKIE).is_none());
+
+        let query = CallbackQuery {
+            code: Some("install-oauth-code".into()),
+            state: None,
+            installation_id: None,
+            setup_action: None,
+        };
+        let origin = resolve_oauth_callback_origin(&state, &query, &headers)
+            .await
+            .expect("valid install continuation must authenticate a code-only callback");
+        assert_eq!(
+            origin,
+            (
+                "install-oauth-code".to_string(),
+                OAuthCallbackOrigin::InstallInitiated {
+                    continuation: continuation.to_string(),
+                },
+            )
+        );
+        assert!(
+            state
+                .validate_pending_install_continuation(continuation)
+                .await,
+            "classification must not consume the retry nonce before binding/transition"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn install_initiated_oauth_routes_unique_installation_without_session_or_admin() {
+        use crate::test_helpers;
+        use djinn_provider::github_app::Installation;
+
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_config(Some(Arc::new(djinn_provider::github_app::AppConfig {
+                app_id: 42,
+                slug: "djinn-install-test".into(),
+                client_id: "Iv1.install-test".into(),
+                client_secret: "install-secret".into(),
+                pem: "PEM".into(),
+                webhook_secret: String::new(),
+                public_url: "http://127.0.0.1:8372".into(),
+            })))
+            .await;
+
+        let continuation = "install-oauth-roundtrip";
+        state
+            .set_pending_install_continuation_for_tests(Some(continuation.into()))
+            .await;
+        *OAUTH_EXCHANGE_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(GithubUserTokens {
+            access_token: "ghu_install_user".into(),
+            expires_in: Some(28_800),
+            refresh_token: Some("ghr_install_user".into()),
+            refresh_token_expires_in: Some(15_897_600),
+        }));
+        *USER_INSTALLATIONS_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(vec![Installation {
+            id: 777,
+            account_login: "acme".into(),
+            account_type: "Organization".into(),
+            target_type: "Organization".into(),
+        }]));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{INSTALL_CONTINUATION_COOKIE}={continuation}"))
+                .unwrap(),
+        );
+        let response = github_callback(
+            State(state.clone()),
+            Query(CallbackQuery {
+                code: Some("github-install-code".into()),
+                state: None,
+                installation_id: None,
+                setup_action: None,
+            }),
+            headers,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        let location = response
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(location.contains("/auth/github/app-setup-callback"));
+        assert!(location.contains("installation_id=777"));
+        assert!(location.contains(&format!("{INSTALL_CONTINUATION_PARAM}={continuation}")));
+        assert!(
+            !response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .any(|cookie| cookie.starts_with(&format!("{SESSION_COOKIE}="))),
+            "code-only install OAuth must not create a browser session"
+        );
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .all(|cookie| !cookie.starts_with(&format!("{OAUTH_STATE_COOKIE}="))),
+            "install-triggered callback does not mint normal OAuth state retroactively"
+        );
+        assert!(
+            state
+                .validate_pending_install_continuation(continuation)
+                .await,
+            "nonce remains pending until the authoritative binding callback succeeds"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ambiguous_install_oauth_issues_picker_capability_without_session_or_admin() {
+        use crate::test_helpers;
+        use djinn_provider::github_app::Installation;
+
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_config(Some(Arc::new(djinn_provider::github_app::AppConfig {
+                app_id: 42,
+                slug: "djinn-picker-test".into(),
+                client_id: "Iv1.picker-test".into(),
+                client_secret: "picker-secret".into(),
+                pem: "PEM".into(),
+                webhook_secret: String::new(),
+                public_url: "http://127.0.0.1:8372".into(),
+            })))
+            .await;
+
+        let continuation = "ambiguous-install-continuation";
+        state
+            .set_pending_install_continuation_for_tests(Some(continuation.into()))
+            .await;
+        *OAUTH_EXCHANGE_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(GithubUserTokens {
+            access_token: "ghu_ambiguous_install_user".into(),
+            expires_in: Some(28_800),
+            refresh_token: Some("ghr_ambiguous_install_user".into()),
+            refresh_token_expires_in: Some(15_897_600),
+        }));
+        *USER_INSTALLATIONS_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(vec![
+            Installation {
+                id: 777,
+                account_login: "acme".into(),
+                account_type: "Organization".into(),
+                target_type: "Organization".into(),
+            },
+            Installation {
+                id: 888,
+                account_login: "other-org".into(),
+                account_type: "Organization".into(),
+                target_type: "Organization".into(),
+            },
+        ]));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{INSTALL_CONTINUATION_COOKIE}={continuation}"))
+                .unwrap(),
+        );
+        let response = github_callback(
+            State(state.clone()),
+            Query(CallbackQuery {
+                code: Some("github-ambiguous-install-code".into()),
+                state: None,
+                installation_id: None,
+                setup_action: None,
+            }),
+            headers,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "http://127.0.0.1:8372/"
+        );
+        let picker_cookie = extract_set_cookie_value(
+            &response,
+            crate::server::github_install::INSTALL_PICKER_CAPABILITY_COOKIE,
+        )
+        .expect("ambiguous continuation must become a picker capability");
+        assert_eq!(picker_cookie, continuation);
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .any(|cookie| {
+                    cookie.starts_with(&format!(
+                        "{}=",
+                        crate::server::github_install::INSTALL_PICKER_CAPABILITY_COOKIE
+                    )) && cookie.contains("Path=/api/github/installations")
+                        && cookie.contains("HttpOnly")
+                        && cookie.contains("SameSite=Lax")
+                }),
+            "picker capability must be HttpOnly, same-site, and path-scoped"
+        );
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .any(|cookie| {
+                    cookie.starts_with(&format!("{INSTALL_CONTINUATION_COOKIE}="))
+                        && cookie.contains("Max-Age=0")
+                }),
+            "the broader auth-path continuation cookie must be retired"
+        );
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .all(|cookie| !cookie.starts_with(&format!("{SESSION_COOKIE}="))),
+            "ambiguous code-only OAuth must not create a Djinn session"
+        );
+        assert_eq!(
+            UserRepository::new(state.db().clone())
+                .admin_count()
+                .await
+                .unwrap(),
+            0,
+            "ambiguous code-only OAuth must not bootstrap an admin"
+        );
+        assert!(
+            state
+                .validate_pending_install_continuation(continuation)
+                .await,
+            "server-held nonce must remain live until the authorized picker binds"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stateful_install_flag_cannot_bootstrap_an_unbound_deployment() {
+        use crate::test_helpers;
+
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_config(Some(Arc::new(djinn_provider::github_app::AppConfig {
+                app_id: 42,
+                slug: "djinn-install-test".into(),
+                client_id: "Iv1.install-test".into(),
+                client_secret: "install-secret".into(),
+                pem: "PEM".into(),
+                webhook_secret: String::new(),
+                public_url: "http://127.0.0.1:8372".into(),
+            })))
+            .await;
+        *OAUTH_EXCHANGE_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(GithubUserTokens {
+            access_token: "ghu_unbound".into(),
+            expires_in: None,
+            refresh_token: None,
+            refresh_token_expires_in: None,
+        }));
+        *GITHUB_USER_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(GhUser {
+            id: 1234,
+            login: "unbound-installer".into(),
+            name: None,
+            avatar_url: None,
+        }));
+        *ORG_CONFIG_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(None));
+
+        let oauth_state = "stateful-install-attempt";
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{OAUTH_STATE_COOKIE}={oauth_state}|i1|/")).unwrap(),
+        );
+        let response = github_callback(
+            State(state.clone()),
+            Query(CallbackQuery {
+                code: Some("stateful-install-code".into()),
+                state: Some(oauth_state.into()),
+                installation_id: None,
+                setup_action: None,
+            }),
+            headers,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PRECONDITION_FAILED);
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .all(|cookie| !cookie.starts_with(&format!("{SESSION_COOKIE}=")))
+        );
+        *OAUTH_EXCHANGE_RESULT_OVERRIDE.lock().unwrap() = None;
+        *GITHUB_USER_RESULT_OVERRIDE.lock().unwrap() = None;
+        *ORG_CONFIG_RESULT_OVERRIDE.lock().unwrap() = None;
+    }
+
+    #[test]
+    fn install_oauth_auto_selects_only_one_allowed_installation() {
+        use djinn_provider::github_app::Installation;
+
+        let installation = |id, account_type: &str| Installation {
+            id,
+            account_login: format!("account-{id}"),
+            account_type: account_type.into(),
+            target_type: account_type.into(),
+        };
+
+        assert_eq!(
+            unique_selectable_installation_id(vec![installation(7, "Organization")], false,),
+            Some(7)
+        );
+        assert_eq!(
+            unique_selectable_installation_id(
+                vec![
+                    installation(7, "Organization"),
+                    installation(8, "Organization"),
+                ],
+                false,
+            ),
+            None,
+            "multiple installations must land on the picker"
+        );
+        assert_eq!(
+            unique_selectable_installation_id(vec![installation(9, "User")], false),
+            None,
+            "personal installs stay gated by the explicit opt-in"
+        );
+        assert_eq!(
+            unique_selectable_installation_id(vec![installation(9, "User")], true),
+            Some(9)
         );
     }
 
@@ -1766,7 +2911,7 @@ mod tests {
     async fn setup_status_reports_unconfigured_on_fresh_state() {
         use crate::test_helpers;
         let state = test_helpers::test_app_state_in_memory().await;
-        let resp = setup_status(State(state)).await;
+        let resp = setup_status(State(state)).await.unwrap();
         let body = resp.0;
         assert!(body.needs_app_install);
         assert!(!body.app_credentials_configured);
@@ -1802,7 +2947,7 @@ mod tests {
             .await
             .unwrap();
 
-        let resp = setup_status(State(state)).await;
+        let resp = setup_status(State(state)).await.unwrap();
         assert!(!resp.0.needs_app_install);
         assert!(resp.0.app_credentials_configured);
         assert_eq!(resp.0.org_login.as_deref(), Some("acme"));
@@ -1827,10 +2972,25 @@ mod tests {
         };
         state.set_app_config(Some(Arc::new(cfg))).await;
 
-        let resp = setup_status(State(state)).await;
+        let resp = setup_status(State(state)).await.unwrap();
         assert!(resp.0.needs_app_install);
         assert!(resp.0.app_credentials_configured);
         assert!(resp.0.org_login.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_status_reports_database_failure_instead_of_needs_install() {
+        use crate::test_helpers;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state.db().pool().close().await;
+
+        let error = match setup_status(State(state)).await {
+            Ok(_) => panic!("closed database must not look like an unbound deployment"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error.1, "failed to read GitHub installation binding");
     }
 
     // ─── Self-setup gate tests ───────────────────────────────────────────────
@@ -1872,7 +3032,7 @@ mod tests {
         use crate::test_helpers;
         let _lock = with_self_setup_override(Some(false)).await;
         let state = test_helpers::test_app_state_in_memory().await;
-        let resp = config(State(state)).await;
+        let resp = config(State(state), HeaderMap::new()).await;
         let body = resp.0;
         assert!(!body.self_setup_available);
     }
@@ -1884,9 +3044,324 @@ mod tests {
         use crate::test_helpers;
         let _lock = with_self_setup_override(Some(true)).await;
         let state = test_helpers::test_app_state_in_memory().await;
-        let resp = config(State(state)).await;
+        let resp = config(State(state), HeaderMap::new()).await;
+        assert!(
+            set_cookie_value(&resp.1, SETUP_LAUNCH_COOKIE).is_none(),
+            "non-browser config reads must not mint setup authority"
+        );
         let body = resp.0;
         assert!(body.self_setup_available);
+        assert!(!body.setup_launch_available);
+    }
+
+    #[test]
+    fn setup_launch_accepts_exact_configured_loopback_origin() {
+        let headers = same_origin_config_headers();
+        assert!(local_setup_launch_available(
+            &headers,
+            "http://127.0.0.1:8372"
+        ));
+    }
+
+    #[test]
+    fn setup_launch_rejects_remote_public_url_even_with_matching_browser_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::HOST, HeaderValue::from_static("djinn.example:8443"));
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("https://djinn.example:8443"),
+        );
+        headers.insert("sec-fetch-site", HeaderValue::from_static("same-origin"));
+        assert!(!local_setup_launch_available(
+            &headers,
+            "https://djinn.example:8443"
+        ));
+    }
+
+    #[test]
+    fn setup_launch_rejects_request_host_mismatch() {
+        let mut headers = same_origin_config_headers();
+        headers.insert(header::HOST, HeaderValue::from_static("127.0.0.1:9999"));
+        assert!(!local_setup_launch_available(
+            &headers,
+            "http://127.0.0.1:8372"
+        ));
+    }
+
+    #[test]
+    fn setup_launch_rejects_localhost_alias_for_127_callback() {
+        let mut headers = same_origin_config_headers();
+        headers.insert(header::HOST, HeaderValue::from_static("localhost:8372"));
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("http://localhost:8372"),
+        );
+        assert!(!local_setup_launch_available(
+            &headers,
+            "http://127.0.0.1:8372"
+        ));
+    }
+
+    #[test]
+    fn setup_launch_loopback_parser_accepts_localhost_ipv4_127_slash_8_and_ipv6() {
+        assert!(configured_loopback_setup_origin("http://localhost:8372").is_some());
+        assert!(configured_loopback_setup_origin("http://127.42.0.9:8372").is_some());
+        assert!(configured_loopback_setup_origin("http://[::1]:8372").is_some());
+        assert!(configured_loopback_setup_origin("http://10.0.0.1:8372").is_none());
+    }
+
+    /// A verified same-origin config fetch receives setup authority only in a
+    /// tightly scoped HttpOnly cookie; the raw capability is absent from JSON.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn same_origin_config_fetch_issues_strict_path_scoped_launch_cookie() {
+        use crate::test_helpers;
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+
+        let output = config(State(state), same_origin_config_headers()).await;
+        let launch_token = set_cookie_value(&output.1, SETUP_LAUNCH_COOKIE)
+            .expect("same-origin config fetch should receive launch cookie");
+        assert_eq!(launch_token.len(), 43, "expected a 256-bit URL-safe token");
+
+        let cookie = output
+            .1
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .find_map(|value| {
+                value
+                    .to_str()
+                    .ok()
+                    .filter(|value| value.starts_with(SETUP_LAUNCH_COOKIE))
+            })
+            .expect("launch Set-Cookie header");
+        assert!(cookie.contains("Path=/auth/github/setup-start"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Strict"));
+        assert!(cookie.contains("Max-Age=120"));
+
+        let json = serde_json::to_string(&output.0).unwrap();
+        assert!(output.0.self_setup_available);
+        assert!(output.0.setup_launch_available);
+        assert!(json.contains("\"setup_launch_available\":true"));
+        assert!(
+            !json.contains(&launch_token),
+            "raw launch authority must never appear in /auth/config JSON"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn config_refuses_to_issue_launch_cookie_to_cross_origin_fetch() {
+        use crate::test_helpers;
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+
+        let mut headers = same_origin_config_headers();
+        headers.insert("sec-fetch-site", HeaderValue::from_static("cross-site"));
+        headers.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("https://attacker.example"),
+        );
+        let output = config(State(state.clone()), headers).await;
+        assert!(set_cookie_value(&output.1, SETUP_LAUNCH_COOKIE).is_none());
+        assert!(!output.0.setup_launch_available);
+
+        let mut same_site_wrong_origin = same_origin_config_headers();
+        same_site_wrong_origin.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("http://localhost:8372"),
+        );
+        let output = config(State(state), same_site_wrong_origin).await;
+        assert!(set_cookie_value(&output.1, SETUP_LAUNCH_COOKIE).is_none());
+        assert!(!output.0.setup_launch_available);
+    }
+
+    /// The CTA exchanges a same-origin launch capability for the existing
+    /// setup session and renders the manifest form exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_start_consumes_launch_and_renders_manifest_form() {
+        use crate::test_helpers;
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+
+        let config_output = config(State(state.clone()), same_origin_config_headers()).await;
+        let launch_token = set_cookie_value(&config_output.1, SETUP_LAUNCH_COOKIE).unwrap();
+        let request_headers = same_origin_setup_headers(&launch_token);
+
+        let response = setup_start(State(state.clone()), request_headers.clone()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let setup_session = set_cookie_value(response.headers(), SETUP_SESSION_COOKIE)
+            .expect("setup session cookie");
+        assert!(state.validate_setup_session_token(&setup_session).await);
+        assert!(
+            set_cookie_value(response.headers(), MANIFEST_STATE_COOKIE).is_some(),
+            "manifest CSRF cookie must be minted"
+        );
+        assert_eq!(
+            set_cookie_value(response.headers(), SETUP_LAUNCH_COOKIE).as_deref(),
+            Some(""),
+            "consumed launch cookie must be cleared"
+        );
+
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let html = String::from_utf8_lossy(&bytes);
+        assert!(html.contains("action=\"https://github.com/settings/apps/new"));
+        assert!(!html.contains(&launch_token));
+        assert!(
+            !html.contains(&setup_session),
+            "setup session authority must remain HttpOnly, never enter markup"
+        );
+
+        let replay = setup_start(State(state), request_headers).await;
+        assert_setup_expired_recovery(&replay);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_start_missing_launch_cookie_redirects_to_spa_recovery() {
+        use crate::test_helpers;
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+
+        let mut headers = same_origin_setup_headers("unused");
+        headers.remove(header::COOKIE);
+        let response = setup_start(State(state), headers).await;
+
+        assert_setup_expired_recovery(&response);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_start_expired_launch_cookie_redirects_to_spa_recovery() {
+        use crate::test_helpers;
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        let launch_token = state
+            .issue_setup_launch_capability(std::time::Duration::ZERO)
+            .await;
+
+        let response = setup_start(State(state), same_origin_setup_headers(&launch_token)).await;
+
+        assert_setup_expired_recovery(&response);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_start_replayed_launch_cookie_redirects_to_spa_recovery() {
+        use crate::test_helpers;
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        let launch_token = state
+            .issue_setup_launch_capability(std::time::Duration::from_secs(120))
+            .await;
+        let headers = same_origin_setup_headers(&launch_token);
+
+        let first = setup_start(State(state.clone()), headers.clone()).await;
+        assert_eq!(first.status(), StatusCode::OK);
+        let replay = setup_start(State(state), headers).await;
+
+        assert_setup_expired_recovery(&replay);
+    }
+
+    /// Even when a test manually attaches the Strict cookie, cross-site or
+    /// cross-origin browser signals are rejected before token consumption.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_start_rejects_drive_by_without_burning_capability() {
+        use crate::test_helpers;
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        let launch_token = state
+            .issue_setup_launch_capability(std::time::Duration::from_secs(120))
+            .await;
+
+        let mut cross_site = same_origin_setup_headers(&launch_token);
+        cross_site.insert("sec-fetch-site", HeaderValue::from_static("cross-site"));
+        cross_site.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("https://attacker.example"),
+        );
+        let cross_site_response = setup_start(State(state.clone()), cross_site).await;
+        assert_eq!(cross_site_response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            cross_site_response
+                .headers()
+                .get(header::LOCATION)
+                .is_none()
+        );
+
+        let mut wrong_origin = same_origin_setup_headers(&launch_token);
+        wrong_origin.insert(
+            header::ORIGIN,
+            HeaderValue::from_static("http://localhost:8372"),
+        );
+        let wrong_origin_response = setup_start(State(state.clone()), wrong_origin).await;
+        assert_eq!(wrong_origin_response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            wrong_origin_response
+                .headers()
+                .get(header::LOCATION)
+                .is_none()
+        );
+
+        assert_eq!(
+            setup_start(State(state), same_origin_setup_headers(&launch_token))
+                .await
+                .status(),
+            StatusCode::OK,
+            "rejected drive-by attempts must not consume the real capability"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_launch_capability_expires_server_side() {
+        use crate::test_helpers;
+        let state = test_helpers::test_app_state_in_memory().await;
+        let launch_token = state
+            .issue_setup_launch_capability(std::time::Duration::ZERO)
+            .await;
+        assert!(!state.consume_setup_launch_capability(&launch_token).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn setup_session_expires_server_side() {
+        use crate::test_helpers;
+        let state = test_helpers::test_app_state_in_memory().await;
+        let token = "expired-setup-session".to_string();
+        state
+            .set_setup_session_token_with_ttl_for_tests(
+                Some(token.clone()),
+                std::time::Duration::ZERO,
+            )
+            .await;
+
+        assert!(!state.validate_setup_session_token(&token).await);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{SETUP_SESSION_COOKIE}={token}")).unwrap(),
+        );
+        assert!(extract_setup_session(&headers, &state).await.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn browser_setup_reuses_only_matching_live_setup_cookie() {
+        use crate::test_helpers;
+        let state = test_helpers::test_app_state_in_memory().await;
+        let existing = "existing-live-setup-session".to_string();
+        state
+            .set_setup_session_token_for_tests(Some(existing.clone()))
+            .await;
+
+        assert_eq!(
+            state.begin_browser_setup_session(Some(&existing)).await,
+            existing
+        );
+
+        let replacement = state
+            .begin_browser_setup_session(Some("wrong-setup-cookie"))
+            .await;
+        assert_ne!(replacement, existing);
+        assert!(!state.validate_setup_session_token(&existing).await);
+        assert!(state.validate_setup_session_token(&replacement).await);
     }
 
     /// `/auth/config` reports `self_setup_available=false` when the gate
@@ -1907,9 +3382,85 @@ mod tests {
         };
         state.set_app_config(Some(Arc::new(cfg))).await;
 
-        let resp = config(State(state)).await;
+        let resp = config(State(state), HeaderMap::new()).await;
         let body = resp.0;
         assert!(!body.self_setup_available);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn invalid_secret_is_retained_exposed_and_never_advertises_setup() {
+        use crate::test_helpers;
+        use djinn_provider::github_app::InvalidSecretDetail;
+
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_credential_state_for_tests(CredentialSourceState::InvalidSecret(
+                InvalidSecretDetail {
+                    issues: vec!["GITHUB_APP_CLIENT_SECRET is empty"],
+                },
+            ))
+            .await;
+
+        let config_body = config(State(state.clone()), HeaderMap::new()).await.0;
+        assert!(!config_body.configured);
+        assert!(!config_body.self_setup_available);
+        assert_eq!(config_body.credential_source, None);
+        assert_eq!(config_body.setup_state, "invalid_secret");
+        assert!(
+            config_body
+                .setup_error
+                .as_deref()
+                .is_some_and(|message| message.contains("GITHUB_APP_CLIENT_SECRET"))
+        );
+        assert!(!config_body.setup_retryable);
+        assert!(!config_body.credentials_unrecoverable);
+
+        let setup_body = setup_status(State(state.clone())).await.unwrap().0;
+        assert_eq!(setup_body.setup_state, "invalid_secret");
+        assert!(!setup_body.app_credentials_configured);
+        assert!(!setup_body.credentials_unrecoverable);
+
+        let response = create_app(
+            State(state),
+            Query(CreateAppQuery { setup_token: None }),
+            HeaderMap::new(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn undecryptable_persisted_state_is_exposed_and_setup_stays_hidden() {
+        use crate::test_helpers;
+
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_credential_state_for_tests(CredentialSourceState::UndecryptablePersisted)
+            .await;
+
+        let config_body = config(State(state.clone()), HeaderMap::new()).await.0;
+        assert!(!config_body.self_setup_available);
+        assert_eq!(config_body.setup_state, "credentials_unrecoverable");
+        assert!(config_body.credentials_unrecoverable);
+        assert!(config_body.setup_error.is_some());
+
+        let setup_body = setup_status(State(state.clone())).await.unwrap().0;
+        assert_eq!(setup_body.setup_state, "credentials_unrecoverable");
+        assert!(setup_body.credentials_unrecoverable);
+        assert!(!setup_body.setup_retryable);
+
+        let response = app_manifest_callback(
+            State(state),
+            Query(ManifestCallbackQuery {
+                code: None,
+                state: None,
+            }),
+            HeaderMap::new(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     // ─── Setup route gate tests ──────────────────────────────────────────────
@@ -2266,9 +3817,9 @@ mod tests {
 
     #[test]
     fn manifest_json_has_expected_shape() {
-        let manifest = build_manifest_json("https://djinn.example.com");
+        let manifest = build_manifest_json("https://djinn.example.com", "a1b2c3d4");
         // App name prefix is `djinn-`
-        assert_eq!(manifest["name"], "djinn-djinn.example.com");
+        assert_eq!(manifest["name"], "djinn-djinn.example.com-a1b2c3d4");
         assert_eq!(manifest["url"], "https://djinn.example.com");
         assert_eq!(
             manifest["redirect_url"],
@@ -2278,21 +3829,29 @@ mod tests {
             manifest["callback_urls"][0],
             "https://djinn.example.com/auth/github/callback"
         );
-        assert_eq!(
-            manifest["hook_attributes"]["url"],
-            "https://djinn.example.com/webhooks/github"
+        assert!(
+            manifest.get("hook_attributes").is_none(),
+            "webhooks are disabled, so the manifest must omit hook_attributes entirely"
         );
-        assert_eq!(manifest["hook_attributes"]["active"], false);
         assert_eq!(manifest["request_oauth_on_install"], true);
         assert_eq!(manifest["public"], false);
-        // Permissions: exactly contents:write, pull_requests:write
+        // Permissions match current runtime consumers. `pull_requests:write`
+        // also authorizes PR issue comments, so a separate `issues` grant is
+        // unnecessary.
         // (metadata:read is granted by GitHub automatically, not listed).
+        assert_eq!(manifest["default_permissions"]["actions"], "read");
+        assert_eq!(manifest["default_permissions"]["checks"], "read");
         assert_eq!(manifest["default_permissions"]["contents"], "write");
+        assert_eq!(manifest["default_permissions"]["members"], "read");
         assert_eq!(manifest["default_permissions"]["pull_requests"], "write");
         assert!(manifest["default_permissions"].get("metadata").is_none());
         // No extra permissions beyond the required set.
         let perms = manifest["default_permissions"].as_object().unwrap();
-        assert_eq!(perms.len(), 2, "only contents, pull_requests");
+        assert_eq!(
+            perms.len(),
+            5,
+            "only actions, checks, contents, members, pull_requests"
+        );
         // Round-trips as valid JSON.
         let s = manifest.to_string();
         let _back: serde_json::Value = serde_json::from_str(&s).unwrap();
@@ -2300,7 +3859,7 @@ mod tests {
 
     #[test]
     fn manifest_json_name_uses_djinn_prefix() {
-        let manifest = build_manifest_json("https://mycompany.example.com");
+        let manifest = build_manifest_json("https://mycompany.example.com", "retry123");
         let name = manifest["name"].as_str().unwrap();
         assert!(
             name.starts_with("djinn-"),
@@ -2310,11 +3869,32 @@ mod tests {
 
     #[test]
     fn manifest_json_no_extra_events() {
-        let manifest = build_manifest_json("https://djinn.example.com");
+        let manifest = build_manifest_json("https://djinn.example.com", "a1b2c3d4");
         // No default_events field — the design requires only permissions.
         assert!(
             manifest.get("default_events").is_none(),
             "manifest should not include default_events"
+        );
+        assert!(
+            manifest.get("hook_attributes").is_none(),
+            "manifest should not include webhook configuration"
+        );
+    }
+
+    #[test]
+    fn local_manifest_does_not_submit_an_invalid_localhost_webhook_url() {
+        let manifest = build_manifest_json("http://localhost:8372", "local123");
+        let serialized = manifest.to_string();
+
+        assert!(manifest.get("hook_attributes").is_none());
+        assert!(!serialized.contains("/webhooks/github"));
+        assert_eq!(
+            manifest["redirect_url"],
+            "http://localhost:8372/auth/github/app-manifest-callback"
+        );
+        assert_eq!(
+            manifest["callback_urls"][0],
+            "http://localhost:8372/auth/github/callback"
         );
     }
 
@@ -2329,6 +3909,17 @@ mod tests {
             Some("djinn.example.com")
         );
         assert_eq!(url_host("not a url").as_deref(), Some("not a url"));
+    }
+
+    #[test]
+    fn manifest_name_suffix_is_fresh_and_token_independent() {
+        let first = manifest_name_suffix();
+        let second = manifest_name_suffix();
+        assert_eq!(first.len(), 8);
+        assert_eq!(second.len(), 8);
+        assert!(first.chars().all(|c| c.is_ascii_alphanumeric()));
+        assert!(second.chars().all(|c| c.is_ascii_alphanumeric()));
+        assert_ne!(first, second);
     }
 
     #[test]
@@ -2598,6 +4189,59 @@ mod tests {
         *EXCHANGE_MANIFEST_RESULT_OVERRIDE.lock().unwrap() = None;
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unusable_post_persist_resolution_fails_and_preserves_setup_session() {
+        use crate::test_helpers;
+        use djinn_provider::github_app::InvalidSecretDetail;
+
+        let _lock = with_self_setup_override(Some(true)).await;
+        *EXCHANGE_MANIFEST_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(ManifestConversion {
+            id: 4242,
+            slug: "djinn-runtime".into(),
+            client_id: "Iv1.runtime".into(),
+            client_secret: "runtime-secret".into(),
+            pem: "PEM".into(),
+            webhook_secret: None,
+        }));
+
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_test_reload_state_override(Some(CredentialSourceState::InvalidSecret(
+                InvalidSecretDetail {
+                    issues: vec!["GITHUB_APP_ID is empty"],
+                },
+            )))
+            .await;
+        let session = register_valid_session(&state).await;
+        let csrf = "persist-failure-csrf";
+        let mut headers = headers_with_session(&session);
+        headers.append(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{MANIFEST_STATE_COOKIE}={csrf}")).unwrap(),
+        );
+
+        let response = app_manifest_callback(
+            State(state.clone()),
+            Query(ManifestCallbackQuery {
+                code: Some("valid-code".into()),
+                state: Some(csrf.into()),
+            }),
+            headers,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(state.validate_setup_session_token(&session).await);
+        assert!(matches!(
+            state.app_credential_state().await,
+            CredentialSourceState::InvalidSecret(_)
+        ));
+        assert!(state.app_config().await.is_none());
+
+        state.set_test_reload_state_override(None).await;
+        *EXCHANGE_MANIFEST_RESULT_OVERRIDE.lock().unwrap() = None;
+    }
+
     // ─── Successful persistence/hot-reload + cookie clearing ──────────────
 
     /// On a successful manifest exchange the callback persists the returned
@@ -2706,6 +4350,14 @@ mod tests {
         assert_eq!(cfg.app_id, 42);
         assert_eq!(cfg.slug, "djinn-test");
         assert_eq!(cfg.client_id, "Iv1.test-client");
+        let runtime_cfg = djinn_provider::github_app::runtime_config()
+            .expect("provider runtime cache must be hot-reloaded with persisted credentials");
+        assert_eq!(runtime_cfg.app_id, 42);
+        assert_eq!(runtime_cfg.slug, "djinn-test");
+        assert_eq!(
+            djinn_provider::github_app::bot_git_identity().0,
+            "djinn-test[bot]"
+        );
 
         assert!(
             !state.validate_setup_session_token(&session).await,
@@ -2793,25 +4445,65 @@ mod tests {
         );
     }
 
-    /// The install-redirect from `/auth/github/callback` does not contain
-    /// any OAuth state, boot tokens, or session tokens.
+    /// The secured code-only install redirect carries only the dedicated
+    /// install-continuation capability; it never reflects the GitHub OAuth
+    /// code, normal OAuth state, boot token, or Djinn session token.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn install_redirect_no_token_leak() {
         use crate::test_helpers;
+        use djinn_provider::github_app::Installation;
+
+        let _lock = with_self_setup_override(Some(true)).await;
         let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_config(Some(Arc::new(djinn_provider::github_app::AppConfig {
+                app_id: 42,
+                slug: "djinn-no-leak-test".into(),
+                client_id: "Iv1.no-leak-test".into(),
+                client_secret: "no-leak-secret".into(),
+                pem: "PEM".into(),
+                webhook_secret: String::new(),
+                public_url: "http://127.0.0.1:8372".into(),
+            })))
+            .await;
+
+        let continuation = "no-leak-install-continuation";
+        state
+            .set_pending_install_continuation_for_tests(Some(continuation.into()))
+            .await;
+        *OAUTH_EXCHANGE_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(GithubUserTokens {
+            access_token: "ghu_no_leak_install_user".into(),
+            expires_in: Some(28_800),
+            refresh_token: Some("ghr_no_leak_install_user".into()),
+            refresh_token_expires_in: Some(15_897_600),
+        }));
+        *USER_INSTALLATIONS_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(vec![Installation {
+            id: 99,
+            account_login: "acme".into(),
+            account_type: "Organization".into(),
+            target_type: "Organization".into(),
+        }]));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{INSTALL_CONTINUATION_COOKIE}={continuation}"))
+                .unwrap(),
+        );
 
         let resp = github_callback(
             State(state),
             Query(CallbackQuery {
                 code: Some("leaked-code".into()),
-                state: Some("leaked-state".into()),
-                installation_id: Some("99".into()),
-                setup_action: Some("install".into()),
+                state: None,
+                installation_id: None,
+                setup_action: None,
             }),
-            HeaderMap::new(),
+            headers,
         )
         .await;
 
+        assert_eq!(resp.status(), StatusCode::FOUND);
         let location = resp
             .headers()
             .get(header::LOCATION)
@@ -2874,7 +4566,7 @@ mod tests {
         let state = test_helpers::test_app_state_in_memory().await;
 
         // Config must not advertise self-setup.
-        let cfg_resp = config(State(state.clone())).await;
+        let cfg_resp = config(State(state.clone()), HeaderMap::new()).await;
         assert!(
             !cfg_resp.0.self_setup_available,
             "self_setup_available must be false when gate is disabled"
@@ -2923,7 +4615,7 @@ mod tests {
         state.set_app_config(Some(Arc::new(cfg))).await;
 
         // Config must report configured=true and self_setup_available=false.
-        let cfg_resp = config(State(state.clone())).await;
+        let cfg_resp = config(State(state.clone()), HeaderMap::new()).await;
         assert!(cfg_resp.0.configured, "must report configured=true");
         assert!(
             !cfg_resp.0.self_setup_available,
@@ -3105,13 +4797,17 @@ mod tests {
     async fn app_setup_callback_returns_conflict_without_credentials() {
         use crate::test_helpers;
         let state = test_helpers::test_app_state_in_memory().await;
+        let continuation = "missing-credentials-continuation";
+        state
+            .set_pending_install_continuation_for_tests(Some(continuation.into()))
+            .await;
 
         let resp = app_setup_callback(
-            State(state),
+            State(state.clone()),
             Query(AppSetupQuery {
                 installation_id: Some("42".into()),
                 setup_action: Some("install".into()),
-                continuation_state: None,
+                continuation_state: Some(continuation.into()),
             }),
             HeaderMap::new(),
         )
@@ -3120,6 +4816,12 @@ mod tests {
             resp.status(),
             StatusCode::CONFLICT,
             "must return 409 when credentials are missing"
+        );
+        assert!(
+            state
+                .validate_pending_install_continuation(continuation)
+                .await,
+            "credential recovery must preserve the valid continuation for retry"
         );
     }
 
@@ -3174,11 +4876,132 @@ mod tests {
             "valid continuation must not be rejected"
         );
 
-        // The nonce should now be consumed (single-use).
+        // The downstream GitHub call failed, so the nonce must remain valid
+        // for a retry instead of being consumed by validation alone.
         assert!(
-            state.validate_and_consume_install_continuation(None).await,
-            "after consumption, no continuation is pending, so None should pass"
+            state.validate_pending_install_continuation(&nonce).await,
+            "fallible installation lookup must preserve the continuation"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn manifest_install_binding_consumes_nonce_then_starts_stateful_oauth() {
+        use crate::test_helpers;
+        use djinn_provider::github_server::InstallationAccount;
+
+        let _lock = with_self_setup_override(Some(true)).await;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_config(Some(Arc::new(djinn_provider::github_app::AppConfig {
+                app_id: 42,
+                slug: "djinn-install-test".into(),
+                client_id: "Iv1.install-test".into(),
+                client_secret: "install-secret".into(),
+                pem: "PEM".into(),
+                webhook_secret: String::new(),
+                public_url: "http://127.0.0.1:8372".into(),
+            })))
+            .await;
+        let continuation = "binding-continuation";
+        state
+            .set_pending_install_continuation_for_tests(Some(continuation.into()))
+            .await;
+        *APP_INSTALLATION_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(AppInstallation {
+            id: 777,
+            account: Some(InstallationAccount {
+                id: 9001,
+                login: "acme".into(),
+                account_type: "Organization".into(),
+            }),
+            repository_selection: Some("all".into()),
+            html_url: None,
+        }));
+
+        let response = app_setup_callback(
+            State(state.clone()),
+            Query(AppSetupQuery {
+                installation_id: Some("777".into()),
+                setup_action: Some("install".into()),
+                continuation_state: Some(continuation.into()),
+            }),
+            HeaderMap::new(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "/auth/github/start?redirect=%2F"
+        );
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .any(|cookie| {
+                    cookie.starts_with(&format!("{INSTALL_CONTINUATION_COOKIE}="))
+                        && cookie.contains("Max-Age=0")
+                }),
+            "successful binding must clear the continuation cookie"
+        );
+        assert!(!state.has_pending_install_continuation().await);
+        let binding = OrgConfigRepository::new(state.db().clone())
+            .get()
+            .await
+            .unwrap()
+            .expect("binding must be persisted before stateful sign-in");
+        assert_eq!(binding.installation_id, 777);
+        assert_eq!(binding.github_org_login, "acme");
+
+        // A later setup callback for a different installation must not
+        // replace the deployment's established one-org binding.
+        let conflicting_continuation = "conflicting-binding-continuation";
+        state
+            .set_pending_install_continuation_for_tests(Some(conflicting_continuation.into()))
+            .await;
+        *APP_INSTALLATION_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(AppInstallation {
+            id: 888,
+            account: Some(InstallationAccount {
+                id: 9002,
+                login: "other-org".into(),
+                account_type: "Organization".into(),
+            }),
+            repository_selection: Some("all".into()),
+            html_url: None,
+        }));
+
+        let conflict = app_setup_callback(
+            State(state.clone()),
+            Query(AppSetupQuery {
+                installation_id: Some("888".into()),
+                setup_action: Some("install".into()),
+                continuation_state: Some(conflicting_continuation.into()),
+            }),
+            HeaderMap::new(),
+        )
+        .await;
+        assert_eq!(conflict.status(), StatusCode::CONFLICT);
+        let unchanged = OrgConfigRepository::new(state.db().clone())
+            .get()
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(unchanged.installation_id, 777);
+        assert_eq!(unchanged.github_org_login, "acme");
+        assert!(
+            state
+                .validate_pending_install_continuation(conflicting_continuation)
+                .await,
+            "a rejected rebind must not consume the retry/audit nonce"
+        );
+
+        *APP_INSTALLATION_RESULT_OVERRIDE.lock().unwrap() = None;
     }
 
     /// When a pending continuation nonce exists but the callback does NOT
@@ -3265,11 +5088,10 @@ mod tests {
         );
     }
 
-    /// When NO pending continuation nonce exists (non-manifest flow), the
-    /// callback proceeds without requiring a continuation_state. This
-    /// preserves the existing behavior for pre-configured credentials.
+    /// An uncorrelated callback must not create the deployment's first binding,
+    /// even when App credentials were pre-configured.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn app_setup_callback_no_pending_continuation_allows_request() {
+    async fn app_setup_callback_no_pending_continuation_rejects_first_binding() {
         use crate::test_helpers;
         let state = test_helpers::test_app_state_in_memory().await;
 
@@ -3284,9 +5106,6 @@ mod tests {
         };
         state.set_app_config(Some(Arc::new(cfg))).await;
 
-        // No pending continuation — don't set one.
-        // Callback without continuation_state should NOT be rejected with
-        // FORBIDDEN (it may fail at the JWT step, which is fine).
         let resp = app_setup_callback(
             State(state),
             Query(AppSetupQuery {
@@ -3298,11 +5117,50 @@ mod tests {
         )
         .await;
 
-        assert_ne!(
+        assert_eq!(
             resp.status(),
             StatusCode::FORBIDDEN,
-            "no pending continuation must not produce FORBIDDEN"
+            "no pending continuation must not authorize the first binding"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn app_setup_callback_allows_uncorrelated_exact_idempotent_replay() {
+        use crate::test_helpers;
+        let state = test_helpers::test_app_state_in_memory().await;
+        state
+            .set_app_config(Some(Arc::new(djinn_provider::github_app::AppConfig {
+                app_id: 1,
+                slug: "djinn".into(),
+                client_id: "Iv1.x".into(),
+                client_secret: "y".into(),
+                pem: "PEM".into(),
+                webhook_secret: "w".into(),
+                public_url: "http://127.0.0.1:8372".into(),
+            })))
+            .await;
+        OrgConfigRepository::new(state.db().clone())
+            .set(NewOrgConfig {
+                github_org_id: 7,
+                github_org_login: "acme",
+                app_id: 1,
+                installation_id: 42,
+            })
+            .await
+            .unwrap();
+
+        let resp = app_setup_callback(
+            State(state),
+            Query(AppSetupQuery {
+                installation_id: Some("42".into()),
+                setup_action: Some("install".into()),
+                continuation_state: None,
+            }),
+            HeaderMap::new(),
+        )
+        .await;
+
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     /// The continuation nonce is included in the manifest callback's install
@@ -3383,8 +5241,8 @@ mod tests {
             "matching continuation nonce must not be rejected"
         );
 
-        // Replay: the nonce was consumed, so a second call without one
-        // should now pass (no pending continuation).
+        // The authoritative installation lookup failed, so the nonce remains
+        // pending and a retry without it must still be rejected.
         let resp = app_setup_callback(
             State(state),
             Query(AppSetupQuery {
@@ -3395,10 +5253,10 @@ mod tests {
             HeaderMap::new(),
         )
         .await;
-        assert_ne!(
+        assert_eq!(
             resp.status(),
             StatusCode::FORBIDDEN,
-            "after nonce consumed, no continuation required"
+            "failed binding must preserve and continue requiring the nonce"
         );
 
         *EXCHANGE_MANIFEST_RESULT_OVERRIDE.lock().unwrap() = None;
@@ -3610,10 +5468,11 @@ mod tests {
             StatusCode::FORBIDDEN,
             "valid continuation through the callback bridge must not be rejected"
         );
-        // The nonce is consumed after this.
+        // The fake App key makes the authoritative installation lookup fail;
+        // validation alone must not consume the retry nonce.
         assert!(
-            state.validate_and_consume_install_continuation(None).await,
-            "nonce must be consumed after successful validation"
+            state.has_pending_install_continuation().await,
+            "nonce must remain pending until binding or picker transition succeeds"
         );
 
         *EXCHANGE_MANIFEST_RESULT_OVERRIDE.lock().unwrap() = None;
@@ -4209,7 +6068,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::FOUND);
 
         // Now check /auth/config.
-        let cfg_resp = config(State(state)).await;
+        let cfg_resp = config(State(state), HeaderMap::new()).await;
         assert!(
             cfg_resp.0.configured,
             "config must report configured=true after persistence"

--- a/server/src/server/github_install.rs
+++ b/server/src/server/github_install.rs
@@ -5,12 +5,16 @@
 //! operator clicks one, and the server writes the deployment-to-org binding
 //! into `org_config`.
 //!
-//! Both routes are public-but-gated:
+//! Both routes are bootstrap-only and capability-gated:
 //!   * The App credentials (`app_config`) **must** be configured — both
 //!     return `503 SERVICE_UNAVAILABLE` otherwise. Without an App JWT we
 //!     can't talk to GitHub at all.
-//!   * No session is required. The picker is the prerequisite to sign-in,
-//!     and on a fresh deployment no user can have signed in yet.
+//!   * No Djinn session is required. The picker is the prerequisite to
+//!     sign-in, and on a fresh deployment no user can have signed in yet.
+//!   * A short-lived HttpOnly capability cookie, issued only after the
+//!     correlated GitHub install/OAuth continuation becomes ambiguous, is
+//!     required. This prevents an arbitrary network caller from winning the
+//!     first-binding race while preserving the no-session bootstrap flow.
 //!
 //! The picker is the only writer of the deployment-to-org binding. There
 //! is no env override; the operator's only responsibility is the App
@@ -22,7 +26,7 @@
 use axum::{
     Json, Router,
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
@@ -31,7 +35,17 @@ use djinn_provider::github_server::GitHubServerClient;
 use serde::{Deserialize, Serialize};
 
 use crate::server::AppState;
+use crate::server::auth::{
+    allow_user_installations, extract_cookie, installation_account_type_allowed, public_url,
+};
 use djinn_db::{NewOrgConfig, OrgConfigRepository};
+
+/// Bearer capability issued after an install-triggered OAuth callback cannot
+/// choose one installation unambiguously. It is deliberately path-scoped to
+/// the two picker endpoints and is never a Djinn login session.
+pub(super) const INSTALL_PICKER_CAPABILITY_COOKIE: &str = "djinn_install_picker";
+const INSTALL_PICKER_CAPABILITY_PATH: &str = "/api/github/installations";
+const INSTALL_PICKER_CAPABILITY_TTL_SECS: i64 = 60 * 10;
 
 pub(super) fn router() -> Router<AppState> {
     Router::new()
@@ -76,13 +90,22 @@ struct SelectResponse {
 
 /// `GET /api/github/installations` — proxy `GET /app/installations` to GitHub
 /// using the App JWT, return a UI-friendly list.
-async fn list_installations(State(state): State<AppState>) -> Response {
+async fn list_installations(State(state): State<AppState>, headers: HeaderMap) -> Response {
     if state.app_config().await.is_none() {
         return app_unconfigured_response();
     }
 
+    if let Err(response) = require_unbound_picker(&state).await {
+        return response;
+    }
+    if let Err(response) = require_picker_capability(&state, &headers).await {
+        return response;
+    }
+
     match fetch_app_installations().await {
-        Ok(list) => Json(list).into_response(),
+        Ok(list) => {
+            Json(selectable_installations(list, allow_user_installations())).into_response()
+        }
         Err(e) => {
             tracing::error!(error = %e, "GET /api/github/installations failed");
             (
@@ -98,11 +121,22 @@ async fn list_installations(State(state): State<AppState>) -> Response {
 /// `GET /app/installations` and write the `org_config` row.
 async fn select_installation(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<SelectRequest>,
 ) -> Response {
     let cfg = match state.app_config().await {
         Some(c) => c,
         None => return app_unconfigured_response(),
+    };
+
+    // The public picker is a bootstrap-only surface. Fail before trusting the
+    // requested id or making an outbound GitHub request once setup is done.
+    if let Err(response) = require_unbound_picker(&state).await {
+        return response;
+    }
+    let capability = match require_picker_capability(&state, &headers).await {
+        Ok(capability) => capability,
+        Err(response) => return response,
     };
 
     if req.installation_id == 0 {
@@ -136,9 +170,22 @@ async fn select_installation(
             .into_response();
     };
 
+    if !installation_account_type_allowed(&chosen.account_type, allow_user_installations()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!(
+                "GitHub account type '{}' cannot be selected. Organization installations are \
+                 supported by default; User installations require \
+                 DJINN_ALLOW_USER_INSTALLATIONS=true.",
+                chosen.account_type
+            ),
+        )
+            .into_response();
+    }
+
     let repo = OrgConfigRepository::new(state.db().clone());
     let result = repo
-        .set(NewOrgConfig {
+        .create_if_absent(NewOrgConfig {
             github_org_id: chosen.account_id as i64,
             github_org_login: &chosen.account_login,
             app_id: cfg.app_id as i64,
@@ -147,17 +194,51 @@ async fn select_installation(
         .await;
 
     match result {
-        Ok(_) => {
+        Ok(Some(_)) => {
+            // The row insert is the durable one-shot boundary. Consume the
+            // matching in-memory capability after it succeeds so transient
+            // GitHub/DB failures remain retryable. The atomic INSERT prevents
+            // two concurrent valid requests from replacing each other.
+            let consumed = state
+                .consume_pending_install_continuation(&capability)
+                .await;
+            if !consumed {
+                tracing::warn!(
+                    installation_id = chosen.installation_id,
+                    "installation picker: binding persisted after capability was concurrently consumed",
+                );
+            }
             tracing::info!(
                 installation_id = chosen.installation_id,
                 account = %chosen.account_login,
                 "installation picker: bound org_config",
             );
-            Json(SelectResponse {
-                installation_id: chosen.installation_id,
-                account_login: chosen.account_login,
-            })
-            .into_response()
+            let mut response_headers = HeaderMap::new();
+            clear_picker_capability_cookie(&mut response_headers);
+            (
+                response_headers,
+                Json(SelectResponse {
+                    installation_id: chosen.installation_id,
+                    account_login: chosen.account_login,
+                }),
+            )
+                .into_response()
+        }
+        Ok(None) => {
+            // A concurrent setup request won the singleton insert. Setup is
+            // terminal either way; retire this bearer capability rather than
+            // leaving a live bootstrap credential in the browser.
+            let _ = state
+                .consume_pending_install_continuation(&capability)
+                .await;
+            tracing::warn!(
+                installation_id = chosen.installation_id,
+                account = %chosen.account_login,
+                "installation picker: refusing to replace existing org_config",
+            );
+            let mut response = already_bound_response();
+            clear_picker_capability_cookie(response.headers_mut());
+            response
         }
         Err(e) => {
             tracing::error!(
@@ -181,6 +262,10 @@ async fn select_installation(
 /// Uses `djinn_provider::github_server::GitHubServerClient` so the server
 /// module does not directly construct an outbound HTTP client.
 async fn fetch_app_installations() -> Result<Vec<InstallationSummary>, String> {
+    #[cfg(test)]
+    if let Some(result) = APP_INSTALLATIONS_RESULT_OVERRIDE.lock().unwrap().clone() {
+        return result;
+    }
     let jwt = mint_app_jwt_anyhow().map_err(|e| e.to_string())?;
     let raws = GitHubServerClient::new()
         .fetch_app_installations(&jwt)
@@ -201,6 +286,132 @@ async fn fetch_app_installations() -> Result<Vec<InstallationSummary>, String> {
         .collect())
 }
 
+#[cfg(test)]
+static APP_INSTALLATIONS_RESULT_OVERRIDE: std::sync::Mutex<
+    Option<Result<Vec<InstallationSummary>, String>>,
+> = std::sync::Mutex::new(None);
+
+fn selectable_installations(
+    installations: Vec<InstallationSummary>,
+    allow_users: bool,
+) -> Vec<InstallationSummary> {
+    installations
+        .into_iter()
+        .filter(|installation| {
+            installation_account_type_allowed(&installation.account_type, allow_users)
+        })
+        .collect()
+}
+
+/// Move the manifest install continuation into a cookie scoped only to the
+/// picker endpoints. The nonce remains server-side in `AppState`, so copying
+/// or inventing an arbitrary cookie value cannot authorize a request.
+pub(super) fn set_picker_capability_cookie(headers: &mut HeaderMap, value: &str) {
+    let secure = if picker_cookie_secure() {
+        "; Secure"
+    } else {
+        ""
+    };
+    let cookie = format!(
+        "{name}={value}; Path={path}; HttpOnly; SameSite=Lax; Max-Age={max_age}{secure}",
+        name = INSTALL_PICKER_CAPABILITY_COOKIE,
+        path = INSTALL_PICKER_CAPABILITY_PATH,
+        max_age = INSTALL_PICKER_CAPABILITY_TTL_SECS,
+    );
+    if let Ok(value) = HeaderValue::from_str(&cookie) {
+        headers.append(header::SET_COOKIE, value);
+    }
+}
+
+fn clear_picker_capability_cookie(headers: &mut HeaderMap) {
+    let secure = if picker_cookie_secure() {
+        "; Secure"
+    } else {
+        ""
+    };
+    let cookie = format!(
+        "{name}=; Path={path}; HttpOnly; SameSite=Lax; Max-Age=0; \
+         Expires=Thu, 01 Jan 1970 00:00:00 GMT{secure}",
+        name = INSTALL_PICKER_CAPABILITY_COOKIE,
+        path = INSTALL_PICKER_CAPABILITY_PATH,
+    );
+    if let Ok(value) = HeaderValue::from_str(&cookie) {
+        headers.append(header::SET_COOKIE, value);
+    }
+}
+
+fn picker_cookie_secure() -> bool {
+    if let Ok(value) = std::env::var("DJINN_COOKIE_SECURE") {
+        matches!(value.as_str(), "true" | "1" | "TRUE" | "yes")
+    } else {
+        public_url().starts_with("https://")
+    }
+}
+
+/// Authenticate the picker without creating a Djinn user or browser session.
+/// The cookie is a bearer copy of the still-pending install continuation;
+/// validation uses the server-held nonce and constant-time comparison.
+async fn require_picker_capability(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<String, Response> {
+    let Some(capability) = extract_cookie(headers, INSTALL_PICKER_CAPABILITY_COOKIE) else {
+        return Err(picker_forbidden_response(false));
+    };
+    if !state
+        .validate_pending_install_continuation(&capability)
+        .await
+    {
+        return Err(picker_forbidden_response(true));
+    }
+    Ok(capability)
+}
+
+fn picker_forbidden_response(clear_cookie: bool) -> Response {
+    let mut response = (
+        StatusCode::FORBIDDEN,
+        "A valid installation-picker capability is required. Restart the correlated GitHub App \
+         setup/install flow.",
+    )
+        .into_response();
+    if clear_cookie {
+        clear_picker_capability_cookie(response.headers_mut());
+    }
+    response
+}
+
+/// Enforce the public picker's one-shot setup contract.
+///
+/// A database read failure is fail-closed: continuing could replace a binding
+/// that exists but could not be read. Callers run this before any GitHub fetch,
+/// while POST's atomic create closes the concurrent-write race.
+async fn require_unbound_picker(state: &AppState) -> Result<(), Response> {
+    match OrgConfigRepository::new(state.db().clone()).get().await {
+        Ok(None) => Ok(()),
+        Ok(Some(_)) => Err(already_bound_response()),
+        Err(error) => {
+            tracing::error!(
+                error = %error,
+                "installation picker: failed to check existing org_config",
+            );
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to verify whether this deployment is already bound",
+            )
+                .into_response())
+        }
+    }
+}
+
+fn already_bound_response() -> Response {
+    (
+        StatusCode::CONFLICT,
+        "This deployment already has a GitHub installation binding. The public setup picker \
+         is only available during initial setup.",
+    )
+        .into_response()
+}
+
 fn app_unconfigured_response() -> Response {
     (
         StatusCode::SERVICE_UNAVAILABLE,
@@ -219,7 +430,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_installations_returns_503_when_app_unconfigured() {
         let state = test_helpers::test_app_state_in_memory().await;
-        let resp = list_installations(State(state)).await;
+        let resp = list_installations(State(state), HeaderMap::new()).await;
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
@@ -228,6 +439,7 @@ mod tests {
         let state = test_helpers::test_app_state_in_memory().await;
         let resp = select_installation(
             State(state),
+            HeaderMap::new(),
             Json(SelectRequest {
                 installation_id: 42,
             }),
@@ -236,8 +448,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn select_installation_rejects_zero_id() {
+    async fn configured_state() -> AppState {
         use std::sync::Arc;
         let state = test_helpers::test_app_state_in_memory().await;
         let cfg = djinn_provider::github_app::AppConfig {
@@ -250,9 +461,218 @@ mod tests {
             public_url: "http://127.0.0.1:8372".into(),
         };
         state.set_app_config(Some(Arc::new(cfg))).await;
+        state
+    }
 
-        let resp =
-            select_installation(State(state), Json(SelectRequest { installation_id: 0 })).await;
+    fn picker_headers(capability: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            HeaderValue::from_str(&format!("{INSTALL_PICKER_CAPABILITY_COOKIE}={capability}"))
+                .unwrap(),
+        );
+        headers
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn picker_get_and_post_reject_requests_without_capability() {
+        let state = configured_state().await;
+
+        let get_response = list_installations(State(state.clone()), HeaderMap::new()).await;
+        assert_eq!(get_response.status(), StatusCode::FORBIDDEN);
+
+        let post_response = select_installation(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(SelectRequest {
+                installation_id: 42,
+            }),
+        )
+        .await;
+        assert_eq!(post_response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            OrgConfigRepository::new(state.db().clone())
+                .get()
+                .await
+                .unwrap()
+                .is_none(),
+            "an unauthenticated request must not win the first-binding race"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn select_installation_rejects_zero_id_after_capability_validation() {
+        let state = configured_state().await;
+        let capability = "picker-zero-id";
+        state
+            .set_pending_install_continuation_for_tests(Some(capability.into()))
+            .await;
+
+        let resp = select_installation(
+            State(state),
+            picker_headers(capability),
+            Json(SelectRequest { installation_id: 0 }),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn authorized_picker_capability_binds_once_and_is_consumed() {
+        let state = configured_state().await;
+        let capability = "authorized-picker-capability";
+        state
+            .set_pending_install_continuation_for_tests(Some(capability.into()))
+            .await;
+        *APP_INSTALLATIONS_RESULT_OVERRIDE.lock().unwrap() = Some(Ok(vec![InstallationSummary {
+            installation_id: 42,
+            account_login: "acme".into(),
+            account_id: 9001,
+            account_type: "Organization".into(),
+            repository_selection: "selected".into(),
+            html_url: "https://github.test/installations/42".into(),
+        }]));
+
+        let response = select_installation(
+            State(state.clone()),
+            picker_headers(capability),
+            Json(SelectRequest {
+                installation_id: 42,
+            }),
+        )
+        .await;
+        *APP_INSTALLATIONS_RESULT_OVERRIDE.lock().unwrap() = None;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response
+                .headers()
+                .get_all(header::SET_COOKIE)
+                .iter()
+                .filter_map(|value| value.to_str().ok())
+                .any(|cookie| {
+                    cookie.starts_with(&format!("{INSTALL_PICKER_CAPABILITY_COOKIE}="))
+                        && cookie.contains("Path=/api/github/installations")
+                        && cookie.contains("Max-Age=0")
+                }),
+            "successful binding must clear the path-scoped picker capability"
+        );
+        assert!(
+            !state.has_pending_install_continuation().await,
+            "successful binding must consume the server-held capability"
+        );
+        let binding = OrgConfigRepository::new(state.db().clone())
+            .get()
+            .await
+            .unwrap()
+            .expect("authorized picker must persist the binding");
+        assert_eq!(binding.installation_id, 42);
+        assert_eq!(binding.github_org_login, "acme");
+    }
+
+    async fn configured_state_with_binding() -> AppState {
+        use std::sync::Arc;
+
+        let state = test_helpers::test_app_state_in_memory().await;
+        let cfg = djinn_provider::github_app::AppConfig {
+            app_id: 1,
+            slug: "djinn".into(),
+            client_id: "Iv1.x".into(),
+            client_secret: "y".into(),
+            // Deliberately invalid: a missing one-shot guard would attempt to
+            // mint a JWT and produce 502 rather than the expected 409.
+            pem: "not-a-private-key".into(),
+            webhook_secret: "w".into(),
+            public_url: "http://127.0.0.1:8372".into(),
+        };
+        state.set_app_config(Some(Arc::new(cfg))).await;
+        OrgConfigRepository::new(state.db().clone())
+            .set(NewOrgConfig {
+                github_org_id: 10,
+                github_org_login: "already-bound",
+                app_id: 1,
+                installation_id: 20,
+            })
+            .await
+            .unwrap();
+        state
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn list_installations_returns_409_when_already_bound_before_github_fetch() {
+        let state = configured_state_with_binding().await;
+
+        let resp = list_installations(State(state), HeaderMap::new()).await;
+
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn select_installation_returns_409_without_overwriting_existing_binding() {
+        let state = configured_state_with_binding().await;
+
+        let resp = select_installation(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(SelectRequest {
+                installation_id: 42,
+            }),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let binding = OrgConfigRepository::new(state.db().clone())
+            .get()
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(binding.github_org_login, "already-bound");
+        assert_eq!(binding.installation_id, 20);
+    }
+
+    fn installation(id: u64, account_type: &str) -> InstallationSummary {
+        InstallationSummary {
+            installation_id: id,
+            account_login: format!("account-{id}"),
+            account_id: id,
+            account_type: account_type.into(),
+            repository_selection: "selected".into(),
+            html_url: format!("https://github.test/installations/{id}"),
+        }
+    }
+
+    #[test]
+    fn picker_filters_personal_and_unknown_account_types_by_policy() {
+        let without_users = selectable_installations(
+            vec![
+                installation(1, "Organization"),
+                installation(2, "User"),
+                installation(3, "Bot"),
+            ],
+            false,
+        );
+        assert_eq!(
+            without_users
+                .iter()
+                .map(|entry| entry.installation_id)
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+
+        let with_users = selectable_installations(
+            vec![
+                installation(1, "Organization"),
+                installation(2, "User"),
+                installation(3, "Bot"),
+            ],
+            true,
+        );
+        assert_eq!(
+            with_users
+                .iter()
+                .map(|entry| entry.installation_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
     }
 }

--- a/server/src/server/org_sync.rs
+++ b/server/src/server/org_sync.rs
@@ -46,9 +46,10 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::server::auth::{allow_user_installations, binding_matches_user};
 use crate::server::{AppState, authenticate};
 use djinn_db::repositories::user::User;
-use djinn_db::{OrgConfigRepository, SessionAuthRepository, UserRepository};
+use djinn_db::{OrgConfig, OrgConfigRepository, SessionAuthRepository, UserRepository};
 use djinn_provider::github_app::get_installation_token;
 use djinn_provider::github_server::GitHubServerClient;
 
@@ -134,10 +135,10 @@ pub fn start_org_member_sync(state: AppState) {
 pub async fn sync_once(state: &AppState) -> SyncReport {
     // 1. Resolve the org binding from the singleton `org_config` row written
     //    by the in-UI installation picker.
-    let (org_login, installation_id) = {
+    let binding = {
         let org_repo = OrgConfigRepository::new(state.db().clone());
         match org_repo.get().await {
-            Ok(Some(cfg)) => (cfg.github_org_login, cfg.installation_id as u64),
+            Ok(Some(cfg)) => cfg,
             Ok(None) => {
                 return SyncReport::skipped("deployment is not bound to a GitHub org yet");
             }
@@ -147,6 +148,23 @@ pub async fn sync_once(state: &AppState) -> SyncReport {
             }
         }
     };
+
+    // Personal-account bindings deliberately have no org roster. When the
+    // opt-in is enabled and the binding matches the exact persisted user
+    // identity, skip reconciliation rather than calling `/orgs/{login}/members`
+    // and deactivating the owner after GitHub returns 404/empty data.
+    match binding_is_personal_account(state, &binding, allow_user_installations()).await {
+        Ok(true) => {
+            return SyncReport::skipped(
+                "deployment is bound to a personal GitHub account; org membership sync does not apply",
+            );
+        }
+        Ok(false) => {}
+        Err(error) => return SyncReport::error(error),
+    }
+
+    let org_login = binding.github_org_login;
+    let installation_id = binding.installation_id as u64;
 
     // 2. Mint an installation token for the App's installation.
     let token = match get_installation_token(installation_id).await {
@@ -229,6 +247,21 @@ pub async fn sync_once(state: &AppState) -> SyncReport {
     }
 
     report
+}
+
+async fn binding_is_personal_account(
+    state: &AppState,
+    binding: &OrgConfig,
+    allow_users: bool,
+) -> Result<bool, String> {
+    if !allow_users {
+        return Ok(false);
+    }
+    let user = UserRepository::new(state.db().clone())
+        .get_by_github_id(binding.github_org_id)
+        .await
+        .map_err(|error| format!("personal binding lookup failed: {error}"))?;
+    Ok(user.is_some_and(|user| binding_matches_user(binding, user.github_id, &user.github_login)))
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────────
@@ -417,6 +450,46 @@ mod tests {
         assert!(diff.to_activate.is_empty());
         assert!(diff.to_deactivate.is_empty());
         assert_eq!(diff.present_members_to_touch.len(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn personal_binding_is_detected_only_with_opt_in_and_exact_identity() {
+        use crate::test_helpers;
+
+        let state = test_helpers::test_app_state_in_memory().await;
+        UserRepository::new(state.db().clone())
+            .upsert_from_github(42, "OctoCat", None, None)
+            .await
+            .unwrap();
+        let binding = OrgConfig {
+            id: 1,
+            github_org_id: 42,
+            github_org_login: "octocat".into(),
+            app_id: 7,
+            installation_id: 9,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        };
+
+        assert!(
+            binding_is_personal_account(&state, &binding, true)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !binding_is_personal_account(&state, &binding, false)
+                .await
+                .unwrap()
+        );
+
+        let mismatched = OrgConfig {
+            github_org_login: "someone-else".into(),
+            ..binding
+        };
+        assert!(
+            !binding_is_personal_account(&state, &mismatched, true)
+                .await
+                .unwrap()
+        );
     }
 
     /// End-to-end happy path against a real in-memory DB: seed local users,

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -779,7 +779,7 @@ impl AppState {
     ) {
         *self.inner.setup_session.write().await = token.map(|token| SetupSession {
             digest: setup_authority_digest(&token),
-            expires_at: Instant::now() + ttl,
+            expires_at: SystemClockTrait::new().now_instant() + ttl,
         });
     }
 
@@ -790,7 +790,7 @@ impl AppState {
     /// invalidating one another when their Set-Cookie headers arrive out of
     /// order; each individual capability is still single-use.
     pub(crate) async fn issue_setup_launch_capability(&self, ttl: Duration) -> String {
-        let now = Instant::now();
+        let now = SystemClockTrait::new().now_instant();
         let token = crate::server::auth::random_token_b64();
         let digest = setup_authority_digest(&token);
         let mut guard = self.inner.setup_launch_capabilities.write().await;
@@ -812,7 +812,7 @@ impl AppState {
     /// sending the cookie after its `Max-Age` elapsed.
     pub(crate) async fn consume_setup_launch_capability(&self, candidate: &str) -> bool {
         let candidate_digest = setup_authority_digest(candidate);
-        let now = Instant::now();
+        let now = SystemClockTrait::new().now_instant();
         let mut guard = self.inner.setup_launch_capabilities.write().await;
         guard.retain(|capability| capability.expires_at > now);
         let Some(index) = guard.iter().position(|capability| {
@@ -839,7 +839,7 @@ impl AppState {
         let mut boot_token = self.inner.boot_token.write().await;
         *boot_token = None;
 
-        let now = Instant::now();
+        let now = SystemClockTrait::new().now_instant();
         let mut setup_session = self.inner.setup_session.write().await;
         if let Some(session) = setup_session.as_ref()
             && session.expires_at > now
@@ -886,7 +886,7 @@ impl AppState {
         let Some(session) = stored.as_ref() else {
             return false;
         };
-        if session.expires_at <= Instant::now() {
+        if session.expires_at <= SystemClockTrait::new().now_instant() {
             *stored = None;
             return false;
         }
@@ -976,7 +976,7 @@ impl AppState {
         // Store so `extract_setup_session` can validate the cookie against it.
         *self.inner.setup_session.write().await = Some(SetupSession {
             digest: setup_authority_digest(&session_token),
-            expires_at: Instant::now() + SETUP_SESSION_TTL,
+            expires_at: SystemClockTrait::new().now_instant() + SETUP_SESSION_TTL,
         });
         BootTokenExchangeResult::Ok(session_token)
     }

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -5,6 +5,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
+use std::time::{Duration, Instant};
 
 use tokio::sync::{Mutex, broadcast};
 use tokio_util::sync::CancellationToken;
@@ -173,6 +174,16 @@ fn missing_github_app_env_vars() -> Vec<&'static str> {
     missing
 }
 
+/// Keep provider-level GitHub App consumers (JWT minting, installation-token
+/// exchange, background OAuth refresh) aligned with AppState's retained
+/// credential-source snapshot.
+fn sync_provider_runtime_config(state: &CredentialSourceState) {
+    match state.app_config() {
+        Some(config) => djinn_provider::github_app::install_runtime_config(config.clone()),
+        None => djinn_provider::github_app::clear_runtime_config(),
+    }
+}
+
 fn canonical_view_resolution(
     active_task_count: usize,
     fallback: Option<crate::server::MemoryMountViewFallback>,
@@ -208,6 +219,30 @@ fn canonical_view_resolution(
 #[derive(Clone)]
 pub struct AppState {
     inner: Arc<Inner>,
+}
+
+/// Server-side half of the browser-only setup-launch capability.
+///
+/// The matching random token is carried in an HttpOnly, SameSite=Strict
+/// cookie. Keeping the expiry here (rather than trusting the browser's
+/// `Max-Age`) makes a copied or manually replayed cookie expire as well.
+struct SetupLaunchCapability {
+    digest: Vec<u8>,
+    expires_at: Instant,
+}
+
+const MAX_SETUP_LAUNCH_CAPABILITIES: usize = 8;
+const SETUP_SESSION_TTL: Duration = Duration::from_secs(60 * 15);
+
+struct SetupSession {
+    digest: Vec<u8>,
+    expires_at: Instant,
+}
+
+fn setup_authority_digest(raw: &str) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+
+    Sha256::digest(raw.as_bytes()).to_vec()
 }
 
 struct Inner {
@@ -261,25 +296,28 @@ struct Inner {
     /// The entry is removed by the spawned task in its completion branch.
     pub canonical_warm_inflight: Arc<std::sync::Mutex<HashSet<String>>>,
     pub memory_mount: Mutex<Option<MountedMemoryFilesystem>>,
-    /// Active GitHub App configuration resolved by the credential-source
-    /// state machine (Secret/env → persisted → unconfigured). Populated
-    /// by `init_app_config` at startup; hot-swapped by
-    /// `persist_and_reload_app_config` after a manifest exchange so
-    /// subsequent requests pick up new credentials without a process
-    /// restart. See [`CredentialSourceState`] for the typed resolution
-    /// states.
-    pub app_config: tokio::sync::RwLock<Option<Arc<GitHubAppConfig>>>,
+    /// Retained GitHub App credential-source state. This is the single source
+    /// of truth for both the active configuration and operator-facing recovery
+    /// state: `app_config()` derives its value from this enum instead of
+    /// discarding the distinction between unconfigured, invalid Secret, and
+    /// undecryptable persisted credentials.
+    pub app_credential_state: tokio::sync::RwLock<CredentialSourceState>,
     /// One-time boot token for the self-setup flow. Generated at startup
     /// when `DJINN_ENABLE_SELF_SETUP=true` and no usable credentials exist.
     /// `None` when the gate is disabled, credentials are present, or the
     /// token was already consumed.
     pub boot_token: tokio::sync::RwLock<Option<crate::server::auth::boot_token::BootToken>>,
-    /// Valid setup session token from the most recent boot-token exchange.
-    /// Populated by [`AppState::exchange_boot_token`]; validated by
-    /// `extract_setup_session` so an arbitrary cookie value is rejected.
-    /// `None` means no exchange has occurred or the session was cleared after
-    /// credential persistence.
-    pub(crate) setup_session_token: tokio::sync::RwLock<Option<String>>,
+    /// Valid setup session from the most recent boot-token exchange or local
+    /// browser launch. The server enforces the same 15-minute lifetime as the
+    /// cookie so manually replaying an expired cookie cannot revive setup.
+    /// `None` means no exchange occurred, the session expired, or it was
+    /// cleared after credential persistence.
+    setup_session: tokio::sync::RwLock<Option<SetupSession>>,
+    /// Short-lived, single-use capability issued only to a same-origin
+    /// browser that fetched `/auth/config`. It authorizes the explicit
+    /// `POST /auth/github/setup-start` UI action without exposing the boot
+    /// token in JSON or markup.
+    setup_launch_capabilities: tokio::sync::RwLock<Vec<SetupLaunchCapability>>,
     /// Pending install-continuation nonce generated after manifest credential
     /// persistence. When present, `/auth/github/app-setup-callback` requires
     /// the caller to include a matching `continuation_state` query parameter.
@@ -294,6 +332,9 @@ struct Inner {
     /// database.
     #[cfg(test)]
     test_bypass_persist: tokio::sync::RwLock<bool>,
+    /// Test-only credential-resolution result injected after real persistence.
+    #[cfg(test)]
+    test_reload_state_override: tokio::sync::RwLock<Option<CredentialSourceState>>,
     /// Per-project bare git mirrors on disk. Single shared instance so
     /// fetches serialize correctly and clones hit the same hardlink pool.
     /// Path resolution mirrors the vault key: `$DJINN_HOME/mirrors` or
@@ -397,12 +438,15 @@ impl AppState {
                 workspace_store,
                 canonical_warm_inflight: Arc::new(std::sync::Mutex::new(HashSet::new())),
                 memory_mount: Mutex::new(None),
-                app_config: tokio::sync::RwLock::new(None),
+                app_credential_state: tokio::sync::RwLock::new(CredentialSourceState::Unconfigured),
                 boot_token: tokio::sync::RwLock::new(None),
-                setup_session_token: tokio::sync::RwLock::new(None),
+                setup_session: tokio::sync::RwLock::new(None),
+                setup_launch_capabilities: tokio::sync::RwLock::new(Vec::new()),
                 pending_install_continuation: tokio::sync::RwLock::new(None),
                 #[cfg(test)]
                 test_bypass_persist: tokio::sync::RwLock::new(false),
+                #[cfg(test)]
+                test_reload_state_override: tokio::sync::RwLock::new(None),
                 mirror,
                 rpc_server: tokio::sync::Mutex::new(None),
                 rpc_registry: Arc::new(ConnectionRegistry::new()),
@@ -678,14 +722,36 @@ impl AppState {
 
     /// Read-only snapshot of the active GitHub App configuration, if any.
     pub async fn app_config(&self) -> Option<Arc<GitHubAppConfig>> {
-        self.inner.app_config.read().await.clone()
+        self.inner
+            .app_credential_state
+            .read()
+            .await
+            .app_config()
+            .cloned()
     }
 
-    /// Hot-swap the in-memory GitHub App configuration. Used by tests that
-    /// seed in-memory state and by [`Self::persist_and_reload_app_config`]
-    /// after a manifest exchange persists new credentials.
+    /// Read-only snapshot of the retained GitHub App credential-source state.
+    pub async fn app_credential_state(&self) -> CredentialSourceState {
+        self.inner.app_credential_state.read().await.clone()
+    }
+
+    /// Hot-swap the in-memory GitHub App configuration. Tests use this helper
+    /// to seed a usable Secret-shaped state without reaching into the retained
+    /// credential-state lock directly.
     pub async fn set_app_config(&self, cfg: Option<Arc<GitHubAppConfig>>) {
-        *self.inner.app_config.write().await = cfg;
+        let state = match cfg {
+            Some(cfg) => CredentialSourceState::ValidSecret(cfg),
+            None => CredentialSourceState::Unconfigured,
+        };
+        *self.inner.app_credential_state.write().await = state;
+    }
+
+    /// Inject a specific credential-source state for focused auth/recovery
+    /// tests. Production code updates this only through initialization and
+    /// manifest persistence/reload.
+    #[cfg(test)]
+    pub(crate) async fn set_app_credential_state_for_tests(&self, state: CredentialSourceState) {
+        *self.inner.app_credential_state.write().await = state;
     }
 
     /// Inject a boot token for testing. Not used in production code.
@@ -700,7 +766,97 @@ impl AppState {
     /// Inject a known setup session token for testing.
     #[cfg(test)]
     pub(crate) async fn set_setup_session_token_for_tests(&self, token: Option<String>) {
-        *self.inner.setup_session_token.write().await = token;
+        self.set_setup_session_token_with_ttl_for_tests(token, SETUP_SESSION_TTL)
+            .await;
+    }
+
+    /// Inject a setup session with a deterministic lifetime for expiry tests.
+    #[cfg(test)]
+    pub(crate) async fn set_setup_session_token_with_ttl_for_tests(
+        &self,
+        token: Option<String>,
+        ttl: Duration,
+    ) {
+        *self.inner.setup_session.write().await = token.map(|token| SetupSession {
+            digest: setup_authority_digest(&token),
+            expires_at: Instant::now() + ttl,
+        });
+    }
+
+    /// Issue a short-lived browser setup-launch capability.
+    ///
+    /// Only its SHA-256 digest is retained. A small bounded set prevents
+    /// concurrent `/auth/config` responses or multiple local tabs from
+    /// invalidating one another when their Set-Cookie headers arrive out of
+    /// order; each individual capability is still single-use.
+    pub(crate) async fn issue_setup_launch_capability(&self, ttl: Duration) -> String {
+        let now = Instant::now();
+        let token = crate::server::auth::random_token_b64();
+        let digest = setup_authority_digest(&token);
+        let mut guard = self.inner.setup_launch_capabilities.write().await;
+        guard.retain(|capability| capability.expires_at > now);
+        if guard.len() >= MAX_SETUP_LAUNCH_CAPABILITIES {
+            guard.remove(0);
+        }
+        guard.push(SetupLaunchCapability {
+            digest,
+            expires_at: now + ttl,
+        });
+        token
+    }
+
+    /// Atomically validate and consume a setup-launch capability.
+    ///
+    /// Invalid guesses do not burn a legitimate browser's token. Expired
+    /// capabilities are cleared server-side even if a client manually keeps
+    /// sending the cookie after its `Max-Age` elapsed.
+    pub(crate) async fn consume_setup_launch_capability(&self, candidate: &str) -> bool {
+        let candidate_digest = setup_authority_digest(candidate);
+        let now = Instant::now();
+        let mut guard = self.inner.setup_launch_capabilities.write().await;
+        guard.retain(|capability| capability.expires_at > now);
+        let Some(index) = guard.iter().position(|capability| {
+            crate::server::auth::constant_time_eq(&candidate_digest, &capability.digest)
+        }) else {
+            return false;
+        };
+        guard.remove(index);
+        true
+    }
+
+    /// Establish (or recover) the setup session used across the GitHub
+    /// manifest round-trip and retire the boot-token fallback once the UI
+    /// path has actually started.
+    ///
+    /// Reusing an existing session keeps a config refetch or second local tab
+    /// from invalidating the first tab's callback cookie.
+    pub(crate) async fn begin_browser_setup_session(
+        &self,
+        existing_cookie: Option<&str>,
+    ) -> String {
+        // Match `exchange_boot_token`'s lock order (boot token, then setup
+        // session) so the two one-time entry paths cannot deadlock or race.
+        let mut boot_token = self.inner.boot_token.write().await;
+        *boot_token = None;
+
+        let now = Instant::now();
+        let mut setup_session = self.inner.setup_session.write().await;
+        if let Some(session) = setup_session.as_ref()
+            && session.expires_at > now
+            && let Some(candidate) = existing_cookie
+            && crate::server::auth::constant_time_eq(
+                &setup_authority_digest(candidate),
+                &session.digest,
+            )
+        {
+            return candidate.to_string();
+        }
+        let token = crate::server::auth::random_token_b64();
+        *setup_session = Some(SetupSession {
+            digest: setup_authority_digest(&token),
+            expires_at: now + SETUP_SESSION_TTL,
+        });
+        token
     }
 
     /// Enable or disable the test bypass for persistence. When enabled,
@@ -711,19 +867,30 @@ impl AppState {
         *self.inner.test_bypass_persist.write().await = bypass;
     }
 
+    /// Override post-persistence credential resolution for failure-path tests.
+    #[cfg(test)]
+    pub(crate) async fn set_test_reload_state_override(
+        &self,
+        state: Option<CredentialSourceState>,
+    ) {
+        *self.inner.test_reload_state_override.write().await = state;
+    }
+
     /// Validate a candidate setup session token against the stored token.
     ///
     /// Returns `true` when a stored token exists and `candidate` matches it
     /// (constant-time comparison). Returns `false` when no token is stored
     /// or the values don't match.
     pub(crate) async fn validate_setup_session_token(&self, candidate: &str) -> bool {
-        let stored = self.inner.setup_session_token.read().await;
-        match stored.as_ref() {
-            Some(expected) => {
-                crate::server::auth::constant_time_eq(candidate.as_bytes(), expected.as_bytes())
-            }
-            None => false,
+        let mut stored = self.inner.setup_session.write().await;
+        let Some(session) = stored.as_ref() else {
+            return false;
+        };
+        if session.expires_at <= Instant::now() {
+            *stored = None;
+            return false;
         }
+        crate::server::auth::constant_time_eq(&setup_authority_digest(candidate), &session.digest)
     }
 
     /// Invalidate the currently stored setup session token.
@@ -732,7 +899,8 @@ impl AppState {
     /// the one-time setup session cannot be replayed in this process after the
     /// terminal setup step completes.
     pub(crate) async fn clear_setup_session_token(&self) {
-        *self.inner.setup_session_token.write().await = None;
+        *self.inner.setup_session.write().await = None;
+        self.inner.setup_launch_capabilities.write().await.clear();
     }
 
     /// Store a pending install-continuation nonce after manifest credential
@@ -742,32 +910,41 @@ impl AppState {
         *self.inner.pending_install_continuation.write().await = Some(nonce);
     }
 
-    /// Validate and consume a pending install-continuation nonce.
-    ///
-    /// Returns `true` when no continuation is pending (non-manifest flow) or
-    /// when the candidate matches the pending nonce. Returns `false` when a
-    /// continuation is pending but the candidate is missing or mismatched.
-    /// On a successful match the pending nonce is cleared (single-use).
-    pub(crate) async fn validate_and_consume_install_continuation(
-        &self,
-        candidate: Option<&str>,
-    ) -> bool {
-        let guard = self.inner.pending_install_continuation.read().await;
-        match guard.as_ref() {
-            None => true, // No continuation pending — non-manifest flow, allow.
-            Some(expected) => {
-                let Some(cand) = candidate else {
-                    return false; // Continuation required but not provided.
-                };
-                if !crate::server::auth::constant_time_eq(cand.as_bytes(), expected.as_bytes()) {
-                    return false; // Mismatch.
-                }
-                // Match — consume the nonce so it cannot be replayed.
-                drop(guard);
-                *self.inner.pending_install_continuation.write().await = None;
-                true
-            }
+    /// Whether a manifest-install continuation is waiting to be completed.
+    pub(crate) async fn has_pending_install_continuation(&self) -> bool {
+        self.inner
+            .pending_install_continuation
+            .read()
+            .await
+            .is_some()
+    }
+
+    /// Validate a continuation candidate without consuming it. Callers use
+    /// this before fallible GitHub API and database work so a transient error
+    /// does not destroy the operator's retry path.
+    pub(crate) async fn validate_pending_install_continuation(&self, candidate: &str) -> bool {
+        self.inner
+            .pending_install_continuation
+            .read()
+            .await
+            .as_deref()
+            .is_some_and(|expected| {
+                crate::server::auth::constant_time_eq(candidate.as_bytes(), expected.as_bytes())
+            })
+    }
+
+    /// Atomically validate and consume a continuation after binding succeeds
+    /// or the flow safely transitions to the installation picker.
+    pub(crate) async fn consume_pending_install_continuation(&self, candidate: &str) -> bool {
+        let mut guard = self.inner.pending_install_continuation.write().await;
+        let Some(expected) = guard.as_deref() else {
+            return false;
+        };
+        if !crate::server::auth::constant_time_eq(candidate.as_bytes(), expected.as_bytes()) {
+            return false;
         }
+        *guard = None;
+        true
     }
 
     /// Inject a pending install-continuation nonce for testing.
@@ -797,7 +974,10 @@ impl AppState {
 
         let session_token = crate::server::auth::random_token_b64();
         // Store so `extract_setup_session` can validate the cookie against it.
-        *self.inner.setup_session_token.write().await = Some(session_token.clone());
+        *self.inner.setup_session.write().await = Some(SetupSession {
+            digest: setup_authority_digest(&session_token),
+            expires_at: Instant::now() + SETUP_SESSION_TTL,
+        });
         BootTokenExchangeResult::Ok(session_token)
     }
 
@@ -812,6 +992,16 @@ impl AppState {
     /// Called during server bootstrap.
     pub async fn init_app_config(&self) {
         let credential_repo = CredentialRepository::new(self.db().clone(), self.event_bus());
+        #[cfg(test)]
+        let override_state = self.inner.test_reload_state_override.read().await.clone();
+        #[cfg(test)]
+        let state = match override_state {
+            Some(state) => state,
+            None => {
+                djinn_provider::github_app::resolve_credential_source(Some(&credential_repo)).await
+            }
+        };
+        #[cfg(not(test))]
         let state =
             djinn_provider::github_app::resolve_credential_source(Some(&credential_repo)).await;
 
@@ -854,12 +1044,22 @@ impl AppState {
             }
         }
 
-        *self.inner.app_config.write().await = state.app_config().cloned();
+        *self.inner.app_credential_state.write().await = state.clone();
+        sync_provider_runtime_config(&state);
+
+        // Re-initialization must not leave a token from an earlier
+        // unconfigured snapshot alive after credentials become invalid or
+        // configured.
+        *self.inner.boot_token.write().await = None;
+        self.inner.setup_launch_capabilities.write().await.clear();
 
         // Generate a one-time boot token when self-setup is enabled and no
-        // usable credentials exist. The raw token is logged once; only the
-        // digest is stored in memory.
-        if crate::server::auth::self_setup_enabled() && !state.is_usable() {
+        // credentials exist at all. Invalid Secret and undecryptable persisted
+        // states require explicit operator recovery and must never silently
+        // fall through to self-setup.
+        if crate::server::auth::self_setup_enabled()
+            && matches!(state, CredentialSourceState::Unconfigured)
+        {
             let (raw, bt) = crate::server::auth::boot_token::BootToken::generate();
             let public_url = crate::server::auth::public_url();
             let setup_url = format!("{public_url}/auth/github/create-app?setup_token={raw}");
@@ -885,21 +1085,55 @@ impl AppState {
         #[cfg(test)]
         if *self.inner.test_bypass_persist.read().await {
             let cfg = Arc::new(config.clone());
-            *self.inner.app_config.write().await = Some(cfg);
+            let state = CredentialSourceState::ValidPersisted(cfg);
+            *self.inner.app_credential_state.write().await = state.clone();
+            sync_provider_runtime_config(&state);
             tracing::info!(
                 app_id = config.app_id,
                 "github_app: (test) simulated persistence and hot-reload"
             );
-            return Ok(CredentialSourceState::ValidSecret(Arc::new(config.clone())));
+            return Ok(state);
         }
 
         let credential_repo = CredentialRepository::new(self.db().clone(), self.event_bus());
         djinn_provider::github_app::persist_app_config(&credential_repo, config).await?;
 
         // Hot-reload: re-resolve to pick up the persisted credentials.
+        #[cfg(test)]
+        let override_state = self.inner.test_reload_state_override.read().await.clone();
+        #[cfg(test)]
+        let state = match override_state {
+            Some(state) => state,
+            None => {
+                djinn_provider::github_app::resolve_credential_source(Some(&credential_repo)).await
+            }
+        };
+        #[cfg(not(test))]
         let state =
             djinn_provider::github_app::resolve_credential_source(Some(&credential_repo)).await;
-        *self.inner.app_config.write().await = state.app_config().cloned();
+        *self.inner.app_credential_state.write().await = state.clone();
+        sync_provider_runtime_config(&state);
+
+        if !state.is_usable() {
+            let detail = match &state {
+                CredentialSourceState::InvalidSecret(detail) => format!(
+                    "invalid Secret/env credentials: {}",
+                    detail.issues.join(", ")
+                ),
+                CredentialSourceState::UndecryptablePersisted => {
+                    "persisted credentials are undecryptable".to_string()
+                }
+                CredentialSourceState::Unconfigured => {
+                    "no usable credential source after persistence".to_string()
+                }
+                CredentialSourceState::ValidSecret(_)
+                | CredentialSourceState::ValidPersisted(_) => unreachable!(),
+            };
+            return Err(format!(
+                "GitHub App credentials were persisted but hot-reload failed: {detail}"
+            ));
+        }
+
         tracing::info!(
             source = ?state.source(),
             app_id = config.app_id,

--- a/ui/src/api/auth.test.ts
+++ b/ui/src/api/auth.test.ts
@@ -37,6 +37,7 @@ describe("fetchAuthConfig", () => {
       missing: ["GITHUB_APP_CLIENT_ID"],
       setup_doc_url: "https://example.test/setup",
       self_setup_available: true,
+      setup_launch_available: true,
     });
 
     const config = await fetchAuthConfig();
@@ -46,6 +47,7 @@ describe("fetchAuthConfig", () => {
       missing: ["GITHUB_APP_CLIENT_ID"],
       setupDocUrl: "https://example.test/setup",
       selfSetupAvailable: true,
+      setupLaunchAvailable: true,
     });
   });
 
@@ -61,6 +63,21 @@ describe("fetchAuthConfig", () => {
 
     expect(config.configured).toBe(false);
     expect(config.selfSetupAvailable).toBe(false);
+    expect(config.setupLaunchAvailable).toBe(false);
+  });
+
+  it("defaults setupLaunchAvailable to false when an older server only advertises self-setup", async () => {
+    mockFetchOk({
+      configured: false,
+      missing: ["GITHUB_APP_PRIVATE_KEY"],
+      setup_doc_url: "https://example.test/setup",
+      self_setup_available: true,
+    });
+
+    const config = await fetchAuthConfig();
+
+    expect(config.selfSetupAvailable).toBe(true);
+    expect(config.setupLaunchAvailable).toBe(false);
   });
 
   it("preserves selfSetupAvailable=false when the server explicitly sends false", async () => {
@@ -69,11 +86,13 @@ describe("fetchAuthConfig", () => {
       missing: [],
       setup_doc_url: "https://example.test/setup",
       self_setup_available: false,
+      setup_launch_available: false,
     });
 
     const config = await fetchAuthConfig();
 
     expect(config.selfSetupAvailable).toBe(false);
+    expect(config.setupLaunchAvailable).toBe(false);
     expect(config.configured).toBe(true);
   });
 });
@@ -181,18 +200,25 @@ describe("fetchSetupStatus", () => {
     expect(status.credentialSource).toBeNull();
   });
 
-  it("maps setup_state=unrecoverable as the unrecoverable state", async () => {
+  it("maps canonical setup_state=credentials_unrecoverable as the unrecoverable state", async () => {
     mockFetchOk({
       needs_app_install: true,
       app_credentials_configured: false,
       org_login: null,
-      setup_state: "unrecoverable",
+      credential_source: null,
+      setup_state: "credentials_unrecoverable",
+      setup_error: "Persisted credentials cannot be decrypted",
+      setup_retryable: false,
+      credentials_unrecoverable: true,
     });
 
     const status = await fetchSetupStatus();
 
     expect(status.setupState).toBe("unrecoverable");
-    expect(status.credentialsUnrecoverable).toBe(false);
+    expect(status.credentialSource).toBeNull();
+    expect(status.setupError).toBe("Persisted credentials cannot be decrypted");
+    expect(status.setupRetryable).toBe(false);
+    expect(status.credentialsUnrecoverable).toBe(true);
   });
 
   it("maps setup_state=unconfigured explicitly", async () => {
@@ -208,12 +234,12 @@ describe("fetchSetupStatus", () => {
     expect(status.setupState).toBe("unconfigured");
   });
 
-  it("maps setup_state=valid explicitly", async () => {
+  it("maps canonical setup_state=valid_secret explicitly", async () => {
     mockFetchOk({
       needs_app_install: false,
       app_credentials_configured: true,
       org_login: "acme",
-      setup_state: "valid",
+      setup_state: "valid_secret",
       credential_source: "secret",
     });
 
@@ -221,6 +247,21 @@ describe("fetchSetupStatus", () => {
 
     expect(status.setupState).toBe("valid");
     expect(status.credentialSource).toBe("secret");
+  });
+
+  it("maps canonical setup_state=valid_persisted explicitly", async () => {
+    mockFetchOk({
+      needs_app_install: false,
+      app_credentials_configured: true,
+      org_login: "acme",
+      setup_state: "valid_persisted",
+      credential_source: "persisted",
+    });
+
+    const status = await fetchSetupStatus();
+
+    expect(status.setupState).toBe("valid");
+    expect(status.credentialSource).toBe("persisted");
   });
 
   it("does not surface raw setup tokens or secret material", async () => {

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -91,6 +91,14 @@ export interface AuthConfig {
    * `self_setup_available`.
    */
   selfSetupAvailable: boolean;
+  /**
+   * Whether this response established the server-owned launch capability
+   * required by `POST /auth/github/setup-start`. This is intentionally
+   * separate from `selfSetupAvailable`: self-setup may be enabled while the
+   * current origin is not allowed to start it. Defaults to `false` for older
+   * servers so the UI never renders a button that cannot work securely.
+   */
+  setupLaunchAvailable: boolean;
 }
 
 /**
@@ -110,6 +118,7 @@ export async function fetchAuthConfig(): Promise<AuthConfig> {
     missing: string[];
     setup_doc_url: string;
     self_setup_available?: boolean;
+    setup_launch_available?: boolean;
   };
   return {
     configured: body.configured,
@@ -118,6 +127,9 @@ export async function fetchAuthConfig(): Promise<AuthConfig> {
     // Default to `false` so older servers (pre-self-setup) don't advertise
     // a setup flow that doesn't exist.
     selfSetupAvailable: body.self_setup_available ?? false,
+    // Launching is opt-in. Older servers and non-canonical origins must fall
+    // back to the one-time URL instead of rendering a dead or unsafe CTA.
+    setupLaunchAvailable: body.setup_launch_available ?? false,
   };
 }
 
@@ -281,7 +293,7 @@ export async function fetchSetupStatus(): Promise<SetupStatus> {
     needs_app_install: boolean;
     app_credentials_configured?: boolean;
     org_login?: string | null;
-    credential_source?: string;
+    credential_source?: string | null;
     setup_state?: string;
     setup_error?: string | null;
     setup_retryable?: boolean;

--- a/ui/src/api/server.test.ts
+++ b/ui/src/api/server.test.ts
@@ -4,8 +4,10 @@ import { callMcpTool } from "@/api/mcpClient";
 import { getServerBaseUrl } from "@/api/serverUrl";
 import {
   checkServerHealth,
+  addProjectFromGithub,
   fetchProviderCatalog,
   getGithubInstallUrl,
+  githubRepoToProjectArgs,
   invalidateProviderCatalogCache,
   listGithubRepos,
   searchTasksAcrossProjects,
@@ -269,6 +271,30 @@ describe("server API helpers", () => {
   });
 
   describe("GitHub project helpers", () => {
+    it("preserves a repository's non-main default branch when adding it", async () => {
+      callMcpToolMock.mockResolvedValueOnce({
+        status: "ok",
+        project: { id: "project-1", github_owner: "acme", github_repo: "legacy" },
+      } as never);
+      const args = githubRepoToProjectArgs({
+        owner: "acme",
+        repo: "legacy",
+        default_branch: "master",
+        private: true,
+        installation_id: 42,
+        account_login: "acme",
+      });
+
+      await addProjectFromGithub(args);
+
+      expect(callMcpToolMock).toHaveBeenCalledWith("project_add_from_github", {
+        owner: "acme",
+        repo: "legacy",
+        ref: "master",
+        installation_id: 42,
+      });
+    });
+
     it("throws the normalized error message from github_list_repos", async () => {
       callMcpToolMock.mockResolvedValueOnce({ status: "error: sign in required" } as never);
 

--- a/ui/src/api/server.ts
+++ b/ui/src/api/server.ts
@@ -251,13 +251,24 @@ export async function getGithubInstallUrl(): Promise<string> {
  * `/var/lib/djinn/projects` under the Helm chart, bind-mounted to
  * `~/.djinn/projects` under docker-compose) and returns the project record.
  */
-export async function addProjectFromGithub(args: {
+export interface AddProjectFromGithubArgs {
   owner: string;
   repo: string;
   name?: string;
   ref?: string;
   installation_id?: number;
-}): Promise<Project> {
+}
+
+export function githubRepoToProjectArgs(entry: GithubRepoEntry): AddProjectFromGithubArgs {
+  return {
+    owner: entry.owner,
+    repo: entry.repo,
+    ref: entry.default_branch || undefined,
+    installation_id: entry.installation_id,
+  };
+}
+
+export async function addProjectFromGithub(args: AddProjectFromGithubArgs): Promise<Project> {
   const response = await callMcpTool("project_add_from_github", {
     owner: args.owner,
     repo: args.repo,

--- a/ui/src/api/userConfig.test.ts
+++ b/ui/src/api/userConfig.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { callMcpTool } from "@/api/mcpClient";
+import {
+  SELF_TARGET,
+  setUserCredential,
+  startUserOAuth,
+} from "@/api/userConfig";
+
+vi.mock("@/api/mcpClient", () => ({
+  callMcpTool: vi.fn(),
+}));
+
+const callMcpToolMock = vi.mocked(callMcpTool);
+
+describe("setUserCredential", () => {
+  beforeEach(() => {
+    callMcpToolMock.mockReset();
+  });
+
+  it("omits the admin-only target_user_id for the signed-in user", async () => {
+    callMcpToolMock.mockResolvedValueOnce({ ok: true, success: true } as never);
+
+    await setUserCredential({
+      targetUserId: SELF_TARGET,
+      providerId: "anthropic",
+      keyName: "ANTHROPIC_API_KEY",
+      apiKey: "sk-ant-test",
+    });
+
+    expect(callMcpToolMock).toHaveBeenCalledWith("credential_set", {
+      provider_id: "anthropic",
+      key_name: "ANTHROPIC_API_KEY",
+      api_key: "sk-ant-test",
+    });
+  });
+
+  it("includes target_user_id when an admin configures another user", async () => {
+    callMcpToolMock.mockResolvedValueOnce({ ok: true, success: true } as never);
+
+    await setUserCredential({
+      targetUserId: "target-user-1",
+      providerId: "anthropic",
+      keyName: "ANTHROPIC_API_KEY",
+      apiKey: "sk-ant-test",
+    });
+
+    expect(callMcpToolMock).toHaveBeenCalledWith("credential_set", {
+      target_user_id: "target-user-1",
+      provider_id: "anthropic",
+      key_name: "ANTHROPIC_API_KEY",
+      api_key: "sk-ant-test",
+    });
+  });
+});
+
+describe("startUserOAuth", () => {
+  beforeEach(() => {
+    callMcpToolMock.mockReset();
+  });
+
+  it("omits the admin-only target_user_id for the signed-in user", async () => {
+    callMcpToolMock.mockResolvedValueOnce({
+      ok: false,
+      error: "Could not persist Codex credentials",
+    } as never);
+
+    await expect(startUserOAuth(SELF_TARGET, "openai")).resolves.toEqual({
+      kind: "error",
+      message: "Could not persist Codex credentials",
+    });
+    expect(callMcpToolMock).toHaveBeenCalledWith("provider_oauth_start", {
+      provider_id: "openai",
+    });
+  });
+
+  it("includes target_user_id when an admin configures another user", async () => {
+    callMcpToolMock.mockResolvedValueOnce({ ok: true, pending: false } as never);
+
+    await expect(startUserOAuth("target-user-1", "openai")).resolves.toEqual({
+      kind: "connected",
+    });
+    expect(callMcpToolMock).toHaveBeenCalledWith("provider_oauth_start", {
+      target_user_id: "target-user-1",
+      provider_id: "openai",
+    });
+  });
+});

--- a/ui/src/api/userConfig.ts
+++ b/ui/src/api/userConfig.ts
@@ -149,7 +149,7 @@ export async function setUserCredential(args: {
   apiKey: string;
 }): Promise<void> {
   const response = await callMcpTool("credential_set", {
-    target_user_id: args.targetUserId,
+    ...targetArgs(args.targetUserId),
     provider_id: args.providerId,
     key_name: args.keyName,
     api_key: args.apiKey,
@@ -183,7 +183,7 @@ export async function startUserOAuth(
 ): Promise<UserOAuthResult> {
   try {
     const result = await callMcpTool("provider_oauth_start", {
-      target_user_id: targetUserId,
+      ...targetArgs(targetUserId),
       provider_id: providerId,
     });
     if (!result.ok) {

--- a/ui/src/components/AddProjectFromGithubDialog.tsx
+++ b/ui/src/components/AddProjectFromGithubDialog.tsx
@@ -15,6 +15,7 @@ import {
   listGithubRepos,
   listGithubInstallations,
   addProjectFromGithub,
+  githubRepoToProjectArgs,
   type GithubRepoEntry,
   type Installation,
   type Project,
@@ -28,7 +29,7 @@ interface Props {
   onAdded: (project: Project) => void;
 }
 
-export const INSTALLATIONS_QUERY_KEY = ['github', 'installations'] as const;
+export const INSTALLATIONS_QUERY_KEY = ['github', 'project-installations'] as const;
 export const REPOS_QUERY_KEY = ['github', 'repos'] as const;
 
 /**
@@ -101,11 +102,7 @@ export function AddProjectFromGithubDialog({ open, onOpenChange, onAdded }: Prop
     const key = `${entry.owner}/${entry.repo}`;
     setAddingKey(key);
     try {
-      const project = await addProjectFromGithub({
-        owner: entry.owner,
-        repo: entry.repo,
-        installation_id: entry.installation_id,
-      });
+      const project = await addProjectFromGithub(githubRepoToProjectArgs(entry));
       showToast.success(`Added ${key}`);
       onAdded(project);
       onOpenChange(false);

--- a/ui/src/components/AuthGate.contract.test.tsx
+++ b/ui/src/components/AuthGate.contract.test.tsx
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@/test/test-utils";
+import { AuthGate } from "@/components/AuthGate";
+import { fetchAuthConfig, fetchCurrentUser } from "@/api/auth";
+
+vi.mock("@/api/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/auth")>();
+  return {
+    ...actual,
+    // Keep the real fetchSetupStatus export. These two unrelated requests are
+    // mocked so each test exercises exactly one raw /setup/status response.
+    fetchCurrentUser: vi.fn(),
+    fetchAuthConfig: vi.fn(),
+  };
+});
+
+type BackendSetupState =
+  | "unconfigured"
+  | "valid_secret"
+  | "valid_persisted"
+  | "invalid_secret"
+  | "credentials_unrecoverable";
+
+interface BackendSetupStatus {
+  needs_app_install: boolean;
+  app_credentials_configured: boolean;
+  org_login: string | null;
+  credential_source: "secret" | "persisted" | null;
+  setup_state: BackendSetupState;
+  setup_error: string | null;
+  setup_retryable: boolean;
+  credentials_unrecoverable: boolean;
+}
+
+function authConfig(
+  selfSetupAvailable: boolean,
+  setupLaunchAvailable = selfSetupAvailable,
+) {
+  return {
+    configured: false,
+    missing: ["GITHUB_APP_ID"],
+    setupDocUrl: "https://www.djinnai.io/docs/setup",
+    selfSetupAvailable,
+    setupLaunchAvailable,
+  };
+}
+
+function stubSetupStatus(payload: BackendSetupStatus) {
+  const fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    if (!url.endsWith("/setup/status")) {
+      throw new Error(`Unexpected fetch in AuthGate contract test: ${url}`);
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(payload),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("AuthGate backend setup-status contract", () => {
+  beforeEach(() => {
+    vi.mocked(fetchCurrentUser).mockReset();
+    vi.mocked(fetchAuthConfig).mockReset();
+    vi.mocked(fetchCurrentUser).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("maps an invalid Secret payload to the fatal Secret screen", async () => {
+    const fetchMock = stubSetupStatus({
+      needs_app_install: true,
+      app_credentials_configured: false,
+      org_login: null,
+      credential_source: null,
+      setup_state: "invalid_secret",
+      setup_error: "GITHUB_APP_CLIENT_ID is empty",
+      setup_retryable: false,
+      credentials_unrecoverable: false,
+    });
+    // A broken mounted Secret must win over the otherwise available self-setup
+    // route; silently falling through would hide an operator error.
+    vi.mocked(fetchAuthConfig).mockResolvedValue(authConfig(true));
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("GitHub App Secret is invalid"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("GITHUB_APP_CLIENT_ID is empty"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Connect GitHub")).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps an undecryptable persisted payload to the recovery screen", async () => {
+    stubSetupStatus({
+      needs_app_install: true,
+      app_credentials_configured: false,
+      org_login: null,
+      credential_source: null,
+      setup_state: "credentials_unrecoverable",
+      setup_error: "Persisted credentials cannot be decrypted",
+      setup_retryable: false,
+      credentials_unrecoverable: true,
+    });
+    vi.mocked(fetchAuthConfig).mockResolvedValue(authConfig(true));
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Stored credentials cannot be recovered"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Persisted credentials cannot be decrypted"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("GitHub App not configured"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("maps an unconfigured payload to the manual runbook screen", async () => {
+    stubSetupStatus({
+      needs_app_install: true,
+      app_credentials_configured: false,
+      org_login: null,
+      credential_source: null,
+      setup_state: "unconfigured",
+      setup_error: null,
+      setup_retryable: false,
+      credentials_unrecoverable: false,
+    });
+    vi.mocked(fetchAuthConfig).mockResolvedValue(authConfig(false));
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub App not configured")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Stored credentials cannot be recovered"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("GitHub App Secret is invalid"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("maps an unconfigured self-setup payload to the direct GitHub setup action", async () => {
+    stubSetupStatus({
+      needs_app_install: true,
+      app_credentials_configured: false,
+      org_login: null,
+      credential_source: null,
+      setup_state: "unconfigured",
+      setup_error: null,
+      setup_retryable: false,
+      credentials_unrecoverable: false,
+    });
+    vi.mocked(fetchAuthConfig).mockResolvedValue(authConfig(true));
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Continue with GitHub" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("form", { name: "Start GitHub App setup" }),
+    ).toHaveAttribute("action", "/auth/github/setup-start");
+    expect(screen.queryByText("GitHub App not configured")).not.toBeInTheDocument();
+  });
+
+  it("maps setup_retryable to the retry screen without losing setup_error", async () => {
+    stubSetupStatus({
+      needs_app_install: true,
+      app_credentials_configured: false,
+      org_login: null,
+      credential_source: null,
+      setup_state: "unconfigured",
+      setup_error: "GitHub manifest exchange timed out",
+      setup_retryable: true,
+      credentials_unrecoverable: false,
+    });
+    vi.mocked(fetchAuthConfig).mockResolvedValue(authConfig(true));
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub App setup in progress")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("GitHub manifest exchange timed out"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Connect GitHub")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/AuthGate.test.tsx
+++ b/ui/src/components/AuthGate.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@/test/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { AuthGate } from "@/components/AuthGate";
 import {
   fetchAuthConfig,
@@ -40,16 +40,20 @@ function baseSetupStatus(overrides: Partial<SetupStatus> = {}): SetupStatus {
 }
 
 /**
- * A minimal auth-config payload with selfSetupAvailable defaulted.
- * Only `selfSetupAvailable` is used by AuthGate's rendering logic; the
- * remaining fields are required by the `AuthConfig` type.
+ * A minimal auth-config payload. Tests that enable self-setup default to a
+ * canonical origin with a launch capability; pass `false` explicitly to
+ * exercise the secure one-time-URL fallback.
  */
-function baseAuthConfig(selfSetupAvailable = false): AuthConfig {
+function baseAuthConfig(
+  selfSetupAvailable = false,
+  setupLaunchAvailable = selfSetupAvailable,
+): AuthConfig {
   return {
     configured: !selfSetupAvailable,
     missing: selfSetupAvailable ? ["GITHUB_APP_CLIENT_ID"] : [],
     setupDocUrl: SETUP_DOC_URL,
     selfSetupAvailable,
+    setupLaunchAvailable,
   };
 }
 
@@ -63,6 +67,11 @@ describe("AuthGate", () => {
     vi.mocked(fetchCurrentUser).mockResolvedValue(null);
     vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
     vi.mocked(fetchAuthConfig).mockResolvedValue(baseAuthConfig(false));
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+    vi.restoreAllMocks();
   });
 
   // ─── Existing behavior preserved ────────────────────────────────────────
@@ -134,6 +143,30 @@ describe("AuthGate", () => {
     });
   });
 
+  it("renders a server error instead of signed-out UI when /auth/me fails", async () => {
+    vi.mocked(fetchCurrentUser).mockRejectedValue(new Error("auth service unavailable"));
+    vi.mocked(fetchSetupStatus).mockResolvedValue(
+      baseSetupStatus({
+        needsAppInstall: false,
+        appCredentialsConfigured: true,
+        orgLogin: "acme",
+        setupState: "valid",
+      }),
+    );
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Can't reach the server")).toBeInTheDocument();
+    });
+    expect(screen.getByText("auth service unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Sign in with GitHub/i })).not.toBeInTheDocument();
+  });
+
   it("renders children when authed and configured", async () => {
     vi.mocked(fetchCurrentUser).mockResolvedValue({
       id: "1",
@@ -162,9 +195,9 @@ describe("AuthGate", () => {
     });
   });
 
-  // ─── Self-setup guidance ────────────────────────────────────────────────
+  // ─── Self-setup launch ──────────────────────────────────────────────────
 
-  it("renders the self-setup guidance screen when self-setup is available and credentials are missing", async () => {
+  it("renders a direct GitHub setup action when self-setup is available and credentials are missing", async () => {
     vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
     vi.mocked(fetchAuthConfig).mockResolvedValue(baseAuthConfig(true));
 
@@ -175,12 +208,139 @@ describe("AuthGate", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Set up GitHub access")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Connect GitHub" })).toBeInTheDocument();
     });
-    // Should mention the boot-log setup URL flow.
+
+    const form = screen.getByRole("form", { name: "Start GitHub App setup" });
+    expect(form).toHaveAttribute("action", "/auth/github/setup-start");
+    expect(form).toHaveAttribute("method", "post");
     expect(
-      screen.getByText(/setup URL printed in the server boot logs/i),
-    ).toBeInTheDocument();
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    ).toHaveAttribute("type", "submit");
+    expect(screen.getByText("Review permissions")).toBeInTheDocument();
+    expect(screen.getByText("Choose repositories")).toBeInTheDocument();
+    expect(screen.getByText("Return to Djinn")).toBeInTheDocument();
+
+    const troubleshooting = screen.getByText("Having trouble?").closest("details");
+    expect(troubleshooting).not.toHaveAttribute("open");
+    expect(troubleshooting).toContainElement(
+      screen.getByText(/setup URL from the server boot logs/i),
+    );
+    expect(troubleshooting).toContainElement(
+      screen.getByText(/restart the local server to generate a new URL/i),
+    );
+  });
+
+  it("refreshes the launch capability immediately before native form submission", async () => {
+    let resolveRefresh!: (config: AuthConfig) => void;
+    const refresh = new Promise<AuthConfig>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
+    vi.mocked(fetchAuthConfig)
+      .mockResolvedValueOnce(baseAuthConfig(true))
+      .mockImplementationOnce(() => refresh);
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, "submit")
+      .mockImplementation(() => undefined);
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    const button = await screen.findByRole("button", {
+      name: "Continue with GitHub",
+    });
+    await userEvent.click(button);
+
+    expect(fetchAuthConfig).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole("button", { name: "Refreshing secure access…" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("form", { name: "Start GitHub App setup" }),
+    ).toHaveAttribute("aria-busy", "true");
+    expect(submitSpy).not.toHaveBeenCalled();
+
+    resolveRefresh(baseAuthConfig(true));
+
+    await waitFor(() => {
+      expect(submitSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows an accessible error and does not submit when capability refresh fails", async () => {
+    vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
+    vi.mocked(fetchAuthConfig)
+      .mockResolvedValueOnce(baseAuthConfig(true))
+      .mockRejectedValueOnce(new Error("server unavailable"));
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, "submit")
+      .mockImplementation(() => undefined);
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Continue with GitHub" }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Could not refresh secure setup access/i,
+    );
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    ).toBeEnabled();
+  });
+
+  it("does not submit when refreshed config revokes setup launch availability", async () => {
+    vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
+    vi.mocked(fetchAuthConfig)
+      .mockResolvedValueOnce(baseAuthConfig(true))
+      .mockResolvedValueOnce(baseAuthConfig(true, false));
+    const submitSpy = vi
+      .spyOn(HTMLFormElement.prototype, "submit")
+      .mockImplementation(() => undefined);
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Continue with GitHub" }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Secure setup is no longer available from this browser address/i,
+    );
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+
+  it("explains an expired setup redirect after config refresh and keeps the CTA available", async () => {
+    window.history.replaceState({}, "", "/?setup=expired");
+    vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
+    vi.mocked(fetchAuthConfig).mockResolvedValue(baseAuthConfig(true));
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    const notice = await screen.findByRole("status");
+    expect(notice).toHaveTextContent(/setup access expired/i);
+    expect(notice).toHaveTextContent(/has been refreshed/i);
+    expect(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    ).toBeEnabled();
   });
 
   it("does not show a self-setup CTA when self-setup is disabled and credentials are missing", async () => {
@@ -196,7 +356,40 @@ describe("AuthGate", () => {
     await waitFor(() => {
       expect(screen.getByText("GitHub App not configured")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Set up GitHub access")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect GitHub")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Continue with GitHub" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the secure log-URL fallback without a fake CTA when launch capability is unavailable", async () => {
+    vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
+    vi.mocked(fetchAuthConfig).mockResolvedValue(baseAuthConfig(true, false));
+
+    render(
+      <AuthGate>
+        <div>signed-in app</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Open the GitHub setup link" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/one-time URL in the server boot logs/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/restart the local server to generate a new URL/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Continue with GitHub" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("form", { name: "Start GitHub App setup" }),
+    ).not.toBeInTheDocument();
+    expect(document.querySelectorAll("input")).toHaveLength(0);
   });
 
   it("falls back to the runbook screen when self-setup is available but the App is configured", async () => {
@@ -230,7 +423,7 @@ describe("AuthGate", () => {
     await waitFor(() => {
       expect(screen.getByText("Pick a GitHub installation")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Set up GitHub access")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect GitHub")).not.toBeInTheDocument();
   });
 
   // ─── Secret / token non-exposure ────────────────────────────────────────
@@ -246,14 +439,15 @@ describe("AuthGate", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Set up GitHub access")).toBeInTheDocument();
+      expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
     });
 
-    // The rendered guidance should explicitly tell the user they don't need
-    // to paste secrets or tokens.
+    // The page explains that no secret copying is required, and the launch
+    // form itself carries no token or credential fields.
     const bodyText = document.body.textContent ?? "";
-    expect(bodyText).toMatch(/never need to paste secrets or tokens/i);
-    // No password inputs or token prompts in the self-setup screen.
+    expect(bodyText).toMatch(/No tokens or private keys to copy into Djinn/i);
+    const form = screen.getByRole("form", { name: "Start GitHub App setup" });
+    expect(form.querySelectorAll("input")).toHaveLength(0);
     expect(screen.queryByPlaceholderText(/paste.*secret/i)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/paste.*token/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/private key/i)).not.toBeInTheDocument();
@@ -285,7 +479,7 @@ describe("AuthGate", () => {
       screen.getByText(/GITHUB_APP_CLIENT_ID is empty/i),
     ).toBeInTheDocument();
     // Fatal Secret must NOT silently fall back to self-setup CTA.
-    expect(screen.queryByText("Set up GitHub access")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect GitHub")).not.toBeInTheDocument();
   });
 
   // ─── Credentials unrecoverable recovery ─────────────────────────────────
@@ -381,7 +575,8 @@ describe("AuthGate", () => {
       "GitHub App Secret is invalid",
       "Stored credentials cannot be recovered",
       "GitHub App setup in progress",
-      "Set up GitHub access",
+      "Connect GitHub",
+      "Open the GitHub setup link",
       "GitHub App not configured",
     ];
 
@@ -414,9 +609,15 @@ describe("AuthGate", () => {
           );
           vi.mocked(fetchAuthConfig).mockResolvedValue(baseAuthConfig(true));
           break;
-        case "Set up GitHub access":
+        case "Connect GitHub":
           vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
           vi.mocked(fetchAuthConfig).mockResolvedValue(baseAuthConfig(true));
+          break;
+        case "Open the GitHub setup link":
+          vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());
+          vi.mocked(fetchAuthConfig).mockResolvedValue(
+            baseAuthConfig(true, false),
+          );
           break;
         case "GitHub App not configured":
           vi.mocked(fetchSetupStatus).mockResolvedValue(baseSetupStatus());

--- a/ui/src/components/AuthGate.tsx
+++ b/ui/src/components/AuthGate.tsx
@@ -1,4 +1,11 @@
-import { createContext, useContext, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { GithubIcon } from "@hugeicons/core-free-icons";
@@ -19,6 +26,163 @@ import {
 const SETUP_DOC_URL = "https://www.djinnai.io/docs/setup";
 
 const AuthUserContext = createContext<User | null>(null);
+
+function SetupLaunchPanel() {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+  const refreshInFlight = useRef(false);
+  const setupExpired =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("setup") === "expired";
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (refreshInFlight.current) return;
+
+    const form = event.currentTarget;
+    refreshInFlight.current = true;
+    setIsRefreshing(true);
+    setLaunchError(null);
+
+    try {
+      // Refresh immediately before the POST so the short-lived, HttpOnly
+      // launch cookie cannot expire while the operator reads this screen.
+      const refreshedConfig = await fetchAuthConfig();
+      if (
+        !refreshedConfig.selfSetupAvailable ||
+        !refreshedConfig.setupLaunchAvailable
+      ) {
+        setLaunchError(
+          "Secure setup is no longer available from this browser address. Use the one-time setup URL under Having trouble?",
+        );
+        return;
+      }
+
+      // Native submission preserves the server redirect/manifest flow. There
+      // are deliberately no token-bearing fields in this form.
+      form.submit();
+    } catch {
+      setLaunchError(
+        "Could not refresh secure setup access. Check the server connection and try again.",
+      );
+    } finally {
+      refreshInFlight.current = false;
+      setIsRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="w-full space-y-5 text-left">
+      <div className="space-y-2 text-center">
+        <h2 className="text-lg font-semibold">Connect GitHub</h2>
+        <p className="text-sm text-muted-foreground">
+          Connect Djinn only to the repositories you choose. GitHub shows the
+          requested permissions before the App is installed.
+        </p>
+      </div>
+
+      {setupExpired ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-lg border border-primary/30 bg-primary/10 px-4 py-3 text-sm text-foreground"
+        >
+          Your setup access expired. Secure access has been refreshed; continue
+          when you are ready.
+        </div>
+      ) : null}
+
+      <form
+        action="/auth/github/setup-start"
+        method="post"
+        aria-label="Start GitHub App setup"
+        aria-busy={isRefreshing}
+        onSubmit={handleSubmit}
+      >
+        <Button
+          type="submit"
+          size="lg"
+          className="h-11 w-full gap-2 px-6 text-base"
+          disabled={isRefreshing}
+          aria-describedby={launchError ? "github-setup-launch-error" : undefined}
+        >
+          <HugeiconsIcon icon={GithubIcon} size={20} />
+          {isRefreshing ? "Refreshing secure access…" : "Continue with GitHub"}
+        </Button>
+      </form>
+
+      {launchError ? (
+        <p
+          id="github-setup-launch-error"
+          role="alert"
+          className="text-center text-sm text-destructive"
+        >
+          {launchError}
+        </p>
+      ) : null}
+
+      <div
+        className="rounded-lg border border-border/60 bg-card/50 p-4"
+        aria-labelledby="github-setup-steps"
+      >
+        <p
+          id="github-setup-steps"
+          className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          What happens next
+        </p>
+        <ol className="space-y-3 text-sm">
+          {[
+            ["Review permissions", "Confirm what Djinn can access."],
+            ["Choose repositories", "Select only the repositories you want."],
+            ["Return to Djinn", "Setup finishes here automatically."],
+          ].map(([title, description], index) => (
+            <li key={title} className="flex gap-3">
+              <span
+                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary"
+                aria-hidden="true"
+              >
+                {index + 1}
+              </span>
+              <span>
+                <span className="font-medium text-foreground">{title}</span>
+                <span className="block text-xs text-muted-foreground">
+                  {description}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <p className="text-center text-xs text-muted-foreground">
+        No tokens or private keys to copy into Djinn.
+      </p>
+
+      <details className="group rounded-lg border border-border/60 px-4 py-3 text-sm text-muted-foreground">
+        <summary className="cursor-pointer select-none font-medium text-foreground outline-none focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-ring/50">
+          Having trouble?
+        </summary>
+        <div className="mt-3 space-y-3 border-t border-border/60 pt-3 text-xs leading-relaxed">
+          <p>
+            If setup has not started, use the one-time setup URL from the server
+            boot logs. If it already started or the link expired, restart the
+            local server to generate a new URL. Never paste that URL or its
+            token into this page.
+          </p>
+          <a
+            href={SETUP_DOC_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block underline underline-offset-4 hover:text-foreground"
+          >
+            Read the full setup guide
+          </a>
+        </div>
+      </details>
+    </div>
+  );
+}
 
 /**
  * Read the authenticated user from the nearest AuthGate.
@@ -65,9 +229,9 @@ export function AuthGate({ children }: { children: ReactNode }) {
     staleTime: 0,
   });
 
-  // Auth config carries `selfSetupAvailable`, which only matters when
-  // credentials are missing. If this endpoint errors (e.g. an older server
-  // without it), we default to `null` and treat self-setup as unavailable —
+  // Auth config carries both whether self-setup is enabled and whether this
+  // browser response received the origin-bound launch capability. If this
+  // endpoint errors, we default to `null` and treat self-setup as unavailable,
   // preserving existing production behavior. We DO wait for it during the
   // initial loading phase so the gate doesn't flash the wrong screen.
   const {
@@ -106,6 +270,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
   const needsAppInstall = !setupStatus || setupStatus.needsAppInstall;
   const needsSignin = !needsAppInstall && !user;
+  const authStateUnavailable = setupIsError || userIsError;
 
   if (needsAppInstall || needsSignin) {
     return (
@@ -124,7 +289,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
           </div>
 
           <AuthBody
-            setupStatus={setupStatus ?? null}
+            setupStatus={authStateUnavailable ? null : setupStatus ?? null}
             authConfig={authConfig ?? null}
             reachError={reachError}
           />
@@ -327,29 +492,67 @@ function AuthBody({
     );
   }
 
-  // Self-setup enabled but credentials not yet configured — show setup
-  // guidance that points to the one-time setup URL emitted in server boot
-  // logs. We never display or request the raw setup token here; the operator
-  // simply opens the URL the server already printed.
+  // Self-setup enabled but credentials not yet configured — start the secure
+  // same-origin setup flow directly. The server owns the short-lived launch
+  // capability; the UI never receives or renders a setup token.
+  if (
+    authConfig?.selfSetupAvailable &&
+    authConfig.setupLaunchAvailable
+  ) {
+    return <SetupLaunchPanel />;
+  }
+
+  // Self-setup is enabled, but this response did not establish the
+  // origin-bound launch capability. This can happen on an older server or
+  // when the UI was opened from a non-canonical address. Keep the secure
+  // one-time URL as the real path forward and do not render a dead CTA.
   if (authConfig?.selfSetupAvailable) {
     return (
       <div className="w-full space-y-4 text-left">
         <div className="space-y-2 text-center">
-          <h2 className="text-lg font-semibold">Set up GitHub access</h2>
+          <h2 className="text-lg font-semibold">
+            Open the GitHub setup link
+          </h2>
           <p className="text-sm text-muted-foreground">
-            This deployment supports one-click GitHub App setup. Find the setup
-            URL printed in the server boot logs and open it in your browser to
-            create and install the App. You never need to paste secrets or
-            tokens here.
+            Direct setup is not available from this browser address. Use the
+            current one-time setup URL, or restart the local server if setup
+            already started.
           </p>
         </div>
 
         <div className="rounded-lg border border-border/60 bg-card/50 p-4 text-sm text-muted-foreground">
-          <p>
-            Check the server logs for a line containing the one-time setup URL,
-            then open that URL in your browser to authorize the GitHub App.
-          </p>
+          <ol className="space-y-3">
+            <li className="flex gap-3">
+              <span
+                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary"
+                aria-hidden="true"
+              >
+                1
+              </span>
+              <span>
+                If setup has not started, find the one-time URL in the server
+                boot logs.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <span
+                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary"
+                aria-hidden="true"
+              >
+                2
+              </span>
+              <span>
+                If it already started, restart the local server to generate a
+                new URL, then open it in this browser.
+              </span>
+            </li>
+          </ol>
         </div>
+
+        <p className="text-center text-xs text-muted-foreground">
+          Treat the one-time URL like a password. Do not paste it into this
+          page or share it.
+        </p>
 
         <div className="text-center">
           <a

--- a/ui/src/components/InstallationPicker.tsx
+++ b/ui/src/components/InstallationPicker.tsx
@@ -20,7 +20,10 @@ import {
   type InstallationSummary,
 } from "@/api/auth";
 
-export const INSTALLATIONS_QUERY_KEY = ["github", "installations"] as const;
+// This endpoint returns a bare InstallationSummary[]. The authenticated
+// Add-Project dialog uses a different endpoint/shape, so sharing a cache key
+// lets React Query hand an array to code expecting `{ installations, ... }`.
+export const INSTALLATIONS_QUERY_KEY = ["github", "setup-installations"] as const;
 export const SETUP_STATUS_QUERY_KEY = ["auth", "setup-status"] as const;
 
 export function InstallationPicker() {

--- a/ui/src/components/UserConfigDialog.test.tsx
+++ b/ui/src/components/UserConfigDialog.test.tsx
@@ -258,6 +258,27 @@ describe("UserConfigDialog", () => {
     });
   });
 
+  it("surfaces a server-reported ChatGPT OAuth failure inline", async () => {
+    vi.mocked(fetchUserConnectedProviders).mockResolvedValue([]);
+    vi.mocked(startUserOAuth).mockResolvedValue({
+      kind: "error",
+      message: "Could not persist Codex credentials",
+    });
+
+    renderDialog();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole("button", { name: /continue with chatgpt/i }));
+
+    expect(
+      await screen.findByText("Could not persist Codex credentials"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+    expect(
+      screen.queryByText(/waiting for sign-in to complete/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows a friendly inline error when model selection fails to load", async () => {
     vi.mocked(fetchUserModelSelection).mockRejectedValue(
       new Error("Failed to load user settings"),


### PR DESCRIPTION
## Summary

- Add one-click GitHub App creation for local deployments through a short-lived, loopback-only setup flow.
- Persist App credentials and hot-reload the GitHub provider without restarting Djinn.
- Support personal installations locally while keeping production organization-only.
- Make installation binding and first-admin bootstrap atomic.
- Add direct setup, expiry recovery, and fallback guidance to the onboarding UI.
- Fix self-service model-provider configuration and preserve a repository default branch during import.

## Security

- Require an exact loopback origin and validate Host and fetch metadata.
- Keep the setup capability in a short-lived HttpOnly cookie; it is not exposed in JSON or markup.
- Do not generate a localhost webhook URL in the GitHub App manifest.
- Prevent the installation OAuth callback alone from creating a session or admin account.
- Protect first-install binding and admin creation with an atomic database operation.

## Validation

### Automated

- Post-rebase GitHub provider tests: 40 passed.
- Post-rebase scoped UI tests: 6 files, 66 tests passed.
- GitHub App Helm render contract passed.
- Helm lint passed with default and local values.
- Production UI build passed.
- Focused pre-rebase database tests: organization config 5 passed; user and settings 16 passed.
- Focused pre-rebase server tests: authentication 103 passed; GitHub installation 8 passed; organization sync 5 passed.

### Live onboarding

Validated from a fresh isolated local Kind environment:

1. Opened Djinn as a first-time user.
2. Created and installed the GitHub App.
3. Completed GitHub authentication and MFA.
4. Connected the ChatGPT/Codex provider.
5. Added a repository with its default branch preserved.

The temporary validation App was subsequently deleted and the local environment was reset.

## Known baseline issues

- The post-rebase macOS server-auth rerun is blocked before tests execute by a type mismatch in cargo_warm_base_gc.rs introduced on current main; this branch does not modify that file.
- Vitest vmThreads fails before component imports with the existing React Router ESM/runtime combination; the same scoped suite passes under the default pool.
- Repository-wide test typechecking reports pre-existing fixture/type errors.
- Scoped lint reports the existing react-refresh/only-export-components violation in AuthGate.
- cargo fmt --check reports an existing unchanged formatting issue in djinn-coordinator/src/pr_poller/tests.rs.

## Non-goals

This PR intentionally does not include:

- Model selection for Plan, Implement, and Review roles.
- Catalog image selection or assignment.
- Tilt, image-building, warm-restart, or local build-speed changes.
- Organization-owned GitHub App manifest creation.