### PR TITLE
chore(nquz-core): Disk-aware admission observe-mode core — run-dir ledger, byte accounting, dark disk-pressure signals

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -157,6 +157,24 @@ pub enum BuildAdmissionDecision {
     Unclassified,
 }
 
+/// Observe-only disk-capacity adapter for build admission (proposal nquz,
+/// phase 1 — DARK).
+///
+/// A source, when installed, returns what disk admission WOULD do for a build
+/// request — never denying and never allocating. In this phase no production
+/// path installs a source, so the disk dimension is inert; it exists so the
+/// observe substrate and its tests can measure the future policy. The concrete
+/// decision logic lives in [`crate::disk_admission`].
+#[async_trait]
+pub trait DiskCapacitySource: Send + Sync {
+    /// Return the observed disk decision for a build request, or `None` when no
+    /// capacity sample is available (which the caller treats as no-op).
+    async fn observe(
+        &self,
+        request: &BuildAdmissionRequest,
+    ) -> Option<crate::disk_admission::DiskObservation>;
+}
+
 /// Bounded, deterministic readiness reason for Enforce admission gating.
 ///
 /// Enforce admission fails closed until every required gate is healthy. Observe
@@ -248,6 +266,14 @@ pub struct BuildAdmissionController {
     permits_by_task_run: Mutex<HashMap<String, WarmAdmissionPermit>>,
     unclassified_observations: Mutex<u64>,
     would_defer_observations: Mutex<u64>,
+    /// Bounded observe-only disk would-defer signal (proposal nquz, phase 1).
+    ///
+    /// DARK by default: it only advances when a [`DiskCapacitySource`] has been
+    /// installed, which no production path does in this phase. The disk
+    /// dimension NEVER changes an admission decision — it records what disk
+    /// admission WOULD do.
+    disk_would_defer_observations: Mutex<u64>,
+    disk_capacity_source: std::sync::Mutex<Option<Arc<dyn DiskCapacitySource>>>,
     /// Readiness gate flags. The bounded [`BuildAdmissionReadiness`] reason is
     /// DERIVED from these flags in fail-closed priority order, so no caller can
     /// mark Enforce healthy without every real startup check completing:
@@ -309,6 +335,8 @@ impl BuildAdmissionController {
             permits_by_task_run: Mutex::new(HashMap::new()),
             unclassified_observations: Mutex::new(0),
             would_defer_observations: Mutex::new(0),
+            disk_would_defer_observations: Mutex::new(0),
+            disk_capacity_source: std::sync::Mutex::new(None),
             journal_recovered: AtomicBool::new(true),
             journal_healthy: AtomicBool::new(true),
             create_unknown_pending: AtomicU64::new(0),
@@ -518,6 +546,57 @@ impl BuildAdmissionController {
         *self.would_defer_observations.lock().await
     }
 
+    /// Install the observe-only disk-capacity source (proposal nquz).
+    ///
+    /// Phase-1 production never calls this; it exists so the dark disk dimension
+    /// and its tests can run. Installing a source can only add telemetry — it
+    /// can never turn a permit into a denial.
+    pub fn set_disk_capacity_source(&self, source: Arc<dyn DiskCapacitySource>) {
+        *self
+            .disk_capacity_source
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(source);
+    }
+
+    fn disk_capacity_source(&self) -> Option<Arc<dyn DiskCapacitySource>> {
+        self.disk_capacity_source
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Bounded observe-only signal that disk admission WOULD have deferred a
+    /// build; values saturate at 1024. Zero unless a source is installed.
+    pub async fn disk_would_defer_observation_count(&self) -> u64 {
+        *self.disk_would_defer_observations.lock().await
+    }
+
+    /// Record what disk admission WOULD do for a granted build. Never denies and
+    /// never allocates: it only advances a bounded counter and emits a typed
+    /// queue-reason metric when a source reports a would-defer.
+    async fn observe_disk_admission(&self, request: &BuildAdmissionRequest) {
+        let Some(source) = self.disk_capacity_source() else {
+            return;
+        };
+        let Some(observation) = source.observe(request).await else {
+            return;
+        };
+        if let Some(reason) = observation.would_defer {
+            let mut count = self.disk_would_defer_observations.lock().await;
+            *count = count.saturating_add(1).min(1024);
+            drop(count);
+            if self.process_metrics_enabled() {
+                djinn_telemetry::run_dir::increment_queue_reason(reason.as_metric());
+            }
+            tracing::debug!(
+                reason = reason.as_metric(),
+                work_id = %request.work_id,
+                projected_reservation_bytes = observation.projected_reservation_bytes,
+                "disk admission would defer this build (observe-only; dispatch unaffected)"
+            );
+        }
+    }
+
     /// Export bounded admission metrics from the durable journal snapshot.
     /// InvocationBuild rows are intentionally excluded from all v0 views.
     pub async fn publish_metrics(&self) {
@@ -597,6 +676,13 @@ impl BuildAdmissionController {
                 cap: self.cap,
             });
         }
+        // Capture an observe-only copy before any field of `request` is moved.
+        // Only cloned when the dark disk dimension is armed (never in phase-1
+        // production), so the default path pays nothing.
+        let disk_observe_request = self
+            .disk_capacity_source()
+            .is_some()
+            .then(|| request.clone());
         let workload_kind = match request.kind {
             BuildWorkloadKind::TaskRun { .. } => match request.domain {
                 AdmissionDomain::TaskObservation => AdmissionWorkloadKind::Task,
@@ -739,6 +825,11 @@ impl BuildAdmissionController {
         // A durable Reserved row occupies immediately; do not wait for a
         // later cap denial or terminal release to refresh the gauge.
         self.publish_metrics().await;
+        // Observe-only disk dimension: records what disk admission WOULD do for
+        // this granted build without ever changing the decision above.
+        if let Some(observe_request) = disk_observe_request.as_ref() {
+            self.observe_disk_admission(observe_request).await;
+        }
         Ok(BuildAdmissionDecision::Permitted { permit, idempotent })
     }
 
@@ -2730,6 +2821,66 @@ mod tests {
             value >= 1.0,
             "would-defer counter must increment when Observe sees a would-defer"
         );
+    }
+
+    struct StubDiskSource {
+        observation: Option<crate::disk_admission::DiskObservation>,
+    }
+
+    #[async_trait]
+    impl DiskCapacitySource for StubDiskSource {
+        async fn observe(
+            &self,
+            _request: &BuildAdmissionRequest,
+        ) -> Option<crate::disk_admission::DiskObservation> {
+            self.observation
+        }
+    }
+
+    #[tokio::test]
+    async fn disk_dimension_records_would_defer_without_denial() {
+        use crate::disk_admission::{DiskObservation, DiskQueueReason};
+        let c = controller(BuildAdmissionMode::Observe, 4);
+        c.set_disk_capacity_source(Arc::new(StubDiskSource {
+            observation: Some(DiskObservation {
+                would_defer: Some(DiskQueueReason::DiskPressure),
+                projected_reservation_bytes: 8_589_934_592,
+            }),
+        }));
+        // The build is still permitted — the disk dimension never denies.
+        let permit = WarmAdmission::admit(&c, warm("disk-a")).await;
+        assert!(permit.is_ok(), "observe-only disk dimension must not deny");
+        assert_eq!(c.disk_would_defer_observation_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn disk_dimension_silent_when_source_grants_or_has_no_sample() {
+        use crate::disk_admission::DiskObservation;
+        let granting = controller(BuildAdmissionMode::Observe, 4);
+        granting.set_disk_capacity_source(Arc::new(StubDiskSource {
+            observation: Some(DiskObservation {
+                would_defer: None,
+                projected_reservation_bytes: 0,
+            }),
+        }));
+        WarmAdmission::admit(&granting, warm("disk-grant"))
+            .await
+            .unwrap();
+        assert_eq!(granting.disk_would_defer_observation_count().await, 0);
+
+        let no_sample = controller(BuildAdmissionMode::Observe, 4);
+        no_sample.set_disk_capacity_source(Arc::new(StubDiskSource { observation: None }));
+        WarmAdmission::admit(&no_sample, warm("disk-none"))
+            .await
+            .unwrap();
+        assert_eq!(no_sample.disk_would_defer_observation_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn disk_dimension_is_dark_without_a_source() {
+        let c = controller(BuildAdmissionMode::Observe, 4);
+        WarmAdmission::admit(&c, warm("dark")).await.unwrap();
+        assert_eq!(c.disk_would_defer_observation_count().await, 0);
     }
 
     #[tokio::test]

--- a/server/crates/djinn-coordinator/src/disk_admission.rs
+++ b/server/crates/djinn-coordinator/src/disk_admission.rs
@@ -1,0 +1,336 @@
+//! Observe-only disk-admission dimension for build workloads (proposal nquz,
+//! phase 1 — DARK/OBSERVE).
+//!
+//! This module is the capacity-snapshot adapter and the typed `disk_pressure` /
+//! `disk_capacity_unknown` queue-reason evaluator. It NEVER denies: it computes
+//! only what disk admission WOULD do given a capacity sample and the run-dir
+//! ledger totals, so telemetry can measure the future policy before it is armed.
+//!
+//! It is deliberately pure and side-effect-free (no filesystem writes, no DB
+//! access, no deletion). `build_admission.rs` remains the policy authority; this
+//! module supplies a self-contained decision that a later phase will consume.
+
+use std::path::Path;
+use std::time::Duration;
+
+/// Bounded classification of a node-local cache volume's free space.
+///
+/// Supplied by the capacity observer (`1c9q`); `Unknown` covers a missing or
+/// unclassifiable sample.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiskCapacityState {
+    Healthy,
+    Warning,
+    Critical,
+    Unknown,
+}
+
+impl DiskCapacityState {
+    /// Classify free space against a critical and a warning floor. `critical`
+    /// must be the smaller floor; a mis-ordered pair still classifies safely by
+    /// checking the critical floor first.
+    #[must_use]
+    pub fn classify(free_bytes: u64, critical_free_bytes: u64, warning_free_bytes: u64) -> Self {
+        if free_bytes <= critical_free_bytes {
+            Self::Critical
+        } else if free_bytes <= warning_free_bytes {
+            Self::Warning
+        } else {
+            Self::Healthy
+        }
+    }
+}
+
+/// A single, timestamped capacity observation for one volume.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CapacitySample {
+    pub free_bytes: u64,
+    pub total_bytes: u64,
+    pub state: DiskCapacityState,
+    /// Age of this sample at evaluation time.
+    pub age: Duration,
+}
+
+/// Current tracked byte totals for a volume, derived from the run-dir ledger.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LedgerTotals {
+    pub tracked_measured_bytes: u64,
+    pub outstanding_reserved_bytes: u64,
+}
+
+/// A build request's disk footprint, as far as disk admission cares.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiskAdmissionRequest {
+    /// The last successful allocated-byte measurement for this project + base
+    /// fingerprint (or a conservative inventory when there is no history). It is
+    /// rounded up by 10% internally to form the seed projection.
+    pub projected_seed_bytes: u64,
+    /// True when the request reuses an already-ready run dir within its existing
+    /// reservation, so no new bytes are reserved.
+    pub reuses_ready_dir: bool,
+}
+
+/// Typed disk queue reason recorded in observe mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiskQueueReason {
+    /// Measured critical pressure, or a fresh sample that fails budget/headroom.
+    DiskPressure,
+    /// The sample is stale or unknown and the request would reserve new bytes.
+    DiskCapacityUnknown,
+}
+
+impl DiskQueueReason {
+    /// The bounded telemetry label for this reason.
+    #[must_use]
+    pub fn as_metric(self) -> &'static str {
+        match self {
+            Self::DiskPressure => djinn_telemetry::run_dir::QUEUE_REASON_DISK_PRESSURE,
+            Self::DiskCapacityUnknown => {
+                djinn_telemetry::run_dir::QUEUE_REASON_DISK_CAPACITY_UNKNOWN
+            }
+        }
+    }
+}
+
+/// The observe-mode outcome. In phase 1 this NEVER changes a dispatch decision;
+/// `would_defer` records what enforce mode would do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiskObservation {
+    /// `Some(reason)` when disk admission WOULD have queued this build.
+    pub would_defer: Option<DiskQueueReason>,
+    /// The bytes this request would reserve (0 for a zero-growth reuse).
+    pub projected_reservation_bytes: u64,
+}
+
+/// Per-volume disk-admission configuration. Phase-1 defaults are inert
+/// placeholders: nothing consumes them for a live decision yet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DiskAdmissionConfig {
+    pub cache_budget_bytes: u64,
+    pub critical_free_bytes: u64,
+    pub emergency_headroom_bytes: u64,
+    pub per_lease_growth_bytes: u64,
+    pub max_sample_age: Duration,
+}
+
+/// 10 GiB, the proposal's default emergency headroom.
+pub const DEFAULT_EMERGENCY_HEADROOM_BYTES: u64 = 10 * 1024 * 1024 * 1024;
+/// 90 seconds, the proposal's freshness bound for a capacity sample.
+pub const DEFAULT_MAX_SAMPLE_AGE: Duration = Duration::from_secs(90);
+
+impl Default for DiskAdmissionConfig {
+    fn default() -> Self {
+        Self {
+            cache_budget_bytes: 200 * 1024 * 1024 * 1024,
+            critical_free_bytes: 20 * 1024 * 1024 * 1024,
+            emergency_headroom_bytes: DEFAULT_EMERGENCY_HEADROOM_BYTES,
+            per_lease_growth_bytes: 4 * 1024 * 1024 * 1024,
+            max_sample_age: DEFAULT_MAX_SAMPLE_AGE,
+        }
+    }
+}
+
+impl DiskAdmissionConfig {
+    /// The effective emergency headroom for a volume: at least the configured
+    /// value, and never less than 5% of filesystem capacity.
+    #[must_use]
+    pub fn effective_emergency_headroom(&self, total_bytes: u64) -> u64 {
+        self.emergency_headroom_bytes.max(total_bytes / 20)
+    }
+}
+
+/// Round a byte count up by 10% (saturating). This is the conservative seed
+/// projection rounding from the proposal.
+#[must_use]
+pub fn round_up_by_10_percent(bytes: u64) -> u64 {
+    bytes.saturating_add(bytes / 10)
+}
+
+/// Evaluate what disk admission WOULD decide for a build request. Pure and
+/// non-denying: the returned `would_defer` is telemetry only in phase 1.
+///
+/// A zero-growth reuse of an already-ready dir is always a grant (no new bytes),
+/// even under critical pressure or an unknown sample, because it consumes no new
+/// allocation. Otherwise:
+///
+/// - `Critical` → `DiskPressure`;
+/// - stale or `Unknown` sample → `DiskCapacityUnknown` (an unmeasured new
+///   allocation is unsafe to claim);
+/// - a fresh `Healthy`/`Warning` sample that fails the budget or the
+///   emergency-headroom check → `DiskPressure`;
+/// - otherwise → grant.
+#[must_use]
+pub fn evaluate_disk_admission_observe(
+    config: &DiskAdmissionConfig,
+    sample: &CapacitySample,
+    ledger: &LedgerTotals,
+    request: &DiskAdmissionRequest,
+) -> DiskObservation {
+    if request.reuses_ready_dir {
+        return DiskObservation {
+            would_defer: None,
+            projected_reservation_bytes: 0,
+        };
+    }
+
+    let reservation = round_up_by_10_percent(request.projected_seed_bytes)
+        .saturating_add(config.per_lease_growth_bytes);
+
+    if sample.state == DiskCapacityState::Critical {
+        return DiskObservation {
+            would_defer: Some(DiskQueueReason::DiskPressure),
+            projected_reservation_bytes: reservation,
+        };
+    }
+
+    let stale = sample.age > config.max_sample_age;
+    if stale || sample.state == DiskCapacityState::Unknown {
+        return DiskObservation {
+            would_defer: Some(DiskQueueReason::DiskCapacityUnknown),
+            projected_reservation_bytes: reservation,
+        };
+    }
+
+    // Fresh Healthy/Warning sample: apply budget and headroom.
+    let projected_tracked = ledger
+        .tracked_measured_bytes
+        .saturating_add(ledger.outstanding_reserved_bytes)
+        .saturating_add(reservation);
+    let budget_ok = projected_tracked <= config.cache_budget_bytes;
+
+    let free_after = sample.free_bytes.saturating_sub(reservation);
+    let headroom_floor = config
+        .critical_free_bytes
+        .saturating_add(config.effective_emergency_headroom(sample.total_bytes));
+    let headroom_ok = free_after > headroom_floor;
+
+    let would_defer = if budget_ok && headroom_ok {
+        None
+    } else {
+        Some(DiskQueueReason::DiskPressure)
+    };
+
+    DiskObservation {
+        would_defer,
+        projected_reservation_bytes: reservation,
+    }
+}
+
+// ── Filesystem project-quota probe ──────────────────────────────────────────
+
+/// Result of probing a volume for filesystem project-quota support. Enforce mode
+/// is prohibited without working project quotas; observe mode remains available.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum QuotaSupport {
+    /// The mount backing the path advertises a project-quota option.
+    Available,
+    /// Project quotas are unavailable; the volume can only run in observe.
+    Unavailable { reason: QuotaUnavailableReason },
+}
+
+/// Bounded reasons a project-quota probe reports unavailable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuotaUnavailableReason {
+    /// No mount line covered the path.
+    NoMatchingMount,
+    /// The covering mount carries no project-quota option.
+    NoQuotaMountOption,
+    /// The mount table could not be read.
+    MountsUnreadable,
+}
+
+impl QuotaUnavailableReason {
+    #[must_use]
+    pub fn as_metric(self) -> &'static str {
+        // Every unavailable reason maps to the bounded probe-unavailable label;
+        // the specific reason is carried in logs, not the metric.
+        match self {
+            Self::NoMatchingMount | Self::NoQuotaMountOption | Self::MountsUnreadable => {
+                djinn_telemetry::run_dir::QUOTA_FAILURE_PROBE_UNAVAILABLE
+            }
+        }
+    }
+}
+
+/// Mount options that indicate project-quota accounting is enabled.
+const PROJECT_QUOTA_OPTIONS: [&str; 3] = ["prjquota", "pquota", "prjjquota"];
+
+/// Parse a Linux `/proc/mounts`-style table and decide whether the mount that
+/// covers `path` advertises a project-quota option. Pure and testable: the
+/// longest mount-point prefix of `path` wins, matching kernel semantics.
+#[must_use]
+pub fn parse_project_quota_support(mounts: &str, path: &Path) -> QuotaSupport {
+    let path_str = path.to_string_lossy();
+    let mut best_len = 0_usize;
+    let mut best_options: Option<String> = None;
+
+    for line in mounts.lines() {
+        let mut fields = line.split_whitespace();
+        let _device = fields.next();
+        let Some(mount_point) = fields.next() else {
+            continue;
+        };
+        let _fstype = fields.next();
+        let options = fields.next().unwrap_or("");
+        if path_covered_by_mount(&path_str, mount_point) && mount_point.len() >= best_len {
+            best_len = mount_point.len();
+            best_options = Some(options.to_owned());
+        }
+    }
+
+    match best_options {
+        None => QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoMatchingMount,
+        },
+        Some(options) => {
+            let has_quota = options
+                .split(',')
+                .any(|opt| PROJECT_QUOTA_OPTIONS.contains(&opt.trim()));
+            if has_quota {
+                QuotaSupport::Available
+            } else {
+                QuotaSupport::Unavailable {
+                    reason: QuotaUnavailableReason::NoQuotaMountOption,
+                }
+            }
+        }
+    }
+}
+
+fn path_covered_by_mount(path: &str, mount_point: &str) -> bool {
+    if mount_point == "/" {
+        return true;
+    }
+    if path == mount_point {
+        return true;
+    }
+    path.strip_prefix(mount_point)
+        .is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Probe the live mount table for project-quota support of `path`.
+///
+/// Read-only and best-effort. When the mount table cannot be read the volume is
+/// reported unavailable (observe), never optimistically available.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn probe_project_quota(path: &Path) -> QuotaSupport {
+    match std::fs::read_to_string("/proc/mounts") {
+        Ok(mounts) => parse_project_quota_support(&mounts, path),
+        Err(_) => QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::MountsUnreadable,
+        },
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+#[must_use]
+pub fn probe_project_quota(_path: &Path) -> QuotaSupport {
+    QuotaSupport::Unavailable {
+        reason: QuotaUnavailableReason::MountsUnreadable,
+    }
+}
+
+#[cfg(test)]
+#[path = "disk_admission_tests.rs"]
+mod tests;

--- a/server/crates/djinn-coordinator/src/disk_admission_tests.rs
+++ b/server/crates/djinn-coordinator/src/disk_admission_tests.rs
@@ -1,0 +1,231 @@
+//! Unit tests for the observe-only disk-admission evaluator and quota probe.
+
+use std::path::Path;
+use std::time::Duration;
+
+use super::*;
+
+const GIB: u64 = 1024 * 1024 * 1024;
+
+fn config() -> DiskAdmissionConfig {
+    DiskAdmissionConfig {
+        cache_budget_bytes: 100 * GIB,
+        critical_free_bytes: 20 * GIB,
+        emergency_headroom_bytes: 10 * GIB,
+        per_lease_growth_bytes: 4 * GIB,
+        max_sample_age: Duration::from_secs(90),
+    }
+}
+
+fn fresh(state: DiskCapacityState, free_bytes: u64) -> CapacitySample {
+    CapacitySample {
+        free_bytes,
+        total_bytes: 500 * GIB,
+        state,
+        age: Duration::from_secs(5),
+    }
+}
+
+fn new_request(seed_bytes: u64) -> DiskAdmissionRequest {
+    DiskAdmissionRequest {
+        projected_seed_bytes: seed_bytes,
+        reuses_ready_dir: false,
+    }
+}
+
+#[test]
+fn round_up_by_10_percent_is_conservative() {
+    assert_eq!(round_up_by_10_percent(0), 0);
+    assert_eq!(round_up_by_10_percent(100), 110);
+    assert_eq!(round_up_by_10_percent(u64::MAX), u64::MAX);
+}
+
+#[test]
+fn classify_orders_critical_then_warning_then_healthy() {
+    assert_eq!(
+        DiskCapacityState::classify(5, 10, 20),
+        DiskCapacityState::Critical
+    );
+    assert_eq!(
+        DiskCapacityState::classify(15, 10, 20),
+        DiskCapacityState::Warning
+    );
+    assert_eq!(
+        DiskCapacityState::classify(50, 10, 20),
+        DiskCapacityState::Healthy
+    );
+}
+
+#[test]
+fn healthy_fresh_within_budget_and_headroom_would_grant() {
+    let obs = evaluate_disk_admission_observe(
+        &config(),
+        &fresh(DiskCapacityState::Healthy, 200 * GIB),
+        &LedgerTotals::default(),
+        &new_request(2 * GIB),
+    );
+    assert_eq!(obs.would_defer, None);
+    // 2 GiB + 10% + 4 GiB per-lease growth.
+    assert_eq!(
+        obs.projected_reservation_bytes,
+        round_up_by_10_percent(2 * GIB) + 4 * GIB
+    );
+}
+
+#[test]
+fn critical_new_reservation_would_defer_disk_pressure() {
+    let obs = evaluate_disk_admission_observe(
+        &config(),
+        &fresh(DiskCapacityState::Critical, 5 * GIB),
+        &LedgerTotals::default(),
+        &new_request(2 * GIB),
+    );
+    assert_eq!(obs.would_defer, Some(DiskQueueReason::DiskPressure));
+}
+
+#[test]
+fn unknown_sample_new_reservation_would_defer_capacity_unknown() {
+    let obs = evaluate_disk_admission_observe(
+        &config(),
+        &fresh(DiskCapacityState::Unknown, 200 * GIB),
+        &LedgerTotals::default(),
+        &new_request(2 * GIB),
+    );
+    assert_eq!(obs.would_defer, Some(DiskQueueReason::DiskCapacityUnknown));
+}
+
+#[test]
+fn stale_sample_new_reservation_would_defer_capacity_unknown() {
+    let mut sample = fresh(DiskCapacityState::Healthy, 200 * GIB);
+    sample.age = Duration::from_secs(120);
+    let obs = evaluate_disk_admission_observe(
+        &config(),
+        &sample,
+        &LedgerTotals::default(),
+        &new_request(2 * GIB),
+    );
+    assert_eq!(obs.would_defer, Some(DiskQueueReason::DiskCapacityUnknown));
+}
+
+#[test]
+fn reuse_of_ready_dir_always_grants_even_under_critical() {
+    let obs = evaluate_disk_admission_observe(
+        &config(),
+        &fresh(DiskCapacityState::Critical, GIB),
+        &LedgerTotals::default(),
+        &DiskAdmissionRequest {
+            projected_seed_bytes: 50 * GIB,
+            reuses_ready_dir: true,
+        },
+    );
+    assert_eq!(obs.would_defer, None);
+    assert_eq!(obs.projected_reservation_bytes, 0);
+}
+
+#[test]
+fn budget_exceeded_would_defer_disk_pressure() {
+    let ledger = LedgerTotals {
+        tracked_measured_bytes: 98 * GIB,
+        outstanding_reserved_bytes: 0,
+    };
+    let obs = evaluate_disk_admission_observe(
+        &config(),
+        &fresh(DiskCapacityState::Healthy, 400 * GIB),
+        &ledger,
+        &new_request(2 * GIB),
+    );
+    assert_eq!(obs.would_defer, Some(DiskQueueReason::DiskPressure));
+}
+
+#[test]
+fn headroom_breach_would_defer_disk_pressure() {
+    // Free is above critical, but reserving new bytes would drop free below
+    // critical + emergency headroom.
+    let obs = evaluate_disk_admission_observe(
+        &config(),
+        &fresh(DiskCapacityState::Warning, 33 * GIB),
+        &LedgerTotals::default(),
+        &new_request(2 * GIB),
+    );
+    assert_eq!(obs.would_defer, Some(DiskQueueReason::DiskPressure));
+}
+
+#[test]
+fn effective_emergency_headroom_never_below_five_percent() {
+    let cfg = config();
+    // 5% of 1000 GiB = 50 GiB, which exceeds the configured 10 GiB.
+    assert_eq!(cfg.effective_emergency_headroom(1000 * GIB), 50 * GIB);
+    // For a small volume the configured floor wins.
+    assert_eq!(cfg.effective_emergency_headroom(20 * GIB), 10 * GIB);
+}
+
+#[test]
+fn queue_reason_metric_labels_are_stable() {
+    assert_eq!(DiskQueueReason::DiskPressure.as_metric(), "disk_pressure");
+    assert_eq!(
+        DiskQueueReason::DiskCapacityUnknown.as_metric(),
+        "disk_capacity_unknown"
+    );
+}
+
+// ── Quota probe parsing ─────────────────────────────────────────────────────
+
+#[test]
+fn parse_quota_available_when_mount_advertises_prjquota() {
+    let mounts = "\
+/dev/sda1 / ext4 rw,relatime 0 0
+/dev/sdb1 /cache xfs rw,relatime,prjquota 0 0
+";
+    assert_eq!(
+        parse_project_quota_support(mounts, Path::new("/cache/cargo-target-runs")),
+        QuotaSupport::Available
+    );
+}
+
+#[test]
+fn parse_quota_unavailable_without_option() {
+    let mounts = "\
+/dev/sda1 / ext4 rw,relatime 0 0
+/dev/sdb1 /cache xfs rw,relatime 0 0
+";
+    assert_eq!(
+        parse_project_quota_support(mounts, Path::new("/cache/runs")),
+        QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoQuotaMountOption,
+        }
+    );
+}
+
+#[test]
+fn parse_quota_prefers_longest_matching_mount() {
+    // Root has no quota; the nested /cache mount does. The longest prefix wins.
+    let mounts = "\
+/dev/sda1 / ext4 rw,relatime,prjquota 0 0
+/dev/sdb1 /cache xfs rw,relatime 0 0
+";
+    assert_eq!(
+        parse_project_quota_support(mounts, Path::new("/cache/runs/x")),
+        QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoQuotaMountOption,
+        }
+    );
+}
+
+#[test]
+fn parse_quota_falls_back_to_root_mount() {
+    let mounts = "/dev/sda1 / ext4 rw,relatime,pquota 0 0\n";
+    assert_eq!(
+        parse_project_quota_support(mounts, Path::new("/cache/runs")),
+        QuotaSupport::Available
+    );
+}
+
+#[test]
+fn parse_quota_no_matching_mount() {
+    assert_eq!(
+        parse_project_quota_support("", Path::new("/cache/runs")),
+        QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoMatchingMount,
+        }
+    );
+}

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -56,6 +56,7 @@ pub mod cargo_warm_base_gc;
 pub(crate) mod ci_preflight_gate;
 pub mod ci_reproduction;
 pub mod context;
