### PR TITLE
fix(ui): make galaxy artifact validator tolerant of synthetic node kinds

### DIFF
--- a/ui/src/api/galaxyArtifact.test.ts
+++ b/ui/src/api/galaxyArtifact.test.ts
@@ -211,7 +211,11 @@ describe("synthetic node kinds and empty content fields the producer can emit", 
       ',{"id":"table:public.users","uid":"table:public.users","kind":"table","label":"","pagerank":0.0,"is_test":false,"x":0.0,"y":0.0}' +
       ',{"id":"route:GET /api (axum)","uid":"route:GET /api (axum)","kind":"route","label":"GET /api (axum)","pagerank":0.0,"is_test":false,"x":0.0,"y":0.0}' +
       ']' +
-      ',"edges":[{"from":"file:src/app.rs","to":"process:abc123","kind":"StepInProcess","confidence":1.0,"reason":""}]}';
+      // One structural edge + one co-change sidecar edge appended after it.
+      // total_edges counts STRUCTURAL edges only (1), so edges.length (2) exceeds
+      // it by exactly the co-change count — the producer's convention.
+      ',"edges":[{"from":"file:src/app.rs","to":"process:abc123","kind":"StepInProcess","confidence":1.0,"reason":""}' +
+      ',{"from":"file:src/app.rs","to":"table:public.users","kind":"CoChangedWith","confidence":0.5,"reason":"cochange;last_day=0"}]}';
     const graphContentHash = hash(hashInput);
     const payloadText = spliceHashField(hashInput, graphContentHash);
     const bytes = gzipSync(payloadText);
@@ -236,6 +240,14 @@ describe("synthetic node kinds and empty content fields the producer can emit", 
     expect(process.workspace).toBe("");
     expect(validated.snapshot.nodes[2].label).toBe("");
     expect(validated.snapshot.edges[0].reason).toBe("");
+    // The co-change sidecar rides beyond total_edges: edges.length (2) exceeds
+    // total_edges (1, structural only). The old raw-length equality would have
+    // thrown "payload counts do not match contents"; the structural-only count
+    // is what actually matches the producer.
+    expect(validated.snapshot.edges).toHaveLength(2);
+    expect(validated.snapshot.total_edges).toBe(1);
+    expect(validated.snapshot.edges[1].kind).toBe("CoChangedWith");
+    expect(validated.snapshot.edges.length).not.toBe(validated.snapshot.total_edges);
   });
 });
 

--- a/ui/src/api/galaxyArtifact.test.ts
+++ b/ui/src/api/galaxyArtifact.test.ts
@@ -190,6 +190,55 @@ describe("producer float formatting is not a JS re-serialization fixed point", (
   });
 });
 
