### PR TITLE
fix(board-health): bound board_health by live work instead of full board history

### DIFF
--- a/server/.sqlx/query-2ef98c766ce5d7132b2942dd1bdd549afc1689f97e7342f520efc3131eff88fe.json
+++ b/server/.sqlx/query-2ef98c766ce5d7132b2942dd1bdd549afc1689f97e7342f520efc3131eff88fe.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT t.id, t.short_id, t.title, t.status, t.updated_at,\n                    e.short_id AS epic_short_id\n             FROM tasks t\n             JOIN epics e ON t.epic_id = e.id\n             WHERE t.status IN ('needs_task_review','in_task_review','approved','pr_draft','pr_review','closed')\n             ORDER BY t.updated_at ASC",
+  "query": "SELECT t.id, t.short_id, t.title, t.status, t.updated_at,\n                    e.short_id AS epic_short_id\n             FROM tasks t\n             JOIN epics e ON t.epic_id = e.id\n             WHERE t.status IN ('needs_task_review','in_task_review','approved','pr_draft','pr_review')\n             ORDER BY t.updated_at ASC\n             LIMIT 500",
   "describe": {
     "columns": [
       {
@@ -46,5 +46,5 @@
       false
     ]
   },
-  "hash": "f0e85b77e1468b300f978678db6b22428362ae51b6c2c71d608de6c7f0c589cd"
+  "hash": "2ef98c766ce5d7132b2942dd1bdd549afc1689f97e7342f520efc3131eff88fe"
 }

--- a/server/.sqlx/query-4b80739aa1c166b40fca44f57cf44ff43fab3fecbb3d68882e67cddfb34ee8c1.json
+++ b/server/.sqlx/query-4b80739aa1c166b40fca44f57cf44ff43fab3fecbb3d68882e67cddfb34ee8c1.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE tasks SET total_reopen_count = 5 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4b80739aa1c166b40fca44f57cf44ff43fab3fecbb3d68882e67cddfb34ee8c1"
+}

--- a/server/crates/djinn-db/src/repositories/task/queries.rs
+++ b/server/crates/djinn-db/src/repositories/task/queries.rs
@@ -117,10 +117,18 @@ fn role_tool_mismatch_reason(
 }
 
 async fn list_board_health_mismatch_candidates(repo: &TaskRepository) -> Result<Vec<Task>> {
+    // Non-closed only: the mismatch report is advisory about LIVE reopen
+    // churn, and closed tasks can never be re-routed to a different role.
+    // The unfiltered form scanned every task on the board (4,949 rows with
+    // ~20 correlated subqueries each, 6–9 s per call) on every board_health
+    // request — the UI polls that every 15 s, which starved the coordinator
+    // tick and the liveness probe as the closed backlog grew (2026-07-17
+    // restart loop). `!closed` bounds the candidate set by WIP, which does
+    // not grow with board history.
     let list = repo
         .list_filtered(ListQuery {
             project_id: None,
-            status: None,
+            status: Some("!closed".to_string()),
             issue_type: None,
             priority: None,
             label: None,
@@ -519,14 +527,20 @@ impl TaskRepository {
             })
             .collect();
 
-        // Review queue: tasks waiting in any review status.
+        // Review queue: tasks waiting in any review status. Closed tasks are
+        // NOT part of a queue of pending review work, and including them made
+        // this an unbounded full-history fetch (every closed task ever,
+        // serialized into JSON on each board_health call — the UI polls this
+        // every poll interval). Bounded defensively: the live review set is
+        // WIP-sized, so the LIMIT only guards against pathological states.
         let review_rows = sqlx::query!(
             r#"SELECT t.id, t.short_id, t.title, t.status, t.updated_at,
                     e.short_id AS epic_short_id
              FROM tasks t
              JOIN epics e ON t.epic_id = e.id
-             WHERE t.status IN ('needs_task_review','in_task_review','approved','pr_draft','pr_review','closed')
-             ORDER BY t.updated_at ASC"#,
+             WHERE t.status IN ('needs_task_review','in_task_review','approved','pr_draft','pr_review')
+             ORDER BY t.updated_at ASC
+             LIMIT 500"#,
         )
         .fetch_all(self.db.pool())
         .await?;
@@ -894,6 +908,8 @@ pub(super) fn sort_to_sql(sort: &str) -> &'static str {
     }
 }
 