+pub mod disk_admission;
 pub mod dispatch_pause;
 pub mod doctor;
 pub mod environment;
@@ -118,6 +119,7 @@ pub async fn record_supervisor_rework_reopen(
 
 pub mod resource_monitor;
 pub mod roles;
+pub mod run_dir_reconcile;
 pub mod supervisor_impl;
 pub mod task_merge;
 pub(crate) mod tripwires;

--- a/server/crates/djinn-coordinator/src/run_dir_reconcile.rs
+++ b/server/crates/djinn-coordinator/src/run_dir_reconcile.rs
@@ -1,0 +1,145 @@
+//! Startup reconciliation planner for the run-dir ledger (proposal nquz,
+//! phase 1 — DARK/OBSERVE).
+//!
+//! This is a PURE planner: it maps an on-disk inventory of UUID-named run
+//! directories to durable-ledger upsert intents. It NEVER deletes a directory
+//! and NEVER writes to the database — the caller applies the plan through
+//! `djinn_db::RunDirRepository::upsert_reconciled`.
+//!
+//! Reconciliation only inserts an authoritative lifecycle state
+//! (`ready_active` / `ready_idle` / `reclaimable`) when a resolver supplies
+//! pod/terminal evidence. Every unresolved, malformed, or non-authoritative
+//! directory is recorded as `quarantined_unowned`: it counts against observed
+//! physical bytes and is NEVER an automated deletion candidate.
+
+use djinn_db::{ReconciledRunDirInput, RunDirKey, RunDirState};
+
+/// One on-disk run directory observed by the inventory.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReconcileInventoryEntry {
+    /// The top-level directory name (a task-run UUID for a well-formed dir).
+    pub dir_name: String,
+    /// Allocated bytes measured for this directory.
+    pub measured_bytes: u64,
+    /// Absolute final path of the directory on the volume.
+    pub final_path: String,
+    /// True when the inventory could not treat this as a well-formed run dir
+    /// (malformed name, unreadable subtree, symlink, ...). Always quarantined.
+    pub malformed: bool,
+}
+
+/// Authoritative ownership resolved from pod/terminal evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedOwnership {
+    pub pod_uid: String,
+    pub task_run_id: String,
+    pub project_id: String,
+    pub base_fingerprint: String,
+    pub state: RunDirState,
+}
+
+/// Resolves a run-dir name to authoritative ownership, or `None` when no
+/// pod/terminal evidence exists (which forces a quarantine).
+pub trait RunDirOwnershipResolver {
+    fn resolve(&self, dir_name: &str) -> Option<ResolvedOwnership>;
+}
+
+/// A resolver that never resolves anything — the phase-1 default, under which
+/// every inventoried directory is quarantined as unowned.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoOwnershipResolver;
+
+impl RunDirOwnershipResolver for NoOwnershipResolver {
+    fn resolve(&self, _dir_name: &str) -> Option<ResolvedOwnership> {
+        None
+    }
+}
+
+/// The reconciliation plan: durable upserts plus bounded accounting. Contains no
+/// deletion intent of any kind.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ReconciliationPlan {
+    /// Rows to insert through the ledger repository, in inventory order.
+    pub upserts: Vec<ReconciledRunDirInput>,
+    /// Number of directories reconciled from authoritative evidence.
+    pub resolved_count: usize,
+    /// Number of directories quarantined as unowned.
+    pub quarantined_count: usize,
+    /// Measured bytes attributed to authoritative rows.
+    pub resolved_bytes: u64,
+    /// Measured bytes attributed to quarantined-unowned rows.
+    pub quarantined_bytes: u64,
+}
+
+/// The only lifecycle states a reconciler may assert from evidence.
+fn is_authoritative_state(state: RunDirState) -> bool {
+    matches!(
+        state,
+        RunDirState::ReadyActive | RunDirState::ReadyIdle | RunDirState::Reclaimable
+    )
+}
+
+/// Build the reconciliation plan for one volume.
+///
+/// Deterministic: entries are processed in the order supplied and the plan
+/// preserves that order, so a fixed inventory yields a byte-identical plan.
+pub fn plan_reconciliation(
+    volume_id: &str,
+    entries: &[ReconcileInventoryEntry],
+    resolver: &dyn RunDirOwnershipResolver,
+) -> ReconciliationPlan {
+    let mut plan = ReconciliationPlan::default();
+    for entry in entries {
+        let resolved = if entry.malformed {
+            None
+        } else {
+            resolver
+                .resolve(&entry.dir_name)
+                .filter(|owned| is_authoritative_state(owned.state))
+        };
+
+        match resolved {
+            Some(owned) => {
+                plan.resolved_count += 1;
+                plan.resolved_bytes = plan.resolved_bytes.saturating_add(entry.measured_bytes);
+                plan.upserts.push(ReconciledRunDirInput {
+                    key: RunDirKey {
+                        volume_id: volume_id.to_owned(),
+                        pod_uid: owned.pod_uid,
+                    },
+                    task_run_id: Some(owned.task_run_id),
+                    project_id: Some(owned.project_id),
+                    base_fingerprint: Some(owned.base_fingerprint),
+                    state: owned.state,
+                    measured_bytes: entry.measured_bytes as i64,
+                    final_path: Some(entry.final_path.clone()),
+                });
+            }
+            None => {
+                plan.quarantined_count += 1;
+                plan.quarantined_bytes =
+                    plan.quarantined_bytes.saturating_add(entry.measured_bytes);
+                plan.upserts.push(ReconciledRunDirInput {
+                    // With no resolved pod UID, the unique directory name keys the
+                    // quarantine row; the untrusted name is NOT stored as an
+                    // authoritative task-run binding.
+                    key: RunDirKey {
+                        volume_id: volume_id.to_owned(),
+                        pod_uid: entry.dir_name.clone(),
+                    },
+                    task_run_id: None,
+                    project_id: None,
+                    base_fingerprint: None,
+                    state: RunDirState::QuarantinedUnowned,
+                    measured_bytes: entry.measured_bytes as i64,
+                    final_path: Some(entry.final_path.clone()),
+                });
+            }
+        }
+    }
+    plan
+}
+
+#[cfg(test)]
+#[path = "run_dir_reconcile_tests.rs"]
+mod tests;

