### PR TITLE
chore(icvs): Version the admission epoch with v0/v1 modes, cap, and live-generation acknowledgements

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -18,6 +18,7 @@ use djinn_db::{
     AdmissionDomain, AdmissionJournalKey, AdmissionJournalRepository, AdmissionJournalRow,
     AdmissionRecoveryResult, AdmissionState, AdmissionWorkloadKind, CreateStartedInput,
     ReserveAdmissionInput, ReserveAdmissionResult, TerminalAdmissionInput, UidFencedAdmissionInput,
+    V0Mode, V1Mode,
 };
 use djinn_k8s::{
     WarmAdmission, WarmAdmissionError, WarmAdmissionPermit, WarmAdmissionRequest,
@@ -54,6 +55,37 @@ impl BuildAdmissionMode {
             _ => Self::Enforce,
         }
     }
+}
+
+/// Smallest legal reference cap. A cap of zero would deny all admission.
+pub const MIN_ADMISSION_CAP: i64 = 1;
+
+/// Largest legal reference cap. A sane upper bound that rejects an obviously
+/// mistyped configuration up front rather than letting it reach the durable row.
+pub const MAX_ADMISSION_CAP: i64 = 4096;
+
+/// Validate an admission-epoch configuration before it is written durably.
+///
+/// Two rules are enforced up front so a bad configuration never reaches the
+/// durable handoff row:
+///
+/// - The illegal mode combination in which neither authority enforces
+///   (`v0 ∈ {observe, disabled} ∧ v1 ∈ {off, shadow}`) is rejected: something
+///   must actually enforce the cap.
+/// - The reference cap must be within `[MIN_ADMISSION_CAP, MAX_ADMISSION_CAP]`.
+pub fn validate_admission_config(v0: V0Mode, v1: V1Mode, cap: i64) -> Result<(), String> {
+    if !v0.is_enforcing() && !v1.is_enforcing() {
+        return Err(format!(
+            "illegal admission mode combination: neither authority enforces \
+             (v0={v0:?}, v1={v1:?}); at least one of v0 or v1 must enforce the cap"
+        ));
+    }
+    if !(MIN_ADMISSION_CAP..=MAX_ADMISSION_CAP).contains(&cap) {
+        return Err(format!(
+            "admission cap {cap} is out of range [{MIN_ADMISSION_CAP}, {MAX_ADMISSION_CAP}]"
+        ));
+    }
+    Ok(())
 }
 
 /// Typed classification captured before dispatch; only the audited bypass weighs zero.
