### PR TITLE
chore(z2pv): Implement protocol-v1 RabbitMQ vhost-isolated fresh-tenant wrapper

### DIFF
--- a/server/crates/djinn-catalog-wrapper/Cargo.toml
+++ b/server/crates/djinn-catalog-wrapper/Cargo.toml
@@ -12,6 +12,10 @@ path = "src/main.rs"
 name = "djinn-redis-wrapper"
 path = "src/redis_main.rs"
 
+[[bin]]
+name = "djinn-rabbitmq-wrapper"
+path = "src/rabbit_main.rs"
+
 [dependencies]
 djinn-sandbox = { path = "../djinn-sandbox" }
 base64 = "0.22"

--- a/server/crates/djinn-catalog-wrapper/src/lib.rs
+++ b/server/crates/djinn-catalog-wrapper/src/lib.rs
@@ -23,6 +23,9 @@ mod redis;
 pub use postgres::{PostgresAdapter, WrapperServer};
 pub use redis::{RedisAdapter, RedisWrapperServer};
 
+mod rabbitmq;
+pub use rabbitmq::{RabbitAdapter, RabbitWrapperServer};
+
 const OPERATION_DEADLINE: Duration = Duration::from_secs(15);
 const MAX_IDENTIFIER_LEN: usize = 64;
 const MAX_LINE_LEN: usize = 4096;

--- a/server/crates/djinn-catalog-wrapper/src/rabbit_main.rs
+++ b/server/crates/djinn-catalog-wrapper/src/rabbit_main.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+use djinn_catalog_wrapper::{RabbitAdapter, RabbitWrapperServer};
+
+#[tokio::main]
+async fn main() -> Result<(), std::io::Error> {
+    let socket = std::env::var_os("CATALOG_CONTROL_SOCKET")
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing control socket")
+        })?;
+    let adapter = RabbitAdapter::from_environment().map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid wrapper configuration",
+        )
+    })?;
+    RabbitWrapperServer::new(adapter).serve(socket).await
+}

