### PR TITLE
ci: deserialize test shards from the planner, event-driven fail-fast, merged guards, release cache fix

### DIFF
--- a/.github/workflows/ci-fail-fast.yml
+++ b/.github/workflows/ci-fail-fast.yml
@@ -1,0 +1,50 @@
+name: CI Fail-Fast
+
+# Event-driven replacement for the in-run "Fail-fast watchdog" job, which
+# used to occupy a runner for the entire CI run (~15 min per merge-group
+# run, ~20% of the run's total compute) polling the jobs API every 20s.
+#
+# This workflow fires when any job in this repository completes; the job
+# below is skipped (no runner allocated) unless the completed job belongs
+# to the CI workflow and concluded failure. Cancelling from a bystander
+# workflow — never from inside the failing job — preserves the property
+# the old watchdog was built for: the culprit job keeps its red "failure"
+# conclusion instead of being stamped "cancelled" by its own cancel racing
+# finalization, so merge-queue ejections stay attributable to a lane.
+#
+# Note: workflow_job-triggered workflows always execute the version of
+# this file on the default branch.
+
+on:
+  workflow_job:
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    name: Cancel failed CI run
+    if: >-
+      github.event.workflow_job.workflow_name == 'CI'
+      && github.event.workflow_job.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RUN_ID: ${{ github.event.workflow_job.run_id }}
+      FAILED_JOB: ${{ github.event.workflow_job.name }}
+    steps:
+      - name: Cancel the remaining jobs of the failed run
+        run: |
+          set -euo pipefail
+          # Main-push runs only warm caches; a warm failure should not
+          # cancel its siblings. Every other event (pull_request,
+          # merge_group, workflow_dispatch) fails fast.
+          event=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID" --jq '.event')
+          if [ "$event" = "push" ]; then
+            echo "Run $RUN_ID is a push event; leaving it alone."
+            exit 0
+          fi
+          echo "::notice::Lane '$FAILED_JOB' failed — cancelling run $RUN_ID."
+          gh run cancel "$RUN_ID" --repo "${{ github.repository }}" \
+            || echo "::warning::Cancel failed (run may already be finished)."

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -682,8 +682,6 @@ jobs:
           echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
           echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
       - uses: taiki-e/install-action@nextest
-      - name: Build test binaries (concurrent with planner discovery)
-        run: cargo nextest run --workspace --all-targets --features qdrant --no-run
       - uses: taiki-e/install-action@v2
         with:
           tool: sqlx-cli
@@ -710,6 +708,13 @@ jobs:
         run: |
           git config --global user.email "ci@test.local"
           git config --global user.name "CI Test"
