### PR TITLE
chore(keoq): Wire the admission epoch into runtime — per-phase v1 lift gating and generation acks

### DIFF
--- a/server/crates/djinn-agent-worker/src/worker_services.rs
+++ b/server/crates/djinn-agent-worker/src/worker_services.rs
@@ -57,10 +57,10 @@ use djinn_slot::helpers::{
 };
 use djinn_stack::environment::EnvironmentConfig;
 use djinn_supervisor::services::{
-    BillingSource, CostBasisHint, LeaseAbandonRequest, LeaseBindRequest, LeaseCancelRequest,
-    LeaseGrantRequest, LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseStatusRequest,
-    SerializableCreateSessionParams, SerializableCreateTaskRunParams, SerializableDjinnEvent,
-    WatchdogTerminationRequest,
+    BillingSource, CostBasisHint, InvocationLiftDecision, LeaseAbandonRequest, LeaseBindRequest,
+    LeaseCancelRequest, LeaseGrantRequest, LeaseQueueRequest, LeaseReleaseRequest, LeaseResult,
+    LeaseStatusRequest, SerializableCreateSessionParams, SerializableCreateTaskRunParams,
+    SerializableDjinnEvent, WatchdogTerminationRequest, evaluate_invocation_lift,
 };
 use djinn_supervisor::{
     BranchPublicationResult, RpcServices, StageError, StageOutcome, SupervisorServices,
@@ -325,6 +325,33 @@ impl SupervisorServices for WorkerSupervisorServices {
         request: WatchdogTerminationRequest,
     ) -> Result<(), String> {
         self.rpc.terminate_watchdog_pod(request).await
+    }
+
+    // Lease-v1 authority (grant/bind above) remains on the host over RPC, but
+    // reading the durable admission epoch does not: workers have direct DB
+    // access by design (see `execute_stage` below, which writes `task_runs`
+    // through `self.agent_context.db`). The epoch is coordination state, and the
+    // pod reads it the same way it reads every other coordination row — from its
+    // in-pod database — rather than adding a bespoke RPC round-trip. Any read
+    // failure fails closed.
+    async fn invocation_lift_decision(&self) -> InvocationLiftDecision {
+        let row = djinn_db::AdmissionHandoffRepository::new(self.agent_context.db.clone())
+            .read()
+            .await
+            .map_err(|_| ());
+        evaluate_invocation_lift(row)
+    }
+
+    async fn record_generation_ack(&self, generation_key: String) -> Result<(), String> {
+        let repo = djinn_db::AdmissionHandoffRepository::new(self.agent_context.db.clone());
+        let epoch = match repo.read().await {
+            Ok(Some(row)) => row.epoch,
+            Ok(None) => return Ok(()),
+            Err(error) => return Err(error.to_string()),
+        };
+        repo.record_generation_ack(epoch, &generation_key)
+            .await
+            .map_err(|error| error.to_string())
     }
 
     async fn report_stage_step(&self, step: &'static str) -> Result<(), String> {

--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -33,10 +33,10 @@ use djinn_db::{EffectiveCreatorProvenance, SessionRepository};
 use djinn_stack::environment::EnvironmentConfig;
 use djinn_supervisor::services::wire::{PlannerAttemptResult, PlannerOutcome};
 use djinn_supervisor::services::{
-    CostBasisHint, LeaseAbandonRequest, LeaseBindRequest, LeaseCancelRequest, LeaseGrantRequest,
-    LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseStatusRequest,
-    SerializableCreateSessionParams, SerializableCreateTaskRunParams, SerializableDjinnEvent,
-    WatchdogTerminationRequest,
+    CostBasisHint, InvocationLiftDecision, LeaseAbandonRequest, LeaseBindRequest,
+    LeaseCancelRequest, LeaseGrantRequest, LeaseQueueRequest, LeaseReleaseRequest, LeaseResult,
+    LeaseStatusRequest, SerializableCreateSessionParams, SerializableCreateTaskRunParams,
+    SerializableDjinnEvent, WatchdogTerminationRequest, evaluate_invocation_lift,
 };
 use djinn_supervisor::{
     BranchPublicationResult, RoleKind, StageError, StageOutcome, SupervisorServices,
@@ -277,10 +277,17 @@ impl DirectServices {
         // The durable cap is recovered from the existing database before the
         // first operation. The constructor's zero is intentionally not a
         // launcher quota lift.
-        let build_lease = Arc::new(BuildLeaseService::new(
-            Arc::new(BuildLeaseRepository::new(agent_context.db.clone())),
-            0,
-        ));
+        let build_lease = Arc::new(
+            BuildLeaseService::new(
+                Arc::new(BuildLeaseRepository::new(agent_context.db.clone())),
+                0,
+            )
+            // Recovery reads the durable admission epoch (and its reference cap)
+            // before the lease service opens.
+            .with_handoff_epoch(Arc::new(djinn_db::AdmissionHandoffRepository::new(
+                agent_context.db.clone(),
+            ))),
+        );
         Self::with_provider_override_and_build_lease(
             agent_context,
             cancel,
@@ -1027,6 +1034,35 @@ impl SupervisorServices for DirectServices {
             .terminate_taskrun_pod_exact(&request.task_run_id, &request.pod_uid)
             .await
             .map_err(|e| e.to_string())
+    }
+
+    /// Read the durable admission epoch (host in-process path) and project
+    /// whether a bound v1 invocation may lift the launcher quota. Any read
+    /// failure fails closed to [`InvocationLiftDecision::Unleased`].
+    async fn invocation_lift_decision(&self) -> InvocationLiftDecision {
+        let row =
+            djinn_db::AdmissionHandoffRepository::new(self.callbacks.agent_context.db.clone())
+                .read()
+                .await
+                .map_err(|_| ());
+        evaluate_invocation_lift(row)
+    }
+
+    /// Record this live generation's acknowledgement of the current admission
+    /// epoch (host in-process path). Idempotent + stale-fenced in the database.
+    /// A missing epoch row or a read/write failure is non-fatal: the durable
+    /// invocation-primary edge stays blocked (fail closed) until the ack lands.
+    async fn record_generation_ack(&self, generation_key: String) -> Result<(), String> {
+        let repo =
+            djinn_db::AdmissionHandoffRepository::new(self.callbacks.agent_context.db.clone());
+        let epoch = match repo.read().await {
+            Ok(Some(row)) => row.epoch,
+            Ok(None) => return Ok(()),
+            Err(error) => return Err(error.to_string()),
+        };
+        repo.record_generation_ack(epoch, &generation_key)
+            .await
+            .map_err(|error| error.to_string())
     }
 
     async fn load_task(&self, task_id: String) -> Result<Task, String> {

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -16,9 +16,9 @@ use std::time::Duration;
 
 use djinn_core::clock::{Clock, SystemClock};
 use djinn_supervisor::services::{
-    LeaseAbandonRequest, LeaseBindRequest, LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest,
-    LeaseIdentity, LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseState,
-    LeaseStatusRequest, SupervisorServices, TaskInvocationLeaseIdentity,
+    InvocationLiftDecision, LeaseAbandonRequest, LeaseBindRequest, LeaseDeadlines,
+    LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest, LeaseReleaseRequest,
+    LeaseResult, LeaseState, LeaseStatusRequest, SupervisorServices, TaskInvocationLeaseIdentity,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -289,9 +289,33 @@ impl LeaseInvocationRunner {
                                     && status.pod_uid.as_deref()
                                         == Some(config.pod_uid.as_str()) =>
                             {
-                                child
-                                    .fenced_lift(&token)
-                                    .map_err(LeaseInvocationError::Launcher)?;
+                                // A matching durable bind is necessary but not
+                                // sufficient: the durable admission epoch decides
+                                // whether the launcher may lift the reserved
+                                // quota. Only a committed overlap /
+                                // invocation-primary epoch (v1 enforcing) lifts;
+                                // shadow observes without lifting; every other
+                                // epoch (baseline, missing, unreadable, stale)
+                                // keeps the quota unleased. The durable lease is
+                                // still held and reconciled to terminal below in
+                                // all three cases, so `fence` is always recorded.
+                                match self.services.invocation_lift_decision().await {
+                                    InvocationLiftDecision::Lift => {
+                                        child
+                                            .fenced_lift(&token)
+                                            .map_err(LeaseInvocationError::Launcher)?;
+                                    }
+                                    InvocationLiftDecision::Shadow => {
+                                        // Reaching a valid bind means v1 would
+                                        // have escalated (lifted); record the
+                                        // bounded shadow observation but leave
+                                        // cpu.max throttled under v0.
+                                        djinn_telemetry::build_admission::record_shadow_invocation(
+                                            true,
+                                        );
+                                    }
+                                    InvocationLiftDecision::Unleased => {}
+                                }
                                 fence = Some(token);
                             }
                             other => lease_failure(

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -222,6 +222,10 @@ struct ScriptedServices {
     pause_grant: AtomicBool,
     queue_entered: Notify,
     grant_entered: Notify,
+    // Durable-epoch lift authorization returned to the runner. Defaults to
+    // `Lift` so the lease-state-machine tests exercise the successful lift path;
+    // the epoch-gating tests override it to `Shadow` / `Unleased`.
+    lift_decision: Mutex<djinn_supervisor::services::InvocationLiftDecision>,
 }
 
 impl ScriptedServices {
@@ -243,7 +247,11 @@ impl ScriptedServices {
             pause_grant: AtomicBool::new(false),
             queue_entered: Notify::new(),
             grant_entered: Notify::new(),
+            lift_decision: Mutex::new(djinn_supervisor::services::InvocationLiftDecision::Lift),
         }
+    }
+    fn set_lift_decision(&self, decision: djinn_supervisor::services::InvocationLiftDecision) {
+        *self.lift_decision.lock().unwrap() = decision;
     }
     fn pop(script: &Mutex<VecDeque<LeaseResult>>) -> LeaseResult {
         script
@@ -304,6 +312,9 @@ impl SupervisorServices for ScriptedServices {
             .unwrap()
             .push(request.fencing_token);
         Self::pop(&self.release)
+    }
+    async fn invocation_lift_decision(&self) -> djinn_supervisor::services::InvocationLiftDecision {
+        *self.lift_decision.lock().unwrap()
     }
     async fn load_task(&self, _: String) -> Result<djinn_core::models::Task, String> {
         unimplemented!()
@@ -517,6 +528,76 @@ async fn repeated_active_statuses_queue_and_lift_exactly_once() {
     assert_eq!(*launcher.lifts.lock().unwrap(), vec![LeaseFencingToken(7)]);
     assert_eq!(launcher.kills.load(Ordering::SeqCst), 1);
     assert_eq!(launcher.empties.load(Ordering::SeqCst), 1);
+    assert!(services.release_calls.load(Ordering::SeqCst) <= 1);
+}
+
+/// AC1: a shadow epoch never lifts cpu.max even on a valid matching bind; the
+/// spawn still traverses the launcher and the durable lease is reconciled.
+#[tokio::test]
+async fn shadow_epoch_binds_but_never_lifts() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![granted(7)],
+        vec![status(LeaseState::Active, Some(7))],
+        vec![status(LeaseState::Active, Some(7)); 20],
+    ));
+    services.set_lift_decision(djinn_supervisor::services::InvocationLiftDecision::Shadow);
+    services
+        .release
+        .lock()
+        .unwrap()
+        .push_back(LeaseResult::Released {
+            candidate_cleanup: false,
+        });
+    let launcher = Arc::new(ScriptedLauncher::default());
+    let cancel = CancellationToken::new();
+    let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+    let run_cancel = cancel.clone();
+    let run = tokio::spawn(async move { runner.output(command(), config(), run_cancel).await });
+    wait_for(&services.status_calls, 3).await;
+    cancel.cancel();
+    run.await.unwrap().unwrap();
+    // The launcher was driven (queue + grant happened) but never lifted.
+    assert_eq!(services.queue_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(services.grant_calls.load(Ordering::SeqCst), 1);
+    assert!(
+        launcher.lifts.lock().unwrap().is_empty(),
+        "shadow epoch must never lift cpu.max"
+    );
+    // The durable lease is still reconciled to terminal (fence recorded).
+    assert!(services.release_calls.load(Ordering::SeqCst) <= 1);
+    assert_eq!(launcher.kills.load(Ordering::SeqCst), 1);
+}
+
+/// AC3 (agent side): an unknown/stale/baseline epoch keeps the quota unleased —
+/// a matching bind does not lift.
+#[tokio::test]
+async fn unleased_epoch_binds_but_never_lifts() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![granted(7)],
+        vec![status(LeaseState::Active, Some(7))],
+        vec![status(LeaseState::Active, Some(7)); 20],
+    ));
+    services.set_lift_decision(djinn_supervisor::services::InvocationLiftDecision::Unleased);
+    services
+        .release
+        .lock()
+        .unwrap()
+        .push_back(LeaseResult::Released {
+            candidate_cleanup: false,
+        });
+    let launcher = Arc::new(ScriptedLauncher::default());
+    let cancel = CancellationToken::new();
+    let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+    let run_cancel = cancel.clone();
+    let run = tokio::spawn(async move { runner.output(command(), config(), run_cancel).await });
+    wait_for(&services.status_calls, 3).await;
+    cancel.cancel();
+    run.await.unwrap().unwrap();
+    assert_eq!(services.grant_calls.load(Ordering::SeqCst), 1);
+    assert!(
+        launcher.lifts.lock().unwrap().is_empty(),
+        "unleased epoch must never lift cpu.max"
+    );
     assert!(services.release_calls.load(Ordering::SeqCst) <= 1);
 }
 

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -906,6 +906,27 @@ pub(crate) async fn execute_stage(
         .map_err(StageError::SessionCreate)?;
     let session_id = session_record.id.clone();
 
+    // The task-run generation is now healthy under the current admission mode:
+    // acknowledge the durable admission epoch for this generation. This runs
+    // through `SupervisorServices` so it covers BOTH the host in-process
+    // (DirectServices → direct DB) and the pod (WorkerSupervisorServices →
+    // in-pod DB) paths. The generation key is the canonical
+    // `TaskObservation:{task_id}:{generation}` form so it byte-matches the
+    // invocation-primary edge's required-generation set. The write is
+    // idempotent and stale-fenced; a failure is non-fatal to the stage (the
+    // durable edge simply stays blocked until a later ack lands).
+    let generation_key = djinn_coordinator::build_admission::task_run_generation_key(
+        &task.id,
+        task.reopen_count.max(0),
+    );
+    if let Err(error) = services.record_generation_ack(generation_key).await {
+        tracing::warn!(
+            task_id = %task.id,
+            %error,
+            "build admission: generation acknowledgement failed; invocation-primary edge stays blocked"
+        );
+    }
+
     // ── MCP + skills ─────────────────────────────────────────────────────────
     // `runtime_role` drives resolution so specialists can override the base
     // role's MCP/skill defaults.  `role_mcp_servers` carries the DB row's

--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -1317,7 +1317,34 @@ fn unavailable(error: impl std::fmt::Display) -> WarmAdmissionError {
 }
 
 fn permit_key(key: &AdmissionJournalKey) -> String {
+    admission_generation_key(key)
+}
+
+/// Canonical string identity for one admission generation.
+///
+/// This is the single source of truth for the `generation_key` used by the
+/// durable admission-handoff per-generation acknowledgements
+/// ([`djinn_db::AdmissionHandoffRepository::record_generation_ack`]) and the
+/// `required_generations` set on the invocation-primary edge. Both the producer
+/// of that required set and every live generation that acknowledges an epoch
+/// MUST format their key through this function so the two byte-match. It is the
+/// same `{domain:?}:{work_id}:{generation}` form used for in-memory permit
+/// bookkeeping.
+#[must_use]
+pub fn admission_generation_key(key: &AdmissionJournalKey) -> String {
     format!("{:?}:{}:{}", key.domain, key.work_id, key.generation)
+}
+
+/// Convenience [`admission_generation_key`] for a task-run generation, whose
+/// admission domain is always [`AdmissionDomain::TaskObservation`] and whose
+/// generation counter is `task.reopen_count`.
+#[must_use]
+pub fn task_run_generation_key(task_id: &str, generation: i64) -> String {
+    admission_generation_key(&AdmissionJournalKey {
+        domain: AdmissionDomain::TaskObservation,
+        work_id: task_id.to_owned(),
+        generation,
+    })
 }
 
 #[async_trait]

--- a/server/crates/djinn-coordinator/src/build_lease.rs
+++ b/server/crates/djinn-coordinator/src/build_lease.rs
@@ -11,8 +11,9 @@ use std::sync::{
 
 use async_trait::async_trait;
 use djinn_db::{
-    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseRow, BuildLeaseState,
-    GrantNextBuildLeaseResult, QueueBuildLeaseInput, QueueBuildLeaseResult,
+    AdmissionHandoffRepository, BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository,
+    BuildLeaseRow, BuildLeaseState, GrantNextBuildLeaseResult, QueueBuildLeaseInput,
+    QueueBuildLeaseResult,
 };
 use djinn_supervisor::services::{
     LeaseAbandonRequest, LeaseBindRequest, LeaseCancelRequest, LeaseDeadlines, LeaseFencingToken,
@@ -188,6 +189,15 @@ pub struct BuildLeaseService {
     telemetry: Arc<dyn LeaseTelemetry>,
     cap: AtomicI64,
     recovered: AtomicBool,
+    /// Durable admission-handoff epoch reader. When present, [`Self::recover`]
+    /// and [`Self::recovery_snapshot`] read the epoch (and its reference cap)
+    /// before the service opens, so a restart never admits or spawns without
+    /// having observed the current epoch. `None` in the many tests that exercise
+    /// the lease state machine in isolation (behaviour then unchanged).
+    handoff: Option<Arc<AdmissionHandoffRepository>>,
+    /// The admission epoch observed by the most recent successful recovery, or
+    /// `-1` when none has been observed (unknown/unreadable ⇒ fail closed).
+    observed_epoch: AtomicI64,
     /// Keeps queue+local-drain atomic in this process. Database advisory locks
     /// serialize the same decisions across replacement coordinators.
     operation: Mutex<()>,
@@ -220,13 +230,61 @@ impl BuildLeaseService {
             telemetry,
             cap: AtomicI64::new(cap.max(0)),
             recovered: AtomicBool::new(false),
+            handoff: None,
+            observed_epoch: AtomicI64::new(-1),
             operation: Mutex::new(()),
         }
+    }
+
+    /// Install the durable admission-handoff epoch reader so recovery reads the
+    /// epoch (and its reference cap) before opening.
+    #[must_use]
+    pub fn with_handoff_epoch(mut self, handoff: Arc<AdmissionHandoffRepository>) -> Self {
+        self.handoff = Some(handoff);
+        self
     }
 
     #[must_use]
     pub fn is_ready(&self) -> bool {
         self.recovered.load(Ordering::Acquire)
+    }
+
+    /// The admission epoch observed by the most recent successful recovery, or
+    /// `None` when none has been observed (unknown/unreadable ⇒ fail closed).
+    #[must_use]
+    pub fn observed_epoch(&self) -> Option<i64> {
+        let epoch = self.observed_epoch.load(Ordering::Acquire);
+        (epoch >= 0).then_some(epoch)
+    }
+
+    /// Read the durable admission-handoff epoch and apply its reference cap.
+    ///
+    /// Returns the reference cap to enforce, defaulting to `fallback` (the
+    /// lease-table cap) when no handoff reader is installed or the row carries
+    /// no cap. An unreadable epoch clears the observed epoch (fail closed) and
+    /// retains the fallback cap. The handoff reference cap is authoritative for
+    /// the v1 authority when set, so a restart converges on the epoch's cap
+    /// rather than a stale lease-table value.
+    async fn read_handoff_epoch(&self, fallback: i64) -> i64 {
+        let Some(handoff) = self.handoff.as_ref() else {
+            return fallback;
+        };
+        match handoff.read().await {
+            Ok(Some(row)) => {
+                self.observed_epoch.store(row.epoch, Ordering::Release);
+                row.cap.unwrap_or(fallback)
+            }
+            Ok(None) => {
+                // No durable epoch row: nothing to observe, keep the fallback.
+                self.observed_epoch.store(-1, Ordering::Release);
+                fallback
+            }
+            Err(_) => {
+                // Unreadable epoch: fail closed on the observed epoch.
+                self.observed_epoch.store(-1, Ordering::Release);
+                fallback
+            }
+        }
     }
 
     /// Recover queued and all occupied rows before opening the service.
@@ -237,7 +295,12 @@ impl BuildLeaseService {
         self.pause.before_transaction(LeaseOperation::Recover).await;
         match self.repository.snapshot().await {
             Ok(snapshot) => {
-                self.cap.store(snapshot.cap, Ordering::Release);
+                // Read the durable admission epoch (and its reference cap)
+                // BEFORE the service opens, so a restart never admits or spawns
+                // without having observed the current epoch. The handoff
+                // reference cap is authoritative when set.
+                let cap = self.read_handoff_epoch(snapshot.cap).await;
+                self.cap.store(cap, Ordering::Release);
                 self.publish(&snapshot.rows);
                 self.recovered.store(true, Ordering::Release);
                 LeaseResult::Status(empty_status())
@@ -247,11 +310,17 @@ impl BuildLeaseService {
     }
 
     /// Return the durable non-terminal recovery view without mutating it.
+    ///
+    /// The admission epoch (and its reference cap) is read alongside the lease
+    /// snapshot so the recovery view reflects the epoch's authoritative cap
+    /// before any spawn decision is made.
     pub async fn recovery_snapshot(&self) -> Result<djinn_db::BuildLeaseSnapshot, ()> {
         if !self.is_ready() {
             return Err(());
         }
-        self.repository.snapshot().await.map_err(|_| ())
+        let mut snapshot = self.repository.snapshot().await.map_err(|_| ())?;
+        snapshot.cap = self.read_handoff_epoch(snapshot.cap).await;
+        Ok(snapshot)
     }
 
     /// Capacity changes never revoke occupied rows. Positive changes drain FIFO.

--- a/server/crates/djinn-coordinator/src/build_lease_integration_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_integration_tests.rs
@@ -909,3 +909,46 @@ async fn production_adapter_cancellation_reconciles_uid_before_capacity_release(
     assert_eq!(repository.snapshot().await.unwrap().occupied, 0);
     assert_eq!(deleted.lock().unwrap().len(), 1);
 }
+
+/// AC3 (v1 restart): recovery reads the durable admission epoch and its
+/// reference cap before the lease service opens. A committed epoch with a cap is
+/// observed; a deleted (missing/unreadable) epoch row fails closed to no
+/// observed epoch.
+#[tokio::test]
+async fn recovery_reads_admission_epoch_and_reference_cap() {
+    use djinn_db::{AdmissionHandoffRepository, V0Mode, V1Mode};
+
+    let database = Database::open_in_memory().unwrap();
+    let handoff = Arc::new(AdmissionHandoffRepository::new(database.clone()));
+    // Advance the durable epoch and set a reference cap of 7.
+    handoff
+        .set_modes_and_cap(0, V0Mode::Enforce, V1Mode::Shadow, Some(7))
+        .await
+        .unwrap();
+    let current = handoff.read().await.unwrap().unwrap();
+    assert_eq!(current.epoch, 1);
+    assert_eq!(current.cap, Some(7));
+
+    let repository = Arc::new(BuildLeaseRepository::new(database.clone()));
+    let service = Arc::new(
+        BuildLeaseService::new(Arc::clone(&repository), 1).with_handoff_epoch(Arc::clone(&handoff)),
+    );
+    // Before recovery the epoch has not been observed.
+    assert_eq!(service.observed_epoch(), None);
+    assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+    // Recovery observed the current epoch and adopted its reference cap.
+    assert_eq!(service.observed_epoch(), Some(1));
+
+    // A missing epoch row fails closed: the observed epoch is cleared.
+    handoff.delete_for_test().await.unwrap();
+    let restarted = Arc::new(
+        BuildLeaseService::new(Arc::new(BuildLeaseRepository::new(database.clone())), 1)
+            .with_handoff_epoch(Arc::clone(&handoff)),
+    );
+    assert!(matches!(restarted.recover().await, LeaseResult::Status(_)));
+    assert_eq!(
+        restarted.observed_epoch(),
+        None,
+        "a missing epoch row must leave the observed epoch unknown (fail closed)"
+    );
+}

--- a/server/crates/djinn-supervisor/src/services.rs
+++ b/server/crates/djinn-supervisor/src/services.rs
@@ -17,11 +17,13 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{RoleKind, StageError, StageOutcome, TaskRunOutcome, TaskRunSpec};
 
+pub mod invocation_admission;
 pub mod lease;
 pub mod rpc;
 pub mod server;
 pub mod wire;
 
+pub use invocation_admission::evaluate_invocation_lift;
 pub use lease::*;
 pub use wire::{
     BillingSource, CostBasisHint, SerializableCreateSessionParams, SerializableCreateTaskRunParams,
@@ -91,6 +93,24 @@ pub trait SupervisorServices: Send + Sync + 'static {
         _request: WatchdogTerminationRequest,
     ) -> Result<(), String> {
         Err("exact-pod watchdog termination is unavailable".to_owned())
+    }
+
+    /// Read the current durable admission epoch and project whether a bound v1
+    /// invocation may lift the launcher cpu.max quota. The default fails closed
+    /// ([`InvocationLiftDecision::Unleased`]) so an impl without coordination
+    /// state never authorizes a lift.
+    async fn invocation_lift_decision(&self) -> InvocationLiftDecision {
+        InvocationLiftDecision::Unleased
+    }
+
+    /// Record this live generation's acknowledgement of the current admission
+    /// epoch, once the task-run is healthy under the new mode. `generation_key`
+    /// MUST be built through the canonical admission generation-key helper so it
+    /// byte-matches the invocation-primary edge's required-generation set. The
+    /// underlying write is idempotent and stale-fenced in the database; the
+    /// default is a no-op for impls without coordination-state access.
+    async fn record_generation_ack(&self, _generation_key: String) -> Result<(), String> {
+        Ok(())
     }
 
     /// Load the [`Task`] row backing this task-run.  Called once, before the

--- a/server/crates/djinn-supervisor/src/services/invocation_admission.rs
+++ b/server/crates/djinn-supervisor/src/services/invocation_admission.rs
@@ -1,0 +1,202 @@
+//! Agent/launcher-side projection of the durable admission epoch.
+//!
+//! The v0 (emergency) side of the handoff is interpreted by the coordinator's
+//! `evaluate_handoff`. This module is the v1 (invocation) counterpart read by
+//! the agent/launcher before it decides whether to lift the reserved cpu.max
+//! quota. It lives here — beside the [`InvocationLiftDecision`] contract and
+//! above `djinn-db` — so BOTH the host path (`DirectServices`) and the pod path
+//! (`WorkerSupervisorServices`) can read it without depending on the
+//! coordinator crate.
+
+use djinn_db::{AdmissionHandoffPhase, AdmissionHandoffRow, V1Mode};
+
+use crate::services::lease::InvocationLiftDecision;
+
+/// Project the durable epoch row into whether a bound v1 invocation may lift the
+/// launcher quota.
+///
+/// It is intentionally independent of the v0 emergency gates and fails closed on
+/// every uncertain input:
+///
+/// - An unreadable (`Err`) or missing (`None`) row keeps the quota unleased.
+/// - The illegal both-non-enforcing combo keeps the quota unleased.
+/// - An incomplete epoch (the current phase's required acknowledgements are not
+///   at the current epoch) keeps the quota unleased — a stale epoch never lifts.
+/// - `v1 = off` keeps the quota unleased; `v1 = shadow` observes only.
+/// - `v1 = enforce` lifts only once the handoff has actually entered an overlap
+///   or invocation-primary phase; a `v1 = enforce` row still parked in the
+///   emergency-primary phase has not armed the overlap and stays unleased.
+///
+/// The caller additionally requires a matching durable fencing token before it
+/// acts on a [`InvocationLiftDecision::Lift`]; this function never authorizes a
+/// lift on epoch alone.
+#[must_use]
+pub fn evaluate_invocation_lift(
+    row: Result<Option<AdmissionHandoffRow>, ()>,
+) -> InvocationLiftDecision {
+    let Ok(Some(row)) = row else {
+        return InvocationLiftDecision::Unleased;
+    };
+    // Neither authority enforces: no admission control at all. Fail closed.
+    if !row.v0_mode.is_enforcing() && !row.v1_mode.is_enforcing() {
+        return InvocationLiftDecision::Unleased;
+    }
+    // The current phase's required acknowledgements must be at the current epoch
+    // before the row's modes are authoritative. Anything else is a stale epoch.
+    let emergency_current = row.emergency_ack_epoch == Some(row.epoch);
+    let invocation_current = row.invocation_ack_epoch == Some(row.epoch);
+    let complete = match row.phase {
+        AdmissionHandoffPhase::EmergencyPrimary => emergency_current,
+        AdmissionHandoffPhase::ForwardOverlap | AdmissionHandoffPhase::RollbackOverlap => {
+            emergency_current && invocation_current
+        }
+        AdmissionHandoffPhase::InvocationPrimary => invocation_current,
+    };
+    if !complete {
+        return InvocationLiftDecision::Unleased;
+    }
+    match row.v1_mode {
+        V1Mode::Off => InvocationLiftDecision::Unleased,
+        V1Mode::Shadow => InvocationLiftDecision::Shadow,
+        V1Mode::Enforce => match row.phase {
+            AdmissionHandoffPhase::ForwardOverlap
+            | AdmissionHandoffPhase::InvocationPrimary
+            | AdmissionHandoffPhase::RollbackOverlap => InvocationLiftDecision::Lift,
+            // v1 enforce configured but the overlap has not been armed yet.
+            AdmissionHandoffPhase::EmergencyPrimary => InvocationLiftDecision::Unleased,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djinn_db::V0Mode;
+
+    fn row(
+        phase: AdmissionHandoffPhase,
+        emergency: bool,
+        invocation: bool,
+        v0_mode: V0Mode,
+        v1_mode: V1Mode,
+    ) -> AdmissionHandoffRow {
+        AdmissionHandoffRow {
+            phase,
+            epoch: 7,
+            emergency_ack_epoch: emergency.then_some(7),
+            invocation_ack_epoch: invocation.then_some(7),
+            v0_mode,
+            v1_mode,
+            cap: None,
+            updated_at: "now".into(),
+        }
+    }
+
+    #[test]
+    fn lifts_only_in_committed_v1_overlap_or_primary() {
+        // Unreadable / missing epochs keep the quota unleased.
+        assert_eq!(
+            evaluate_invocation_lift(Err(())),
+            InvocationLiftDecision::Unleased
+        );
+        assert_eq!(
+            evaluate_invocation_lift(Ok(None)),
+            InvocationLiftDecision::Unleased
+        );
+
+        // Baseline (v1 off) never lifts even with a complete emergency ack.
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::EmergencyPrimary,
+                true,
+                false,
+                V0Mode::Enforce,
+                V1Mode::Off,
+            )))),
+            InvocationLiftDecision::Unleased
+        );
+
+        // Shadow observes but never lifts.
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::EmergencyPrimary,
+                true,
+                false,
+                V0Mode::Enforce,
+                V1Mode::Shadow,
+            )))),
+            InvocationLiftDecision::Shadow
+        );
+
+        // v1 enforce still parked in emergency-primary has not armed the overlap.
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::EmergencyPrimary,
+                true,
+                false,
+                V0Mode::Enforce,
+                V1Mode::Enforce,
+            )))),
+            InvocationLiftDecision::Unleased
+        );
+
+        // A committed forward overlap with v1 enforcing lifts.
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::ForwardOverlap,
+                true,
+                true,
+                V0Mode::Enforce,
+                V1Mode::Enforce,
+            )))),
+            InvocationLiftDecision::Lift
+        );
+        // Invocation-primary lifts (v0 disabled, v1 enforcing).
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::InvocationPrimary,
+                false,
+                true,
+                V0Mode::Disabled,
+                V1Mode::Enforce,
+            )))),
+            InvocationLiftDecision::Lift
+        );
+        // Rollback overlap still has v1 enforcing, so it may still lift.
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::RollbackOverlap,
+                true,
+                true,
+                V0Mode::Enforce,
+                V1Mode::Enforce,
+            )))),
+            InvocationLiftDecision::Lift
+        );
+
+        // An INCOMPLETE overlap epoch (missing the invocation ack) is stale and
+        // must not lift.
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::ForwardOverlap,
+                true,
+                false,
+                V0Mode::Enforce,
+                V1Mode::Enforce,
+            )))),
+            InvocationLiftDecision::Unleased
+        );
+
+        // The illegal both-non-enforcing combo fails closed.
+        assert_eq!(
+            evaluate_invocation_lift(Ok(Some(row(
+                AdmissionHandoffPhase::EmergencyPrimary,
+                true,
+                false,
+                V0Mode::Observe,
+                V1Mode::Shadow,
+            )))),
+            InvocationLiftDecision::Unleased
+        );
+    }
+}

