### PR TITLE
fix(ci): repair the mold thread-cap release gate (never compiled, never ran)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,8 +175,14 @@ jobs:
           mkdir -p evidence/runtime-base evidence/generated-rust
           docker run --rm -v "$PWD:/validation" --entrypoint bash djinn-agent-runtime-base:validation /validation/scripts/image-ci/probe-mold-compatibility.sh --evidence-dir /validation/evidence/runtime-base
           docker run --rm -v "$PWD:/validation" --entrypoint bash djinn-generated-rust:validation /validation/scripts/image-ci/probe-mold-compatibility.sh --evidence-dir /validation/evidence/generated-rust
+      # RUSTUP_HOME must point at the BAKED toolchain. The image ships
+      # RUSTUP_HOME=/cache/rustup (an empty dir) and relies on the top image's
+      # entrypoint to seed it from RUSTUP_SEED_DIR=/usr/local/rustup on first
+      # start. `--entrypoint bash` bypasses that seeding, so rustup finds no
+      # default toolchain and cargo dies with "could not choose a version of
+      # cargo to run" before mold is ever invoked.
       - name: Run runtime-base mold thread-cap smoke
-        run: docker run --rm -v "$PWD:/validation" --entrypoint bash djinn-agent-runtime-base:validation /validation/scripts/image-ci/run-mold-thread-smoke.sh --threads 4 --evidence-dir /validation/evidence/runtime-base
+        run: docker run --rm -e RUSTUP_HOME=/usr/local/rustup -v "$PWD:/validation" --entrypoint bash djinn-agent-runtime-base:validation /validation/scripts/image-ci/run-mold-thread-smoke.sh --threads 4 --evidence-dir /validation/evidence/runtime-base
       - name: Upload mold image validation evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/image-ci/run-mold-thread-smoke.sh
+++ b/scripts/image-ci/run-mold-thread-smoke.sh
@@ -34,7 +34,11 @@ EOF
 {
     printf 'pub static PAYLOAD: [u64; 1048576] = ['
     awk 'BEGIN { for (i = 0; i < 1048576; i++) printf "0," }'
-    printf '];\nfn main() { println!("%d", PAYLOAD.len()); }\n'
+    # Rust's own placeholder is `{}`, and it must survive printf verbatim.
+    # `%d` here was consumed by printf itself (no argument -> substituted "0"),
+    # emitting `println!("0", PAYLOAD.len())`, which fails to compile with
+    # "argument never used" and took the whole release gate down.
+    printf '];\nfn main() { println!("{}", PAYLOAD.len()); }\n'
 } > "$work/src/main.rs"
 
 (


### PR DESCRIPTION
## Impact

The mold thread-cap gate added in #2293 failed on its **first real invocation** — the v0.6.109 release — and blocks publishing all four images. Releases are currently broken.

## Two defects, neither catchable by #2293's own CI

`release.yml`'s image-validation steps run **only on tag pushes**, so the PR lane never executed this code path. A gate that could never compile reached main with a green PR.

**1. printf ate the format specifier**

```bash
printf '];\nfn main() { println!("%d", PAYLOAD.len()); }\n'
```

`printf` consumed `%d` itself and substituted `0` (no argument supplied), generating:

```rust
fn main() { println!("0", PAYLOAD.len()); }
```

```
error: argument never used
 --> src/main.rs:2:27
  |
2 | fn main() { println!("0", PAYLOAD.len()); }
  |                      ---  ^^^^^^^^^^^^^ argument never used
```

**2. `--entrypoint bash` bypasses RUSTUP_HOME seeding**

The base image ships `RUSTUP_HOME=/cache/rustup` — an empty directory — plus `RUSTUP_SEED_DIR=/usr/local/rustup` holding the baked toolchain. The *top* image's entrypoint copies seed → home on first start. Running with `--entrypoint bash` skips that, so:

```
error: rustup could not choose a version of cargo to run, because one wasn't
specified explicitly, and no default is configured
```

cargo dies before mold is ever invoked, the poll loop observes no mold process, and the script exits 1.

## Verification

Reproduced and fixed against the published `ghcr.io/djinnos/djinn-agent-runtime-base:0.6.108`, invoked exactly as CI does.

| Config | Result |
|---|---|
| image default `RUSTUP_HOME` | `rustup could not choose a version of cargo` — identical to the CI failure |
| `RUSTUP_HOME=/usr/local/rustup` | `cargo 1.97.1` |

Full script, both fixes applied:

```
RC=0
configured_threads=4 maximum_observed_tasks=1
samples: 2
```

So the gate now actually observes mold and enforces the cap, rather than failing before reaching it.

## Follow-up (deliberately not in scope)

`release.yml`'s image validation has no PR-lane coverage. That gap is the reason this shipped. Worth a proposal rather than bolting it on here.