### PR TITLE
fix(provider): never capture or replay empty Anthropic text blocks

### DIFF
--- a/server/crates/djinn-provider/src/provider/format/anthropic/request.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/request.rs
@@ -141,6 +141,10 @@ impl AnthropicProvider {
     /// omitted rather than turned into an empty text placeholder.
     fn serialize_content_block(block: &ContentBlock, assistant_replay: bool) -> Option<Value> {
         match block {
+            // Anthropic and Anthropic-compatible endpoints reject empty text
+            // blocks (Moonshot/Kimi: 400 "Invalid request: text content is
+            // empty"), so blocks with no usable text are omitted from replay.
+            ContentBlock::Text { text } if text.trim().is_empty() => None,
             ContentBlock::Text { text } => Some(json!({"type": "text", "text": text})),
             ContentBlock::ToolUse { id, name, input } => Some(json!({
                 "type": "tool_use", "id": id, "name": name, "input": input,
@@ -149,14 +153,24 @@ impl AnthropicProvider {
                 tool_use_id,
                 content,
                 is_error,
-            } => Some(json!({
-                "type": "tool_result",
-                "tool_use_id": tool_use_id,
-                "content": content.iter()
+            } => {
+                let mut inner = content
+                    .iter()
                     .filter_map(|block| Self::serialize_content_block(block, false))
-                    .collect::<Vec<_>>(),
-                "is_error": is_error,
-            })),
+                    .collect::<Vec<_>>();
+                // A tool that produced no output must not serialize an empty
+                // text block (or an empty content array, which some strict
+                // Anthropic-compatible endpoints also reject) — say so instead.
+                if inner.is_empty() {
+                    inner.push(json!({"type": "text", "text": "(no output)"}));
+                }
+                Some(json!({
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": inner,
+                    "is_error": is_error,
+                }))
+            }
             ContentBlock::Image { media_type, data } => Some(json!({
                 "type": "image",
                 "source": {"type": "base64", "media_type": media_type, "data": data}
@@ -188,6 +202,19 @@ impl AnthropicProvider {
                 content_type,
                 extra,
             } if assistant_replay => {
+                // Sessions captured before the streaming parser grew a "text"
+                // arm persisted text blocks as Unknown { content_type: "text",
+                // extra: {"text": ""} }. Replaying that serializes to
+                // {"type":"text","text":""}, which Anthropic-compatible
+                // endpoints reject — drop it like any other empty text block.
+                if content_type == "text"
+                    && extra
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_none_or(|text| text.trim().is_empty())
+                {
+                    return None;
+                }
                 // Insert opaque fields first so Djinn's owned discriminant cannot
                 // be overridden by a persisted/foreign `extra.type` value.
                 let mut object = extra.clone();
@@ -218,6 +245,12 @@ impl AnthropicProvider {
                     .iter()
                     .filter_map(|block| Self::serialize_content_block(block, assistant_replay))
                     .collect::<Vec<_>>();
+                // A message whose every block was filtered out (empty text,
+                // unsigned thinking, …) must be omitted entirely: Anthropic
+                // rejects messages with empty content.
+                if content.is_empty() {
+                    return None;
+                }
                 Some(json!({"role": role, "content": content}))
             })
             .collect()

--- a/server/crates/djinn-provider/src/provider/format/anthropic/streaming.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/streaming.rs
@@ -102,6 +102,22 @@ pub(crate) fn parse_anthropic_event(
                     .and_then(Value::as_str)
                     .unwrap_or("")
                 {
+                    "text" => {
+                        // Text content streams via `text_delta` events; the start
+                        // frame carries at most an initial fragment. Never track a
+                        // text block as pending Unknown state: the captured
+                        // `{"type":"text","text":""}` would be replayed verbatim on
+                        // the next request, which strict Anthropic-compatible
+                        // endpoints reject with 400 "text content is empty".
+                        if let Some(initial) = content_block.get("text").and_then(Value::as_str)
+                            && !initial.is_empty()
+                        {
+                            events.push(StreamEvent::Delta(ContentBlock::Text {
+                                text: initial.to_string(),
+                            }));
+                        }
+                        return events;
+                    }
                     "tool_use" => PendingContentBlock::ToolUse {
                         id: content_block
                             .get("id")

--- a/server/crates/djinn-provider/src/provider/format/anthropic/tests/request.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/tests/request.rs
@@ -493,3 +493,131 @@ fn test_build_request_replays_all_anthropic_thinking_blocks() {
         ]
     );
 }
+
+#[test]
+fn test_build_request_drops_empty_text_blocks_from_replay() {
+    // kimi-for-coding/k3 emits an empty text block mid-turn; replaying it
+    // verbatim gets 400 "Invalid request: text content is empty" from
+    // Anthropic-compatible endpoints. Empty/whitespace text blocks must be
+    // filtered from both assistant and user replay.
+    let provider = test_provider();
+    let mut conv = Conversation::default();
+    conv.push(crate::message::Message {
+        role: djinn_core::message::Role::Assistant,
+        content: vec![
+            ContentBlock::text(""),
+            ContentBlock::text("   \n"),
+            ContentBlock::text("visible output"),
+        ],
+        metadata: None,
+    });
+
+    let req = provider.build_request(&conv, &[], None);
+    let content = req["messages"][0]["content"].as_array().unwrap();
+    assert_eq!(
+        content,
+        &vec![json!({"type": "text", "text": "visible output"})]
+    );
+}
+
+#[test]
+fn test_build_request_drops_captured_empty_text_unknown_block() {
+    // Sessions persisted before the streaming parser grew a "text" arm carry
+    // text blocks captured as Unknown { content_type: "text", extra: {"text": ""} }.
+    // Those must not be replayed as {"type":"text","text":""}.
+    let provider = test_provider();
+    let mut empty_extra = serde_json::Map::new();
+    empty_extra.insert("text".to_string(), json!(""));
+    let mut populated_extra = serde_json::Map::new();
+    populated_extra.insert("text".to_string(), json!("legacy captured text"));
+    let mut conv = Conversation::default();
+    conv.push(crate::message::Message {
+        role: djinn_core::message::Role::Assistant,
+        content: vec![
+            ContentBlock::Unknown {
+                content_type: "text".to_string(),
+                extra: empty_extra,
+            },
+            ContentBlock::Unknown {
+                content_type: "text".to_string(),
+                extra: populated_extra,
+            },
+            ContentBlock::ToolUse {
+                id: "tool_1".to_string(),
+                name: "shell".to_string(),
+                input: json!({"command": "ls"}),
+            },
+        ],
+        metadata: None,
+    });
+
+    let req = provider.build_request(&conv, &[], None);
+    let content = req["messages"][0]["content"].as_array().unwrap();
+    assert_eq!(content.len(), 2);
+    assert_eq!(
+        content[0],
+        json!({"type": "text", "text": "legacy captured text"})
+    );
+    assert_eq!(content[1]["type"], "tool_use");
+}
+
+#[test]
+fn test_build_request_omits_message_with_no_serializable_content() {
+    // An assistant message whose every block filters out (unsigned thinking,
+    // empty text) must be omitted entirely — Anthropic rejects messages with
+    // empty content arrays.
+    let provider = test_provider();
+    let mut conv = Conversation::default();
+    conv.push(crate::message::Message {
+        role: djinn_core::message::Role::User,
+        content: vec![ContentBlock::text("do the thing")],
+        metadata: None,
+    });
+    conv.push(crate::message::Message {
+        role: djinn_core::message::Role::Assistant,
+        content: vec![
+            ContentBlock::text(""),
+            ContentBlock::Thinking {
+                thinking: "unsigned".to_string(),
+                signature: None,
+            },
+        ],
+        metadata: None,
+    });
+    conv.push(crate::message::Message {
+        role: djinn_core::message::Role::User,
+        content: vec![ContentBlock::text("still there?")],
+        metadata: None,
+    });
+
+    let req = provider.build_request(&conv, &[], None);
+    let messages = req["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0]["role"], "user");
+    assert_eq!(messages[1]["role"], "user");
+}
+
+#[test]
+fn test_build_request_tool_result_with_no_output_gets_placeholder() {
+    // A tool that produced no output must not serialize an empty text block
+    // (or an empty content array) inside its tool_result.
+    let provider = test_provider();
+    let mut conv = Conversation::default();
+    conv.push(crate::message::Message {
+        role: djinn_core::message::Role::User,
+        content: vec![ContentBlock::ToolResult {
+            tool_use_id: "tool_1".to_string(),
+            content: vec![ContentBlock::text("")],
+            is_error: false,
+        }],
+        metadata: None,
+    });
+
+    let req = provider.build_request(&conv, &[], None);
+    let content = req["messages"][0]["content"].as_array().unwrap();
+    assert_eq!(content.len(), 1);
+    assert_eq!(
+        content[0]["content"],
+        json!([{"type": "text", "text": "(no output)"}])
+    );
+}

--- a/server/crates/djinn-provider/src/provider/format/anthropic/tests/streaming.rs
+++ b/server/crates/djinn-provider/src/provider/format/anthropic/tests/streaming.rs
@@ -628,3 +628,59 @@ fn test_indexed_thinking_redacted_unknown_and_tool_blocks() {
         matches!(&unknown[..], [StreamEvent::Delta(ContentBlock::Unknown { content_type, extra })] if content_type == "vendor_block" && extra["vendor_id"] == "v1" && extra["cursor"] == "next")
     );
 }
+
+#[test]
+fn test_text_content_block_start_is_not_captured_as_unknown() {
+    // A text content_block_start (always `{"type":"text","text":""}` on the
+    // wire) must not be tracked as a pending Unknown block: the captured
+    // {"type":"text","text":""} would be replayed on the next request, which
+    // strict Anthropic-compatible endpoints reject with
+    // 400 "text content is empty" (kimi-for-coding/k3 incident, 2026-07-16).
+    let mut acc = ContentBlockAcc::default();
+    let mut input_tokens = 0u32;
+    let mut cache_read = 0u32;
+    let mut cache_write = 0u32;
+    let start_events = parse_anthropic_event(
+        "content_block_start",
+        r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+        &mut acc,
+        &mut input_tokens,
+        &mut cache_read,
+        &mut cache_write,
+    );
+    assert!(start_events.is_empty());
+    assert!(acc.is_empty());
+
+    let stop_events = parse_anthropic_event(
+        "content_block_stop",
+        r#"{"type":"content_block_stop","index":0}"#,
+        &mut acc,
+        &mut input_tokens,
+        &mut cache_read,
+        &mut cache_write,
+    );
+    assert!(stop_events.is_empty());
+}
+
+#[test]
+fn test_text_content_block_start_emits_initial_fragment() {
+    // A provider that front-loads text into the start frame must not lose it.
+    let mut acc = ContentBlockAcc::default();
+    let mut input_tokens = 0u32;
+    let mut cache_read = 0u32;
+    let mut cache_write = 0u32;
+    let events = parse_anthropic_event(
+        "content_block_start",
+        r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"head"}}"#,
+        &mut acc,
+        &mut input_tokens,
+        &mut cache_read,
+        &mut cache_write,
+    );
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        StreamEvent::Delta(ContentBlock::Text { text }) => assert_eq!(text, "head"),
+        other => panic!("expected text delta, got {other:?}"),
+    }
+    assert!(acc.is_empty());
+}


### PR DESCRIPTION
## Problem

`kimi-for-coding/k3` sessions failed 3/3 (tasks 8lb0, xptc ×2, 2026-07-16) with:

```
provider API error 400 Bad Request: {"error":{"type":"invalid_request_error","message":"Invalid request: text content is empty"}}
```

Root cause is ours, not Moonshot's:

1. **Capture**: `parse_anthropic_event` had no `"text"` arm in `content_block_start`, so every text block's start frame (`{"type":"text","text":""}`) was tracked as a pending `Unknown` block and flushed at `content_block_stop` as `Unknown { content_type: "text", extra: {"text": ""} }` into the persisted assistant message.
2. **Replay**: `serialize_content_block` replays `Unknown` blocks verbatim on assistant history, producing `{"type":"text","text":""}`, and also serialized empty `Text` blocks unconditionally (the empty-text filter existed only for system blocks). Strict Anthropic-compatible endpoints reject both; Claude never emits empty text blocks so this never fired before.

## Fix

- `content_block_start` now recognizes `"text"`: never tracked as pending Unknown state; a non-empty initial fragment is emitted as a normal text delta so front-loading providers lose nothing.
- Assistant/user replay: drop empty/whitespace `Text` blocks; drop legacy captured `Unknown` text blocks with no usable text (pre-fix persisted sessions); omit messages whose entire content filtered out (Anthropic rejects empty content arrays); tool_results whose content filters to nothing get a `"(no output)"` placeholder text block.

## Testing

- 6 new unit tests (4 request-serialization, 2 streaming-parser); all 70 `format::anthropic` tests pass.
- `cargo clippy -p djinn-provider --all-features` clean.