### PR TITLE
feat(memory-graph): ship created_at on the wire and scale the canvas to prod graphs

### DIFF
--- a/server/.sqlx/query-1c469df37eeaf9ee74b98ed6037a1c3ebcaa6cfdb2761592e26e7122f6434ee5.json
+++ b/server/.sqlx/query-1c469df37eeaf9ee74b98ed6037a1c3ebcaa6cfdb2761592e26e7122f6434ee5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT n.id AS \"id!\", n.permalink AS \"permalink!\",\n                    n.title AS \"title!\", n.note_type AS \"note_type!\",\n                    n.folder AS \"folder!\",\n                    (SELECT COUNT(*) FROM note_links WHERE source_id = n.id\n                       AND target_id IS NOT NULL)\n                    + (SELECT COUNT(*) FROM note_links WHERE target_id = n.id)\n                      AS \"connection_count!: i64\"\n             FROM notes n\n             WHERE n.project_id = $1\n             ORDER BY n.folder, n.title",
+  "query": "SELECT n.id AS \"id!\", n.permalink AS \"permalink!\",\n                    n.title AS \"title!\", n.note_type AS \"note_type!\",\n                    n.folder AS \"folder!\", n.created_at AS \"created_at!\",\n                    (SELECT COUNT(*) FROM note_links WHERE source_id = n.id\n                       AND target_id IS NOT NULL)\n                    + (SELECT COUNT(*) FROM note_links WHERE target_id = n.id)\n                      AS \"connection_count!: i64\"\n             FROM notes n\n             WHERE n.project_id = $1\n             ORDER BY n.folder, n.title",
   "describe": {
     "columns": [
       {
@@ -30,6 +30,11 @@
       },
       {
         "ordinal": 5,
+        "name": "created_at!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
         "name": "connection_count!: i64",
         "type_info": "Int8"
       }
@@ -45,8 +50,9 @@
       false,
       false,
       false,
+      false,
       null
     ]
   },
-  "hash": "550787895b0dc09a072863220cacf58b1f72bc0897b9c3875d95af0861f54c40"
+  "hash": "1c469df37eeaf9ee74b98ed6037a1c3ebcaa6cfdb2761592e26e7122f6434ee5"
 }

