### PR TITLE
fix: warm-Job watcher deadline follows configured Job timeout

### DIFF
--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -61,7 +61,10 @@ pub struct KubernetesConfig {
     /// run in the background and don't affect worker latency, so a generous
     /// deadline is safe. Tunable per deployment via
     /// `DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS`; raise it if a larger workspace
-    /// consistently hits the deadline.
+    /// consistently hits the deadline. This sets the Job's
+    /// `activeDeadlineSeconds`; the in-process watcher deadline follows it
+    /// (plus a small grace) so a long warm run is not declared failed while the
+    /// Job is still legitimately running.
     pub warm_job_timeout_seconds: i64,
     /// MySQL DSN forwarded to the warm Pod so `djinn-agent-worker
     /// warm-graph` can reuse the server's backing MySQL instance.

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -243,7 +243,9 @@ pub use graph_warmer_lifecycle::{
     KubeClientJobWatcher, NoopJobWatcher, WarmJobWatcher, WarmTerminalOutcome,
 };
 #[cfg(test)]
-use graph_warmer_lifecycle::{WarmJobObservation, terminal_outcome_after_poll};
+use graph_warmer_lifecycle::{
+    WATCH_DEADLINE_SLACK, WarmJobObservation, terminal_outcome_after_poll, watch_deadline,
+};
 
 /// In-process convergence hook invoked when a warm Job reaches terminal
 /// success. The canonical-graph warm runs in a *separate* K8s Job pod that
@@ -811,7 +813,10 @@ impl K8sGraphWarmer {
     /// path). Reads the merge-storm debounce policy from the environment.
     pub fn new(client: kube::Client, config: KubernetesConfig, db: Database) -> Self {
         let dispatcher = Arc::new(KubeClientDispatcher::new(client.clone()));
-        let watcher = Arc::new(KubeClientJobWatcher::new(client.clone()));
+        let watcher = Arc::new(KubeClientJobWatcher::new(
+            client.clone(),
+            config.warm_job_timeout_seconds,
+        ));
         let lister: Arc<dyn WarmJobLister> = Arc::new(KubeClientWarmJobLister::new(client.clone()));
         let mut w = Self::with_dispatcher_and_lister(config, db, dispatcher, watcher, Some(lister));
         w.client = Some(client);

--- a/server/crates/djinn-k8s/src/graph_warmer_lifecycle.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_lifecycle.rs
@@ -14,8 +14,12 @@ use tracing::{debug, warn};
 /// Interval used by the Job-watcher loop to poll `.status.succeeded` /
 /// `.status.failed`.
 const WATCH_POLL_INTERVAL: Duration = Duration::from_secs(2);
-/// Backstop cap on watcher polling if the apiserver keeps returning errors.
-const WATCH_DEADLINE: Duration = Duration::from_secs(3600);
+/// Grace added on top of the Job's `activeDeadlineSeconds` to derive the
+/// watcher deadline. `activeDeadlineSeconds` bounds the Job itself — after it
+/// expires the apiserver marks the Job Failed — so the watcher should outlive
+/// that moment slightly to report the apiserver's real terminal verdict
+/// instead of manufacturing one.
+pub(super) const WATCH_DEADLINE_SLACK: Duration = Duration::from_secs(300);
 
 /// Terminal outcome reported by a [`WarmJobWatcher`]. Drives the in-process
 /// convergence hook: on [`WarmTerminalOutcome::Succeeded`] the warm Job pod has
@@ -57,11 +61,24 @@ pub trait WarmJobWatcher: Send + Sync {
 /// [`WATCH_POLL_INTERVAL`].
 pub struct KubeClientJobWatcher {
     client: kube::Client,
+    /// How long to keep polling before failing conservatively. Follows the
+    /// Job's `activeDeadlineSeconds` plus [`WATCH_DEADLINE_SLACK`] so the
+    /// watcher outlives the Job it observes.
+    deadline: Duration,
+}
+
+/// Derive the watcher deadline from the Job's configured
+/// `activeDeadlineSeconds` (`KubernetesConfig::warm_job_timeout_seconds`).
+pub(super) fn watch_deadline(job_timeout_seconds: i64) -> Duration {
+    Duration::from_secs(job_timeout_seconds.max(0) as u64) + WATCH_DEADLINE_SLACK
 }
 
 impl KubeClientJobWatcher {
-    pub fn new(client: kube::Client) -> Self {
-        Self { client }
+    pub fn new(client: kube::Client, job_timeout_seconds: i64) -> Self {
+        Self {
+            client,
+            deadline: watch_deadline(job_timeout_seconds),
+        }
     }
 }
 
@@ -105,7 +122,7 @@ pub(super) fn terminal_outcome_after_poll(
 impl WarmJobWatcher for KubeClientJobWatcher {
     async fn wait_terminal(&self, namespace: &str, job_name: &str) -> WarmTerminalOutcome {
         let api: Api<Job> = Api::namespaced(self.client.clone(), namespace);
-        let deadline = SystemClock::new().now_instant() + WATCH_DEADLINE;
+        let deadline = SystemClock::new().now_instant() + self.deadline;
         loop {
             let observation = match api.get(job_name).await {
                 Ok(job) => {

--- a/server/crates/djinn-k8s/src/graph_warmer_tests.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use djinn_core::events::EventBus;
 use djinn_db::RepoGraphCacheInsert;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 type CapturedJobs = Arc<Mutex<Vec<(String, Job)>>>;
 
@@ -170,6 +170,21 @@ fn watcher_poll_retries_transient_errors_and_respects_deadline() {
         terminal_outcome_after_poll(WarmJobObservation::ApiError, true),
         Some(WarmTerminalOutcome::Failed),
         "persistent API errors cannot extend polling past the deadline"
+    );
+}
+
+#[test]
+fn watch_deadline_follows_configured_job_timeout_plus_slack() {
+    assert_eq!(
+        watch_deadline(7200),
+        Duration::from_secs(7200) + WATCH_DEADLINE_SLACK,
+        "the watcher deadline tracks the Job's activeDeadlineSeconds so a long \
+         warm run reports the apiserver's verdict rather than a manufactured one"
+    );
+    assert_eq!(
+        watch_deadline(-1),
+        WATCH_DEADLINE_SLACK,
+        "a non-positive timeout clamps to zero before adding slack"
     );
 }
 


### PR DESCRIPTION
## What was wrong

The coordinator's warm-Job watcher (`KubeClientJobWatcher::wait_terminal`) used a hard-coded `WATCH_DEADLINE = 3600s`, while the Kubernetes Job it observes is allowed `activeDeadlineSeconds` derived from `KubernetesConfig::warm_job_timeout_seconds` — 7200s in production (helm sets `DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS=7200`). Any warm run longer than one hour was declared `Failed` by the watcher while the Job pod was still legitimately running.

Live incident 2026-07-22: a warm Job started ~10:13Z; the watcher logged "deadline exceeded" at 11:12:31Z and reported `Failed`, yet the Job pod was still `Running` and productive at 11:30Z.

## The fix

- `KubeClientJobWatcher` gains a `deadline` field. `KubeClientJobWatcher::new` now takes the configured Job timeout (`config.warm_job_timeout_seconds`, passed from `K8sGraphWarmer::new`) and derives `deadline = max(0, job_timeout) + WATCH_DEADLINE_SLACK`, where `WATCH_DEADLINE_SLACK` is a new 300s constant. The slack lets the watcher outlive the Job's `activeDeadlineSeconds` moment so it reports the apiserver's real terminal verdict rather than manufacturing one.
- `wait_terminal` uses `self.deadline`; the unused `WATCH_DEADLINE` constant is removed (`WATCH_POLL_INTERVAL` kept).
- Doc comment on `warm_job_timeout_seconds` in `config.rs` now notes the watcher deadline follows it.
- New unit test `watch_deadline_follows_configured_job_timeout_plus_slack` proves the derivation (timeout + slack, and negative-timeout clamping). It is apiserver-free like the existing lifecycle tests.

Only one production construction site of `KubeClientJobWatcher` exists; tests use `NoopJobWatcher`. Verified no other `KubeClientJobWatcher::new` / `WATCH_DEADLINE` references remain.

## Verification

- `cargo check -p djinn-k8s` — clean
- `cargo clippy -p djinn-k8s --all-targets` — no new warnings
- `cargo test -p djinn-k8s --lib` — all apiserver-free tests pass (the new deadline test + existing lifecycle tests). The 22 failures in this crate are pre-existing DB-connection-refused tests requiring Postgres; not run against live infra per policy.
- `cargo fmt` on touched files