--- a/server/crates/djinn-coordinator/src/run_dir_reconcile_tests.rs
+++ b/server/crates/djinn-coordinator/src/run_dir_reconcile_tests.rs
@@ -1,0 +1,158 @@
+//! Deterministic fixtures and tests for the run-dir reconciliation planner.
+
+use std::collections::HashMap;
+
+use super::*;
+
+const VOLUME: &str = "node-vol-a";
+
+/// A resolver backed by a fixed map for deterministic fixtures.
+struct MapResolver {
+    map: HashMap<String, ResolvedOwnership>,
+}
+
+impl RunDirOwnershipResolver for MapResolver {
+    fn resolve(&self, dir_name: &str) -> Option<ResolvedOwnership> {
+        self.map.get(dir_name).cloned()
+    }
+}
+
+fn entry(name: &str, bytes: u64, malformed: bool) -> ReconcileInventoryEntry {
+    ReconcileInventoryEntry {
+        dir_name: name.to_owned(),
+        measured_bytes: bytes,
+        final_path: format!("/cache/cargo-target-runs/{name}"),
+        malformed,
+    }
+}
+
+/// A fixed three-directory inventory: one resolvable-live, one resolvable-
+/// terminal, one unresolved, plus one malformed entry.
+fn fixture_inventory() -> Vec<ReconcileInventoryEntry> {
+    vec![
+        entry("11111111-1111-1111-1111-111111111111", 1_000, false),
+        entry("22222222-2222-2222-2222-222222222222", 2_000, false),
+        entry("33333333-3333-3333-3333-333333333333", 4_000, false),
+        entry("not-a-uuid", 8_000, true),
+    ]
+}
+
+fn fixture_resolver() -> MapResolver {
+    let mut map = HashMap::new();
+    map.insert(
+        "11111111-1111-1111-1111-111111111111".to_owned(),
+        ResolvedOwnership {
+            pod_uid: "pod-live".to_owned(),
+            task_run_id: "run-live".to_owned(),
+            project_id: "proj-1".to_owned(),
+            base_fingerprint: "fp-1".to_owned(),
+            state: RunDirState::ReadyActive,
+        },
+    );
+    map.insert(
+        "22222222-2222-2222-2222-222222222222".to_owned(),
+        ResolvedOwnership {
+            pod_uid: "pod-terminal".to_owned(),
+            task_run_id: "run-terminal".to_owned(),
+            project_id: "proj-1".to_owned(),
+            base_fingerprint: "fp-1".to_owned(),
+            state: RunDirState::Reclaimable,
+        },
+    );
+    // "3333..." is deliberately absent from the map -> unresolved -> quarantine.
+    MapResolver { map }
+}
+
+#[test]
+fn phase1_no_resolver_quarantines_everything() {
+    let inventory = fixture_inventory();
+    let plan = plan_reconciliation(VOLUME, &inventory, &NoOwnershipResolver);
+    assert_eq!(plan.resolved_count, 0);
+    assert_eq!(plan.quarantined_count, 4);
+    assert_eq!(plan.quarantined_bytes, 1_000 + 2_000 + 4_000 + 8_000);
+    assert!(
+        plan.upserts
+            .iter()
+            .all(|u| u.state == RunDirState::QuarantinedUnowned),
+        "phase 1 default resolver must quarantine every dir"
+    );
+    // No deletion intent is expressible: the plan is upserts only.
+}
+
+#[test]
+fn resolved_and_unresolved_partition_deterministically() {
+    let inventory = fixture_inventory();
+    let plan = plan_reconciliation(VOLUME, &inventory, &fixture_resolver());
+
+    assert_eq!(plan.resolved_count, 2);
+    assert_eq!(plan.resolved_bytes, 1_000 + 2_000);
+    assert_eq!(plan.quarantined_count, 2); // unresolved + malformed
+    assert_eq!(plan.quarantined_bytes, 4_000 + 8_000);
+
+    // Order is preserved; identity is taken from authoritative evidence.
+    let live = &plan.upserts[0];
+    assert_eq!(live.state, RunDirState::ReadyActive);
+    assert_eq!(live.key.pod_uid, "pod-live");
+    assert_eq!(live.task_run_id.as_deref(), Some("run-live"));
+
+    let terminal = &plan.upserts[1];
+    assert_eq!(terminal.state, RunDirState::Reclaimable);
+    assert_eq!(terminal.key.pod_uid, "pod-terminal");
+
+    // Unresolved: keyed by the untrusted dir name, no task-run binding stored.
+    let unresolved = &plan.upserts[2];
+    assert_eq!(unresolved.state, RunDirState::QuarantinedUnowned);
+    assert_eq!(
+        unresolved.key.pod_uid,
+        "33333333-3333-3333-3333-333333333333"
+    );
+    assert_eq!(unresolved.task_run_id, None);
+
+    // Malformed is always quarantined regardless of any resolver answer.
+    let malformed = &plan.upserts[3];
+    assert_eq!(malformed.state, RunDirState::QuarantinedUnowned);
+    assert_eq!(malformed.key.pod_uid, "not-a-uuid");
+}
+
+#[test]
+fn malformed_entry_is_quarantined_even_if_resolvable() {
+    // A resolver that WOULD resolve the malformed name must be ignored.
+    let mut map = HashMap::new();
+    map.insert(
+        "not-a-uuid".to_owned(),
+        ResolvedOwnership {
+            pod_uid: "pod-x".to_owned(),
+            task_run_id: "run-x".to_owned(),
+            project_id: "proj-1".to_owned(),
+            base_fingerprint: "fp-1".to_owned(),
+            state: RunDirState::ReadyActive,
+        },
+    );
+    let inventory = vec![entry("not-a-uuid", 8_000, true)];
+    let plan = plan_reconciliation(VOLUME, &inventory, &MapResolver { map });
+    assert_eq!(plan.quarantined_count, 1);
+    assert_eq!(plan.resolved_count, 0);
+    assert_eq!(plan.upserts[0].state, RunDirState::QuarantinedUnowned);
+}
+
+#[test]
+fn non_authoritative_resolved_state_is_quarantined() {
+    // A resolver returning a non-authoritative state (e.g. seeding) must not be
+    // asserted as a reconciled row.
+    let mut map = HashMap::new();
+    map.insert(
+        "11111111-1111-1111-1111-111111111111".to_owned(),
+        ResolvedOwnership {
+            pod_uid: "pod-live".to_owned(),
+            task_run_id: "run-live".to_owned(),
+            project_id: "proj-1".to_owned(),
+            base_fingerprint: "fp-1".to_owned(),
+            state: RunDirState::Seeding,
+        },
+    );
+    let inventory = vec![entry("11111111-1111-1111-1111-111111111111", 1_000, false)];
+    let plan = plan_reconciliation(VOLUME, &inventory, &MapResolver { map });
+    assert_eq!(plan.resolved_count, 0);
+    assert_eq!(plan.quarantined_count, 1);
+    assert_eq!(plan.upserts[0].state, RunDirState::QuarantinedUnowned);
+}