@@ -1361,6 +1393,37 @@ mod tests {
     use futures::FutureExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::Notify;
+
+    #[test]
+    fn validate_admission_config_rejects_illegal_combo_and_out_of_range_cap() {
+        // At least one enforcing authority is legal across the cap range.
+        assert!(validate_admission_config(V0Mode::Enforce, V1Mode::Off, 1).is_ok());
+        assert!(validate_admission_config(V0Mode::Enforce, V1Mode::Shadow, 8).is_ok());
+        assert!(validate_admission_config(V0Mode::Observe, V1Mode::Enforce, 3).is_ok());
+        assert!(
+            validate_admission_config(V0Mode::Disabled, V1Mode::Enforce, MAX_ADMISSION_CAP).is_ok()
+        );
+
+        // Neither authority enforcing is illegal for every non-enforcing pairing.
+        for (v0, v1) in [
+            (V0Mode::Observe, V1Mode::Off),
+            (V0Mode::Observe, V1Mode::Shadow),
+            (V0Mode::Disabled, V1Mode::Off),
+            (V0Mode::Disabled, V1Mode::Shadow),
+        ] {
+            assert!(
+                validate_admission_config(v0, v1, 4).is_err(),
+                "{v0:?}/{v1:?} must be rejected"
+            );
+        }
+
+        // Cap out of range is rejected even with an enforcing authority.
+        assert!(validate_admission_config(V0Mode::Enforce, V1Mode::Off, 0).is_err());
+        assert!(validate_admission_config(V0Mode::Enforce, V1Mode::Off, -1).is_err());
+        assert!(
+            validate_admission_config(V0Mode::Enforce, V1Mode::Off, MAX_ADMISSION_CAP + 1).is_err()
+        );
+    }
 
     fn controller(mode: BuildAdmissionMode, cap: i64) -> BuildAdmissionController {
         BuildAdmissionController::new(

--- a/server/crates/djinn-coordinator/src/build_admission_handoff.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_handoff.rs
@@ -28,6 +28,9 @@ impl HandoffSnapshot {
             HandoffState::UnexpectedOverlap => Some(HandoffWarningReason::UnexpectedOverlap),
             HandoffState::IncompleteEpoch => Some(HandoffWarningReason::StaleEpoch),
             HandoffState::EpochUnreadable => Some(HandoffWarningReason::EpochUnreadable),
+            // A row where neither authority enforces is a fail-closed
+            // misconfiguration that must surface for attention.
+            HandoffState::IllegalModeCombo => Some(HandoffWarningReason::StaleEpoch),
             HandoffState::ForwardOverlap | HandoffState::RollbackOverlap => {
                 if emergency_enforcing && invocation.enforcing {
                     None
@@ -35,7 +38,8 @@ impl HandoffSnapshot {
                     Some(HandoffWarningReason::StaleEpoch)
                 }
             }
-            HandoffState::EmergencyPrimary => {
+            // Baseline and shadow are both the v0-primary steady state.
+            HandoffState::EmergencyPrimary | HandoffState::Shadow => {
                 if emergency_enforcing {
                     invocation
                         .enforcing
@@ -69,16 +73,26 @@ pub enum EmergencyAuthorityDecision {
 }
 
 /// Bounded protocol classification consumed by later telemetry.
+///
+/// `EmergencyPrimary` is the v0-only baseline (v1 off); `Shadow` is that same
+/// v0 baseline with v1 observing without enforcing; `ForwardOverlap` /
+/// `RollbackOverlap` are the both-enforcing overlaps. `IllegalModeCombo` is the
+/// fail-closed classification for a row in which neither authority enforces.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HandoffState {
     MissingRow,
+    /// v0 baseline: v0 enforcing, v1 off.
     EmergencyPrimary,
+    /// v0 baseline with v1 shadowing (observing, not enforcing).
+    Shadow,
     ForwardOverlap,
     InvocationPrimary,
     RollbackOverlap,
     IncompleteEpoch,
     EpochUnreadable,
     UnexpectedOverlap,
+    /// Neither authority enforces — a misconfiguration that fails closed.
+    IllegalModeCombo,
 }
 
 /// The bounded reasons used by handoff telemetry and persistent lifecycle logs.
@@ -189,6 +203,13 @@ pub fn evaluate_handoff(
             EmergencyAuthorityDecision::ConfiguredStandalone,
             None,
         ),
+        Ok(Some(row)) if !row.v0_mode.is_enforcing() && !row.v1_mode.is_enforcing() => (
+            // Neither authority enforces: no admission control at all. This is a
+            // misconfiguration and fails closed regardless of phase or acks.
+            HandoffState::IllegalModeCombo,
+            EmergencyAuthorityDecision::RequiredFailClosed,
+            Some(row),
+        ),
         Ok(Some(row)) => {
             let emergency_current = row.emergency_ack_epoch == Some(row.epoch);
             let invocation_current = row.invocation_ack_epoch == Some(row.epoch);
@@ -207,11 +228,20 @@ pub fn evaluate_handoff(
                 )
             } else {
                 match row.phase {
-                    AdmissionHandoffPhase::EmergencyPrimary => (
-                        HandoffState::EmergencyPrimary,
-                        EmergencyAuthorityDecision::RequiredFailClosed,
-                        Some(row),
-                    ),
+                    // The v0 baseline distinguishes pure baseline (v1 off) from
+                    // v1 shadowing; both keep v0 enforcing.
+                    AdmissionHandoffPhase::EmergencyPrimary => {
+                        let state = if row.v1_mode == djinn_db::V1Mode::Shadow {
+                            HandoffState::Shadow
+                        } else {
+                            HandoffState::EmergencyPrimary
+                        };
+                        (
+                            state,
+                            EmergencyAuthorityDecision::RequiredFailClosed,
+                            Some(row),
+                        )
+                    }
                     AdmissionHandoffPhase::ForwardOverlap => (
                         HandoffState::ForwardOverlap,
                         EmergencyAuthorityDecision::RequiredFailClosed,
@@ -248,13 +278,158 @@ mod tests {
     use super::*;
 
     fn row(phase: AdmissionHandoffPhase, emergency: bool, invocation: bool) -> AdmissionHandoffRow {
+        row_with_modes(
+            phase,
+            emergency,
+            invocation,
+            djinn_db::V0Mode::Enforce,
+            djinn_db::V1Mode::Off,
+        )
+    }
+
+    fn row_with_modes(
+        phase: AdmissionHandoffPhase,
+        emergency: bool,
+        invocation: bool,
+        v0_mode: djinn_db::V0Mode,
+        v1_mode: djinn_db::V1Mode,
+    ) -> AdmissionHandoffRow {
         AdmissionHandoffRow {
             phase,
             epoch: 7,
             emergency_ack_epoch: emergency.then_some(7),
             invocation_ack_epoch: invocation.then_some(7),
+            v0_mode,
+            v1_mode,
+            cap: None,
             updated_at: "now".into(),
         }
+    }
+
+    #[test]
+    fn evaluate_handoff_distinguishes_baseline_shadow_overlap_and_fails_closed_on_illegal_combo() {
+        use djinn_db::{V0Mode, V1Mode};
+        // Baseline: v0 enforce, v1 off.
+        let baseline = evaluate_handoff(
+            Ok(Some(row_with_modes(
+                AdmissionHandoffPhase::EmergencyPrimary,
+                true,
+                false,
+                V0Mode::Enforce,
+                V1Mode::Off,
+            ))),
+            BuildAdmissionMode::Enforce,
+            true,
+            BuildAdmissionReadiness::Healthy,
+            InvocationAuthorityObservation::default(),
+        );
+        assert_eq!(baseline.state, HandoffState::EmergencyPrimary);
+        assert_eq!(
+            baseline.emergency,
+            EmergencyAuthorityDecision::RequiredFailClosed
+        );
+
+        // Shadow: v0 enforce, v1 shadow — distinct from baseline.
+        let shadow = evaluate_handoff(
+            Ok(Some(row_with_modes(
+                AdmissionHandoffPhase::EmergencyPrimary,
+                true,
+                false,
+                V0Mode::Enforce,
+                V1Mode::Shadow,
+            ))),
+            BuildAdmissionMode::Enforce,
+            true,
+            BuildAdmissionReadiness::Healthy,
+            InvocationAuthorityObservation::default(),
+        );
+        assert_eq!(shadow.state, HandoffState::Shadow);
+        assert_eq!(
+            shadow.emergency,
+            EmergencyAuthorityDecision::RequiredFailClosed
+        );
+
+        // Overlap: both enforce.
+        let overlap = evaluate_handoff(
+            Ok(Some(row_with_modes(
+                AdmissionHandoffPhase::ForwardOverlap,
+                true,
+                true,
+                V0Mode::Enforce,
+                V1Mode::Enforce,
+            ))),
+            BuildAdmissionMode::Enforce,
+            true,
+            BuildAdmissionReadiness::Healthy,
+            InvocationAuthorityObservation { enforcing: true },
+        );
+        assert_eq!(overlap.state, HandoffState::ForwardOverlap);
+
+        // Illegal combo: neither authority enforces — fails closed regardless of acks.
+        for (v0, v1) in [
+            (V0Mode::Observe, V1Mode::Off),
+            (V0Mode::Observe, V1Mode::Shadow),
+            (V0Mode::Disabled, V1Mode::Off),
+            (V0Mode::Disabled, V1Mode::Shadow),
+        ] {
+            let illegal = evaluate_handoff(
+                Ok(Some(row_with_modes(
+                    AdmissionHandoffPhase::EmergencyPrimary,
+                    true,
+                    false,
+                    v0,
+                    v1,
+                ))),
+                BuildAdmissionMode::Enforce,
+                true,
+                BuildAdmissionReadiness::Healthy,
+                InvocationAuthorityObservation::default(),
+            );
+            assert_eq!(
+                illegal.state,
+                HandoffState::IllegalModeCombo,
+                "{v0:?}/{v1:?}"
+            );
+            assert_eq!(
+                illegal.emergency,
+                EmergencyAuthorityDecision::RequiredFailClosed,
+                "illegal combo must fail closed for {v0:?}/{v1:?}"
+            );
+            assert_eq!(
+                illegal.warning_reason(true, InvocationAuthorityObservation::default()),
+                Some(HandoffWarningReason::StaleEpoch)
+            );
+        }
+
+        // Unreadable and incomplete epochs also fail closed.
+        assert_eq!(
+            evaluate_handoff(
+                Err(()),
+                BuildAdmissionMode::Enforce,
+                true,
+                BuildAdmissionReadiness::Healthy,
+                InvocationAuthorityObservation::default(),
+            )
+            .emergency,
+            EmergencyAuthorityDecision::RequiredFailClosed
+        );
+        assert_eq!(
+            evaluate_handoff(
+                Ok(Some(row_with_modes(
+                    AdmissionHandoffPhase::ForwardOverlap,
+                    true,
+                    false,
+                    V0Mode::Enforce,
+                    V1Mode::Enforce,
+                ))),
+                BuildAdmissionMode::Enforce,
+                true,
+                BuildAdmissionReadiness::Healthy,
+                InvocationAuthorityObservation { enforcing: true },
+            )
+            .state,
+            HandoffState::IncompleteEpoch
+        );
     }
 
     #[test]

--- a/server/crates/djinn-coordinator/src/build_admission_integration_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_integration_tests.rs
@@ -952,14 +952,14 @@ async fn assert_handoff_restart_snapshot(
         ));
     }
     assert!(matches!(
-        repo.advance(row.epoch, handoff_next(expected.legal_next))
+        repo.advance(row.epoch, handoff_next(expected.legal_next), &[])
             .await,
         Err(djinn_db::Error::InvalidTransition(_))
     ));
     if !expected.advance_allowed {
         assert!(
             matches!(
-                repo.advance(row.epoch, expected.legal_next).await,
+                repo.advance(row.epoch, expected.legal_next, &[]).await,
                 Err(djinn_db::Error::InvalidTransition(_))
             ),
             "current-epoch acknowledgement guard rejects phase advance"
@@ -1135,7 +1135,7 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
             }
             HandoffMatrixAction::Commit(next) => {
                 assert_eq!(next, handoff_next(before.phase));
-                repo.advance(before.epoch, next).await.unwrap();
+                repo.advance(before.epoch, next, &[]).await.unwrap();
             }
         }
     }
@@ -1148,13 +1148,17 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
         Err(djinn_db::Error::InvalidTransition(_))
     ));
     assert!(matches!(
-        repo.advance(current.epoch, AdmissionHandoffPhase::InvocationPrimary)
+        repo.advance(current.epoch, AdmissionHandoffPhase::InvocationPrimary, &[])
             .await,
         Err(djinn_db::Error::InvalidTransition(_))
     ));
     assert!(matches!(
-        repo.advance(current.epoch - 1, AdmissionHandoffPhase::ForwardOverlap)
-            .await,
+        repo.advance(
+            current.epoch - 1,
+            AdmissionHandoffPhase::ForwardOverlap,
+            &[]
+        )
+        .await,
         Err(djinn_db::Error::InvalidTransition(_))
     ));
 
@@ -1193,6 +1197,9 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
                 epoch: 9,
                 emergency_ack_epoch: Some(9),
                 invocation_ack_epoch: None,
+                v0_mode: djinn_db::V0Mode::Enforce,
+                v1_mode: djinn_db::V1Mode::Off,
+                cap: None,
                 updated_at: "test".into(),
             })),
             true,
@@ -1209,6 +1216,9 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
                 epoch: 9,
                 emergency_ack_epoch: None,
                 invocation_ack_epoch: Some(9),
+                v0_mode: djinn_db::V0Mode::Enforce,
+                v1_mode: djinn_db::V1Mode::Off,
+                cap: None,
                 updated_at: "test".into(),
             })),
             true,
