### PR TITLE
ci: warm the release-bins cache from main (tag-ref caches are unreachable by later releases)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -248,6 +248,67 @@ jobs:
           echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
           echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
         if: always()
+  # Release builds trigger only on v* tag pushes, and GitHub caches saved on
+  # a tag ref are invisible to every other ref — so a cache saved BY a
+  # release run can never be restored by the next release, and every release
+  # cold-compiled the workspace (~22 min of a ~25 min run). Caches created
+  # on the DEFAULT branch are readable from all refs, so main owns the
+  # release-bins family and release.yml is a restore-only consumer.
+  # The env below must stay byte-identical to the release binaries job's
+  # cargo-relevant env (RUSTFLAGS, CARGO_*): Swatinem/rust-cache hashes
+  # those env vars into the cache key, and any drift silently produces a
+  # second, unreachable cache family.
+  cache-warm-x86_64-release:
+    name: Cache Warm x86_64 (Release)
+    needs:
+      - preflight
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.preflight.outputs.serverTest == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    env:
+      SQLX_OFFLINE: "true"
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+    steps:
+      - name: Main admission delay
+        if: github.event_name == 'push'
+        run: sleep 90
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install
+        working-directory: server
+      - name: Install mold
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: server
+          shared-key: release-bins
+          cache-on-failure: true
+          save-if: true
+          cache-all-crates: true
+        id: rust-cache
+      - name: Log cache family and restore status
+        run: |-
+          echo "cache-family=release-bins"
+          echo "shared-key=release-bins"
+          echo "runner-os=${{ runner.os }}"
+          echo "rustc=$(rustc --version || echo 'unknown')"
+          echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+          echo "::notice::cache-family=release-bins shared-key=release-bins cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+      # No UI build here: rust-embed bakes ui/dist at compile time, so
+      # warming without it embeds the build.rs placeholder. That only
+      # affects the final djinn-server crate's own artifact — every
+      # dependency and intermediate workspace artifact still populates the
+      # cache the release job restores. Worker first, then server, in the
+      # same order and with the same flags as release.yml so feature
+      # resolution matches (a unified build would feature-unify qdrant
+      # onto worker deps).
+      - name: Cargo build worker (populate cache)
+        run: cargo build --release --locked -p djinn-agent-worker
+      - name: Cargo build server (populate cache)
+        run: cargo build --release --locked --features qdrant -p djinn-server
   cache-warm-aarch64:
     name: Cache Warm aarch64
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   RUSTC_WRAPPER: ""
+  # Explicit cargo default, present so the cargo-relevant env here is
+  # byte-identical to quality-gate.yml's — Swatinem/rust-cache hashes
+  # CARGO_*/RUST* env vars into its key, and the release-bins cache is
+  # warmed by quality-gate's cache-warm-x86_64-release job on main.
+  CARGO_BUILD_BUILD_DIR: target
 
 jobs:
   # ── Image-only jobs (no rust compile) ─────────────────────────────────
@@ -204,14 +209,15 @@ jobs:
           shared-key: release-bins
           cache-on-failure: true
           cache-all-crates: true
-          # This workflow only ever runs on v* tag pushes and manual
-          # dispatch — never on a branch ref — so the previous
-          # `github.ref == 'refs/heads/main'` condition was never true and
-          # the release-bins cache was never saved: every release
-          # cold-compiled the whole workspace (~19 min in the binaries
-          # job). Saving on every run keeps releases incremental against
-          # the previous tag.
-          save-if: true
+          # Restore-only: this workflow runs on v* tag refs, and a cache
+          # saved on one tag ref is invisible to every other ref — a
+          # `save-if: true` here writes a cache no future release can
+          # restore (verified: three consecutive releases each logged
+          # "No cache found" then "Saving cache"). The release-bins family
+          # is owned and saved by quality-gate.yml's
+          # cache-warm-x86_64-release job on main pushes; default-branch
+          # caches are readable from all refs, including tag runs.
+          save-if: false
       # Worker FIRST so its deps resolve WITHOUT qdrant (default features);
       # the server build then layers only the qdrant-extra deps on top,
       # reusing every shared non-qdrant artifact already on disk.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ on:
 permissions:
   contents: read
   packages: write
