### PR TITLE
fix(dispatch): dampen and surface single-candidate failover exhaustion instead of hot-looping

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -104,6 +104,48 @@ async fn surface_credential_revocation(
     }
 }
 
+/// Best-effort dedup for the repeated "failed over off model X" failover
+/// comments. A role lane with a single candidate model that keeps failing
+/// environmentally (image pull, unschedulable, stage-init hang) would otherwise
+/// append an identical — or, when the elapsed time varies, near-identical —
+/// comment every dispatch cycle, burying the task timeline (the k6hm loop,
+/// 2026-07-22, logged the same comment three times in a day). Returns `true`
+/// when a prior activity comment for THIS task already reports a failover off
+/// `model_id`, so the caller can skip re-appending. Matches on the stable
+/// `failed over off model {model_id}` phrase so it is insensitive to the
+/// per-cycle elapsed-time suffix. On a read failure it returns `false` (better a
+/// duplicate than a silently dropped operator signal). This only gates the
+/// timeline COMMENT — the health/breaker `record_stall` +
+/// `note_task_provider_failure` side effects still fire every cycle.
+async fn failover_comment_already_logged(
+    task_repo: &TaskRepository,
+    task_id: &str,
+    model_id: &str,
+) -> bool {
+    let needle = format!("failed over off model {model_id}");
+    match task_repo.list_activity(task_id).await {
+        Ok(entries) => entries.iter().any(|entry| {
+            serde_json::from_str::<serde_json::Value>(&entry.payload)
+                .ok()
+                .and_then(|v| {
+                    v.get("body")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned)
+                })
+                .is_some_and(|body| body.contains(&needle))
+        }),
+        Err(e) => {
+            tracing::warn!(
+                task_id,
+                error = %e,
+                "supervisor dispatch: failed to read activity for failover-comment dedup; \
+                 appending anyway"
+            );
+            false
+        }
+    }
+}
+
 /// Record stall + failover + activity when the worker never completed its
 /// startup handshake within the deadline.
 async fn apply_handshake_timeout_failover(
@@ -123,22 +165,24 @@ async fn apply_handshake_timeout_failover(
             retry_after_ms: None,
         },
     );
-    let _ = task_repo
-        .log_activity(
-            Some(&task.id),
-            "system",
-            "system",
-            "comment",
-            &serde_json::json!({
-                "body": format!(
-                    "Worker Pod failed to complete its startup handshake within the \
-                     deadline (image pull, unschedulable, or crash-loop). Tore down the \
-                     Job and failed over off model {model_id}."
-                )
-            })
-            .to_string(),
-        )
-        .await;
+    if !failover_comment_already_logged(task_repo, &task.id, model_id).await {
+        let _ = task_repo
+            .log_activity(
+                Some(&task.id),
+                "system",
+                "system",
+                "comment",
+                &serde_json::json!({
+                    "body": format!(
+                        "Worker Pod failed to complete its startup handshake within the \
+                         deadline (image pull, unschedulable, or crash-loop). Tore down the \
+                         Job and failed over off model {model_id}."
+                    )
+                })
+                .to_string(),
+            )
+            .await;
+    }
     tracing::warn!(
         task_id = %task.short_id,
         %model_id,
@@ -609,24 +653,26 @@ pub(super) async fn dispatch_task_runtime(
                 retry_after_ms: None,
             },
         );
-        let _ = task_repo
-            .log_activity(
-                Some(&task.id),
-                "agent-supervisor",
-                "system",
-                "stage_init_timeout",
-                &serde_json::json!({
-                    "body": format!(
-                        "Stage init hung at step '{step}' — no session / first provider \
-                         turn within {elapsed_secs}s (pre-session liveness deadline). \
-                         Tore down the Job and failed over off model {model_id}."
-                    ),
-                    "stage_step": step,
-                    "elapsed_secs": elapsed_secs,
-                })
-                .to_string(),
-            )
-            .await;
+        if !failover_comment_already_logged(&task_repo, &task.id, &model_id).await {
+            let _ = task_repo
+                .log_activity(
+                    Some(&task.id),
+                    "agent-supervisor",
+                    "system",
+                    "stage_init_timeout",
+                    &serde_json::json!({
+                        "body": format!(
+                            "Stage init hung at step '{step}' — no session / first provider \
+                             turn within {elapsed_secs}s (pre-session liveness deadline). \
+                             Tore down the Job and failed over off model {model_id}."
+                        ),
+                        "stage_step": step,
+                        "elapsed_secs": elapsed_secs,
+                    })
+                    .to_string(),
+                )
+                .await;
+        }
         return Err(anyhow::Error::new(timeout));
     }
     match (report_result, teardown) {
@@ -2723,5 +2769,61 @@ mod tests {
                 "{label} must remain pending because it is not in the current exact group"
             );
         }
