### PR TITLE
fix: repair the agent execution environment (missing tooling + test DB port)

### DIFF
--- a/server/crates/djinn-db/src/database.rs
+++ b/server/crates/djinn-db/src/database.rs
@@ -215,8 +215,7 @@ impl Database {
     /// Open an isolated test database.
     ///
     /// Uses the Postgres template-clone approach: take the base URL from
-    /// `DJINN_TEST_DATABASE_URL` (falling back to `TEST_POSTGRES_URL`, then
-    /// `postgres://postgres:postgres@127.0.0.1:5433/postgres`), strip any
+    /// [`test_database_base_url`], strip any
     /// trailing `/<db>` segment, then construct an admin connection against
     /// `<base>/postgres`, `CREATE DATABASE djinn_test_<uuid> TEMPLATE
     /// djinn_test_template`, and connect the per-test pool to it.
@@ -228,9 +227,7 @@ impl Database {
     /// Each test gets a UUIDv7-named database — no collisions under
     /// `cargo nextest` parallelism.
     pub fn open_in_memory() -> DbResult<Self> {
-        let base = std::env::var("DJINN_TEST_DATABASE_URL")
-            .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-            .unwrap_or_else(|_| "postgres://postgres:postgres@127.0.0.1:5433/postgres".to_owned());
+        let base = test_database_base_url();
         let server_prefix = strip_server_prefix(&base);
         let test_db = format!("djinn_test_{}", uuid::Uuid::now_v7().simple());
         let url = format!("{server_prefix}/{test_db}");
@@ -551,6 +548,41 @@ impl Database {
             .await?;
         Ok(())
     }
+}
+
+/// Default base URL for the ephemeral test Postgres server.
+///
+/// Deliberately a local, unprivileged address: a test helper must never be
+/// able to fall back onto a real deployment's database.
+const DEFAULT_TEST_DATABASE_URL: &str = "postgres://postgres:postgres@127.0.0.1:5433/postgres";
+
+/// Base URL of the Postgres server that integration tests should use.
+///
+/// Resolution order is `TEST_POSTGRES_URL`, then `DJINN_TEST_DATABASE_URL`,
+/// then [`DEFAULT_TEST_DATABASE_URL`]. **The order matters and is not
+/// arbitrary:**
+///
+/// - Task-run Pods inject `TEST_POSTGRES_URL` pointing at the in-Pod
+///   `svc-postgres` sidecar on `127.0.0.1:5432`.
+/// - `server/.cargo/config.toml` bakes `DJINN_TEST_DATABASE_URL` at `:5433`
+///   for local development, and CI sets the same value explicitly.
+///
+/// Cargo's `[env]` table applies to every process cargo launches, so when
+/// `DJINN_TEST_DATABASE_URL` was checked first, `cargo test` inside a Pod
+/// always dialled `:5433` — where nothing listens — while running the
+/// compiled test binary directly worked, because cargo was not in the loop to
+/// inject the variable. That split is what made in-Pod database tests look
+/// intermittently flaky when they were in fact deterministic.
+///
+/// Checking `TEST_POSTGRES_URL` first is correct everywhere: neither CI nor
+/// local development sets it, so both fall through to `:5433` unchanged.
+///
+/// Every integration test must use this helper rather than reading the
+/// environment directly, so the precedence exists in exactly one place.
+pub fn test_database_base_url() -> String {
+    std::env::var("TEST_POSTGRES_URL")
+        .or_else(|_| std::env::var("DJINN_TEST_DATABASE_URL"))
+        .unwrap_or_else(|_| DEFAULT_TEST_DATABASE_URL.to_owned())
 }
 
 fn strip_server_prefix(base_url: &str) -> String {

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -30,7 +30,7 @@ pub mod test_support {
 pub use database::{
     Database, DatabaseBackendCapabilities, DatabaseBackendKind, DatabaseBootstrapInfo,
     DatabaseConnectConfig, NoteSearchBackend, NoteVectorBackend, PostgresDatabaseConfig,
-    SqliteVecStatus, default_db_path,
+    SqliteVecStatus, default_db_path, test_database_base_url,
 };
 pub use error::{DbError as Error, DbResult as Result};
 #[cfg(any(test, feature = "test-support"))]

--- a/server/crates/djinn-db/tests/compaction_hardening/boundary.rs
+++ b/server/crates/djinn-db/tests/compaction_hardening/boundary.rs
@@ -20,10 +20,10 @@ const SESSION_ID: &str = "13400000-0000-0000-0000-000000000003";
 const HISTORIC_BOUNDARY_ID: &str = "13400000-0000-0000-0000-000000000004";
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .or_else(|_| std::env::var("DATABASE_URL"))
-        .expect("live PostgreSQL URL for compaction migration fixture")
+    // `DATABASE_URL` is deliberately not consulted: it is a generic name that
+    // can point at a real deployment. Task-run Pods set it to the same
+    // sidecar value as `TEST_POSTGRES_URL`, so nothing is lost by ignoring it.
+    djinn_db::test_database_base_url()
 }
 
 async fn apply_migration(conn: &mut PgConnection, target: u64) {

--- a/server/crates/djinn-db/tests/migration_connection_context.rs
+++ b/server/crates/djinn-db/tests/migration_connection_context.rs
@@ -6,12 +6,7 @@ use sqlx::postgres::{PgConnection, PgPoolOptions};
 use sqlx::{Connection, Executor};
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .unwrap_or_else(|_| {
-        "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-            .to_owned()
-    })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_dispatch_ownership_correlation.rs
+++ b/server/crates/djinn-db/tests/migrations_dispatch_ownership_correlation.rs
@@ -17,12 +17,7 @@ const MIGRATION_VERSION: u64 = 133;
 const MIGRATION_FILE: &str = "133_dispatch_ownership_correlation.sql";
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .unwrap_or_else(|_| {
-            "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-                .to_owned()
-        })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_doctor_findings.rs
+++ b/server/crates/djinn-db/tests/migrations_doctor_findings.rs
@@ -15,10 +15,7 @@ use sqlx::postgres::{PgConnection, PgPoolOptions};
 use sqlx::{Connection, Executor};
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL").unwrap_or_else(|_| {
-        "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-            .to_owned()
-    })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_extension_load_diagnostics.rs
+++ b/server/crates/djinn-db/tests/migrations_extension_load_diagnostics.rs
@@ -13,12 +13,7 @@ const MIGRATION_VERSION: u64 = 131;
 const MIGRATION_FILE: &str = "131_retire_skill_manifest_diagnostics.sql";
 
 fn base_database_url() -> String {
-    std::env::var("TEST_POSTGRES_URL")
-        .or_else(|_| std::env::var("DJINN_TEST_DATABASE_URL"))
-        .unwrap_or_else(|_| {
-            "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-                .to_owned()
-        })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_liveness_evidence_outcomes.rs
+++ b/server/crates/djinn-db/tests/migrations_liveness_evidence_outcomes.rs
@@ -24,12 +24,7 @@ const MIGRATION_VERSION: u64 = 95;
 const MIGRATION_FILE: &str = "95_liveness_evidence_outcomes.sql";
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .unwrap_or_else(|_| {
-            "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-                .to_owned()
-        })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_note_association_provenance.rs
+++ b/server/crates/djinn-db/tests/migrations_note_association_provenance.rs
@@ -28,12 +28,7 @@ const MIGRATION_VERSION: u64 = 97;
 const MIGRATION_FILE: &str = "97_note_association_provenance.sql";
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .unwrap_or_else(|_| {
-            "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-                .to_owned()
-        })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_note_lifecycle_changed_at.rs
+++ b/server/crates/djinn-db/tests/migrations_note_lifecycle_changed_at.rs
@@ -10,9 +10,7 @@ const MIGRATION_VERSION: u64 = 135;
 const MIGRATION_FILE: &str = "135_note_lifecycle_changed_at.sql";
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .expect("Postgres URL is required for migration tests")
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_note_revision_events.rs
+++ b/server/crates/djinn-db/tests/migrations_note_revision_events.rs
@@ -4,9 +4,7 @@ use sqlx::postgres::{PgConnection, PgPoolOptions};
 use sqlx::{Connection, Executor};
 
 fn database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .expect("Postgres URL is required for migration tests")
+    djinn_db::test_database_base_url()
 }
 
 async fn with_database(f: impl AsyncFnOnce(sqlx::PgPool)) {

--- a/server/crates/djinn-db/tests/migrations_repo_graph_generation_expand.rs
+++ b/server/crates/djinn-db/tests/migrations_repo_graph_generation_expand.rs
@@ -27,9 +27,7 @@ const EXPAND_VERSION: u64 = 125;
 // ── connection / database helpers ────────────────────────────────────────────
 
 fn base_database_url() -> String {
-    std::env::var("TEST_POSTGRES_URL")
-        .or_else(|_| std::env::var("DJINN_TEST_DATABASE_URL"))
-        .expect("live PostgreSQL URL")
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_repo_graph_publish_lock.rs
+++ b/server/crates/djinn-db/tests/migrations_repo_graph_publish_lock.rs
@@ -8,9 +8,7 @@ use sqlx::{Connection, Executor, Row};
 const MIGRATION_VERSION: u64 = 125;
 
 fn base_database_url() -> String {
-    std::env::var("TEST_POSTGRES_URL")
-        .or_else(|_| std::env::var("DJINN_TEST_DATABASE_URL"))
-        .expect("live PostgreSQL URL")
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_retrieval_traces_rollout_outcome.rs
+++ b/server/crates/djinn-db/tests/migrations_retrieval_traces_rollout_outcome.rs
@@ -32,12 +32,7 @@ const MIGRATION_FILE: &str = "119_retrieval_traces_rollout_outcome.sql";
 const ABSENT_CANDIDATES_FIXTURE_ID: &str = "rt-absent-candidates-default";
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .unwrap_or_else(|_| {
-            "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-                .to_owned()
-        })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_sessions_parked_reason.rs
+++ b/server/crates/djinn-db/tests/migrations_sessions_parked_reason.rs
@@ -4,10 +4,7 @@ use sqlx::postgres::{PgConnection, PgPoolOptions};
 use sqlx::{Connection, Executor};
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL").unwrap_or_else(|_| {
-        "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-            .to_owned()
-    })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/migrations_task_pr_ci_snapshots.rs
+++ b/server/crates/djinn-db/tests/migrations_task_pr_ci_snapshots.rs
@@ -8,12 +8,7 @@ const MIGRATION_VERSION: u64 = 85;
 const MIGRATION_FILE: &str = "85_task_pr_ci_snapshots.sql";
 
 fn base_database_url() -> String {
-    std::env::var("DJINN_TEST_DATABASE_URL")
-        .or_else(|_| std::env::var("TEST_POSTGRES_URL"))
-        .unwrap_or_else(|_| {
-            "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-                .to_owned()
-        })
+    djinn_db::test_database_base_url()
 }
 
 fn server_prefix(base: &str) -> String {

--- a/server/crates/djinn-db/tests/repo_graph_publication_compatibility.rs
+++ b/server/crates/djinn-db/tests/repo_graph_publication_compatibility.rs
@@ -27,9 +27,7 @@ const OLD_LATEST: &str = "SELECT project_id, commit_sha, graph_blob, built_at, g
                           FROM repo_graph_cache WHERE project_id = $1 ORDER BY built_at DESC LIMIT 1";
 
 fn base_url() -> String {
-    std::env::var("TEST_POSTGRES_URL")
-        .or_else(|_| std::env::var("DJINN_TEST_DATABASE_URL"))
-        .expect("live PostgreSQL URL")
+    djinn_db::test_database_base_url()
 }
 
 async fn assert_strict_history_order(conn: &mut PgConnection) {

--- a/server/crates/djinn-db/tests/repo_graph_retention_compatibility.rs
+++ b/server/crates/djinn-db/tests/repo_graph_retention_compatibility.rs
@@ -37,10 +37,7 @@ async fn fresh() -> (Database, RepoGraphRetentionRepository) {
     // Dedicated live-test URLs remain authoritative. Server-test shards expose
     // only DATABASE_URL, so accept it as the final fallback rather than turning
     // this required live-Postgres regression into an environment panic.
-    let base = std::env::var("TEST_POSTGRES_URL")
-        .or_else(|_| std::env::var("DJINN_TEST_DATABASE_URL"))
-        .or_else(|_| std::env::var("DATABASE_URL"))
-        .expect("live PostgreSQL URL");
+    let base = djinn_db::test_database_base_url();
     let prefix = base.rsplit_once('/').expect("database URL").0;
     let name = format!("djinn_retention_{}", uuid::Uuid::now_v7().simple());
     let mut admin = PgConnection::connect(&format!("{prefix}/postgres"))

--- a/server/crates/djinn-db/tests/setup_test_template.rs
+++ b/server/crates/djinn-db/tests/setup_test_template.rs
@@ -13,10 +13,7 @@ async fn setup_test_template() {
     use sqlx::postgres::PgConnection;
 
     const TEMPLATE_OPERATOR_ID: &str = "00000000-0000-7000-8000-000000000001";
-    let base = std::env::var("DJINN_TEST_DATABASE_URL").unwrap_or_else(|_| {
-        "postgres://djinn:VipjO1uAdxAGvNSA6EcJdZMdHAquYeJj@djinn-postgres.djinn.svc.cluster.local:5432/djinn"
-            .to_owned()
-    });
+    let base = djinn_db::test_database_base_url();
     let server_prefix = base
         .rsplit_once('/')
         .map(|(prefix, _)| prefix)

--- a/server/crates/djinn-image-builder/scripts/base-debian.sh
+++ b/server/crates/djinn-image-builder/scripts/base-debian.sh
@@ -2,10 +2,11 @@
 # Base layer for Debian-derived images. Installs the essentials every
 # downstream script assumes are available: bash, curl, git, tini,
 # ca-certificates, gnupg (for third-party repo keys). It also bakes in the
-# common native build deps (libpq-dev, cmake, pkg-config) so project
-# build/test commands can link the ubiquitous `-sys` crates by default —
-# see the second install pass below. apt-cache is left dirty on purpose —
-# install-system.sh cleans up after its own pass.
+# common native build deps (libpq-dev, cmake, make, pkg-config) so project
+# build/test commands can link the ubiquitous `-sys` crates by default, plus
+# the baseline agent tooling (ripgrep, jq, python3) that coding agents assume
+# is present — see the second and third install passes below. apt-cache is
+# left dirty on purpose — install-system.sh cleans up after its own pass.
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
@@ -34,10 +35,35 @@ apt-get install -y --no-install-recommends \
 #                   which fails its cc fallback without it.
 #   - pkg-config  : how openssl-sys / libpq-sys / many `-sys` crates locate
 #                   their system libs at build time.
+#   - make        : required by three separate paths that were silently broken
+#                   without it: (1) cmake's default Unix generator emits
+#                   Makefiles and then shells out to `make`, so the `cmake`
+#                   above was non-functional on its own; (2) vendored OpenSSL
+#                   (`openssl-src`) drives its build through `make` — `perl`
+#                   ships in the base but `make` did not, so the vendored
+#                   feature failed at the make invocation; (3) repos that keep
+#                   a Makefile (djinn itself has `make sqlx-verify`) could not
+#                   run their own verification targets inside a task Pod.
+#                   Note gcc/g++ are deliberately still absent: `cc` resolves
+#                   to clang via install-rust.sh, which covers the `-sys`
+#                   crates in practice.
 apt-get install -y --no-install-recommends \
     cmake \
     libpq-dev \
+    make \
     pkg-config
+# Agent tooling. The generated image *is* the environment coding agents run in,
+# so the tools they reach for by reflex have to exist here. `ripgrep` is the
+# important one and the reason this block exists: a missing `rg` does not fail
+# loudly. Agents overwhelmingly call it in a pipeline (`rg pat | wc -l`), where
+# the shell reports the exit status of the *last* stage, so the call yields
+# "0" on stdout and exit 0. The agent reads that as "no matches found" and
+# reports the absence of a symbol as verified fact. A missing search tool that
+# silently answers "nothing there" is worse than one that errors.
+apt-get install -y --no-install-recommends \
+    jq \
+    python3 \
+    ripgrep
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 

--- a/server/crates/djinn-image-builder/scripts/install-rust.sh
+++ b/server/crates/djinn-image-builder/scripts/install-rust.sh
@@ -26,8 +26,9 @@ export PATH="${CARGO_HOME}/bin:${PATH}"
 
 # Rust build toolchain beyond rustc/cargo: a real linker + the sccache wrapper
 # that repos routinely pin in .cargo/config.toml (e.g. `linker = "clang"`,
-# `-fuse-ld=mold`, `rustc-wrapper = "sccache"`). Without these the image only
-# has gcc from build-essential, so `cargo check`/`clippy`/`build` fail at link
+# `-fuse-ld=mold`, `rustc-wrapper = "sccache"`). base-debian.sh installs no C
+# compiler at all (it does NOT install build-essential), so clang here is the
+# image's only `cc`; without it `cargo check`/`clippy`/`build` fail at link
 # time (or on the missing wrapper) and the worker can't compile or debug Rust
 # at all. clang/lld/mold are required (the linker); sccache is best-effort so a
 # distro without the package never fails the image build.


### PR DESCRIPTION
Agents could not reliably execute or verify their own code. Two independent root causes, both confirmed by probing a live task-run Pod.

## 1. The generated project image is missing core tooling

Task Pods do not run `djinn-agent-runtime` — they run the project's **catalog image** built by `djinn-image-builder`, whose package set comes only from `base-debian.sh` and `install-rust.sh`. Neither installs `build-essential`.

Probed on a live Pod: `make`, `gcc`, `python3`, `rg`, `jq` — all **MISSING**.

**`make`** broke three paths simultaneously:
- `cmake`'s default Unix generator emits Makefiles and then shells out to `make`, so the `cmake` we install for `aws-lc-sys` was non-functional on its own
- vendored OpenSSL (`openssl-src`) drives its build through `make`
- a repo's own Makefile targets — this repo has `make sqlx-verify` — could not run inside a Pod at all

**`ripgrep`** is the more damaging omission, because it fails *silently*:

```
$ rg nonexistent-pattern . | wc -l
bash: line 1: rg: command not found
0
pipeline exit: 0
```

Agents call `rg` in pipelines, where the shell reports the **last** stage's status. The agent reads `0`, concludes the pattern does not occur, and reports that absence as verified fact. Across 166 sampled sessions: 122 `rg` invocations, **39 measured cases of exit 0 with empty output**.

Adds `make`, `ripgrep`, `jq`, `python3`. `gcc`/`g++` stay deliberately absent — `install-rust.sh` provides clang as the image's `cc`. The stale comment there claiming the image "only has gcc from build-essential" is corrected.

## 2. Test-database resolution dialled a port nothing listens on

The Postgres sidecar is injected reliably and is ready before the worker starts — it was never the problem.

| source | value |
|---|---|
| Pod-injected `TEST_POSTGRES_URL` | `127.0.0.1:`**`5432`** (the sidecar) |
| `server/.cargo/config.toml` → `DJINN_TEST_DATABASE_URL` | `127.0.0.1:`**`5433`** |
| old resolution order | `DJINN_…` first |

Cargo's `[env]` table applies to every process cargo launches. So `cargo test` in a Pod always dialled `:5433` — where nothing listens — while running a compiled test binary **directly** worked, because cargo was not in the loop to inject the variable. That split is why in-Pod DB tests looked flaky when they were deterministic. Four sessions that manually exported `DJINN_TEST_DATABASE_URL="$TEST_POSTGRES_URL"` went green immediately.

Resolution is now single-sourced in `djinn_db::test_database_base_url()`, checking `TEST_POSTGRES_URL` first. CI and local dev never set it, so both fall through to `:5433` unchanged.

The precedence had been open-coded at **17 sites in four mutually inconsistent orderings** — five already had it right. All now call the helper.

## ⚠️ Credential rotation required

Ten of those sites carried a **live production connection string, password included**, as their fallback — so an unset variable pointed template-database setup at production. The literals are removed and the shared default is local-only, but **the credential is in git history and must be rotated independently of this PR.**

## Verification

- `cargo clippy --all-targets --features qdrant -- -D warnings` — exit 0
- `cargo check -p djinn-db --all-targets` — exit 0
- `cargo test -p djinn-image-builder` — 20 passed, goldens unchanged
- `cargo fmt`

## Follow-up

Generated images must be rebuilt (`retrigger_image_build`) for the tooling changes to reach Pods. Separately worth considering: the silent-`rg` class is a harness gap as much as a packaging one — a missing binary that answers "nothing found" with exit 0 will recur with the next absent tool.