### PR TITLE
fix(sse): enrich epic events with proposal swimlane labels so live boards group correctly

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/proposal_tools/lifecycle.rs
+++ b/server/crates/djinn-control-plane/src/tools/proposal_tools/lifecycle.rs
@@ -691,9 +691,7 @@ impl DjinnMcpServer {
         let epic_repo = EpicRepository::new(self.state.db().clone(), self.state.event_bus());
         for epic_id in epic_ids {
             if let Ok(Some(epic)) = epic_repo.get(epic_id).await {
-                self.state
-                    .event_bus()
-                    .send(DjinnEventEnvelope::epic_updated(&epic));
+                epic_repo.emit_updated(&epic).await;
             }
         }
     }

--- a/server/crates/djinn-coordinator/src/rules.rs
+++ b/server/crates/djinn-coordinator/src/rules.rs
@@ -1800,7 +1800,9 @@ mod tests {
         // While that review is still open, neither a re-emitted close nor the
         // second epic closing stacks a duplicate (dedup: one open review).
         let closed_e1 = epic_repo.get(&e1.id).await.unwrap().unwrap();
-        let _ = tx.send(DjinnEventEnvelope::epic_updated(&closed_e1));
+        let _ = tx.send(DjinnEventEnvelope::epic_updated(
+            &djinn_core::models::EpicEventPayload::bare(&closed_e1),
+        ));
         epic_repo.close(&e2.id).await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(400)).await;
         assert_eq!(

--- a/server/crates/djinn-coordinator/src/wave.rs
+++ b/server/crates/djinn-coordinator/src/wave.rs
@@ -344,7 +344,9 @@ mod tests {
         let decomp_tasks = wait_for_decomp_tasks(&db, &tx, &epic.id, 1).await;
         assert_eq!(decomp_tasks.len(), 1);
 
-        let _ = tx.send(DjinnEventEnvelope::epic_created(&epic));
+        let _ = tx.send(DjinnEventEnvelope::epic_created(
+            &djinn_core::models::EpicEventPayload::bare(&epic),
+        ));
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
@@ -431,7 +433,9 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let promoted = epic_repo.set_status_raw(&epic.id, "open").await.unwrap();
-        let _ = tx.send(DjinnEventEnvelope::epic_updated(&promoted));
+        let _ = tx.send(DjinnEventEnvelope::epic_updated(
+            &djinn_core::models::EpicEventPayload::bare(&promoted),
+        ));
 
         let decomp_tasks = wait_for_decomp_tasks(&db, &tx, &epic.id, 1).await;
         assert_eq!(decomp_tasks.len(), 1);
@@ -468,12 +472,16 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let promoted = epic_repo.set_status_raw(&epic.id, "open").await.unwrap();
-        let _ = tx.send(DjinnEventEnvelope::epic_updated(&promoted));
+        let _ = tx.send(DjinnEventEnvelope::epic_updated(
+            &djinn_core::models::EpicEventPayload::bare(&promoted),
+        ));
 
         let decomp_tasks = wait_for_decomp_tasks(&db, &tx, &epic.id, 1).await;
         assert_eq!(decomp_tasks.len(), 1);
 
-        let _ = tx.send(DjinnEventEnvelope::epic_updated(&promoted));
+        let _ = tx.send(DjinnEventEnvelope::epic_updated(
+            &djinn_core::models::EpicEventPayload::bare(&promoted),
+        ));
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let task_repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
@@ -553,7 +561,9 @@ mod tests {
             .update_memory_refs(&epic.id, r#"["design/roadmap"]"#)
             .await
             .unwrap();
-        let _ = tx.send(DjinnEventEnvelope::epic_updated(&touched));
+        let _ = tx.send(DjinnEventEnvelope::epic_updated(
+            &djinn_core::models::EpicEventPayload::bare(&touched),
+        ));
         tokio::time::sleep(std::time::Duration::from_millis(400)).await;
 
         // No NEW planning task must have been created — the worker task is still

--- a/server/crates/djinn-core/src/events.rs
+++ b/server/crates/djinn-core/src/events.rs
@@ -3,7 +3,7 @@ use crate::models::Credential;
 use crate::models::CustomProvider;
 use crate::models::DispatchPause;
 use crate::models::DispatchPauseScope;
-use crate::models::Epic;
+use crate::models::EpicEventPayload;
 use crate::models::GitSettings;
 use crate::models::Project;
 use crate::models::Proposal;
@@ -124,21 +124,21 @@ impl DjinnEventEnvelope {
         }
     }
 
-    pub fn epic_created(epic: &Epic) -> Self {
+    pub fn epic_created(payload: &EpicEventPayload<'_>) -> Self {
         Self {
             entity_type: "epic",
             action: "created",
-            payload: serde_json::to_value(epic).unwrap(),
+            payload: serde_json::to_value(payload).unwrap(),
             id: None,
             project_id: None,
             from_sync: false,
         }
     }
-    pub fn epic_updated(epic: &Epic) -> Self {
+    pub fn epic_updated(payload: &EpicEventPayload<'_>) -> Self {
         Self {
             entity_type: "epic",
             action: "updated",
-            payload: serde_json::to_value(epic).unwrap(),
+            payload: serde_json::to_value(payload).unwrap(),
             id: None,
             project_id: None,
             from_sync: false,

--- a/server/crates/djinn-core/src/models/epic.rs
+++ b/server/crates/djinn-core/src/models/epic.rs
@@ -34,3 +34,37 @@ pub struct Epic {
     #[serde(default)]
     pub proposal_id: Option<String>,
 }
+
+/// Payload for `epic.created` / `epic.updated` events: the epic row plus the
+/// proposal swimlane labels the board needs to group live epics, mirroring
+/// the `epic_list` enrichment. Emit through `EpicRepository::emit_created` /
+/// `emit_updated`, which hydrate the labels; [`EpicEventPayload::bare`] is
+/// for epics with no proposal linkage, lookup-failure fallbacks, and tests.
+#[derive(Debug, serde::Serialize)]
+pub struct EpicEventPayload<'a> {
+    #[serde(flatten)]
+    pub epic: &'a Epic,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_short_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposal_build_owner_user_id: Option<String>,
+}
+
+impl<'a> EpicEventPayload<'a> {
+    /// Payload without proposal labels. Consumers treat missing labels as
+    /// "linkage unknown", so only use this when the epic has no
+    /// `proposal_id` or the label lookup failed.
+    pub fn bare(epic: &'a Epic) -> Self {
+        Self {
+            epic,
+            proposal_short_id: None,
+            proposal_title: None,
+            proposal_status: None,
+            proposal_build_owner_user_id: None,
+        }
+    }
+}

--- a/server/crates/djinn-core/src/models/mod.rs
+++ b/server/crates/djinn-core/src/models/mod.rs
@@ -19,7 +19,7 @@ pub mod verify_run;
 pub use agent::Agent;
 pub use credential::Credential;
 pub use dispatch_state::DispatchStateRecord;
-pub use epic::Epic;
+pub use epic::{Epic, EpicEventPayload};
 pub use git_settings::GitSettings;
 pub use org_ai_policy::{LockLevel, OrgAiPolicy, OrgDefaultLanes};
 pub use project::Project;

--- a/server/crates/djinn-db/src/repositories/epic.rs
+++ b/server/crates/djinn-db/src/repositories/epic.rs
@@ -1,6 +1,6 @@
 // djinn:allow-oversize — legacy module over size-guard threshold; split when touched substantively.
 use djinn_core::events::{DjinnEventEnvelope, EventBus};
-use djinn_core::models::Epic;
+use djinn_core::models::{Epic, EpicEventPayload};
 
 use crate::database::Database;
 use crate::repositories::task::{DispositionScope, TaskRepository, apply_parent_disposition_tx};
@@ -101,6 +101,55 @@ pub struct EpicRepository {
 impl EpicRepository {
     pub fn new(db: Database, events: EventBus) -> Self {
         Self { db, events }
+    }
+
+    /// Hydrate the proposal swimlane labels (short_id/title/status/build
+    /// owner) for an epic's event payload, mirroring the `epic_list`
+    /// enrichment so live SSE payloads match snapshot rows. Fail-open: a
+    /// lookup failure logs and falls back to a bare payload — the event must
+    /// still go out so live boards hear about the change.
+    async fn event_payload<'a>(&self, epic: &'a Epic) -> EpicEventPayload<'a> {
+        let Some(proposal_id) = epic.proposal_id.clone() else {
+            return EpicEventPayload::bare(epic);
+        };
+        let proposals = crate::repositories::proposal::ProposalRepository::new(
+            self.db.clone(),
+            self.events.clone(),
+        );
+        match proposals.refs_by_ids(&[proposal_id]).await {
+            Ok(refs) => match refs.into_iter().next() {
+                Some(r) => EpicEventPayload {
+                    epic,
+                    proposal_short_id: Some(r.short_id),
+                    proposal_title: Some(r.title),
+                    proposal_status: Some(r.status),
+                    proposal_build_owner_user_id: r.build_owner_user_id,
+                },
+                None => EpicEventPayload::bare(epic),
+            },
+            Err(e) => {
+                tracing::warn!(
+                    epic_id = %epic.id,
+                    error = %e,
+                    "failed to hydrate proposal labels for epic event; sending bare payload"
+                );
+                EpicEventPayload::bare(epic)
+            }
+        }
+    }
+
+    /// Emit `epic.created` with hydrated proposal swimlane labels.
+    pub async fn emit_created(&self, epic: &Epic) {
+        self.events.send(DjinnEventEnvelope::epic_created(
+            &self.event_payload(epic).await,
+        ));
+    }
+
+    /// Emit `epic.updated` with hydrated proposal swimlane labels.
+    pub async fn emit_updated(&self, epic: &Epic) {
+        self.events.send(DjinnEventEnvelope::epic_updated(
+            &self.event_payload(epic).await,
+        ));
     }
 
     /// Close a set of epics inside an existing lifecycle transaction.
@@ -270,7 +319,7 @@ impl EpicRepository {
             }
         }
 
-        self.events.send(DjinnEventEnvelope::epic_created(&epic));
+        self.emit_created(&epic).await;
         Ok(epic)
     }
 
@@ -310,7 +359,7 @@ impl EpicRepository {
         .fetch_one(self.db.pool())
         .await?;
 
-        self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+        self.emit_updated(&epic).await;
         Ok(epic)
     }
 
@@ -361,7 +410,7 @@ impl EpicRepository {
             }
         }
 
-        self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+        self.emit_updated(&epic).await;
         // Re-drive wave-1 for any epics that were blocked by this one and are
         // now fully unblocked (mirror of task `emit_unblocked_tasks`).
         self.emit_unblocked_epics(id).await?;
@@ -419,7 +468,7 @@ impl EpicRepository {
         .fetch_one(self.db.pool())
         .await?;
 
-        self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+        self.emit_updated(&epic).await;
         Ok(epic)
     }
 
@@ -454,7 +503,7 @@ impl EpicRepository {
         .execute(self.db.pool())
         .await?;
         if let Some(epic) = self.get(epic_id).await? {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            self.emit_updated(&epic).await;
         }
         Ok(())
     }
@@ -470,7 +519,7 @@ impl EpicRepository {
         .execute(self.db.pool())
         .await?;
         if let Some(epic) = self.get(epic_id).await? {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            self.emit_updated(&epic).await;
         }
         Ok(())
     }
@@ -546,10 +595,10 @@ impl EpicRepository {
         .await?;
 
         if let Some(epic) = self.get(epic_id).await? {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            self.emit_updated(&epic).await;
         }
         if let Some(epic) = self.get(blocking_id).await? {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            self.emit_updated(&epic).await;
         }
         Ok(())
     }
@@ -566,10 +615,10 @@ impl EpicRepository {
         .await?;
 
         if let Some(epic) = self.get(epic_id).await? {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            self.emit_updated(&epic).await;
         }
         if let Some(epic) = self.get(blocking_id).await? {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            self.emit_updated(&epic).await;
         }
         Ok(())
     }
@@ -651,7 +700,7 @@ impl EpicRepository {
         }
         for id in &notified {
             if let Some(epic) = self.get(id).await? {
-                self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+                self.emit_updated(&epic).await;
             }
         }
         Ok(())
@@ -731,7 +780,7 @@ impl EpicRepository {
         .await?;
 
         for epic in unblocked {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            self.emit_updated(&epic).await;
         }
         Ok(())
     }
@@ -808,7 +857,7 @@ impl EpicRepository {
         .fetch_one(self.db.pool())
         .await?;
 
-        self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+        self.emit_updated(&epic).await;
         Ok(epic)
     }
 
@@ -846,7 +895,7 @@ impl EpicRepository {
         .fetch_one(self.db.pool())
         .await?;
 
-        self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+        self.emit_updated(&epic).await;
         Ok(epic)
     }
 
@@ -1628,6 +1677,55 @@ mod tests {
         assert_eq!(e.id, epic.id);
         assert_eq!(e.status, "open");
         assert!(e.closed_at.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn epic_events_carry_proposal_swimlane_labels() {
+        let (bus, captured) = capturing_bus();
+        let db = test_db();
+        let repo = EpicRepository::new(db.clone(), bus);
+
+        let epic = repo.create("Linked", "", "", "", "", None).await.unwrap();
+        let proposal_id = insert_proposal_link(&db, &epic, "building").await;
+        sqlx::query("UPDATE epics SET proposal_id = $1 WHERE id = $2")
+            .bind(&proposal_id)
+            .bind(&epic.id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        captured.lock().unwrap().clear();
+
+        repo.update_memory_refs(&epic.id, r#"["design/roadmap"]"#)
+            .await
+            .unwrap();
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].entity_type, "epic");
+        assert_eq!(events[0].action, "updated");
+        // Live SSE payloads must match the epic_list enrichment: without
+        // these labels the board drops freshly created/linked epics into the
+        // "No proposal" swimlane until a full page reload.
+        let payload = &events[0].payload;
+        assert_eq!(payload["proposal_id"].as_str().unwrap(), proposal_id);
+        assert_eq!(payload["proposal_status"], "building");
+        assert_eq!(payload["proposal_title"], "Proposal");
+        assert!(payload["proposal_short_id"].is_string());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn epic_event_without_proposal_omits_labels() {
+        let (bus, captured) = capturing_bus();
+        let repo = EpicRepository::new(test_db(), bus);
+
+        repo.create("Unlinked", "", "", "", "", None).await.unwrap();
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].entity_type, "epic");
+        assert_eq!(events[0].action, "created");
+        assert!(events[0].payload.get("proposal_status").is_none());
+        assert!(events[0].payload.get("proposal_short_id").is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-db/src/repositories/proposal.rs
+++ b/server/crates/djinn-db/src/repositories/proposal.rs
@@ -2242,7 +2242,7 @@ impl ProposalRepository {
         .await?;
         let epics = EpicRepository::new(self.db.clone(), self.events.clone());
         if let Some(epic) = epics.get(epic_id).await? {
-            self.events.send(DjinnEventEnvelope::epic_updated(&epic));
+            epics.emit_updated(&epic).await;
         }
         Ok(())
     }

--- a/server/crates/djinn-db/src/repositories/task/mod.rs
+++ b/server/crates/djinn-db/src/repositories/task/mod.rs
@@ -2802,7 +2802,9 @@ pub(super) async fn maybe_reopen_epic(
     .fetch_optional(db.pool())
     .await?
     {
-        events.send(DjinnEventEnvelope::epic_updated(&epic));
+        crate::repositories::epic::EpicRepository::new(db.clone(), events.clone())
+            .emit_updated(&epic)
+            .await;
     }
 
     Ok(())

--- a/ui/src/stores/epicStore.ts
+++ b/ui/src/stores/epicStore.ts
@@ -39,9 +39,11 @@ export const epicStore = createStore<EpicState>()(
         if (!existingEpic) return state;
 
         const newEpics = new Map(state.epics);
-        // SSE epic payloads carry `proposal_id` but not the list-only
-        // proposal label enrichment (short_id/title/status); preserve the
-        // known labels unless the linkage itself changed.
+        // SSE epic payloads carry the proposal label enrichment
+        // (short_id/title/status) just like epic_list rows. The server's
+        // label hydration is fail-open, though: on a lookup failure it sends
+        // the epic bare, so preserve the known labels unless the linkage
+        // itself changed.
         const sameProposal = payload.proposal_id === existingEpic.proposal_id;
         newEpics.set(payload.id, {
           ...payload,


### PR DESCRIPTION
## Problem

Plan/breakdown tasks for freshly created epics show under the **"No proposal"** swimlane on the Kanban board even though their epics are linked to a building proposal (observed today with the 01mm/xg69/t7lh wave epics).

Root cause: SSE `epic.created`/`epic.updated` payloads serialize the raw `Epic` row — `proposal_id` but none of the proposal label enrichment (`proposal_short_id`/`proposal_title`/`proposal_status`/`proposal_build_owner_user_id`) that `epic_list` responses carry. The board only renders a proposal swimlane when `epic.proposal_status === "building"` (`KanbanBoard.tsx::isBuildingProposalEpic`), so an epic created while a board tab is open sits in the store without labels forever — its tasks land in the catch-all lane until a hard reload. The `updateEpic` store merge preserves labels for epics hydrated by the snapshot, but a fresh `epic_created` payload has nothing to preserve.

## Fix (at the emission source)

- `DjinnEventEnvelope::epic_created/epic_updated` now take an `EpicEventPayload` — the epic plus the proposal swimlane labels, flattened, matching the `epic_list` row shape the UI already types.
- Every production emitter (EpicRepository, `maybe_reopen_epic`, `set_epic_proposal_link`, proposal-lifecycle disposition events) goes through new `EpicRepository::emit_created/emit_updated`, which hydrate the labels via the same `ProposalRepository::refs_by_ids` lookup `epic_list` uses. No-proposal epics short-circuit with zero extra queries.
- Hydration is fail-open: on lookup failure the event is sent bare (warn log), and the UI's existing label-preserving merge covers the gap, so live boards always hear about the change.
- UI: comment update only — `updateEpic`'s label preservation is now a defensive fallback rather than the primary mechanism.

## Testing

- New repo tests: `epic_events_carry_proposal_swimlane_labels` (linked epic → payload carries `proposal_status: building` etc.) and `epic_event_without_proposal_omits_labels`.
- `cargo nextest`: djinn-db lib (977), djinn-coordinator `rules::`+`wave::` (167, 3 consecutive clean runs), djinn-control-plane (1039) — all green.
- UI: epicStore/KanbanBoard/sseEventHandlers vitest suites pass.
- Note: under plain `cargo test` at high parallelism the coordinator deadline tests flake identically on unmodified main (reproduced 2/5 on main vs this branch) — pre-existing load flake, not introduced here; nextest (CI parity) is stable.