### PR TITLE
Make MDX proposal QuestionForm block optional

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/parser.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/parser.rs
@@ -315,25 +315,31 @@ pub fn validate_mdx_blocks(body: &str) -> Result<(), BlockError> {
 
 /// Enforce the MDX proposal question form placement contract.
 ///
-/// MDX proposals must contain exactly one registered `question-form` block, and
-/// that block must be the final parsed proposal block in the body.
+/// The `question-form` block is OPTIONAL: an MDX proposal may contain zero or
+/// more of them. Many proposals have no open questions, and requiring a
+/// question form on every proposal made no sense.
+///
+/// No downstream flow reads the question-form block as a data source — it is a
+/// read-only rendering construct (the UI simply renders each present block as an
+/// "Open Questions" section, and renders nothing when none are present), so its
+/// absence is safe. The refinement/debate/feedback flows operate on separate
+/// concepts (e.g. the evidence-spike feasibility *question*), not this block.
+///
+/// The only remaining constraint is placement: when one or more question-form
+/// blocks are present, the FINAL parsed proposal block must be a question-form,
+/// so open questions render at the end of the proposal body.
 pub fn validate_question_form_placement(body: &str) -> Result<(), String> {
     let blocks = parse_mdx_blocks(body).map_err(|e| e.to_string())?;
-    let question_form_count = blocks
+    let has_question_form = blocks
         .iter()
-        .filter(|block| block.block_type == "question-form")
-        .count();
+        .any(|block| block.block_type == "question-form");
 
-    if question_form_count != 1 {
-        return Err(format!(
-            "Exactly one question-form block is required in MDX proposals (found {question_form_count})"
-        ));
-    }
-
-    if !matches!(
-        blocks.last(),
-        Some(block) if block.block_type == "question-form"
-    ) {
+    if has_question_form
+        && !matches!(
+            blocks.last(),
+            Some(block) if block.block_type == "question-form"
+        )
+    {
         return Err(
             "The question-form block must be the last block in the proposal body".to_string(),
         );

--- a/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_blocks/tests.rs
@@ -407,31 +407,35 @@ fn validate_ids_fails_on_duplicate() {
 }
 
 #[test]
-fn test_validate_question_form_missing() {
+fn test_validate_question_form_missing_ok() {
+    // The question-form block is OPTIONAL: a proposal with zero of them (no open
+    // questions) must be accepted.
     let body = r#"# Proposal
 
 <FileTree id="schema" name="repo" />"#;
 
-    let err = validate_question_form_placement(body).unwrap_err();
-    assert_eq!(
-        err,
-        "Exactly one question-form block is required in MDX proposals (found 0)"
-    );
+    assert!(validate_question_form_placement(body).is_ok());
 }
 
 #[test]
-fn test_validate_question_form_multiple() {
+fn test_validate_question_form_none_at_all_ok() {
+    // A body with no registered blocks at all is likewise accepted.
+    let body = "# Proposal\n\nJust some prose, no blocks.";
+
+    assert!(validate_question_form_placement(body).is_ok());
+}
+
+#[test]
+fn test_validate_question_form_multiple_last_ok() {
+    // Multiple question-form blocks are allowed as long as the final block is a
+    // question-form (open questions render at the end).
     let body = r#"# Proposal
 
 <QuestionForm id="questions-a" title="Open questions" />
 
 <QuestionForm id="questions-b" title="More questions" />"#;
 
-    let err = validate_question_form_placement(body).unwrap_err();
-    assert_eq!(
-        err,
-        "Exactly one question-form block is required in MDX proposals (found 2)"
-    );
+    assert!(validate_question_form_placement(body).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`proposal_create` / `proposal_update` with `body_format: "mdx"` rejected any body without **exactly one** question-form block:

> Exactly one question-form block is required in MDX proposals (found 0)

Many proposals have no open questions, so mandating a QuestionForm on every MDX proposal was needless friction.

## Consumer audit (why zero is safe)

The question-form block is a **read-only rendering construct**, not a data contract:

- **UI** (`QuestionFormBlock.tsx`): renders each present block as an "Open Questions" section; renders nothing when none are present. Zero blocks is a no-op.
- **Refinement / debate / feedback**: none of these read the question-form block. The refinement `question` concept (`refinement_tools.rs`, `refinement_helpers.rs`) is the *evidence-spike feasibility question*, a different thing entirely.
- **Readiness** (`proposal_readiness.rs`): `has_open_questions_coverage` is heading/keyword based (`# Open Questions`, `Risks:`, …), not tied to this block, so it is unaffected.

No consumer assumes the block exists, so its absence needs no handling.

## Change

`validate_question_form_placement` now allows **zero or more** question-form blocks. The only remaining constraint is placement: **when one or more are present, the final proposal block must be a question-form**, so open questions still render at the end. Single-block behavior is unchanged; the "must be last" error is preserved for a misplaced block.

## Tests

- Replaced the two "required / count != 1" rejection tests with acceptance tests: zero blocks OK, no-blocks-at-all OK, multiple-with-trailing-question-form OK.
- Kept `not_last` (still rejects), `valid`, and `markdown_skipped`.
- No golden files reference the removed error string (grep-verified), so no golden regeneration is needed.
- `cargo test -p djinn-control-plane --lib proposal_blocks`: 55 passed, 0 failed.