@@ -1225,6 +1235,9 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
                 epoch: 9,
                 emergency_ack_epoch: Some(9),
                 invocation_ack_epoch: None,
+                v0_mode: djinn_db::V0Mode::Enforce,
+                v1_mode: djinn_db::V1Mode::Off,
+                cap: None,
                 updated_at: "test".into(),
             })),
             true,
@@ -1238,6 +1251,9 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
                 epoch: 9,
                 emergency_ack_epoch: Some(9),
                 invocation_ack_epoch: Some(9),
+                v0_mode: djinn_db::V0Mode::Enforce,
+                v1_mode: djinn_db::V1Mode::Off,
+                cap: None,
                 updated_at: "test".into(),
             })),
             true,
@@ -1251,6 +1267,9 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
                 epoch: 9,
                 emergency_ack_epoch: Some(8),
                 invocation_ack_epoch: Some(9),
+                v0_mode: djinn_db::V0Mode::Enforce,
+                v1_mode: djinn_db::V1Mode::Off,
+                cap: None,
                 updated_at: "test".into(),
             })),
             true,

--- a/server/crates/djinn-db/migrations_postgres/149_admission_epoch_modes.sql
+++ b/server/crates/djinn-db/migrations_postgres/149_admission_epoch_modes.sql
@@ -1,0 +1,48 @@
+-- Version the admission epoch: the durable handoff row now carries the v0/v1
+-- authority modes and the reference cap alongside the phase, so one serialized
+-- transaction owns modes, cap, phase, and acknowledgements together. A
+-- companion table records per-generation acknowledgements for the current
+-- epoch, letting an overlap require that every live generation has confirmed
+-- v1 before the InvocationPrimary edge commits.
+
+ALTER TABLE admission_handoff
+    ADD COLUMN v0_mode VARCHAR(16) NOT NULL DEFAULT 'enforce',
+    ADD COLUMN v1_mode VARCHAR(16) NOT NULL DEFAULT 'off',
+    ADD COLUMN cap     BIGINT      NULL;
+
+-- v0 authority (the emergency controller) is enforce / observe / disabled.
+ALTER TABLE admission_handoff
+    ADD CONSTRAINT admission_handoff_v0_mode_check CHECK (
+        v0_mode IN ('enforce', 'observe', 'disabled')
+    );
+
+-- v1 authority (the invocation controller) is off / shadow / enforce.
+ALTER TABLE admission_handoff
+    ADD CONSTRAINT admission_handoff_v1_mode_check CHECK (
+        v1_mode IN ('off', 'shadow', 'enforce')
+    );
+
+-- A configured cap is a positive concurrency bound; NULL means "unset, defer to
+-- the controller default".
+ALTER TABLE admission_handoff
+    ADD CONSTRAINT admission_handoff_cap_positive_check CHECK (
+        cap IS NULL OR cap > 0
+    );
+
+-- The seeded emergency_primary baseline keeps v0 enforcing and v1 off, which the
+-- NOT NULL DEFAULTs above already applied to the existing singleton row. This
+-- statement is an explicit, idempotent restatement of that baseline.
+UPDATE admission_handoff
+   SET v0_mode = 'enforce', v1_mode = 'off'
+ WHERE name = 'build';
+
+-- Per-generation acknowledgements for a handoff epoch. Every generation in the
+-- live set captured when overlap was armed records exactly one row here; the
+-- primary key makes re-acknowledgement idempotent, and keying on epoch means an
+-- acknowledgement for a superseded epoch can never satisfy the current one.
+CREATE TABLE admission_handoff_generation_ack (
+    epoch          BIGINT      NOT NULL,
+    generation_key TEXT        NOT NULL,
+    acked_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (epoch, generation_key)
+);

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -57,7 +57,7 @@ pub use repositories::tool_call_metrics::{
 pub use repositories::{
     admission_handoff::{
         AdmissionHandoffAuthority, AdmissionHandoffPhase, AdmissionHandoffRepository,
-        AdmissionHandoffRow,
+        AdmissionHandoffRow, V0Mode, V1Mode,
     },
     admission_journal::{
         AdmissionDomain, AdmissionJournalKey, AdmissionJournalRepository, AdmissionJournalRow,

--- a/server/crates/djinn-db/src/repositories/admission_handoff.rs
+++ b/server/crates/djinn-db/src/repositories/admission_handoff.rs
@@ -3,6 +3,8 @@
 //! The handoff row is deliberately separate from the workload admission journal:
 //! it records which authority may admit work, not the work that has been admitted.
 
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
 
@@ -10,8 +12,8 @@ use crate::database::Database;
 use crate::error::{DbError, DbResult};
 
 const HANDOFF_NAME: &str = "build";
-const HANDOFF_COLUMNS: &str =
-    "name, phase, epoch, emergency_ack_epoch, invocation_ack_epoch, updated_at::text";
+const HANDOFF_COLUMNS: &str = "name, phase, epoch, emergency_ack_epoch, invocation_ack_epoch, \
+     v0_mode, v1_mode, cap, updated_at::text";
 
 /// The only supported admission-authority phases.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,6 +65,84 @@ pub enum AdmissionHandoffAuthority {
     Invocation,
 }
 
+/// Mode of the v0 (emergency) admission authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum V0Mode {
+    /// Atomically enforce the reference cap.
+    Enforce,
+    /// Record reservations but never deny.
+    Observe,
+    /// The v0 authority is released.
+    Disabled,
+}
+
+impl V0Mode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Enforce => "enforce",
+            Self::Observe => "observe",
+            Self::Disabled => "disabled",
+        }
+    }
+
+    fn parse(value: &str) -> DbResult<Self> {
+        match value {
+            "enforce" => Ok(Self::Enforce),
+            "observe" => Ok(Self::Observe),
+            "disabled" => Ok(Self::Disabled),
+            _ => Err(DbError::InvalidData(format!(
+                "invalid v0 admission mode `{value}`"
+            ))),
+        }
+    }
+
+    /// Only `Enforce` actually denies over the cap; observe/disabled do not.
+    #[must_use]
+    pub const fn is_enforcing(self) -> bool {
+        matches!(self, Self::Enforce)
+    }
+}
+
+/// Mode of the v1 (invocation) admission authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum V1Mode {
+    /// The v1 authority is not running.
+    Off,
+    /// The v1 authority observes but never denies.
+    Shadow,
+    /// The v1 authority atomically enforces the reference cap.
+    Enforce,
+}
+
+impl V1Mode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Shadow => "shadow",
+            Self::Enforce => "enforce",
+        }
+    }
+
+    fn parse(value: &str) -> DbResult<Self> {
+        match value {
+            "off" => Ok(Self::Off),
+            "shadow" => Ok(Self::Shadow),
+            "enforce" => Ok(Self::Enforce),
+            _ => Err(DbError::InvalidData(format!(
+                "invalid v1 admission mode `{value}`"
+            ))),
+        }
+    }
+
+    /// Only `Enforce` actually denies over the cap; off/shadow do not.
+    #[must_use]
+    pub const fn is_enforcing(self) -> bool {
+        matches!(self, Self::Enforce)
+    }
+}
+
 /// The single durable build-admission handoff record.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AdmissionHandoffRow {