+    }
+
+    /// The failover-comment dedup guard must recognize a prior "failed over off
+    /// model X" comment (insensitive to a per-cycle elapsed-time suffix), so the
+    /// same comment is not appended every dispatch cycle — while a failover onto
+    /// a DIFFERENT model still surfaces a fresh comment.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failover_comment_dedup_suppresses_repeats_per_model() {
+        use crate::test_helpers;
+        use tokio_util::sync::CancellationToken;
+
+        let db = test_helpers::create_test_db();
+        let project = test_helpers::create_test_project(&db).await;
+        let epic = test_helpers::create_test_epic(&db, &project.id).await;
+        let task = test_helpers::create_test_task(&db, &project.id, &epic.id).await;
+        let app_state = test_helpers::agent_context_from_db(db.clone(), CancellationToken::new());
+        let task_repo = TaskRepository::new(db.clone(), app_state.event_bus.clone());
+
+        let model = "openai/gpt-5.6-sol";
+
+        // No prior comment: the guard allows the write.
+        assert!(
+            !failover_comment_already_logged(&task_repo, &task.id, model).await,
+            "no prior comment ⇒ dedup guard must not suppress"
+        );
+
+        // First failover comment, with a cycle-specific elapsed suffix.
+        task_repo
+            .log_activity(
+                Some(&task.id),
+                "agent-supervisor",
+                "system",
+                "stage_init_timeout",
+                &serde_json::json!({
+                    "body": format!(
+                        "Stage init hung ... within 480s. Tore down the Job and \
+                         failed over off model {model}."
+                    ),
+                })
+                .to_string(),
+            )
+            .await
+            .expect("log first failover comment");
+
+        // A later cycle for the SAME model is suppressed even though its elapsed
+        // suffix would differ.
+        assert!(
+            failover_comment_already_logged(&task_repo, &task.id, model).await,
+            "an existing failover comment for this model must suppress the repeat"
+        );
+
+        // A failover onto a DIFFERENT model is still surfaced.
+        assert!(
+            !failover_comment_already_logged(&task_repo, &task.id, "zai/glm-5.2").await,
+            "a different model has no prior comment ⇒ must not be suppressed"
+        );
     }
 }

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1478,6 +1478,11 @@ impl CoordinatorActor {
         &mut self,
         task: &djinn_core::models::Task,
         role: &str,
+        // The full candidate list the exhausted chain traversed (the role
+        // lane's resolved fallback models). Used only to detect the
+        // single-candidate case for the operator-visible signal; breaker/
+        // cooldown accounting is unchanged for multi-candidate lanes.
+        candidate_models: &[String],
         exhausted_observations: &[djinn_provider::catalog::HealthKey],
     ) {
         // Apply deferred breaker checks for THIS chain's observed failures
@@ -1542,6 +1547,116 @@ impl CoordinatorActor {
                 },
             )
             .await;