+      # DB setup must precede this build: the sqlx macros compile against
+      # the live migrated database (server/.env DATABASE_URL), not the
+      # offline cache. The build overlaps the planner's discovery compile
+      # of the same crates — that concurrency is the whole point of the
+      # shards not depending on nextest-plan.
+      - name: Build test binaries (concurrent with planner discovery)
+        run: cargo nextest run --workspace --all-targets --features qdrant --no-run
       - name: Wait for and download full shard plan
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -11,12 +11,13 @@ on:
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || github.event_name == 'push' && 'ci-main' || github.event_name == 'merge_group' && format('ci-merge-group-{0}', github.event.merge_group.head_sha || github.ref) || format('ci-dispatch-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name != 'merge_group' }}
-# actions: write lets the fail-fast watchdog job (`gh run cancel`)
-# actually cancel the run — without it the cancel dies with HTTP 403 and
-# the expensive test/clippy jobs run to completion behind a failed gate.
+# actions: read lets the nextest planner restore timing artifacts and the
+# test shards poll for the in-run plan artifact. Fail-fast cancellation
+# lives in ci-fail-fast.yml (workflow_job trigger), which carries its own
+# actions: write grant.
 permissions:
   contents: read
-  actions: write
+  actions: read
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
@@ -268,22 +269,45 @@ jobs:
           echo "::notice::cache-family=server-aarch64-check shared-key=server-aarch64-check cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
       - name: cargo check (aarch64)
         run: cargo check -p djinn-sandbox --all-targets --target aarch64-unknown-linux-gnu
-  server-cargo-deny:
-    name: Server cargo-deny
+  # One runner for every cheap guard lane. Each lane was previously its own
+  # job doing ~15s of scripting behind ~30s of runner spin-up and a full
+  # fetch-depth: 0 clone; merging them frees four to five concurrent job
+  # slots per run for the merge queue. Preflight routing granularity is
+  # preserved through per-step `if` guards on the same router outputs, and
+  # the quality gate pairs the union of those selections with this job's
+  # result.
+  server-guards:
+    name: Server Guards
     needs: preflight
-    if: needs.preflight.outputs.cargoDeny == 'true' && github.event_name != 'push'
+    if: >-
+      github.event_name != 'push' && (
+        needs.preflight.outputs.cargoDeny == 'true'
+        || needs.preflight.outputs.size == 'true'
+        || needs.preflight.outputs.migrations == 'true'
+        || needs.preflight.outputs.rawSql == 'true'
+        || needs.preflight.outputs.capability == 'true'
+        || needs.preflight.outputs.boundaries == 'true'
+      )
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: server
+    env:
+      BASE_SHA: |-
+        ${{ github.event.pull_request.base.sha
+           || github.event.merge_group.base_sha
+           || '' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: rustup toolchain install
+        if: needs.preflight.outputs.cargoDeny == 'true'
         working-directory: server
       - uses: taiki-e/install-action@v2
+        if: needs.preflight.outputs.cargoDeny == 'true'
         with:
           tool: cargo-deny
       - name: cargo-deny check
+        if: needs.preflight.outputs.cargoDeny == 'true'
+        working-directory: server
         run: |
           # Retry up to 3 times with backoff — crates.io downloads can
           # fail transiently (Connection reset by peer, DNS hiccups).
@@ -302,6 +326,50 @@ jobs:
           done
           echo "::error::cargo-deny check failed after 3 attempts"
           exit 1
+      - name: Check changed Rust file sizes
+        if: needs.preflight.outputs.size == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -eu
+
+          if [ -z "$BASE_SHA" ]; then
+            # workflow_dispatch has no PR/merge context; fall back to origin/main
+            # so the guard still runs against changes since the main branch.
+            git fetch --no-tags --depth=1 origin main >/dev/null 2>&1 || true
+            BASE_SHA="$(git rev-parse --verify origin/main 2>/dev/null || true)"
+          fi
+
+          if [ -z "$BASE_SHA" ]; then
+            echo "::error::Could not determine a base SHA for changed-file detection (event=$EVENT_NAME)."
+            exit 1
+          fi
+
+          echo "Computing changed-file diff against base $BASE_SHA (event=$EVENT_NAME)..."
+          # --diff-filter=AMR = Added, Modified, Renamed. D (Deleted) is
+          # intentionally excluded so deleted files are not re-checked.
+          # The three-dot form uses the merge base of $BASE_SHA and HEAD,
+          # which tolerates a slightly stale PR base SHA after main advances.
+          git diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" \
+            | ./scripts/check-file-size.sh --files-from-stdin
+      - name: Check applied migrations are immutable
+        if: needs.preflight.outputs.migrations == 'true'
+        run: ./scripts/check-migrations-immutable.sh
+      - name: Check raw-SQL boundary
+        if: needs.preflight.outputs.rawSql == 'true'
+        run: ./scripts/check-raw-sql-boundary.sh
+      - name: Self-test capability boundary detectors
+        if: needs.preflight.outputs.capability == 'true'
+        run: ./scripts/test-capability-boundaries.sh
+      - name: Check capability boundaries
+        if: needs.preflight.outputs.capability == 'true'
+        run: |
+          ./scripts/check-git-boundary.sh
+          ./scripts/check-http-boundary.sh
+          ./scripts/check-k8s-boundary.sh
+      - name: Check architectural boundaries
+        if: needs.preflight.outputs.boundaries == 'true'
+        run: python3 scripts/check_boundaries.py
   server-clippy:
     name: Server Clippy
     needs: preflight
@@ -386,106 +454,6 @@ jobs:
           echo "::notice::cache-family=server-aarch64-check shared-key=server-aarch64-check cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
       - name: cargo check (aarch64)
         run: cargo check -p djinn-sandbox --all-targets --target aarch64-unknown-linux-gnu
-  server-size-guard:
-    name: Server Size Guard
-    needs: preflight
-    if: needs.preflight.outputs.size == 'true' && github.event_name != 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check changed Rust file sizes
-        env:
-          BASE_SHA: |-
-            ${{ github.event.pull_request.base.sha
-               || github.event.merge_group.base_sha
-               || '' }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -eu
-
-          if [ -z "$BASE_SHA" ]; then
-            # workflow_dispatch has no PR/merge context; fall back to origin/main
-            # so the guard still runs against changes since the main branch.
-            git fetch --no-tags --depth=1 origin main >/dev/null 2>&1 || true
-            BASE_SHA="$(git rev-parse --verify origin/main 2>/dev/null || true)"
-          fi
-
-          if [ -z "$BASE_SHA" ]; then
-            echo "::error::Could not determine a base SHA for changed-file detection (event=$EVENT_NAME)."
-            exit 1
-          fi
-
-          echo "Computing changed-file diff against base $BASE_SHA (event=$EVENT_NAME)..."
-          # --diff-filter=AMR = Added, Modified, Renamed. D (Deleted) is
-          # intentionally excluded so deleted files are not re-checked.
-          # The three-dot form uses the merge base of $BASE_SHA and HEAD,
-          # which tolerates a slightly stale PR base SHA after main advances.
-          git diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" \
-            | ./scripts/check-file-size.sh --files-from-stdin
-  server-migrations-guard:
-    name: Server Migrations Guard
-    needs: preflight
-    if: needs.preflight.outputs.migrations == 'true' && github.event_name != 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check applied migrations are immutable
-        env:
-          BASE_SHA: |-
-            ${{ github.event.pull_request.base.sha
-               || github.event.merge_group.base_sha
-               || '' }}
-        run: ./scripts/check-migrations-immutable.sh
-  server-raw-sql-boundary:
-    name: Server Raw-SQL Boundary
-    needs: preflight
-    if: needs.preflight.outputs.rawSql == 'true' && github.event_name != 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check raw-SQL boundary
-        env:
-          BASE_SHA: |-
-            ${{ github.event.pull_request.base.sha
-               || github.event.merge_group.base_sha
-               || '' }}
-        run: ./scripts/check-raw-sql-boundary.sh
-  server-capability-boundaries:
-    name: Server Capability Boundaries
-    needs: preflight
-    if: needs.preflight.outputs.capability == 'true' && github.event_name != 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Self-test capability boundary detectors
-        run: ./scripts/test-capability-boundaries.sh
-      - name: Check capability boundaries
-        env:
-          BASE_SHA: |-
-            ${{ github.event.pull_request.base.sha
-               || github.event.merge_group.base_sha
-               || '' }}
-        run: |
-          ./scripts/check-git-boundary.sh
-          ./scripts/check-http-boundary.sh
-          ./scripts/check-k8s-boundary.sh
-  server-boundaries:
-    name: Server Architectural Boundaries
-    needs: preflight
-    if: needs.preflight.outputs.boundaries == 'true' && github.event_name != 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check architectural boundaries
-        run: python3 scripts/check_boundaries.py
   nextest-plan:
     name: Plan Server Test Shards
     needs: preflight
@@ -649,14 +617,33 @@ jobs:
           retention-days: 30
   server-test:
     name: Server Test
+    # Shards deliberately do NOT `needs: nextest-plan`. The planner's
+    # ~5-minute discovery compile used to serialize ahead of every shard's
+    # own ~5-minute compile of the same crates; instead the shards start at
+    # preflight-time, run their build concurrently with the planner, and
+    # poll for the plan artifact (normally already uploaded by the time the
+    # build finishes). The matrix is statically provisioned at the planner's
+    # maximum width (COLD_START_SHARDS / WIDE_DEFAULT_SHARDS / PR_MAX_SHARDS
+    # in scripts/ci-nextest-plan.mjs are all 4); when a plan selects fewer
+    # shards, the surplus indices resolve no shard row and no-op, and the
+    # timing-publish job still verifies exact-once coverage across the
+    # shards that ran.
     needs:
       - preflight
-      - nextest-plan
     if: needs.preflight.outputs.serverTest == 'true' && github.event_name != 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.nextest-plan.outputs.matrix) }}
+      matrix:
+        include:
+          - shard: shard-1
+            shardIndex: 0
+          - shard: shard-2
+            shardIndex: 1
+          - shard: shard-3
+            shardIndex: 2
+          - shard: shard-4
+            shardIndex: 3
     defaults:
       run:
         working-directory: server
@@ -695,6 +682,8 @@ jobs:
           echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
           echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
       - uses: taiki-e/install-action@nextest
+      - name: Build test binaries (concurrent with planner discovery)
+        run: cargo nextest run --workspace --all-targets --features qdrant --no-run
       - uses: taiki-e/install-action@v2
         with:
           tool: sqlx-cli
@@ -721,16 +710,57 @@ jobs:
         run: |
           git config --global user.email "ci@test.local"
           git config --global user.name "CI Test"
-      - name: Download full shard plan
-        uses: actions/download-artifact@v4
-        with:
-          name: nextest-plan-${{ github.run_id }}
-          path: server/nextest-plan
+      - name: Wait for and download full shard plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The planner runs concurrently with this shard's build; by the
+          # time the build finishes the plan artifact is normally already
+          # uploaded, so this loop usually exits on the first probe. If the
+          # planner concludes without publishing a plan, fail immediately
+          # instead of burning the full timeout.
+          for attempt in $(seq 1 60); do
+            artifact_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=nextest-plan-${{ github.run_id }}" \
+              --jq '.artifacts[0].id // empty')
+            if [ -n "$artifact_id" ]; then
+              mkdir -p nextest-plan
+              gh api "repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" > nextest-plan/plan.zip
+              unzip -o nextest-plan/plan.zip -d nextest-plan
+              rm nextest-plan/plan.zip
+              exit 0
+            fi
+            planner=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.name == "Plan Server Test Shards")][0].conclusion // empty')
+            case "$planner" in
+              failure|cancelled|timed_out)
+                echo "::error::Plan Server Test Shards concluded '$planner' without publishing a plan."
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "::error::Timed out waiting for the nextest plan artifact."
+          exit 1
       - name: Resolve and validate shard filter and test IDs