+  # actions: read lets the binaries job poll for and download the ui-dist
+  # artifact produced concurrently in this same run.
+  actions: read
 
 env:
   REGISTRY: ghcr.io
@@ -161,29 +164,12 @@ jobs:
           cache-from: type=gha,scope=djinn-agent-runtime-base
           cache-to: type=gha,scope=djinn-agent-runtime-base,mode=max
 
-  # ── Rust binary job (produces artifacts the image jobs COPY in) ───────
-  # Both release binaries build in ONE job sharing a single `server/target`
-  # dir + one Swatinem cache, so the common dependency graph (tokio, sqlx,
-  # axum, …) compiles ONCE instead of twice. Two SEQUENTIAL cargo builds —
-  # NOT a unified `-p A -p B` — keep each binary's exact feature resolution
-  # (a unified build would feature-unify qdrant onto worker deps). Worker
-  # first (default features, no qdrant), then server (adds qdrant on top),
-  # reusing the on-disk artifacts of the shared non-qdrant deps.
-  binaries:
-    name: djinn-server + djinn-agent-worker binaries (+ UI embed)
+  # ── UI build (parallel with the worker cargo build) ───────────────────
+  ui-dist:
+    name: UI dist for server embed
     runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: server
-    env:
-      SQLX_OFFLINE: "true"
-      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - uses: actions/checkout@v4
-
-      # UI first — rust-embed reads `ui/dist/` at compile time and bakes
-      # it into the server binary. Without this step the binary would
-      # embed only the `<p>UI not built.</p>` placeholder from build.rs.
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -197,7 +183,38 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ui-dist
+          path: ui/dist
+          retention-days: 1
+          if-no-files-found: error
 
+  # ── Rust binary job (produces artifacts the image jobs COPY in) ───────
+  # Both release binaries build in ONE job sharing a single `server/target`
+  # dir + one Swatinem cache, so the common dependency graph (tokio, sqlx,
+  # axum, …) compiles ONCE instead of twice. Two SEQUENTIAL cargo builds —
+  # NOT a unified `-p A -p B` — keep each binary's exact feature resolution
+  # (a unified build would feature-unify qdrant onto worker deps). Worker
+  # first (default features, no qdrant), then server (adds qdrant on top),
+  # reusing the on-disk artifacts of the shared non-qdrant deps.
+  #
+  # The UI builds in the parallel ui-dist job above; rust-embed reads
+  # `ui/dist/` at compile time during the SERVER build only, so the worker
+  # build starts immediately and the dist artifact is fetched between the
+  # two cargo builds (deliberately no `needs:` edge — that would serialize
+  # the ~3-minute pnpm build ahead of the worker compile).
+  binaries:
+    name: djinn-server + djinn-agent-worker binaries (+ UI embed)
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: server
+    env:
+      SQLX_OFFLINE: "true"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+    steps:
+      - uses: actions/checkout@v4
       - run: rustup toolchain install
       - name: Install mold
         run: |
@@ -223,6 +240,38 @@ jobs:
       # reusing every shared non-qdrant artifact already on disk.
       - name: Cargo build worker
         run: cargo build --release --locked -p djinn-agent-worker