+
+            // Single-candidate lanes cannot fail *over* to anything: when the
+            // one configured model keeps failing environmentally the escalating
+            // cooldown above quietly decays the retry cadence, but nothing tells
+            // an operator the lane is wedged on one model. Surface a durable,
+            // deduplicated signal exactly as the streak crosses the threshold
+            // (fires once per climb, not every cycle) so the timeline stays
+            // readable. The task is NOT closed — it resumes automatically once
+            // the environment heals.
+            if candidate_models.len() == 1 && streak == SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD
+            {
+                self.emit_single_candidate_exhaustion_signal(
+                    task,
+                    role,
+                    &candidate_models[0],
+                    streak,
+                )
+                .await;
+            }
+        }
+    }
+
+    /// Emit a durable, operator-visible task activity entry stating plainly that
+    /// a role lane has a single candidate model that has failed environmentally
+    /// for several consecutive dispatch cycles, so an operator can add a second
+    /// candidate or investigate provider health.
+    ///
+    /// Deduplicated: if an identical signal body is already on the task's
+    /// activity log this is a no-op, so re-entry at the same streak (or a read
+    /// failure elsewhere) never double-posts. The `streak` is baked into the
+    /// body, so a later climb to a higher threshold would post a distinct entry;
+    /// today the single call site fires only at
+    /// [`SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD`], giving one entry per
+    /// climb.
+    async fn emit_single_candidate_exhaustion_signal(
+        &self,
+        task: &djinn_core::models::Task,
+        role: &str,
+        model_id: &str,
+        streak: u32,
+    ) {
+        let body = format!(
+            "Role lane `{role}` has a single candidate model `{model_id}`, and {streak} \
+             consecutive dispatch cycles for this task have failed environmentally — the \
+             failover chain has no alternative candidate to fail over to. The task is on an \
+             escalating dispatch backoff and will resume automatically once the environment \
+             heals; it has NOT been closed. To stop the retries, add a second candidate model \
+             to this role lane or investigate the health of `{model_id}` / its provider."
+        );
+        let repo = self.task_repo();
+        // Dedup: skip if this exact signal body already exists on the timeline.
+        // Best-effort — on a read failure we fall through and post (better a
+        // duplicate than a silently-dropped operator signal).
+        match repo.list_activity(&task.id).await {
+            Ok(entries) => {
+                let already_present = entries.iter().any(|entry| {
+                    entry.event_type == "single_candidate_failover_exhaustion"
+                        && serde_json::from_str::<serde_json::Value>(&entry.payload)
+                            .ok()
+                            .and_then(|v| {
+                                v.get("body")
+                                    .and_then(serde_json::Value::as_str)
+                                    .map(str::to_owned)
+                            })
+                            .as_deref()
+                            == Some(body.as_str())
+                });
+                if already_present {
+                    return;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    error = %e,
+                    "CoordinatorActor: failed to read activity for single-candidate \
+                     exhaustion dedup; posting signal anyway"
+                );
+            }
+        }
+        let payload = serde_json::json!({
+            "body": body,
+            "role": role,
+            "model_id": model_id,
+            "consecutive_exhaustions": streak,
+        });
+        if let Err(e) = repo
+            .log_activity(
+                Some(&task.id),
+                "coordinator",
+                "system",
+                "single_candidate_failover_exhaustion",
+                &payload.to_string(),
+            )
+            .await
+        {
+            tracing::warn!(
+                task_id = %task.short_id,
+                error = %e,
+                "CoordinatorActor: failed to persist single-candidate failover exhaustion signal"
+            );
+        } else {
+            tracing::warn!(
+                task_id = %task.short_id,
+                role,
+                %model_id,
+                streak,
+                "CoordinatorActor: single-candidate role lane exhausted for \
+                 {streak} consecutive cycles — surfaced operator signal"
+            );
         }
     }
 
@@ -3013,8 +3128,13 @@ impl CoordinatorActor {
                     // breaker side effects apply ONLY to failures from THIS
                     // dispatch attempt — not from a fallback-rescued or
                     // unrelated earlier chain (AC2).
-                    self.apply_chain_exhaustion_side_effects(&task, role, &exhausted_observations)
-                        .await;
+                    self.apply_chain_exhaustion_side_effects(
+                        &task,
+                        role,
+                        model_ids,
+                        &exhausted_observations,
+                    )
+                    .await;
                 }
             }
         }
@@ -6002,7 +6122,12 @@ mod failover_chain_tests {
             _ => panic!("expected DispatchOutcome::Failed"),
         };
         actor
-            .apply_chain_exhaustion_side_effects(&task, "worker", &exhausted_observations)
+            .apply_chain_exhaustion_side_effects(
+                &task,
+                "worker",
+                &[String::from("m-a"), String::from("m-b")],
+                &exhausted_observations,
+            )
             .await;
 
         // failure streak should be 1
