### PR TITLE
ci: checkout before the inline admission delay in Cache Warm x86_64 (Release)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -297,10 +297,12 @@ jobs:
       SQLX_OFFLINE: "true"
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
+      # checkout must precede the admission delay: the job-level
+      # working-directory (server) does not exist until the repo is checked out.
+      - uses: actions/checkout@v4
       - name: Main admission delay
         if: github.event_name == 'push'
         run: sleep 90
-      - uses: actions/checkout@v4
       - run: rustup toolchain install
         working-directory: server
       - name: Install mold


### PR DESCRIPTION
Same root cause as #2282, sibling job: `cache-warm-x86_64-release` runs the push-only `sleep 90` admission-delay step before `actions/checkout`, but the job's default working-directory (`server/`) doesn't exist until checkout — so every push-to-main run of this job fails instantly (e.g. run 29689126215). Moves checkout above the delay, mirroring the (Test) job fix; the 90s stagger and dispatch route are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)