--- a/server/crates/djinn-core/src/cargo_target_runs.rs
+++ b/server/crates/djinn-core/src/cargo_target_runs.rs
@@ -238,6 +238,95 @@ pub fn inventory_cargo_target_runs(
     Err(CargoTargetRunsInventoryError::UnsupportedPlatform)
 }
 
+/// Measure the allocated bytes (`st_blocks * 512`, inode-deduplicated, no symlink
+/// follow) of a single per-run directory `<root>/<id>`.
+///
+/// This is the per-row measurement the disk-admission ledger records as
+/// `measured_bytes` during reconciliation and after a lease releases. It never
+/// deletes and never follows symlinks. Returns:
+///
+/// - `Ok(Some(bytes))` when the run dir exists and was fully measured;
+/// - `Ok(None)` when `id` is malformed (cannot be a seeded run dir) or the dir
+///   is absent — a missing dir contributes zero tracked bytes;
+/// - `Err(..)` only on a byte-accounting overflow or an unreadable, present dir,
+///   which must never be mistaken for zero.
+#[cfg(unix)]
+pub fn measure_run_dir_allocated_bytes(
+    root: &Path,
+    id: &str,
+) -> Result<Option<u64>, CargoTargetRunsInventoryError> {
+    let Some(dir) = run_dir_within(root, id) else {
+        return Ok(None);
+    };
+    let metadata = match fs::symlink_metadata(&dir) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(CargoTargetRunsInventoryError::RootRead(err)),
+    };
+    // A top-level symlink is never a seeded run dir; refuse to measure through it.
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Ok(None);
+    }
+    let mut seen = HashSet::new();
+    let mut total = allocated_bytes(&metadata, &mut seen)?.unwrap_or(0);
+    total = total
+        .checked_add(measure_dir_tree(&dir, &mut seen)?)
+        .ok_or(CargoTargetRunsInventoryError::ByteOverflow)?;
+    Ok(Some(total))
+}
+
+#[cfg(not(unix))]
+pub fn measure_run_dir_allocated_bytes(
+    _root: &Path,
+    _id: &str,
+) -> Result<Option<u64>, CargoTargetRunsInventoryError> {
+    Err(CargoTargetRunsInventoryError::UnsupportedPlatform)
+}
+
+/// Recursively sum `st_blocks * 512` for a directory subtree, deduplicating by
+/// `(dev, ino)` and never following symlinks. A present-but-unreadable subtree is
+/// a hard error so a partial measurement cannot masquerade as a small dir.
+#[cfg(unix)]
+fn measure_dir_tree(
+    path: &Path,
+    seen: &mut HashSet<(u64, u64)>,
+) -> Result<u64, CargoTargetRunsInventoryError> {
+    let entries = fs::read_dir(path).map_err(CargoTargetRunsInventoryError::RootRead)?;
+    let mut total = 0_u64;
+    for entry in entries {
+        let entry = entry.map_err(CargoTargetRunsInventoryError::RootRead)?;
+        let metadata =
+            fs::symlink_metadata(entry.path()).map_err(CargoTargetRunsInventoryError::RootRead)?;
+        if let Some(bytes) = allocated_bytes(&metadata, seen)? {
+            total = total
+                .checked_add(bytes)
+                .ok_or(CargoTargetRunsInventoryError::ByteOverflow)?;
+        }
+        if metadata.is_dir() && !metadata.file_type().is_symlink() {
+            total = total
+                .checked_add(measure_dir_tree(&entry.path(), seen)?)
+                .ok_or(CargoTargetRunsInventoryError::ByteOverflow)?;
+        }
+    }
+    Ok(total)
+}
+
+/// Allocated bytes for one inode, or `None` if already counted this walk.
+#[cfg(unix)]
+fn allocated_bytes(
+    metadata: &fs::Metadata,
+    seen: &mut HashSet<(u64, u64)>,
+) -> Result<Option<u64>, CargoTargetRunsInventoryError> {
+    if !seen.insert((metadata.dev(), metadata.ino())) {
+        return Ok(None);
+    }
+    metadata
+        .blocks()
+        .checked_mul(512)
+        .ok_or(CargoTargetRunsInventoryError::ByteOverflow)
+        .map(Some)
+}
+
 #[cfg(unix)]
 fn inventory_directory(
     path: &Path,

--- a/server/crates/djinn-core/src/cargo_target_runs_tests.rs
+++ b/server/crates/djinn-core/src/cargo_target_runs_tests.rs
@@ -756,3 +756,56 @@ impl Filesystem for RaceToSymlinkFilesystem {
         fs::remove_dir_all(path)
     }
 }
