### PR TITLE
chore(twqh): Operator safe-ordering executor for admission-epoch cutover, kill-switch, and rollback

### DIFF
--- a/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
+++ b/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
@@ -1,0 +1,192 @@
+# Build-admission epoch operator runbook
+
+Operator diagnostics and recovery for the durable **admission epoch** that owns
+the Build Leases v1 rollout (epic `23or`, proposal `goxi`). The epoch is a single
+durable row (`admission_handoff`, singleton `name = 'build'`) carrying the v0/v1
+authority modes, the reference cap, the phase, and the per-authority + per-generation
+acknowledgements. One serialized compare-and-swap owns all of them, so a cap
+change and a phase advance can never interleave into a contradictory committed
+state.
+
+This runbook is diagnosis-and-recovery only. It never asks an operator to hand-edit
+the durable row with raw SQL; the safe-ordering executor and the `epoch` admin
+commands are the supported surface.
+
+## Authorities, modes, and phases
+
+- **v0 (emergency)** — the coordinator `BuildAdmissionController`. Modes:
+  `enforce` / `observe` / `disabled`. Only `enforce` denies over the cap.
+- **v1 (invocation)** — the per-spawn launcher quota lift, read directly from the
+  epoch by the agents via `evaluate_invocation_lift`. Modes: `off` / `shadow` /
+  `enforce`. Only `enforce` lifts the reserved `cpu.max`.
+- **Phases** — `emergency_primary` → `forward_overlap` → `invocation_primary` →
+  `rollback_overlap` → `emergency_primary`. Baseline is `emergency_primary` with
+  `v0 = enforce, v1 = off`; `shadow` is that same baseline with `v1 = shadow`.
+
+**Invariant:** every committed state has at least one enforcing authority. The
+illegal combination in which neither authority enforces
+(`v0 ∈ {observe, disabled} ∧ v1 ∈ {off, shadow}`) is rejected up front by
+`validate_admission_config` and, if it is ever observed durably, fails closed via
+`evaluate_handoff` (`HandoffState::IllegalModeCombo`).
+
+## Operator commands
+
+Run against a coordinator image with a current schema. These are one-shot admin
+modes of the server binary; they open the DB, act, print, and exit before any
+actor or HTTP listener starts.
+
+```
+djinn-server epoch show                  # print the durable row + derived state
+djinn-server epoch advance --cap N       # perform the next safe FORWARD step
+djinn-server epoch set-cap --cap N        # change the reference cap (epoch-fenced)
+djinn-server epoch rollback --cap N        # perform the next safe ROLLBACK step
+djinn-server epoch kill-switch --cap N      # rollback from invocation-primary, urgent
+```
+
+`advance`, `rollback`, and `kill-switch` each perform exactly **one** safe step
+and report what they did and what they are waiting on (a v0 controller-replica
+ack, or the live-generation acks). Re-run the command after the awaited
+acknowledgement lands; the epoch fence makes re-runs safe. Under the hood these
+compose `AdmissionTransitionExecutor` in
+`server/crates/djinn-coordinator/src/build_admission_transition.rs`.
+
+### Forward cutover order
+
+1. `arm_shadow` — `v0 = enforce, v1 = shadow`, phase stays `emergency_primary`.
+2. `arm_overlap` — `v0 = enforce, v1 = enforce`, phase stays `emergency_primary`.
+3. `enter_forward_overlap` — advance to `forward_overlap` **after** the v0
+   controller-replica acks the epoch.
+4. `commit_invocation_primary` — advance to `invocation_primary` **after** modes,
+   cap, and **every** armed live generation have acknowledged the current epoch.
+5. `observe_v0` — `v0 = observe, v1 = enforce`. Terminal forward state.
+
+### Reverse kill-switch / rollback order
+
+The reverse ordering is the safety-critical part. It **confirms v0 is enforcing
+with a controller-replica ack before any transaction lifts or disables v1
+quota**, and if v0 cannot be confirmed it **halts with both authorities
+enforcing and never disables v1**.
+
+1. `arm_rollback` — commit `v0 = enforce, v1 = enforce` at a **same-or-lower**
+   cap (a rollback must not raise the cap). v1 keeps enforcing; nothing disabled.
+2. `enter_rollback_overlap` — advance `invocation_primary` → `rollback_overlap`
+   **only** once v0 is confirmed enforcing (`v0 = enforce` and
+   `emergency_ack_epoch == epoch`). If not, the step returns
+   `HaltedV0Unconfirmed`, makes no mutation, and leaves both enforcing.
+3. `complete_rollback` — confirm v0 again, advance `rollback_overlap` →
+   `emergency_primary` (v1 stops lifting the instant the phase is
+   `emergency_primary`), then set `v1 = off`.
+
+## Diagnosis and recovery procedures
+
+### 1. Fail-closed suspect rows and forced exact-UID deletion
+
+A build lease can land in `suspect` when the coordinator cannot confirm a lease
+holder's terminal state (`BuildLeaseState::Suspect`, one of the five occupying
+states in `server/crates/djinn-db/src/repositories/build_lease.rs`). A suspect row
+keeps counting against the cap on purpose: it is fail-closed until the exact pod
+is proven gone.
+
+- **Detect:** `epoch show` reports the effective cap; compare against occupancy.
+  Suspect rows appear in `build_lease` with `state = 'suspect'` and in the
+  `djinn_build_lease_*` occupancy telemetry.
+- **Recover:** do not delete the durable row. Force termination of the **exact**
+  pod UID through the watchdog termination seam
+  (`WatchdogTerminationRequest` handled in
+  `server/crates/djinn-agent/src/direct_services.rs` and
+  `server/crates/djinn-agent-worker/src/worker_services.rs`). This deletes only
+  the pod whose UID matches — it refuses on empty/mismatched task, task-run, or
+  pod UID — so a stale row can never reap a live successor. The reclamation of
+  the exact predecessor UID on restart runs through
+  `AdmissionJournalRepository` with `UidFencedAdmissionInput`
+  (`server/crates/djinn-db/src/repositories/admission_journal.rs`); the row stays
+  counted until that fenced terminal write lands.
+
+### 2. Graph-warm candidate cleanup
+
+A warm consumer that grabbed a launching grant but never bound an immutable pod
+UID leaves a candidate that must be cleaned before its slot frees.
+
+- **Detect:** the warm adapter
+  (`server/crates/djinn-coordinator/src/graph_warm_lease.rs`) surfaces
+  `candidate_cleanup` on the durable row; the Kubernetes side is inventoried by
+  `server/crates/djinn-k8s/src/warm_job.rs`.
+- **Recover:** let the reconciler
+  (`BuildAdmissionReconciler::reconcile` in
+  `server/crates/djinn-coordinator/src/build_admission_inventory.rs`) adopt live
+  and release terminal warm workloads. Unclassifiable non-terminal build
+  workloads become `blockers` in the `InventoryReport` and hold the gate closed
+  fail-closed until relabeled or removed.
+
+### 3. Cap zero (drain without disabling admission)
+
+- **Do NOT** set the cap to zero through `epoch set-cap` — the epoch cap is
+  validated to `[MIN_ADMISSION_CAP, MAX_ADMISSION_CAP]` (`1..=4096`) and the
+  durable CHECK constraint rejects `cap <= 0`. A zero epoch cap is not a legal
+  epoch state.
+- To drain, use the lease service's `BuildLeaseService::set_cap(0)`
+  (`server/crates/djinn-coordinator/src/build_lease.rs`), which stops granting new
+  leases while occupied rows drain naturally. Light (coordinator-free) commands
+  stay unaffected. Restore the cap with the same call once drained.
+
+### 4. Stale epochs
+
+A stale epoch is any durable row whose current-phase acknowledgements are not at
+the current epoch, or that cannot be read.
+
+- **Detect:** the `djinn_build_admission_handoff_warning{reason}` gauge and the
+  logged warning carry one of the three bounded reasons from
+  `HandoffWarningReason`: `stale_epoch`, `unexpected_overlap`, `epoch_unreadable`.
+  `epoch show` prints the phase, epoch, both ack epochs, and the derived
+  `HandoffState`.
+- **Recover:** a stale/incomplete/unreadable epoch is already fail-closed —
+  `evaluate_handoff` returns `RequiredFailClosed` and `evaluate_invocation_lift`
+  returns `Unleased`, so v0 keeps enforcing and v1 never lifts. Re-run the
+  executor step for the current phase once the coordinator leader re-acknowledges
+  the current epoch (the leader's live handoff loop,
+  `finalize_build_admission_handoff`, writes the emergency ack when the controller
+  is a healthy `enforce`). Never advance from a stale epoch: the compare-and-swap
+  returns `InvalidTransition`.
+
+### 5. Unsupported node / runtime readiness
+
+Enforcement must never be enabled without kernel isolation and inventory proofs.
+
+- **Detect:** `BuildAdmissionReadiness` (`server/crates/djinn-coordinator/src/build_admission.rs`)
+  reports the gate that is not yet healthy — `JournalRecoveryIncomplete`,
+  `JournalUnhealthy`, `InventoryPending`, `TopologyPending`,
+  `SeededOccupancyAboveCap`, `CreateUnknownHealth`, or `ShutdownDraining`. Only
+  `Healthy` allows a v0 ack. On the launcher side an unsupported node surfaces as
+  `LeaseContainmentFailed` (the launcher refuses to lift without cgroup-v2
+  containment).
+- **Recover:** do not force an epoch advance while any gate is unhealthy — the v0
+  ack is gated on `readiness.is_healthy()`, so `enter_forward_overlap` will keep
+  returning `AwaitingEmergencyAck`. Resolve the underlying gate (recover the
+  journal, complete the Kubernetes inventory, confirm single-active topology),
+  then retry. A `LeaseContainmentFailed` node must be drained or fixed before it
+  can host v1-enforcing spawns; until then the epoch keeps v1 unleased on that
+  node fail-closed.
+
+## Aborting a forward overlap
+
+The phase machine is a strict forward cycle, so you cannot advance
+`forward_overlap` backward. If you must abort a cutover **before**
+`invocation_primary`, use `epoch set-cap`/mode change to set `v1 = off` while
+`v0` stays `enforce`: v0 remains the sole enforcing authority (safe, fail-closed)
+and no v1 quota is lifted. Re-arm shadow/overlap later to resume. A full reverse
+rollback (`rollback_overlap`) is only defined from `invocation_primary`.
+
+## Shadow-mode observability gap (deferred to `u2oz`)
+
+In `shadow` every user spawn traverses the broker, but the runtime currently
+records only the `would_escalate` shadow-invocation decision
+(`djinn_telemetry::build_admission::record_shadow_invocation`, called from
+`server/crates/djinn-agent/src/process.rs`). The complementary `would_throttle`
+decision (v1 *would* have kept the quota throttled because the reference cap is
+already met) is **not** emitted: a shadow request that the invocation authority
+would have denied is not distinguished, because shadow still takes a real lease
+grant rather than a non-enforcing would-decision. This does not weaken v0 (shadow
+never lifts and never denies) and does not affect the executor's shadow arm,
+which correctly sets `v1 = shadow`. Wiring the `would_throttle` branch requires a
+non-enforcing broker capacity check on the shadow request path and belongs with
+the cross-component work in `u2oz`.

