### PR TITLE
feat(kanban): proposal swimlanes — group the board by building proposals

### DIFF
--- a/server/.sqlx/query-21f2b4d78d265eb6a0193ccf58d2fbe2bc51efd8b3087916626697180e44b1c7.json
+++ b/server/.sqlx/query-21f2b4d78d265eb6a0193ccf58d2fbe2bc51efd8b3087916626697180e44b1c7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT e.id, e.project_id, e.short_id, e.title, e.description, e.emoji, e.color,\n                    e.status AS \"status!\", e.owner, e.created_at, e.updated_at, e.closed_at,\n                    e.memory_refs::text AS \"memory_refs!\", e.auto_breakdown AS \"auto_breakdown!: bool\",\n                    e.originating_adr_id, e.created_by_user_id\n             FROM epic_blockers b\n             JOIN epics e ON e.id = b.epic_id\n             WHERE b.blocking_epic_id = $1\n               AND e.status = 'open'\n               AND NOT EXISTS (\n                   SELECT 1 FROM epic_blockers b2\n                   JOIN epics be ON be.id = b2.blocking_epic_id\n                   WHERE b2.epic_id = e.id AND be.status != 'closed'\n               )",
+  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id, proposal_id\n             FROM epics WHERE project_id = $1 AND (id = $2 OR short_id = $3)",
   "describe": {
     "columns": [
       {
@@ -82,10 +82,17 @@
         "ordinal": 15,
         "name": "created_by_user_id",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 16,
+        "name": "proposal_id",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
       "Left": [
+        "Text",
+        "Text",
         "Text"
       ]
     },
@@ -105,8 +112,9 @@
       null,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "dde22f45d0d0f92cbee2d81b47dcc2be09fc70d0191d58037f6d0f6e1d11755a"
+  "hash": "21f2b4d78d265eb6a0193ccf58d2fbe2bc51efd8b3087916626697180e44b1c7"
 }

--- a/server/.sqlx/query-2e53757f78b065067d36e3415fef2bdcf5bb2ae4c5b0b4e39a0b7a240352d9f6.json
+++ b/server/.sqlx/query-2e53757f78b065067d36e3415fef2bdcf5bb2ae4c5b0b4e39a0b7a240352d9f6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id\n             FROM epics ORDER BY created_at",
+  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id, proposal_id\n             FROM epics WHERE id = $1",
   "describe": {
     "columns": [
       {
@@ -82,10 +82,17 @@
         "ordinal": 15,
         "name": "created_by_user_id",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 16,
+        "name": "proposal_id",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
-      "Left": []
+      "Left": [
+        "Text"
+      ]
     },
     "nullable": [
       false,
@@ -103,8 +110,9 @@
       null,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "8f48ab498ac5f22a5cef794d649b761dd8317c7e7b833aac5357ca9be6604a37"
+  "hash": "2e53757f78b065067d36e3415fef2bdcf5bb2ae4c5b0b4e39a0b7a240352d9f6"
 }

--- a/server/.sqlx/query-414165863459fcf7ba77d590d38d16b465c239da7642b0278540514e0d43fcad.json
+++ b/server/.sqlx/query-414165863459fcf7ba77d590d38d16b465c239da7642b0278540514e0d43fcad.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id\n             FROM epics WHERE short_id = $1",
+  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id, proposal_id\n             FROM epics WHERE short_id = $1",
   "describe": {
     "columns": [
       {
@@ -82,6 +82,11 @@
         "ordinal": 15,
         "name": "created_by_user_id",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 16,
+        "name": "proposal_id",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
@@ -105,8 +110,9 @@
       null,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "f2cf44b1004a9865c9bb48e4254851395db8965fc58ebceac647122bf3740859"
+  "hash": "414165863459fcf7ba77d590d38d16b465c239da7642b0278540514e0d43fcad"
 }

--- a/server/.sqlx/query-6768e7ec0f98e4c5b64201c1eb6af148ba5877ce54b2c9be24136a4713f82748.json
+++ b/server/.sqlx/query-6768e7ec0f98e4c5b64201c1eb6af148ba5877ce54b2c9be24136a4713f82748.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id\n             FROM epics WHERE id = $1",
+  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id, proposal_id\n             FROM epics WHERE id = $1 OR short_id = $2",
   "describe": {
     "columns": [
       {
@@ -82,10 +82,16 @@
         "ordinal": 15,
         "name": "created_by_user_id",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 16,
+        "name": "proposal_id",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
       "Left": [
+        "Text",
         "Text"
       ]
     },
@@ -105,8 +111,9 @@
       null,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "a76eef3f70169f952b069d023a110bf00bac25b420da000be018123d2aa70b6d"
+  "hash": "6768e7ec0f98e4c5b64201c1eb6af148ba5877ce54b2c9be24136a4713f82748"
 }

--- a/server/.sqlx/query-7314858a39842c6f07cc4ffed8b66f3c479b7ed126426fd6f4bc47391129ac86.json
+++ b/server/.sqlx/query-7314858a39842c6f07cc4ffed8b66f3c479b7ed126426fd6f4bc47391129ac86.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, project_id, short_id, title, description, emoji, color, status,\n                owner, created_at, updated_at, closed_at, memory_refs::text AS \"memory_refs!\",\n                auto_breakdown AS \"auto_breakdown!: bool\",\n                originating_adr_id, created_by_user_id\n         FROM epics WHERE id = $1",
+  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id, proposal_id\n             FROM epics ORDER BY created_at",
   "describe": {
     "columns": [
       {
@@ -40,7 +40,7 @@
       },
       {
         "ordinal": 7,
-        "name": "status",
+        "name": "status!",
         "type_info": "Varchar"
       },
       {
@@ -82,12 +82,15 @@
         "ordinal": 15,
         "name": "created_by_user_id",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 16,
+        "name": "proposal_id",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
-      "Left": [
-        "Text"
-      ]
+      "Left": []
     },
     "nullable": [
       false,
@@ -105,8 +108,9 @@
       null,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "2daa1e0f1b319e2a668fde38b8902384a9b61565c1caa23b15097dc8adb566aa"
+  "hash": "7314858a39842c6f07cc4ffed8b66f3c479b7ed126426fd6f4bc47391129ac86"
 }

--- a/server/.sqlx/query-8e4fe05d44eba74b7d4940c479f7dcf8762f524d3e96a7f0b244a21c1c2dfa26.json
+++ b/server/.sqlx/query-8e4fe05d44eba74b7d4940c479f7dcf8762f524d3e96a7f0b244a21c1c2dfa26.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id\n             FROM epics WHERE id = $1 OR short_id = $2",
+  "query": "SELECT id, project_id, short_id, title, description, emoji, color, status,\n                owner, created_at, updated_at, closed_at, memory_refs::text AS \"memory_refs!\",\n                auto_breakdown AS \"auto_breakdown!: bool\",\n                originating_adr_id, created_by_user_id, proposal_id\n         FROM epics WHERE id = $1",
   "describe": {
     "columns": [
       {
@@ -40,7 +40,7 @@
       },
       {
         "ordinal": 7,
-        "name": "status!",
+        "name": "status",
         "type_info": "Varchar"
       },
       {
@@ -82,11 +82,15 @@
         "ordinal": 15,
         "name": "created_by_user_id",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 16,
+        "name": "proposal_id",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Text"
       ]
     },
@@ -106,8 +110,9 @@
       null,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "90b55e771c487357099695682c5cf9e91e3f3250476afa89559268e2b1e2f139"
+  "hash": "8e4fe05d44eba74b7d4940c479f7dcf8762f524d3e96a7f0b244a21c1c2dfa26"
 }

--- a/server/.sqlx/query-a2a69e6d6e9f038e6400b3d0004577d3b83be38bc79baeebdd3eafc1b0c2d4c7.json
+++ b/server/.sqlx/query-a2a69e6d6e9f038e6400b3d0004577d3b83be38bc79baeebdd3eafc1b0c2d4c7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, project_id, short_id, title, description, emoji, color,\n                    status AS \"status!\", owner, created_at, updated_at, closed_at,\n                    memory_refs::text AS \"memory_refs!\", auto_breakdown AS \"auto_breakdown!: bool\",\n                    originating_adr_id, created_by_user_id\n             FROM epics WHERE project_id = $1 AND (id = $2 OR short_id = $3)",
+  "query": "SELECT e.id, e.project_id, e.short_id, e.title, e.description, e.emoji, e.color,\n                    e.status AS \"status!\", e.owner, e.created_at, e.updated_at, e.closed_at,\n                    e.memory_refs::text AS \"memory_refs!\", e.auto_breakdown AS \"auto_breakdown!: bool\",\n                    e.originating_adr_id, e.created_by_user_id, e.proposal_id\n             FROM epic_blockers b\n             JOIN epics e ON e.id = b.epic_id\n             WHERE b.blocking_epic_id = $1\n               AND e.status = 'open'\n               AND NOT EXISTS (\n                   SELECT 1 FROM epic_blockers b2\n                   JOIN epics be ON be.id = b2.blocking_epic_id\n                   WHERE b2.epic_id = e.id AND be.status != 'closed'\n               )",
   "describe": {
     "columns": [
       {
@@ -82,12 +82,15 @@
         "ordinal": 15,
         "name": "created_by_user_id",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 16,
+        "name": "proposal_id",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Text",
         "Text"
       ]
     },
@@ -107,8 +110,9 @@
       null,
       false,
       true,
+      true,
       true
     ]
   },
-  "hash": "8b4aef8bb345f1de307be9440204eb1d297c643cfaca82b74c41f60dbb495cbf"
+  "hash": "a2a69e6d6e9f038e6400b3d0004577d3b83be38bc79baeebdd3eafc1b0c2d4c7"
 }

--- a/server/.sqlx/query-fe8a28496626da558b5ba36a72be26ef7cc821289d242dcdd5daed1909bafbab.json
+++ b/server/.sqlx/query-fe8a28496626da558b5ba36a72be26ef7cc821289d242dcdd5daed1909bafbab.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE epics SET proposal_id = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fe8a28496626da558b5ba36a72be26ef7cc821289d242dcdd5daed1909bafbab"
+}

--- a/server/crates/djinn-control-plane/src/tools/epic_ops.rs
+++ b/server/crates/djinn-control-plane/src/tools/epic_ops.rs
@@ -44,6 +44,29 @@ pub struct EpicModel {
     /// `TaskModel::created_by_user_id`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_by_user_id: Option<String>,
+    /// Originating proposal id (denormalized from `proposal_epics` at
+    /// graduation). `None` for hand-created epics. The board groups its
+    /// swimlanes by it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_id: Option<String>,
+    /// Proposal short id, enriched on `epic_list` responses so the board can
+    /// label and link proposal swimlanes without loading proposals.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_short_id: Option<String>,
+    /// Proposal title, enriched on `epic_list` responses (see
+    /// `proposal_short_id`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_title: Option<String>,
+    /// Proposal status (`building`, `shipped`, …), enriched on `epic_list`
+    /// responses. The board only renders proposal swimlanes for `building`
+    /// proposals so the kanban stays scoped to active work.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_status: Option<String>,
+    /// Build owner of the proposal (whose credentials the build consumes),
+    /// enriched on `epic_list` responses. The board shows their avatar on the
+    /// proposal swimlane.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_build_owner_user_id: Option<String>,
 }
 
 impl From<&Epic> for EpicModel {
@@ -64,6 +87,11 @@ impl From<&Epic> for EpicModel {
             auto_breakdown: e.auto_breakdown,
             originating_adr_id: e.originating_adr_id.clone(),
             created_by_user_id: e.created_by_user_id.clone(),
+            proposal_id: e.proposal_id.clone(),
+            proposal_short_id: None,
+            proposal_title: None,
+            proposal_status: None,
+            proposal_build_owner_user_id: None,
         }
     }
 }

--- a/server/crates/djinn-control-plane/src/tools/epic_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/epic_tools.rs
@@ -568,14 +568,60 @@ impl DjinnMcpServer {
         };
         let repo = EpicRepository::new(self.state.db().clone(), self.state.event_bus());
         match repo.list_filtered(query).await {
-            Ok(result) => Json(list_response::success::<EpicListResponse>(
-                result.epics.iter().map(EpicModel::from).collect(),
-                result.total_count,
-                limit,
-                offset,
-            )),
+            Ok(result) => {
+                let mut epics: Vec<EpicModel> =
+                    result.epics.iter().map(EpicModel::from).collect();
+                if let Err(e) = self.enrich_epic_proposal_refs(&mut epics).await {
+                    return Json(list_response::error::<EpicListResponse>(e));
+                }
+                Json(list_response::success::<EpicListResponse>(
+                    epics,
+                    result.total_count,
+                    limit,
+                    offset,
+                ))
+            }
             Err(e) => Json(list_response::error::<EpicListResponse>(e.to_string())),
         }
+    }
+
+    /// Fill `proposal_short_id`/`proposal_title`/`proposal_status` on epics
+    /// that carry a `proposal_id`, with one batched proposals lookup. Lets the
+    /// board label proposal swimlanes without hydrating proposals.
+    async fn enrich_epic_proposal_refs(
+        &self,
+        epics: &mut [EpicModel],
+    ) -> std::result::Result<(), String> {
+        let mut ids: Vec<String> = epics
+            .iter()
+            .filter_map(|e| e.proposal_id.clone())
+            .collect();
+        ids.sort();
+        ids.dedup();
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let proposals =
+            djinn_db::ProposalRepository::new(self.state.db().clone(), self.state.event_bus());
+        let refs = proposals
+            .refs_by_ids(&ids)
+            .await
+            .map_err(|e| e.to_string())?;
+        let by_id: std::collections::HashMap<&str, &djinn_db::ProposalRef> =
+            refs.iter().map(|r| (r.id.as_str(), r)).collect();
+        for epic in epics.iter_mut() {
+            if let Some(r) = epic
+                .proposal_id
+                .as_deref()
+                .and_then(|id| by_id.get(id))
+            {
+                epic.proposal_short_id = Some(r.short_id.clone());
+                epic.proposal_title = Some(r.title.clone());
+                epic.proposal_status = Some(r.status.clone());
+                epic.proposal_build_owner_user_id = r.build_owner_user_id.clone();
+            }
+        }
+        Ok(())
     }
 
     /// Update allowed fields of an epic.

--- a/server/crates/djinn-core/src/models/epic.rs
+++ b/server/crates/djinn-core/src/models/epic.rs
@@ -27,4 +27,10 @@ pub struct Epic {
     /// Tasks broken down from this epic inherit it; the board uses it to
     /// scope epics to the owner filter, mirroring `Task::created_by_user_id`.
     pub created_by_user_id: Option<String>,
+    /// Originating proposal, denormalized from `proposal_epics` (unique per
+    /// epic) at graduation link time. `None` for hand-created epics; cleared
+    /// when the proposal unlinks or is deleted. The board groups swimlanes
+    /// by it.
+    #[serde(default)]
+    pub proposal_id: Option<String>,
 }

--- a/server/crates/djinn-db/migrations_postgres/115_epics_proposal_id.sql
+++ b/server/crates/djinn-db/migrations_postgres/115_epics_proposal_id.sql
@@ -1,0 +1,15 @@
+-- The kanban board groups its swimlanes by proposal, so epic reads and SSE
+-- payloads must carry the epic→proposal linkage without a join per event.
+-- `proposal_epics` stays the canonical link table (a proposal graduates into
+-- one epic per primary target project); `epics.proposal_id` denormalizes the
+-- reverse mapping, which is unique per epic. Written at graduation link time,
+-- cleared on unlink; proposal deletion clears it via ON DELETE SET NULL.
+
+ALTER TABLE epics ADD COLUMN proposal_id VARCHAR(36) NULL REFERENCES proposals(id) ON DELETE SET NULL;
+
+CREATE INDEX epics_proposal_id ON epics(proposal_id);
+
+UPDATE epics
+   SET proposal_id = pe.proposal_id
+  FROM proposal_epics pe
+ WHERE pe.epic_id = epics.id;

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -139,8 +139,8 @@ pub use repositories::{
     proposal::{
         AwaitingReviewPark, NeedsEvidenceCapStatus, NeedsEvidenceClaimLink, ProposalCreateInput,
         ProposalDebateTrailCreateInput, ProposalFeedbackCreateInput, ProposalListQuery,
-        ProposalListResult, ProposalListSummaryRow, ProposalMemoryRef, ProposalRepository,
-        ProposalUpdateInput,
+        ProposalListResult, ProposalListSummaryRow, ProposalMemoryRef, ProposalRef,
+        ProposalRepository, ProposalUpdateInput,
     },
     repo_graph_cache::{CachedRepoGraph, RepoGraphCacheInsert, RepoGraphCacheRepository},
     scip_indexer_timing::{

--- a/server/crates/djinn-db/src/repositories/epic.rs
+++ b/server/crates/djinn-db/src/repositories/epic.rs
@@ -127,7 +127,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics ORDER BY created_at"#
         )
         .fetch_all(self.db.pool())
@@ -141,7 +141,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status, owner, created_at, updated_at, closed_at,
                     memory_refs::text, auto_breakdown,
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE project_id = $1 ORDER BY created_at"#,
         )
         .bind(project_id)
@@ -156,7 +156,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1"#,
             id
         )
@@ -171,7 +171,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE short_id = $1"#,
             short_id
         )
@@ -247,7 +247,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1"#,
             id
         )
