### PR TITLE
fix(coordinator): pending monitored reopen yields to normal dispatch instead of starving the worker behind the park rung

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -1550,6 +1550,43 @@ impl CoordinatorActor {
                             .await;
                     }
 
+                    // Monitored-reopen starvation fix (incident v1ej,
+                    // 2026-07-17): an unconsumed row whose directive is a
+                    // `reopen` decision IS the monitored-reopen contract in
+                    // flight — the arbiter already decided, and the one
+                    // monitored worker attempt is what must run next.  Routing
+                    // "Lead arbiter" here (and then short-circuiting on
+                    // `AlreadyExistsUnconsumed`) starves that worker dispatch
+                    // on every tick once `intervention_count` reaches this
+                    // rung, so the monitored attempt never starts and the task
+                    // wedges until the 24h arbitration deadline.  Yield to the
+                    // normal dispatch pass instead: it applies the arbiter's
+                    // `exclude_models`, injects the directive one-shot
+                    // (`mark_directive_injected`), the respawn guard dedupes
+                    // while the monitored worker is live, and the supervisor's
+                    // terminal hook (`complete_monitored_reopen`) consumes the
+                    // row.  The deadline-expiry and decision-failure-cap parks
+                    // above still fire first, so an abandoned reopen cannot
+                    // yield forever.
+                    let is_monitored_reopen = existing
+                        .directive
+                        .as_ref()
+                        .and_then(|directive| directive.get("decision"))
+                        .and_then(serde_json::Value::as_str)
+                        == Some("reopen");
+                    if is_monitored_reopen {
+                        tracing::info!(
+                            task_id = %task.short_id,
+                            hold_cycle = cycle,
+                            directive_injected = existing.directive_injected,
+                            monitored_reopen_count = existing.monitored_reopen_count,
+                            "CoordinatorActor: second-strike — unconsumed arbitration row is a \
+                             monitored reopen; yielding to normal dispatch so the monitored \
+                             worker attempt can run"
+                        );
+                        return false;
+                    }
+
                     tracing::info!(
                         task_id = %task.short_id,
                         hold_cycle = cycle,

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -3945,6 +3945,99 @@ async fn reentry_with_unconsumed_arbiter_does_not_create_second_arbiter() {
     );
 }
 
+/// Monitored-reopen starvation regression (incident v1ej, 2026-07-17): when
+/// the current hold cycle's unconsumed arbitration row carries a `reopen`
+/// decision, the arbiter has ALREADY decided and the one monitored worker
+/// attempt is what must run next.  `route_planner_intervention` must yield
+/// (return `false`) so the normal dispatch pass can run that worker — instead
+/// of treating the row as "arbiter in flight" on every tick, which starves the
+/// monitored attempt until the 24h arbitration deadline.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pending_monitored_reopen_yields_to_normal_dispatch() {
+    use djinn_db::repositories::task_arbitration::UpdateDispatchLedgerParams;
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let task = make_task_with_reopen_count(&db, &tx, REOPEN_INTERVENTION_THRESHOLD).await;
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    for _ in 0..REOPEN_INTERVENTION_THRESHOLD {
+        repo.set_status(&task.id, "closed").await.unwrap();
+        repo.set_status(&task.id, "open").await.unwrap();
+    }
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(task.intervention_count, MAX_PLANNER_INTERVENTIONS);
+
+    seed_terminated_post_intervention_sessions(&db, &tx, &task.id, &["m-a", "m-b"]).await;
+
+    // First dispatch creates the arbitration row (arbiter routed).
+    let first_handled = actor
+        .route_planner_intervention(&task, "worker", "second strike first dispatch", None, 5)
+        .await;
+    assert!(first_handled, "first dispatch must handle the task");
+
+    let arb_repo = TaskArbitrationRepository::new(db.clone());
+    let all_arbs = arb_repo.list_for_task(&task.id).await.unwrap();
+    assert_eq!(all_arbs.len(), 1, "one arbitration row after first dispatch");
+    let cycle = all_arbs[0].hold_cycle;
+
+    // Simulate the Lead arbiter's `reopen` decision: persist the directive on
+    // the unconsumed row, record the monitored-reopen start, and return the
+    // task to `open` (the reopen transition the arbiter's decision applies).
+    let reopen_directive = serde_json::json!({
+        "decision": "reopen",
+        "directive": "repair the failing fixtures and push so CI reruns",
+    });
+    arb_repo
+        .update_dispatch_ledger(UpdateDispatchLedgerParams {
+            task_id: &task.id,
+            hold_cycle: cycle,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            pr_url: None,
+            failing_ci_job_ids: None,
+            dossier: None,
+            directive: Some(&reopen_directive),
+            verification_command: None,
+            excluded_models: None,
+        })
+        .await
+        .unwrap();
+    arb_repo
+        .record_monitored_reopen(&task.id, cycle)
+        .await
+        .unwrap();
+    repo.set_status(&task.id, "open").await.unwrap();
+
+    // Re-entry with the monitored reopen pending must YIELD to normal
+    // dispatch — not spin "arbiter already in flight".
+    let refreshed = repo.get(&task.id).await.unwrap().unwrap();
+    let handled = actor
+        .route_planner_intervention(&refreshed, "worker", "second strike reentry", None, 5)
+        .await;
+    assert!(
+        !handled,
+        "a pending monitored reopen must yield to normal dispatch so the \
+         monitored worker attempt can run (incident v1ej: returning true here \
+         starved the worker until the 24h arbitration deadline)"
+    );
+
+    // No second arbitration row, and the reopen row stays unconsumed for the
+    // monitored worker to pick up.
+    let all_arbs_after = arb_repo.list_for_task(&task.id).await.unwrap();
+    assert_eq!(
+        all_arbs_after.len(),
+        1,
+        "yielding must not create a second arbitration row"
+    );
+    assert_eq!(
+        all_arbs_after[0].state, "unconsumed",
+        "the monitored-reopen row must remain unconsumed for the worker dispatch"
+    );
+}
+
 /// Recovery/replay after a transition-before-activity partial failure.
 ///
 /// The arbiter dispatch commits its durable state in two steps that are NOT in
