### PR TITLE
ci: fix Cache Warm x86_64 (Test) failing on every main push (checkout after admission delay)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -222,10 +222,13 @@ jobs:
     env:
       SQLX_OFFLINE: "true"
     steps:
+      # checkout must precede the admission delay: the job-level
+      # working-directory (server/) does not exist until checkout, and a
+      # run step cannot even start bash in a missing directory.
+      - uses: actions/checkout@v4
       - name: Main admission delay
         if: github.event_name == 'push'
         run: sleep 90
-      - uses: actions/checkout@v4
       - run: rustup toolchain install
         working-directory: server
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Root cause

#2275 inlined the push-only admission delay into `cache-warm-x86_64-test` as its **first** step, ahead of `actions/checkout` (so that `workflow_dispatch` seeding could bypass a `needs: main-admission` edge that would auto-skip). The job sets `defaults.run.working-directory: server`, and GitHub Actions cannot start `bash` in a working directory that does not exist yet — the repo is only checked out later. Every push-to-main run therefore fails immediately:

```
##[error]An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/djinn/djinn/server'. No such file or directory
```

The `if: always()` "Log cache family and restore status" step then runs after the failure — still without a checkout — and fails identically. `workflow_dispatch` runs skip the delay step entirely, which is why the branch-dispatch seeding runs during the arm64 trial passed and masked the break.

## Fix

Move `actions/checkout` to the top of the job so `server/` exists for every subsequent step. The 90s push-only admission stagger and the dispatch route from #2275 are both preserved.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow: OK
- Diff is confined to step ordering in `cache-warm-x86_64-test`; no conditions or cache keys changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)