@@ -303,7 +303,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1"#,
             id
         )
@@ -339,7 +339,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status, owner, created_at, updated_at, closed_at,
                     memory_refs::text, auto_breakdown,
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1"#,
         )
         .bind(id)
@@ -412,7 +412,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1"#,
             id
         )
@@ -715,7 +715,7 @@ impl EpicRepository {
             r#"SELECT e.id, e.project_id, e.short_id, e.title, e.description, e.emoji, e.color,
                     e.status AS "status!", e.owner, e.created_at, e.updated_at, e.closed_at,
                     e.memory_refs::text AS "memory_refs!", e.auto_breakdown AS "auto_breakdown!: bool",
-                    e.originating_adr_id, e.created_by_user_id
+                    e.originating_adr_id, e.created_by_user_id, e.proposal_id
              FROM epic_blockers b
              JOIN epics e ON e.id = b.epic_id
              WHERE b.blocking_epic_id = $1
@@ -746,7 +746,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1 OR short_id = $2"#,
             id_or_short,
             id_or_short
@@ -767,7 +767,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE project_id = $1 AND (id = $2 OR short_id = $3)"#,
             project_id,
             id_or_short,
@@ -801,7 +801,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1"#,
             id
         )
@@ -839,7 +839,7 @@ impl EpicRepository {
             r#"SELECT id, project_id, short_id, title, description, emoji, color,
                     status AS "status!", owner, created_at, updated_at, closed_at,
                     memory_refs::text AS "memory_refs!", auto_breakdown AS "auto_breakdown!: bool",
-                    originating_adr_id, created_by_user_id
+                    originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE id = $1"#,
             id
         )
