### PR TITLE
fix: derive cost_basis billing signal on the worker-pod path and repair stragglers at boot

### DIFF
--- a/server/crates/djinn-agent-worker/src/worker_services.rs
+++ b/server/crates/djinn-agent-worker/src/worker_services.rs
@@ -57,8 +57,8 @@ use djinn_slot::helpers::{
 };
 use djinn_stack::environment::EnvironmentConfig;
 use djinn_supervisor::services::{
-    LeaseAbandonRequest, LeaseBindRequest, LeaseCancelRequest, LeaseGrantRequest,
-    LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseStatusRequest,
+    BillingSource, CostBasisHint, LeaseAbandonRequest, LeaseBindRequest, LeaseCancelRequest,
+    LeaseGrantRequest, LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseStatusRequest,
     SerializableCreateSessionParams, SerializableCreateTaskRunParams, SerializableDjinnEvent,
 };
 use djinn_supervisor::{
@@ -116,6 +116,30 @@ impl WorkerSupervisorServices {
             captured_workspace_path,
         }
     }
+}
+
+/// Derive the `(CostBasisHint, BillingSource)` for a worker-pod session from the
+/// Secret-mounted credential kind plus the model id.
+///
+/// The in-Pod path builds its provider locally and never runs the host's
+/// `resolve_model_and_credential`, so `stage.rs` cannot derive the billing
+/// signal from a resolved credential — the worker must derive it here and hand
+/// it through `worker_execute_stage`. The `SerializableCredential` variant is
+/// exactly the `credential_is_oauth` evidence `derive_billing_signal` needs.
+///
+/// Returns `None` only when `model_id` fails to parse into `provider/model`; the
+/// stage then keeps its legacy string-classifier behavior for that session.
+fn worker_billing_signal(
+    cred: &SerializableCredential,
+    model_id: &str,
+) -> Option<(CostBasisHint, BillingSource)> {
+    let (provider_id, model_name) = parse_model_id(model_id).ok()?;
+    let credential_is_oauth = matches!(cred, SerializableCredential::OAuthConfig { .. });
+    Some(djinn_agent::supervisor::derive_billing_signal(
+        &provider_id,
+        &model_name,
+        credential_is_oauth,
+    ))
 }
 
 /// Reconstruct an [`LlmProvider`] from a per-role [`SerializableCredential`]
