### PR TITLE
ci: retire two cache families to fund workspace-crate caching

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -190,63 +190,6 @@ jobs:
           helm lint deploy/helm/djinn --values deploy/helm/djinn/values.local.yaml
       - name: Test Helm rendering contracts
         run: bash scripts/test-helm-github-app-render.sh
-  main-admission:
-    name: Main admission delay
-    needs: preflight
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - run: sleep 90
-  cache-warm-x86_64-quality:
-    name: Cache Warm x86_64 (Quality)
-    needs:
-      - preflight
-      - main-admission
-    if: github.event_name == 'push' && needs.preflight.outputs.clippy == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    defaults:
-      run:
-        working-directory: server
-    env:
-      SQLX_OFFLINE: "true"
-    steps:
-      - uses: actions/checkout@v4
-      - run: rustup toolchain install
-        working-directory: server
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: server
-          shared-key: server-quality
-          cache-on-failure: true
-          save-if: true
-          cache-all-crates: true
-        id: rust-cache
-      - name: Log cache family and restore status
-        run: |-
-          echo "cache-family=server-quality"
-          echo "shared-key=server-quality"
-          echo "runner-os=${{ runner.os }}"
-          echo "rustc=$(rustc --version || echo 'unknown')"
-          echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
-          echo "::notice::cache-family=server-quality shared-key=server-quality cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
-      - name: Build workspace (populate cache)
-        run: cargo clippy --all-targets --features qdrant -- -D warnings
-  # workflow_dispatch is a supported warm route so the test cache can be
-  # (re)seeded on demand — e.g. from a branch before a cache-family
-  # migration lands — not just on main pushes. The push-only admission
-  # delay lives inline as a step because a `needs: main-admission` edge
-  # would auto-skip this job on dispatch (skipped dependency).
-  # NOTE: a full arm64 trial (2026-07-18, PR #2275 branch) measured
-  # GitHub's free ubuntu-24.04-arm runners slower than x64 for this
-  # workspace with a genuinely warm cache: shard builds 316-385s vs
-  # 272-289s (~15-35% slower) and test execution 285-310s vs 230-239s
-  # (~25% slower), roughly +1.5-2.5 min per run. Keep the lane on x64
-  # unless those runners improve. (Cache-scoping gotcha from the trial:
-  # PR merge-ref runs cannot restore head-branch-scoped caches — only
-  # base/default branch scopes — so branch-seeded warm caches look
-  # cold from the PR run.)
   cache-warm-x86_64-test:
     name: Cache Warm x86_64 (Test)
     needs:
@@ -276,6 +219,18 @@ jobs:
           cache-on-failure: true
           save-if: true
           cache-all-crates: true
+          # rust-cache strips workspace-member artifacts before saving by
+          # default, so every consumer recompiled the ~30 djinn-* crates even
+          # on a "full match" restore — that is the whole cost of the shards'
+          # `Build test binaries` step (4.85-4.97 min x 4, on the critical
+          # path). Budget for this comes from retiring the server-quality and
+          # release-bins families in this same change.
+          #
+          # This only affects the SAVE path and is NOT part of the cache key,
+          # so it belongs on the owner alone; restore-only consumers need no
+          # change. If the shards' build time does not drop, revert this line
+          # and keep the reclaimed budget.
+          cache-workspace-crates: true
         id: rust-cache
       - uses: taiki-e/install-action@nextest
       - name: Build test binaries (populate cache)
@@ -289,70 +244,6 @@ jobs:
           echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
           echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
         if: always()
