### PR TITLE
fix(coordinator): route merge-conflict reopens to rework workers regardless of intervention budget

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/park_reason_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/park_reason_tests.rs
@@ -142,6 +142,34 @@ fn review_rejected_park_reason_keeps_ac_phrasing() {
 }
 
 #[test]
+fn merge_conflict_park_reason_never_uses_ac_phrasing() {
+    // A merge conflict means main moved under an approved PR — it must be
+    // labeled as a mechanical rebase, never as an acceptance-criteria failure
+    // (incident k6hm mislabeled a conflict as AC non-convergence).
+    let task = test_task("passing", "[]", None);
+    let history = post_intervention_history_with_submission(ReopenClass::MergeConflict);
+
+    let reason = CoordinatorActor::compute_park_reason(&task, &history);
+
+    assert!(
+        reason.contains("merge conflict against the base branch"),
+        "merge_conflict park should name the conflict; got: {reason}"
+    );
+    assert!(
+        reason.contains("mechanical rebase"),
+        "merge_conflict park should frame it as a mechanical rebase; got: {reason}"
+    );
+    assert!(
+        !reason.contains("acceptance criteria still did not pass"),
+        "merge_conflict park must NOT use the AC phrasing; got: {reason}"
+    );
+    assert!(
+        !reason.contains("merge-queue full suite failed"),
+        "merge_conflict park must NOT be mislabeled as a merge-queue failure; got: {reason}"
+    );
+}
+
+#[test]
 fn merge_queue_failed_with_unknown_checks_falls_back_gracefully() {
     let task = test_task("failing", "[]", None);
     let history = post_intervention_history_with_submission(ReopenClass::MergeQueueFailed);

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -948,6 +948,19 @@ impl CoordinatorActor {
                          healthy infrastructure rather than penalizing the task.{skip_note}"
                     )
                 }
