### PR TITLE
Record merge-queue failure lane in task CI snapshots

### DIFF
--- a/server/crates/djinn-coordinator/src/ci_preflight_gate.rs
+++ b/server/crates/djinn-coordinator/src/ci_preflight_gate.rs
@@ -364,6 +364,7 @@ mod tests {
             last_seen_at: "now".to_string(),
             same_signature_count: 1,
             last_remediation_base_sha: baseline.map(str::to_string),
+            merge_queue: None,
         }
     }
 

--- a/server/crates/djinn-coordinator/src/pr_poller/pr_commands.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/pr_commands.rs
@@ -1,4 +1,5 @@
 use super::*;
+use djinn_core::models::TaskPrCiSnapshotMqLaneInput;
 
 impl CoordinatorActor {
     #[allow(clippy::too_many_arguments)]
@@ -330,6 +331,56 @@ impl CoordinatorActor {
                                     repo,
                                 )
                                 .await;
+
+                                // Durably record the merge-queue failure lane on
+                                // the CI snapshot. Without this the snapshot's
+                                // PR-head lane still reads `passing` (the PR
+                                // head's own checks are green — the heavy stages
+                                // run only on `merge_group`), so same-signature
+                                // counting / 3-strike escalation was blind to
+                                // merge-queue rejections. The fingerprint is
+                                // computed from the failing merge-group check
+                                // names (empty sections — the check-run names are
+                                // the stable signal we have in hand here), mirror-
+                                // ing the PR-head lane's fingerprinting. Non-fatal
+                                // on error (warn + continue), matching
+                                // `persist_ci_snapshot`'s posture.
+                                let mq_fingerprint = compute_ci_failure_fingerprint(&failed, &[]);
+                                let mq_failed_names: Vec<String> =
+                                    failed.iter().map(|cr| cr.name.clone()).collect();
+                                match self
+                                    .task_repo()
+                                    .upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+                                        task_id: task_id.to_owned(),
+                                        pr_number: pull_number as i64,
+                                        state: "dequeued_failure".to_owned(),
+                                        run_id: i64::try_from(run.id).ok(),
+                                        head_sha: Some(run.head_sha.clone()),
+                                        failed_check_names: mq_failed_names,
+                                        failure_fingerprint: Some(mq_fingerprint.clone()),
+                                    })
+                                    .await
+                                {
+                                    Ok(snap) => tracing::info!(
+                                        task_id = %task_short_id,
+                                        pr = pull_number,
+                                        run_id = run.id,
+                                        fingerprint = %mq_fingerprint,
+                                        mq_same_signature_count = snap
+                                            .merge_queue
+                                            .as_ref()
+                                            .map(|l| l.same_signature_count)
+                                            .unwrap_or(0),
+                                        "PR poller: recorded merge-queue failure lane on CI snapshot"
+                                    ),
+                                    Err(e) => tracing::warn!(
+                                        task_id = %task_short_id,
+                                        pr = pull_number,
+                                        run_id = run.id,
+                                        error = %e,
+                                        "PR poller: failed to record merge-queue failure lane on CI snapshot (non-fatal)"
+                                    ),
+                                }
                             }
                         }
                         Err(e) => tracing::warn!(

--- a/server/crates/djinn-coordinator/src/pr_poller/tests.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/tests.rs
@@ -2958,6 +2958,7 @@ fn gate_snapshot(task_id: &str, head_sha: &str, ci_status: CiStatus) -> TaskPrCi
         last_seen_at: "2026-01-01T00:00:00.000Z".to_owned(),
         same_signature_count: 0,
         last_remediation_base_sha: None,
+        merge_queue: None,
     }
 }
 
@@ -3996,6 +3997,7 @@ fn durable_snapshot(
         last_seen_at: "2026-07-01T00:00:00.000Z".to_owned(),
         same_signature_count,
         last_remediation_base_sha: Some(head_sha.to_owned()),
+        merge_queue: None,
     }
 }
 

--- a/server/crates/djinn-core/src/models/mod.rs
+++ b/server/crates/djinn-core/src/models/mod.rs
@@ -32,9 +32,10 @@ pub use session::{CostBasis, SessionRecord, SessionStatus};
 pub use session_message::SessionMessage;
 pub use settings::{DispatchPause, DispatchPauseScope, DispatchPauseState, DjinnSettings, Setting};
 pub use task::{
-    ActivityEntry, CiStatus, IssueType, PRIORITY_CRITICAL, ReopenClass, ReopenLedgerEntry, Task,
-    TaskPrCiSnapshot, TaskPrCiSnapshotInput, TaskStatus, TransitionAction, TransitionApply,
-    compute_transition, compute_transition_for_issue_type,
+    ActivityEntry, CiStatus, IssueType, MergeQueueLane, PRIORITY_CRITICAL, ReopenClass,
+    ReopenLedgerEntry, Task, TaskPrCiSnapshot, TaskPrCiSnapshotInput, TaskPrCiSnapshotMqLaneInput,
+    TaskStatus, TransitionAction, TransitionApply, compute_transition,
+    compute_transition_for_issue_type,
 };
 pub use task_attempt::{
     GuardDecision, GuardReason, LogTailMeta, TASK_ATTEMPT_DISPATCH_KEY_MAX_LEN,

--- a/server/crates/djinn-core/src/models/task.rs
+++ b/server/crates/djinn-core/src/models/task.rs
@@ -176,6 +176,45 @@ pub struct TaskPrCiSnapshot {
     /// Base SHA of the last remediation attempt for this failing signature.
     /// `None` when no remediation has been attempted yet.
     pub last_remediation_base_sha: Option<String>,
+    /// Merge-queue (`merge_group`) failure lane. Written ONLY by the PR-poller
+    /// dequeue path — never by the PR-head writer — and cleared when a new PR
+    /// head is observed. `None` when no merge-queue failure has been recorded
+    /// for the current head. See [`MergeQueueLane`].
+    pub merge_queue: Option<MergeQueueLane>,
+}
+
+/// The merge-queue (`merge_group`) failure lane of a [`TaskPrCiSnapshot`].
+///
+/// GitHub's merge queue runs the heavy CI stages (unit/integration) on the
+/// ephemeral `merge_group` ref, not on the PR head. A PR head whose own checks
+/// are green can still be rejected by the queue. The PR poller discovers these
+/// rejections at dequeue time and records them here so the durable snapshot
+/// reflects the queue verdict and merge-group failures get their own failure
+/// fingerprint / same-signature counting (independent of the PR-head lane).
+///
+/// This lane is populated from the flat `mq_*` columns of
+/// `task_pr_ci_snapshots`; it is `Some` only when a merge-queue state has been
+/// recorded.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeQueueLane {
+    /// Lane state, e.g. `"dequeued_failure"`.
+    pub state: String,
+    /// The `merge_group` Actions run id that failed, when known.
+    pub run_id: Option<i64>,
+    /// The `head_sha` of the failed merge-group run (the ephemeral queue ref
+    /// head), when known.
+    pub head_sha: Option<String>,
+    /// Names of the merge-group check runs that failed.
+    pub failed_check_names: Vec<String>,
+    /// Stable fingerprint of the merge-group failure signature.
+    pub failure_fingerprint: Option<String>,
+    /// How many consecutive dequeue observations carried the same
+    /// `failure_fingerprint` in this lane.
+    pub same_signature_count: i64,
+    /// ISO-8601 timestamp when this merge-queue lane state was first observed.
+    pub first_seen_at: Option<String>,
+    /// ISO-8601 timestamp when this merge-queue lane state was last observed.
+    pub last_seen_at: Option<String>,
 }
 
 /// Input shape for creating or upserting a [`TaskPrCiSnapshot`].
