### PR TITLE
chore(ny3o): Exact-arithmetic 12-CPU/48Gi bin-packing fixture for role-classed rendering

### DIFF
--- a/scripts/test-tilt-warm-restart.sh
+++ b/scripts/test-tilt-warm-restart.sh
@@ -110,7 +110,11 @@ if [[ "${1:-}" == "run" ]]; then
                 output_dir="${arg%:/out}"
                 printf 'server fixture\n' > "$output_dir/djinn-server"
                 printf 'worker fixture\n' > "$output_dir/djinn-agent-worker"
-                chmod +x "$output_dir/djinn-server" "$output_dir/djinn-agent-worker"
+                printf 'launcher fixture\n' > "$output_dir/djinn-cgroup-launcher"
+                chmod +x \
+                    "$output_dir/djinn-server" \
+                    "$output_dir/djinn-agent-worker" \
+                    "$output_dir/djinn-cgroup-launcher"
                 ;;
         esac
     done
@@ -245,6 +249,7 @@ assert_equal 'concurrent UI triggers perform one build' \
 run_binaries
 [[ -x "$ARTIFACTS/djinn-server" ]]
 [[ -x "$ARTIFACTS/djinn-agent-worker" ]]
+[[ -x "$ARTIFACTS/djinn-cgroup-launcher" ]]
 [[ -f "$ARTIFACTS/.binaries-inputs.fingerprint" ]]
 assert_contains 'cold binary build invokes Docker' 'docker build' "$CALL_LOG"
 

--- a/scripts/tilt/build-binaries.sh
+++ b/scripts/tilt/build-binaries.sh
@@ -128,12 +128,14 @@ if [[ -f "$UI_OUTPUT_FINGERPRINT" ]]; then
 fi
 
 if [[ -x "$ARTIFACTS_DIR/djinn-server" \
-    && -x "$ARTIFACTS_DIR/djinn-agent-worker" ]] \
+    && -x "$ARTIFACTS_DIR/djinn-agent-worker" \
+    && -x "$ARTIFACTS_DIR/djinn-cgroup-launcher" ]] \
     && tilt_fingerprint_matches "$BUILD_FINGERPRINT" "$CURRENT_FINGERPRINT"; then
     CURRENT_BINARY_OUTPUT_FINGERPRINT="$(
         tilt_input_fingerprint "$ARTIFACTS_DIR" \
             "$ARTIFACTS_DIR/djinn-server" \
-            "$ARTIFACTS_DIR/djinn-agent-worker"
+            "$ARTIFACTS_DIR/djinn-agent-worker" \
+            "$ARTIFACTS_DIR/djinn-cgroup-launcher"
     )"
     if tilt_fingerprint_matches \
         "$BINARY_OUTPUT_FINGERPRINT" "$CURRENT_BINARY_OUTPUT_FINGERPRINT"; then
@@ -189,7 +191,8 @@ echo "==> cargo build (djinn-server + djinn-agent-worker) in $BUILDER_IMAGE_ID"
         cargo build --release --locked \
             --features qdrant \
             -p djinn-server \
-            -p djinn-agent-worker
+            -p djinn-agent-worker \
+            -p djinn-cgroup-launcher
         sccache --show-stats || true
     '
 
@@ -206,33 +209,39 @@ echo "==> extracting binaries into $ARTIFACTS_DIR"
         set -eux
         server_tmp="/out/.djinn-server.$$"
         worker_tmp="/out/.djinn-agent-worker.$$"
-        trap '\''rm -f "$server_tmp" "$worker_tmp"'\'' EXIT
+        launcher_tmp="/out/.djinn-cgroup-launcher.$$"
+        trap '\''rm -f "$server_tmp" "$worker_tmp" "$launcher_tmp"'\'' EXIT
         cp /target/release/djinn-server "$server_tmp"
         cp /target/release/djinn-agent-worker "$worker_tmp"
-        # Strip both binaries to trim image size. `strip` is in binutils
+        cp /target/release/djinn-cgroup-launcher "$launcher_tmp"
+        # Strip all binaries to trim image size. `strip` is in binutils
         # which ships in the rust:*-slim base.
         strip "$server_tmp"
         strip "$worker_tmp"
-        chmod +x "$server_tmp" "$worker_tmp"
+        strip "$launcher_tmp"
+        chmod +x "$server_tmp" "$worker_tmp" "$launcher_tmp"
         # Publish each artifact with one rename. Direct copy + strip generated
         # several file-watch events, reparsed the Tiltfile repeatedly, and
         # could briefly hash an unstripped/partial worker binary.
         mv -f "$server_tmp" /out/djinn-server
         mv -f "$worker_tmp" /out/djinn-agent-worker
+        mv -f "$launcher_tmp" /out/djinn-cgroup-launcher
         trap - EXIT
     '
 
 if [[ ! -x "$ARTIFACTS_DIR/djinn-server" \
-    || ! -x "$ARTIFACTS_DIR/djinn-agent-worker" ]]; then
-    echo "error: binary build completed without both executable artifacts" >&2
+    || ! -x "$ARTIFACTS_DIR/djinn-agent-worker" \
+    || ! -x "$ARTIFACTS_DIR/djinn-cgroup-launcher" ]]; then
+    echo "error: binary build completed without all executable artifacts" >&2
     exit 1
 fi
 CURRENT_BINARY_OUTPUT_FINGERPRINT="$(
     tilt_input_fingerprint "$ARTIFACTS_DIR" \
         "$ARTIFACTS_DIR/djinn-server" \
-        "$ARTIFACTS_DIR/djinn-agent-worker"
+        "$ARTIFACTS_DIR/djinn-agent-worker" \
+        "$ARTIFACTS_DIR/djinn-cgroup-launcher"
 )"
 tilt_store_fingerprint "$BINARY_OUTPUT_FINGERPRINT" "$CURRENT_BINARY_OUTPUT_FINGERPRINT"
 tilt_store_fingerprint "$BUILD_FINGERPRINT" "$CURRENT_FINGERPRINT"
 
-echo "==> done: $ARTIFACTS_DIR/{djinn-server,djinn-agent-worker}"
+echo "==> done: $ARTIFACTS_DIR/{djinn-server,djinn-agent-worker,djinn-cgroup-launcher}"

--- a/scripts/tilt/wrap-agent-runtime-image.sh
+++ b/scripts/tilt/wrap-agent-runtime-image.sh
@@ -16,10 +16,15 @@ BASE_IMAGE="${BASE_IMAGE:-djinn-agent-runtime-base:dev}"
 BASE_BUILD_SCRIPT="${BASE_BUILD_SCRIPT:-$REPO_ROOT/scripts/tilt/build-agent-runtime-base.sh}"
 ARTIFACTS_DIR="${ARTIFACTS_DIR:-$REPO_ROOT/.tilt/artifacts}"
 BINARY="$ARTIFACTS_DIR/djinn-agent-worker"
+LAUNCHER_BINARY="$ARTIFACTS_DIR/djinn-cgroup-launcher"
 DOCKERFILE="$REPO_ROOT/server/docker/djinn-agent-runtime.Dockerfile"
 
 if [[ ! -x "$BINARY" ]]; then
     echo "error: $BINARY not found or not executable — run build-binaries.sh first" >&2
+    exit 1
+fi
+if [[ ! -x "$LAUNCHER_BINARY" ]]; then
+    echo "error: $LAUNCHER_BINARY not found or not executable — run build-binaries.sh first" >&2
     exit 1
 fi
 
@@ -37,6 +42,7 @@ BUILD_CTX="$(mktemp -d)"
 trap 'rm -rf "$BUILD_CTX"' EXIT
 
 cp "$BINARY" "$BUILD_CTX/djinn-agent-worker"
+cp "$LAUNCHER_BINARY" "$BUILD_CTX/djinn-cgroup-launcher"
 cp "$DOCKERFILE" "$BUILD_CTX/Dockerfile"
 
 echo "==> building $IMAGE_TAG (FROM $BASE_IMAGE)"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1512,6 +1512,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
+ "djinn-cgroup-launcher",
  "djinn-core",
  "djinn-db",
  "djinn-git",

--- a/server/crates/djinn-cgroup-launcher/Cargo.toml
+++ b/server/crates/djinn-cgroup-launcher/Cargo.toml
@@ -7,6 +7,14 @@ edition = "2024"
 [lib]
 doctest = false
 
+# Packaged sidecar entrypoint. Ships as `/opt/djinn/bin/djinn-cgroup-launcher`
+# in the per-project image alongside `djinn-agent-worker`; the task-run Job
+# renders the launcher sidecar to run it (see `djinn-k8s::launcher`). The binary
+# only composes the lib primitives — it adds no runtime behavior of its own.
+[[bin]]
+name = "djinn-cgroup-launcher"
+path = "src/main.rs"
+
 [dependencies]
 libc = "0.2"
 thiserror = "2"