@@ -386,6 +410,14 @@ impl SupervisorServices for WorkerSupervisorServices {
         let provider =
             build_provider_from_serializable(cred, &model_id, context_window, base_url_override)?;
 
+        // Derive the billing signal HERE — the in-Pod path never runs the host's
+        // `resolve_model_and_credential`, so `stage.rs` cannot derive it from a
+        // resolved credential. The `SerializableCredential` kind IS the
+        // `credential_is_oauth` evidence. Without this, every worker-pod session
+        // fell to the legacy string path and mis-booked openai plan usage as
+        // `cost_basis = 'actual'` with a NULL `billing_source`.
+        let billing_signal = worker_billing_signal(cred, &model_id);
+
         worker_execute_stage(
             task,
             workspace,
@@ -395,6 +427,7 @@ impl SupervisorServices for WorkerSupervisorServices {
             self.agent_context.clone(),
             self.cancel.clone(),
             provider,
+            billing_signal,
             self,
         )
         .await
@@ -690,6 +723,32 @@ mod tests {
             key_name: "MINIMAX_API_KEY".to_string(),
             api_key: "test-key".to_string(),
         }
+    }
+
+    /// Regression for the prod pod-path bug: a ChatGPT/Codex PLAN OAuth
+    /// credential on an `openai/*` model must yield `SubscriptionPlan` +
+    /// `PlanOauth` through `worker_billing_signal`, so the worker-created
+    /// session books `projected` instead of `actual` with a NULL billing_source.
+    #[test]
+    fn worker_billing_signal_openai_oauth_is_subscription_plan() {
+        let oauth = SerializableCredential::OAuthConfig {
+            config_json: "{}".to_string(),
+        };
+        let (hint, source) =
+            worker_billing_signal(&oauth, "openai/gpt-5.6-terra").expect("model id parses");
+        assert_eq!(hint, CostBasisHint::SubscriptionPlan);
+        assert_eq!(source, BillingSource::PlanOauth);
+    }
+
+    /// An API-key credential on a metered provider stays `MeteredApi` +
+    /// `ApiKey` — OAuth transport is the only thing that flips a session to a
+    /// plan, and there is none here.
+    #[test]
+    fn worker_billing_signal_anthropic_api_key_is_metered() {
+        let (hint, source) = worker_billing_signal(&api_key_credential(), "anthropic/claude-opus-4-8")
+            .expect("model id parses");
+        assert_eq!(hint, CostBasisHint::MeteredApi);
+        assert_eq!(source, BillingSource::ApiKey);
     }
 
     #[test]

--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -275,6 +275,9 @@ impl DirectServices {
                 agent_context,
                 cancel,
                 provider_override,
+                // Host path derives the billing signal from the resolved
+                // credential inside `execute_stage`; nothing to pre-supply.
+                billing_signal: None,
             },
             task_runs,
             build_lease,

--- a/server/crates/djinn-agent/src/supervisor.rs
+++ b/server/crates/djinn-agent/src/supervisor.rs
@@ -40,6 +40,12 @@ use crate::direct_services::DirectServices;
 use crate::supervisor_impl::SupervisorCallbackContext;
 use djinn_provider::provider::LlmProvider;
 
+/// Re-export the billing-signal deriver so the in-Pod worker
+/// (`djinn-agent-worker`) can classify a session's `cost_basis` from the
+/// Secret-mounted credential kind — the worker never runs the host's
+/// `resolve_model_and_credential`.
+pub use crate::supervisor_impl::stage::derive_billing_signal;
+
 /// Build a `SupervisorServices` pre-wired with the in-tree `djinn-agent`
 /// lifecycle bodies.
 ///
@@ -94,12 +100,17 @@ pub async fn worker_execute_stage(
     agent_context: AgentContext,
     cancel: CancellationToken,
     provider: Arc<dyn LlmProvider>,
+    billing_signal: Option<(
+        djinn_supervisor::services::CostBasisHint,
+        djinn_supervisor::services::BillingSource,
+    )>,
     services: &dyn SupervisorServices,
 ) -> Result<djinn_supervisor::StageOutcome, djinn_supervisor::StageError> {
     let callbacks = SupervisorCallbackContext {
         agent_context,
         cancel,
         provider_override: Some(provider),
+        billing_signal,
     };
     crate::supervisor_impl::execute_stage(
         task,

--- a/server/crates/djinn-agent/src/supervisor_impl/mod.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/mod.rs
@@ -56,8 +56,19 @@ pub(crate) use stage::execute_stage;
 pub(crate) struct SupervisorCallbackContext {
     pub agent_context: AgentContext,
     pub cancel: CancellationToken,
-    /// Test seam: integration tests inject a stubbed `LlmProvider` so the
-    /// stage can run end-to-end without a real vault credential.  Production
-    /// callers leave this `None`.
+    /// Injected `LlmProvider`. This is THE production in-Pod worker path
+    /// (`djinn-agent-worker` builds the provider from a Secret-mounted
+    /// credential and passes it here) as well as the integration-test stub
+    /// seam. When set, `execute_stage` skips `resolve_model_and_credential`.
+    /// Host dispatch leaves this `None` and resolves the credential itself.
     pub provider_override: Option<Arc<dyn LlmProvider>>,
+    /// Billing signal `(CostBasisHint, BillingSource)` pre-derived by the
+    /// caller. The worker path derives it from the `SerializableCredential`
+    /// kind (host resolution is unavailable in-Pod) and supplies it here so
+    /// the session books the correct `cost_basis`. `None` for the host path
+    /// (derived from the resolved credential) and the supervisor-stub test.
+    pub billing_signal: Option<(
+        djinn_supervisor::services::CostBasisHint,
+        djinn_supervisor::services::BillingSource,
+    )>,
 }

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -250,7 +250,13 @@ fn classify_provider_failure(err: &anyhow::Error) -> Option<ProviderFailureClass
 /// (`is_subscription_provider` / `governable_subscription_for_model`) remain an
 /// additional signal so e.g. a `zai-coding-plan/...` API-key session is still
 /// `SubscriptionPlan`.
-fn derive_billing_signal(
+///
+/// Exported (via `crate::supervisor::derive_billing_signal`) because the in-Pod
+/// worker path (`djinn-agent-worker`) builds its provider from a Secret-mounted
+/// credential and never runs `resolve_model_and_credential`; it derives the
+/// signal itself from the `SerializableCredential` kind and hands it to
+/// `worker_execute_stage`.
+pub fn derive_billing_signal(
     provider_id: &str,
     model_name: &str,
     credential_is_oauth: bool,
@@ -857,18 +863,27 @@ pub(crate) async fn execute_stage(
     };
 
     // The session is intentionally created before extension loading so every
-    // diagnostic has a session foreign key. Preserve its billing attribution
-    // from the credential already resolved above rather than dropping it while
-    // moving creation earlier in the stage.
-    let billing_signal = resolved.as_ref().map(|resolved| {
-        derive_billing_signal(
-            &resolved.catalog_provider_id,
-            &resolved.model_name,
-            matches!(
-                resolved.provider_credential.as_ref(),
-                Some(ProviderCredential::OAuthConfig(_))
-            ),
-        )
+    // diagnostic has a session foreign key. Preserve its billing attribution.
+    //
+    // On the host path `resolved` is populated and we derive the signal from the
+    // resolved credential. On the in-Pod worker path `provider_override` is set,
+    // `resolved` is `None`, and the worker has already derived the signal from
+    // the Secret-mounted `SerializableCredential` — it arrives via
+    // `callbacks.billing_signal`. Without this, every worker-pod session fell
+    // through to the legacy string path and mis-booked openai plan usage as
+    // `actual` (billing_source NULL). The `test/supervisor-stub` integration
+    // case passes `None` and keeps its prior unpriced/legacy behavior.
+    let billing_signal = callbacks.billing_signal.or_else(|| {
+        resolved.as_ref().map(|resolved| {
+            derive_billing_signal(
+                &resolved.catalog_provider_id,
+                &resolved.model_name,
+                matches!(
+                    resolved.provider_credential.as_ref(),
+                    Some(ProviderCredential::OAuthConfig(_))
+                ),
+            )
+        })
     });
 
     let _ = services

--- a/server/crates/djinn-db/src/repositories/session.rs
+++ b/server/crates/djinn-db/src/repositories/session.rs
@@ -1256,38 +1256,42 @@ impl SessionRepository {
     }
 
     /// Best-effort backfill of price snapshot columns for existing sessions
-    /// whose snapshots were never captured at creation time.
+    /// whose snapshots were never captured (`NULL`) OR were captured all-zero
+    /// (the flat-rate coding-plan signature — e.g. the kimi-for-coding/k3 rows
+    /// migration 141 flipped to `unpriced`, which the catalog can now price via
+    /// the k3 alias).
     ///
     /// **Approximate historical pricing:** the pricing data passed in comes from
     /// the *current* catalog and does not reflect what the model cost when the
-    /// session actually ran.  Callers should log this caveat.  Sessions whose
-    /// `model_id` is not present in `pricing_by_model`, or whose supplied
-    /// pricing is all-zero/default, are intentionally skipped — they remain
-    /// all-NULL for snapshots and `cost_usd`.
+    /// session actually ran.  Callers should log this caveat.  Models whose
+    /// supplied pricing is all-zero/default are intentionally skipped — an
+    /// unknown price must never be recorded as a real $0.00.
     ///
-    /// Only sessions with all four snapshot columns `NULL` are touched;
-    /// sessions that already captured a start-time snapshot are preserved.
-    /// Idempotent: re-running with the same pricing is a no-op on already-
-    /// backfilled rows.
+    /// Each tuple is `(model_id, pricing, is_subscription)`. A repriced row that
+    /// is currently `cost_basis = 'unpriced'` is promoted to `'projected'` when
+    /// its model's provider classifies as a subscription; for non-subscription
+    /// providers the pricing is filled but the basis stays `'unpriced'` (we
+    /// cannot know plan-vs-key without per-row credential evidence). Rows already
+    /// `'actual'` / `'projected'` keep their basis.
+    ///
+    /// Only rows whose four snapshot columns are ALL `NULL` or ALL literal `0`
+    /// are touched; partially-zero rows and rows with a real captured snapshot
+    /// are preserved. Idempotent: once repriced (non-zero snapshots) a row no
+    /// longer matches either arm, so re-running is a no-op.
     ///
     /// Returns the total number of rows updated across all models.
     pub async fn backfill_pricing_snapshots(
         &self,
-        pricing_by_model: &[(String, Pricing)],
+        pricing_by_model: &[(String, Pricing, bool)],
     ) -> Result<u64> {
         self.db.ensure_initialized().await?;
 
         let mut total_updated: u64 = 0;
-        for (model_id, pricing) in pricing_by_model {
-            // `Pricing::default()` (all zero rates) represents "pricing
-            // unknown" for custom/seed catalog entries, not a known free
-            // model.  Leave those rows NULL so the analytics layer never
-            // conflates unknown cost with zero cost.
-            if pricing.input_per_million == 0.0
-                && pricing.output_per_million == 0.0
-                && pricing.cache_read_per_million == 0.0
-                && pricing.cache_write_per_million == 0.0
-            {
+        for (model_id, pricing, is_subscription) in pricing_by_model {
+            // All-zero pricing represents "pricing unknown" for custom/seed
+            // catalog entries, not a known free model.  Leave those rows as-is
+            // so the analytics layer never conflates unknown cost with zero.
+            if !pricing.is_priced() {
                 continue;
             }
 
@@ -1307,18 +1311,29 @@ impl SessionRepository {
                          + COALESCE(tokens_out, 0)::double precision * $2
                          + COALESCE(cache_read_tokens, 0)::double precision * $3
                          + COALESCE(cache_write_tokens, 0)::double precision * $4
-                     ) / 1000000.0
+                     ) / 1000000.0,
+                     cost_basis = CASE
+                         WHEN cost_basis = 'unpriced' AND $6 THEN 'projected'
+                         ELSE cost_basis
+                     END
                  WHERE model_id = $5
-                   AND input_price_per_million_snapshot IS NULL
-                   AND output_price_per_million_snapshot IS NULL
-                   AND cache_read_price_per_million_snapshot IS NULL
-                   AND cache_write_price_per_million_snapshot IS NULL"#,
+                   AND (
+                        (input_price_per_million_snapshot IS NULL
+                         AND output_price_per_million_snapshot IS NULL
+                         AND cache_read_price_per_million_snapshot IS NULL
+                         AND cache_write_price_per_million_snapshot IS NULL)
+                     OR (input_price_per_million_snapshot = 0
+                         AND output_price_per_million_snapshot = 0
+                         AND cache_read_price_per_million_snapshot = 0
+                         AND cache_write_price_per_million_snapshot = 0)
+                   )"#,
             )
             .bind(input_rate)
             .bind(output_rate)
             .bind(cache_read_rate)
             .bind(cache_write_rate)
             .bind(model_id.as_str())
+            .bind(*is_subscription)
             .execute(self.db.pool())
             .await?;
 
@@ -1326,6 +1341,43 @@ impl SessionRepository {
         }
 
         Ok(total_updated)
+    }
+
+    /// Boot-time, idempotent repair of plan-backed `openai/*` sessions that old
+    /// worker pods mis-booked as `cost_basis = 'actual'` before the in-Pod
+    /// billing-signal fix. Runtime equivalent of migration 141 step 2, re-run
+    /// every boot so sessions created during a post-deploy image-rebuild window
+    /// (an old worker image still dispatching) are cleaned on the next restart.
+    ///
+    /// GATED on install-wide credential evidence, queried live so it stays
+    /// generic for any deployment: applies ONLY when a non-revoked ChatGPT/Codex
+    /// plan OAuth credential (`__OAUTH_CHATGPT_CODEX`) exists AND no non-revoked
+    /// `OPENAI_API_KEY` credential exists — under that gate an `openai/*` session
+    /// cannot be metered API spend, so the correct basis is `projected`. The
+    /// EXISTS / NOT EXISTS gate is inlined in the UPDATE so it is atomic.
+    /// Idempotent: gated on `cost_basis = 'actual'`, so once rewritten a row no
+    /// longer matches.
+    ///
+    /// Returns the number of rows reclassified (0 when the gate does not hold).
+    pub async fn reclassify_plan_openai_sessions_if_gated(&self) -> Result<u64> {
+        self.db.ensure_initialized().await?;
+        let result = sqlx::query(
+            r#"UPDATE sessions
+                 SET cost_basis = 'projected'
+               WHERE cost_basis = 'actual'
+                 AND model_id LIKE 'openai/%'
+                 AND EXISTS (
+                      SELECT 1 FROM credentials c
+                       WHERE c.key_name = '__OAUTH_CHATGPT_CODEX'
+                         AND c.revoked_at IS NULL)
+                 AND NOT EXISTS (
+                      SELECT 1 FROM credentials c
+                       WHERE c.key_name = 'OPENAI_API_KEY'
+                         AND c.revoked_at IS NULL)"#,
+        )
+        .execute(self.db.pool())
+        .await?;
+        Ok(result.rows_affected())
     }
 
     /// Candidates for the extraction backfill sweep: completed task-runs whose
@@ -3180,6 +3232,7 @@ mod tests {
                 cache_read_per_million: 0.5,
                 cache_write_per_million: 2.5,
             },
+            false,
         )];
 
         let updated = repo.backfill_pricing_snapshots(&pricing).await.unwrap();
@@ -3236,6 +3289,7 @@ mod tests {
                 cache_read_per_million: 99.0,
                 cache_write_per_million: 99.0,
             },
+            false,
         )];
         let updated = repo.backfill_pricing_snapshots(&new_pricing).await.unwrap();
         assert_eq!(updated, 0, "existing snapshots must not be overwritten");
@@ -3287,6 +3341,7 @@ mod tests {
                 cache_read_per_million: 0.5,
                 cache_write_per_million: 2.5,
             },
+            false,
         )];
         let updated = repo.backfill_pricing_snapshots(&pricing).await.unwrap();
         assert_eq!(updated, 0, "uncatalogued model must not be touched");
@@ -3331,7 +3386,7 @@ mod tests {
         .await
         .unwrap();
 
-        let pricing = vec![("custom/seed-model".to_string(), Pricing::default())];
+        let pricing = vec![("custom/seed-model".to_string(), Pricing::default(), false)];
         let updated = repo.backfill_pricing_snapshots(&pricing).await.unwrap();
         assert_eq!(
             updated, 0,
@@ -3374,6 +3429,7 @@ mod tests {
                 cache_read_per_million: 1.0,
                 cache_write_per_million: 3.0,
             },
+            false,
         )];
 
         // First run.
@@ -3389,6 +3445,160 @@ mod tests {
         assert_eq!(fetched.output_price_per_million_snapshot, Some(15.0));
         assert_eq!(fetched.cache_read_price_per_million_snapshot, Some(1.0));
         assert_eq!(fetched.cache_write_price_per_million_snapshot, Some(3.0));
+    }
+
+    /// The migration-141 aftermath: a zero-snapshot 'unpriced' session for a
+    /// subscription-provider model is now repriced from the catalog AND promoted
+    /// to 'projected'. Idempotent on a second run.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backfill_reprices_zero_snapshot_unpriced_subscription_session() {
+        let db = test_db();
+        let (project_id, task_id) = create_task(&db, EventBus::noop()).await;
+        let repo = SessionRepository::new(db.clone(), EventBus::noop());
+
+        // Zero-snapshot 'unpriced' row — the flat-rate coding-plan k3 signature.
+        let created = repo
+            .create(CreateSessionParams {
+                project_id: &project_id,
+                task_id: Some(&task_id),
+                model: "kimi-for-coding/k3",
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: None,
+                pricing: Some(&Pricing::default()),
+                cost_basis: Some("unpriced"),
+            })
+            .await
+            .unwrap();
+        assert_eq!(created.input_price_per_million_snapshot, Some(0.0));
+        assert_eq!(created.cost_basis, "unpriced");
+
+        sqlx::query(
+            "UPDATE sessions SET tokens_in = 1000000, tokens_out = 1000000 WHERE id = $1",
+        )
+        .bind(&created.id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let pricing = vec![(
+            "kimi-for-coding/k3".to_string(),
+            Pricing {
+                input_per_million: 3.0,
+                output_per_million: 15.0,
+                cache_read_per_million: 0.3,
+                cache_write_per_million: 0.0,
+            },
+            true, // subscription provider
+        )];
+
+        let n = repo.backfill_pricing_snapshots(&pricing).await.unwrap();
+        assert_eq!(n, 1, "zero-snapshot row must be repriced");
+
+        let f = repo.get(&created.id).await.unwrap().unwrap();
+        assert_eq!(f.input_price_per_million_snapshot, Some(3.0));
+        assert_eq!(f.output_price_per_million_snapshot, Some(15.0));
+        assert_eq!(f.cost_basis, "projected", "subscription row promoted");
+        // cost_usd = (1M*3 + 1M*15) / 1M = 18.0
+        assert!((f.cost_usd.unwrap() - 18.0).abs() < 1e-6);
+
+        // Second run: snapshots are now non-zero → no match → no-op.
+        let n2 = repo.backfill_pricing_snapshots(&pricing).await.unwrap();
+        assert_eq!(n2, 0, "repricing must be idempotent");
+    }
+
+    /// Boot-repair gate: `openai/*` 'actual' rows flip to 'projected' only when a
+    /// Codex plan OAuth credential exists and no OpenAI API key does.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reclassify_plan_openai_sessions_is_credential_gated() {
+        let db = test_db();
+        let (project_id, task_id) = create_task(&db, EventBus::noop()).await;
+        let repo = SessionRepository::new(db.clone(), EventBus::noop());
+
+        let priced = Pricing {
+            input_per_million: 2.0,
+            output_per_million: 8.0,
+            cache_read_per_million: 0.5,
+            cache_write_per_million: 2.5,
+        };
+        let s = repo
+            .create(CreateSessionParams {
+                project_id: &project_id,
+                task_id: Some(&task_id),
+                model: "openai/gpt-5.6-terra",
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: None,
+                pricing: Some(&priced),
+                cost_basis: Some("actual"),
+            })
+            .await
+            .unwrap();
+
+        let insert_cred = |key: &str| {
+            let db = db.clone();
+            let key = key.to_string();
+            async move {
+                sqlx::query(
+                    "INSERT INTO credentials (id, provider_id, key_name, encrypted_value) \
+                     VALUES ($1, $2, $3, $4)",
+                )
+                .bind(uuid::Uuid::now_v7().to_string())
+                .bind("chatgpt_codex")
+                .bind(key)
+                .bind(Vec::<u8>::new())
+                .execute(db.pool())
+                .await
+                .unwrap();
+            }
+        };
+
+        // No credentials → gate closed → no-op.
+        assert_eq!(
+            repo.reclassify_plan_openai_sessions_if_gated().await.unwrap(),
+            0
+        );
+        assert_eq!(repo.get(&s.id).await.unwrap().unwrap().cost_basis, "actual");
+
+        // Codex plan OAuth present, no OpenAI API key → gate open → flip.
+        insert_cred("__OAUTH_CHATGPT_CODEX").await;
+        assert_eq!(
+            repo.reclassify_plan_openai_sessions_if_gated().await.unwrap(),
+            1
+        );
+        assert_eq!(
+            repo.get(&s.id).await.unwrap().unwrap().cost_basis,
+            "projected"
+        );
+
+        // Idempotent second run.
+        assert_eq!(
+            repo.reclassify_plan_openai_sessions_if_gated().await.unwrap(),
+            0
+        );
+
+        // With an OpenAI API key also present, the gate closes: a fresh 'actual'
+        // openai row is left untouched.
+        let s2 = repo
+            .create(CreateSessionParams {
+                project_id: &project_id,
+                task_id: Some(&task_id),
+                model: "openai/gpt-5.5",
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: None,
+                pricing: Some(&priced),
+                cost_basis: Some("actual"),
+            })
+            .await
+            .unwrap();
+        insert_cred("OPENAI_API_KEY").await;
+        assert_eq!(
+            repo.reclassify_plan_openai_sessions_if_gated().await.unwrap(),
+            0,
+            "presence of an OpenAI API key closes the gate"
+        );
+        assert_eq!(repo.get(&s2.id).await.unwrap().unwrap().cost_basis, "actual");
     }
 
     // ── Cost-basis derivation tests ─────────────────────────────────────────

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -2544,6 +2544,7 @@ impl AppState {
     /// as free).  Idempotent — safe to rerun.
     async fn backfill_session_pricing_on_startup(&self) {
         use djinn_db::SessionRepository;
+        use djinn_provider::catalog::builtin::classify_provider;
 
         let pricing_map = self.catalog().pricing_for_all_models();
         if pricing_map.is_empty() {
@@ -2551,8 +2552,18 @@ impl AppState {
             return;
         }
 
-        let pricing_vec: Vec<(String, djinn_core::models::Pricing)> =
-            pricing_map.into_iter().collect();
+        // Tag each model with whether its provider classifies as a subscription
+        // so the repository can promote a repriced 'unpriced' row to 'projected'.
+        // The catalog key is the canonical `<provider_id>/<model_id>`; the
+        // provider is the segment before the first '/'.
+        let pricing_vec: Vec<(String, djinn_core::models::Pricing, bool)> = pricing_map
+            .into_iter()
+            .map(|(model_id, pricing)| {
+                let provider_id = model_id.split_once('/').map(|(p, _)| p).unwrap_or("");
+                let is_subscription = classify_provider(provider_id).is_subscription();
+                (model_id, pricing, is_subscription)
+            })
+            .collect();
         let model_count = pricing_vec.len();
 
         let repo = SessionRepository::new(self.db().clone(), self.event_bus());
@@ -2570,7 +2581,27 @@ impl AppState {
             Err(e) => {
                 tracing::warn!(
                     error = %e,
-                    "pricing backfill failed — sessions with NULL snapshots remain"
+                    "pricing backfill failed — sessions with NULL/zero snapshots remain"
+                );
+            }
+        }
+
+        // Clean up plan-backed openai sessions that old worker pods mis-booked
+        // as 'actual' during a post-deploy image-rebuild window. Gated on live
+        // credential evidence, so it's a no-op on deployments without a Codex
+        // plan credential (or with an OpenAI API key present).
+        match repo.reclassify_plan_openai_sessions_if_gated().await {
+            Ok(0) => {}
+            Ok(n) => {
+                tracing::info!(
+                    rows_reclassified = n,
+                    "cost_basis repair: plan-backed openai sessions moved actual → projected"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "cost_basis repair for plan-backed openai sessions failed"
                 );
             }
         }


### PR DESCRIPTION
## Problem (found in prod after #2457 deployed, v0.6.116)

New `openai` sessions still booked `cost_basis = 'actual'` and `billing_source` was NULL on every row — the billing-hint path had **never fired in prod**.

Root cause: the production pod path does **not** go through `resolve_model_and_credential`. `worker_services::execute_stage` builds the provider from the Secret-mounted `SerializableCredential` and injects it via `provider_override`. In `stage.rs`, `provider_override.is_some()` ⇒ `resolved = None` ⇒ `billing_signal = None` ⇒ `cost_basis_hint: None` ⇒ legacy string path ⇒ `openai`+priced ⇒ `'actual'`. The `provider_override` comments claiming "integration tests" were wrong — it is THE prod path.

## Fix

### 1. Derive the billing signal on the pod path (main fix)
- `derive_billing_signal` is now exported from djinn-agent (`crate::supervisor::derive_billing_signal`).
- `worker_services::execute_stage` derives `(CostBasisHint, BillingSource)` from the credential kind (`OAuthConfig` ⇒ `credential_is_oauth`) + the parsed model id, via a new `worker_billing_signal` helper, and threads it through `worker_execute_stage` into a new `SupervisorCallbackContext.billing_signal` field.
- `stage.rs`: `let billing_signal = callbacks.billing_signal.or_else(|| resolved.as_ref().map(...))` — pod path uses the pre-derived signal, host path keeps deriving from the resolved credential, `test/supervisor-stub` passes `None`.
- Corrected the misleading `provider_override` comments.

### 2. Boot repair: widen the pricing-snapshot backfill
`backfill_pricing_snapshots` now also matches rows whose four snapshot columns are all literal `0` (not just all-NULL), recomputes `cost_usd`, and promotes a repriced `'unpriced'` row to `'projected'` when its provider classifies as a subscription (flag supplied by the caller in `state/mod.rs`, which has catalog access via `classify_provider`). Non-subscription rows are repriced but left `'unpriced'`. Fixes historical kimi-for-coding/k3 sessions showing "—" now that the catalog serves real k3 pricing. Idempotent (repriced rows have non-zero snapshots and no longer match).

### 3. Boot repair: gated openai `actual` → `projected`
New `reclassify_plan_openai_sessions_if_gated` — a runtime, idempotent equivalent of migration 141 step 2 (`openai/*` `actual` → `projected`, gated on a live `__OAUTH_CHATGPT_CODEX` credential existing AND no `OPENAI_API_KEY`). Runs every boot so sessions mis-booked by old worker pods during a post-deploy image-rebuild window get cleaned on the next restart. **No new SQL migration** (avoids a 142/143 renumber collision).

## Tests (all run locally, `SQLX_OFFLINE=true`; DB tests on the dedicated test Postgres)
- `djinn-agent-worker` (bin): `worker_billing_signal_openai_oauth_is_subscription_plan`, `..._anthropic_api_key_is_metered` — pass. `in_pod_drive` integration test passes.
- `djinn-agent`: 15 `billing_signal` + `cost_basis` tests pass.
- `djinn-db`: 7 session backfill/reclassify tests pass, incl. 2 new ones (zero-snapshot subscription reprice → `projected` + idempotence; credential-gated openai flip with both open and closed gates). Refreshed the stale local `djinn_test_template` (was missing migrations 141–143).
- Clippy clean on all touched code. Pre-existing baseline: `cargo clippy --all-targets` denies `SystemTime::now`/`Instant::now` in `djinn-agent-worker`'s **test** module (present verbatim on origin/main, untouched by this PR); `cargo test`/`check` compile it fine.