@@ -193,6 +232,24 @@ pub struct TaskPrCiSnapshotInput {
     pub failure_fingerprint: Option<String>,
     pub same_signature_count: i64,
     pub last_remediation_base_sha: Option<String>,
+}
+
+/// Input shape for upserting ONLY the merge-queue lane of a
+/// [`TaskPrCiSnapshot`] (the `mq_*` columns).
+///
+/// Written exclusively by the PR-poller dequeue path. Per-lane same-signature
+/// counting and first/last-seen timestamps are resolved by the repository
+/// layer, so callers supply only the observed fields.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskPrCiSnapshotMqLaneInput {
+    pub task_id: String,
+    pub pr_number: i64,
+    /// Lane state, e.g. `"dequeued_failure"`.
+    pub state: String,
+    pub run_id: Option<i64>,
+    pub head_sha: Option<String>,
+    pub failed_check_names: Vec<String>,
+    pub failure_fingerprint: Option<String>,
 }
 
 impl TaskPrCiSnapshot {
@@ -213,6 +270,7 @@ impl TaskPrCiSnapshot {
             last_seen_at,
             same_signature_count: input.same_signature_count,
             last_remediation_base_sha: input.last_remediation_base_sha,
+            merge_queue: None,
         }
     }
 }
@@ -1877,6 +1935,7 @@ mod tests {
             last_seen_at: "2026-06-29T12:00:00Z".to_owned(),
             same_signature_count: 0,
             last_remediation_base_sha: None,
+            merge_queue: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
         let parsed: TaskPrCiSnapshot = serde_json::from_str(&json).unwrap();

--- a/server/crates/djinn-db/migrations_postgres/116_task_pr_ci_snapshots_merge_queue_lane.sql
+++ b/server/crates/djinn-db/migrations_postgres/116_task_pr_ci_snapshots_merge_queue_lane.sql
@@ -1,0 +1,43 @@
+-- Add a merge-queue (`merge_group`) failure lane to the per-task CI snapshot.
+--
+-- GitHub's merge queue runs the heavy CI stages on the ephemeral `merge_group`
+-- ref, not on the PR head. A PR head whose own required checks are green can
+-- still be rejected by the queue at dequeue time. The PR poller already
+-- discovers those rejections (it looks up the failed `merge_group` Actions run
+-- and its failing check runs) but previously only wrote an activity comment —
+-- so the durable snapshot said "passing" while the queue kept rejecting, and
+-- merge-queue failures never got a failure fingerprint for same-signature
+-- counting / escalation.
+--
+-- These `mq_*` columns form a SECOND lane on the snapshot, written ONLY by the
+-- dequeue path and never touched by the PR-head writer (to avoid flip-flop).
+-- The PR-head writer clears this lane when it observes a NEW head SHA (a new
+-- head invalidates the old queue verdict).
+--
+-- Purely additive: every column is nullable / defaulted, no backfill.
+
+-- Every column is nullable with NO default: an absent merge-queue observation
+-- is represented by NULL, and an explicit `DEFAULT NULL` on `ADD COLUMN` would
+-- persist a `NULL::type` default expression (unlike `CREATE TABLE`), so it is
+-- omitted deliberately.
+ALTER TABLE task_pr_ci_snapshots
+    ADD COLUMN IF NOT EXISTS mq_state                TEXT        NULL,
+    ADD COLUMN IF NOT EXISTS mq_run_id               BIGINT      NULL,
+    ADD COLUMN IF NOT EXISTS mq_head_sha             VARCHAR(64) NULL,
+    ADD COLUMN IF NOT EXISTS mq_failed_check_names   JSONB       NULL,
+    ADD COLUMN IF NOT EXISTS mq_failure_fingerprint  TEXT        NULL,
+    ADD COLUMN IF NOT EXISTS mq_same_signature_count BIGINT      NULL,
+    ADD COLUMN IF NOT EXISTS mq_first_seen_at        VARCHAR(64) NULL,
+    ADD COLUMN IF NOT EXISTS mq_last_seen_at         VARCHAR(64) NULL;
+
+-- When present, mq_failed_check_names must be a JSON array (mirrors the
+-- PR-head lane's blocking_required_check_names invariant), but NULL is allowed
+-- (no merge-queue observation for this head).
+ALTER TABLE task_pr_ci_snapshots
+    ADD CONSTRAINT task_pr_ci_snapshots_mq_failed_names_array_check
+        CHECK (mq_failed_check_names IS NULL
+               OR jsonb_typeof(mq_failed_check_names) = 'array');
+
+ALTER TABLE task_pr_ci_snapshots
+    ADD CONSTRAINT task_pr_ci_snapshots_mq_same_signature_count_check
+        CHECK (mq_same_signature_count IS NULL OR mq_same_signature_count >= 0);

--- a/server/crates/djinn-db/src/repositories/task/ci.rs
+++ b/server/crates/djinn-db/src/repositories/task/ci.rs
@@ -1,6 +1,24 @@
 use super::*;
-use djinn_core::models::{CiStatus, TaskPrCiSnapshot, TaskPrCiSnapshotInput};
+use djinn_core::models::{
+    CiStatus, MergeQueueLane, TaskPrCiSnapshot, TaskPrCiSnapshotInput, TaskPrCiSnapshotMqLaneInput,
+};
 use sqlx::Row;
+
+/// The full column list read back by [`ci_snapshot_from_row`]. Shared between
+/// the SELECT, the upsert `RETURNING`, and the reset `RETURNING` so every path
+/// that maps a row through `ci_snapshot_from_row` returns the same shape —
+/// including the merge-queue (`mq_*`) lane.
+const CI_SNAPSHOT_COLUMNS: &str = "task_id, pr_number, head_sha, ci_status, \
+     blocking_required_check_names, failure_fingerprint, \
+     first_seen_at, last_seen_at, same_signature_count, \
+     last_remediation_base_sha, \
+     mq_state, mq_run_id, mq_head_sha, mq_failed_check_names, \
+     mq_failure_fingerprint, mq_same_signature_count, \
+     mq_first_seen_at, mq_last_seen_at";
+
+/// SQL expression producing the canonical UTC text timestamp used by every
+/// snapshot column (`YYYY-MM-DDThh:mm:ss.mmmZ`).
+const UTC_NOW_TEXT: &str = "to_char(now() at time zone 'utc', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')";
 
 fn ci_snapshot_from_row(row: sqlx::postgres::PgRow) -> Result<TaskPrCiSnapshot> {
     let names: serde_json::Value = row.try_get("blocking_required_check_names")?;
@@ -10,6 +28,36 @@ fn ci_snapshot_from_row(row: sqlx::postgres::PgRow) -> Result<TaskPrCiSnapshot> 
         ))
     })?;
     let ci_status_raw: String = row.try_get("ci_status")?;