@@ -70,6 +150,12 @@ pub struct AdmissionHandoffRow {
     pub epoch: i64,
     pub emergency_ack_epoch: Option<i64>,
     pub invocation_ack_epoch: Option<i64>,
+    /// Mode of the v0 (emergency) authority for this epoch.
+    pub v0_mode: V0Mode,
+    /// Mode of the v1 (invocation) authority for this epoch.
+    pub v1_mode: V1Mode,
+    /// Reference concurrency cap; `None` defers to the controller default.
+    pub cap: Option<i64>,
     /// RFC3339-formatted by PostgreSQL.
     pub updated_at: String,
 }
@@ -141,16 +227,109 @@ impl AdmissionHandoffRepository {
         updated.try_into()
     }
 
+    /// Compare-and-swap the v0/v1 modes and reference cap at the current epoch.
+    ///
+    /// Serialized inside the same row lock as [`Self::advance`] and
+    /// [`Self::acknowledge`], so a mode/cap change and a phase advance cannot
+    /// both apply from the same stale epoch: applying a change increments the
+    /// epoch, clears the per-authority acknowledgements, and retires the
+    /// per-generation acknowledgements of superseded epochs.
+    pub async fn set_modes_and_cap(
+        &self,
+        expected_epoch: i64,
+        v0: V0Mode,
+        v1: V1Mode,
+        cap: Option<i64>,
+    ) -> DbResult<AdmissionHandoffRow> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        let row = current_row_for_update(&mut tx).await?;
+        if row.epoch != expected_epoch {
+            return Err(DbError::InvalidTransition(format!(
+                "stale admission handoff expected epoch {expected_epoch}; current epoch is {}",
+                row.epoch
+            )));
+        }
+        let updated = sqlx::query_as::<_, HandoffDbRow>(&format!(
+            "UPDATE admission_handoff \
+             SET v0_mode = $1, v1_mode = $2, cap = $3, epoch = epoch + 1, \
+                 emergency_ack_epoch = NULL, invocation_ack_epoch = NULL, updated_at = now() \
+             WHERE name = $4 AND epoch = $5 RETURNING {HANDOFF_COLUMNS}"
+        ))
+        .bind(v0.as_str())
+        .bind(v1.as_str())
+        .bind(cap)
+        .bind(HANDOFF_NAME)
+        .bind(expected_epoch)
+        .fetch_one(&mut *tx)
+        .await?;
+        retire_stale_generation_acks(&mut tx, updated.epoch).await?;
+        tx.commit().await?;
+        updated.try_into()
+    }
+
+    /// Record one live generation's current-epoch acknowledgement.
+    ///
+    /// The `generation_key` follows the [`crate::AdmissionJournalKey`]
+    /// `{domain, work_id, generation}` identity convention. Recording is
+    /// idempotent (repeats of the same current key are accepted) and
+    /// stale-fenced: an acknowledgement for a superseded epoch is rejected so
+    /// the generation re-acknowledges the current epoch.
+    pub async fn record_generation_ack(&self, epoch: i64, generation_key: &str) -> DbResult<()> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        let row = current_row_for_update(&mut tx).await?;
+        if row.epoch != epoch {
+            return Err(DbError::InvalidTransition(format!(
+                "stale admission handoff generation acknowledgement epoch {epoch}; \
+                 current epoch is {}",
+                row.epoch
+            )));
+        }
+        sqlx::query(
+            "INSERT INTO admission_handoff_generation_ack (epoch, generation_key) \
+             VALUES ($1, $2) ON CONFLICT (epoch, generation_key) DO NOTHING",
+        )
+        .bind(epoch)
+        .bind(generation_key)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Whether every generation in `required` has a current-epoch ack row.
+    ///
+    /// An empty required set is trivially complete: an epoch with no armed live
+    /// generation has nothing to wait for.
+    pub async fn generation_ack_complete(&self, epoch: i64, required: &[String]) -> DbResult<bool> {
+        if required.is_empty() {
+            return Ok(true);
+        }
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        let acked = generation_acks_at_epoch(&mut tx, epoch).await?;
+        tx.commit().await?;
+        Ok(required.iter().all(|key| acked.contains(key)))
+    }
+
     /// Compare-and-swap from the current phase to its only legal successor.
     ///
     /// Each edge requires evidence at the current epoch. Entering an overlap
     /// requires the outgoing primary authority; leaving an overlap requires both
     /// authorities, so neither authority can be disabled without confirming that
     /// the other remains healthy for this exact epoch.
