### PR TITLE
fix: seed workspace git identity from task creator to prevent CLA-failing shell commits

### DIFF
--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -1289,6 +1289,30 @@ impl TaskRunSupervisor {
             );
         }
 
+        // Seed the workspace-local git identity so RAW shell `git` run by the
+        // in-pod agent (e.g. `git merge <sha>`) is authored as the task creator,
+        // matching the programmatic commit paths (proactive sync below, the
+        // post-worker auto-commit, the checkpoint) that already pass identity
+        // explicitly via env. Without this the agent's shell commits fall back
+        // to the pod's generic `Djinn Agent <djinn@djinn.task>` identity, which
+        // fails the repo's CLA check and hard-blocks the PR (observed on
+        // task/5qnq: a raw `git merge` merge commit authored as the bot). Only
+        // seeded when the host resolved a creator identity; absent → leave the
+        // config unset (current behavior). Best-effort; never fails the run.
+        if let (Some(name), Some(email)) = (
+            spec.commit_author_name.as_deref(),
+            spec.commit_author_email.as_deref(),
+        ) {
+            if let Err(e) = workspace.set_identity(GitIdentity { name, email }).await {
+                tracing::warn!(
+                    task_run_id = %run_id,
+                    task_id = %spec.task_id,
+                    error = %e,
+                    "supervisor: failed to seed workspace git identity (raw shell commits may fall back to the pod default)"
+                );
+            }
+        }
+
         // Reset tracked-file mtimes to their last-touched commit time so cargo's
         // path-crate fingerprints match the shared CARGO_TARGET_DIR across runs
         // (the ephemeral clone gave every file a fresh checkout mtime). Done

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -1302,15 +1302,14 @@ impl TaskRunSupervisor {
         if let (Some(name), Some(email)) = (
             spec.commit_author_name.as_deref(),
             spec.commit_author_email.as_deref(),
-        ) {
-            if let Err(e) = workspace.set_identity(GitIdentity { name, email }).await {
-                tracing::warn!(
-                    task_run_id = %run_id,
-                    task_id = %spec.task_id,
-                    error = %e,
-                    "supervisor: failed to seed workspace git identity (raw shell commits may fall back to the pod default)"
-                );
-            }
+        ) && let Err(e) = workspace.set_identity(GitIdentity { name, email }).await
+        {
+            tracing::warn!(
+                task_run_id = %run_id,
+                task_id = %spec.task_id,
+                error = %e,
+                "supervisor: failed to seed workspace git identity (raw shell commits may fall back to the pod default)"
+            );
         }
 
         // Reset tracked-file mtimes to their last-touched commit time so cargo's

--- a/server/crates/djinn-workspace/src/workspace.rs
+++ b/server/crates/djinn-workspace/src/workspace.rs
@@ -434,6 +434,32 @@ impl Workspace {
             .map(|_| ())
     }
 
+    /// Seed the workspace-local git identity (`user.name` + `user.email`).
+    ///
+    /// The programmatic commit paths ([`Workspace::commit`], the worker
+    /// checkpoint, the supervisor's proactive-sync merge) all pass identity
+    /// explicitly via `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env, so they are
+    /// authored correctly regardless of repo config. But the in-pod agent runs
+    /// RAW `git` (e.g. `git merge <sha>`) via its shell tool against this SAME
+    /// workspace, and those commits pick up whatever identity the pod happens
+    /// to carry — a generic default like `Djinn Agent <djinn@djinn.task>` —
+    /// which fails a repo's CLA check and hard-blocks the PR.
+    ///
+    /// Writing the resolved task-creator identity into the workspace-LOCAL
+    /// config (`git config user.*`, never `--global`) makes EVERY commit —
+    /// programmatic or raw-shell — author as the task creator. The config is
+    /// scoped to this ephemeral clone and discarded when it is torn down.
+    pub async fn set_identity(
+        &self,
+        identity: GitIdentity<'_>,
+    ) -> Result<(), EphemeralWorkspaceError> {
+        self.run_git(&["config", "user.name", identity.name], &[])
+            .await?;
+        self.run_git(&["config", "user.email", identity.email], &[])
+            .await?;
+        Ok(())
+    }
+
     /// Move HEAD to `ref_selector` in detached mode WITHOUT advancing any
     /// branch ref. Used by the resume-via-git worktree-setup path to land the
     /// workspace on a chosen checkpoint SHA / alternate checkpoint ref while
@@ -1209,6 +1235,64 @@ mod tests {
         git(pp, &["add", "-A"]);
         git(pp, &["commit", "-m", msg]);
         git(pp, &["push", "origin", "main"]);
+    }
+
+    /// Run `git <args>` in `dir` WITHOUT seeding any author identity in the
+    /// environment, so the repo's own config is the only identity source —
+    /// mirroring how the in-pod agent's raw shell `git` runs.
+    fn git_no_identity(dir: &Path, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .env_remove("GIT_AUTHOR_NAME")
+            .env_remove("GIT_AUTHOR_EMAIL")
+            .env_remove("GIT_COMMITTER_NAME")
+            .env_remove("GIT_COMMITTER_EMAIL")
+            .output()
+            .expect("spawn git")
+    }
+
+    #[tokio::test]
+    async fn set_identity_authors_raw_shell_commits_as_task_creator() {
+        let (_origin, clone, ws) = fixture();
+        let cp = clone.path();
+
+        ws.set_identity(GitIdentity {
+            name: "Ada Lovelace",
+            email: "1+ada@users.noreply.github.com",
+        })
+        .await
+        .expect("set_identity");
+
+        // The workspace-LOCAL config is what a RAW `git` invocation reads.
+        assert_eq!(
+            git(cp, &["config", "--local", "user.name"]).trim(),
+            "Ada Lovelace"
+        );
+        assert_eq!(
+            git(cp, &["config", "--local", "user.email"]).trim(),
+            "1+ada@users.noreply.github.com"
+        );
+
+        // A raw shell commit with NO author env — exactly what the in-pod agent
+        // does via its shell tool — must be authored as the seeded identity,
+        // not a pod default like `Djinn Agent <djinn@djinn.task>`.
+        write(cp, "agent.txt", "raw shell edit\n");
+        assert!(git_no_identity(cp, &["add", "-A"]).status.success());
+        let commit = git_no_identity(cp, &["commit", "-m", "raw shell commit"]);
+        assert!(
+            commit.status.success(),
+            "commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+
+        let author = git(cp, &["log", "-1", "--format=%an <%ae>"]);
+        assert_eq!(
+            author.trim(),
+            "Ada Lovelace <1+ada@users.noreply.github.com>",
+            "raw shell commit must be authored as the seeded task-creator identity"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Incident

On PR #2415 (branch `task/5qnq`), the merge commit `418bb35db` ("Merge commit '68fc0af25' into task/5qnq") was authored **and** committed as `Djinn Agent <djinn@djinn.task>`. That failed the repository's required CLA check and hard-blocked the PR (fixed manually by rewriting the commit). Every other commit on the branch was correctly authored as the task creator's GitHub noreply identity.

## Root cause

The platform's programmatic commit paths all pass identity **explicitly via `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env**:

- `Workspace::commit` (`djinn-workspace/src/workspace.rs`) — proactive-sync merge + post-worker auto-commit
- the worker checkpoint (`djinn-agent-worker/src/checkpoint.rs`)

Those env vars are inherited only by the git process the platform spawns. The **in-pod agent runs RAW `git` via its shell tool** (e.g. `git merge <sha>`) against the *same* ephemeral workspace clone. Those invocations don't get the env, and the ephemeral clone's local git config has **no `user.name` / `user.email`** — `MirrorManager::clone_ephemeral` never seeds one — so git falls back to whatever identity the pod carries (`Djinn Agent <djinn@djinn.task>`), producing CLA-failing commits.

Confirming detail: the incident commit message `Merge commit '68fc0af25' into task/5qnq` is git's **default** message for `git merge <sha>` — the agent's raw shell merge — whereas the programmatic proactive-sync uses `Merge {base} into {task_branch}`.

## Fix

Seed the workspace-**local** git identity right after the workspace is cloned and the task branch is ensured, reusing the already-resolved task-creator identity (`spec.commit_author_name` / `spec.commit_author_email`, derived host-side as `<id>+<login>@users.noreply.github.com`). Now **every** commit in the workspace — programmatic or raw-shell — is authored as the task creator.

- `djinn-workspace`: new `Workspace::set_identity(GitIdentity)` writing `git config user.name` / `user.email` (local only, never `--global`; discarded with the ephemeral clone).
- `djinn-supervisor`: `run_inner` calls it after `ensure_branch`, gated on a resolvable creator identity. When absent, config is left unset (unchanged fallback — no synthetic identity invented).
- Unit test: `set_identity_authors_raw_shell_commits_as_task_creator` proves a raw shell `git commit` (no author env, mirroring the in-pod agent) is authored as the seeded identity.

No repo-specific logic; the identity-derivation code is reused, not duplicated.

## Verification

- `cargo test -p djinn-workspace --lib set_identity_authors_raw_shell_commits_as_task_creator` — pass
- `cargo check -p djinn-supervisor` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