+        id: shard
         env:
           SHARD_INDEX: ${{ matrix.shardIndex }}
         run: |
           set -euo pipefail
+          matched=$(jq -r --argjson idx "$SHARD_INDEX" '[.shards[] | select(.shardIndex == $idx)] | length' nextest-plan/matrix.json)
+          shard_count=$(jq -r '.shardCount' nextest-plan/matrix.json)
+          if [ "$matched" -eq 0 ]; then
+            if [ "$SHARD_INDEX" -ge "$shard_count" ]; then
+              # The matrix provisions the planner's maximum width; this plan
+              # selected fewer shards, so this surplus index has no work.
+              echo "::notice::Plan selected $shard_count shard(s); shardIndex $SHARD_INDEX is surplus and no-ops."
+              echo "active=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Plan claims $shard_count shard(s) but has no row for shardIndex $SHARD_INDEX."
+            exit 1
+          fi
           jq -e --argjson idx "$SHARD_INDEX" '
             ([.shards[] | select(.shardIndex == $idx)]) as $matches
             | ($matches | length == 1)
@@ -748,7 +778,9 @@ jobs:
             ([.shards[] | select(.shardIndex == $idx)]) as $matches
             | if ($matches | length) != 1 then error("expected exactly one shard row for shardIndex \($idx)") else $matches[0].testIds end
           ' nextest-plan/matrix.json > nextest-plan/shard-test-ids.json