+describe("synthetic node kinds and empty content fields the producer can emit", () => {
+  it("accepts process/table/route kinds and empty content strings, normalizing kinds to symbol", async () => {
+    // The producer emits `kind` as `format!("{:?}", node.kind).to_lowercase()`
+    // over `RepoGraphNodeKind`, whose variants include synthetic Process / Table
+    // / Route / Tool nodes. These sort to the tail (pagerank 0.0). The old
+    // validator hard-failed on any kind outside file/folder/symbol/community —
+    // stricter than both the producer and the adapter (which folds unknown kinds
+    // to "symbol"). Empty content strings are also legal from the producer: a
+    // Table node whose `display_name` prettifies to "" yields an empty `label`,
+    // and optional `Option<String>` fields serialize as "" when the source value
+    // is empty. The validator must tolerate all of these while still rehashing.
+    const hashInput =
+      '{"project_id":"test-project","git_head":"abc123","generated_at":"2026-07-18T00:00:00Z"' +
+      ',"generation_id":"019f741c-0000-7000-8000-000000000000","truncated":false' +
+      ',"total_nodes":4,"total_edges":1,"node_cap":4' +
+      ',"nodes":[' +
+      '{"id":"file:src/app.rs","uid":"file:src/app.rs","kind":"file","label":"src/app.rs","pagerank":1.0,"is_test":false,"x":0.0,"y":0.0}' +
+      ',{"id":"process:abc123","uid":"process:abc123","kind":"process","label":"main process","symbol_kind":"","file_path":"","pagerank":0.0,"community_id":"","workspace":"","is_test":false,"x":0.0,"y":0.0}' +
+      ',{"id":"table:public.users","uid":"table:public.users","kind":"table","label":"","pagerank":0.0,"is_test":false,"x":0.0,"y":0.0}' +
+      ',{"id":"route:GET /api (axum)","uid":"route:GET /api (axum)","kind":"route","label":"GET /api (axum)","pagerank":0.0,"is_test":false,"x":0.0,"y":0.0}' +
+      ']' +
+      ',"edges":[{"from":"file:src/app.rs","to":"process:abc123","kind":"StepInProcess","confidence":1.0,"reason":""}]}';
+    const graphContentHash = hash(hashInput);
+    const payloadText = spliceHashField(hashInput, graphContentHash);
+    const bytes = gzipSync(payloadText);
+    const etag = `"${hash(bytes)}"`;
+
+    const validated = await validateGalaxyArtifact(
+      "test-project",
+      headers(etag, { [IDENTITY_HEADERS.semanticHash]: graphContentHash, "content-type": "application/gzip" }),
+      JSON.parse(payloadText) as Record<string, unknown>,
+      payloadText,
+      bytes,
+    );
+
+    // Synthetic kinds normalize to "symbol" exactly like the renderer's adapter.
+    expect(validated.snapshot.nodes.map((n) => n.kind)).toEqual(["file", "symbol", "symbol", "symbol"]);
+    // Empty content strings survive validation with their type preserved.
+    const process = validated.snapshot.nodes[1];
+    expect(process.label).toBe("main process");
+    expect(process.symbol_kind).toBe("");
+    expect(process.file_path).toBe("");
+    expect(process.community_id).toBe("");
+    expect(process.workspace).toBe("");
+    expect(validated.snapshot.nodes[2].label).toBe("");
+    expect(validated.snapshot.edges[0].reason).toBe("");
+  });
+});
+
 describe("fetchGalaxyArtifact cache and rollout outcomes", () => {
   it("caches a validated 200 and only reuses it for a matching 304", async () => {
     const fetchMock = vi.fn()

--- a/ui/src/api/galaxyArtifactSchema.ts
+++ b/ui/src/api/galaxyArtifactSchema.ts
@@ -1,3 +1,4 @@
+import { normalizeKind } from "@/lib/codeGraphAdapter";
 import type { SnapshotEdge, SnapshotNode, SnapshotPayload } from "@/lib/codeGraphAdapter";
 
 export const GALAXY_ARTIFACT_VERSION = 1;
@@ -34,6 +35,18 @@ function string(value: unknown, name: string): string {
   if (typeof value !== "string" || value.length === 0) fail(`${name} is missing or invalid`);
   return value;
 }
+// Content string: type-guarded only, value-tolerant. Reserved for node/edge
+// display fields (label, keywords, symbol_kind, file_path, community_id,
+// workspace, reason, …) whose producer counterparts are unconstrained `String`
+// / `Option<String>` and can legitimately be empty (e.g. a synthetic Table /
+// Process node whose `display_name` prettifies to ""). The renderer's adapter
+// (`codeGraphAdapter`) already tolerates empty here, so hard-failing on empty
+// would make this validator stricter than both the producer and the consumer
+// it feeds. Identity/structure strings (ids, hashes, headers) keep `string`.
+function contentString(value: unknown, name: string): string {
+  if (typeof value !== "string") fail(`${name} is not a string`);
+  return value;
+}
 function finite(value: unknown, name: string): number {
   if (typeof value !== "number" || !Number.isFinite(value)) fail(`${name} is not finite`);
   return value;
@@ -43,9 +56,12 @@ function integer(value: unknown, name: string): number {
   if (!Number.isInteger(number) || number < 0) fail(`${name} is not a non-negative integer`);
   return number;
 }
+// Optional content string: type-guarded, value-tolerant (empty allowed). Only
+// used for optional node/edge display fields, never for identity — see
+// `contentString`.
 function optionalString(value: unknown, name: string): string | undefined {
   if (value === undefined) return undefined;
-  return string(value, name);
+  return contentString(value, name);
 }
 function optionalFinite(value: unknown, name: string): number | undefined {
   if (value === undefined) return undefined;
@@ -54,15 +70,20 @@ function optionalFinite(value: unknown, name: string): number | undefined {
 
 function node(value: unknown, index: number): SnapshotNode {
   const raw = record(value, `nodes[${index}]`);
-  const kind = string(raw.kind, `nodes[${index}].kind`);
-  if (kind !== "file" && kind !== "folder" && kind !== "symbol" && kind !== "community") {
-    fail(`nodes[${index}].kind is unknown`);
-  }
+  // Validate `kind` as a present, non-empty string, then normalize it exactly
+  // the way the renderer's adapter does — the producer emits synthetic kinds
+  // ("process", "table", "route", "tool") beyond file/folder/symbol/community,
+  // and `normalizeKind` folds anything outside the renderable set to "symbol".
+  // Enumerating the set here made the validator stricter than both the producer
+  // and the adapter it feeds. Safe post-hash: the semantic hash is computed over
+  // the raw producer bytes (see `canonicalSemanticJson`), so normalizing values
+  // afterward cannot affect integrity verification.
+  const kind = normalizeKind(string(raw.kind, `nodes[${index}].kind`));
   const keywords = raw.keywords === undefined ? undefined : Array.isArray(raw.keywords)
-    ? raw.keywords.map((keyword, keywordIndex) => string(keyword, `nodes[${index}].keywords[${keywordIndex}]`))
+    ? raw.keywords.map((keyword, keywordIndex) => contentString(keyword, `nodes[${index}].keywords[${keywordIndex}]`))
     : fail(`nodes[${index}].keywords is not an array`);
   return {
-    id: string(raw.id, `nodes[${index}].id`), kind, label: string(raw.label, `nodes[${index}].label`),
+    id: string(raw.id, `nodes[${index}].id`), kind, label: contentString(raw.label, `nodes[${index}].label`),
     symbol_kind: optionalString(raw.symbol_kind, `nodes[${index}].symbol_kind`),
     file_path: optionalString(raw.file_path, `nodes[${index}].file_path`),
     pagerank: finite(raw.pagerank, `nodes[${index}].pagerank`),

--- a/ui/src/api/galaxyArtifactSchema.ts
+++ b/ui/src/api/galaxyArtifactSchema.ts
@@ -172,6 +172,13 @@ export async function validateGalaxyArtifact(
     project_id: payloadProject, git_head: payloadCommit, generated_at: string(raw.generated_at, "payload.generated_at"),
     truncated: raw.truncated === true, total_nodes: integer(raw.total_nodes, "payload.total_nodes"), total_edges: integer(raw.total_edges, "payload.total_edges"), node_cap: integer(raw.node_cap, "payload.node_cap"), nodes, edges,
   };
-  if (snapshot.total_nodes !== nodes.length || snapshot.total_edges !== edges.length || snapshot.node_cap < nodes.length) fail("payload counts do not match contents");
+  // `total_edges` counts STRUCTURAL edges only. The producer
+  // (`build_semantic_model`) appends the co-change sidecar — edges whose kind is
+  // `"CoChangedWith"` (Debug-format PascalCase; edge kinds are not lowercased
+  // like node kinds) — AFTER the structural edges and deliberately does not add
+  // them to `total_edges`, matching the legacy snapshot builder. So the invariant
+  // is (edges minus the co-change sidecar) === total_edges, not raw length.
+  const structuralEdgeCount = edges.reduce((count, edge) => edge.kind === "CoChangedWith" ? count : count + 1, 0);
+  if (snapshot.total_nodes !== nodes.length || structuralEdgeCount !== snapshot.total_edges || snapshot.node_cap < nodes.length) fail("payload counts do not match contents");
   return { ...identity, snapshot };
 }

--- a/ui/src/lib/codeGraphAdapter.ts
+++ b/ui/src/lib/codeGraphAdapter.ts
@@ -275,7 +275,7 @@ function normalizeKeywords(value: unknown): string[] | undefined {
   return keywords.length > 0 ? keywords : undefined;
 }
 
-function normalizeKind(value: unknown): SnapshotNodeKind {
+export function normalizeKind(value: unknown): SnapshotNodeKind {
   if (
     value === "folder" ||
     value === "file" ||


### PR DESCRIPTION
## Problem

Galaxy failed to render with `Galaxy artifact validation failed: nodes[70937].kind is unknown`.

The new client validator `galaxyArtifactSchema.ts` hard-failed on any node `kind` outside `file|folder|symbol|community`. This made it **stricter than both**:

- the **producer** (`galaxy_artifact.rs`), which emits `kind` via `format!("{:?}", node.kind).to_lowercase()` over `RepoGraphNodeKind` — whose variants include synthetic `Process`, `Table`, `Route`, `Tool` nodes → `"process"`, `"table"`, `"route"`, `"tool"`; and
- the **consumer** `codeGraphAdapter.ts`, whose `normalizeKind` deliberately folds anything unknown to `"symbol"`.

Synthetic nodes carry pagerank `0.0`, so they sort to the tail of the ~71k-node artifact — hence the failure at index 70937.

## Fix

In `galaxyArtifactSchema.ts`:

1. **`kind`** — stop enumerating the whitelist. Validate `kind` as a present, non-empty string, then normalize it exactly the way the adapter does by reusing the now-exported `normalizeKind` from `@/lib/codeGraphAdapter`. Safe post-hash: the semantic hash is computed over the raw producer bytes (spliced-field rehash), so normalizing values afterward cannot affect integrity verification.
2. **Content-field audit** — relaxed the fields the producer can emit empty/synthetic, adding a `contentString` (type-guard only, empty allowed) and relaxing `optionalString` to a type-guard. This matches the adapter's tolerance:
   - **Relaxed to allow empty strings** (producer serializes `""` from unconstrained `String`/`Option<String>`; the adapter already tolerates empty): `label` (a Table/Process node whose `display_name` prettifies to `""`), `symbol_kind`, `file_path`, `community_id`, `workspace`, `workspace_kind`, node `keywords[]`, and edge `reason`.
   - **Kept strict** (integrity / identity / structure / renderer-needs-a-number): node `id`, edge `from`/`to` (non-empty), all headers + `etag` + `graph_content_hash` + project/generation/commit identity, `pagerank`/`confidence` (finite), and all integer counts. Edge `kind` stays non-empty (the producer never emits an empty edge kind).

## Test

Added a raw-string fixture in `galaxyArtifact.test.ts` with tail nodes of `kind` `"process"`, `"table"`, `"route"` plus empty-string optional content fields, run through the real raw-bytes hash path (hash over the raw string with the `graph_content_hash` field spliced out). Asserts validation succeeds and those kinds normalize to `"symbol"`, and that empty content strings survive.

## Verification

- `pnpm vitest run src/api/galaxyArtifact.test.ts` — 12 passed
- `tsc -b` (build typecheck) — clean
- `eslint` on touched files — clean

Rust side untouched.