+                djinn_core::models::ReopenClass::MergeConflict => {
+                    // Merge-conflict reopen: main moved under an approved PR. This
+                    // is NOT a worker quality strike (it is excluded from
+                    // quality-strike counts and does not increment reopen_count),
+                    // so it must never use the AC-non-convergence phrasing. A
+                    // conflict is a mechanical rebase, not a failure to converge.
+                    format!(
+                        "The post-intervention remediation WAS attempted and submitted, but the PR \
+                         then hit a merge conflict against the base branch (main moved). This is a \
+                         mechanical rebase, not an acceptance-criteria failure, and is excluded from \
+                         quality-strike counts.{skip_note}"
+                    )
+                }
                 _ => {
                     // review_rejected / other quality strikes keep the existing AC phrasing.
                     format!(

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -2119,7 +2119,29 @@ impl CoordinatorActor {
             // existing intervention machinery (planner Workflow C). This is a
             // no-op (returns false) for non-worker roles, tasks under the
             // threshold, or tasks already routed at this reopen count.
-            if role == "worker" && self.maybe_intervene_on_stuck_task(&task).await {
+            //
+            // A merge-conflict rework is exempt from trigger A entirely. When
+            // the current re-dispatch is driven by an unresolved merge conflict
+            // (`PrReworkSignal::MergeConflict` — populated conflict metadata with
+            // required CI NOT failing), main moved under an otherwise-healthy PR;
+            // that is not evidence the worker cannot converge on the acceptance
+            // criteria. Trigger A gates on the DB-backed quality-strike count,
+            // which persists across a task's whole life, so a task that already
+            // exhausted its intervention budget on *earlier* review rejections
+            // would be parked to `needs_lead_intervention` the moment a trivial
+            // conflict reopened it — routing a mechanical rebase to the
+            // arbitration lane and mislabeling it as AC non-convergence (incident
+            // k6hm, 2026-07-21: a twice-approved, CI-green task hit a one-line
+            // conflict and sat in the lead lane for 19h). Route it to the normal
+            // ConflictRetry rework worker regardless of the intervention budget.
+            // Genuine quality strikes (review rejections, CI-failure loops) still
+            // flow through trigger A on their own re-dispatch passes.
+            let is_merge_conflict_rework =
+                pr_rework_signal == Some(super::respawn_guard::PrReworkSignal::MergeConflict);
+            if role == "worker"
+                && !is_merge_conflict_rework
+                && self.maybe_intervene_on_stuck_task(&task).await
+            {
                 // The planner escalation dispatched a new session (under the
                 // same creator, potentially the same model). Bump the local
                 // per-(creator, model) count so a later task in THIS pass sees

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -1609,6 +1609,128 @@ async fn second_strike_parks_task_after_prior_intervention() {
     );
 }
 
+/// Drive a task to the exact second-strike park condition — `intervention_count
+/// == 1`, quality strikes back at threshold, and enough terminated
+/// post-intervention sessions to satisfy the uv3p attempted-remediation gate —
+/// so that trigger A WOULD park it on the next worker dispatch. Returns the task
+/// after the setup completes.
+async fn seed_task_at_second_strike_park_condition(
+    db: &Database,
+    tx: &broadcast::Sender<DjinnEventEnvelope>,
+) -> djinn_core::models::Task {
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(tx));
+    let task = make_task_with_reopen_count(db, tx, REOPEN_INTERVENTION_THRESHOLD).await;
+    // One completed planner intervention (bumps intervention_count, resets
+    // reopen_count), then climb back to the quality-strike threshold.
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    for _ in 0..REOPEN_INTERVENTION_THRESHOLD {
+        repo.set_status(&task.id, "closed").await.unwrap();
+        repo.set_status(&task.id, "open").await.unwrap();
+    }
+    // uv3p attempted-remediation gate: NON_ATTEMPT_PARK_THRESHOLD (2) distinct
+    // models terminated pre-submission after the intervention, so the park rung
+    // would fire rather than redispatch for more evidence.
+    seed_terminated_post_intervention_sessions(db, tx, &task.id, &["m-a", "m-b"]).await;
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(task.intervention_count, 1, "one prior planner intervention");
+    assert_eq!(task.reopen_count, REOPEN_INTERVENTION_THRESHOLD);
+    task
+}
+
+/// Regression (incident k6hm, 2026-07-21): a task that has exhausted its
+/// intervention budget on EARLIER review rejections then hits a trivial merge
+/// conflict against main. A conflict means main moved under an otherwise-healthy
+/// PR — it is not evidence the worker cannot converge on the acceptance
+/// criteria — so the dispatch tick must route it to the normal ConflictRetry
+/// rework worker, NOT consume the second strike and park it into
+/// `needs_lead_intervention` / the arbitration lane.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn merge_conflict_reopen_at_intervention_cap_does_not_park() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let task = seed_task_at_second_strike_park_condition(&db, &tx).await;
+
+    // The current re-dispatch is driven by an unresolved merge conflict on an
+    // otherwise-green PR (required CI not failing + populated conflict metadata).
+    repo.set_pr_url(&task.id, "https://github.com/acme/repo/pull/2412")
+        .await
+        .unwrap();
+    repo.set_merge_conflict_metadata(&task.id, Some(r#"{"files":["src/lib.rs"]}"#))
+        .await
+        .unwrap();
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+
+    // Precondition: the task-row facts derive a MergeConflict rework signal.
+    assert_eq!(
+        crate::dispatch::respawn_guard::PrReworkSignal::from_task_row(
+            task.ci_status.as_str(),
+            task.merge_conflict_metadata.as_deref(),
+        ),
+        Some(crate::dispatch::respawn_guard::PrReworkSignal::MergeConflict),
+        "setup must present a merge-conflict rework signal (CI not failing)"
+    );
+
+    actor.dispatch_ready_tasks(Some(&task.project_id)).await;
+
+    // The merge conflict must NOT have been parked to the arbitration lane.
+    let after = repo.get(&task.id).await.unwrap().unwrap();
+    assert_ne!(
+        after.status, "needs_lead_intervention",
+        "a merge-conflict reopen must never park to needs_lead_intervention, even at \
+         the intervention cap — it routes to the ConflictRetry rework worker"
+    );
+
+    let arb_repo = TaskArbitrationRepository::new(db.clone());
+    let (_cycle, existing) = arb_repo.resolve_current_hold_cycle(&task.id).await.unwrap();
+    assert!(
+        existing.is_none(),
+        "a merge-conflict reopen must not create an arbitration/hold-cycle row"
+    );
+    let blockers = repo.list_blockers(&task.id).await.unwrap();
+    assert!(
+        blockers.iter().all(|b| b.status == "closed"),
+        "a merge-conflict reopen must not create a human-review hold blocker"
+    );
+}
+
+/// Control for `merge_conflict_reopen_at_intervention_cap_does_not_park`:
+/// through the SAME dispatch tick, an identical second-strike task WITHOUT a
+/// merge-conflict signal (a genuine quality strike) still parks to
+/// `needs_lead_intervention` with a durable arbitration row. Proves the exempt
+/// path above is scoped to merge conflicts and does not weaken genuine
+/// quality-strike parking.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn genuine_quality_strike_at_intervention_cap_still_parks_through_dispatch() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    // No pr_url / no merge_conflict_metadata — a plain review-rejection loop.
+    let task = seed_task_at_second_strike_park_condition(&db, &tx).await;
+    assert!(
+        task.merge_conflict_metadata.is_none(),
+        "control task must carry no merge-conflict signal"
+    );
+
+    actor.dispatch_ready_tasks(Some(&task.project_id)).await;
+
+    let after = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        after.status, "needs_lead_intervention",
+        "a genuine quality strike at the intervention cap must still park"
+    );
+    let arb_repo = TaskArbitrationRepository::new(db.clone());
+    let (_cycle, existing) = arb_repo.resolve_current_hold_cycle(&task.id).await.unwrap();
+    assert!(
+        existing.is_some(),
+        "the genuine-quality-strike park must create an unconsumed arbitration row"
+    );
+}
+
 /// uv3p Part B (AC #2 / cgcl-7fj3-nlus shape): a task at the second-strike
 /// condition (`intervention_count == 1`, quality strikes at threshold) with
 /// ZERO sessions dispatched since the intervention must NOT park — the


### PR DESCRIPTION
## Bug (B2, verified in production 2026-07-21/22)

Task `k6hm` was fully approved (all ACs met, twice reviewer-approved, CI green on PR head #2412), then hit a trivial one-line merge conflict against `main`. Instead of the normal PrConflict → ConflictRetry rework flow, the coordinator auto-parked it to `needs_lead_intervention` and emitted an `arbiter_dispatched` event that mislabeled a mechanical rebase as an AC-convergence failure. A mechanical rebase then sat in the arbitration lane for 19 hours.

## Diagnosis (file:line)

- `server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs:2122` — the dispatch loop runs trigger A (`maybe_intervene_on_stuck_task`) for **any** worker re-dispatch, including a merge-conflict rework. The merge conflict reopened the task and it was re-dispatched as a worker.
- `server/crates/djinn-coordinator/src/dispatch/retry.rs:469,482` — trigger A gates on the DB-backed `quality_reopen_count` (correctly excludes `merge_conflict`/`superseded`), but that count reflects a task's **whole life**. `k6hm` had 3 earlier *review-rejection* quality strikes (which had converged), so the gate still passed on the conflict re-dispatch.
- `server/crates/djinn-coordinator/src/dispatch/retry.rs:1236` — `route_planner_intervention`'s second-strike gate `if task.intervention_count >= MAX_PLANNER_INTERVENTIONS` (=1, `types.rs:345`) fires **before** any idempotency/attempt check, so once a task is at the intervention cap, the *next* trigger of any kind — including a conflict reopen — parks it to `needs_lead_intervention` via the Lead-arbiter dispatch path (`arbiter_dispatched`, retry.rs:~1750).

Net: `quality_reopen_count` already excludes conflicts, but the persistent historical strikes plus `intervention_count == cap` made a brand-new merge conflict trip the second-strike park.

## Fix

1. `task_dispatch.rs` — exempt merge-conflict reworks from trigger A entirely. When the current re-dispatch is driven by `PrReworkSignal::MergeConflict` (populated `merge_conflict_metadata` with required CI **not** failing — an otherwise-healthy PR whose base moved), skip the intervention gate and let the normal ConflictRetry rework worker dispatch, regardless of the intervention/reopen budget. No park, no `arbiter_dispatched`. Genuine quality strikes (review rejections, CI-failure loops) are untouched — they carry no conflict signal and still route through trigger A.
2. `retry.rs::park_reason_detail` — add a truthful `ReopenClass::MergeConflict` branch so any remaining conflict-adjacent park describes a mechanical rebase, never AC non-convergence or a merge-queue failure.

## Test evidence

New tests (run with `--features djinn-db/test-support`, Postgres on :5433):

- `merge_conflict_reopen_at_intervention_cap_does_not_park` — a task driven to the exact second-strike park condition (`intervention_count == 1`, quality strikes at threshold, 2 terminated post-intervention sessions so the uv3p gate would otherwise park) that then carries a `MergeConflict` signal is run through the full dispatch tick: it is **not** parked to `needs_lead_intervention` and creates **no** arbitration/hold-cycle row.
- `genuine_quality_strike_at_intervention_cap_still_parks_through_dispatch` — control: the identical second-strike setup **without** a conflict signal, through the same dispatch tick, still parks to `needs_lead_intervention` with an unconsumed arbitration row.
- `merge_conflict_park_reason_never_uses_ac_phrasing` — `compute_park_reason` for a `MergeConflict` reopen names the conflict / mechanical rebase and never uses AC or merge-queue phrasing.

Results:
- Focused: `merge_conflict_reopen_at_intervention_cap_does_not_park`, `genuine_quality_strike_at_intervention_cap_still_parks_through_dispatch`, `second_strike_parks_task_after_prior_intervention` — 3 passed.
- `tests::intervention` + `respawn_guard` modules — 118 passed.
- `park_reason` tests — 20 passed.
- `cargo clippy -p djinn-coordinator --lib` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
