### PR TITLE
feat(ui): board polish, proposals list redesign, and storybook coverage

### DIFF
--- a/ui/src/components/KanbanBoard.tsx
+++ b/ui/src/components/KanbanBoard.tsx
@@ -6,6 +6,7 @@ import { useProjects } from "@/stores/useProjectStore";
 import { taskStore } from "@/stores/taskStore";
 import type { Epic, Task } from "@/api/types";
 import { TaskCard, DoneTaskRow } from "@/components/TaskCard";
+import { TaskIdLabel } from "@/components/TaskIdLabel";
 import { TaskDetailPanel } from "@/components/TaskDetailPanel";
 import { BoardHealthBanner } from "@/components/BoardHealthBanner";
 import { GitHubAppBanner } from "@/components/GitHubAppBanner";
@@ -75,7 +76,7 @@ const STATUS_COLUMNS: Array<{
 // Shared column grid: the sticky status header and every swimlane use the same
 // template so cards stay aligned under their column while scrolling lanes.
 const COLUMN_GRID_CLASS =
-  "grid grid-cols-[repeat(4,minmax(280px,1fr))] gap-x-5";
+  "grid grid-cols-[repeat(4,minmax(280px,1fr))] gap-x-8";
 
 function taskToColumnKey(task: Task): ColumnKey | null {
   if (task.status === "closed") {
@@ -119,6 +120,7 @@ type Lane = {
   kind: "proposal" | "other";
   title: string;
   proposalId?: string;
+  proposalShortId?: string | null;
   buildOwnerUserId?: string | null;
   columns: Map<ColumnKey, Task[]>;
   total: number;
@@ -284,6 +286,7 @@ export function KanbanBoard({
               ? `Proposal ${epic.proposal_short_id}`
               : "Proposal"),
           proposalId: epic.proposal_id!,
+          proposalShortId: epic.proposal_short_id,
           buildOwnerUserId: epic.proposal_build_owner_user_id,
           columns: new Map(),
           total: 0,
@@ -443,7 +446,7 @@ export function KanbanBoard({
                 const isClickableName = lane.kind === "proposal";
 
                 return (
-                  <section key={lane.key} className="pb-2">
+                  <section key={lane.key} className="pb-4">
                     {/* Swimlane header: full-width row spanning all columns. */}
                     <div
                       className="flex cursor-pointer items-center gap-2 rounded-md bg-zinc-900 px-2.5 py-2 ring-1 ring-white/[0.04] transition-colors hover:bg-zinc-800/80"
@@ -460,10 +463,17 @@ export function KanbanBoard({
                           className="size-4"
                         />
                       )}
+                      {lane.proposalShortId && (
+                        <TaskIdLabel
+                          taskId={lane.proposalId ?? lane.proposalShortId}
+                          shortId={lane.proposalShortId}
+                          className="shrink-0"
+                        />
+                      )}
                       {isClickableName ? (
                         <button
                           type="button"
-                          className="truncate text-sm font-medium hover:underline"
+                          className="cursor-pointer truncate text-sm font-medium hover:underline"
                           onClick={(e) => {
                             e.stopPropagation();
                             handleLaneNameClick(lane);
@@ -495,7 +505,30 @@ export function KanbanBoard({
                           No tasks yet
                         </p>
                       ) : (
-                        <div className={cn(COLUMN_GRID_CLASS, "px-1 pt-3 pb-2")}>
+                        <div className="relative">
+                          {/* Column separators, scoped to this lane's card
+                              area so they never cross the lane header rows.
+                              Same grid template as the cards, one hairline
+                              centered in each column gap. */}
+                          <div
+                            aria-hidden
+                            className={cn(
+                              COLUMN_GRID_CLASS,
+                              "pointer-events-none absolute inset-x-0 top-3 bottom-1 px-1",
+                            )}
+                          >
+                            {STATUS_COLUMNS.map((column, index) => (
+                              <div
+                                key={column.key}
+                                className={
+                                  index === 0
+                                    ? undefined
+                                    : "-ml-4 w-px bg-border/70"
+                                }
+                              />
+                            ))}
+                          </div>
+                          <div className={cn(COLUMN_GRID_CLASS, "px-1 pt-4 pb-3")}>
                           {STATUS_COLUMNS.map((column) => {
                             const columnTasks =
                               lane.columns.get(column.key) ?? [];
@@ -540,6 +573,7 @@ export function KanbanBoard({
                               </ul>
                             );
                           })}
+                          </div>
                         </div>
                       ))}
                   </section>

--- a/ui/src/components/Sidebar.stories.tsx
+++ b/ui/src/components/Sidebar.stories.tsx
@@ -1,0 +1,246 @@
+/**
+ * Navigation/Sidebar — the app's left navigation rail.
+ *
+ * The Sidebar pulls from four independent seams, each mocked here:
+ *   - `useAuthUser()` (the footer identity + the admin-only Usage/Users items)
+ *     resolves only inside a real `AuthGate`, which performs REST calls to
+ *     `/auth/me`, `/setup/status` and `/auth/config`. Exactly like
+ *     `Settings/SettingsPage`, we install a one-time `window.fetch` shim (under
+ *     its OWN guard flag so it never fights the Settings shim) that answers just
+ *     those endpoints and falls through for everything else. `sidebarIsAdmin` is
+ *     flipped per-story BEFORE `AuthGate` mounts so `/auth/me` reports the right
+ *     flag.
+ *   - The Proposals badge counts non-terminal proposals from
+ *     `proposalListQueryOptions()` → `callMcpTool("proposal_list")`.
+ *   - The Repositories warning badge counts projects whose image build
+ *     `failed`, via `useDevcontainerWarnings` →
+ *     `callMcpTool("get_project_devcontainer_status")` fanned out over the
+ *     seeded `projectStore` projects.
+ * Both MCP-backed seams are served by a per-story responder installed in
+ * `beforeEach`.
+ */
+
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { Sidebar } from "./Sidebar";
+import { AuthGate } from "@/components/AuthGate";
+import { setMcpToolResponder } from "@/storybook-mocks/mcpClient";
+import { projectStore } from "@/stores/projectStore";
+import type { Project } from "@/api/types";
+import type { ProposalListRow } from "@/api/types";
+
+// ── Auth fetch shim (own guard flag; unknown URLs fall through) ───────────────
+
+// Flipped from each story's decorator before AuthGate mounts and fires
+// `/auth/me`, so the footer + admin items render for the right caller.
+let sidebarIsAdmin = false;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+if (!(window as unknown as { __djinnSidebarFetchStub?: boolean }).__djinnSidebarFetchStub) {
+  (window as unknown as { __djinnSidebarFetchStub?: boolean }).__djinnSidebarFetchStub = true;
+  const realFetch = window.fetch.bind(window);
+  const stub: typeof window.fetch = (input, init) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.includes("/auth/me")) {
+      return Promise.resolve(
+        json({
+          id: "u-fernando",
+          login: "fernando",
+          name: "Fernando Bandeira",
+          avatar_url: null,
+          is_admin: sidebarIsAdmin,
+          role: "engineer",
+        }),
+      );
+    }
+    if (url.includes("/setup/status")) {
+      return Promise.resolve(
+        json({
+          needs_app_install: false,
+          app_credentials_configured: true,
+          org_login: "djinnos",
+          setup_state: "valid",
+        }),
+      );
+    }
+    if (url.includes("/auth/config")) {
+      return Promise.resolve(
+        json({
+          configured: true,
+          missing: [],
+          setup_doc_url: "https://www.djinnai.io/docs/setup",
+          self_setup_available: false,
+        }),
+      );
+    }
+    return realFetch(input, init);
+  };
+  window.fetch = stub;
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const projects: Project[] = [
+  { id: "project-djinn", name: "djinnos/djinn", github_owner: "djinnos", github_repo: "djinn" },
+  { id: "project-catalog", name: "djinnos/catalog", github_owner: "djinnos", github_repo: "catalog" },
+  { id: "project-web", name: "djinnos/pink-web", github_owner: "djinnos", github_repo: "pink-web" },
+];
+
+const ISO = (msAgo: number): string => new Date(Date.now() - msAgo).toISOString();
+
+function row(id: string, status: string, title: string): ProposalListRow {
+  return {
+    id,
+    short_id: id,
+    title,
+    status,
+    ac_met: 2,
+    ac_total: 3,
+    pending_reconcile: false,
+    created_at: ISO(86_400_000),
+    updated_at: ISO(3_600_000),
+  };
+}
+
+// Four non-terminal proposals → the Proposals nav badge reads "4".
+const activeProposals: ProposalListRow[] = [
+  row("prop-warm", "building", "Graph-warm lease fault matrix"),
+  row("prop-sweep", "in_review", "Proposal integrity sweep canary"),
+  row("prop-park", "approved", "Atomic source-intent park transitions"),
+  row("prop-broker", "draft", "Broker command rejection semantics"),
+];
+
+/**
+ * Two of the three seeded projects report a `failed` image build → the
+ * Repositories nav item shows an amber "2" warning badge. "building" is
+ * excluded from the count by design (it's informational).
+ */
+function devcontainerStatusFor(projectId: string): unknown {
+  if (projectId === "project-djinn" || projectId === "project-web") {
+    return { image_status: "failed", graph_warm_status: "failed", needs_image: false };
+  }
+  return { image_status: "ready", graph_warm_status: "ready", needs_image: false };
+}
+
+function busyResponder(name: string, args: Record<string, unknown> | undefined): unknown {
+  switch (name) {
+    case "proposal_list":
+      return { proposals: activeProposals };
+    case "get_project_devcontainer_status":
+      return devcontainerStatusFor(String(args?.project ?? ""));
+    default:
+      return {};
+  }
+}
+
+function quietResponder(name: string): unknown {
+  switch (name) {
+    case "proposal_list":
+      return { proposals: [] };
+    case "get_project_devcontainer_status":
+      return { image_status: "ready", graph_warm_status: "ready", needs_image: false };
+    default:
+      return {};
+  }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+function ProjectSeeder({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    projectStore.setState({
+      projects,
+      selectedProjectId: projects[0]!.id,
+      lastViewPerProject: {},
+    });
+    return () => {
+      projectStore.setState({ projects: [], selectedProjectId: null, lastViewPerProject: {} });
+    };
+  }, []);
+  return <>{children}</>;
+}
+
+interface SidebarStoryArgs {
+  initialPath: string;
+}
+
+function SidebarStory({ initialPath }: SidebarStoryArgs) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AuthGate>
+          <ProjectSeeder>
+            <div className="flex h-screen bg-background text-foreground">
+              <Sidebar />
+              <div className="flex-1" />
+            </div>
+          </ProjectSeeder>
+        </AuthGate>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: "Navigation/Sidebar",
+  component: SidebarStory,
+  parameters: { layout: "fullscreen" },
+  args: { initialPath: "/tasks" },
+  decorators: [
+    (Story, ctx) => {
+      sidebarIsAdmin = (ctx.parameters?.isAdmin as boolean | undefined) ?? false;
+      return <Story />;
+    },
+  ],
+} satisfies Meta<typeof SidebarStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Member caller on the Tasks view: the Proposals badge shows "4" pending, the
+ * Repositories item shows an amber "2" warning, and the footer shows the signed
+ * in user. Admin-only Usage/Users items are hidden.
+ */
+export const Default: Story = {
+  parameters: { isAdmin: false },
+  beforeEach: () => setMcpToolResponder(busyResponder),
+};
+
+/**
+ * Admin caller: the footer reveals the admin-only Usage and Users items above
+ * Settings. Same proposal + devcontainer badges as Default.
+ */
+export const Admin: Story = {
+  parameters: { isAdmin: true },
+  beforeEach: () => setMcpToolResponder(busyResponder),
+};
+
+/**
+ * Nothing pending: no proposals in flight and every project's image is healthy,
+ * so both badges are absent — the resting state of the rail.
+ */
+export const Quiet: Story = {
+  parameters: { isAdmin: false },
+  beforeEach: () => setMcpToolResponder(quietResponder),
+};
+
+/** Repositories active (the URL drives the highlighted section). */
+export const RepositoriesActive: Story = {
+  args: { initialPath: "/repositories" },
+  parameters: { isAdmin: true },
+  beforeEach: () => setMcpToolResponder(busyResponder),
+};

--- a/ui/src/components/TaskCard.tsx
+++ b/ui/src/components/TaskCard.tsx
@@ -267,7 +267,7 @@ export function TaskCard({ task, epic, moving = false, onClick }: TaskCardProps)
       )}
       onClick={onClick}
     >
-      <CardContent className="flex min-h-[3.5rem] flex-col gap-1.5">
+      <CardContent className="flex min-h-[3rem] flex-col gap-1">
         {/* Row 1: ID, priority, badges, pipeline */}
         <div className="flex items-center gap-2 overflow-hidden text-[11px] text-muted-foreground">
           <TaskIdLabel taskId={task.id} shortId={task.short_id} />
@@ -391,7 +391,9 @@ export function TaskCard({ task, epic, moving = false, onClick }: TaskCardProps)
             title={epic.title}
             data-testid="taskcard-epic-chip"
           >
-            <span className="shrink-0 leading-none">{epic.emoji}</span>
+            {epic.emoji && (
+              <span className="shrink-0 leading-none">{epic.emoji}</span>
+            )}
             <span className="truncate">{epic.title}</span>
           </div>
         )}

--- a/ui/src/pages/ImageEditorPage.stories.tsx
+++ b/ui/src/pages/ImageEditorPage.stories.tsx
@@ -1,0 +1,140 @@
+/**
+ * Images/ImageEditorPage — the full-page create/edit flow for a catalog image.
+ *
+ * Routes: `/images/new` (create) and `/images/:id/edit` (edit). The page and
+ * its embedded `ImageConfigEditor` pull three MCP tools:
+ *   - `service_preset_list` (the injected-services picker),
+ *   - `toolchain_versions` (the per-language version selectors — TanStack Query
+ *     inside `ImageConfigEditor`; served here through the same responder), and
+ *   - `image_list` (edit route only, to seed the form from the target image).
+ * A per-tool responder on the aliased `@/api/mcpClient` mock serves all three;
+ * a per-story `QueryClient` (retry:false) wraps the page so the toolchain query
+ * resolves from the fixture instead of a live backend.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ImageEditorPage } from "./ImageEditorPage";
+import { setMcpToolResponder } from "@/storybook-mocks/mcpClient";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const servicePresets = [
+  {
+    id: "postgres-16",
+    name: "PostgreSQL 16",
+    service_type: "postgres",
+    image: "postgres:16",
+    conn_env_var: "TEST_POSTGRES_URL",
+  },
+  {
+    id: "redis-7",
+    name: "Redis 7",
+    service_type: "redis",
+    image: "redis:7",
+    conn_env_var: "TEST_REDIS_URL",
+  },
+  {
+    id: "rabbitmq-3",
+    name: "RabbitMQ 3",
+    service_type: "rabbitmq",
+    image: "rabbitmq:3",
+    conn_env_var: "TEST_AMQP_URL",
+  },
+];
+
+const toolchainVersions = {
+  rust: ["stable", "beta", "nightly"],
+  node: ["lts", "24", "22", "20"],
+  python: ["3.13", "3.12", "3.11"],
+  go: ["1.26", "1.25", "1.24"],
+};
+
+// The image the edit route seeds its form from (matched by id from the URL).
+const editImage = {
+  id: "img-rust-node",
+  name: "Rust + Node",
+  description: "Primary monorepo image — Rust workspace plus the pnpm UI.",
+  status: "ready",
+  config: {
+    schema_version: 1,
+    source: "user-edited",
+    languages: {
+      rust: { default_toolchain: "stable" },
+      node: { default_version: "22" },
+    },
+    workspaces: [],
+    system_packages: ["postgresql-client", "protobuf-compiler"],
+    env: { RUST_BACKTRACE: "1" },
+    lifecycle: {},
+  },
+  service_presets: ["postgres-16"],
+};
+
+function responder(name: string): unknown {
+  switch (name) {
+    case "service_preset_list":
+      return { status: "ok", presets: servicePresets };
+    case "toolchain_versions":
+      return { status: "ok", versions: toolchainVersions };
+    case "image_list":
+      return { status: "ok", images: [editImage] };
+    default:
+      return {};
+  }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+interface EditorStoryArgs {
+  initialPath: string;
+}
+
+function ImageEditorStory({ initialPath }: EditorStoryArgs) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <div className="h-screen bg-background text-foreground">
+          <Routes>
+            <Route path="/images/new" element={<ImageEditorPage />} />
+            <Route path="/images/:id/edit" element={<ImageEditorPage />} />
+            <Route path="/images" element={<div />} />
+          </Routes>
+        </div>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: "Images/ImageEditorPage",
+  component: ImageEditorStory,
+  parameters: { layout: "fullscreen" },
+  beforeEach: () => setMcpToolResponder(responder),
+} satisfies Meta<typeof ImageEditorStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Create route (`/images/new`): empty name/description, the Form tab with every
+ * language toggle off, and the full injected-services picker.
+ */
+export const Create: Story = {
+  args: { initialPath: "/images/new" },
+};
+
+/**
+ * Edit route (`/images/:id/edit`): the form is seeded from the "Rust + Node"
+ * catalog image — name/description filled, Rust + Node enabled with their
+ * versions, two system packages, an env var, and the Postgres service toggled
+ * on.
+ */
+export const Edit: Story = {
+  args: { initialPath: "/images/img-rust-node/edit" },
+};

--- a/ui/src/pages/ImagesPage.stories.tsx
+++ b/ui/src/pages/ImagesPage.stories.tsx
@@ -1,0 +1,135 @@
+/**
+ * Images/ImagesPage — the routed `/images` catalog table.
+ *
+ * The page imperatively loads two MCP tools on mount (`image_list` +
+ * `service_preset_list`, via `listImages` / `listServicePresets`) — there is no
+ * TanStack Query seam, so we install a per-tool responder on the aliased
+ * `@/api/mcpClient` mock. `listImages` runs each row's `config` through
+ * `normalizeConfig`, so the fixtures send raw (server-shaped) config blobs and
+ * the languages column ("Rust, Node") is derived exactly as in production.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router-dom";
+
+import { ImagesPage } from "./ImagesPage";
+import { setMcpToolResponder } from "@/storybook-mocks/mcpClient";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+// Raw config blobs as the server serializes them; `listImages` normalizes.
+function config(languages: Record<string, unknown>): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    source: "user-edited",
+    languages,
+    workspaces: [],
+    system_packages: [],
+    env: {},
+    lifecycle: {},
+  };
+}
+
+const servicePresets = [
+  {
+    id: "postgres-16",
+    name: "PostgreSQL 16",
+    service_type: "postgres",
+    image: "postgres:16",
+    conn_env_var: "TEST_POSTGRES_URL",
+  },
+  {
+    id: "redis-7",
+    name: "Redis 7",
+    service_type: "redis",
+    image: "redis:7",
+    conn_env_var: "TEST_REDIS_URL",
+  },
+];
+
+const images = [
+  {
+    id: "img-rust-node",
+    name: "Rust + Node",
+    description: "Primary monorepo image — Rust workspace plus the pnpm UI.",
+    status: "ready",
+    config: config({
+      rust: { default_toolchain: "stable" },
+      node: { default_version: "22" },
+    }),
+    service_presets: ["postgres-16"],
+  },
+  {
+    id: "img-python",
+    name: "Python 3.13",
+    description: "Data + scripting image with Postgres and Redis sidecars.",
+    status: "building",
+    config: config({ python: { default_version: "3.13" } }),
+    service_presets: ["postgres-16", "redis-7"],
+  },
+  {
+    id: "img-go",
+    name: "Go 1.26",
+    description: "Standalone Go services image.",
+    status: "failed",
+    config: config({ go: { default_version: "1.26" } }),
+    service_presets: [],
+  },
+];
+
+function populatedResponder(name: string): unknown {
+  switch (name) {
+    case "image_list":
+      return { status: "ok", images };
+    case "service_preset_list":
+      return { status: "ok", presets: servicePresets };
+    default:
+      return {};
+  }
+}
+
+function emptyResponder(name: string): unknown {
+  switch (name) {
+    case "image_list":
+      return { status: "ok", images: [] };
+    case "service_preset_list":
+      return { status: "ok", presets: servicePresets };
+    default:
+      return {};
+  }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+function ImagesStory() {
+  return (
+    <MemoryRouter initialEntries={["/images"]}>
+      <div className="h-screen bg-background text-foreground">
+        <ImagesPage />
+      </div>
+    </MemoryRouter>
+  );
+}
+
+const meta = {
+  title: "Images/ImagesPage",
+  component: ImagesStory,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ImagesStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Three catalog images across the build lifecycle: a ready Rust+Node image with
+ * a Postgres sidecar, a building Python image with Postgres+Redis, and a failed
+ * Go image with no services.
+ */
+export const Populated: Story = {
+  beforeEach: () => setMcpToolResponder(populatedResponder),
+};
+
+/** Empty catalog → the "No images yet" EmptyState with the "New image" CTA. */
+export const Empty: Story = {
+  beforeEach: () => setMcpToolResponder(emptyResponder),
+};

--- a/ui/src/pages/ProjectEnvironmentPage.stories.tsx
+++ b/ui/src/pages/ProjectEnvironmentPage.stories.tsx
@@ -1,0 +1,145 @@
+/**
+ * Environment/ProjectEnvironmentPage — the routed `/projects/:id/environment`
+ * per-project config page.
+ *
+ * The page reads the project name from the real `projectStore` (seeded here)
+ * and loads its config imperatively via `fetchEnvironmentConfig` →
+ * `callMcpTool("project_environment_config_get")`. The header's
+ * `ProjectImagePicker` separately lists the catalog through
+ * `callMcpTool("image_list")` and pre-selects `selected_image_id`. A per-tool
+ * responder on the aliased `@/api/mcpClient` mock serves both; the page uses
+ * `useParams`, so it is mounted under a matching `Routes`/`MemoryRouter`.
+ */
+
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { ProjectEnvironmentPage } from "./ProjectEnvironmentPage";
+import { setMcpToolResponder } from "@/storybook-mocks/mcpClient";
+import { projectStore } from "@/stores/projectStore";
+import type { Project } from "@/api/types";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const project: Project = {
+  id: "project-djinn",
+  name: "djinnos/djinn",
+  github_owner: "djinnos",
+  github_repo: "djinn",
+  branch: "main",
+};
+
+const catalogImages = [
+  {
+    id: "img-rust-node",
+    name: "Rust + Node",
+    description: "Primary monorepo image.",
+    status: "ready",
+    config: { schema_version: 1, source: "user-edited", languages: {}, workspaces: [], system_packages: [], env: {}, lifecycle: {} },
+    service_presets: ["postgres-16"],
+  },
+  {
+    id: "img-python",
+    name: "Python 3.13",
+    description: "Scripting image.",
+    status: "ready",
+    config: { schema_version: 1, source: "user-edited", languages: {}, workspaces: [], system_packages: [], env: {}, lifecycle: {} },
+    service_presets: [],
+  },
+];
+
+function envConfig(workspaces: Array<{ root: string; language: string }>): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    source: "user-edited",
+    languages: {},
+    workspaces,
+    system_packages: [],
+    env: {},
+    lifecycle: {},
+  };
+}
+
+function makeResponder(workspaces: Array<{ root: string; language: string }>) {
+  return (name: string): unknown => {
+    switch (name) {
+      case "project_environment_config_get":
+        return {
+          status: "ok",
+          config: envConfig(workspaces),
+          selected_image_id: "img-rust-node",
+          selected_image_name: "Rust + Node",
+        };
+      case "image_list":
+        return { status: "ok", images: catalogImages };
+      default:
+        return {};
+    }
+  };
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+function ProjectSeeder({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    projectStore.setState({
+      projects: [project],
+      selectedProjectId: project.id,
+      lastViewPerProject: {},
+    });
+    return () => {
+      projectStore.setState({ projects: [], selectedProjectId: null, lastViewPerProject: {} });
+    };
+  }, []);
+  return <>{children}</>;
+}
+
+function EnvironmentStory() {
+  return (
+    <MemoryRouter initialEntries={[`/projects/${project.id}/environment`]}>
+      <ProjectSeeder>
+        <div className="h-screen bg-background text-foreground">
+          <Routes>
+            <Route
+              path="/projects/:id/environment"
+              element={<ProjectEnvironmentPage />}
+            />
+            <Route path="/repositories" element={<div />} />
+          </Routes>
+        </div>
+      </ProjectSeeder>
+    </MemoryRouter>
+  );
+}
+
+const meta = {
+  title: "Environment/ProjectEnvironmentPage",
+  component: EnvironmentStory,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof EnvironmentStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Two code-graph workspaces configured (a Rust server root, a Node UI root),
+ * with the "Rust + Node" catalog image pre-selected in the header picker.
+ */
+export const Populated: Story = {
+  beforeEach: () =>
+    setMcpToolResponder(
+      makeResponder([
+        { root: "server", language: "rust" },
+        { root: "ui", language: "node" },
+      ]),
+    ),
+};
+
+/**
+ * No workspaces yet → the dashed empty-state prompt inside the workspaces
+ * editor, with the catalog image still assigned.
+ */
+export const NoWorkspaces: Story = {
+  beforeEach: () => setMcpToolResponder(makeResponder([])),
+};

--- a/ui/src/pages/ProjectEnvironmentPage.stories.tsx
+++ b/ui/src/pages/ProjectEnvironmentPage.stories.tsx
@@ -114,7 +114,7 @@ function EnvironmentStory() {
 }
 
 const meta = {
-  title: "Environment/ProjectEnvironmentPage",
+  title: "Repositories/ProjectEnvironmentPage",
   component: EnvironmentStory,
   parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof EnvironmentStory>;

--- a/ui/src/pages/ProposalsPage.test.tsx
+++ b/ui/src/pages/ProposalsPage.test.tsx
@@ -425,19 +425,28 @@ describe("ProposalsPage", () => {
     expect(reviewSection).not.toBeNull();
     const section = within(reviewSection!);
 
-    // One unified tribunal chip per state.
-    expect(section.getByText("Review")).toBeInTheDocument();
-    expect(section.getByText("R3 running")).toBeInTheDocument();
-    expect(section.getByText("evidence")).toBeInTheDocument();
+    // One tribunal icon per state, identified by its tooltip — the icon-only
+    // treatment keeps the row text-free.
+    expect(
+      section.getByTitle("Tribunal converged — awaiting your review"),
+    ).toBeInTheDocument();
+    expect(
+      section.getByTitle("Tribunal refinement running (round 3)"),
+    ).toBeInTheDocument();
+    expect(
+      section.getByTitle("Parked on a needs-evidence spike"),
+    ).toBeInTheDocument();
 
-    // Idle-but-blocking row shows a single red tribunal chip (no scattered
-    // objection glyph in the gate slot).
-    expect(section.getByText("R1 · 2 open")).toBeInTheDocument();
-    expect(section.queryByText("⛔2")).not.toBeInTheDocument();
-    expect(section.queryByText("DoR ✗")).not.toBeInTheDocument();
+    // Idle-but-blocking row shows the red scale with just the open count.
+    expect(
+      section.getByTitle(
+        "Tribunal round 1 left 2 unresolved blocking objections",
+      ),
+    ).toHaveTextContent("2");
 
-    // Gate dots carry their reason in the tooltip only.
-    expect(section.getByTitle("Gate ready")).toBeInTheDocument();
+    // Gate icons carry their reason in the tooltip only, and a READY gate
+    // renders nothing at all.
+    expect(section.queryByTitle("Gate ready")).not.toBeInTheDocument();
     expect(
       section.getByTitle("Gate blocked — 2 unresolved blocking objections"),
     ).toBeInTheDocument();
@@ -475,12 +484,11 @@ describe("ProposalsPage", () => {
 
     renderProposalsRoute("/proposals");
 
-    // Neutral dot, explanatory tooltip, no red alarm, no "DoR ✗" text.
+    // Faint neutral shield, explanatory tooltip, no red alarm.
     const gate = await screen.findByTitle("Definition of Ready not yet met");
     expect(gate).toBeInTheDocument();
-    expect(gate.querySelector("span")).toHaveClass("bg-transparent");
-    expect(gate.querySelector(".bg-red-500")).toBeNull();
-    expect(screen.queryByText("DoR ✗")).not.toBeInTheDocument();
+    expect(gate).toHaveClass("text-muted-foreground/50");
+    expect(gate).not.toHaveClass("text-red-500");
     expect(screen.queryByText(/Gate blocked/)).not.toBeInTheDocument();
   });
 
@@ -515,7 +523,7 @@ describe("ProposalsPage", () => {
     const gate = await screen.findByTitle(
       "Gate blocked — 3 unresolved blocking objections",
     );
-    expect(gate.querySelector(".bg-red-500")).not.toBeNull();
+    expect(gate).toHaveClass("text-red-500");
   });
 
   it("sorts awaiting-review rows first and summarizes them in the group header", async () => {

--- a/ui/src/pages/ProposalsPage.tsx
+++ b/ui/src/pages/ProposalsPage.tsx
@@ -7,8 +7,10 @@ import {
   Alert02Icon,
   ArrowLeft01Icon,
   Comment01Icon,
-  JusticeScale01Icon,
+  Legal01Icon,
   Robot01Icon,
+  SecurityBlockIcon,
+  Shield01Icon,
   TestTube01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -22,8 +24,22 @@ import {
 } from "@/components/proposals/blocks";
 import { AcceptanceProgressBadge } from "@/components/AcceptanceProgressBadge";
 import { UserAvatar } from "@/components/UserAvatar";
+import { TaskIdLabel } from "@/components/TaskIdLabel";
 import { CopyButton } from "@/components/CopyButton";
 import { InlineError } from "@/components/InlineError";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/combobox";
+import { OwnerAvatar } from "@/components/board/boardFilterControls";
+import {
+  makeOwnerLabel,
+  UNASSIGNED_OWNER,
+} from "@/components/board/boardFilters";
 import { relativeTime } from "@/components/memory/memoryUtils";
 import {
   PROPOSAL_STATUS_META,
@@ -92,54 +108,54 @@ function tribunalEngaged(summary: ProposalListSummary): boolean {
 }
 
 /**
- * One unified tribunal chip for a list row, resolved as a single state machine
- * (priority order, first match wins):
+ * Tribunal state as a bare icon — shown only while something is in flight or
+ * needs a human; a quiet tribunal renders nothing. Resolved as a single state
+ * machine (priority order, first match wins):
  *
- *  1. awaiting_review → accent `⚖ Review` — the actionable, human-bottleneck
- *     state; the most prominent thing on the row.
- *  2. needs_evidence → muted `🧪 evidence` — parked on a needs-evidence spike.
- *  3. refinement_active → pulsing `⚖ R{n} running` — a round is in flight.
+ *  1. awaiting_review → amber scale — the actionable, human-bottleneck state.
+ *  2. needs_evidence → muted test tube — parked on a needs-evidence spike.
+ *  3. refinement_active → muted pulsing scale — a round is in flight.
  *  4. tribunal ran (round > 0), idle, and left blocking objections →
- *     red `⚖ R{n} · {count} open`.
- *  5. otherwise → nothing (the slot stays empty but keeps its width).
+ *     red scale + open-objection count.
+ *  5. otherwise → nothing.
+ *
+ * The full explanation lives in the tooltip; the icon only signals which
+ * bucket the row is in.
  */
-function TribunalChip({ summary }: { summary: ProposalListSummary }) {
+function TribunalIcon({ summary }: { summary: ProposalListSummary }) {
   const round = summary.current_round || 1;
 
   if (summary.awaiting_review) {
     return (
       <span
-        className="flex items-center gap-0.5 text-xs font-semibold text-amber-500"
+        className="flex items-center text-amber-500"
         title="Tribunal converged — awaiting your review"
       >
-        <HugeiconsIcon icon={JusticeScale01Icon} size={13} />
-        Review
+        <HugeiconsIcon icon={Legal01Icon} size={14} />
       </span>
     );
   }
   if (summary.needs_evidence) {
     return (
       <span
-        className="flex items-center gap-0.5 text-xs text-muted-foreground"
+        className="flex items-center text-muted-foreground"
         title="Parked on a needs-evidence spike"
       >
-        <HugeiconsIcon icon={TestTube01Icon} size={13} />
-        evidence
+        <HugeiconsIcon icon={TestTube01Icon} size={14} />
       </span>
     );
   }
   if (summary.refinement_active) {
     return (
       <span
-        className="flex items-center gap-0.5 text-xs text-muted-foreground"
+        className="flex items-center text-muted-foreground"
         title={`Tribunal refinement running (round ${round})`}
       >
         <HugeiconsIcon
-          icon={JusticeScale01Icon}
-          size={13}
+          icon={Legal01Icon}
+          size={14}
           className="animate-pulse"
         />
-        R{round} running
       </span>
     );
   }
@@ -152,8 +168,8 @@ function TribunalChip({ summary }: { summary: ProposalListSummary }) {
           n === 1 ? "" : "s"
         }`}
       >
-        <HugeiconsIcon icon={JusticeScale01Icon} size={13} />
-        R{summary.current_round} · {n} open
+        <HugeiconsIcon icon={Legal01Icon} size={14} />
+        {n}
       </span>
     );
   }
@@ -161,24 +177,23 @@ function TribunalChip({ summary }: { summary: ProposalListSummary }) {
 }
 
 /**
- * Gate readiness as a single dot. Red is RESERVED for "a tribunal engaged and
- * the gate is actually stuck" — the only time an operator needs to act:
+ * Gate readiness as a shield icon, shown ONLY while the gate is failing — a
+ * ready gate renders nothing (quiet rows stay quiet). Red is RESERVED for "a
+ * tribunal engaged and the gate is actually stuck" — the only time an
+ * operator needs to act:
  *
- *  - gate_ready → subtle, quiet green dot.
- *  - blocked AND a tribunal has engaged → red dot, the reason in the tooltip.
+ *  - gate_ready → nothing.
+ *  - blocked AND a tribunal has engaged → red blocked-shield, the reason in
+ *    the tooltip.
  *  - blocked but no tribunal ever engaged (a fresh draft naturally failing
- *    Definition of Ready) → neutral hollow dot; the tooltip still explains it,
- *    but there is no red and no "DoR ✗" shouting on the row.
+ *    Definition of Ready) → faint plain shield; the tooltip still explains
+ *    it, but there is no red shouting on the row.
  */
-function GateDot({ summary }: { summary: ProposalListSummary }) {
-  let dotClass: string;
-  let title: string;
+function GateIcon({ summary }: { summary: ProposalListSummary }) {
+  if (summary.gate_ready) return null;
 
-  if (summary.gate_ready) {
-    dotClass = "bg-emerald-500/50";
-    title = "Gate ready";
-  } else if (tribunalEngaged(summary)) {
-    dotClass = "bg-red-500";
+  if (tribunalEngaged(summary)) {
+    let title: string;
     if (summary.unresolved_blocking_count > 0) {
       const n = summary.unresolved_blocking_count;
       title = `Gate blocked — ${n} unresolved blocking objection${
@@ -191,17 +206,19 @@ function GateDot({ summary }: { summary: ProposalListSummary }) {
     } else {
       title = "Gate blocked — judge verdict: needs work";
     }
-  } else {
-    dotClass = "border border-muted-foreground/40 bg-transparent";
-    title = "Definition of Ready not yet met";
+    return (
+      <span className="flex items-center text-red-500" title={title}>
+        <HugeiconsIcon icon={SecurityBlockIcon} size={14} />
+      </span>
+    );
   }
 
   return (
-    <span className="flex items-center" title={title}>
-      <span
-        className={cn("inline-block size-2 rounded-full", dotClass)}
-        aria-hidden="true"
-      />
+    <span
+      className="flex items-center text-muted-foreground/50"
+      title="Definition of Ready not yet met"
+    >
+      <HugeiconsIcon icon={Shield01Icon} size={14} />
     </span>
   );
 }
@@ -358,6 +375,7 @@ function ProposalsListView() {
   const navigate = useNavigate();
   const [search, setSearch] = useState("");
   const [showArchived, setShowArchived] = useState(false);
+  const [ownerFilters, setOwnerFilters] = useState<string[]>([]);
   const [collapsedGroups, setCollapsedGroups] = useState<
     Partial<Record<ProposalStatus, boolean>>
   >({});
@@ -365,13 +383,38 @@ function ProposalsListView() {
   const listQuery = useQuery(
     proposalListQueryOptions({ text: search.trim() || undefined })
   );
-  const usersQuery = useQuery(usersQueryOptions());
+  const { data: users = [] } = useQuery(usersQueryOptions());
   const userFor = (id?: string | null) =>
-    id ? (usersQuery.data ?? []).find((u: OrgUser) => u.id === id) : undefined;
+    id ? users.find((u: OrgUser) => u.id === id) : undefined;
+
+  // Owner filter — the same Combobox + avatar UX the Tasks board uses, mirrored
+  // to local state (the list has no URL-filter contract like the board). Owners
+  // resolve against `author_user_id`, the proposal's creator.
+  const userById = useMemo(() => {
+    const map = new Map<string, OrgUser>();
+    for (const user of users) map.set(user.id, user);
+    return map;
+  }, [users]);
+  const ownerLabel = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const user of users) labels.set(user.id, userDisplayName(user));
+    return makeOwnerLabel(labels);
+  }, [users]);
+  const ownerOptions = useMemo(() => {
+    const owners = new Set<string>();
+    for (const p of listQuery.data ?? [])
+      owners.add(p.author_user_id ?? UNASSIGNED_OWNER);
+    return Array.from(owners).sort((a, b) =>
+      ownerLabel(a).localeCompare(ownerLabel(b)),
+    );
+  }, [listQuery.data, ownerLabel]);
 
   const groups = useMemo(() => {
     const visible = (listQuery.data ?? []).filter(
-      (p) => showArchived || !isArchivedLike(p.status)
+      (p) =>
+        (showArchived || !isArchivedLike(p.status)) &&
+        (ownerFilters.length === 0 ||
+          ownerFilters.includes(p.author_user_id ?? UNASSIGNED_OWNER))
     );
     return PROPOSAL_STATUS_KEYS.map((status) => ({
       status,
@@ -386,13 +429,46 @@ function ProposalsListView() {
           return a.updated_at < b.updated_at ? 1 : -1;
         }),
     })).filter((g) => g.items.length > 0);
-  }, [listQuery.data, showArchived]);
+  }, [listQuery.data, showArchived, ownerFilters]);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex items-center justify-between gap-4 border-b p-4">
         <h1 className="text-lg font-semibold">Proposals</h1>
         <div className="flex items-center gap-3">
+          <Combobox
+            multiple
+            value={ownerFilters}
+            onValueChange={(v) => setOwnerFilters(v ?? [])}
+            itemToStringLabel={ownerLabel}
+          >
+            <ComboboxInput
+              aria-label="Filter by owner"
+              placeholder={
+                ownerFilters.length > 0
+                  ? `${ownerFilters.length} owner${ownerFilters.length > 1 ? "s" : ""}`
+                  : "All owners"
+              }
+              className="w-40"
+            />
+            <ComboboxContent className="min-w-60">
+              <ComboboxList>
+                <ComboboxEmpty>No owners found</ComboboxEmpty>
+                {ownerOptions.map((owner) => (
+                  <ComboboxItem key={owner} value={owner}>
+                    <OwnerAvatar
+                      user={
+                        owner === UNASSIGNED_OWNER
+                          ? undefined
+                          : userById.get(owner)
+                      }
+                    />
+                    <span className="truncate">{ownerLabel(owner)}</span>
+                  </ComboboxItem>
+                ))}
+              </ComboboxList>
+            </ComboboxContent>
+          </Combobox>
           <Input
             placeholder="Search proposals…"
             value={search}
@@ -477,27 +553,22 @@ function ProposalsListView() {
                             onClick={() => navigate(`/proposals/${p.id}`)}
                             className="flex w-full items-center gap-3 border-b border-border/40 px-4 py-2.5 text-left hover:bg-muted/40"
                           >
+                            {/* Lead — status glyph, then a copyable short id,
+                                then the title with the unresolved-comment
+                                count kept close to it. */}
                             <StatusIcon status={p.status} />
-                            <span className="min-w-0 flex-1 truncate text-sm">
-                              {p.title}
-                            </span>
-                            {/* Right rail — fixed-width slots so every row's
-                                columns line up down the list. Empty slots keep
-                                their width so nothing shifts. */}
-                            <span className="flex w-28 shrink-0 items-center justify-start">
-                              {p.list_summary && (
-                                <TribunalChip summary={p.list_summary} />
-                              )}
-                            </span>
-                            <span className="flex w-4 shrink-0 justify-center">
-                              {p.list_summary && (
-                                <GateDot summary={p.list_summary} />
-                              )}
-                            </span>
-                            <span className="flex w-9 shrink-0 justify-end">
+                            <TaskIdLabel
+                              taskId={p.id}
+                              shortId={p.short_id}
+                              className="shrink-0"
+                            />
+                            <span className="flex min-w-0 flex-1 items-center gap-2">
+                              <span className="min-w-0 truncate text-sm">
+                                {p.title}
+                              </span>
                               {(p.unresolved_feedback_count ?? 0) > 0 && (
                                 <span
-                                  className="flex items-center gap-1 text-xs text-muted-foreground"
+                                  className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
                                   title={`${p.unresolved_feedback_count} unresolved comment${
                                     p.unresolved_feedback_count === 1 ? "" : "s"
                                   }`}
@@ -507,19 +578,25 @@ function ProposalsListView() {
                                 </span>
                               )}
                             </span>
-                            <span className="flex w-11 shrink-0 justify-end">
+                            {/* Right rail — tribunal status, readiness, ACs,
+                                updated-ago, owner. Natural widths, matching
+                                the left side's flow. */}
+                            <span className="flex shrink-0 items-center gap-3">
+                              {p.list_summary && (
+                                <TribunalIcon summary={p.list_summary} />
+                              )}
+                              {p.list_summary && (
+                                <GateIcon summary={p.list_summary} />
+                              )}
                               <AcceptanceProgressBadge met={p.ac_met ?? 0} total={p.ac_total ?? 0} />
+                              <span className="whitespace-nowrap text-xs text-muted-foreground">
+                                {relativeTime(p.updated_at)}
+                              </span>
+                              <UserAvatar
+                                user={userFor(p.author_user_id)}
+                                className="size-5 shrink-0"
+                              />
                             </span>
-                            <span className="hidden w-10 shrink-0 text-right font-mono text-xs text-muted-foreground sm:inline-block">
-                              {p.short_id}
-                            </span>
-                            <span className="w-16 shrink-0 whitespace-nowrap text-right text-xs text-muted-foreground">
-                              {relativeTime(p.updated_at)}
-                            </span>
-                            <UserAvatar
-                              user={userFor(p.author_user_id)}
-                              className="size-5 shrink-0"
-                            />
                           </button>
                         </li>
                       ))}

--- a/ui/src/pages/RepositoriesPage.stories.tsx
+++ b/ui/src/pages/RepositoriesPage.stories.tsx
@@ -1,0 +1,159 @@
+/**
+ * Repositories/RepositoriesPage — the routed `/repositories` table.
+ *
+ * The page reads its rows from the real `projectStore` (seeded here) and each
+ * row drives two independent MCP-backed sub-widgets:
+ *   - `BranchPicker` fetches `['project', id, 'branches']` via
+ *     `fetchProjectBranches` → `callMcpTool("project_branches")`.
+ *   - `ImageStatusBadge` polls `callMcpTool("get_project_devcontainer_status")`.
+ * Neither goes through a cache seam we can seed by key alone (the branch query
+ * is created inside the row with a live `queryFn`), so we install a per-tool
+ * responder on the aliased `@/api/mcpClient` mock and branch on the requested
+ * `project` id to give each row a distinct status (ready / building / needs
+ * image). A per-story `QueryClient` (retry:false) wraps the page.
+ */
+
+import { useEffect } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { RepositoriesPage } from "./RepositoriesPage";
+import { setMcpToolResponder } from "@/storybook-mocks/mcpClient";
+import { projectStore } from "@/stores/projectStore";
+import type { Project } from "@/api/types";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const projects: Project[] = [
+  {
+    id: "project-djinn",
+    name: "djinnos/djinn",
+    github_owner: "djinnos",
+    github_repo: "djinn",
+    branch: "main",
+  },
+  {
+    id: "project-catalog",
+    name: "djinnos/catalog",
+    github_owner: "djinnos",
+    github_repo: "catalog",
+    branch: "release/2026.07",
+  },
+  {
+    id: "project-web",
+    name: "djinnos/pink-web",
+    github_owner: "djinnos",
+    github_repo: "pink-web",
+    branch: "main",
+  },
+];
+
+const branchesByProject: Record<string, string[]> = {
+  "project-djinn": ["main", "develop", "feat/graph-warm", "hotfix/oom"],
+  "project-catalog": ["main", "release/2026.07", "release/2026.06"],
+  "project-web": ["main", "redesign", "wip/pricing"],
+};
+
+// A distinct image/warm status per project so the row badges read differently:
+// djinn is healthy (no badge), catalog is mid-build, pink-web needs an image.
+function devcontainerStatusFor(projectId: string): unknown {
+  switch (projectId) {
+    case "project-catalog":
+      return { image_status: "building", graph_warm_status: "pending", needs_image: false };
+    case "project-web":
+      return { image_status: "none", graph_warm_status: "pending", needs_image: true };
+    default:
+      return { image_status: "ready", graph_warm_status: "ready", needs_image: false };
+  }
+}
+
+function repositoriesResponder(
+  name: string,
+  args: Record<string, unknown> | undefined,
+): unknown {
+  switch (name) {
+    case "project_branches": {
+      const id = String(args?.project_id ?? "");
+      return { status: "ok", branches: branchesByProject[id] ?? ["main"], current: null };
+    }
+    case "get_project_devcontainer_status":
+      return devcontainerStatusFor(String(args?.project ?? ""));
+    default:
+      return {};
+  }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+function ProjectSeeder({
+  seeded,
+  children,
+}: {
+  seeded: Project[];
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    projectStore.setState({
+      projects: seeded,
+      selectedProjectId: seeded[0]?.id ?? null,
+      lastViewPerProject: {},
+    });
+    return () => {
+      projectStore.setState({ projects: [], selectedProjectId: null, lastViewPerProject: {} });
+    };
+  }, [seeded]);
+  return <>{children}</>;
+}
+
+interface RepositoriesStoryArgs {
+  seeded: Project[];
+}
+
+function RepositoriesStory({ seeded }: RepositoriesStoryArgs) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/repositories"]}>
+        <ProjectSeeder seeded={seeded}>
+          <div className="h-screen bg-background text-foreground">
+            <Routes>
+              <Route path="/repositories" element={<RepositoriesPage />} />
+              {/* Sinks for row / action navigation. */}
+              <Route path="/tasks" element={<div />} />
+              <Route path="/projects/:id/environment" element={<div />} />
+            </Routes>
+          </div>
+        </ProjectSeeder>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: "Repositories/RepositoriesPage",
+  component: RepositoriesStory,
+  parameters: { layout: "fullscreen" },
+  beforeEach: () => {
+    setMcpToolResponder(repositoriesResponder);
+  },
+} satisfies Meta<typeof RepositoriesStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Three repositories, each with a populated branch picker and a distinct image
+ * state: djinn healthy (no status badge), catalog mid-build ("Building"),
+ * pink-web unassigned ("Needs image").
+ */
+export const Populated: Story = {
+  args: { seeded: projects },
+};
+
+/** No repositories registered → the EmptyState with the "Add repository" CTA. */
+export const Empty: Story = {
+  args: { seeded: [] },
+};


### PR DESCRIPTION
## Summary

Three UI iterations from a Storybook-driven design session:

**Kanban board** (`KanbanBoard.tsx`, `TaskCard.tsx`)
- Hairline column separators scoped to each lane's card area (never crossing lane headers), centered in the grid gaps via a shared-template overlay
- Lane headers lead with the proposal short id (copyable `TaskIdLabel`)
- Wider gutters, more lane padding, pointer cursor on lane names; slightly more compact task cards; epic breadcrumb aligns left when the epic has no emoji

**Proposals list** (`ProposalsPage.tsx`)
- Rows lead with status icon → copyable short id → title → comment count; right rail flows naturally (tribunal, gate, ACs, updated-ago, owner avatar) with no forced column slots
- Tribunal state is icon-only: gavel in amber (awaiting review), pulsing muted (round running), red with open-objection count (blocking), test tube (evidence parked); quiet tribunals render nothing
- DoR gate shows only while failing: red blocked-shield when a tribunal is engaged and stuck, faint shield outline for fresh drafts; ready gates render nothing
- New multi-select owner filter in the header over `author_user_id`, reusing the board's owner-filter controls

**Storybook** (5 new story files)
- Navigation/Sidebar, Repositories/RepositoriesPage, Images/ImagesPage, Images/ImageEditorPage, Environment/ProjectEnvironmentPage — populated + empty/admin variants on the existing `setMcpToolResponder` + seeded-QueryClient patterns

## Testing

- `eslint` clean on all touched files
- `ProposalsPage.test.tsx`: 23/25 pass — the 2 failures are pre-existing on `main` (lint-banner `toHaveTextContent` separator mismatch), verified by running against the pristine HEAD file
- All stories and the redesigned pages verified visually in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)