-  # Release builds trigger only on v* tag pushes, and GitHub caches saved on
-  # a tag ref are invisible to every other ref — so a cache saved BY a
-  # release run can never be restored by the next release, and every release
-  # cold-compiled the workspace (~22 min of a ~25 min run). Caches created
-  # on the DEFAULT branch are readable from all refs, so main owns the
-  # release-bins family and release.yml is a restore-only consumer.
-  # The env below must stay byte-identical to the release binaries job's
-  # cargo-relevant env (RUSTFLAGS, CARGO_*): Swatinem/rust-cache hashes
-  # those env vars into the cache key, and any drift silently produces a
-  # second, unreachable cache family.
-  cache-warm-x86_64-release:
-    name: Cache Warm x86_64 (Release)
-    needs:
-      - preflight
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.preflight.outputs.serverTest == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    defaults:
-      run:
-        working-directory: server
-    env:
-      SQLX_OFFLINE: "true"
-      RUSTFLAGS: -C link-arg=-fuse-ld=mold
-    steps:
-      # checkout must precede the admission delay: the job-level
-      # working-directory (server) does not exist until the repo is checked out.
-      - uses: actions/checkout@v4
-      - name: Main admission delay
-        if: github.event_name == 'push'
-        run: sleep 90
-      - run: rustup toolchain install
-        working-directory: server
-      - name: Install mold
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: server
-          shared-key: release-bins
-          cache-on-failure: true
-          save-if: true
-          cache-all-crates: true
-        id: rust-cache
-      - name: Log cache family and restore status
-        run: |-
-          echo "cache-family=release-bins"
-          echo "shared-key=release-bins"
-          echo "runner-os=${{ runner.os }}"
-          echo "rustc=$(rustc --version || echo 'unknown')"
-          echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
-          echo "::notice::cache-family=release-bins shared-key=release-bins cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
-      # No UI build here: rust-embed bakes ui/dist at compile time, so
-      # warming without it embeds the build.rs placeholder. That only
-      # affects the final djinn-server crate's own artifact — every
-      # dependency and intermediate workspace artifact still populates the
-      # cache the release job restores. Worker first, then server, in the
-      # same order and with the same flags as release.yml so feature
-      # resolution matches (a unified build would feature-unify qdrant
-      # onto worker deps).
-      - name: Cargo build worker (populate cache)
-        run: cargo build --release --locked -p djinn-agent-worker
-      - name: Cargo build server (populate cache)
-        run: cargo build --release --locked --features qdrant -p djinn-server
   cache-warm-aarch64:
     name: Cache Warm aarch64
     needs:
@@ -513,19 +404,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
-          shared-key: server-quality
+          # The dedicated `server-quality` family is gone. After #2342 moved
+          # server-sqlx-freshness and memory-eval onto server-test, it served
+          # exactly one job — this one — while holding ~2.5 GB of a 10 GB
+          # repo-wide budget. Clippy only substitutes clippy-driver for
+          # WORKSPACE crates (RUSTC_WORKSPACE_WRAPPER); dependencies build
+          # with ordinary rustc, so a codegen-warm family serves them.
+          shared-key: server-test
           cache-on-failure: true
           cache-all-crates: true
           save-if: false
         id: rust-cache
       - name: Log cache family and restore status
         run: |-
-          echo "cache-family=server-quality"
-          echo "shared-key=server-quality"
+          echo "cache-family=server-test"
+          echo "shared-key=server-test"
           echo "runner-os=${{ runner.os }}"
           echo "rustc=$(rustc --version || echo 'unknown')"
           echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
-          echo "::notice::cache-family=server-quality shared-key=server-quality cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+          echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
       - uses: taiki-e/install-action@v2
         if: github.event_name != 'merge_group'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,21 +258,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y mold
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: server
-          shared-key: release-bins
-          cache-on-failure: true
-          cache-all-crates: true
-          # Restore-only: this workflow runs on v* tag refs, and a cache
-          # saved on one tag ref is invisible to every other ref — a
-          # `save-if: true` here writes a cache no future release can
-          # restore (verified: three consecutive releases each logged
-          # "No cache found" then "Saving cache"). The release-bins family
-          # is owned and saved by quality-gate.yml's
-          # cache-warm-x86_64-release job on main pushes; default-branch
-          # caches are readable from all refs, including tag runs.
-          save-if: false
+      # No Rust cache here on purpose. The release-bins family was retired:
+      # it held ~1.53 GB of a 10 GB repo-wide budget to serve ~1.9 releases
+      # a day, while CI runs ~298 times a day and its cache was starved by
+      # the same budget. Releases now cold-compile (~22 min); the budget
+      # went to cache-workspace-crates on server-test, which every CI run
+      # reads. Revisit if release cadence rises or the budget grows.
       # Worker FIRST so its deps resolve WITHOUT qdrant (default features);
       # the server build then layers only the qdrant-extra deps on top,
       # reusing every shared non-qdrant artifact already on disk.