+#[cfg(test)]
+mod board_health_bounds_tests;
 #[cfg(test)]
 mod merged_classification_tests;
 #[cfg(test)]

--- a/server/crates/djinn-db/src/repositories/task/queries/board_health_bounds_tests.rs
+++ b/server/crates/djinn-db/src/repositories/task/queries/board_health_bounds_tests.rs
@@ -1,0 +1,176 @@
+//! Regression: `board_health` must stay bounded by live (non-closed) work.
+//!
+//! The 2026-07-17 restart loop: the mismatch-candidate pull scanned every
+//! task on the board (closed history included, ~20 correlated subqueries per
+//! row) and the review-queue section fetched every closed task ever — both on
+//! every `board_health` call, which the UI polls continuously. As the closed
+//! backlog grew the calls reached 6–9 s, starving the coordinator tick and
+//! the liveness probe. Closed tasks must appear in NEITHER section.
+use super::*;
+use crate::database::Database;
+use crate::repositories::epic::EpicCreateInput;
+use crate::repositories::task::TaskRepository;
+use djinn_core::events::EventBus;
+
+async fn setup_project(db: &Database) -> (String, String) {
+    let project_id = uuid::Uuid::now_v7().to_string();
+    sqlx::query!(
+        "INSERT INTO projects (id, name, github_owner, github_repo) VALUES ($1, $2, $3, $4)",
+        project_id,
+        "p",
+        "test",
+        format!("board-health-bounds-{project_id}"),
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let epic_repo = crate::repositories::epic::EpicRepository::new(db.clone(), EventBus::noop());
+    let epic = epic_repo
+        .create_for_project(
+            &project_id,
+            EpicCreateInput {
+                title: "Board health epic",
+                description: "",
+                emoji: "",
+                color: "",
+                owner: "",
+                memory_refs: None,
+                status: None,
+                auto_breakdown: None,
+                originating_adr_id: None,
+                blocked_by: None,
+            },
+        )
+        .await
+        .unwrap();
+    (project_id, epic.id)
+}
+
+/// A closed task with heavy reopen churn and planner-toolset signals must NOT
+/// surface as a role/tool mismatch — the report is advisory about live work,
+/// and pulling closed history made the candidate scan unbounded.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn board_health_mismatch_candidates_exclude_closed_tasks() {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let (project_id, epic_id) = setup_project(&db).await;
+    let task_repo = TaskRepository::new(db.clone(), EventBus::noop());
+
+    // Two identical churn-heavy tasks whose text carries planner signals
+    // ("task_create") while the dispatched role for a plain `task` is worker.
+    let mut ids = Vec::new();
+    for title in ["live mismatch", "closed mismatch"] {
+        let task = task_repo
+            .create_in_project(
+                &project_id,
+                Some(&epic_id),
+                title,
+                "this needs task_create and epic_update to proceed",
+                "",
+                "task",
+                0,
+                "",
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        sqlx::query!(
+            "UPDATE tasks SET total_reopen_count = 5 WHERE id = $1",
+            task.id
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        ids.push(task.id);
+    }
+    sqlx::query!("UPDATE tasks SET status = 'closed' WHERE id = $1", ids[1])
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let health = task_repo.board_health(24).await.unwrap();
+    let mismatches = health["repeated_reopen_role_tool_mismatches"]
+        .as_array()
+        .expect("mismatch section is an array");
+    let listed: Vec<&str> = mismatches
+        .iter()
+        .filter_map(|m| m["id"].as_str())
+        .collect();
+    assert!(
+        listed.contains(&ids[0].as_str()),
+        "the live churn-heavy task must be reported; got {listed:?}"
+    );
+    assert!(
+        !listed.contains(&ids[1].as_str()),
+        "a closed task must never surface as a mismatch candidate; got {listed:?}"
+    );
+}
+
+/// The review queue lists work WAITING for review; closed tasks are history,
+/// and including them fetched the entire closed backlog on every call.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn board_health_review_queue_excludes_closed_tasks() {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let (project_id, epic_id) = setup_project(&db).await;
+    let task_repo = TaskRepository::new(db.clone(), EventBus::noop());
+
+    let waiting = task_repo
+        .create_in_project(
+            &project_id,
+            Some(&epic_id),
+            "waiting for review",
+            "",
+            "",
+            "task",
+            0,
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    sqlx::query!(
+        "UPDATE tasks SET status = 'needs_task_review' WHERE id = $1",
+        waiting.id
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let done = task_repo
+        .create_in_project(
+            &project_id,
+            Some(&epic_id),
+            "already closed",
+            "",
+            "",
+            "task",
+            0,
+            "",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    sqlx::query!("UPDATE tasks SET status = 'closed' WHERE id = $1", done.id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let health = task_repo.board_health(24).await.unwrap();
+    let queue = health["review_queue"]
+        .as_array()
+        .expect("review_queue is an array");
+    let listed: Vec<&str> = queue.iter().filter_map(|m| m["id"].as_str()).collect();
+    assert!(
+        listed.contains(&waiting.id.as_str()),
+        "a needs_task_review task must be in the review queue; got {listed:?}"
+    );
+    assert!(
+        !listed.contains(&done.id.as_str()),
+        "closed tasks must not be in the review queue; got {listed:?}"
+    );
+}

--- a/server/crates/djinn-db/src/repositories/task/queries/board_health_bounds_tests.rs
+++ b/server/crates/djinn-db/src/repositories/task/queries/board_health_bounds_tests.rs
@@ -6,7 +6,6 @@
 //! every `board_health` call, which the UI polls continuously. As the closed
 //! backlog grew the calls reached 6–9 s, starving the coordinator tick and
 //! the liveness probe. Closed tasks must appear in NEITHER section.
-use super::*;
 use crate::database::Database;
 use crate::repositories::epic::EpicCreateInput;
 use crate::repositories::task::TaskRepository;

--- a/ui/src/components/BoardHealthBanner.tsx
+++ b/ui/src/components/BoardHealthBanner.tsx
@@ -56,7 +56,11 @@ function useBoardHealth(projectSlugs: string[]): BoardHealthData | null {
     };
 
     fetch();
-    const interval = setInterval(fetch, 15_000);
+    // 60 s: board_health aggregates several board-wide queries server-side and
+    // is fetched once per project per tick — a health banner does not need
+    // 15 s freshness, and the tighter interval multiplied across open tabs
+    // kept the server's heaviest read path continuously hot.
+    const interval = setInterval(fetch, 60_000);
     return () => {
       active = false;
       clearInterval(interval);


### PR DESCRIPTION
## Problem

`board_health` answers a live-operations question ("what needs attention right now?") with full-history scans, and the UI's BoardHealthBanner polls it every 15 s from every open tab:

1. **Mismatch candidates**: `list_board_health_mismatch_candidates` listed **every task on the board** (`status: None, LIMIT 10_000`) — currently 4,949 rows, each paying ~20 correlated subqueries (`task_pr_ci_snapshots` ×15, `task_attempts` ×4, blockers count). Observed at 5.8–8.9 s per call in prod, several times per coordinator tick, growing with every closed task.
2. **review_queue**: included `'closed'` in its status list with no bound — the entire closed backlog fetched and serialized into JSON on every call.

Under the 15 s poll this kept the heaviest read path continuously hot, starved the coordinator tick and the `/health` liveness probe, and drove the 2026-07-17 restart loop (4 server restarts in one day, each interrupting in-flight runs and burning dispatch strikes — see incident lre2 / proposal 9gg5).

## Fix

Both sections are now bounded by **work-in-progress**, which does not grow with board age:

- Mismatch candidates filter `status != 'closed'` in SQL. The report is advisory about *live* reopen churn — a closed task can never be re-routed to a different role — so closed history was pure waste.
- `review_queue` drops `'closed'` (a queue lists work *waiting* for review) and adds a defensive `LIMIT 500`. Verified consumer-safe: the UI banner reads only `project_issues`/`pr_errors`, and the doctor checks consume their own dedicated sections.
- The banner poll relaxes 15 s → 60 s.

The durable memory work (jemalloc, bounded board-health mismatch scan redesign, graph-cache retention, streamed galaxy artifact) is owned by approved proposal **ob3k**; this PR is the surgical cut that stops the restart loop now and stays compatible with that design.

## Testing

- New `board_health_bounds_tests`: a closed churn-heavy task with planner signals must NOT surface as a mismatch candidate (its live twin must); closed tasks must NOT appear in `review_queue` (a `needs_task_review` task must).
- Full `task::` suite (100) and `board_health` suite (13) green; clippy `--all-features` clean; `.sqlx` regenerated via `make sqlx-prepare` (420 entries, net diff = the one changed query + the new test query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)