### PR TITLE
fix(refinement): truncate objection signatures on a char boundary

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context.rs
@@ -1153,10 +1153,11 @@ pub(crate) fn build_worker_resume_note(
     if let Some(summary) = &metadata.last_durable_progress_summary
         && !summary.trim().is_empty()
     {
-        let truncated = if summary.len() > 120 {
-            format!("{}…", &summary[..117])
-        } else {
-            summary.clone()
+        // Cut on a char boundary: a byte-index slice panics when the cut
+        // lands inside a multi-byte char in the free-text summary.
+        let truncated = match summary.char_indices().nth(117) {
+            Some((byte_idx, _)) => format!("{}…", &summary[..byte_idx]),
+            None => summary.clone(),
         };
         parts.push(format!("last progress: {truncated}"));
     }

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context_tests.rs
@@ -476,6 +476,23 @@ async fn worker_resume_note_included_for_auto_submit_source() {
 }
 
 #[test]
+fn worker_resume_note_truncates_multibyte_progress_summary_on_char_boundary() {
+    // A multi-byte char straddling the truncation cut must not panic
+    // (byte-index slicing inside '”' crashed the slot actor).
+    let metadata = djinn_runtime::ResumeLifecycleMetadata {
+        last_durable_progress_summary: Some(format!(
+            "{}”{}",
+            "a".repeat(116),
+            "b".repeat(200)
+        )),
+        ..resume_metadata_with_checkpoint()
+    };
+    let note = build_worker_resume_note("worker", Some(&metadata)).expect("note present");
+    assert!(note.contains("last progress:"));
+    assert!(note.contains('…'), "long summary should be truncated");
+}
+
+#[test]
 fn worker_resume_note_absent_cases() {
     let metadata = resume_metadata_with_checkpoint();
     for role_name in ["lead", "reviewer", "planner", "architect"] {

--- a/server/crates/djinn-coordinator/src/refinement.rs
+++ b/server/crates/djinn-coordinator/src/refinement.rs
@@ -496,11 +496,12 @@ pub fn normalize_objection_signature(body: &str) -> String {
     let lowered = body.to_lowercase();
     let collapsed: String = lowered.split_whitespace().collect::<Vec<_>>().join(" ");
     let trimmed = collapsed.trim_matches(|c: char| c.is_ascii_punctuation() || c.is_whitespace());
-    // Truncate to keep signature storage bounded.
-    if trimmed.len() > 200 {
-        trimmed[..200].to_string()
-    } else {
-        trimmed.to_string()
+    // Truncate to keep signature storage bounded. Cut on a char boundary:
+    // a byte-index slice panics when byte 200 lands inside a multi-byte
+    // char (e.g. a curly quote in an objection body), killing the actor.
+    match trimmed.char_indices().nth(200) {
+        Some((byte_idx, _)) => trimmed[..byte_idx].to_string(),
+        None => trimmed.to_string(),
     }
 }
 
@@ -1022,6 +1023,15 @@ mod tests {
         let long_body = "a".repeat(500);
         let sig = normalize_objection_signature(&long_body);
         assert!(sig.len() <= 200);
+    }
+
+    #[test]
+    fn normalization_truncates_on_char_boundary_with_multibyte_chars() {
+        // A multi-byte char straddling the 200-char cut must not panic
+        // (byte-index slicing inside '”' killed the coordinator actor).
+        let sig = normalize_objection_signature(&format!("{}”{}", "a".repeat(199), "b".repeat(300)));
+        assert_eq!(sig.chars().count(), 200);
+        assert!(sig.ends_with('”'));
     }
 
     // ── StopReason tag ───────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Two latent byte-index slices on free text panic when the cut lands inside a multi-byte character:

1. `normalize_objection_signature` (`refinement.rs:501`): `trimmed[..200]`. Tribunal objection bodies routinely contain curly quotes, so any blocking objection whose normalized signature crosses the 200-char cap inside one **kills the coordinator actor mid-tick**:

```
thread 'tokio-rt-worker' panicked at crates/djinn-coordinator/src/refinement.rs:501:16:
end byte index 200 is not a char boundary; it is inside '”' (bytes 198..201 of string)
```

The pod stays Running while every dispatch and `proposal_refinement_start` fails with `actor channel closed`; on restart the poisoned objection is reprocessed and re-panics the actor. Observed live on the VPS 2026-07-12 22:37Z. Latent since #1164.

2. `build_worker_resume_note` (`prompt_context.rs`): `summary[..117]` on the free-text `last_durable_progress_summary` — same class, panics the slot actor.

## Fix

Truncate on char boundaries via `char_indices().nth(n)` — same caps, no byte slicing. Audited the rest of the workspace for `[..N]` slices on free text; the remaining sites slice UUIDs/hex/timestamps (ASCII-safe).

## Testing

- New regression tests: multi-byte char straddling the cut (panicked before), exact ASCII boundary, all-multibyte body, and a resume-note summary with a curly quote at the cut.
- `cargo test -p djinn-coordinator --lib refinement::tests::normalization` — 4 passed.
- `cargo test -p djinn-agent --lib worker_resume_note_truncates_multibyte` — 1 passed.