+
+// ── Per-run allocated-byte measurement (proposal nquz phase 1) ──────────────
+
+#[cfg(unix)]
+#[test]
+fn measure_run_dir_returns_positive_bytes_for_seeded_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let id = "22222222-2222-2222-2222-222222222222";
+    mkdir(tmp.path(), id);
+    let bytes = measure_run_dir_allocated_bytes(tmp.path(), id)
+        .unwrap()
+        .expect("seeded dir is measurable");
+    assert!(bytes > 0, "a seeded dir with artifacts must allocate bytes");
+}
+
+#[cfg(unix)]
+#[test]
+fn measure_run_dir_absent_dir_is_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let id = "33333333-3333-3333-3333-333333333333";
+    assert_eq!(
+        measure_run_dir_allocated_bytes(tmp.path(), id).unwrap(),
+        None
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn measure_run_dir_malformed_id_is_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert_eq!(
+        measure_run_dir_allocated_bytes(tmp.path(), "../escape").unwrap(),
+        None
+    );
+    assert_eq!(
+        measure_run_dir_allocated_bytes(tmp.path(), "").unwrap(),
+        None
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn measure_run_dir_refuses_top_level_symlink() {
+    let tmp = tempfile::tempdir().unwrap();
+    let real = mkdir(tmp.path(), "real-target");
+    let link_id = "44444444-4444-4444-4444-444444444444";
+    symlink(&real, tmp.path().join(link_id)).unwrap();
+    assert_eq!(
+        measure_run_dir_allocated_bytes(tmp.path(), link_id).unwrap(),
+        None,
+        "a top-level symlink is never a seeded run dir"
+    );
+}

--- a/server/crates/djinn-db/migrations_postgres/151_run_dir_disk_admission.sql
+++ b/server/crates/djinn-db/migrations_postgres/151_run_dir_disk_admission.sql
@@ -1,0 +1,64 @@
+-- Durable run-dir ledger for disk-aware build admission (proposal nquz, phase 1).
+--
+-- This migration is purely additive: it introduces the run-dir ledger and does
+-- NOT modify any existing admission_journal / admission_handoff row. In this
+-- phase the ledger ships DARK/OBSERVE — nothing writes production rows through
+-- it yet, eager cargo-target seeding stays enabled, and no GC deletion path is
+-- wired to it.
+--
+-- A row is keyed by (volume_id, pod_uid) and carries the lease-coupled
+-- run-dir lifecycle. Generations are compared-and-set by the repository under a
+-- per-volume advisory lock plus `SELECT FOR UPDATE` on the row itself, mirroring
+-- the admission_journal serialization conventions.
+CREATE TABLE run_dirs (
+    volume_id        VARCHAR(255) NOT NULL,
+    pod_uid          VARCHAR(255) NOT NULL,
+    task_run_id      VARCHAR(255) NULL,
+    project_id       VARCHAR(255) NULL,
+    base_fingerprint VARCHAR(255) NULL,
+    state            VARCHAR(24)  NOT NULL,
+    generation       BIGINT       NOT NULL DEFAULT 0,
+    reserved_bytes   BIGINT       NOT NULL DEFAULT 0,
+    measured_bytes   BIGINT       NOT NULL DEFAULT 0,
+    quota_id         VARCHAR(255) NULL,
+    last_lease_at    TIMESTAMPTZ  NULL,
+    temp_path        TEXT         NULL,
+    final_path       TEXT         NULL,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (volume_id, pod_uid),
+    CONSTRAINT run_dirs_generation_nonneg CHECK (generation >= 0),
+    CONSTRAINT run_dirs_reserved_bytes_nonneg CHECK (reserved_bytes >= 0),
+    CONSTRAINT run_dirs_measured_bytes_nonneg CHECK (measured_bytes >= 0),
+    -- The eight lease-lifecycle states plus the reconciliation-only
+    -- `quarantined_unowned` bucket. Quarantined dirs count against observed
+    -- physical bytes but are never an automated deletion candidate.
+    CONSTRAINT run_dirs_state_check CHECK (
+        state IN (
+            'absent',
+            'reserved',
+            'seeding',
+            'ready_active',
+            'ready_idle',
+            'reclaimable',
+            'reclaiming',
+            'quarantined_unowned'
+        )
+    )
+);
+
+-- Volume/state aggregation drives GC ordering and bounded telemetry rollups.
+CREATE INDEX run_dirs_volume_state_idx
+    ON run_dirs (volume_id, state);
+
+-- Terminal-callback reconciliation resolves a run row by its runtime task-run
+-- UID; only non-null bindings are ever queried this way.
+CREATE INDEX run_dirs_task_run_idx
+    ON run_dirs (task_run_id)
+    WHERE task_run_id IS NOT NULL;
+
+-- The seed byte projection consults the last successful measurement for the
+-- same project and base fingerprint.
+CREATE INDEX run_dirs_project_fingerprint_idx
+    ON run_dirs (project_id, base_fingerprint)
+    WHERE project_id IS NOT NULL AND base_fingerprint IS NOT NULL;

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -222,6 +222,10 @@ pub use repositories::{
         RepoGraphRetentionRepository, RetentionMode, RetentionSkipClass, RetentionSweepOutcome,
         RetentionSweepRequest,
     },
+    run_dirs::{
+        ReconciledRunDirInput, ReserveRunDirInput, RunDirKey, RunDirRepository, RunDirRow,
+        RunDirState, RunDirStateTotals,
+    },
     scip_indexer_timing::{
         ScipIndexerTiming, ScipIndexerTimingObservation, ScipIndexerTimingRepository,
         TIMING_STATUS_FAILED, TIMING_STATUS_SUCCESS, TIMING_STATUS_TIMED_OUT,

--- a/server/crates/djinn-db/src/repositories/mod.rs
+++ b/server/crates/djinn-db/src/repositories/mod.rs
@@ -40,6 +40,7 @@ pub mod repo_graph_retention;
 pub mod retrieval_trace;
 #[cfg(test)]
 pub mod retrieval_trace_tests;
+pub mod run_dirs;
 pub mod scip_indexer_timing;
 pub mod service;
 pub mod session;

--- a/server/crates/djinn-db/src/repositories/run_dirs.rs
+++ b/server/crates/djinn-db/src/repositories/run_dirs.rs
@@ -1,0 +1,650 @@
+//! Durable run-dir ledger primitives for disk-aware build admission.
+//!
+//! This repository owns storage invariants and compare-and-set generation
+//! transitions for per-pod Cargo run directories. Admission policy, capacity
+//! observation, seeding, reconciliation orchestration, and any deletion decision
+//! remain in higher layers. Nothing here creates, seeds, or deletes a filesystem
+//! directory — the ledger only records the durable lifecycle state.
+//!
+//! Ships DARK/OBSERVE (proposal nquz, phase 1): no production caller writes rows
+//! through this ledger yet, and no automated GC path consumes it.
+//!
+//! Serialization mirrors `admission_journal.rs`: every mutating transition takes
+//! a per-volume transaction-scoped advisory lock plus `SELECT ... FOR UPDATE` on
+//! the run-dir row, then applies a compare-and-set on `(state, generation)`.
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Postgres, Transaction};
+
+use crate::database::Database;
+use crate::error::{DbError, DbResult};
+
+const RUN_DIR_COLUMNS: &str = "volume_id, pod_uid, task_run_id, project_id, base_fingerprint, \
+     state, generation, reserved_bytes, measured_bytes, quota_id, \
+     last_lease_at::text, temp_path, final_path, created_at::text, updated_at::text";
+
+/// Durable lease-coupled lifecycle state of a run directory.
+///
+/// The eight lifecycle states follow the proposal state table. The extra
+/// [`RunDirState::QuarantinedUnowned`] bucket is reconciliation-only: it counts
+/// against observed physical bytes but is never an automated deletion candidate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunDirState {
+    /// No published or temporary directory.
+    Absent,
+    /// Bytes and quota ID committed; no allocation yet.
+    Reserved,
+    /// One generation owns a temp path.
+    Seeding,
+    /// Published and protected by a current/recent lease.
+    ReadyActive,
+    /// Live pod, lease-recency window elapsed.
+    ReadyIdle,
+    /// Terminal pod proof landed; eligible for reclaim.
+    Reclaimable,
+    /// One GC generation owns deletion.
+    Reclaiming,
+    /// Reconciliation could not resolve authoritative ownership.
+    QuarantinedUnowned,
+}
+
+impl RunDirState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Absent => "absent",
+            Self::Reserved => "reserved",
+            Self::Seeding => "seeding",
+            Self::ReadyActive => "ready_active",
+            Self::ReadyIdle => "ready_idle",
+            Self::Reclaimable => "reclaimable",
+            Self::Reclaiming => "reclaiming",
+            Self::QuarantinedUnowned => "quarantined_unowned",
+        }
+    }
+
+    fn parse(value: &str) -> DbResult<Self> {
+        match value {
+            "absent" => Ok(Self::Absent),
+            "reserved" => Ok(Self::Reserved),
+            "seeding" => Ok(Self::Seeding),
+            "ready_active" => Ok(Self::ReadyActive),
+            "ready_idle" => Ok(Self::ReadyIdle),
+            "reclaimable" => Ok(Self::Reclaimable),
+            "reclaiming" => Ok(Self::Reclaiming),
+            "quarantined_unowned" => Ok(Self::QuarantinedUnowned),
+            _ => Err(DbError::InvalidData(format!(
+                "invalid run-dir state `{value}`"
+            ))),
+        }
+    }
+
+    /// Every state string, for bounded telemetry rollups.
+    pub const ALL: [RunDirState; 8] = [
+        Self::Absent,
+        Self::Reserved,
+        Self::Seeding,
+        Self::ReadyActive,
+        Self::ReadyIdle,
+        Self::Reclaimable,
+        Self::Reclaiming,
+        Self::QuarantinedUnowned,
+    ];
+}
+
+/// Identity of one run directory on a node-local cache volume.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunDirKey {
+    pub volume_id: String,
+    pub pod_uid: String,
+}
+
+/// Input required to reserve one run-dir generation.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReserveRunDirInput {
+    pub key: RunDirKey,
+    pub task_run_id: Option<String>,
+    pub project_id: Option<String>,
+    pub base_fingerprint: Option<String>,
+    pub reserved_bytes: i64,
+    pub quota_id: Option<String>,
+}
+
+/// Authoritative evidence used to insert a reconciled row at startup.
+///
+/// Reconciliation never deletes: an unresolved or malformed directory is
+/// recorded as [`RunDirState::QuarantinedUnowned`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReconciledRunDirInput {
+    pub key: RunDirKey,
+    pub task_run_id: Option<String>,
+    pub project_id: Option<String>,
+    pub base_fingerprint: Option<String>,
+    pub state: RunDirState,
+    pub measured_bytes: i64,
+    pub final_path: Option<String>,
+}
+
+/// Durable ledger record. Timestamps are RFC3339-formatted by PostgreSQL.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunDirRow {
+    pub key: RunDirKey,
+    pub task_run_id: Option<String>,
+    pub project_id: Option<String>,
+    pub base_fingerprint: Option<String>,
+    pub state: RunDirState,
+    pub generation: i64,
+    pub reserved_bytes: i64,
+    pub measured_bytes: i64,
+    pub quota_id: Option<String>,
+    pub last_lease_at: Option<String>,
+    pub temp_path: Option<String>,
+    pub final_path: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Aggregated per-state totals for one volume; drives bounded telemetry.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunDirStateTotals {
+    pub state: RunDirState,
+    pub count: i64,
+    pub reserved_bytes: i64,
+    pub measured_bytes: i64,
+}
+
+/// Atomic Postgres repository for the run-dir ledger.
+pub struct RunDirRepository {
+    db: Database,
+}
+
+impl RunDirRepository {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Reserve a new generation for a run directory.
+    ///
+    /// A missing or `absent` row transitions to `reserved` with an incremented
+    /// generation so a stale later callback for the prior generation can never
+    /// match. Any non-absent existing state is a conflict and fails closed.
+    /// Re-reserving an already-`reserved` row with the same identity is
+    /// idempotent and returns the current row unchanged.
+    pub async fn reserve(&self, input: &ReserveRunDirInput) -> DbResult<RunDirRow> {
+        if input.reserved_bytes < 0 {
+            return Err(DbError::InvalidData(
+                "run-dir reserved_bytes must be non-negative".into(),
+            ));
+        }
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        lock_volume(&mut tx, &input.key.volume_id).await?;
+
+        let existing = fetch_for_update(&mut tx, &input.key).await?;
+        let row = match existing {
+            None => {
+                let inserted = sqlx::query_as::<_, RunDirDbRow>(&format!(
+                    "INSERT INTO run_dirs \
+                     (volume_id, pod_uid, task_run_id, project_id, base_fingerprint, \
+                      state, generation, reserved_bytes, measured_bytes, quota_id) \
+                     VALUES ($1, $2, $3, $4, $5, 'reserved', 0, $6, 0, $7) \
+                     RETURNING {RUN_DIR_COLUMNS}"
+                ))
+                .bind(&input.key.volume_id)
+                .bind(&input.key.pod_uid)
+                .bind(&input.task_run_id)
+                .bind(&input.project_id)
+                .bind(&input.base_fingerprint)
+                .bind(input.reserved_bytes)
+                .bind(&input.quota_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                inserted.try_into()?
+            }
+            Some(current) if current.state == RunDirState::Reserved => current,
+            Some(current) if current.state == RunDirState::Absent => {
+                let updated = sqlx::query_as::<_, RunDirDbRow>(&format!(
+                    "UPDATE run_dirs SET state = 'reserved', generation = generation + 1, \
+                     task_run_id = $3, project_id = $4, base_fingerprint = $5, \
+                     reserved_bytes = $6, measured_bytes = 0, quota_id = $7, \
+                     temp_path = NULL, final_path = NULL, updated_at = now() \
+                     WHERE volume_id = $1 AND pod_uid = $2 RETURNING {RUN_DIR_COLUMNS}"
+                ))
+                .bind(&input.key.volume_id)
+                .bind(&input.key.pod_uid)
+                .bind(&input.task_run_id)
+                .bind(&input.project_id)
+                .bind(&input.base_fingerprint)
+                .bind(input.reserved_bytes)
+                .bind(&input.quota_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                updated.try_into()?
+            }
+            Some(current) => {
+                return Err(DbError::InvalidTransition(format!(
+                    "cannot reserve run-dir from {:?}",
+                    current.state
+                )));
+            }
+        };
+        tx.commit().await?;
+        Ok(row)
+    }
+
+    /// Compare-and-set a run-dir transition.
+    ///
+    /// The transition proceeds only when the current row exists with
+    /// `generation == expected_generation` and `state ∈ allowed_from`. It is the
+    /// linearization point: exactly one of a competing acquire and GC wins.
+    async fn transition(
+        &self,
+        key: &RunDirKey,
+        expected_generation: i64,
+        allowed_from: &[RunDirState],
+        spec: TransitionSpec<'_>,
+    ) -> DbResult<RunDirRow> {
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        lock_volume(&mut tx, &key.volume_id).await?;
+
+        let current = fetch_for_update(&mut tx, key)
+            .await?
+            .ok_or_else(|| DbError::InvalidTransition(format!("run-dir {key:?} does not exist")))?;
+        if current.generation != expected_generation {
+            return Err(DbError::InvalidTransition(format!(
+                "stale run-dir generation {} (durable {})",
+                expected_generation, current.generation
+            )));
+        }
+        // A same-target no-op re-application is idempotent within the generation.
+        if current.state == spec.to && !spec.bump_generation {
+            return Ok(current);
+        }
+        if !allowed_from.contains(&current.state) {
+            return Err(DbError::InvalidTransition(format!(
+                "cannot transition run-dir to {:?} from {:?}",
+                spec.to, current.state
+            )));
+        }
+        let gen_expr = if spec.bump_generation {
+            "generation + 1"
+        } else {
+            "generation"
+        };
+        let sql = format!(
+            "UPDATE run_dirs SET state = $3, generation = {gen_expr}, \
+             temp_path = CASE WHEN $4 THEN $5 ELSE temp_path END, \
+             final_path = CASE WHEN $6 THEN $7 ELSE final_path END, \
+             measured_bytes = CASE WHEN $8 THEN $9 ELSE measured_bytes END, \
+             reserved_bytes = CASE WHEN $10 THEN 0 ELSE reserved_bytes END, \
+             quota_id = CASE WHEN $10 THEN NULL ELSE quota_id END, \
+             last_lease_at = CASE WHEN $11 THEN now() ELSE last_lease_at END, \
+             updated_at = now() \
+             WHERE volume_id = $1 AND pod_uid = $2 RETURNING {RUN_DIR_COLUMNS}"
+        );
+        let updated = sqlx::query_as::<_, RunDirDbRow>(&sql)
+            .bind(&key.volume_id)
+            .bind(&key.pod_uid)
+            .bind(spec.to.as_str())
+            .bind(spec.temp_path.is_some())
+            .bind(spec.temp_path)
+            .bind(spec.final_path.is_some())
+            .bind(spec.final_path)
+            .bind(spec.measured_bytes.is_some())
+            .bind(spec.measured_bytes.unwrap_or(0))
+            .bind(spec.release_reservation)
+            .bind(spec.touch_lease)
+            .fetch_one(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        updated.try_into()
+    }
+
+    /// `reserved` → `seeding`: one generation takes ownership of a temp path.
+    pub async fn mark_seeding(
+        &self,
+        key: &RunDirKey,
+        generation: i64,
+        temp_path: &str,
+    ) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::Reserved],
+            TransitionSpec {
+                to: RunDirState::Seeding,
+                temp_path: Some(temp_path),
+                ..TransitionSpec::default_for(RunDirState::Seeding)
+            },
+        )
+        .await
+    }
+
+    /// `seeding` → `ready_active`: publication landed with measured bytes.
+    pub async fn mark_ready_active(
+        &self,
+        key: &RunDirKey,
+        generation: i64,
+        final_path: &str,
+        measured_bytes: i64,
+    ) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::Seeding],
+            TransitionSpec {
+                to: RunDirState::ReadyActive,
+                final_path: Some(final_path),
+                measured_bytes: Some(measured_bytes),
+                touch_lease: true,
+                ..TransitionSpec::default_for(RunDirState::ReadyActive)
+            },
+        )
+        .await
+    }
+
+    /// `ready_idle` (or `ready_active`) → `ready_active`: a fresh lease.
+    pub async fn touch_lease(&self, key: &RunDirKey, generation: i64) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::ReadyIdle, RunDirState::ReadyActive],
+            TransitionSpec {
+                to: RunDirState::ReadyActive,
+                touch_lease: true,
+                ..TransitionSpec::default_for(RunDirState::ReadyActive)
+            },
+        )
+        .await
+    }
+
+    /// `ready_active` → `ready_idle`: the lease-recency window elapsed.
+    pub async fn mark_ready_idle(&self, key: &RunDirKey, generation: i64) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::ReadyActive],
+            TransitionSpec::default_for(RunDirState::ReadyIdle),
+        )
+        .await
+    }
+
+    /// `ready_active` | `ready_idle` → `reclaimable`: terminal pod proof landed.
+    pub async fn mark_reclaimable(&self, key: &RunDirKey, generation: i64) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::ReadyActive, RunDirState::ReadyIdle],
+            TransitionSpec::default_for(RunDirState::Reclaimable),
+        )
+        .await
+    }
+
+    /// `ready_idle` | `reclaimable` → `reclaiming`: a GC generation owns deletion.
+    ///
+    /// The generation is bumped so a later acquire that raced this selection
+    /// fails its own compare-and-set.
+    pub async fn mark_reclaiming(&self, key: &RunDirKey, generation: i64) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::ReadyIdle, RunDirState::Reclaimable],
+            TransitionSpec {
+                bump_generation: true,
+                ..TransitionSpec::default_for(RunDirState::Reclaiming)
+            },
+        )
+        .await
+    }
+
+    /// `reclaiming` → `absent`: deletion committed; reservation/quota released.
+    pub async fn mark_absent_after_reclaim(
+        &self,
+        key: &RunDirKey,
+        generation: i64,
+    ) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::Reclaiming],
+            TransitionSpec {
+                release_reservation: true,
+                ..TransitionSpec::default_for(RunDirState::Absent)
+            },
+        )
+        .await
+    }
+
+    /// `reserved` | `seeding` → `absent`: recovery released a partial generation.
+    pub async fn release_reservation(
+        &self,
+        key: &RunDirKey,
+        generation: i64,
+    ) -> DbResult<RunDirRow> {
+        self.transition(
+            key,
+            generation,
+            &[RunDirState::Reserved, RunDirState::Seeding],
+            TransitionSpec {
+                release_reservation: true,
+                ..TransitionSpec::default_for(RunDirState::Absent)
+            },
+        )
+        .await
+    }
+
+    /// Insert a reconciled row from authoritative inventory evidence.
+    ///
+    /// Idempotent: a pre-existing `(volume_id, pod_uid)` row is left untouched
+    /// and returned as-is, so re-running reconciliation never overwrites a live
+    /// lifecycle row.
+    pub async fn upsert_reconciled(&self, input: &ReconciledRunDirInput) -> DbResult<RunDirRow> {
+        if input.measured_bytes < 0 {
+            return Err(DbError::InvalidData(
+                "run-dir measured_bytes must be non-negative".into(),
+            ));
+        }
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        lock_volume(&mut tx, &input.key.volume_id).await?;
+        if let Some(existing) = fetch_for_update(&mut tx, &input.key).await? {
+            tx.commit().await?;
+            return Ok(existing);
+        }
+        let inserted = sqlx::query_as::<_, RunDirDbRow>(&format!(
+            "INSERT INTO run_dirs \
+             (volume_id, pod_uid, task_run_id, project_id, base_fingerprint, \
+              state, generation, reserved_bytes, measured_bytes, quota_id, \
+              last_lease_at, final_path) \
+             VALUES ($1, $2, $3, $4, $5, $6, 0, 0, $7, NULL, \
+                     CASE WHEN $6 IN ('ready_active','ready_idle') THEN now() ELSE NULL END, $8) \
+             RETURNING {RUN_DIR_COLUMNS}"
+        ))
+        .bind(&input.key.volume_id)
+        .bind(&input.key.pod_uid)
+        .bind(&input.task_run_id)
+        .bind(&input.project_id)
+        .bind(&input.base_fingerprint)
+        .bind(input.state.as_str())
+        .bind(input.measured_bytes)
+        .bind(&input.final_path)
+        .fetch_one(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        inserted.try_into()
+    }
+
+    /// Return one run-dir row by identity.
+    pub async fn get(&self, key: &RunDirKey) -> DbResult<Option<RunDirRow>> {
+        self.db.ensure_initialized().await?;
+        let row = sqlx::query_as::<_, RunDirDbRow>(&format!(
+            "SELECT {RUN_DIR_COLUMNS} FROM run_dirs WHERE volume_id = $1 AND pod_uid = $2"
+        ))
+        .bind(&key.volume_id)
+        .bind(&key.pod_uid)
+        .fetch_optional(self.db.pool())
+        .await?;
+        row.map(TryInto::try_into).transpose()
+    }
+
+    /// List every run-dir row on a volume, ordered by pod UID.
+    pub async fn list_by_volume(&self, volume_id: &str) -> DbResult<Vec<RunDirRow>> {
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query_as::<_, RunDirDbRow>(&format!(
+            "SELECT {RUN_DIR_COLUMNS} FROM run_dirs WHERE volume_id = $1 ORDER BY pod_uid"
+        ))
+        .bind(volume_id)
+        .fetch_all(self.db.pool())
+        .await?;
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    /// Aggregate per-state count and byte totals for one volume.
+    ///
+    /// Only states with at least one row are returned; callers fill absent
+    /// states with zero for bounded telemetry.
+    pub async fn volume_state_totals(&self, volume_id: &str) -> DbResult<Vec<RunDirStateTotals>> {
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query_as::<_, (String, i64, i64, i64)>(
+            "SELECT state, COUNT(*)::bigint, \
+                    COALESCE(SUM(reserved_bytes), 0)::bigint, \
+                    COALESCE(SUM(measured_bytes), 0)::bigint \
+             FROM run_dirs WHERE volume_id = $1 GROUP BY state ORDER BY state",
+        )
+        .bind(volume_id)
+        .fetch_all(self.db.pool())
+        .await?;
+        rows.into_iter()
+            .map(|(state, count, reserved_bytes, measured_bytes)| {
+                Ok(RunDirStateTotals {
+                    state: RunDirState::parse(&state)?,
+                    count,
+                    reserved_bytes,
+                    measured_bytes,
+                })
+            })
+            .collect()
+    }
+
+    /// Return the most recent successful measured-byte reading for the seed
+    /// projection of a `(project, base fingerprint)` pair.
+    pub async fn latest_measured_bytes(
+        &self,
+        project_id: &str,
+        base_fingerprint: &str,
+    ) -> DbResult<Option<i64>> {
+        self.db.ensure_initialized().await?;
+        sqlx::query_scalar(
+            "SELECT measured_bytes FROM run_dirs \
+             WHERE project_id = $1 AND base_fingerprint = $2 \
+               AND state IN ('ready_active', 'ready_idle') AND measured_bytes > 0 \
+             ORDER BY updated_at DESC LIMIT 1",
+        )
+        .bind(project_id)
+        .bind(base_fingerprint)
+        .fetch_optional(self.db.pool())
+        .await
+        .map_err(Into::into)
+    }
+}
+
+/// Field updates carried by a compare-and-set transition.
+struct TransitionSpec<'a> {
+    to: RunDirState,
+    bump_generation: bool,
+    temp_path: Option<&'a str>,
+    final_path: Option<&'a str>,
+    measured_bytes: Option<i64>,
+    release_reservation: bool,
+    touch_lease: bool,
+}
+
+impl TransitionSpec<'_> {
+    fn default_for(to: RunDirState) -> Self {
+        Self {
+            to,
+            bump_generation: false,
+            temp_path: None,
+            final_path: None,
+            measured_bytes: None,
+            release_reservation: false,
+            touch_lease: false,
+        }
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct RunDirDbRow {
+    volume_id: String,
+    pod_uid: String,
+    task_run_id: Option<String>,
+    project_id: Option<String>,
+    base_fingerprint: Option<String>,
+    state: String,
+    generation: i64,
+    reserved_bytes: i64,
+    measured_bytes: i64,
+    quota_id: Option<String>,
+    last_lease_at: Option<String>,
+    temp_path: Option<String>,
+    final_path: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+impl TryFrom<RunDirDbRow> for RunDirRow {
+    type Error = DbError;
+
+    fn try_from(value: RunDirDbRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key: RunDirKey {
+                volume_id: value.volume_id,
+                pod_uid: value.pod_uid,
+            },
+            task_run_id: value.task_run_id,
+            project_id: value.project_id,
+            base_fingerprint: value.base_fingerprint,
+            state: RunDirState::parse(&value.state)?,
+            generation: value.generation,
+            reserved_bytes: value.reserved_bytes,
+            measured_bytes: value.measured_bytes,
+            quota_id: value.quota_id,
+            last_lease_at: value.last_lease_at,
+            temp_path: value.temp_path,
+            final_path: value.final_path,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+        })
+    }
+}
+
+async fn lock_volume(tx: &mut Transaction<'_, Postgres>, volume_id: &str) -> DbResult<()> {
+    let lock_key = format!("run-dir-volume:{volume_id}");
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        .bind(lock_key)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn fetch_for_update(
+    tx: &mut Transaction<'_, Postgres>,
+    key: &RunDirKey,
+) -> DbResult<Option<RunDirRow>> {
+    let row = sqlx::query_as::<_, RunDirDbRow>(&format!(
+        "SELECT {RUN_DIR_COLUMNS} FROM run_dirs \
+         WHERE volume_id = $1 AND pod_uid = $2 FOR UPDATE"
+    ))
+    .bind(&key.volume_id)
+    .bind(&key.pod_uid)
+    .fetch_optional(&mut **tx)
+    .await?;
+    row.map(TryInto::try_into).transpose()
+}
+
+#[cfg(test)]
+#[path = "run_dirs_tests.rs"]
+mod tests;

--- a/server/crates/djinn-db/src/repositories/run_dirs_tests.rs
+++ b/server/crates/djinn-db/src/repositories/run_dirs_tests.rs
@@ -1,0 +1,266 @@
+//! Fresh-DB tests for the run-dir ledger. Each test uses the template-cloned
+//! ephemeral Postgres harness via [`Database::open_in_memory`].
+
+use super::*;
+
+const VOLUME: &str = "node-vol-a";
+
+fn key(pod: &str) -> RunDirKey {
+    RunDirKey {
+        volume_id: VOLUME.into(),
+        pod_uid: pod.into(),
+    }
+}
+
+fn reserve_input(pod: &str) -> ReserveRunDirInput {
+    ReserveRunDirInput {
+        key: key(pod),
+        task_run_id: Some(format!("run-{pod}")),
+        project_id: Some("proj-1".into()),
+        base_fingerprint: Some("fp-1".into()),
+        reserved_bytes: 4_096,
+        quota_id: Some(format!("quota-{pod}")),
+    }
+}
+
+#[tokio::test]
+async fn reserve_inserts_reserved_row() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let row = repo.reserve(&reserve_input("p1")).await.unwrap();
+    assert_eq!(row.state, RunDirState::Reserved);
+    assert_eq!(row.generation, 0);
+    assert_eq!(row.reserved_bytes, 4_096);
+    assert_eq!(row.quota_id.as_deref(), Some("quota-p1"));
+    assert!(row.final_path.is_none());
+}
+
+#[tokio::test]
+async fn reserve_is_idempotent_while_reserved() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let first = repo.reserve(&reserve_input("p1")).await.unwrap();
+    let second = repo.reserve(&reserve_input("p1")).await.unwrap();
+    assert_eq!(first.generation, second.generation);
+    assert_eq!(second.state, RunDirState::Reserved);
+}
+
+#[tokio::test]
+async fn full_lifecycle_reserve_to_absent() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let k = key("p1");
+    let reserved = repo.reserve(&reserve_input("p1")).await.unwrap();
+    assert_eq!(reserved.generation, 0);
+
+    let seeding = repo
+        .mark_seeding(&k, 0, "/cache/runs/.seed-p1-0")
+        .await
+        .unwrap();
+    assert_eq!(seeding.state, RunDirState::Seeding);
+    assert_eq!(seeding.temp_path.as_deref(), Some("/cache/runs/.seed-p1-0"));
+
+    let ready = repo
+        .mark_ready_active(&k, 0, "/cache/runs/p1", 9_999)
+        .await
+        .unwrap();
+    assert_eq!(ready.state, RunDirState::ReadyActive);
+    assert_eq!(ready.final_path.as_deref(), Some("/cache/runs/p1"));
+    assert_eq!(ready.measured_bytes, 9_999);
+    assert!(ready.last_lease_at.is_some());
+
+    let idle = repo.mark_ready_idle(&k, 0).await.unwrap();
+    assert_eq!(idle.state, RunDirState::ReadyIdle);
+
+    let active_again = repo.touch_lease(&k, 0).await.unwrap();
+    assert_eq!(active_again.state, RunDirState::ReadyActive);
+
+    let reclaimable = repo.mark_reclaimable(&k, 0).await.unwrap();
+    assert_eq!(reclaimable.state, RunDirState::Reclaimable);
+
+    let reclaiming = repo.mark_reclaiming(&k, 0).await.unwrap();
+    assert_eq!(reclaiming.state, RunDirState::Reclaiming);
+    // Reclaiming bumps the generation to fence a racing acquire.
+    assert_eq!(reclaiming.generation, 1);
+
+    let absent = repo.mark_absent_after_reclaim(&k, 1).await.unwrap();
+    assert_eq!(absent.state, RunDirState::Absent);
+    assert_eq!(absent.reserved_bytes, 0);
+    assert!(absent.quota_id.is_none());
+}
+
+#[tokio::test]
+async fn stale_generation_transition_fails_closed() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let k = key("p1");
+    repo.reserve(&reserve_input("p1")).await.unwrap();
+    // Expected generation 7 does not match durable 0.
+    assert!(matches!(
+        repo.mark_seeding(&k, 7, "/tmp/x").await,
+        Err(DbError::InvalidTransition(_))
+    ));
+}
+
+#[tokio::test]
+async fn gc_reclaiming_fences_a_racing_acquire() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let k = key("p1");
+    repo.reserve(&reserve_input("p1")).await.unwrap();
+    repo.mark_seeding(&k, 0, "/tmp/seed").await.unwrap();
+    repo.mark_ready_active(&k, 0, "/cache/runs/p1", 1)
+        .await
+        .unwrap();
+    repo.mark_ready_idle(&k, 0).await.unwrap();
+
+    // GC wins: ready_idle -> reclaiming bumps generation 0 -> 1.
+    let reclaiming = repo.mark_reclaiming(&k, 0).await.unwrap();
+    assert_eq!(reclaiming.generation, 1);
+
+    // A late acquire holding the pre-GC generation cannot re-activate.
+    assert!(matches!(
+        repo.touch_lease(&k, 0).await,
+        Err(DbError::InvalidTransition(_))
+    ));
+}
+
+#[tokio::test]
+async fn release_reservation_from_reserved_and_seeding() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+
+    let k1 = key("p1");
+    repo.reserve(&reserve_input("p1")).await.unwrap();
+    let released = repo.release_reservation(&k1, 0).await.unwrap();
+    assert_eq!(released.state, RunDirState::Absent);
+    assert_eq!(released.reserved_bytes, 0);
+
+    let k2 = key("p2");
+    repo.reserve(&reserve_input("p2")).await.unwrap();
+    repo.mark_seeding(&k2, 0, "/tmp/seed-p2").await.unwrap();
+    let released = repo.release_reservation(&k2, 0).await.unwrap();
+    assert_eq!(released.state, RunDirState::Absent);
+}
+
+#[tokio::test]
+async fn reserving_an_absent_row_bumps_generation() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let k = key("p1");
+    repo.reserve(&reserve_input("p1")).await.unwrap();
+    repo.release_reservation(&k, 0).await.unwrap();
+    // Re-reserving the same identity after absent advances the generation so a
+    // stale prior-generation callback cannot match.
+    let reserved = repo.reserve(&reserve_input("p1")).await.unwrap();
+    assert_eq!(reserved.state, RunDirState::Reserved);
+    assert_eq!(reserved.generation, 1);
+}
+
+#[tokio::test]
+async fn upsert_reconciled_is_idempotent_and_quarantines() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let input = ReconciledRunDirInput {
+        key: key("unknown-pod"),
+        task_run_id: None,
+        project_id: None,
+        base_fingerprint: None,
+        state: RunDirState::QuarantinedUnowned,
+        measured_bytes: 12_345,
+        final_path: Some("/cache/runs/unknown-pod".into()),
+    };
+    let first = repo.upsert_reconciled(&input).await.unwrap();
+    assert_eq!(first.state, RunDirState::QuarantinedUnowned);
+    assert_eq!(first.measured_bytes, 12_345);
+
+    // Re-running reconciliation never overwrites an existing row.
+    let mut mutated = input.clone();
+    mutated.measured_bytes = 999;
+    let second = repo.upsert_reconciled(&mutated).await.unwrap();
+    assert_eq!(second.measured_bytes, 12_345);
+}
+
+#[tokio::test]
+async fn upsert_reconciled_ready_active_sets_lease() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let input = ReconciledRunDirInput {
+        key: key("live-pod"),
+        task_run_id: Some("run-live".into()),
+        project_id: Some("proj-1".into()),
+        base_fingerprint: Some("fp-1".into()),
+        state: RunDirState::ReadyActive,
+        measured_bytes: 5_000,
+        final_path: Some("/cache/runs/live-pod".into()),
+    };
+    let row = repo.upsert_reconciled(&input).await.unwrap();
+    assert_eq!(row.state, RunDirState::ReadyActive);
+    assert!(row.last_lease_at.is_some());
+}
+
+#[tokio::test]
+async fn volume_state_totals_aggregate_by_state() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    // One reserved (4096 reserved bytes), one reconciled ready_active.
+    repo.reserve(&reserve_input("p1")).await.unwrap();
+    repo.upsert_reconciled(&ReconciledRunDirInput {
+        key: key("p2"),
+        task_run_id: Some("run-p2".into()),
+        project_id: Some("proj-1".into()),
+        base_fingerprint: Some("fp-1".into()),
+        state: RunDirState::ReadyActive,
+        measured_bytes: 7_000,
+        final_path: Some("/cache/runs/p2".into()),
+    })
+    .await
+    .unwrap();
+
+    let totals = repo.volume_state_totals(VOLUME).await.unwrap();
+    let reserved = totals
+        .iter()
+        .find(|t| t.state == RunDirState::Reserved)
+        .unwrap();
+    assert_eq!(reserved.count, 1);
+    assert_eq!(reserved.reserved_bytes, 4_096);
+    let ready = totals
+        .iter()
+        .find(|t| t.state == RunDirState::ReadyActive)
+        .unwrap();
+    assert_eq!(ready.count, 1);
+    assert_eq!(ready.measured_bytes, 7_000);
+}
+
+#[tokio::test]
+async fn latest_measured_bytes_projection() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    assert_eq!(
+        repo.latest_measured_bytes("proj-1", "fp-1").await.unwrap(),
+        None
+    );
+    let k = key("p1");
+    repo.reserve(&reserve_input("p1")).await.unwrap();
+    repo.mark_seeding(&k, 0, "/tmp/seed").await.unwrap();
+    repo.mark_ready_active(&k, 0, "/cache/runs/p1", 8_192)
+        .await
+        .unwrap();
+    assert_eq!(
+        repo.latest_measured_bytes("proj-1", "fp-1").await.unwrap(),
+        Some(8_192)
+    );
+}
+
+#[tokio::test]
+async fn illegal_transition_is_rejected() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = RunDirRepository::new(db);
+    let k = key("p1");
+    repo.reserve(&reserve_input("p1")).await.unwrap();
+    // Cannot go straight from reserved to ready_active.
+    assert!(matches!(
+        repo.mark_ready_active(&k, 0, "/cache/runs/p1", 1).await,
+        Err(DbError::InvalidTransition(_))
+    ));
+}

