### PR TITLE
chore(vtdo): Wire journal watchdog to exact recorded pod termination

### DIFF
--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -37,10 +37,37 @@ use djinn_orchestration_types::coordinator::BackgroundWorkTracker;
 use djinn_provider::catalog::{CatalogService, HealthTracker};
 use djinn_slot::reply_loop::CompactionCriticalSection;
 use djinn_supervisor::SupervisorServices;
+use djinn_supervisor::services::WatchdogTerminationRequest;
 
 /// Shared tracker for per-task last-activity timestamps (unix seconds).
 /// Used by stall detection to kill sessions that stop producing tokens.
 pub type ActivityTracker = Arc<std::sync::Mutex<HashMap<String, Arc<AtomicU64>>>>;
+
+/// Issue the exact-pod watchdog termination for one grace-expired durable
+/// record. The [`WatchdogTerminationRequest`] carries the task, task-run, and
+/// immutable pod UID read from the durable journal record — never this
+/// process's current identity — so a reconstructed pod terminates exactly the
+/// pod that was recorded.
+///
+/// A failed or transport-unavailable response is logged and deliberately
+/// swallowed: the recovery scan has already persisted `watchdog_notified`
+/// (serialized CAS), so this request is issued at most once and never retried
+/// in a loop; the durable record and its counted lease are retained, and only a
+/// matching durable terminal confirmation clears the record on a later scan.
+async fn terminate_watchdog_pod(
+    services: Arc<dyn SupervisorServices>,
+    request: WatchdogTerminationRequest,
+) {
+    if let Err(error) = services.terminate_watchdog_pod(request.clone()).await {
+        tracing::error!(
+            task_id = %request.task_id,
+            task_run_id = %request.task_run_id,
+            pod_uid = %request.pod_uid,
+            error = %error,
+            "exact-pod watchdog termination failed; retaining durable record and counted lease"
+        );
+    }
+}
 
 /// Immutable broker-backed shell authority composed from trusted task-run inputs.
 #[derive(Clone)]