+
+    // The merge-queue lane is present only when a lane state has been recorded
+    // (`mq_state IS NOT NULL`). All other `mq_*` columns are nullable and are
+    // cleared together with `mq_state` when a new PR head is observed.
+    let merge_queue = match row.try_get::<Option<String>, _>("mq_state")? {
+        Some(state) => {
+            let failed_check_names =
+                match row.try_get::<Option<serde_json::Value>, _>("mq_failed_check_names")? {
+                    Some(v) => serde_json::from_value(v).map_err(|e| {
+                        Error::InvalidData(format!(
+                            "invalid task_pr_ci_snapshots.mq_failed_check_names: {e}"
+                        ))
+                    })?,
+                    None => Vec::new(),
+                };
+            Some(MergeQueueLane {
+                state,
+                run_id: row.try_get("mq_run_id")?,
+                head_sha: row.try_get("mq_head_sha")?,
+                failed_check_names,
+                failure_fingerprint: row.try_get("mq_failure_fingerprint")?,
+                same_signature_count: row
+                    .try_get::<Option<i64>, _>("mq_same_signature_count")?
+                    .unwrap_or(0),
+                first_seen_at: row.try_get("mq_first_seen_at")?,
+                last_seen_at: row.try_get("mq_last_seen_at")?,
+            })
+        }
+        None => None,
+    };
 
     Ok(TaskPrCiSnapshot {
         task_id: row.try_get("task_id")?,
@@ -24,6 +72,7 @@ fn ci_snapshot_from_row(row: sqlx::postgres::PgRow) -> Result<TaskPrCiSnapshot> 
         last_seen_at: row.try_get("last_seen_at")?,
         same_signature_count: row.try_get("same_signature_count")?,
         last_remediation_base_sha: row.try_get("last_remediation_base_sha")?,
+        merge_queue,
     })
 }
 
@@ -35,30 +84,37 @@ impl TaskRepository {
         pr_number: i64,
     ) -> Result<Option<TaskPrCiSnapshot>> {
         self.db.ensure_initialized().await?;
-        let row = sqlx::query(
-            r#"SELECT task_id, pr_number, head_sha, ci_status,
-                      blocking_required_check_names, failure_fingerprint,
-                      first_seen_at, last_seen_at, same_signature_count,
-                      last_remediation_base_sha
-                 FROM task_pr_ci_snapshots
-                WHERE task_id = $1 AND pr_number = $2"#,
-        )
-        .bind(task_id)
-        .bind(pr_number)
-        .fetch_optional(self.db.pool())
-        .await?;
+        let sql = format!(
+            "SELECT {CI_SNAPSHOT_COLUMNS} \
+               FROM task_pr_ci_snapshots \
+              WHERE task_id = $1 AND pr_number = $2"
+        );
+        let row = sqlx::query(&sql)
+            .bind(task_id)
+            .bind(pr_number)
+            .fetch_optional(self.db.pool())
+            .await?;
         row.map(ci_snapshot_from_row).transpose()
     }
 
     /// Upsert a task/PR CI snapshot, resetting first-seen semantics whenever the
     /// observed head or failure signature changes.
