### PR TITLE
ci: grant actions:write so the quality-gate fail-fast cancel actually works

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -11,6 +11,12 @@ on:
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || github.event_name == 'push' && 'ci-main' || github.event_name == 'merge_group' && format('ci-merge-group-{0}', github.event.merge_group.head_sha || github.ref) || format('ci-dispatch-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+# actions: write lets the guard jobs' "Fail fast" steps (`gh run cancel`)
+# actually cancel the run — without it the cancel dies with HTTP 403 and
+# the expensive test/clippy jobs run to completion behind a failed gate.
+permissions:
+  contents: read
+  actions: write
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"


### PR DESCRIPTION
## Problem

Every guard job in `quality-gate.yml` ends with a **Fail fast** step:

```yaml
- name: Fail fast
  if: failure()
  run: gh run cancel ${{ github.run_id }} ... || echo '::warning::Fail-fast cancel failed'
```

But the workflow declares no `permissions:` block and the default `GITHUB_TOKEN` is read-only, so the cancel has **always** failed:

```
HTTP 403: Resource not accessible by integration
##[warning]Fail-fast cancel failed; letting the run finish.
```

(Observed on run 29212200737: Server Size Guard failed in 14s, and the four test shards + clippy + memory-eval all kept running to completion anyway.)

Net effect: every red gate still pays for the full expensive matrix, and djinn workers polling PR CI wait the full wall-clock for a verdict that was known in seconds.

## Fix

Top-level `permissions: { contents: read, actions: write }`. The only `github.token` usages in this workflow are the 11 Fail fast steps, so nothing else needs more than checkout.