+    ///
+    /// The InvocationPrimary edge (leaving the forward overlap) additionally
+    /// requires that every generation in `required_generations` — the live set
+    /// captured when the overlap was armed — has an idempotent current-epoch
+    /// acknowledgement, so v0 is released only once every live generation has
+    /// confirmed v1. Every other edge ignores `required_generations`.
     pub async fn advance(
         &self,
         expected_epoch: i64,
         next_phase: AdmissionHandoffPhase,
+        required_generations: &[String],
     ) -> DbResult<AdmissionHandoffRow> {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
@@ -168,6 +347,18 @@ impl AdmissionHandoffRepository {
             )));
         }
         require_acknowledgements(&row)?;
+        if next_phase == AdmissionHandoffPhase::InvocationPrimary {
+            let acked = generation_acks_at_epoch(&mut tx, expected_epoch).await?;
+            if let Some(missing) = required_generations
+                .iter()
+                .find(|key| !acked.contains(*key))
+            {
+                return Err(DbError::InvalidTransition(format!(
+                    "admission handoff invocation-primary edge blocked at epoch {expected_epoch}: \
+                     generation `{missing}` has not acknowledged"
+                )));
+            }
+        }
         let updated = sqlx::query_as::<_, HandoffDbRow>(&format!(
             "UPDATE admission_handoff \
              SET phase = $1, epoch = epoch + 1, emergency_ack_epoch = NULL, \
@@ -179,6 +370,7 @@ impl AdmissionHandoffRepository {
         .bind(expected_epoch)
         .fetch_one(&mut *tx)
         .await?;
+        retire_stale_generation_acks(&mut tx, updated.epoch).await?;
         tx.commit().await?;
         updated.try_into()
     }
@@ -191,6 +383,9 @@ struct HandoffDbRow {
     epoch: i64,
     emergency_ack_epoch: Option<i64>,
     invocation_ack_epoch: Option<i64>,
+    v0_mode: String,
+    v1_mode: String,
+    cap: Option<i64>,
     updated_at: String,
 }
 
@@ -214,9 +409,41 @@ impl TryFrom<HandoffDbRow> for AdmissionHandoffRow {
             epoch: value.epoch,
             emergency_ack_epoch: value.emergency_ack_epoch,
             invocation_ack_epoch: value.invocation_ack_epoch,
+            v0_mode: V0Mode::parse(&value.v0_mode)?,
+            v1_mode: V1Mode::parse(&value.v1_mode)?,
+            cap: value.cap,
             updated_at: value.updated_at,
         })
     }
