### PR TITLE
fix(coordinator): reap and strike-exempt restart-orphaned pending attempts at startup

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -929,7 +929,11 @@ impl CoordinatorActor {
         // Reap pending task_attempts orphaned while this coordinator was down
         // (or wedged from before the reaper existed) so the respawn guard
         // unblocks those (task, role) pairs immediately after a deploy.
-        health::reap_orphaned_pending_attempts_for_startup(&self.db).await;
+        health::reap_orphaned_pending_attempts_for_startup(
+            &self.db,
+            &self.coordinator_incarnation_id,
+        )
+        .await;
         let startup_context = self.maintenance_context();
         health::reap_orphaned_taskrun_jobs_for_startup(&self.db, &startup_context).await;
         self.rehydrate_durable_dispatch_state().await;

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -44,22 +44,44 @@ impl CoordinatorActor {
             "crashed" => djinn_telemetry::dispatch::STRIKE_SOURCE_CRASHED,
             _ => djinn_telemetry::dispatch::STRIKE_SOURCE_OTHER_TERMINAL,
         };
-        let exempted = attempt.outcome == "interrupted"
-            && attempt
-                .dispatch_owner_incarnation_id
-                .as_deref()
-                .is_some_and(|owner| {
-                    attempt
-                        .summary_json
-                        .as_deref()
-                        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
-                        .is_some_and(|evidence| {
-                            evidence["failure_class"] == "environmental_owner_expired"
-                                && evidence["owner_incarnation_id"] == owner
-                                && evidence["owner_classification"] == "expired"
-                                && evidence["owner_lease_last_renewed_at"].is_string()
-                        })
-                });
+        // Environmental exemption: a restart/deploy interruption never books a
+        // dispatch strike. Two evidence tuples qualify, both deterministic:
+        //   1. environmental_owner_expired — a periodic/startup reap proved the
+        //      row's non-NULL owner lease expired beyond threshold.
+        //   2. environmental_restart_orphan — a STARTUP reap proved a pre-boot
+        //      orphan had no live owner under single-leader (owner NULL, missing,
+        //      or a different incarnation than the boot's). The recorded
+        //      `boot_incarnation_id` + startup reason is the proof; the owner may
+        //      legitimately be NULL, so no owner-field match is required here.
+        // Returns the distinct environmental source label when exempt so restart
+        // orphans and owner-expiry are counted on separate series.
+        let exempt_source = (attempt.outcome == "interrupted")
+            .then_some(attempt.summary_json.as_deref())
+            .flatten()
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+            .and_then(|evidence| {
+                let owner_expired = attempt
+                    .dispatch_owner_incarnation_id
+                    .as_deref()
+                    .is_some_and(|owner| {
+                        evidence["failure_class"] == "environmental_owner_expired"
+                            && evidence["owner_incarnation_id"] == owner
+                            && evidence["owner_classification"] == "expired"
+                            && evidence["owner_lease_last_renewed_at"].is_string()
+                    });
+                let restart_orphan = evidence["failure_class"]
+                    == "environmental_restart_orphan"
+                    && evidence["reason"] == "startup"
+                    && evidence["boot_incarnation_id"].is_string();
+                if owner_expired {
+                    Some(djinn_telemetry::dispatch::STRIKE_SOURCE_ENVIRONMENTAL_OWNER_EXPIRED)
+                } else if restart_orphan {
+                    Some(djinn_telemetry::dispatch::STRIKE_SOURCE_ENVIRONMENTAL_RESTART_ORPHAN)
+                } else {
+                    None
+                }
+            });
+        let exempted = exempt_source.is_some();
         Some(DispatchStrikeDecision {
             exempted,
             decision: if exempted {
@@ -67,11 +89,7 @@ impl CoordinatorActor {
             } else {
                 djinn_telemetry::dispatch::STRIKE_DECISION_COUNTED
             },
-            source: if exempted {
-                djinn_telemetry::dispatch::STRIKE_SOURCE_ENVIRONMENTAL_OWNER_EXPIRED
-            } else {
-                source
-            },
+            source: exempt_source.unwrap_or(source),
         })
     }
 }

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -42,6 +42,23 @@ const STARTUP_TASK_RUN_THRESHOLD_SECS: i64 = 10;
 /// while staying safely clear of any real starting attempt.
 const ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS: i64 = 5 * 60;
 