+    ///
+    /// This is the sole PR-head lane writer. It NEVER writes the merge-queue
+    /// (`mq_*`) lane values; it only PRESERVES them on a same-head observation
+    /// and CLEARS them when a new head SHA is observed (a new head invalidates
+    /// the prior queue verdict). The merge-queue lane is written exclusively by
+    /// [`Self::upsert_ci_snapshot_mq_lane`].
     pub async fn upsert_ci_snapshot(
         &self,
         input: TaskPrCiSnapshotInput,
     ) -> Result<TaskPrCiSnapshot> {
         self.db.ensure_initialized().await?;
         let blocking_names = serde_json::to_value(&input.blocking_required_check_names)?;
-        let row = sqlx::query(
+        // `same_head` is true when this observation is for the SAME head SHA as
+        // the stored row; it gates both the existing downgrade/first-seen
+        // guards and the merge-queue lane preservation.
+        let sql = format!(
             r#"INSERT INTO task_pr_ci_snapshots (
                     task_id, pr_number, head_sha, ci_status,
                     blocking_required_check_names, failure_fingerprint,
@@ -71,7 +127,7 @@ impl TaskRepository {
                          AND task_pr_ci_snapshots.blocking_required_check_names = EXCLUDED.blocking_required_check_names
                          AND COALESCE(task_pr_ci_snapshots.failure_fingerprint, '') = COALESCE(EXCLUDED.failure_fingerprint, '')
                         THEN task_pr_ci_snapshots.first_seen_at
-                        ELSE to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                        ELSE {UTC_NOW_TEXT}
                     END,
                     head_sha = EXCLUDED.head_sha,
                     -- Downgrade guard: a later `unknown` observation (empty
@@ -91,7 +147,7 @@ impl TaskRepository {
                     END,
                     blocking_required_check_names = EXCLUDED.blocking_required_check_names,
                     failure_fingerprint = EXCLUDED.failure_fingerprint,
-                    last_seen_at = to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+                    last_seen_at = {UTC_NOW_TEXT},
                     same_signature_count = CASE
                         WHEN EXCLUDED.same_signature_count > 0
                         THEN EXCLUDED.same_signature_count
@@ -101,26 +157,103 @@ impl TaskRepository {
                         WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '')
                         THEN EXCLUDED.last_remediation_base_sha
                         ELSE NULL
+                    END,
+                    -- Merge-queue lane: PRESERVE on a same-head observation
+                    -- (this PR-head writer must never clobber the dequeue-path
+                    -- lane and cause the snapshot to flip-flop), CLEAR on a new
+                    -- head (the prior queue verdict was for a head that no
+                    -- longer exists). Never SET to a fresh value here — the lane
+                    -- is written solely by `upsert_ci_snapshot_mq_lane`.
+                    mq_state = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_state ELSE NULL END,
+                    mq_run_id = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_run_id ELSE NULL END,
+                    mq_head_sha = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_head_sha ELSE NULL END,
+                    mq_failed_check_names = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_failed_check_names ELSE NULL END,
+                    mq_failure_fingerprint = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_failure_fingerprint ELSE NULL END,
+                    mq_same_signature_count = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_same_signature_count ELSE NULL END,
+                    mq_first_seen_at = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_first_seen_at ELSE NULL END,
+                    mq_last_seen_at = CASE WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '') THEN task_pr_ci_snapshots.mq_last_seen_at ELSE NULL END
+                RETURNING {CI_SNAPSHOT_COLUMNS}"#
+        );
+        let row = sqlx::query(&sql)
+            .bind(&input.task_id)
+            .bind(input.pr_number)
+            .bind(&input.head_sha)
+            .bind(input.ci_status.as_str())
+            .bind(blocking_names)
+            .bind(&input.failure_fingerprint)
+            .bind(input.same_signature_count)
+            .bind(&input.last_remediation_base_sha)
+            .fetch_one(self.db.pool())
+            .await?;
+        ci_snapshot_from_row(row)
+    }
+
+    /// Upsert ONLY the merge-queue (`merge_group`) failure lane for a task/PR.
+    ///
+    /// Written exclusively by the PR-poller dequeue path when GitHub's merge
+    /// queue rejects the PR. The PR-head lane fields are left at their defaults
+    /// when the row is created here (an mq observation can precede any PR-head
+    /// observation). Per-lane same-signature semantics mirror the PR-head lane:
+    /// the same fingerprint increments `mq_same_signature_count` and keeps
+    /// `mq_first_seen_at`; a different fingerprint resets the count to 1 and
+    /// resets `mq_first_seen_at`.
+    pub async fn upsert_ci_snapshot_mq_lane(
+        &self,
+        input: TaskPrCiSnapshotMqLaneInput,
+    ) -> Result<TaskPrCiSnapshot> {
+        self.db.ensure_initialized().await?;
+        let failed_names = serde_json::to_value(&input.failed_check_names)?;
+        // `same_fp` is true when the incoming fingerprint matches the stored
+        // lane fingerprint (NULL-safe): same signature → increment + keep
+        // first_seen; different → reset count to 1 + reset first_seen.
+        let sql = format!(
+            r#"INSERT INTO task_pr_ci_snapshots (
+                    task_id, pr_number,
+                    mq_state, mq_run_id, mq_head_sha, mq_failed_check_names,
+                    mq_failure_fingerprint, mq_same_signature_count,
+                    mq_first_seen_at, mq_last_seen_at
+                ) VALUES (
+                    $1, $2,
+                    $3, $4, $5, $6::jsonb,
+                    $7, 1,
+                    {UTC_NOW_TEXT}, {UTC_NOW_TEXT}
+                )
+                ON CONFLICT (task_id, pr_number) DO UPDATE SET
+                    mq_state = EXCLUDED.mq_state,
+                    mq_run_id = EXCLUDED.mq_run_id,
+                    mq_head_sha = EXCLUDED.mq_head_sha,
+                    mq_failed_check_names = EXCLUDED.mq_failed_check_names,
+                    mq_failure_fingerprint = EXCLUDED.mq_failure_fingerprint,
+                    mq_first_seen_at = CASE
+                        WHEN COALESCE(task_pr_ci_snapshots.mq_failure_fingerprint, '') = COALESCE(EXCLUDED.mq_failure_fingerprint, '')
+                        THEN COALESCE(task_pr_ci_snapshots.mq_first_seen_at, {UTC_NOW_TEXT})
+                        ELSE {UTC_NOW_TEXT}
+                    END,
+                    mq_last_seen_at = {UTC_NOW_TEXT},
+                    mq_same_signature_count = CASE
+                        WHEN COALESCE(task_pr_ci_snapshots.mq_failure_fingerprint, '') = COALESCE(EXCLUDED.mq_failure_fingerprint, '')
+                        THEN COALESCE(task_pr_ci_snapshots.mq_same_signature_count, 0) + 1
+                        ELSE 1
                     END
-                RETURNING task_id, pr_number, head_sha, ci_status,
-                          blocking_required_check_names, failure_fingerprint,
-                          first_seen_at, last_seen_at, same_signature_count,
-                          last_remediation_base_sha"#,
-        )
-        .bind(&input.task_id)
-        .bind(input.pr_number)
-        .bind(&input.head_sha)
-        .bind(input.ci_status.as_str())
-        .bind(blocking_names)
-        .bind(&input.failure_fingerprint)
-        .bind(input.same_signature_count)
-        .bind(&input.last_remediation_base_sha)
-        .fetch_one(self.db.pool())
-        .await?;
+                RETURNING {CI_SNAPSHOT_COLUMNS}"#
+        );
+        let row = sqlx::query(&sql)
+            .bind(&input.task_id)
+            .bind(input.pr_number)
+            .bind(&input.state)
+            .bind(input.run_id)
+            .bind(&input.head_sha)
+            .bind(failed_names)
+            .bind(&input.failure_fingerprint)
+            .fetch_one(self.db.pool())
+            .await?;
         ci_snapshot_from_row(row)
     }
 
     /// Reset stale CI state after observing a different PR head SHA.
+    ///
+    /// Clears both the PR-head lane (back to `unknown`) and the merge-queue
+    /// (`mq_*`) lane — a new head invalidates any prior queue verdict.
     pub async fn reset_ci_snapshot_for_head(
         &self,
         task_id: &str,
@@ -128,7 +261,7 @@ impl TaskRepository {
         head_sha: &str,
     ) -> Result<TaskPrCiSnapshot> {
         self.db.ensure_initialized().await?;
-        let row = sqlx::query(
+        let sql = format!(
             r#"INSERT INTO task_pr_ci_snapshots (
                     task_id, pr_number, head_sha, ci_status,
                     blocking_required_check_names, failure_fingerprint,
@@ -142,21 +275,28 @@ impl TaskRepository {
                     first_seen_at = CASE
                         WHEN COALESCE(task_pr_ci_snapshots.head_sha, '') = COALESCE(EXCLUDED.head_sha, '')
                         THEN task_pr_ci_snapshots.first_seen_at
-                        ELSE to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                        ELSE {UTC_NOW_TEXT}
                     END,
-                    last_seen_at = to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+                    last_seen_at = {UTC_NOW_TEXT},
                     same_signature_count = 0,
-                    last_remediation_base_sha = NULL
-                RETURNING task_id, pr_number, head_sha, ci_status,
-                          blocking_required_check_names, failure_fingerprint,
-                          first_seen_at, last_seen_at, same_signature_count,
-                          last_remediation_base_sha"#,
-        )
-        .bind(task_id)
-        .bind(pr_number)
-        .bind(head_sha)
-        .fetch_one(self.db.pool())
-        .await?;
+                    last_remediation_base_sha = NULL,
+                    -- New head → drop the prior merge-queue verdict entirely.
+                    mq_state = NULL,
+                    mq_run_id = NULL,
+                    mq_head_sha = NULL,
+                    mq_failed_check_names = NULL,
+                    mq_failure_fingerprint = NULL,
+                    mq_same_signature_count = NULL,
+                    mq_first_seen_at = NULL,
+                    mq_last_seen_at = NULL
+                RETURNING {CI_SNAPSHOT_COLUMNS}"#
+        );
+        let row = sqlx::query(&sql)
+            .bind(task_id)
+            .bind(pr_number)
+            .bind(head_sha)
+            .fetch_one(self.db.pool())
+            .await?;
         ci_snapshot_from_row(row)
     }
 }

--- a/server/crates/djinn-db/src/repositories/task/mod.rs
+++ b/server/crates/djinn-db/src/repositories/task/mod.rs
@@ -50,7 +50,8 @@ mod tests {
 
     use djinn_core::events::{DjinnEventEnvelope, EventBus};
     use djinn_core::models::{
-        CiStatus, Project, Task, TaskPrCiSnapshotInput, TaskStatus, TransitionAction,
+        CiStatus, Project, Task, TaskPrCiSnapshotInput, TaskPrCiSnapshotMqLaneInput, TaskStatus,
+        TransitionAction,
     };
 
     use crate::database::Database;
@@ -1235,6 +1236,294 @@ mod tests {
             .unwrap();
         assert_eq!(new_head.ci_status, CiStatus::Unknown);
         assert_eq!(new_head.head_sha, "sha-new");
+    }
+
+    // ── Merge-queue lane tests (PR A) ────────────────────────────────────
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mq_lane_upsert_creates_row_and_sets_fields() {
+        let db = Database::open_in_memory().unwrap();
+        let (bus, _captured) = capturing_bus();
+        let repo = TaskRepository::new(db.clone(), bus);
+        let project = make_project(&db).await;
+        let epic_id = make_epic(&db, &project.id).await;
+        let task = make_task(&repo, &epic_id, "task", Some(r#"[{"title":"ac"}]"#)).await;
+
+        // No PR-head observation yet: the mq lane upsert must create the row.
+        let snap = repo
+            .upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+                task_id: task.id.clone(),
+                pr_number: 42,
+                state: "dequeued_failure".to_string(),
+                run_id: Some(9001),
+                head_sha: Some("mq-head-1".to_string()),
+                failed_check_names: vec!["Server Test".to_string(), "Server Clippy".to_string()],
+                failure_fingerprint: Some("mq-fp-1".to_string()),
+            })
+            .await
+            .unwrap();
+
+        // PR-head lane stays at its unknown defaults (mq observation preceded
+        // any PR-head observation).
+        assert_eq!(snap.ci_status, CiStatus::Unknown);
+        assert!(snap.head_sha.is_empty());
+        assert!(snap.blocking_required_check_names.is_empty());
+
+        let lane = snap.merge_queue.expect("merge-queue lane present");
+        assert_eq!(lane.state, "dequeued_failure");
+        assert_eq!(lane.run_id, Some(9001));
+        assert_eq!(lane.head_sha.as_deref(), Some("mq-head-1"));
+        assert_eq!(lane.failed_check_names, ["Server Test", "Server Clippy"]);
+        assert_eq!(lane.failure_fingerprint.as_deref(), Some("mq-fp-1"));
+        assert_eq!(lane.same_signature_count, 1);
+        assert!(lane.first_seen_at.is_some());
+        assert!(lane.last_seen_at.is_some());
+
+        // A fresh read returns the same lane.
+        let read = repo
+            .get_ci_snapshot_for_task_pr(&task.id, 42)
+            .await
+            .unwrap()
+            .unwrap();
+        let read_lane = read.merge_queue.expect("lane persisted");
+        assert_eq!(read_lane.state, "dequeued_failure");
+        assert_eq!(read_lane.same_signature_count, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mq_lane_same_fingerprint_increments_and_keeps_first_seen() {
+        let db = Database::open_in_memory().unwrap();
+        let (bus, _captured) = capturing_bus();
+        let repo = TaskRepository::new(db.clone(), bus);
+        let project = make_project(&db).await;
+        let epic_id = make_epic(&db, &project.id).await;
+        let task = make_task(&repo, &epic_id, "task", Some(r#"[{"title":"ac"}]"#)).await;
+
+        let first = repo
+            .upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+                task_id: task.id.clone(),
+                pr_number: 7,
+                state: "dequeued_failure".to_string(),
+                run_id: Some(1),
+                head_sha: Some("h1".to_string()),
+                failed_check_names: vec!["Server Test".to_string()],
+                failure_fingerprint: Some("same-fp".to_string()),
+            })
+            .await
+            .unwrap();
+        let first_lane = first.merge_queue.unwrap();
+        assert_eq!(first_lane.same_signature_count, 1);
+        let original_first_seen = first_lane.first_seen_at.clone();
+
+        // Same fingerprint again → increment count, keep first_seen.
+        let second = repo
+            .upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+                task_id: task.id.clone(),
+                pr_number: 7,
+                state: "dequeued_failure".to_string(),
+                run_id: Some(2),
+                head_sha: Some("h2".to_string()),
+                failed_check_names: vec!["Server Test".to_string()],
+                failure_fingerprint: Some("same-fp".to_string()),
+            })
+            .await
+            .unwrap();
+        let second_lane = second.merge_queue.unwrap();
+        assert_eq!(second_lane.same_signature_count, 2);
+        assert_eq!(
+            second_lane.first_seen_at, original_first_seen,
+            "same fingerprint must keep the original first_seen_at"
+        );
+        // Latest observed run/head are updated.
+        assert_eq!(second_lane.run_id, Some(2));
+        assert_eq!(second_lane.head_sha.as_deref(), Some("h2"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mq_lane_different_fingerprint_resets_count_and_first_seen() {
+        let db = Database::open_in_memory().unwrap();
+        let (bus, _captured) = capturing_bus();
+        let repo = TaskRepository::new(db.clone(), bus);
+        let project = make_project(&db).await;
+        let epic_id = make_epic(&db, &project.id).await;
+        let task = make_task(&repo, &epic_id, "task", Some(r#"[{"title":"ac"}]"#)).await;
+
+        // Build the count up to 2 on one fingerprint.
+        for run in [1_i64, 2] {
+            repo.upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+                task_id: task.id.clone(),
+                pr_number: 9,
+                state: "dequeued_failure".to_string(),
+                run_id: Some(run),
+                head_sha: Some("h".to_string()),
+                failed_check_names: vec!["A".to_string()],
+                failure_fingerprint: Some("fp-a".to_string()),
+            })
+            .await
+            .unwrap();
+        }
+        let before = repo
+            .get_ci_snapshot_for_task_pr(&task.id, 9)
+            .await
+            .unwrap()
+            .unwrap()
+            .merge_queue
+            .unwrap();
+        assert_eq!(before.same_signature_count, 2);
+
+        // Different fingerprint → reset count to 1 and reset first_seen.
+        let changed = repo
+            .upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+                task_id: task.id.clone(),
+                pr_number: 9,
+                state: "dequeued_failure".to_string(),
+                run_id: Some(3),
+                head_sha: Some("h".to_string()),
+                failed_check_names: vec!["B".to_string()],
+                failure_fingerprint: Some("fp-b".to_string()),
+            })
+            .await
+            .unwrap();
+        let lane = changed.merge_queue.unwrap();
+        assert_eq!(lane.same_signature_count, 1, "new fingerprint resets count");
+        assert_eq!(lane.failure_fingerprint.as_deref(), Some("fp-b"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pr_head_upsert_same_sha_preserves_mq_lane() {
+        let db = Database::open_in_memory().unwrap();
+        let (bus, _captured) = capturing_bus();
+        let repo = TaskRepository::new(db.clone(), bus);
+        let project = make_project(&db).await;
+        let epic_id = make_epic(&db, &project.id).await;
+        let task = make_task(&repo, &epic_id, "task", Some(r#"[{"title":"ac"}]"#)).await;
+
+        // Establish a PR-head snapshot on head `sha-x`.
+        repo.upsert_ci_snapshot(TaskPrCiSnapshotInput {
+            task_id: task.id.clone(),
+            pr_number: 11,
+            head_sha: "sha-x".to_string(),
+            ci_status: CiStatus::Passing,
+            blocking_required_check_names: vec![],
+            failure_fingerprint: None,
+            same_signature_count: 0,
+            last_remediation_base_sha: None,
+        })
+        .await
+        .unwrap();
+
+        // Record a merge-queue failure lane.
+        repo.upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+            task_id: task.id.clone(),
+            pr_number: 11,
+            state: "dequeued_failure".to_string(),
+            run_id: Some(55),
+            head_sha: Some("mq-x".to_string()),
+            failed_check_names: vec!["Server Test".to_string()],
+            failure_fingerprint: Some("mq-fp".to_string()),
+        })
+        .await
+        .unwrap();
+
+        // A subsequent PR-head observation on the SAME head must NOT clobber
+        // the mq lane.
+        let after = repo
+            .upsert_ci_snapshot(TaskPrCiSnapshotInput {
+                task_id: task.id.clone(),
+                pr_number: 11,
+                head_sha: "sha-x".to_string(),
+                ci_status: CiStatus::Passing,
+                blocking_required_check_names: vec![],
+                failure_fingerprint: None,
+                same_signature_count: 0,
+                last_remediation_base_sha: None,
+            })
+            .await
+            .unwrap();
+        let lane = after
+            .merge_queue
+            .expect("mq lane preserved on same-head PR-head observation");
+        assert_eq!(lane.state, "dequeued_failure");
+        assert_eq!(lane.run_id, Some(55));
+        assert_eq!(lane.failure_fingerprint.as_deref(), Some("mq-fp"));
+        assert_eq!(lane.same_signature_count, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pr_head_upsert_new_sha_clears_mq_lane() {
+        let db = Database::open_in_memory().unwrap();
+        let (bus, _captured) = capturing_bus();
+        let repo = TaskRepository::new(db.clone(), bus);
+        let project = make_project(&db).await;
+        let epic_id = make_epic(&db, &project.id).await;
+        let task = make_task(&repo, &epic_id, "task", Some(r#"[{"title":"ac"}]"#)).await;
+
+        repo.upsert_ci_snapshot(TaskPrCiSnapshotInput {
+            task_id: task.id.clone(),
+            pr_number: 12,
+            head_sha: "old-sha".to_string(),
+            ci_status: CiStatus::Passing,
+            blocking_required_check_names: vec![],
+            failure_fingerprint: None,
+            same_signature_count: 0,
+            last_remediation_base_sha: None,
+        })
+        .await
+        .unwrap();
+        repo.upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+            task_id: task.id.clone(),
+            pr_number: 12,
+            state: "dequeued_failure".to_string(),
+            run_id: Some(77),
+            head_sha: Some("mq-old".to_string()),
+            failed_check_names: vec!["Server Test".to_string()],
+            failure_fingerprint: Some("mq-fp".to_string()),
+        })
+        .await
+        .unwrap();
+
+        // A PR-head observation on a NEW head invalidates the queue verdict:
+        // the mq lane must be cleared.
+        let after = repo
+            .upsert_ci_snapshot(TaskPrCiSnapshotInput {
+                task_id: task.id.clone(),
+                pr_number: 12,
+                head_sha: "new-sha".to_string(),
+                ci_status: CiStatus::Pending,
+                blocking_required_check_names: vec![],
+                failure_fingerprint: None,
+                same_signature_count: 0,
+                last_remediation_base_sha: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(after.head_sha, "new-sha");
+        assert!(
+            after.merge_queue.is_none(),
+            "a new PR head must clear the merge-queue lane"
+        );
+
+        // `reset_ci_snapshot_for_head` (the head-change path used by the
+        // watcher) must also clear the lane.
+        repo.upsert_ci_snapshot_mq_lane(TaskPrCiSnapshotMqLaneInput {
+            task_id: task.id.clone(),
+            pr_number: 12,
+            state: "dequeued_failure".to_string(),
+            run_id: Some(78),
+            head_sha: Some("mq-new".to_string()),
+            failed_check_names: vec!["Server Test".to_string()],
+            failure_fingerprint: Some("mq-fp2".to_string()),
+        })
+        .await
+        .unwrap();
+        let reset = repo
+            .reset_ci_snapshot_for_head(&task.id, 12, "newer-sha")
+            .await
+            .unwrap();
+        assert!(
+            reset.merge_queue.is_none(),
+            "reset_ci_snapshot_for_head must clear the merge-queue lane"
+        );
     }
 
     // ── CI head reconciliation tests (m116) ─────────────────────────────

--- a/server/crates/djinn-db/tests/migrations_task_pr_ci_snapshots.rs
+++ b/server/crates/djinn-db/tests/migrations_task_pr_ci_snapshots.rs
@@ -406,3 +406,128 @@ async fn migration_85_backfills_open_pr_tasks_to_unknown_and_skips_closed_tasks(
     })
     .await;
 }
+
+/// Migration 116 is purely additive: it adds the nullable `mq_*` merge-queue
+/// lane columns plus two CHECK constraints, with no backfill. Assert the
+/// columns exist as nullable-without-default, the constraints are present, and
+/// that they reject bad values while accepting a NULL lane and a well-formed
+/// lane.
+#[tokio::test]
+async fn migration_116_adds_nullable_merge_queue_lane_columns_and_constraints() {
+    with_temp_database("mq_lane", |db_url| async move {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&db_url)
+            .await
+            .expect("connect fresh migration database");
+        sqlx::migrate!("./migrations_postgres")
+            .run(&pool)
+            .await
+            .expect("apply all migrations to fresh database");
+
+        // Pre-existing PR-head lane schema is still intact.
+        assert_schema(&pool).await;
+
+        for (column, data_type) in [
+            ("mq_state", "text"),
+            ("mq_run_id", "bigint"),
+            ("mq_head_sha", "character varying"),
+            ("mq_failed_check_names", "jsonb"),
+            ("mq_failure_fingerprint", "text"),
+            ("mq_same_signature_count", "bigint"),
+            ("mq_first_seen_at", "character varying"),
+            ("mq_last_seen_at", "character varying"),
+        ] {
+            let (actual_type, actual_nullable, actual_default): (String, String, Option<String>) =
+                sqlx::query_as(
+                    "SELECT data_type, is_nullable, column_default \
+                     FROM information_schema.columns \
+                     WHERE table_name = 'task_pr_ci_snapshots' AND column_name = $1",
+                )
+                .bind(column)
+                .fetch_one(&pool)
+                .await
+                .unwrap_or_else(|e| panic!("inspect mq column {column}: {e}"));
+            assert_eq!(actual_type, data_type, "unexpected type for {column}");
+            assert_eq!(actual_nullable, "YES", "mq column {column} must be nullable");
+            assert_eq!(
+                actual_default, None,
+                "mq column {column} must have no default"
+            );
+        }
+
+        let constraints: Vec<String> = sqlx::query_scalar(
+            "SELECT conname FROM pg_constraint \
+             WHERE conrelid = 'task_pr_ci_snapshots'::regclass \
+             ORDER BY conname",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("inspect task_pr_ci_snapshots constraints");
+        for expected in [
+            "task_pr_ci_snapshots_mq_failed_names_array_check",
+            "task_pr_ci_snapshots_mq_same_signature_count_check",
+        ] {
+            assert!(
+                constraints.iter().any(|c| c == expected),
+                "expected constraint {expected}, got {constraints:?}"
+            );
+        }
+
+        sqlx::query(
+            "INSERT INTO projects (id, name, github_owner, github_repo) \
+             VALUES ('project-mq', 'project-mq', 'djinnos', 'djinn-mq')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed mq project");
+        sqlx::query(
+            "INSERT INTO tasks \
+             (id, project_id, short_id, title, description, design, labels, acceptance_criteria, memory_refs) \
+             VALUES ('task-mq', 'project-mq', 'mq', 'title', 'description', 'design', \
+                     '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed mq task");
+
+        // A NULL merge-queue lane is allowed (the additive default).
+        sqlx::query("INSERT INTO task_pr_ci_snapshots (task_id, pr_number) VALUES ('task-mq', 1)")
+            .execute(&pool)
+            .await
+            .expect("NULL mq lane is permitted");
+
+        // A well-formed lane (JSON array + non-negative count) is accepted.
+        sqlx::query(
+            "INSERT INTO task_pr_ci_snapshots \
+             (task_id, pr_number, mq_state, mq_failed_check_names, mq_same_signature_count) \
+             VALUES ('task-mq', 2, 'dequeued_failure', '[\"Server Test\"]'::jsonb, 1)",
+        )
+        .execute(&pool)
+        .await
+        .expect("well-formed mq lane is accepted");
+
+        // A non-array mq_failed_check_names is rejected by the CHECK.
+        sqlx::query(
+            "INSERT INTO task_pr_ci_snapshots \
+             (task_id, pr_number, mq_failed_check_names) \
+             VALUES ('task-mq', 3, '{}'::jsonb)",
+        )
+        .execute(&pool)
+        .await
+        .expect_err("non-array mq_failed_check_names should be rejected");
+
+        // A negative mq_same_signature_count is rejected by the CHECK.
+        sqlx::query(
+            "INSERT INTO task_pr_ci_snapshots \
+             (task_id, pr_number, mq_same_signature_count) \
+             VALUES ('task-mq', 4, -1)",
+        )
+        .execute(&pool)
+        .await
+        .expect_err("negative mq_same_signature_count should be rejected");
+
+        pool.close().await;
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary

The durable per-task CI snapshot (`task_pr_ci_snapshots`) only records **PR-head** check observations. Merge-queue (`merge_group`) failures are discovered by the PR poller at dequeue time but discarded after an activity comment — so the snapshot reads `passing` while the queue is rejecting the PR, and merge-queue failures never get a `failure_fingerprint`, leaving same-signature counting and the 3-strike escalation machinery blind to the single largest reopen category.

This adds a **merge-queue lane** to the snapshot (pure data capture; surfacing to task_show/prompts and the ci_job_log rework land separately):

- **Migration 116**: additive nullable `mq_*` columns (`mq_state`, `mq_run_id`, `mq_head_sha`, `mq_failed_check_names`, `mq_failure_fingerprint`, `mq_same_signature_count`, `mq_first_seen_at`, `mq_last_seen_at`), no backfill.
- **Model**: `TaskPrCiSnapshot.merge_queue: Option<MergeQueueLane>`, read from the flat columns; lane present iff `mq_state IS NOT NULL`.
- **Writer split to prevent flip-flop**: the dequeue handler is the sole writer of the lane via new `upsert_ci_snapshot_mq_lane` (per-lane fingerprint/same-signature/first-seen semantics mirroring the PR-head lane). The PR-head upsert never sets mq values — it preserves the lane on same-`head_sha` re-observations and clears it when a new head is observed (a fresh push invalidates the old queue verdict).
- **Dequeue wiring**: `pr_commands.rs` computes `compute_ci_failure_fingerprint` over the failing merge-group check runs it already fetched and upserts the lane (`dequeued_failure`, run id, run head_sha, failed check names) — zero additional GitHub API calls; non-fatal on error.

## Testing

- 5 new repo tests (lane create; same-fingerprint increments count and keeps `first_seen`; different fingerprint resets; PR-head upsert with same head preserves lane; new head clears lane incl. `reset_ci_snapshot_for_head`) + dedicated migration-116 test — all passing against live Postgres.
- `cargo check`/`clippy -p djinn-db -p djinn-coordinator --all-features` clean; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)