+      - name: Wait for and fetch UI dist for the server embed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The ui-dist job (~3 min) runs concurrently with the worker
+          # build above (longer even when warm), so this normally exits on
+          # the first probe. Fail-closed: the server binary must never
+          # ship the build.rs placeholder UI.
+          for attempt in $(seq 1 60); do
+            artifact_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=ui-dist" \
+              --jq '.artifacts[0].id // empty')
+            if [ -n "$artifact_id" ]; then
+              mkdir -p ../ui/dist
+              gh api "repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" > /tmp/ui-dist.zip
+              unzip -q -o /tmp/ui-dist.zip -d ../ui/dist
+              rm /tmp/ui-dist.zip
+              test -s ../ui/dist/index.html || { echo "::error::ui-dist artifact lacks index.html"; exit 1; }
+              exit 0
+            fi
+            ui_state=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.name == "UI dist for server embed")][0].conclusion // empty')
+            case "$ui_state" in
+              failure|cancelled|timed_out)
+                echo "::error::UI dist job concluded '$ui_state' without publishing an artifact."
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "::error::Timed out waiting for the ui-dist artifact."
+          exit 1
       - name: Cargo build server
         run: cargo build --release --locked --features qdrant -p djinn-server
       - name: Stage + strip binaries

--- a/scripts/ci-cache-policy.test.mjs
+++ b/scripts/ci-cache-policy.test.mjs
@@ -10,6 +10,10 @@ const WORKFLOW = resolve('.github/workflows/quality-gate.yml');
 const CACHE_OWNERS = new Map([
   ['server-quality', 'cache-warm-x86_64-quality'],
   ['server-test', 'cache-warm-x86_64-test'],
+  // Saved on main so tag-triggered release runs can restore it: caches
+  // saved on a tag ref are invisible to every other ref, so release.yml
+  // itself must stay a restore-only consumer of this family.
+  ['release-bins', 'cache-warm-x86_64-release'],
   ['server-aarch64-check', 'cache-warm-aarch64'],
 ]);
 


### PR DESCRIPTION
## Why

Release CI takes ~25 min, ~22 of them in the `binaries` job. Two independent causes fixed here: the release cache is written to an unreachable scope, and the UI build serializes ahead of both cargo builds.

## What

**1. Warm the `release-bins` cache from main — tag-ref caches are unreachable by later releases.**
The `save-if` fix from #2221 made release runs save their rust cache — but GitHub scopes a cache to the ref that created it, and Release triggers on `v*` tag pushes: a cache saved on `refs/tags/vX` is invisible to `refs/tags/vY`. All three releases since the fix (e.g. [29666176762](https://github.com/djinnos/djinn/actions/runs/29666176762)) still logged `No cache found`, cold-compiled ~22 min, then saved another unreachable cache. Same ref-scoping behavior that confounded the arm64 benchmark.
- `quality-gate.yml` gains `cache-warm-x86_64-release`: main pushes (+ dispatch for on-demand seeding), building worker then server in release mode with the exact order, flags, and cargo-relevant env of the release `binaries` job — rust-cache hashes `RUSTFLAGS`/`CARGO_*` env into its key, so parity is load-bearing (`release.yml` gains an explicit `CARGO_BUILD_BUILD_DIR: target` for the same reason). No UI when warming: rust-embed bakes the placeholder, costing only the final `djinn-server` crate's own artifact.
- `release.yml` becomes a restore-only consumer (`save-if: false` with the scoping explanation inline).
- `ci-cache-policy.test.mjs` records main as the single saving owner of `release-bins` (26/26 pass).

**2. Build the UI in a parallel job; fetch dist between the worker and server cargo builds.**
rust-embed only needs `ui/dist` during the *server* build, but the ~3-min pnpm install+build ran serially ahead of both cargo builds. The new `ui-dist` job runs concurrently with the worker compile and the `binaries` job fetches the artifact between its two cargo builds with a fail-closed poll (the server binary must never ship the `build.rs` placeholder UI; missing/failed artifact fails the job). Deliberately no `needs:` edge — that would re-serialize the pnpm build ahead of the worker compile. Worker/server deliberately stay one sequential job: the server build reuses the worker's on-disk non-qdrant artifacts, which a job split would forfeit for ~1 min of wall.

## Expected effect

First main push after merge seeds the release cache cold in a parallel non-blocking job; after that, the `binaries` job drops from ~22–23 min to roughly the incremental release-delta build (~4–7 min), and the UI no longer adds ~3 serial minutes. Whole release: ~25 min → **~8–11 min**.