--- a/server/crates/djinn-cgroup-launcher/src/main.rs
+++ b/server/crates/djinn-cgroup-launcher/src/main.rs
@@ -1,0 +1,139 @@
+//! Packaged entrypoint for the mandatory cgroup-launcher sidecar.
+//!
+//! This binary is deliberately thin: it only *composes* the crate's existing,
+//! separately-tested primitives (`NativeCgroupFs`, `NativeClone3`, `Launcher`,
+//! `Broker`, `UnixBrokerServer`) into a fail-closed serve loop. It adds no lease
+//! policy and no new syscall surface — the crate's runtime behavior is unchanged;
+//! this file is the packaging seam so the launcher ships as a real binary
+//! (`/opt/djinn/bin/djinn-cgroup-launcher`) alongside `djinn-agent-worker` in the
+//! same per-project image (see `server/crates/djinn-image-builder/src/dockerfile.rs`).
+//!
+//! Configuration is read from the environment the Job renders
+//! (`djinn-k8s::launcher`): the delegated cgroup root, control socket path, the
+//! worker-private credential path, the expected delegated-root owner uid, and the
+//! unleased broker quota. Anything missing/invalid, or a delegated cgroup that
+//! fails the [`Readiness`](djinn_cgroup_launcher::Readiness) contract, exits
+//! non-zero BEFORE the broker accepts a single connection.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use djinn_cgroup_launcher::broker::{Broker, BrokerConfig, OsNonceSource};
+use djinn_cgroup_launcher::transport::UnixBrokerServer;
+use djinn_cgroup_launcher::{
+    Error as LauncherError, Launcher, LauncherConfig, NativeCgroupFs, NativeClone3,
+};
+
+/// Worker→launcher handshake filename (holds the worker PID) written by the
+/// worker into the shared IPC mount next to the private credential.
+const WORKER_PID_FILE: &str = "worker.pid";
+/// Bounded wait for the worker handshake files to appear (100ms × 600 = 60s).
+const HANDSHAKE_POLL: Duration = Duration::from_millis(100);
+const HANDSHAKE_ATTEMPTS: u32 = 600;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            // Not `eprintln!`: the `print_stderr` lint is denied workspace-wide.
+            let _ = writeln!(std::io::stderr(), "djinn-cgroup-launcher: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), MainError> {
+    // Accept `serve` (the rendered arg) or no subcommand; reject anything else.
+    match std::env::args().nth(1).as_deref() {
+        None | Some("serve") => {}
+        Some(other) => return Err(MainError::UnknownSubcommand(other.to_string())),
+    }
+
+    let socket = env_required("DJINN_LAUNCHER_SOCKET")?;
+    let cgroup_root = env_required("DJINN_LAUNCHER_CGROUP_ROOT")?;
+    let credential_path = env_required("DJINN_LAUNCHER_CREDENTIAL_PATH")?;
+    let expected_uid: u32 = env_required("DJINN_LAUNCHER_EXPECTED_UID")?
+        .parse()
+        .map_err(|_| MainError::InvalidEnv("DJINN_LAUNCHER_EXPECTED_UID"))?;
+    let unleased: u16 = env_required("DJINN_LAUNCHER_UNLEASED_MILLICORES")?
+        .parse()
+        .map_err(|_| MainError::InvalidEnv("DJINN_LAUNCHER_UNLEASED_MILLICORES"))?;
+
+    // Open + validate the delegated cgroup root. `NativeCgroupFs::open` runs the
+    // full readiness contract (cgroup-v2, root writable, owner == expected uid,
+    // exactly the cpu controller delegated) and fails closed otherwise.
+    let fs = NativeCgroupFs::open(&cgroup_root, expected_uid)?;
+    let launcher = Launcher::new(
+        fs,
+        NativeClone3,
+        LauncherConfig::new(Some(unleased), expected_uid)?,
+    )?;
+
+    // Read the worker handshake (private credential + PID) the worker writes into
+    // the shared IPC mount at startup. The broker binds every control to that
+    // authenticated (pid, credential) pair.
+    let (worker_pid, credential) = read_worker_handshake(&credential_path)?;
+    let broker = Broker::new(
+        launcher,
+        BrokerConfig::worker(worker_pid, credential)?,
+        OsNonceSource,
+    )?;
+
+    let mut server = UnixBrokerServer::bind(&socket, broker)?;
+    // One connection at a time: the broker is scoped to a single authenticated
+    // worker for the pod's lifetime.
+    loop {
+        server.serve_once()?;
+    }
+}
+
+/// Poll for the worker-private credential and PID files, then read them.
+/// Fails closed if the worker never completes the handshake within the window.
+fn read_worker_handshake(credential_path: &str) -> Result<(u32, Vec<u8>), MainError> {
+    let credential = Path::new(credential_path);
+    let pid_file = credential
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(WORKER_PID_FILE);
+
+    for _ in 0..HANDSHAKE_ATTEMPTS {
+        if credential.exists() && pid_file.exists() {
+            let bytes = std::fs::read(credential)?;
+            let pid_text = std::fs::read_to_string(&pid_file)?;
+            let worker_pid: u32 = pid_text
+                .trim()
+                .parse()
+                .map_err(|_| MainError::InvalidHandshake)?;
+            if bytes.is_empty() || worker_pid == 0 {
+                return Err(MainError::InvalidHandshake);
+            }
+            return Ok((worker_pid, bytes));
+        }
+        std::thread::sleep(HANDSHAKE_POLL);
+    }
+    Err(MainError::HandshakeTimeout)
+}
+
+fn env_required(key: &'static str) -> Result<String, MainError> {
+    std::env::var(key).map_err(|_| MainError::MissingEnv(key))
+}
+
+#[derive(Debug, thiserror::Error)]
+enum MainError {
+    #[error("unknown subcommand: {0}")]
+    UnknownSubcommand(String),
+    #[error("required environment variable {0} is not set")]
+    MissingEnv(&'static str),
+    #[error("environment variable {0} is malformed")]
+    InvalidEnv(&'static str),
+    #[error("worker handshake files were malformed")]
+    InvalidHandshake,
+    #[error("worker handshake did not complete in time")]
+    HandshakeTimeout,
+    #[error(transparent)]
+    Launcher(#[from] LauncherError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/server/crates/djinn-image-builder/src/dockerfile.rs
+++ b/server/crates/djinn-image-builder/src/dockerfile.rs
@@ -284,6 +284,16 @@ fn emit_agent_worker(df: &mut String, agent_worker: &AgentWorkerImage) {
         agent_worker.full_ref()
     )
     .unwrap();
+    // The mandatory cgroup-launcher sidecar runs from THIS image with a
+    // different entrypoint (`/opt/djinn/bin/djinn-cgroup-launcher`, rendered by
+    // djinn-k8s::launcher). Copy it from the same agent-worker stage so the
+    // launcher command resolves to a real packaged artifact — no separate image.
+    writeln!(
+        df,
+        "COPY --from={} /usr/local/bin/djinn-cgroup-launcher /opt/djinn/bin/djinn-cgroup-launcher",
+        agent_worker.full_ref()
+    )
+    .unwrap();
     writeln!(df, "RUN /tmp/djinn-scripts/install-agent-worker.sh").unwrap();
 }
 
@@ -676,6 +686,15 @@ mod tests {
         assert!(
             df.dockerfile
                 .contains("COPY --from=djinn/agent-worker:sha256-deadbeef")
+        );
+        // The cgroup-launcher binary ships in the SAME per-project image (copied
+        // from the agent-worker stage) so the rendered launcher sidecar command
+        // resolves to a real packaged artifact — no separate/fabricated image.
+        assert!(
+            df.dockerfile.contains(
+                "/usr/local/bin/djinn-cgroup-launcher /opt/djinn/bin/djinn-cgroup-launcher"
+            ),
+            "per-project image must package the cgroup-launcher binary at /opt/djinn/bin"
         );
         assert!(df.dockerfile.contains("install-agent-worker.sh"));
         assert!(!df.dockerfile.contains("install-rust.sh"));

--- a/server/crates/djinn-k8s/Cargo.toml
+++ b/server/crates/djinn-k8s/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 doctest = false
 
 [dependencies]
+djinn-cgroup-launcher = { path = "../djinn-cgroup-launcher" }
 djinn-core = { path = "../djinn-core" }
 djinn-db = { path = "../djinn-db" }
 djinn-git = { path = "../djinn-git" }

--- a/server/crates/djinn-k8s/src/bin_packing_fixture_tests.rs
+++ b/server/crates/djinn-k8s/src/bin_packing_fixture_tests.rs
@@ -1,0 +1,381 @@
+//! Exact-arithmetic bin-packing fixture for the role-classed enforcement pod
+//! shape rendered by qut0 (`launcher.rs` / `sidecar.rs` / `warm_job.rs`).
+//!
+//! This is a **pure-arithmetic** guard, NOT a scheduler simulation: it parses
+//! the CPU/memory `Quantity` strings that qut0 actually renders into the worker
+//! container, the mandatory cgroup-launcher sidecar, and a default backing
+//! service sidecar, converts them to exact integer millicores / bytes, and does
+//! integer addition against a named 12-CPU / 48Gi node fixture with a protected
+//! core (3.4 CPU / 8Gi) and one warm Job (4 CPU / 2Gi, sourced from the rendered
+//! warm manifest).
+//!
+//! Why the values are *rendered* rather than typed as literals: every request
+//! this fixture reasons about comes back out of the real render path
+//! (`worker_resources`, `launcher_sidecar_container`, `sidecar_container`,
+//! `build_warm_job`, and the sidecar default envelope via [`super::parse_resources`]).
+//! A change to any role request, the launcher/sidecar request, or the default
+//! backing-service envelope therefore flows straight into these sums, so the
+//! pinned per-component assertions and the zero-slack build-capable identity
+//! fail loudly (AC3). This module lives as a child of `sidecar` purely so it can
+//! read the private default-resource envelope from [`super::parse_resources`]
+//! without adding any production surface — it is `#[cfg(test)]` only.
+//!
+//! Reconciled sums (all CPU in millicores):
+//!   node                = 12000        (12 CPU)
+//!   protected core      =  3400        (3.4 CPU)   — fixture constant
+//!   warm Job            =  4000        (4 CPU)     — rendered
+//!   remaining           =  4600        (node - protected - warm)
+//!   light pod           =   350        (worker 300 + launcher 50)
+//!   light pod + sidecar =   450        (+ backing sidecar 100)
+//!   build-capable pod   =  1150        (worker 1000 + launcher 50 + sidecar 100)
+//!
+//!   10 light, no sidecar : 3400 + 4000 + 10*350  = 10900 <= 12000  (fits)
+//!   10 light, + sidecar  : 3400 + 4000 + 10*450  = 11900 <= 12000  (fits, 100m slack)
+//!   4 build-capable      : 3400 + 4000 +  4*1150 = 12000 == 12000  (exactly full)
+//!   5 build-capable      : 3400 + 4000 +  5*1150 = 13150 >  12000  (infeasible)
+
+use k8s_openapi::api::core::v1::ResourceRequirements;
+
+use super::{BackingServiceSpec, parse_resources, sidecar_container};
+use crate::config::KubernetesConfig;
+use crate::launcher::{RoleResourceClass, launcher_sidecar_container, worker_resources};
+use crate::warm_job::build_warm_job;
+
+// ---- Named node / protected-core fixture constants ------------------------
+//
+// The node shape and the protected core are *environment* inputs (not rendered
+// by qut0), so they are encoded here as explicit named values. Any future
+// change to them is a deliberate edit that reruns every sum below.
+
+/// Total allocatable CPU of the fixture node, in millicores (12 CPU).
+const NODE_CPU_MILLICORES: i64 = 12_000;
+/// Total allocatable memory of the fixture node, in bytes (48 GiB).
+const NODE_MEMORY_BYTES: i64 = 48 * GIB;
+/// Protected-core (djinn-server + always-on infra) CPU reservation, millicores.
+const PROTECTED_CORE_CPU_MILLICORES: i64 = 3_400;
+/// Protected-core memory reservation, in bytes (8 GiB).
+const PROTECTED_CORE_MEMORY_BYTES: i64 = 8 * GIB;
+
+const KIB: i64 = 1 << 10;
+const MIB: i64 = 1 << 20;
+const GIB: i64 = 1 << 30;
+
+const IMAGE: &str = "registry.example/proj:fixture";
+
+// ---- Exact Quantity parsers ----------------------------------------------
+
+/// Parse a rendered CPU `Quantity` string to exact integer millicores.
+///
+/// Only the two forms qut0 actually renders are accepted: `"<n>m"` (millicores)
+/// and `"<n>"` (whole cores). Anything else (a fractional-core string, a bare
+/// float) is a render-shape change we want to notice, so it panics rather than
+/// silently rounding.
+fn cpu_millicores(q: &str) -> i64 {
+    match q.strip_suffix('m') {
+        Some(m) => m
+            .parse()
+            .unwrap_or_else(|_| panic!("non-integer millicore quantity: {q:?}")),
+        None => {
+            q.parse::<i64>()
+                .unwrap_or_else(|_| panic!("non-integer whole-core quantity: {q:?}"))
+                * 1000
+        }
+    }
+}
+
+/// Parse a rendered memory `Quantity` string to exact integer bytes.
+fn memory_bytes(q: &str) -> i64 {
+    for (suffix, mult) in [("Gi", GIB), ("Mi", MIB), ("Ki", KIB)] {
+        if let Some(n) = q.strip_suffix(suffix) {
+            return n
+                .parse::<i64>()
+                .unwrap_or_else(|_| panic!("non-integer memory quantity: {q:?}"))
+                * mult;
+        }
+    }
+    q.parse::<i64>()
+        .unwrap_or_else(|_| panic!("unrecognized memory quantity: {q:?}"))
+}
+
+fn request_cpu(r: &ResourceRequirements) -> i64 {
+    cpu_millicores(
+        &r.requests
+            .as_ref()
+            .expect("requests set")
+            .get("cpu")
+            .expect("cpu request set")
+            .0,
+    )
+}
+
+fn request_memory(r: &ResourceRequirements) -> i64 {
+    memory_bytes(
+        &r.requests
+            .as_ref()
+            .expect("requests set")
+            .get("memory")
+            .expect("memory request set")
+            .0,
+    )
+}
+
+// ---- Rendered per-component requests (the single source of truth) ----------
+
+/// A default backing-service sidecar spec: the CPU/memory *request* is the
+/// default envelope the dispatch path falls back to (rendered via the private
+/// [`super::parse_resources`] with an empty JSON object), so a change to that
+/// default flows into the sums below.
+fn default_backing_sidecar_spec() -> BackingServiceSpec {
+    let (cpu_request, memory_request, cpu_limit, memory_limit) = parse_resources("{}");
+    BackingServiceSpec {
+        service_type: "postgres".into(),
+        image: "postgres:18-alpine".into(),
+        port: 5432,
+        env: Vec::new(),
+        cpu_request,
+        memory_request,
+        cpu_limit,
+        memory_limit,
+        conn_template: "postgres://postgres:postgres@{host}:{port}/app_test".into(),
+        conn_env_var: "DATABASE_URL".into(),
+    }
+}
+
+/// All rendered requests the fixture reasons about, in exact integer units.
+struct Rendered {
+    light_worker_cpu: i64,
+    light_worker_mem: i64,
+    build_worker_cpu: i64,
+    build_worker_mem: i64,
+    launcher_cpu: i64,
+    launcher_mem: i64,
+    sidecar_cpu: i64,
+    sidecar_mem: i64,
+    warm_cpu: i64,
+    warm_mem: i64,
+}
+
+impl Rendered {
+    fn from_render() -> Self {
+        let cfg = KubernetesConfig::for_testing();
+
+        let light = worker_resources(&cfg, RoleResourceClass::Light);
+        let build = worker_resources(&cfg, RoleResourceClass::BuildCapable);
+
+        let launcher = launcher_sidecar_container(&cfg, IMAGE);
+        let launcher_res = launcher.resources.as_ref().expect("launcher resources");
+
+        let sidecar = sidecar_container(&cfg, &default_backing_sidecar_spec());
+        let sidecar_res = sidecar.resources.as_ref().expect("sidecar resources");
+
+        // One rendered warm Job; parse the warm container's own requests so a
+        // change to the warm resource render (not just the config field) shows.
+        let warm = build_warm_job(&cfg, "fixture", IMAGE, None);
+        let warm_container = &warm
+            .spec
+            .as_ref()
+            .expect("warm job spec")
+            .template
+            .spec
+            .as_ref()
+            .expect("warm pod spec")
+            .containers[0];
+        let warm_res = warm_container.resources.as_ref().expect("warm resources");
+
+        Self {
+            light_worker_cpu: request_cpu(&light),
+            light_worker_mem: request_memory(&light),
+            build_worker_cpu: request_cpu(&build),
+            build_worker_mem: request_memory(&build),
+            launcher_cpu: request_cpu(launcher_res),
+            launcher_mem: request_memory(launcher_res),
+            sidecar_cpu: request_cpu(sidecar_res),
+            sidecar_mem: request_memory(sidecar_res),
+            warm_cpu: request_cpu(warm_res),
+            warm_mem: request_memory(warm_res),
+        }
+    }
+
+    fn light_pod_cpu(&self) -> i64 {
+        self.light_worker_cpu + self.launcher_cpu
+    }
+    fn light_pod_mem(&self) -> i64 {
+        self.light_worker_mem + self.launcher_mem
+    }
+    fn build_pod_cpu(&self) -> i64 {
+        self.build_worker_cpu + self.launcher_cpu + self.sidecar_cpu
+    }
+    fn build_pod_mem(&self) -> i64 {
+        self.build_worker_mem + self.launcher_mem + self.sidecar_mem
+    }
+    fn reserved_cpu(&self) -> i64 {
+        PROTECTED_CORE_CPU_MILLICORES + self.warm_cpu
+    }
+    fn reserved_mem(&self) -> i64 {
+        PROTECTED_CORE_MEMORY_BYTES + self.warm_mem
+    }
+}
+
+// ---- AC3: every request the sums depend on is pinned to its rendered value --
+//
+// This is the "fail loudly on any future change" guard. Each rendered request
+// is asserted equal to the exact value the reconciled arithmetic assumes; a
+// change to a role request, the launcher/sidecar request, the default
+// backing-service envelope, or the warm/protected-core constants breaks a named
+// assertion here with the offending value in the message.
+
+#[test]
+fn rendered_requests_match_the_bin_packing_fixture_values() {
+    let r = Rendered::from_render();
+
+    // Role-classed worker CPU requests.
+    assert_eq!(r.light_worker_cpu, 300, "light worker CPU request changed");
+    assert_eq!(
+        r.build_worker_cpu, 1000,
+        "build-capable worker CPU request changed"
+    );
+    // Shared worker memory request (same across roles).
+    assert_eq!(r.light_worker_mem, 2 * GIB, "worker memory request changed");
+    assert_eq!(
+        r.build_worker_mem, r.light_worker_mem,
+        "worker memory request must be role-independent"
+    );
+
+    // Launcher sidecar (role-independent, fixed envelope).
+    assert_eq!(r.launcher_cpu, 50, "launcher sidecar CPU request changed");
+    assert_eq!(
+        r.launcher_mem,
+        64 * MIB,
+        "launcher sidecar memory request changed"
+    );
+
+    // Default backing-service sidecar envelope.
+    assert_eq!(
+        r.sidecar_cpu, 100,
+        "default backing sidecar CPU request changed"
+    );
+    assert_eq!(
+        r.sidecar_mem,
+        256 * MIB,
+        "default backing sidecar memory request changed"
+    );
+
+    // Warm Job.
+    assert_eq!(r.warm_cpu, 4000, "warm Job CPU request changed");
+    assert_eq!(r.warm_mem, 2 * GIB, "warm Job memory request changed");
+
+    // Node / protected-core fixture constants.
+    assert_eq!(NODE_CPU_MILLICORES, 12_000);
+    assert_eq!(NODE_MEMORY_BYTES, 48 * GIB);
+    assert_eq!(PROTECTED_CORE_CPU_MILLICORES, 3_400);
+    assert_eq!(PROTECTED_CORE_MEMORY_BYTES, 8 * GIB);
+}
+
+// ---- AC1: ten light pods + protected core + warm Job, without and with a
+//           default backing sidecar each, by exact arithmetic ----------------
+
+#[test]
+fn ten_light_pods_fit_alongside_protected_core_and_warm_without_sidecars() {
+    let r = Rendered::from_render();
+
+    // CPU: 3400 + 4000 + 10*(300+50) = 10900 <= 12000.
+    let total_cpu = r.reserved_cpu() + 10 * r.light_pod_cpu();
+    assert_eq!(r.light_pod_cpu(), 350);
+    assert_eq!(total_cpu, 10_900);
+    assert!(
+        total_cpu <= NODE_CPU_MILLICORES,
+        "ten light pods (no sidecar) must fit on CPU: {total_cpu} > {NODE_CPU_MILLICORES}"
+    );
+    assert_eq!(
+        NODE_CPU_MILLICORES - total_cpu,
+        1_100,
+        "CPU slack for ten sidecar-less light pods"
+    );
+
+    // Memory: 10Gi reserved + 10*(2Gi+64Mi) well under 48Gi.
+    let total_mem = r.reserved_mem() + 10 * r.light_pod_mem();
+    assert!(
+        total_mem <= NODE_MEMORY_BYTES,
+        "ten light pods (no sidecar) must fit on memory: {total_mem} > {NODE_MEMORY_BYTES}"
+    );
+}
+
+#[test]
+fn ten_light_pods_fit_alongside_protected_core_and_warm_with_one_sidecar_each() {
+    let r = Rendered::from_render();
+
+    // CPU: 3400 + 4000 + 10*(300+50+100) = 11900 <= 12000 (only 100m slack).
+    let pod_cpu = r.light_pod_cpu() + r.sidecar_cpu;
+    let total_cpu = r.reserved_cpu() + 10 * pod_cpu;
+    assert_eq!(pod_cpu, 450);
+    assert_eq!(total_cpu, 11_900);
+    assert!(
+        total_cpu <= NODE_CPU_MILLICORES,
+        "ten light pods (one sidecar each) must fit on CPU: {total_cpu} > {NODE_CPU_MILLICORES}"
+    );
+    assert_eq!(
+        NODE_CPU_MILLICORES - total_cpu,
+        100,
+        "CPU slack for ten light pods each with one backing sidecar"
+    );
+
+    // Memory: 10Gi reserved + 10*(2Gi+64Mi+256Mi) still under 48Gi.
+    let pod_mem = r.light_pod_mem() + r.sidecar_mem;
+    let total_mem = r.reserved_mem() + 10 * pod_mem;
+    assert!(
+        total_mem <= NODE_MEMORY_BYTES,
+        "ten light pods (one sidecar each) must fit on memory: {total_mem} > {NODE_MEMORY_BYTES}"
+    );
+}
+
+// ---- AC2: four build-capable pods total exactly 12 CPU; a fifth is infeasible
+
+#[test]
+fn four_build_capable_pods_with_launcher_and_sidecar_total_exactly_twelve_cpu() {
+    let r = Rendered::from_render();
+
+    // build-capable pod = worker 1000 + launcher 50 + sidecar 100 = 1150m.
+    assert_eq!(r.build_pod_cpu(), 1150);
+
+    // Exactly full: 3400 + 4000 + 4*1150 = 12000 == node.
+    let total_four = r.reserved_cpu() + 4 * r.build_pod_cpu();
+    assert_eq!(
+        total_four, NODE_CPU_MILLICORES,
+        "four build-capable pods must total EXACTLY 12 CPU with protected core + warm"
+    );
+
+    // Zero slack: the room left after protected core + warm is exactly four
+    // build-capable pods. This is the assertion that makes any future
+    // zero-slack request change explicit.
+    assert_eq!(
+        NODE_CPU_MILLICORES - r.reserved_cpu(),
+        4 * r.build_pod_cpu(),
+        "remaining CPU after protected core + warm must equal exactly four build-capable pods"
+    );
+
+    // Memory is NOT the binding constraint here — confirm four build pods fit.
+    let total_mem = r.reserved_mem() + 4 * r.build_pod_mem();
+    assert!(
+        total_mem <= NODE_MEMORY_BYTES,
+        "four build-capable pods must fit on memory: {total_mem} > {NODE_MEMORY_BYTES}"
+    );
+}
+
+#[test]
+fn a_fifth_build_capable_pod_is_infeasible_on_cpu() {
+    let r = Rendered::from_render();
+
+    // 3400 + 4000 + 5*1150 = 13150 > 12000.
+    let total_five = r.reserved_cpu() + 5 * r.build_pod_cpu();
+    assert_eq!(total_five, 13_150);
+    assert!(
+        total_five > NODE_CPU_MILLICORES,
+        "a fifth build-capable pod must overcommit CPU: {total_five} <= {NODE_CPU_MILLICORES}"
+    );
+    // The overshoot is exactly one build-capable pod beyond a full node.
+    assert_eq!(
+        total_five - NODE_CPU_MILLICORES,
+        r.build_pod_cpu(),
+        "the fifth pod overshoots the full node by exactly one build-capable pod"
+    );
+}

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -22,13 +22,39 @@ pub struct KubernetesConfig {
     /// ServiceAccount mounted into each worker Pod. Provides the projected
     /// token authenticating back to djinn-server.
     pub service_account: String,
-    /// CPU request (e.g. `"2"`).
+    /// CPU **request** for a *build-capable* task-run Pod (Worker / Verifier /
+    /// Architect and their retry/resume flows, plus the fail-safe default for
+    /// any unknown/new role — see [`crate::launcher::RoleResourceClass`]).
+    ///
+    /// v1 leases default: `"1"`. The `cpu.weight` (CFS share) a container gets
+    /// derives from its REQUEST, so a build-capable pod that will actually
+    /// compile needs a full core of guaranteed share. Prod overrides this to
+    /// `4` via `DJINN_K8S_CPU_REQUEST` (see the taskrun-pod-cpu-4 benchmark
+    /// note) — the env override is preserved, so this default only sets the
+    /// out-of-the-box value.
     pub cpu_request: String,
-    /// CPU limit (e.g. `"2"`).
+    /// CPU **request** for a *light* task-run Pod (Planner / Reviewer / Lead /
+    /// every Refinement sub-role / grooming). These pods orchestrate an agent
+    /// session and never run the project's compile/test toolchain, so they get
+    /// a fractional-core request. v1 leases default: `"300m"`. Overridable via
+    /// `DJINN_K8S_LIGHT_CPU_REQUEST`.
+    ///
+    /// Only the CPU REQUEST is role-classed: the CPU **limit**
+    /// ([`Self::cpu_limit`]) and both memory bounds are identical for light and
+    /// build-capable pods ("same limits everywhere"), and the launcher/broker
+    /// contract is identical regardless of role.
+    pub light_cpu_request: String,
+    /// CPU limit shared by both role classes (light and build-capable). v1
+    /// leases default: `"4"`. The limit is deliberately NOT role-classed — only
+    /// the guaranteed request differs by role. Overridable via
+    /// `DJINN_K8S_CPU_LIMIT`.
     pub cpu_limit: String,
-    /// Memory request (e.g. `"4Gi"`).
+    /// Memory request shared by both role classes. v1 leases default: `"2Gi"`.
+    /// Overridable via `DJINN_K8S_MEMORY_REQUEST` (prod projects a larger
+    /// Burstable value — see the taskrun-memory-burstable note).
     pub memory_request: String,
-    /// Memory limit (e.g. `"4Gi"`).
+    /// Memory limit shared by both role classes. v1 leases default: `"4Gi"`.
+    /// Overridable via `DJINN_K8S_MEMORY_LIMIT`.
     pub memory_limit: String,
     /// TTL (seconds) applied to completed Jobs for auto-GC.
     pub ttl_seconds_after_finished: i32,
@@ -141,6 +167,22 @@ pub struct KubernetesConfig {
     /// `node_selector` above. Surfaced in the chart as
     /// `resources.taskrun.tolerations`.
     pub tolerations: Vec<Toleration>,
+    /// Cgroup-v2 delegation profile the enforcement launcher runs under. The
+    /// only profile v1 supports is `"cgroup-v2-cpu-only"`
+    /// ([`crate::launcher::CGROUP_PROFILE_V2_CPU_ONLY`]): a cgroup-v2 mount with
+    /// a delegated root owned by uid 0 and exactly the `cpu` controller enabled
+    /// for children. [`crate::launcher::validate_enforcement_render`] maps this
+    /// string onto the SAME `Readiness::validate` the launcher runs in-pod, so a
+    /// misconfigured node profile fails closed at dispatch BEFORE any user code
+    /// executes. Overridable via `DJINN_K8S_CGROUP_DELEGATION_PROFILE`.
+    pub cgroup_delegation_profile: String,
+    /// Volume-ownership mode used for the workspace/cache/mirror surfaces. v1
+    /// requires `"fsgroup-on-root-mismatch"`
+    /// ([`crate::launcher::VOLUME_OWNERSHIP_ON_ROOT_MISMATCH`]): `fsGroup =
+    /// ARTIFACT_GID (1000)` re-owned only when the volume root gid mismatches.
+    /// Any other mode fails render validation. Overridable via
+    /// `DJINN_K8S_VOLUME_OWNERSHIP_MODE`.
+    pub volume_ownership_mode: String,
 }
 
 impl KubernetesConfig {
@@ -152,9 +194,15 @@ impl KubernetesConfig {
             image: "djinn-agent-runtime:dev".into(),
             image_pull_policy: "IfNotPresent".into(),
             service_account: "djinn-taskrun".into(),
-            cpu_request: "2".into(),
-            cpu_limit: "2".into(),
-            memory_request: "4Gi".into(),
+            // v1 leases role-classed CPU requests: build-capable pods request a
+            // full core; light (orchestration-only) pods request 300m. The CPU
+            // LIMIT and both memory bounds are shared across roles ("same limits
+            // everywhere"). Prod overrides cpu_request/cpu_limit/memory_* via
+            // the DJINN_K8S_* envs, which are all still honored in from_env().
+            cpu_request: "1".into(),
+            light_cpu_request: "300m".into(),
+            cpu_limit: "4".into(),
+            memory_request: "2Gi".into(),
             memory_limit: "4Gi".into(),
             ttl_seconds_after_finished: 300,
             mirror_pvc: "djinn-mirror".into(),
@@ -183,6 +231,10 @@ impl KubernetesConfig {
             warm_memory_limit: "6Gi".into(),
             node_selector: BTreeMap::new(),
             tolerations: Vec::new(),
+            // v1 leases enforcement contract. Both fail render validation if set
+            // to anything the launcher's runtime readiness check would reject.
+            cgroup_delegation_profile: crate::launcher::CGROUP_PROFILE_V2_CPU_ONLY.into(),
+            volume_ownership_mode: crate::launcher::VOLUME_OWNERSHIP_ON_ROOT_MISMATCH.into(),
         }
     }
 
@@ -200,10 +252,11 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_IMAGE` | `image` | `djinn-agent-runtime:dev` |
     /// | `DJINN_K8S_IMAGE_PULL_POLICY` | `image_pull_policy` | `IfNotPresent` |
     /// | `DJINN_K8S_SERVICE_ACCOUNT` | `service_account` | `djinn-taskrun` |
-    /// | `DJINN_K8S_CPU_REQUEST` | `cpu_request` | `2` |
-    /// | `DJINN_K8S_CPU_LIMIT` | `cpu_limit` | `2` |
-    /// | `DJINN_K8S_MEMORY_REQUEST` | `memory_request` | `4Gi` |
-    /// | `DJINN_K8S_MEMORY_LIMIT` | `memory_limit` | `4Gi` |
+    /// | `DJINN_K8S_CPU_REQUEST` | `cpu_request` (build-capable) | `1` |
+    /// | `DJINN_K8S_LIGHT_CPU_REQUEST` | `light_cpu_request` | `300m` |
+    /// | `DJINN_K8S_CPU_LIMIT` | `cpu_limit` (shared) | `4` |
+    /// | `DJINN_K8S_MEMORY_REQUEST` | `memory_request` (shared) | `2Gi` |
+    /// | `DJINN_K8S_MEMORY_LIMIT` | `memory_limit` (shared) | `4Gi` |
     /// | `DJINN_K8S_TTL_SECONDS` | `ttl_seconds_after_finished` | `300` (parsed as `i32`) |
     /// | `DJINN_K8S_MIRROR_PVC` | `mirror_pvc` | `djinn-mirror` |
     /// | `DJINN_K8S_CACHE_PVC` | `cache_pvc` | `djinn-cache` |
@@ -219,6 +272,8 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_WARM_MEMORY_LIMIT` | `warm_memory_limit` | `6Gi` |
     /// | `DJINN_K8S_NODE_SELECTOR` | `node_selector` | `{}` (parsed as a JSON object of string→string) |
     /// | `DJINN_K8S_TOLERATIONS` | `tolerations` | `[]` (parsed as a JSON array of k8s `Toleration` objects) |
+    /// | `DJINN_K8S_CGROUP_DELEGATION_PROFILE` | `cgroup_delegation_profile` | `cgroup-v2-cpu-only` |
+    /// | `DJINN_K8S_VOLUME_OWNERSHIP_MODE` | `volume_ownership_mode` | `fsgroup-on-root-mismatch` |
     ///
     /// `DJINN_DATABASE_URL` is read from djinn-server's own environment (the
     /// Helm chart projects it via `envFrom: configMap djinn-config`) and
@@ -246,6 +301,9 @@ impl KubernetesConfig {
         }
         if let Ok(v) = std::env::var("DJINN_K8S_CPU_REQUEST") {
             cfg.cpu_request = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_LIGHT_CPU_REQUEST") {
+            cfg.light_cpu_request = v;
         }
         if let Ok(v) = std::env::var("DJINN_K8S_CPU_LIMIT") {
             cfg.cpu_limit = v;
@@ -356,6 +414,12 @@ impl KubernetesConfig {
                     "DJINN_K8S_TOLERATIONS not valid JSON (expected array of Toleration objects) — keeping default"
                 ),
             }
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_CGROUP_DELEGATION_PROFILE") {
+            cfg.cgroup_delegation_profile = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_VOLUME_OWNERSHIP_MODE") {
+            cfg.volume_ownership_mode = v;
         }
         cfg
     }

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -3,7 +3,7 @@
 //! No cluster interaction — [`build_task_run_job`] produces a
 //! [`k8s_openapi::api::batch::v1::Job`] value that PR 3 will hand to
 //! `kube::Api::<Job>::create`. Structuring the builder as a pure function
-//! keeps unit testing trivial: `build_task_run_job(&cfg, &id, secret_name)` +
+//! keeps unit testing trivial: `build_task_run_job(&cfg, &id, secret_name, None)` +
 //! struct assertions against the returned `Job`.
 
 use std::collections::BTreeMap;
@@ -11,16 +11,21 @@ use std::collections::BTreeMap;
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     Container, EmptyDirVolumeSource, EnvVar, KeyToPath, PersistentVolumeClaimVolumeSource, PodSpec,
-    PodTemplateSpec, ProjectedVolumeSource, ResourceRequirements, SecretVolumeSource,
-    ServiceAccountTokenProjection, Toleration, Volume, VolumeMount, VolumeProjection,
+    PodTemplateSpec, ProjectedVolumeSource, SecretVolumeSource, ServiceAccountTokenProjection,
+    Toleration, Volume, VolumeMount, VolumeProjection,
 };
-use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use uuid::Uuid;
 
+use djinn_runtime::RoleKind;
 use djinn_supervisor::cargo_target_run_dir;
 
 use crate::config::KubernetesConfig;
+use crate::launcher::{
+    RoleResourceClass, launcher_cgroup_volume, launcher_ipc_volume, launcher_sidecar_container,
+    pod_security_context, worker_launcher_env, worker_launcher_ipc_mount, worker_resources,
+    worker_security_context,
+};
 use crate::sidecar::{
     BackingServiceSpec, control_volume, control_volume_mount, sidecar_conn_env, sidecar_container,
     sidecar_dshm_volume,
@@ -198,10 +203,16 @@ pub fn build_task_run_job(
     services: &[BackingServiceSpec],
     policy: Option<&djinn_stack::environment::CargoCachePolicy>,
     is_evidence_spike: bool,
+    // The RoleKind that executes this task-run, threaded from dispatch (derived
+    // from `spec.flow` — see `runtime.rs`). Drives the role-classed CPU request
+    // via [`RoleResourceClass`]. `None` / unknown / any future role FAILS SAFE
+    // to build-capable so a pod that might compile is never under-provisioned.
+    role: Option<RoleKind>,
 ) -> Job {
     let task_run_id_str = task_run_id.to_string();
     let labels = job_labels(&task_run_id_str);
     let job_name = format!("djinn-taskrun-{task_run_id}");
+    let role_class = RoleResourceClass::for_role(role);
 
     // Evidence-spike runs receive no backing-service connection env vars —
     // the worker has no business reaching product databases/queues for a
@@ -229,6 +240,9 @@ pub fn build_task_run_job(
     // runs use `effective_services` (empty) so no DB connection env is injected.
     let mut worker_env = build_task_run_env(config, &task_run_id_str, project_id, policy);
     worker_env.extend(effective_services.iter().flat_map(sidecar_conn_env));
+    // Broker socket + worker-private credential paths so the worker can dial the
+    // mandatory cgroup-launcher sidecar.
+    worker_env.extend(worker_launcher_env());
 
     // The private control emptyDir is added only when a wrapper sidecar is
     // injected, and mounted only into the worker and the wrapper sidecars — never
@@ -256,6 +270,10 @@ pub fn build_task_run_job(
         // comment above for why this narrow exception is safe.
         volume_mount(VOLUME_WORKSPACE, WORKSPACE_MOUNT_DIR, None),
         crate::env_config::env_config_volume_mount(),
+        // Broker control socket + worker-private launcher credential. Shared
+        // with the mandatory cgroup-launcher sidecar only; never mounted into a
+        // backing sidecar, and closed off from the launcher-spawned child.
+        worker_launcher_ipc_mount(),
     ];
     if any_wrapper {
         worker_volume_mounts.push(control_volume_mount());
@@ -277,21 +295,19 @@ pub fn build_task_run_job(
             "task-run".to_string(),
         ]),
         env: Some(worker_env),
+        // Base mounts + ij6g's conditional wrapper control mount + qut0's
+        // mandatory launcher IPC mount are all folded into worker_volume_mounts
+        // above.
         volume_mounts: Some(worker_volume_mounts),
-        resources: Some(ResourceRequirements {
-            requests: Some(BTreeMap::from([
-                ("cpu".to_string(), Quantity(config.cpu_request.clone())),
-                (
-                    "memory".to_string(),
-                    Quantity(config.memory_request.clone()),
-                ),
-            ])),
-            limits: Some(BTreeMap::from([
-                ("cpu".to_string(), Quantity(config.cpu_limit.clone())),
-                ("memory".to_string(), Quantity(config.memory_limit.clone())),
-            ])),
-            ..ResourceRequirements::default()
-        }),
+        // Role-classed resources: CPU request varies by role class; CPU limit
+        // and memory bounds are shared ("role changes REQUESTS only").
+        resources: Some(worker_resources(config, role_class)),
+        // v1 security contract: worker runs as uid/gid 1000 (NOT the legacy
+        // pod-wide uid 10001), drops all capabilities, restricted seccomp.
+        // Non-dumpability is asserted by the worker at runtime before it
+        // authenticates to the broker. See the fsGroup deploy-risk note on the
+        // pod securityContext below.
+        security_context: Some(worker_security_context()),
         ..Container::default()
     };
 
@@ -393,6 +409,13 @@ pub fn build_task_run_job(
             ..Volume::default()
         },
         crate::env_config::env_config_volume(project_id),
+        // Enforcement volumes for the mandatory cgroup-launcher sidecar. Always
+        // present on a task-run pod: the launcher is mandatory. `launcher-ipc`
+        // (Memory emptyDir) carries the broker control socket + worker-private
+        // credential (worker + launcher only); `launcher-cgroup` is the
+        // launcher's private delegated cgroup root (launcher only).
+        launcher_ipc_volume(),
+        launcher_cgroup_volume(),
     ];
     // Backing-service sidecars share a Memory /dev/shm (Postgres needs more than
     // the 64Mi default). Added only when services are injected so the manifest
@@ -408,17 +431,22 @@ pub fn build_task_run_job(
         volumes.push(control_volume());
     }
 
-    // Each declared backing service becomes a native sidecar (initContainer +
-    // restartPolicy: Always). `None` when there are none, keeping the manifest
-    // unchanged for projects without injected services.  For evidence-spike
-    // runs, `effective_services` is empty so no sidecar init containers are
-    // injected — the read-only investigation must not start product databases.
-    let init_containers = (!effective_services.is_empty()).then(|| {
+    // The mandatory cgroup-launcher is a native sidecar (initContainer +
+    // restartPolicy: Always): it comes up before the worker (which dials its
+    // broker socket) and is torn down when the worker exits, so the Job still
+    // reaches Completed. It is ALWAYS present — including for evidence spikes —
+    // because enforcement is not optional.
+    //
+    // Each declared backing service is then ALSO a native sidecar, appended
+    // AFTER the launcher.  For evidence-spike runs, `effective_services` is
+    // empty so no product databases start, but the launcher stays.
+    let mut init_container_vec = vec![launcher_sidecar_container(config, project_image_tag)];
+    init_container_vec.extend(
         effective_services
             .iter()
-            .map(|s| sidecar_container(config, s))
-            .collect::<Vec<_>>()
-    });
+            .map(|s| sidecar_container(config, s)),
+    );
+    let init_containers = Some(init_container_vec);
 
     // Pin Pods to a dedicated NodePool when the operator has configured one.
     // Both fields stay `None` if the corresponding config entry is empty so
@@ -439,23 +467,30 @@ pub fn build_task_run_job(
         // RPC frame (TerminalReport) before SIGKILL — K8s default 30s is
         // tight when the supervisor is mid-stream over a slow link.
         termination_grace_period_seconds: Some(config.task_run_termination_grace_period_seconds),
-        // Force the worker to run as uid 10001 (the djinn user baked
-        // into the agent-runtime base image — see
-        // server/docker/djinn-agent-runtime.Dockerfile) so it matches
-        // the uid that owns the shared /mirror PVC. The per-project
-        // devcontainer image layers `USER root` for apt-installs and
-        // never restores USER djinn, so without this override the
-        // worker runs as uid 0 and git 2.35.2+ rejects /mirror with
-        // "dubious ownership". GIT_CONFIG_VALUE_0=* via env vars (set
-        // in build_task_run_env) was tried first and silently failed
-        // — git apparently disregards wildcard safe.directory from
-        // env, only honoring it from file config. fsGroup doesn't
-        // apply to PVCs (only to emptyDir / configMap volumes).
-        security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
-            run_as_user: Some(10001),
-            run_as_group: Some(10001),
-            ..Default::default()
-        }),
+        // shareProcessNamespace lets the launcher sidecar see the worker process
+        // (PID auth via SO_PEERCRED / the broker's worker_pid contract) so it can
+        // authenticate the worker and clone children into the delegated cgroup.
+        share_process_namespace: Some(true),
+        // v1 leases security contract (qut0). The per-container securityContexts
+        // set the UIDs now (worker=1000, launcher=0); the pod context ties
+        // `fsGroup` to the artifact GID (1000) with `fsGroupChangePolicy:
+        // OnRootMismatch` so workspace/cache/mirror volumes are group-owned by
+        // the artifact GID (setgid), letting the launcher-spawned child (group
+        // 1000) write artifacts the worker (uid/gid 1000) can read.
+        //
+        // DEPLOY RISK: the legacy pod ran as uid 10001, and the VPS's large
+        // `/mirror` and `/cache` PVCs are currently owned by 10001:10001.
+        // `fsGroup=1000` makes the kubelet recursively re-own the volume to group
+        // 1000 on the first mount whose root gid mismatches. `OnRootMismatch`
+        // limits this to that first pod, but that first task-run/warm pod after
+        // deploy pays a one-time, potentially slow recursive re-own of those huge
+        // caches. Mitigation: run a one-shot `chgrp -R 1000 /mirror /cache`
+        // before cutover so the root gid already matches and the recursive pass
+        // is skipped. See the matching notes in `launcher.rs` and `config.rs`.
+        //
+        // (The legacy uid-10001 / git "dubious ownership" concern is now covered
+        // by the `safe.directory=*` GIT_CONFIG_* envs set in build_task_run_env.)
+        security_context: Some(pod_security_context()),
         ..PodSpec::default()
     };
 
@@ -517,6 +552,7 @@ pub fn build_task_run_job_with_read_sources(
     services: &[BackingServiceSpec],
     policy: Option<&djinn_stack::environment::CargoCachePolicy>,
     is_evidence_spike: bool,
+    role: Option<RoleKind>,
     owner_cache_sub_path: Option<&str>,
 ) -> Job {
     let mut job = build_task_run_job(
@@ -528,6 +564,7 @@ pub fn build_task_run_job_with_read_sources(
         services,
         policy,
         is_evidence_spike,
+        role,
     );
     let Some(owner_cache_sub_path) = owner_cache_sub_path else {
         return job;
@@ -942,6 +979,7 @@ mod tests {
             &all_three_wrappers(),
             None,
             false,
+            None,
         )
     }
 
@@ -969,7 +1007,18 @@ mod tests {
         let job = wrapper_job();
         let pod = pod_of(&job);
         let inits = pod.init_containers.as_ref().expect("init containers set");
-        assert_eq!(inits.len(), 3, "one wrapper sidecar per service type");
+        // The mandatory cgroup-launcher sidecar renders first, followed by one
+        // wrapper sidecar per service type.
+        assert_eq!(
+            inits.len(),
+            4,
+            "mandatory launcher sidecar + one wrapper sidecar per service type"
+        );
+        assert_eq!(
+            inits[0].name,
+            crate::launcher::LAUNCHER_CONTAINER_NAME,
+            "the mandatory cgroup-launcher sidecar renders first"
+        );
 
         for (svc, port, socket) in [
             ("postgres", 5432, "preset-postgres-18.sock"),
@@ -1068,6 +1117,7 @@ mod tests {
             &[legacy],
             None,
             false,
+            None,
         );
         let pod = pod_of(&job);
         assert!(
@@ -1204,6 +1254,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
 
         // Metadata.
@@ -1353,10 +1404,10 @@ mod tests {
         );
 
         // Volume mounts: 5 from the pre-env-config layout + the
-        // environment-config mount added in P4.
+        // environment-config mount (P4) + the launcher IPC mount (qut0 leases v1).
         let mounts = container.volume_mounts.as_ref().expect("volume_mounts set");
-        assert_eq!(mounts.len(), 6, "expected 6 volume mounts");
-        let expected_mounts: [(&str, &str, Option<bool>); 6] = [
+        assert_eq!(mounts.len(), 7, "expected 7 volume mounts");
+        let expected_mounts: [(&str, &str, Option<bool>); 7] = [
             (VOLUME_SPEC, SPEC_MOUNT_DIR, Some(true)),
             (VOLUME_AUTH_TOKEN, TOKEN_MOUNT_DIR, Some(true)),
             (VOLUME_MIRROR, MIRROR_MOUNT_DIR, Some(false)),
@@ -1367,6 +1418,11 @@ mod tests {
                 crate::env_config::ENV_CONFIG_MOUNT_DIR,
                 Some(true),
             ),
+            (
+                crate::launcher::VOLUME_LAUNCHER_IPC,
+                crate::launcher::LAUNCHER_IPC_DIR,
+                None,
+            ),
         ];
         for (mount, (exp_name, exp_path, exp_ro)) in mounts.iter().zip(expected_mounts.iter()) {
             assert_eq!(&mount.name, exp_name);
@@ -1374,9 +1430,9 @@ mod tests {
             assert_eq!(mount.read_only, *exp_ro);
         }
 
-        // Volumes mirror the mount list.
+        // Volumes mirror the mount list, plus the launcher-only cgroup volume.
         let volumes = pod.volumes.as_ref().expect("volumes set");
-        assert_eq!(volumes.len(), 6, "expected 6 volumes");
+        assert_eq!(volumes.len(), 8, "expected 8 volumes");
         let expected_volume_names = [
             VOLUME_SPEC,
             VOLUME_AUTH_TOKEN,
@@ -1384,6 +1440,8 @@ mod tests {
             VOLUME_CACHE,
             VOLUME_WORKSPACE,
             crate::env_config::VOLUME_ENV_CONFIG,
+            crate::launcher::VOLUME_LAUNCHER_IPC,
+            crate::launcher::VOLUME_LAUNCHER_CGROUP,
         ];
         for (volume, expected_name) in volumes.iter().zip(expected_volume_names.iter()) {
             assert_eq!(&volume.name, expected_name);
@@ -1500,6 +1558,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
 
         let pod = job
@@ -1541,6 +1600,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
 
         let pod = job
@@ -1601,20 +1661,20 @@ mod tests {
         );
         assert_eq!(
             envs.get("CARGO_BUILD_RUSTFLAGS").copied(),
-            Some("-Clink-arg=-fuse-ld=mold -Clink-arg=-Wl,--threads=2"),
+            Some("-Clink-arg=-fuse-ld=mold -Clink-arg=-Wl,--threads=4"),
             "task-runs default to the mold fast linker (installed in the devcontainer image)"
         );
         // Cargo/nextest parallelism is capped at the task-run pod's CPU LIMIT
-        // (for_testing default "2") so a node full of cold-rebuilding pods can't
-        // oversubscribe on the host core count (load-103 incident).
+        // (v1 leases for_testing default "4") so a node full of cold-rebuilding
+        // pods can't oversubscribe on the host core count (load-103 incident).
         assert_eq!(
             envs.get("CARGO_BUILD_JOBS").copied(),
-            Some("2"),
+            Some("4"),
             "task-run CARGO_BUILD_JOBS must be pinned to the pod's CPU limit, not the host core count"
         );
         assert_eq!(
             envs.get("NEXTEST_TEST_THREADS").copied(),
-            Some("2"),
+            Some("4"),
             "task-run NEXTEST_TEST_THREADS must match the pod's CPU limit"
         );
     }
@@ -1632,6 +1692,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
         let env = task_run_job_envs(&job);
 
@@ -2122,6 +2183,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
         let second_job = build_task_run_job(
             &cfg,
@@ -2132,6 +2194,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
 
         let first_envs = task_run_job_envs(&first_job);
@@ -2197,6 +2260,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
 
         let pod = job
@@ -2248,16 +2312,21 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
         let bare_pod = bare
             .spec
             .as_ref()
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec");
-        assert!(
-            bare_pod.init_containers.is_none(),
-            "no services ⇒ no initContainers (manifest unchanged)"
-        );
+        // The mandatory launcher sidecar is ALWAYS present; with no backing
+        // services it is the ONLY init container and there is no svc-dshm volume.
+        let bare_inits = bare_pod
+            .init_containers
+            .as_ref()
+            .expect("launcher sidecar is always an init container");
+        assert_eq!(bare_inits.len(), 1, "no services ⇒ launcher sidecar only");
+        assert_eq!(bare_inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
         assert!(
             !bare_pod
                 .volumes
@@ -2278,6 +2347,7 @@ mod tests {
             std::slice::from_ref(&postgres),
             None,
             false,
+            None,
         );
         let pod = job
             .spec
@@ -2285,11 +2355,13 @@ mod tests {
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec");
 
-        // Native sidecar in initContainers.
+        // Native sidecars in initContainers: the mandatory launcher first, then
+        // the backing service after it.
         let inits = pod.init_containers.as_ref().expect("init_containers set");
-        assert_eq!(inits.len(), 1);
-        assert_eq!(inits[0].name, "svc-postgres");
-        assert_eq!(inits[0].restart_policy.as_deref(), Some("Always"));
+        assert_eq!(inits.len(), 2);
+        assert_eq!(inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
+        assert_eq!(inits[1].name, "svc-postgres");
+        assert_eq!(inits[1].restart_policy.as_deref(), Some("Always"));
 
         // Connection env var exported to the worker container.
         let worker = &pod.containers[0];
@@ -2427,6 +2499,7 @@ mod tests {
             &[],
             None,
             true, // is_evidence_spike
+            None,
         );
         let pod = job
             .spec
@@ -2478,6 +2551,7 @@ mod tests {
             &[],
             None,
             true,
+            None,
         );
         let pod = job
             .spec
@@ -2527,6 +2601,7 @@ mod tests {
             &[],
             None,
             true,
+            None,
         );
         let pod = job
             .spec
@@ -2578,6 +2653,7 @@ mod tests {
             std::slice::from_ref(&postgres),
             None,
             true, // is_evidence_spike
+            None,
         );
         let pod = job
             .spec
@@ -2585,9 +2661,20 @@ mod tests {
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec set");
 
-        // No init containers (no sidecar).
+        // The mandatory launcher sidecar is still present (enforcement is not
+        // optional), but NO backing-service sidecar is injected.
+        let inits = pod
+            .init_containers
+            .as_ref()
+            .expect("launcher sidecar is always present");
+        assert_eq!(
+            inits.len(),
+            1,
+            "evidence-spike must inject only the launcher, no backing services"
+        );
+        assert_eq!(inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
         assert!(
-            pod.init_containers.is_none(),
+            !inits.iter().any(|c| c.name.starts_with("svc-")),
             "evidence-spike must not inject backing-service sidecars"
         );
 
@@ -2647,6 +2734,7 @@ mod tests {
             std::slice::from_ref(&postgres),
             None,
             false, // NOT evidence spike
+            None,
         );
         let pod = job
             .spec
@@ -2654,10 +2742,11 @@ mod tests {
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec set");
 
-        // Sidecar IS injected for normal runs.
+        // Launcher + backing-service sidecar both injected for normal runs.
         let inits = pod.init_containers.as_ref().expect("init_containers set");
-        assert_eq!(inits.len(), 1);
-        assert_eq!(inits[0].name, "svc-postgres");
+        assert_eq!(inits.len(), 2);
+        assert_eq!(inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
+        assert_eq!(inits[1].name, "svc-postgres");
 
         // Connection env var IS present.
         let worker = &pod.containers[0];
@@ -2735,6 +2824,7 @@ mod tests {
             std::slice::from_ref(&postgres),
             None,
             false,
+            None,
         );
         let pod = job
             .spec
@@ -2777,6 +2867,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
         );
         let pod = job
             .spec
@@ -2861,6 +2952,7 @@ mod tests {
             std::slice::from_ref(&postgres),
             None,
             false,
+            None,
         );
         let pod = job
             .spec
@@ -2926,6 +3018,7 @@ mod tests {
             std::slice::from_ref(&postgres),
             None,
             false,
+            None,
         );
         let pod = job
             .spec
@@ -3022,6 +3115,7 @@ mod tests {
             &[],
             None,
             false,
+            None,
             Some("octo/owner-repo/.task-runtime/read-sources"),
         );
         let pod = job.spec.unwrap().template.spec.unwrap();
@@ -3081,6 +3175,7 @@ mod tests {
             None,
             false,
             None,
+            None,
         );
         let pod = job.spec.unwrap().template.spec.unwrap();
         assert!(!pod.volumes.as_ref().unwrap().iter().any(|volume| {
@@ -3097,5 +3192,314 @@ mod tests {
                 .iter()
                 .any(|mount| mount.name == "read-sources")
         );
+    }
+
+    // ── qut0: v1 leases enforcement rendering ─────────────────────────────
+
+    fn job_for_role(role: Option<RoleKind>) -> Job {
+        build_task_run_job(
+            &KubernetesConfig::for_testing(),
+            &Uuid::now_v7(),
+            "proj-xyz",
+            "djinn-taskrun-role",
+            "registry.example/proj:tag",
+            &[],
+            None,
+            false,
+            role,
+        )
+    }
+
+    fn worker_cpu_request(job: &Job) -> String {
+        let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        pod.containers[0]
+            .resources
+            .as_ref()
+            .unwrap()
+            .requests
+            .as_ref()
+            .unwrap()
+            .get("cpu")
+            .unwrap()
+            .0
+            .clone()
+    }
+
+    /// AC1: every RoleKind — plus grooming (Planner flow), retry/resume, and the
+    /// unknown/missing default — renders the correct role-classed CPU request.
+    #[test]
+    fn role_classed_cpu_request_covers_every_role_and_default() {
+        let cfg = KubernetesConfig::for_testing();
+
+        // Light roles (Planner covers grooming; Refinement covers every
+        // advocate/adversary/judge sub-role).
+        for role in [
+            RoleKind::Planner,
+            RoleKind::Reviewer,
+            RoleKind::Lead,
+            RoleKind::Refinement,
+        ] {
+            assert_eq!(
+                worker_cpu_request(&job_for_role(Some(role))),
+                cfg.light_cpu_request,
+                "{role:?} must render the light CPU request"
+            );
+        }
+
+        // Build-capable roles (Worker/Verifier/Architect). Retry/resume of these
+        // routes through the same RoleKind at dispatch, so classifying the
+        // RoleKind is sufficient.
+        for role in [RoleKind::Worker, RoleKind::Verifier, RoleKind::Architect] {
+            assert_eq!(
+                worker_cpu_request(&job_for_role(Some(role))),
+                cfg.cpu_request,
+                "{role:?} must render the build-capable CPU request"
+            );
+        }
+
+        // Missing/unknown role fails safe to build-capable.
+        assert_eq!(worker_cpu_request(&job_for_role(None)), cfg.cpu_request);
+
+        // Limits + memory are identical across classes ("same limits everywhere").
+        let light = job_for_role(Some(RoleKind::Planner));
+        let build = job_for_role(Some(RoleKind::Worker));
+        let res = |job: &Job| {
+            job.spec
+                .as_ref()
+                .unwrap()
+                .template
+                .spec
+                .as_ref()
+                .unwrap()
+                .containers[0]
+                .resources
+                .clone()
+                .unwrap()
+        };
+        assert_eq!(res(&light).limits, res(&build).limits);
+        assert_eq!(
+            res(&light).requests.unwrap().get("memory"),
+            res(&build).requests.unwrap().get("memory"),
+        );
+    }
+
+    /// AC1/AC3: the mandatory launcher sidecar renders on every task pod with
+    /// shareProcessNamespace, reusing the worker image with the packaged
+    /// launcher binary as its entrypoint.
+    #[test]
+    fn mandatory_launcher_sidecar_with_share_process_namespace() {
+        let image = "registry.example/proj:tag";
+        let job = build_task_run_job(
+            &KubernetesConfig::for_testing(),
+            &Uuid::now_v7(),
+            "proj-xyz",
+            "djinn-taskrun-role",
+            image,
+            &[],
+            None,
+            false,
+            Some(RoleKind::Worker),
+        );
+        let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        assert_eq!(pod.share_process_namespace, Some(true));
+
+        let launcher = pod
+            .init_containers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
+            .expect("launcher sidecar present");
+        assert_eq!(
+            launcher.image.as_deref(),
+            Some(image),
+            "reuses worker image"
+        );
+        assert_eq!(
+            launcher.command.as_deref(),
+            Some(&[crate::launcher::LAUNCHER_BIN.to_string()][..]),
+            "runs the packaged launcher binary — no fabricated image ref"
+        );
+        assert_eq!(launcher.restart_policy.as_deref(), Some("Always"));
+    }
+
+    /// AC1: distinct worker/child UIDs, artifact GID, fsGroup/setgid ownership,
+    /// and the restricted capability/seccomp profile on both containers.
+    #[test]
+    fn worker_child_launcher_security_contract_is_rendered() {
+        let job = job_for_role(Some(RoleKind::Worker));
+        let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+
+        // Worker container: uid/gid 1000, non-root, drop ALL, restricted seccomp.
+        let worker = &pod.containers[0];
+        let wsc = worker
+            .security_context
+            .as_ref()
+            .expect("worker securityContext");
+        assert_eq!(wsc.run_as_user, Some(1000));
+        assert_eq!(wsc.run_as_group, Some(1000));
+        assert_eq!(wsc.allow_privilege_escalation, Some(false));
+        assert_eq!(
+            wsc.capabilities.as_ref().unwrap().drop.as_deref(),
+            Some(&["ALL".to_string()][..])
+        );
+        assert_eq!(
+            wsc.seccomp_profile.as_ref().unwrap().type_,
+            "RuntimeDefault"
+        );
+
+        // Launcher container: uid 0, minimal caps only, restricted seccomp.
+        let launcher = pod
+            .init_containers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
+            .unwrap();
+        let lsc = launcher
+            .security_context
+            .as_ref()
+            .expect("launcher securityContext");
+        assert_eq!(lsc.run_as_user, Some(0));
+        let add = lsc.capabilities.as_ref().unwrap().add.as_ref().unwrap();
+        assert_eq!(add, &["SETUID", "SETGID", "SETPCAP"]);
+        assert!(!add.iter().any(|c| c == "SYS_ADMIN"));
+        assert_eq!(
+            lsc.seccomp_profile.as_ref().unwrap().type_,
+            "RuntimeDefault"
+        );
+
+        // Distinct worker vs launcher UIDs.
+        assert_ne!(wsc.run_as_user, lsc.run_as_user);
+
+        // Pod-level fsGroup ties workspace/cache ownership to the artifact GID
+        // (child writes group 1000; worker reads it), re-owned OnRootMismatch.
+        let psc = pod.security_context.as_ref().expect("pod securityContext");
+        assert_eq!(psc.fs_group, Some(1000));
+        assert_eq!(
+            psc.fs_group_change_policy.as_deref(),
+            Some("OnRootMismatch")
+        );
+        // Legacy pod-wide uid 10001 override is gone.
+        assert_eq!(psc.run_as_user, None);
+    }
+
+    /// AC1/AC2: credential + delegated-cgroup mount isolation. The IPC surface
+    /// is shared only by worker + launcher; the delegated cgroup is launcher-only;
+    /// no backing sidecar can touch either (no workspace/broker access).
+    #[test]
+    fn launcher_credential_and_cgroup_mounts_are_isolated() {
+        let cfg = KubernetesConfig::for_testing();
+        let postgres = BackingServiceSpec {
+            service_type: "postgres".into(),
+            image: "postgres:18-alpine".into(),
+            is_wrapper: false,
+            control_socket_name: "preset-postgres-18.sock".into(),
+            wrapper_env: Vec::new(),
+            port: 5432,
+            env: vec![("POSTGRES_PASSWORD".into(), "postgres".into())],
+            cpu_request: "100m".into(),
+            memory_request: "256Mi".into(),
+            cpu_limit: "500m".into(),
+            memory_limit: "512Mi".into(),
+            conn_template: "postgres://postgres:postgres@{host}:{port}/app_test".into(),
+            conn_env_var: "TEST_POSTGRES_URL".into(),
+        };
+        let job = build_task_run_job(
+            &cfg,
+            &Uuid::now_v7(),
+            "proj-xyz",
+            "djinn-taskrun-role",
+            "registry.example/proj:tag",
+            std::slice::from_ref(&postgres),
+            None,
+            false,
+            Some(RoleKind::Worker),
+        );
+        let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+
+        let mount_names = |c: &Container| -> Vec<String> {
+            c.volume_mounts
+                .as_ref()
+                .map(|m| m.iter().map(|v| v.name.clone()).collect())
+                .unwrap_or_default()
+        };
+
+        // IPC volume: worker + launcher only.
+        let worker = &pod.containers[0];
+        assert!(mount_names(worker).contains(&crate::launcher::VOLUME_LAUNCHER_IPC.to_string()));
+        let launcher = pod
+            .init_containers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
+            .unwrap();
+        assert!(mount_names(launcher).contains(&crate::launcher::VOLUME_LAUNCHER_IPC.to_string()));
+        // Delegated cgroup: launcher only (not the worker).
+        assert!(
+            mount_names(launcher).contains(&crate::launcher::VOLUME_LAUNCHER_CGROUP.to_string())
+        );
+        assert!(
+            !mount_names(worker).contains(&crate::launcher::VOLUME_LAUNCHER_CGROUP.to_string())
+        );
+
+        // Backing sidecar gets neither IPC nor cgroup nor workspace access.
+        let svc = pod
+            .init_containers
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|c| c.name == "svc-postgres")
+            .unwrap();
+        let svc_mounts = mount_names(svc);
+        for forbidden in [
+            crate::launcher::VOLUME_LAUNCHER_IPC,
+            crate::launcher::VOLUME_LAUNCHER_CGROUP,
+            VOLUME_WORKSPACE,
+            VOLUME_MIRROR,
+        ] {
+            assert!(
+                !svc_mounts.contains(&forbidden.to_string()),
+                "backing sidecar must not mount {forbidden}"
+            );
+        }
+
+        // The IPC volume is a Memory-backed emptyDir (socket + credential never
+        // touch disk), and the worker carries the broker socket/credential env.
+        let ipc_vol = pod
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|v| v.name == crate::launcher::VOLUME_LAUNCHER_IPC)
+            .unwrap();
+        assert_eq!(
+            ipc_vol.empty_dir.as_ref().unwrap().medium.as_deref(),
+            Some("Memory")
+        );
+        let worker_envs: BTreeMap<&str, &str> = worker
+            .env
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
+            .collect();
+        assert_eq!(
+            worker_envs.get("DJINN_LAUNCHER_SOCKET").copied(),
+            Some(crate::launcher::LAUNCHER_SOCKET_PATH)
+        );
+    }
+
+    /// AC1: graph-warm resources must NOT regress (config.rs ~L175). The v1
+    /// leases work only touches the task-run CPU request classing; the warm
+    /// pod's 4 CPU / 2Gi request / 6Gi limit envelope is preserved.
+    #[test]
+    fn graph_warm_resources_are_preserved() {
+        let cfg = KubernetesConfig::for_testing();
+        assert_eq!(cfg.warm_cpu_request, "4");
+        assert_eq!(cfg.warm_cpu_limit, "4");
+        assert_eq!(cfg.warm_memory_request, "2Gi");
+        assert_eq!(cfg.warm_memory_limit, "6Gi");
     }
 }

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -1,0 +1,686 @@
+//! Enforcement-pod rendering: role-classed resources, the mandatory
+//! cgroup-launcher sidecar, the v1 worker/child/launcher security contract, and
+//! the fail-closed render/startup validation seam.
+//!
+//! This module is *pure*: every function is a deterministic manifest builder or
+//! a `Result`-returning validator. Nothing here talks to a cluster or mutates
+//! process state — that keeps the whole v1 pod shape unit-testable via struct
+//! assertions (the pattern the existing `job.rs` tests already rely on).
+//!
+//! The security constants are re-exported from the landed `djinn-cgroup-launcher`
+//! crate (epic kh95) so the render side and the launcher's *runtime* readiness
+//! validation can never drift:
+//!   * worker container UID/GID = [`WORKER_UID`]/[`WORKER_GID`] (1000/1000);
+//!   * the launcher-spawned child runs as [`CHILD_UID`] (1001) with the
+//!     [`ARTIFACT_GID`] (1000) primary group — applied by the launcher at
+//!     runtime, so the render only ties `fsGroup` to `ARTIFACT_GID`;
+//!   * the delegated cgroup root is owned by [`LAUNCHER_UID`] (0), exactly the
+//!     `expected_uid` the launcher's [`Readiness::validate`] checks.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use k8s_openapi::api::core::v1::{
+    Capabilities, Container, EmptyDirVolumeSource, EnvVar, PodSecurityContext,
+    ResourceRequirements, SeccompProfile, SecurityContext, Volume, VolumeMount,
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use thiserror::Error;
+
+use djinn_cgroup_launcher::broker::{WORKER_GID, WORKER_UID};
+// Re-export the child/artifact contract constants so djinn-k8s consumers (and
+// intra-doc links here) see the same UIDs the launcher enforces at runtime.
+// `CHILD_UID` is applied by the launcher when it spawns the child, not in the
+// pod manifest, so it is only referenced by tests/docs on the render side.
+pub use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
+use djinn_cgroup_launcher::{CgroupMode, Error as LauncherError, Readiness, UnleasedQuota};
+use djinn_runtime::RoleKind;
+
+use crate::config::KubernetesConfig;
+
+/// UID the privileged launcher/broker container runs as. Root is required so the
+/// launcher can `setresuid`/`setresgid` the child down to [`CHILD_UID`]/
+/// [`ARTIFACT_GID`] and write `cpu.max` in its delegated cgroup root; it holds
+/// ONLY the minimal capabilities in [`launcher_capabilities`]. This is also the
+/// `expected_uid` the launcher's [`Readiness::validate`] requires the delegated
+/// cgroup root to be owned by.
+pub const LAUNCHER_UID: i64 = 0;
+
+/// Container name of the mandatory cgroup-launcher sidecar.
+pub const LAUNCHER_CONTAINER_NAME: &str = "cgroup-launcher";
+
+/// Path of the packaged launcher binary inside the per-project devcontainer
+/// image. Parallels [`crate::warm_job::WARM_COMMAND_BIN`]
+/// (`/opt/djinn/bin/djinn-agent-worker`): both are laid down at `/opt/djinn/bin`
+/// by the image-builder so the launcher rides the SAME image as the worker with
+/// a different entrypoint (see `server/crates/djinn-image-builder/src/dockerfile.rs`
+/// and `server/docker/djinn-agent-runtime.Dockerfile`). No fabricated image ref:
+/// the launcher container reuses `project_image_tag`.
+pub const LAUNCHER_BIN: &str = "/opt/djinn/bin/djinn-cgroup-launcher";
+
+/// Unleased CPU quota (millicores) the broker pins on every child cgroup before
+/// a lease lifts it. Sourced from the launcher crate's own default so the value
+/// the render advertises is exactly what the crate accepts. "Same broker
+/// everywhere" — this is role-independent.
+pub const LAUNCHER_UNLEASED_MILLICORES: u16 = UnleasedQuota::DEFAULT_MILLICORES;
+
+/// Supported cgroup delegation profile string (the only one v1 accepts).
+pub const CGROUP_PROFILE_V2_CPU_ONLY: &str = "cgroup-v2-cpu-only";
+/// Supported volume-ownership mode string (fsGroup re-owned OnRootMismatch).
+pub const VOLUME_OWNERSHIP_ON_ROOT_MISMATCH: &str = "fsgroup-on-root-mismatch";
+
+/// Launcher sidecar CPU/memory bounds — a tiny, fixed envelope; the broker does
+/// almost no work of its own. Role-independent ("same broker everywhere").
+pub const LAUNCHER_CPU_REQUEST: &str = "50m";
+pub const LAUNCHER_CPU_LIMIT: &str = "250m";
+pub const LAUNCHER_MEMORY_REQUEST: &str = "64Mi";
+pub const LAUNCHER_MEMORY_LIMIT: &str = "128Mi";
+
+/// Volume name for the worker↔launcher IPC surface (broker control socket +
+/// worker-private launcher credential). Memory-backed emptyDir, mounted into the
+/// worker and launcher ONLY — never into a backing-service sidecar, and closed
+/// off from the launcher-spawned child (the launcher clones the child with
+/// `ChildMounts::isolated()`).
+pub const VOLUME_LAUNCHER_IPC: &str = "launcher-ipc";
+/// Mount path of [`VOLUME_LAUNCHER_IPC`] in the worker and launcher.
+pub const LAUNCHER_IPC_DIR: &str = "/var/run/djinn/launcher";
+/// Broker control socket path inside [`LAUNCHER_IPC_DIR`].
+pub const LAUNCHER_SOCKET_PATH: &str = "/var/run/djinn/launcher/broker.sock";
+/// Worker-private launcher credential path inside [`LAUNCHER_IPC_DIR`].
+pub const LAUNCHER_CREDENTIAL_PATH: &str = "/var/run/djinn/launcher/credential";
+
+/// Volume name for the launcher's private delegated cgroup root. Mounted into
+/// the launcher container ONLY.
+pub const VOLUME_LAUNCHER_CGROUP: &str = "launcher-cgroup";
+/// Mount path of [`VOLUME_LAUNCHER_CGROUP`] (the delegated cgroup-v2 root the
+/// launcher opens; owned by [`LAUNCHER_UID`]).
+pub const LAUNCHER_CGROUP_ROOT: &str = "/run/djinn-cgroup";
+
+/// v1 resource class a task-run Pod is provisioned under, derived from the role
+/// that executes the run. Only the CPU **request** differs between the two — the
+/// CPU limit, both memory bounds, and the launcher/broker contract are identical
+/// ("role changes REQUESTS only — same limits, same broker everywhere").
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RoleResourceClass {
+    /// Orchestration-only roles that never run the project's compile/test
+    /// toolchain: Planner, Reviewer, Lead, every Refinement sub-role, and
+    /// grooming (a Planner-driven flow). Fractional-core CPU request.
+    Light,
+    /// Roles that may compile/build/test: Worker, Verifier, Architect, and any
+    /// retry/resume of those. Full-core CPU request. Also the FAIL-SAFE default
+    /// for a missing/unknown/newly-added role.
+    BuildCapable,
+}
+
+impl RoleResourceClass {
+    /// Classify the role that executes a task-run.
+    ///
+    /// Deliberately a catch-all (`_ => BuildCapable`) rather than an exhaustive
+    /// match on [`RoleKind`]: an unrecognized, missing (`None`), or
+    /// newly-introduced role must **fail safe to build-capable** so a pod that
+    /// might compile is never under-provisioned. Only the explicitly-listed
+    /// light roles are ever classed light.
+    pub fn for_role(role: Option<RoleKind>) -> Self {
+        match role {
+            Some(
+                RoleKind::Planner | RoleKind::Reviewer | RoleKind::Lead | RoleKind::Refinement,
+            ) => Self::Light,
+            _ => Self::BuildCapable,
+        }
+    }
+
+    /// The CPU request quantity string for this class, sourced from the
+    /// (env-overridable) config.
+    pub fn cpu_request<'a>(&self, config: &'a KubernetesConfig) -> &'a str {
+        match self {
+            Self::Light => &config.light_cpu_request,
+            Self::BuildCapable => &config.cpu_request,
+        }
+    }
+
+    /// Stable telemetry/label string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Light => "light",
+            Self::BuildCapable => "build-capable",
+        }
+    }
+}
+
+/// Worker-container resource requirements for a task-run of the given role
+/// class. CPU request is role-classed; CPU limit and both memory bounds are the
+/// shared, env-overridable config values.
+pub fn worker_resources(
+    config: &KubernetesConfig,
+    class: RoleResourceClass,
+) -> ResourceRequirements {
+    ResourceRequirements {
+        requests: Some(BTreeMap::from([
+            (
+                "cpu".to_string(),
+                Quantity(class.cpu_request(config).to_string()),
+            ),
+            (
+                "memory".to_string(),
+                Quantity(config.memory_request.clone()),
+            ),
+        ])),
+        limits: Some(BTreeMap::from([
+            ("cpu".to_string(), Quantity(config.cpu_limit.clone())),
+            ("memory".to_string(), Quantity(config.memory_limit.clone())),
+        ])),
+        ..ResourceRequirements::default()
+    }
+}
+
+/// `RuntimeDefault` seccomp profile shared by the worker and launcher
+/// containers.
+fn runtime_default_seccomp() -> SeccompProfile {
+    SeccompProfile {
+        type_: "RuntimeDefault".to_string(),
+        ..SeccompProfile::default()
+    }
+}
+
+/// Container-level security context for the worker.
+///
+/// v1 contract: runs as [`WORKER_UID`]/[`WORKER_GID`] (1000/1000) — NOT the
+/// legacy pod-wide uid 10001 — drops all capabilities, forbids privilege
+/// escalation, and pins the restricted seccomp profile. Non-dumpability is
+/// asserted by the worker itself at runtime (`prepare_worker_readiness` sets
+/// `PR_SET_DUMPABLE=0` and re-reads it) before it authenticates to the broker;
+/// there is no Pod-manifest field for dumpability, so the render supplies the
+/// restricted profile and the runtime supplies the prctl.
+///
+/// The root filesystem is left writable: the worker legitimately writes
+/// `/workspace`, `/cache`, and `/mirror`. Isolation of secrets is by mount
+/// (private credential volume) and by the Pod boundary, not by a read-only
+/// rootfs.
+pub fn worker_security_context() -> SecurityContext {
+    SecurityContext {
+        run_as_user: Some(i64::from(WORKER_UID)),
+        run_as_group: Some(i64::from(WORKER_GID)),
+        run_as_non_root: Some(true),
+        allow_privilege_escalation: Some(false),
+        capabilities: Some(Capabilities {
+            drop: Some(vec!["ALL".to_string()]),
+            ..Capabilities::default()
+        }),
+        seccomp_profile: Some(runtime_default_seccomp()),
+        ..SecurityContext::default()
+    }
+}
+
+/// Minimal capability set the launcher keeps. It runs as root but drops
+/// everything except the three it needs to move the child across the credential
+/// boundary before exec:
+///   * `SETUID`/`SETGID` — `setresuid(1001)` / `setresgid(1000)` +
+///     `setgroups(0)` to drop the child to [`CHILD_UID`]/[`ARTIFACT_GID`];
+///   * `SETPCAP` — clear the child's capability bounding/ambient set.
+///
+/// It needs no `SYS_ADMIN`: cgroup control is confined to the *delegated* root
+/// mounted at [`LAUNCHER_CGROUP_ROOT`] (owned by uid 0), and the child is born
+/// there via `clone3(CLONE_INTO_CGROUP)` with no mount/namespace ops.
+fn launcher_capabilities() -> Capabilities {
+    Capabilities {
+        drop: Some(vec!["ALL".to_string()]),
+        add: Some(vec![
+            "SETUID".to_string(),
+            "SETGID".to_string(),
+            "SETPCAP".to_string(),
+        ]),
+    }
+}
+
+/// Container-level security context for the launcher sidecar. Root, minimal
+/// caps, restricted seccomp, read-only rootfs (it only writes the delegated
+/// cgroup and the control socket, both on dedicated mounts). `no_new_privs` on
+/// the *children* it spawns is applied by the launcher at runtime
+/// (`child::prepare_child`); `allowPrivilegeEscalation: false` here matches that
+/// intent for the launcher process itself (dropping to the child uid still works
+/// under NNP).
+pub fn launcher_security_context() -> SecurityContext {
+    SecurityContext {
+        run_as_user: Some(LAUNCHER_UID),
+        run_as_group: Some(LAUNCHER_UID),
+        run_as_non_root: Some(false),
+        allow_privilege_escalation: Some(false),
+        read_only_root_filesystem: Some(true),
+        capabilities: Some(launcher_capabilities()),
+        seccomp_profile: Some(runtime_default_seccomp()),
+        ..SecurityContext::default()
+    }
+}
+
+/// Pod-level security context for an enforcement task-run Pod.
+///
+/// Sets `fsGroup = ARTIFACT_GID` (1000) with `fsGroupChangePolicy:
+/// OnRootMismatch`, so the workspace/cache/mirror volumes are group-owned by the
+/// artifact GID: the launcher-spawned child (primary group 1000) writes build
+/// artifacts and the worker (uid 1000, also group 1000) can read them, with
+/// setgid semantics preserving group ownership on new files.
+///
+/// DEPLOY RISK (documented per task qut0): the legacy pod ran as uid 10001 and
+/// the VPS's large `/mirror` and `/cache` PVCs are currently owned by
+/// 10001:10001. Switching to `fsGroup=1000` means the kubelet will, on first
+/// mount where the volume ROOT's gid != 1000, recursively `chown`/setgid the
+/// volume to group 1000. `OnRootMismatch` avoids re-chowning on every pod start
+/// (it only acts when the top-level gid is wrong), but the FIRST pod after this
+/// ships will pay a one-time recursive re-own of those huge cache volumes, which
+/// can be slow and I/O-heavy. Coordinate the rollout: expect the first
+/// task-run/warm pods post-deploy to start slowly while ownership converges, and
+/// consider a one-shot maintenance `chgrp -R 1000` on `/mirror` and `/cache`
+/// before the cutover so `OnRootMismatch` sees a matching root and skips the
+/// recursive pass. See the matching note in `config.rs` and `job.rs`.
+pub fn pod_security_context() -> PodSecurityContext {
+    PodSecurityContext {
+        fs_group: Some(i64::from(ARTIFACT_GID)),
+        fs_group_change_policy: Some("OnRootMismatch".to_string()),
+        ..PodSecurityContext::default()
+    }
+}
+
+/// The worker↔launcher IPC volume (broker socket + worker-private credential).
+pub fn launcher_ipc_volume() -> Volume {
+    Volume {
+        name: VOLUME_LAUNCHER_IPC.to_string(),
+        empty_dir: Some(EmptyDirVolumeSource {
+            // Memory-backed: the control socket + credential never touch disk.
+            medium: Some("Memory".to_string()),
+            size_limit: Some(Quantity("1Mi".to_string())),
+        }),
+        ..Volume::default()
+    }
+}
+
+/// The launcher's private delegated cgroup root volume (launcher-only).
+pub fn launcher_cgroup_volume() -> Volume {
+    Volume {
+        name: VOLUME_LAUNCHER_CGROUP.to_string(),
+        empty_dir: Some(EmptyDirVolumeSource::default()),
+        ..Volume::default()
+    }
+}
+
+/// Worker-side mount of the IPC volume so the worker can dial the broker socket
+/// and read its private credential.
+pub fn worker_launcher_ipc_mount() -> VolumeMount {
+    VolumeMount {
+        name: VOLUME_LAUNCHER_IPC.to_string(),
+        mount_path: LAUNCHER_IPC_DIR.to_string(),
+        ..VolumeMount::default()
+    }
+}
+
+/// Env the worker needs to reach the broker.
+pub fn worker_launcher_env() -> Vec<EnvVar> {
+    vec![
+        env_var("DJINN_LAUNCHER_SOCKET", LAUNCHER_SOCKET_PATH),
+        env_var("DJINN_LAUNCHER_CREDENTIAL_PATH", LAUNCHER_CREDENTIAL_PATH),
+    ]
+}
+
+/// Build the mandatory cgroup-launcher sidecar container.
+///
+/// Reuses `project_image_tag` (the SAME image the worker runs) with the packaged
+/// launcher binary as its entrypoint — no fabricated image ref. It is a native
+/// sidecar (`restartPolicy: Always` init container) so it is up before the
+/// worker and torn down when the worker exits.
+pub fn launcher_sidecar_container(config: &KubernetesConfig, project_image_tag: &str) -> Container {
+    Container {
+        name: LAUNCHER_CONTAINER_NAME.to_string(),
+        image: Some(project_image_tag.to_string()),
+        image_pull_policy: Some(config.image_pull_policy.clone()),
+        // Native sidecar: init container that lives for the worker's lifetime.
+        restart_policy: Some("Always".to_string()),
+        command: Some(vec![LAUNCHER_BIN.to_string()]),
+        args: Some(vec!["serve".to_string()]),
+        env: Some(vec![
+            env_var("DJINN_LAUNCHER_SOCKET", LAUNCHER_SOCKET_PATH),
+            env_var("DJINN_LAUNCHER_CGROUP_ROOT", LAUNCHER_CGROUP_ROOT),
+            env_var("DJINN_LAUNCHER_CREDENTIAL_PATH", LAUNCHER_CREDENTIAL_PATH),
+            env_var("DJINN_LAUNCHER_EXPECTED_UID", &LAUNCHER_UID.to_string()),
+            env_var(
+                "DJINN_LAUNCHER_UNLEASED_MILLICORES",
+                &LAUNCHER_UNLEASED_MILLICORES.to_string(),
+            ),
+        ]),
+        volume_mounts: Some(vec![
+            worker_launcher_ipc_mount(),
+            VolumeMount {
+                name: VOLUME_LAUNCHER_CGROUP.to_string(),
+                mount_path: LAUNCHER_CGROUP_ROOT.to_string(),
+                ..VolumeMount::default()
+            },
+        ]),
+        security_context: Some(launcher_security_context()),
+        resources: Some(ResourceRequirements {
+            requests: Some(BTreeMap::from([
+                (
+                    "cpu".to_string(),
+                    Quantity(LAUNCHER_CPU_REQUEST.to_string()),
+                ),
+                (
+                    "memory".to_string(),
+                    Quantity(LAUNCHER_MEMORY_REQUEST.to_string()),
+                ),
+            ])),
+            limits: Some(BTreeMap::from([
+                ("cpu".to_string(), Quantity(LAUNCHER_CPU_LIMIT.to_string())),
+                (
+                    "memory".to_string(),
+                    Quantity(LAUNCHER_MEMORY_LIMIT.to_string()),
+                ),
+            ])),
+            ..ResourceRequirements::default()
+        }),
+        ..Container::default()
+    }
+}
+
+/// Fail-closed render/startup validation for an enforcement task-run.
+///
+/// Rejects unsupported cgroup-v2 delegation profiles, an out-of-bounds broker
+/// quota, and incompatible volume-ownership modes BEFORE the Job is submitted —
+/// i.e. before any user code can execute. The cgroup check is grounded in the
+/// launcher crate's OWN [`Readiness::validate`]: the configured profile is
+/// mapped onto the `Readiness` the launcher will re-validate at runtime, so the
+/// render can never describe a delegation the launcher would reject after boot.
+// No `PartialEq`/`Eq`: the `RejectedCgroupProfile { source }` variant wraps the
+// launcher crate's `Error`, which is not comparable. Tests match on variants.
+#[derive(Debug, Error)]
+pub enum RenderValidationError {
+    #[error("broker unleased quota {millicores}m is outside the launcher's accepted bounds")]
+    UnsupportedBrokerQuota { millicores: u16 },
+    #[error("unsupported cgroup delegation profile: {profile}")]
+    UnsupportedCgroupProfile { profile: String },
+    #[error(
+        "configured cgroup profile {profile} is rejected by the launcher readiness contract: {source}"
+    )]
+    RejectedCgroupProfile {
+        profile: String,
+        source: LauncherError,
+    },
+    #[error("incompatible volume-ownership mode: {mode} (v1 requires {expected})")]
+    IncompatibleVolumeOwnership {
+        mode: String,
+        expected: &'static str,
+    },
+}
+
+/// Map a supported/unsupported cgroup-delegation profile string onto the
+/// [`Readiness`] the launcher validates at runtime. `None` means the string is
+/// not a recognized profile at all (→ [`RenderValidationError::UnsupportedCgroupProfile`]);
+/// a recognized-but-non-conforming profile yields a `Readiness` that
+/// [`Readiness::validate`] will REJECT (→ `RejectedCgroupProfile`), keeping the
+/// render consistent with the crate's fail-closed runtime checks.
+fn cgroup_profile_readiness(profile: &str) -> Option<Readiness> {
+    let cpu_only = BTreeSet::from(["cpu".to_owned()]);
+    match profile {
+        CGROUP_PROFILE_V2_CPU_ONLY => Some(Readiness {
+            mode: CgroupMode::V2,
+            root_writable: true,
+            owner_uid: LAUNCHER_UID as u32,
+            delegated_controllers: cpu_only,
+        }),
+        // Recognized-but-unsupported delegations map to a Readiness the crate
+        // rejects, so the SAME validation that runs in-pod runs at render time.
+        "cgroup-v1" => Some(Readiness {
+            mode: CgroupMode::V1,
+            root_writable: true,
+            owner_uid: LAUNCHER_UID as u32,
+            delegated_controllers: BTreeSet::from(["cpu".to_owned()]),
+        }),
+        "cgroup-v2-hybrid" => Some(Readiness {
+            mode: CgroupMode::Hybrid,
+            root_writable: true,
+            owner_uid: LAUNCHER_UID as u32,
+            delegated_controllers: BTreeSet::from(["cpu".to_owned()]),
+        }),
+        "cgroup-v2-overbroad" => Some(Readiness {
+            mode: CgroupMode::V2,
+            root_writable: true,
+            owner_uid: LAUNCHER_UID as u32,
+            delegated_controllers: BTreeSet::from(["cpu".to_owned(), "memory".to_owned()]),
+        }),
+        "cgroup-v2-readonly" => Some(Readiness {
+            mode: CgroupMode::V2,
+            root_writable: false,
+            owner_uid: LAUNCHER_UID as u32,
+            delegated_controllers: BTreeSet::from(["cpu".to_owned()]),
+        }),
+        _ => None,
+    }
+}
+
+/// Validate that the config describes an enforcement pod the launcher can
+/// actually run. Call this at dispatch BEFORE building/submitting the Job.
+pub fn validate_enforcement_render(config: &KubernetesConfig) -> Result<(), RenderValidationError> {
+    // 1. Broker quota must satisfy the launcher crate's own bounds.
+    UnleasedQuota::new(LAUNCHER_UNLEASED_MILLICORES).map_err(|_| {
+        RenderValidationError::UnsupportedBrokerQuota {
+            millicores: LAUNCHER_UNLEASED_MILLICORES,
+        }
+    })?;
+
+    // 2. Cgroup delegation profile: recognized AND accepted by the launcher's
+    //    runtime readiness contract.
+    let readiness =
+        cgroup_profile_readiness(&config.cgroup_delegation_profile).ok_or_else(|| {
+            RenderValidationError::UnsupportedCgroupProfile {
+                profile: config.cgroup_delegation_profile.clone(),
+            }
+        })?;
+    readiness.validate(LAUNCHER_UID as u32).map_err(|source| {
+        RenderValidationError::RejectedCgroupProfile {
+            profile: config.cgroup_delegation_profile.clone(),
+            source,
+        }
+    })?;
+
+    // 3. Volume ownership must be the fsGroup-OnRootMismatch mode v1 renders.
+    if config.volume_ownership_mode != VOLUME_OWNERSHIP_ON_ROOT_MISMATCH {
+        return Err(RenderValidationError::IncompatibleVolumeOwnership {
+            mode: config.volume_ownership_mode.clone(),
+            expected: VOLUME_OWNERSHIP_ON_ROOT_MISMATCH,
+        });
+    }
+
+    Ok(())
+}
+
+fn env_var(name: &str, value: &str) -> EnvVar {
+    EnvVar {
+        name: name.to_string(),
+        value: Some(value.to_string()),
+        ..EnvVar::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_role_kind_maps_to_a_resource_class() {
+        // Light: orchestration-only roles.
+        for role in [
+            RoleKind::Planner,
+            RoleKind::Reviewer,
+            RoleKind::Lead,
+            RoleKind::Refinement,
+        ] {
+            assert_eq!(
+                RoleResourceClass::for_role(Some(role)),
+                RoleResourceClass::Light,
+                "{role:?} must be light"
+            );
+        }
+        // Build-capable: roles that may compile.
+        for role in [RoleKind::Worker, RoleKind::Verifier, RoleKind::Architect] {
+            assert_eq!(
+                RoleResourceClass::for_role(Some(role)),
+                RoleResourceClass::BuildCapable,
+                "{role:?} must be build-capable"
+            );
+        }
+    }
+
+    #[test]
+    fn missing_role_fails_safe_to_build_capable() {
+        assert_eq!(
+            RoleResourceClass::for_role(None),
+            RoleResourceClass::BuildCapable
+        );
+    }
+
+    #[test]
+    fn light_and_build_capable_share_limits_but_not_cpu_request() {
+        let cfg = KubernetesConfig::for_testing();
+        let light = worker_resources(&cfg, RoleResourceClass::Light);
+        let build = worker_resources(&cfg, RoleResourceClass::BuildCapable);
+
+        // CPU request differs by class.
+        assert_eq!(
+            light.requests.as_ref().unwrap().get("cpu").unwrap().0,
+            cfg.light_cpu_request
+        );
+        assert_eq!(
+            build.requests.as_ref().unwrap().get("cpu").unwrap().0,
+            cfg.cpu_request
+        );
+        assert_ne!(
+            light.requests.as_ref().unwrap().get("cpu"),
+            build.requests.as_ref().unwrap().get("cpu"),
+        );
+
+        // Limits + memory identical across classes ("same limits everywhere").
+        assert_eq!(light.limits, build.limits);
+        assert_eq!(
+            light.requests.as_ref().unwrap().get("memory"),
+            build.requests.as_ref().unwrap().get("memory"),
+        );
+        assert_eq!(
+            light.limits.as_ref().unwrap().get("cpu").unwrap().0,
+            cfg.cpu_limit
+        );
+        assert_eq!(
+            light.limits.as_ref().unwrap().get("memory").unwrap().0,
+            cfg.memory_limit
+        );
+    }
+
+    #[test]
+    fn worker_and_launcher_have_distinct_uids_matching_the_launcher_contract() {
+        let worker = worker_security_context();
+        let launcher = launcher_security_context();
+        assert_eq!(worker.run_as_user, Some(i64::from(WORKER_UID)));
+        assert_eq!(worker.run_as_user, Some(1000));
+        assert_eq!(launcher.run_as_user, Some(LAUNCHER_UID));
+        assert_eq!(launcher.run_as_user, Some(0));
+        assert_ne!(worker.run_as_user, launcher.run_as_user);
+        // Child + artifact contract constants come straight from the crate.
+        assert_eq!(CHILD_UID, 1001);
+        assert_eq!(ARTIFACT_GID, 1000);
+    }
+
+    #[test]
+    fn worker_security_context_is_restricted() {
+        let sc = worker_security_context();
+        assert_eq!(sc.allow_privilege_escalation, Some(false));
+        assert_eq!(sc.run_as_non_root, Some(true));
+        assert_eq!(
+            sc.capabilities.as_ref().unwrap().drop.as_deref(),
+            Some(&["ALL".to_string()][..])
+        );
+        assert_eq!(sc.seccomp_profile.as_ref().unwrap().type_, "RuntimeDefault");
+    }
+
+    #[test]
+    fn launcher_keeps_only_minimal_capabilities() {
+        let caps = launcher_capabilities();
+        assert_eq!(caps.drop.as_deref(), Some(&["ALL".to_string()][..]));
+        let add = caps.add.expect("launcher adds minimal caps");
+        assert_eq!(add, vec!["SETUID", "SETGID", "SETPCAP"]);
+        // Never privileged, never SYS_ADMIN.
+        assert!(!add.iter().any(|c| c == "SYS_ADMIN"));
+        let sc = launcher_security_context();
+        assert_eq!(sc.privileged, None);
+        assert_eq!(sc.allow_privilege_escalation, Some(false));
+        assert_eq!(sc.read_only_root_filesystem, Some(true));
+    }
+
+    #[test]
+    fn pod_security_context_ties_fsgroup_to_artifact_gid_on_root_mismatch() {
+        let sc = pod_security_context();
+        assert_eq!(sc.fs_group, Some(i64::from(ARTIFACT_GID)));
+        assert_eq!(sc.fs_group, Some(1000));
+        assert_eq!(sc.fs_group_change_policy.as_deref(), Some("OnRootMismatch"));
+        // The legacy pod-wide uid override is gone from the pod context.
+        assert_eq!(sc.run_as_user, None);
+    }
+
+    #[test]
+    fn launcher_sidecar_reuses_worker_image_with_launcher_entrypoint() {
+        let cfg = KubernetesConfig::for_testing();
+        let image = "registry.example/proj:tag";
+        let c = launcher_sidecar_container(&cfg, image);
+        assert_eq!(c.name, LAUNCHER_CONTAINER_NAME);
+        // Same image as the worker, different entrypoint (real packaged binary).
+        assert_eq!(c.image.as_deref(), Some(image));
+        assert_eq!(c.command.as_deref(), Some(&[LAUNCHER_BIN.to_string()][..]));
+        assert_eq!(c.restart_policy.as_deref(), Some("Always"));
+        // Tiny fixed envelope.
+        let req = c.resources.as_ref().unwrap().requests.as_ref().unwrap();
+        assert_eq!(req.get("cpu").unwrap().0, LAUNCHER_CPU_REQUEST);
+        assert_eq!(req.get("memory").unwrap().0, LAUNCHER_MEMORY_REQUEST);
+        let lim = c.resources.as_ref().unwrap().limits.as_ref().unwrap();
+        assert_eq!(lim.get("cpu").unwrap().0, LAUNCHER_CPU_LIMIT);
+        assert_eq!(lim.get("memory").unwrap().0, LAUNCHER_MEMORY_LIMIT);
+    }
+
+    #[test]
+    fn valid_config_passes_render_validation() {
+        let cfg = KubernetesConfig::for_testing();
+        assert!(validate_enforcement_render(&cfg).is_ok());
+    }
+
+    #[test]
+    fn unknown_cgroup_profile_fails_closed() {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.cgroup_delegation_profile = "cgroup-v3-experimental".to_string();
+        assert!(matches!(
+            validate_enforcement_render(&cfg),
+            Err(RenderValidationError::UnsupportedCgroupProfile { .. })
+        ));
+    }
+
+    #[test]
+    fn recognized_but_nonconforming_cgroup_profiles_are_rejected_by_the_launcher_contract() {
+        for profile in [
+            "cgroup-v1",
+            "cgroup-v2-hybrid",
+            "cgroup-v2-overbroad",
+            "cgroup-v2-readonly",
+        ] {
+            let mut cfg = KubernetesConfig::for_testing();
+            cfg.cgroup_delegation_profile = profile.to_string();
+            assert!(
+                matches!(
+                    validate_enforcement_render(&cfg),
+                    Err(RenderValidationError::RejectedCgroupProfile { .. })
+                ),
+                "{profile} must be rejected by the launcher readiness contract"
+            );
+        }
+    }
+
+    #[test]
+    fn incompatible_volume_ownership_mode_fails_closed() {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.volume_ownership_mode = "chown-recursive-always".to_string();
+        assert!(matches!(
+            validate_enforcement_render(&cfg),
+            Err(RenderValidationError::IncompatibleVolumeOwnership { .. })
+        ));
+    }
+}

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -13,6 +13,7 @@ pub mod graph_warmer_identity;
 pub mod infra_death_log_tail;
 pub mod job;
 pub mod label_value;
+pub mod launcher;
 pub mod runtime;
 pub mod secret;
 pub mod sidecar;

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -657,9 +657,25 @@ impl SessionRuntime for KubernetesRuntime {
             ),
         }
 
-        // 2. Build + create the Job manifest.  The `cargo_cache_policy`
-        //    was extracted from the effective EnvironmentConfig earlier
-        //    (step 1) and is passed through as before.
+        // 2a. Fail-closed enforcement render validation BEFORE the Job is
+        //     submitted — i.e. before any user code can execute. Rejects
+        //     unsupported cgroup-v2 delegation profiles, an out-of-bounds broker
+        //     quota, or an incompatible volume-ownership mode. Grounded in the
+        //     launcher crate's own `Readiness::validate`.
+        if let Err(error) = crate::launcher::validate_enforcement_render(&self.config) {
+            self.drop_pending(&task_run_id_str).await;
+            return Err(RuntimeError::Prepare(format!(
+                "enforcement render validation failed: {error}"
+            )));
+        }
+
+        // 2b. Build + create the Job manifest.  The `cargo_cache_policy`
+        //     was extracted from the effective EnvironmentConfig earlier
+        //     (step 1) and is passed through as before.  The role that executes
+        //     this run is the primary role of its supervisor flow; it drives the
+        //     role-classed CPU request (light vs build-capable). `None` (an
+        //     empty sequence) fails safe to build-capable in the renderer.
+        let role = spec.flow.role_sequence().first().copied();
         let job = build_task_run_job_with_read_sources(
             &self.config,
             &task_run_id,
@@ -669,6 +685,7 @@ impl SessionRuntime for KubernetesRuntime {
             services,
             cargo_cache_policy.as_ref(),
             spec.is_evidence_spike,
+            role,
             read_source_cache_sub_path.as_deref(),
         );
         let jobs: Api<Job> = Api::namespaced(self.client.clone(), ns);
@@ -2905,6 +2922,7 @@ mod tests {
             &[],
             None,
             false,
+            Some(djinn_runtime::RoleKind::Worker),
         );
 
         // The Secret and Job share the same resource name.

--- a/server/crates/djinn-k8s/src/sidecar.rs
+++ b/server/crates/djinn-k8s/src/sidecar.rs
@@ -1,3 +1,6 @@
+// djinn:allow-oversize — wrapper-service control wiring plus launcher mount
+// isolation tipped this just past the 50KB byte guard; split the sidecar/wrapper
+// halves when this module is touched substantively.
 //! Native-sidecar injection for backing services (Postgres / Redis / RabbitMQ).
 //!
 //! A project's selected catalog image declares which service presets every
@@ -827,6 +830,61 @@ mod tests {
         let envs = sidecar_conn_env(&s);
         let names: Vec<&str> = envs.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(names, vec!["DATABASE_URL", "TEST_POSTGRES_URL"]);
+    }
+
+    /// AC (qut0): backing-service sidecar resources fall back to the explicit
+    /// 100m/256Mi request + 500m/512Mi limit envelope when the preset omits or
+    /// malforms them, and an explicit resources JSON overrides each field.
+    #[test]
+    fn sidecar_resources_fall_back_and_override() {
+        // Fallback: empty object and malformed JSON both yield the defaults.
+        for json in ["{}", "not-json", ""] {
+            assert_eq!(
+                parse_resources(json),
+                (
+                    "100m".to_string(),
+                    "256Mi".to_string(),
+                    "500m".to_string(),
+                    "512Mi".to_string(),
+                ),
+                "malformed/empty resources {json:?} must fall back to the default envelope"
+            );
+        }
+        // Override: explicit values win per field.
+        assert_eq!(
+            parse_resources(
+                r#"{"cpu_request":"250m","memory_request":"512Mi","cpu_limit":"1","memory_limit":"1Gi"}"#
+            ),
+            (
+                "250m".to_string(),
+                "512Mi".to_string(),
+                "1".to_string(),
+                "1Gi".to_string(),
+            )
+        );
+    }
+
+    /// AC (qut0): a backing-service sidecar has no workspace/broker access — it
+    /// mounts ONLY its shared `/dev/shm` scratch, never the workspace, mirror,
+    /// launcher IPC, or delegated cgroup.
+    #[test]
+    fn sidecar_has_no_workspace_or_broker_mounts() {
+        let cfg = KubernetesConfig::for_testing();
+        let c = sidecar_container(&cfg, &spec());
+        let mounts = c.volume_mounts.as_ref().expect("sidecar mounts");
+        assert_eq!(mounts.len(), 1, "sidecar mounts only /dev/shm");
+        assert_eq!(mounts[0].name, SIDECAR_DSHM_VOLUME);
+        for forbidden in [
+            crate::job::VOLUME_WORKSPACE,
+            crate::job::VOLUME_MIRROR,
+            crate::launcher::VOLUME_LAUNCHER_IPC,
+            crate::launcher::VOLUME_LAUNCHER_CGROUP,
+        ] {
+            assert!(
+                !mounts.iter().any(|m| m.name == forbidden),
+                "backing sidecar must not mount {forbidden}"
+            );
+        }
     }
 
     #[test]

--- a/server/crates/djinn-k8s/src/sidecar.rs
+++ b/server/crates/djinn-k8s/src/sidecar.rs
@@ -771,6 +771,14 @@ pub async fn resolve_image_services_with_metadata(
     }
 }
 
+// Exact-arithmetic 12-CPU/48Gi bin-packing fixture (task ny3o). Declared here,
+// as a child of `sidecar`, so it can read the private default-resource envelope
+// via `parse_resources` without adding any production surface. `#[cfg(test)]`
+// only — no effect on production builds.
+#[cfg(test)]
+#[path = "bin_packing_fixture_tests.rs"]
+mod bin_packing_fixture_tests;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/docker/djinn-agent-runtime.Dockerfile
+++ b/server/docker/djinn-agent-runtime.Dockerfile
@@ -21,6 +21,13 @@ FROM ${BASE_IMAGE}
 COPY djinn-agent-worker /usr/local/bin/djinn-agent-worker
 RUN chmod +x /usr/local/bin/djinn-agent-worker
 
+# The mandatory cgroup-launcher sidecar runs from the SAME image as the worker
+# with a different entrypoint (see djinn-k8s::launcher). Ship its binary here at
+# /usr/local/bin; the image-builder copies it on to /opt/djinn/bin in the
+# per-project image so the rendered launcher command resolves to a real artifact.
+COPY djinn-cgroup-launcher /usr/local/bin/djinn-cgroup-launcher
+RUN chmod +x /usr/local/bin/djinn-cgroup-launcher
+
 # Seed the cache-backed RUSTUP_HOME from the build-time install on first start.
 # The base image installs rustup into $RUSTUP_SEED_DIR (=/usr/local/rustup,
 # read-only for the djinn user) so the heavy layer is shared and immutable.


### PR DESCRIPTION
Test-only djinn-k8s fixture (epic 9y1a) that guards the role-classed enforcement pod shape rendered by qut0. It is a pure-arithmetic guard, not a scheduler simulation: it parses the CPU/memory `Quantity` strings qut0 actually renders (`worker_resources`, `launcher_sidecar_container`, `sidecar_container`, `build_warm_job`, and the default backing-service envelope via the private `parse_resources`), converts them to exact integer millicores/bytes, and does integer addition against a named 12-CPU / 48Gi node fixture.

## Reconciled arithmetic (all CPU in millicores)

Rendered per-component requests, each pinned to its live value in `rendered_requests_match_the_bin_packing_fixture_values`:
- light worker = 300, build-capable worker = 1000, worker mem = 2Gi (role-independent)
- launcher sidecar = 50 / 64Mi
- default backing sidecar = 100 / 256Mi (from `parse_resources("{}")`)
- warm Job = 4000 / 2Gi (rendered)

Fixture constants: node = 12000 / 48Gi; protected core = 3400 / 8Gi.

Derived pod shapes and the node sums:
- light pod = 300 + 50 = 350; +backing sidecar = 450
- build-capable pod = 1000 + 50 + 100 = 1150
- reserved = protected 3400 + warm 4000 = 7400; remaining = 4600
- 10 light, no sidecar: 3400 + 4000 + 10*350 = 10900 <= 12000 (1100m slack)
- 10 light, +sidecar each: 3400 + 4000 + 10*450 = 11900 <= 12000 (100m slack)
- 4 build-capable: 3400 + 4000 + 4*1150 = 12000 == 12000 (exactly full, zero slack)
- 5 build-capable: 3400 + 4000 + 5*1150 = 13150 > 12000 (infeasible, overshoots by exactly one pod)

## Fails loudly on future request changes

Because every value comes back out of the real render path, any change to a role request, the launcher/sidecar request, the default backing-service envelope, or the warm render flows straight into these sums and breaks a named per-component assertion (AC3) with the offending value in the message. The module lives as a `#[cfg(test)]` child of `sidecar` purely to read the private `parse_resources` envelope; it adds no production surface (only an 8-line `mod` declaration in `sidecar.rs`).

## Rebase / reconciliation note

Rebased onto current qut0. qut0's catalog-wrapper work added three fields to `BackingServiceSpec` (`is_wrapper`, `control_socket_name`, `wrapper_env`); the fixture's default spec now sets `is_wrapper: false` with empty wrapper fields, keeping the pre-wrapper dispatch shape. Those fields drive only the private control mount and admin env, not the resource request, so the reconciled sums above are unchanged. All 223 djinn-k8s tests pass (qut0's 218 + these 5).

Stacked on #2533 (qut0); retarget to main after qut0 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)