@@ -65,21 +92,16 @@ impl ShellLaunchContext {
         let journal = Arc::new(InvocationJournal::new(journal_dir, pod_uid.clone())?);
         const WATCHDOG_GRACE: Duration = Duration::from_secs(300);
         let recovery_clock = SystemClock::new();
+        let startup_watchdog_services = services.clone();
         InvocationRecovery {
             journal: journal.as_ref(),
             services: services.as_ref(),
             clock: &recovery_clock,
             watchdog_grace: WATCHDOG_GRACE,
         }
-        .run(|recorded_pod_uid| {
-            // The exact-pod termination transport is deliberately injected by
-            // its owning runtime layer. This journal callback only preserves a
-            // seam and reports the immutable UID; cancelling this worker does
-            // not prove that Kubernetes deleted the recorded pod.
-            tracing::error!(
-                pod_uid = recorded_pod_uid,
-                "unresolved invocation watchdog fired; exact-pod termination is not wired"
-            );
+        .run(|request| {
+            let services = startup_watchdog_services.clone();
+            terminate_watchdog_pod(services, request)
         })
         .await?;
 
@@ -106,21 +128,23 @@ impl ShellLaunchContext {
                     break;
                 };
                 let recovery_clock = SystemClock::new();
+                let sweep_watchdog_services = services.clone();
                 let _ = InvocationRecovery {
                     journal: recovery_journal.as_ref(),
                     services: services.as_ref(),
                     clock: &recovery_clock,
                     watchdog_grace: WATCHDOG_GRACE,
                 }
-                .run(|recorded_pod_uid| {
-                    tracing::error!(
-                        pod_uid = recorded_pod_uid,
-                        "unresolved invocation watchdog fired; exact-pod termination is not wired"
-                    );
+                .run(|request| {
+                    let services = sweep_watchdog_services.clone();
+                    terminate_watchdog_pod(services, request)
                 })
                 .await;
-                // Drop the strong handle before sleeping again so a concurrent
-                // worker shutdown is never blocked while this sweep is idle.
+                // Drop every strong handle before sleeping again so a concurrent
+                // worker shutdown is never blocked while this sweep is idle. The
+                // per-call watchdog clones live only inside the `run` future,
+                // which has already completed here.
+                drop(sweep_watchdog_services);
                 drop(services);
             }
         });

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -23,7 +23,7 @@ use djinn_supervisor::services::{
     InvocationLiftDecision, LeaseAbandonRequest, LeaseBindRequest, LeaseDeadlines,
     LeaseFencingToken, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest, LeaseReleaseRequest,
     LeaseResult, LeaseState, LeaseStatus, LeaseStatusRequest, SupervisorServices,
-    TaskInvocationLeaseIdentity,
+    TaskInvocationLeaseIdentity, WatchdogTerminationRequest,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -143,10 +143,18 @@ impl InvocationJournal {
                 .as_millis(),
         })
     }
+    /// Serialized compare-and-set: persist `watchdog_notified` for the current
+    /// durable record, then hand back the exact-pod termination request built
+    /// from that record. The immutable pod UID (and task/task-run identity) come
+    /// from the durable content, never from the reconstructing process's own
+    /// environment, so recovery targets recorded pod A even when this process is
+    /// pod B. Returns `None` when the record is gone, has advanced to a
+    /// different identity, or was already notified — the persisted bit is what
+    /// makes the callback fire at most once across recurring scans.
     fn notify_if_current(
         &self,
         identity: &TaskInvocationLeaseIdentity,
-    ) -> io::Result<Option<String>> {
+    ) -> io::Result<Option<WatchdogTerminationRequest>> {
         let _guard = self.update_lock.lock().unwrap();
         let content = match fs::read_to_string(self.path(identity)) {
             Ok(content) => content,
@@ -158,9 +166,13 @@ impl InvocationJournal {
             return Ok(None);
         }
         current.watchdog_notified = true;
-        let pod_uid = current.pod_uid.clone();
+        let request = WatchdogTerminationRequest {
+            task_id: current.identity.task_id.clone(),
+            task_run_id: current.identity.task_run_id.clone(),
+            pod_uid: current.pod_uid.clone(),
+        };
         self.replace_unlocked(current)?;
-        Ok(Some(pod_uid))
+        Ok(Some(request))
     }
     fn clear(&self, identity: &TaskInvocationLeaseIdentity) -> io::Result<()> {
         let _guard = self.update_lock.lock().unwrap();
@@ -266,7 +278,19 @@ pub struct InvocationRecovery<'a> {
 }
 
 impl<'a> InvocationRecovery<'a> {
-    pub async fn run(&self, mut watchdog: impl FnMut(&str)) -> io::Result<()> {
+    /// Sweep the durable journal, reconciling terminal records and firing the
+    /// exact-pod `watchdog` for a grace-expired record exactly once. The
+    /// callback receives the full [`WatchdogTerminationRequest`] read from the
+    /// durable record (task, task-run, immutable pod UID); it is invoked only
+    /// after `watchdog_notified` is durably persisted. A callback that cannot
+    /// confirm termination (lost/unavailable transport) must leave the record
+    /// in place — this loop never re-issues the callback once the bit is set,
+    /// and only a matching durable terminal confirmation clears the record.
+    pub async fn run<W, Fut>(&self, mut watchdog: W) -> io::Result<()>
+    where
+        W: FnMut(WatchdogTerminationRequest) -> Fut,
+        Fut: Future<Output = ()>,
+    {
         for record in self.journal.unresolved()? {
             let lease = LeaseIdentity::TaskInvocation(record.identity.clone());
             // Always query the coordinator's durable view. An unavailable reply
@@ -304,9 +328,11 @@ impl<'a> InvocationRecovery<'a> {
                 && !record.watchdog_notified
             {
                 // Re-read while serialized with lifecycle writes. Only the
-                // current durable record can authorize exact-pod deletion.
-                if let Some(pod_uid) = self.journal.notify_if_current(&record.identity)? {
-                    watchdog(&pod_uid);
+                // current durable record can authorize exact-pod deletion, and
+                // it carries the recorded task/task-run/pod UID the callback
+                // must target — not this process's current identity.
+                if let Some(request) = self.journal.notify_if_current(&record.identity)? {
+                    watchdog(request).await;
                 }
             }
         }
@@ -314,11 +340,15 @@ impl<'a> InvocationRecovery<'a> {
     }
 }
 #[allow(dead_code)]
-pub async fn recover_unresolved_invocations(
+pub async fn recover_unresolved_invocations<W, Fut>(
     journal: &InvocationJournal,
     services: &dyn SupervisorServices,
-    watchdog: impl FnMut(&str),
-) -> io::Result<()> {
+    watchdog: W,
+) -> io::Result<()>
+where
+    W: FnMut(WatchdogTerminationRequest) -> Fut,
+    Fut: Future<Output = ()>,
+{
     let clock = SystemClock::new();
     InvocationRecovery {
         journal,

--- a/server/crates/djinn-agent/src/process/tests/process_lease_recovery_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_recovery_tests.rs
@@ -34,7 +34,10 @@ async fn journal_restart_grace_persists_exact_uid_before_single_watchdog() {
         clock: &clock,
         watchdog_grace: Duration::from_secs(10),
     }
-    .run(|uid| calls.lock().unwrap().push(uid.to_owned()))
+    .run(|request| {
+        calls.lock().unwrap().push(request.pod_uid.clone());
+        std::future::ready(())
+    })
     .await
     .unwrap();
     assert!(calls.lock().unwrap().is_empty());
@@ -47,9 +50,10 @@ async fn journal_restart_grace_persists_exact_uid_before_single_watchdog() {
         clock: &clock,
         watchdog_grace: Duration::from_secs(10),
     }
-    .run(|uid| {
+    .run(|request| {
         assert!(reconstructed.unresolved().unwrap()[0].watchdog_notified);
-        calls.lock().unwrap().push(uid.to_owned());
+        calls.lock().unwrap().push(request.pod_uid.clone());
+        std::future::ready(())
     })
     .await
     .unwrap();
@@ -62,7 +66,7 @@ async fn journal_restart_grace_persists_exact_uid_before_single_watchdog() {
         clock: &clock,
         watchdog_grace: Duration::from_secs(10),
     }
-    .run(|_| panic!("durable watchdog bit must prevent duplicate callback"))
+    .run(|_request| async move { panic!("durable watchdog bit must prevent duplicate callback") })
     .await
     .unwrap();
     assert_eq!(reconstructed.unresolved().unwrap().len(), 1);
@@ -100,7 +104,10 @@ async fn watchdog_notification_survives_matching_lifecycle_advancement() {
         clock: &clock,
         watchdog_grace: Duration::ZERO,
     }
-    .run(|uid| calls.lock().unwrap().push(uid.to_owned()))
+    .run(|request| {
+        calls.lock().unwrap().push(request.pod_uid.clone());
+        std::future::ready(())
+    })
     .await
     .unwrap();
     assert_eq!(*calls.lock().unwrap(), vec!["immutable-pod-uid"]);
@@ -126,7 +133,10 @@ async fn watchdog_notification_survives_matching_lifecycle_advancement() {
         clock: &clock,
         watchdog_grace: Duration::ZERO,
     }
-    .run(|uid| calls.lock().unwrap().push(uid.to_owned()))
+    .run(|request| {
+        calls.lock().unwrap().push(request.pod_uid.clone());
+        std::future::ready(())
+    })
     .await
     .unwrap();
     assert_eq!(*calls.lock().unwrap(), vec!["immutable-pod-uid"]);
@@ -167,7 +177,10 @@ async fn paused_recovery_notification_preserves_lifecycle_advancement() {
                 clock: clock.as_ref(),
                 watchdog_grace: Duration::ZERO,
             }
-            .run(|uid| calls.lock().unwrap().push(uid.to_owned()))
+            .run(|request| {
+                calls.lock().unwrap().push(request.pod_uid.clone());
+                std::future::ready(())
+            })
             .await
         })
     };
@@ -233,7 +246,10 @@ async fn paused_recovery_does_not_resurrect_confirmed_lifecycle_cleanup() {
                 clock: clock.as_ref(),
                 watchdog_grace: Duration::ZERO,
             }
-            .run(|uid| calls.lock().unwrap().push(uid.to_owned()))
+            .run(|request| {
+                calls.lock().unwrap().push(request.pod_uid.clone());
+                std::future::ready(())
+            })
             .await
         })
     };
@@ -284,7 +300,10 @@ async fn recovery_retains_nonterminal_record_and_counted_lease() {
         clock: &clock,
         watchdog_grace: Duration::from_secs(1),
     }
-    .run(|uid| assert_eq!(uid, "recorded-pod"))
+    .run(|request| {
+        assert_eq!(request.pod_uid, "recorded-pod");
+        std::future::ready(())
+    })
     .await
     .unwrap();
 
@@ -354,7 +373,7 @@ async fn recovery_terminal_intent_retains_every_ambiguous_or_nonterminal_status(
             clock: &clock,
             watchdog_grace: Duration::from_secs(1),
         }
-        .run(|_| panic!("{name} must retain the unresolved pod"))
+        .run(|_request| async move { panic!("{name} must retain the unresolved pod") })
         .await
         .unwrap();
         assert_eq!(services.status_calls.load(Ordering::SeqCst), 1, "{name}");
@@ -398,7 +417,7 @@ async fn recovery_abandons_only_a_terminal_intent_queued_record_then_rechecks() 
         clock: &clock,
         watchdog_grace: Duration::ZERO,
     }
-    .run(|_| panic!("confirmed cleanup must not notify"))
+    .run(|_request| async move { panic!("confirmed cleanup must not notify") })
     .await
     .unwrap();
     assert_eq!(services.abandon_calls.load(Ordering::SeqCst), 1);
@@ -433,7 +452,7 @@ async fn recovery_clears_only_after_terminal_intent_and_matching_confirmation() 
         clock: &clock,
         watchdog_grace: Duration::from_secs(1),
     }
-    .run(|_| panic!("confirmed lease must not notify"))
+    .run(|_request| async move { panic!("confirmed lease must not notify") })
     .await
     .unwrap();
     assert_eq!(journal.unresolved().unwrap().len(), 1);
@@ -457,8 +476,71 @@ async fn recovery_clears_only_after_terminal_intent_and_matching_confirmation() 
         clock: &clock,
         watchdog_grace: Duration::from_secs(1),
     }
-    .run(|_| panic!("confirmed lease must not notify"))
+    .run(|_request| async move { panic!("confirmed lease must not notify") })
     .await
     .unwrap();
     assert!(journal.unresolved().unwrap().is_empty());
+}
+
+/// The grace watchdog must target the exact task/task-run/pod UID recorded in
+/// the durable journal — even when the reconstructing process runs as a
+/// different pod — and fire that exact-pod request at most once. A lost or
+/// unavailable termination response leaves the record and its counted lease in
+/// place and must not re-issue the callback on the next scan; only a matching
+/// durable terminal confirmation ever clears it.
+#[tokio::test]
+async fn watchdog_targets_recorded_identity_exactly_once_across_pod_reconstruction() {
+    let directory = tempfile::tempdir().unwrap();
+    let identity = TaskInvocationLeaseIdentity {
+        task_id: "task-A".into(),
+        task_run_id: "run-A".into(),
+        invocation_id: "durable-A".into(),
+    };
+    // Recorded while running as pod A, then reconstructed by a process whose
+    // own current pod identity is pod B.
+    let recording = InvocationJournal::new(directory.path().to_path_buf(), "pod-A".into()).unwrap();
+    recording
+        .record_at(
+            &identity,
+            Some(LeaseFencingToken(5)),
+            true,
+            SystemTime::UNIX_EPOCH,
+        )
+        .unwrap();
+    let reconstructed =
+        InvocationJournal::new(directory.path().to_path_buf(), "pod-B".into()).unwrap();
+    // The coordinator view stays ambiguous (unavailable) across scans: never a
+    // terminal confirmation, so the record and its counted lease are retained.
+    let services = ScriptedServices::new(vec![], vec![], vec![LeaseResult::LeaseUnavailable; 4]);
+    let clock = TestClock::new(SystemTime::UNIX_EPOCH, Instant::now());
+    let requests = Arc::new(Mutex::new(Vec::new()));
+
+    for _ in 0..2 {
+        InvocationRecovery {
+            journal: &reconstructed,
+            services: &services,
+            clock: &clock,
+            watchdog_grace: Duration::ZERO,
+        }
+        .run(|request| {
+            requests.lock().unwrap().push(request);
+            std::future::ready(())
+        })
+        .await
+        .unwrap();
+    }
+
+    let fired = requests.lock().unwrap();
+    assert_eq!(
+        fired.len(),
+        1,
+        "watchdog must fire exactly once for the recorded pod across scans"
+    );
+    assert_eq!(fired[0].task_id, "task-A");
+    assert_eq!(fired[0].task_run_id, "run-A");
+    // The recorded pod UID, not this reconstructing process's pod-B identity.
+    assert_eq!(fired[0].pod_uid, "pod-A");
+    let records = reconstructed.unresolved().unwrap();
+    assert_eq!(records.len(), 1);
+    assert!(records[0].watchdog_notified);
 }


### PR DESCRIPTION
Completes epic kh95 (proposal goxi) by replacing the placeholder invocation-journal watchdog callback with the real exact-pod termination request, consuming znrf's durable journal/recovery (#2523) and tdde's exact-UID supervisor operation (#2527).

## What changed
- **`process.rs`** — `notify_if_current` now returns a `WatchdogTerminationRequest` built from the *current durable record* (recorded task, task-run, and immutable pod UID), persisted through the serialized `watchdog_notified` CAS before returning. `InvocationRecovery::run` (and the `recover_unresolved_invocations` wrapper) take an async watchdog callback and await it after the CAS, preserving persist-before-request ordering.
- **`context.rs`** — added `terminate_watchdog_pod`, wiring both the startup/reconnect recovery run and the detached grace sweep to `SupervisorServices::terminate_watchdog_pod` (→ RPC → host `terminate_taskrun_pod_exact`). A failed/unavailable response is logged and swallowed: the durable record and its counted lease are retained and the callback is never re-issued, so durable terminal confirmation remains the only cleanup gate. The detached sweep keeps its `Weak`/owned-scope discipline so worker shutdown never hangs.
- **Tests** — migrated the recovery-test callbacks to the async signature and added `watchdog_targets_recorded_identity_exactly_once_across_pod_reconstruction`, proving the watchdog targets recorded pod A exactly once even when the reconstructing process is pod B, retaining the record + lease on ambiguous status.

## Acceptance criteria evidence
- **AC1 (exact-UID from durable record)** — recovery builds the request from the recorded record's identity/pod UID, never the current environment; new reconstruction test asserts `pod_uid == "pod-A"` while the process runs as `pod-B`.
- **AC2 (persist-before-request, at-most-once, conservative retention)** — CAS persists `watchdog_notified` before the callback; second scan does not re-issue; record + counted lease retained on `LeaseUnavailable`.
- **AC3 (deterministic reconstruction/grace tests)** — callback ordering, exactly-once for recorded pod UID A vs different current pod identity, and cleanup only after matching durable terminal confirmation, all covered by the recovery test suite.

## Gates
- `cargo fmt --all`; `cargo clippy -p djinn-agent --tests` clean (0 warnings)
- `cargo test -p djinn-agent --lib process::tests::lease_runner_tests` — 26 passed
- `cargo test -p djinn-agent-worker --test cancel_path --test in_pod_drive` — both passed (worker shutdown completes, no hang)
- `SQLX_OFFLINE=1 cargo check --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
