### PR TITLE
fix(helm): probe timeouts + 2-core server request to stop liveness-kill storms

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -528,12 +528,22 @@ spec:
               port: api
             periodSeconds: 10
             initialDelaySeconds: 5
+            # The default 1s timeout fails spuriously when task-run pods
+            # oversubscribe the node during compile/link storms; /health is
+            # cheap, so a slow answer means CPU starvation, not sickness.
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
               port: api
             periodSeconds: 30
             initialDelaySeconds: 30
+            timeoutSeconds: 5
+            # 5 × 30s = 150s of sustained unresponsiveness before a restart.
+            # Every liveness restart wipes in-memory session-activity state
+            # and orphans the running worker fleet, so restarting the server
+            # must be a last resort, not a response to load spikes.
+            failureThreshold: 5
       volumes:
         - name: mirrors
           persistentVolumeClaim:

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -121,9 +121,12 @@ resources:
       # CPU requests are the CFS weight under contention. At 250m-500m the
       # server lost enough CPU during compile storms (a full worker fleet
       # linking at once) to fail its readiness probe — transient 521s observed
-      # in production. Pin the request to 1 full core so the long-lived
-      # controller keeps a guaranteed share while task-run pods burst.
-      cpu: "1"
+      # in production. 1 core was still not enough: with five task-run pods
+      # bursting past their requests the server missed 1s-deadline health
+      # probes for minutes at a stretch and was liveness-killed ~10×/day,
+      # orphaning every running session. 2 cores keeps the control plane
+      # responsive through full-fleet link storms.
+      cpu: "2"
       memory: "512Mi"
     limits:
       cpu: "2"


### PR DESCRIPTION
## Problem

djinn-server on the prod VPS has been liveness-killed **21 times in 2 days** (~10/day). Events show readiness/liveness probes failing with \`context deadline exceeded\` — the probes run with the k8s default \`timeoutSeconds: 1\`, and under full-fleet cargo compile/link storms (node load 16–19 on ~12 cores) the CPU-starved server can't answer /health within 1s, even though the handler is trivially cheap.

Each restart is catastrophic for the fleet: the coordinator's in-memory ActivityTracker and stall watermarks are wiped, so the post-restart stall sweep false-kills the entire generation of productive worker sessions (observed: sessions with 3.4M tokens of active work killed as \"stalled\"), which respawn, re-read multi-million-token contexts, and re-run builds — feeding the next load spike. Coordinator-side hardening lands separately; this PR removes the trigger.

## Changes

- \`timeoutSeconds: 5\` on both probes — a slow /health under node contention means CPU starvation, not a sick server.
- \`failureThreshold: 5\` on liveness (5 × 30s = 150s sustained unresponsiveness before restart) — restarting the control plane orphans the running fleet and must be a last resort.
- Server CPU request 1 → 2 cores. Node headroom verified: requests go 8.9 → 9.9 of 12 allocatable cores; task-run pods request 1 CPU each so scheduling is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)