### PR TITLE
fix(c2): unblock pod-run submissions — worker-persisted workspace_path + typed skip for unconfigured final-verification plans

### DIFF
--- a/server/crates/djinn-agent-worker/src/worker_services.rs
+++ b/server/crates/djinn-agent-worker/src/worker_services.rs
@@ -282,12 +282,38 @@ impl SupervisorServices for WorkerSupervisorServices {
         // before delegating the host RPC.  The supervisor passes the same
         // `&Workspace` to every stage, so capturing on the first call is
         // sufficient; subsequent calls overwrite with the same path.
-        {
+        let first_capture = {
             let mut slot = self
                 .captured_workspace_path
                 .lock()
                 .expect("captured_workspace_path mutex poisoned");
+            let first = slot.is_none();
             *slot = Some(workspace.path().to_path_buf());
+            first
+        };
+        // Persist the workspace path onto the task_runs row exactly once, on
+        // the first capture. The coordinator creates K8s pod-run rows with
+        // `workspace_path = NULL` (it cannot know the in-pod clone path), and
+        // the completion boundary (`resolve_final_verification`) and the
+        // auto-submit fingerprint path resolve the run's worktree from that
+        // row — a NULL there fails every `submit_work`. Best-effort: a write
+        // failure is logged and never fails the stage.
+        if first_capture {
+            let workspace_path = workspace.path().to_string_lossy().into_owned();
+            if let Err(e) = djinn_db::repositories::task_run::TaskRunRepository::new(
+                self.agent_context.db.clone(),
+            )
+            .set_workspace_path(task_run_id, &workspace_path)
+            .await
+            {
+                tracing::warn!(
+                    task_run_id = %task_run_id,
+                    workspace_path = %workspace_path,
+                    error = %e,
+                    "worker_services::execute_stage: failed to persist workspace_path \
+                     on the task_runs row; final verification may not resolve the worktree"
+                );
+            }
         }
 
         let cred = self.credentials.per_role.get(&role_kind).ok_or_else(|| {

--- a/server/crates/djinn-agent/src/actors/slot/adapter.rs
+++ b/server/crates/djinn-agent/src/actors/slot/adapter.rs
@@ -232,7 +232,7 @@ impl djinn_slot::host::SlotHostCallbacks for AgentHostCallbacks {
         Box<
             dyn Future<
                     Output = Result<
-                        djinn_slot::final_verification::FinalVerificationResolvedMaterial,
+                        Option<djinn_slot::final_verification::FinalVerificationResolvedMaterial>,
                         String,
                     >,
                 > + Send
@@ -247,18 +247,23 @@ impl djinn_slot::host::SlotHostCallbacks for AgentHostCallbacks {
                 .await
                 .map_err(|e| e.to_string())?
                 .ok_or("task run missing")?;
-            let worktree = run
-                .workspace_path
-                .map(PathBuf::from)
-                .ok_or("task run has no worktree")?;
             let plan =
                 crate::environment::environment_config_for_project_id(&agent.db, &run.project_id)
                     .await
                     .lifecycle
                     .final_verification;
+            // Typed skip, checked BEFORE the worktree requirement: a project
+            // with zero final-verification commands has no completion boundary
+            // to enforce, so submission must not depend on a resolvable
+            // worktree. A configured plan keeps the fail-closed worktree
+            // requirement below.
             if plan.commands.is_empty() {
-                return Err("final-verification plan is not configured".into());
+                return Ok(None);
             }
+            let worktree = run
+                .workspace_path
+                .map(PathBuf::from)
+                .ok_or("task run has no worktree")?;
             let commands: Vec<_> = plan
                 .commands
                 .iter()
@@ -333,7 +338,7 @@ impl djinn_slot::host::SlotHostCallbacks for AgentHostCallbacks {
             };
             let resolver: EnvironmentIdentityResolver = Arc::new(move || Ok(identity.clone()));
             let output_directories = output_directories(&manifest.output_only_globs)?;
-            Ok(
+            Ok(Some(
                 djinn_slot::final_verification::FinalVerificationResolvedMaterial {
                     execution_request: FinalVerificationExecutionRequest {
                         worktree,
@@ -354,7 +359,7 @@ impl djinn_slot::host::SlotHostCallbacks for AgentHostCallbacks {
                     required_checks: plan.required_checks,
                     diff_fingerprint: String::new(),
                 },
-            )
+            ))
         })
     }
     fn acquire_final_verification_lease<'a>(
@@ -548,5 +553,130 @@ impl djinn_slot::host::SlotHostCallbacks for AgentHostCallbacks {
                 ),
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod resolve_final_verification_tests {
+    use djinn_core::events::EventBus;
+    use djinn_db::ProjectRepository;
+    use djinn_db::repositories::task_run::CreateTaskRunParams;
+    use djinn_slot::host::SlotHostCallbacks;
+    use djinn_stack::environment::{EnvironmentConfig, FinalVerificationCommand};
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::test_helpers::{
+        agent_context_from_db, create_test_db, create_test_epic, create_test_project,
+        create_test_task,
+    };
+
+    struct Fixture {
+        agent: AgentContext,
+        project_id: String,
+        task_id: String,
+        task_run_id: String,
+    }
+
+    /// Seed a project/epic/task and a task_run row shaped like a K8s pod run
+    /// (coordinator-inserted, `workspace_path` as given).
+    async fn fixture(workspace_path: Option<&str>) -> Fixture {
+        let db = create_test_db();
+        let project = create_test_project(&db).await;
+        let epic = create_test_epic(&db, &project.id).await;
+        let task = create_test_task(&db, &project.id, &epic.id).await;
+        let task_run_id = uuid::Uuid::now_v7().to_string();
+        TaskRunRepository::new(db.clone())
+            .create(CreateTaskRunParams {
+                id: &task_run_id,
+                project_id: &project.id,
+                task_id: &task.id,
+                trigger_type: "dispatch",
+                status: Some("running"),
+                workspace_path,
+                mirror_ref: None,
+            })
+            .await
+            .unwrap();
+        Fixture {
+            agent: agent_context_from_db(db, CancellationToken::new()),
+            project_id: project.id,
+            task_id: task.id,
+            task_run_id,
+        }
+    }
+
+    async fn configure_final_verification_plan(fx: &Fixture) {
+        let mut cfg = EnvironmentConfig::empty();
+        cfg.lifecycle.final_verification.commands = vec![FinalVerificationCommand {
+            check_id: "lint".into(),
+            executable: "true".into(),
+            ..Default::default()
+        }];
+        cfg.lifecycle.final_verification.required_checks = vec!["lint".into()];
+        ProjectRepository::new(fx.agent.db.clone(), EventBus::noop())
+            .set_environment_config(&fx.project_id, &serde_json::to_string(&cfg).unwrap())
+            .await
+            .unwrap();
+    }
+
+    async fn resolve(
+        fx: &Fixture,
+    ) -> Result<Option<djinn_slot::final_verification::FinalVerificationResolvedMaterial>, String>
+    {
+        let callbacks = AgentHostCallbacks::dispatch(&fx.agent);
+        let ctx = agent_to_slot_context(&fx.agent);
+        callbacks
+            .resolve_final_verification(&fx.task_id, &fx.task_run_id, "attempt", "run", &ctx)
+            .await
+    }
+
+    /// Defect 2 regression: a project with no final-verification plan resolves
+    /// the typed `Ok(None)` skip — even when the pod run's `workspace_path` is
+    /// NULL — instead of erroring and blocking every submission.
+    #[tokio::test]
+    async fn unconfigured_plan_resolves_typed_skip_even_without_worktree() {
+        let fx = fixture(None).await;
+        let resolved = resolve(&fx).await;
+        assert!(
+            matches!(resolved, Ok(None)),
+            "unconfigured plan must resolve the typed skip, got {:?}",
+            resolved.map(|m| m.map(|_| "material"))
+        );
+    }
+
+    /// A configured plan keeps the fail-closed worktree requirement: a run row
+    /// without a workspace_path is a hard resolution error, never a skip.
+    #[tokio::test]
+    async fn configured_plan_with_missing_worktree_fails_closed() {
+        let fx = fixture(None).await;
+        configure_final_verification_plan(&fx).await;
+        let resolved = resolve(&fx).await;
+        match resolved {
+            Err(detail) => assert!(
+                detail.contains("task run has no worktree"),
+                "configured plan without a worktree must fail closed, got {detail}"
+            ),
+            Ok(material) => panic!(
+                "configured plan without a worktree must not resolve, got {:?}",
+                material.map(|_| "material")
+            ),
+        }
+    }
+
+    /// A configured plan with a recorded worktree resolves full material.
+    #[tokio::test]
+    async fn configured_plan_with_worktree_resolves_material() {
+        let fx = fixture(Some("/workspace/run-clone")).await;
+        configure_final_verification_plan(&fx).await;
+        let material = resolve(&fx)
+            .await
+            .expect("configured plan with worktree must resolve")
+            .expect("configured plan must not be a typed skip");
+        assert_eq!(
+            material.execution_request.worktree,
+            PathBuf::from("/workspace/run-clone")
+        );
+        assert_eq!(material.required_checks, vec!["lint"]);
     }
 }

--- a/server/crates/djinn-db/src/repositories/task_run.rs
+++ b/server/crates/djinn-db/src/repositories/task_run.rs
@@ -117,6 +117,24 @@ impl TaskRunRepository {
         Ok(())
     }
 
+    /// Record the workspace path for a run once it is known.
+    ///
+    /// K8s pod runs are created by the coordinator with `workspace_path =
+    /// NULL` because the in-pod supervisor clones its ephemeral workspace
+    /// after dispatch. The in-pod worker calls this on its first
+    /// `execute_stage` so consumers that resolve the run's worktree from the
+    /// row (final-verification resolution, auto-submit diff fingerprinting,
+    /// rejected-submission integrity) see the real path instead of NULL.
+    pub async fn set_workspace_path(&self, id: &str, workspace_path: &str) -> Result<()> {
+        self.db.ensure_initialized().await?;
+        sqlx::query("UPDATE task_runs SET workspace_path = $2 WHERE id = $1")
+            .bind(id)
+            .bind(workspace_path)
+            .execute(self.db.pool())
+            .await?;
+        Ok(())
+    }
+
     pub async fn list_for_task(&self, task_id: &str) -> Result<Vec<TaskRunRecord>> {
         self.db.ensure_initialized().await?;
         Ok(sqlx::query_as!(
@@ -433,6 +451,38 @@ mod tests {
         assert_eq!(fetched.trigger_type, "conflict_retry");
         assert!(fetched.workspace_path.is_none());
         assert!(fetched.mirror_ref.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn set_workspace_path_populates_null_row() {
+        let db = test_db();
+        let (project_id, task_id) = create_task(&db, EventBus::noop()).await;
+        let repo = TaskRunRepository::new(db);
+
+        // K8s pod-run shape: the coordinator inserts the row with no
+        // workspace_path.
+        let id = new_run_id();
+        repo.create(CreateTaskRunParams {
+            id: &id,
+            project_id: &project_id,
+            task_id: &task_id,
+            trigger_type: TaskRunTrigger::NewTask.as_str(),
+            status: Some("starting"),
+            workspace_path: None,
+            mirror_ref: None,
+        })
+        .await
+        .unwrap();
+        assert!(repo.get(&id).await.unwrap().unwrap().workspace_path.is_none());
+
+        repo.set_workspace_path(&id, "/workspace/run-clone")
+            .await
+            .unwrap();
+        let after = repo.get(&id).await.unwrap().unwrap();
+        assert_eq!(after.workspace_path.as_deref(), Some("/workspace/run-clone"));
+        // Nothing else on the row changes.
+        assert_eq!(after.status, "starting");
+        assert!(after.ended_at.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-slot/src/final_verification.rs
+++ b/server/crates/djinn-slot/src/final_verification.rs
@@ -104,6 +104,16 @@ pub enum FinalVerificationRecordingOutcome {
         verification_attempt_id: String,
         detail: String,
     },
+    /// The host resolved a typed "no final-verification plan is configured"
+    /// signal (`Ok(None)` from `resolve_final_verification`): the project
+    /// declares zero canonical commands. No lease is acquired, no command is
+    /// executed, no evidence is fabricated, and no row is written; the
+    /// completion-intent path treats this as "proceed without evidence"
+    /// (the pre-completion-boundary submission behavior). A configured plan
+    /// never reaches this variant — its failures stay `Ineligible`/`Error`.
+    NotConfigured {
+        verification_attempt_id: String,
+    },
 }
 
 /// Run the one authoritative completion boundary for either a model tool call
@@ -112,6 +122,13 @@ pub enum FinalVerificationRecordingOutcome {
 /// `submit_tool_label` names the finalize tool that initiated verification
 /// (e.g. `"submit_work"` for a worker or `"submit_review"` for a reviewer) so
 /// error messages reference the correct request without hard-coding a role.
+///
+/// Returns `Ok(Some(evidence))` for a stored/reused pass, `Ok(None)` when the
+/// project has no final-verification plan configured (the typed
+/// [`FinalVerificationRecordingOutcome::NotConfigured`] skip — the submission
+/// proceeds without evidence, as it did before the completion boundary
+/// existed), and `Err` for every ineligible/error outcome of a configured
+/// plan (submission stays blocked, fail closed).
 pub(crate) async fn verify_completion_intent(
     intent: &mut CompletionIntent,
     task_id: &str,
@@ -119,7 +136,7 @@ pub(crate) async fn verify_completion_intent(
     cancellation: CancellationToken,
     slot_ctx: &SlotContext,
     submit_tool_label: &str,
-) -> Result<FinalVerificationSuccessEvidence, String> {
+) -> Result<Option<FinalVerificationSuccessEvidence>, String> {
     let task_run_id = match task_run_id {
         Some(task_run_id) => task_run_id.to_owned(),
         None => {
@@ -150,7 +167,20 @@ pub(crate) async fn verify_completion_intent(
         | FinalVerificationRecordingOutcome::Reused { evidence, .. } => {
             let evidence = *evidence;
             intent.final_verification_evidence = Some(evidence.clone());
-            Ok(evidence)
+            Ok(Some(evidence))
+        }
+        FinalVerificationRecordingOutcome::NotConfigured { .. } => {
+            // Typed skip: no plan is configured for this project, so the
+            // completion boundary has nothing to enforce. Proceed with no
+            // evidence — never synthesize a success record.
+            intent.final_verification_evidence = None;
+            tracing::info!(
+                task_id = %task_id,
+                submit_tool = %submit_tool_label,
+                "final verification skipped: no final-verification plan is configured; \
+                 proceeding without evidence"
+            );
+            Ok(None)
         }
         FinalVerificationRecordingOutcome::Ineligible { reason, .. } => Err(format!(
             "Final verification rejected this {submit_tool_label} request: {reason}. Fix the worktree and resubmit."
@@ -170,7 +200,7 @@ pub(crate) async fn validate_or_reverify_completion_intent(
     cancellation: CancellationToken,
     slot_ctx: &SlotContext,
     submit_tool_label: &str,
-) -> Result<FinalVerificationSuccessEvidence, String> {
+) -> Result<Option<FinalVerificationSuccessEvidence>, String> {
     let task_run_id = match task_run_id {
         Some(id) => id.to_owned(),
         None => djinn_db::repositories::task_run::TaskRunRepository::new(slot_ctx.db.clone())
@@ -184,7 +214,7 @@ pub(crate) async fn validate_or_reverify_completion_intent(
     };
     if let Some(candidate) = intent.final_verification_evidence.clone() {
         let current = async {
-            let material = slot_ctx
+            match slot_ctx
                 .callbacks
                 .resolve_final_verification(
                     task_id,
@@ -193,18 +223,25 @@ pub(crate) async fn validate_or_reverify_completion_intent(
                     "completion-c2",
                     slot_ctx,
                 )
-                .await?;
-            Ok::<_, String>((derive_current_inputs(&material).await?, material))
+                .await?
+            {
+                // An unconfigured plan cannot revalidate prior evidence; the
+                // canonical path below resolves the typed skip.
+                None => Ok::<_, String>(None),
+                Some(material) => {
+                    Ok(Some((derive_current_inputs(&material).await?, material)))
+                }
+            }
         }
         .await;
-        if let Ok((inputs, material)) = current
+        if let Ok(Some((inputs, material))) = current
             && candidate.verification_input_fingerprint == inputs.fingerprint
             && candidate.environment_identity_digest == inputs.identity.digest
             && candidate.manifest_version == inputs.manifest_version
             && candidate.required_checks == material.required_checks
             && coverage_equals_required(Some(&candidate.covered_checks), &material.required_checks)
         {
-            return Ok(candidate);
+            return Ok(Some(candidate));
         }
         // Every mismatch/error discards evidence; only the canonical path below
         // may produce replacement evidence for the current inputs.
@@ -267,7 +304,18 @@ pub async fn coordinate_final_verification(
         )
         .await
     {
-        Ok(material) => material,
+        Ok(Some(material)) => material,
+        // Typed skip: the host resolved "no plan configured". Return before
+        // any lease, execution, or persistence — there is nothing to verify
+        // and nothing may be recorded.
+        Ok(None) => {
+            return emit_outcome(
+                &request,
+                FinalVerificationRecordingOutcome::NotConfigured {
+                    verification_attempt_id,
+                },
+            );
+        }
         Err(detail) => return emit_error(&request, &verification_attempt_id, &detail),
     };
     if request.cancellation.is_cancelled() {
@@ -401,7 +449,10 @@ async fn consult_reusable_final_verification(
         )
         .await
     {
-        Ok(material) => material,
+        Ok(Some(material)) => material,
+        // No plan configured: nothing is reusable; the writer path resolves
+        // the typed NotConfigured skip.
+        Ok(None) => return lookup_none("miss", request, attempt_id, "not_configured", ""),
         Err(error) => return lookup_none("error", request, attempt_id, "resolution", &error),
     };
     if injected_consultation_failure(
@@ -488,7 +539,8 @@ async fn consult_reusable_final_verification(
         )
         .await
     {
-        Ok(material) => material,
+        Ok(Some(material)) => material,
+        Ok(None) => return lookup_none("miss", request, attempt_id, "c1_not_configured", ""),
         Err(error) => return lookup_none("error", request, attempt_id, "c1_resolution", &error),
     };
     let c1 = match derive_current_inputs(&c1_material).await {
@@ -839,6 +891,13 @@ fn emit_outcome(
         } => tracing::error!(
             recording_outcome = "error", task_id = %request.task_id, task_run_id = %request.task_run_id,
             verification_attempt_id = %verification_attempt_id, detail = %detail,
+            "final verification recording completed"
+        ),
+        FinalVerificationRecordingOutcome::NotConfigured {
+            verification_attempt_id,
+        } => tracing::info!(
+            recording_outcome = "not_configured", task_id = %request.task_id, task_run_id = %request.task_run_id,
+            verification_attempt_id = %verification_attempt_id,
             "final verification recording completed"
         ),
     }

--- a/server/crates/djinn-slot/src/final_verification/recording_tests.rs
+++ b/server/crates/djinn-slot/src/final_verification/recording_tests.rs
@@ -118,6 +118,8 @@ struct CoordinatorProbe {
     material: FinalVerificationResolvedMaterial,
     evidence: Mutex<Option<FinalVerificationExecutionEvidence>>,
     resolve_error: Option<String>,
+    /// Resolve the typed "no plan configured" signal (`Ok(None)`).
+    resolve_not_configured: bool,
     cancel_on_evidence: bool,
     resolved_ids: Mutex<Vec<(String, String)>>,
 }
@@ -129,6 +131,7 @@ impl CoordinatorProbe {
             material,
             evidence: Mutex::new(None),
             resolve_error: None,
+            resolve_not_configured: false,
             cancel_on_evidence: false,
             resolved_ids: Mutex::new(Vec::new()),
         }
@@ -184,8 +187,13 @@ impl SlotHostCallbacks for CoordinatorProbe {
         verification_attempt_id: &'a str,
         verify_run_id: &'a str,
         _ctx: &'a SlotContext,
-    ) -> Pin<Box<dyn Future<Output = Result<FinalVerificationResolvedMaterial, String>> + Send + 'a>>
-    {
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<Option<FinalVerificationResolvedMaterial>, String>>
+                + Send
+                + 'a,
+        >,
+    > {
         self.events.lock().unwrap().push("resolve");
         self.resolved_ids
             .lock()
@@ -193,10 +201,12 @@ impl SlotHostCallbacks for CoordinatorProbe {
             .push((verification_attempt_id.to_owned(), verify_run_id.to_owned()));
         let material = self.material.clone();
         let error = self.resolve_error.clone();
+        let not_configured = self.resolve_not_configured;
         Box::pin(async move {
             match error {
                 Some(detail) => Err(detail),
-                None => Ok(material),
+                None if not_configured => Ok(None),
+                None => Ok(Some(material)),
             }
         })
     }
@@ -727,6 +737,77 @@ async fn resolution_failures_record_no_row_and_never_lease() {
             "{label} failure must record no passing row"
         );
     }
+}
+
+/// Defect regression (post-#2270 production outage): a project with no
+/// final-verification plan is a typed `NotConfigured` skip, not an error. The
+/// coordinator returns before any lease/execution/persistence, and the
+/// completion-intent path proceeds with `Ok(None)` — no fabricated evidence,
+/// no blocked submission.
+#[tokio::test]
+async fn unconfigured_plan_is_typed_skip_and_submission_proceeds_without_evidence() {
+    let rig = build_rig(&["lint", "test"], |probe| {
+        probe.resolve_not_configured = true;
+        // Evidence is injected but must never be consulted: the typed skip
+        // returns before the executor seam.
+        probe.inject_evidence(passing("never-executed"));
+    })
+    .await;
+    let outcome = coordinate_final_verification(rig.request.clone(), &rig.ctx).await;
+    assert!(
+        matches!(
+            outcome,
+            FinalVerificationRecordingOutcome::NotConfigured { .. }
+        ),
+        "unconfigured plan must produce the typed skip, got {outcome:?}"
+    );
+    assert_eq!(
+        rig.probe.events(),
+        vec!["resolve"],
+        "the typed skip must never lease, execute, or release"
+    );
+    assert!(
+        recorded_rows(&rig.ctx, &rig.request.task_run_id)
+            .await
+            .is_empty(),
+        "the typed skip must record no verify-run row"
+    );
+
+    // The completion-intent boundary maps the typed skip to "proceed without
+    // evidence": Ok(None), and the intent carries no evidence.
+    let mut intent = crate::output_parser::CompletionIntent {
+        finalize_payload: serde_json::json!({}),
+        tool_use_id: "finalize-tool-use".to_owned(),
+        final_verification_evidence: None,
+    };
+    let proceed = verify_completion_intent(
+        &mut intent,
+        &rig.request.task_id,
+        Some(&rig.request.task_run_id),
+        CancellationToken::new(),
+        &rig.ctx,
+        "submit_work",
+    )
+    .await;
+    assert!(
+        matches!(proceed, Ok(None)),
+        "unconfigured plan must let the submission proceed without evidence, got {proceed:?}"
+    );
+    assert!(
+        intent.final_verification_evidence.is_none(),
+        "no evidence may be synthesized for an unconfigured plan"
+    );
+    assert_eq!(
+        rig.probe.events(),
+        vec!["resolve", "resolve"],
+        "the completion-intent path must also stop at resolution"
+    );
+    assert!(
+        recorded_rows(&rig.ctx, &rig.request.task_run_id)
+            .await
+            .is_empty(),
+        "the completion-intent path must record no verify-run row"
+    );
 }
 
 /// Cancellation observed while injected executor evidence is in flight:

--- a/server/crates/djinn-slot/src/finalize_handlers.rs
+++ b/server/crates/djinn-slot/src/finalize_handlers.rs
@@ -59,8 +59,10 @@ pub async fn process_finalize_payload_with_outcome(
             )
             .await
             {
+                // `Ok(None)` is the typed unconfigured-plan skip: the
+                // submission proceeds with no evidence attached.
                 Ok(evidence) => {
-                    handle_submit_work(payload, task_id, app_state, true, Some(&evidence)).await
+                    handle_submit_work(payload, task_id, app_state, true, evidence.as_ref()).await
                 }
                 Err(error) => {
                     tracing::warn!(task_id = %task_id, error = %error, "finalize_handlers: submit_work verification failed");
@@ -131,13 +133,15 @@ pub async fn process_completion_intent_with_outcome(
             )
             .await
             {
+                // `Ok(None)` is the typed unconfigured-plan skip: the
+                // submission proceeds with no evidence attached.
                 Ok(evidence) => {
                     handle_submit_work(
                         &intent.finalize_payload,
                         task_id,
                         app_state,
                         true,
-                        Some(&evidence),
+                        evidence.as_ref(),
                     )
                     .await
                 }
@@ -200,13 +204,15 @@ pub async fn process_auto_submit_payload(
     )
     .await
     {
+        // `Ok(None)` is the typed unconfigured-plan skip: the auto-submit
+        // proceeds with no evidence attached.
         Ok(evidence) => {
             handle_submit_work(
                 &intent.finalize_payload,
                 task_id,
                 app_state,
                 false,
-                Some(&evidence),
+                evidence.as_ref(),
             )
             .await
         }

--- a/server/crates/djinn-slot/src/host.rs
+++ b/server/crates/djinn-slot/src/host.rs
@@ -108,6 +108,15 @@ pub trait SlotHostCallbacks: Send + Sync + 'static {
         None
     }
     /// Resolve canonical material for an authoritative final-verification call.
+    ///
+    /// `Ok(Some(material))` is a configured plan and keeps the full
+    /// fail-closed completion boundary. `Ok(None)` is the typed
+    /// "no final-verification plan is configured" signal: the coordinator
+    /// records a [`FinalVerificationRecordingOutcome::NotConfigured`] outcome
+    /// and the completion-intent path proceeds without evidence instead of
+    /// blocking submission. Hosts must return `Ok(None)` only when the
+    /// project genuinely declares zero final-verification commands — every
+    /// resolution failure for a configured plan stays `Err` (fail closed).
     /// The default fails closed until a host wires completion intent.
     fn resolve_final_verification<'a>(
         &'a self,
@@ -116,8 +125,13 @@ pub trait SlotHostCallbacks: Send + Sync + 'static {
         _verification_attempt_id: &'a str,
         _verify_run_id: &'a str,
         _ctx: &'a SlotContext,
-    ) -> Pin<Box<dyn Future<Output = Result<FinalVerificationResolvedMaterial, String>> + Send + 'a>>
-    {
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<Option<FinalVerificationResolvedMaterial>, String>>
+                + Send
+                + 'a,
+        >,
+    > {
         Box::pin(async { Err("final verification resolution is not available".to_owned()) })
     }
     /// Acquire the ordinary per-invocation verification lease.

--- a/server/crates/djinn-slot/src/lifecycle/teardown.rs
+++ b/server/crates/djinn-slot/src/lifecycle/teardown.rs
@@ -235,7 +235,8 @@ pub(crate) async fn settle_auto_submit_if_eligible(
     }
     // This is the same intent/coordinator boundary as model-called submit_work.
     // Constructing or persisting an auto-submit payload is forbidden until it
-    // returns `Stored`.
+    // returns a stored/reused pass — or the typed `NotConfigured` skip
+    // (`Ok(None)`), in which case the settlement proceeds without evidence.
     let mut intent = CompletionIntent::auto_submit(&settlement.task_run_id);
     if let Err(error) = verify_completion_intent(
         &mut intent,

--- a/server/crates/djinn-slot/src/reply_loop_completion_intent_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop_completion_intent_tests.rs
@@ -652,8 +652,13 @@ impl SlotHostCallbacks for CompletionIntentCallbacks {
         _verification_attempt_id: &'a str,
         verify_run_id: &'a str,
         _ctx: &'a SlotContext,
-    ) -> Pin<Box<dyn Future<Output = Result<FinalVerificationResolvedMaterial, String>> + Send + 'a>>
-    {
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<Option<FinalVerificationResolvedMaterial>, String>>
+                + Send
+                + 'a,
+        >,
+    > {
         let probe = self.reuse_probe.as_ref();
         Box::pin(async move {
             let probe = probe.ok_or_else(|| "not implemented in test".to_owned())?;
@@ -673,7 +678,7 @@ impl SlotHostCallbacks for CompletionIntentCallbacks {
                 )
                 .map_err(|error| error.to_string())?;
             }
-            Ok(probe.material.clone())
+            Ok(Some(probe.material.clone()))
         })
     }
 

--- a/server/crates/djinn-slot/src/reply_loop_reviewer_reuse_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop_reviewer_reuse_tests.rs
@@ -202,15 +202,20 @@ impl SlotHostCallbacks for ReviewerReuseCallbacks {
         _verification_attempt_id: &'a str,
         verify_run_id: &'a str,
         _ctx: &'a SlotContext,
-    ) -> Pin<Box<dyn Future<Output = Result<FinalVerificationResolvedMaterial, String>> + Send + 'a>>
-    {
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<Option<FinalVerificationResolvedMaterial>, String>>
+                + Send
+                + 'a,
+        >,
+    > {
         self.events.lock().unwrap().push(match verify_run_id {
             "reuse-c0" => "consult-reuse-c0",
             "reuse-c1" => "consult-reuse-c1",
             _ => "writer-resolution",
         });
         let material = self.material.clone();
-        Box::pin(async move { Ok(material) })
+        Box::pin(async move { Ok(Some(material)) })
     }
 
     fn acquire_final_verification_lease<'a>(


### PR DESCRIPTION
## Production impact

Since #2270 ("Land the validated C2 completion-boundary implementation from i67o") deployed, **every k8s pod-run submission has failed**: workers complete implementations, `submit_work` errors, and sessions escalate endlessly. Zero PRs/pushes have succeeded since it landed.

## Root cause — two compounding defects

**1. `task_runs.workspace_path` is never populated for pod runs.**
`AgentHostCallbacks::resolve_final_verification` (djinn-agent `actors/slot/adapter.rs`) resolves the run's worktree from the `task_runs` row and errors `task run has no worktree` when it is NULL. For k8s runs the coordinator inserts the row with `workspace_path: None` and nothing ever updates it — the in-pod worker is the only party that knows the ephemeral clone path.

**2. An unconfigured final-verification plan hard-fails submission.**
The same resolver errors `final-verification plan is not configured` when `plan.commands` is empty. `FinalVerificationPlan.commands` defaults to empty (djinn-stack `environment.rs`) and no production project configures it, so even with (1) fixed every submission still fails: `verify_completion_intent` / `validate_or_reverify_completion_intent` turn `Ineligible`/`Error` outcomes into submit-blocking `Err`s.

## Fix

**Defect 1** — new `TaskRunRepository::set_workspace_path` (non-macro `sqlx::query`, offline-safe); the in-pod worker (`djinn-agent-worker/src/worker_services.rs::execute_stage`) persists `workspace.path()` onto the row exactly once, at the first workspace capture. A write failure logs a warning and never fails the stage.

**Defect 2** — the unconfigured case is a **typed skip**, detected at the resolve site, never string-matched:
- `SlotHostCallbacks::resolve_final_verification` now returns `Result<Option<FinalVerificationResolvedMaterial>, String>`; the adapter returns `Ok(None)` when the project declares zero commands, checked **before** the worktree requirement.
- `coordinate_final_verification` maps `Ok(None)` to a new `FinalVerificationRecordingOutcome::NotConfigured` — emitted before any lease acquisition, command execution, or persistence. The reuse consultation (c0/c1) treats it as a miss.
- `verify_completion_intent` / `validate_or_reverify_completion_intent` return `Result<Option<FinalVerificationSuccessEvidence>, String>`: `Ok(None)` means "proceed without evidence" (the pre-#2270 submission path); finalize handlers pass the evidence through as `Option` (`handle_submit_work` already accepted `Option`).
- No fake success evidence is ever synthesized, and a **configured** plan keeps full fail-closed behavior: missing worktree, ineligible, and error outcomes still block submission exactly as before.

## Test coverage

- `djinn-db`: `set_workspace_path_populates_null_row` — worker-persisted path lands on a coordinator-shaped NULL row without touching status/ended_at.
- `djinn-slot` (`recording_tests`): `unconfigured_plan_is_typed_skip_and_submission_proceeds_without_evidence` — coordinator returns `NotConfigured` after resolve only (no lease/execution/release), records no verify-run row, and `verify_completion_intent` returns `Ok(None)` with no evidence on the intent.
- `djinn-agent` (`adapter.rs`): `unconfigured_plan_resolves_typed_skip_even_without_worktree`, `configured_plan_with_missing_worktree_fails_closed`, `configured_plan_with_worktree_resolves_material`.
- Full `#2270` lineage kept green: `cargo test -p djinn-slot --lib` — 561/562 pass; the one failure (`llm_extraction_semantic_duplicate_skips_create_and_boosts_existing_confidence`) fails identically on the baseline tree (pre-existing flake, unrelated). `cargo check`/`clippy` clean on djinn-db, djinn-slot, djinn-agent, djinn-agent-worker (one pre-existing clippy error in an untouched djinn-db test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)