### PR TITLE
fix(k8s): keep warm Job identifiers inside Kubernetes label budgets

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -1363,7 +1363,7 @@ mod tests {
             "epoch",
         ));
         let project_id = seed_project_with_ready_image(&db, "shared-cap").await;
-        let work_id = format!("graph-warm:{project_id}:unknown");
+        let work_id = djinn_k8s::warm_work_id(&project_id, "unknown");
         let posts = Arc::new(AtomicUsize::new(0));
         let posted = Arc::new(Notify::new());
         let warmer = K8sGraphWarmer::with_dispatcher(
@@ -1453,7 +1453,7 @@ mod tests {
             "epoch",
         ));
         let project_id = seed_project_with_ready_image(&db, "create-started-failure").await;
-        let work_id = format!("graph-warm:{project_id}:unknown");
+        let work_id = djinn_k8s::warm_work_id(&project_id, "unknown");
         let posts = Arc::new(AtomicUsize::new(0));
         let posted = Arc::new(Notify::new());
         let warmer = K8sGraphWarmer::with_dispatcher(

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -16,6 +16,9 @@ use tokio::sync::{Mutex, Notify};
 use tracing::{debug, info, warn};
 
 use crate::config::KubernetesConfig;
+use crate::graph_warmer_identity::{
+    deterministic_warm_job_name, stamp_admission_identity, warm_work_id,
+};
 use crate::warm_job::{LABEL_PROJECT_ID, LABEL_WARM, build_warm_job};
 
 /// Warm Job manifest accepted by [`WarmJobDispatcher`].
@@ -786,90 +789,6 @@ fn dispatcher_error_is_definitive(error: &str) -> bool {
     .any(|marker| error.contains(marker))
 }
 
-/// Apply the admission identity (deterministic name + the three
-/// `djinn.app/admission-*` labels) to a freshly built warm Job.
-///
-/// Extracted from the dispatch path so the manifest that actually reaches the
-/// apiserver can be asserted against Kubernetes label validation in a unit
-/// test — the validation gap that let an invalid manifest ship.
-fn stamp_admission_identity(job: &mut Job, request: &WarmAdmissionRequest) {
-    job.metadata.name = Some(request.object_name.clone());
-    let labels = job.metadata.labels.get_or_insert_default();
-    labels.insert(
-        crate::workload_inventory::LABEL_ADMISSION_DOMAIN.into(),
-        "warm_build".into(),
-    );
-    labels.insert(
-        crate::workload_inventory::LABEL_ADMISSION_WORK_ID.into(),
-        request.work_id.clone(),
-    );
-    labels.insert(
-        crate::workload_inventory::LABEL_ADMISSION_GENERATION.into(),
-        request.generation.to_string(),
-    );
-}
-
-/// Longest project segment that keeps [`deterministic_warm_job_name`] inside
-/// the label-value budget: `djinn-warm-` (11) + project + `-g1-` (4) +
-/// 16 hex digits = 31 + project, so the project segment gets 32 bytes.
-const WARM_NAME_PROJECT_BUDGET: usize = crate::label_value::LABEL_VALUE_MAX_BYTES - 31;
-
-/// Reduce `raw` to lowercase alphanumerics and `-`, capped at `budget` bytes,
-/// with non-alphanumeric edges trimmed so the result can sit at the end of a
-/// label value.
-fn warm_id_segment(raw: &str, budget: usize) -> String {
-    let mapped: String = raw
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' {
-                c.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .take(budget)
-        .collect();
-    mapped
-        .trim_matches(|c: char| !c.is_ascii_alphanumeric())
-        .to_string()
-}
-
-/// Stable admission identity for one (project, revision) warm.
-///
-/// This value is stamped into `djinn.app/admission-work-id` and read back out
-/// by inventory reconciliation to rebuild the journal key, so it must be a
-/// legal label value *natively* — sanitising it at the stamp site would make
-/// the label-derived key differ from the durable one. Budget: `gw.` (3) +
-/// project (≤32) + `.` (1) + revision (≤12) = 48 bytes worst case.
-pub fn warm_work_id(project_id: &str, revision: &str) -> String {
-    let project = warm_id_segment(project_id, WARM_NAME_PROJECT_BUDGET);
-    let revision = warm_id_segment(revision, 12);
-    let revision = if revision.is_empty() {
-        "unknown".to_string()
-    } else {
-        revision
-    };
-    format!("gw.{project}.{revision}")
-}
-
-/// Deterministic Job name for one warm generation.
-///
-/// Kept within [`LABEL_VALUE_MAX_BYTES`] rather than the 253-byte object-name
-/// budget: the Job controller defaults `metadata.name` into
-/// `spec.template.labels[job-name]`, where the *label* limit applies. A name
-/// that is legal as a name but oversized as a label 422s the whole create.
-///
-/// [`LABEL_VALUE_MAX_BYTES`]: crate::label_value::LABEL_VALUE_MAX_BYTES
-fn deterministic_warm_job_name(project_id: &str, work_id: &str) -> String {
-    let project = warm_id_segment(project_id, WARM_NAME_PROJECT_BUDGET);
-    let mut hash = 0xcbf29ce484222325_u64;
-    for byte in work_id.bytes() {
-        hash ^= u64::from(byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    format!("djinn-warm-{project}-g1-{hash:016x}")
-}
-
 /// Kubernetes-backed canonical-graph warmer.
 pub struct K8sGraphWarmer {
     dispatch: WarmDispatch,
@@ -1227,9 +1146,6 @@ impl GraphWarmerService for K8sGraphWarmer {
 #[cfg(test)]
 #[path = "graph_warmer_admission_tests.rs"]
 mod admission_tests;
-#[cfg(test)]
-#[path = "graph_warmer_label_tests.rs"]
-mod label_tests;
 #[cfg(test)]
 #[path = "graph_warmer_tests.rs"]
 mod tests;

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -395,7 +395,11 @@ impl WarmDispatch {
         let revision = discover_mirror_main_tip(project_id)
             .await
             .unwrap_or_else(|| "unknown".to_string());
-        let work_id = format!("graph-warm:{project_id}:{revision}");
+        let work_id = warm_work_id(project_id, &revision);
+        debug_assert!(
+            crate::label_value::is_valid_label_value(&work_id),
+            "warm work_id must be label-safe: {work_id}"
+        );
         WarmAdmissionRequest {
             domain: "graph-warm".to_string(),
             object_name: deterministic_warm_job_name(project_id, &work_id),
@@ -614,20 +618,7 @@ impl WarmDispatch {
             &image_tag,
             cargo_cache_policy.as_ref(),
         );
-        job.metadata.name = Some(admission_request.object_name.clone());
-        let labels = job.metadata.labels.get_or_insert_default();
-        labels.insert(
-            crate::workload_inventory::LABEL_ADMISSION_DOMAIN.into(),
-            "warm_build".into(),
-        );
-        labels.insert(
-            crate::workload_inventory::LABEL_ADMISSION_WORK_ID.into(),
-            admission_request.work_id.clone(),
-        );
-        labels.insert(
-            crate::workload_inventory::LABEL_ADMISSION_GENERATION.into(),
-            admission_request.generation.to_string(),
-        );
+        stamp_admission_identity(&mut job, &admission_request);
         let namespace = self.config.namespace.clone();
         let permit = match self.admission.as_ref() {
             Some(admission) => match admission.admit(admission_request).await {
@@ -795,8 +786,39 @@ fn dispatcher_error_is_definitive(error: &str) -> bool {
     .any(|marker| error.contains(marker))
 }
 
-fn deterministic_warm_job_name(project_id: &str, work_id: &str) -> String {
-    let project: String = project_id
+/// Apply the admission identity (deterministic name + the three
+/// `djinn.app/admission-*` labels) to a freshly built warm Job.
+///
+/// Extracted from the dispatch path so the manifest that actually reaches the
+/// apiserver can be asserted against Kubernetes label validation in a unit
+/// test — the validation gap that let an invalid manifest ship.
+fn stamp_admission_identity(job: &mut Job, request: &WarmAdmissionRequest) {
+    job.metadata.name = Some(request.object_name.clone());
+    let labels = job.metadata.labels.get_or_insert_default();
+    labels.insert(
+        crate::workload_inventory::LABEL_ADMISSION_DOMAIN.into(),
+        "warm_build".into(),
+    );
+    labels.insert(
+        crate::workload_inventory::LABEL_ADMISSION_WORK_ID.into(),
+        request.work_id.clone(),
+    );
+    labels.insert(
+        crate::workload_inventory::LABEL_ADMISSION_GENERATION.into(),
+        request.generation.to_string(),
+    );
+}
+
+/// Longest project segment that keeps [`deterministic_warm_job_name`] inside
+/// the label-value budget: `djinn-warm-` (11) + project + `-g1-` (4) +
+/// 16 hex digits = 31 + project, so the project segment gets 32 bytes.
+const WARM_NAME_PROJECT_BUDGET: usize = crate::label_value::LABEL_VALUE_MAX_BYTES - 31;
+
+/// Reduce `raw` to lowercase alphanumerics and `-`, capped at `budget` bytes,
+/// with non-alphanumeric edges trimmed so the result can sit at the end of a
+/// label value.
+fn warm_id_segment(raw: &str, budget: usize) -> String {
+    let mapped: String = raw
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '-' {
@@ -805,8 +827,41 @@ fn deterministic_warm_job_name(project_id: &str, work_id: &str) -> String {
                 '-'
             }
         })
-        .take(36)
+        .take(budget)
         .collect();
+    mapped
+        .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+        .to_string()
+}
+
+/// Stable admission identity for one (project, revision) warm.
+///
+/// This value is stamped into `djinn.app/admission-work-id` and read back out
+/// by inventory reconciliation to rebuild the journal key, so it must be a
+/// legal label value *natively* — sanitising it at the stamp site would make
+/// the label-derived key differ from the durable one. Budget: `gw.` (3) +
+/// project (≤32) + `.` (1) + revision (≤12) = 48 bytes worst case.
+pub fn warm_work_id(project_id: &str, revision: &str) -> String {
+    let project = warm_id_segment(project_id, WARM_NAME_PROJECT_BUDGET);
+    let revision = warm_id_segment(revision, 12);
+    let revision = if revision.is_empty() {
+        "unknown".to_string()
+    } else {
+        revision
+    };
+    format!("gw.{project}.{revision}")
+}
+
+/// Deterministic Job name for one warm generation.
+///
+/// Kept within [`LABEL_VALUE_MAX_BYTES`] rather than the 253-byte object-name
+/// budget: the Job controller defaults `metadata.name` into
+/// `spec.template.labels[job-name]`, where the *label* limit applies. A name
+/// that is legal as a name but oversized as a label 422s the whole create.
+///
+/// [`LABEL_VALUE_MAX_BYTES`]: crate::label_value::LABEL_VALUE_MAX_BYTES
+fn deterministic_warm_job_name(project_id: &str, work_id: &str) -> String {
+    let project = warm_id_segment(project_id, WARM_NAME_PROJECT_BUDGET);
     let mut hash = 0xcbf29ce484222325_u64;
     for byte in work_id.bytes() {
         hash ^= u64::from(byte);
@@ -1172,6 +1227,9 @@ impl GraphWarmerService for K8sGraphWarmer {
 #[cfg(test)]
 #[path = "graph_warmer_admission_tests.rs"]
 mod admission_tests;
+#[cfg(test)]
+#[path = "graph_warmer_label_tests.rs"]
+mod label_tests;
 #[cfg(test)]
 #[path = "graph_warmer_tests.rs"]
 mod tests;

--- a/server/crates/djinn-k8s/src/graph_warmer_identity.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_identity.rs
@@ -1,0 +1,98 @@
+//! Admission identity for graph-warm Jobs: the work id, the deterministic
+//! Job name, and the labels that carry both onto the manifest.
+//!
+//! Everything here is budgeted against Kubernetes label validation rather
+//! than the (far more generous) object-name budget, because all three values
+//! end up in `metadata.labels` or `spec.template.labels` — the Job controller
+//! defaults `metadata.name` into `job-name`, so a name that is legal as a name
+//! but oversized as a label rejects the entire create with a 422.
+
+use k8s_openapi::api::batch::v1::Job;
+
+use crate::graph_warmer::WarmAdmissionRequest;
+use crate::label_value::LABEL_VALUE_MAX_BYTES;
+
+/// Longest project segment that keeps [`deterministic_warm_job_name`] inside
+/// the label-value budget: `djinn-warm-` (11) + project + `-g1-` (4) +
+/// 16 hex digits = 31 + project, so the project segment gets 32 bytes.
+const WARM_NAME_PROJECT_BUDGET: usize = LABEL_VALUE_MAX_BYTES - 31;
+
+/// Reduce `raw` to lowercase alphanumerics and `-`, capped at `budget` bytes,
+/// with non-alphanumeric edges trimmed so the result can sit at the end of a
+/// label value.
+fn warm_id_segment(raw: &str, budget: usize) -> String {
+    let mapped: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .take(budget)
+        .collect();
+    mapped
+        .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+        .to_string()
+}
+
+/// Stable admission identity for one (project, revision) warm.
+///
+/// This value is stamped into `djinn.app/admission-work-id` and read back out
+/// by inventory reconciliation to rebuild the journal key, so it must be a
+/// legal label value *natively* — sanitising it at the stamp site would make
+/// the label-derived key differ from the durable one. Budget: `gw.` (3) +
+/// project (≤32) + `.` (1) + revision (≤12) = 48 bytes worst case.
+pub fn warm_work_id(project_id: &str, revision: &str) -> String {
+    let project = warm_id_segment(project_id, WARM_NAME_PROJECT_BUDGET);
+    let revision = warm_id_segment(revision, 12);
+    let revision = if revision.is_empty() {
+        "unknown".to_string()
+    } else {
+        revision
+    };
+    format!("gw.{project}.{revision}")
+}
+
+/// Deterministic Job name for one warm generation.
+///
+/// Kept within [`LABEL_VALUE_MAX_BYTES`] rather than the 253-byte object-name
+/// budget, for the `job-name` projection described in the module docs.
+/// Determinism is what makes the create idempotent across dispatch retries.
+pub(crate) fn deterministic_warm_job_name(project_id: &str, work_id: &str) -> String {
+    let project = warm_id_segment(project_id, WARM_NAME_PROJECT_BUDGET);
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in work_id.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("djinn-warm-{project}-g1-{hash:016x}")
+}
+
+/// Apply the admission identity (deterministic name + the three
+/// `djinn.app/admission-*` labels) to a freshly built warm Job.
+///
+/// Extracted from the dispatch path so the manifest that actually reaches the
+/// apiserver can be asserted against Kubernetes label validation in a unit
+/// test — the validation gap that let an invalid manifest ship.
+pub(crate) fn stamp_admission_identity(job: &mut Job, request: &WarmAdmissionRequest) {
+    job.metadata.name = Some(request.object_name.clone());
+    let labels = job.metadata.labels.get_or_insert_default();
+    labels.insert(
+        crate::workload_inventory::LABEL_ADMISSION_DOMAIN.into(),
+        "warm_build".into(),
+    );
+    labels.insert(
+        crate::workload_inventory::LABEL_ADMISSION_WORK_ID.into(),
+        request.work_id.clone(),
+    );
+    labels.insert(
+        crate::workload_inventory::LABEL_ADMISSION_GENERATION.into(),
+        request.generation.to_string(),
+    );
+}
+
+#[cfg(test)]
+#[path = "graph_warmer_label_tests.rs"]
+mod label_tests;

--- a/server/crates/djinn-k8s/src/graph_warmer_label_tests.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_label_tests.rs
@@ -1,0 +1,191 @@
+//! Regression guards for Kubernetes identifier budgets on the warm Job.
+//!
+//! The graph warmer once stalled for a full day because every `Job` create was
+//! rejected 422: an 88-byte colon-separated `work_id` was stamped straight
+//! into `djinn.app/admission-work-id`, and the 67-char deterministic Job name
+//! overran the `job-name` label the Job controller derives from
+//! `metadata.name`. Nothing caught it — the existing admission tests assert
+//! against an in-memory inventory, which performs no apiserver validation, so
+//! the invalid manifest type-checked and shipped.
+//!
+//! These tests validate the manifest *as dispatched*, so any future label
+//! added to the warm Job is checked against the real grammar before it can
+//! reach a cluster.
+
+use super::*;
+use crate::label_value::{LABEL_VALUE_MAX_BYTES, is_valid_label_value};
+
+/// A realistic production project id — a full 36-char UUIDv7, which is what
+/// overran every budget in the original failure.
+const PROJECT_ID: &str = "019ea3bd-a305-73e3-806c-4edcc96ebfe2";
+/// A realistic 40-char git revision.
+const REVISION: &str = "d6360bb71ebb0824da8c85b4633e582c879c983b";
+
+fn warm_request(project_id: &str, revision: &str) -> WarmAdmissionRequest {
+    let work_id = warm_work_id(project_id, revision);
+    WarmAdmissionRequest {
+        domain: "graph-warm".to_string(),
+        object_name: deterministic_warm_job_name(project_id, &work_id),
+        work_id,
+        generation: 1,
+    }
+}
+
+/// Assert every label on `job` (both object and Pod-template) is legal, and
+/// that `metadata.name` survives being defaulted into the `job-name` label.
+fn assert_job_identifiers_are_kubernetes_legal(job: &Job) {
+    let name = job.metadata.name.as_deref().expect("job name");
+    assert!(
+        is_valid_label_value(name),
+        "metadata.name {name:?} ({} bytes) is not a legal label value; the Job \
+         controller defaults it into spec.template.labels[job-name], so an \
+         oversized name 422s the create",
+        name.len()
+    );
+
+    let mut label_sets = [("metadata", job.metadata.labels.as_ref())].to_vec();
+    if let Some(spec) = job.spec.as_ref() {
+        label_sets.push((
+            "spec.template.metadata",
+            spec.template
+                .metadata
+                .as_ref()
+                .and_then(|m| m.labels.as_ref()),
+        ));
+    }
+    for (where_, labels) in label_sets {
+        let Some(labels) = labels else { continue };
+        for (key, value) in labels {
+            assert!(
+                is_valid_label_value(value),
+                "{where_}.labels[{key}] = {value:?} ({} bytes) is not a legal \
+                 Kubernetes label value (max {LABEL_VALUE_MAX_BYTES} bytes, \
+                 alphanumeric/-/_/. only, alphanumeric edges)",
+                value.len()
+            );
+        }
+    }
+}
+
+#[test]
+fn dispatched_warm_job_identifiers_are_kubernetes_legal() {
+    let mut cfg = KubernetesConfig::for_testing();
+    cfg.database_url = Some("postgres://djinn@djinn-postgres:5432/djinn".into());
+    let mut job = build_warm_job(&cfg, PROJECT_ID, "reg.example:5000/p:abc123", None);
+    stamp_admission_identity(&mut job, &warm_request(PROJECT_ID, REVISION));
+
+    assert_job_identifiers_are_kubernetes_legal(&job);
+}
+
+#[test]
+fn admission_labels_carry_the_identity_reconciliation_reads_back() {
+    let mut cfg = KubernetesConfig::for_testing();
+    cfg.database_url = Some("postgres://djinn@djinn-postgres:5432/djinn".into());
+    let mut job = build_warm_job(&cfg, PROJECT_ID, "reg.example:5000/p:abc123", None);
+    let request = warm_request(PROJECT_ID, REVISION);
+    stamp_admission_identity(&mut job, &request);
+
+    let labels = job.metadata.labels.as_ref().expect("labels");
+    assert_eq!(
+        labels
+            .get(crate::workload_inventory::LABEL_ADMISSION_DOMAIN)
+            .map(String::as_str),
+        Some("warm_build")
+    );
+    // The label must equal the durable work id verbatim: inventory
+    // reconciliation rebuilds the journal key from this label, so any
+    // sanitisation applied here (rather than at construction) would make the
+    // recovered key un-matchable against the journal row.
+    assert_eq!(
+        labels
+            .get(crate::workload_inventory::LABEL_ADMISSION_WORK_ID)
+            .map(String::as_str),
+        Some(request.work_id.as_str())
+    );
+    assert_eq!(
+        labels
+            .get(crate::workload_inventory::LABEL_ADMISSION_GENERATION)
+            .map(String::as_str),
+        Some("1")
+    );
+}
+
+#[test]
+fn work_id_is_natively_label_safe_and_revision_scoped() {
+    let work_id = warm_work_id(PROJECT_ID, REVISION);
+    assert!(
+        is_valid_label_value(&work_id),
+        "work_id {work_id:?} is not a legal label value"
+    );
+    // Distinct revisions are distinct admission identities — otherwise a warm
+    // for a new HEAD would be deduped against the previous generation.
+    let other = warm_work_id(PROJECT_ID, "96dc7aa21ad520b0d435ddbecafbe14b254589fd");
+    assert_ne!(work_id, other);
+    // Distinct projects stay distinct.
+    assert_ne!(
+        work_id,
+        warm_work_id("019f7cbc-f0b2-7f73-ae27-d51460869dc3", REVISION)
+    );
+}
+
+#[test]
+fn job_name_is_deterministic_and_within_the_label_budget() {
+    let work_id = warm_work_id(PROJECT_ID, REVISION);
+    let name = deterministic_warm_job_name(PROJECT_ID, &work_id);
+
+    assert!(
+        name.len() <= LABEL_VALUE_MAX_BYTES,
+        "job name {name:?} is {} bytes, over the {LABEL_VALUE_MAX_BYTES}-byte \
+         job-name label budget",
+        name.len()
+    );
+    assert!(is_valid_label_value(&name));
+    assert!(name.starts_with("djinn-warm-"), "name: {name}");
+    // Determinism is what makes the create idempotent across retries.
+    assert_eq!(name, deterministic_warm_job_name(PROJECT_ID, &work_id));
+    // Different work ids must not collide onto one Job name.
+    assert_ne!(
+        name,
+        deterministic_warm_job_name(PROJECT_ID, &warm_work_id(PROJECT_ID, "cafebabe"))
+    );
+}
+
+#[test]
+fn identifiers_stay_legal_for_hostile_project_ids() {
+    // Project ids are not always tidy UUIDs — a slug-shaped or over-long id
+    // must still yield legal identifiers rather than a silent 422.
+    for project_id in [
+        "019ea3bd-a305-73e3-806c-4edcc96ebfe2",
+        "a",
+        "UPPER-Case-Project",
+        "owner/repo:weird*chars",
+        &"x".repeat(200),
+        "---leading-and-trailing---",
+    ] {
+        let work_id = warm_work_id(project_id, REVISION);
+        let name = deterministic_warm_job_name(project_id, &work_id);
+        assert!(
+            is_valid_label_value(&work_id),
+            "work_id {work_id:?} illegal for project {project_id:?}"
+        );
+        assert!(
+            is_valid_label_value(&name),
+            "job name {name:?} ({} bytes) illegal for project {project_id:?}",
+            name.len()
+        );
+    }
+}
+
+#[test]
+fn empty_revision_falls_back_without_producing_a_trailing_separator() {
+    // `discover_mirror_main_tip` can fail; the fallback must still be legal
+    // (a bare `gw.<project>.` would end on `.` and be rejected).
+    for revision in ["", "***"] {
+        let work_id = warm_work_id(PROJECT_ID, revision);
+        assert!(
+            is_valid_label_value(&work_id),
+            "work_id {work_id:?} illegal for revision {revision:?}"
+        );
+        assert!(work_id.ends_with("unknown"), "work_id: {work_id}");
+    }
+}

--- a/server/crates/djinn-k8s/src/graph_warmer_label_tests.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_label_tests.rs
@@ -13,7 +13,9 @@
 //! reach a cluster.
 
 use super::*;
+use crate::config::KubernetesConfig;
 use crate::label_value::{LABEL_VALUE_MAX_BYTES, is_valid_label_value};
+use crate::warm_job::build_warm_job;
 
 /// A realistic production project id — a full 36-char UUIDv7, which is what
 /// overran every budget in the original failure.

--- a/server/crates/djinn-k8s/src/label_value.rs
+++ b/server/crates/djinn-k8s/src/label_value.rs
@@ -1,0 +1,136 @@
+//! Kubernetes label-value and object-name budget helpers.
+//!
+//! Every string djinn stamps into `metadata.labels` (or into a
+//! `metadata.name` that the apiserver then defaults into
+//! `spec.template.labels`, as the Job controller does with `job-name`)
+//! must satisfy the label-value grammar:
+//!
+//! - at most [`LABEL_VALUE_MAX_BYTES`] bytes;
+//! - alphanumerics, `-`, `_`, `.` only;
+//! - first and last characters alphanumeric (empty is also legal).
+//!
+//! Violating either half is a **422 at Job-create time**, which surfaces as
+//! a workload that silently never runs — the apiserver rejects the POST, so
+//! there is no Pod, no event, and no log beyond the dispatcher's own warning.
+//! That is exactly how the graph warmer stalled: an 88-byte colon-separated
+//! `work_id` and a 67-char Job name both failed validation on every tick
+//! while the warmer looked healthy from the outside.
+//!
+//! Prefer constructing identifiers that are *natively* legal
+//! ([`is_valid_label_value`] as an assertion) over sanitising at the stamp
+//! site: admission work ids round-trip through labels back into journal keys,
+//! so a lossy sanitiser would break reconciliation matching by making the
+//! label-derived key differ from the durable one.
+
+/// Maximum byte length of a Kubernetes label value.
+pub const LABEL_VALUE_MAX_BYTES: usize = 63;
+
+/// Is `value` a legal Kubernetes label value?
+///
+/// Mirrors apiserver validation (`IsValidLabelValue`): the empty string is
+/// legal, otherwise `[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?` within
+/// [`LABEL_VALUE_MAX_BYTES`].
+pub fn is_valid_label_value(value: &str) -> bool {
+    if value.is_empty() {
+        return true;
+    }
+    if value.len() > LABEL_VALUE_MAX_BYTES {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    let alnum = |b: u8| b.is_ascii_alphanumeric();
+    if !alnum(bytes[0]) || !alnum(bytes[bytes.len() - 1]) {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|b| alnum(*b) || *b == b'-' || *b == b'_' || *b == b'.')
+}
+
+/// Coerce `value` into a legal label value.
+///
+/// Illegal bytes become `-`, the result is truncated to
+/// [`LABEL_VALUE_MAX_BYTES`], and non-alphanumeric edges are trimmed. This is
+/// a defence-in-depth net for values that cannot be made natively legal — it
+/// is **lossy and not injective**, so never use it on a value that has to
+/// match a durable identity (see the module docs).
+pub fn sanitize_label_value(value: &str) -> String {
+    let mut out: String = value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    out.truncate(LABEL_VALUE_MAX_BYTES);
+    let trimmed = out.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+    trimmed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_legal_values() {
+        for value in [
+            "",
+            "a",
+            "true",
+            "graph-warm",
+            "gw.019ea3bd-a305-73e3-806c-4edcc96ebfe2.f2d49f5a27dd",
+            &"a".repeat(LABEL_VALUE_MAX_BYTES),
+        ] {
+            assert!(is_valid_label_value(value), "should accept: {value}");
+        }
+    }
+
+    #[test]
+    fn rejects_the_two_failure_modes_that_stalled_the_warmer() {
+        // Over budget: the 67-char deterministic Job name, which the
+        // apiserver defaults into `spec.template.labels[job-name]`.
+        let long = "djinn-warm-019ea3bd-a305-73e3-806c-4edcc96ebfe2-g1-a29aafdb20df2fc9";
+        assert_eq!(long.len(), 67);
+        assert!(!is_valid_label_value(long));
+
+        // Illegal character *and* over budget: the colon-separated work id.
+        let work_id = "graph-warm:019ea3bd-a305-73e3-806c-4edcc96ebfe2:d6360bb71ebb0824da8c85b4633e582c879c983b";
+        assert!(!is_valid_label_value(work_id));
+        // Colons are illegal even well within the byte budget.
+        assert!(!is_valid_label_value("graph-warm:abc"));
+    }
+
+    #[test]
+    fn rejects_non_alphanumeric_edges() {
+        assert!(!is_valid_label_value("-lead"));
+        assert!(!is_valid_label_value("trail-"));
+        assert!(!is_valid_label_value(".dot"));
+    }
+
+    #[test]
+    fn sanitize_produces_valid_values() {
+        for value in [
+            "graph-warm:019ea3bd-a305-73e3-806c-4edcc96ebfe2:d6360bb71ebb0824da8c85b4633e582c879c983b",
+            "-leading",
+            "trailing-",
+            "with spaces and/slashes",
+            "::::",
+        ] {
+            let sanitized = sanitize_label_value(value);
+            assert!(
+                is_valid_label_value(&sanitized),
+                "sanitize({value}) = {sanitized} is still invalid"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_is_identity_on_already_legal_values() {
+        for value in ["true", "graph-warm", "gw.019ea3bd.f2d49f5a27dd", "1"] {
+            assert_eq!(sanitize_label_value(value), value);
+        }
+    }
+}

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -10,6 +10,7 @@ pub mod env_config;
 pub mod graph_warmer;
 pub mod infra_death_log_tail;
 pub mod job;
+pub mod label_value;
 pub mod runtime;
 pub mod secret;
 pub mod sidecar;
@@ -27,7 +28,7 @@ pub use graph_warmer::{
     K8sGraphWarmer, KubeClientDispatcher, KubeClientJobWatcher, KubeClientWarmJobLister,
     NoopJobWatcher, NoopWarmJobLister, WarmAdmission, WarmAdmissionError, WarmAdmissionPermit,
     WarmAdmissionRequest, WarmAdmissionTransition, WarmCompletionSink, WarmJobDispatcher,
-    WarmJobLister, WarmJobManifest, WarmJobWatcher, WarmTerminalOutcome,
+    WarmJobLister, WarmJobManifest, WarmJobWatcher, WarmTerminalOutcome, warm_work_id,
 };
 pub use runtime::KubernetesRuntime;
 pub use token_review::TokenReviewer;

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod config;
 pub mod env_config;
 pub mod graph_warmer;
+pub mod graph_warmer_identity;
 pub mod infra_death_log_tail;
 pub mod job;
 pub mod label_value;
@@ -28,8 +29,9 @@ pub use graph_warmer::{
     K8sGraphWarmer, KubeClientDispatcher, KubeClientJobWatcher, KubeClientWarmJobLister,
     NoopJobWatcher, NoopWarmJobLister, WarmAdmission, WarmAdmissionError, WarmAdmissionPermit,
     WarmAdmissionRequest, WarmAdmissionTransition, WarmCompletionSink, WarmJobDispatcher,
-    WarmJobLister, WarmJobManifest, WarmJobWatcher, WarmTerminalOutcome, warm_work_id,
+    WarmJobLister, WarmJobManifest, WarmJobWatcher, WarmTerminalOutcome,
 };
+pub use graph_warmer_identity::warm_work_id;
 pub use runtime::KubernetesRuntime;
 pub use token_review::TokenReviewer;
 pub use warm_job::build_warm_job;

--- a/server/crates/djinn-k8s/src/sidecar.rs
+++ b/server/crates/djinn-k8s/src/sidecar.rs
@@ -617,7 +617,7 @@ mod tests {
     /// into the metadata the runtime logs as `task_run_services_resolved`.
     #[test]
     fn injected_service_metadata_has_no_pretask_fields() {
-        let requested = vec!["preset-postgres-18".to_string()];
+        let requested = ["preset-postgres-18".to_string()];
         let mut services = Vec::new();
         let mut injected = Vec::new();
         let mut skipped = Vec::new();


### PR DESCRIPTION
## What was broken

Every graph-warm `Job` create has been rejected **422 by the apiserver**, so the canonical code graph silently stopped advancing while the warmer looked healthy from the outside — debounce windows opened, dispatch was attempted every ~15 min, and each POST was refused before a Pod ever existed.

Observed on prod (`djinn-server`), repeating on every tick:

```
K8sGraphWarmer: Job dispatch failed
ApiError: Job.batch "djinn-warm-019ea3bd-...-g1-a29aafdb20df2fc9" is invalid: [
  metadata.labels: Invalid value: "graph-warm:019ea3bd-...:d6360bb7...": must be no more than 63 bytes,
  metadata.labels: Invalid value: ...: a valid label must consist of alphanumeric characters, '-', '_' or '.',
  spec.template.labels: Invalid value: "djinn-warm-...-g1-a29aafdb20df2fc9": must be no more than 63 bytes
]: Invalid (code: 422)
```

The graph sat pinned at `f2d49f5a` (last successful warm `2026-07-19T00:56Z`). Note `code_graph status` reports `"warmed": true` throughout — it reflects the last *successful* warm, so there is no signal that every attempt since has failed. Task-run dispatch was unaffected.

## Root cause

Two independent violations, both introduced with the admission-inventory labels in #2226:

1. **`work_id` stamped raw into a label.** Built as `graph-warm:{project_id}:{revision}` — 88 bytes with `:` separators — then written to `djinn.app/admission-work-id`. Illegal twice over: label values cap at 63 bytes and `:` is not in the permitted character set.
2. **Job name over the label budget.** `deterministic_warm_job_name` produced 67 chars. That is legal as a `metadata.name` (253-byte budget), but the Job controller defaults the name into `spec.template.labels[job-name]`, where the 63-byte *label* cap applies.

## The fix

Both identifiers are now constructed **natively legal** rather than sanitised at the stamp site. That distinction matters: the work id round-trips through the label back into the admission journal key during inventory reconciliation (`build_admission_inventory.rs`), so a lossy sanitiser would have made the recovered key un-matchable against its durable row.

- `work_id` → `gw.{project}.{revision[..12]}` (48 bytes worst case)
- Job name → capped at 63 bytes, still deterministic (create stays idempotent across retries)
- `warm_work_id` is exported so the admission tests derive the identity from the same constructor production uses, instead of re-spelling the literal and drifting

Changing the work-id format does not strand admission capacity: 422 is already classified definitive by `dispatcher_error_is_definitive`, so the old-format reservations were released on each failed dispatch rather than accumulating.

## Why this shipped, and what stops it next time

The gap was validation, not review — the existing admission tests assert against an **in-memory inventory, which performs no apiserver validation**, so an invalid manifest type-checked and deployed.

Added `label_value` (mirroring apiserver `IsValidLabelValue`) plus a regression suite that validates the warm Job **as dispatched**: every object and Pod-template label, and the name under its `job-name` projection. The label-stamping was extracted into a pure `stamp_admission_identity` so the manifest that actually reaches the apiserver is the one under test. Any label added to this manifest is now checked against the real grammar before it can reach a cluster.

## Verification

- `cargo test -p djinn-k8s` — all pass, including 13 new regression tests
- `cargo test -p djinn-coordinator` — admission suites pass; the two tests that hardcoded the old `work_id` literal now derive it from `warm_work_id`
- Both new tests fail against the pre-fix identifiers (asserted explicitly in `rejects_the_two_failure_modes_that_stalled_the_warmer`)
- `cargo fmt` / `cargo clippy` clean

Unrelated pre-existing flakiness in `djinn-coordinator` (a different set of ~4 tests fails per run at high `--test-threads`, all passing in isolation) is being fixed separately — root cause is tests asserting absolute values of process-global Prometheus metrics.