--- a/server/crates/djinn-coordinator/src/build_admission_transition.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_transition.rs
@@ -1,0 +1,727 @@
+//! Operator-driven safe-ordering executor for the durable admission epoch.
+//!
+//! This module sits beside [`crate::build_admission_handoff`] (the emergency-side
+//! policy interpreter) and composes the three durable primitives that
+//! [`AdmissionHandoffRepository`] exposes —
+//! [`AdmissionHandoffRepository::set_modes_and_cap`],
+//! [`AdmissionHandoffRepository::acknowledge`], and
+//! [`AdmissionHandoffRepository::advance`] — into the multi-step operator
+//! workflows the rollout requires. It re-implements none of the fencing: every
+//! mutation is the same epoch-fenced compare-and-swap the repository already
+//! serializes on one row lock, so a cap change and a phase advance can never
+//! interleave into a contradictory committed state.
+//!
+//! ## Authority acknowledgements
+//!
+//! Two acknowledgement writers exist. The v0 (emergency) authority ack is
+//! written by the coordinator leader's live handoff loop
+//! (`finalize_build_admission_handoff`) once the emergency controller is a
+//! *healthy* `Enforce` — the executor therefore never fabricates it, it *waits*
+//! for it (returning [`TransitionError::AwaitingEmergencyAck`]). This is the
+//! "controller-replica ack" the reverse ordering confirms before it disables
+//! v1. The v1 (invocation) authority ack has no separate runtime writer — the
+//! agents read the epoch directly through
+//! `evaluate_invocation_lift` — so the executor records it as it drives each
+//! transition, representing the operator arming the invocation authority.
+//!
+//! ## Forward cutover
+//!
+//! `arm_shadow` → `arm_overlap` → `enter_forward_overlap` →
+//! `commit_invocation_primary` → `observe_v0`. `commit_invocation_primary`
+//! reaches [`AdmissionHandoffPhase::InvocationPrimary`] only after modes/cap and
+//! every armed live generation have acknowledged the current epoch.
+//!
+//! ## Reverse kill-switch / rollback
+//!
+//! `arm_rollback` (commit v0 `Enforce` at a same-or-lower cap) →
+//! `enter_rollback_overlap` (**halts** unless v0 is confirmed enforcing with a
+//! replica ack, leaving both authorities enforcing and v1 un-disabled) →
+//! `complete_rollback` (disable v1 only after the overlap confirms v0 again).
+//! No transaction lifts or disables v1 quota before v0 is confirmed.
+
+use std::sync::Arc;
+
+use djinn_db::error::DbError;
+use djinn_db::{
+    AdmissionHandoffAuthority, AdmissionHandoffPhase, AdmissionHandoffRepository,
+    AdmissionHandoffRow, V0Mode, V1Mode,
+};
+
+use crate::build_admission::validate_admission_config;
+
+/// Why an operator transition could not complete.
+///
+/// Every variant is a bounded, actionable classification: a stale epoch or
+/// illegal edge is [`Self::InvalidTransition`]; a step that is blocked waiting
+/// for an external acknowledgement is [`Self::AwaitingEmergencyAck`] or
+/// [`Self::AwaitingGenerationAcks`]; a rollback that refused to disable v1
+/// because v0 was not confirmed is [`Self::HaltedV0Unconfirmed`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransitionError {
+    /// A stale-epoch or illegal-edge compare-and-swap was rejected by the
+    /// durable layer (or the observed epoch no longer matches the operator's).
+    InvalidTransition(String),
+    /// The v0 (emergency) controller-replica has not acknowledged the current
+    /// epoch yet. Retry once the coordinator leader re-acknowledges.
+    AwaitingEmergencyAck { epoch: i64 },
+    /// Not every armed live generation has acknowledged the current epoch.
+    AwaitingGenerationAcks { epoch: i64, missing: usize },
+    /// A rollback step halted before touching v1 because v0 could not be
+    /// confirmed enforcing at the current epoch. Both authorities remain
+    /// enforcing and no v1 quota was lifted or disabled.
+    HaltedV0Unconfirmed { epoch: i64 },
+    /// A configuration was rejected before it could reach the durable row.
+    InvalidConfig(String),
+    /// A rollback cap must be the same as or lower than the current cap.
+    CapNotSameOrLower { requested: i64, current: i64 },
+    /// An underlying storage failure that is not an epoch/edge rejection.
+    Storage(String),
+}
+
+impl std::fmt::Display for TransitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidTransition(msg) => write!(f, "invalid transition: {msg}"),
+            Self::AwaitingEmergencyAck { epoch } => {
+                write!(f, "awaiting v0 emergency acknowledgement at epoch {epoch}")
+            }
+            Self::AwaitingGenerationAcks { epoch, missing } => write!(
+                f,
+                "awaiting {missing} live-generation acknowledgement(s) at epoch {epoch}"
+            ),
+            Self::HaltedV0Unconfirmed { epoch } => write!(
+                f,
+                "halted at epoch {epoch}: v0 not confirmed enforcing; both authorities remain \
+                 enforcing and v1 was not disabled"
+            ),
+            Self::InvalidConfig(msg) => write!(f, "invalid admission configuration: {msg}"),
+            Self::CapNotSameOrLower { requested, current } => write!(
+                f,
+                "rollback cap {requested} exceeds the current cap {current}; a rollback must not \
+                 raise the cap"
+            ),
+            Self::Storage(msg) => write!(f, "storage error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for TransitionError {}
+
+fn map_db(err: DbError) -> TransitionError {
+    match err {
+        DbError::InvalidTransition(msg) => TransitionError::InvalidTransition(msg),
+        other => TransitionError::Storage(other.to_string()),
+    }
+}
+
+/// Validate a mode/cap combination before it can reach the durable row.
+///
+/// Reuses [`validate_admission_config`] when a concrete cap is present (rejecting
+/// the illegal both-non-enforcing combo and an out-of-range cap up front); when
+/// the cap is inherited (`None`) only the mode combo is checked.
+fn validate_config(v0: V0Mode, v1: V1Mode, cap: Option<i64>) -> Result<(), TransitionError> {
+    match cap {
+        Some(cap) => validate_admission_config(v0, v1, cap).map_err(TransitionError::InvalidConfig),
+        None if !v0.is_enforcing() && !v1.is_enforcing() => Err(TransitionError::InvalidConfig(
+            format!("neither authority enforces (v0={v0:?}, v1={v1:?})"),
+        )),
+        None => Ok(()),
+    }
+}
+
+/// Composes the durable epoch primitives into safe operator workflows.
+pub struct AdmissionTransitionExecutor {
+    repo: Arc<AdmissionHandoffRepository>,
+}
+
+impl AdmissionTransitionExecutor {
+    #[must_use]
+    pub fn new(repo: Arc<AdmissionHandoffRepository>) -> Self {
+        Self { repo }
+    }
+
+    /// Read the durable row for `epoch show`.
+    pub async fn show(&self) -> Result<Option<AdmissionHandoffRow>, TransitionError> {
+        self.repo.read().await.map_err(map_db)
+    }
+
+    /// Read the current row and fail fast if it no longer matches the epoch the
+    /// operator observed — a stale-epoch attempt returns `InvalidTransition`
+    /// before any mutation is issued.
+    async fn current(&self, expected_epoch: i64) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.repo.read().await.map_err(map_db)?.ok_or_else(|| {
+            TransitionError::InvalidTransition("admission handoff row absent".into())
+        })?;
+        if row.epoch != expected_epoch {
+            return Err(TransitionError::InvalidTransition(format!(
+                "stale epoch {expected_epoch}; current epoch is {}",
+                row.epoch
+            )));
+        }
+        Ok(row)
+    }
+
+    fn require_phase(
+        row: &AdmissionHandoffRow,
+        expected: AdmissionHandoffPhase,
+    ) -> Result<(), TransitionError> {
+        if row.phase == expected {
+            Ok(())
+        } else {
+            Err(TransitionError::InvalidTransition(format!(
+                "expected phase {expected:?} but the durable phase is {:?}",
+                row.phase
+            )))
+        }
+    }
+
+    /// Record the v1 (invocation) authority ack at `epoch` and return the row as
+    /// it stands after the ack, so callers can return a final state consistent
+    /// with the acknowledgement they just wrote.
+    async fn record_invocation_ack(
+        &self,
+        epoch: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        self.repo
+            .acknowledge(AdmissionHandoffAuthority::Invocation, epoch)
+            .await
+            .map_err(map_db)
+    }
+
+    // ── Forward cutover ────────────────────────────────────────────────────
+
+    /// Arm the v1 shadow: v0 stays `Enforce`, v1 moves to `Shadow`. The phase
+    /// stays `EmergencyPrimary`, so v0 remains the sole enforcing authority
+    /// while v1 observes every spawn through the broker without lifting.
+    pub async fn arm_shadow(
+        &self,
+        expected_epoch: i64,
+        cap: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::EmergencyPrimary)?;
+        validate_config(V0Mode::Enforce, V1Mode::Shadow, Some(cap))?;
+        self.repo
+            .set_modes_and_cap(expected_epoch, V0Mode::Enforce, V1Mode::Shadow, Some(cap))
+            .await
+            .map_err(map_db)
+    }
+
+    /// Arm the conservative overlap modes: both authorities `Enforce` at `cap`.
+    /// The phase stays `EmergencyPrimary` (v0 still primary) until
+    /// [`Self::enter_forward_overlap`] advances it, so this step alone never
+    /// lets v1 lift.
+    pub async fn arm_overlap(
+        &self,
+        expected_epoch: i64,
+        cap: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::EmergencyPrimary)?;
+        validate_config(V0Mode::Enforce, V1Mode::Enforce, Some(cap))?;
+        self.repo
+            .set_modes_and_cap(expected_epoch, V0Mode::Enforce, V1Mode::Enforce, Some(cap))
+            .await
+            .map_err(map_db)
+    }
+
+    /// Advance `EmergencyPrimary` → `ForwardOverlap` once the v0 controller-replica
+    /// has acknowledged the current epoch, then record the v1 authority ack so
+    /// the overlap is complete. Returns [`TransitionError::AwaitingEmergencyAck`]
+    /// until the leader acknowledges.
+    pub async fn enter_forward_overlap(
+        &self,
+        expected_epoch: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::EmergencyPrimary)?;
+        if row.emergency_ack_epoch != Some(row.epoch) {
+            return Err(TransitionError::AwaitingEmergencyAck { epoch: row.epoch });
+        }
+        let overlap = self
+            .repo
+            .advance(expected_epoch, AdmissionHandoffPhase::ForwardOverlap, &[])
+            .await
+            .map_err(map_db)?;
+        self.record_invocation_ack(overlap.epoch).await
+    }
+
+    /// Commit `ForwardOverlap` → `InvocationPrimary`. This edge opens only after
+    /// modes/cap plus both authority acks are current AND every generation in
+    /// `armed_generations` — the live set captured when the overlap was armed —
+    /// has an idempotent current-epoch acknowledgement. It records the v1
+    /// authority ack on the committed invocation-primary epoch so the invocation
+    /// authority keeps lifting.
+    pub async fn commit_invocation_primary(
+        &self,
+        expected_epoch: i64,
+        armed_generations: &[String],
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::ForwardOverlap)?;
+        if row.emergency_ack_epoch != Some(row.epoch) {
+            return Err(TransitionError::AwaitingEmergencyAck { epoch: row.epoch });
+        }
+        // The v1 authority ack is the executor's to write; re-assert it so a
+        // retry after a cleared ack still makes progress.
+        if row.invocation_ack_epoch != Some(row.epoch) {
+            self.record_invocation_ack(row.epoch).await?;
+        }
+        if !self
+            .repo
+            .generation_ack_complete(row.epoch, armed_generations)
+            .await
+            .map_err(map_db)?
+        {
+            // Report how many are still missing without leaking generation
+            // identities into the error.
+            let missing = self
+                .count_missing_generation_acks(row.epoch, armed_generations)
+                .await?;
+            return Err(TransitionError::AwaitingGenerationAcks {
+                epoch: row.epoch,
+                missing,
+            });
+        }
+        let primary = self
+            .repo
+            .advance(
+                expected_epoch,
+                AdmissionHandoffPhase::InvocationPrimary,
+                armed_generations,
+            )
+            .await
+            .map_err(map_db)?;
+        self.record_invocation_ack(primary.epoch).await
+    }
+
+    async fn count_missing_generation_acks(
+        &self,
+        epoch: i64,
+        armed_generations: &[String],
+    ) -> Result<usize, TransitionError> {
+        let mut missing = 0;
+        for key in armed_generations {
+            if !self
+                .repo
+                .generation_ack_complete(epoch, std::slice::from_ref(key))
+                .await
+                .map_err(map_db)?
+            {
+                missing += 1;
+            }
+        }
+        Ok(missing)
+    }
+
+    /// Move v0 to `Observe` after invocation-primary is committed: v1 keeps
+    /// `Enforce`, v0 stops denying. This is the terminal forward step and
+    /// preserves the current reference cap. Re-records the v1 authority ack on
+    /// the new epoch so the invocation authority keeps lifting.
+    pub async fn observe_v0(
+        &self,
+        expected_epoch: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::InvocationPrimary)?;
+        validate_config(V0Mode::Observe, V1Mode::Enforce, row.cap)?;
+        let updated = self
+            .repo
+            .set_modes_and_cap(expected_epoch, V0Mode::Observe, V1Mode::Enforce, row.cap)
+            .await
+            .map_err(map_db)?;
+        self.record_invocation_ack(updated.epoch).await
+    }
+
+    // ── Reverse kill-switch / rollback ─────────────────────────────────────
+
+    /// Begin a rollback from `InvocationPrimary`: commit v0 back to `Enforce`
+    /// (both authorities enforcing) at a **same-or-lower** cap. This is the
+    /// first, safe half of the reverse ordering: v0 re-enforces and v1 keeps
+    /// enforcing, so at least one — here both — authority enforces at every
+    /// committed point. It never disables v1.
+    pub async fn arm_rollback(
+        &self,
+        expected_epoch: i64,
+        cap: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::InvocationPrimary)?;
+        if let Some(current) = row.cap
+            && cap > current
+        {
+            return Err(TransitionError::CapNotSameOrLower {
+                requested: cap,
+                current,
+            });
+        }
+        validate_config(V0Mode::Enforce, V1Mode::Enforce, Some(cap))?;
+        self.repo
+            .set_modes_and_cap(expected_epoch, V0Mode::Enforce, V1Mode::Enforce, Some(cap))
+            .await
+            .map_err(map_db)
+    }
+
+    /// Advance `InvocationPrimary` → `RollbackOverlap` **only** after confirming
+    /// v0 is enforcing with a controller-replica acknowledgement at the current
+    /// epoch. If v0 is not confirmed this returns
+    /// [`TransitionError::HaltedV0Unconfirmed`] and makes no mutation — both
+    /// authorities remain enforcing and v1 is not disabled.
+    pub async fn enter_rollback_overlap(
+        &self,
+        expected_epoch: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::InvocationPrimary)?;
+        let v0_confirmed =
+            row.v0_mode == V0Mode::Enforce && row.emergency_ack_epoch == Some(row.epoch);
+        if !v0_confirmed {
+            return Err(TransitionError::HaltedV0Unconfirmed { epoch: row.epoch });
+        }
+        // Leaving InvocationPrimary requires the v1 authority ack at the current
+        // epoch; record it now that v0 is confirmed. The v0 controller stays
+        // durably `Enforce` and the epoch is unchanged, so the advance commits
+        // with both authorities enforcing even if the leader's in-memory
+        // controller briefly observes the now-complete InvocationPrimary.
+        self.record_invocation_ack(row.epoch).await?;
+        let overlap = self
+            .repo
+            .advance(expected_epoch, AdmissionHandoffPhase::RollbackOverlap, &[])
+            .await
+            .map_err(map_db)?;
+        self.record_invocation_ack(overlap.epoch).await
+    }
+
+    /// Complete the rollback from `RollbackOverlap`: confirm v0 once more (both
+    /// authorities acked), advance `RollbackOverlap` → `EmergencyPrimary` (at
+    /// which point v1 stops lifting regardless of its mode), then set v1 to
+    /// `Off` to formally disable it. Returns
+    /// [`TransitionError::AwaitingEmergencyAck`] until v0 is re-confirmed, never
+    /// disabling v1 without it.
+    pub async fn complete_rollback(
+        &self,
+        expected_epoch: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        Self::require_phase(&row, AdmissionHandoffPhase::RollbackOverlap)?;
+        if row.v0_mode != V0Mode::Enforce || row.emergency_ack_epoch != Some(row.epoch) {
+            return Err(TransitionError::AwaitingEmergencyAck { epoch: row.epoch });
+        }
+        // Leaving the RollbackOverlap requires BOTH authority acks; v0 is
+        // confirmed above, so record the v1 authority ack before the advance.
+        self.record_invocation_ack(row.epoch).await?;
+        let baseline = self
+            .repo
+            .advance(expected_epoch, AdmissionHandoffPhase::EmergencyPrimary, &[])
+            .await
+            .map_err(map_db)?;
+        // v1 already stopped lifting the moment the phase became EmergencyPrimary;
+        // formally disable it so the durable modes match the v0-only baseline.
+        validate_config(V0Mode::Enforce, V1Mode::Off, baseline.cap)?;
+        self.repo
+            .set_modes_and_cap(baseline.epoch, V0Mode::Enforce, V1Mode::Off, baseline.cap)
+            .await
+            .map_err(map_db)
+    }
+
+    // ── Cap changes (serialize with the handoff edge) ──────────────────────
+
+    /// Change the reference cap while preserving the current modes. Because this
+    /// is the same epoch-fenced compare-and-swap as a phase advance, a cap change
+    /// and an advance can never interleave into a contradictory committed state:
+    /// whichever commits first bumps the epoch and the other is rejected as a
+    /// stale-epoch [`TransitionError::InvalidTransition`]. Re-records the v1
+    /// authority ack when v1 was authoritative so the invocation side keeps
+    /// lifting across the cap change.
+    pub async fn set_cap(
+        &self,
+        expected_epoch: i64,
+        cap: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        validate_config(row.v0_mode, row.v1_mode, Some(cap))?;
+        let updated = self
+            .repo
+            .set_modes_and_cap(expected_epoch, row.v0_mode, row.v1_mode, Some(cap))
+            .await
+            .map_err(map_db)?;
+        // Preserve v1 authority continuity across a cap change in the phases
+        // where the invocation side must stay acknowledged to keep lifting.
+        let needs_invocation_ack = matches!(
+            updated.phase,
+            AdmissionHandoffPhase::ForwardOverlap
+                | AdmissionHandoffPhase::InvocationPrimary
+                | AdmissionHandoffPhase::RollbackOverlap
+        );
+        if needs_invocation_ack {
+            return self.record_invocation_ack(updated.epoch).await;
+        }
+        Ok(updated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djinn_db::Database;
+
+    async fn executor() -> AdmissionTransitionExecutor {
+        let repo = Arc::new(AdmissionHandoffRepository::new(
+            Database::open_in_memory().unwrap(),
+        ));
+        AdmissionTransitionExecutor::new(repo)
+    }
+
+    /// Simulate the coordinator leader's live handoff loop acknowledging the v0
+    /// (emergency) authority at the row's current epoch.
+    async fn leader_acks_emergency(exec: &AdmissionTransitionExecutor) -> i64 {
+        let row = exec.show().await.unwrap().unwrap();
+        exec.repo
+            .acknowledge(AdmissionHandoffAuthority::Emergency, row.epoch)
+            .await
+            .unwrap();
+        row.epoch
+    }
+
+    /// Drive the whole forward cutover, returning the invocation-primary row.
+    async fn cutover(
+        exec: &AdmissionTransitionExecutor,
+        cap: i64,
+        armed: &[String],
+    ) -> AdmissionHandoffRow {
+        // Baseline EmergencyPrimary(0) → arm shadow.
+        let shadow = exec.arm_shadow(0, cap).await.unwrap();
+        assert_eq!(shadow.v1_mode, V1Mode::Shadow);
+        assert_eq!(shadow.phase, AdmissionHandoffPhase::EmergencyPrimary);
+        // Arm overlap modes (both enforce), phase still EmergencyPrimary.
+        let overlap_modes = exec.arm_overlap(shadow.epoch, cap).await.unwrap();
+        assert_eq!(overlap_modes.v1_mode, V1Mode::Enforce);
+        assert_eq!(overlap_modes.phase, AdmissionHandoffPhase::EmergencyPrimary);
+        // Advance into ForwardOverlap requires the leader's emergency ack.
+        assert!(matches!(
+            exec.enter_forward_overlap(overlap_modes.epoch).await,
+            Err(TransitionError::AwaitingEmergencyAck { .. })
+        ));
+        leader_acks_emergency(exec).await;
+        let overlap = exec
+            .enter_forward_overlap(overlap_modes.epoch)
+            .await
+            .unwrap();
+        assert_eq!(overlap.phase, AdmissionHandoffPhase::ForwardOverlap);
+        // Commit needs the leader ack + all generation acks.
+        assert!(matches!(
+            exec.commit_invocation_primary(overlap.epoch, armed).await,
+            Err(TransitionError::AwaitingEmergencyAck { .. })
+        ));
+        leader_acks_emergency(exec).await;
+        if !armed.is_empty() {
+            assert!(matches!(
+                exec.commit_invocation_primary(overlap.epoch, armed).await,
+                Err(TransitionError::AwaitingGenerationAcks { .. })
+            ));
+            for key in armed {
+                exec.repo
+                    .record_generation_ack(overlap.epoch, key)
+                    .await
+                    .unwrap();
+            }
+        }
+        let primary = exec
+            .commit_invocation_primary(overlap.epoch, armed)
+            .await
+            .unwrap();
+        assert_eq!(primary.phase, AdmissionHandoffPhase::InvocationPrimary);
+        primary
+    }
+
+    /// AC1: the forward executor reaches invocation_primary only after modes/cap
+    /// and all live-generation acks are committed.
+    #[tokio::test]
+    async fn forward_reaches_invocation_primary_only_after_all_generation_acks() {
+        let exec = executor().await;
+        let armed = vec![
+            "warm_build/alpha/0".to_string(),
+            "task_run/beta/3".to_string(),
+        ];
+        let primary = cutover(&exec, 3, &armed).await;
+        assert_eq!(primary.v0_mode, V0Mode::Enforce);
+        assert_eq!(primary.v1_mode, V1Mode::Enforce);
+        assert_eq!(primary.invocation_ack_epoch, Some(primary.epoch));
+
+        // Terminal forward step: v0 → observe, v1 stays enforcing.
+        let observed = exec.observe_v0(primary.epoch).await.unwrap();
+        assert_eq!(observed.v0_mode, V0Mode::Observe);
+        assert_eq!(observed.v1_mode, V1Mode::Enforce);
+        assert_eq!(observed.phase, AdmissionHandoffPhase::InvocationPrimary);
+        assert_eq!(observed.invocation_ack_epoch, Some(observed.epoch));
+    }
+
+    /// AC1: the forward executor refuses to skip an edge, and stale-epoch /
+    /// illegal-edge attempts return InvalidTransition.
+    #[tokio::test]
+    async fn forward_refuses_to_skip_edges_and_rejects_stale_epochs() {
+        let exec = executor().await;
+        // Cannot commit invocation-primary straight from the baseline phase.
+        assert!(matches!(
+            exec.commit_invocation_primary(0, &[]).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+        // Cannot enter the forward overlap from the baseline phase either
+        // (no overlap modes / no emergency ack yet): the ack gate fires first.
+        assert!(matches!(
+            exec.enter_forward_overlap(0).await,
+            Err(TransitionError::AwaitingEmergencyAck { .. })
+        ));
+
+        let shadow = exec.arm_shadow(0, 3).await.unwrap();
+        // A stale epoch (the operator's observed epoch is behind the durable row)
+        // is rejected before any mutation.
+        assert!(matches!(
+            exec.arm_overlap(0, 3).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+        // The correct epoch works.
+        exec.arm_overlap(shadow.epoch, 3).await.unwrap();
+    }
+
+    /// AC1 config guard: the illegal both-non-enforcing combo and an
+    /// out-of-range cap are rejected up front.
+    #[tokio::test]
+    async fn forward_rejects_illegal_config_up_front() {
+        let exec = executor().await;
+        // Cap out of range.
+        assert!(matches!(
+            exec.arm_shadow(0, 0).await,
+            Err(TransitionError::InvalidConfig(_))
+        ));
+        assert!(matches!(
+            exec.arm_shadow(0, 1_000_000).await,
+            Err(TransitionError::InvalidConfig(_))
+        ));
+    }
+
+    /// AC2: the rollback executor confirms v0 Enforce with replica acks before
+    /// any transaction lifts/disables v1 quota; if v0 confirmation fails it
+    /// halts with both authorities enforcing and never disables v1.
+    #[tokio::test]
+    async fn rollback_halts_with_both_enforcing_when_v0_unconfirmed() {
+        let exec = executor().await;
+        let primary = cutover(&exec, 3, &[]).await;
+        // Post-cutover: move v0 to observe (v1 primary).
+        let observed = exec.observe_v0(primary.epoch).await.unwrap();
+        assert_eq!(observed.v0_mode, V0Mode::Observe);
+
+        // Begin rollback at a same-or-lower cap: v0 back to Enforce, both enforce.
+        let armed = exec.arm_rollback(observed.epoch, 2).await.unwrap();
+        assert_eq!(armed.v0_mode, V0Mode::Enforce);
+        assert_eq!(armed.v1_mode, V1Mode::Enforce);
+        assert_eq!(armed.cap, Some(2));
+
+        // v0 not yet confirmed (leader has not acked): the rollback HALTS and
+        // makes no mutation — both authorities remain enforcing.
+        assert!(matches!(
+            exec.enter_rollback_overlap(armed.epoch).await,
+            Err(TransitionError::HaltedV0Unconfirmed { .. })
+        ));
+        let after_halt = exec.show().await.unwrap().unwrap();
+        assert_eq!(after_halt.epoch, armed.epoch, "halt made no mutation");
+        assert_eq!(after_halt.v0_mode, V0Mode::Enforce);
+        assert_eq!(after_halt.v1_mode, V1Mode::Enforce);
+
+        // Once v0 is confirmed (leader acks), the rollback proceeds.
+        leader_acks_emergency(&exec).await;
+        let overlap = exec.enter_rollback_overlap(armed.epoch).await.unwrap();
+        assert_eq!(overlap.phase, AdmissionHandoffPhase::RollbackOverlap);
+
+        // Completing the rollback needs v0 re-confirmed at the overlap epoch.
+        assert!(matches!(
+            exec.complete_rollback(overlap.epoch).await,
+            Err(TransitionError::AwaitingEmergencyAck { .. })
+        ));
+        leader_acks_emergency(&exec).await;
+        let baseline = exec.complete_rollback(overlap.epoch).await.unwrap();
+        assert_eq!(baseline.phase, AdmissionHandoffPhase::EmergencyPrimary);
+        assert_eq!(baseline.v0_mode, V0Mode::Enforce);
+        assert_eq!(
+            baseline.v1_mode,
+            V1Mode::Off,
+            "v1 disabled only after v0 confirmed"
+        );
+    }
+
+    /// AC2 cap guard: a rollback must not raise the cap.
+    #[tokio::test]
+    async fn rollback_rejects_a_higher_cap() {
+        let exec = executor().await;
+        let primary = cutover(&exec, 3, &[]).await;
+        let observed = exec.observe_v0(primary.epoch).await.unwrap();
+        assert!(matches!(
+            exec.arm_rollback(observed.epoch, 4).await,
+            Err(TransitionError::CapNotSameOrLower {
+                requested: 4,
+                current: 3
+            })
+        ));
+    }
+
+    /// AC3: a cap change and a phase advance cannot interleave into a
+    /// contradictory committed state — the second CAS against the now-stale
+    /// epoch is rejected as an InvalidTransition.
+    #[tokio::test]
+    async fn cap_change_and_phase_advance_do_not_interleave() {
+        let exec = executor().await;
+        // Reach a ForwardOverlap so both a cap change and an advance are legal.
+        let shadow = exec.arm_shadow(0, 3).await.unwrap();
+        let overlap_modes = exec.arm_overlap(shadow.epoch, 3).await.unwrap();
+        leader_acks_emergency(&exec).await;
+        let overlap = exec
+            .enter_forward_overlap(overlap_modes.epoch)
+            .await
+            .unwrap();
+        leader_acks_emergency(&exec).await;
+        let observed_epoch = exec.show().await.unwrap().unwrap().epoch;
+        assert_eq!(observed_epoch, overlap.epoch);
+
+        // A cap change commits first and bumps the epoch.
+        let recapped = exec.set_cap(observed_epoch, 2).await.unwrap();
+        assert_eq!(recapped.cap, Some(2));
+        assert_eq!(recapped.epoch, observed_epoch + 1);
+
+        // An advance from the now-stale observed epoch is rejected: the two
+        // mutations serialized and did not interleave.
+        assert!(matches!(
+            exec.commit_invocation_primary(observed_epoch, &[]).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+
+        // And the reverse ordering: an advance first makes a stale cap change fail.
+        let exec2 = executor().await;
+        let shadow2 = exec2.arm_shadow(0, 3).await.unwrap();
+        let stale = shadow2.epoch;
+        // A phase-adjacent mutation (arm_overlap) commits at `stale`.
+        exec2.arm_overlap(stale, 3).await.unwrap();
+        // A cap change against the pre-advance epoch is now stale.
+        assert!(matches!(
+            exec2.set_cap(stale, 2).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+    }
+
+    /// A kill-switch initiated directly from invocation-primary (v0 already
+    /// enforcing) confirms v0 and disables v1 through the same safe ordering.
+    #[tokio::test]
+    async fn kill_switch_from_invocation_primary_disables_v1_after_confirming_v0() {
+        let exec = executor().await;
+        let primary = cutover(&exec, 3, &[]).await;
+        // Do NOT observe_v0: v0 is still Enforce from the overlap. Kill-switch
+        // re-commits both-enforce at a same cap, then rolls back.
+        let armed = exec.arm_rollback(primary.epoch, 3).await.unwrap();
+        leader_acks_emergency(&exec).await;
+        let overlap = exec.enter_rollback_overlap(armed.epoch).await.unwrap();
+        leader_acks_emergency(&exec).await;
+        let baseline = exec.complete_rollback(overlap.epoch).await.unwrap();
+        assert_eq!(baseline.phase, AdmissionHandoffPhase::EmergencyPrimary);
+        assert_eq!(baseline.v1_mode, V1Mode::Off);
+        assert_eq!(baseline.v0_mode, V0Mode::Enforce);
+    }
+}

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -50,6 +50,9 @@ pub mod audit_sampler;
 pub mod build_admission;
 pub mod build_admission_handoff;
 pub mod build_admission_inventory;
+/// Operator safe-ordering executor composing the durable epoch primitives into
+/// forward-cutover, kill-switch, and rollback workflows.
+pub mod build_admission_transition;
 /// Durable v1 lease service; v0 admission remains rollout authority.
 pub mod build_lease;
 pub mod cargo_warm_base_gc;

--- a/server/src/admin.rs
+++ b/server/src/admin.rs
@@ -1,0 +1,229 @@
+//! One-shot operator admin commands.
+//!
+//! These are short-circuit modes of the server binary (like `--migrate-only`):
+//! they open the database, perform one operation, render a result, and exit
+//! before any actor, listener, or background task starts. The rendered `String`
+//! is returned to `main`, which prints it — this module performs no I/O to
+//! stdout/stderr itself so the coordinator lint budget stays clean.
+//!
+//! The `epoch` subtree drives the Build Leases v1 admission-epoch rollout through
+//! [`AdmissionTransitionExecutor`], the safe-ordering executor. Each `advance` /
+//! `rollback` / `kill-switch` invocation performs exactly one epoch-fenced step
+//! from the current durable state and reports what it did or what it is waiting
+//! on, so an operator (or the runbook) re-runs the command as controller and
+//! generation acknowledgements land.
+
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+use djinn_coordinator::build_admission_transition::{AdmissionTransitionExecutor, TransitionError};
+use djinn_db::{
+    AdmissionHandoffPhase, AdmissionHandoffRepository, AdmissionHandoffRow, Database, V0Mode,
+    V1Mode,
+};
+
+/// Top-level operator admin commands.
+#[derive(clap::Subcommand, Debug)]
+pub enum AdminCommand {
+    /// Admission-epoch operator commands (Build Leases v1 rollout).
+    Epoch {
+        #[command(subcommand)]
+        action: EpochAction,
+    },
+}
+
+/// Admission-epoch operator actions.
+#[derive(clap::Subcommand, Debug)]
+pub enum EpochAction {
+    /// Print the durable epoch row and its derived handoff state.
+    Show,
+    /// Perform the next safe FORWARD step: arm shadow → arm overlap → enter
+    /// overlap → commit invocation-primary → observe v0.
+    Advance {
+        /// Reference cap for an arming step; defaults to the current cap.
+        #[arg(long)]
+        cap: Option<i64>,
+        /// Live generation keys that must acknowledge before invocation-primary.
+        #[arg(long = "generation")]
+        generations: Vec<String>,
+    },
+    /// Change the reference cap (epoch-fenced; serializes with the handoff edge).
+    SetCap {
+        #[arg(long)]
+        cap: i64,
+    },
+    /// Perform the next safe ROLLBACK step from invocation-primary.
+    Rollback {
+        /// Same-or-lower cap for the rollback arm; defaults to the current cap.
+        #[arg(long)]
+        cap: Option<i64>,
+    },
+    /// Urgent rollback from invocation-primary — the same safe ordering as
+    /// `rollback`, initiated while v0 is still enforcing from the overlap.
+    KillSwitch {
+        /// Same-or-lower cap for the rollback arm; defaults to the current cap.
+        #[arg(long)]
+        cap: Option<i64>,
+    },
+}
+
+/// Run an admin command against `db`, returning a rendered result to print.
+///
+/// A returned `Err` is a genuine failure (invalid transition, invalid config,
+/// storage error) that should exit non-zero. Expected "waiting" and "halted"
+/// outcomes are folded into the `Ok` rendering so an operator polling the command
+/// sees them without a non-zero exit.
+pub async fn run_admin_command(db: &Database, command: AdminCommand) -> Result<String, String> {
+    let repo = Arc::new(AdmissionHandoffRepository::new(db.clone()));
+    let exec = AdmissionTransitionExecutor::new(repo);
+    match command {
+        AdminCommand::Epoch { action } => run_epoch_action(&exec, action).await,
+    }
+}
+
+async fn run_epoch_action(
+    exec: &AdmissionTransitionExecutor,
+    action: EpochAction,
+) -> Result<String, String> {
+    match action {
+        EpochAction::Show => {
+            let row = exec.show().await.map_err(|e| e.to_string())?;
+            Ok(render_show(row.as_ref()))
+        }
+        EpochAction::SetCap { cap } => {
+            let row = require_row(exec).await?;
+            fold(exec.set_cap(row.epoch, cap).await, "set-cap")
+        }
+        EpochAction::Advance { cap, generations } => advance_forward(exec, cap, &generations).await,
+        EpochAction::Rollback { cap } | EpochAction::KillSwitch { cap } => {
+            advance_rollback(exec, cap).await
+        }
+    }
+}
+
+async fn require_row(exec: &AdmissionTransitionExecutor) -> Result<AdmissionHandoffRow, String> {
+    exec.show()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "admission handoff row is absent".to_string())
+}
+
+/// Drive the next forward step from the current durable state.
+async fn advance_forward(
+    exec: &AdmissionTransitionExecutor,
+    cap: Option<i64>,
+    generations: &[String],
+) -> Result<String, String> {
+    let row = require_row(exec).await?;
+    let epoch = row.epoch;
+    match (row.phase, row.v0_mode, row.v1_mode) {
+        (AdmissionHandoffPhase::EmergencyPrimary, _, V1Mode::Off) => {
+            let cap = resolve_cap(cap, row.cap)?;
+            fold(exec.arm_shadow(epoch, cap).await, "arm-shadow")
+        }
+        (AdmissionHandoffPhase::EmergencyPrimary, _, V1Mode::Shadow) => {
+            let cap = resolve_cap(cap, row.cap)?;
+            fold(exec.arm_overlap(epoch, cap).await, "arm-overlap")
+        }
+        (AdmissionHandoffPhase::EmergencyPrimary, _, V1Mode::Enforce) => fold(
+            exec.enter_forward_overlap(epoch).await,
+            "enter-forward-overlap",
+        ),
+        (AdmissionHandoffPhase::ForwardOverlap, _, _) => fold(
+            exec.commit_invocation_primary(epoch, generations).await,
+            "commit-invocation-primary",
+        ),
+        (AdmissionHandoffPhase::InvocationPrimary, V0Mode::Enforce, _) => {
+            fold(exec.observe_v0(epoch).await, "observe-v0")
+        }
+        (AdmissionHandoffPhase::InvocationPrimary, _, _) => {
+            Ok("forward cutover complete: invocation-primary with v0 observing".to_string())
+        }
+        (phase, _, _) => Err(format!("no forward step is defined from phase {phase:?}")),
+    }
+}
+
+/// Drive the next rollback step from the current durable state.
+async fn advance_rollback(
+    exec: &AdmissionTransitionExecutor,
+    cap: Option<i64>,
+) -> Result<String, String> {
+    let row = require_row(exec).await?;
+    let epoch = row.epoch;
+    match row.phase {
+        AdmissionHandoffPhase::InvocationPrimary => {
+            let both_enforce = row.v0_mode == V0Mode::Enforce && row.v1_mode == V1Mode::Enforce;
+            if both_enforce {
+                fold(
+                    exec.enter_rollback_overlap(epoch).await,
+                    "enter-rollback-overlap",
+                )
+            } else {
+                let cap = resolve_cap(cap, row.cap)?;
+                fold(exec.arm_rollback(epoch, cap).await, "arm-rollback")
+            }
+        }
+        AdmissionHandoffPhase::RollbackOverlap => {
+            fold(exec.complete_rollback(epoch).await, "complete-rollback")
+        }
+        AdmissionHandoffPhase::EmergencyPrimary if row.v1_mode == V1Mode::Off => {
+            Ok("rollback complete: emergency-primary baseline (v0 enforce, v1 off)".to_string())
+        }
+        phase => Err(format!("no rollback step is defined from phase {phase:?}")),
+    }
+}
+
+/// Use the requested cap, or fall back to the current durable cap; error when
+/// neither is available (an arming step must have a concrete cap).
+fn resolve_cap(requested: Option<i64>, current: Option<i64>) -> Result<i64, String> {
+    requested
+        .or(current)
+        .ok_or_else(|| "this step needs a cap; pass --cap N".to_string())
+}
+
+/// Fold a step result: success and the expected waiting/halted outcomes render
+/// to `Ok`; genuine failures render to `Err`.
+fn fold(
+    result: Result<AdmissionHandoffRow, TransitionError>,
+    step: &str,
+) -> Result<String, String> {
+    match result {
+        Ok(row) => Ok(format!("{step}: applied\n{}", render_show(Some(&row)))),
+        Err(err @ TransitionError::AwaitingEmergencyAck { .. })
+        | Err(err @ TransitionError::AwaitingGenerationAcks { .. })
+        | Err(err @ TransitionError::HaltedV0Unconfirmed { .. }) => {
+            Ok(format!("{step}: waiting — {err}"))
+        }
+        Err(err) => Err(format!("{step}: {err}")),
+    }
+}
+
+fn render_show(row: Option<&AdmissionHandoffRow>) -> String {
+    let Some(row) = row else {
+        return "admission handoff row: <absent>".to_string();
+    };
+    let mut out = String::new();
+    let _ = writeln!(out, "phase                 {:?}", row.phase);
+    let _ = writeln!(out, "epoch                 {}", row.epoch);
+    let _ = writeln!(out, "v0_mode               {:?}", row.v0_mode);
+    let _ = writeln!(out, "v1_mode               {:?}", row.v1_mode);
+    let _ = writeln!(
+        out,
+        "cap                   {}",
+        row.cap
+            .map_or_else(|| "<unset>".to_string(), |c| c.to_string())
+    );
+    let _ = writeln!(
+        out,
+        "emergency_ack_epoch   {}",
+        row.emergency_ack_epoch
+            .map_or_else(|| "<none>".to_string(), |e| e.to_string())
+    );
+    let _ = write!(
+        out,
+        "invocation_ack_epoch  {}",
+        row.invocation_ack_epoch
+            .map_or_else(|| "<none>".to_string(), |e| e.to_string())
+    );
+    out
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(unreachable_pub)]
 
+pub mod admin;
 pub mod allocator;
 pub mod codex_keepalive;
 pub mod db;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -81,6 +81,13 @@ struct Cli {
     /// This exits before logging, telemetry, Tokio, or database startup.
     #[arg(long, default_value_t = false)]
     allocator_settings: bool,
+
+    /// One-shot operator admin command. When present the process opens the
+    /// database, runs the command, prints its result, and exits before any
+    /// actor or listener starts — the same short-circuit shape as
+    /// `--migrate-only`.
+    #[command(subcommand)]
+    admin: Option<djinn_server::admin::AdminCommand>,
 }
 
 #[allow(clippy::print_stderr)] // Startup validation errors must be visible before logging initializes.
@@ -138,6 +145,11 @@ fn report_allocator_settings() {
         eprintln!("effective jemalloc settings are only available on Linux");
         std::process::exit(1);
     }
+}
+
+#[allow(clippy::print_stdout)] // One-shot operator admin output is written to stdout by design.
+fn print_admin_result(rendered: &str) {
+    println!("{rendered}");
 }
 
 async fn async_main(cli: Cli) {
@@ -281,6 +293,25 @@ async fn async_main(cli: Cli) {
         );
         db.pool().close().await;
         std::process::exit(1);
+    }
+
+    // ── Operator admin short-circuit ──────────────────────────────────
+    // Like `--migrate-only`: run one operator command against the current
+    // schema, print the result, and exit before any actor or listener starts.
+    if let Some(admin) = cli.admin {
+        let result = djinn_server::admin::run_admin_command(&db, admin).await;
+        db.pool().close().await;
+        match result {
+            Ok(rendered) => {
+                print_admin_result(&rendered);
+                return;
+            }
+            Err(error) => {
+                tracing::error!(%error, "admin command failed");
+                print_admin_result(&format!("error: {error}"));
+                std::process::exit(1);
+            }
+        }
     }
 
     // Resolve canonical settings before application composition. Present malformed


### PR DESCRIPTION
Composes the durable admission-epoch primitives (`set_modes_and_cap` + `acknowledge` + `advance` from icvs/keoq) into the operator rollout workflows, adds the operator CLI, and ships the diagnostics runbook epic 23or requires. Lands after keoq's runtime wiring; re-implements no fencing.

## Executor (`djinn-coordinator/src/build_admission_transition.rs`)
`AdmissionTransitionExecutor` beside `build_admission_handoff.rs`:
- **Forward**: `arm_shadow` → `arm_overlap` → `enter_forward_overlap` → `commit_invocation_primary` → `observe_v0`. Reaches `invocation_primary` only after modes/cap and **every armed live-generation ack** are committed. Stale-epoch / illegal-edge attempts return `InvalidTransition`.
- **Reverse (kill-switch/rollback)**: `arm_rollback` (commit v0 `Enforce` at a same-or-lower cap) → `enter_rollback_overlap` (**halts with both authorities enforcing** unless v0 is confirmed with a controller-replica ack; never disables v1) → `complete_rollback` (disables v1 only after v0 is re-confirmed).
- Cap changes go through the same epoch-fenced CAS as the handoff edge, so a cap change and a phase advance cannot interleave into a contradictory committed state.

The executor waits for the v0 (emergency) authority ack written by the coordinator leader's live handoff loop; it records the v1 (invocation) authority ack as it drives each transition (v1 has no separate runtime acking entity — agents read the epoch directly).

## Operator CLI (`djinn-server/src/admin.rs`, wired in `main.rs`)
`djinn-server epoch show | advance | set-cap | rollback | kill-switch` — one-shot admin modes (like `--migrate-only`) that perform one safe step and report what they are waiting on. No agent-facing tool schema touched, so no golden regeneration.

## Runbook (`docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md`)
Covers fail-closed suspect rows + forced exact-UID deletion, graph-warm candidate cleanup, cap-zero drain, stale epochs, and unsupported node/runtime readiness, each pointing at the real command/seam. Also documents the deferred shadow `would_throttle` wiring for u2oz.

## Tests
7 new executor tests (all 77 `build_admission*` lib tests green) cover: forward-to-invocation-primary gated on all generation acks; edge-skip and stale-epoch rejection; illegal-config rejection; rollback halt-with-both-enforcing when v0 unconfirmed; rollback same-or-lower cap guard; cap-change/advance non-interleaving; kill-switch. Gates: fmt, clippy (touched crates, `--all-targets`), `SQLX_OFFLINE=1 cargo check --workspace --all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)