--- a/scripts/ci-cache-policy.test.mjs
+++ b/scripts/ci-cache-policy.test.mjs
@@ -23,13 +23,14 @@ function cacheWorkflows() {
 
 // Each family has exactly one job permitted to save it. Adding a family requires
 // adding its owner here before it can be used in the quality-gate workflow.
+// `server-quality` and `release-bins` were retired. GitHub caps a repo at
+// 10 GB and evicts LRU, and four families sat at ~8.94 GB — so every family
+// was competing with the one CI actually reads on every run. server-quality
+// served a single job after #2342; release-bins served ~1.9 releases a day
+// against ~298 CI runs. Their ~4 GB funds cache-workspace-crates on
+// server-test. Adding a family back means finding budget for it first.
 const CACHE_OWNERS = new Map([
-  ['server-quality', 'cache-warm-x86_64-quality'],
   ['server-test', 'cache-warm-x86_64-test'],
-  // Saved on main so tag-triggered release runs can restore it: caches
-  // saved on a tag ref are invisible to every other ref, so release.yml
-  // itself must stay a restore-only consumer of this family.
-  ['release-bins', 'cache-warm-x86_64-release'],
   ['server-aarch64-check', 'cache-warm-aarch64'],
 ]);
 


### PR DESCRIPTION
Follow-up to #2342.

## Problem

GitHub caps a repo at **10 GB** of Actions cache and evicts LRU. Four Rust families sat at **8.94 GB**, so each was competing with the one CI actually reads on every run.

Meanwhile rust-cache **strips workspace-member artifacts before saving**, so every consumer recompiles the ~30 `djinn-*` crates even on a `full match: true` restore. That is the entire cost of the shards' `Build test binaries` step — **4.85–4.97 min × 4, on the critical path**.

## Change

Retire two families and spend the budget on the shards.

**`server-quality` — ~2.5 GB (853 MB × 3 generations).** After #2342 moved `server-sqlx-freshness` and `memory-eval` onto `server-test`, this family served **exactly one job**. `server-clippy` now restores `server-test`: clippy only substitutes `clippy-driver` for *workspace* crates via `RUSTC_WORKSPACE_WRAPPER`, so a codegen-warm family serves its dependency graph. The warm lane is deleted, and with it `main-admission`, whose only consumer was that lane (the test lane carries its delay inline).

**`release-bins` — 1.53 GB.** Measured cadence:

| | per day |
|---|---|
| CI runs | **~298** (125 PR, 41 merge_group, 34 push in 24h) |
| release successes | **~1.9** (13 in 7 days) |

~150:1. Releases go back to cold-compiling (~22 min each, so ~44 min/day); every one of ~298 CI runs gets a warmer cache. `release.yml` drops its restore-only step.

**`cache-workspace-crates: true`** on the `server-test` owner. It affects only the save path and is **not part of the cache key**, so it belongs on the owner alone — restore-only consumers need no change.

## What to measure after merge

The shards' `Build test binaries` step (4.85–4.97 min today). **If it does not drop, revert that one line and keep the reclaimed budget** — the win is unproven until a warm run on main shows it, because workspace crates change on most commits and the benefit depends on how much of the tree a typical PR leaves untouched.

## Deliberately not included

Making `CARGO_BUILD_BUILD_DIR` absolute. It is still a relative path and still the trap #2342 spent four rounds on — but `djinn-qa` spawns `cargo` as a child process and `djinn-stack` has fixture workspaces under `tests/fixtures/`, so an absolute build-dir would redirect those child builds into `server/target`. That needs its own change and its own verification, not a ride along a cache-budget PR.

## Verification

- All 6 workflow test files pass (83 tests); `ci-cache-policy` updated for the two-family world and still passes its mutation test
- All three workflows parse; job graph validated — no broken `needs:`, no orphaned jobs, all 15 remaining jobs still carry `timeout-minutes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)