### PR TITLE
ci: fail fast on duplicate migration version numbers

### DIFF
--- a/scripts/check-migrations-immutable.sh
+++ b/scripts/check-migrations-immutable.sh
@@ -69,3 +69,36 @@ if [ -n "$offenders" ]; then
 fi
 
 echo "OK: no existing migrations were modified, renamed, or deleted."
+
+# Two migrations claiming the same version number. This is invisible on the
+# branch itself and only appears on the PR merge ref, when two PRs each add
+# the next number independently — so it lands on whoever merges second and is
+# guaranteed to recur whenever two migration PRs are open at once.
+#
+# Without this guard the failure surfaces from Postgres as
+#   duplicate key value violates unique constraint "_sqlx_migrations_pkey"
+# during migration application, which names neither the version nor the files
+# (observed on PR #2353, where main's 134_compaction_boundary_telemetry and
+# the branch's 134_note_lifecycle_changed_at collided).
+migrations_dir="$MIGRATIONS_GLOB"
+duplicates=$(
+    ls "$migrations_dir" 2>/dev/null \
+        | grep -E '^[0-9]+_.*\.sql$' \
+        | cut -d_ -f1 \
+        | sort -n \
+        | uniq -d
+)
+
+if [ -n "$duplicates" ]; then
+    echo "::error::Two or more migrations claim the same version number. sqlx keys _sqlx_migrations by version, so applying them fails with a duplicate-key error. Renumber the newer file to the next free version." >&2
+    printf '%s\n' "$duplicates" | while IFS= read -r v; do
+        [ -z "$v" ] && continue
+        echo "  version $v is claimed by:" >&2
+        ls "$migrations_dir" | grep -E "^${v}_" | while IFS= read -r f; do
+            echo "    - $f" >&2
+        done
+    done
+    exit 1
+fi
+
+echo "OK: no duplicate migration version numbers."


### PR DESCRIPTION
## Problem

#2353 added `134_note_lifecycle_changed_at` while main already had `134_compaction_boundary_telemetry`. **Each branch is fine on its own** — the PR *merge ref* contains both, so sqlx inserts version 134 twice and Postgres reports:

```
duplicate key value violates unique constraint "_sqlx_migrations_pkey"
```

That names neither the version nor the files. It recurs whenever two migration PRs are open at once, and always lands on whoever merges second.

## Fix

`check-migrations-immutable.sh` now fails with the version and both filenames:

```
::error::Two or more migrations claim the same version number...
  version 134 is claimed by:
    - 134_compaction_boundary_telemetry.sql
    - 134_note_lifecycle_changed_at.sql
```

Verified against the real collision: exits 1 and prints both files; exits 0 on a clean tree. (I also caught a bug in my own first version — a stray `dirname` pointed at the parent directory, making the check a silent no-op that passed on everything.)

## Dropped from the earlier draft of this PR

Rotating rust-cache's `prefix-key` to force `cache-workspace-crates` (from #2349) to take effect. **It's unnecessary.** The cache key already hashes `Cargo.lock` and the manifests, so merged PRs rotate it on their own — observed roughly every 1.5–3 hours today:

```
673bb8e8 ~07:05   0e1107ec ~10:27   54026ef4 ~12:18   bb5e22ce 14:00   6a1469fc 15:35
```

The next natural rotation makes the warm lane miss, rebuild, and save with workspace crates included. A manual prefix bump would buy a couple of hours and cost every job an immediate cold cycle.

That does still leave #2349's `cache-workspace-crates` unproven — the measurement is the shards' `Build test binaries` (~4.9 min today) after the next key rotation. If it doesn't drop, the right move is reverting that line and keeping the reclaimed budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)