+          echo "active=true" >> "$GITHUB_OUTPUT"
       - name: Generate nextest config with file-backed shard filter
+        if: steps.shard.outputs.active == 'true'
         env:
           NEXTEST_PROFILE: ${{ github.event_name == 'pull_request' && 'pull-request' || github.event_name == 'merge_group' && 'merge-group' || 'full-validation' }}
         run: |
@@ -769,6 +801,7 @@ jobs:
           NODE
           echo "::notice::Generated nextest config for profile $NEXTEST_PROFILE with file-backed default-filter."
       - name: Run planner-selected shard tests
+        if: steps.shard.outputs.active == 'true'
         env:
           NEXTEST_PROFILE: ${{ github.event_name == 'pull_request' && 'pull-request' || github.event_name == 'merge_group' && 'merge-group' || 'full-validation' }}
         run: |
@@ -792,7 +825,7 @@ jobs:
           ' nextest-plan/shard-test-ids.json > "nextest-timing/timing-${{ matrix.shardIndex }}.json"
           exit "$status"
       - name: Upload retained shard timing data
-        if: always()
+        if: always() && steps.shard.outputs.active == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: nextest-timing-${{ github.run_id }}-${{ matrix.shard }}
@@ -1155,6 +1188,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Generated MCP types are up to date
@@ -1167,56 +1202,15 @@ jobs:
         run: pnpm test
       - name: Production build
         run: pnpm build
