### PR TITLE
ci: route sibling-workflow changes narrowly; lint all workflows in preflight

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -59,6 +59,29 @@ jobs:
         run: node --test scripts/test-djinn-retirement-manifest.mjs
       - name: Run retirement manifest strict reconciliation guard
         run: ./scripts/check-djinn-retirement-manifest.sh
+      - name: Lint all workflow files (actionlint)
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          # Sibling workflows (release.yml, cla.yml, stale-branches.yml,
+          # memory-qa-nightly.yml) route narrowly in the scope router, so
+          # this always-on lint is their gate. It also catches invalid
+          # triggers that GitHub only surfaces as a red zero-job run on
+          # every subsequent push (e.g. `on: workflow_job`, which is a
+          # webhook event, not a workflow trigger — the exact bug shipped
+          # in #2221's ci-fail-fast.yml).
+          curl --fail --silent --show-error --location \
+            --retry 3 --connect-timeout 10 --max-time 60 \
+            --output "$RUNNER_TEMP/actionlint.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          printf '%s  %s\n' "$ACTIONLINT_SHA256" "$RUNNER_TEMP/actionlint.tar.gz" | sha256sum --check --strict
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
+          # shellcheck/pyflakes deliberately disabled: schema, trigger, and
+          # expression checks only, so run-block style nits cannot wedge
+          # the gate.
+          "$RUNNER_TEMP/actionlint" -shellcheck= -pyflakes= .github/workflows/*.yml
       - name: Compute safe event diff and route it
         id: router
         env:

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -84,12 +84,32 @@ const UI_CODEGEN_INPUTS = new Set([
   'server/schemas/usage-analytics.schema.json',
 ]);
 
+// Only the quality gate's own workflow can change what this PR/merge-queue
+// pipeline does, so only it fails closed into full validation. The
+// enumerated siblings cannot affect the gate (Release triggers on tag
+// pushes; the others are independent automations) and are validated by
+// preflight's always-on actionlint pass instead. A workflow file on
+// NEITHER list — a new or renamed workflow — stays fail-closed via the
+// unknown lane: an unreviewed workflow could still interact with the gate
+// (for example through a colliding concurrency group).
+const GATE_WORKFLOW = '.github/workflows/quality-gate.yml';
+const SIBLING_WORKFLOWS = new Set([
+  '.github/workflows/release.yml',
+  '.github/workflows/cla.yml',
+  '.github/workflows/stale-branches.yml',
+  '.github/workflows/memory-qa-nightly.yml',
+]);
+
+function isKnownWorkflow(path) {
+  return path === GATE_WORKFLOW || SIBLING_WORKFLOWS.has(path);
+}
+
 function isUnclassifiedNonDocumentation(path) {
   // Documentation, the explicitly enumerated local-dev contract, and
   // deterministic QA smoke inputs are narrow lanes. Every other
   // executable/configuration path receives fail-closed full validation.
   return !isDocumentation(path) && !matches(path, 'ui') && !matches(path, 'server') &&
-    !matches(path, '.github/workflows') && !isTiltContract(path) && !isQaSmoke(path);
+    !isKnownWorkflow(path) && !isTiltContract(path) && !isQaSmoke(path);
 }
 
 /**
@@ -111,6 +131,7 @@ export function classifyChangedScope(files) {
     tiltContracts: false,
     qaSmoke: false,
     workflowCi: false,
+    workflowSibling: false,
     unknown: false,
   };
   for (const path of normalizedFiles) {
@@ -128,7 +149,8 @@ export function classifyChangedScope(files) {
     if (isMemoryRanking(path)) lanes.memoryRanking = true;
     if (isTiltContract(path)) lanes.tiltContracts = true;
     if (isQaSmoke(path)) lanes.qaSmoke = true;
-    if (matches(path, '.github/workflows')) lanes.workflowCi = true;
+    if (path === GATE_WORKFLOW) lanes.workflowCi = true;
+    if (SIBLING_WORKFLOWS.has(path)) lanes.workflowSibling = true;
     if (isUnclassifiedNonDocumentation(path)) lanes.unknown = true;
   }
   // A source/configuration path that is not a recognized UI, server, or local
@@ -163,9 +185,10 @@ export function planChangedScope(input) {
   if (lanes.ui || lanes.workflowCi || fullValidation || lanes.unknown) jobs.ui = true;
   if (lanes.qaSmoke || lanes.workflowCi || fullValidation || lanes.unknown) jobs.qaSmoke = true;
 
-  // Merge queues must validate the server policy set even for docs-only changes;
-  // UI remains intentionally independent so docs queue entries do not pay it.
-  if (event === 'merge_group' && lanes.docs && !lanes.unknown) {
+  // Merge queues must validate the server policy set even for docs-only or
+  // sibling-workflow-only changes; UI remains intentionally independent so
+  // those queue entries do not pay it.
+  if (event === 'merge_group' && (lanes.docs || lanes.workflowSibling) && !lanes.unknown) {
     for (const name of PROTECTED_SERVER_JOBS) jobs[name] = true;
   }
 

--- a/scripts/ci-changed-scope.test.mjs
+++ b/scripts/ci-changed-scope.test.mjs
@@ -122,11 +122,41 @@ test('memory ranking selects memory evaluation and server policy', () => {
   assertOnlyJobs(result, protectedJobs);
 });
 
-test('workflow CI changes route every job', () => {
+test('gate workflow changes route every job', () => {
   const result = plan(['.github/workflows/quality-gate.yml']);
   assert.equal(result.lanes.workflowCi, true);
   assert.equal(result.jobs.qaSmoke, true);
   assertOnlyJobs(result, Object.keys(result.jobs));
+});
+
+test('enumerated sibling workflows route narrowly on pull requests', () => {
+  for (const path of [
+    '.github/workflows/release.yml',
+    '.github/workflows/cla.yml',
+    '.github/workflows/stale-branches.yml',
+    '.github/workflows/memory-qa-nightly.yml',
+  ]) {
+    const result = plan([path]);
+    assert.equal(result.lanes.workflowSibling, true, path);
+    assert.equal(result.lanes.workflowCi, false, path);
+    assert.equal(result.lanes.unknown, false, path);
+    assertOnlyJobs(result, []);
+  }
+});
+
+test('sibling-workflow-only merge_group entries still run the protected server set', () => {
+  const result = plan(['.github/workflows/release.yml'], { event: 'merge_group' });
+  for (const name of protectedJobs) assert.equal(result.jobs[name], true, name);
+  assert.equal(result.jobs.ui, false);
+  assert.equal(result.jobs.aarch64, false);
+});
+
+test('unrecognized workflow files fail closed', () => {
+  for (const path of ['.github/workflows/deploy.yml', '.github/workflows/quality-gate2.yml']) {
+    const result = plan([path]);
+    assert.equal(result.lanes.unknown, true, path);
+    assertOnlyJobs(result, Object.keys(result.jobs));
+  }
 });
 
 test('full validation selects every job regardless of a docs-only diff', () => {


### PR DESCRIPTION
## Why

Editing `release.yml` (or cla/stale-branches/memory-qa-nightly) runs all 2,584 tests, yet none of those workflows can affect the PR gate — Release only triggers on tag pushes. Meanwhile the validation those files actually need didn't exist anywhere: #2221's `on: workflow_job` trigger was valid YAML that no check could catch, and it produced a red zero-job run on every push until #2275 removed it.

## What

- **Routing:** only `quality-gate.yml` keeps the fail-closed route-everything behavior (deliberately — that property caught every real bug during this week's CI work). The four enumerated sibling workflows route to a new `workflowSibling` lane: no gate jobs on PRs, the protected server set on `merge_group` (same conservative shape as docs-only entries). A workflow file on *neither* list — new or renamed — stays fail-closed via the `unknown` lane, since an unreviewed workflow could still interact with the gate (e.g. a colliding concurrency group).
- **Lint:** preflight gains an always-on, checksum-pinned `actionlint` pass over every workflow file (schema/trigger/expression checks; shellcheck/pyflakes disabled so run-block style nits can't wedge the gate). Verified locally that it flags `on: workflow_job` with "unknown Webhook event", and that all current workflows pass clean.

Contract tests: 29/29 (four new cases: sibling-narrow on PR, sibling merge_group protected set, unrecognized-workflow fail-closed, gate-workflow unchanged).

Effect: a sibling-workflow-only PR drops from ~11 min / ~15 jobs to a ~40s preflight — with strictly *more* real validation of the changed file than before.