--- a/server/crates/djinn-supervisor/src/services/lease.rs
+++ b/server/crates/djinn-supervisor/src/services/lease.rs
@@ -24,6 +24,32 @@ pub struct LeaseDeadlines {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeaseFencingToken(pub u64);
+/// Whether the current durable admission epoch authorizes the launcher to lift
+/// the reserved cpu.max quota for a bound v1 (invocation) lease.
+///
+/// This is the agent/launcher-side projection of the admission handoff epoch.
+/// It is deliberately small and fail-closed: only a committed overlap or
+/// invocation-primary epoch with v1 enforcing yields [`Self::Lift`]. A shadow
+/// epoch is observed but never lifts; every other epoch (baseline, missing,
+/// unreadable, stale, or the illegal both-non-enforcing combo) keeps the quota
+/// unleased.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InvocationLiftDecision {
+    /// The epoch is a committed overlap or invocation-primary phase with v1
+    /// enforcing: a matching durable fencing token may lift cpu.max.
+    Lift,
+    /// v1 is shadowing: the invocation authority observes what it would do but
+    /// never lifts. The launcher stays throttled under v0.
+    Shadow,
+    /// Baseline / missing / unreadable / stale / contradictory epoch: keep the
+    /// launcher quota unleased. This is the fail-closed default.
+    Unleased,
+}
+impl Default for InvocationLiftDecision {
+    fn default() -> Self {
+        Self::Unleased
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimeoutCredit {
     pub units: u8,

--- a/server/crates/djinn-supervisor/src/services/lease.rs
+++ b/server/crates/djinn-supervisor/src/services/lease.rs
@@ -33,7 +33,7 @@ pub struct LeaseFencingToken(pub u64);
 /// epoch is observed but never lifts; every other epoch (baseline, missing,
 /// unreadable, stale, or the illegal both-non-enforcing combo) keeps the quota
 /// unleased.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InvocationLiftDecision {
     /// The epoch is a committed overlap or invocation-primary phase with v1
     /// enforcing: a matching durable fencing token may lift cpu.max.
@@ -43,12 +43,8 @@ pub enum InvocationLiftDecision {
     Shadow,
     /// Baseline / missing / unreadable / stale / contradictory epoch: keep the
     /// launcher quota unleased. This is the fail-closed default.
+    #[default]
     Unleased,
-}
-impl Default for InvocationLiftDecision {
-    fn default() -> Self {
-        Self::Unleased
-    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimeoutCredit {

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -177,6 +177,8 @@ const BUILD_ADMISSION_UNKNOWN_CLASSIFICATION_TOTAL: &str =
 const BUILD_ADMISSION_INVENTORY_DEGRADED: &str = "djinn_build_admission_inventory_degraded";
 const BUILD_ADMISSION_JOURNAL_DEGRADED: &str = "djinn_build_admission_journal_degraded";
 const BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH: &str = "djinn_build_admission_create_unknown_health";
+const BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL: &str =
+    "djinn_build_admission_shadow_invocation_total";
 const BUILD_ADMISSION_HANDOFF_WARNING: &str = "djinn_build_admission_handoff_warning";
 const BUILD_ADMISSION_HANDOFF_WARNING_REASONS: [&str; 3] =
     ["unexpected_overlap", "stale_epoch", "epoch_unreadable"];
@@ -1568,6 +1570,10 @@ fn register_metrics() {
         BUILD_ADMISSION_UNKNOWN_CLASSIFICATION_TOTAL,
         "Build-admission requests with an unknown workload classification."
     );
+    metrics::describe_counter!(
+        BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL,
+        "Shadow-mode v1 invocation decisions the launcher observed but did not act on."
+    );
     for metric in [
         BUILD_ADMISSION_INVENTORY_DEGRADED,
         BUILD_ADMISSION_JOURNAL_DEGRADED,
@@ -2698,6 +2704,23 @@ pub mod build_admission {
     /// Record one bounded unknown-classification event.
     pub fn increment_unknown_classification(effective_mode: &'static str, effective_cap: i64) {
         metrics::counter!(super::BUILD_ADMISSION_UNKNOWN_CLASSIFICATION_TOTAL, "effective_mode" => effective_mode, "effective_cap" => effective_cap.to_string()).increment(1);
+    }
+
+    /// Record one bounded shadow-mode v1 invocation decision.
+    ///
+    /// Emitted per user spawn while the epoch has v1 shadowing: the invocation
+    /// authority observes what it *would* do but the launcher never lifts. The
+    /// `decision` label is one of the two bounded outcomes — `would_escalate`
+    /// (v1 would have lifted the quota) or `would_throttle` (v1 would have kept
+    /// it throttled) — so the shadow rollout can be measured before enforcement.
+    pub fn record_shadow_invocation(would_escalate: bool) {
+        let decision = if would_escalate {
+            "would_escalate"
+        } else {
+            "would_throttle"
+        };
+        metrics::counter!(super::BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL, "decision" => decision)
+            .increment(1);
     }
 }
 

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -588,10 +588,13 @@ impl AppState {
                 server_epoch,
             )),
         });
-        let build_lease = Arc::new(BuildLeaseService::new(
-            Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())),
-            0,
-        ));
+        let build_lease = Arc::new(
+            BuildLeaseService::new(Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())), 0)
+                // The v1 lease service reads the durable admission epoch (and its
+                // reference cap) on recovery, so a restart observes the current
+                // epoch before admitting or spawning.
+                .with_handoff_epoch(Arc::new(AdmissionHandoffRepository::new(db.clone()))),
+        );
         Self {
             inner: Arc::new(Inner {
                 db,
@@ -915,6 +918,17 @@ impl AppState {
             loop {
                 tokio::select! {
                     _ = ticker.tick() => {
+                        // Drive the controller from the durable epoch on each
+                        // tick so a mid-run epoch advance is authoritative
+                        // without a restart: RequiredFailClosed re-closes a
+                        // controller that is no longer Enforce, and MayDisable
+                        // releases emergency once invocation-primary is
+                        // committed. This runs only on the leader (the loop is
+                        // started inside `become_leader`, after topology is
+                        // confirmed), so it mirrors `finalize` semantics.
+                        if let Some(admission) = state.inner.build_admission.clone() {
+                            state.finalize_build_admission_handoff(&admission).await;
+                        }
                         if let Some(event) = log_state.observe_persistent(
                             SystemClockTrait::new().now_instant(),
                             state.publish_handoff_warning().await,


### PR DESCRIPTION
Second 23or task (proposal goxi): makes the admission epoch authoritative at runtime. Builds on icvs (merged #2530), which already had the coordinator/v0-side epoch machinery — this adds the v1/invocation side.

- New `evaluate_invocation_lift` contract in djinn-supervisor (shared by host DirectServices and pod WorkerSupervisorServices, avoiding a djinn-coordinator dep in the worker): shadow ⇒ broker is traversed and a bounded would-throttle/would-escalate decision is recorded but the launcher never lifts cpu.max and v0 stays Enforce; overlap/invocation_primary ⇒ lift only on a matching durable fencing token.
- Live handoff tick now drives the BuildAdmissionController so a mid-run advance releases v0 without a restart.
- BuildLeaseService gains a with_handoff_epoch seam; recover()/recovery_snapshot() read the epoch + reference cap before opening; unreadable/stale/contradictory ⇒ v0 enforce + v1 unleased.
- Each live task-run generation records a current-epoch ack from the shared stage executor over both the direct and supervisor-RPC paths, keyed by canonical generation key.

Per-AC tests in djinn-supervisor/djinn-agent/djinn-coordinator; workspace check clean under SQLX_OFFLINE; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)