@@ -7069,7 +7162,9 @@ async fn reentry_with_stale_decided_arbitration_self_consumes_and_dispatches_fre
 
 /// A monitored-reopen row (directive decision "reopen") keeps its unconsumed
 /// state by design until `complete_monitored_reopen` — the self-recovery path
-/// must NOT consume it.
+/// must NOT consume it.  Since the v1ej starvation fix, the re-entry also
+/// YIELDS (returns `false`) so the normal dispatch pass can run the monitored
+/// worker instead of spinning "arbiter already in flight" every tick.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn reentry_with_monitored_reopen_directive_does_not_self_consume() {
     let db = test_helpers::create_test_db();
@@ -7112,7 +7207,11 @@ async fn reentry_with_monitored_reopen_directive_does_not_self_consume() {
     let handled = actor
         .route_planner_intervention(&task, "worker", "monitored reopen reentry", None, 5)
         .await;
-    assert!(handled, "monitored-reopen re-entry must be handled");
+    assert!(
+        !handled,
+        "monitored-reopen re-entry must YIELD to normal dispatch so the \
+         monitored worker attempt can run (v1ej starvation fix)"
+    );
 
     // The single row survives unconsumed — no self-consume, no second row.
     let all_arbs = arb_repo.list_for_task(&task.id).await.unwrap();


### PR DESCRIPTION
## Incident (v1ej, 2026-07-17)

At 12:23 a Lead arbiter issued a `reopen` decision with a detailed repair directive (monitored reopen, hold cycle 1). The task returned to `open` — and then nothing dispatched for 2+ hours. Every coordinator tick logged:

> second-strike — current hold cycle already has an unconsumed arbiter; ensuring Lead arbiter routing
> second-strike — outbox replay; arbiter already in flight

## Root cause

The monitored-reopen lifecycle keeps the arbitration row **unconsumed by design** until the monitored worker's terminal outcome (`complete_monitored_reopen` in the supervisor). But once `intervention_count` reaches `MAX_PLANNER_INTERVENTIONS`, `route_planner_intervention` intercepts every ready pass **before** normal dispatch, sees the unconsumed row, short-circuits on `AlreadyExistsUnconsumed`, and returns handled — starving the very worker dispatch the arbiter's decision requires. Hold cycle 0 on the same task worked only because the intervention count was still below the cap at the time.

## Fix

In the `'unconsumed` block, after the deadline-expiry and decision-failure-cap parks (which still fire first, so an abandoned reopen cannot yield forever): when the row's directive decision is `reopen`, **yield** (`return false`) so the normal dispatch pass runs the monitored worker — which already applies the arbiter's `exclude_models`, injects the directive one-shot, dedupes via the respawn guard while live, and consumes the row on the terminal outcome.

## Testing

- New `pending_monitored_reopen_yields_to_normal_dispatch` regression: seeds the exact v1ej state (cap reached, unconsumed reopen row, monitored attempt recorded, task back in `open`) and asserts the gate yields without creating a second arbitration row and leaves the row unconsumed.
- Updated `reentry_with_monitored_reopen_directive_does_not_self_consume`: its core assertions (no self-consume, single row) are unchanged; the `handled` expectation flips to the new yield behavior it previously baked in as the bug.
- `intervention` (83), `monitored_reopen` (5), `retry` (14), `i3mv` (22) suites green; clippy `--all-features` clean.