+}
+
+/// Read every generation key acknowledged at `epoch` under the held row lock.
+async fn generation_acks_at_epoch(
+    tx: &mut Transaction<'_, Postgres>,
+    epoch: i64,
+) -> DbResult<HashSet<String>> {
+    let rows = sqlx::query_as::<_, (String,)>(
+        "SELECT generation_key FROM admission_handoff_generation_ack WHERE epoch = $1",
+    )
+    .bind(epoch)
+    .fetch_all(&mut **tx)
+    .await?;
+    Ok(rows.into_iter().map(|(key,)| key).collect())
+}
+
+/// Drop per-generation acknowledgements for every epoch before `current_epoch`.
+///
+/// Called inside the same transaction that advanced the epoch, so the table
+/// only ever holds acknowledgements for the live epoch.
+async fn retire_stale_generation_acks(
+    tx: &mut Transaction<'_, Postgres>,
+    current_epoch: i64,
+) -> DbResult<()> {
+    sqlx::query("DELETE FROM admission_handoff_generation_ack WHERE epoch < $1")
+        .bind(current_epoch)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
 }
 
 async fn current_row_for_update(
@@ -285,7 +512,7 @@ mod tests {
                         .unwrap();
                 }
             }
-            repo.advance(row.epoch, row.phase.legal_next())
+            repo.advance(row.epoch, row.phase.legal_next(), &[])
                 .await
                 .unwrap();
         }
@@ -345,7 +572,7 @@ mod tests {
                         .unwrap();
                 }
             }
-            let advanced = repo.advance(row.epoch, next).await.unwrap();
+            let advanced = repo.advance(row.epoch, next, &[]).await.unwrap();
             assert_eq!(advanced.phase, next);
             assert_eq!(advanced.epoch, row.epoch + 1);
             assert_eq!(advanced.emergency_ack_epoch, None);
@@ -365,7 +592,7 @@ mod tests {
             move_to(&repo, phase).await;
             let row = repo.read().await.unwrap().unwrap();
             assert!(matches!(
-                repo.advance(row.epoch, row.phase.legal_next()).await,
+                repo.advance(row.epoch, row.phase.legal_next(), &[]).await,
                 Err(DbError::InvalidTransition(_))
             ));
         }
@@ -384,16 +611,16 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(
-            repo.advance(row.epoch, AdmissionHandoffPhase::InvocationPrimary)
+            repo.advance(row.epoch, AdmissionHandoffPhase::InvocationPrimary, &[])
                 .await,
             Err(DbError::InvalidTransition(_))
         ));
         let advanced = repo
