### PR TITLE
fix(ui): rehash galaxy artifact over producer bytes, not a JS re-serialization

### DIFF
--- a/ui/src/api/galaxyArtifact.test.ts
+++ b/ui/src/api/galaxyArtifact.test.ts
@@ -1,5 +1,7 @@
 import { createHash, webcrypto } from "node:crypto";
 import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,8 +14,17 @@ import {
   validateGalaxyArtifact,
 } from "./galaxyArtifactSchema";
 
-const fixture = new URL("../../../server/crates/djinn-graph/src/galaxy_artifact/fixtures/", import.meta.url);
+// Resolve the producer's golden fixtures from a plain filesystem path. Building
+// it from `fileURLToPath(import.meta.url)` avoids Vite's `new URL(<literal>,
+// import.meta.url)` asset rewrite, which would otherwise turn the fixture path
+// into a non-file `/@fs/` URL that `readFile` rejects.
+const fixtureDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../server/crates/djinn-graph/src/galaxy_artifact/fixtures",
+);
+const fixturePath = (name: string) => path.join(fixtureDir, name);
 let payloadText: string;
+let hashInputText: string;
 let payload: Record<string, unknown>;
 let gzip: Uint8Array;
 let manifest: { graph_content_hash: string; transport_sha256: string };
@@ -21,10 +32,13 @@ let manifest: { graph_content_hash: string; transport_sha256: string };
 beforeAll(async () => {
   // The browser client uses Web Crypto; jsdom supplies no subtle implementation.
   if (!globalThis.crypto?.subtle) Object.defineProperty(globalThis, "crypto", { value: webcrypto });
-  [payloadText, gzip, manifest] = await Promise.all([
-    readFile(new URL("payload.json", fixture), "utf8"),
-    readFile(new URL("payload.json.gz", fixture)),
-    readFile(new URL("manifest.json", fixture), "utf8").then(JSON.parse),
+  [payloadText, hashInputText, gzip, manifest] = await Promise.all([
+    readFile(fixturePath("payload.json"), "utf8"),
+    // The producer's exact hash-input bytes: the final payload with only the
+    // graph_content_hash field absent. The client rehashes over these bytes.
+    readFile(fixturePath("hash_input.json"), "utf8"),
+    readFile(fixturePath("payload.json.gz")),
+    readFile(fixturePath("manifest.json"), "utf8").then(JSON.parse),
   ]);
   payload = JSON.parse(payloadText) as Record<string, unknown>;
 });
@@ -54,17 +68,34 @@ function artifactResponse(etag = `"${manifest.transport_sha256}"`): Response {
   return new Response(gzip, { status: 200, headers: headers(etag, { "content-type": "application/gzip" }) });
 }
 
+/**
+ * Splice the graph_content_hash field into producer-serialized bytes at its
+ * fixed serde position (immediately after generation_id, immediately before
+ * truncated), mirroring how the Rust producer serializes the final payload so
+ * that final-minus-field is byte-identical to the hashed input.
+ */
+function spliceHashField(hashInput: string, graphContentHash: string): string {
+  const marker = ',"truncated":';
+  const at = hashInput.indexOf(marker);
+  if (at === -1) throw new Error("test fixture is missing the truncated field");
+  return `${hashInput.slice(0, at)},"graph_content_hash":"${graphContentHash}"${hashInput.slice(at)}`;
+}
+
 /** Derive valid later generations from the producer golden, never a hand schema. */
 function generationResponse(generationId: string, generatedAt: string) {
+  // Mirror the producer: hash the payload bytes with graph_content_hash absent,
+  // then serialize the final payload with the hash spliced back into place.
   const next = structuredClone(payload);
   next.generation_id = generationId;
   next.generated_at = generatedAt;
-  next.graph_content_hash = hash(canonicalSemanticJson(next));
-  const bytes = gzipSync(JSON.stringify(next));
+  delete next.graph_content_hash;
+  const hashInput = JSON.stringify(next);
+  const graphContentHash = hash(hashInput);
+  const bytes = gzipSync(spliceHashField(hashInput, graphContentHash));
   const etag = `"${hash(bytes)}"`;
   const responseHeaders = headers(etag, {
     [IDENTITY_HEADERS.generationId]: generationId,
-    [IDENTITY_HEADERS.semanticHash]: next.graph_content_hash as string,
+    [IDENTITY_HEADERS.semanticHash]: graphContentHash,
     "content-type": "application/gzip",
   });
   return { etag, response: new Response(bytes, { status: 200, headers: responseHeaders }) };
@@ -74,12 +105,17 @@ describe("producer galaxy artifact golden", () => {
   it("independently hashes both producer domains and validates the real payload", async () => {
     // This is intentionally Node crypto rather than the validator helper.
     expect(hash(gzip)).toBe(manifest.transport_sha256);
-    expect(hash(canonicalSemanticJson(payload))).toBe(manifest.graph_content_hash);
+    // The semantic domain is the payload bytes with only the hash field spliced
+    // out — byte-identical to the producer's separate hash_input.json.
+    const spliced = canonicalSemanticJson(payloadText, manifest.graph_content_hash);
+    expect(spliced).toBe(hashInputText);
+    expect(hash(spliced)).toBe(manifest.graph_content_hash);
 
     const validated = await validateGalaxyArtifact(
       "test-project",
       headers(`"${manifest.transport_sha256}"`),
       payload,
+      payloadText,
       gzip,
     );
     expect(validated.snapshot.nodes).toHaveLength(5);
@@ -87,8 +123,70 @@ describe("producer galaxy artifact golden", () => {
 
   it("rejects valid JSON when the syntactically strong ETag is not its transport hash", async () => {
     await expect(validateGalaxyArtifact(
-      "test-project", headers(`"${"a".repeat(64)}"`), payload, gzip,
+      "test-project", headers(`"${"a".repeat(64)}"`), payload, payloadText, gzip,
     )).rejects.toThrow("transport etag recomputation mismatch");
+  });
+
+  it("refuses to guess when the semantic hash field is not uniquely spliceable", () => {
+    const h = "b".repeat(64);
+    const literal = `"graph_content_hash":"${h}",`;
+    expect(() => canonicalSemanticJson(`{${literal}"truncated":false}${literal}`, h))
+      .toThrow("semantic hash field is not uniquely spliceable");
+    expect(() => canonicalSemanticJson('{"truncated":false}', h))
+      .toThrow("semantic hash field is not uniquely spliceable");
+  });
+});
+
+describe("producer float formatting is not a JS re-serialization fixed point", () => {
+  it("validates producer bytes whose integral floats JSON.stringify would renormalize", async () => {
+    // serde_json/ryu emits an integral f64 as 0.0 / 1.0; JSON.parse->JSON.stringify
+    // collapses these to 0 / 1, so a re-stringify would never rehash. The client
+    // must hash the producer's raw bytes with only the hash field spliced out.
+    const hashInput =
+      '{"project_id":"test-project","git_head":"abc123","generated_at":"2026-07-18T00:00:00Z"' +
+      ',"generation_id":"019f741c-0000-7000-8000-000000000000","truncated":false' +
+      ',"total_nodes":1,"total_edges":1,"node_cap":1' +
+      ',"nodes":[{"id":"file:src/app.rs","uid":"file:src/app.rs","kind":"file"' +
+      ',"label":"src/app.rs","pagerank":0.0,"is_test":false,"x":1.0,"y":0.0}]' +
+      ',"edges":[{"from":"file:src/app.rs","to":"file:src/app.rs"' +
+      ',"kind":"ContainsDefinition","confidence":1.0}]}';
+    // Proof this exercises the bug: a JS round-trip is not byte-stable here.
+    expect(JSON.stringify(JSON.parse(hashInput))).not.toBe(hashInput);
+
+    const graphContentHash = hash(hashInput);
+    const bytes = gzipSync(spliceHashField(hashInput, graphContentHash));
+    const etag = `"${hash(bytes)}"`;
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(bytes, {
+      status: 200,
+      headers: headers(etag, {
+        [IDENTITY_HEADERS.semanticHash]: graphContentHash,
+        "content-type": "application/gzip",
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const outcome = await fetchGalaxyArtifact("test-project");
+    expect(outcome).toMatchObject({ kind: "artifact" });
+    if (outcome.kind === "artifact") {
+      expect(outcome.artifact.snapshot.nodes[0].pagerank).toBe(0);
+      expect(outcome.artifact.snapshot.nodes[0].x).toBe(1);
+    }
+  });
+
+  it("rejects tampered payload bytes even when transport and identity self-agree", async () => {
+    // Flip one semantic byte (a pagerank digit) while leaving the graph_content_hash
+    // field intact, and recompute the transport etag over the tampered gzip so the
+    // transport and identity checks pass. The spliced rehash must still catch it.
+    const tampered = payloadText.replace('"pagerank":0.38662203610895207', '"pagerank":0.38662203610895208');
+    expect(tampered).not.toBe(payloadText);
+    const bytes = gzipSync(tampered);
+    const etag = `"${hash(bytes)}"`;
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(bytes, {
+      status: 200,
+      headers: headers(etag, { "content-type": "application/gzip" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchGalaxyArtifact("test-project")).rejects.toThrow("semantic hash recomputation mismatch");
   });
 });
 

--- a/ui/src/api/galaxyArtifact.ts
+++ b/ui/src/api/galaxyArtifact.ts
@@ -38,7 +38,7 @@ async function errorCode(response: Response): Promise<string> {
   return (body as { code: string }).code;
 }
 
-async function parseResponseJson(response: Response): Promise<{ payload: unknown; transportBytes: ArrayBuffer }> {
+async function parseResponseJson(response: Response): Promise<{ payload: unknown; payloadText: string; transportBytes: ArrayBuffer }> {
   const bytes = await response.arrayBuffer();
   // The route deliberately sends an explicit gzip artifact rather than HTTP
   // Content-Encoding gzip: Fetch would otherwise decode the bytes before this
@@ -50,7 +50,9 @@ async function parseResponseJson(response: Response): Promise<{ payload: unknown
     const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("gzip"));
     text = await new Response(stream).text();
   } catch { failure("artifact gzip could not be parsed"); }
-  try { return { payload: JSON.parse(text), transportBytes: bytes }; } catch { failure("artifact JSON could not be parsed"); }
+  // The decompressed text is the producer's own serialization; the validator
+  // recomputes the semantic hash over these exact bytes, never a re-stringify.
+  try { return { payload: JSON.parse(text), payloadText: text, transportBytes: bytes }; } catch { failure("artifact JSON could not be parsed"); }
 }
 
 /**
@@ -88,8 +90,8 @@ export async function fetchGalaxyArtifact(
   }
   if (response.status === 401 || response.status === 403) failure(`authorization failed (${response.status})`);
   if (response.status !== 200) failure(`unexpected HTTP status ${response.status}`);
-  const { payload, transportBytes } = await parseResponseJson(response);
-  const artifact = await validateGalaxyArtifact(projectId, response.headers, payload, transportBytes);
+  const { payload, payloadText, transportBytes } = await parseResponseJson(response);
+  const artifact = await validateGalaxyArtifact(projectId, response.headers, payload, payloadText, transportBytes);
   const projectCache = cache.get(projectId) ?? new Map<string, ValidatedGalaxyArtifact>();
   projectCache.set(artifact.etag, artifact);
   cache.set(projectId, projectCache);

--- a/ui/src/api/galaxyArtifactSchema.ts
+++ b/ui/src/api/galaxyArtifactSchema.ts
@@ -87,16 +87,36 @@ export async function sha256Hex(bytes: BufferSource): Promise<string> {
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-/** The producer's canonical semantic domain: payload JSON with only this hash omitted. */
-export function canonicalSemanticJson(payload: Record<string, unknown>): string {
-  const { graph_content_hash: _graphContentHash, ...hashInput } = payload;
-  return JSON.stringify(hashInput);
+/**
+ * The producer's canonical semantic domain is the payload's own decoded BYTES
+ * with only the `graph_content_hash` field spliced out — deliberately not a JS
+ * re-serialization. serde_json/ryu formats an integral f64 as `0.0`/`1.0`,
+ * which is not a fixed point of `JSON.parse`→`JSON.stringify` (`0`/`1`), so
+ * re-stringifying would diverge from the producer bytes for real artifacts.
+ *
+ * The producer serializes the same struct twice: once with `graph_content_hash`
+ * absent (the hash input) and once with it present (the final payload). Because
+ * the field is written in a fixed serde position (immediately after
+ * `generation_id`, immediately before `truncated`), the final payload minus the
+ * literal `"graph_content_hash":"<hex>",` substring is byte-identical to the
+ * hash input. `payloadHash` has already been validated as 64 lowercase hex, so
+ * the literal is exact; it must occur exactly once or we refuse to guess.
+ */
+export function canonicalSemanticJson(payloadText: string, payloadHash: string): string {
+  const literal = `"graph_content_hash":"${payloadHash}",`;
+  const first = payloadText.indexOf(literal);
+  if (first === -1 || payloadText.indexOf(literal, first + 1) !== -1) {
+    fail("semantic hash field is not uniquely spliceable");
+  }
+  return payloadText.slice(0, first) + payloadText.slice(first + literal.length);
 }
 
 export async function validateGalaxyArtifact(
   requestedProjectId: string,
   headers: Headers,
   payload: unknown,
+  /** Exact decompressed payload bytes as text, the producer's own serialization. */
+  payloadText: string,
   /** Exact compressed HTTP representation, before gzip decoding. */
   transportBytes: BufferSource,
 ): Promise<ValidatedGalaxyArtifact> {
@@ -123,7 +143,7 @@ export async function validateGalaxyArtifact(
   if (payloadGeneration !== identity.generationId) fail("generation identity mismatch");
   if (payloadCommit !== identity.commitSha) fail("commit identity mismatch");
   if (payloadHash !== identity.semanticHash || !/^[0-9a-f]{64}$/.test(payloadHash)) fail("semantic hash identity mismatch");
-  const computedHash = await sha256Hex(new TextEncoder().encode(canonicalSemanticJson(raw)));
+  const computedHash = await sha256Hex(new TextEncoder().encode(canonicalSemanticJson(payloadText, payloadHash)));
   if (computedHash !== payloadHash) fail("semantic hash recomputation mismatch");
   if (!Array.isArray(raw.nodes) || !Array.isArray(raw.edges)) fail("nodes or edges is not an array");
   const nodes = raw.nodes.map(node); const edges = raw.edges.map(edge);

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -9,6 +9,23 @@ if (typeof globalThis.TransformStream === "undefined") {
   globalThis.WritableStream = streams.WritableStream as typeof globalThis.WritableStream;
 }
 
+// jsdom also omits the Compression Streams API — the galaxy artifact client
+// decodes an explicit gzip body via DecompressionStream. Expose the Node
+// implementation so that code path is exercised under test.
+if (typeof globalThis.DecompressionStream === "undefined") {
+  const streams = await import("node:stream/web");
+  globalThis.CompressionStream = streams.CompressionStream as typeof globalThis.CompressionStream;
+  globalThis.DecompressionStream = streams.DecompressionStream as typeof globalThis.DecompressionStream;
+}
+
+// jsdom's Blob (v29) has no `.stream()`, which real browsers do and the galaxy
+// artifact client uses to feed the gzip decoder. Swap in Node's spec-complete
+// Blob so that decode path runs under test.
+if (typeof (globalThis.Blob?.prototype as { stream?: unknown } | undefined)?.stream !== "function") {
+  const { Blob } = await import("node:buffer");
+  globalThis.Blob = Blob as unknown as typeof globalThis.Blob;
+}
+
 // jsdom doesn't provide WebGL2RenderingContext — sigma 3.x CJS build
 // references it at import time; stub so the module can load.
 if (typeof globalThis.WebGL2RenderingContext === "undefined") {


### PR DESCRIPTION
## Problem

The Galaxy view failed with `Galaxy artifact validation failed: semantic hash recomputation mismatch` on every real artifact.

The client recomputed `graph_content_hash` by `JSON.stringify`-ing the parsed payload minus the hash field. That is **not byte-stable** against the server's `serde_json`/`ryu` output: an integral `f64` (pagerank fallback `0.0`, edge confidence `1.0`, layout `x`/`y`) serializes as `0.0`/`1.0` on the server but collapses to `0`/`1` through `JSON.parse`→`JSON.stringify`. So the recomputed hash never matched Rust-produced bytes.

The existing test suite missed it because its fixtures were built with `JSON.stringify` in JS (trivially JS-canonical) and the fixture payload deliberately contains no integral floats — the contract was never exercised against Rust-shaped bytes.

## Fix (client-side only; works with already-published artifacts)

Hash the **producer's own decompressed bytes** with only the hash field spliced out, instead of a JS re-serialization:

- `parseResponseJson` now also returns the decompressed `payloadText`, threaded through `fetchGalaxyArtifact` into `validateGalaxyArtifact`.
- `canonicalSemanticJson` reconstructs the hash input by splicing the exact literal `"graph_content_hash":"<payloadHash>",` (validated 64-hex, trailing comma → `"truncated"` in serde order) out of the raw text. It `fail(...)`s if that literal is absent or non-unique — never guesses.
- Verified against the real producer golden: `payload.json` minus that literal is byte-identical to the producer's `hash_input.json`, and hashing it reproduces `manifest.graph_content_hash`.

## Tests

- **Critical new golden**: a payload authored as raw bytes with Rust-style floats (`0.0`/`1.0`) whose `JSON.stringify` round-trip differs; validation now succeeds. Empirically confirmed to **fail against the old re-stringify path**.
- Negative test: tampered payload bytes (transport/identity recomputed to self-agree) still caught as `semantic hash recomputation mismatch`.
- Splice uniqueness guard test (absent / duplicated field).
- Existing generation/rollback helpers adapted to compute the hash over the actual serialized bytes, mirroring the producer.
- Test-infra: fixtures loaded via `fileURLToPath(import.meta.url)` (avoids Vite's `new URL(<literal>, import.meta.url)` asset rewrite); `setup.ts` polyfills `DecompressionStream`/`CompressionStream` and a `Blob` with `.stream()` so the gzip-decode path runs under jsdom.

No Rust changes.