### PR TITLE
chore(supervisor): Allow real-time TestClock seeding in test module

### DIFF
--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -3117,6 +3117,7 @@ pub fn trigger_as_str(t: TaskRunTrigger) -> &'static str {
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#[allow(clippy::disallowed_methods)] // tests seed TestClock with real time for duration/timeout assertions
 mod tests {
     use super::*;
     use async_trait::async_trait;


### PR DESCRIPTION
Warm's `cargo clippy --workspace --all-targets` denies `Instant::now` via the workspace `disallowed_methods` lint and fails on ten test-only calls in djinn-supervisor's test module. CI's clippy job runs without `--workspace` from the server workspace root, so it never lints djinn-supervisor's test targets and never caught this. The failure forces the warm pipeline into its slow full-build fallback on every run.

Fix follows the existing repo convention (see `djinn-agent/src/process.rs`, `djinn-core/src/clock.rs`): a module-scoped `#[allow(clippy::disallowed_methods)]` with a one-line justification on the test module. Verified locally: `cargo clippy -p djinn-supervisor --all-targets` exits clean; all 172 lib tests pass.