### PR TITLE
chore(ij6g): Package catalog wrappers and wire private K8s control mounts end to end

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/adapter.rs
+++ b/server/crates/djinn-agent/src/actors/slot/adapter.rs
@@ -389,10 +389,12 @@ pub async fn resolve_final_verification_for_task_run(
     let service_provisioners: ServiceProvisioners = services
         .iter()
         .map(|service| {
+            // The socket path is the canonical one strict resolution computed and
+            // rejected collisions on, so a client socket always names the socket
+            // the corresponding wrapper sidecar binds.
             Arc::new(UnixCatalogServiceProvisioner::new(
                 service.preset_id.clone(),
-                PathBuf::from("/var/run/djinn/service-control")
-                    .join(format!("{}.sock", service.preset_id)),
+                djinn_k8s::sidecar::control_socket_path_from_name(&service.control_socket_name),
                 service.exported_environment_names.clone(),
             ))
                 as Arc<dyn djinn_sandbox::service_provisioning::CatalogServiceProvisioner>

--- a/server/crates/djinn-catalog-wrapper/src/lib.rs
+++ b/server/crates/djinn-catalog-wrapper/src/lib.rs
@@ -10,11 +10,13 @@
 //! per-service adapters live in [`postgres`] and [`redis`].
 
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::time::Duration;
 
 use base64::Engine as _;
 use djinn_sandbox::service_provisioning::{CONTROL_PROTOCOL_REVISION, Request, Response};
 use ring::rand::{SecureRandom, SystemRandom};
+use tokio::net::UnixListener;
 use tokio::sync::Notify;
 
 mod postgres;
@@ -58,6 +60,23 @@ struct CreatedLease {
 fn signal_completion(notify: &Notify) {
     notify.notify_waiters();
     notify.notify_one();
+}
+
+/// Bind a wrapper control socket, replacing any stale socket file, and relax its
+/// mode so the uid-10001 worker in the same Pod can connect to a socket the root
+/// wrapper process created. The Pod boundary is the security perimeter; the
+/// control emptyDir is private to the worker and its wrapper sidecars.
+fn bind_control_socket(socket: &Path) -> std::io::Result<UnixListener> {
+    if socket.exists() {
+        std::fs::remove_file(socket)?;
+    }
+    let listener = UnixListener::bind(socket)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o666))?;
+    }
+    Ok(listener)
 }
 
 fn request_revision(request: &Request) -> u32 {

--- a/server/crates/djinn-catalog-wrapper/src/postgres.rs
+++ b/server/crates/djinn-catalog-wrapper/src/postgres.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use djinn_sandbox::service_provisioning::{CONTROL_PROTOCOL_REVISION, Request, Response};
 use sqlx::{Connection, PgConnection};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::{UnixListener, UnixStream};
+use tokio::net::UnixStream;
 use tokio::sync::{Mutex, Notify};
 use url::Url;
 
@@ -435,11 +435,7 @@ impl WrapperServer {
     }
 
     pub async fn serve(self, socket: impl AsRef<Path>) -> Result<(), std::io::Error> {
-        let socket = socket.as_ref();
-        if socket.exists() {
-            std::fs::remove_file(socket)?;
-        }
-        let listener = UnixListener::bind(socket)?;
+        let listener = crate::bind_control_socket(socket.as_ref())?;
         loop {
             let (stream, _) = listener.accept().await?;
             let adapter = self.adapter.clone();

--- a/server/crates/djinn-catalog-wrapper/src/rabbitmq.rs
+++ b/server/crates/djinn-catalog-wrapper/src/rabbitmq.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use djinn_sandbox::service_provisioning::{CONTROL_PROTOCOL_REVISION, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::{TcpStream, UnixListener, UnixStream};
+use tokio::net::{TcpStream, UnixStream};
 use tokio::sync::{Mutex, Notify};
 use url::Url;
 
@@ -766,11 +766,7 @@ impl RabbitWrapperServer {
     }
 
     pub async fn serve(self, socket: impl AsRef<Path>) -> Result<(), std::io::Error> {
-        let socket = socket.as_ref();
-        if socket.exists() {
-            std::fs::remove_file(socket)?;
-        }
-        let listener = UnixListener::bind(socket)?;
+        let listener = crate::bind_control_socket(socket.as_ref())?;
         loop {
             let (stream, _) = listener.accept().await?;
             let adapter = self.adapter.clone();

--- a/server/crates/djinn-catalog-wrapper/src/redis.rs
+++ b/server/crates/djinn-catalog-wrapper/src/redis.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use djinn_sandbox::service_provisioning::{CONTROL_PROTOCOL_REVISION, Request, Response};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::{TcpStream, UnixListener, UnixStream};
+use tokio::net::{TcpStream, UnixStream};
 use tokio::sync::{Mutex, Notify};
 use url::Url;
 
@@ -657,11 +657,7 @@ impl RedisWrapperServer {
         Self { adapter }
     }
     pub async fn serve(self, socket: impl AsRef<Path>) -> Result<(), std::io::Error> {
-        let socket = socket.as_ref();
-        if socket.exists() {
-            std::fs::remove_file(socket)?;
-        }
-        let listener = UnixListener::bind(socket)?;
+        let listener = crate::bind_control_socket(socket.as_ref())?;
         loop {
             let (stream, _) = listener.accept().await?;
             let adapter = self.adapter.clone();

--- a/server/crates/djinn-catalog-wrapper/src/redis_main.rs
+++ b/server/crates/djinn-catalog-wrapper/src/redis_main.rs
@@ -1,17 +1,19 @@
-use djinn_catalog_wrapper::{RedisAdapter, RedisWrapperServer};
 use std::path::PathBuf;
+
+use djinn_catalog_wrapper::{RedisAdapter, RedisWrapperServer};
+
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
-    let _socket = std::env::var_os("CATALOG_CONTROL_SOCKET")
+    let socket = std::env::var_os("CATALOG_CONTROL_SOCKET")
         .map(PathBuf::from)
         .ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing control socket")
         })?;
-    let _adapter = RedisAdapter::from_environment().map_err(|_| {
+    let adapter = RedisAdapter::from_environment().map_err(|_| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "invalid wrapper configuration",
         )
     })?;
-    RedisWrapperServer::new(_adapter).serve(_socket).await
+    RedisWrapperServer::new(adapter).serve(socket).await
 }

--- a/server/crates/djinn-db/migrations_postgres/150_service_preset_wrapper_identity.sql
+++ b/server/crates/djinn-db/migrations_postgres/150_service_preset_wrapper_identity.sql
@@ -1,0 +1,36 @@
+-- ij6g: catalog wrapper artifact identity.
+--
+-- The deployable catalog service image is the *wrapper* artifact, which packages
+-- the stock service runtime plus the protocol-v1 control server in one image.
+-- The wrapper is identified by `{wrapper_image}@{image_digest}`: `wrapper_image`
+-- is a mutable repository reference and `image_digest` is the immutable manifest
+-- digest that strict canonical verification pins.
+--
+-- Migration 147 seeded fabricated placeholder digests directly into
+-- `image_digest`. Those literals are not deployable images. This migration
+-- removes them so strict resolution fails closed until the build/controller path
+-- records a real published digest, and records the catalog-owned wrapper
+-- repositories the build produces.
+ALTER TABLE service_presets
+    ADD COLUMN IF NOT EXISTS wrapper_image TEXT NULL;
+
+-- A wrapper repository reference is a plain repository ref (optionally tagged)
+-- with no digest suffix; the immutable digest lives only in `image_digest`.
+ALTER TABLE service_presets
+    ADD CONSTRAINT service_preset_wrapper_image_no_digest CHECK
+      (wrapper_image IS NULL OR wrapper_image NOT LIKE '%@%');
+
+-- Record the catalog-owned wrapper repositories and clear the fabricated
+-- placeholder digests seeded by migration 147. The real immutable digests are
+-- published by the build/controller path (see djinn-image-controller
+-- wrapper_catalog reconciliation); until then `image_digest` stays NULL and
+-- strict resolution rejects the preset.
+UPDATE service_presets
+SET wrapper_image = CASE id
+    WHEN 'preset-postgres-18' THEN 'ghcr.io/djinnos/djinn-postgres-wrapper'
+    WHEN 'preset-redis-7' THEN 'ghcr.io/djinnos/djinn-redis-wrapper'
+    WHEN 'preset-rabbitmq-4' THEN 'ghcr.io/djinnos/djinn-rabbitmq-wrapper'
+    ELSE wrapper_image
+END,
+image_digest = NULL
+WHERE id IN ('preset-postgres-18', 'preset-redis-7', 'preset-rabbitmq-4');

--- a/server/crates/djinn-db/src/repositories/service.rs
+++ b/server/crates/djinn-db/src/repositories/service.rs
@@ -18,7 +18,16 @@ pub struct ServicePreset {
     pub name: String,
     pub service_type: String,
     pub image: String,
-    /// Immutable manifest digest consumed by strict canonical verification.
+    /// Catalog-owned wrapper artifact repository reference (no digest suffix).
+    /// The deployable wrapper image is `{wrapper_image}@{image_digest}`; the
+    /// wrapper packages the stock service runtime plus the protocol-v1 control
+    /// server. `None` = legacy preset with no wrapper (dispatch-only, never
+    /// eligible for strict canonical verification).
+    pub wrapper_image: Option<String>,
+    /// Immutable manifest digest of the wrapper artifact, consumed by strict
+    /// canonical verification. Recorded by the build/controller path; the seed
+    /// leaves it NULL so strict resolution fails closed until a real digest is
+    /// published.
     pub image_digest: Option<String>,
     /// Revision of the catalog wrapper verification protocol.
     pub verification_protocol_revision: Option<i32>,
@@ -42,7 +51,8 @@ fn map_preset(r: &sqlx::postgres::PgRow) -> ServicePreset {
         name: r.get("name"),
         service_type: r.get("service_type"),
         image: r.get("image"),
-        image_digest: r.try_get("image_digest").ok(),
+        wrapper_image: r.try_get("wrapper_image").ok().flatten(),
+        image_digest: r.try_get("image_digest").ok().flatten(),
         verification_protocol_revision: r.try_get("verification_protocol_revision").ok(),
         port: r.get("port"),
         env: r.get("env"),
@@ -56,7 +66,7 @@ fn map_preset(r: &sqlx::postgres::PgRow) -> ServicePreset {
 
 const PRESET_COLS: &str = r#"id, name, service_type, image, port,
     env::text AS env, resources::text AS resources, conn_template, conn_env_var,
-    client_package, image_digest, verification_protocol_revision"#;
+    client_package, wrapper_image, image_digest, verification_protocol_revision"#;
 
 pub struct ServicePresetRepository {
     db: Database,
@@ -83,6 +93,56 @@ impl ServicePresetRepository {
             .await?;
         Ok(row.as_ref().map(map_preset))
     }
+
+    /// Record the build/controller-published wrapper artifact identity for a
+    /// preset: the wrapper repository reference and its immutable manifest
+    /// digest. This is the sole write path for wrapper identity — presets are
+    /// otherwise seeded by migrations, and strict resolution stays fail-closed
+    /// until a real digest is recorded here.
+    ///
+    /// `wrapper_image` must be a plain repository reference with no digest
+    /// suffix; `image_digest` must be a `sha256:<64 lowercase hex>` literal.
+    /// Malformed arguments are rejected before touching the database so a
+    /// fabricated or mutable identity can never be persisted. Returns the number
+    /// of rows updated (0 when the preset id is unknown).
+    pub async fn set_wrapper_identity(
+        &self,
+        preset_id: &str,
+        wrapper_image: &str,
+        image_digest: &str,
+    ) -> Result<u64> {
+        if wrapper_image.trim().is_empty() || wrapper_image.contains('@') {
+            return Err(crate::error::DbError::InvalidData(format!(
+                "wrapper_image for preset {preset_id} must be a digest-free repository reference"
+            )));
+        }
+        if !is_sha256_digest(image_digest) {
+            return Err(crate::error::DbError::InvalidData(format!(
+                "image_digest for preset {preset_id} must be sha256:<64 lowercase hex>"
+            )));
+        }
+        self.db.ensure_initialized().await?;
+        let result = sqlx::query(
+            "UPDATE service_presets SET wrapper_image = $2, image_digest = $3, \
+             verification_protocol_revision = COALESCE(verification_protocol_revision, 1) \
+             WHERE id = $1",
+        )
+        .bind(preset_id)
+        .bind(wrapper_image)
+        .bind(image_digest)
+        .execute(self.db.pool())
+        .await?;
+        Ok(result.rows_affected())
+    }
+}
+
+/// A `sha256:<64 lowercase hex>` digest literal.
+fn is_sha256_digest(value: &str) -> bool {
+    value.len() == 71
+        && value.starts_with("sha256:")
+        && value[7..]
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
 #[cfg(test)]
@@ -106,5 +166,77 @@ mod tests {
         // sidecar exports the connection under the conventional DATABASE_URL too.
         assert_eq!(pg.conn_env_var, "DATABASE_URL,TEST_POSTGRES_URL");
         assert_eq!(pg.client_package.as_deref(), Some("postgresql-client"));
+    }
+
+    /// AC1: the seed records catalog-owned wrapper repositories but leaves the
+    /// immutable digest NULL, so strict resolution stays fail-closed until a
+    /// real published digest is recorded (no fabricated literals survive).
+    #[tokio::test]
+    async fn seed_records_wrapper_repository_without_a_digest() {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        let repo = ServicePresetRepository::new(db.clone());
+        for (id, wrapper) in [
+            (
+                "preset-postgres-18",
+                "ghcr.io/djinnos/djinn-postgres-wrapper",
+            ),
+            ("preset-redis-7", "ghcr.io/djinnos/djinn-redis-wrapper"),
+            (
+                "preset-rabbitmq-4",
+                "ghcr.io/djinnos/djinn-rabbitmq-wrapper",
+            ),
+        ] {
+            let preset = repo.get(id).await.unwrap().expect("seeded preset");
+            assert_eq!(preset.wrapper_image.as_deref(), Some(wrapper));
+            assert!(
+                preset.image_digest.is_none(),
+                "fabricated placeholder digest must be cleared for {id}"
+            );
+        }
+    }
+
+    /// AC1: the build/controller write path records a real digest and rejects
+    /// mutable/fabricated identities before touching the database.
+    #[tokio::test]
+    async fn set_wrapper_identity_records_real_digest_and_rejects_malformed() {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        let repo = ServicePresetRepository::new(db.clone());
+        let digest = "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+        // A digest-suffixed wrapper reference is a mutable/ambiguous identity.
+        assert!(matches!(
+            repo.set_wrapper_identity("preset-redis-7", "repo@sha256:dead", digest)
+                .await,
+            Err(crate::error::DbError::InvalidData(_))
+        ));
+        // A non-sha256 digest is rejected before the database write.
+        assert!(matches!(
+            repo.set_wrapper_identity("preset-redis-7", "repo", "latest")
+                .await,
+            Err(crate::error::DbError::InvalidData(_))
+        ));
+
+        let updated = repo
+            .set_wrapper_identity(
+                "preset-redis-7",
+                "ghcr.io/djinnos/djinn-redis-wrapper",
+                digest,
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated, 1);
+        let redis = repo.get("preset-redis-7").await.unwrap().expect("preset");
+        assert_eq!(redis.image_digest.as_deref(), Some(digest));
+        assert_eq!(redis.verification_protocol_revision, Some(1));
+
+        // Unknown preset id updates no rows.
+        assert_eq!(
+            repo.set_wrapper_identity("preset-nope", "repo", digest)
+                .await
+                .unwrap(),
+            0
+        );
     }
 }

--- a/server/crates/djinn-image-controller/src/lib.rs
+++ b/server/crates/djinn-image-controller/src/lib.rs
@@ -41,6 +41,7 @@ pub mod retention;
 pub mod retention_preflight;
 pub mod types;
 pub mod watcher;
+pub mod wrapper_catalog;
 
 pub use build_job::{BuildSubject, LABEL_IMAGE_ID, LABEL_PROJECT_ID};
 pub use config::ImageControllerConfig;
@@ -59,3 +60,8 @@ pub use retention_preflight::{
 };
 pub use types::{BuildRequest, BuildStatus, ProjectImageView};
 pub use watcher::ImageBuildWatcher;
+pub use wrapper_catalog::{
+    WRAPPER_IMAGE_MANIFEST_ENV, WrapperCatalogError, WrapperCatalogReconcileStats,
+    WrapperImageEntry, WrapperImageManifest, load_wrapper_image_manifest,
+    reconcile_wrapper_catalog, reconcile_wrapper_catalog_from_env,
+};

--- a/server/crates/djinn-image-controller/src/wrapper_catalog.rs
+++ b/server/crates/djinn-image-controller/src/wrapper_catalog.rs
@@ -1,0 +1,199 @@
+//! ij6g: record build/controller-published catalog wrapper image digests.
+//!
+//! The three catalog wrapper images (Postgres/Redis/RabbitMQ) are built and
+//! pushed by `server/docker/build-wrapper-images.sh`, which captures each
+//! image's REAL immutable digest from the registry push and writes a manifest.
+//! This module consumes that manifest and records the identities into
+//! `service_presets`, so strict canonical verification can resolve
+//! `{wrapper_image}@{digest}`.
+//!
+//! The manifest is the only supported channel for wrapper digests: fabricated or
+//! mutable identities are rejected by [`ServicePresetRepository::set_wrapper_identity`]
+//! before any database write, so a placeholder literal can never become
+//! deployable.
+
+use std::path::Path;
+
+use djinn_db::{Database, ServicePresetRepository};
+use serde::Deserialize;
+
+/// One catalog wrapper image identity published by the build.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct WrapperImageEntry {
+    /// The `service_presets.id` this identity belongs to.
+    pub preset_id: String,
+    /// The wrapper repository reference (no digest suffix).
+    pub wrapper_image: String,
+    /// The immutable `sha256:<64 hex>` digest of the pushed wrapper image.
+    pub image_digest: String,
+}
+
+/// The manifest `build-wrapper-images.sh` emits after pushing every wrapper.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct WrapperImageManifest {
+    pub entries: Vec<WrapperImageEntry>,
+}
+
+/// Outcome of a reconcile pass.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WrapperCatalogReconcileStats {
+    /// Presets whose wrapper identity was recorded (row updated).
+    pub recorded: Vec<String>,
+    /// Manifest entries whose preset id matched no catalog row.
+    pub unknown_presets: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WrapperCatalogError {
+    #[error("read wrapper image manifest {path}: {source}")]
+    Read {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("parse wrapper image manifest {path}: {source}")]
+    Parse {
+        path: String,
+        source: serde_json::Error,
+    },
+    #[error("record wrapper identity for preset {preset_id}: {detail}")]
+    Record { preset_id: String, detail: String },
+}
+
+/// Environment variable naming the wrapper image manifest path the deploy
+/// pipeline writes. Unset ⇒ no wrapper digests to reconcile (strict resolution
+/// stays fail-closed).
+pub const WRAPPER_IMAGE_MANIFEST_ENV: &str = "DJINN_WRAPPER_IMAGE_MANIFEST";
+
+/// Parse a manifest from JSON bytes.
+pub fn parse_wrapper_image_manifest(json: &str) -> Result<WrapperImageManifest, serde_json::Error> {
+    serde_json::from_str(json)
+}
+
+/// Load and parse the manifest at `path`.
+pub fn load_wrapper_image_manifest(
+    path: &Path,
+) -> Result<WrapperImageManifest, WrapperCatalogError> {
+    let raw = std::fs::read_to_string(path).map_err(|source| WrapperCatalogError::Read {
+        path: path.display().to_string(),
+        source,
+    })?;
+    parse_wrapper_image_manifest(&raw).map_err(|source| WrapperCatalogError::Parse {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+/// Record every manifest entry's wrapper identity into `service_presets`. Each
+/// write is validated (digest-free wrapper ref + `sha256:` digest) before it
+/// touches the database. An entry whose preset id is unknown is reported rather
+/// than failing the whole pass, so a manifest can safely list presets a given
+/// deployment has not seeded.
+pub async fn reconcile_wrapper_catalog(
+    db: &Database,
+    manifest: &WrapperImageManifest,
+) -> Result<WrapperCatalogReconcileStats, WrapperCatalogError> {
+    let presets = ServicePresetRepository::new(db.clone());
+    let mut stats = WrapperCatalogReconcileStats::default();
+    for entry in &manifest.entries {
+        let updated = presets
+            .set_wrapper_identity(&entry.preset_id, &entry.wrapper_image, &entry.image_digest)
+            .await
+            .map_err(|error| WrapperCatalogError::Record {
+                preset_id: entry.preset_id.clone(),
+                detail: error.to_string(),
+            })?;
+        if updated == 0 {
+            stats.unknown_presets.push(entry.preset_id.clone());
+        } else {
+            stats.recorded.push(entry.preset_id.clone());
+        }
+    }
+    Ok(stats)
+}
+
+/// Load the manifest named by [`WRAPPER_IMAGE_MANIFEST_ENV`] (if set) and
+/// reconcile it. Returns `Ok(None)` when the env var is unset — the controller
+/// then leaves wrapper digests unpopulated and strict resolution stays
+/// fail-closed.
+pub async fn reconcile_wrapper_catalog_from_env(
+    db: &Database,
+) -> Result<Option<WrapperCatalogReconcileStats>, WrapperCatalogError> {
+    let Some(path) = std::env::var_os(WRAPPER_IMAGE_MANIFEST_ENV) else {
+        return Ok(None);
+    };
+    let manifest = load_wrapper_image_manifest(Path::new(&path))?;
+    let stats = reconcile_wrapper_catalog(db, &manifest).await?;
+    tracing::info!(
+        recorded = stats.recorded.len(),
+        unknown = stats.unknown_presets.len(),
+        "wrapper_catalog: reconciled catalog wrapper image digests"
+    );
+    Ok(Some(stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_parses_from_build_output() {
+        let json = r#"{"entries":[
+            {"preset_id":"preset-redis-7","wrapper_image":"ghcr.io/djinnos/djinn-redis-wrapper","image_digest":"sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}
+        ]}"#;
+        let manifest = parse_wrapper_image_manifest(json).expect("parse");
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].preset_id, "preset-redis-7");
+    }
+
+    #[tokio::test]
+    async fn reconcile_records_real_digests_and_reports_unknown() {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        let digest = "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let manifest = WrapperImageManifest {
+            entries: vec![
+                WrapperImageEntry {
+                    preset_id: "preset-redis-7".into(),
+                    wrapper_image: "ghcr.io/djinnos/djinn-redis-wrapper".into(),
+                    image_digest: digest.into(),
+                },
+                WrapperImageEntry {
+                    preset_id: "preset-does-not-exist".into(),
+                    wrapper_image: "ghcr.io/djinnos/other".into(),
+                    image_digest: digest.into(),
+                },
+            ],
+        };
+        let stats = reconcile_wrapper_catalog(&db, &manifest).await.unwrap();
+        assert_eq!(stats.recorded, vec!["preset-redis-7"]);
+        assert_eq!(stats.unknown_presets, vec!["preset-does-not-exist"]);
+
+        let redis = ServicePresetRepository::new(db.clone())
+            .get("preset-redis-7")
+            .await
+            .unwrap()
+            .expect("preset");
+        assert_eq!(redis.image_digest.as_deref(), Some(digest));
+        assert_eq!(
+            redis.wrapper_image.as_deref(),
+            Some("ghcr.io/djinnos/djinn-redis-wrapper")
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_rejects_a_fabricated_digest() {
+        let db = Database::open_in_memory().unwrap();
+        db.ensure_initialized().await.unwrap();
+        let manifest = WrapperImageManifest {
+            entries: vec![WrapperImageEntry {
+                preset_id: "preset-redis-7".into(),
+                wrapper_image: "ghcr.io/djinnos/djinn-redis-wrapper".into(),
+                image_digest: "not-a-digest".into(),
+            }],
+        };
+        assert!(matches!(
+            reconcile_wrapper_catalog(&db, &manifest).await,
+            Err(WrapperCatalogError::Record { .. })
+        ));
+    }
+}

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -22,7 +22,8 @@ use djinn_supervisor::cargo_target_run_dir;
 
 use crate::config::KubernetesConfig;
 use crate::sidecar::{
-    BackingServiceSpec, sidecar_conn_env, sidecar_container, sidecar_dshm_volume,
+    BackingServiceSpec, control_volume, control_volume_mount, sidecar_conn_env, sidecar_container,
+    sidecar_dshm_volume,
 };
 
 /// Label key for the task-run id (Djinn's primary correlator).
@@ -229,6 +230,37 @@ pub fn build_task_run_job(
     let mut worker_env = build_task_run_env(config, &task_run_id_str, project_id, policy);
     worker_env.extend(effective_services.iter().flat_map(sidecar_conn_env));
 
+    // The private control emptyDir is added only when a wrapper sidecar is
+    // injected, and mounted only into the worker and the wrapper sidecars — never
+    // a canonical command container or an unrelated container.
+    let any_wrapper = effective_services.iter().any(|service| service.is_wrapper);
+
+    let mut worker_volume_mounts = vec![
+        volume_mount(VOLUME_SPEC, SPEC_MOUNT_DIR, Some(true)),
+        volume_mount(VOLUME_AUTH_TOKEN, TOKEN_MOUNT_DIR, Some(true)),
+        // Mirror PVC: mounted RW for normal workers (push task_branch
+        // before delegating open_pr) but RO for evidence-spike runs
+        // where write access to the host mirror is a safety violation.
+        volume_mount(VOLUME_MIRROR, MIRROR_MOUNT_DIR, Some(mirror_read_only)),
+        // Cache PVC: default mutable for normal workers (cargo builds write
+        // to private per-run target dirs under /cache).  For evidence-spike
+        // runs, explicitly read-only — no build artifacts should persist.
+        // The None (non-evidence) path preserves the original manifest shape.
+        volume_mount(
+            VOLUME_CACHE,
+            CACHE_MOUNT_DIR,
+            if is_evidence_spike { Some(true) } else { None },
+        ),
+        // Workspace emptyDir: always mutable.  Ephemeral per-Pod
+        // storage — dies with the Pod.  See the `mirror_read_only`
+        // comment above for why this narrow exception is safe.
+        volume_mount(VOLUME_WORKSPACE, WORKSPACE_MOUNT_DIR, None),
+        crate::env_config::env_config_volume_mount(),
+    ];
+    if any_wrapper {
+        worker_volume_mounts.push(control_volume_mount());
+    }
+
     let container = Container {
         name: "worker".to_string(),
         image: Some(project_image_tag.to_string()),
@@ -245,28 +277,7 @@ pub fn build_task_run_job(
             "task-run".to_string(),
         ]),
         env: Some(worker_env),
-        volume_mounts: Some(vec![
-            volume_mount(VOLUME_SPEC, SPEC_MOUNT_DIR, Some(true)),
-            volume_mount(VOLUME_AUTH_TOKEN, TOKEN_MOUNT_DIR, Some(true)),
-            // Mirror PVC: mounted RW for normal workers (push task_branch
-            // before delegating open_pr) but RO for evidence-spike runs
-            // where write access to the host mirror is a safety violation.
-            volume_mount(VOLUME_MIRROR, MIRROR_MOUNT_DIR, Some(mirror_read_only)),
-            // Cache PVC: default mutable for normal workers (cargo builds write
-            // to private per-run target dirs under /cache).  For evidence-spike
-            // runs, explicitly read-only — no build artifacts should persist.
-            // The None (non-evidence) path preserves the original manifest shape.
-            volume_mount(
-                VOLUME_CACHE,
-                CACHE_MOUNT_DIR,
-                if is_evidence_spike { Some(true) } else { None },
-            ),
-            // Workspace emptyDir: always mutable.  Ephemeral per-Pod
-            // storage — dies with the Pod.  See the `mirror_read_only`
-            // comment above for why this narrow exception is safe.
-            volume_mount(VOLUME_WORKSPACE, WORKSPACE_MOUNT_DIR, None),
-            crate::env_config::env_config_volume_mount(),
-        ]),
+        volume_mounts: Some(worker_volume_mounts),
         resources: Some(ResourceRequirements {
             requests: Some(BTreeMap::from([
                 ("cpu".to_string(), Quantity(config.cpu_request.clone())),
@@ -390,6 +401,11 @@ pub fn build_task_run_job(
     // when `is_evidence_spike` is true, so this block is a no-op.
     if !effective_services.is_empty() {
         volumes.push(sidecar_dshm_volume());
+    }
+    // One private control emptyDir, shared only by the worker and the wrapper
+    // sidecars (whose mounts are added in `sidecar_container`).
+    if any_wrapper {
+        volumes.push(control_volume());
     }
 
     // Each declared backing service becomes a native sidecar (initContainer +
@@ -882,6 +898,202 @@ fn volume_mount(name: &str, mount_path: &str, read_only: Option<bool>) -> Volume
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- ij6g catalog wrapper manifest tests --------------------------------
+
+    /// A digest-pinned wrapper sidecar spec for one service type.
+    fn wrapper_spec(service_type: &str, port: i32, preset_id: &str) -> BackingServiceSpec {
+        let socket = crate::sidecar::control_socket_file_name(preset_id);
+        BackingServiceSpec {
+            service_type: service_type.into(),
+            image: format!(
+                "ghcr.io/djinnos/djinn-{service_type}-wrapper@sha256:\
+                 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ),
+            is_wrapper: true,
+            control_socket_name: socket,
+            wrapper_env: vec![("CATALOG_TEST_ENV".into(), "value".into())],
+            port,
+            env: Vec::new(),
+            cpu_request: "100m".into(),
+            memory_request: "256Mi".into(),
+            cpu_limit: "500m".into(),
+            memory_limit: "512Mi".into(),
+            conn_template: format!("proto://{{host}}:{{port}}/{service_type}"),
+            conn_env_var: "SVC_URL".into(),
+        }
+    }
+
+    fn all_three_wrappers() -> Vec<BackingServiceSpec> {
+        vec![
+            wrapper_spec("postgres", 5432, "preset-postgres-18"),
+            wrapper_spec("redis", 6379, "preset-redis-7"),
+            wrapper_spec("rabbitmq", 5672, "preset-rabbitmq-4"),
+        ]
+    }
+
+    fn wrapper_job() -> Job {
+        build_task_run_job(
+            &KubernetesConfig::for_testing(),
+            &Uuid::now_v7(),
+            "proj-wrap",
+            "djinn-taskrun-wrap",
+            "registry.example/djinn-project:abc123",
+            &all_three_wrappers(),
+            None,
+            false,
+        )
+    }
+
+    fn pod_of(job: &Job) -> &k8s_openapi::api::core::v1::PodSpec {
+        job.spec
+            .as_ref()
+            .and_then(|s| s.template.spec.as_ref())
+            .expect("pod spec set")
+    }
+
+    fn mounts_control(container: &Container) -> bool {
+        container.volume_mounts.as_ref().is_some_and(|mounts| {
+            mounts
+                .iter()
+                .any(|m| m.name == crate::sidecar::CONTROL_VOLUME)
+        })
+    }
+
+    /// AC3/AC4: all three wrapper sidecars render with the digest-pinned wrapper
+    /// image, the CATALOG_CONTROL_SOCKET env pointing at their per-preset socket,
+    /// and the private control mount; and the worker also mounts the control
+    /// volume so its adapter can reach the sockets.
+    #[test]
+    fn wrapper_sidecars_render_control_socket_and_mounts_for_all_three_types() {
+        let job = wrapper_job();
+        let pod = pod_of(&job);
+        let inits = pod.init_containers.as_ref().expect("init containers set");
+        assert_eq!(inits.len(), 3, "one wrapper sidecar per service type");
+
+        for (svc, port, socket) in [
+            ("postgres", 5432, "preset-postgres-18.sock"),
+            ("redis", 6379, "preset-redis-7.sock"),
+            ("rabbitmq", 5672, "preset-rabbitmq-4.sock"),
+        ] {
+            let c = inits
+                .iter()
+                .find(|c| c.name == format!("svc-{svc}"))
+                .unwrap_or_else(|| panic!("sidecar for {svc}"));
+            // Digest-pinned wrapper image, not the stock image.
+            let image = c.image.as_deref().unwrap();
+            assert!(
+                image.starts_with(&format!("ghcr.io/djinnos/djinn-{svc}-wrapper@sha256:")),
+                "{svc} sidecar must run the digest-pinned wrapper image, got {image}"
+            );
+            let _ = port;
+            // The sidecar binds the exact socket the worker adapter connects to.
+            let env = c.env.as_ref().unwrap();
+            let socket_env = env
+                .iter()
+                .find(|e| e.name == crate::sidecar::CONTROL_SOCKET_ENV)
+                .unwrap_or_else(|| panic!("{svc} CATALOG_CONTROL_SOCKET env"));
+            assert_eq!(
+                socket_env.value.as_deref(),
+                Some(format!("/var/run/djinn/service-control/{socket}").as_str())
+            );
+            // The wrapper admin/env-name wiring is present.
+            assert!(env.iter().any(|e| e.name == "CATALOG_TEST_ENV"));
+            // The private control mount is present on every wrapper sidecar.
+            assert!(
+                mounts_control(c),
+                "{svc} sidecar must mount the control volume"
+            );
+        }
+
+        // The worker mounts the control volume too.
+        assert!(
+            mounts_control(&pod.containers[0]),
+            "worker must mount the control volume"
+        );
+    }
+
+    /// AC3/AC4: exactly one private control emptyDir exists, and it is mounted
+    /// ONLY by the worker and the wrapper sidecars — never any other container.
+    #[test]
+    fn control_volume_is_private_to_worker_and_wrapper_sidecars() {
+        let job = wrapper_job();
+        let pod = pod_of(&job);
+        let volumes = pod.volumes.as_ref().expect("volumes set");
+        let control_volumes = volumes
+            .iter()
+            .filter(|v| v.name == crate::sidecar::CONTROL_VOLUME)
+            .count();
+        assert_eq!(control_volumes, 1, "exactly one private control emptyDir");
+        assert!(
+            volumes
+                .iter()
+                .find(|v| v.name == crate::sidecar::CONTROL_VOLUME)
+                .and_then(|v| v.empty_dir.as_ref())
+                .is_some(),
+            "control volume must be an emptyDir"
+        );
+
+        // Count every container (worker + sidecars) that mounts the control
+        // volume. It must be exactly the worker plus the three wrapper sidecars.
+        let mut mounters = 0;
+        for c in pod
+            .init_containers
+            .iter()
+            .flatten()
+            .chain(pod.containers.iter())
+        {
+            if mounts_control(c) {
+                mounters += 1;
+            }
+        }
+        assert_eq!(mounters, 4, "worker + 3 wrapper sidecars mount control");
+    }
+
+    /// AC3/AC4: a legacy non-wrapper sidecar mounts no control volume, and when
+    /// no wrapper is injected the control emptyDir is absent entirely (manifest
+    /// stays byte-compatible with the pre-wrapper shape).
+    #[test]
+    fn non_wrapper_service_adds_no_control_volume() {
+        let mut legacy = wrapper_spec("postgres", 5432, "preset-postgres-18");
+        legacy.is_wrapper = false;
+        legacy.image = "postgres:18-alpine".into();
+        legacy.wrapper_env = Vec::new();
+        let job = build_task_run_job(
+            &KubernetesConfig::for_testing(),
+            &Uuid::now_v7(),
+            "proj-legacy",
+            "djinn-taskrun-legacy",
+            "registry.example/djinn-project:abc123",
+            &[legacy],
+            None,
+            false,
+        );
+        let pod = pod_of(&job);
+        assert!(
+            pod.volumes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .all(|v| v.name != crate::sidecar::CONTROL_VOLUME),
+            "no control volume without a wrapper sidecar"
+        );
+        assert!(
+            !mounts_control(&pod.containers[0]),
+            "worker must not mount a control volume when no wrapper is injected"
+        );
+        let sidecar = &pod.init_containers.as_ref().unwrap()[0];
+        assert!(!mounts_control(sidecar));
+        assert!(
+            sidecar
+                .env
+                .as_ref()
+                .unwrap()
+                .iter()
+                .all(|e| e.name != crate::sidecar::CONTROL_SOCKET_ENV),
+            "legacy sidecar must not carry the control socket env"
+        );
+    }
 
     fn inventory_job(name: Option<&str>, label: Option<&str>) -> Job {
         let mut labels = BTreeMap::new();
@@ -2013,6 +2225,9 @@ mod tests {
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),
@@ -2340,6 +2555,9 @@ mod tests {
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),
@@ -2407,6 +2625,9 @@ mod tests {
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),
@@ -2492,6 +2713,9 @@ mod tests {
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),
@@ -2615,6 +2839,9 @@ mod tests {
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),
@@ -2677,6 +2904,9 @@ mod tests {
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),
@@ -2739,6 +2969,9 @@ mod tests {
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),

--- a/server/crates/djinn-k8s/src/sidecar.rs
+++ b/server/crates/djinn-k8s/src/sidecar.rs
@@ -22,6 +22,7 @@
 //! a project's image (used by the task-run dispatch paths).
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
 
 use k8s_openapi::api::core::v1::{
     Container, ContainerPort, EmptyDirVolumeSource, EnvVar, Probe, ResourceRequirements,
@@ -43,12 +44,122 @@ use crate::config::KubernetesConfig;
 /// only when at least one service is injected.
 pub const SIDECAR_DSHM_VOLUME: &str = "svc-dshm";
 
+/// Pod volume name for the private service-control `emptyDir`. Mounted only into
+/// the worker container and the wrapper sidecars — never a canonical command
+/// container. The wrapper sidecars bind their protocol-v1 control sockets here
+/// and the worker adapter connects to them.
+pub const CONTROL_VOLUME: &str = "svc-control";
+
+/// In-Pod mount path of the private service-control `emptyDir`. Each wrapper
+/// sidecar binds `<CONTROL_SOCKET_DIR>/<socket>` and the worker adapter connects
+/// to the identical path. This directory is deliberately absent from every
+/// canonical-command Landlock grant, so verification commands cannot reach it.
+pub const CONTROL_SOCKET_DIR: &str = "/var/run/djinn/service-control";
+
+/// Environment variable a wrapper sidecar reads to learn where to bind its
+/// control socket. Consumed by the `djinn-*-wrapper` binaries.
+pub const CONTROL_SOCKET_ENV: &str = "CATALOG_CONTROL_SOCKET";
+
+/// Deterministic, sanitized socket file name for a preset. Every byte that is
+/// not `[a-z0-9_-]` collapses to `_`; the result is lowercased and bounded so a
+/// preset id can never escape the control directory or produce a path-unsafe
+/// name. Distinct presets whose ids sanitize to the same stem collide on
+/// purpose — strict resolution rejects that collision rather than silently
+/// serving two services from one socket.
+pub fn control_socket_file_name(preset_id: &str) -> String {
+    let mut stem: String = preset_id
+        .chars()
+        .map(|c| {
+            let c = c.to_ascii_lowercase();
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    stem.truncate(64);
+    if stem.is_empty() {
+        stem.push('_');
+    }
+    format!("{stem}.sock")
+}
+
+/// Absolute in-Pod path of a preset's control socket. The worker adapter and
+/// the wrapper sidecar derive the identical path from this function so a client
+/// socket always names the socket its wrapper server binds.
+pub fn control_socket_path(preset_id: &str) -> PathBuf {
+    PathBuf::from(CONTROL_SOCKET_DIR).join(control_socket_file_name(preset_id))
+}
+
+/// Absolute in-Pod path for an already-sanitized socket file name.
+pub fn control_socket_path_from_name(socket_name: &str) -> PathBuf {
+    PathBuf::from(CONTROL_SOCKET_DIR).join(socket_name)
+}
+
+/// The private control `emptyDir` volume. Added to the Pod only when at least
+/// one wrapper sidecar is injected.
+pub fn control_volume() -> Volume {
+    Volume {
+        name: CONTROL_VOLUME.to_string(),
+        empty_dir: Some(EmptyDirVolumeSource::default()),
+        ..Volume::default()
+    }
+}
+
+/// The control-socket mount shared by the worker and every wrapper sidecar.
+pub fn control_volume_mount() -> VolumeMount {
+    VolumeMount {
+        name: CONTROL_VOLUME.to_string(),
+        mount_path: CONTROL_SOCKET_DIR.to_string(),
+        ..VolumeMount::default()
+    }
+}
+
+/// The admin-URL environment variable each wrapper binary reads to reach its
+/// co-located stock daemon on Pod loopback. Returns `None` for a service type
+/// that has no catalog wrapper.
+fn wrapper_admin_env_var(service_type: &str) -> Option<&'static str> {
+    match service_type {
+        "postgres" => Some("POSTGRES_WRAPPER_ADMIN_URL"),
+        "redis" => Some("REDIS_WRAPPER_ADMIN_URL"),
+        "rabbitmq" => Some("RABBITMQ_WRAPPER_AMQP_URL"),
+        _ => None,
+    }
+}
+
+/// The exported-environment-names variable each wrapper binary reads to learn
+/// which env names a lease URL is returned under. Returns `None` for a service
+/// type that has no catalog wrapper.
+fn wrapper_env_names_var(service_type: &str) -> Option<&'static str> {
+    match service_type {
+        "postgres" => Some("CATALOG_POSTGRES_ENV_NAMES"),
+        "redis" => Some("CATALOG_REDIS_ENV_NAMES"),
+        "rabbitmq" => Some("CATALOG_RABBITMQ_ENV_NAMES"),
+        _ => None,
+    }
+}
+
 /// Everything the sidecar builder needs from a `service_presets` row. The
 /// caller maps it so this module never reaches into DB row shape.
 #[derive(Clone, Debug)]
 pub struct BackingServiceSpec {
     pub service_type: String,
+    /// The container image the sidecar runs. When a wrapper artifact is
+    /// resolved this is the digest-pinned wrapper reference
+    /// (`{wrapper_image}@{digest}`); legacy presets without a wrapper keep the
+    /// stock service image for dispatch compatibility.
     pub image: String,
+    /// `true` when the sidecar runs a catalog wrapper (stock daemon + protocol
+    /// control server). Drives the private control mount, the socket env, and
+    /// the wrapper admin env. `false` keeps the pre-wrapper dispatch shape.
+    pub is_wrapper: bool,
+    /// Sanitized per-preset control socket file name (see
+    /// [`control_socket_file_name`]).
+    pub control_socket_name: String,
+    /// Extra environment the wrapper binary needs (admin URL + exported env
+    /// names). Empty for non-wrapper sidecars.
+    pub wrapper_env: Vec<(String, String)>,
     pub port: i32,
     pub env: Vec<(String, String)>,
     pub cpu_request: String,
@@ -114,7 +225,8 @@ fn strict_catalog_from_presets(
     // this validation boundary so every caller receives the same identity
     // material even when rows were loaded in a different order.
     rows.sort_by(|left, right| left.0.cmp(&right.0));
-    let (mut ids, mut types, mut ports, mut env_names) = (
+    let (mut ids, mut types, mut ports, mut env_names, mut socket_names) = (
+        BTreeSet::new(),
         BTreeSet::new(),
         BTreeSet::new(),
         BTreeSet::new(),
@@ -127,6 +239,20 @@ fn strict_catalog_from_presets(
                 kind: "preset ID",
                 value: preset_id,
             });
+        }
+        // A wrapper artifact reference is mandatory: a bare stock image has no
+        // protocol control server, so it can never satisfy strict verification.
+        let wrapper_image = p.wrapper_image.clone().filter(|w| !w.trim().is_empty());
+        let wrapper_image = match wrapper_image {
+            Some(w) => w,
+            None => {
+                return Err(CatalogServiceResolutionError::StockImageWithoutWrapper { preset_id });
+            }
+        };
+        // The wrapper reference must be a plain repository ref; the digest is the
+        // sole immutable pin. A digest-suffixed (mutable/ambiguous) ref fails.
+        if wrapper_image.contains('@') {
+            return Err(CatalogServiceResolutionError::MutableWrapperReference { preset_id });
         }
         let digest = p
             .image_digest
@@ -184,13 +310,25 @@ fn strict_catalog_from_presets(
                 });
             }
         }
-        let effective = serde_json::json!({"env": serde_json::from_str::<serde_json::Value>(&p.env).unwrap(), "resources": serde_json::from_str::<serde_json::Value>(&p.resources).unwrap(), "conn_template": p.conn_template, "port": p.port, "protocol": revision});
+        // The socket the worker adapter connects to is derived deterministically
+        // from the preset id. Two presets that sanitize to the same socket name
+        // would share one control socket ambiguously — reject that collision.
+        let control_socket_name = control_socket_file_name(&preset_id);
+        if !socket_names.insert(control_socket_name.clone()) {
+            return Err(CatalogServiceResolutionError::Duplicate {
+                kind: "control socket identity",
+                value: control_socket_name,
+            });
+        }
+        let effective = serde_json::json!({"env": serde_json::from_str::<serde_json::Value>(&p.env).unwrap(), "resources": serde_json::from_str::<serde_json::Value>(&p.resources).unwrap(), "conn_template": p.conn_template, "port": p.port, "protocol": revision, "wrapper_image": wrapper_image});
         result.push(ResolvedCatalogService {
             preset_id: preset_id.clone(),
             service_type: p.service_type,
             image_reference: p.image,
+            wrapper_reference: format!("{wrapper_image}@{digest}"),
             image_digest: digest,
             port: p.port,
+            control_socket_name,
             exported_environment_names: names,
             verification_protocol_revision: revision as u32,
             effective_configuration_digest: format!(
@@ -207,9 +345,16 @@ fn strict_catalog_from_presets(
 pub struct ResolvedCatalogService {
     pub preset_id: String,
     pub service_type: String,
+    /// The stock service image reference (retained for identity/observability).
     pub image_reference: String,
+    /// The digest-pinned wrapper artifact reference the sidecar actually runs:
+    /// `{wrapper_image}@{image_digest}`.
+    pub wrapper_reference: String,
     pub image_digest: String,
     pub port: i32,
+    /// Deterministic sanitized control socket file name the worker adapter
+    /// connects to and the wrapper sidecar binds.
+    pub control_socket_name: String,
     pub exported_environment_names: Vec<String>,
     pub verification_protocol_revision: u32,
     pub effective_configuration_digest: String,
@@ -227,6 +372,10 @@ pub enum CatalogServiceResolutionError {
     MissingPreset { preset_id: String },
     #[error("service preset {preset_id} has a missing or malformed immutable image digest")]
     MalformedServiceDigest { preset_id: String },
+    #[error("service preset {preset_id} has no catalog wrapper image (stock image only)")]
+    StockImageWithoutWrapper { preset_id: String },
+    #[error("service preset {preset_id} wrapper reference is mutable (carries a digest suffix)")]
+    MutableWrapperReference { preset_id: String },
     #[error("duplicate {kind}: {value}")]
     Duplicate { kind: &'static str, value: String },
     #[error("service preset {preset_id} has malformed configuration")]
@@ -319,7 +468,7 @@ pub fn sidecar_conn_env(spec: &BackingServiceSpec) -> Vec<EnvVar> {
 /// appends it to the Pod's `initContainers` (NOT `containers`); the
 /// `restartPolicy: Always` is what makes the kubelet treat it as a sidecar.
 pub fn sidecar_container(config: &KubernetesConfig, spec: &BackingServiceSpec) -> Container {
-    let env: Vec<EnvVar> = spec
+    let mut env: Vec<EnvVar> = spec
         .env
         .iter()
         .map(|(k, v)| EnvVar {
@@ -328,6 +477,33 @@ pub fn sidecar_container(config: &KubernetesConfig, spec: &BackingServiceSpec) -
             ..EnvVar::default()
         })
         .collect();
+    // A wrapper sidecar additionally learns where to bind its control socket and
+    // how to reach its co-located stock daemon (wrapper_env).
+    if spec.is_wrapper {
+        env.push(EnvVar {
+            name: CONTROL_SOCKET_ENV.to_string(),
+            value: Some(
+                control_socket_path_from_name(&spec.control_socket_name)
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            ..EnvVar::default()
+        });
+        env.extend(spec.wrapper_env.iter().map(|(k, v)| EnvVar {
+            name: k.clone(),
+            value: Some(v.clone()),
+            ..EnvVar::default()
+        }));
+    }
+
+    let mut volume_mounts = vec![VolumeMount {
+        name: SIDECAR_DSHM_VOLUME.to_string(),
+        mount_path: "/dev/shm".to_string(),
+        ..VolumeMount::default()
+    }];
+    if spec.is_wrapper {
+        volume_mounts.push(control_volume_mount());
+    }
 
     let probe = || Probe {
         tcp_socket: Some(TCPSocketAction {
@@ -354,11 +530,7 @@ pub fn sidecar_container(config: &KubernetesConfig, spec: &BackingServiceSpec) -
             container_port: spec.port,
             ..ContainerPort::default()
         }]),
-        volume_mounts: Some(vec![VolumeMount {
-            name: SIDECAR_DSHM_VOLUME.to_string(),
-            mount_path: "/dev/shm".to_string(),
-            ..VolumeMount::default()
-        }]),
+        volume_mounts: Some(volume_mounts),
         // The worker container does not start until this startup probe passes —
         // so the service is accepting connections before any test runs.
         startup_probe: Some(probe()),
@@ -430,15 +602,36 @@ fn append_preset_resolution(
                 port: p.port,
                 conn_env_var: p.conn_env_var.clone(),
             });
+            // A preset with a wrapper repository AND a valid immutable digest
+            // runs the digest-pinned wrapper artifact (stock daemon + control
+            // server). Legacy presets missing either keep the stock image so
+            // ordinary dispatch stays byte-compatible with the pre-wrapper shape.
+            let wrapper = p
+                .wrapper_image
+                .as_deref()
+                .map(str::trim)
+                .filter(|w| !w.is_empty())
+                .zip(p.image_digest.as_deref().filter(|d| valid_digest(d)));
+            let (is_wrapper, image, wrapper_env) = match wrapper {
+                Some((wrapper_image, digest)) => {
+                    let mut wrapper_env = Vec::new();
+                    let admin = render_local_conn(&p.conn_template, p.port);
+                    if let Some(name) = wrapper_admin_env_var(&p.service_type) {
+                        wrapper_env.push((name.to_string(), admin));
+                    }
+                    if let Some(name) = wrapper_env_names_var(&p.service_type) {
+                        wrapper_env.push((name.to_string(), p.conn_env_var.clone()));
+                    }
+                    (true, format!("{wrapper_image}@{digest}"), wrapper_env)
+                }
+                None => (false, p.image.clone(), Vec::new()),
+            };
             specs.push(BackingServiceSpec {
+                control_socket_name: control_socket_file_name(preset_id),
+                is_wrapper,
+                wrapper_env,
                 service_type: p.service_type,
-                // Keep ordinary dispatch compatible with legacy rows, while
-                // rendering every catalog-owned valid digest immutably.
-                image: p
-                    .image_digest
-                    .as_deref()
-                    .filter(|d| valid_digest(d))
-                    .map_or(p.image.clone(), |digest| format!("{}@{digest}", p.image)),
+                image,
                 port: p.port,
                 env: parse_env(&p.env),
                 cpu_request,
@@ -582,6 +775,9 @@ mod tests {
         BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
             port: 5432,
             env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
             cpu_request: "100m".into(),
@@ -599,6 +795,7 @@ mod tests {
             name: "Postgres 18".into(),
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
+            wrapper_image: Some("ghcr.io/djinnos/djinn-postgres-wrapper".into()),
             image_digest: Some("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into()),
             verification_protocol_revision: Some(1),
             port: 5432,
@@ -654,7 +851,7 @@ mod tests {
     }
 
     #[test]
-    fn catalog_digest_pins_dispatch_sidecar_image() {
+    fn catalog_wrapper_digest_pins_dispatch_sidecar_image() {
         let mut services = Vec::new();
         append_preset_resolution(
             "project",
@@ -664,9 +861,102 @@ mod tests {
             &mut Vec::new(),
             &mut Vec::new(),
         );
+        // A wrapper preset renders the digest-pinned wrapper artifact, not the
+        // stock image, and is marked as a wrapper so job.rs wires the private
+        // control mount + socket env.
         assert_eq!(
             services[0].image,
-            "postgres:18-alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            "ghcr.io/djinnos/djinn-postgres-wrapper@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+        assert!(services[0].is_wrapper);
+        assert_eq!(services[0].control_socket_name, "preset-postgres-18.sock");
+        // The wrapper admin URL + exported env names are wired for the binary.
+        assert!(
+            services[0]
+                .wrapper_env
+                .iter()
+                .any(|(k, v)| k == "POSTGRES_WRAPPER_ADMIN_URL"
+                    && v == "postgres://postgres:postgres@127.0.0.1:5432/app_test")
+        );
+        assert!(services[0].wrapper_env.iter().any(
+            |(k, v)| k == "CATALOG_POSTGRES_ENV_NAMES" && v == "DATABASE_URL,TEST_POSTGRES_URL"
+        ));
+    }
+
+    /// A legacy preset with no wrapper image stays dispatch-compatible: the
+    /// sidecar runs the stock image and is not marked as a wrapper.
+    #[test]
+    fn legacy_preset_without_wrapper_runs_stock_image() {
+        let mut legacy = preset();
+        legacy.wrapper_image = None;
+        legacy.image_digest = None;
+        let mut services = Vec::new();
+        append_preset_resolution(
+            "project",
+            "preset-postgres-18",
+            Ok(Some(legacy)),
+            &mut services,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        );
+        assert_eq!(services[0].image, "postgres:18-alpine");
+        assert!(!services[0].is_wrapper);
+        assert!(services[0].wrapper_env.is_empty());
+    }
+
+    /// AC2: strict resolution rejects a preset that has no catalog wrapper
+    /// image, a mutable (digest-suffixed) wrapper reference, and two presets
+    /// whose ids sanitize to a colliding control socket identity.
+    #[test]
+    fn strict_catalog_rejects_wrapper_and_socket_faults() {
+        let mut no_wrapper = preset();
+        no_wrapper.wrapper_image = None;
+        assert!(matches!(
+            strict_catalog_from_presets(vec![("postgres-a".into(), no_wrapper)]),
+            Err(CatalogServiceResolutionError::StockImageWithoutWrapper { .. })
+        ));
+
+        let mut mutable_wrapper = preset();
+        mutable_wrapper.wrapper_image =
+            Some("ghcr.io/djinnos/djinn-postgres-wrapper@sha256:dead".into());
+        assert!(matches!(
+            strict_catalog_from_presets(vec![("postgres-a".into(), mutable_wrapper)]),
+            Err(CatalogServiceResolutionError::MutableWrapperReference { .. })
+        ));
+
+        // "svc/a" and "svc:a" both sanitize to "svc_a.sock".
+        let mut left = preset();
+        left.service_type = "redis".into();
+        left.port = 6390;
+        left.conn_env_var = "LEFT_URL".into();
+        let mut right = preset();
+        right.service_type = "rabbitmq".into();
+        right.port = 6391;
+        right.conn_env_var = "RIGHT_URL".into();
+        assert!(matches!(
+            strict_catalog_from_presets(vec![("svc/a".into(), left), ("svc:a".into(), right)]),
+            Err(CatalogServiceResolutionError::Duplicate {
+                kind: "control socket identity",
+                ..
+            })
+        ));
+    }
+
+    /// AC2: a resolved wrapper service names the exact socket the worker adapter
+    /// connects to, and the pinned wrapper reference the sidecar runs.
+    #[test]
+    fn strict_resolution_exposes_wrapper_reference_and_socket() {
+        let resolved =
+            strict_catalog_from_presets(vec![("preset-postgres-18".into(), preset())]).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved[0].wrapper_reference,
+            "ghcr.io/djinnos/djinn-postgres-wrapper@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+        assert_eq!(resolved[0].control_socket_name, "preset-postgres-18.sock");
+        assert_eq!(
+            control_socket_path("preset-postgres-18"),
+            std::path::Path::new("/var/run/djinn/service-control/preset-postgres-18.sock")
         );
     }
 

--- a/server/crates/djinn-sandbox/tests/fake_wrapper.rs
+++ b/server/crates/djinn-sandbox/tests/fake_wrapper.rs
@@ -1,0 +1,138 @@
+//! ij6g: fake protocol-v1 wrapper integration test.
+//!
+//! A fixture wrapper server binds a real Unix control socket at the exact path
+//! the worker adapter is told to use and speaks protocol v1. This proves the
+//! production `UnixCatalogServiceProvisioner` client connects to the socket a
+//! wrapper server actually creates, drives the full create→ready→delete
+//! lifecycle in order, tears leases down in reverse, and fails closed on a
+//! missing socket or a mismatched protocol revision.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use djinn_sandbox::service_provisioning::{
+    CatalogServiceProvisioner, ServiceProvisioningCode, UnixCatalogServiceProvisioner,
+    create_ready_leases, delete_leases,
+};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+/// Records the operation of every request that reaches the socket.
+type Journal = Arc<Mutex<Vec<String>>>;
+
+/// A minimal protocol-v1 wrapper: creates the socket and answers create/ready/
+/// delete. `revision` lets a test force a protocol mismatch. Loops until aborted.
+fn spawn_fake_wrapper(
+    socket: &Path,
+    revision: u32,
+    env_name: &'static str,
+    journal: Journal,
+) -> tokio::task::JoinHandle<()> {
+    let listener = UnixListener::bind(socket).expect("bind fake wrapper socket");
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let journal = journal.clone();
+            tokio::spawn(async move {
+                handle(stream, revision, env_name, journal).await;
+            });
+        }
+    })
+}
+
+async fn handle(stream: UnixStream, revision: u32, env_name: &'static str, journal: Journal) {
+    let (read, mut write) = stream.into_split();
+    let mut line = String::new();
+    if BufReader::new(read).read_line(&mut line).await.is_err() {
+        return;
+    }
+    let request: serde_json::Value = match serde_json::from_str(&line) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+    let operation = request["operation"].as_str().unwrap_or_default().to_owned();
+    journal.lock().unwrap().push(operation.clone());
+    let response = match operation.as_str() {
+        "create_fresh" => serde_json::json!({
+            "status": "created",
+            "revision": revision,
+            "lease_id": "lease_abc",
+            "environment": { env_name: "proto://127.0.0.1:5432/lease" },
+        }),
+        "ready" => serde_json::json!({"status": "ready", "revision": revision}),
+        "delete" => serde_json::json!({"status": "deleted", "revision": revision}),
+        _ => serde_json::json!({"status": "error", "revision": revision, "code": "rejected"}),
+    };
+    let mut body = serde_json::to_vec(&response).unwrap();
+    body.push(b'\n');
+    let _ = write.write_all(&body).await;
+}
+
+#[tokio::test]
+async fn adapter_drives_full_lifecycle_against_a_real_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    // The adapter connects to the exact path we hand the provisioner — the same
+    // shape djinn-k8s renders (`<control-dir>/<preset>.sock`).
+    let socket = dir.path().join("preset-postgres-18.sock");
+    let journal: Journal = Arc::new(Mutex::new(Vec::new()));
+    let server = spawn_fake_wrapper(&socket, 1, "TEST_URL", journal.clone());
+
+    let provisioner: Arc<dyn CatalogServiceProvisioner> =
+        Arc::new(UnixCatalogServiceProvisioner::new(
+            "preset-postgres-18".into(),
+            socket.clone(),
+            vec!["TEST_URL".into()],
+        ));
+
+    let leases = create_ready_leases(std::slice::from_ref(&provisioner), "attempt-1")
+        .await
+        .expect("create + ready succeed against the fake wrapper");
+    assert_eq!(leases.len(), 1);
+    assert_eq!(
+        leases[0].1.environment["TEST_URL"],
+        "proto://127.0.0.1:5432/lease"
+    );
+
+    // Create is followed by readiness — the canonical order.
+    assert_eq!(*journal.lock().unwrap(), vec!["create_fresh", "ready"]);
+
+    delete_leases(&leases).await.expect("reverse teardown");
+    assert_eq!(
+        *journal.lock().unwrap(),
+        vec!["create_fresh", "ready", "delete"]
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn adapter_fails_closed_on_a_missing_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    let provisioner = UnixCatalogServiceProvisioner::new(
+        "preset-postgres-18".into(),
+        dir.path().join("never-bound.sock"),
+        vec!["TEST_URL".into()],
+    );
+    let error = provisioner.create("attempt").await.unwrap_err();
+    assert_eq!(error.code, ServiceProvisioningCode::Unavailable);
+}
+
+#[tokio::test]
+async fn adapter_fails_closed_on_protocol_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("preset-redis-7.sock");
+    let journal: Journal = Arc::new(Mutex::new(Vec::new()));
+    // The fake wrapper answers with revision 2 — an unsupported protocol.
+    let server = spawn_fake_wrapper(&socket, 2, "REDIS_URL", journal);
+    let provisioner = UnixCatalogServiceProvisioner::new(
+        "preset-redis-7".into(),
+        socket,
+        vec!["REDIS_URL".into()],
+    );
+    let error = provisioner.create("attempt").await.unwrap_err();
+    assert_eq!(error.code, ServiceProvisioningCode::ProtocolMismatch);
+    server.abort();
+}

--- a/server/docker/build-wrapper-images.sh
+++ b/server/docker/build-wrapper-images.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ij6g: build the three catalog wrapper images and record their REAL immutable
+# digests.
+#
+# Each image packages the stock service runtime plus the djinn protocol-v1
+# control server. The digest written to the output manifest is the digest
+# buildx reports for the pushed image — never a fabricated literal. The manifest
+# is consumed by the djinn-image-controller wrapper_catalog reconciler
+# (`reconcile_wrapper_catalog`) which records it into service_presets so strict
+# canonical verification resolves `{wrapper_image}@{digest}`.
+#
+# Usage:
+#   REGISTRY=ghcr.io/djinnos TAG=v0.6.130 ./server/docker/build-wrapper-images.sh
+#
+# Env:
+#   REGISTRY   registry/org prefix for the wrapper repositories (required)
+#   TAG        image tag to push (default: git short sha)
+#   MANIFEST   output manifest path (default: ./wrapper-image-manifest.json)
+#   PUSH       "1" to push (default 1); "0" builds locally without pushing/digest
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/../.." && pwd)
+
+REGISTRY=${REGISTRY:?set REGISTRY (e.g. ghcr.io/djinnos)}
+TAG=${TAG:-$(git -C "$REPO_ROOT" rev-parse --short HEAD)}
+MANIFEST=${MANIFEST:-"$REPO_ROOT/wrapper-image-manifest.json"}
+PUSH=${PUSH:-1}
+
+# preset_id : wrapper repository (matches migration 149 seed) : bin : dockerfile
+WRAPPERS="
+preset-postgres-18|djinn-postgres-wrapper|djinn-postgres-wrapper|djinn-postgres-wrapper.Dockerfile
+preset-redis-7|djinn-redis-wrapper|djinn-redis-wrapper|djinn-redis-wrapper.Dockerfile
+preset-rabbitmq-4|djinn-rabbitmq-wrapper|djinn-rabbitmq-wrapper|djinn-rabbitmq-wrapper.Dockerfile
+"
+
+echo ">> building catalog wrapper binaries"
+( cd "$REPO_ROOT/server" && cargo build --release --locked -p djinn-catalog-wrapper )
+
+entries=""
+for row in $WRAPPERS; do
+    [ -n "$row" ] || continue
+    preset_id=$(echo "$row" | cut -d'|' -f1)
+    repo_name=$(echo "$row" | cut -d'|' -f2)
+    bin=$(echo "$row" | cut -d'|' -f3)
+    dockerfile=$(echo "$row" | cut -d'|' -f4)
+    wrapper_image="$REGISTRY/$repo_name"
+    ref="$wrapper_image:$TAG"
+
+    echo ">> staging $bin"
+    cp "$REPO_ROOT/server/target/release/$bin" "$SCRIPT_DIR/$bin"
+
+    metafile=$(mktemp)
+    if [ "$PUSH" = "1" ]; then
+        echo ">> building + pushing $ref"
+        docker buildx build \
+            --file "$SCRIPT_DIR/$dockerfile" \
+            --tag "$ref" \
+            --push \
+            --metadata-file "$metafile" \
+            "$SCRIPT_DIR"
+        digest=$(grep -o '"containerimage.digest"[^,}]*' "$metafile" \
+            | grep -o 'sha256:[a-f0-9]\{64\}' || true)
+        if [ -z "$digest" ]; then
+            echo "ERROR: no digest reported for $ref" >&2
+            exit 1
+        fi
+        entries="$entries{\"preset_id\":\"$preset_id\",\"wrapper_image\":\"$wrapper_image\",\"image_digest\":\"$digest\"},"
+        echo "   $preset_id -> $wrapper_image@$digest"
+    else
+        echo ">> building (no push) $ref"
+        docker build --file "$SCRIPT_DIR/$dockerfile" --tag "$ref" "$SCRIPT_DIR"
+    fi
+    rm -f "$metafile" "$SCRIPT_DIR/$bin"
+done
+
+if [ "$PUSH" = "1" ]; then
+    printf '{"entries":[%s]}\n' "${entries%,}" > "$MANIFEST"
+    echo ">> wrote wrapper image manifest: $MANIFEST"
+fi

--- a/server/docker/catalog-wrapper/postgres-wrapper-entrypoint.sh
+++ b/server/docker/catalog-wrapper/postgres-wrapper-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# ij6g: catalog Postgres wrapper supervising entrypoint.
+#
+# Runs the stock Postgres daemon on Pod loopback via the official image
+# entrypoint, waits until it accepts connections, then execs the protocol-v1
+# control server. The control server binds the Unix socket named by
+# CATALOG_CONTROL_SOCKET and provisions fresh per-attempt tenants against
+# POSTGRES_WRAPPER_ADMIN_URL (both injected by the djinn sidecar wiring).
+set -eu
+
+: "${CATALOG_CONTROL_SOCKET:?missing CATALOG_CONTROL_SOCKET}"
+: "${POSTGRES_WRAPPER_ADMIN_URL:?missing POSTGRES_WRAPPER_ADMIN_URL}"
+
+docker-entrypoint.sh postgres &
+DAEMON_PID=$!
+
+# Bounded readiness wait so a wedged daemon fails the sidecar startup probe
+# rather than hanging forever.
+i=0
+until pg_isready -h 127.0.0.1 -p "${PGPORT:-5432}" -U "${POSTGRES_USER:-postgres}" >/dev/null 2>&1; do
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+        echo "catalog-wrapper: postgres daemon exited during startup" >&2
+        exit 1
+    fi
+    i=$((i + 1))
+    if [ "$i" -ge 120 ]; then
+        echo "catalog-wrapper: postgres daemon did not become ready" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+exec djinn-postgres-wrapper

--- a/server/docker/catalog-wrapper/rabbitmq-wrapper-entrypoint.sh
+++ b/server/docker/catalog-wrapper/rabbitmq-wrapper-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# ij6g: catalog RabbitMQ wrapper supervising entrypoint.
+#
+# Runs the stock RabbitMQ broker on Pod loopback, waits until it finishes
+# startup, then execs the protocol-v1 control server. The control server binds
+# the Unix socket named by CATALOG_CONTROL_SOCKET, provisions vhost-isolated
+# per-attempt tenants over RABBITMQ_WRAPPER_AMQP_URL, and drives lifecycle via
+# the local rabbitmqctl in this image (both injected by the sidecar wiring).
+set -eu
+
+: "${CATALOG_CONTROL_SOCKET:?missing CATALOG_CONTROL_SOCKET}"
+: "${RABBITMQ_WRAPPER_AMQP_URL:?missing RABBITMQ_WRAPPER_AMQP_URL}"
+
+docker-entrypoint.sh rabbitmq-server &
+DAEMON_PID=$!
+
+i=0
+until rabbitmqctl await_startup >/dev/null 2>&1; do
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+        echo "catalog-wrapper: rabbitmq broker exited during startup" >&2
+        exit 1
+    fi
+    i=$((i + 1))
+    if [ "$i" -ge 120 ]; then
+        echo "catalog-wrapper: rabbitmq broker did not become ready" >&2
+        exit 1
+    fi
+    sleep 2
+done
+
+exec djinn-rabbitmq-wrapper

--- a/server/docker/catalog-wrapper/redis-wrapper-entrypoint.sh
+++ b/server/docker/catalog-wrapper/redis-wrapper-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# ij6g: catalog Redis wrapper supervising entrypoint.
+#
+# Runs the stock Redis daemon on Pod loopback, waits until it answers PING, then
+# execs the protocol-v1 control server. The control server binds the Unix socket
+# named by CATALOG_CONTROL_SOCKET and provisions prefix-isolated per-attempt
+# tenants against REDIS_WRAPPER_ADMIN_URL (both injected by the sidecar wiring).
+set -eu
+
+: "${CATALOG_CONTROL_SOCKET:?missing CATALOG_CONTROL_SOCKET}"
+: "${REDIS_WRAPPER_ADMIN_URL:?missing REDIS_WRAPPER_ADMIN_URL}"
+
+docker-entrypoint.sh redis-server --appendonly no &
+DAEMON_PID=$!
+
+i=0
+until redis-cli -h 127.0.0.1 -p "${REDIS_PORT:-6379}" ping 2>/dev/null | grep -q PONG; do
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+        echo "catalog-wrapper: redis daemon exited during startup" >&2
+        exit 1
+    fi
+    i=$((i + 1))
+    if [ "$i" -ge 120 ]; then
+        echo "catalog-wrapper: redis daemon did not become ready" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+exec djinn-redis-wrapper

--- a/server/docker/djinn-postgres-wrapper.Dockerfile
+++ b/server/docker/djinn-postgres-wrapper.Dockerfile
@@ -1,0 +1,15 @@
+# ij6g: catalog Postgres wrapper image.
+#
+# One image that supervises the stock Postgres daemon AND the protocol-v1
+# control server, so a single native sidecar provides both the loopback service
+# and the private lease-provisioning socket. Debian (glibc) base matches the
+# release binary linkage. Build context is server/docker/ (see
+# build-wrapper-images.sh, which stages the pre-built binary here).
+ARG POSTGRES_IMAGE=postgres:18
+FROM ${POSTGRES_IMAGE}
+
+COPY djinn-postgres-wrapper /usr/local/bin/djinn-postgres-wrapper
+COPY catalog-wrapper/postgres-wrapper-entrypoint.sh /usr/local/bin/djinn-wrapper-entrypoint
+RUN chmod +x /usr/local/bin/djinn-postgres-wrapper /usr/local/bin/djinn-wrapper-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/djinn-wrapper-entrypoint"]

--- a/server/docker/djinn-rabbitmq-wrapper.Dockerfile
+++ b/server/docker/djinn-rabbitmq-wrapper.Dockerfile
@@ -1,0 +1,14 @@
+# ij6g: catalog RabbitMQ wrapper image.
+#
+# One image that supervises the stock RabbitMQ broker AND the protocol-v1
+# control server; the broker's own `rabbitmqctl` drives vhost/user lifecycle.
+# Debian (glibc) base matches the release binary linkage. Build context is
+# server/docker/ (build-wrapper-images.sh stages the pre-built binary here).
+ARG RABBITMQ_IMAGE=rabbitmq:4
+FROM ${RABBITMQ_IMAGE}
+
+COPY djinn-rabbitmq-wrapper /usr/local/bin/djinn-rabbitmq-wrapper
+COPY catalog-wrapper/rabbitmq-wrapper-entrypoint.sh /usr/local/bin/djinn-wrapper-entrypoint
+RUN chmod +x /usr/local/bin/djinn-rabbitmq-wrapper /usr/local/bin/djinn-wrapper-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/djinn-wrapper-entrypoint"]

--- a/server/docker/djinn-redis-wrapper.Dockerfile
+++ b/server/docker/djinn-redis-wrapper.Dockerfile
@@ -1,0 +1,13 @@
+# ij6g: catalog Redis wrapper image.
+#
+# One image that supervises the stock Redis daemon AND the protocol-v1 control
+# server. Debian (glibc) base matches the release binary linkage. Build context
+# is server/docker/ (build-wrapper-images.sh stages the pre-built binary here).
+ARG REDIS_IMAGE=redis:7
+FROM ${REDIS_IMAGE}
+
+COPY djinn-redis-wrapper /usr/local/bin/djinn-redis-wrapper
+COPY catalog-wrapper/redis-wrapper-entrypoint.sh /usr/local/bin/djinn-wrapper-entrypoint
+RUN chmod +x /usr/local/bin/djinn-redis-wrapper /usr/local/bin/djinn-wrapper-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/djinn-wrapper-entrypoint"]

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -710,6 +710,26 @@ impl AppState {
             "environment_config: boot reseed complete"
         );
 
+        // ij6g: record build/controller-published catalog wrapper image digests
+        // into service_presets so strict canonical verification resolves
+        // `{wrapper_image}@{digest}`. A no-op when the deploy sets no manifest —
+        // strict resolution then stays fail-closed rather than trusting a
+        // fabricated digest.
+        match djinn_image_controller::reconcile_wrapper_catalog_from_env(self.db()).await {
+            Ok(Some(stats)) => tracing::info!(
+                recorded = stats.recorded.len(),
+                unknown = stats.unknown_presets.len(),
+                "wrapper_catalog: boot reconcile complete"
+            ),
+            Ok(None) => {
+                tracing::info!("wrapper_catalog: no wrapper image manifest configured; skipping")
+            }
+            Err(error) => tracing::warn!(
+                %error,
+                "wrapper_catalog: boot reconcile failed; wrapper digests unchanged"
+            ),
+        }
+
         let config = ImageControllerConfig::from_env();
         tracing::info!(
             buildkitd_host = %config.buildkitd_host,


### PR DESCRIPTION
## Summary

Packages the catalog service wrappers as real container images and wires the private K8s control plane through to the worker and wrapper sidecars end to end, replacing migration-147's fabricated placeholder digests with a fail-closed, real-digest resolution path.

### Wrapper-image packaging flow (real digests)
- `server/docker/build-wrapper-images.sh` builds the postgres/redis/rabbitmq wrapper Dockerfiles and emits a manifest of real image digests.
- The image-controller reconciles that manifest at boot (`wrapper_catalog.rs`): it records the real digests, rejects any fabricated digest, and reports presets whose wrapper image is still unknown.
- Per-preset wrapper Dockerfiles and entrypoints added under `server/docker/catalog-wrapper/`.

### Migration 150 (`service_preset_wrapper_identity`)
- NULLs the fabricated placeholder digests that migration-147 seeded so strict service verification no longer trusts synthetic identities.
- Backs the fail-closed strict resolution: unresolved wrapper identities keep the service verification path closed rather than dispatching against a fabricated digest.

### Private control mounts + deterministic sockets
- A private control `emptyDir` is mounted onto the worker and the wrapper sidecars only, keeping the control channel off ordinary containers.
- Socket names are derived deterministically per preset so the worker and each wrapper sidecar agree on the control socket without coordination.

### Tests
- `djinn-sandbox` fake-wrapper lifecycle tests: full lifecycle against a real socket, fail-closed on a missing socket, fail-closed on protocol mismatch.
- `djinn-image-controller` wrapper_catalog tests: manifest parsing, real-digest recording with unknown reporting, and fabricated-digest rejection.

## Release notes

- The new migration (150) must be applied with `--migration-designated-operator-user-id`.
- Deployments must run `server/docker/build-wrapper-images.sh` and set `DJINN_WRAPPER_IMAGE_MANIFEST` (or provide the reconciled manifest), otherwise strict service verification stays fail-closed. Ordinary task dispatch is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
