### PR TITLE
fix(agent): remove test_helpers from the release worker's first-turn path

### DIFF
--- a/server/crates/djinn-agent-worker/Cargo.toml
+++ b/server/crates/djinn-agent-worker/Cargo.toml
@@ -13,7 +13,11 @@ name = "djinn-agent-worker"
 path = "src/main.rs"
 
 [dependencies]
-djinn-agent = { path = "../djinn-agent", features = ["test-support"] }
+# NOTE: keep `test-support` OFF this production edge. Enabling it here compiles
+# djinn-agent's test scaffolding (test_helpers and the `durable_root()` tempdir
+# variant) into the shipped worker binary, which panics at runtime. The feature
+# is activated only for tests via the [dev-dependencies] edge below.
+djinn-agent = { path = "../djinn-agent" }
 djinn-core = { path = "../djinn-core" }
 djinn-db = { path = "../djinn-db" }
 djinn-git = { path = "../djinn-git" }
@@ -45,6 +49,7 @@ uuid = { version = "1", features = ["v7"] }
 workspace-hack.workspace = true
 
 [dev-dependencies]
+djinn-agent = { path = "../djinn-agent", features = ["test-support"] }
 djinn-db = { path = "../djinn-db", features = ["test-support"] }
 djinn-graph = { path = "../djinn-graph", features = ["test-support"] }
 futures = "0.3"


### PR DESCRIPTION
## The panic (production canary, 2026-07-22, v0.6.115 worker; task tmbl, run 019f8aad-2a0e, session turn=1)

```
thread 'main' (1) panicked at crates/djinn-agent/src/test_helpers.rs:42:36:
create test tempdir base: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
```

Every production worker task-run died with exit 101 on the first reply-loop turn.

## Call-chain diagnosis

The panic is test scaffolding running inside the shipped **release** worker binary.

1. `djinn-agent/src/output_stash/mod.rs` has two mutually-exclusive `durable_root()` impls:
   - `#[cfg(not(any(test, feature = "test-support")))]` (mod.rs:340) — the **production** path: `$XDG_CACHE_HOME` / `$HOME/.cache/djinn/output_stash`.
   - `#[cfg(any(test, feature = "test-support"))]` (mod.rs:335) — returns `test_durable_root()` -> `crate::test_helpers::test_persistent_dir(...)` -> `test_tempdir` -> `test_tmp_base()`, which does `create_dir_all(cwd.join("target/test-tmp"))`. In the pod the cwd is not writable -> `expect("create test tempdir base")` panics at **test_helpers.rs:42**.

2. `durable_root()` is called every turn while persisting/externalizing tool results (mod.rs:385/482), so it fires on the first turn.

3. `test_helpers` is correctly gated `#[cfg(any(test, feature = "test-support"))]` (lib.rs:115). The regression is that the **worker enabled that feature on its production dependency edge**:

   Commit `1a68c9098` — **#2451 "is6k: Prove direct and in-memory worker-RPC lease conformance"** — changed `djinn-agent-worker/Cargo.toml`:
   ```diff
   -djinn-agent = { path = "../djinn-agent" }
   +djinn-agent = { path = "../djinn-agent", features = ["test-support"] }
   ```
   That was done so the worker's own `#[cfg(test)]` modules (`worker_services.rs`, `tests/in_pod_drive.rs`) could call `djinn_agent::test_helpers`, but placing it on the normal `[dependencies]` edge turned `test-support` **on for every `cargo build --release`**, selecting the test `durable_root()` in the shipped binary. v0.6.113 did not have this edge, which is why the same tasks/models worked there.

## The fix

Move `test-support` off the production `[dependencies]` edge and onto `[dev-dependencies]`, matching the pattern already used for djinn-db/djinn-graph in this same manifest. The workspace uses `resolver = "2"`, so dev-dependency features are **not** activated for `cargo build --release` — the release worker compiles the production `durable_root()` (real `$HOME/.cache` path, exactly v0.6.113 behavior) — while `cargo test` still activates `test-support` so the worker's test modules keep compiling. The `test_helpers` gate now becomes effective: any production reference to it is a compile error rather than a runtime panic.

## Test evidence

- `cargo build --release -p djinn-agent-worker` — **compiles (exit 0)** with `test-support` off the production edge. Production code needs no test scaffolding.
- Release binary symbol check: `strings target/release/djinn-agent-worker | grep -c "create test tempdir base"` -> **0**; `grep -c "src/test_helpers.rs"` -> **0**. The test tempdir path and its panic string are gone from the shipped binary.
- `cargo test -p djinn-agent-worker --no-run` — **compiles (exit 0)**; all five test executables build, including `in_pod_drive.rs` (which uses `djinn_agent::test_helpers`), proving test-support still reaches tests via dev-deps.
- `cargo test -p djinn-agent output_stash` — **129 passed, 0 failed**, including `stash_insert_writes_durable_blob_to_disk`, `durable_path_survives_via_handle_stash_tool`, and the durable read/eviction tests that exercise the durable-root path under test-support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
