### PR TITLE
fix: backfill plan-billed cost_basis and price kimi k3 at moonshotai list rates

### DIFF
--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -2600,9 +2600,16 @@ fn intern_envelope(wire: SerializableDjinnEvent) -> Result<DjinnEventEnvelope, (
 /// path) provider classification.
 ///
 /// Precedence:
-/// 1. `SubscriptionPlan` hint → `"projected"`
-/// 2. `MeteredApi` hint → priced `"actual"` / unpriced `"unpriced"`
+/// 1. `SubscriptionPlan` hint → `"projected"` when priced, else `"unpriced"`
+/// 2. `MeteredApi` hint → `"actual"` when priced, else `"unpriced"`
 /// 3. No hint → legacy `classify_provider` + pricing availability
+///
+/// A `Pricing` snapshot only counts as priced when at least one per-million rate
+/// is non-zero (`Pricing::is_priced`). Flat-rate subscription / coding-plan
+/// models carry an all-zero snapshot in the catalog; classifying them as
+/// `"projected"` $0.00 (or a zero-priced metered session as `"actual"` $0.00)
+/// pollutes the usage dashboard's cost stack. Missing pricing (`None`) and
+/// all-zero pricing both resolve to `"unpriced"`.
 ///
 /// This is extracted as a pure function so the decision logic can be tested
 /// without instantiating a `DirectServices` / database.
@@ -2611,19 +2618,27 @@ pub(crate) fn determine_cost_basis(
     pricing: Option<&djinn_core::models::Pricing>,
     provider_id: Option<&str>,
 ) -> &'static str {
+    // A snapshot counts as "priced" only when present AND non-zero.
+    let is_priced = pricing.is_some_and(djinn_core::models::Pricing::is_priced);
     match hint {
-        Some(CostBasisHint::SubscriptionPlan) => "projected",
+        Some(CostBasisHint::SubscriptionPlan) => {
+            if is_priced {
+                "projected"
+            } else {
+                "unpriced"
+            }
+        }
         Some(CostBasisHint::MeteredApi) => {
-            if pricing.is_some() {
+            if is_priced {
                 "actual"
             } else {
                 "unpriced"
             }
         }
         None => {
-            // Legacy path: classify by provider id alone.
-            match (provider_id, pricing) {
-                (Some(pid), Some(_)) => {
+            // Legacy path: classify by provider id + non-zero pricing.
+            match (provider_id, is_priced) {
+                (Some(pid), true) => {
                     if classify_provider(pid).is_subscription() {
                         "projected"
                     } else {
@@ -2706,6 +2721,48 @@ mod tests {
         );
         // Also covers the case where no provider_id is present at all.
         assert_eq!(determine_cost_basis(hint, None, None), "unpriced");
+    }
+
+    /// A subscription-plan session whose catalog pricing is all-zero (the
+    /// flat-rate coding-plan case) must NOT book as `"projected"` $0.00 — an
+    /// all-zero snapshot is unpriced, not real projected spend. Both an explicit
+    /// all-zero `Pricing` and missing pricing resolve to `"unpriced"`.
+    #[test]
+    fn cost_basis_subscription_plan_zero_pricing_gives_unpriced() {
+        let hint = Some(CostBasisHint::SubscriptionPlan);
+        assert_eq!(
+            determine_cost_basis(hint, Some(&Pricing::default()), Some("kimi-for-coding")),
+            "unpriced"
+        );
+        assert_eq!(
+            determine_cost_basis(hint, None, Some("kimi-for-coding")),
+            "unpriced"
+        );
+    }
+
+    /// A metered session with an all-zero pricing snapshot must NOT book as
+    /// `"actual"` $0.00 — it is unpriced, like a missing snapshot.
+    #[test]
+    fn cost_basis_metered_zero_pricing_gives_unpriced() {
+        let hint = Some(CostBasisHint::MeteredApi);
+        assert_eq!(
+            determine_cost_basis(hint, Some(&Pricing::default()), Some("openai")),
+            "unpriced"
+        );
+    }
+
+    /// Legacy (no hint) path also requires non-zero pricing: an all-zero
+    /// snapshot resolves to `"unpriced"` regardless of provider class.
+    #[test]
+    fn cost_basis_legacy_zero_pricing_gives_unpriced() {
+        assert_eq!(
+            determine_cost_basis(None, Some(&Pricing::default()), Some("openai")),
+            "unpriced"
+        );
+        assert_eq!(
+            determine_cost_basis(None, Some(&Pricing::default()), Some("minimax-coding-plan")),
+            "unpriced"
+        );
     }
 
     /// OAuth transport alone (without subscription evidence) must NOT blanket

--- a/server/crates/djinn-core/src/models/provider.rs
+++ b/server/crates/djinn-core/src/models/provider.rs
@@ -22,6 +22,23 @@ pub struct Pricing {
     pub cache_write_per_million: f64,
 }
 
+impl Pricing {
+    /// `true` when at least one per-million rate is non-zero.
+    ///
+    /// An all-zero `Pricing` is what the catalog carries for flat-rate
+    /// subscription / coding-plan models (billed monthly, so models.dev reports
+    /// $0 per token). Cost-basis classification treats such a snapshot as
+    /// *unpriced* rather than a real $0.00 spend: a zero-priced subscription
+    /// session must not book as `"projected"` $0.00, and a zero-priced metered
+    /// session must not book as `"actual"` $0.00.
+    pub fn is_priced(&self) -> bool {
+        self.input_per_million != 0.0
+            || self.output_per_million != 0.0
+            || self.cache_read_per_million != 0.0
+            || self.cache_write_per_million != 0.0
+    }
+}
+
 /// A single model from the catalog.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Model {

--- a/server/crates/djinn-db/migrations_postgres/141_cost_basis_backfill.sql
+++ b/server/crates/djinn-db/migrations_postgres/141_cost_basis_backfill.sql
@@ -1,0 +1,121 @@
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 141: Backfill cost_basis for historical sessions mis-booked before the
+--      billing-hint forward fix (derive_billing_signal, #2352) shipped.
+-- ──────────────────────────────────────────────────────────────────────────────
+--
+-- CONTEXT
+--   Two classes of historical `sessions` rows carry the wrong `cost_basis`:
+--
+--     (1) ZERO-PRICED rows booked as real spend. Migration 83 backfilled every
+--         row with a non-NULL price snapshot to 'actual', and later runtime code
+--         booked flat-rate coding-plan sessions (whose catalog pricing is
+--         all-zero) as 'projected' $0.00. A zero-priced session is neither real
+--         API spend nor a meaningful projection — it is 'unpriced'. The forward
+--         fix (task, PART B) now requires NON-ZERO pricing for both the metered
+--         ('actual') and subscription ('projected') arms of `determine_cost_basis`.
+--         This migration repairs the pre-fix rows.
+--
+--     (2) PLAN-BACKED `openai/*` rows booked as 'actual'. Before #2352, an
+--         openai-namespace session backed by a personal ChatGPT/Codex PLAN OAuth
+--         credential (real API spend = $0) was priced and booked 'actual' by the
+--         legacy `determine_cost_basis` path. `derive_billing_signal` now emits a
+--         SubscriptionPlan hint for those sessions, but no backfill of the
+--         historical rows was ever shipped for the full `openai/*` set.
+--
+-- ORDER MATTERS
+--   Step 1 (zero-priced → 'unpriced') MUST run before step 2 (openai 'actual' →
+--   'projected'). After step 1, any zero-priced openai 'actual' row has already
+--   become 'unpriced', so step 2 only promotes genuinely priced openai rows to
+--   'projected' and never resurrects a zero-priced $0.00 as projected spend.
+--
+-- IDEMPOTENCE
+--   Both statements are gated on the cost_basis they rewrite AWAY from, so a
+--   re-run matches zero rows. No guard table or idempotency key is required.
+-- ──────────────────────────────────────────────────────────────────────────────
+
+
+-- ── STEP 1: zero-priced sessions → 'unpriced' ────────────────────────────────
+--
+-- Reclassify any 'actual' / 'projected' row whose FOUR pricing-snapshot columns
+-- are all literally zero. NULL snapshots must NOT match (a NULL snapshot means
+-- "no pricing recorded", already handled by 83's 'unpriced' default and not this
+-- migration's concern). Only an all-literal-zero snapshot — the flat-rate
+-- subscription / coding-plan signature — is rewritten here.
+UPDATE sessions
+   SET cost_basis = 'unpriced'
+ WHERE cost_basis IN ('actual', 'projected')
+   AND input_price_per_million_snapshot       = 0
+   AND output_price_per_million_snapshot      = 0
+   AND cache_read_price_per_million_snapshot  = 0
+   AND cache_write_price_per_million_snapshot = 0;
+
+
+-- ── STEP 2: plan-backed openai/* 'actual' → 'projected' ──────────────────────
+--
+-- Reclassify priced `openai/*` sessions still booked as 'actual' to 'projected',
+-- but ONLY when durable install-wide credential evidence proves this deployment
+-- could not have paid per-token for OpenAI:
+--
+--   • a (non-revoked) ChatGPT/Codex plan OAuth credential EXISTS
+--     (key_name = '__OAUTH_CHATGPT_CODEX', provider_id = 'chatgpt_codex'), AND
+--   • NO (non-revoked) 'OPENAI_API_KEY' credential exists anywhere.
+--
+-- The `sessions` schema has no per-row credential linkage, so the gate is
+-- install-wide and all-or-nothing — matching the conservative stance of
+-- migrations 84 and 89. On a deployment that mixed a real OpenAI API key with a
+-- Codex plan, the gate does nothing (the ambiguity cannot be resolved from
+-- stored data) and openai rows stay 'actual'. This makes the migration safe to
+-- ship to any deployment: only installs that provably ran openai on a plan are
+-- rewritten. Zero-priced openai rows are already 'unpriced' from step 1.
+UPDATE sessions
+   SET cost_basis = 'projected'
+ WHERE cost_basis = 'actual'
+   AND model_id LIKE 'openai/%'
+   -- Install-wide credential gate: a ChatGPT/Codex plan OAuth credential exists…
+   AND EXISTS (
+        SELECT 1 FROM credentials c
+         WHERE c.key_name = '__OAUTH_CHATGPT_CODEX'
+           AND c.revoked_at IS NULL
+   )
+   -- …and NO OpenAI API-key credential exists anywhere in the install.
+   AND NOT EXISTS (
+        SELECT 1 FROM credentials c
+         WHERE c.key_name = 'OPENAI_API_KEY'
+           AND c.revoked_at IS NULL
+   );
+
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- VALIDATION / OBSERVABILITY QUERIES  (NOT auto-executed — commented out)
+-- ══════════════════════════════════════════════════════════════════════════════
+-- (1) Cost-basis distribution before/after:
+-- SELECT cost_basis, COUNT(*) AS sessions, COALESCE(SUM(cost_usd), 0) AS total_usd
+--   FROM sessions GROUP BY cost_basis ORDER BY cost_basis;
+--
+-- (2) Install-gate state — does this install qualify for step 2 at all?
+-- SELECT
+--   EXISTS (SELECT 1 FROM credentials WHERE key_name = '__OAUTH_CHATGPT_CODEX'
+--             AND revoked_at IS NULL) AS has_codex_plan_oauth,
+--   EXISTS (SELECT 1 FROM credentials WHERE key_name = 'OPENAI_API_KEY'
+--             AND revoked_at IS NULL) AS has_openai_api_key;
+-- Qualifying install: (true, false). Any other combination reclassifies ZERO
+-- rows in step 2.
+--
+-- (3) Zero-priced rows targeted by step 1 (run BEFORE; must be 0 AFTER):
+-- SELECT COUNT(*) FROM sessions
+--  WHERE cost_basis IN ('actual', 'projected')
+--    AND input_price_per_million_snapshot = 0
+--    AND output_price_per_million_snapshot = 0
+--    AND cache_read_price_per_million_snapshot = 0
+--    AND cache_write_price_per_million_snapshot = 0;
+--
+-- (4) Residual priced openai 'actual' AFTER (0 for a qualifying install):
+-- SELECT COUNT(*), COALESCE(SUM(cost_usd), 0) FROM sessions
+--  WHERE cost_basis = 'actual' AND model_id LIKE 'openai/%';
+--
+-- ROLLBACK
+--   Neither step is auto-reversible from stored data alone (step 1 collapses two
+--   source states into 'unpriced'). Do NOT drop the column. To reverse step 2
+--   only, run the same predicate with the cost_basis filter inverted
+--   (SET cost_basis='actual' WHERE cost_basis='projected' AND model_id LIKE
+--   'openai/%' AND <same credential gate>).

--- a/server/crates/djinn-provider/src/catalog/service.rs
+++ b/server/crates/djinn-provider/src/catalog/service.rs
@@ -19,10 +19,9 @@ const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 const REFRESH_LOG_MAX_AGE: Duration = Duration::from_secs(60 * 60); // 1 hour
 
 fn has_nonzero_pricing(pricing: &Pricing) -> bool {
-    pricing.input_per_million != 0.0
-        || pricing.output_per_million != 0.0
-        || pricing.cache_read_per_million != 0.0
-        || pricing.cache_write_per_million != 0.0
+    // Single source of truth: `Pricing::is_priced` (djinn-core). Kept as a
+    // free fn so it can still be passed as a fn-pointer to `Option::filter`.
+    pricing.is_priced()
 }
 
 /// Build-time embedded snapshot of models.dev/api.json.
@@ -966,17 +965,39 @@ const PRICING_REFERENCE_MAP: &[(&str, &str)] = &[
 /// canonical match in the base provider's catalog, so [`PRICING_REFERENCE_MAP`]
 /// alone can't price them.
 ///
-/// Kimi for Coding ships coding ids (`k2p7`, `k2p5`) that don't appear in
-/// moonshotai's pay-as-you-go list (which uses `kimi-k2-thinking`, `kimi-k2.5`,
-/// …). They're the same Kimi-K2 family billed at the standard K2 rate, so we
-/// point them at `moonshotai/kimi-k2-thinking` ($0.6 in / $2.5 out / $0.15
-/// cache). The second tuple field is the **canonical** plan-model id (see
-/// [`canonical_model_id`]).
+/// Kimi for Coding ships coding ids (`k3`, `k2p7`, `k2p5`, and the newer
+/// upstream `kimi-for-coding` / `kimi-for-coding-highspeed`) that don't
+/// canonically match a moonshotai pay-as-you-go id, so we pin each to its true
+/// counterpart in moonshotai's list:
+///   • `k3`  → `moonshotai/kimi-k3`             ($3 in / $15 out / $0.3 cache)
+///   • `k2p7`→ `moonshotai/kimi-k2.7-code`      ($0.95 / $4 / $0.19)
+///   • `k2p5`→ `moonshotai/kimi-k2.5`           ($0.6 / $3 / $0.1)
+///   • `kimi-for-coding`           → `moonshotai/kimi-k2.7-code`
+///   • `kimi-for-coding-highspeed` → `moonshotai/kimi-k2.7-code-highspeed`
+///
+/// `k2p7`/`k2p5` previously stood in on `kimi-k2-thinking` because their true
+/// counterparts did not yet exist upstream; models.dev now carries them, so the
+/// aliases point at the exact plan-equivalent models. The second tuple field is
+/// the **canonical** plan-model id (see [`canonical_model_id`]) — lowercase
+/// alphanumeric only, so `kimi-for-coding` → `kimiforcoding`.
 ///
 /// (plan_provider_id, canonical_plan_model_id, base_provider_id, base_model_id)
 const PRICING_MODEL_ALIAS: &[(&str, &str, &str, &str)] = &[
-    ("kimi-for-coding", "k2p7", "moonshotai", "kimi-k2-thinking"),
-    ("kimi-for-coding", "k2p5", "moonshotai", "kimi-k2-thinking"),
+    ("kimi-for-coding", "k3", "moonshotai", "kimi-k3"),
+    ("kimi-for-coding", "k2p7", "moonshotai", "kimi-k2.7-code"),
+    ("kimi-for-coding", "k2p5", "moonshotai", "kimi-k2.5"),
+    (
+        "kimi-for-coding",
+        "kimiforcoding",
+        "moonshotai",
+        "kimi-k2.7-code",
+    ),
+    (
+        "kimi-for-coding",
+        "kimiforcodinghighspeed",
+        "moonshotai",
+        "kimi-k2.7-code-highspeed",
+    ),
 ];
 
 /// Strip non-alphanumeric chars and lowercase so plan/base model ids match

--- a/server/crates/djinn-provider/src/catalog/service_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/service_tests.rs
@@ -279,30 +279,16 @@ fn enrich_plan_pricing_borrows_payg_rates_for_zero_priced_plan_models() {
 
 #[test]
 fn enrich_plan_pricing_applies_explicit_model_alias() {
-    // kimi-for-coding ships `k3`/`k2p7`/`k2p5`, which don't canonically match
-    // any moonshotai id — they must be priced via PRICING_MODEL_ALIAS from their
-    // true moonshotai counterparts.
-    let k3_rate = Pricing {
-        input_per_million: 3.0,
-        output_per_million: 15.0,
-        cache_read_per_million: 0.3,
-        cache_write_per_million: 0.0,
+    // kimi-for-coding ships `k3`/`k2p7`/`k2p5` (+ the upstream `kimi-for-coding`
+    // id) which don't canonically match any moonshotai id — they must be priced
+    // via PRICING_MODEL_ALIAS from their true moonshotai counterparts.
+    let rate = |o: f64| Pricing {
+        output_per_million: o,
+        ..Pricing::default()
     };
-    let k2p7_rate = Pricing {
-        input_per_million: 0.95,
-        output_per_million: 4.0,
-        cache_read_per_million: 0.19,
-        cache_write_per_million: 0.0,
-    };
-    let k2p5_rate = Pricing {
-        input_per_million: 0.6,
-        output_per_million: 3.0,
-        cache_read_per_million: 0.1,
-        cache_write_per_million: 0.0,
-    };
-    let mk = |provider: &str, id: &str, pricing: Pricing| Model {
+    let mk = |id: &str, pricing: Pricing| Model {
         id: id.to_string(),
-        provider_id: provider.to_string(),
+        provider_id: String::new(),
         name: id.to_string(),
         tool_call: true,
         reasoning: true,
@@ -316,61 +302,36 @@ fn enrich_plan_pricing_applies_explicit_model_alias() {
     idx.insert(
         "moonshotai".to_string(),
         vec![
-            mk("moonshotai", "kimi-k3", k3_rate.clone()),
-            mk("moonshotai", "kimi-k2.7-code", k2p7_rate.clone()),
-            mk("moonshotai", "kimi-k2.5", k2p5_rate.clone()),
+            mk("kimi-k3", rate(15.0)),
+            mk("kimi-k2.7-code", rate(4.0)),
+            mk("kimi-k2.5", rate(3.0)),
         ],
     );
     idx.insert(
         "kimi-for-coding".to_string(),
-        vec![
-            mk("kimi-for-coding", "k3", Pricing::default()),
-            mk("kimi-for-coding", "k2p7", Pricing::default()),
-            mk("kimi-for-coding", "k2p5", Pricing::default()),
-            // Newer upstream model ids that canonicalize to `kimiforcoding`.
-            mk("kimi-for-coding", "kimi-for-coding", Pricing::default()),
-        ],
+        // `kimi-for-coding` canonicalizes to `kimiforcoding` (upstream id alias).
+        ["k3", "k2p7", "k2p5", "kimi-for-coding"]
+            .map(|id| mk(id, Pricing::default()))
+            .to_vec(),
     );
 
     enrich_plan_pricing(&mut idx);
 
-    // k3 is priced from moonshotai/kimi-k3 (the fix: previously k3 had no alias
-    // and booked $0.00 "projected").
-    let k3 = idx["kimi-for-coding"]
-        .iter()
-        .find(|m| m.id == "k3")
-        .unwrap();
-    assert!(
-        has_nonzero_pricing(&k3.pricing),
-        "k3 should be priced via the explicit kimi alias"
-    );
-    assert_eq!(k3.pricing.input_per_million, 3.0);
-    assert_eq!(k3.pricing.output_per_million, 15.0);
-    assert_eq!(k3.pricing.cache_read_per_million, 0.3);
-
-    // k2p7 / k2p5 now resolve to their true counterparts, not kimi-k2-thinking.
-    let k2p7 = idx["kimi-for-coding"]
-        .iter()
-        .find(|m| m.id == "k2p7")
-        .unwrap();
-    assert_eq!(k2p7.pricing.output_per_million, 4.0);
-    let k2p5 = idx["kimi-for-coding"]
-        .iter()
-        .find(|m| m.id == "k2p5")
-        .unwrap();
-    assert_eq!(k2p5.pricing.output_per_million, 3.0);
-
-    // The upstream `kimi-for-coding` model id (canonical `kimiforcoding`) is
-    // priced from kimi-k2.7-code.
-    let kfc = idx["kimi-for-coding"]
-        .iter()
-        .find(|m| m.id == "kimi-for-coding")
-        .unwrap();
-    assert!(
-        has_nonzero_pricing(&kfc.pricing),
-        "kimi-for-coding model id should be priced via the explicit alias"
-    );
-    assert_eq!(kfc.pricing.output_per_million, 4.0);
+    let out = |id: &str| {
+        idx["kimi-for-coding"]
+            .iter()
+            .find(|m| m.id == id)
+            .unwrap()
+            .pricing
+            .output_per_million
+    };
+    // k3 is the fix: previously it had no alias and booked $0.00 "projected".
+    assert_eq!(out("k3"), 15.0);
+    // k2p7/k2p5 resolve to their true counterparts, not kimi-k2-thinking.
+    assert_eq!(out("k2p7"), 4.0);
+    assert_eq!(out("k2p5"), 3.0);
+    // Upstream `kimi-for-coding` id (canonical `kimiforcoding`) → kimi-k2.7-code.
+    assert_eq!(out("kimi-for-coding"), 4.0);
 }
 
 #[test]

--- a/server/crates/djinn-provider/src/catalog/service_tests.rs
+++ b/server/crates/djinn-provider/src/catalog/service_tests.rs
@@ -279,12 +279,25 @@ fn enrich_plan_pricing_borrows_payg_rates_for_zero_priced_plan_models() {
 
 #[test]
 fn enrich_plan_pricing_applies_explicit_model_alias() {
-    // kimi-for-coding ships `k2p7`/`k2p5`, which don't canonically match any
-    // moonshotai id — they must be priced via PRICING_MODEL_ALIAS instead.
-    let kimi_rate = Pricing {
+    // kimi-for-coding ships `k3`/`k2p7`/`k2p5`, which don't canonically match
+    // any moonshotai id — they must be priced via PRICING_MODEL_ALIAS from their
+    // true moonshotai counterparts.
+    let k3_rate = Pricing {
+        input_per_million: 3.0,
+        output_per_million: 15.0,
+        cache_read_per_million: 0.3,
+        cache_write_per_million: 0.0,
+    };
+    let k2p7_rate = Pricing {
+        input_per_million: 0.95,
+        output_per_million: 4.0,
+        cache_read_per_million: 0.19,
+        cache_write_per_million: 0.0,
+    };
+    let k2p5_rate = Pricing {
         input_per_million: 0.6,
-        output_per_million: 2.5,
-        cache_read_per_million: 0.15,
+        output_per_million: 3.0,
+        cache_read_per_million: 0.1,
         cache_write_per_million: 0.0,
     };
     let mk = |provider: &str, id: &str, pricing: Pricing| Model {
@@ -302,26 +315,62 @@ fn enrich_plan_pricing_applies_explicit_model_alias() {
     let mut idx: HashMap<String, Vec<Model>> = HashMap::new();
     idx.insert(
         "moonshotai".to_string(),
-        vec![mk("moonshotai", "kimi-k2-thinking", kimi_rate.clone())],
+        vec![
+            mk("moonshotai", "kimi-k3", k3_rate.clone()),
+            mk("moonshotai", "kimi-k2.7-code", k2p7_rate.clone()),
+            mk("moonshotai", "kimi-k2.5", k2p5_rate.clone()),
+        ],
     );
     idx.insert(
         "kimi-for-coding".to_string(),
         vec![
+            mk("kimi-for-coding", "k3", Pricing::default()),
             mk("kimi-for-coding", "k2p7", Pricing::default()),
             mk("kimi-for-coding", "k2p5", Pricing::default()),
+            // Newer upstream model ids that canonicalize to `kimiforcoding`.
+            mk("kimi-for-coding", "kimi-for-coding", Pricing::default()),
         ],
     );
 
     enrich_plan_pricing(&mut idx);
 
-    for id in ["k2p7", "k2p5"] {
-        let m = idx["kimi-for-coding"].iter().find(|m| m.id == id).unwrap();
-        assert!(
-            has_nonzero_pricing(&m.pricing),
-            "{id} should be priced via the explicit kimi alias"
-        );
-        assert_eq!(m.pricing.output_per_million, 2.5);
-    }
+    // k3 is priced from moonshotai/kimi-k3 (the fix: previously k3 had no alias
+    // and booked $0.00 "projected").
+    let k3 = idx["kimi-for-coding"]
+        .iter()
+        .find(|m| m.id == "k3")
+        .unwrap();
+    assert!(
+        has_nonzero_pricing(&k3.pricing),
+        "k3 should be priced via the explicit kimi alias"
+    );
+    assert_eq!(k3.pricing.input_per_million, 3.0);
+    assert_eq!(k3.pricing.output_per_million, 15.0);
+    assert_eq!(k3.pricing.cache_read_per_million, 0.3);
+
+    // k2p7 / k2p5 now resolve to their true counterparts, not kimi-k2-thinking.
+    let k2p7 = idx["kimi-for-coding"]
+        .iter()
+        .find(|m| m.id == "k2p7")
+        .unwrap();
+    assert_eq!(k2p7.pricing.output_per_million, 4.0);
+    let k2p5 = idx["kimi-for-coding"]
+        .iter()
+        .find(|m| m.id == "k2p5")
+        .unwrap();
+    assert_eq!(k2p5.pricing.output_per_million, 3.0);
+
+    // The upstream `kimi-for-coding` model id (canonical `kimiforcoding`) is
+    // priced from kimi-k2.7-code.
+    let kfc = idx["kimi-for-coding"]
+        .iter()
+        .find(|m| m.id == "kimi-for-coding")
+        .unwrap();
+    assert!(
+        has_nonzero_pricing(&kfc.pricing),
+        "kimi-for-coding model id should be priced via the explicit alias"
+    );
+    assert_eq!(kfc.pricing.output_per_million, 4.0);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The usage dashboard splits session cost by `sessions.cost_basis` (`actual` = real API-key spend, `projected` = subscription-equivalent, `unpriced`). Two bugs corrupted it.

**Bug 1 — historical plan usage booked as real API spend.** The forward fix (#2352) made `derive_billing_signal` emit a `SubscriptionPlan` hint for Codex-OAuth openai sessions, but every session created *before* that deploy went through the legacy `determine_cost_basis` path (`openai` is not a subscription -> priced -> `actual`). ~$18k of ChatGPT-Codex plan usage (`openai/gpt-5.6-*`, `openai/gpt-5.5`) was misbooked as real spend. No backfill migration was ever shipped.

**Bug 2 — `kimi-for-coding/k3` booked $0.00 `projected`** and won "Best cost/task": the catalog had no pricing alias for `k3`, and `determine_cost_basis` treated `Some(pricing)` as priced even when every rate was zero.

## Fix

### Migration `141_cost_basis_backfill.sql` (raw SQL, generic, credential-gated)
1. Reclassify all-literal-zero-priced `actual`/`projected` rows to `unpriced` (NULL snapshots deliberately excluded).
2. Reclassify priced `openai/*` `actual` rows to `projected`, gated with `EXISTS`/`NOT EXISTS` on the `credentials` table: only when a non-revoked `__OAUTH_CHATGPT_CODEX` OAuth credential exists AND no non-revoked `OPENAI_API_KEY` exists. Install-wide, all-or-nothing, safe for any deployment (mirrors migrations 84/89). Step 1 runs before step 2 so zero-priced openai rows land in `unpriced`, never `projected` $0.00.

### Catalog pricing (`catalog/service.rs`)
- `PRICING_MODEL_ALIAS`: add `k3 -> moonshotai/kimi-k3` ($3/$15/$0.3), retarget `k2p7 -> kimi-k2.7-code` and `k2p5 -> kimi-k2.5` (true upstream counterparts now exist, previously stood in on `kimi-k2-thinking`), and alias the newer upstream `kimi-for-coding` / `kimi-for-coding-highspeed` model ids (canonical `kimiforcoding` / `kimiforcodinghighspeed`).

### Zero-priced classification (`direct_services.rs` + `djinn-core`)
- Add `Pricing::is_priced()` (any rate non-zero) in djinn-core.
- `determine_cost_basis` now requires non-zero pricing on both hint arms and the legacy arm: zero/missing pricing -> `unpriced` for `SubscriptionPlan`, `MeteredApi`, and legacy. `service.rs::has_nonzero_pricing` delegates to the new helper.

## Tests
- `cargo test -p djinn-provider` — enrich alias tests pass (extended to cover the k3 alias and the true k2p7/k2p5 counterparts + the upstream `kimi-for-coding` id).
- `cargo test -p djinn-agent --lib cost_basis` / `billing_signal` — all pass, incl. 3 new tests (SubscriptionPlan/MeteredApi/legacy + all-zero pricing -> `unpriced`).
- Clippy clean on the three touched crates (`djinn-core`, `djinn-provider`, `djinn-agent` lib). Pre-existing baseline warnings/errors in untouched crates (e.g. `djinn-agent-worker` disallowed `SystemTime::now`) are unrelated.