-            .advance(row.epoch, AdmissionHandoffPhase::ForwardOverlap)
+            .advance(row.epoch, AdmissionHandoffPhase::ForwardOverlap, &[])
             .await
             .unwrap();
         assert!(matches!(
-            repo.advance(row.epoch, AdmissionHandoffPhase::InvocationPrimary)
+            repo.advance(row.epoch, AdmissionHandoffPhase::InvocationPrimary, &[])
                 .await,
             Err(DbError::InvalidTransition(_))
         ));
@@ -403,5 +630,182 @@ mod tests {
             Err(DbError::InvalidTransition(_))
         ));
         assert_eq!(advanced.epoch, row.epoch + 1);
+    }
+
+    #[tokio::test]
+    async fn set_modes_and_cap_round_trips_and_bumps_the_epoch() {
+        let repo = repository().await;
+        let seeded = repo.read().await.unwrap().unwrap();
+        assert_eq!(seeded.v0_mode, V0Mode::Enforce);
+        assert_eq!(seeded.v1_mode, V1Mode::Off);
+        assert_eq!(seeded.cap, None);
+        assert_eq!(seeded.epoch, 0);
+
+        let updated = repo
+            .set_modes_and_cap(0, V0Mode::Enforce, V1Mode::Shadow, Some(7))
+            .await
+            .unwrap();
+        assert_eq!(updated.v0_mode, V0Mode::Enforce);
+        assert_eq!(updated.v1_mode, V1Mode::Shadow);
+        assert_eq!(updated.cap, Some(7));
+        assert_eq!(updated.epoch, 1);
+        assert_eq!(updated.emergency_ack_epoch, None);
+        assert_eq!(updated.invocation_ack_epoch, None);
+
+        // A stale-epoch mode change is rejected.
+        assert!(matches!(
+            repo.set_modes_and_cap(0, V0Mode::Observe, V1Mode::Enforce, None)
+                .await,
+            Err(DbError::InvalidTransition(_))
+        ));
+        // The cap CHECK constraint rejects a non-positive cap.
+        assert!(
+            repo.set_modes_and_cap(1, V0Mode::Enforce, V1Mode::Off, Some(0))
+                .await
+                .is_err()
+        );
+        // The rejected writes left the durable row untouched.
+        let current = repo.read().await.unwrap().unwrap();
+        assert_eq!(current.epoch, 1);
+        assert_eq!(current.v1_mode, V1Mode::Shadow);
+        assert_eq!(current.cap, Some(7));
+    }
+
+    /// Acceptance criterion 1: a mode/cap change and a phase advance are both
+    /// epoch-fenced compare-and-swaps serialized on the same row lock. With a
+    /// paused transaction holding that lock, both mutations queue; when it is
+    /// released exactly one applies (advancing the epoch) and the other is
+    /// rejected as stale.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn mode_change_and_phase_advance_cannot_both_apply_from_a_stale_epoch() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = std::sync::Arc::new(AdmissionHandoffRepository::new(db.clone()));
+        // Force the template clone / schema initialization before the manual lock.
+        assert_eq!(repo.read().await.unwrap().unwrap().epoch, 0);
+        // Emergency acknowledges epoch 0 so the ForwardOverlap advance is
+        // otherwise legal and the only remaining fence is the epoch.
+        repo.acknowledge(AdmissionHandoffAuthority::Emergency, 0)
+            .await
+            .unwrap();
+
+        // A paused transaction holds the singleton row lock.
+        let mut hold = db.pool().begin().await.unwrap();
+        sqlx::query("SELECT 1 FROM admission_handoff WHERE name = 'build' FOR UPDATE")
+            .fetch_one(&mut *hold)
+            .await
+            .unwrap();
+
+        let advance = {
+            let repo = std::sync::Arc::clone(&repo);
+            tokio::spawn(async move {
+                repo.advance(0, AdmissionHandoffPhase::ForwardOverlap, &[])
+                    .await
+            })
+        };
+        let modes = {
+            let repo = std::sync::Arc::clone(&repo);
+            tokio::spawn(async move {
+                repo.set_modes_and_cap(0, V0Mode::Enforce, V1Mode::Shadow, Some(4))
+                    .await
+            })
+        };
+        // Let both spawned mutations block on the held FOR UPDATE lock.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        // Release the paused transaction; the two mutations now serialize.
+        hold.rollback().await.unwrap();
+
+        let advance = advance.await.unwrap();
+        let modes = modes.await.unwrap();
+        let successes = [advance.is_ok(), modes.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(successes, 1, "exactly one epoch-0 mutation applies");
+        let stale = [advance.err(), modes.err()].into_iter().flatten().count();
+        assert_eq!(stale, 1, "the loser is rejected as a stale epoch");
+
+        let current = repo.read().await.unwrap().unwrap();
+        assert_eq!(
+            current.epoch, 1,
+            "the winning mutation advanced the epoch exactly once"
+        );
+    }
+
+    /// Acceptance criterion 2: the InvocationPrimary edge stays closed until
+    /// every generation in the armed live set has an idempotent current-epoch
+    /// acknowledgement, then commits exactly once.
+    #[tokio::test]
+    async fn invocation_primary_edge_requires_every_armed_generation_to_acknowledge() {
+        let repo = repository().await;
+        // EmergencyPrimary(0) --emergency ack--> ForwardOverlap(1).
+        repo.acknowledge(AdmissionHandoffAuthority::Emergency, 0)
+            .await
+            .unwrap();
+        let overlap = repo
+            .advance(0, AdmissionHandoffPhase::ForwardOverlap, &[])
+            .await
+            .unwrap();
+        assert_eq!(overlap.phase, AdmissionHandoffPhase::ForwardOverlap);
+        assert_eq!(overlap.epoch, 1);
+
+        // Leaving the overlap needs both authority acks first.
+        repo.acknowledge(AdmissionHandoffAuthority::Emergency, 1)
+            .await
+            .unwrap();
+        repo.acknowledge(AdmissionHandoffAuthority::Invocation, 1)
+            .await
+            .unwrap();
+        let armed = vec![
+            "warm_build/alpha/0".to_string(),
+            "task_observation/beta/3".to_string(),
+        ];
+
+        // No generation has acknowledged: the edge is blocked.
+        assert!(!repo.generation_ack_complete(1, &armed).await.unwrap());
+        assert!(matches!(
+            repo.advance(1, AdmissionHandoffPhase::InvocationPrimary, &armed)
+                .await,
+            Err(DbError::InvalidTransition(_))
+        ));
+
+        // One generation acknowledges: still blocked.
+        repo.record_generation_ack(1, &armed[0]).await.unwrap();
+        assert!(!repo.generation_ack_complete(1, &armed).await.unwrap());
+        assert!(matches!(
+            repo.advance(1, AdmissionHandoffPhase::InvocationPrimary, &armed)
+                .await,
+            Err(DbError::InvalidTransition(_))
+        ));
+
+        // The second generation acknowledges (idempotently repeated).
+        repo.record_generation_ack(1, &armed[1]).await.unwrap();
+        repo.record_generation_ack(1, &armed[1]).await.unwrap();
+        assert!(repo.generation_ack_complete(1, &armed).await.unwrap());
+
+        // A stale-epoch generation acknowledgement is rejected.
+        assert!(matches!(
+            repo.record_generation_ack(0, "warm_build/alpha/0").await,
+            Err(DbError::InvalidTransition(_))
+        ));
+
+        // With the full armed set acknowledged the edge commits exactly once.
+        let primary = repo
+            .advance(1, AdmissionHandoffPhase::InvocationPrimary, &armed)
+            .await
+            .unwrap();
+        assert_eq!(primary.phase, AdmissionHandoffPhase::InvocationPrimary);
+        assert_eq!(primary.epoch, 2);
+
+        // A second attempt from the now-stale epoch fails.
+        assert!(matches!(
+            repo.advance(1, AdmissionHandoffPhase::InvocationPrimary, &armed)
+                .await,
+            Err(DbError::InvalidTransition(_))
+        ));
+        // Advancing retired the epoch-1 acknowledgements.
+        assert!(
+            !repo.generation_ack_complete(1, &armed).await.unwrap(),
+            "advancing retired the epoch-1 generation acknowledgements"
+        );
     }
 }

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -3853,7 +3853,7 @@ mod build_admission_config_tests {
                         .await
                         .expect("emergency ack");
                     repository
-                        .advance(row.epoch, AdmissionHandoffPhase::ForwardOverlap)
+                        .advance(row.epoch, AdmissionHandoffPhase::ForwardOverlap, &[])
                         .await
                         .expect("forward advance");
                 }