+/// Startup-only AGE gate for the orphaned-pending-attempt reaper, decoupled from
+/// the owner-lease liveness threshold above. At cold start any pre-boot `pending`
+/// attempt with no live (`starting`/`running`) `task_run` and no `running`
+/// session is definitionally orphaned: single-leader (advisory lock) means the
+/// previous incarnation is gone, startup task-run reaping
+/// ([`STARTUP_TASK_RUN_THRESHOLD_SECS`], which runs BEFORE this at boot) has
+/// already terminalized its runs, and nothing can ever advance the attempt.
+/// Mirrors the 10s task-run startup convention so a deploy that stranded a
+/// seconds-old dispatch self-heals at boot instead of surviving the 5-minute
+/// periodic age gate and wedging the respawn guard for ~15 min.
+///
+/// CRITICAL: only the AGE gate tightens. The owner-lease liveness check keeps
+/// [`ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS`] — a just-dead owner that renewed
+/// its lease 30s before the crash must not read "live" against a 10s window and
+/// get mis-stamped `crashed`. The two thresholds feed different predicates.
+const STARTUP_ORPHANED_PENDING_ATTEMPT_AGE_THRESHOLD_SECS: i64 = 10;
+
 pub(super) async fn renew_coordinator_incarnation(db: &djinn_db::Database, incarnation_id: &str) {
     let repository = djinn_db::CoordinatorIncarnationRepository::new(db.clone());
     match repository.renew(incarnation_id).await {
@@ -2809,40 +2826,102 @@ async fn reap_orphaned_pending_attempts(db: &djinn_db::Database) {
     .await;
 }
 
-/// Startup variant of [`reap_orphaned_pending_attempts`]. Runs with the same
-/// conservative threshold (a fresh boot proves nothing about a minutes-old
-/// dispatch on another coordinator instance behind the same DB), but firing
-/// at boot means long-orphaned rows self-heal immediately after a deploy
-/// instead of waiting for the first periodic stale sweep.
-pub(super) async fn reap_orphaned_pending_attempts_for_startup(db: &djinn_db::Database) {
-    reap_orphaned_pending_attempts_with_threshold(
+/// Startup variant of [`reap_orphaned_pending_attempts`]. Decouples the two
+/// thresholds ([`STARTUP_ORPHANED_PENDING_ATTEMPT_AGE_THRESHOLD_SECS`] age gate,
+/// [`ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS`] lease liveness) so a seconds-old
+/// pre-boot orphan self-heals at boot, and applies startup boot-evidence
+/// classification: single-leader means any pre-boot orphan whose owner is NULL,
+/// missing, or a DIFFERENT incarnation than this boot's cannot have a live owner
+/// (this process holds the advisory lock), so it is an environmental restart
+/// orphan — `interrupted` and strike-exempt, never a `crashed` penalty.
+///
+/// `current_incarnation_id` is this boot's immutable incarnation UUID, already
+/// registered by the time startup reaping runs (see `CoordinatorActor::run`).
+pub(super) async fn reap_orphaned_pending_attempts_for_startup(
+    db: &djinn_db::Database,
+    current_incarnation_id: &str,
+) {
+    reap_orphaned_pending_attempts_core(
         db,
-        ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS,
-        "startup",
+        OrphanReapParams {
+            age_threshold_secs: STARTUP_ORPHANED_PENDING_ATTEMPT_AGE_THRESHOLD_SECS,
+            lease_threshold_secs: ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS,
+            reason: "startup",
+            startup_incarnation_id: Some(current_incarnation_id),
+        },
     )
     .await;
 }
 
+/// Backstop entry point that keeps a single age/lease threshold and no startup
+/// boot evidence (the pre-existing periodic contract). The core reaper
+/// decouples the two, so this forwards the same value to both.
 pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
     db: &djinn_db::Database,
     threshold_secs: i64,
     reason: &'static str,
 ) {
-    let cutoff = time::OffsetDateTime::now_utc() - time::Duration::seconds(threshold_secs);
+    reap_orphaned_pending_attempts_core(
+        db,
+        OrphanReapParams {
+            age_threshold_secs: threshold_secs,
+            lease_threshold_secs: threshold_secs,
+            reason,
+            startup_incarnation_id: None,
+        },
+    )
+    .await;
+}
+
+/// Parameters for [`reap_orphaned_pending_attempts_core`]. The age gate and
+/// lease-liveness thresholds are decoupled (Part 1): the age gate decides WHICH
+/// pending rows are candidates; the lease threshold decides whether a candidate's
+/// owner is expired. `startup_incarnation_id` is `Some` only on the startup path
+/// and enables boot-evidence classification (Part 2).
+struct OrphanReapParams<'a> {
+    age_threshold_secs: i64,
+    lease_threshold_secs: i64,
+    reason: &'static str,
+    startup_incarnation_id: Option<&'a str>,
+}
+
+async fn reap_orphaned_pending_attempts_core(
+    db: &djinn_db::Database,
+    params: OrphanReapParams<'_>,
+) {
+    let OrphanReapParams {
+        age_threshold_secs,
+        lease_threshold_secs,
+        reason,
+        startup_incarnation_id,
+    } = params;
+
     let format = time::macros::format_description!(
         "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z"
     );
-    let threshold_iso = match cutoff.format(&format) {
+    let now = time::OffsetDateTime::now_utc();
+    // Age gate for `list_orphaned_pending` (tight at startup) and the durable
+    // lease-liveness gate for `is_live` (always the 5-minute owner window).
+    let age_threshold_iso = match (now - time::Duration::seconds(age_threshold_secs)).format(&format)
+    {
         Ok(s) => s,
         Err(e) => {
-            tracing::warn!(error = %e, "reap_orphaned_pending_attempts: failed to format threshold");
+            tracing::warn!(error = %e, "reap_orphaned_pending_attempts: failed to format age threshold");
             return;
         }
     };
+    let lease_threshold_iso =
+        match (now - time::Duration::seconds(lease_threshold_secs)).format(&format) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "reap_orphaned_pending_attempts: failed to format lease threshold");
+                return;
+            }
+        };
 
     let repo = djinn_db::TaskAttemptRepository::new(db.clone());
     let incarnation_repo = djinn_db::CoordinatorIncarnationRepository::new(db.clone());
-    let orphans = match repo.list_orphaned_pending(&threshold_iso).await {
+    let orphans = match repo.list_orphaned_pending(&age_threshold_iso).await {
         Ok(rows) => rows,
         Err(e) => {
             tracing::warn!(
@@ -2856,16 +2935,21 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
 
     // Evidence-based orphan classification (proposal 9gg5 / epic ars3).
     //
-    // Startup and periodic sweeps apply exactly the same owner-lease rule: only
-    // a non-NULL immutable owner whose durable lease is resolved AND expired
-    // beyond the supplied threshold may be stamped `interrupted` with
-    // `failure_class=environmental_owner_expired`. The `reason` argument is log
-    // context only and must never influence the exemption decision.
+    // Periodic sweep applies the strict owner-lease rule: only a non-NULL
+    // immutable owner whose durable lease is resolved AND expired beyond the
+    // lease threshold may be stamped `interrupted` /
+    // `failure_class=environmental_owner_expired`.
     //
     //   - Expired owner → interrupted / environmental_owner_expired
     //   - Live owner     → crashed / orphaned_pending_attempt
     //   - NULL, malformed, missing, lookup-error, or otherwise ambiguous
     //     ownership → crashed / orphaned_pending_attempt_unproven
+    //
+    // Startup sweep (`startup_incarnation_id` Some) additionally applies
+    // boot-evidence classification: single-leader means a pre-boot orphan whose
+    // owner is NULL, missing, or a DIFFERENT incarnation than this boot's cannot
+    // have a live owner, so it is stamped `interrupted` /
+    // `environmental_restart_orphan` and is strike-exempt.
     //
     // For a candidate with a non-NULL dispatch_group_id, reconcile pending
     // correlated peers with the transactional exact-group terminalization
@@ -2885,13 +2969,20 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
             continue;
         }
         // Resolve the durable owner lease for the evidence decision.
-        let (outcome, failure_class, summary, owner_evidence) =
-            classify_orphan_owner(&incarnation_repo, orphan, &threshold_iso).await;
+        let (outcome, failure_class, summary, owner_evidence) = classify_orphan_owner(
+            &incarnation_repo,
+            orphan,
+            OrphanClassifyCtx {
+                lease_threshold_iso: &lease_threshold_iso,
+                startup_incarnation_id,
+            },
+        )
+        .await;
 
         let summary_json = build_reap_evidence_json(
             reason,
-            threshold_secs,
-            &threshold_iso,
+            lease_threshold_secs,
+            &lease_threshold_iso,
             failure_class,
             &owner_evidence,
         );
@@ -2961,7 +3052,7 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
                         role = %orphan.role,
                         dispatch_key = %orphan.dispatch_key,
                         attempt_created_at = %orphan.created_at,
-                        threshold = %threshold_iso,
+                        threshold = %lease_threshold_iso,
                         outcome = %updated.outcome,
                         reason = reason,
                         "CoordinatorActor: reaped orphaned pending task_attempt"
@@ -3000,7 +3091,9 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
     // dispatches to redo it. `submitted` rows for poller-polled statuses
     // (`pr_draft`/`pr_review`) with a PR are strictly untouched (excluded by the
     // query). Forward-only + idempotent.
-    let submitted_orphans = match repo.list_orphaned_submitted_unowned(&threshold_iso).await {
+    // The submitted-orphan cleanup is age-based and owner-lease-agnostic; keep
+    // it on the (unchanged) lease-window threshold so startup does not tighten it.
+    let submitted_orphans = match repo.list_orphaned_submitted_unowned(&lease_threshold_iso).await {
         Ok(rows) => rows,
         Err(e) => {
             tracing::warn!(
@@ -3016,7 +3109,7 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
         let summary_json = serde_json::json!({
             "recovery_classifier": "orphaned_submitted_unowned_reaper",
             "reason": reason,
-            "threshold_secs": threshold_secs,
+            "threshold_secs": lease_threshold_secs,
             "failure_class": "orphaned_submitted_unowned",
         })
         .to_string();
@@ -3044,7 +3137,7 @@ pub(super) async fn reap_orphaned_pending_attempts_with_threshold(
                     role = %orphan.role,
                     dispatch_key = %orphan.dispatch_key,
                     attempt_created_at = %orphan.created_at,
-                    threshold = %threshold_iso,
+                    threshold = %lease_threshold_iso,
                     outcome = %updated.outcome,
                     reason = reason,
                     "CoordinatorActor: reaped poller-unowned submitted task_attempt to reopened"
@@ -3080,11 +3173,24 @@ struct OwnerLeaseEvidence {
     last_renewed_at: Option<String>,
     /// The incarnation's `registered_at` timestamp (present when resolved).
     registered_at: Option<String>,
+    /// This boot's incarnation id, recorded ONLY for a startup
+    /// `environmental_restart_orphan` classification. Its presence (with
+    /// `failure_class=environmental_restart_orphan` and `reason=startup`) is the
+    /// deterministic strike-exemption evidence for restart orphans.
+    boot_incarnation_id: Option<String>,
     /// Human-readable classification of why the owner was classified this way
     /// (expired / live / null_owner / malformed_owner / missing_owner /
-    /// lookup_error / ambiguous). For structured-log diagnostics only; not a
-    /// retry-accounting key.
+    /// lookup_error / ambiguous / restart_orphan_*). For structured-log
+    /// diagnostics only; not a retry-accounting key.
     classification: &'static str,
+}
+
+/// Inputs to [`classify_orphan_owner`]. The lease threshold is decoupled from
+/// the age gate (Part 1). `startup_incarnation_id` is `Some` only at boot and
+/// enables restart-orphan classification (Part 2).
+struct OrphanClassifyCtx<'a> {
+    lease_threshold_iso: &'a str,
+    startup_incarnation_id: Option<&'a str>,
 }
 
 /// Classify one orphaned pending attempt from its durable owner lease.
@@ -3094,7 +3200,7 @@ struct OwnerLeaseEvidence {
 async fn classify_orphan_owner(
     incarnation_repo: &djinn_db::CoordinatorIncarnationRepository,
     orphan: &djinn_db::OrphanedPendingAttempt,
-    threshold_iso: &str,
+    ctx: OrphanClassifyCtx<'_>,
 ) -> (
     djinn_core::models::task_attempt::TaskAttemptOutcome,
     &'static str,
@@ -3103,10 +3209,16 @@ async fn classify_orphan_owner(
 ) {
     use djinn_core::models::task_attempt::TaskAttemptOutcome;
 
-    let owner_id = match &orphan.dispatch_owner_incarnation_id {
-        Some(id) if uuid::Uuid::parse_str(id).is_ok() => id.as_str(),
+    let OrphanClassifyCtx {
+        lease_threshold_iso,
+        startup_incarnation_id,
+    } = ctx;
+
+    // Owner id from the row's own column. A malformed owner is a corruption
+    // signal and always fails closed.
+    let owner_id: Option<String> = match &orphan.dispatch_owner_incarnation_id {
+        Some(id) if uuid::Uuid::parse_str(id).is_ok() => Some(id.clone()),
         Some(_) => {
-            // Malformed owner UUID — ambiguous ownership, fail closed.
             return (
                 TaskAttemptOutcome::Crashed,
                 "orphaned_pending_attempt_unproven",
@@ -3117,25 +3229,80 @@ async fn classify_orphan_owner(
                 },
             );
         }
-        None => {
-            // NULL owner (legacy row or never-propagated) — ambiguous, fail closed.
+        None => None,
+    };
+
+    // Startup boot-evidence classification (Part 2). Single-leader: this process
+    // holds the advisory lock, so a pre-boot orphan (guaranteed by the age gate
+    // plus no live run/session) whose owner is NULL, missing, or a DIFFERENT
+    // incarnation than this boot's cannot have a live owner. It is an
+    // environmental restart orphan — `interrupted`, strike-exempt — never a
+    // `crashed` penalty (which is durable and survives further restarts). The
+    // lease liveness verdict is deliberately NOT consulted here: a just-dead
+    // previous incarnation whose lease still reads "live" against the 5-minute
+    // window is nonetheless definitively gone at our boot.
+    if let Some(current) = startup_incarnation_id {
+        // An owner equal to the current boot incarnation is impossible for a
+        // pre-boot row (random per-process UUID just registered): fail closed.
+        if owner_id.as_deref() == Some(current) {
             return (
                 TaskAttemptOutcome::Crashed,
                 "orphaned_pending_attempt_unproven",
-                "orphaned pending attempt reaped: no dispatch owner incarnation (legacy NULL)",
+                "orphaned pending attempt reaped: pre-boot orphan owned by the current \
+                 boot incarnation (ambiguous)",
                 OwnerLeaseEvidence {
-                    classification: "null_owner",
+                    owner_incarnation_id: owner_id,
+                    classification: "current_incarnation_startup",
                     ..Default::default()
                 },
             );
         }
+        let mut evidence = OwnerLeaseEvidence {
+            boot_incarnation_id: Some(current.to_string()),
+            ..Default::default()
+        };
+        match &owner_id {
+            Some(id) => {
+                evidence.owner_incarnation_id = Some(id.clone());
+                match incarnation_repo.get(id).await {
+                    Ok(Some(inc)) => {
+                        evidence.last_renewed_at = Some(inc.last_renewed_at.clone());
+                        evidence.registered_at = Some(inc.registered_at.clone());
+                        evidence.classification = "restart_orphan_different_incarnation";
+                    }
+                    _ => evidence.classification = "restart_orphan_missing_owner",
+                }
+            }
+            None => evidence.classification = "restart_orphan_null_owner",
+        }
+        return (
+            TaskAttemptOutcome::Interrupted,
+            "environmental_restart_orphan",
+            "orphaned pending attempt reaped at startup: pre-boot dispatch with no live \
+             owner under single-leader (environmental restart, no dispatch penalty)",
+            evidence,
+        );
+    }
+
+    // Periodic sweep: strict owner-lease rule. A NULL/missing owner fails closed.
+    let Some(owner_id) = owner_id else {
+        return (
+            TaskAttemptOutcome::Crashed,
+            "orphaned_pending_attempt_unproven",
+            "orphaned pending attempt reaped: no dispatch owner incarnation (legacy NULL)",
+            OwnerLeaseEvidence {
+                classification: "null_owner",
+                ..Default::default()
+            },
+        );
     };
+    let owner_id = owner_id.as_str();
 
     // Resolve the durable lease row for this owner.
     match incarnation_repo.get(owner_id).await {
         Ok(Some(inc)) => {
-            // Lease resolved — check liveness against the same orphan threshold.
-            match incarnation_repo.is_live(owner_id, threshold_iso).await {
+            // Lease resolved — check liveness against the owner-lease threshold.
+            match incarnation_repo.is_live(owner_id, lease_threshold_iso).await {
                 Ok(Some(true)) => {
                     // Live owner — the dispatch is still potentially owned.
                     // Count as crashed (genuine orphan with a live owner).
@@ -3148,6 +3315,7 @@ async fn classify_orphan_owner(
                             owner_incarnation_id: Some(inc.id.clone()),
                             last_renewed_at: Some(inc.last_renewed_at.clone()),
                             registered_at: Some(inc.registered_at.clone()),
+                            boot_incarnation_id: None,
                             classification: "live",
                         },
                     )
@@ -3164,6 +3332,7 @@ async fn classify_orphan_owner(
                             owner_incarnation_id: Some(inc.id.clone()),
                             last_renewed_at: Some(inc.last_renewed_at.clone()),
                             registered_at: Some(inc.registered_at.clone()),
+                            boot_incarnation_id: None,
                             classification: "expired",
                         },
                     )
@@ -3180,6 +3349,7 @@ async fn classify_orphan_owner(
                             owner_incarnation_id: Some(owner_id.to_string()),
                             last_renewed_at: Some(inc.last_renewed_at.clone()),
                             registered_at: Some(inc.registered_at.clone()),
+                            boot_incarnation_id: None,
                             classification: "ambiguous",
                         },
                     )
@@ -3195,6 +3365,7 @@ async fn classify_orphan_owner(
                             owner_incarnation_id: Some(owner_id.to_string()),
                             last_renewed_at: Some(inc.last_renewed_at.clone()),
                             registered_at: Some(inc.registered_at.clone()),
+                            boot_incarnation_id: None,
                             classification: "lookup_error",
                         },
                     )
@@ -3253,6 +3424,7 @@ fn build_reap_evidence_json(
         "owner_incarnation_id": evidence.owner_incarnation_id,
         "owner_lease_last_renewed_at": evidence.last_renewed_at,
         "owner_lease_registered_at": evidence.registered_at,
+        "boot_incarnation_id": evidence.boot_incarnation_id,
         "owner_classification": evidence.classification,
     })
     .to_string()

--- a/server/crates/djinn-coordinator/src/tests/deploy_interruptions_environmental.rs
+++ b/server/crates/djinn-coordinator/src/tests/deploy_interruptions_environmental.rs
@@ -112,6 +112,65 @@ async fn environmental_interrupt_reappearance_dispatches_without_streak_or_coold
     );
 }
 
+/// A startup restart-orphan (`environmental_restart_orphan` + startup boot
+/// evidence) has no owner-expiry tuple — its owner may legitimately be NULL — but
+/// the recorded boot evidence proves it was an environmental server restart. The
+/// same-role dispatch path must re-dispatch it once with no streak or cooldown.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn environmental_restart_orphan_reappearance_dispatches_without_streak_or_cooldown() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let (task, _project_path) =
+        create_simple_task(&db, &tx, "task", "worker interrupted by server restart").await;
+    let task = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx))
+        .set_status(&task.id, "needs_task_review")
+        .await
+        .unwrap();
+
+    let boot = uuid::Uuid::now_v7().to_string();
+    let evidence = serde_json::json!({
+        "failure_class": "environmental_restart_orphan",
+        "reason": "startup",
+        "boot_incarnation_id": boot,
+        "owner_classification": "restart_orphan_null_owner",
+    })
+    .to_string();
+    // NULL owner: exactly the mixed-version supervisor row the incident struck.
+    seed_terminal_attempt(
+        &db,
+        &task.id,
+        "reviewer",
+        TaskAttemptOutcome::Interrupted,
+        None,
+        Some(&evidence),
+    )
+    .await;
+
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    actor.last_dispatched.insert(
+        task.id.clone(),
+        DispatchMarker {
+            instant: StdInstant::now(),
+            role: "reviewer".to_owned(),
+        },
+    );
+
+    actor.dispatch_ready_tasks(None).await;
+
+    assert_eq!(
+        actor.dispatched, 1,
+        "a startup restart orphan must re-dispatch"
+    );
+    assert!(
+        !actor.dispatch_failure_streak.contains_key(&task.id),
+        "a startup restart orphan must not add a dispatch-failure streak"
+    );
+    assert!(
+        !actor.dispatch_cooldowns.contains_key(&task.id),
+        "a startup restart orphan must not apply an escalating cooldown"
+    );
+}
+
 /// A generic `interrupted` row has no durable owner-expiry proof. The actual
 /// same-role dispatch path must count it once, rather than using outcome alone.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/server/crates/djinn-coordinator/src/tests/session_reaping.rs
+++ b/server/crates/djinn-coordinator/src/tests/session_reaping.rs
@@ -7093,6 +7093,192 @@ async fn evidence_reap_null_owner_counts_as_crashed_unproven() {
     assert_eq!(sj["owner_classification"], "null_owner");
 }
 
+/// Startup boot-evidence classification (Part 2): a pre-boot orphan whose owner
+/// is a DIFFERENT incarnation than this boot's is an environmental restart
+/// orphan — `interrupted`/`environmental_restart_orphan` — even when the prior
+/// owner's lease still reads "live" (a just-dead incarnation renewed 30s before
+/// the crash). This is the exact incident case: the reap must NOT stamp
+/// `crashed` (durable, strike-counted) for a server-restart orphan.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_reap_classifies_different_incarnation_orphan_as_environmental_restart() {
+    use djinn_db::TaskAttemptRepository;
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskAttemptRepository::new(db.clone());
+
+    // Prior incarnation whose lease still reads LIVE against the 5-minute window
+    // (it renewed seconds before the crash). Under a single 10s startup
+    // threshold this owner would read "live" and mis-classify `crashed`.
+    let prior_owner = register_incarnation(&db, false).await;
+    let group_id = uuid::Uuid::now_v7().to_string();
+    let (task, _n) = create_task_with_note(&db, &tx, "restart-orphan-different").await;
+    let attempt = seed_pending_attempt_with_identity(
+        &db,
+        &task.id,
+        "worker",
+        Some(&prior_owner),
+        Some(&group_id),
+    )
+    .await;
+    // 30s old: past the 10s startup age gate, inside the 5m lease window.
+    djinn_db::test_support::backdate_task_attempt_created_at(&db, &attempt, "30 seconds").await;
+
+    // This boot's incarnation differs from the orphan's owner (single-leader).
+    let current = uuid::Uuid::now_v7().to_string();
+    crate::health::reap_orphaned_pending_attempts_for_startup(&db, &current).await;
+
+    let row = repo.get(&attempt).await.unwrap().unwrap();
+    assert_eq!(
+        row.outcome, "interrupted",
+        "a pre-boot different-incarnation orphan is environmental, not crashed"
+    );
+    let sj: serde_json::Value = serde_json::from_str(row.summary_json.as_deref().unwrap()).unwrap();
+    assert_eq!(sj["failure_class"], "environmental_restart_orphan");
+    assert_eq!(sj["owner_classification"], "restart_orphan_different_incarnation");
+    assert_eq!(sj["boot_incarnation_id"], current);
+    assert_eq!(sj["reason"], "startup");
+}
+
+/// Startup boot-evidence classification (Part 2): a pre-boot orphan with a NULL
+/// owner (a mixed-version supervisor `task-run:<id>` row, the k6hm case) is also
+/// an environmental restart orphan at boot — never `crashed`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_reap_classifies_null_owner_orphan_as_environmental_restart() {
+    use djinn_db::TaskAttemptRepository;
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskAttemptRepository::new(db.clone());
+
+    let (task, _n) = create_task_with_note(&db, &tx, "restart-orphan-null").await;
+    let attempt = seed_pending_attempt(&db, &task.id, "worker").await; // NULL owner
+    djinn_db::test_support::backdate_task_attempt_created_at(&db, &attempt, "30 seconds").await;
+
+    let current = uuid::Uuid::now_v7().to_string();
+    crate::health::reap_orphaned_pending_attempts_for_startup(&db, &current).await;
+
+    let row = repo.get(&attempt).await.unwrap().unwrap();
+    assert_eq!(row.outcome, "interrupted");
+    let sj: serde_json::Value = serde_json::from_str(row.summary_json.as_deref().unwrap()).unwrap();
+    assert_eq!(sj["failure_class"], "environmental_restart_orphan");
+    assert_eq!(sj["owner_classification"], "restart_orphan_null_owner");
+    assert_eq!(sj["boot_incarnation_id"], current);
+}
+
+/// Part 1 age-gate decoupling: the startup reap uses a 10s age gate, so a
+/// 30-second-old pre-boot orphan is reaped while a freshly-created (<10s) one is
+/// spared — the sub-threshold row could still be a legitimately-starting
+/// dispatch that has not yet registered its run/session.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn startup_reap_age_gate_reaps_thirty_second_orphan_spares_fresh() {
+    use djinn_db::TaskAttemptRepository;
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskAttemptRepository::new(db.clone());
+
+    let (task_old, _n) = create_task_with_note(&db, &tx, "age-gate-old").await;
+    let old = seed_pending_attempt(&db, &task_old.id, "worker").await;
+    djinn_db::test_support::backdate_task_attempt_created_at(&db, &old, "30 seconds").await;
+
+    let (task_new, _n) = create_task_with_note(&db, &tx, "age-gate-new").await;
+    let fresh = seed_pending_attempt(&db, &task_new.id, "worker").await; // ~0s old
+
+    let current = uuid::Uuid::now_v7().to_string();
+    crate::health::reap_orphaned_pending_attempts_for_startup(&db, &current).await;
+
+    assert_eq!(
+        repo.get(&old).await.unwrap().unwrap().outcome,
+        "interrupted",
+        "a 30s-old pre-boot orphan is past the 10s startup age gate → reaped"
+    );
+    assert_eq!(
+        repo.get(&fresh).await.unwrap().unwrap().outcome,
+        "pending",
+        "a sub-10s orphan is spared: it may still be a starting dispatch"
+    );
+}
+
+/// The `environmental_restart_orphan` startup evidence is strike-exempt (Part 2):
+/// a restart must never book a dispatch strike, even for a NULL-owner row where
+/// the owner-expiry tuple cannot be satisfied.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn latest_attempt_strike_decision_exempts_environmental_restart_orphan() {
+    use djinn_core::models::task_attempt::TaskAttemptOutcome;
+    use djinn_db::{TaskAttemptRepository, TerminalTaskAttemptParams};
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let actor = coordinator_actor_for_tests(&db, &tx);
+
+    // Reproduce the durable evidence the startup reaper writes for a NULL-owner
+    // restart orphan.
+    let boot = uuid::Uuid::now_v7().to_string();
+    let evidence = format!(
+        r#"{{"failure_class":"environmental_restart_orphan","reason":"startup","boot_incarnation_id":"{boot}","owner_classification":"restart_orphan_null_owner"}}"#
+    );
+    let (task, _n) = create_task_with_note(&db, &tx, "restart-orphan-strike").await;
+    let attempt = seed_pending_attempt(&db, &task.id, "reviewer").await; // NULL owner
+    TaskAttemptRepository::new(db.clone())
+        .advance_to_terminal(TerminalTaskAttemptParams {
+            id: &attempt,
+            outcome: TaskAttemptOutcome::Interrupted,
+            pr_url: None,
+            submit_ref: None,
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: None,
+            summary_json: Some(&evidence),
+            log_tail: None,
+        })
+        .await
+        .unwrap();
+
+    let decision = actor
+        .latest_attempt_strike_decision(&task.id, "reviewer")
+        .await
+        .unwrap();
+    assert!(
+        decision.exempted,
+        "a startup restart orphan must be strike-exempt"
+    );
+    assert_eq!(
+        decision.decision,
+        djinn_telemetry::dispatch::STRIKE_DECISION_EXEMPTED
+    );
+
+    // A restart-orphan class WITHOUT the boot evidence must fail closed.
+    let (task2, _n) = create_task_with_note(&db, &tx, "restart-orphan-noboot").await;
+    let a2 = seed_pending_attempt(&db, &task2.id, "reviewer").await;
+    TaskAttemptRepository::new(db.clone())
+        .advance_to_terminal(TerminalTaskAttemptParams {
+            id: &a2,
+            outcome: TaskAttemptOutcome::Interrupted,
+            pr_url: None,
+            submit_ref: None,
+            checkpoint_ref: None,
+            mirror_head_sha: None,
+            github_head_sha: None,
+            summary: None,
+            summary_json: Some(
+                r#"{"failure_class":"environmental_restart_orphan","reason":"periodic"}"#,
+            ),
+            log_tail: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        !actor
+            .latest_attempt_strike_decision(&task2.id, "reviewer")
+            .await
+            .unwrap()
+            .exempted,
+        "restart-orphan evidence without startup boot proof must fail closed"
+    );
+}
+
 /// A malformed owner UUID is counted `crashed/orphaned_pending_attempt_unproven`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn evidence_reap_malformed_owner_counts_as_crashed_unproven() {

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -1543,6 +1543,7 @@ pub mod dispatch {
     pub const STRIKE_DECISION_COUNTED: &str = "counted";
     pub const STRIKE_DECISION_EXEMPTED: &str = "exempted";
     pub const STRIKE_SOURCE_ENVIRONMENTAL_OWNER_EXPIRED: &str = "environmental_owner_expired";
+    pub const STRIKE_SOURCE_ENVIRONMENTAL_RESTART_ORPHAN: &str = "environmental_restart_orphan";
     pub const STRIKE_SOURCE_SPAWN_FAILED: &str = "spawn_failed";
     pub const STRIKE_SOURCE_CRASHED: &str = "crashed";
     pub const STRIKE_SOURCE_OTHER_TERMINAL: &str = "other_terminal";


### PR DESCRIPTION
## Incident (2026-07-21, all verified live)

The djinn-server coordinator was liveness-probe-killed repeatedly. Each restart stranded `task_attempts` rows in `pending`, wedging dispatch:

1. Old incarnation ran 22:03→22:51 UTC, created pending attempts for no8i (22:47:14) and k6hm (22:49:12), then was killed.
2. New incarnation booted 22:51:38. Its startup reap correctly reaped OLDER pending attempts (22:19–22:42) as `interrupted`/`environmental_owner_expired`, but the 22:47/22:49 attempts were younger than the shared 5-minute age gate, so they SURVIVED boot even though their backing runs had already been startup-reaped and their Jobs deleted. For ~15 min every ready pass logged `respawn_guard: non-terminal attempt already exists — deferring dispatch`.
3. At 23:06:42 the periodic sweep finally reaped them but classified all four rows `crashed` (fail-closed) instead of environmental, even though the owner had been dead 15 min. `crashed` is strike-counted: k6hm landed on a durable dispatch-cooldown ladder that survived a later restart. A restart (environmental) must never book strikes.

## What each part changes

**Part 1 — startup age gate decoupled from lease liveness** (`health.rs`). New `STARTUP_ORPHANED_PENDING_ATTEMPT_AGE_THRESHOLD_SECS = 10`. The reaper core now takes separate `age_threshold_secs` (which rows are candidates) and `lease_threshold_secs` (owner-lease `is_live` window). Startup passes `age=10s, lease=5m`; periodic/backstop pass the same value to both (unchanged). The critical subtlety is handled: a just-dead owner that renewed its lease 30s before the crash is still evaluated for liveness against the 5-minute window, never the 10s age window. Startup task-run reaping already runs BEFORE attempt reaping at boot (`actor.rs` 918 before 922), so the age-gate `NOT EXISTS live task_run` predicate is satisfied.

**Part 2 — startup boot-evidence classification** (`health.rs`, `retry.rs`, `telemetry`). `reap_orphaned_pending_attempts_for_startup` now takes the current incarnation id. At startup, single-leader (advisory lock) guarantees any pre-boot orphan whose owner is NULL, missing, or a DIFFERENT incarnation than this boot's has no live owner — so it is stamped `interrupted` / `environmental_restart_orphan` with `boot_incarnation_id` recorded, deliberately NOT consulting lease liveness (a just-dead owner reading "live" is nonetheless gone at our boot). The strike-decision predicate in `latest_attempt_strike_decision` is extended to exempt this evidence tuple (`failure_class=environmental_restart_orphan` + `reason=startup` + `boot_incarnation_id` string), with no owner-column match required since the owner may legitimately be NULL. A distinct `environmental_restart_orphan` strike source keeps its telemetry series separate. The periodic sweep keeps its strict fail-closed owner-lease rule unchanged.

**Part 3 — periodic-sweep root cause** (diagnosis; no periodic behavior change).

## Part 3 root-cause finding

The periodic sweep stamped `crashed`/`orphaned_pending_attempt_unproven` because the supervisor-created `task-run:<run_id>` attempt rows carried a NULL `dispatch_owner_incarnation_id` on fresh dispatches: `supervisor_runner.rs:1108-1109` reads owner/group from `resume_lifecycle_metadata` via `validated_dispatch_identity`, which returns `(None, None)` when that metadata is absent — and on the incident's code, fresh dispatches never populated it, so `classify_orphan_owner`'s NULL-owner branch fails closed to `crashed`. This is already fixed on current main: `task_dispatch.rs:2820-2821` injects `dispatch_owner_incarnation_id` and `dispatch_group_id` into `resume_lifecycle_metadata` for every dispatch, threaded through `dispatch_with_resume_metadata` → `dispatch_task_runtime` → `TaskRunSpecInputs::resolve` → `create_or_get_pending` (`supervisor_runner.rs:1115-1128`), so supervisor rows now carry the same non-NULL owner and share the coordinator-key row's group. The periodic path therefore stays fail-closed and unchanged; Parts 1+2 additionally ensure such orphans are reaped as strike-exempt restart orphans at STARTUP before they can ever reach the periodic sweep.

## Test evidence

`SQLX_OFFLINE=true cargo test -p djinn-coordinator --lib` (against a local postgres:16):

- New: `startup_reap_classifies_different_incarnation_orphan_as_environmental_restart`, `startup_reap_classifies_null_owner_orphan_as_environmental_restart`, `startup_reap_age_gate_reaps_thirty_second_orphan_spares_fresh`, `latest_attempt_strike_decision_exempts_environmental_restart_orphan`, `environmental_restart_orphan_reappearance_dispatches_without_streak_or_cooldown` — all pass.
- Regression: full `session_reaping` suite (109 passed), all `deploy_interruptions_environmental` (4 passed), `evidence_reap_*` + `latest_attempt_strike_decision_requires_complete_owner_expiry_tuple` (15 passed).
- `cargo check -p djinn-coordinator` and `cargo clippy -p djinn-coordinator --lib` clean; file-size guard passes.

## Risk

Low. The periodic path is byte-for-byte unchanged (backstop wrapper forwards one threshold to both gates, `startup_incarnation_id=None`). The startup path only ever UPGRADES a would-be `crashed` to strike-exempt `interrupted` for pre-boot orphans, which single-leader proves are ownerless — it never suppresses a genuine same-incarnation strike (the `owner == current boot incarnation` case fails closed). The 10s startup age gate spares sub-10s rows that could still be legitimately-starting dispatches. Shared-process telemetry counters made one existing delta-assertion test race until the restart-orphan source was split onto its own series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
