### PR TITLE
test(coordinator): stop tests asserting absolute values of process-global metrics

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -244,6 +244,19 @@ pub struct BuildAdmissionController {
     released: Notify,
     queued_lifecycle: std::sync::Mutex<HashMap<String, Instant>>,
     queue_clock: Arc<dyn QueueClock>,
+    /// Whether this controller writes the process-global admission metrics.
+    ///
+    /// Always set in production. Test builds default it OFF because the
+    /// Prometheus recorder is a process-wide singleton while cargo runs every
+    /// test in the binary as a thread of one process: the occupancy gauges are
+    /// unlabelled and written with `set`, so any controller publishing
+    /// concurrently makes another test's reading arbitrary. Only the tests that
+    /// actually assert on these series opt in, via
+    /// `enable_process_metrics_for_test`, and they serialize against each other
+    /// on [`telemetry_guard`]. Gating emission at the writer means a
+    /// test that never opts in cannot corrupt the reading no matter what
+    /// admission path it exercises.
+    emit_process_metrics: AtomicBool,
 }
 
 impl BuildAdmissionController {
@@ -274,7 +287,21 @@ impl BuildAdmissionController {
             released: Notify::new(),
             queued_lifecycle: std::sync::Mutex::new(HashMap::new()),
             queue_clock: Arc::new(SystemQueueClock),
+            emit_process_metrics: AtomicBool::new(!cfg!(test)),
         }
+    }
+
+    /// Whether this controller may write the process-global admission metrics.
+    fn process_metrics_enabled(&self) -> bool {
+        self.emit_process_metrics.load(Ordering::Acquire)
+    }
+
+    /// Opt this controller into publishing the process-global admission
+    /// metrics. Only for tests that assert on those series, and only while
+    /// holding [`telemetry_guard`].
+    #[cfg(test)]
+    pub(crate) fn enable_process_metrics_for_test(&self) {
+        self.emit_process_metrics.store(true, Ordering::Release);
     }
 
     #[cfg(test)]
@@ -428,7 +455,9 @@ impl BuildAdmissionController {
         // finish_all_queued_waits drains the single lifecycle map atomically,
         // clearing both membership and timestamps in one critical section.
         self.finish_all_queued_waits(djinn_telemetry::build_slot_queue::OUTCOME_SHUTDOWN);
-        djinn_telemetry::build_slot_occupancy::set_slots_queued(0);
+        if self.process_metrics_enabled() {
+            djinn_telemetry::build_slot_occupancy::set_slots_queued(0);
+        }
     }
 
     #[must_use]