--- a/server/crates/djinn-catalog-wrapper/src/rabbitmq.rs
+++ b/server/crates/djinn-catalog-wrapper/src/rabbitmq.rs
@@ -1,0 +1,846 @@
+//! Protocol-v1 RabbitMQ catalog wrapper: one vhost + one vhost-scoped user per
+//! lease.
+//!
+//! Each lease is a dedicated vhost plus a dedicated user whose configure/write/
+//! read permissions exist on that vhost alone, so a RabbitMQ user with no
+//! permissions on any other vhost is structurally isolated. Provisioning and
+//! teardown use fixed-argument local `rabbitmqctl` subprocesses (never a network
+//! management endpoint, shell, Kubernetes exec, or operator AMQP credentials),
+//! compatible with the catalog's management-plugin-free `rabbitmq:4-alpine`
+//! runtime. Readiness proves the lease credentials open AMQP against the lease
+//! vhost by declaring and deleting a probe queue.
+//!
+//! Like the Postgres (g3fq) and Redis (2o5t) halves, provisioning/rollback are
+//! owned by a background task (never the request future or a mutex held across
+//! subprocess I/O), the request identity is the CreateFresh idempotency key, and
+//! the returned URL is self-describing: its userinfo and `/<vhost>` path name the
+//! lease's own namespace. Only catalog-configured environment names are returned,
+//! and every bounded error is the payload-free [`AdapterError`] — no credential,
+//! generated vhost/user, raw stderr, or backend command output can enter it.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use djinn_sandbox::service_provisioning::{CONTROL_PROTOCOL_REVISION, Request, Response};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{TcpStream, UnixListener, UnixStream};
+use tokio::sync::{Mutex, Notify};
+use url::Url;
+
+use crate::{
+    AdapterError, CreatedLease, CreationKey, LEASE_PREFIX, MAX_LINE_LEN, OPERATION_DEADLINE,
+    error_response, generated, random_password, request_revision, signal_completion,
+    valid_environment_name, valid_identifier,
+};
+
+const RABBIT_VHOST_PREFIX: &str = "djinn_vhost_";
+const RABBIT_USER_PREFIX: &str = "djinn_rabbit_user_";
+const RABBIT_PROBE_PREFIX: &str = "djinn_probe_";
+const MAX_RABBIT_LEASES: usize = 1024;
+/// Bytes retained from a local-control subprocess. Output beyond this is drained
+/// (so the child never blocks on a full pipe) but discarded; captured bytes are
+/// only ever inspected in-process to answer membership questions, never logged.
+const MAX_CONTROL_OUTPUT: usize = 64 * 1024;
+const DEFAULT_RABBIT_CONTROL: &str = "rabbitmqctl";
+
+const AMQP_FRAME_METHOD: u8 = 1;
+const AMQP_FRAME_END: u8 = 0xCE;
+const AMQP_MAX_FRAME: usize = 128 * 1024;
+
+#[derive(Clone)]
+pub struct RabbitAdapter {
+    endpoint: AmqpEndpoint,
+    control_program: String,
+    environment_names: Vec<String>,
+    leases: Arc<Mutex<HashMap<String, RabbitLease>>>,
+    creations: Arc<Mutex<HashMap<CreationKey, RabbitCreationState>>>,
+    operation_deadline: Duration,
+    #[cfg(test)]
+    fail_rollback_attempts: Arc<AtomicUsize>,
+}
+
+/// AMQP data-plane endpoint the lease URL advertises and readiness probes. Only
+/// host and port are taken from the admin URL; per-lease credentials and the
+/// per-lease vhost replace any userinfo/path it carries.
+#[derive(Clone)]
+struct AmqpEndpoint {
+    host: String,
+    port: u16,
+}
+
+#[derive(Clone)]
+struct RabbitLease {
+    user: String,
+    vhost: String,
+    password: String,
+}
+
+/// Cleanup authority retained when provisioning may have created a vhost and/or
+/// user. Passwords are never retained because cleanup does not need them.
+#[derive(Clone)]
+struct RabbitPartialTenant {
+    user: String,
+    vhost: String,
+}
+
+impl From<&RabbitLease> for RabbitPartialTenant {
+    fn from(lease: &RabbitLease) -> Self {
+        Self {
+            user: lease.user.clone(),
+            vhost: lease.vhost.clone(),
+        }
+    }
+}
+
+enum RabbitCreationState {
+    Creating(Arc<Notify>),
+    Created(CreatedLease),
+    CleanupPending(RabbitPartialTenant),
+}
+
+impl AmqpEndpoint {
+    fn parse(admin_url: &str) -> Result<Self, AdapterError> {
+        let url = Url::parse(admin_url).map_err(|_| AdapterError::Rejected)?;
+        if url.scheme() != "amqp" {
+            return Err(AdapterError::Rejected);
+        }
+        Ok(Self {
+            host: url.host_str().ok_or(AdapterError::Rejected)?.to_owned(),
+            port: url.port().unwrap_or(5672),
+        })
+    }
+}
+
+impl RabbitAdapter {
+    pub fn new(
+        admin_url: &str,
+        control_program: &str,
+        mut environment_names: Vec<String>,
+    ) -> Result<Self, AdapterError> {
+        if control_program.is_empty()
+            || environment_names.is_empty()
+            || environment_names
+                .iter()
+                .any(|name| !valid_environment_name(name))
+        {
+            return Err(AdapterError::Rejected);
+        }
+        environment_names.sort();
+        environment_names.dedup();
+        Ok(Self {
+            endpoint: AmqpEndpoint::parse(admin_url)?,
+            control_program: control_program.to_owned(),
+            environment_names,
+            leases: Arc::new(Mutex::new(HashMap::new())),
+            creations: Arc::new(Mutex::new(HashMap::new())),
+            operation_deadline: OPERATION_DEADLINE,
+            #[cfg(test)]
+            fail_rollback_attempts: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    pub fn from_environment() -> Result<Self, AdapterError> {
+        let admin_url = std::env::var("RABBITMQ_WRAPPER_AMQP_URL")
+            .or_else(|_| std::env::var("AMQP_URL"))
+            .map_err(|_| AdapterError::Rejected)?;
+        let control_program =
+            std::env::var("RABBITMQ_WRAPPER_CTL").unwrap_or_else(|_| DEFAULT_RABBIT_CONTROL.into());
+        let names = std::env::var("CATALOG_RABBITMQ_ENV_NAMES")
+            .unwrap_or_else(|_| "AMQP_URL".to_owned())
+            .split(',')
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned)
+            .collect();
+        Self::new(&admin_url, &control_program, names)
+    }
+
+    /// CreateFresh mirrors the g3fq/2o5t halves: the request identity is the
+    /// idempotency key, provisioning and rollback are owned by a background task
+    /// (never the request future or the lease-map mutex, and never held across
+    /// subprocess I/O), and a retry that finds retained cleanup authority retries
+    /// cleanup rather than orphaning a vhost/user.
+    async fn create(
+        &self,
+        attempt_id: String,
+        lease_nonce: String,
+    ) -> Result<(String, BTreeMap<String, String>), AdapterError> {
+        let key = CreationKey {
+            attempt_id,
+            lease_nonce,
+        };
+        let notify = {
+            let mut creations = self.creations.lock().await;
+            match creations.get(&key) {
+                Some(RabbitCreationState::Created(created)) => {
+                    return Ok((created.lease_id.clone(), created.environment.clone()));
+                }
+                Some(RabbitCreationState::Creating(notify)) => notify.clone(),
+                Some(RabbitCreationState::CleanupPending(partial)) => {
+                    let partial = partial.clone();
+                    let notify = Arc::new(Notify::new());
+                    creations.insert(key.clone(), RabbitCreationState::Creating(notify.clone()));
+                    let adapter = self.clone();
+                    let task_key = key.clone();
+                    let task_notify = notify.clone();
+                    // A retry first retries bounded cleanup. Do not discard the
+                    // partial tenant and create another one while it remains.
+                    tokio::spawn(async move {
+                        adapter.finish_cleanup(task_key, partial, task_notify).await;
+                    });
+                    notify
+                }
+                None => {
+                    let notify = Arc::new(Notify::new());
+                    creations.insert(key.clone(), RabbitCreationState::Creating(notify.clone()));
+                    let adapter = self.clone();
+                    let task_key = key.clone();
+                    let task_notify = notify.clone();
+                    // This task, not the request future, owns provisioning and
+                    // rollback. A socket deadline cannot cancel cleanup.
+                    tokio::spawn(async move {
+                        adapter.complete_creation(task_key, task_notify).await;
+                    });
+                    notify
+                }
+            }
+        };
+        self.await_creation(&key, notify).await
+    }
+
+    async fn await_creation(
+        &self,
+        key: &CreationKey,
+        mut notify: Arc<Notify>,
+    ) -> Result<(String, BTreeMap<String, String>), AdapterError> {
+        let deadline = tokio::time::Instant::now() + self.operation_deadline;
+        loop {
+            let wait_notify = notify.clone();
+            let notified = wait_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            let current_notify = {
+                let creations = self.creations.lock().await;
+                match creations.get(key) {
+                    Some(RabbitCreationState::Created(created)) => {
+                        return Ok((created.lease_id.clone(), created.environment.clone()));
+                    }
+                    Some(RabbitCreationState::Creating(current_notify)) => current_notify.clone(),
+                    Some(RabbitCreationState::CleanupPending(_)) | None => {
+                        return Err(AdapterError::Rejected);
+                    }
+                }
+            };
+
+            if !Arc::ptr_eq(&notify, &current_notify) {
+                notify = current_notify;
+                continue;
+            }
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
+                return Err(AdapterError::Rejected);
+            }
+        }
+    }
+
+    async fn complete_creation(&self, key: CreationKey, notify: Arc<Notify>) {
+        // Admission control: bound the number of concurrently live tenants.
+        if self.leases.lock().await.len() >= MAX_RABBIT_LEASES {
+            self.creations.lock().await.remove(&key);
+            signal_completion(&notify);
+            return;
+        }
+        let Ok((lease_id, lease)) = self.new_lease() else {
+            self.creations.lock().await.remove(&key);
+            signal_completion(&notify);
+            return;
+        };
+        if self.provision(&lease).await.is_err() {
+            self.finish_cleanup(key, RabbitPartialTenant::from(&lease), notify)
+                .await;
+            return;
+        }
+        let url = self.lease_url(&lease);
+        let environment = self
+            .environment_names
+            .iter()
+            .cloned()
+            .map(|name| (name, url.clone()))
+            .collect();
+        self.leases.lock().await.insert(lease_id.clone(), lease);
+        self.creations.lock().await.insert(
+            key,
+            RabbitCreationState::Created(CreatedLease {
+                lease_id,
+                environment,
+            }),
+        );
+        signal_completion(&notify);
+    }
+
+    async fn finish_cleanup(
+        &self,
+        key: CreationKey,
+        partial: RabbitPartialTenant,
+        notify: Arc<Notify>,
+    ) {
+        let cleanup_succeeded = self.rollback(&partial.vhost, &partial.user).await.is_ok();
+        let mut creations = self.creations.lock().await;
+        if cleanup_succeeded {
+            creations.remove(&key);
+        } else {
+            // Preserve the generated vhost/user until cleanup succeeds. This is
+            // the sole authority capable of removing a partial tenant.
+            creations.insert(key, RabbitCreationState::CleanupPending(partial));
+        }
+        drop(creations);
+        signal_completion(&notify);
+    }
+
+    fn new_lease(&self) -> Result<(String, RabbitLease), AdapterError> {
+        let lease_id = generated(LEASE_PREFIX, 20)?;
+        let user = generated(RABBIT_USER_PREFIX, 20)?;
+        let vhost = generated(RABBIT_VHOST_PREFIX, 20)?;
+        let password = random_password()?;
+        Ok((
+            lease_id,
+            RabbitLease {
+                user,
+                vhost,
+                password,
+            },
+        ))
+    }
+
+    fn lease_url(&self, lease: &RabbitLease) -> String {
+        let host = if self.endpoint.host.contains(':') {
+            format!("[{}]", self.endpoint.host)
+        } else {
+            self.endpoint.host.clone()
+        };
+        // The vhost, user, and URL-safe password are drawn from the safe
+        // identifier/password alphabets, so no percent-encoding is required.
+        format!(
+            "amqp://{}:{}@{}:{}/{}",
+            lease.user, lease.password, host, self.endpoint.port, lease.vhost,
+        )
+    }
+
+    /// Create the vhost, then the user, then grant configure/write/read on that
+    /// vhost alone. Ordering matches Delete's teardown (vhost then user).
+    async fn provision(&self, lease: &RabbitLease) -> Result<(), AdapterError> {
+        let provision = async {
+            self.control_ok(&["add_vhost".to_owned(), lease.vhost.clone()])
+                .await?;
+            self.control_ok(&[
+                "add_user".to_owned(),
+                lease.user.clone(),
+                lease.password.clone(),
+            ])
+            .await?;
+            self.control_ok(&[
+                "set_permissions".to_owned(),
+                "-p".to_owned(),
+                lease.vhost.clone(),
+                lease.user.clone(),
+                ".*".to_owned(),
+                ".*".to_owned(),
+                ".*".to_owned(),
+            ])
+            .await?;
+            Ok::<(), AdapterError>(())
+        };
+        tokio::time::timeout(self.operation_deadline, provision)
+            .await
+            .ok()
+            .and_then(Result::ok)
+            .ok_or(AdapterError::Rejected)
+    }
+
+    async fn rollback(&self, vhost: &str, user: &str) -> Result<(), AdapterError> {
+        #[cfg(test)]
+        if self
+            .fail_rollback_attempts
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(AdapterError::Rejected);
+        }
+        // Cleanup is independently bounded; on timeout its retained partial state
+        // makes the next identical request retry safely.
+        tokio::time::timeout(OPERATION_DEADLINE, self.cleanup(vhost, user))
+            .await
+            .map_err(|_| AdapterError::Rejected)?
+    }
+
+    /// Drop only this lease's vhost then its user. Existence is checked first so
+    /// cleanup is idempotent (a not-yet-created or already-removed entity is
+    /// skipped) while a genuine backend failure still surfaces as an error and
+    /// retains cleanup authority. Deleting a vhost/user removes only the objects
+    /// and permissions bound to it, so other leases are untouched.
+    async fn cleanup(&self, vhost: &str, user: &str) -> Result<(), AdapterError> {
+        let vhosts = self.control_capture(&["list_vhosts".to_owned()]).await?;
+        if control_output_lists(&vhosts, vhost) {
+            self.control_ok(&["delete_vhost".to_owned(), vhost.to_owned()])
+                .await?;
+        }
+        let users = self.control_capture(&["list_users".to_owned()]).await?;
+        if control_output_lists(&users, user) {
+            self.control_ok(&["delete_user".to_owned(), user.to_owned()])
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Run a local-control command and require success, discarding its output.
+    async fn control_ok(&self, args: &[String]) -> Result<(), AdapterError> {
+        let output = self.run_control(args).await?;
+        output.success.then_some(()).ok_or(AdapterError::Rejected)
+    }
+
+    /// Run a local-control command, require success, and return captured stdout
+    /// for in-process membership checks (never logged, never returned to callers).
+    async fn control_capture(&self, args: &[String]) -> Result<Vec<u8>, AdapterError> {
+        let output = self.run_control(args).await?;
+        if output.success {
+            Ok(output.stdout)
+        } else {
+            Err(AdapterError::Rejected)
+        }
+    }
+
+    /// Execute a fixed-argument `rabbitmqctl` subprocess with no shell, stdin
+    /// closed, and bounded output capture, all under the operation deadline. A
+    /// timed-out child is killed on drop. Neither stdout nor stderr is logged.
+    async fn run_control(&self, args: &[String]) -> Result<ControlOutput, AdapterError> {
+        let program = self.control_program.clone();
+        let args = args.to_vec();
+        let run = async move {
+            let mut child = spawn_control(&program, &args).await?;
+            let mut stdout = child.stdout.take().ok_or(AdapterError::Rejected)?;
+            let mut stderr = child.stderr.take().ok_or(AdapterError::Rejected)?;
+            let mut captured = Vec::new();
+            let mut discarded = Vec::new();
+            // Drain both pipes concurrently so a chatty child can always exit.
+            tokio::join!(
+                read_capped(&mut stdout, &mut captured),
+                read_capped(&mut stderr, &mut discarded),
+            );
+            let status = child.wait().await.map_err(|_| AdapterError::Rejected)?;
+            Ok::<ControlOutput, AdapterError>(ControlOutput {
+                success: status.success(),
+                stdout: captured,
+            })
+        };
+        tokio::time::timeout(self.operation_deadline, run)
+            .await
+            .map_err(|_| AdapterError::Rejected)?
+    }
+
+    #[cfg(test)]
+    fn fail_next_rollbacks(&self, attempts: usize) {
+        self.fail_rollback_attempts
+            .store(attempts, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn with_operation_deadline(mut self, deadline: Duration) -> Self {
+        self.operation_deadline = deadline;
+        self
+    }
+
+    async fn ready(&self, lease_id: &str) -> Result<(), AdapterError> {
+        let lease = self
+            .leases
+            .lock()
+            .await
+            .get(lease_id)
+            .cloned()
+            .ok_or(AdapterError::Rejected)?;
+        let probe = generated(RABBIT_PROBE_PREFIX, 12)?;
+        tokio::time::timeout(
+            self.operation_deadline,
+            amqp_probe(
+                &self.endpoint,
+                &lease.user,
+                &lease.password,
+                &lease.vhost,
+                &probe,
+            ),
+        )
+        .await
+        .map_err(|_| AdapterError::Rejected)?
+    }
+
+    async fn delete(&self, lease_id: &str) -> Result<(), AdapterError> {
+        // Retried Delete after a successful first call is intentionally a no-op.
+        // Keep a lease whose cleanup failed so a caller can retry rather than
+        // losing the sole authority to clean up its tenant.
+        let Some(lease) = self.leases.lock().await.get(lease_id).cloned() else {
+            return Ok(());
+        };
+        tokio::time::timeout(OPERATION_DEADLINE, self.cleanup(&lease.vhost, &lease.user))
+            .await
+            .map_err(|_| AdapterError::Rejected)??;
+        self.leases.lock().await.remove(lease_id);
+        self.creations.lock().await.retain(|_, state| {
+            !matches!(state, RabbitCreationState::Created(created) if created.lease_id == lease_id)
+        });
+        Ok(())
+    }
+}
+
+/// Spawn a fixed-argument control subprocess with stdin closed and both pipes
+/// captured. A just-created executable can transiently exec-fail with `ETXTBSY`
+/// when another thread in this process forked while the file was briefly open
+/// for writing; a bounded retry absorbs that race. In production the control
+/// program is a stable pre-installed binary, so this retry path is effectively
+/// never taken. All other spawn failures fail closed. Overall duration remains
+/// bounded by the enclosing operation deadline.
+async fn spawn_control(
+    program: &str,
+    args: &[String],
+) -> Result<tokio::process::Child, AdapterError> {
+    const TEXT_FILE_BUSY: i32 = 26;
+    const MAX_ATTEMPTS: usize = 20;
+    for attempt in 0..MAX_ATTEMPTS {
+        let mut command = tokio::process::Command::new(program);
+        command
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error)
+                if error.raw_os_error() == Some(TEXT_FILE_BUSY) && attempt + 1 < MAX_ATTEMPTS =>
+            {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(_) => return Err(AdapterError::Rejected),
+        }
+    }
+    Err(AdapterError::Rejected)
+}
+
+struct ControlOutput {
+    success: bool,
+    stdout: Vec<u8>,
+}
+
+/// Read to EOF, storing at most `MAX_CONTROL_OUTPUT` bytes but always draining
+/// the rest so the child process can never block on a full pipe.
+async fn read_capped<R>(reader: &mut R, sink: &mut Vec<u8>)
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut chunk = [0u8; 512];
+    loop {
+        match reader.read(&mut chunk).await {
+            Ok(0) | Err(_) => break,
+            Ok(count) => {
+                if sink.len() < MAX_CONTROL_OUTPUT {
+                    let room = MAX_CONTROL_OUTPUT - sink.len();
+                    sink.extend_from_slice(&chunk[..count.min(room)]);
+                }
+            }
+        }
+    }
+}
+
+/// True when `token` appears as a whitespace-delimited entry of control output.
+/// The lease's vhost/user names are unique random identifiers, so an exact token
+/// match is robust across `rabbitmqctl` listing formats and never collides with
+/// a header word such as `Listing`.
+fn control_output_lists(output: &[u8], token: &str) -> bool {
+    String::from_utf8_lossy(output)
+        .split_whitespace()
+        .any(|entry| entry == token)
+}
+
+// ----- Minimal hand-rolled AMQP 0-9-1 readiness client -----
+//
+// Like the Redis half hand-rolls RESP, the readiness probe hand-rolls just the
+// AMQP 0-9-1 connection/channel handshake plus Queue.Declare/Delete over a
+// `TcpStream`. This keeps the crate free of a heavyweight async AMQP dependency
+// (and avoids the workspace-hack / merge-queue churn adding one would incur)
+// while still proving the lease credentials authenticate against the lease vhost.
+
+fn amqp_method_frame(channel: u16, class: u16, method: u16, args: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(4 + args.len());
+    payload.extend_from_slice(&class.to_be_bytes());
+    payload.extend_from_slice(&method.to_be_bytes());
+    payload.extend_from_slice(args);
+    let mut frame = Vec::with_capacity(8 + payload.len());
+    frame.push(AMQP_FRAME_METHOD);
+    frame.extend_from_slice(&channel.to_be_bytes());
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&payload);
+    frame.push(AMQP_FRAME_END);
+    frame
+}
+
+fn amqp_short_string(out: &mut Vec<u8>, value: &str) {
+    out.push(value.len() as u8);
+    out.extend_from_slice(value.as_bytes());
+}
+
+fn amqp_long_string(out: &mut Vec<u8>, value: &[u8]) {
+    out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    out.extend_from_slice(value);
+}
+
+fn amqp_expect(method: &AmqpMethod, class: u16, id: u16) -> Result<(), AdapterError> {
+    (method.class == class && method.method == id)
+        .then_some(())
+        .ok_or(AdapterError::Rejected)
+}
+
+struct AmqpMethod {
+    class: u16,
+    method: u16,
+    args: Vec<u8>,
+}
+
+struct Amqp {
+    reader: BufReader<OwnedReadHalf>,
+    writer: OwnedWriteHalf,
+}
+
+impl Amqp {
+    async fn connect(endpoint: &AmqpEndpoint) -> Result<Self, AdapterError> {
+        let stream = TcpStream::connect((endpoint.host.as_str(), endpoint.port))
+            .await
+            .map_err(|_| AdapterError::Rejected)?;
+        let (read, writer) = stream.into_split();
+        Ok(Self {
+            reader: BufReader::new(read),
+            writer,
+        })
+    }
+
+    async fn write_method(
+        &mut self,
+        channel: u16,
+        class: u16,
+        method: u16,
+        args: &[u8],
+    ) -> Result<(), AdapterError> {
+        self.writer
+            .write_all(&amqp_method_frame(channel, class, method, args))
+            .await
+            .map_err(|_| AdapterError::Rejected)
+    }
+
+    async fn read_method(&mut self) -> Result<AmqpMethod, AdapterError> {
+        let mut header = [0u8; 7];
+        self.reader
+            .read_exact(&mut header)
+            .await
+            .map_err(|_| AdapterError::Rejected)?;
+        let size = u32::from_be_bytes([header[3], header[4], header[5], header[6]]) as usize;
+        if size > AMQP_MAX_FRAME {
+            return Err(AdapterError::Rejected);
+        }
+        let mut payload = vec![0u8; size];
+        self.reader
+            .read_exact(&mut payload)
+            .await
+            .map_err(|_| AdapterError::Rejected)?;
+        let mut end = [0u8; 1];
+        self.reader
+            .read_exact(&mut end)
+            .await
+            .map_err(|_| AdapterError::Rejected)?;
+        // Only method frames are expected during the handshake; a server
+        // Connection.Close (auth/vhost denial) is a method too and is caught by
+        // the class/method expectation at each step.
+        if header[0] != AMQP_FRAME_METHOD || end[0] != AMQP_FRAME_END || payload.len() < 4 {
+            return Err(AdapterError::Rejected);
+        }
+        Ok(AmqpMethod {
+            class: u16::from_be_bytes([payload[0], payload[1]]),
+            method: u16::from_be_bytes([payload[2], payload[3]]),
+            args: payload[4..].to_vec(),
+        })
+    }
+}
+
+async fn amqp_probe(
+    endpoint: &AmqpEndpoint,
+    user: &str,
+    password: &str,
+    vhost: &str,
+    probe_queue: &str,
+) -> Result<(), AdapterError> {
+    let mut connection = Amqp::connect(endpoint).await?;
+    connection
+        .writer
+        .write_all(b"AMQP\x00\x00\x09\x01")
+        .await
+        .map_err(|_| AdapterError::Rejected)?;
+
+    amqp_expect(&connection.read_method().await?, 10, 10)?; // Connection.Start
+
+    let mut start_ok = Vec::new();
+    amqp_long_string(&mut start_ok, &[]); // client-properties: empty field table
+    amqp_short_string(&mut start_ok, "PLAIN");
+    let mut response = Vec::with_capacity(user.len() + password.len() + 2);
+    response.push(0);
+    response.extend_from_slice(user.as_bytes());
+    response.push(0);
+    response.extend_from_slice(password.as_bytes());
+    amqp_long_string(&mut start_ok, &response);
+    amqp_short_string(&mut start_ok, "en_US");
+    connection.write_method(0, 10, 11, &start_ok).await?; // Connection.Start-Ok
+
+    let tune = connection.read_method().await?;
+    amqp_expect(&tune, 10, 30)?; // Connection.Tune
+    let (channel_max, frame_max) = if tune.args.len() >= 6 {
+        (
+            u16::from_be_bytes([tune.args[0], tune.args[1]]),
+            u32::from_be_bytes([tune.args[2], tune.args[3], tune.args[4], tune.args[5]]),
+        )
+    } else {
+        (0, 0)
+    };
+    let mut tune_ok = Vec::new();
+    tune_ok.extend_from_slice(&channel_max.to_be_bytes());
+    tune_ok.extend_from_slice(&frame_max.to_be_bytes());
+    tune_ok.extend_from_slice(&0u16.to_be_bytes()); // heartbeat disabled
+    connection.write_method(0, 10, 31, &tune_ok).await?; // Connection.Tune-Ok
+
+    let mut open = Vec::new();
+    amqp_short_string(&mut open, vhost);
+    amqp_short_string(&mut open, ""); // reserved-1
+    open.push(0); // reserved-2
+    connection.write_method(0, 10, 40, &open).await?; // Connection.Open
+    amqp_expect(&connection.read_method().await?, 10, 41)?; // Connection.Open-Ok
+
+    let mut channel_open = Vec::new();
+    amqp_short_string(&mut channel_open, ""); // reserved-1
+    connection.write_method(1, 20, 10, &channel_open).await?; // Channel.Open
+    amqp_expect(&connection.read_method().await?, 20, 11)?; // Channel.Open-Ok
+
+    let mut declare = Vec::new();
+    declare.extend_from_slice(&0u16.to_be_bytes()); // reserved-1
+    amqp_short_string(&mut declare, probe_queue);
+    declare.push(0b0000_1100); // exclusive + auto-delete
+    amqp_long_string(&mut declare, &[]); // arguments: empty field table
+    connection.write_method(1, 50, 10, &declare).await?; // Queue.Declare
+    amqp_expect(&connection.read_method().await?, 50, 11)?; // Queue.Declare-Ok
+
+    let mut queue_delete = Vec::new();
+    queue_delete.extend_from_slice(&0u16.to_be_bytes()); // reserved-1
+    amqp_short_string(&mut queue_delete, probe_queue);
+    queue_delete.push(0); // no flags
+    connection.write_method(1, 50, 40, &queue_delete).await?; // Queue.Delete
+    amqp_expect(&connection.read_method().await?, 50, 41)?; // Queue.Delete-Ok
+
+    let mut close = Vec::new();
+    close.extend_from_slice(&200u16.to_be_bytes()); // reply-code
+    amqp_short_string(&mut close, ""); // reply-text
+    close.extend_from_slice(&0u16.to_be_bytes()); // class-id
+    close.extend_from_slice(&0u16.to_be_bytes()); // method-id
+    connection.write_method(0, 10, 50, &close).await?; // Connection.Close
+    let _ = connection.read_method().await; // Connection.Close-Ok (best-effort)
+    Ok(())
+}
+
+pub struct RabbitWrapperServer {
+    adapter: RabbitAdapter,
+}
+
+impl RabbitWrapperServer {
+    pub fn new(adapter: RabbitAdapter) -> Self {
+        Self { adapter }
+    }
+
+    pub async fn serve(self, socket: impl AsRef<Path>) -> Result<(), std::io::Error> {
+        let socket = socket.as_ref();
+        if socket.exists() {
+            std::fs::remove_file(socket)?;
+        }
+        let listener = UnixListener::bind(socket)?;
+        loop {
+            let (stream, _) = listener.accept().await?;
+            let adapter = self.adapter.clone();
+            tokio::spawn(async move {
+                rabbit_socket(stream, adapter).await;
+            });
+        }
+    }
+}
+
+async fn rabbit_socket(stream: UnixStream, adapter: RabbitAdapter) {
+    let (read, mut write) = stream.into_split();
+    let mut line = String::new();
+    let response = match tokio::time::timeout(
+        OPERATION_DEADLINE,
+        BufReader::new(read).read_line(&mut line),
+    )
+    .await
+    {
+        Ok(Ok(n)) if n > 0 && n <= MAX_LINE_LEN => match serde_json::from_str(&line) {
+            Ok(request) => rabbit_dispatch(request, adapter).await,
+            Err(_) => error_response("invalid_request"),
+        },
+        _ => error_response("invalid_request"),
+    };
+    if let Ok(body) = serde_json::to_vec(&response) {
+        let _ = write.write_all(&body).await;
+        let _ = write.write_all(b"\n").await;
+    }
+}
+
+async fn rabbit_dispatch(request: Request, adapter: RabbitAdapter) -> Response {
+    if request_revision(&request) != CONTROL_PROTOCOL_REVISION {
+        return error_response("revision_mismatch");
+    }
+    let operation = async {
+        match request {
+            Request::CreateFresh {
+                attempt_id,
+                lease_nonce,
+                ..
+            } if valid_identifier(&attempt_id) && valid_identifier(&lease_nonce) => {
+                let (lease_id, environment) = adapter.create(attempt_id, lease_nonce).await?;
+                Ok(Response::Created {
+                    revision: CONTROL_PROTOCOL_REVISION,
+                    lease_id,
+                    environment,
+                })
+            }
+            Request::Ready { lease_id, .. } if valid_identifier(&lease_id) => {
+                adapter.ready(&lease_id).await?;
+                Ok(Response::Ready {
+                    revision: CONTROL_PROTOCOL_REVISION,
+                })
+            }
+            Request::Delete { lease_id, .. } if valid_identifier(&lease_id) => {
+                adapter.delete(&lease_id).await?;
+                Ok(Response::Deleted {
+                    revision: CONTROL_PROTOCOL_REVISION,
+                })
+            }
+            _ => Err(AdapterError::Rejected),
+        }
+    };
+    match tokio::time::timeout(OPERATION_DEADLINE, operation).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(_)) => error_response("rejected"),
+        Err(_) => error_response("timeout"),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/crates/djinn-catalog-wrapper/src/rabbitmq/tests.rs
+++ b/server/crates/djinn-catalog-wrapper/src/rabbitmq/tests.rs
@@ -1,0 +1,667 @@
+//! RabbitMQ execution coverage for the [`super`] adapter.
+//!
+//! The control plane is a real `rabbitmqctl` subprocess (a generated shell
+//! script), so every assertion exercises the wrapper's real fixed-argument
+//! spawn + bounded-capture path; the AMQP data plane is an in-process 0-9-1
+//! fake that validates the very vhost/user/password state the fake
+//! `rabbitmqctl` wrote. No network management endpoint, shell interpolation,
+//! or operator credential is involved. A real broker is not spawned.
+
+use super::*;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use tokio::net::TcpListener;
+
+// ----- Fake `rabbitmqctl`: a real subprocess over a shared state dir -----
+
+const FAKE_CONTROL_SCRIPT: &str = r#"#!/bin/sh
+DIR="__STATE__"
+printf '%s\n' "$*" >> "$DIR/calls.log"
+op="$1"
+if [ -f "$DIR/slow.$op" ]; then sleep "$(cat "$DIR/slow.$op")"; fi
+if [ -f "$DIR/fail.$op" ]; then cat "$DIR/fail.$op"; cat "$DIR/fail.$op" >&2; exit 70; fi
+case "$op" in
+  add_vhost) mkdir -p "$DIR/vhosts"; : > "$DIR/vhosts/$2" ;;
+  add_user) mkdir -p "$DIR/users"; printf '%s' "$3" > "$DIR/users/$2" ;;
+  set_permissions) mkdir -p "$DIR/perms"; printf '%s\n' "$3" >> "$DIR/perms/$4" ;;
+  delete_vhost) rm -f "$DIR/vhosts/$2" ;;
+  delete_user) rm -f "$DIR/users/$2" "$DIR/perms/$2" ;;
+  list_vhosts)
+echo "Listing vhosts ..."
+if [ -d "$DIR/vhosts" ]; then ls "$DIR/vhosts"; fi ;;
+  list_users)
+echo "Listing users ..."
+if [ -d "$DIR/users" ]; then for u in "$DIR"/users/*; do [ -e "$u" ] && printf '%s\t[]\n' "$(basename "$u")"; done; fi ;;
+  *) echo "unknown command: $op" >&2; exit 64 ;;
+esac
+exit 0
+"#;
+
+struct FakeControl {
+    _dir: tempfile::TempDir,
+    state: PathBuf,
+    script: PathBuf,
+}
+
+impl FakeControl {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let state = dir.path().join("state");
+        std::fs::create_dir_all(&state).unwrap();
+        let script = dir.path().join("rabbitmqctl");
+        std::fs::write(
+            &script,
+            FAKE_CONTROL_SCRIPT.replace("__STATE__", state.to_str().unwrap()),
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+        Self {
+            _dir: dir,
+            state,
+            script,
+        }
+    }
+
+    fn program(&self) -> String {
+        self.script.to_str().unwrap().to_owned()
+    }
+
+    fn calls(&self) -> Vec<String> {
+        std::fs::read_to_string(self.state.join("calls.log"))
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    fn vhosts(&self) -> Vec<String> {
+        list_dir(&self.state.join("vhosts"))
+    }
+
+    fn users(&self) -> Vec<String> {
+        list_dir(&self.state.join("users"))
+    }
+
+    fn fail_op(&self, op: &str, content: &str) {
+        std::fs::write(self.state.join(format!("fail.{op}")), content).unwrap();
+    }
+
+    fn slow_op(&self, op: &str, seconds: &str) {
+        std::fs::write(self.state.join(format!("slow.{op}")), seconds).unwrap();
+    }
+}
+
+fn list_dir(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect()
+}
+
+// ----- In-process fake AMQP 0-9-1 broker over the same state dir -----
+
+struct FakeAmqp {
+    port: u16,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for FakeAmqp {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl FakeAmqp {
+    async fn start(state: PathBuf) -> Self {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let state = state.clone();
+                tokio::spawn(async move {
+                    fake_amqp_connection(stream, state).await;
+                });
+            }
+        });
+        Self { port, handle }
+    }
+
+    fn admin_url(&self) -> String {
+        format!("amqp://127.0.0.1:{}", self.port)
+    }
+}
+
+async fn read_fake_method(reader: &mut BufReader<OwnedReadHalf>) -> Option<(u16, u16, Vec<u8>)> {
+    let mut header = [0u8; 7];
+    reader.read_exact(&mut header).await.ok()?;
+    let size = u32::from_be_bytes([header[3], header[4], header[5], header[6]]) as usize;
+    let mut payload = vec![0u8; size];
+    reader.read_exact(&mut payload).await.ok()?;
+    let mut end = [0u8; 1];
+    reader.read_exact(&mut end).await.ok()?;
+    if end[0] != AMQP_FRAME_END || payload.len() < 4 {
+        return None;
+    }
+    Some((
+        u16::from_be_bytes([payload[0], payload[1]]),
+        u16::from_be_bytes([payload[2], payload[3]]),
+        payload[4..].to_vec(),
+    ))
+}
+
+fn parse_plain(args: &[u8]) -> Option<(String, String)> {
+    let mut offset = 0usize;
+    let properties = u32::from_be_bytes(args.get(offset..offset + 4)?.try_into().ok()?) as usize;
+    offset += 4 + properties;
+    let mechanism = *args.get(offset)? as usize;
+    offset += 1 + mechanism;
+    let response_len = u32::from_be_bytes(args.get(offset..offset + 4)?.try_into().ok()?) as usize;
+    offset += 4;
+    let response = args.get(offset..offset + response_len)?;
+    let mut parts = response.split(|&byte| byte == 0);
+    let _leading = parts.next()?;
+    let user = String::from_utf8(parts.next()?.to_vec()).ok()?;
+    let password = String::from_utf8(parts.next()?.to_vec()).ok()?;
+    Some((user, password))
+}
+
+fn parse_short(args: &[u8], offset: usize) -> Option<String> {
+    let length = *args.get(offset)? as usize;
+    let bytes = args.get(offset + 1..offset + 1 + length)?;
+    String::from_utf8(bytes.to_vec()).ok()
+}
+
+async fn fake_amqp_connection(stream: TcpStream, state: PathBuf) {
+    let (read, mut write) = stream.into_split();
+    let mut reader = BufReader::new(read);
+
+    let mut protocol = [0u8; 8];
+    if reader.read_exact(&mut protocol).await.is_err() {
+        return;
+    }
+
+    let mut start = Vec::new();
+    start.push(0); // version-major
+    start.push(9); // version-minor
+    amqp_long_string(&mut start, &[]); // server-properties: empty field table
+    amqp_long_string(&mut start, b"PLAIN"); // mechanisms
+    amqp_long_string(&mut start, b"en_US"); // locales
+    if write
+        .write_all(&amqp_method_frame(0, 10, 10, &start))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let Some((10, 11, args)) = read_fake_method(&mut reader).await else {
+        return;
+    };
+    let Some((user, password)) = parse_plain(&args) else {
+        return;
+    };
+    // Authenticate against exactly the user/password the fake rabbitmqctl wrote.
+    match std::fs::read_to_string(state.join("users").join(&user)) {
+        Ok(stored) if stored == password => {}
+        _ => return, // auth failure: drop the connection
+    }
+
+    let mut tune = Vec::new();
+    tune.extend_from_slice(&0u16.to_be_bytes()); // channel-max
+    tune.extend_from_slice(&131_072u32.to_be_bytes()); // frame-max
+    tune.extend_from_slice(&0u16.to_be_bytes()); // heartbeat
+    if write
+        .write_all(&amqp_method_frame(0, 10, 30, &tune))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let Some((10, 31, _)) = read_fake_method(&mut reader).await else {
+        return;
+    };
+    let Some((10, 40, args)) = read_fake_method(&mut reader).await else {
+        return;
+    };
+    let Some(vhost) = parse_short(&args, 0) else {
+        return;
+    };
+    // The vhost must exist and this user must hold permission on it.
+    if !state.join("vhosts").join(&vhost).exists() {
+        return;
+    }
+    let perms = std::fs::read_to_string(state.join("perms").join(&user)).unwrap_or_default();
+    if !perms.lines().any(|line| line == vhost) {
+        return;
+    }
+
+    let mut open_ok = Vec::new();
+    amqp_short_string(&mut open_ok, ""); // reserved-1
+    if write
+        .write_all(&amqp_method_frame(0, 10, 41, &open_ok))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let Some((20, 10, _)) = read_fake_method(&mut reader).await else {
+        return;
+    };
+    let mut channel_ok = Vec::new();
+    amqp_long_string(&mut channel_ok, &[]); // reserved-1
+    if write
+        .write_all(&amqp_method_frame(1, 20, 11, &channel_ok))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let Some((50, 10, args)) = read_fake_method(&mut reader).await else {
+        return;
+    };
+    let Some(queue) = parse_short(&args, 2) else {
+        return;
+    };
+    let mut declare_ok = Vec::new();
+    amqp_short_string(&mut declare_ok, &queue);
+    declare_ok.extend_from_slice(&0u32.to_be_bytes()); // message-count
+    declare_ok.extend_from_slice(&0u32.to_be_bytes()); // consumer-count
+    if write
+        .write_all(&amqp_method_frame(1, 50, 11, &declare_ok))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let Some((50, 40, _)) = read_fake_method(&mut reader).await else {
+        return;
+    };
+    let mut delete_ok = Vec::new();
+    delete_ok.extend_from_slice(&0u32.to_be_bytes()); // message-count
+    if write
+        .write_all(&amqp_method_frame(1, 50, 41, &delete_ok))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let Some((10, 50, _)) = read_fake_method(&mut reader).await else {
+        return;
+    };
+    let _ = write.write_all(&amqp_method_frame(0, 10, 51, &[])).await; // Close-Ok
+}
+
+struct Harness {
+    control: FakeControl,
+    amqp: FakeAmqp,
+    adapter: RabbitAdapter,
+}
+
+async fn harness() -> Harness {
+    let control = FakeControl::new();
+    let amqp = FakeAmqp::start(control.state.clone()).await;
+    let adapter = RabbitAdapter::new(
+        &amqp.admin_url(),
+        &control.program(),
+        vec!["AMQP_URL".into()],
+    )
+    .unwrap();
+    Harness {
+        control,
+        amqp,
+        adapter,
+    }
+}
+
+fn lease_parts(url: &str) -> (String, String, String) {
+    let parsed = Url::parse(url).unwrap();
+    (
+        parsed.username().to_owned(),
+        parsed.password().unwrap().to_owned(),
+        parsed.path().trim_start_matches('/').to_owned(),
+    )
+}
+
+async fn wait_for_empty_creations(adapter: &RabbitAdapter) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if adapter.creations.lock().await.is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("background cleanup did not finish");
+}
+
+async fn wait_for_cleanup_pending(adapter: &RabbitAdapter, attempt: &str, nonce: &str) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if matches!(
+                adapter.creations.lock().await.get(&CreationKey {
+                    attempt_id: attempt.to_owned(),
+                    lease_nonce: nonce.to_owned(),
+                }),
+                Some(RabbitCreationState::CleanupPending(_))
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("partial cleanup authority was discarded");
+}
+
+// ----- Configuration validation -----
+
+#[test]
+fn rejects_invalid_configuration() {
+    assert!(
+        RabbitAdapter::new(
+            "amqp://127.0.0.1:5672",
+            "rabbitmqctl",
+            vec!["AMQP_URL".into()]
+        )
+        .is_ok()
+    );
+    // Wrong scheme, empty control program, and unsafe env name each fail closed.
+    assert!(
+        RabbitAdapter::new("redis://127.0.0.1", "rabbitmqctl", vec!["AMQP_URL".into()]).is_err()
+    );
+    assert!(RabbitAdapter::new("amqp://127.0.0.1", "", vec!["AMQP_URL".into()]).is_err());
+    assert!(
+        RabbitAdapter::new("amqp://127.0.0.1", "rabbitmqctl", vec!["AMQP-URL".into()]).is_err()
+    );
+}
+
+#[tokio::test]
+async fn protocol_mismatch_fails_closed_without_backend_access() {
+    let control = FakeControl::new();
+    let adapter = RabbitAdapter::new(
+        "amqp://127.0.0.1:5672",
+        &control.program(),
+        vec!["AMQP_URL".into()],
+    )
+    .unwrap();
+    let response = rabbit_dispatch(
+        Request::Delete {
+            revision: 2,
+            lease_id: "lease_1".into(),
+        },
+        adapter,
+    )
+    .await;
+    assert_eq!(response, error_response("revision_mismatch"));
+    // A protocol mismatch never touches the local control plane.
+    assert!(control.calls().is_empty());
+}
+
+// ----- AC1: fixed-argument vhost + user + vhost-scoped permissions -----
+
+#[tokio::test]
+async fn create_provisions_vhost_user_and_scoped_permissions() {
+    let Harness {
+        control, adapter, ..
+    } = harness().await;
+    let (lease_id, env) = adapter
+        .create("attempt_a".into(), "nonce_a".into())
+        .await
+        .unwrap();
+    // Only the catalog-configured environment name is returned.
+    assert_eq!(env.keys().cloned().collect::<Vec<_>>(), vec!["AMQP_URL"]);
+    let (user, password, vhost) = lease_parts(&env["AMQP_URL"]);
+
+    // Fixed argument sequence: vhost, then user, then vhost-scoped grant.
+    let calls = control.calls();
+    assert_eq!(calls[0], format!("add_vhost {vhost}"));
+    assert_eq!(calls[1], format!("add_user {user} {password}"));
+    assert_eq!(
+        calls[2],
+        format!("set_permissions -p {vhost} {user} .* .* .*")
+    );
+    assert!(control.vhosts().contains(&vhost));
+    assert!(control.users().contains(&user));
+
+    adapter.delete(&lease_id).await.unwrap();
+}
+
+// ----- AC2: readiness authenticates over AMQP; isolation holds -----
+
+#[tokio::test]
+async fn ready_authenticates_over_amqp_and_cross_lease_access_is_denied() {
+    // Keep the fake control script and AMQP server alive for the whole test.
+    let Harness {
+        control: _control,
+        amqp: _amqp,
+        adapter,
+    } = harness().await;
+    let (a_id, a_env) = adapter
+        .create("attempt_a".into(), "nonce_a".into())
+        .await
+        .unwrap();
+    let (b_id, b_env) = adapter
+        .create("attempt_b".into(), "nonce_b".into())
+        .await
+        .unwrap();
+
+    // Each lease's own credentials open its own vhost.
+    adapter.ready(&a_id).await.unwrap();
+    adapter.ready(&b_id).await.unwrap();
+    // Unknown lease never touches the backend.
+    assert_eq!(
+        adapter.ready("lease_missing").await,
+        Err(AdapterError::Rejected)
+    );
+
+    // Lease A's credentials cannot open lease B's vhost.
+    let (a_user, a_password, _) = lease_parts(&a_env["AMQP_URL"]);
+    let (_, _, b_vhost) = lease_parts(&b_env["AMQP_URL"]);
+    assert_eq!(
+        amqp_probe(&adapter.endpoint, &a_user, &a_password, &b_vhost, "probe").await,
+        Err(AdapterError::Rejected)
+    );
+
+    adapter.delete(&a_id).await.unwrap();
+    adapter.delete(&b_id).await.unwrap();
+}
+
+// ----- AC2/AC5: Delete drops only the leased vhost then user, in order -----
+
+#[tokio::test]
+async fn delete_removes_only_its_own_vhost_then_user() {
+    let Harness {
+        control,
+        adapter,
+        amqp: _amqp,
+    } = harness().await;
+    let (a_id, a_env) = adapter
+        .create("attempt_a".into(), "nonce_a".into())
+        .await
+        .unwrap();
+    let (b_id, b_env) = adapter
+        .create("attempt_b".into(), "nonce_b".into())
+        .await
+        .unwrap();
+    let (a_user, _, a_vhost) = lease_parts(&a_env["AMQP_URL"]);
+    let (_, _, b_vhost) = lease_parts(&b_env["AMQP_URL"]);
+
+    let before = control.calls().len();
+    adapter.delete(&a_id).await.unwrap();
+    let delete_calls: Vec<String> = control.calls().into_iter().skip(before).collect();
+
+    // vhost is dropped before the user, and only lease A's identifiers appear.
+    assert_eq!(delete_calls[0], "list_vhosts");
+    assert_eq!(delete_calls[1], format!("delete_vhost {a_vhost}"));
+    assert_eq!(delete_calls[2], "list_users");
+    assert_eq!(delete_calls[3], format!("delete_user {a_user}"));
+
+    assert!(!control.vhosts().contains(&a_vhost));
+    assert!(!control.users().contains(&a_user));
+    // Lease B is untouched: its vhost survives and it still readies over AMQP.
+    assert!(control.vhosts().contains(&b_vhost));
+    adapter.ready(&b_id).await.unwrap();
+
+    adapter.delete(&b_id).await.unwrap();
+}
+
+// ----- AC3: idempotent create; repeated and unknown delete are no-ops -----
+
+#[tokio::test]
+async fn create_is_idempotent_and_delete_is_repeatable() {
+    let Harness {
+        control: _control,
+        amqp: _amqp,
+        adapter,
+    } = harness().await;
+    let (first, first_env) = adapter
+        .create("attempt_retry".into(), "nonce_retry".into())
+        .await
+        .unwrap();
+    let (retry, retry_env) = adapter
+        .create("attempt_retry".into(), "nonce_retry".into())
+        .await
+        .unwrap();
+    assert_eq!(first, retry);
+    assert_eq!(first_env, retry_env);
+    assert_eq!(adapter.leases.lock().await.len(), 1);
+
+    adapter.delete(&first).await.unwrap();
+    // Repeated delete of the same lease and an unknown lease are no-op successes.
+    adapter.delete(&first).await.unwrap();
+    adapter.delete("lease_unknown").await.unwrap();
+}
+
+// ----- AC1/AC4: partial create failure rolls back the created vhost -----
+
+#[tokio::test]
+async fn partial_create_failure_rolls_back_the_vhost() {
+    let Harness {
+        control, adapter, ..
+    } = harness().await;
+    // add_vhost succeeds; add_user fails, so the vhost must be rolled back.
+    control.fail_op("add_user", "boom");
+    assert_eq!(
+        adapter.create("attempt_x".into(), "nonce_x".into()).await,
+        Err(AdapterError::Rejected)
+    );
+    wait_for_empty_creations(&adapter).await;
+    assert!(adapter.leases.lock().await.is_empty());
+    assert!(control.vhosts().is_empty());
+    assert!(control.users().is_empty());
+}
+
+// ----- AC3/finding: a failed rollback retains authority until a retry -----
+
+#[tokio::test]
+async fn failed_rollback_retains_authority_until_a_retry_cleans_it() {
+    let Harness {
+        control, adapter, ..
+    } = harness().await;
+    control.fail_op("add_user", "boom");
+    adapter.fail_next_rollbacks(1);
+    assert_eq!(
+        adapter.create("attempt_c".into(), "nonce_c".into()).await,
+        Err(AdapterError::Rejected)
+    );
+    wait_for_cleanup_pending(&adapter, "attempt_c", "nonce_c").await;
+    // The created vhost is still present under retained cleanup authority.
+    assert!(!control.vhosts().is_empty());
+    // The identical retry retries cleanup rather than orphaning the vhost.
+    assert_eq!(
+        adapter.create("attempt_c".into(), "nonce_c".into()).await,
+        Err(AdapterError::Rejected)
+    );
+    wait_for_empty_creations(&adapter).await;
+    assert!(control.vhosts().is_empty());
+}
+
+// ----- AC4: control failure is bounded and leaks no backend output -----
+
+#[tokio::test]
+async fn control_failure_is_bounded_without_leaking_backend_output() {
+    let Harness {
+        control, adapter, ..
+    } = harness().await;
+    // The failing command emits secret-shaped bytes to stdout and stderr.
+    control.fail_op(
+        "add_vhost",
+        "SUPER_SECRET_CREDENTIAL leaked vhost=secretvhost user=secretuser",
+    );
+    // The adapter surfaces only the payload-free error type.
+    assert_eq!(
+        adapter.create("attempt_r".into(), "nonce_r".into()).await,
+        Err(AdapterError::Rejected)
+    );
+    wait_for_empty_creations(&adapter).await;
+
+    // Through the protocol, the response is the bounded revision-1 error and
+    // carries none of the backend's stdout/stderr.
+    let response = rabbit_dispatch(
+        Request::CreateFresh {
+            revision: CONTROL_PROTOCOL_REVISION,
+            attempt_id: "attempt_r2".into(),
+            lease_nonce: "nonce_r2".into(),
+        },
+        adapter.clone(),
+    )
+    .await;
+    assert_eq!(response, error_response("rejected"));
+    let serialized = serde_json::to_string(&response).unwrap();
+    assert!(!serialized.contains("SUPER_SECRET_CREDENTIAL"));
+    assert!(!serialized.contains("secretvhost"));
+    assert!(!serialized.contains("secretuser"));
+    wait_for_empty_creations(&adapter).await;
+}
+
+// ----- AC4: a control call exceeding the deadline is killed and rolled back -----
+
+#[tokio::test]
+async fn control_deadline_expiry_is_bounded_and_rolls_back() {
+    let control = FakeControl::new();
+    let amqp = FakeAmqp::start(control.state.clone()).await;
+    let adapter = RabbitAdapter::new(
+        &amqp.admin_url(),
+        &control.program(),
+        vec!["AMQP_URL".into()],
+    )
+    .unwrap()
+    .with_operation_deadline(Duration::from_secs(1));
+    // add_vhost sleeps far past the deadline (before creating anything), so the
+    // subprocess is killed on drop and nothing is left to clean up.
+    control.slow_op("add_vhost", "30");
+    assert_eq!(
+        adapter.create("attempt_t".into(), "nonce_t".into()).await,
+        Err(AdapterError::Rejected)
+    );
+    wait_for_empty_creations(&adapter).await;
+    assert!(adapter.leases.lock().await.is_empty());
+    assert!(control.vhosts().is_empty());
+    assert!(control.users().is_empty());
+}
+
+// ----- Suppress unused-field warnings for harness fields kept for lifetime -----
+
+#[tokio::test]
+async fn harness_fields_are_retained_for_backend_lifetime() {
+    let harness = harness().await;
+    assert!(harness.amqp.port > 0);
+    assert!(!harness.control.program().is_empty());
+    assert!(harness.adapter.leases.lock().await.is_empty());
+}


### PR DESCRIPTION
RabbitMQ adapter for the catalog wrapper server (epic xy15, proposal jvpm). Stacked on #2529 (Redis wrapper + module split) — enqueue after it merges.

- Per-lease unique vhost + user + random credential; permissions scoped `-p <vhost> .* .* .*` only. Create rolls back vhost on partial failure; failed rollback retains CleanupPending authority.
- Ready performs a real AMQP 0-9-1 handshake (hand-rolled PLAIN auth + Queue.Declare/Delete probe over TcpStream — no lapin dep, no hakari churn); cross-lease credentials are rejected on a sibling vhost.
- Local control via fixed-argument rabbitmqctl subprocesses (no shell, bounded 64KB capture, kill_on_drop, deadline-killed) — alpine-runtime compatible, no management HTTP plugin, no operator credentials.
- Payload-free error enum makes backend-text leakage structurally impossible; a test plants secret-shaped bytes on the failing control command and asserts the serialized response contains none of them.
- Tests drive the real spawn/capture path via a generated fake rabbitmqctl + in-process AMQP fake sharing state: isolation, reverse cleanup order, idempotent/repeatable delete, deadline expiry, protocol mismatch. 32 wrapper tests green; fmt/clippy clean; full workspace check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)