@@ -3867,7 +3867,7 @@ mod build_admission_config_tests {
                         .await
                         .expect("invocation ack");
                     repository
-                        .advance(row.epoch, AdmissionHandoffPhase::InvocationPrimary)
+                        .advance(row.epoch, AdmissionHandoffPhase::InvocationPrimary, &[])
                         .await
                         .expect("invocation advance");
                 }
@@ -3877,7 +3877,7 @@ mod build_admission_config_tests {
                         .await
                         .expect("invocation ack");
                     repository
-                        .advance(row.epoch, AdmissionHandoffPhase::RollbackOverlap)
+                        .advance(row.epoch, AdmissionHandoffPhase::RollbackOverlap, &[])
                         .await
                         .expect("rollback advance");
                 }
@@ -3891,7 +3891,7 @@ mod build_admission_config_tests {
                         .await
                         .expect("invocation ack");
                     repository
-                        .advance(row.epoch, AdmissionHandoffPhase::EmergencyPrimary)
+                        .advance(row.epoch, AdmissionHandoffPhase::EmergencyPrimary, &[])
                         .await
                         .expect("emergency advance");
                 }


### PR DESCRIPTION
First 23or cutover task (epic 23or, proposal goxi), implemented locally during the dispatch pause.

- Migration 149: admission_handoff gains CHECKed v0_mode/v1_mode/cap columns (seeded to the emergency_primary baseline) plus admission_handoff_generation_ack(epoch, generation_key).
- set_modes_and_cap is an epoch-fenced CAS serialized on the same FOR UPDATE lock as advance()/acknowledge(); a stale-epoch mode change and phase advance are mutually exclusive (proven by a paused-transaction test).
- advance() to invocation_primary now additionally requires an idempotent current-epoch ack row for every generation in the armed live set; acks retire on advance.
- evaluate_handoff distinguishes baseline/shadow/overlap, fails closed on the illegal v0∈{observe,disabled} ∧ v1∈{shadow,disabled} combo and on unreadable/incomplete epochs; bounded warning labels unchanged.
- validate_admission_config rejects the illegal combo and caps outside [1,4096] up front.

No runtime wiring in this PR (that is the chained keoq task). 7 djinn-db + 67 djinn-coordinator tests green; fmt/clippy clean; full workspace check clean under SQLX_OFFLINE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)