-  fail-fast-watchdog:
-    name: Fail-fast watchdog
-    needs: preflight
-    if: needs.preflight.result == 'success' && github.event_name != 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Cancel the run when any lane concludes failure
-        run: |
-          # Fail-fast used to be a self-cancel step inside each guard job.
-          # Cancelling a run from INSIDE the failing job races that job's
-          # own finalization: GitHub usually stamps the culprit "cancelled"
-          # instead of "failure", hiding which lane broke and making merge
-          # queue ejections look like queue rebuilds. A bystander watchdog
-          # only cancels after a lane has CONCLUDED failure, so the red
-          # label survives.
-          for _ in $(seq 1 300); do
-            jobs_json=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100")
-            failed=$(jq -r '[.jobs[] | select(.conclusion == "failure") | .name] | first // empty' <<<"$jobs_json")
-            if [ -n "$failed" ]; then
-              echo "::error::Lane '$failed' failed — cancelling the remaining jobs."
-              gh run cancel ${{ github.run_id }} --repo ${{ github.repository }} \
-                || echo "::warning::Fail-fast cancel failed; letting the run finish."
-              exit 0
-            fi
-            running=$(jq -r --arg self "Fail-fast watchdog" --arg gate "Quality Gate" \
-              '[.jobs[] | select(.name != $self and .name != $gate) | select(.status != "completed")] | length' <<<"$jobs_json")
-            if [ "$running" -eq 0 ]; then
-              echo "All lanes completed without failure."
-              exit 0
-            fi
-            sleep 20
-          done
-          echo "::warning::Watchdog window elapsed; letting the run finish."
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
     if: always() && github.event_name != 'push'
     needs:
       - preflight
-      - server-cargo-deny
+      - server-guards
       - server-clippy
       - server-aarch64-check
