### PR TITLE
ci: revert cache-workspace-crates, it cannot work here

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -219,18 +219,25 @@ jobs:
           cache-on-failure: true
           save-if: true
           cache-all-crates: true
-          # rust-cache strips workspace-member artifacts before saving by
-          # default, so every consumer recompiled the ~30 djinn-* crates even
-          # on a "full match" restore — that is the whole cost of the shards'
-          # `Build test binaries` step (4.85-4.97 min x 4, on the critical
-          # path). Budget for this comes from retiring the server-quality and
-          # release-bins families in this same change.
+          # Do NOT re-add `cache-workspace-crates: true`. It was tried in
+          # #2349 and measured worthless: the saved cache grew 1267 MB ->
+          # 2283 MB (+1016 MB of a 10 GB repo budget) and the shards' `Build
+          # test binaries` step did not move (4.6-5.0 min before, 4.8-5.1 min
+          # after, across four runs).
           #
-          # This only affects the SAVE path and is NOT part of the cache key,
-          # so it belongs on the owner alone; restore-only consumers need no
-          # change. If the shards' build time does not drop, revert this line
-          # and keep the reclaimed budget.
-          cache-workspace-crates: true
+          # Why it cannot help here: cargo fingerprints path/workspace crates
+          # by source MTIME, and a fresh `actions/checkout` stamps every file
+          # with a new mtime (git does not record them). Restored workspace
+          # artifacts are therefore stale on arrival and rebuilt regardless —
+          # rust-lang/cargo#11682, "crates always considered dirty when
+          # building in a fresh git clone". rust-cache excludes workspace
+          # members by default for exactly this reason, and documents the
+          # option as useful only for "libraries that are only updated
+          # sporadically". All 29 djinn-* crates churn constantly, so the
+          # option's precondition does not hold for this workspace.
+          #
+          # Fixing this needs CONTENT-addressed compilation caching (sccache,
+          # cargo-hold), not more mtime-based artifact caching.
         id: rust-cache
       - uses: taiki-e/install-action@nextest
       - name: Build test binaries (populate cache)


### PR DESCRIPTION
Reverts the `cache-workspace-crates: true` line from #2349. Keeps everything else in that PR.

## Measurement

The cache key rotated naturally at 17:53 and the warm lane saved with workspace crates included — `server-test` went **1267 MB → 2283 MB**, so the setting was genuinely in effect:

```
14:00:22  1287MB  bb5e22ce
15:35:15  1267MB  6a1469fc
17:53:43  2283MB  3d301d11   <- +1016MB
```

| `Build test binaries`, 4-shard average | |
|---|---|
| before | 4.6–5.0 min |
| after | **4.8–5.1 min** (four runs: 5.1, 4.8, 4.8, 4.9) |

No movement, for +1016 MB of a 10 GB repo-wide budget.

## Why it's structural, not tuning

Cargo fingerprints path/workspace crates by source **mtime**, and `actions/checkout` stamps every file with a fresh mtime because git doesn't record them. Restored workspace artifacts are therefore dirty on arrival regardless of what the cache holds — [rust-lang/cargo#11682](https://github.com/rust-lang/cargo/issues/11682), *"crates always considered dirty when building in a fresh git clone"*.

[rust-cache excludes workspace members by default](https://github.com/Swatinem/rust-cache) for exactly this reason, and documents the option as useful only for *"libraries that are only updated sporadically"*. All 29 `djinn-*` crates churn constantly, so the option's precondition never held for this workspace. I enabled it without checking that precondition.

Beating this requires **content-addressed compilation caching** (sccache, cargo-hold), which is a different mechanism — not a bigger artifact cache.

## Unaffected

The ~4 GB reclaimed by retiring `server-quality` and `release-bins` stands on its own; that was justified by consumer count and the 150:1 CI-to-release ratio, independent of this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)