@@ -460,6 +489,13 @@ impl BuildAdmissionController {
     /// Export bounded admission metrics from the durable journal snapshot.
     /// InvocationBuild rows are intentionally excluded from all v0 views.
     pub async fn publish_metrics(&self) {
+        // Every emission below targets the process-global registry; a
+        // controller that has not opted in stays out of it entirely. The body
+        // is pure export — a journal read plus gauge writes — so skipping it
+        // changes no admission state.
+        if !self.process_metrics_enabled() {
+            return;
+        }
         let mode = match self.mode() {
             BuildAdmissionMode::Off => "off",
             BuildAdmissionMode::Observe => "observe",
@@ -593,7 +629,11 @@ impl BuildAdmissionController {
                 if observed.would_defer {
                     let mut count = self.would_defer_observations.lock().await;
                     *count = count.saturating_add(1).min(1024);
-                    djinn_telemetry::build_admission::increment_would_defer("observe", self.cap);
+                    if self.process_metrics_enabled() {
+                        djinn_telemetry::build_admission::increment_would_defer(
+                            "observe", self.cap,
+                        );
+                    }
                 }
                 observed.reservation
             } else {
@@ -785,7 +825,9 @@ impl BuildAdmissionController {
             BuildAdmissionMode::Observe => "observe",
             BuildAdmissionMode::Enforce => "enforce",
         };
-        djinn_telemetry::build_admission::increment_unknown_classification(mode, self.cap);
+        if self.process_metrics_enabled() {
+            djinn_telemetry::build_admission::increment_unknown_classification(mode, self.cap);
+        }
         tracing::warn!(
             observations = *count,
             "build admission classification missing or unknown; denying dispatch"
@@ -868,7 +910,9 @@ impl BuildAdmissionController {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .remove(key);
-        if let Some(queued_at) = queued_at {
+        if let Some(queued_at) = queued_at
+            && self.process_metrics_enabled()
+        {
             djinn_telemetry::build_slot_queue::record_wait_seconds(
                 outcome,
                 self.queue_clock.now().saturating_duration_since(queued_at),
@@ -887,6 +931,9 @@ impl BuildAdmissionController {
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             std::mem::take(&mut *lifecycle)
         };
+        if !self.process_metrics_enabled() {
+            return;
+        }
         for queued_at in waiters.into_values() {
             djinn_telemetry::build_slot_queue::record_wait_seconds(
                 outcome,
@@ -1247,6 +1294,25 @@ impl WarmAdmission for BuildAdmissionController {
     ) -> Result<(), WarmAdmissionError> {
         self.transition_permit(permit, transition).await
     }
+}
+
+/// Serializes every test that asserts on the process-global build-admission
+/// metrics, across all modules in this crate.
+///
+/// The occupancy gauges are unlabelled and the health gauges are keyed only by
+/// mode and cap, so two tests publishing at once make each other's reading
+/// arbitrary. `enable_process_metrics_for_test` decides *which* controllers may
+/// write at all; this lock decides that only one of them writes at a time. Both
+/// are needed — the flag alone would still let two opted-in tests collide.
+///
+/// Poisoning is recovered rather than propagated so one failing test reports
+/// its own assertion instead of turning its peers into unwrap panics.
+#[cfg(test)]
+pub(crate) fn telemetry_guard() -> std::sync::MutexGuard<'static, ()> {
+    static TELEMETRY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    TELEMETRY_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[cfg(test)]
@@ -2337,17 +2403,10 @@ mod tests {
 
     // ── Build-admission telemetry regression tests ──────────────────────
     //
-    // The Prometheus recorder is a process-global singleton shared by every
-    // test in the binary. These tests serialize through a static mutex to
-    // avoid cross-test metric interference, and each initializes the recorder
-    // (idempotent) before rendering.
-    static TELEMETRY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn telemetry_guard() -> std::sync::MutexGuard<'static, ()> {
-        TELEMETRY_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
+    // Each of these holds `telemetry_guard()` for its whole assertion window
+    // and opts its controller into publishing via
+    // `enable_process_metrics_for_test`, so exactly one controller is writing
+    // the process-global admission series at a time.
 
     fn sample_value(rendered: &str, metric: &str, labels: &[(&str, &str)]) -> f64 {
         if matches!(
@@ -2399,6 +2458,7 @@ mod tests {
         // immediately refresh the occupied gauge — it must not wait for a
         // later cap denial or terminal release.
         let c = controller(BuildAdmissionMode::Enforce, 3);
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         c.admit_task_run(
             Some("worker"),
@@ -2463,6 +2523,7 @@ mod tests {
         }
         let controller =
             BuildAdmissionController::new_closed(Arc::clone(&journal), 64, "replacement-epoch");
+        controller.enable_process_metrics_for_test();
         controller
             .recover_all_predecessors_and_seed()
             .await
@@ -2501,6 +2562,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Off, 0);
+        c.enable_process_metrics_for_test();
         c.publish_metrics().await;
 
         let rendered = djinn_telemetry::render().unwrap();
@@ -2524,6 +2586,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Enforce, 3);
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         // A NonBuild request with an empty audit reason triggers unknown
         // classification.
@@ -2561,6 +2624,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Observe, 1);
+        c.enable_process_metrics_for_test();
         // First admission succeeds.
         let _ = WarmAdmission::admit(&c, warm("first")).await.unwrap();
         // Second admission would exceed the cap (but Observe permits anyway).
@@ -2584,6 +2648,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Enforce, 1);
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         // Fill the cap.
         let _ = WarmAdmission::admit(&c, warm("queued-a")).await.unwrap();
@@ -2623,6 +2688,7 @@ mod tests {
                 elapsed_seconds: AtomicU64::new(0),
             }),
         );
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         let first = WarmAdmission::admit(&c, warm("release-a")).await.unwrap();
         assert!(WarmAdmission::admit(&c, warm("release-b")).await.is_err());
@@ -2695,6 +2761,7 @@ mod tests {
 
         let controller =
             BuildAdmissionController::new_closed(Arc::clone(&journal), 64, "replacement-epoch");
+        controller.enable_process_metrics_for_test();
         controller
             .recover_all_predecessors_and_seed()
             .await
@@ -2748,6 +2815,7 @@ mod tests {
         // Use a non-closed controller (journal is healthy by default) and
         // simulate the post-recovery state where inventory is still pending.
         let c = controller(BuildAdmissionMode::Enforce, 3);
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         c.mark_inventory_pending();
         c.publish_metrics().await;
@@ -2784,6 +2852,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Enforce, 3);
+        c.enable_process_metrics_for_test();
         c.mark_journal_unhealthy();
         c.publish_metrics().await;
 
@@ -2806,6 +2875,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Enforce, 3);
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         // Reserve an InvocationBuild row — it must not appear in occupied.
         let _ = c
@@ -2840,6 +2910,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Enforce, 1);
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         // Reserve a task — occupies 1.
         let task = c
@@ -2919,6 +2990,7 @@ mod tests {
             1,
             "epoch",
         );
+        c.enable_process_metrics_for_test();
 
         // An Observe journal failure must permit dispatch (telemetry-only)
         // but must surface the degradation.
@@ -2950,6 +3022,7 @@ mod tests {
             1,
             "transition-failure",
         );
+        c.enable_process_metrics_for_test();
         let permit = WarmAdmission::admit(&c, warm("transition-down"))
             .await
             .unwrap();
@@ -2976,6 +3049,7 @@ mod tests {
         djinn_telemetry::init().unwrap();
 
         let c = controller(BuildAdmissionMode::Enforce, 5);
+        c.enable_process_metrics_for_test();
         c.mark_ready();
         c.publish_metrics().await;
 
@@ -3037,6 +3111,7 @@ mod tests {
             "fake-clock",
             clock.clone(),
         );
+        controller.enable_process_metrics_for_test();
         controller.mark_ready();
         let occupied = WarmAdmission::admit(&controller, warm("occupied"))
             .await
@@ -3144,6 +3219,7 @@ mod tests {
             "gauge-test",
             clock.clone(),
         );
+        controller.enable_process_metrics_for_test();
         controller.mark_ready();
 
         // One slot occupied → in_use=1, queued=0.
@@ -3277,6 +3353,7 @@ mod tests {
             "cancel-task-test",
             clock.clone(),
         );
+        controller.enable_process_metrics_for_test();
         controller.mark_ready();
         let _occupied = WarmAdmission::admit(&controller, warm("occupied"))
             .await

--- a/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
@@ -1,4 +1,8 @@
 //! Deterministic inventory/adoption and conservative proof-rule tests.
+// The telemetry test lock is deliberately a std mutex held across awaits: it
+// serializes whole test bodies, and libtest threads (not tasks) contend for it.
+#![allow(clippy::await_holding_lock)]
+
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
@@ -336,6 +340,11 @@ async fn authoritative_uid_not_found_releases_and_emits_wakeup() {
 
 #[tokio::test]
 async fn journal_snapshot_failure_degrades_and_keeps_enforce_closed() {
+    // Reads the process-global health gauge, so it shares the crate's
+    // telemetry lock with the build_admission telemetry tests: that series is
+    // keyed only by mode and cap, and those tests publish the same
+    // enforce-mode bucket.
+    let _telemetry = crate::build_admission::telemetry_guard();
     djinn_telemetry::init().unwrap();
     let db = Database::open_in_memory().unwrap();
     db.ensure_initialized().await.unwrap();
@@ -345,6 +354,7 @@ async fn journal_snapshot_failure_degrades_and_keeps_enforce_closed() {
         1,
         "failed-reconcile",
     ));
+    controller.enable_process_metrics_for_test();
     controller.mark_ready();
     db.pool().close().await;
     let report =

--- a/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/pressure_execution.rs
+++ b/server/crates/djinn-coordinator/src/cargo_warm_base_gc/tests/pressure_execution.rs
@@ -1,4 +1,6 @@
 // djinn:allow-oversize — pressure executor regressions share fixtures and race helpers.
+#![allow(clippy::await_holding_lock)]
+
 use super::*;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -14,6 +16,26 @@ struct EventRecordingLayer {
 
 const PRESSURE_METRICS_FIXTURE: &str =
     include_str!("../../../../djinn-telemetry/tests/fixtures/cache_cleanup/expected_metrics.json");
+
+/// Serializes every test that consumes a pressure plan.
+///
+/// Executing a plan increments the process-global `djinn_cache_pressure_*`
+/// counters, and cargo runs this file's tests as threads of one process, so a
+/// second executor running concurrently lands its increments inside another
+/// test's measurement window. Reading a delta is not enough on its own — the
+/// delta only cancels history that predates the window, not a writer that
+/// arrives during it. Every plan-consuming test therefore takes this guard so
+/// exactly one of them is emitting at a time; the work under it is tempdir I/O
+/// measured in milliseconds, so serializing costs effectively nothing.
+///
+/// Poisoning is recovered rather than propagated: one failing test should
+/// report its own assertion, not convert its peers into unwrap panics.
+fn pressure_metrics_guard() -> std::sync::MutexGuard<'static, ()> {
+    static PRESSURE_METRICS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PRESSURE_METRICS_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 fn rendered_counter(rendered: &str, metric: &str, labels: &[(&str, &str)]) -> u64 {
     rendered
@@ -178,6 +200,7 @@ fn three_rung_clock() -> TestClock {
 
 #[tokio::test]
 async fn three_rung_executor_retains_terminal_precheck_suffix() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let first = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000020");
     let second = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000021");
@@ -209,6 +232,7 @@ async fn three_rung_executor_retains_terminal_precheck_suffix() {
 
 #[tokio::test]
 async fn three_rung_executor_keeps_success_and_retains_postcheck_suffix() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let first = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000022");
     let second = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000023");
@@ -246,6 +270,7 @@ async fn three_rung_executor_keeps_success_and_retains_postcheck_suffix() {
 
 #[tokio::test]
 async fn three_rung_executor_absent_unit_blocks_same_base_escalation() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let base = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000024");
     let absent = eligible_three_rung_unit(
@@ -557,6 +582,7 @@ impl FilesystemCapacity for RemovingCapacity {
 
 #[tokio::test]
 async fn three_rung_executor_external_reclamation_before_first_retains_suffix() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let first = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000030");
     let second = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000031");
@@ -596,6 +622,7 @@ async fn three_rung_executor_external_reclamation_before_first_retains_suffix() 
 
 #[tokio::test]
 async fn three_rung_executor_external_reclamation_between_attempts_stops_before_next_remove() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let first = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000032");
     let second = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000033");
@@ -667,6 +694,7 @@ impl FilesystemCapacity for LockAssertingCapacity {
 
 #[tokio::test]
 async fn three_rung_executor_measures_immediately_under_held_lock() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let base = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000034");
     let unit = eligible_three_rung_unit(&base, &base, PressureRung::WholeBase);
@@ -692,6 +720,7 @@ async fn three_rung_executor_measures_immediately_under_held_lock() {
 
 #[tokio::test]
 async fn three_rung_executor_absent_during_removal_blocks_same_base_escalation() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let base = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000035");
     let target = base.join("debug").join("incremental");
@@ -732,6 +761,7 @@ async fn three_rung_executor_absent_during_removal_blocks_same_base_escalation()
 
 #[tokio::test]
 async fn three_rung_executor_removal_failure_blocks_same_base_escalation() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let base = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000036");
     let target = base.join("debug").join("incremental");
@@ -801,6 +831,7 @@ impl ActivityGuard for SwappingActivity {
 #[cfg(unix)]
 #[tokio::test]
 async fn three_rung_executor_path_swap_to_symlink_is_retained_without_mutation() {
+    let _pressure_metrics = pressure_metrics_guard();
     let temp = tempfile::tempdir().unwrap();
     let base = old_base(&temp, "018f8b9a-0d70-7f0a-8000-000000000037");
     let target = base.join("debug").join("incremental");
@@ -835,6 +866,7 @@ async fn three_rung_executor_path_swap_to_symlink_is_retained_without_mutation()
 
 #[tokio::test]
 async fn pressure_metrics_match_the_bounded_fixture_for_execution_boundaries() {
+    let _pressure_metrics = pressure_metrics_guard();
     let fixture: serde_json::Value = serde_json::from_str(PRESSURE_METRICS_FIXTURE).unwrap();
     let case = |name: &str| &fixture["cases"][name];
     let value = |case: &serde_json::Value, field: &str| case[field].as_u64().unwrap();
@@ -1192,6 +1224,7 @@ fn assert_fixture_result(
 
 #[tokio::test]
 async fn frozen_race_cases_execute_post_plan_guards_and_removal_seam() {
+    let _pressure_metrics = pressure_metrics_guard();
     let fixture = frozen_coordinator_fixture();
     let temp = tempfile::tempdir().unwrap();
     for (index, case) in fixture["race_cases"].as_array().unwrap().iter().enumerate() {
@@ -1281,6 +1314,7 @@ async fn frozen_race_cases_execute_post_plan_guards_and_removal_seam() {
 
 #[tokio::test]
 async fn frozen_capacity_cases_execute_external_reclamation_and_probe_failures() {
+    let _pressure_metrics = pressure_metrics_guard();
     let fixture = frozen_coordinator_fixture();
     let temp = tempfile::tempdir().unwrap();
     for (index, case) in fixture["capacity_cases"]
@@ -1437,6 +1471,7 @@ fn frozen_coordinator_fixture_records_exact_three_rung_cases() {
 
 #[tokio::test]
 async fn frozen_cold_rebuild_cases_execute_and_preserve_required_siblings() {
+    let _pressure_metrics = pressure_metrics_guard();
     let fixture = frozen_coordinator_fixture();
     let temp = tempfile::tempdir().unwrap();
     for (index, case) in fixture["cold_rebuild_cases"]
@@ -1732,6 +1767,7 @@ impl PressureOperationObserver for RecordingObserver {
 #[cfg(unix)]
 #[tokio::test]
 async fn frozen_two_actor_schedule_serializes_warm_work_and_pressure_retry() {
+    let _pressure_metrics = pressure_metrics_guard();
     use std::process::{Command, Stdio};
 
     // ---------- Child entry: run the landed warm path ----------

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -3483,12 +3483,20 @@ mod inflight_ledger_tests {
 
     fn assert_wnd1_observed_cap(
         cap: u32,
+        creator_user_id: &str,
+        model: &str,
         observations: &mut Vec<DispatchCapObservation>,
         phase: &str,
     ) {
         observations.extend(take_dispatch_cap_observations());
         let max_observed = observations
             .iter()
+            // The observation buffer is a process-global sink shared by every
+            // dispatch test in this binary, so a concurrently running test's
+            // passes land in it too. The cap this harness asserts is scoped to
+            // one (creator, model) bucket, and a foreign bucket's count says
+            // nothing about it — filter to this fixture's own bucket.
+            .filter(|obs| obs.creator_user_id == creator_user_id && obs.model == model)
             // LedgerOverlay and CapConsidered may conservatively count both a
             // newly visible session row and its reservation for one pass. The
             // admission invariant is the count after a successful increment.
@@ -3806,6 +3814,8 @@ mod inflight_ledger_tests {
                                 .expect("wnd1 observations mutex poisoned");
                             assert_wnd1_observed_cap(
                                 cap,
+                                &creator_user_id,
+                                &model_id,
                                 &mut observations,
                                 "concurrent repeated dispatch passes",
                             );
@@ -3858,7 +3868,13 @@ mod inflight_ledger_tests {
                 let mut observations = observations
                     .lock()
                     .expect("wnd1 observations mutex poisoned");
-                assert_wnd1_observed_cap(cap, &mut observations, "quiescence reconciliation");
+                assert_wnd1_observed_cap(
+                    cap,
+                    &fixture.created_by_user_id,
+                    &fixture.model_id,
+                    &mut observations,
+                    "quiescence reconciliation",
+                );
             }
 
             {
@@ -4016,20 +4032,34 @@ mod inflight_ledger_tests {
         );
     }
 
+    /// Drain the process-global observation sink down to one bucket.
+    ///
+    /// The sink is shared by every dispatch test in this binary, so a
+    /// concurrently running test's observations land in it too and a whole-sink
+    /// assertion reads them as its own. Each caller below uses a creator id
+    /// unique to itself, which keeps these assertions exact without
+    /// serializing the module. Clearing the sink first would be the other
+    /// option, but it would silently discard a peer test's observations.
+    fn observations_for(creator_user_id: &str, model: &str) -> Vec<DispatchCapObservation> {
+        take_dispatch_cap_observations()
+            .into_iter()
+            .filter(|obs| obs.creator_user_id == creator_user_id && obs.model == model)
+            .collect()
+    }
+
     /// The overshoot fix: a dispatch whose `running` session row hasn't landed
     /// yet still counts against the per-user cap. The DB seed shows 0 running,
     /// but four in-flight dispatches must raise the count to 4 so the next pass
     /// defers instead of dispatching four more.
     #[test]
     fn ledger_overlay_counts_inflight_dispatches_when_db_seed_is_cold() {
-        clear_dispatch_cap_observations();
         let mut running: HashMap<(String, String), u32> = HashMap::new(); // cold DB seed
         let mut inflight: HashMap<String, InflightDispatch> = HashMap::new();
         for i in 0..4 {
             inflight.insert(
                 format!("task-{i}"),
                 inflight_entry(
-                    Some("user-a"),
+                    Some("cold-seed-user"),
                     "openai/gpt-5.5",
                     djinn_core::models::ModelLane::Implement,
                 ),
@@ -4039,14 +4069,16 @@ mod inflight_ledger_tests {
         overlay_inflight_ledger(&mut running, &inflight);
 
         assert_eq!(
-            running.get(&key("user-a", "openai/gpt-5.5")).copied(),
+            running
+                .get(&key("cold-seed-user", "openai/gpt-5.5"))
+                .copied(),
             Some(4),
             "four in-flight dispatches must count against the cap even with a cold DB seed"
         );
         assert_eq!(
-            take_dispatch_cap_observations(),
+            observations_for("cold-seed-user", "openai/gpt-5.5"),
             vec![DispatchCapObservation {
-                creator_user_id: "user-a".to_owned(),
+                creator_user_id: "cold-seed-user".to_owned(),
                 model: "openai/gpt-5.5".to_owned(),
                 effective_count: 4,
                 stage: DispatchCapObservationStage::LedgerOverlay,
@@ -4060,12 +4092,11 @@ mod inflight_ledger_tests {
     /// as two. This is the case `max(DB, ledger)` previously undercounted.
     #[test]
     fn ledger_overlay_adds_disjoint_booting_reservations() {
-        clear_dispatch_cap_observations();
-        let mut running = HashMap::from([(key("user-a", "m"), 1)]);
+        let mut running = HashMap::from([(key("disjoint-booting-user", "m"), 1)]);
         let inflight = HashMap::from([(
             "booting-task".to_owned(),
             inflight_entry(
-                Some("user-a"),
+                Some("disjoint-booting-user"),
                 "m",
                 djinn_core::models::ModelLane::Implement,
             ),
@@ -4073,11 +4104,14 @@ mod inflight_ledger_tests {
 
         overlay_inflight_ledger(&mut running, &inflight);
 
-        assert_eq!(running.get(&key("user-a", "m")).copied(), Some(2));
         assert_eq!(
-            take_dispatch_cap_observations(),
+            running.get(&key("disjoint-booting-user", "m")).copied(),
+            Some(2)
+        );
+        assert_eq!(
+            observations_for("disjoint-booting-user", "m"),
             vec![DispatchCapObservation {
-                creator_user_id: "user-a".to_owned(),
+                creator_user_id: "disjoint-booting-user".to_owned(),
                 model: "m".to_owned(),
                 effective_count: 2,
                 stage: DispatchCapObservationStage::LedgerOverlay,
@@ -4215,19 +4249,17 @@ mod inflight_ledger_tests {
 
     #[test]
     fn dispatch_cap_observer_records_new_inflight_increments() {
-        clear_dispatch_cap_observations();
-
         observe_dispatch_cap_count(
             DispatchCapObservationStage::InflightIncremented,
-            "user-a",
+            "inflight-observer-user",
             "m",
             2,
         );
 
         assert_eq!(
-            take_dispatch_cap_observations(),
+            observations_for("inflight-observer-user", "m"),
             vec![DispatchCapObservation {
-                creator_user_id: "user-a".to_owned(),
+                creator_user_id: "inflight-observer-user".to_owned(),
                 model: "m".to_owned(),
                 effective_count: 2,
                 stage: DispatchCapObservationStage::InflightIncremented,
@@ -4346,16 +4378,24 @@ mod inflight_ledger_tests {
     /// so they must not contribute to any count.
     #[test]
     fn ledger_overlay_ignores_creatorless_entries() {
-        clear_dispatch_cap_observations();
         let mut running: HashMap<(String, String), u32> = HashMap::new();
         let mut inflight: HashMap<String, InflightDispatch> = HashMap::new();
         inflight.insert(
             "sys".into(),
-            inflight_entry(None, "m", djinn_core::models::ModelLane::Plan),
+            inflight_entry(None, "creatorless-m", djinn_core::models::ModelLane::Plan),
         );
         overlay_inflight_ledger(&mut running, &inflight);
         assert!(running.is_empty());
-        assert!(take_dispatch_cap_observations().is_empty());
+        // Scoped by model rather than creator: the assertion is that a
+        // creator-less entry produces no observation at all, so there is no
+        // creator id to match on. The model name is unique to this test, which
+        // keeps a peer test's observations out of the check.
+        assert!(
+            take_dispatch_cap_observations()
+                .iter()
+                .all(|obs| obs.model != "creatorless-m"),
+            "a creator-less dispatch is ungated and must not be observed"
+        );
     }
 
     /// With cap N for a model and N running mixed-role sessions for the same

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -2983,6 +2983,11 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
 
 #[cfg(test)]
 mod cache_cleanup_cross_path_tests {
+    // `engine_calls_guard` is deliberately a std mutex held across awaits: it
+    // serializes whole test bodies, and libtest threads (not tasks) contend
+    // for it.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use crate::context::{CacheCleanupConfig, CacheCleanupMode};
 
@@ -3016,6 +3021,22 @@ mod cache_cleanup_cross_path_tests {
     const RUN_A: &str = "019f5df4-06f6-7d71-b9c7-aa50090e4e18";
     const RUN_B: &str = "019f5df4-06f6-7d71-b9c7-aa50090e4e19";
     static ENGINE_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+    /// Serializes the tests that drive [`counting_engine`].
+    ///
+    /// `ENGINE_CALLS` is one process-wide counter, and cargo runs these tests
+    /// as threads of one process. `each_protected_id_lookup_failure_aborts_before_mutation`
+    /// resets it and then asserts it is still zero — a real invariant (the
+    /// lookup failure must abort before the engine runs), but one that a peer
+    /// test invoking the engine concurrently would falsify. Taking this guard
+    /// makes the reset-and-observe window exclusive without weakening the
+    /// assertion.
+    fn engine_calls_guard() -> std::sync::MutexGuard<'static, ()> {
+        static ENGINE_CALLS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        ENGINE_CALLS_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     fn lookup_none(
         _db: djinn_db::Database,
@@ -3114,6 +3135,7 @@ mod cache_cleanup_cross_path_tests {
 
     #[tokio::test]
     async fn active_task_run_and_running_session_are_joint_cap_protected() {
+        let _engine_calls = engine_calls_guard();
         let db = crate::test_helpers::create_test_db();
         let root = create_run_root(&[RUN_A, RUN_B]);
         let stats = sweep_orphaned_cargo_target_run_dirs_under_with_caps_and_seams(
@@ -3144,6 +3166,7 @@ mod cache_cleanup_cross_path_tests {
 
     #[tokio::test]
     async fn each_protected_id_lookup_failure_aborts_before_mutation() {
+        let _engine_calls = engine_calls_guard();
         for (task_run_ids, session_task_run_ids) in [
             (
                 lookup_failure as ProtectedIdLookup,
@@ -3207,6 +3230,7 @@ mod cache_cleanup_cross_path_tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn real_joint_cap_engine_propagates_all_five_bounded_outcomes() {
+        let _engine_calls = engine_calls_guard();
         use djinn_core::cargo_target_runs::CargoTargetRunsCaps;
 
         let within = create_run_root(&[]);

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -2025,14 +2025,17 @@ async fn preservation_gate_called_during_terminal_task_failure() {
 /// trigger labels.
 #[test]
 fn preservation_telemetry_counter_increments() {
-    djinn_telemetry::init().unwrap();
+    // `request_session_preservation` increments this exact series whenever a
+    // stall reap runs without runtime_ops, and those recovery tests share this
+    // process's recorder. Emit into a thread-private registry so the count
+    // reflects this test's single increment and nothing else.
+    let (_, rendered) = djinn_telemetry::render_isolated(|| {
+        djinn_telemetry::preservation::increment_attempt(
+            djinn_telemetry::preservation::OUTCOME_RUNTIME_UNAVAILABLE,
+            djinn_telemetry::preservation::TRIGGER_STALL,
+        );
+    });
 
-    djinn_telemetry::preservation::increment_attempt(
-        djinn_telemetry::preservation::OUTCOME_RUNTIME_UNAVAILABLE,
-        djinn_telemetry::preservation::TRIGGER_STALL,
-    );
-
-    let rendered = djinn_telemetry::render().unwrap();
     let stall_line = rendered
         .lines()
         .find(|line| {

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -719,6 +719,31 @@ pub fn render() -> Result<String, String> {
     handle().map(|handle| prioritize_dispatch_attempts(handle.render()))
 }
 
+/// Test support: run `f` against a private recorder and render only what `f`
+/// itself emitted.
+///
+/// The recorder installed by [`init`] is process-global, and cargo runs every
+/// test in a binary as a thread of one process. A test that asserts an
+/// *absolute* value for a metric series is therefore asserting on the whole
+/// binary's cumulative total, which any concurrently running test can move.
+/// Reading a delta around the emission narrows but does not close that window,
+/// because a concurrent writer can still land between the two renders. Scoping
+/// a recorder to the calling thread instead gives the test a registry no other
+/// test can reach, so exact assertions become deterministic without
+/// serializing anything.
+///
+/// Only sound for synchronous bodies. The scope is thread-local, so anything
+/// `f` moves to another thread — `tokio::spawn`, a multi-thread runtime — will
+/// record to the global recorder and go unseen here.
+pub fn render_isolated<T>(f: impl FnOnce() -> T) -> (T, String) {
+    let recorder = PrometheusBuilder::new().build_recorder();
+    let value = metrics::with_local_recorder(&recorder, f);
+    (
+        value,
+        prioritize_dispatch_attempts(recorder.handle().render()),
+    )
+}
+
 fn prioritize_dispatch_attempts(rendered: String) -> String {
     const DISPATCH_HELP: &str = "# HELP djinn_dispatch_attempts_total";
     if rendered.starts_with(DISPATCH_HELP) {


### PR DESCRIPTION
## The symptom

`cargo test -p djinn-coordinator` fails a **different set of ~4 tests on every run** at `--test-threads=8`, and all of them pass in isolation. It reads like database contention. It isn't.

`djinn-telemetry` installs a **process-global** Prometheus recorder, and cargo runs a binary's tests as threads of one process. A test asserting an *absolute* value for a metric series is therefore asserting on the whole binary's cumulative total — which any concurrently running test can move. Reproduced directly:

```
assertion `left == right` failed: preservation counter should be 1 after a single increment
  left: 3.0
 right: 1.0
```

## Four distinct causes, each fixed at the level it warrants

**1. Admission gauges** (`build_admission`). A `telemetry_guard` already existed and every gauge *reader* held it — but ~16 tests in the module are unguarded *writers* via `publish_metrics`. Classic partial application. Rather than hunt every writer crate-wide (exactly what failed here), emission is gated **at the writer**: `emit_process_metrics` defaults off under `cfg!(test)`, and only the tests asserting on those series opt in. A controller that never opts in cannot corrupt a reading regardless of which admission path it exercises, and the other ~16 tests keep running in parallel.

**2. Preservation counter** (`session_reaping`). Production increments the same series from six call sites in `session_recovery.rs` that concurrent recovery tests exercise. The test body is synchronous, so the new `render_isolated` scopes a recorder to the calling thread — true isolation, no lock and no delta, and the exact `1.0` assertion survives intact.

**3. Pressure fixture** (`cargo_warm_base_gc`). This one *already used deltas* and still failed. Worth stating plainly: a delta cancels history that **predates** the window, not a writer that arrives **during** it. Serial guard over the 14 plan-consuming tests in the single file that writes them.

**4. Dispatch cap observations** (`task_dispatch`). Not Prometheus at all — a `#[cfg(test)]` global vec. Assertions now filter to each test's own `(creator, model)` bucket. The destructive `clear()` calls are removed: they were wiping *peer* tests' observations, which corrupts runs rather than merely flaking them.

## Non-vacuity verified, not assumed

A guarded or isolated assertion is worthless if it no longer fails on regression. Checked by mutation:

- `set_slots_in_use(occupied + 1)` → caught by 5 tests
- `TRIGGER_STALL` → `"stall_MUTANT"` → caught by the preservation test

## Evidence

| | runs | metrics-class failures |
|---|---|---|
| baseline `t=8` | 3 | **13** |
| fixed `t=8` | 6 | **0** |
| fixed `t=16` | 3 | **0** |

Independently reproduced over 5 further runs at `t=8`: zero. `cargo fmt` + `clippy -p djinn-coordinator -p djinn-telemetry --all-targets` clean.

## What this does NOT fix

A second, unrelated class remains: tests that spawn a live `CoordinatorHandle` and poll a 10-second deadline (`rules::*`, `wave::*`, `status_and_stuck::*`) still fail 1–2 per run. **The suite is not yet green — this removes one of two causes.**

That class was measured, not guessed. Raising the deadline to 60s (diagnostic only) made all runs pass but took ~20s on the slow ones: the coordinator is **slow, not stuck**. `CoordinatorActor::run()` completes a startup recovery sequence before entering its `select!` loop, and `run_tick()` is a long sequential await chain that blocks event handling — under whole-binary Postgres load that exceeds the 10s poll budget.

Serializing those tests was implemented and **rejected on evidence**: it roughly doubled their wall clock and did not fix the failures, because the contention is with the other ~1700 tests, not among themselves. Also ruled out experimentally: broadcast lag (0 lagged messages), pool starvation (raising 4→12 connections made it *worse*).

The real fix is to drive the actor directly via `coordinator_actor_for_tests` (which `tests::intervention::*` already does — direct evidence the pattern works) or to cut the actor's test-time startup cost. Both are follow-up work, deliberately not attempted here.

### Related defect found, not fixed

`CoordinatorActor::new` registers sources into the process-global `djinn_core::doctor::registry()` on **every** construction, and `run_tick` sweeps that registry. Under parallelism each tick can do unbounded DB work against a *foreign* test's board. It cannot move the asserted counts so it is not the direct cause, but it plausibly amplifies the tick cost above and is worth investigating as part of that follow-up.