### PR TITLE
feat(galaxy): hotspot leaderboard panel — complexity × co-change, heat-mode cutover

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -94,10 +94,10 @@ describe("MainLayout — project selector chrome", () => {
     expect(selector).toBeInTheDocument();
   });
 
-  it("renders the shared project selector on /code-graph (global-project-context)", () => {
+  it("does NOT render the project selector on /code-graph (galaxy HUD has its own chip)", () => {
     render(<MainLayout />, { wrapperOptions: { routerProps: { initialEntries: ["/code-graph"] } } });
-    const selector = screen.getByLabelText("Select project");
-    expect(selector).toBeInTheDocument();
+    const selector = screen.queryByLabelText("Select project");
+    expect(selector).not.toBeInTheDocument();
   });
 
   it("does NOT render the project selector on /tasks (url-filtered board route)", () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { useServerHealth } from "@/hooks/useServerHealth";
 import { useEventSource } from "@/hooks/useEventSource";
 import { Sidebar } from "@/components/Sidebar";
 import { ProjectSelector } from "@/components/ProjectSelector";
-import { isGlobalProjectContextRoute } from "@/lib/routeScopes";
+import { needsChromeProjectSelector } from "@/lib/routeScopes";
 import { KanbanPage } from "@/pages/KanbanPage";
 import { DependenciesPage } from "@/pages/DependenciesPage";
 import { BoardLayout } from "@/components/board/BoardLayout";
@@ -38,7 +38,7 @@ import { useDispatchPauseHydration } from "@/hooks/useDispatchPauseHydration";
 export function MainLayout() {
   const isAdmin = useAuthUser()?.isAdmin ?? false;
   const location = useLocation();
-  const showProjectSelector = isGlobalProjectContextRoute(location.pathname);
+  const showProjectSelector = needsChromeProjectSelector(location.pathname);
 
   return (
     <main className="flex h-screen overflow-hidden bg-background">

--- a/ui/src/components/codegraph/GalaxyView.tsx
+++ b/ui/src/components/codegraph/GalaxyView.tsx
@@ -7,7 +7,10 @@
  * renders `GalaxyCanvas` with:
  *
  *   - top-left: project selector + workspace picker,
- *   - top-right: color mode (communities / complexity) + hide-tests toggle,
+ *   - top-right: hide-tests toggle + hotspot-panel toggle,
+ *   - right: the HotspotPanel leaderboard (complexity × co-change);
+ *     clicking a row flies the camera to the file + its co-change
+ *     partners and lights their pink coupling web,
  *   - Cmd-K integration: search hits / AI citations from the shared
  *     codeGraphStore fly the camera to the matching stars.
  *
@@ -25,11 +28,9 @@ import {
   type CodeGraphWorkspace,
 } from "@/api/codeGraph";
 import { CoverageGapBanner } from "@/components/codegraph/CoverageGapBanner";
+import { HotspotPanel } from "@/components/codegraph/HotspotPanel";
 import { GalaxyCanvas } from "@/components/galaxy/GalaxyCanvas";
-import type {
-  GalaxyColorMode,
-  GalaxyData,
-} from "@/components/galaxy/galaxyTypes";
+import type { GalaxyData } from "@/components/galaxy/galaxyTypes";
 import { layoutInWorker } from "@/components/galaxy/galaxyLayoutClient";
 import {
   Select,
@@ -39,7 +40,9 @@ import {
 } from "@/components/ui/select";
 import {
   galaxyLayoutSeed,
+  snapshotHotspots,
   snapshotToGalaxy,
+  type GalaxyHotspot,
 } from "@/lib/codeGraphGalaxyAdapter";
 import { parseSnapshotResponse } from "@/lib/codeGraphAdapter";
 import { useCodeGraphStore } from "@/stores/codeGraphStore";
@@ -56,12 +59,7 @@ const GALAXY_NODE_BUDGET = 1_000_000;
 type GalaxyState =
   | { phase: "loading"; message: string }
   | { phase: "error"; message: string }
-  | { phase: "ready"; data: GalaxyData };
-
-const COLOR_MODES: Array<{ value: GalaxyColorMode; label: string }> = [
-  { value: "group", label: "Communities" },
-  { value: "heat", label: "Complexity" },
-];
+  | { phase: "ready"; data: GalaxyData; hotspots: GalaxyHotspot[] };
 
 /** One chip voice for every HUD control (chips, selects, toggles). The
  * dark-variant background mirrors what SelectTrigger's base classes
@@ -77,25 +75,38 @@ export function GalaxyView({ projectId }: { projectId: string }) {
     phase: "loading",
     message: "Fetching graph…",
   });
-  const [colorMode, setColorMode] = useState<GalaxyColorMode>("group");
   const [hideTests, setHideTests] = useState(false);
   const [workspaces, setWorkspaces] = useState<CodeGraphWorkspace[]>([]);
   const [workspaceSlug, setWorkspaceSlug] = useState<string | null>(null);
   const [coverage, setCoverage] = useState<CodeGraphCoverage | null>(null);
+  const [showHotspots, setShowHotspots] = useState(false);
+  const [hotspotSelection, setHotspotSelection] =
+    useState<GalaxyHotspot | null>(null);
 
-  // Cmd-K search hits / AI citations fly the camera to their stars.
+  // Cmd-K search hits / AI citations fly the camera to their stars. An
+  // active hotspot row takes over the focus set (file + co-change
+  // partners); a fresh Cmd-K/citation signal takes it back.
   const citationIds = useCodeGraphStore((s) => s.citationIds);
   const toolHighlightIds = useCodeGraphStore((s) => s.toolHighlightIds);
-  const focusIds = useMemo(
-    () => [...citationIds, ...toolHighlightIds],
-    [citationIds, toolHighlightIds],
-  );
+  const focusIds = useMemo(() => {
+    if (hotspotSelection) {
+      return [hotspotSelection.fileId, ...hotspotSelection.partnerIds];
+    }
+    return [...citationIds, ...toolHighlightIds];
+  }, [hotspotSelection, citationIds, toolHighlightIds]);
+  useEffect(() => {
+    if (citationIds.size > 0 || toolHighlightIds.size > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- external focus signal preempts the panel selection.
+      setHotspotSelection(null);
+    }
+  }, [citationIds, toolHighlightIds]);
 
   useEffect(() => {
     let cancelled = false;
     // eslint-disable-next-line react-hooks/set-state-in-effect -- async snapshot-fetch state machine: reset/loading transition around the network read, same convention as the old page's workspace fetch.
     setState({ phase: "loading", message: "Fetching graph…" });
     setWorkspaceSlug(null);
+    setHotspotSelection(null);
 
     void fetchWorkspaces(projectId)
       .then((list) => {
@@ -130,12 +141,13 @@ export function GalaxyView({ projectId }: { projectId: string }) {
           return;
         }
         const data = snapshotToGalaxy(snapshot, { layout: false });
+        const hotspots = snapshotHotspots(snapshot);
         // lmkv fast path: the server already shipped a warm-time galaxy layout
         // for every node — render immediately, no worker, no seconds-long
         // main-thread-free-but-still-slow force pass.
         if (data.serverPositioned) {
           if (cancelled) return;
-          setState({ phase: "ready", data });
+          setState({ phase: "ready", data, hotspots });
           return;
         }
         setState({
@@ -148,7 +160,11 @@ export function GalaxyView({ projectId }: { projectId: string }) {
           galaxyLayoutSeed(snapshot.project_id),
         );
         if (cancelled) return;
-        setState({ phase: "ready", data: { ...data, nodes: positioned } });
+        setState({
+          phase: "ready",
+          data: { ...data, nodes: positioned },
+          hotspots,
+        });
       } catch (error) {
         if (cancelled) return;
         setState({
@@ -181,6 +197,16 @@ export function GalaxyView({ projectId }: { projectId: string }) {
     return { ...full, nodes, edges };
   }, [state, hideTests, workspaceSlug]);
 
+  // Hotspot rows obey the same post-layout filters as the stars.
+  const visibleHotspots = useMemo<GalaxyHotspot[]>(() => {
+    if (state.phase !== "ready") return [];
+    return state.hotspots.filter(
+      (h) =>
+        (!hideTests || !h.isTest) &&
+        (!workspaceSlug || h.workspace === undefined || h.workspace === workspaceSlug),
+    );
+  }, [state, hideTests, workspaceSlug]);
+
   if (state.phase !== "ready" || !visibleData) {
     return (
       <div className="flex h-full w-full items-center justify-center bg-[#06090f] font-mono text-sm text-slate-400">
@@ -201,9 +227,17 @@ export function GalaxyView({ projectId }: { projectId: string }) {
   return (
     <GalaxyCanvas
       data={visibleData}
-      colorMode={colorMode}
       focusIds={focusIds}
       banner={<CoverageGapBanner coverage={coverage} />}
+      sidePanel={
+        showHotspots ? (
+          <HotspotPanel
+            hotspots={visibleHotspots}
+            selectedId={hotspotSelection?.fileId ?? null}
+            onSelect={setHotspotSelection}
+          />
+        ) : undefined
+      }
       headerPrimary={
         <>
           <Select
@@ -270,28 +304,21 @@ export function GalaxyView({ projectId }: { projectId: string }) {
           >
             {hideTests ? "Tests hidden" : "Hide tests"}
           </button>
-          <Select
-            value={colorMode}
-            onValueChange={(value) => {
-              if (typeof value === "string") {
-                setColorMode(value as GalaxyColorMode);
-              }
+          <button
+            type="button"
+            aria-pressed={showHotspots}
+            onClick={() => {
+              if (showHotspots) setHotspotSelection(null);
+              setShowHotspots(!showHotspots);
             }}
+            className={cn(
+              "h-7 rounded-lg border px-2.5 transition-colors",
+              HUD_CHIP,
+              showHotspots ? "text-sky-300" : "hover:text-slate-100",
+            )}
           >
-            <SelectTrigger size="sm" aria-label="Color mode" className={HUD_CHIP}>
-              <span>
-                {COLOR_MODES.find((m) => m.value === colorMode)?.label ??
-                  "Communities"}
-              </span>
-            </SelectTrigger>
-            <SelectContent className="min-w-40">
-              {COLOR_MODES.map(({ value, label }) => (
-                <SelectItem key={value} value={value}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            Hotspots
+          </button>
         </>
       }
     />

--- a/ui/src/components/codegraph/HotspotPanel.tsx
+++ b/ui/src/components/codegraph/HotspotPanel.tsx
@@ -1,0 +1,186 @@
+/**
+ * HotspotPanel — the galaxy's right-side complexity/co-change leaderboard.
+ *
+ * Replaces the old heat color mode (a 3D point cloud can't rank): a table
+ * of the worst files by hotspot score — worst-function cognitive
+ * complexity × commit co-change coupling (proposal qoxm) — with Sonar-band
+ * badges (green < 15 ≤ yellow < 25 ≤ red). Clicking a row flies the galaxy
+ * camera to the file and its co-change partners and lights their pink
+ * coupling web; clicking again clears.
+ */
+
+import { useMemo, useState } from "react";
+
+import {
+  COMPLEXITY_SEVERE,
+  COMPLEXITY_WARN,
+  type GalaxyHotspot,
+} from "@/lib/codeGraphGalaxyAdapter";
+import { cn } from "@/lib/utils";
+
+/** Leaderboard, not a browser: past ~30 rows nothing is a "top" anything.
+ * The footer stays honest about what was cut. */
+const MAX_ROWS = 30;
+
+type SortKey = "hotspot" | "complexity" | "coupling";
+
+const SORTS: Array<{ key: SortKey; label: string }> = [
+  { key: "hotspot", label: "Hotspot" },
+  { key: "complexity", label: "Complexity" },
+  { key: "coupling", label: "Coupling" },
+];
+
+function badgeClass(complexity: number): string {
+  if (complexity >= COMPLEXITY_SEVERE)
+    return "border-red-500/40 bg-red-500/15 text-red-400";
+  if (complexity >= COMPLEXITY_WARN)
+    return "border-yellow-500/40 bg-yellow-500/15 text-yellow-400";
+  return "border-emerald-500/40 bg-emerald-500/15 text-emerald-400";
+}
+
+function basename(path: string): string {
+  const segments = path.split("/");
+  return segments[segments.length - 1] || path;
+}
+
+/** Epoch day → compact age ("today", "12d", "3mo", "2y"). */
+function agoLabel(epochDay: number): string {
+  const days = Math.max(0, Math.floor(Date.now() / 86_400_000) - epochDay);
+  if (days === 0) return "today";
+  if (days < 30) return `${days}d`;
+  if (days < 365) return `${Math.round(days / 30)}mo`;
+  return `${Math.round(days / 365)}y`;
+}
+
+export interface HotspotPanelProps {
+  /** Pre-ranked rows (snapshotHotspots order = hotspot score). */
+  hotspots: GalaxyHotspot[];
+  /** fileId of the active row, if any. */
+  selectedId: string | null;
+  /** Row click — the row itself, or null when toggling the active row off. */
+  onSelect: (hotspot: GalaxyHotspot | null) => void;
+}
+
+export function HotspotPanel({
+  hotspots,
+  selectedId,
+  onSelect,
+}: HotspotPanelProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("hotspot");
+
+  const rows = useMemo(() => {
+    const sorted = [...hotspots];
+    if (sortKey === "complexity") {
+      sorted.sort((a, b) => b.complexity - a.complexity || b.score - a.score);
+    } else if (sortKey === "coupling") {
+      sorted.sort(
+        (a, b) =>
+          b.coupling - a.coupling ||
+          b.partnerIds.length - a.partnerIds.length ||
+          b.score - a.score,
+      );
+    }
+    return sorted.slice(0, MAX_ROWS);
+  }, [hotspots, sortKey]);
+
+  return (
+    <div
+      data-testid="hotspot-panel"
+      className="flex max-h-full w-80 flex-col overflow-hidden rounded-lg border border-slate-700/60 bg-slate-950/85 font-mono text-[11px] text-slate-300 shadow-xl backdrop-blur-md"
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-slate-800/70 px-3 py-2">
+        <span className="font-semibold tracking-wide text-slate-200">
+          Hotspots
+        </span>
+        <div className="flex items-center gap-1">
+          {SORTS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={sortKey === key}
+              onClick={() => setSortKey(key)}
+              className={cn(
+                "rounded px-1.5 py-0.5 text-[10px] transition-colors",
+                sortKey === key
+                  ? "bg-slate-800/80 text-sky-300"
+                  : "text-slate-500 hover:text-slate-300",
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {rows.length === 0 ? (
+          <p className="px-3 py-4 text-slate-500">
+            No scored functions in view — is the graph warmed?
+          </p>
+        ) : (
+          rows.map((h, rank) => {
+            const selected = h.fileId === selectedId;
+            return (
+              <button
+                key={h.fileId}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => onSelect(selected ? null : h)}
+                className={cn(
+                  "block w-full border-b border-slate-800/50 px-3 py-2 text-left transition-colors",
+                  selected ? "bg-sky-500/10" : "hover:bg-slate-800/40",
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="w-5 shrink-0 text-right text-slate-600">
+                    {rank + 1}
+                  </span>
+                  <span
+                    className="min-w-0 flex-1 truncate text-slate-200"
+                    title={h.path}
+                  >
+                    {basename(h.path)}
+                  </span>
+                  <span
+                    className={cn(
+                      "shrink-0 rounded border px-1.5 py-px text-[10px] font-semibold tabular-nums",
+                      badgeClass(h.complexity),
+                    )}
+                    title={`Worst cognitive complexity (${h.functionCount} scored ${h.functionCount === 1 ? "function" : "functions"})`}
+                  >
+                    {h.complexity}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 pl-7 text-[10px] text-slate-500">
+                  <span className="min-w-0 truncate" title={h.worstSymbol}>
+                    {h.worstSymbol}
+                  </span>
+                  {h.partnerIds.length > 0 && (
+                    <span
+                      className="ml-auto flex shrink-0 items-center gap-1 text-pink-400/90"
+                      title={`Co-changes with ${h.partnerIds.length} ${h.partnerIds.length === 1 ? "file" : "files"} (max coupling ${h.coupling.toFixed(2)})`}
+                    >
+                      <span className="inline-block h-1.5 w-1.5 rounded-full bg-pink-500/80" />
+                      ×{h.partnerIds.length}
+                      {h.lastCoChangeDay !== undefined && (
+                        <span className="text-slate-500">
+                          · {agoLabel(h.lastCoChangeDay)}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </div>
+              </button>
+            );
+          })
+        )}
+      </div>
+
+      {hotspots.length > rows.length && (
+        <div className="border-t border-slate-800/70 px-3 py-1.5 text-[10px] text-slate-500">
+          top {rows.length} of {hotspots.length.toLocaleString()} scored files
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/codegraph/snapshotHotspots.test.ts
+++ b/ui/src/components/codegraph/snapshotHotspots.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Hotspot leaderboard derivation (`snapshotHotspots`): per-file worst
+ * cognitive complexity joined with qoxm co-change coupling (partner ids,
+ * max score, last-co-change day decoded from the edge reason), ranked by
+ * complexity × (1 + Σ coupling).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { SnapshotPayload } from "@/lib/codeGraphAdapter";
+import { snapshotHotspots } from "@/lib/codeGraphGalaxyAdapter";
+
+type NodeOverride = Record<string, unknown>;
+type EdgeOverride = Record<string, unknown>;
+
+function snapshot(
+  nodes: NodeOverride[],
+  edges: EdgeOverride[],
+): SnapshotPayload {
+  return {
+    project_id: "proj-1",
+    git_head: "deadbeef",
+    generated_at: "2026-07-15T00:00:00Z",
+    truncated: false,
+    total_nodes: nodes.length,
+    total_edges: edges.length,
+    node_cap: 1000,
+    nodes,
+    edges,
+  } as unknown as SnapshotPayload;
+}
+
+function file(
+  id: string,
+  path: string,
+  extra: NodeOverride = {},
+): NodeOverride {
+  return {
+    id,
+    kind: "file",
+    label: path,
+    file_path: path,
+    pagerank: 0.1,
+    ...extra,
+  };
+}
+
+function fn(
+  id: string,
+  label: string,
+  fileId: string,
+  cognitive: number,
+): {
+  node: NodeOverride;
+  edge: EdgeOverride;
+} {
+  return {
+    node: {
+      id,
+      kind: "symbol",
+      label,
+      symbol_kind: "function",
+      pagerank: 0.1,
+      cognitive,
+    },
+    edge: { from: fileId, to: id, kind: "ContainsDefinition", confidence: 1 },
+  };
+}
+
+describe("snapshotHotspots", () => {
+  it("rolls function complexity up to the containing file and keeps the worst", () => {
+    const tame = fn("sym:tame", "tame", "file:a.rs", 3);
+    const monster = fn("sym:monster", "monster", "file:a.rs", 31);
+    const snap = snapshot(
+      [file("file:a.rs", "src/a.rs"), tame.node, monster.node],
+      [tame.edge, monster.edge],
+    );
+
+    const rows = snapshotHotspots(snap);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      fileId: "file:a.rs",
+      path: "src/a.rs",
+      complexity: 31,
+      worstSymbol: "monster",
+      functionCount: 2,
+      partnerIds: [],
+      coupling: 0,
+      score: 31,
+    });
+  });
+
+  it("joins co-change coupling and ranks by complexity × (1 + Σ coupling)", () => {
+    const fa = fn("sym:a", "handler_a", "file:a.rs", 10);
+    const fb = fn("sym:b", "handler_b", "file:b.rs", 12);
+    const snap = snapshot(
+      [
+        file("file:a.rs", "src/a.rs"),
+        file("file:b.rs", "src/b.rs"),
+        fa.node,
+        fb.node,
+      ],
+      [
+        fa.edge,
+        fb.edge,
+        // a co-changes with b (score 0.8, last day 20000).
+        {
+          from: "file:a.rs",
+          to: "file:b.rs",
+          kind: "CoChangedWith",
+          confidence: 0.8,
+          reason: "cochange;last_day=20000",
+        },
+      ],
+    );
+
+    const rows = snapshotHotspots(snap);
+
+    expect(rows).toHaveLength(2);
+    // b (12 × 1.8 = 21.6) outranks a (10 × 1.8 = 18).
+    expect(rows[0].fileId).toBe("file:b.rs");
+    expect(rows[0].score).toBeCloseTo(12 * 1.8);
+    // Coupling is symmetric — both ends carry the partner and the day.
+    for (const row of rows) {
+      expect(row.coupling).toBeCloseTo(0.8);
+      expect(row.lastCoChangeDay).toBe(20000);
+      expect(row.partnerIds).toHaveLength(1);
+    }
+    expect(rows[1].partnerIds).toEqual(["file:b.rs"]);
+  });
+
+  it("excludes files with no scored functions and zero-complexity files", () => {
+    const zero = fn("sym:zero", "zero", "file:a.rs", 0);
+    const snap = snapshot(
+      [
+        file("file:a.rs", "src/a.rs"),
+        // Coupled but unscored: churn on simple code is not a hotspot.
+        file("file:b.rs", "src/b.rs"),
+        zero.node,
+      ],
+      [
+        zero.edge,
+        {
+          from: "file:a.rs",
+          to: "file:b.rs",
+          kind: "CoChangedWith",
+          confidence: 0.9,
+          reason: "cochange;last_day=20000",
+        },
+      ],
+    );
+
+    expect(snapshotHotspots(snap)).toHaveLength(0);
+  });
+
+  it("tolerates a missing/malformed co-change reason (no recency, coupling kept)", () => {
+    const fa = fn("sym:a", "handler_a", "file:a.rs", 20);
+    const snap = snapshot(
+      [file("file:a.rs", "src/a.rs"), file("file:b.rs", "src/b.rs"), fa.node],
+      [
+        fa.edge,
+        {
+          from: "file:a.rs",
+          to: "file:b.rs",
+          kind: "CoChangedWith",
+          confidence: 0.5,
+        },
+      ],
+    );
+
+    const rows = snapshotHotspots(snap);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].coupling).toBeCloseTo(0.5);
+    expect(rows[0].lastCoChangeDay).toBeUndefined();
+    expect(rows[0].score).toBeCloseTo(20 * 1.5);
+  });
+});

--- a/ui/src/components/galaxy/Galaxy.stories.tsx
+++ b/ui/src/components/galaxy/Galaxy.stories.tsx
@@ -9,8 +9,7 @@
  * no MCP mock needed (the component is fed data directly).
  *
  * Judge with: Medium for the default look, Large for density compensation
- * at ~20k nodes, ComplexityHeat for the heat mode, Labels for the sprite
- * pass. Click a star to fly to its neighborhood; click space to fly back;
+ * at ~20k nodes, Labels for the sprite pass. Click a star to fly to its neighborhood; click space to fly back;
  * idle 20s for the ambient auto-rotate.
  */
 
@@ -34,7 +33,6 @@ function xlarge() {
 
 interface GalaxyArgs {
   fixture: "small" | "medium" | "large" | "xlarge";
-  colorMode: "group" | "heat";
   showLabels: boolean;
   edgeBrightness: number;
   nodeGlow: number;
@@ -48,7 +46,6 @@ function fixtureData(name: GalaxyArgs["fixture"]) {
 
 function GalaxyHarness({
   fixture,
-  colorMode,
   showLabels,
   edgeBrightness,
   nodeGlow,
@@ -60,7 +57,6 @@ function GalaxyHarness({
     <div className="h-screen w-full">
       <GalaxyCanvas
         data={data}
-        colorMode={colorMode}
         showLabels={showLabels}
         display={display}
         title={`djinn / ${fixture} fixture`}
@@ -75,7 +71,6 @@ const meta = {
   parameters: { layout: "fullscreen" },
   args: {
     fixture: "medium",
-    colorMode: "group",
     showLabels: false,
     edgeBrightness: DEFAULT_GALAXY_DISPLAY.edgeBrightness,
     nodeGlow: DEFAULT_GALAXY_DISPLAY.nodeGlow,
@@ -83,7 +78,6 @@ const meta = {
   },
   argTypes: {
     fixture: { control: "radio", options: ["small", "medium", "large", "xlarge"] },
-    colorMode: { control: "radio", options: ["group", "heat"] },
     edgeBrightness: { control: { type: "range", min: 0.1, max: 3, step: 0.05 } },
     nodeGlow: { control: { type: "range", min: 0, max: 2, step: 0.05 } },
     bloom: { control: { type: "range", min: 0, max: 2, step: 0.05 } },
@@ -109,11 +103,6 @@ export const XLarge50k: Story = {
 /** Small graph — verifies the look doesn't fall apart under sparse data. */
 export const Small: Story = {
   args: { fixture: "small" },
-};
-
-/** Cognitive-complexity heat mode: hot functions burn red, types/files mute. */
-export const ComplexityHeat: Story = {
-  args: { colorMode: "heat" },
 };
 
 /** Label sprites for the top nodes by visual weight. */

--- a/ui/src/components/galaxy/GalaxyCanvas.tsx
+++ b/ui/src/components/galaxy/GalaxyCanvas.tsx
@@ -30,14 +30,12 @@ import { boundsOf } from "./galaxyLayout";
 import { GalaxyScene, type FlyTarget } from "./GalaxyScene";
 import {
   DEFAULT_GALAXY_DISPLAY,
-  type GalaxyColorMode,
   type GalaxyData,
   type GalaxyDisplay,
 } from "./galaxyTypes";
 
 export interface GalaxyCanvasProps {
   data: GalaxyData;
-  colorMode?: GalaxyColorMode;
   showLabels?: boolean;
   display?: GalaxyDisplay;
   /** Optional headline shown in the HUD chip (e.g. project name). */
@@ -54,6 +52,11 @@ export interface GalaxyCanvasProps {
    */
   banner?: ReactNode;
   /**
+   * Optional right-side overlay panel (e.g. the hotspot leaderboard) —
+   * rendered below the top-right HUD controls, scrolling internally.
+   */
+  sidePanel?: ReactNode;
+  /**
    * External focus (Cmd-K search hits, AI citations): when non-empty the
    * camera flies to these nodes and they become the highlight set,
    * replacing any click selection. Cleared by passing null/empty.
@@ -66,12 +69,6 @@ export interface GalaxyCanvasProps {
 // Focus ids round-trip through a joined string (effect dep); ids can
 // contain spaces, so the separator must be a char no id can contain.
 const FOCUS_KEY_SEP = "\u0000";
-
-const HEAT_LEGEND: Array<{ color: string; label: string }> = [
-  { color: "#34d399", label: "tame" },
-  { color: "#eab308", label: "warm" },
-  { color: "#ef4444", label: "hot" },
-];
 
 /** `server:djinn-graph` → `djinn-graph` — the workspace prefix is noise in
  * a dropdown that already groups by crate. Full key stays in the tooltip. */
@@ -121,13 +118,13 @@ class SceneErrorBoundary extends Component<
 
 export function GalaxyCanvas({
   data,
-  colorMode = "group",
   showLabels = false,
   display = DEFAULT_GALAXY_DISPLAY,
   title,
   headerPrimary,
   headerExtra,
   banner,
+  sidePanel,
   focusIds,
   className,
   onSelect,
@@ -300,9 +297,6 @@ export function GalaxyCanvas({
     : null;
   const truncated =
     data.totalNodes !== undefined && data.totalNodes > data.nodes.length;
-  // Group mode carries its color key inside the Fly-to dropdown (a dot per
-  // crate), so the corner legend would be redundant there.
-  const legend = colorMode === "heat" ? HEAT_LEGEND : null;
 
   return (
     <div
@@ -314,7 +308,6 @@ export function GalaxyCanvas({
         <GalaxyScene
           key={sceneGeneration}
           data={data}
-          colorMode={colorMode}
           highlight={highlight}
           display={display}
           showLabels={showLabels}
@@ -462,18 +455,10 @@ export function GalaxyCanvas({
         )}
       </div>
 
-      {/* ── HUD: legend (bottom-right; group mode keys colors in Fly-to) ── */}
-      {legend && (
-        <div className="pointer-events-none absolute bottom-4 right-4 flex items-center gap-3 rounded-md border border-slate-800/60 bg-slate-950/60 px-3 py-1.5 font-mono text-[10px] text-slate-400 backdrop-blur-sm">
-          {legend.map(({ color, label }) => (
-            <span key={label} className="flex items-center gap-1.5">
-              <span
-                className="inline-block h-2 w-2 rounded-full"
-                style={{ background: color, boxShadow: `0 0 6px ${color}` }}
-              />
-              {label}
-            </span>
-          ))}
+      {/* ── HUD: side panel (right, below the controls row) ── */}
+      {sidePanel && (
+        <div className="absolute bottom-4 right-4 top-14 flex items-start">
+          {sidePanel}
         </div>
       )}
 
@@ -487,9 +472,6 @@ export function GalaxyCanvas({
           <div className="text-slate-400">
             {hoveredNode.group && <span>{hoveredNode.group} · </span>}
             {hoveredNode.degree} connections
-            {hoveredNode.heatEligible && hoveredNode.heat !== undefined && (
-              <span> · heat {(hoveredNode.heat * 100).toFixed(0)}%</span>
-            )}
           </div>
         </div>
       )}

--- a/ui/src/components/galaxy/GalaxyScene.tsx
+++ b/ui/src/components/galaxy/GalaxyScene.tsx
@@ -21,14 +21,12 @@ import * as THREE from "three";
 import {
   bloomIntensityScale,
   edgeIntensityScale,
+  edgeKindColor,
   groupColor,
-  heatColor,
-  HEAT_MUTED,
   nodeBoostScale,
   nodeGlowBoost,
-  type Rgb,
 } from "./galaxyColors";
-import type { GalaxyColorMode, GalaxyData, GalaxyDisplay } from "./galaxyTypes";
+import type { GalaxyData, GalaxyDisplay } from "./galaxyTypes";
 
 /** At most this many labels render, picked by visual weight. */
 const MAX_LABELS = 70;
@@ -57,7 +55,6 @@ export interface FlyTarget {
 
 interface SceneProps {
   data: GalaxyData;
-  colorMode: GalaxyColorMode;
   /** Node ids to spotlight; everything else dims. Null = no highlight. */
   highlight: Set<string> | null;
   display: GalaxyDisplay;
@@ -73,14 +70,6 @@ interface SceneProps {
   onContextRestored?: () => void;
 }
 
-function baseColorOf(data: GalaxyData, index: number, colorMode: GalaxyColorMode): Rgb {
-  const node = data.nodes[index];
-  if (colorMode === "heat") {
-    return node.heatEligible ? heatColor(node.heat ?? 0) : HEAT_MUTED;
-  }
-  return groupColor(node.group);
-}
-
 // ── Nodes ───────────────────────────────────────────────────────────────────
 
 function sphereDetail(count: number): [number, number, number] {
@@ -91,7 +80,6 @@ function sphereDetail(count: number): [number, number, number] {
 
 interface NodeModeProps {
   data: GalaxyData;
-  colorMode: GalaxyColorMode;
   highlight: Set<string> | null;
   /** nodeBoostScale(count) × user nodeGlow — 1 = full glow, 0 = flat. */
   boost: number;
@@ -131,7 +119,6 @@ const POINT_FRAGMENT = /* glsl */ `
 
 function GalaxyNodeSpheres({
   data,
-  colorMode,
   highlight,
   boost,
   objectRef,
@@ -159,7 +146,7 @@ function GalaxyNodeSpheres({
       tempObj.updateMatrix();
       mesh.setMatrixAt(i, tempObj.matrix);
 
-      const [r, g, b] = baseColorOf(data, i, colorMode);
+      const [r, g, b] = groupColor(node.group);
       if (!isLit) {
         color.setRGB(r * NODE_DIM, g * NODE_DIM, b * NODE_DIM);
       } else {
@@ -173,7 +160,7 @@ function GalaxyNodeSpheres({
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
     mesh.computeBoundingSphere();
-  }, [data, colorMode, highlight, boost, count, sizeDamp, objectRef]);
+  }, [data, highlight, boost, count, sizeDamp, objectRef]);
 
   return (
     <instancedMesh
@@ -192,7 +179,6 @@ function GalaxyNodeSpheres({
  * with per-star sizes and sub-pixel fading via the custom point shader. */
 function GalaxyNodePoints({
   data,
-  colorMode,
   highlight,
   boost,
   objectRef,
@@ -223,7 +209,7 @@ function GalaxyNodePoints({
       positions[i * 3] = node.x;
       positions[i * 3 + 1] = node.y;
       positions[i * 3 + 2] = node.z;
-      const [r, g, b] = baseColorOf(data, i, colorMode);
+      const [r, g, b] = groupColor(node.group);
       const isLit = !hasHighlight || highlight.has(node.id);
       // Same scale voice as sphere mode (diameter = size × damp, dimmed
       // stars shrink to 40%).
@@ -241,7 +227,7 @@ function GalaxyNodePoints({
       }
     }
     return { positions, colors, sizes };
-  }, [data, colorMode, highlight, boost, count, sizeDamp]);
+  }, [data, highlight, boost, count, sizeDamp]);
 
   return (
     <points
@@ -268,7 +254,6 @@ function GalaxyNodePoints({
 
 function GalaxyNodes({
   data,
-  colorMode,
   highlight,
   boost,
   onNodePointer,
@@ -351,32 +336,23 @@ function GalaxyNodes({
 
   const Mode = pointMode ? GalaxyNodePoints : GalaxyNodeSpheres;
   return (
-    <Mode
-      data={data}
-      colorMode={colorMode}
-      highlight={highlight}
-      boost={boost}
-      objectRef={objectRef}
-    />
+    <Mode data={data} highlight={highlight} boost={boost} objectRef={objectRef} />
   );
 }
 
 // ── Edges ───────────────────────────────────────────────────────────────────
 
-// Heat mode exists to make hot code pop — community-colored strands fight
-// that, so edges collapse to this dim neutral at a fraction of their
-// group-mode strength (structure stays visible, color belongs to stars).
-const HEAT_EDGE_NEUTRAL: Rgb = [0.45, 0.55, 0.7];
-const HEAT_EDGE_DAMP = 0.3;
+// Highlighted co-change edges render in their kind color (pink) so a
+// hotspot selection's coupling web reads as its own channel instead of
+// blending into the structural strands.
+const COCHANGE_LIT = edgeKindColor("CoChangedWith");
 
 function GalaxyEdges({
   data,
-  colorMode,
   highlight,
   brightness,
 }: {
   data: GalaxyData;
-  colorMode: GalaxyColorMode;
   highlight: Set<string> | null;
   brightness: number;
 }) {
@@ -384,7 +360,6 @@ function GalaxyEdges({
     const indexById = new Map<string, number>();
     data.nodes.forEach((node, i) => indexById.set(node.id, i));
 
-    const heatMode = colorMode === "heat";
     const densityScale = edgeIntensityScale(data.edges.length) * brightness;
     // 0 at ≤50k edges (approved look untouched), full strength at ≥250k.
     const hubCoefficient =
@@ -409,6 +384,8 @@ function GalaxyEdges({
       // faint and only read in aggregate — that's what keeps hub fans from
       // becoming searchlights.
       const sameCluster = (s.group ?? "") === (t.group ?? "");
+      const coChange = edge.kind === "CoChangedWith";
+      const coChangeLit = coChange && hasHighlight && sLit && tLit;
       let intensity = sameCluster ? 0.25 : 0.06;
       if (hasHighlight) {
         // A selection stays at full strength (never density-scaled).
@@ -426,24 +403,22 @@ function GalaxyEdges({
       }
 
       // Proposal qoxm: commit co-change edges ("these files change together")
-      // are a distinct, evidential channel — not structural dependencies. Draw
-      // them at a fraction of their computed strength so they read as a subtle
-      // overlay on the structural galaxy rather than competing with it. Kept
-      // deliberately simple (a dim multiplier); the community fade below still
-      // colors them by endpoint, so they tint toward their files' crates.
-      if (edge.kind === "CoChangedWith") {
+      // are a distinct, evidential channel — not structural dependencies. In
+      // the ambient galaxy they draw at a fraction of their computed strength
+      // (a subtle overlay, community-tinted by endpoint). Inside a highlight
+      // they flip to the full-strength pink kind color so a hotspot's
+      // coupling web is unmistakable against the structural strands.
+      if (coChange && !coChangeLit) {
         intensity *= 0.35;
       }
 
       // Community-colored edges: each end takes its own group's color, so
       // an import strand fades importer-hue → imported-hue instead of
       // stacking into one uniform blue glare across the whole galaxy.
-      // Heat mode neutralizes them instead — see HEAT_EDGE_NEUTRAL.
       let sr: number, sg: number, sb: number, tr: number, tg: number, tb: number;
-      if (heatMode) {
-        [sr, sg, sb] = HEAT_EDGE_NEUTRAL;
-        [tr, tg, tb] = HEAT_EDGE_NEUTRAL;
-        intensity *= HEAT_EDGE_DAMP;
+      if (coChangeLit) {
+        [sr, sg, sb] = COCHANGE_LIT;
+        [tr, tg, tb] = COCHANGE_LIT;
       } else {
         [sr, sg, sb] = groupColor(s.group);
         [tr, tg, tb] = groupColor(t.group);
@@ -467,7 +442,7 @@ function GalaxyEdges({
       positions: positions.slice(0, valid * 6),
       colors: colors.slice(0, valid * 6),
     };
-  }, [data, colorMode, highlight, brightness]);
+  }, [data, highlight, brightness]);
 
   return (
     <lineSegments key={positions.length} frustumCulled={false}>
@@ -699,7 +674,6 @@ function CameraRig({ flyTarget }: { flyTarget: FlyTarget }) {
 
 export function GalaxyScene({
   data,
-  colorMode,
   highlight,
   display,
   showLabels,
@@ -725,7 +699,6 @@ export function GalaxyScene({
 
       <GalaxyNodes
         data={data}
-        colorMode={colorMode}
         highlight={highlight}
         boost={boost}
         onNodePointer={onNodePointer}
@@ -733,7 +706,6 @@ export function GalaxyScene({
       />
       <GalaxyEdges
         data={data}
-        colorMode={colorMode}
         highlight={highlight}
         brightness={display.edgeBrightness}
       />

--- a/ui/src/components/galaxy/galaxyColors.ts
+++ b/ui/src/components/galaxy/galaxyColors.ts
@@ -14,22 +14,8 @@ function hexToRgb(hex: number): Rgb {
   return [((hex >> 16) & 0xff) / 255, ((hex >> 8) & 0xff) / 255, (hex & 0xff) / 255];
 }
 
-// ── Heat scale (cognitive-complexity mode) ──────────────────────────────────
-
-const HEAT_LOW: Rgb = [0.204, 0.827, 0.6]; // emerald-400
-const HEAT_MID: Rgb = [0.918, 0.702, 0.031]; // yellow-500
-const HEAT_HIGH: Rgb = [0.937, 0.267, 0.267]; // red-500
-/** Muted slate for nodes that don't participate in the heat mode. */
-export const HEAT_MUTED: Rgb = [0.24, 0.29, 0.36];
-
-function mix(a: Rgb, b: Rgb, t: number): Rgb {
-  return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t];
-}
-
-export function heatColor(heat: number): Rgb {
-  const t = Math.min(1, Math.max(0, heat));
-  return t < 0.5 ? mix(HEAT_LOW, HEAT_MID, t * 2) : mix(HEAT_MID, HEAT_HIGH, (t - 0.5) * 2);
-}
+/** Muted slate for nodes with no group. */
+const GROUP_MUTED: Rgb = [0.24, 0.29, 0.36];
 
 // ── Group (crate/community) colors ──────────────────────────────────────────
 //
@@ -78,7 +64,7 @@ function groupHsl(group: string): [number, number, number] {
 }
 
 export function groupColor(group: string | undefined): Rgb {
-  if (!group) return HEAT_MUTED;
+  if (!group) return GROUP_MUTED;
   const [h, s, l] = groupHsl(group);
   return hslToRgb(h, s, l);
 }

--- a/ui/src/components/galaxy/galaxyFixture.ts
+++ b/ui/src/components/galaxy/galaxyFixture.ts
@@ -4,8 +4,7 @@
  * Produces graphs shaped like real repositories so the galaxy can be judged
  * at realistic scale without a live server: packages containing files
  * containing symbols, preferential-attachment call edges (power-law degree
- * distribution → a few blazing hubs, many dim leaves), a long-tailed
- * cognitive-complexity distribution for the heat mode, and cross-package
+ * distribution → a few blazing hubs, many dim leaves), and cross-package
  * edges that render as the long strands between clusters.
  */
 
@@ -70,7 +69,6 @@ export function makeGalaxyFixture(options: GalaxyFixtureOptions): GalaxyData {
         degree: 0,
         size: 8,
         group: pkg,
-        heatEligible: false,
       });
 
       // Power-law-ish symbol count: most files small, a few big.
@@ -80,8 +78,6 @@ export function makeGalaxyFixture(options: GalaxyFixtureOptions): GalaxyData {
         const stem2 = SYMBOL_STEMS[Math.floor(rng() * SYMBOL_STEMS.length)];
         const isType = rng() < 0.16;
         const symId = `${fileId}#${stem2}${s}`;
-        // Long-tailed complexity: mostly tame, occasional monsters.
-        const cognitive = Math.pow(rng(), 3.2) * 42;
         nodes.push({
           id: symId,
           label: isType ? `${capitalize(stem2)}${s}` : `${stem2}_${s}`,
@@ -90,8 +86,6 @@ export function makeGalaxyFixture(options: GalaxyFixtureOptions): GalaxyData {
           size: isType ? 6 : 4,
           group: pkg,
           parent: fileId,
-          heat: cognitive / 42,
-          heatEligible: !isType,
         });
         symbols.push(symId);
         edges.push({ source: fileId, target: symId, kind: "Defines" });
@@ -115,7 +109,6 @@ export function makeGalaxyFixture(options: GalaxyFixtureOptions): GalaxyData {
           size: 4,
           group: pkg,
           parent: fileId,
-          heatEligible: false,
         });
         edges.push({ source: fileId, target: fieldId, kind: "Defines" });
       }

--- a/ui/src/components/galaxy/galaxyTypes.ts
+++ b/ui/src/components/galaxy/galaxyTypes.ts
@@ -3,9 +3,8 @@
  *
  * Deliberately generic: nothing here knows about SCIP, symbols, or memory
  * notes. The code graph feeds it through an adapter (positions from the
- * warm-time server layout, degree from edge counts, heat from cognitive-
- * complexity percentiles); the memory graph can feed the same shape with
- * heat = recency/confidence. Keeping the model this small is what lets one
+ * warm-time server layout, degree from edge counts); the memory graph can
+ * feed the same shape. Keeping the model this small is what lets one
  * renderer serve both.
  */
 
@@ -30,17 +29,6 @@ export interface GalaxyNode {
    * clusters their grape-bunch texture instead of a uniform cloud.
    */
   parent?: string;
-  /**
-   * 0..1 heat for the alternate color mode — cognitive-complexity
-   * percentile for code, recency/decay for memories.
-   */
-  heat?: number;
-  /**
-   * Whether this node participates in the heat color mode. Ineligible
-   * nodes (files, folders, non-function symbols) render muted so they
-   * don't dominate the eye.
-   */
-  heatEligible?: boolean;
   /** Test file/symbol — drives the hide-tests toggle. */
   isTest?: boolean;
   /** Workspace slug (multi-workspace projects) — drives the workspace filter. */
@@ -68,8 +56,6 @@ export interface GalaxyData {
    */
   serverPositioned?: boolean;
 }
-
-export type GalaxyColorMode = "group" | "heat";
 
 /**
  * User display multipliers layered on top of the automatic density

--- a/ui/src/lib/codeGraphGalaxyAdapter.ts
+++ b/ui/src/lib/codeGraphGalaxyAdapter.ts
@@ -12,10 +12,12 @@
  *
  * Degree is computed from the collapsed edge list. Group is the
  * crate/top-level directory, parent is the containing file (from
- * ContainsDefinition), and heat maps cognitive complexity onto an
- * absolute Sonar-style scale (0 tame → HEAT_CEILING red). Positions come
- * from `layoutGalaxy` until the server ships 3D coordinates in the
- * snapshot (proposal lmkv).
+ * ContainsDefinition). Positions come from `layoutGalaxy` until the
+ * server ships 3D coordinates in the snapshot (proposal lmkv).
+ *
+ * `snapshotHotspots` derives the complexity/co-change leaderboard the
+ * HotspotPanel renders: per-file worst cognitive complexity joined with
+ * qoxm co-change coupling (partners, max score, recency).
  */
 
 import { layoutGalaxy } from "@/components/galaxy/galaxyLayout";
@@ -31,9 +33,11 @@ const TYPE_LIKE_SYMBOL_KINDS = new Set([
   "type",
 ]);
 
-/** Cognitive complexity that maps to full-red heat. 25 is Sonar's "very
- * complex" band for a function; the scale is linear below it. */
-const HEAT_CEILING = 25;
+/** Sonar cognitive-complexity bands: below WARN reads green ("fine"),
+ * WARN..SEVERE yellow ("needs attention" — Sonar's default per-function
+ * threshold is 15), at or above SEVERE red ("very complex"). */
+export const COMPLEXITY_WARN = 15;
+export const COMPLEXITY_SEVERE = 25;
 
 /** Usage kinds collapsed to one file→file edge per file pair. Everything
  * else (containment, Implements/Extends, process steps) renders raw. */
@@ -174,13 +178,6 @@ export function snapshotToGalaxy(
     }
   }
 
-  // Cognitive complexity → heat on an ABSOLUTE Sonar-style scale, not a
-  // percentile: ~70% of real functions score 0, so a rank-based heat put
-  // the entire tied-at-zero mass at percentile ~0.7 (yellow) and nothing
-  // could ever read tame. 0 = green, ~12 = yellow, ≥HEAT_CEILING = red.
-  const heatOf = (value: number): number =>
-    Math.min(1, Math.max(0, value) / HEAT_CEILING);
-
   const nodes: GalaxyNode[] = kept.map((n) => {
     const degree = serverDegreeById.get(n.id) ?? degreeById.get(n.id) ?? 0;
     const server = serverById.get(n.id);
@@ -192,7 +189,6 @@ export function snapshotToGalaxy(
     const baseSize =
       n.kind === "folder" ? 12 : n.kind === "file" ? 8 : typeLike ? 6 : 4;
     const degreeBoost = degree > 5 ? Math.min(degree * 0.3, 10) : 0;
-    const hasCognitive = typeof n.cognitive === "number";
     return {
       id: n.id,
       label: displayLabel(n.label, n.kind),
@@ -203,8 +199,6 @@ export function snapshotToGalaxy(
       size: baseSize + degreeBoost,
       group: deriveGalaxyGroup(n.file_path, n.workspace),
       parent: parentById.get(n.id),
-      heat: hasCognitive ? heatOf(n.cognitive as number) : undefined,
-      heatEligible: hasCognitive,
       isTest: n.is_test === true,
       workspace: n.workspace,
     };
@@ -231,6 +225,124 @@ export function snapshotToGalaxy(
     totalEdges: serverTruncated ? snapshot.total_edges : undefined,
     serverPositioned,
   };
+}
+
+// ── Hotspots (complexity × co-change) ───────────────────────────────────────
+
+/** One leaderboard row: a file's worst cognitive complexity joined with its
+ * qoxm co-change coupling. `partnerIds` feeds the fly-to/highlight set. */
+export interface GalaxyHotspot {
+  fileId: string;
+  /** Full repo path (rows show the basename, tooltip the full path). */
+  path: string;
+  workspace?: string;
+  isTest: boolean;
+  /** Max cognitive complexity among the file's scored functions. */
+  complexity: number;
+  /** Label of the worst-scoring function. */
+  worstSymbol: string;
+  /** Number of scored (function-like) symbols in the file. */
+  functionCount: number;
+  /** Co-change partner file ids (empty when uncoupled). */
+  partnerIds: string[];
+  /** Max co-change coupling score across partners (0..1; 0 = uncoupled). */
+  coupling: number;
+  /** Most recent co-change, as an epoch day (from the qoxm edge reason). */
+  lastCoChangeDay?: number;
+  /** Hotspot rank basis: complexity × (1 + Σ partner coupling scores) —
+   * uncoupled files rank by complexity alone. */
+  score: number;
+}
+
+/** Shape of the qoxm co-change edge reason: `cochange;last_day=<i64>`. */
+const COCHANGE_REASON = /^cochange;last_day=(-?\d+)$/;
+
+/**
+ * Derive the hotspot leaderboard from a snapshot. Only files with at least
+ * one scored function appear — co-change coupling without any complexity is
+ * churn on simple code, not a hotspot. Sorted by `score`, descending.
+ */
+export function snapshotHotspots(snapshot: SnapshotPayload): GalaxyHotspot[] {
+  const nodeById = new Map(snapshot.nodes.map((n) => [n.id, n]));
+
+  // Same containment pass as snapshotToGalaxy — symbols → containing file.
+  const parentById = new Map<string, string>();
+  for (const e of snapshot.edges) {
+    if (e.kind === "ContainsDefinition") parentById.set(e.to, e.from);
+    else if (e.kind === "DeclaredInFile") parentById.set(e.from, e.to);
+  }
+
+  const complexityByFile = new Map<
+    string,
+    { complexity: number; worstSymbol: string; functionCount: number }
+  >();
+  for (const n of snapshot.nodes) {
+    if (n.kind !== "symbol" || typeof n.cognitive !== "number") continue;
+    const fileId = parentById.get(n.id);
+    if (!fileId) continue;
+    const entry = complexityByFile.get(fileId);
+    if (!entry) {
+      complexityByFile.set(fileId, {
+        complexity: n.cognitive,
+        worstSymbol: n.label,
+        functionCount: 1,
+      });
+    } else {
+      entry.functionCount += 1;
+      if (n.cognitive > entry.complexity) {
+        entry.complexity = n.cognitive;
+        entry.worstSymbol = n.label;
+      }
+    }
+  }
+
+  const couplingByFile = new Map<
+    string,
+    { partnerIds: string[]; max: number; sum: number; lastDay?: number }
+  >();
+  for (const e of snapshot.edges) {
+    if (e.kind !== "CoChangedWith") continue;
+    const day = e.reason
+      ? Number(COCHANGE_REASON.exec(e.reason)?.[1])
+      : Number.NaN;
+    for (const [self, partner] of [
+      [e.from, e.to],
+      [e.to, e.from],
+    ]) {
+      let entry = couplingByFile.get(self);
+      if (!entry) couplingByFile.set(self, (entry = { partnerIds: [], max: 0, sum: 0 }));
+      entry.partnerIds.push(partner);
+      entry.max = Math.max(entry.max, e.confidence);
+      entry.sum += e.confidence;
+      if (Number.isFinite(day)) {
+        entry.lastDay = entry.lastDay === undefined ? day : Math.max(entry.lastDay, day);
+      }
+    }
+  }
+
+  const hotspots: GalaxyHotspot[] = [];
+  for (const [fileId, cx] of complexityByFile) {
+    if (cx.complexity <= 0) continue;
+    const node = nodeById.get(fileId);
+    if (!node) continue;
+    const coupling = couplingByFile.get(fileId);
+    hotspots.push({
+      fileId,
+      path: node.file_path ?? node.label,
+      workspace: node.workspace,
+      isTest: node.is_test === true,
+      complexity: cx.complexity,
+      worstSymbol: cx.worstSymbol,
+      functionCount: cx.functionCount,
+      partnerIds: coupling?.partnerIds ?? [],
+      coupling: coupling?.max ?? 0,
+      lastCoChangeDay: coupling?.lastDay,
+      score: cx.complexity * (1 + (coupling?.sum ?? 0)),
+    });
+  }
+  return hotspots.sort(
+    (a, b) => b.score - a.score || a.path.localeCompare(b.path),
+  );
 }
 
 function hashSeed(input: string): number {

--- a/ui/src/lib/routeScopes.test.ts
+++ b/ui/src/lib/routeScopes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getRouteScopeEntry,
   isGlobalProjectContextRoute,
+  needsChromeProjectSelector,
   ROUTE_SCOPES,
 } from "./routeScopes";
 
@@ -20,7 +21,7 @@ describe("routeScopes", () => {
       expect(isGlobalProjectContextRoute("/memory")).toBe(true);
     });
 
-    it("returns true for /code-graph (local picker removed)", () => {
+    it("returns true for /code-graph (reads the global store)", () => {
       expect(isGlobalProjectContextRoute("/code-graph")).toBe(true);
     });
 
@@ -64,6 +65,23 @@ describe("routeScopes", () => {
       expect(isGlobalProjectContextRoute("/projects/proj-1/environment")).toBe(
         false,
       );
+    });
+  });
+
+  describe("needsChromeProjectSelector", () => {
+    it("returns true for global-project-context routes without an in-page selector", () => {
+      expect(needsChromeProjectSelector("/agents")).toBe(true);
+      expect(needsChromeProjectSelector("/task/abc-123")).toBe(true);
+      expect(needsChromeProjectSelector("/memory")).toBe(true);
+    });
+
+    it("returns false for /code-graph (galaxy HUD project chip writes the store)", () => {
+      expect(needsChromeProjectSelector("/code-graph")).toBe(false);
+    });
+
+    it("returns false for non-global-project-context routes", () => {
+      expect(needsChromeProjectSelector("/tasks")).toBe(false);
+      expect(needsChromeProjectSelector("/proposals")).toBe(false);
     });
   });
 

--- a/ui/src/lib/routeScopes.ts
+++ b/ui/src/lib/routeScopes.ts
@@ -47,6 +47,12 @@ export interface RouteScopeEntry {
   /** react-router-compatible path pattern (may include :params and * wildcards) */
   pattern: string;
   scope: RouteScope;
+  /**
+   * global-project-context pages that render their OWN writer of the global
+   * project store (e.g. the galaxy HUD project chip) — the shared chrome
+   * ProjectSelector is suppressed for them so the control isn't duplicated.
+   */
+  inPageSelector?: boolean;
   /** Human-readable note — purely documentary */
   note?: string;
 }
@@ -79,7 +85,8 @@ export const ROUTE_SCOPES: readonly RouteScopeEntry[] = [
   {
     pattern: "/code-graph",
     scope: "global-project-context",
-    note: "CodeGraphPage reads useSelectedProject() for snapshot/workspace data; local picker removed",
+    inPageSelector: true,
+    note: "CodeGraphPage reads useSelectedProject(); the galaxy HUD project chip writes the store, so the chrome selector is suppressed",
   },
   {
     pattern: "/memory",
@@ -145,9 +152,19 @@ export function getRouteScopeEntry(
   return ROUTE_SCOPES.find((entry) => matchPath(entry.pattern, pathname));
 }
 
-/** Convenience: does this pathname need the global project selector? */
+/** Convenience: does this pathname read the global project store? */
 export function isGlobalProjectContextRoute(pathname: string): boolean {
   return getRouteScopeEntry(pathname)?.scope === "global-project-context";
+}
+
+/**
+ * Should the shared chrome ProjectSelector render for this pathname?
+ * True for global-project-context routes that do NOT carry their own
+ * in-page writer of the project store.
+ */
+export function needsChromeProjectSelector(pathname: string): boolean {
+  const entry = getRouteScopeEntry(pathname);
+  return entry?.scope === "global-project-context" && !entry.inPageSelector;
 }
 
 /**

--- a/ui/src/pages/CodeGraphPage.test.tsx
+++ b/ui/src/pages/CodeGraphPage.test.tsx
@@ -226,7 +226,39 @@ describe("CodeGraphPage (galaxy)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("offers the crate/complexity color modes", async () => {
+  it("opens the hotspot panel from the HUD toggle and selects a row", async () => {
+    fetchSnapshotMock.mockResolvedValueOnce(POPULATED);
+    selectProjectA();
+
+    render(<CodeGraphPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("galaxy-canvas")).toBeInTheDocument();
+    });
+    // The color-mode select is gone — communities is the only star coloring;
+    // complexity moved into the hotspot leaderboard.
+    expect(
+      screen.queryByRole("combobox", { name: /color mode/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("hotspot-panel")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^hotspots$/i }));
+
+    const panel = await screen.findByTestId("hotspot-panel");
+    // One scored file: lib.rs, worst function `resolve` at cognitive 12.
+    expect(panel).toHaveTextContent("lib.rs");
+    expect(panel).toHaveTextContent("12");
+    expect(panel).toHaveTextContent("resolve");
+
+    const row = screen.getByRole("button", { name: /lib\.rs/i });
+    fireEvent.click(row);
+    expect(row).toHaveAttribute("aria-pressed", "true");
+    // Toggle the row off again.
+    fireEvent.click(row);
+    expect(row).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders the project picker inside the galaxy HUD (chrome selector is suppressed on /code-graph)", async () => {
     fetchSnapshotMock.mockResolvedValueOnce(POPULATED);
     selectProjectA();
 
@@ -234,16 +266,8 @@ describe("CodeGraphPage (galaxy)", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: /color mode/i }),
+        screen.getByRole("combobox", { name: /^project$/i }),
       ).toBeInTheDocument();
     });
-  });
-
-  it("does NOT render a local project picker in the page body (shared chrome handles it)", () => {
-    selectProjectA();
-
-    render(<CodeGraphPage />);
-
-    expect(screen.queryByLabelText(/^project$/i)).not.toBeInTheDocument();
   });
 });

--- a/ui/src/pages/CodeGraphPage.tsx
+++ b/ui/src/pages/CodeGraphPage.tsx
@@ -5,8 +5,9 @@
  * Sigma canvas, lens toolbar, and symbol detail panel were removed with
  * it (cutover over strangler); Cmd-K hybrid search stays and flies the
  * galaxy camera to its hits via the shared codeGraphStore citation /
- * tool-highlight sets. Project selection lives in the shared chrome;
- * workspace + test filters live inside the galaxy HUD.
+ * tool-highlight sets. Project selection, workspace + test filters, and
+ * the hotspot panel all live inside the galaxy HUD (the chrome selector
+ * is suppressed for this route — see routeScopes.ts).
  */
 
 import { HugeiconsIcon } from "@hugeicons/react";


### PR DESCRIPTION
## What

Replaces the galaxy's communities/complexity color-mode select with a right-side **Hotspots panel** — a ranked leaderboard of the worst files by *worst-function cognitive complexity × commit co-change coupling* (qoxm edges). The heat color mode asked a 3D point cloud to do a ranking job it can't (no ordering, occlusion, ~70% of functions tied at zero); a table answers "what's bad and how bad" in one glance, and the 3D view now earns its keep on selection instead.

- **Panel** (`HotspotPanel.tsx`): top 30 rows with Sonar-band score badges (green < 15 ≤ yellow < 25 ≤ red), worst-function label, pink coupling chip (partner count + recency), sortable by hotspot/complexity/coupling, honest "top N of M" footer. Toggled by a `Hotspots` HUD chip; rows obey the hide-tests + workspace filters.
- **Click a row** → camera flies to the file + its co-change partners, and their `CoChangedWith` edges render at full strength in the pink kind color (ambient co-change stays the dim 0.35 overlay), so a hotspot's coupling web is unmistakable.
- **Adapter** (`snapshotHotspots`): rolls per-symbol `cognitive` up to the containing file, joins qoxm edges (coupling score = edge confidence, last-co-change epoch day decoded from the `cochange;last_day=` reason). Score = `complexity × (1 + Σ coupling)`; coupled-but-unscored files are excluded.
- **Cutover, no strangler**: `GalaxyColorMode`, node `heat`/`heatEligible`, the heat scale/legend, and the `ComplexityHeat` story are deleted — communities is the only star coloring. `GalaxyCanvas` gains a generic `sidePanel` slot.
- **Chrome dedup**: `/code-graph` no longer renders the shared chrome ProjectSelector (the galaxy HUD project chip writes the same store). `routeScopes` gains `inPageSelector` + `needsChromeProjectSelector`.

## Verification

- `tsc --noEmit`, eslint clean on all touched files.
- Full UI vitest suite: 1450 passed / 1 expected fail; the `useSigmaGraph.test.tsx` worker-terminate warning reproduces on a clean checkout (pre-existing; that hook is lmkv-cutover deletion backlog).
- New unit tests for `snapshotHotspots` (roll-up, coupling join + reason decode, ranking, exclusions, malformed reason) and a page-level test driving toggle → panel → row select/deselect.
- Not verified live: the pink coupling-web highlight needs a warmed graph with co-change edges — worth an eyeball on the deployed galaxy after merge.

Closes the complexity-visualization gap flagged after the lmkv cutover (lmkv/qoxm/glqk are all marked done).