-      - server-size-guard
-      - server-migrations-guard
-      - server-raw-sql-boundary
-      - server-capability-boundaries
-      - server-boundaries
       - nextest-plan
       - server-test
       - nextest-timing-publish
@@ -1229,14 +1223,15 @@ jobs:
       - name: Fail closed on selected work
         env:
           PREFLIGHT: ${{ needs.preflight.result }}
-          CARGO_DENY: ${{ needs.preflight.outputs.cargoDeny }}:${{ needs.server-cargo-deny.result }}
+          GUARDS: |-
+            ${{ (needs.preflight.outputs.cargoDeny == 'true'
+               || needs.preflight.outputs.size == 'true'
+               || needs.preflight.outputs.migrations == 'true'
+               || needs.preflight.outputs.rawSql == 'true'
+               || needs.preflight.outputs.capability == 'true'
+               || needs.preflight.outputs.boundaries == 'true') }}:${{ needs.server-guards.result }}
           CLIPPY: ${{ needs.preflight.outputs.clippy }}:${{ needs.server-clippy.result }}
           AARCH64: ${{ needs.preflight.outputs.aarch64 }}:${{ needs.server-aarch64-check.result }}
-          SIZE: ${{ needs.preflight.outputs.size }}:${{ needs.server-size-guard.result }}
-          MIGRATIONS: ${{ needs.preflight.outputs.migrations }}:${{ needs.server-migrations-guard.result }}
-          RAW_SQL: ${{ needs.preflight.outputs.rawSql }}:${{ needs.server-raw-sql-boundary.result }}
-          CAPABILITY: ${{ needs.preflight.outputs.capability }}:${{ needs.server-capability-boundaries.result }}
-          BOUNDARIES: ${{ needs.preflight.outputs.boundaries }}:${{ needs.server-boundaries.result }}
           SERVER_TEST_PLAN: ${{ needs.preflight.outputs.serverTest }}:${{ needs.nextest-plan.result }}
           SERVER_TEST_SHARDS: ${{ needs.preflight.outputs.serverTest }}:${{ needs.server-test.result }}
           SERVER_TEST_TIMING: ${{ needs.preflight.outputs.serverTest }}:${{ needs.nextest-timing-publish.result }}
@@ -1254,9 +1249,7 @@ jobs:
             if [ "$selected" = false ] && [ "$result" = skipped ]; then return; fi
             echo "lane $lane selected=$selected result=$result"; return 1
           }
-          check cargo-deny "$CARGO_DENY"; check clippy "$CLIPPY"; check aarch64 "$AARCH64"
-          check size "$SIZE"; check migrations "$MIGRATIONS"; check raw-sql "$RAW_SQL"
-          check capability "$CAPABILITY"; check boundaries "$BOUNDARIES"
+          check server-guards "$GUARDS"; check clippy "$CLIPPY"; check aarch64 "$AARCH64"
           check server-test-plan "$SERVER_TEST_PLAN"; check server-test-shards "$SERVER_TEST_SHARDS"; check server-test-timing "$SERVER_TEST_TIMING"
           check sqlx-freshness "$SQLX"; check memory-eval "$MEMORY"
           check local-dev-contracts "$TILT_CONTRACTS"; check qa-smoke "$QA_SMOKE"; check ui "$UI"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,14 @@ jobs:
           shared-key: release-bins
           cache-on-failure: true
           cache-all-crates: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # This workflow only ever runs on v* tag pushes and manual
+          # dispatch — never on a branch ref — so the previous
+          # `github.ref == 'refs/heads/main'` condition was never true and
+          # the release-bins cache was never saved: every release
+          # cold-compiled the whole workspace (~19 min in the binaries
+          # job). Saving on every run keeps releases incremental against
+          # the previous tag.
+          save-if: true
       # Worker FIRST so its deps resolve WITHOUT qdrant (default features);
       # the server build then layers only the qdrant-extra deps on top,
       # reusing every shared non-qdrant artifact already on disk.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -102,7 +102,7 @@ Lightweight guard for Rust source files under `server/crates/**` and `server/src
 
 ### CI gate
 