--- a/server/crates/djinn-db/tests/migrations_run_dir_disk_admission.rs
+++ b/server/crates/djinn-db/tests/migrations_run_dir_disk_admission.rs
@@ -1,0 +1,373 @@
+//! Migration 151 — `run_dirs` durable ledger for disk-aware build admission
+//! (proposal nquz, phase 1).
+//!
+//! Verifies the migration applies cleanly on a fresh database AND on top of the
+//! prior schema (so additive ordering is correct), installs the documented
+//! columns / CHECK constraints / indexes, and — critically — does NOT modify any
+//! existing `admission_journal` row.
+//!
+//! Mirrors the harness in `migrations_liveness_evidence_outcomes.rs`.
+
+use std::path::{Path, PathBuf};
+
+use sqlx::postgres::{PgConnection, PgPoolOptions};
+use sqlx::{Connection, Executor};
+
+const MIGRATION_VERSION: u64 = 151;
+const MIGRATION_FILE: &str = "151_run_dir_disk_admission.sql";
+
+fn base_database_url() -> String {
+    djinn_db::test_database_base_url()
+}
+
+fn server_prefix(base: &str) -> String {
+    base.rsplit_once('/')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(base)
+        .trim_end_matches('/')
+        .to_owned()
+}
+
+fn migrations_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations_postgres")
+}
+
+fn migration_entries(dir: &Path) -> Vec<(u64, PathBuf)> {
+    let mut entries: Vec<(u64, PathBuf)> = std::fs::read_dir(dir)
+        .expect("read migrations dir")
+        .map(|entry| {
+            let path = entry.expect("migration dir entry").path();
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            let version = name
+                .split_once('_')
+                .and_then(|(prefix, _)| prefix.parse::<u64>().ok())
+                .unwrap_or(0);
+            (version, path)
+        })
+        .filter(|(_, path)| path.extension().and_then(|e| e.to_str()) == Some("sql"))
+        .collect();
+    entries.sort_by(|(av, ap), (bv, bp)| {
+        av.cmp(bv).then_with(|| {
+            ap.file_name()
+                .unwrap_or_default()
+                .cmp(bp.file_name().unwrap_or_default())
+        })
+    });
+    entries
+}
+
+async fn with_temp_database<T, Fut>(suffix: &str, f: impl FnOnce(String) -> Fut) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    let base = base_database_url();
+    let prefix = server_prefix(&base);
+    let db_name = format!(
+        "djinn_migration_{}_{}",
+        suffix,
+        uuid::Uuid::now_v7().simple()
+    );
+    let admin_url = format!("{prefix}/postgres");
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("connect postgres admin database");
+    admin
+        .execute(format!(r#"CREATE DATABASE "{db_name}""#).as_str())
+        .await
+        .expect("create migration test database");
+    drop(admin);
+
+    let db_url = format!("{prefix}/{db_name}");
+    let result = f(db_url).await;
+
+    let mut admin = PgConnection::connect(&admin_url)
+        .await
+        .expect("reconnect postgres admin database");
+    let _ = admin
+        .execute(
+            format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+            )
+            .as_str(),
+        )
+        .await;
+    admin
+        .execute(format!(r#"DROP DATABASE IF EXISTS "{db_name}""#).as_str())
+        .await
+        .expect("drop migration test database");
+
+    result
+}
+
+/// Designated operator the creator-contract migration (142) validates against.
+const MIGRATION_OPERATOR_ID: &str = "00000000-0000-7000-8000-000000000151";
+/// The version of the creator-contract migration that requires the operator.
+const CREATOR_CONTRACT_VERSION: u64 = 142;
+
+/// Seed the validated designated operator required by migration 142.
+async fn seed_migration_operator(conn: &mut PgConnection) {
+    conn.execute(
+        format!(
+            "INSERT INTO users (id, github_id, github_login) \
+             VALUES ('{MIGRATION_OPERATOR_ID}', 9000000151, 'run-dir-migration-operator') \
+             ON CONFLICT DO NOTHING"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("seed designated migration operator");
+}
+
+async fn apply_prior_migrations(conn: &mut PgConnection) {
+    // Migration 142 (task creator contract) refuses to run without a validated
+    // designated operator supplied via a session GUC. Set the GUC for the whole
+    // session, then seed the operator user just before that migration applies.
+    conn.execute(
+        format!(
+            "SELECT set_config('djinn.migration_designated_operator_user_id', '{MIGRATION_OPERATOR_ID}', false)"
+        )
+        .as_str(),
+    )
+    .await
+    .expect("set designated operator GUC");
+
+    for (version, path) in migration_entries(&migrations_dir()) {
+        if version >= MIGRATION_VERSION {
+            break;
+        }
+        if version == 0 {
+            continue;
+        }
+        if version == CREATOR_CONTRACT_VERSION {
+            seed_migration_operator(conn).await;
+        }
+        let sql = std::fs::read_to_string(&path).expect("read migration sql");
+        conn.execute(sql.as_str())
+            .await
+            .unwrap_or_else(|err| panic!("apply migration {} failed: {err}", path.display()));
+    }
+}
+
+async fn apply_migration_151(conn: &mut PgConnection) {
+    let migration = migrations_dir().join(MIGRATION_FILE);
+    let sql = std::fs::read_to_string(&migration).expect("read migration 151 sql");
+    conn.execute(sql.as_str())
+        .await
+        .expect("apply migration 151 after prior migrations");
+}
+
+async fn assert_run_dirs_schema(pool: &sqlx::PgPool) {
+    for (column, data_type, nullable) in [
+        ("volume_id", "character varying", "NO"),
+        ("pod_uid", "character varying", "NO"),
+        ("task_run_id", "character varying", "YES"),
+        ("project_id", "character varying", "YES"),
+        ("base_fingerprint", "character varying", "YES"),
+        ("state", "character varying", "NO"),
+        ("generation", "bigint", "NO"),
+        ("reserved_bytes", "bigint", "NO"),
+        ("measured_bytes", "bigint", "NO"),
+        ("quota_id", "character varying", "YES"),
+        ("last_lease_at", "timestamp with time zone", "YES"),
+        ("temp_path", "text", "YES"),
+        ("final_path", "text", "YES"),
+        ("created_at", "timestamp with time zone", "NO"),
+        ("updated_at", "timestamp with time zone", "NO"),
+    ] {
+        let (actual_type, actual_nullable): (Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT data_type, is_nullable FROM information_schema.columns \
+             WHERE table_name = 'run_dirs' AND column_name = $1",
+        )
+        .bind(column)
+        .fetch_one(pool)
+        .await
+        .unwrap_or_else(|e| panic!("inspect run_dirs.{column}: {e}"));
+        assert_eq!(
+            actual_type.as_deref(),
+            Some(data_type),
+            "run_dirs.{column} should be {data_type}, got {actual_type:?}"
+        );
+        assert_eq!(
+            actual_nullable.as_deref(),
+            Some(nullable),
+            "run_dirs.{column} nullability should be {nullable}, got {actual_nullable:?}"
+        );
+    }
+
+    // Primary key is (volume_id, pod_uid).
+    let pk_cols: Vec<String> = sqlx::query_scalar(
+        "SELECT a.attname FROM pg_index i \
+         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) \
+         WHERE i.indrelid = 'run_dirs'::regclass AND i.indisprimary ORDER BY a.attname",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("inspect run_dirs primary key");
+    assert_eq!(
+        pk_cols,
+        vec!["pod_uid".to_string(), "volume_id".to_string()]
+    );
+
+    // The state CHECK constraint accepts every documented state.
+    let state_check: Option<String> = sqlx::query_scalar(
+        "SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'run_dirs_state_check'",
+    )
+    .fetch_optional(pool)
+    .await
+    .expect("inspect run_dirs_state_check body");
+    let body = state_check.unwrap_or_default();
+    for value in [
+        "absent",
+        "reserved",
+        "seeding",
+        "ready_active",
+        "ready_idle",
+        "reclaimable",
+        "reclaiming",
+        "quarantined_unowned",
+    ] {
+        assert!(
+            body.contains(&format!("'{value}'")),
+            "run_dirs_state_check should accept '{value}', got body: {body}"
+        );
+    }
+
+    // Non-negative byte / generation constraints exist.
+    let check_constraints: Vec<String> = sqlx::query_scalar(
+        "SELECT conname FROM pg_constraint WHERE conrelid = 'run_dirs'::regclass \
+           AND contype = 'c' ORDER BY conname",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("inspect run_dirs CHECK constraints");
+    for expected in [
+        "run_dirs_generation_nonneg",
+        "run_dirs_measured_bytes_nonneg",
+        "run_dirs_reserved_bytes_nonneg",
+        "run_dirs_state_check",
+    ] {
+        assert!(
+            check_constraints.iter().any(|c| c == expected),
+            "expected CHECK {expected} on run_dirs, got {check_constraints:?}"
+        );
+    }
+
+    // Indexes.
+    let index_names: Vec<String> = sqlx::query_scalar(
+        "SELECT c.relname FROM pg_class c \
+         JOIN pg_index i ON i.indexrelid = c.oid \
+         JOIN pg_class t ON t.oid = i.indrelid \
+         WHERE t.relname = 'run_dirs' AND c.relname IN ( \
+             'run_dirs_volume_state_idx', 'run_dirs_task_run_idx', \
+             'run_dirs_project_fingerprint_idx') ORDER BY c.relname",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("inspect run_dirs indexes");
+    let mut expected_indexes = vec![
+        "run_dirs_project_fingerprint_idx",
+        "run_dirs_task_run_idx",
+        "run_dirs_volume_state_idx",
+    ];
+    expected_indexes.sort();
+    assert_eq!(index_names, expected_indexes);
+}
+
+/// Seed a live admission_journal row through raw SQL so we can prove migration
+/// 151 leaves existing admission rows byte-for-byte unmodified.
+async fn seed_admission_row(pool: &sqlx::PgPool) {
+    sqlx::query(
+        "INSERT INTO admission_journal \
+         (domain, work_id, generation, workload_kind, state, creator_server_epoch, object_name) \
+         VALUES ('task_observation', 'work-preexisting', 0, 'task', 'live', 'epoch-1', 'obj-1')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed pre-existing admission row");
+}
+
+async fn assert_admission_row_unchanged(pool: &sqlx::PgPool) {
+    let (state, epoch): (String, String) = sqlx::query_as(
+        "SELECT state, creator_server_epoch FROM admission_journal WHERE work_id = 'work-preexisting'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("load pre-existing admission row");
+    assert_eq!(
+        state, "live",
+        "migration must not modify existing admission rows"
+    );
+    assert_eq!(epoch, "epoch-1");
+}
+
+#[tokio::test]
+async fn migration_151_applies_on_fresh_database() {
+    with_temp_database("fresh_run_dirs", |db_url| async move {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&db_url)
+            .await
+            .expect("connect fresh migration database");
+        djinn_db::test_support::apply_all_migrations_to_fresh_database(&db_url).await;
+
+        assert_run_dirs_schema(&pool).await;
+
+        // A fresh run_dir row can be inserted and read back.
+        sqlx::query(
+            "INSERT INTO run_dirs (volume_id, pod_uid, state) VALUES ('vol', 'pod', 'reserved')",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert run_dir row");
+        let state: String =
+            sqlx::query_scalar("SELECT state FROM run_dirs WHERE volume_id = 'vol'")
+                .fetch_one(&pool)
+                .await
+                .expect("read run_dir row");
+        assert_eq!(state, "reserved");
+
+        // An out-of-vocabulary state is rejected by the CHECK constraint.
+        let bad = sqlx::query(
+            "INSERT INTO run_dirs (volume_id, pod_uid, state) VALUES ('vol', 'pod2', 'bogus')",
+        )
+        .execute(&pool)
+        .await;
+        assert!(bad.is_err(), "state CHECK must reject an unknown state");
+
+        pool.close().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn migration_151_applies_after_prior_migrations_without_touching_admission() {
+    with_temp_database("prior_run_dirs", |db_url| async move {
+        let mut conn = PgConnection::connect(&db_url)
+            .await
+            .expect("connect prior migration database");
+        apply_prior_migrations(&mut conn).await;
+
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&db_url)
+            .await
+            .expect("connect prior migration database (pool)");
+        seed_admission_row(&pool).await;
+        pool.close().await;
+
+        apply_migration_151(&mut conn).await;
+        drop(conn);
+
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&db_url)
+            .await
+            .expect("connect migrated database");
+
+        assert_run_dirs_schema(&pool).await;
+        assert_admission_row_unchanged(&pool).await;
+
+        pool.close().await;
+    })
+    .await;
+}

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -172,6 +172,21 @@ const BUILD_ADMISSION_HANDOFF_WARNING_REASONS: [&str; 3] =
     ["unexpected_overlap", "stale_epoch", "epoch_unreadable"];
 const AGENT_SESSION_PHASE_SECONDS_TOTAL: &str = "djinn_agent_session_phase_seconds_total";
 
+// ─── Run-dir disk-admission telemetry (proposal nquz, phase 1) ─────────────
+// Labels are strictly bounded: `state`, `reason`, `tier`, and `outcome` are
+// closed enumerations. Volume, pod, task, and project identifiers appear only in
+// logs and traces, never as metric labels.
+const RUN_DIR_COUNT: &str = "djinn_run_dir_count";
+const RUN_DIR_ALLOCATED_BYTES: &str = "djinn_run_dir_allocated_bytes";
+const RUN_DIR_RESERVED_BYTES: &str = "djinn_run_dir_reserved_bytes";
+const RUN_DIR_UNOWNED_BYTES: &str = "djinn_run_dir_unowned_bytes";
+const RUN_DIR_QUEUE_REASON_TOTAL: &str = "djinn_run_dir_queue_reason_total";
+const RUN_DIR_QUOTA_FAILURE_TOTAL: &str = "djinn_run_dir_quota_failure_total";
+const RUN_DIR_RECLAIM_TOTAL: &str = "djinn_run_dir_reclaim_total";
+const RUN_DIR_RECLAIM_BYTES_TOTAL: &str = "djinn_run_dir_reclaim_bytes_total";
+const RUN_DIR_SEED_TOTAL: &str = "djinn_run_dir_seed_total";
+const RUN_DIR_WARM_BASE_REMOVED_TOTAL: &str = "djinn_run_dir_warm_base_removed_total";
+
 // ─── Linux PSI telemetry (proposal zp5t) ──────────────────────────────
 const NODE_PSI_SOME_AVG10_RATIO: &str = "node_psi_some_avg10_ratio";
 const NODE_PSI_AVAILABLE: &str = "node_psi_available";
@@ -2616,6 +2631,95 @@ pub mod build_admission {
     /// Record one bounded unknown-classification event.
     pub fn increment_unknown_classification(effective_mode: &'static str, effective_cap: i64) {
         metrics::counter!(super::BUILD_ADMISSION_UNKNOWN_CLASSIFICATION_TOTAL, "effective_mode" => effective_mode, "effective_cap" => effective_cap.to_string()).increment(1);
+    }
+}
+
+/// Run-dir disk-admission telemetry (proposal nquz, phase 1 — dark/observe).
+///
+/// Every label is a closed enumeration so Prometheus cardinality stays bounded.
+/// Volume, pod, task, and project identifiers are logged, never labelled. In
+/// phase 1 nothing production wires these emitters to a live caller; they exist
+/// so the observe substrate and its tests can record what disk admission WOULD
+/// do without changing any dispatch decision.
+pub mod run_dir {
+    /// The eight lease-lifecycle states plus the reconciliation-only quarantine
+    /// bucket, matching `djinn_db::RunDirState`.
+    pub const STATE_ABSENT: &str = "absent";
+    pub const STATE_RESERVED: &str = "reserved";
+    pub const STATE_SEEDING: &str = "seeding";
+    pub const STATE_READY_ACTIVE: &str = "ready_active";
+    pub const STATE_READY_IDLE: &str = "ready_idle";
+    pub const STATE_RECLAIMABLE: &str = "reclaimable";
+    pub const STATE_RECLAIMING: &str = "reclaiming";
+    pub const STATE_QUARANTINED_UNOWNED: &str = "quarantined_unowned";
+
+    /// Typed queue reasons emitted when disk admission WOULD defer a build.
+    pub const QUEUE_REASON_DISK_PRESSURE: &str = "disk_pressure";
+    pub const QUEUE_REASON_DISK_CAPACITY_UNKNOWN: &str = "disk_capacity_unknown";
+
+    /// Quota-probe / installation failure reasons.
+    pub const QUOTA_FAILURE_PROBE_UNAVAILABLE: &str = "probe_unavailable";
+    pub const QUOTA_FAILURE_INSTALL_FAILED: &str = "install_failed";
+
+    /// Reclaim ordering tiers (dark this phase; defined for a bounded family).
+    pub const RECLAIM_TIER_RECLAIMABLE: &str = "reclaimable";
+    pub const RECLAIM_TIER_READY_IDLE: &str = "ready_idle";
+    pub const RECLAIM_TIER_WARM_BASE_AUX: &str = "warm_base_aux";
+
+    /// Seed / recovery outcomes.
+    pub const SEED_OUTCOME_SEEDED: &str = "seeded";
+    pub const SEED_OUTCOME_RESEEDED: &str = "reseeded";
+    pub const SEED_OUTCOME_RECOVERED_PROMOTED: &str = "recovered_promoted";
+    pub const SEED_OUTCOME_RECOVERED_QUARANTINED: &str = "recovered_quarantined";
+
+    /// Set the absolute run-dir count for one bounded `state`.
+    pub fn set_state_count(state: &'static str, count: u64) {
+        metrics::gauge!(super::RUN_DIR_COUNT, "state" => state).set(count as f64);
+    }
+
+    /// Set the absolute measured allocated bytes tracked in one bounded `state`.
+    pub fn set_state_allocated_bytes(state: &'static str, bytes: u64) {
+        metrics::gauge!(super::RUN_DIR_ALLOCATED_BYTES, "state" => state).set(bytes as f64);
+    }
+
+    /// Set the absolute outstanding reserved bytes for a volume.
+    pub fn set_reserved_bytes(bytes: u64) {
+        metrics::gauge!(super::RUN_DIR_RESERVED_BYTES).set(bytes as f64);
+    }
+
+    /// Set the absolute quarantined-unowned bytes for a volume.
+    pub fn set_unowned_bytes(bytes: u64) {
+        metrics::gauge!(super::RUN_DIR_UNOWNED_BYTES).set(bytes as f64);
+    }
+
+    /// Record one observe-mode disk queue event. `reason` MUST be a
+    /// `QUEUE_REASON_*` constant.
+    pub fn increment_queue_reason(reason: &'static str) {
+        metrics::counter!(super::RUN_DIR_QUEUE_REASON_TOTAL, "reason" => reason).increment(1);
+    }
+
+    /// Record one quota-probe / install failure. `reason` MUST be a
+    /// `QUOTA_FAILURE_*` constant.
+    pub fn increment_quota_failure(reason: &'static str) {
+        metrics::counter!(super::RUN_DIR_QUOTA_FAILURE_TOTAL, "reason" => reason).increment(1);
+    }
+
+    /// Record a reclaim of `count` dirs releasing `bytes` for one bounded
+    /// `tier`. `tier` MUST be a `RECLAIM_TIER_*` constant.
+    pub fn increment_reclaim(tier: &'static str, count: u64, bytes: u64) {
+        metrics::counter!(super::RUN_DIR_RECLAIM_TOTAL, "tier" => tier).increment(count);
+        metrics::counter!(super::RUN_DIR_RECLAIM_BYTES_TOTAL, "tier" => tier).increment(bytes);
+    }
+
+    /// Record one seed / recovery outcome. `outcome` MUST be a `SEED_OUTCOME_*`
+    /// constant.
+    pub fn increment_seed_outcome(outcome: &'static str) {
+        metrics::counter!(super::RUN_DIR_SEED_TOTAL, "outcome" => outcome).increment(1);
+    }
+
+    /// Record one operator-authorized warm-base removal.
+    pub fn increment_warm_base_removed() {
+        metrics::counter!(super::RUN_DIR_WARM_BASE_REMOVED_TOTAL).increment(1);
     }
 }
 


### PR DESCRIPTION
First phase of proposal nquz (epic hip3), DARK/OBSERVE ONLY. No eager-seed removal, no enforcement, no GC deletion, no first-use activation — those are later phases gated on goxi detection + jvpm prepare_build_cache + worker disk_run_dir_v1.

- Migration 151: additive run_dirs table keyed by (volume_id, pod_uid) with the 8-state lifecycle + quarantined_unowned; no existing admission row altered (asserted).
- RunDirRepository: CAS generation transitions under per-volume advisory lock + SELECT FOR UPDATE, mirroring admission_journal.rs; mark_reclaiming bumps generation so a racing acquire's CAS loses.
- cargo_target_runs: per-dir allocated-byte measurement added; safe-deletion primitives unchanged and unwired.
- build_admission: disk dimension gated behind Option<Arc<dyn DiskCapacitySource>> defaulting to None — no production code installs a source; even installed it can only record/emit, never convert a permit to a denial (proven by test).
- Reconciliation is a pure upsert planner (no deletion intent expressible); phase-1 resolver quarantines everything. Bounded telemetry defined but reached only by dormant paths.

Inert-by-default guaranteed at every seam. Fresh-DB tests use apply_all_migrations_to_fresh_database. Workspace check clean under SQLX_OFFLINE; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)