@@ -6052,7 +6177,12 @@ mod failover_chain_tests {
             _ => Vec::new(),
         };
         actor
-            .apply_chain_exhaustion_side_effects(&task, "worker", &exhausted_observations2)
+            .apply_chain_exhaustion_side_effects(
+                &task,
+                "worker",
+                &[String::from("m-a"), String::from("m-b")],
+                &exhausted_observations2,
+            )
             .await;
 
         assert_eq!(
@@ -6174,7 +6304,12 @@ mod failover_chain_tests {
                 _ => Vec::new(),
             };
             actor
-                .apply_chain_exhaustion_side_effects(&task, "worker", &exhausted_observations)
+                .apply_chain_exhaustion_side_effects(
+                    &task,
+                    "worker",
+                    &[String::from("m-a"), String::from("m-b")],
+                    &exhausted_observations,
+                )
                 .await;
 
             // After round 2: consecutive_failures = 2 for each candidate.
@@ -6221,7 +6356,12 @@ mod failover_chain_tests {
             _ => Vec::new(),
         };
         actor
-            .apply_chain_exhaustion_side_effects(&task, "worker", &exhausted_observations)
+            .apply_chain_exhaustion_side_effects(
+                &task,
+                "worker",
+                &[String::from("m-a"), String::from("m-b")],
+                &exhausted_observations,
+            )
             .await;
 
         // Breaker IS tripped for model-a after chain exhaustion.
@@ -6588,6 +6728,7 @@ mod failover_chain_tests {
             .apply_chain_exhaustion_side_effects(
                 &task, // reuse the task fixture (only its id is read for streak)
                 "worker",
+                &[String::from("m-a"), String::from("m-b")],
                 &exhausted_unrelated,
             )
             .await;
@@ -6818,7 +6959,12 @@ mod failover_chain_tests {
             _ => unreachable!("asserted Failed above"),
         };
         actor
-            .apply_chain_exhaustion_side_effects(&task, "worker", &exhausted_observations)
+            .apply_chain_exhaustion_side_effects(
+                &task,
+                "worker",
+                &[String::from("m-a"), String::from("m-b")],
+                &exhausted_observations,
+            )
             .await;
 
         // ── Step 3: After ONE exhausted-chain failure, breaker MUST NOT trip
@@ -6880,7 +7026,12 @@ mod failover_chain_tests {
                 _ => unreachable!(),
             };
             actor
-                .apply_chain_exhaustion_side_effects(&task, "worker", &exhausted_observations)
+                .apply_chain_exhaustion_side_effects(
+                    &task,
+                    "worker",
+                    &[String::from("m-a"), String::from("m-b")],
+                    &exhausted_observations,
+                )
                 .await;
 
             let running_total = 1 + exhaustion_round;

--- a/server/crates/djinn-coordinator/src/tests/dispatch_flow.rs
+++ b/server/crates/djinn-coordinator/src/tests/dispatch_flow.rs
@@ -163,12 +163,22 @@ async fn dispatch_exhaustion_cap_hands_pr_to_poller_and_force_closes_no_pr() {
     let mut actor = coordinator_actor_for_tests(&db, &tx);
     for _ in 0..MAX_DISPATCH_FAILURES {
         actor
-            .apply_chain_exhaustion_side_effects(&pr_task, "worker", &[])
+            .apply_chain_exhaustion_side_effects(
+                &pr_task,
+                "worker",
+                &[String::from("m-a"), String::from("m-b")],
+                &[],
+            )
             .await;
     }
     for _ in 0..MAX_DISPATCH_FAILURES {
         actor
-            .apply_chain_exhaustion_side_effects(&no_pr_task, "worker", &[])
+            .apply_chain_exhaustion_side_effects(
+                &no_pr_task,
+                "worker",
+                &[String::from("m-a"), String::from("m-b")],
+                &[],
+            )
             .await;
     }
 
@@ -186,6 +196,109 @@ async fn dispatch_exhaustion_cap_hands_pr_to_poller_and_force_closes_no_pr() {
     let no_pr_after = repo.get(&no_pr_task.id).await.unwrap().unwrap();
     assert_eq!(no_pr_after.status, "closed");
     assert!(no_pr_after.close_reason.is_some());
+}
+
+/// A single-candidate role lane that keeps exhausting must surface a durable,
+/// deduplicated operator signal (not silently back off forever, and not
+/// spam the timeline every cycle). The signal fires exactly once as the streak
+/// crosses [`SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD`], names the stuck
+/// model, does NOT close the task, and never fires for a multi-candidate lane.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn single_candidate_exhaustion_surfaces_dedup_operator_signal() {
+    fn signal_count(entries: &[djinn_core::models::ActivityEntry]) -> usize {
+        entries
+            .iter()
+            .filter(|e| e.event_type == "single_candidate_failover_exhaustion")
+            .count()
+    }
+
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let single_task = open_task(&db, &tx, "single-candidate-lane").await;
+    let multi_task = open_task(&db, &tx, "multi-candidate-lane").await;
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let model = "openai/gpt-5.6-sol".to_string();
+
+    // Below the threshold: backing off, but no operator signal yet.
+    for _ in 0..(SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD - 1) {
+        actor
+            .apply_chain_exhaustion_side_effects(
+                &single_task,
+                "worker",
+                std::slice::from_ref(&model),
+                &[],
+            )
+            .await;
+    }
+    let entries = repo.list_activity(&single_task.id).await.unwrap();
+    assert_eq!(signal_count(&entries), 0, "no signal before the threshold");
+
+    // Crossing the threshold: exactly one signal, naming the stuck model.
+    actor
+        .apply_chain_exhaustion_side_effects(
+            &single_task,
+            "worker",
+            std::slice::from_ref(&model),
+            &[],
+        )
+        .await;
+    let entries = repo.list_activity(&single_task.id).await.unwrap();
+    assert_eq!(
+        signal_count(&entries),
+        1,
+        "exactly one signal at the threshold"
+    );
+    let signal = entries
+        .iter()
+        .find(|e| e.event_type == "single_candidate_failover_exhaustion")
+        .unwrap();
+    assert!(
+        signal.payload.contains("openai/gpt-5.6-sol"),
+        "signal must name the stuck single candidate model"
+    );
+
+    // Further exhaustion cycles must NOT append another identical signal.
+    actor
+        .apply_chain_exhaustion_side_effects(
+            &single_task,
+            "worker",
+            std::slice::from_ref(&model),
+            &[],
+        )
+        .await;
+    let entries = repo.list_activity(&single_task.id).await.unwrap();
+    assert_eq!(
+        signal_count(&entries),
+        1,
+        "signal must not be re-appended every cycle (dedup)"
+    );
+
+    // The task must NOT be closed — it resumes when the environment heals.
+    assert_task_status(&db, &tx, &single_task, "open").await;
+
+    // A multi-candidate lane never triggers the single-candidate signal, even
+    // past the threshold (existing rotation behavior is preserved).
+    for _ in 0..(SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD + 1) {
+        actor
+            .apply_chain_exhaustion_side_effects(
+                &multi_task,
+                "worker",
+                &[
+                    String::from("openai/gpt-5.6-sol"),
+                    String::from("zai/glm-5.2"),
+                ],
+                &[],
+            )
+            .await;
+    }
+    let entries = repo.list_activity(&multi_task.id).await.unwrap();
+    assert_eq!(
+        signal_count(&entries),
+        0,
+        "multi-candidate lanes must never emit the single-candidate signal"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -488,6 +488,24 @@ pub(super) const PROVIDER_RETRY_AFTER_MAX: Duration = Duration::from_secs(6 * 60
 /// also keeps review-type tasks from wedging open forever.
 pub(super) const MAX_DISPATCH_FAILURES: u32 = 10;
 
+/// Consecutive failover-chain exhaustions for a task whose role lane has a
+/// SINGLE candidate model, after which the coordinator surfaces a durable,
+/// operator-visible signal (a task activity entry) instead of only backing off
+/// silently.
+///
+/// A single-candidate lane cannot fail *over* to anything — when that one model
+/// keeps failing environmentally the escalating cooldown quietly decays the
+/// retry cadence, but nothing tells an operator the lane is stuck on one model
+/// that needs a second candidate or provider investigation (the k6hm ~19h hot
+/// loop, 2026-07-22). The signal is emitted **once** as the streak crosses this
+/// threshold (not every cycle) so the timeline stays readable, and the task is
+/// NOT closed — it resumes automatically once the environment heals.
+///
+/// `3` mirrors the depth of [`STREAK_INTERVENTION_THRESHOLD`]'s intent: past the
+/// first couple of cooldown rungs a one-off pod/infra blip has been absorbed, so
+/// a persisting single-candidate exhaustion is worth an operator's attention.
+pub(super) const SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD: u32 = 3;
+
 /// Consecutive same-role failed dispatch attempts after which the task is
 /// routed to a Planner intervention (trigger B) instead of only riding the
 /// cooldown ladder toward [`MAX_DISPATCH_FAILURES`].


### PR DESCRIPTION
## Diagnosis (B3, verified in prod 2026-07-22 — task k6hm looped ~19h)

A role lane with a **single** candidate model (e.g. the lead lane with only `openai/gpt-5.6-sol`) that keeps failing environmentally hot-looped every ~15 min with no alert, no terminal state, and an unreadable timeline.

- **Timeline spam** — `server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs:126` (`apply_handshake_timeout_failover`) and `:612` (stage-init timeout) append an identical `"...failed over off model {model_id}."` comment **every cycle**, no dedup. This is the `"failed over off model openai/gpt-5.6-sol"` comment repeated 3× on 07-22.
- **Invisible exhaustion** — `server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs` `try_dispatch_to_pool` (`:1409`) returns `DispatchOutcome::Failed{}` when the single candidate is skipped (breaker-open → `observed_failures:0, outcome:"breaker"`, the `failover_chain_exhausted` log at 11:04:25). The caller (`:2986`) runs `apply_chain_exhaustion_side_effects` (`:1477`), which applies an escalating cooldown but emits **no operator-visible signal** that a single-candidate lane is environmentally wedged — the stuck state exists only as a warn log + telemetry, so nobody is told "add a second candidate".

## Fix (minimal; scoped to failover / lane-resolution / supervisor — no `retry.rs` park logic touched)

1. **Durable, deduplicated operator signal.** `apply_chain_exhaustion_side_effects` now receives the candidate model list. When the lane has exactly **one** candidate and the exhaustion streak crosses `SINGLE_CANDIDATE_EXHAUSTION_SIGNAL_THRESHOLD` (3), it posts **one** `single_candidate_failover_exhaustion` activity entry naming the stuck model and stating plainly that the task stays on an escalating backoff and resumes automatically once the environment heals. Fires once per climb (not every cycle; check-before-write dedup on the body). The task is **not** closed or parked. Multi-candidate rotation is untouched — the signal never fires for `len > 1`.
2. **Reused dampening.** The existing escalating `dispatch_cooldowns` ladder already decays the retry cadence on chain exhaustion; the fix leans on it rather than adding a new backoff path.
3. **Comment dedup.** `supervisor_runner` gates both `"failed over off model X"` writes behind `failover_comment_already_logged`, a check-before-write keyed on the stable `failed over off model {model}` phrase (insensitive to the per-cycle elapsed-time suffix). Same model ⇒ suppressed; a failover onto a different model still surfaces a fresh comment. Health/breaker side effects (`record_stall`, `note_task_provider_failure`) still fire every cycle.

## Test evidence (`SQLX_OFFLINE=true`, `--features` per neighboring tests)

- `single_candidate_exhaustion_surfaces_dedup_operator_signal` (coordinator): no signal below threshold; exactly one at the threshold naming the model; not re-appended on further cycles; task stays `open`; multi-candidate lane never signals. **PASS**
- `failover_comment_dedup_suppresses_repeats_per_model` (agent): guard allows first write, suppresses same-model repeat, allows a different model. **PASS**
- Regression: all `exhaust`/`failover`/`tests::dispatch_flow` coordinator suites green (10 + 20 + 16 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