--- a/server/crates/djinn-db/src/repositories/note/graph.rs
+++ b/server/crates/djinn-db/src/repositories/note/graph.rs
@@ -23,7 +23,7 @@ impl NoteRepository {
         let node_rows = sqlx::query!(
             r#"SELECT n.id AS "id!", n.permalink AS "permalink!",
                     n.title AS "title!", n.note_type AS "note_type!",
-                    n.folder AS "folder!",
+                    n.folder AS "folder!", n.created_at AS "created_at!",
                     (SELECT COUNT(*) FROM note_links WHERE source_id = n.id
                        AND target_id IS NOT NULL)
                     + (SELECT COUNT(*) FROM note_links WHERE target_id = n.id)
@@ -72,13 +72,14 @@ impl NoteRepository {
                 folder: row.folder,
                 connection_count: row.connection_count,
                 entity_type: "note".to_string(),
+                created_at: Some(row.created_at),
             })
             .collect();
 
         // ── Proposal nodes ──────────────────────────────────────────────────────
         // Fetch proposals linked to this project via proposal_targets.
         let proposal_rows = sqlx::query(
-            r#"SELECT p.id, p.short_id, p.title
+            r#"SELECT p.id, p.short_id, p.title, p.created_at
                FROM proposals p
                JOIN proposal_targets pt ON pt.proposal_id = p.id
                WHERE pt.project_id = $1"#,
@@ -91,6 +92,7 @@ impl NoteRepository {
             let id: String = row.get("id");
             let short_id: String = row.get("short_id");
             let title: String = row.get("title");
+            let created_at: String = row.get("created_at");
             // Count heterogeneous typed edges incident to this proposal.
             let connection_count: i64 = sqlx::query_scalar(
                 r#"SELECT COUNT(*) FROM memory_entity_associations
@@ -111,6 +113,7 @@ impl NoteRepository {
                 is_orphan: false,
                 broken_targets: Vec::new(),
                 entity_type: "proposal".to_string(),
+                created_at: Some(created_at),
             });
         }
 

--- a/server/crates/djinn-memory/src/note.rs
+++ b/server/crates/djinn-memory/src/note.rs
@@ -465,6 +465,10 @@ pub struct GraphNode {
     /// remain backward-compatible.
     #[serde(default = "default_note_entity_type")]
     pub entity_type: String,
+    /// Creation time (ISO-8601 UTC string, as stored). Drives the graph
+    /// canvas time axis; optional so older serialized responses stay valid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 fn default_note_entity_type() -> String {

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -7728,6 +7728,13 @@
               "description": "Entity type discriminator: `\"note\"` for note rows, `\"proposal\"` for\nproposal rows. Defaults to `\"note\"` so existing serialized responses\nremain backward-compatible.",
               "type": "string",
               "default": "note"
+            },
+            "created_at": {
+              "description": "Creation time (ISO-8601 UTC string, as stored). Drives the graph\ncanvas time axis; optional so older serialized responses stay valid.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -7665,6 +7665,13 @@ expression: signatures
               "format": "int64",
               "type": "integer"
             },
+            "created_at": {
+              "description": "Creation time (ISO-8601 UTC string, as stored). Drives the graph\ncanvas time axis; optional so older serialized responses stay valid.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "entity_type": {
               "default": "note",
               "description": "Entity type discriminator: `\"note\"` for note rows, `\"proposal\"` for\nproposal rows. Defaults to `\"note\"` so existing serialized responses\nremain backward-compatible.",

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -3720,6 +3720,11 @@ export namespace MemoryGraphOutputSchema {
    */
   connection_count: number
   /**
+   * Creation time (ISO-8601 UTC string, as stored). Drives the graph
+   * canvas time axis; optional so older serialized responses stay valid.
+   */
+  created_at?: string
+  /**
    * Entity type discriminator: `"note"` for note rows, `"proposal"` for
    * proposal rows. Defaults to `"note"` so existing serialized responses
    * remain backward-compatible.

--- a/ui/src/components/memory/MemoryGraphCanvas.stories.tsx
+++ b/ui/src/components/memory/MemoryGraphCanvas.stories.tsx
@@ -18,6 +18,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { MemoryGraphCanvas } from "./MemoryGraphCanvas";
+import { createSeededRandom } from "@/lib/memoryGraphAdapter";
 import { setMcpToolResponder } from "@/storybook-mocks/mcpClient";
 
 // ── Seeded memory_graph payloads ─────────────────────────────────────────────
@@ -163,6 +164,42 @@ const largePayload = {
   ],
 };
 
+/**
+ * Prod-scale synthetic payload (~6.5k notes over five months, recency-heavy,
+ * ~55% orphans — the shape that broke the first cut of this canvas). Seeded so
+ * every render is identical.
+ */
+function densePayload(count = 6500) {
+  const rng = createSeededRandom(11);
+  const types = ["pitfall", "case", "adr", "pattern", "reference", "research", "entity", "claim"];
+  const start = ts("2026-02-15T00:00:00Z");
+  const end = ts("2026-07-13T00:00:00Z");
+  const nodes = [];
+  const edges = [];
+  for (let i = 0; i < count; i += 1) {
+    // Recency-heavy spread (prod memory grows over time), with day-level noise.
+    const t = start + Math.floor(Math.pow(rng(), 0.6) * (end - start));
+    const note_type = types[Math.floor(rng() * types.length)];
+    const is_orphan = rng() < 0.55;
+    const connection_count = is_orphan ? 0 : Math.floor(rng() * rng() * 12);
+    nodes.push({
+      id: `n${i}`,
+      permalink: `memory/${note_type}/n${i}`,
+      title: `Synthetic note ${i}`,
+      note_type,
+      folder: `memory/${note_type}`,
+      connection_count,
+      is_orphan,
+      broken_targets: [],
+      created_at: t,
+    });
+    if (i > 0 && !is_orphan && rng() < 0.6) {
+      edges.push({ source_id: `n${i}`, target_id: `n${Math.floor(rng() * i)}`, raw_text: `Synthetic note` });
+    }
+  }
+  return { nodes, edges, typed_edges: [] };
+}
+
 /** Same notes with `created_at` stripped — drives the ordinal-fallback path. */
 const undatedPayload = {
   ...smallPayload,
@@ -215,6 +252,13 @@ export const SmallGraph: Story = {
 export const LargeGraph: Story = {
   beforeEach: () => {
     setMcpToolResponder(graphResponder(largePayload));
+  },
+};
+
+/** ~6.5k dated notes (prod scale) — layout speed, density scaling, orphan dimming. */
+export const DenseGraph: Story = {
+  beforeEach: () => {
+    setMcpToolResponder(graphResponder(densePayload()));
   },
 };
 

--- a/ui/src/components/memory/MemoryGraphCanvas.tsx
+++ b/ui/src/components/memory/MemoryGraphCanvas.tsx
@@ -195,9 +195,14 @@ function bucketStart(ts: number, unit: (typeof UNITS)[number]): number {
 const populatedStarts = (stamps: number[], unit: (typeof UNITS)[number]) =>
   [...new Set(stamps.map((t) => bucketStart(t, unit)))].sort((a, b) => a - b);
 
-/** Aim for ~5–12 rings (growing ~log2 with span), snapped to a calendar interval. */
-function chooseUnit(stamps: number[], spanDays: number): (typeof UNITS)[number] {
-  const target = clamp(Math.round(4 + Math.log2(Math.max(1, spanDays / 60))), 5, 12);
+/**
+ * Aim for ~5–12 rings (growing ~log2 with span), snapped to a calendar
+ * interval. Dense graphs push the target up so the disk grows outward and
+ * thousands of notes get room instead of packing a fixed area solid.
+ */
+function chooseUnit(stamps: number[], spanDays: number, nodeCount: number): (typeof UNITS)[number] {
+  const densityBoost = nodeCount > 200 ? Math.round(Math.log2(nodeCount / 200)) : 0;
+  const target = clamp(Math.round(4 + Math.log2(Math.max(1, spanDays / 60))) + densityBoost, 5, 24);
   let best = UNITS[0];
   let bestScore = Number.POSITIVE_INFINITY;
   for (const unit of UNITS) {
@@ -258,7 +263,7 @@ function buildDisk(payload: MemoryGraphOutput): DiskModel {
   let rings: DiskRing[];
   let ringIndexOf: (n: MemoryGraphOutput["nodes"][number]) => number;
   if (timed && minTs !== null && maxTs !== null) {
-    const unit = chooseUnit(stamps, (maxTs - minTs) / DAY);
+    const unit = chooseUnit(stamps, (maxTs - minTs) / DAY, rawNodes.length);
     const starts = populatedStarts(stamps, unit);
     const last = Math.max(1, starts.length - 1);
     const indexOfStart = new Map(starts.map((s, i) => [s, i]));
@@ -272,10 +277,13 @@ function buildDisk(payload: MemoryGraphOutput): DiskModel {
       return ts !== null ? (indexOfStart.get(bucketStart(ts, unit)) ?? starts.length - 1) : starts.length - 1;
     };
   } else {
-    rings = Array.from({ length: RING_STEPS + 1 }, (_, i) => ({
+    // Undated fallback: scale the ring count with node count so a large
+    // graph still gets a proportionally large disk.
+    const steps = clamp(Math.round(Math.sqrt(rawNodes.length) / 6), RING_STEPS, 24);
+    rings = Array.from({ length: steps + 1 }, (_, i) => ({
       label: null,
       r: ringRadius(i),
-      ratio: recForRatio(i / RING_STEPS),
+      ratio: recForRatio(i / steps),
     }));
     ringIndexOf = (n) => {
       const rec = recOf(n);
@@ -313,6 +321,10 @@ function buildDisk(payload: MemoryGraphOutput): DiskModel {
   const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
   const orderIndex = new Map(ordered.map((n, i) => [n.id, i]));
 
+  // Shrink orbs as the graph grows so dense disks read as star fields, not a
+  // solid ball. ~1500 notes is where the default size starts crowding.
+  const sizeScale = clamp(Math.sqrt(1500 / Math.max(1, rawNodes.length)), 0.45, 1);
+
   const nodes: DiskNode[] = rawNodes.map((n) => {
     const rec = recOf(n);
     const tr = placeRadius(ringIndexOf(n), n.id);
@@ -331,7 +343,7 @@ function buildDisk(payload: MemoryGraphOutput): DiskModel {
       rec,
       igniteAt: igniteByNode.get(n.id) ?? rec,
       tr,
-      r: 3 + Math.sqrt(connectionCount) * 0.9 + (n.entity_type === "proposal" ? 0.6 : 0),
+      r: Math.max(1.1, (3 + Math.sqrt(connectionCount) * 0.9 + (n.entity_type === "proposal" ? 0.6 : 0)) * sizeScale),
       x: Math.cos(angle) * tr,
       y: Math.sin(angle) * tr,
       vx: 0,
@@ -356,35 +368,79 @@ function buildDisk(payload: MemoryGraphOutput): DiskModel {
   return { links, maxTs, minTs, nodes, rings, timed };
 }
 
+/** Short-range repulsion cutoff (world units, squared). */
+const REPULSE_CUTOFF_SQ = 2600;
+const GRID_CELL = Math.ceil(Math.sqrt(REPULSE_CUTOFF_SQ));
+
 /**
  * Tiny bespoke force relaxation: a dominant radial spring pins each node to
  * its date band; short-range repulsion, weak link springs, and collision
  * passes fan co-timed nodes out by angle. Runs once at build time.
+ *
+ * Neighbor lookups go through a uniform grid (cell = the repulsion cutoff),
+ * so a tick is O(n · local density) instead of O(n²) — a 6.5k-note prod
+ * graph relaxes in well under a second where the naive pairwise version
+ * froze the tab.
  */
 function relax(nodes: DiskNode[], links: DiskLink[]): void {
+  const ticks = nodes.length > 2500 ? 120 : nodes.length > 800 ? 200 : 300;
+  const grid = new Map<number, number[]>();
+  const cellOf = (x: number, y: number) =>
+    (Math.floor(x / GRID_CELL) + 32768) * 65536 + (Math.floor(y / GRID_CELL) + 32768);
+
   let alpha = 1;
-  for (let tick = 0; tick < 300 && alpha > 0.02; tick += 1) {
+  for (let tick = 0; tick < ticks && alpha > 0.02; tick += 1) {
     for (const n of nodes) {
       const r = Math.hypot(n.x, n.y) || 1;
       const k = ((n.tr - r) * 0.55 * alpha) / r;
       n.vx += n.x * k;
       n.vy += n.y * k;
     }
+
+    grid.clear();
+    nodes.forEach((n, i) => {
+      const key = cellOf(n.x, n.y);
+      const cell = grid.get(key);
+      if (cell) cell.push(i);
+      else grid.set(key, [i]);
+    });
+
+    // Repulsion + positional collision in one 3×3-neighborhood sweep; each
+    // pair is handled once from the lower index.
     for (let i = 0; i < nodes.length; i += 1) {
-      for (let j = i + 1; j < nodes.length; j += 1) {
-        const a = nodes[i];
-        const b = nodes[j];
-        const dx = b.x - a.x;
-        const dy = b.y - a.y;
-        const d2 = dx * dx + dy * dy;
-        if (d2 > 2600 || d2 === 0) continue;
-        const f = (14 * alpha) / d2;
-        a.vx -= dx * f;
-        a.vy -= dy * f;
-        b.vx += dx * f;
-        b.vy += dy * f;
+      const a = nodes[i];
+      const cx = Math.floor(a.x / GRID_CELL);
+      const cy = Math.floor(a.y / GRID_CELL);
+      for (let gx = cx - 1; gx <= cx + 1; gx += 1) {
+        for (let gy = cy - 1; gy <= cy + 1; gy += 1) {
+          const cell = grid.get((gx + 32768) * 65536 + (gy + 32768));
+          if (!cell) continue;
+          for (const j of cell) {
+            if (j <= i) continue;
+            const b = nodes[j];
+            const dx = b.x - a.x;
+            const dy = b.y - a.y;
+            const d2 = dx * dx + dy * dy;
+            if (d2 > REPULSE_CUTOFF_SQ || d2 === 0) continue;
+            const f = (14 * alpha) / d2;
+            a.vx -= dx * f;
+            a.vy -= dy * f;
+            b.vx += dx * f;
+            b.vy += dy * f;
+            const min = a.r + b.r + 2.5;
+            if (d2 < min * min) {
+              const d = Math.sqrt(d2);
+              const push = (min - d) / d / 2;
+              a.x -= dx * push;
+              a.y -= dy * push;
+              b.x += dx * push;
+              b.y += dy * push;
+            }
+          }
+        }
       }
     }
+
     for (const l of links) {
       const a = nodes[l.a];
       const b = nodes[l.b];
@@ -403,25 +459,86 @@ function relax(nodes: DiskNode[], links: DiskLink[]): void {
       n.x += n.vx;
       n.y += n.vy;
     }
-    // Positional collision pass.
-    for (let i = 0; i < nodes.length; i += 1) {
-      for (let j = i + 1; j < nodes.length; j += 1) {
-        const a = nodes[i];
-        const b = nodes[j];
-        const min = a.r + b.r + 2.5;
-        const dx = b.x - a.x;
-        const dy = b.y - a.y;
-        const d = Math.hypot(dx, dy);
-        if (d >= min || d === 0) continue;
-        const push = (min - d) / d / 2;
-        a.x -= dx * push;
-        a.y -= dy * push;
-        b.x += dx * push;
-        b.y += dy * push;
-      }
-    }
     alpha *= 0.985;
   }
+}
+
+// ── Orb rendering ────────────────────────────────────────────────────────────
+
+/** Supersample factor for cached orb sprites (stays crisp up to ~3× zoom). */
+const SPRITE_SS = 3;
+
+/** Paint one orb (glow + body + highlight core) at (x, y) with radius r·scale. */
+function drawOrb(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  color: string,
+  bodyInk: number,
+  glowInk: number,
+  glowMult: number,
+  isProposal: boolean,
+  scale: number,
+): void {
+  const gr = r * glowMult * scale;
+  const rr = r * scale;
+  const glow = ctx.createRadialGradient(x, y, 0, x, y, gr);
+  glow.addColorStop(0, rgba(color, glowInk));
+  glow.addColorStop(1, rgba(color, 0));
+  ctx.fillStyle = glow;
+  ctx.beginPath();
+  ctx.arc(x, y, gr, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.beginPath();
+  if (isProposal) {
+    // Proposals are diamonds; notes are orbs.
+    ctx.moveTo(x, y - rr);
+    ctx.lineTo(x + rr, y);
+    ctx.lineTo(x, y + rr);
+    ctx.lineTo(x - rr, y);
+    ctx.closePath();
+  } else {
+    ctx.arc(x, y, rr, 0, Math.PI * 2);
+  }
+  ctx.fillStyle = rgba(color, bodyInk);
+  ctx.fill();
+  // A brighter core so dense clusters read as individual stars.
+  ctx.beginPath();
+  ctx.arc(x - rr * 0.25, y - rr * 0.25, rr * 0.35, 0, Math.PI * 2);
+  ctx.fillStyle = `rgba(255,255,255,${(bodyInk * 0.5).toFixed(3)})`;
+  ctx.fill();
+}
+
+/**
+ * Cached supersampled orb sprite. Radius and ink are quantized so the cache
+ * stays bounded (colors × ~radius steps × 9 ink levels × 2 glyphs); birth and
+ * age transitions step through quantized levels, which is invisible at orb
+ * sizes.
+ */
+function orbSprite(
+  cache: Map<string, HTMLCanvasElement>,
+  color: string,
+  r: number,
+  ink: number,
+  glowMult: number,
+  isProposal: boolean,
+): HTMLCanvasElement {
+  const rq = Math.max(0.5, Math.round(r * 2) / 2);
+  const inkq = Math.round(clamp(ink, 0, 1) * 8) / 8;
+  const key = `${color}|${rq}|${inkq}|${isProposal ? "p" : "n"}|${glowMult}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+  if (cache.size > 1500) cache.clear();
+  const half = Math.ceil(rq * glowMult * SPRITE_SS) + 2;
+  const sprite = document.createElement("canvas");
+  sprite.width = half * 2;
+  sprite.height = half * 2;
+  const g = sprite.getContext("2d");
+  if (g) drawOrb(g, half, half, rq, color, inkq, inkq * 0.38, glowMult, isProposal, SPRITE_SS);
+  cache.set(key, sprite);
+  return sprite;
 }
 
 // ── Component ────────────────────────────────────────────────────────────────
@@ -544,6 +661,10 @@ export function MemoryGraphCanvas({ projectSlug, reloadKey, onSelectNote }: Memo
     ro.observe(container);
     cameraRef.current = fitCamera(size.w, size.h, fullOuter, fullOuter);
 
+    // Orb sprite cache for this graph; tighter glow on dense disks.
+    const sprites = new Map<string, HTMLCanvasElement>();
+    const glowMult = disk.nodes.length > 1500 ? 2.4 : 3.4;
+
     // Static starfield, seeded so it never re-rolls between frames.
     const rand = createSeededRandom(7);
     const stars = Array.from({ length: 160 }, () => ({
@@ -648,68 +769,80 @@ export function MemoryGraphCanvas({ projectSlug, reloadKey, onSelectNote }: Memo
         ctx.stroke();
       });
 
-      // Links: quiet threads; a hovered node's links light up.
+      // Links: quiet threads; a hovered node's links light up. Quiet edges
+      // batch into one path per style so a 10k-edge graph costs a handful of
+      // stroke calls, not one per edge.
       const hover = hoverRef.current;
       const revealed = (idx: number) => disk.nodes[idx].igniteAt <= reveal + 1e-3;
+      const hotLinks: DiskLink[] = [];
+      const quietByStyle = new Map<string, DiskLink[]>();
       for (const l of disk.links) {
         if (!revealed(l.a) || !revealed(l.b)) continue;
-        const a = disk.nodes[l.a];
-        const b = disk.nodes[l.b];
-        const hot = hover === l.a || hover === l.b;
-        const typed = TYPED_EDGE_STYLES[l.kind];
+        if (hover === l.a || hover === l.b) {
+          hotLinks.push(l);
+          continue;
+        }
+        const bucket = quietByStyle.get(l.kind);
+        if (bucket) bucket.push(l);
+        else quietByStyle.set(l.kind, [l]);
+      }
+      for (const [kind, bucket] of quietByStyle) {
+        const typed = TYPED_EDGE_STYLES[kind];
         ctx.beginPath();
-        ctx.moveTo(a.x, a.y);
-        ctx.lineTo(b.x, b.y);
+        for (const l of bucket) {
+          ctx.moveTo(disk.nodes[l.a].x, disk.nodes[l.a].y);
+          ctx.lineTo(disk.nodes[l.b].x, disk.nodes[l.b].y);
+        }
         if (typed) {
-          ctx.strokeStyle = rgba(typed.color, hot ? 0.85 : 0.3);
-          ctx.lineWidth = (hot ? 1.4 : 0.9) / cam.k;
+          ctx.strokeStyle = rgba(typed.color, 0.3);
+          ctx.lineWidth = 0.9 / cam.k;
           ctx.setLineDash(typed.dashed ? [4 / cam.k, 4 / cam.k] : []);
         } else {
-          ctx.strokeStyle = `rgba(148,163,184,${hot ? 0.7 : 0.14})`;
-          ctx.lineWidth = (hot ? 1.2 : 0.7) / cam.k;
+          ctx.strokeStyle = "rgba(148,163,184,0.14)";
+          ctx.lineWidth = 0.7 / cam.k;
+          ctx.setLineDash([]);
+        }
+        ctx.stroke();
+      }
+      for (const l of hotLinks) {
+        const typed = TYPED_EDGE_STYLES[l.kind];
+        ctx.beginPath();
+        ctx.moveTo(disk.nodes[l.a].x, disk.nodes[l.a].y);
+        ctx.lineTo(disk.nodes[l.b].x, disk.nodes[l.b].y);
+        if (typed) {
+          ctx.strokeStyle = rgba(typed.color, 0.85);
+          ctx.lineWidth = 1.4 / cam.k;
+          ctx.setLineDash(typed.dashed ? [4 / cam.k, 4 / cam.k] : []);
+        } else {
+          ctx.strokeStyle = "rgba(148,163,184,0.7)";
+          ctx.lineWidth = 1.2 / cam.k;
           ctx.setLineDash([]);
         }
         ctx.stroke();
       }
       ctx.setLineDash([]);
 
-      // Nodes: glow + core, aged ink, warp-in on ignite.
+      // Nodes: glow + core, aged ink, warp-in on ignite. Steady-state nodes
+      // draw from a sprite cache (one drawImage each) so big graphs never pay
+      // for per-node gradient allocation; only the hovered node paints live.
       const appear = appearRef.current;
       disk.nodes.forEach((n, i) => {
         const on = n.igniteAt <= reveal + 1e-3;
         appear[i] = clamp(appear[i] + (on ? 1 : -1) * (dt / 420), 0, 1);
         if (appear[i] <= 0.01) return;
         const birth = smooth(appear[i]);
-        const ink = styleInk(n.rec) * birth;
+        // Orphans dim to 55% so a mostly-orphan graph doesn't drown in red.
+        const ink = styleInk(n.rec) * birth * (n.isOrphan ? 0.55 : 1);
         const hot = hover === i;
         const r = n.r * (0.35 + 0.65 * birth) * (hot ? 1.25 : 1);
 
-        const glow = ctx.createRadialGradient(n.x, n.y, 0, n.x, n.y, r * 3.4);
-        glow.addColorStop(0, rgba(n.color, ink * (hot ? 0.6 : 0.38)));
-        glow.addColorStop(1, rgba(n.color, 0));
-        ctx.fillStyle = glow;
-        ctx.beginPath();
-        ctx.arc(n.x, n.y, r * 3.4, 0, Math.PI * 2);
-        ctx.fill();
-
-        ctx.beginPath();
-        if (n.isProposal) {
-          // Proposals are diamonds; notes are orbs.
-          ctx.moveTo(n.x, n.y - r);
-          ctx.lineTo(n.x + r, n.y);
-          ctx.lineTo(n.x, n.y + r);
-          ctx.lineTo(n.x - r, n.y);
-          ctx.closePath();
-        } else {
-          ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+        if (hot) {
+          drawOrb(ctx, n.x, n.y, r, n.color, clamp(ink + 0.15, 0, 1), 0.6 * ink, glowMult, n.isProposal, 1);
+          return;
         }
-        ctx.fillStyle = rgba(n.color, clamp(ink + (hot ? 0.15 : 0), 0, 1));
-        ctx.fill();
-        // A brighter core so dense clusters read as individual stars.
-        ctx.beginPath();
-        ctx.arc(n.x - r * 0.25, n.y - r * 0.25, r * 0.35, 0, Math.PI * 2);
-        ctx.fillStyle = `rgba(255,255,255,${(ink * 0.5).toFixed(3)})`;
-        ctx.fill();
+        const sprite = orbSprite(sprites, n.color, r, ink, glowMult, n.isProposal);
+        const w = sprite.width / SPRITE_SS;
+        ctx.drawImage(sprite, n.x - w / 2, n.y - w / 2, w, w);
       });
 
       ctx.restore();

--- a/ui/src/lib/memoryGraphAdapter.test.ts
+++ b/ui/src/lib/memoryGraphAdapter.test.ts
@@ -196,14 +196,14 @@ describe("parseMemoryGraphResponse", () => {
     ]);
   });
 
-  it("passes through created_at as epoch seconds or ISO string", () => {
+  it("passes through ISO created_at and normalizes epoch seconds to ISO", () => {
     const parsed = parseMemoryGraphResponse({
       nodes: [
         { id: "num", created_at: 1773964800 },
         { id: "iso", created_at: "2026-07-12T08:00:00Z" },
       ],
     });
-    expect(parsed!.nodes[0].created_at).toBe(1773964800);
+    expect(parsed!.nodes[0].created_at).toBe(new Date(1773964800 * 1000).toISOString());
     expect(parsed!.nodes[1].created_at).toBe("2026-07-12T08:00:00Z");
   });
 

--- a/ui/src/lib/memoryGraphAdapter.ts
+++ b/ui/src/lib/memoryGraphAdapter.ts
@@ -132,14 +132,16 @@ export function parseMemoryGraphResponse(raw: unknown): MemoryGraphOutput | null
             : 0,
         is_orphan: n.is_orphan === true,
         broken_targets: brokenTargets,
-        // Optional wire fields passed through untouched: the graph canvas
-        // reads `entity_type` (note vs proposal glyph) and `created_at`
-        // (epoch seconds or ISO string) when the backend provides them.
+        // Optional wire fields the graph canvas reads: `entity_type` (note vs
+        // proposal glyph) and `created_at`. The wire type is an ISO-8601
+        // string; numeric epoch seconds (accepted for fixtures) normalize to
+        // ISO so the parsed shape always matches `GraphNode`.
         ...(typeof n.entity_type === "string" ? { entity_type: n.entity_type } : {}),
-        ...(typeof n.created_at === "string" ||
-        (typeof n.created_at === "number" && Number.isFinite(n.created_at))
+        ...(typeof n.created_at === "string"
           ? { created_at: n.created_at }
-          : {}),
+          : typeof n.created_at === "number" && Number.isFinite(n.created_at)
+            ? { created_at: new Date(n.created_at * 1000).toISOString() }
+            : {}),
       };
     })
     .filter((n) => n.id.length > 0);


### PR DESCRIPTION
## Why

The new time-disk canvas fell apart on prod (6,573 notes): `memory_graph` ships no timestamps, so layout fell back to a five-ring ordinal spread and packed everything into a solid ball; the O(n²) relaxation froze the tab; per-frame gradient allocation kept it slow afterwards; and the orphan-red override painted most of the disk red.

## Backend

`GraphNode` gains an optional `created_at` (ISO-8601 string, as stored) populated for both note and proposal rows — the canvas time axis now works on prod. Regenerated: tool-schema snapshot, generated UI types, sqlx offline cache.

## Frontend (canvas)

- **Layout perf**: `relax()` neighbor lookups use a uniform grid with adaptive tick count — O(n · local density) instead of O(n²). 6.5k notes settle in well under a second.
- **Render perf**: steady-state orbs draw from a quantized supersampled sprite cache (one `drawImage` each); quiet edges batch into one stroked path per style; only the hovered node paints live gradients.
- **Density scaling**: orb radius shrinks past ~1.5k notes; calendar bucketing targets more rings on dense graphs; the undated fallback grows ring count with √n — big graphs grow the disk outward instead of packing a fixed area solid.
- **Orphan dimming**: orphans render at 55% ink, so a mostly-orphan graph reads as a star field with red accents, not a red wall.
- Parser normalizes numeric epoch `created_at` to ISO strings so the parsed shape matches the wire type.

## Verification

- New seeded `DenseGraph` story (~6.5k notes, recency-heavy, 55% orphans): interactive ~2.3s from cold navigation in Storybook (previously multi-second freeze), biweekly dated rings, legible star-field at full reveal, hover pill works.
- Server: `cargo clippy` (no new warnings vs baseline), 63 djinn-db graph tests pass, tool_schemas snapshots updated via insta, `make sqlx-prepare` clean.
- UI: `tsc -b`, eslint, adapter tests (20) green; `pnpm mcp:types:check` clean.