@@ -910,7 +910,7 @@ impl EpicRepository {
         let sql = format!(
             r#"SELECT id, project_id, short_id, title, description, emoji, color, status,
                     owner, created_at, updated_at, closed_at, memory_refs::text AS memory_refs,
-                    auto_breakdown, originating_adr_id, created_by_user_id
+                    auto_breakdown, originating_adr_id, created_by_user_id, proposal_id
              FROM epics WHERE {where_sql} ORDER BY {order_sql} LIMIT {limit_ph} OFFSET {offset_ph}"#
         );
         let mut epic_q = sqlx::query_as::<_, Epic>(&sql);

--- a/server/crates/djinn-db/src/repositories/proposal.rs
+++ b/server/crates/djinn-db/src/repositories/proposal.rs
@@ -8,6 +8,7 @@ use djinn_core::models::{
 };
 
 use crate::database::Database;
+use crate::repositories::epic::EpicRepository;
 use crate::repositories::note::NoteRepository;
 use crate::repositories::note::{LexicalSearchBackend, sanitize_postgres_tsquery};
 use crate::{Error, Result};
@@ -576,6 +577,18 @@ pub struct AwaitingReviewPark {
     /// `round_cap`, `repeated_objection`). `None` for a clean judge-ready
     /// convergence.
     pub stop_reason: Option<String>,
+}
+
+/// Minimal proposal reference for labelling (board swimlanes, links).
+#[derive(Debug, sqlx::FromRow)]
+pub struct ProposalRef {
+    pub id: String,
+    pub short_id: String,
+    pub title: String,
+    pub status: String,
+    /// Participant accountable for the build (whose credentials the epics'
+    /// tasks burn). The board shows their avatar on the proposal swimlane.
+    pub build_owner_user_id: Option<String>,
 }
 
 pub struct ProposalRepository {
@@ -2046,6 +2059,8 @@ impl ProposalRepository {
         )
         .execute(self.db.pool())
         .await?;
+        self.set_epic_proposal_link(epic_id, Some(proposal_id))
+            .await?;
         if let Some(proposal) = self.get(proposal_id).await?
             && proposal.status == "building"
         {
@@ -2198,18 +2213,60 @@ impl ProposalRepository {
             .collect())
     }
 
+    /// Lightweight `(id, short_id, title)` lookup for a set of proposal ids.
+    /// Used by `epic_list` to label proposal swimlanes on the board without
+    /// hydrating full proposals.
+    pub async fn refs_by_ids(&self, ids: &[String]) -> Result<Vec<ProposalRef>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.db.ensure_initialized().await?;
+        Ok(sqlx::query_as::<_, ProposalRef>(
+            "SELECT id, short_id, title, status, build_owner_user_id FROM proposals WHERE id = ANY($1)",
+        )
+        .bind(ids)
+        .fetch_all(self.db.pool())
+        .await?)
+    }
+
+    /// Mirror a `proposal_epics` link change onto the denormalized
+    /// `epics.proposal_id` column and re-emit the epic so live boards regroup
+    /// the swimlane immediately.
+    async fn set_epic_proposal_link(
+        &self,
+        epic_id: &str,
+        proposal_id: Option<&str>,
+    ) -> Result<()> {
+        sqlx::query!(
+            "UPDATE epics SET proposal_id = $1 WHERE id = $2",
+            proposal_id,
+            epic_id
+        )
+        .execute(self.db.pool())
+        .await?;
+        let epics = EpicRepository::new(self.db.clone(), self.events.clone());
+        if let Some(epic) = epics.get(epic_id).await? {
+            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+        }
+        Ok(())
+    }
+
     /// Drop every graduated-epic link for a proposal. The missing counterpart
     /// to [`Self::link_epic`] (which only ever inserts): an aborted build must
     /// unlink its epics so a later re-graduation starts from a clean set
     /// instead of accumulating closed epics from prior generations.
     pub async fn unlink_epics(&self, proposal_id: &str) -> Result<()> {
         self.db.ensure_initialized().await?;
+        let linked = self.graduated_epics(proposal_id).await?;
         sqlx::query!(
             "DELETE FROM proposal_epics WHERE proposal_id = $1",
             proposal_id
         )
         .execute(self.db.pool())
         .await?;
+        for (epic_id, _) in linked {
+            self.set_epic_proposal_link(&epic_id, None).await?;
+        }
         Ok(())
     }
 
@@ -2218,6 +2275,10 @@ impl ProposalRepository {
         proposal_id: &str,
     ) -> Result<()> {
         sqlx::query("DELETE FROM proposal_epics WHERE proposal_id = $1")
+            .bind(proposal_id)
+            .execute(&mut **tx)
+            .await?;
+        sqlx::query("UPDATE epics SET proposal_id = NULL WHERE proposal_id = $1")
             .bind(proposal_id)
             .execute(&mut **tx)
             .await?;
@@ -2236,6 +2297,7 @@ impl ProposalRepository {
             .bind(epic_id)
             .execute(self.db.pool())
             .await?;
+        self.set_epic_proposal_link(epic_id, None).await?;
         Ok(())
     }
 
@@ -2246,6 +2308,10 @@ impl ProposalRepository {
     ) -> Result<()> {
         sqlx::query("DELETE FROM proposal_epics WHERE proposal_id = $1 AND epic_id = $2")
             .bind(proposal_id)
+            .bind(epic_id)
+            .execute(&mut **tx)
+            .await?;
+        sqlx::query("UPDATE epics SET proposal_id = NULL WHERE id = $1")
             .bind(epic_id)
             .execute(&mut **tx)
             .await?;

--- a/server/crates/djinn-db/src/repositories/task/mod.rs
+++ b/server/crates/djinn-db/src/repositories/task/mod.rs
@@ -2498,7 +2498,7 @@ pub(super) async fn maybe_reopen_epic(
         r#"SELECT id, project_id, short_id, title, description, emoji, color, status,
                 owner, created_at, updated_at, closed_at, memory_refs::text AS "memory_refs!",
                 auto_breakdown AS "auto_breakdown!: bool",
-                originating_adr_id, created_by_user_id
+                originating_adr_id, created_by_user_id, proposal_id
          FROM epics WHERE id = $1"#,
         epic_id
     )

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -2609,6 +2609,41 @@
             "null"
           ]
         },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "error": {
           "type": [
             "string",
@@ -2870,6 +2905,41 @@
             "null"
           ]
         },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "error": {
           "type": [
             "string",
@@ -3048,6 +3118,41 @@
             },
             "created_by_user_id": {
               "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_id": {
+              "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_short_id": {
+              "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_title": {
+              "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_status": {
+              "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_build_owner_user_id": {
+              "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
               "type": [
                 "string",
                 "null"
@@ -3309,6 +3414,41 @@
             "null"
           ]
         },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "error": {
           "type": [
             "string",
@@ -3403,6 +3543,41 @@
         },
         "created_by_user_id": {
           "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
           "type": [
             "string",
             "null"
@@ -3828,6 +4003,41 @@
         },
         "created_by_user_id": {
           "description": "Real user FK of the epic's creator (NULL for system/unowned epics).\nSurfaced so the board can scope epics to the owner filter, mirroring\n`TaskModel::created_by_user_id`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
           "type": [
             "string",
             "null"

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -2585,6 +2585,41 @@ expression: signatures
         "owner": {
           "type": "string"
         },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "short_id": {
           "type": "string"
         },
@@ -2844,6 +2879,41 @@ expression: signatures
         "owner": {
           "type": "string"
         },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "short_id": {
           "type": "string"
         },
@@ -3016,6 +3086,41 @@ expression: signatures
             },
             "owner": {
               "type": "string"
+            },
+            "proposal_build_owner_user_id": {
+              "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_id": {
+              "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_short_id": {
+              "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_status": {
+              "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "proposal_title": {
+              "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "short_id": {
               "type": "string"
@@ -3278,6 +3383,41 @@ expression: signatures
         "owner": {
           "type": "string"
         },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "short_id": {
           "type": "string"
         },
@@ -3387,6 +3527,41 @@ expression: signatures
         },
         "owner": {
           "type": "string"
+        },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "short_id": {
           "type": "string"
@@ -3798,6 +3973,41 @@ expression: signatures
         },
         "owner": {
           "type": "string"
+        },
+        "proposal_build_owner_user_id": {
+          "description": "Build owner of the proposal (whose credentials the build consumes),\nenriched on `epic_list` responses. The board shows their avatar on the\nproposal swimlane.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_id": {
+          "description": "Originating proposal id (denormalized from `proposal_epics` at\ngraduation). `None` for hand-created epics. The board groups its\nswimlanes by it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_short_id": {
+          "description": "Proposal short id, enriched on `epic_list` responses so the board can\nlabel and link proposal swimlanes without loading proposals.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_status": {
+          "description": "Proposal status (`building`, `shipped`, …), enriched on `epic_list`\nresponses. The board only renders proposal swimlanes for `building`\nproposals so the kanban stays scoped to active work.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proposal_title": {
+          "description": "Proposal title, enriched on `epic_list` responses (see\n`proposal_short_id`).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "short_id": {
           "type": "string"

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -1322,6 +1322,34 @@ export namespace EpicCloseOutputSchema {
    */
   originating_adr_id?: string
   owner?: string
+  /**
+   * Build owner of the proposal (whose credentials the build consumes),
+   * enriched on `epic_list` responses. The board shows their avatar on the
+   * proposal swimlane.
+   */
+  proposal_build_owner_user_id?: string
+  /**
+   * Originating proposal id (denormalized from `proposal_epics` at
+   * graduation). `None` for hand-created epics. The board groups its
+   * swimlanes by it.
+   */
+  proposal_id?: string
+  /**
+   * Proposal short id, enriched on `epic_list` responses so the board can
+   * label and link proposal swimlanes without loading proposals.
+   */
+  proposal_short_id?: string
+  /**
+   * Proposal status (`building`, `shipped`, …), enriched on `epic_list`
+   * responses. The board only renders proposal swimlanes for `building`
+   * proposals so the kanban stays scoped to active work.
+   */
+  proposal_status?: string
+  /**
+   * Proposal title, enriched on `epic_list` responses (see
+   * `proposal_short_id`).
+   */
+  proposal_title?: string
   short_id?: string
   status?: string
   title?: string
@@ -1445,6 +1473,34 @@ export namespace EpicCreateOutputSchema {
    */
   originating_adr_id?: string
   owner?: string
+  /**
+   * Build owner of the proposal (whose credentials the build consumes),
+   * enriched on `epic_list` responses. The board shows their avatar on the
+   * proposal swimlane.
+   */
+  proposal_build_owner_user_id?: string
+  /**
+   * Originating proposal id (denormalized from `proposal_epics` at
+   * graduation). `None` for hand-created epics. The board groups its
+   * swimlanes by it.
+   */
+  proposal_id?: string
+  /**
+   * Proposal short id, enriched on `epic_list` responses so the board can
+   * label and link proposal swimlanes without loading proposals.
+   */
+  proposal_short_id?: string
+  /**
+   * Proposal status (`building`, `shipped`, …), enriched on `epic_list`
+   * responses. The board only renders proposal swimlanes for `building`
+   * proposals so the kanban stays scoped to active work.
+   */
+  proposal_status?: string
+  /**
+   * Proposal title, enriched on `epic_list` responses (see
+   * `proposal_short_id`).
+   */
+  proposal_title?: string
   short_id?: string
   status?: string
   title?: string
@@ -1534,6 +1590,34 @@ export namespace EpicListOutputSchema {
    */
   originating_adr_id?: string
   owner: string
+  /**
+   * Build owner of the proposal (whose credentials the build consumes),
+   * enriched on `epic_list` responses. The board shows their avatar on the
+   * proposal swimlane.
+   */
+  proposal_build_owner_user_id?: string
+  /**
+   * Originating proposal id (denormalized from `proposal_epics` at
+   * graduation). `None` for hand-created epics. The board groups its
+   * swimlanes by it.
+   */
+  proposal_id?: string
+  /**
+   * Proposal short id, enriched on `epic_list` responses so the board can
+   * label and link proposal swimlanes without loading proposals.
+   */
+  proposal_short_id?: string
+  /**
+   * Proposal status (`building`, `shipped`, …), enriched on `epic_list`
+   * responses. The board only renders proposal swimlanes for `building`
+   * proposals so the kanban stays scoped to active work.
+   */
+  proposal_status?: string
+  /**
+   * Proposal title, enriched on `epic_list` responses (see
+   * `proposal_short_id`).
+   */
+  proposal_title?: string
   short_id: string
   status: string
   title: string
@@ -1642,6 +1726,34 @@ export namespace EpicReopenOutputSchema {
    */
   originating_adr_id?: string
   owner?: string
+  /**
+   * Build owner of the proposal (whose credentials the build consumes),
+   * enriched on `epic_list` responses. The board shows their avatar on the
+   * proposal swimlane.
+   */
+  proposal_build_owner_user_id?: string
+  /**
+   * Originating proposal id (denormalized from `proposal_epics` at
+   * graduation). `None` for hand-created epics. The board groups its
+   * swimlanes by it.
+   */
+  proposal_id?: string
+  /**
+   * Proposal short id, enriched on `epic_list` responses so the board can
+   * label and link proposal swimlanes without loading proposals.
+   */
+  proposal_short_id?: string
+  /**
+   * Proposal status (`building`, `shipped`, …), enriched on `epic_list`
+   * responses. The board only renders proposal swimlanes for `building`
+   * proposals so the kanban stays scoped to active work.
+   */
+  proposal_status?: string
+  /**
+   * Proposal title, enriched on `epic_list` responses (see
+   * `proposal_short_id`).
+   */
+  proposal_title?: string
   short_id?: string
   status?: string
   title?: string
@@ -1694,6 +1806,34 @@ export namespace EpicShowOutputSchema {
    */
   originating_adr_id?: string
   owner?: string
+  /**
+   * Build owner of the proposal (whose credentials the build consumes),
+   * enriched on `epic_list` responses. The board shows their avatar on the
+   * proposal swimlane.
+   */
+  proposal_build_owner_user_id?: string
+  /**
+   * Originating proposal id (denormalized from `proposal_epics` at
+   * graduation). `None` for hand-created epics. The board groups its
+   * swimlanes by it.
+   */
+  proposal_id?: string
+  /**
+   * Proposal short id, enriched on `epic_list` responses so the board can
+   * label and link proposal swimlanes without loading proposals.
+   */
+  proposal_short_id?: string
+  /**
+   * Proposal status (`building`, `shipped`, …), enriched on `epic_list`
+   * responses. The board only renders proposal swimlanes for `building`
+   * proposals so the kanban stays scoped to active work.
+   */
+  proposal_status?: string
+  /**
+   * Proposal title, enriched on `epic_list` responses (see
+   * `proposal_short_id`).
+   */
+  proposal_title?: string
   short_id?: string
   status?: string
   task_count?: number
@@ -1837,6 +1977,34 @@ export namespace EpicUpdateOutputSchema {
    */
   originating_adr_id?: string
   owner?: string
+  /**
+   * Build owner of the proposal (whose credentials the build consumes),
+   * enriched on `epic_list` responses. The board shows their avatar on the
+   * proposal swimlane.
+   */
+  proposal_build_owner_user_id?: string
+  /**
+   * Originating proposal id (denormalized from `proposal_epics` at
+   * graduation). `None` for hand-created epics. The board groups its
+   * swimlanes by it.
+   */
+  proposal_id?: string
+  /**
+   * Proposal short id, enriched on `epic_list` responses so the board can
+   * label and link proposal swimlanes without loading proposals.
+   */
+  proposal_short_id?: string
+  /**
+   * Proposal status (`building`, `shipped`, …), enriched on `epic_list`
+   * responses. The board only renders proposal swimlanes for `building`
+   * proposals so the kanban stays scoped to active work.
+   */
+  proposal_status?: string
+  /**
+   * Proposal title, enriched on `epic_list` responses (see
+   * `proposal_short_id`).
+   */
+  proposal_title?: string
   short_id?: string
   status?: string
   title?: string

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -62,6 +62,14 @@ export type Task = Omit<TaskShowOutputSchema.TaskShowOutput, "owner"> & {
 
 export type Epic = Omit<EpicListOutputSchema.EpicModel, "owner"> & {
   owner: string | null;
+  /** Originating proposal id (denormalized at graduation). */
+  proposal_id?: string | null;
+  /** Proposal short id/title/status — enriched on `epic_list` responses so the
+   * board can label proposal swimlanes; absent on SSE epic payloads. */
+  proposal_short_id?: string | null;
+  proposal_title?: string | null;
+  proposal_status?: string | null;
+  proposal_build_owner_user_id?: string | null;
 };
 
 // Global proposals layer (project-independent). `acceptance_criteria` arrives

--- a/ui/src/components/KanbanBoard.stories.tsx
+++ b/ui/src/components/KanbanBoard.stories.tsx
@@ -6,7 +6,7 @@ type BoardFixture = {
   epics: Epic[];
   tasks: Task[];
   initialPath?: string;
-  initialCollapsedEpics?: string[];
+  initialCollapsedLanes?: string[];
 };
 
 const emptyFixture: BoardFixture = {
@@ -14,23 +14,47 @@ const emptyFixture: BoardFixture = {
   tasks: [],
 };
 
-const makeEpic = (id: string, title: string, emoji: string, owner: string): Epic => ({
+const makeEpic = (
+  id: string,
+  title: string,
+  emoji: string,
+  owner: string,
+  overrides?: Partial<Epic>,
+): Epic => ({
   id,
   short_id: id.slice(0, 4),
   title,
   description: "",
   emoji,
   color: "#3B82F6",
-  status: "active",
+  status: "open",
   owner,
   created_at: "2026-03-01T10:00:00.000Z",
   updated_at: "2026-03-01T10:00:00.000Z",
+  ...overrides,
 });
 
+// Two building proposals: the auth one fans out to two epics (a proposal
+// graduates into one epic per target project), the UX one to a single epic.
+// A no-epic task exercises the catch-all "No proposal" lane.
+const authProposal = {
+  proposal_id: "prop-auth",
+  proposal_short_id: "p4au",
+  proposal_title: "Unify platform authentication",
+  proposal_status: "building",
+};
+
+const uxProposal = {
+  proposal_id: "prop-ux",
+  proposal_short_id: "p7ux",
+  proposal_title: "Polish the first-run experience",
+  proposal_status: "building",
+};
+
 const epicsFixture: Epic[] = [
-  makeEpic("epic-foundation", "Platform Foundation", "🚀", "Alex"),
-  makeEpic("epic-ux", "UX Polish", "🎨", "Mina"),
-  makeEpic("epic-auth", "Authentication", "🔐", "Priya"),
+  makeEpic("epic-foundation", "Platform Foundation", "🚀", "Alex", authProposal),
+  makeEpic("epic-auth", "Authentication", "🔐", "Priya", authProposal),
+  makeEpic("epic-ux", "UX Polish", "🎨", "Mina", uxProposal),
 ];
 
 const makeTask = (
@@ -54,6 +78,7 @@ const makeTask = (
   status,
   priority,
   owner,
+  created_by_user_id: owner,
   epic_id: epicId,
   labels,
   memory_refs: [],
@@ -89,12 +114,14 @@ const tasksFixture: Task[] = [
     duration_seconds: 360,
   }),
 
-  // Done
+  // Done (merged — the board only shows closed tasks that actually landed)
   makeTask("t-4", "Keyboard navigation pass", "closed", 1, "Alex", "epic-ux", ["accessibility"], "2026-03-01T11:30:00.000Z", {
     duration_seconds: 1380,
+    merge_commit_sha: "abc123",
   }),
   makeTask("t-7", "SSE initial connect", "closed", 1, "Priya", "epic-foundation", [], "2026-03-01T11:35:00.000Z", {
     duration_seconds: 300,
+    merge_commit_sha: "def456",
   }),
 ];
 
@@ -115,7 +142,7 @@ const meta = {
             <KanbanBoard
               tasks={fixture.tasks}
               epics={new Map(fixture.epics.map((epic) => [epic.id, epic]))}
-              initialCollapsedEpics={fixture.initialCollapsedEpics}
+              initialCollapsedLanes={fixture.initialCollapsedLanes}
             />
           </div>
         </MemoryRouter>
@@ -141,12 +168,12 @@ export const PopulatedAcrossColumns = {
   },
 };
 
-export const CollapsedEpicGroups = {
+export const CollapsedLanes = {
   args: {
     fixture: {
       epics: epicsFixture,
       tasks: tasksFixture,
-      initialCollapsedEpics: ["open:epic-foundation", "done:epic-ux"],
+      initialCollapsedLanes: ["proposal:prop-auth", "proposal:prop-ux"],
     },
   },
 };

--- a/ui/src/components/KanbanBoard.test.tsx
+++ b/ui/src/components/KanbanBoard.test.tsx
@@ -1,8 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
-import { render, screen, userEvent, waitFor, within } from "@/test/test-utils";
+import { render, screen, waitFor, within } from "@/test/test-utils";
 import { KanbanBoard } from "@/components/KanbanBoard";
 import { mergedColumnStore } from "@/stores/mergedColumnStore";
-import { loadMoreClosedTasks } from "@/api/server";
 import type { Epic, Task } from "@/api/types";
 
 vi.mock("@/electron/commands", () => ({
@@ -55,6 +54,39 @@ const epicB: Epic = {
   updated_at: "2026-01-01T00:00:00Z",
 };
 
+// Two epics graduated from the same building proposal — they share a lane.
+const buildingProposal = {
+  proposal_id: "prop-1",
+  proposal_short_id: "pr1s",
+  proposal_title: "Proposal One",
+  proposal_status: "building",
+};
+
+const epicP1: Epic = {
+  ...epicA,
+  id: "epic-p1",
+  title: "Graduated One",
+  ...buildingProposal,
+};
+
+const epicP2: Epic = {
+  ...epicA,
+  id: "epic-p2",
+  title: "Graduated Two",
+  ...buildingProposal,
+};
+
+// An epic whose proposal already shipped — no longer building.
+const shippedEpic: Epic = {
+  ...epicA,
+  id: "epic-shipped",
+  title: "Shipped Epic",
+  proposal_id: "prop-shipped",
+  proposal_short_id: "prsh",
+  proposal_title: "Shipped Proposal",
+  proposal_status: "shipped",
+};
+
 const makeTask = (
   overrides: Partial<Task> & Pick<Task, "id" | "title" | "status">,
 ): Task => ({
@@ -75,8 +107,6 @@ const makeTask = (
 describe("KanbanBoard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // The Merged-column pagination state is a global store; reset it so tests
-    // that don't opt into "Load more" see no affordance.
     mergedColumnStore.getState().reset();
   });
 
@@ -125,17 +155,122 @@ describe("KanbanBoard", () => {
     expect(inFlightCol).toHaveTextContent("1");
     expect(doneCol).toHaveTextContent("1");
 
+    // Tasks land in their status cell inside the epic's swimlane.
     expect(
-      within(openCol!.parentElement as HTMLElement).getByText("Open task"),
+      within(screen.getByTestId("lane-no-proposal-open")).getByText(
+        "Open task",
+      ),
     ).toBeInTheDocument();
     expect(
-      within(inFlightCol!.parentElement as HTMLElement).getByText(
+      within(screen.getByTestId("lane-no-proposal-in_progress")).getByText(
         "Flight task",
       ),
     ).toBeInTheDocument();
     expect(
-      within(doneCol!.parentElement as HTMLElement).getByText("Done task"),
+      within(screen.getByTestId("lane-no-proposal-done")).getByText(
+        "Done task",
+      ),
     ).toBeInTheDocument();
+  });
+
+  it("groups epics graduated from the same building proposal into one proposal lane", () => {
+    const tasks: Task[] = [
+      makeTask({
+        id: "t-p1",
+        title: "Task in graduated one",
+        status: "open",
+        epic_id: epicP1.id,
+      }),
+      makeTask({
+        id: "t-p2",
+        title: "Task in graduated two",
+        status: "in_progress",
+        epic_id: epicP2.id,
+      }),
+    ];
+
+    render(
+      <KanbanBoard
+        tasks={tasks}
+        epics={
+          new Map([
+            [epicP1.id, epicP1],
+            [epicP2.id, epicP2],
+          ])
+        }
+      />,
+    );
+
+    // One lane titled by the proposal, holding both epics' tasks. The epics
+    // do not get their own lanes (their titles only appear as card chips).
+    expect(screen.getByText("Proposal One")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("lane-header-epic:epic-p1"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("lane-header-epic:epic-p2"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("lane-proposal:prop-1-open")).getByText(
+        "Task in graduated one",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByTestId("lane-proposal:prop-1-in_progress"),
+      ).getByText("Task in graduated two"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the epic chip on cards inside proposal lanes", () => {
+    const tasks: Task[] = [
+      makeTask({
+        id: "t-p1",
+        title: "Task in graduated one",
+        status: "open",
+        epic_id: epicP1.id,
+      }),
+    ];
+
+    render(
+      <KanbanBoard tasks={tasks} epics={new Map([[epicP1.id, epicP1]])} />,
+    );
+
+    const chip = screen.getByTestId("taskcard-epic-chip");
+    expect(chip).toHaveTextContent("Graduated One");
+  });
+
+  it("hides merged tasks of non-building proposals but keeps their active tasks visible", () => {
+    const tasks: Task[] = [
+      makeTask({
+        id: "t-shipped-open",
+        title: "Straggler open task",
+        status: "open",
+        epic_id: shippedEpic.id,
+      }),
+      makeTask({
+        id: "t-shipped-done",
+        title: "Old merged task",
+        status: "closed",
+        epic_id: shippedEpic.id,
+        merge_commit_sha: "old123",
+      }),
+    ];
+
+    render(
+      <KanbanBoard
+        tasks={tasks}
+        epics={new Map([[shippedEpic.id, shippedEpic]])}
+      />,
+    );
+
+    // No proposal lane for a shipped proposal; the straggler shows under the
+    // epic lane so live work never disappears, but the old merged task ages
+    // off the board.
+    expect(screen.queryByText("Shipped Proposal")).not.toBeInTheDocument();
+    expect(screen.getByText("Shipped Epic")).toBeInTheDocument();
+    expect(screen.getByText("Straggler open task")).toBeInTheDocument();
+    expect(screen.queryByText("Old merged task")).not.toBeInTheDocument();
   });
 
   it("applies the text search from the shared filter URL param", async () => {
@@ -287,12 +422,13 @@ describe("KanbanBoard", () => {
   it("shows empty board state when no tasks", () => {
     render(<KanbanBoard tasks={[]} epics={new Map()} />);
 
-    expect(screen.getAllByText("No tasks")).toHaveLength(4);
+    expect(screen.getByText("No tasks")).toBeInTheDocument();
   });
 
-  it("shows the exact server merged total (not the loaded count) and Load more when more merged pages exist", async () => {
-    // Simulate the first merged page having been loaded with more remaining.
-    // The server reports 1231 merged tasks total even though only one is loaded.
+  it("never shows merged-column pagination — the board stays scoped to active proposals", () => {
+    // Even when the merged store reports more pages server-side, the board
+    // renders no Load more affordance: old merged tasks belong to retired
+    // proposals and age off the board instead.
     mergedColumnStore.getState().setProjectPage({
       slug: "owner/repo",
       projectId: "p1",
@@ -313,46 +449,15 @@ describe("KanbanBoard", () => {
 
     render(<KanbanBoard tasks={tasks} epics={new Map([[epicA.id, epicA]])} />);
 
-    // Header shows the exact server total (1231), never a "+"-suffixed estimate.
-    const doneCol = screen.getByText("Merged").closest(".flex.flex-col");
-    expect(doneCol).toHaveTextContent("1231");
-    expect(doneCol).not.toHaveTextContent("+");
-
-    const loadMore = screen.getByRole("button", { name: "Load more" });
-    await userEvent.click(loadMore);
-    expect(loadMoreClosedTasks).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not show Load more when all merged pages are loaded and shows the exact total", () => {
-    mergedColumnStore.getState().setProjectPage({
-      slug: "owner/repo",
-      projectId: "p1",
-      loaded: 1,
-      hasMore: false,
-      totalMerged: 1,
-    });
-
-    const tasks: Task[] = [
-      makeTask({
-        id: "t-done",
-        title: "Merged task",
-        status: "closed",
-        epic_id: epicA.id,
-        merge_commit_sha: "abc123merged",
-      }),
-    ];
-
-    render(<KanbanBoard tasks={tasks} epics={new Map([[epicA.id, epicA]])} />);
-
-    const doneCol = screen.getByText("Merged").closest(".flex.flex-col");
-    expect(doneCol).toHaveTextContent("1");
-    expect(doneCol).not.toHaveTextContent("+");
     expect(
       screen.queryByRole("button", { name: "Load more" }),
     ).not.toBeInTheDocument();
+    // The Merged header counts what is on the board, not the server total.
+    const doneCol = screen.getByText("Merged").closest(".flex.flex-col");
+    expect(doneCol).not.toHaveTextContent("1231");
   });
 
-  it("shows empty open epics in the Open column when they have no tasks", () => {
+  it("does not create lanes for standalone epics without tasks — lanes are proposals", () => {
     render(
       <KanbanBoard
         tasks={[]}
@@ -365,11 +470,18 @@ describe("KanbanBoard", () => {
       />,
     );
 
-    const openCol = screen.getByText("Open").closest(".flex.flex-col")
-      ?.parentElement as HTMLElement;
+    expect(screen.queryByText("Epic Alpha")).not.toBeInTheDocument();
+    expect(screen.queryByText("Epic Draft")).not.toBeInTheDocument();
+    expect(screen.getByText("No tasks")).toBeInTheDocument();
+  });
 
-    expect(within(openCol).getByText("Epic Alpha")).toBeInTheDocument();
-    expect(within(openCol).getByText("Epic Draft")).toBeInTheDocument();
-    expect(within(openCol).getAllByText("No tasks yet")).toHaveLength(2);
+  it("seeds a proposal lane for an empty epic under a building proposal", () => {
+    render(
+      <KanbanBoard tasks={[]} epics={new Map([[epicP1.id, epicP1]])} />,
+    );
+
+    expect(screen.getByText("Proposal One")).toBeInTheDocument();
+    expect(screen.queryByText("Graduated One")).not.toBeInTheDocument();
+    expect(screen.getByText("No tasks yet")).toBeInTheDocument();
   });
 });

--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -4,8 +4,6 @@ import { useTaskStore } from "@/stores/useTaskStore";
 import { useEpicStore } from "@/stores/useEpicStore";
 import { useProjects } from "@/stores/useProjectStore";
 import { taskStore } from "@/stores/taskStore";
-import { useMergedColumnStore } from "@/stores/useMergedColumnStore";
-import { loadMoreClosedTasks } from "@/api/server";
 import type { Epic, Task } from "@/api/types";
 import { TaskCard, DoneTaskRow } from "@/components/TaskCard";
 import { TaskDetailPanel } from "@/components/TaskDetailPanel";
@@ -21,18 +19,21 @@ import {
   Progress02Icon,
   type UnavailableIcon,
 } from "@hugeicons/core-free-icons";
+import { useQuery } from "@tanstack/react-query";
+import { usersQueryOptions } from "@/api/queryOptions";
+import { UserAvatar } from "@/components/UserAvatar";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { cn } from "@/lib/utils";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   epicMatchesOwnerFilter,
-  getEpicEmoji,
   matchesStructuredFilters,
   useBoardFilters,
 } from "@/components/board/boardFilters";
 import { useBoardServerSearch } from "@/components/board/useBoardServerSearch";
 
 type ColumnKey = "open" | "in_progress" | "pr_ready" | "done";
+
+const NO_PROPOSAL_KEY = "no-proposal";
 
 const STATUS_COLUMNS: Array<{
   key: ColumnKey;
@@ -71,6 +72,11 @@ const STATUS_COLUMNS: Array<{
   },
 ];
 
+// Shared column grid: the sticky status header and every swimlane use the same
+// template so cards stay aligned under their column while scrolling lanes.
+const COLUMN_GRID_CLASS =
+  "grid grid-cols-[repeat(4,minmax(280px,1fr))] gap-x-5";
+
 function taskToColumnKey(task: Task): ColumnKey | null {
   if (task.status === "closed") {
     // A task lands in "Merged" when we have the landed merge-commit SHA. Tasks
@@ -101,44 +107,52 @@ function taskToColumnKey(task: Task): ColumnKey | null {
   return "open";
 }
 
-function getEpicTitle(
-  epic: Epic | undefined,
-  epicId: string | undefined,
-): string {
-  if (!epicId) return "No Epic";
-  return epic?.title ?? "Unknown Epic";
+/**
+ * One full-width swimlane. Lanes are building proposals (Linear's "project"
+ * rows), labelled with the build owner's avatar; everything without a
+ * building-proposal linkage (standalone epics, un-epiced tasks) folds into a
+ * single catch-all lane at the bottom. The epic renders on each card, not on
+ * the lane.
+ */
+type Lane = {
+  key: string;
+  kind: "proposal" | "other";
+  title: string;
+  proposalId?: string;
+  buildOwnerUserId?: string | null;
+  columns: Map<ColumnKey, Task[]>;
+  total: number;
+  mergedCount: number;
+};
+
+/** Whether an epic belongs to a proposal that is actively building. */
+function isBuildingProposalEpic(epic: Epic | undefined): boolean {
+  return !!epic?.proposal_id && epic.proposal_status === "building";
 }
 
 type KanbanBoardProps = {
   tasks?: Task[];
   epics?: Map<string, Epic>;
-  initialCollapsedEpics?: string[];
+  /** Lane keys (`proposal:<id>`, `epic:<id>`, or `no-epic`) that start collapsed. */
+  initialCollapsedLanes?: string[];
 };
 
 export function KanbanBoard({
   tasks: tasksProp,
   epics: epicsProp,
-  initialCollapsedEpics,
+  initialCollapsedLanes,
 }: KanbanBoardProps = {}) {
   const navigate = useNavigate();
   const storeTasks = useTaskStore((state) => Array.from(state.tasks.values()));
   const storeEpics = useEpicStore((state) => state.epics);
   const projects = useProjects();
 
-  // Merged-column pagination: the board loads active tasks first, then the
-  // merged tasks page-by-page. `hasMoreClosed` drives the "Load more"
-  // affordance; `mergedTotal` is the EXACT merged count summed across projects
-  // (the backend `status=merged` filter counts only actually-merged rows, so no
-  // "+" estimate is needed). When the board is rendered in controlled mode
-  // (`tasksProp`) the store is empty, so the affordance is hidden and the header
-  // falls back to the loaded count.
-  const hasMoreClosed = useMergedColumnStore((state) => state.hasMore());
-  const loadingMoreClosed = useMergedColumnStore((state) => state.loadingMore);
-  const mergedTotal = useMergedColumnStore((state) => state.totalMerged());
-  const hasMergedTotals = useMergedColumnStore((state) => state.hasTotals());
-  const handleLoadMoreClosed = () => {
-    void loadMoreClosedTasks();
-  };
+  // Org roster, for the build-owner avatar on proposal swimlanes.
+  const { data: orgUsers = [] } = useQuery(usersQueryOptions());
+  const usersById = useMemo(
+    () => new Map(orgUsers.map((u) => [u.id, u])),
+    [orgUsers],
+  );
 
   // Filter values come from the shared header via the URL search params.
   const { projectFilters, epicFilters, ownerFilters, issueTypeFilters, search } =
@@ -151,10 +165,10 @@ export function KanbanBoard({
 
   const tasks = tasksProp ?? storeTasks;
   const epics = epicsProp ?? storeEpics;
-  const [collapsedEpics, setCollapsedEpics] = useState<Record<string, boolean>>(
+  const [collapsedLanes, setCollapsedLanes] = useState<Record<string, boolean>>(
     () => {
       const next: Record<string, boolean> = {};
-      for (const key of initialCollapsedEpics ?? []) next[key] = true;
+      for (const key of initialCollapsedLanes ?? []) next[key] = true;
       return next;
     },
   );
@@ -248,57 +262,117 @@ export function KanbanBoard({
     search,
   ]);
 
-  const groupedByStatusThenEpic = useMemo(() => {
-    const byColumn = new Map<ColumnKey, Map<string, Task[]>>();
+  // Group tasks into swimlanes: one lane per building proposal (Linear
+  // "project" rows), plus a single catch-all lane for everything without a
+  // building-proposal linkage. Merged tasks whose proposal is no longer
+  // building are dropped — retired proposals age off the board — while their
+  // *active* stragglers stay visible in the catch-all so live work never
+  // disappears.
+  const lanes = useMemo<Lane[]>(() => {
+    const byLane = new Map<string, Lane>();
 
-    for (const column of STATUS_COLUMNS) {
-      byColumn.set(column.key, new Map());
-    }
+    const proposalLane = (epic: Epic): Lane => {
+      const key = `proposal:${epic.proposal_id}`;
+      let lane = byLane.get(key);
+      if (!lane) {
+        lane = {
+          key,
+          kind: "proposal",
+          title:
+            epic.proposal_title ??
+            (epic.proposal_short_id
+              ? `Proposal ${epic.proposal_short_id}`
+              : "Proposal"),
+          proposalId: epic.proposal_id!,
+          buildOwnerUserId: epic.proposal_build_owner_user_id,
+          columns: new Map(),
+          total: 0,
+          mergedCount: 0,
+        };
+        byLane.set(key, lane);
+      }
+      return lane;
+    };
+
+    const otherLane = (): Lane => {
+      let lane = byLane.get(NO_PROPOSAL_KEY);
+      if (!lane) {
+        lane = {
+          key: NO_PROPOSAL_KEY,
+          kind: "other",
+          title: "No proposal",
+          columns: new Map(),
+          total: 0,
+          mergedCount: 0,
+        };
+        byLane.set(NO_PROPOSAL_KEY, lane);
+      }
+      return lane;
+    };
 
     for (const task of filteredTasks) {
-      const epicKey = task.epic_id ?? "no-epic";
       const columnKey = taskToColumnKey(task);
       if (columnKey === null) continue;
-      const columnMap = byColumn.get(columnKey);
-      if (!columnMap) continue;
+      const epic = task.epic_id ? epics.get(task.epic_id) : undefined;
 
-      const existing = columnMap.get(epicKey) ?? [];
+      let lane: Lane;
+      if (epic && isBuildingProposalEpic(epic)) {
+        lane = proposalLane(epic);
+      } else {
+        // Merged work of a retired (non-building) proposal ages off the board.
+        if (epic?.proposal_id && columnKey === "done") continue;
+        lane = otherLane();
+      }
+
+      const existing = lane.columns.get(columnKey) ?? [];
       existing.push(task);
-      columnMap.set(epicKey, existing);
+      lane.columns.set(columnKey, existing);
+      lane.total += 1;
+      if (columnKey === "done") lane.mergedCount += 1;
     }
 
-    // Seed empty open epics into the Open column so they are visible on the board
-    const epicIdsWithTasks = new Set<string>();
-    for (const columnMap of byColumn.values()) {
-      for (const epicKey of columnMap.keys()) {
-        epicIdsWithTasks.add(epicKey);
-      }
-    }
-    const openColumn = byColumn.get("open");
-    if (openColumn) {
-      const visibleEpicIds =
-        epicFilters.length > 0 ? new Set(epicFilters) : null;
-      for (const [epicId, epic] of epics) {
-        if (epic.status !== "open") continue;
-        if (epicIdsWithTasks.has(epicId)) continue;
-        if (visibleEpicIds && !visibleEpicIds.has(epicId)) continue;
-        // Scope empty epic shells to the owner filter the same way tasks are:
-        // an epic is "owned" by its `created_by_user_id` (which its tasks
-        // inherit), so a shell only shows when its owner is selected.
-        if (!epicMatchesOwnerFilter(epic, ownerFilters)) continue;
-        openColumn.set(epicId, []);
-      }
+    // Seed lanes for building proposals whose epics have no tasks yet, so a
+    // freshly kicked-off build is visible before its breakdown lands.
+    const visibleEpicIds = epicFilters.length > 0 ? new Set(epicFilters) : null;
+    for (const [epicId, epic] of epics) {
+      if (epic.status !== "open") continue;
+      if (!isBuildingProposalEpic(epic)) continue;
+      if (visibleEpicIds && !visibleEpicIds.has(epicId)) continue;
+      // Scope empty epic shells to the owner filter the same way tasks are:
+      // an epic is "owned" by its `created_by_user_id` (which its tasks
+      // inherit), so a shell only shows when its owner is selected.
+      if (!epicMatchesOwnerFilter(epic, ownerFilters)) continue;
+      proposalLane(epic);
     }
 
-    return byColumn;
+    return Array.from(byLane.values()).sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "proposal" ? -1 : 1;
+      return a.title.localeCompare(b.title);
+    });
   }, [filteredTasks, epics, epicFilters, ownerFilters]);
 
-  const toggleEpic = (columnKey: ColumnKey, epicKey: string) => {
-    const collapseKey = `${columnKey}:${epicKey}`;
-    setCollapsedEpics((prev) => ({
+  const columnCounts = useMemo(() => {
+    const counts = new Map<ColumnKey, number>();
+    for (const column of STATUS_COLUMNS) counts.set(column.key, 0);
+    for (const lane of lanes) {
+      for (const [columnKey, columnTasks] of lane.columns) {
+        counts.set(columnKey, (counts.get(columnKey) ?? 0) + columnTasks.length);
+      }
+    }
+    return counts;
+  }, [lanes]);
+
+  const toggleLane = (laneKey: string) => {
+    setCollapsedLanes((prev) => ({
       ...prev,
-      [collapseKey]: !prev[collapseKey],
+      [laneKey]: !prev[laneKey],
     }));
+  };
+
+  const handleLaneNameClick = (lane: Lane) => {
+    if (lane.kind === "proposal" && lane.proposalId) {
+      navigate(`/proposals/${lane.proposalId}`);
+    }
   };
 
   return (
@@ -307,26 +381,20 @@ export function KanbanBoard({
 
       <GitHubAppBanner projectSlugs={bannerSlugs} />
 
-      <div className="flex min-h-0 flex-1 overflow-x-auto pb-1">
-        {STATUS_COLUMNS.map((column, colIdx) => {
-          const statusMap =
-            groupedByStatusThenEpic.get(column.key) ??
-            new Map<string, Task[]>();
-          const epicGroups = Array.from(statusMap.entries());
-          const taskCount = epicGroups.reduce(
-            (total, [, epicTasks]) => total + epicTasks.length,
-            0,
-          );
-          const hasContent = epicGroups.length > 0;
-
-          return (
-            <div key={column.key} className="flex min-h-0 min-w-[360px] flex-1">
-              {colIdx > 0 && (
-                <div className="w-px shrink-0 self-stretch bg-white/[0.03]" />
-              )}
-              <Card className="relative min-h-0 flex-1 gap-0 border-transparent bg-transparent py-0 ring-0 transition-all duration-300 ease-in-out">
-                <div className="flex flex-col">
-                  <div className="relative px-4 pb-2.5 pt-3.5 text-sm font-semibold">
+      <div className="min-h-0 flex-1 overflow-auto pb-1">
+        <div className="min-w-fit">
+          {/* Status column header — sticky above the swimlanes. */}
+          <div
+            className={cn(
+              COLUMN_GRID_CLASS,
+              "sticky top-0 z-20 bg-background/95 px-1 backdrop-blur-sm",
+            )}
+          >
+            {STATUS_COLUMNS.map((column) => {
+              const taskCount = columnCounts.get(column.key) ?? 0;
+              return (
+                <div key={column.key} className="flex flex-col">
+                  <div className="relative pb-2.5 pt-1.5 text-sm font-semibold">
                     <div className="flex items-center gap-2.5">
                       {column.key === "in_progress" ? (
                         <HugeiconsIcon
@@ -348,137 +416,138 @@ export function KanbanBoard({
                       )}
                       <span className="leading-none">{column.label}</span>
                       <span className="text-xs leading-none text-muted-foreground">
-                        {column.key === "done" && hasMergedTotals
-                          ? mergedTotal
-                          : taskCount}
+                        {taskCount}
                       </span>
                     </div>
                   </div>
-                  <div className="px-4">
-                    <div
-                      className={cn(
-                        "h-0.5 w-10 rounded-full",
-                        column.colorClass,
-                        column.glowClass,
-                      )}
-                    />
-                  </div>
+                  <div
+                    className={cn(
+                      "h-0.5 w-10 rounded-full",
+                      column.colorClass,
+                      column.glowClass,
+                    )}
+                  />
                 </div>
+              );
+            })}
+          </div>
 
-                <CardContent className="relative z-10 flex-1 overflow-y-auto px-3 pt-4">
-                  {!hasContent &&
-                  !(column.key === "done" && hasMoreClosed) ? (
-                    <p className="px-1 text-xs text-muted-foreground/50">
-                      No tasks
-                    </p>
-                  ) : (
-                    <div className="flex flex-col gap-3.5">
-                      {epicGroups.map(([epicKey, epicTasks]) => {
-                        const firstTaskEpicId =
-                          epicTasks[0]?.epic_id ??
-                          (epicKey !== "no-epic" ? epicKey : undefined);
-                        const epic = firstTaskEpicId
-                          ? epics.get(firstTaskEpicId)
-                          : undefined;
-                        const collapseKey = `${column.key}:${epicKey}`;
-                        const isCollapsed = !!collapsedEpics[collapseKey];
+          {lanes.length === 0 ? (
+            <p className="px-1 pt-4 text-xs text-muted-foreground/50">
+              No tasks
+            </p>
+          ) : (
+            <div className="flex flex-col pt-3">
+              {lanes.map((lane) => {
+                const isCollapsed = !!collapsedLanes[lane.key];
+                const isClickableName = lane.kind === "proposal";
 
-                        return (
-                          <Card
-                            key={epicKey}
-                            size="sm"
-                            className={cn(
-                              "gap-0 cursor-pointer py-3 bg-zinc-900 ring-white/[0.04]",
-                            )}
-                            onClick={() => toggleEpic(column.key, epicKey)}
-                          >
-                            <CardContent>
-                              <div className="flex w-full items-center justify-between gap-2 px-1 py-1.5 text-sm font-medium">
-                                <span className="flex items-center gap-2 truncate">
-                                  <span className="shrink-0 text-xs leading-none">
-                                    {getEpicEmoji(epic)}
-                                  </span>
-                                  <span className="truncate">
-                                    {getEpicTitle(epic, firstTaskEpicId)}
-                                  </span>
-                                </span>
-                                <HugeiconsIcon
-                                  icon={
-                                    isCollapsed
-                                      ? ArrowRight01Icon
-                                      : ArrowDown01Icon
-                                  }
-                                  className="size-4 shrink-0 text-muted-foreground"
-                                />
-                              </div>
+                return (
+                  <section key={lane.key} className="pb-2">
+                    {/* Swimlane header: full-width row spanning all columns. */}
+                    <div
+                      className="flex cursor-pointer items-center gap-2 rounded-md bg-zinc-900 px-2.5 py-2 ring-1 ring-white/[0.04] transition-colors hover:bg-zinc-800/80"
+                      onClick={() => toggleLane(lane.key)}
+                      data-testid={`lane-header-${lane.key}`}
+                    >
+                      <HugeiconsIcon
+                        icon={isCollapsed ? ArrowRight01Icon : ArrowDown01Icon}
+                        className="size-4 shrink-0 text-muted-foreground"
+                      />
+                      {lane.kind === "proposal" && (
+                        <UserAvatar
+                          user={usersById.get(lane.buildOwnerUserId ?? "")}
+                          className="size-4"
+                        />
+                      )}
+                      {isClickableName ? (
+                        <button
+                          type="button"
+                          className="truncate text-sm font-medium hover:underline"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleLaneNameClick(lane);
+                          }}
+                          title={lane.title}
+                        >
+                          {lane.title}
+                        </button>
+                      ) : (
+                        <span className="truncate text-sm font-medium">
+                          {lane.title}
+                        </span>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        {lane.total}
+                      </span>
+                      <div className="flex-1" />
+                      {lane.mergedCount > 0 && (
+                        <span className="shrink-0 text-[11px] text-muted-foreground">
+                          {lane.mergedCount}/{lane.total} merged
+                        </span>
+                      )}
+                    </div>
 
-                              {!isCollapsed && epicTasks.length === 0 && (
-                                <p className="px-1 pt-1.5 text-xs text-muted-foreground/50">
-                                  No tasks yet
-                                </p>
-                              )}
-
-                              {!isCollapsed &&
-                                epicTasks.length > 0 &&
-                                (column.key === "done" ? (
-                                  <ul
-                                    className="flex flex-col pt-1.5"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    {epicTasks.map((task) => (
-                                      <li key={task.id}>
-                                        <DoneTaskRow
-                                          task={task}
-                                          onClick={() => handleTaskClick(task)}
-                                        />
-                                      </li>
-                                    ))}
-                                  </ul>
-                                ) : (
-                                  <ul
-                                    className="flex flex-col gap-3 pt-2.5"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    {epicTasks.map((task) => (
-                                      <li key={task.id}>
-                                        <TaskCard
-                                          task={task}
-                                          epic={
-                                            task.epic_id
-                                              ? epics.get(task.epic_id)
-                                              : undefined
-                                          }
-                                          moving={!!movingTaskIds[task.id]}
-                                          onClick={() => handleTaskClick(task)}
-                                        />
-                                      </li>
-                                    ))}
-                                  </ul>
+                    {/* Lane body: cards aligned under their status column. */}
+                    {!isCollapsed &&
+                      (lane.total === 0 ? (
+                        <p className="px-2 pt-2.5 pb-1 text-xs text-muted-foreground/50">
+                          No tasks yet
+                        </p>
+                      ) : (
+                        <div className={cn(COLUMN_GRID_CLASS, "px-1 pt-3 pb-2")}>
+                          {STATUS_COLUMNS.map((column) => {
+                            const columnTasks =
+                              lane.columns.get(column.key) ?? [];
+                            if (columnTasks.length === 0) {
+                              return <div key={column.key} />;
+                            }
+                            return column.key === "done" ? (
+                              <ul
+                                key={column.key}
+                                data-testid={`lane-${lane.key}-${column.key}`}
+                                className="flex flex-col self-start"
+                              >
+                                {columnTasks.map((task) => (
+                                  <li key={task.id}>
+                                    <DoneTaskRow
+                                      task={task}
+                                      onClick={() => handleTaskClick(task)}
+                                    />
+                                  </li>
                                 ))}
-                            </CardContent>
-                          </Card>
-                        );
-                      })}
-                    </div>
-                  )}
-
-                  {column.key === "done" && hasMoreClosed && (
-                    <div className="px-1 pt-3">
-                      <button
-                        type="button"
-                        onClick={handleLoadMoreClosed}
-                        disabled={loadingMoreClosed}
-                        className="w-full rounded-md border border-white/[0.06] bg-zinc-900/60 px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        {loadingMoreClosed ? "Loading…" : "Load more"}
-                      </button>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
+                              </ul>
+                            ) : (
+                              <ul
+                                key={column.key}
+                                data-testid={`lane-${lane.key}-${column.key}`}
+                                className="flex flex-col gap-3 self-start"
+                              >
+                                {columnTasks.map((task) => (
+                                  <li key={task.id}>
+                                    <TaskCard
+                                      task={task}
+                                      epic={
+                                        task.epic_id
+                                          ? epics.get(task.epic_id)
+                                          : undefined
+                                      }
+                                      moving={!!movingTaskIds[task.id]}
+                                      onClick={() => handleTaskClick(task)}
+                                    />
+                                  </li>
+                                ))}
+                              </ul>
+                            );
+                          })}
+                        </div>
+                      ))}
+                  </section>
+                );
+              })}
             </div>
-          );
-        })}
+          )}
+        </div>
       </div>
 
       <TaskDetailPanel

--- a/ui/src/components/TaskCard.test.tsx
+++ b/ui/src/components/TaskCard.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@/test/test-utils";
 import { mockTaskA, mockCiPassing, mockCiPending, mockCiFailing, mockCiUnknown, mockCiAdvisoryFailure } from "@/test/fixtures";
 
 describe("TaskCard", () => {
-  it("renders title, short_id, status badge, priority, labels, and AC count", () => {
+  it("renders title, short_id, status badge, priority, and AC count (labels stay off the card)", () => {
     const task = {
       ...mockTaskA,
       id: "task-card-1",
@@ -34,7 +34,8 @@ describe("TaskCard", () => {
     expect(screen.getByText("starting")).toBeInTheDocument();
     expect(screen.getByLabelText(`Priority P${task.priority}`)).toBeInTheDocument();
     expect(screen.getByText("1/2")).toBeInTheDocument();
-    expect(screen.getByText(/frontend/i)).toBeInTheDocument();
+    // Label chips were dropped from the card to keep rows scannable.
+    expect(screen.queryByText(/frontend/i)).not.toBeInTheDocument();
   });
 
   it("renders the real 'starting' status (not a derived 'setting up') for a dispatched, pre-session run", () => {

--- a/ui/src/components/TaskCard.tsx
+++ b/ui/src/components/TaskCard.tsx
@@ -24,6 +24,8 @@ import { projectStore } from "@/stores/projectStore";
 
 type TaskCardProps = {
   task: Task;
+  /** When provided, the card names its epic (emoji + title) at the bottom —
+   * lanes group by proposal, so the epic context lives on the card. */
   epic?: Epic;
   moving?: boolean;
   onClick?: () => void;
@@ -197,7 +199,7 @@ function ProjectBadge({ projectId }: { projectId?: string }) {
   );
 }
 
-export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
+export function TaskCard({ task, epic, moving = false, onClick }: TaskCardProps) {
   const [now, setNow] = useState(() => Date.now());
 
   const startedAt = task.active_session?.started_at;
@@ -378,16 +380,19 @@ export function TaskCard({ task, moving = false, onClick }: TaskCardProps) {
           {task.title}
         </h4>
 
-        {task.labels?.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {task.labels.map((label: string) => (
-              <span
-                key={label}
-                className="rounded bg-zinc-700/60 px-1.5 py-0.5 text-[10px] text-zinc-200"
-              >
-                {label}
-              </span>
-            ))}
+        {/* Epic breadcrumb — lanes group by proposal, so each card names its
+            epic at the bottom (Linear's sub-issue parent pattern). */}
+        {epic && (
+          <div
+            className={cn(
+              "flex items-center gap-1 overflow-hidden text-[10px] text-muted-foreground",
+              task.active_session && "pr-12",
+            )}
+            title={epic.title}
+            data-testid="taskcard-epic-chip"
+          >
+            <span className="shrink-0 leading-none">{epic.emoji}</span>
+            <span className="truncate">{epic.title}</span>
           </div>
         )}
 

--- a/ui/src/components/proposals/blocks/DiffBlock.test.tsx
+++ b/ui/src/components/proposals/blocks/DiffBlock.test.tsx
@@ -80,34 +80,47 @@ describe("DiffBlock", () => {
     expect(screen.getByText("No changes")).toBeInTheDocument();
   });
 
-  it("syntax-highlights the code with Prism tokens while keeping the +/- tint", async () => {
-    const { container } = render(
-      <DiffBlock id="d4" attributes={{ filename: "src/loop.rs", lang: "rust" }}>
-        {RUST_DIFF}
-      </DiffBlock>,
-    );
+  it(
+    "syntax-highlights the code with Prism tokens while keeping the +/- tint",
+    { timeout: 20_000 },
+    async () => {
+      const { container } = render(
+        <DiffBlock
+          id="d4"
+          attributes={{ filename: "src/loop.rs", lang: "rust" }}
+        >
+          {RUST_DIFF}
+        </DiffBlock>,
+      );
 
-    // The Prism surface lazy-loads; once it does, code lines tokenize into
-    // coloured `.token` spans (RSH inlines the oneDark colour onto each token).
-    const tokens = await waitFor(() => {
-      const found = container.querySelectorAll("span.token");
-      expect(found.length).toBeGreaterThan(0);
-      return found;
-    });
-    // A `let` keyword token carries an inline colour — proof of highlighting.
-    const keyword = Array.from(tokens).find((t) => t.textContent === "let");
-    expect(keyword).toBeTruthy();
-    expect((keyword as HTMLElement).style.color).not.toBe("");
+      // The Prism surface lazy-loads; once it does, code lines tokenize into
+      // coloured `.token` spans (RSH inlines the oneDark colour onto each
+      // token). The chunk (refractor + every grammar) is heavy, so give it a
+      // generous window — under a fully loaded suite the import alone can
+      // exceed the default 1s waitFor budget.
+      const tokens = await waitFor(
+        () => {
+          const found = container.querySelectorAll("span.token");
+          expect(found.length).toBeGreaterThan(0);
+          return found;
+        },
+        { timeout: 15_000 },
+      );
+      // A `let` keyword token carries an inline colour — proof of highlighting.
+      const keyword = Array.from(tokens).find((t) => t.textContent === "let");
+      expect(keyword).toBeTruthy();
+      expect((keyword as HTMLElement).style.color).not.toBe("");
 
-    // The +/- tint still rides underneath: the added/removed rows keep their
-    // low-alpha emerald/rose backgrounds (token colours show through them).
-    expect(container.querySelector(".bg-emerald-500\\/10")).not.toBeNull();
-    expect(container.querySelector(".bg-red-500\\/10")).not.toBeNull();
+      // The +/- tint still rides underneath: the added/removed rows keep their
+      // low-alpha emerald/rose backgrounds (token colours show through them).
+      expect(container.querySelector(".bg-emerald-500\\/10")).not.toBeNull();
+      expect(container.querySelector(".bg-red-500\\/10")).not.toBeNull();
 
-    // Stats still computed correctly (+1 / −1).
-    expect(screen.getByText("+1")).toBeInTheDocument();
-    expect(screen.getByText("−1")).toBeInTheDocument();
-  });
+      // Stats still computed correctly (+1 / −1).
+      expect(screen.getByText("+1")).toBeInTheDocument();
+      expect(screen.getByText("−1")).toBeInTheDocument();
+    },
+  );
 
   it("keeps the collapsible unchanged run and toggle working under highlighting", () => {
     render(
@@ -124,35 +137,46 @@ describe("DiffBlock", () => {
     ).toHaveAttribute("aria-expanded", "true");
   });
 
-  it("highlights both columns in split view (and the toggle persists)", async () => {
-    const { container } = render(
-      <DiffBlock id="d6" attributes={{ filename: "src/loop.rs", lang: "rust" }}>
-        {RUST_DIFF}
-      </DiffBlock>,
-    );
-    // Switch to split view.
-    fireEvent.click(screen.getByRole("button", { name: "Split" }));
-    expect(screen.getByRole("button", { name: "Split" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    // The choice is persisted to localStorage.
-    expect(window.localStorage.getItem("djinn:proposal-diff-view-mode")).toBe(
-      "split",
-    );
-    // Both side-by-side columns highlight (tokens present in each half).
-    await waitFor(() => {
-      const columns = container.querySelectorAll(".flex-1");
-      expect(columns.length).toBeGreaterThanOrEqual(2);
-      for (const col of [columns[0], columns[1]]) {
-        expect(
-          within(col as HTMLElement).getAllByText(
-            (_, el) => el?.classList.contains("token") ?? false,
-          ).length,
-        ).toBeGreaterThan(0);
-      }
-    });
-  });
+  it(
+    "highlights both columns in split view (and the toggle persists)",
+    { timeout: 20_000 },
+    async () => {
+      const { container } = render(
+        <DiffBlock
+          id="d6"
+          attributes={{ filename: "src/loop.rs", lang: "rust" }}
+        >
+          {RUST_DIFF}
+        </DiffBlock>,
+      );
+      // Switch to split view.
+      fireEvent.click(screen.getByRole("button", { name: "Split" }));
+      expect(screen.getByRole("button", { name: "Split" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      // The choice is persisted to localStorage.
+      expect(window.localStorage.getItem("djinn:proposal-diff-view-mode")).toBe(
+        "split",
+      );
+      // Both side-by-side columns highlight (tokens present in each half).
+      // Same generous window as the unified test — the Prism chunk lazy-loads.
+      await waitFor(
+        () => {
+          const columns = container.querySelectorAll(".flex-1");
+          expect(columns.length).toBeGreaterThanOrEqual(2);
+          for (const col of [columns[0], columns[1]]) {
+            expect(
+              within(col as HTMLElement).getAllByText(
+                (_, el) => el?.classList.contains("token") ?? false,
+              ).length,
+            ).toBeGreaterThan(0);
+          }
+        },
+        { timeout: 15_000 },
+      );
+    },
+  );
 
   it("falls back to plain (uncoloured) code when the language is unknown", async () => {
     const { container } = render(

--- a/ui/src/stores/epicStore.ts
+++ b/ui/src/stores/epicStore.ts
@@ -37,9 +37,27 @@ export const epicStore = createStore<EpicState>()(
       set((state) => {
         const existingEpic = state.epics.get(payload.id);
         if (!existingEpic) return state;
-        
+
         const newEpics = new Map(state.epics);
-        newEpics.set(payload.id, payload);
+        // SSE epic payloads carry `proposal_id` but not the list-only
+        // proposal label enrichment (short_id/title/status); preserve the
+        // known labels unless the linkage itself changed.
+        const sameProposal = payload.proposal_id === existingEpic.proposal_id;
+        newEpics.set(payload.id, {
+          ...payload,
+          proposal_short_id:
+            payload.proposal_short_id ??
+            (sameProposal ? existingEpic.proposal_short_id : null),
+          proposal_title:
+            payload.proposal_title ??
+            (sameProposal ? existingEpic.proposal_title : null),
+          proposal_status:
+            payload.proposal_status ??
+            (sameProposal ? existingEpic.proposal_status : null),
+          proposal_build_owner_user_id:
+            payload.proposal_build_owner_user_id ??
+            (sameProposal ? existingEpic.proposal_build_owner_user_id : null),
+        });
         return { epics: newEpics };
       });
     },


### PR DESCRIPTION
## What

Replaces the kanban's per-column epic group cards with Linear-style full-width swimlanes, one per **building** proposal.

### Board (UI)
- Sticky status header (Open / In Progress / PR Ready / Merged) over a shared 4-column grid; cards align under their status column inside each lane.
- Lane header: build owner's avatar (whose credentials the build consumes), proposal title (click → `/proposals/:id`), total task count, merged-progress fraction (`2/7 merged`); clicking the row collapses the lane.
- Cards name their epic (emoji + title) at the bottom — lanes group by proposal, so epic context lives on the card. Label chips are removed from cards.
- Only building proposals form lanes. Tasks without a building-proposal linkage (standalone epics, no-epic chores, stragglers of retired proposals) fold into one **No proposal** catch-all lane; merged tasks of retired proposals age off the board, and the merged-column "Load more" pagination affordance is gone.

### Backend
The epic→proposal linkage was not on the wire, so:
- Migration `114_epics_proposal_id.sql`: denormalized `epics.proposal_id` (FK, `ON DELETE SET NULL`, indexed, backfilled). `proposal_epics` stays canonical.
- `link_epic`/`unlink_epic(s)` (+ tx variants) mirror the column and re-emit `epic_updated` so live boards regroup at graduation time.
- `epic_list` enriches epics with `proposal_short_id`/`proposal_title`/`proposal_status`/`proposal_build_owner_user_id` via one batched proposals lookup; the epic store preserves the enrichment across SSE updates.
- Goldens regenerated: `.sqlx` offline cache, server `mcp_tools_schema.snap`, `DjinnMcpServer` corpus fixture, `ui/src/api/generated/mcp-tools.gen.ts`. Role snapshots and contract snaps verified untouched (input-only / `None`-skipping).

### Also
- Stabilized the flaky DiffBlock Prism test (lazy grammar import racing `waitFor`'s 1s default under full-suite CPU load) with generous explicit timeouts; assertions unchanged.

## Verification
- Server: workspace compiles, clippy clean; djinn-db epic (42) + proposal (102) and control-plane epic tool tests pass against the test Postgres; all schema-golden suites green.
- UI: full vitest suite passes; typecheck + lint clean; interactions (collapse, proposal navigation, filters, epic chips, avatar lanes) verified in Storybook via browser.

Follow-up candidate: the merged-pagination data machinery (`mergedColumnStore`, `loadMoreClosedTasks`) still loads the first merged page; if the building-only board proves out it can be removed entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)