-`.github/workflows/quality-gate.yml` runs the `server-size-guard` job for PR and merge-queue server changes. The job computes added, modified, and renamed files with `git diff --name-only --diff-filter=AMR` and pipes that list to changed-file mode:
+`.github/workflows/quality-gate.yml` runs the "Check changed Rust file sizes" step of the `server-guards` job for PR and merge-queue server changes. The step computes added, modified, and renamed files with `git diff --name-only --diff-filter=AMR` and pipes that list to changed-file mode:
 
 ```sh
 ./scripts/check-file-size.sh --files-from-stdin


### PR DESCRIPTION
## Why

Merge-group CI runs take ~15.7 min wall-clock and ~77 runner-minutes. Analysis of run [29605917651](https://github.com/djinnos/djinn/actions/runs/29605917651) showed the critical path is almost entirely `preflight (20s) → nextest-plan (5:16) → Server Test shards (~9:30) → gate`, with the same incremental compile of the test binaries happening **five times** (planner discovery + each of 4 shards), a watchdog runner polling for the whole run (~20% of total compute), and five micro-guard jobs each paying ~30s of spin-up for ~15s of scripting. Separately, every Release cold-compiled the whole workspace because its cache `save-if` condition could never be true on a tag ref.

## What

**1. Server Test shards no longer serialize behind the planner** (wall-clock: ~15.7 → ~11 min expected)
- Shards `needs: preflight` only, with a statically provisioned 4-wide matrix (the planner's max width — `COLD_START_SHARDS`/`WIDE_DEFAULT_SHARDS`/`PR_MAX_SHARDS` are all 4).
- Each shard builds test binaries (`cargo nextest run --no-run`) concurrently with the planner's discovery compile, then polls for the in-run `nextest-plan-<run_id>` artifact — normally already uploaded by the time the shard's build finishes, so the wait is ~0.
- If the plan selects fewer shards (narrow PR profile), surplus indices resolve no shard row and no-op; the exact-once proof and `nextest-timing-publish` verification are byte-for-byte unchanged.
- The wait loop fails fast if the planner concludes failure/cancelled instead of burning the timeout.

**2. Event-driven fail-fast replaces the watchdog job** (compute: −15 runner-min/run)
- New `ci-fail-fast.yml` triggers on `workflow_job: completed`; its single job is skipped (no runner allocated) unless the completed job belongs to the CI workflow and concluded `failure`, then it cancels the run.
- Preserves the bystander-cancel property the watchdog was built for: the failing lane keeps its red `failure` conclusion. Push-event runs are exempt, as before.
- `quality-gate.yml` permissions drop from `actions: write` to `actions: read`.
- Note: `workflow_job` workflows run from the default branch, so fail-fast is briefly absent between this PR's CI run and its merge.

**3. Five micro-guard jobs + cargo-deny merge into one `Server Guards` job**
- Size, migrations, raw-SQL, capability, and architectural boundary checks plus cargo-deny become conditional steps routed by the same preflight outputs. Frees five runner spin-ups and five concurrent-job slots per run for merge-queue throughput. The quality gate pairs the union of the six selections with the merged job's result, still fail-closed.

**4. Release: `release-bins` cache is now actually saved** (release: ~20.5 → ~8–10 min expected after first warm run)
- `save-if` was `github.ref == 'refs/heads/main'`, but Release only triggers on `v*` tags and dispatch — the cache was never saved and the binaries job cold-compiled for ~19 min every release. Now `save-if: true`.

**5. UI job caches the pnpm store** via `setup-node`.

All three CI contract suites pass locally (`ci-changed-scope`, `ci-cache-policy`, `ci-qa-smoke-workflow` — 26/26). Since this PR touches `quality-gate.yml`, preflight routes every lane, so this run exercises the full new topology including the shard poll-wait path.