### PR TITLE
fix(coordinator): survive slow ticks without self-re-election reaping in-flight dispatches

### DIFF
--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -865,14 +865,54 @@ impl CoordinatorActor {
         }
     }
 
-    /// Renew this runtime's immutable incarnation lease on the maintenance cadence.
-    async fn renew_coordinator_incarnation(&self) {
-        health::renew_coordinator_incarnation(&self.db, &self.coordinator_incarnation_id).await;
+    /// Spawn the dedicated incarnation-lease renewal task.
+    ///
+    /// Renewal must NOT live on the coordinator mailbox / tick path. It used to
+    /// piggy-back on the 15-minute [`STALE_SWEEP_INTERVAL`] inside `run_tick`,
+    /// so this live coordinator's own lease was always ~15 min stale by the time
+    /// the orphan reaper (same sweep, run first) checked it against the 5-minute
+    /// [`health::ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS`] liveness window. The
+    /// reaper then read the live owner as "expired" and stamped its in-flight
+    /// pending dispatch groups `interrupted` / `environmental_owner_expired` — a
+    /// strike-exempt outcome that let genuinely-failing tasks loop
+    /// dispatch→reap forever without ever accumulating a strike.
+    ///
+    /// A dedicated task renewing every
+    /// [`health::COORDINATOR_INCARNATION_RENEWAL_INTERVAL`] (60s, 5x under the
+    /// expiry window) cannot be starved by a slow tick or the heavy stale sweep,
+    /// so the live owner reads truthfully live. It is scoped to the actor's
+    /// cancellation token: when the process/leader stops, renewal stops and the
+    /// lease correctly expires for the next boot's startup reaper.
+    fn spawn_incarnation_renewal(&self) {
+        let db = self.db.clone();
+        let incarnation_id = self.coordinator_incarnation_id.clone();
+        let cancel = self.cancel.clone();
+        tokio::spawn(async move {
+            let mut ticker = time::interval(health::COORDINATOR_INCARNATION_RENEWAL_INTERVAL);
+            // A delayed renewal must not fire a catch-up burst; one on-time
+            // renewal restores liveness.
+            ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+            // The first tick is immediate; startup already registered the lease,
+            // so skip it and renew on the cadence thereafter.
+            ticker.tick().await;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => break,
+                    _ = ticker.tick() => {
+                        health::renew_coordinator_incarnation(&db, &incarnation_id).await;
+                    }
+                }
+            }
+        });
     }
 
     pub(super) async fn run(mut self) {
         tracing::info!("CoordinatorActor started");
         self.register_coordinator_incarnation().await;
+        // Keep the incarnation lease fresh from a dedicated task so a slow tick
+        // never lets the reaper read this live coordinator as expired.
+        self.spawn_incarnation_renewal();
 
         let _startup_imports_complete = match ProjectRepository::new(
             self.db.clone(),
@@ -1105,8 +1145,11 @@ impl CoordinatorActor {
         self.poll_pr_statuses().await;
         if self.last_stale_sweep.elapsed() >= STALE_SWEEP_INTERVAL {
             let app_state = self.maintenance_context();
+            // The incarnation lease is NOT renewed here: it lives on the
+            // dedicated `spawn_incarnation_renewal` task so a slow tick or this
+            // heavy sweep can never let the reaper (run inside
+            // `sweep_stale_resources`) read this live coordinator as expired.
             health::sweep_stale_resources(&self.db, &app_state).await;
-            self.renew_coordinator_incarnation().await;
             self.last_stale_sweep = SystemClock::new().now_instant();
         }
         if self.last_auto_dispatch_sweep.elapsed() >= AUTO_DISPATCH_SWEEP_INTERVAL {
@@ -2512,7 +2555,7 @@ mod tests {
         );
 
         tokio::time::sleep(StdDuration::from_millis(10)).await;
-        first.renew_coordinator_incarnation().await;
+        health::renew_coordinator_incarnation(&first.db, &first.coordinator_incarnation_id).await;
         let first_after_first = leases
             .get(&first.coordinator_incarnation_id)
             .await
@@ -2538,7 +2581,7 @@ mod tests {
         );
 
         tokio::time::sleep(StdDuration::from_millis(10)).await;
-        second.renew_coordinator_incarnation().await;
+        health::renew_coordinator_incarnation(&second.db, &second.coordinator_incarnation_id).await;
         let first_after_second = leases
             .get(&first.coordinator_incarnation_id)
             .await

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -59,6 +59,26 @@ const ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS: i64 = 5 * 60;
 /// get mis-stamped `crashed`. The two thresholds feed different predicates.
 const STARTUP_ORPHANED_PENDING_ATTEMPT_AGE_THRESHOLD_SECS: i64 = 10;
 
+/// How often the live coordinator renews its immutable incarnation lease.
+///
+/// MUST stay comfortably below [`ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS`] (the
+/// 5-minute owner-lease liveness window). The orphan reaper reads an incarnation
+/// as "expired" once its `last_renewed_at` is older than that threshold and then
+/// reaps the *live* coordinator's OWN pending dispatch groups, mis-stamping them
+/// `interrupted` / `environmental_owner_expired` — a **strike-exempt** outcome
+/// (see `dispatch::retry::latest_attempt_strike_decision`). A genuinely-failing
+/// task whose reaps are all strike-exempt never accumulates a strike, so it never
+/// routes to Planner intervention and loops dispatch→reap forever.
+///
+/// Renewal previously piggy-backed on the 15-minute [`STALE_SWEEP_INTERVAL`]
+/// inside the coordinator tick, so the live owner's lease was always ~15 min
+/// stale (>5 min) at reap time — the whole board's periodic reaps mis-classified
+/// as environmental. Renewing every 60s from a dedicated task (never the mailbox
+/// / tick path, which a slow tick or the heavy stale sweep can starve) keeps a 5x
+/// margin under the expiry window so the live owner reads truthfully live.
+pub(super) const COORDINATOR_INCARNATION_RENEWAL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(60);
+
 pub(super) async fn renew_coordinator_incarnation(db: &djinn_db::Database, incarnation_id: &str) {
     let repository = djinn_db::CoordinatorIncarnationRepository::new(db.clone());
     match repository.renew(incarnation_id).await {
@@ -1124,6 +1144,30 @@ mod cargo_cache_health_tests {
         let age =
             compute_warm_base_age_secs(Path::new("/nonexistent/path/xyz"), 1_700_000_000).await;
         assert!(age.is_none());
+    }
+
+    // ── Incarnation-lease renewal cadence invariant ─────────────────────
+
+    /// The live coordinator must renew its incarnation lease well within the
+    /// orphan reaper's owner-lease liveness window. If renewal ever lags the
+    /// window, the reaper reads this live coordinator as "expired" and reaps its
+    /// own in-flight dispatches as strike-exempt `environmental_owner_expired`,
+    /// letting a genuinely-failing task loop dispatch→reap forever (the
+    /// 2026-07-22 k6hm incident: renewal was on the 15-min stale sweep while the
+    /// window is 5 min). Guard the invariant with a generous 2x safety margin.
+    #[test]
+    fn incarnation_renewal_interval_is_safely_below_orphan_expiry() {
+        let renewal_secs = COORDINATOR_INCARNATION_RENEWAL_INTERVAL.as_secs() as i64;
+        assert!(
+            renewal_secs > 0,
+            "renewal interval must be positive; got {renewal_secs}s"
+        );
+        assert!(
+            renewal_secs * 2 <= ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS,
+            "incarnation renewal ({renewal_secs}s) must renew at least twice within the \
+             orphan-expiry window ({ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS}s) so the live \
+             owner never reads expired between renewals"
+        );
     }
 
     // ── Hit-rate aggregation ────────────────────────────────────────────

--- a/server/crates/djinn-coordinator/src/tests/incarnation_lease_liveness.rs
+++ b/server/crates/djinn-coordinator/src/tests/incarnation_lease_liveness.rs
@@ -1,0 +1,144 @@
+//! Regression coverage for the 2026-07-22 self-reap incident.
+//!
+//! The single live coordinator renewed its incarnation lease only on the 15-min
+//! stale sweep, while the orphan reaper reads a lease as "expired" after 5 min.
+//! So the live owner's lease was always stale at reap time and its own orphaned
+//! pending dispatches were mis-stamped `interrupted` / `environmental_owner_expired`
+//! — a strike-exempt outcome that let a genuinely-failing task loop forever.
+//!
+//! The fix renews the lease every 60s from a dedicated task, so a live owner
+//! reads truthfully live and its genuine orphans classify as `crashed`
+//! (strike-counting). These tests pin the reaper's owner-liveness contract that
+//! the renewal cadence exists to satisfy: a freshly-renewed owner reaps as
+//! `crashed`; a stale owner reaps as environmental `interrupted`.
+
+use super::*;
+use djinn_db::{CoordinatorIncarnationRepository, CreateTaskAttemptParams, TaskAttemptRepository};
+
+/// Threshold used for both the age gate and the lease-liveness window in these
+/// tests. Small so the tests stay fast while leaving a comfortable margin over
+/// the post-seed sleep.
+const REAP_THRESHOLD_SECS: i64 = 2;
+
+/// Seed a `pending` attempt owned by `owner`, with no live task_run/session, so
+/// it is an orphan-reaper candidate once older than the age gate.
+async fn seed_pending_attempt(db: &Database, task_id: &str, owner: &str) -> String {
+    let id = uuid::Uuid::now_v7().to_string();
+    let dispatch_key = format!("{task_id}:lead:{id}");
+    TaskAttemptRepository::new(db.clone())
+        .create_or_get_pending(CreateTaskAttemptParams {
+            id: &id,
+            task_id,
+            role: "lead",
+            dispatch_key: &dispatch_key,
+            session_id: None,
+            attempt_seq: None,
+            dispatch_owner_incarnation_id: Some(owner),
+            dispatch_group_id: None,
+        })
+        .await
+        .unwrap();
+    id
+}
+
+async fn reaped_attempt(db: &Database, task_id: &str, attempt_id: &str) -> (String, String) {
+    let attempts = TaskAttemptRepository::new(db.clone())
+        .list_for_task(task_id)
+        .await
+        .unwrap();
+    let attempt = attempts
+        .into_iter()
+        .find(|a| a.id == attempt_id)
+        .expect("seeded attempt must still exist");
+    let failure_class = attempt
+        .summary_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|v| v["failure_class"].as_str().map(str::to_owned))
+        .unwrap_or_default();
+    (attempt.outcome, failure_class)
+}
+
+/// A live owner (lease renewed within the liveness window) must reap its
+/// orphaned pending attempt as `crashed` / `orphaned_pending_attempt` — a
+/// strike-counting outcome — never as strike-exempt environmental interruption.
+/// This is what the 60s renewal cadence guarantees in production.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn live_owner_orphan_reaps_as_crashed_not_environmental() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(16);
+    let (task, _path) = create_simple_task(&db, &tx, "task", "live owner orphan").await;
+
+    let owner = uuid::Uuid::now_v7().to_string();
+    CoordinatorIncarnationRepository::new(db.clone())
+        .register(&owner)
+        .await
+        .unwrap();
+    let attempt_id = seed_pending_attempt(&db, &task.id, &owner).await;
+
+    // Age the attempt past the gate, then renew so the owner reads live — the
+    // production invariant the dedicated renewal task upholds.
+    tokio::time::sleep(std::time::Duration::from_millis(
+        (REAP_THRESHOLD_SECS as u64) * 1000 + 600,
+    ))
+    .await;
+    CoordinatorIncarnationRepository::new(db.clone())
+        .renew(&owner)
+        .await
+        .unwrap();
+
+    crate::health::reap_orphaned_pending_attempts_with_threshold(
+        &db,
+        REAP_THRESHOLD_SECS,
+        "periodic",
+    )
+    .await;
+
+    let (outcome, failure_class) = reaped_attempt(&db, &task.id, &attempt_id).await;
+    assert_eq!(
+        outcome, "crashed",
+        "a live owner's orphan must reap as strike-counting `crashed`"
+    );
+    assert_eq!(
+        failure_class, "orphaned_pending_attempt",
+        "a live owner's orphan must NOT be classified environmental_owner_expired"
+    );
+}
+
+/// Contrast: an owner whose lease has aged past the window (the pre-fix 15-min
+/// starvation) still reaps as environmental `interrupted`. This confirms the
+/// classification hinges on lease freshness — the exact signal the renewal
+/// cadence controls.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_owner_orphan_reaps_as_environmental_interrupted() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(16);
+    let (task, _path) = create_simple_task(&db, &tx, "task", "stale owner orphan").await;
+
+    let owner = uuid::Uuid::now_v7().to_string();
+    CoordinatorIncarnationRepository::new(db.clone())
+        .register(&owner)
+        .await
+        .unwrap();
+    let attempt_id = seed_pending_attempt(&db, &task.id, &owner).await;
+
+    // Never renew: the lease ages past the window alongside the attempt.
+    tokio::time::sleep(std::time::Duration::from_millis(
+        (REAP_THRESHOLD_SECS as u64) * 1000 + 600,
+    ))
+    .await;
+
+    crate::health::reap_orphaned_pending_attempts_with_threshold(
+        &db,
+        REAP_THRESHOLD_SECS,
+        "periodic",
+    )
+    .await;
+
+    let (outcome, failure_class) = reaped_attempt(&db, &task.id, &attempt_id).await;
+    assert_eq!(
+        outcome, "interrupted",
+        "a genuinely-expired owner's orphan reaps as environmental interrupted"
+    );
+    assert_eq!(failure_class, "environmental_owner_expired");
+}

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -1434,3 +1434,6 @@ mod tripwire_planner_escalation;
 
 #[cfg(test)]
 mod escalation_ceiling;
+
+#[cfg(test)]
+mod incarnation_lease_liveness;


### PR DESCRIPTION
## Incident

Prod (2026-07-22): the djinn-server process was healthy (0 restarts, 9h up), yet task `k6hm` (`019f84d7`) looped dispatch→interrupt→reap for ~19h, and the periodic health sweep kept reaping in-flight dispatch groups as `outcome:"interrupted", reason:"periodic"`.

## Root cause (verified from prod logs, not the incident's initial theory)

The incident hypothesized coordinator **re-election/respawn** minting a new incarnation each cycle. Prod logs disprove that: `0` occurrences of `CoordinatorActor started` in 2h, and the incarnation id `019f879c-1bf3-7183-85ea-62ef2d8e4b29` is **identical** across renewals 15 min apart. The observed `cycle_id` "resets" are just the normal `prune_tick_counter` wrap at 120 (`actor.rs:1127`).

The real bug is a cadence mismatch on the single, long-lived incarnation:

- The incarnation lease was renewed **only on the 15-minute `STALE_SWEEP_INTERVAL`** inside `run_tick` (`actor.rs:1149`, now removed).
- The orphan reaper treats a lease as **expired after 5 minutes** (`ORPHANED_PENDING_ATTEMPT_THRESHOLD_SECS`, `health.rs:43`).
- The reaper runs in the **same** sweep, immediately **before** the renewal (`sweep_stale_resources` → `reap_orphaned_pending_attempts`, `actor.rs:1148`). So at reap time the live coordinator's own lease was always ~15 min stale → `CoordinatorIncarnationRepository::is_live()` returned false → `classify_orphan_owner` stamped its own in-flight pending dispatch groups `interrupted` / `environmental_owner_expired` (`health.rs:3331-3346`).
- That outcome is **strike-exempt** (`dispatch::retry::latest_attempt_strike_decision`, `retry.rs:58-82`). A genuinely-failing task whose reaps are all strike-exempt never accumulates a strike, never routes to Planner intervention, and **loops forever**.

Prod evidence: reaps at 11:18:26 / 11:33:53 (15 min apart) fire right before renewals at 11:18:42 / 11:34:00; the same task `019f84d7` is reaped each sweep, its `lead`/`worker` pods self-terminating `Interrupted, stages_completed:[]` shortly after connect, then re-dispatched only after the next 15-min reap unblocks the respawn guard.

## Fix

Renew the incarnation lease from a **dedicated task every 60s** (5x under the 5-min expiry window), decoupled from the coordinator mailbox / tick path so a slow tick (the 6s 5551-row scan, ~1.5s note searches) or the heavy 15-min stale sweep can no longer starve renewal (directions **a**/**b** of the brief, achieved without touching the query surface).

- `actor.rs`: new `spawn_incarnation_renewal()` started once in `run()` after registration; removed the renewal from the 15-min sweep gate. Task is scoped to the actor's `CancellationToken`, so a stopped process/leader still lets the lease expire for the next boot's startup reaper (unchanged single-leader semantics).
- `health.rs`: added `COORDINATOR_INCARNATION_RENEWAL_INTERVAL` (60s) co-located with the expiry threshold it must stay under, with the invariant documented.

Now the live owner reads truthfully live, so its genuine orphans classify as `crashed` / `orphaned_pending_attempt` (**strike-counting**) instead of strike-exempt environmental interruptions — and the existing park/intervention machinery breaks the loop.

### Tradeoffs / residual risk
- No SQL changed → no SQLx metadata impact.
- The dedicated renewer keeps the lease alive even if the actor's mailbox loop wedges while the process lives; this is strictly better than the old behavior (a wedged/slow tick used to falsely expire the live owner). A truly dead **process** still stops renewing because the task shares the actor's cancellation scope.
- This fix corrects the coordinator's contribution (the strike-exempt mislabel that made the loop infinite). The upstream reason these pods self-terminate `Interrupted` on resume is a separate session/runtime concern outside `djinn-coordinator` and is not addressed here.

## Tests
Postgres-backed integration + a deterministic invariant unit test, all green:

- `health::…::incarnation_renewal_interval_is_safely_below_orphan_expiry` — pins renewal ≤ ½ the expiry window.
- `tests::incarnation_lease_liveness::live_owner_orphan_reaps_as_crashed_not_environmental` — a freshly-renewed owner's orphan reaps `crashed`/`orphaned_pending_attempt`.
- `tests::incarnation_lease_liveness::stale_owner_orphan_reaps_as_environmental_interrupted` — a stale owner still reaps environmental `interrupted` (behavior preserved).
- Regression suites re-run green: `incarnation` (5/5, incl. the updated `overlapping_coordinator_runtimes…` and startup-reap classification), `environmental` (10/10). `cargo check -p djinn-coordinator` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)