### PR TITLE
chore(rmxn): ri23 Part 2 — warm-dispatch freshness gate and per-project seed telemetry

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -407,7 +407,11 @@ fn set_cargo_target_dir_for_children(destination: &Path) {
     unsafe { std::env::set_var(CARGO_TARGET_DIR_ENV, destination) };
 }
 
-fn record_cargo_target_seed_result(seed_context: &'static str, result: &CargoTargetSeedResult) {
+fn record_cargo_target_seed_result(
+    seed_context: &'static str,
+    project_id: &str,
+    result: &CargoTargetSeedResult,
+) {
     let seed_outcome = if result.cold_started() {
         "fallback"
     } else {
@@ -419,8 +423,15 @@ fn record_cargo_target_seed_result(seed_context: &'static str, result: &CargoTar
         ""
     };
 
-    if !result.cold_started() {
+    if result.cold_started() {
+        // Light up the previously-dark per-project cold counter at the seed
+        // decision. The bounded reason label is the same closed
+        // `FALLBACK_REASON_*` value used by the global seed metric.
+        cargo_metrics::record_seed_cold(project_id, fallback_reason);
+    } else {
         djinn_telemetry::cargo_target_seed::increment_seed_hit();
+        // Light up the previously-dark per-project seed-hit counter.
+        cargo_metrics::record_seed_hit(project_id);
     }
 
     info!(
@@ -604,7 +615,7 @@ async fn prepare_cargo_target_dir(spec: &TaskRunSpec, workspace_path: &Path) -> 
     record_seed_terminal_seconds(seed_elapsed, SeedAttemptTerminal::Join(&seed_join_result));
     match seed_join_result {
         Ok(Ok(result)) => {
-            record_cargo_target_seed_result("task_run", &result);
+            record_cargo_target_seed_result("task_run", &spec.project_id, &result);
             let fallback_reason = result
                 .fallback_reason
                 .as_ref()
@@ -666,6 +677,10 @@ async fn prepare_cargo_target_dir(spec: &TaskRunSpec, workspace_path: &Path) -> 
             djinn_telemetry::cargo_target_seed::increment_seed_fallback(
                 djinn_telemetry::cargo_target_seed::FALLBACK_REASON_UNKNOWN,
             );
+            cargo_metrics::record_seed_cold(
+                &spec.project_id,
+                djinn_telemetry::cargo_target_seed::FALLBACK_REASON_UNKNOWN,
+            );
             let fallback_reason = format!("seed helper failed: {err}");
             info!(
                 task_run_id = %spec.task_run_id,
@@ -692,6 +707,10 @@ async fn prepare_cargo_target_dir(spec: &TaskRunSpec, workspace_path: &Path) -> 
         }
         Err(err) => {
             djinn_telemetry::cargo_target_seed::increment_seed_fallback(
+                djinn_telemetry::cargo_target_seed::FALLBACK_REASON_UNKNOWN,
+            );
+            cargo_metrics::record_seed_cold(
+                &spec.project_id,
                 djinn_telemetry::cargo_target_seed::FALLBACK_REASON_UNKNOWN,
             );
             let fallback_reason = format!("seed task join failed: {err}");
@@ -4203,6 +4222,105 @@ warning: something
             "ok seed sum delta must equal elapsed"
         );
         assert_no_seed_identity_labels(&after);
+    }
+
+    /// Read a labeled counter sample value, or 0.0 when absent.
+    fn labeled_counter(rendered: &str, metric: &str, labels: &[(&str, &str)]) -> f64 {
+        rendered
+            .lines()
+            .find(|line| {
+                line.starts_with(metric)
+                    && labels
+                        .iter()
+                        .all(|(k, v)| line.contains(&format!("{k}=\"{v}\"")))
+            })
+            .and_then(|line| line.rsplit_once(' ').and_then(|(_, v)| v.parse().ok()))
+            .unwrap_or(0.0)
+    }
+
+    /// The seed decision must light the previously-dark per-project seed
+    /// counters: a hit increments `djinn_cargo_seed_hit_total{project_id}`, and
+    /// a cold-start fallback increments
+    /// `djinn_cargo_seed_cold_total{project_id, fallback_reason}` with the
+    /// bounded reason label — each exactly once.
+    #[test]
+    fn record_seed_result_lights_per_project_hit_and_cold_counters() {
+        let _guard = seed_telemetry_guard();
+        djinn_telemetry::init().expect("telemetry init");
+
+        let hit_project = "rmxn-seed-hit-project";
+        let cold_project = "rmxn-seed-cold-project";
+
+        let before = djinn_telemetry::render().expect("render before");
+        let hit_before = labeled_counter(
+            &before,
+            djinn_telemetry::cargo_cache::SEED_HIT_TOTAL,
+            &[("project_id", hit_project)],
+        );
+        let cold_reason = djinn_telemetry::cargo_target_seed::FALLBACK_REASON_BASE_MISSING;
+        let cold_before = labeled_counter(
+            &before,
+            djinn_telemetry::cargo_cache::SEED_COLD_TOTAL,
+            &[
+                ("project_id", cold_project),
+                ("fallback_reason", cold_reason),
+            ],
+        );
+
+        let hit_result = CargoTargetSeedResult {
+            elapsed: Duration::from_millis(5),
+            linked_file_count: 1,
+            copied_file_count: 0,
+            skipped_file_count: 0,
+            linked_bytes: 10,
+            copied_bytes: 0,
+            fallback_reason: None,
+        };
+        let cold_result = CargoTargetSeedResult {
+            elapsed: Duration::from_millis(5),
+            linked_file_count: 0,
+            copied_file_count: 0,
+            skipped_file_count: 0,
+            linked_bytes: 0,
+            copied_bytes: 0,
+            fallback_reason: Some(CargoTargetSeedFallback::BaseMissing),
+        };
+
+        record_cargo_target_seed_result("task_run", hit_project, &hit_result);
+        record_cargo_target_seed_result("task_run", cold_project, &cold_result);
+
+        let after = djinn_telemetry::render().expect("render after");
+        assert_eq!(
+            labeled_counter(
+                &after,
+                djinn_telemetry::cargo_cache::SEED_HIT_TOTAL,
+                &[("project_id", hit_project)],
+            ),
+            hit_before + 1.0,
+            "seed hit must light the per-project hit counter exactly once"
+        );
+        assert_eq!(
+            labeled_counter(
+                &after,
+                djinn_telemetry::cargo_cache::SEED_COLD_TOTAL,
+                &[
+                    ("project_id", cold_project),
+                    ("fallback_reason", cold_reason)
+                ],
+            ),
+            cold_before + 1.0,
+            "cold fallback must light the per-project cold counter with the bounded reason once"
+        );
+        // A hit must never touch the cold counter for its project.
+        assert_eq!(
+            labeled_counter(
+                &after,
+                djinn_telemetry::cargo_cache::SEED_COLD_TOTAL,
+                &[("project_id", hit_project)],
+            ),
+            0.0,
+            "a seed hit must not increment the cold counter"
+        );
     }
 
     /// A cold-start fallback seed (missing base) records exactly one `ok`

--- a/server/crates/djinn-coordinator/src/dispatch/mod.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/mod.rs
@@ -17,6 +17,10 @@ pub mod resume_source;
 mod retry;
 pub(crate) mod session_recovery;
 mod task_dispatch;
+/// Pre-pod-allocation warm build-cache freshness gate (ri23 Part 2). Reads warm
+/// freshness facts, bounds the wait, and labels the dispatch decision without
+/// owning any warm state.
+pub(crate) mod warm_dispatch_gate;
 mod wave_dispatch;
 
 #[cfg(test)]

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -1708,6 +1708,39 @@ impl CoordinatorActor {
         false
     }
 
+    /// Optional warm build-cache freshness probe (proposal ri23 Part 2).
+    ///
+    /// Returns the warm-substrate probe when one is wired. It is `None` today:
+    /// the warm substrate — which owns inventory / warming / freshness /
+    /// eviction / seeding — has not yet exposed a coordinator-facing probe, so
+    /// the pre-allocation gate is a no-op and dispatch proceeds unchanged. When
+    /// the substrate lands a probe, this is the single seam that lights the gate;
+    /// the dispatch loop below already calls it before pod allocation.
+    fn warm_build_cache_probe(
+        &self,
+    ) -> Option<Arc<dyn super::warm_dispatch_gate::WarmBuildCacheProbe>> {
+        None
+    }
+
+    /// Resolved compile-mode for a project's warm build cache. Defaults to
+    /// `Compile`; the gate only runs when a probe is wired, and the substrate's
+    /// probe remains authoritative for freshness and identity. A future
+    /// stack-aware resolver can return `None` for non-compile stacks so the gate
+    /// bypasses entirely.
+    fn warm_compile_mode_for(&self, _project_id: &str) -> super::warm_dispatch_gate::CompileMode {
+        super::warm_dispatch_gate::CompileMode::Compile
+    }
+
+    /// Resolved environment-identity token the warm base must match to be a hit.
+    ///
+    /// The warm substrate owns the canonical identity; this only threads it to
+    /// the probe, which performs the comparison. Empty until a substrate-defined
+    /// resolver is wired (the probe is `None` until then, so the gate never runs
+    /// with a placeholder identity).
+    fn warm_cache_environment_identity(&self, _project_id: &str) -> String {
+        String::new()
+    }
+
     /// Find all ready tasks (open, no unresolved blockers, non-epic) and dispatch
     /// those that don't already have an active session.
     #[tracing::instrument(
@@ -2923,6 +2956,33 @@ impl CoordinatorActor {
                         std::time::Duration::from_secs(45),
                     )
                     .await;
+            }
+
+            // ri23 Part 2: pre-pod-allocation warm build-cache freshness gate.
+            // Mirrors the architect graph gate above, but for the per-project
+            // warm Cargo build cache. When the warm substrate has wired a
+            // probe, this bounds the wait for a fresh cache and labels the
+            // decision; otherwise it is a best-effort no-op. The task-run pod is
+            // still allocated exactly once below, regardless of the decision.
+            if let Some(warm_probe) = self.warm_build_cache_probe() {
+                let identity = super::warm_dispatch_gate::WarmCacheIdentity {
+                    project_id: task.project_id.clone(),
+                    environment_identity: self.warm_cache_environment_identity(&task.project_id),
+                };
+                let decision = super::warm_dispatch_gate::WarmDispatchGate::default()
+                    .decide_and_record(
+                        self.warm_compile_mode_for(&task.project_id),
+                        warm_probe.as_ref(),
+                        &identity,
+                        &SystemClock::new(),
+                    )
+                    .await;
+                tracing::debug!(
+                    task_id = %task.short_id,
+                    project_id = %task.project_id,
+                    warm_hit = decision.is_warm_hit(),
+                    "CoordinatorActor: warm build-cache dispatch gate decision"
+                );
             }
 
             let build_admission = match self

--- a/server/crates/djinn-coordinator/src/dispatch/warm_dispatch_gate.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/warm_dispatch_gate.rs
@@ -1,0 +1,278 @@
+//! Pre-pod-allocation warm build-cache freshness gate (proposal ri23 Part 2).
+//!
+//! Mirrors the bounded-wait / single-flight / timeout-best-effort shape of
+//! `djinn_agent::warmer::InProcessGraphWarmer::await_fresh` (already used in
+//! this dispatcher for the canonical graph cache), but for the per-project warm
+//! Cargo build-cache. Before a task-run pod is allocated the dispatcher asks
+//! this gate whether the warm build cache is fresh for the resolved environment
+//! identity:
+//!
+//! - a compile-mode stack whose cache is fresh allocates immediately;
+//! - a `CompileMode::None` (no-compile) stack bypasses the gate entirely;
+//! - a missing/stale cache triggers a single-flight warm and waits, but only up
+//!   to the configured bound;
+//! - a bound timeout, an inventory-probe error, or a warmer-trigger error each
+//!   cold-dispatches exactly once and records a bounded project+reason metric.
+//!
+//! Ownership boundary: the warm substrate owns inventory / warming / freshness /
+//! eviction / seeding. This gate only READS freshness facts through the
+//! [`WarmBuildCacheProbe`] trait, decides whether to wait, labels the decision,
+//! and lets the caller allocate exactly once afterwards. It never mutates warm
+//! state. This is a distinct pre-allocation seam from the worker-runtime
+//! `prepare_build_cache` seeding path (sibling `1bnj`).
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_core::clock::Clock;
+use djinn_runtime::WarmerError;
+use djinn_telemetry::warm_cache::{Outcome, Reason};
+
+/// Poll interval while waiting for a background warm to make the cache fresh.
+/// Matches `InProcessGraphWarmer::await_fresh`'s cadence: well below any
+/// realistic warm completion time while keeping the probe cheap.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Default bounded wait for a warm build cache to go fresh before the gate
+/// gives up and cold-dispatches. Same order as the architect graph gate (45s).
+pub const DEFAULT_WAIT_BOUND: Duration = Duration::from_secs(45);
+
+/// Whether a task's stack has a compile step the warm build cache can serve.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CompileMode {
+    /// A compile-mode stack (e.g. a Cargo workspace) — the gate applies.
+    Compile,
+    /// No compile step — the gate is bypassed and the run allocates directly.
+    None,
+}
+
+/// A freshness fact READ from the warm substrate for a resolved identity.
+///
+/// Variants are constructed by [`WarmBuildCacheProbe`] implementations: the
+/// contract-test fake today, and the warm substrate's coordinator-facing probe
+/// once it is wired (see [`super::task_dispatch`]'s `warm_build_cache_probe`
+/// seam). Until that production impl lands, the non-test build constructs none
+/// of them, so dead-code analysis is suppressed for this not-yet-wired seam.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WarmFreshness {
+    /// Present, within the age policy, and built for the resolved identity.
+    Fresh,
+    /// Present but outside the age policy (or otherwise not usable as-is).
+    Stale,
+    /// No warm base exists for this identity.
+    Missing,
+}
+
+/// The warm inventory probe failed to determine freshness. Carries a bounded
+/// human string for logs only — it never becomes a metric label.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WarmProbeError(pub String);
+
+impl std::fmt::Display for WarmProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "warm inventory probe error: {}", self.0)
+    }
+}
+
+/// The resolved environment identity a warm base must match to be a hit.
+///
+/// The freshness comparison against this identity happens INSIDE the probe (the
+/// warm substrate owns the notion of identity); the gate merely threads it
+/// through. A probe that ignores identity, or reports `Fresh` for a mismatched
+/// identity, is a substrate bug the gate cannot paper over — but the gate never
+/// upgrades a non-`Fresh` observation to fresh, so a mismatch reported as
+/// `Stale`/`Missing` is never treated as fresh here.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WarmCacheIdentity {
+    pub project_id: String,
+    /// Opaque, substrate-defined identity token (e.g. image + toolchain +
+    /// mold-jobs variant digest). Compared for equality by the probe.
+    pub environment_identity: String,
+}
+
+/// Reads warm build-cache freshness facts and single-flight-triggers a warm.
+///
+/// Implemented by the warm substrate (production) and by a scripted fake (the
+/// contract test). Both methods are identity-scoped so freshness always answers
+/// "fresh FOR THIS resolved environment identity".
+#[async_trait]
+pub trait WarmBuildCacheProbe: Send + Sync {
+    /// Read the current freshness of the warm base for `identity`.
+    async fn probe(&self, identity: &WarmCacheIdentity) -> Result<WarmFreshness, WarmProbeError>;
+
+    /// Single-flight-trigger a warm for `identity`. Safe to call repeatedly;
+    /// the substrate coalesces concurrent triggers for the same identity.
+    async fn trigger(&self, identity: &WarmCacheIdentity) -> Result<(), WarmerError>;
+}
+
+/// Why the gate cold-dispatched instead of allocating against a warm cache.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ColdReason {
+    /// The bounded wait elapsed without the cache going fresh.
+    Timeout,
+    /// A freshness probe returned an inventory error.
+    InventoryError,
+    /// The single-flight warm trigger returned an error.
+    WarmerError,
+}
+
+/// The terminal decision the gate reached for one dispatch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WarmDispatchDecision {
+    /// No-compile stack: the gate was bypassed.
+    Bypass,
+    /// The cache was fresh on the first probe.
+    FreshImmediate,
+    /// The cache was `initial` (stale/missing), then went fresh within bound.
+    WaitedFresh { initial: WarmFreshness },
+    /// The gate gave up and cold-dispatched.
+    ColdDispatch { reason: ColdReason },
+}
+
+impl WarmDispatchDecision {
+    /// `true` when the run should allocate against a warm cache (a hit). Cold
+    /// dispatch and bypass still allocate — this only distinguishes the
+    /// warm-served path.
+    pub fn is_warm_hit(self) -> bool {
+        matches!(self, Self::FreshImmediate | Self::WaitedFresh { .. })
+    }
+
+    /// Map the decision to its closed `(outcome, reason)` telemetry labels.
+    ///
+    /// - fresh / waited-fresh → `hit` with the reason it started from;
+    /// - cold dispatch → `cold` with the failure reason;
+    /// - bypass → `fallback` with `no_compile` (never `cold`).
+    pub fn telemetry_labels(self) -> (Outcome, Reason) {
+        match self {
+            Self::Bypass => (Outcome::Fallback, Reason::NoCompile),
+            Self::FreshImmediate => (Outcome::Hit, Reason::Fresh),
+            Self::WaitedFresh {
+                initial: WarmFreshness::Stale,
+            } => (Outcome::Hit, Reason::Stale),
+            Self::WaitedFresh {
+                initial: WarmFreshness::Missing,
+            } => (Outcome::Hit, Reason::Missing),
+            // A `WaitedFresh` can only start from stale/missing; treat the
+            // impossible fresh-initial case as a plain fresh hit.
+            Self::WaitedFresh {
+                initial: WarmFreshness::Fresh,
+            } => (Outcome::Hit, Reason::Fresh),
+            Self::ColdDispatch {
+                reason: ColdReason::Timeout,
+            } => (Outcome::Cold, Reason::Timeout),
+            Self::ColdDispatch {
+                reason: ColdReason::InventoryError,
+            } => (Outcome::Cold, Reason::InventoryError),
+            Self::ColdDispatch {
+                reason: ColdReason::WarmerError,
+            } => (Outcome::Cold, Reason::WarmerError),
+        }
+    }
+}
+
+/// Bounded warm build-cache freshness gate.
+#[derive(Clone, Copy, Debug)]
+pub struct WarmDispatchGate {
+    /// Maximum time to wait for a missing/stale cache to go fresh.
+    pub wait_bound: Duration,
+    /// Freshness re-probe cadence during the bounded wait.
+    pub poll_interval: Duration,
+}
+
+impl Default for WarmDispatchGate {
+    fn default() -> Self {
+        Self::new(DEFAULT_WAIT_BOUND, DEFAULT_POLL_INTERVAL)
+    }
+}
+
+impl WarmDispatchGate {
+    pub fn new(wait_bound: Duration, poll_interval: Duration) -> Self {
+        Self {
+            wait_bound,
+            poll_interval,
+        }
+    }
+
+    /// Decide, without allocating, whether the warm cache is usable.
+    ///
+    /// Mirrors `await_fresh`: fresh returns immediately; a missing/stale cache
+    /// fires a single-flight warm and polls until fresh or the bound elapses;
+    /// any inventory/warmer error short-circuits to a single cold dispatch. The
+    /// wait is always bounded by `self.wait_bound` measured on `clock`.
+    pub async fn decide(
+        &self,
+        compile_mode: CompileMode,
+        probe: &dyn WarmBuildCacheProbe,
+        identity: &WarmCacheIdentity,
+        clock: &dyn Clock,
+    ) -> WarmDispatchDecision {
+        if compile_mode == CompileMode::None {
+            return WarmDispatchDecision::Bypass;
+        }
+
+        let initial = match probe.probe(identity).await {
+            Ok(WarmFreshness::Fresh) => return WarmDispatchDecision::FreshImmediate,
+            Ok(other) => other,
+            Err(_) => {
+                return WarmDispatchDecision::ColdDispatch {
+                    reason: ColdReason::InventoryError,
+                };
+            }
+        };
+
+        // Fire a (single-flight-safe) warm, then poll until fresh or bound.
+        if probe.trigger(identity).await.is_err() {
+            return WarmDispatchDecision::ColdDispatch {
+                reason: ColdReason::WarmerError,
+            };
+        }
+
+        let deadline = clock.now_instant() + self.wait_bound;
+        loop {
+            match probe.probe(identity).await {
+                Ok(WarmFreshness::Fresh) => {
+                    return WarmDispatchDecision::WaitedFresh { initial };
+                }
+                Ok(_) => {}
+                Err(_) => {
+                    return WarmDispatchDecision::ColdDispatch {
+                        reason: ColdReason::InventoryError,
+                    };
+                }
+            }
+
+            let remaining = deadline.saturating_duration_since(clock.now_instant());
+            if remaining.is_zero() {
+                return WarmDispatchDecision::ColdDispatch {
+                    reason: ColdReason::Timeout,
+                };
+            }
+            tokio::time::sleep(remaining.min(self.poll_interval)).await;
+        }
+    }
+
+    /// Run the gate before pod allocation: decide, then emit the bounded
+    /// per-project `(outcome, reason)` decision metric exactly once.
+    ///
+    /// The caller MUST invoke this strictly before allocating the task-run pod
+    /// and then allocate exactly once regardless of the decision — cold dispatch
+    /// is best-effort, mirroring `await_fresh`'s timeout behaviour. Returns the
+    /// decision so the caller can log the warm-hit / cold path.
+    pub async fn decide_and_record(
+        &self,
+        compile_mode: CompileMode,
+        probe: &dyn WarmBuildCacheProbe,
+        identity: &WarmCacheIdentity,
+        clock: &dyn Clock,
+    ) -> WarmDispatchDecision {
+        let decision = self.decide(compile_mode, probe, identity, clock).await;
+        let (outcome, reason) = decision.telemetry_labels();
+        djinn_telemetry::warm_cache::record_decision(&identity.project_id, outcome, reason);
+        decision
+    }
+}
+
+#[cfg(test)]
+#[path = "warm_dispatch_gate_tests.rs"]
+mod warm_dispatch_gate_tests;

--- a/server/crates/djinn-coordinator/src/dispatch/warm_dispatch_gate_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/warm_dispatch_gate_tests.rs
@@ -1,0 +1,251 @@
+//! Contract test for the pre-pod-allocation warm build-cache dispatch gate,
+//! driven by the frozen `tests/fixtures/warm_dispatch/warm_dispatch_gate_v1.json`
+//! fixture (proposal ri23 Part 2).
+//!
+//! The fixture is normative. For every scenario the test asserts that:
+//!   - the warm decision completes BEFORE pod allocation (allocation is
+//!     sequenced strictly after every probe/trigger the decision performed);
+//!   - a fresh matching cache allocates immediately (one probe, no trigger);
+//!   - a no-compile stack bypasses the gate (no probe, no trigger);
+//!   - a missing/stale cache waits only up to the configured bound;
+//!   - timeout / inventory-error / warmer-error each cold-dispatch and allocate
+//!     EXACTLY ONCE;
+//!   - an identity mismatch (probe reports non-fresh) is never treated as fresh.
+//!
+//! It fails (nonzero) on allocation-before-decision, an unbounded wait, an
+//! identity mismatch treated as fresh, or a failure to cold-dispatch (allocate)
+//! after the bound/error.
+
+#![allow(clippy::disallowed_methods)] // test: TestClock monotonic base needs a real Instant
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant, SystemTime};
+
+use async_trait::async_trait;
+use djinn_core::clock::TestClock;
+use serde_json::Value;
+
+use super::{
+    CompileMode, WarmBuildCacheProbe, WarmCacheIdentity, WarmDispatchDecision, WarmDispatchGate,
+    WarmFreshness, WarmProbeError,
+};
+
+const FIXTURE: &str = include_str!("../../tests/fixtures/warm_dispatch/warm_dispatch_gate_v1.json");
+
+/// A deterministic, scripted [`WarmBuildCacheProbe`] built from a fixture case.
+///
+/// Replays `probe_results` in order (repeating the last once exhausted) and
+/// advances the shared [`TestClock`] by `advance_per_poll` on every probe call
+/// after the first, so the bounded-wait deadline is crossed without real time.
+/// Records global sequence numbers for every probe/trigger so the test can
+/// prove allocation is sequenced after the decision.
+struct ScriptedProbe {
+    results: Vec<String>,
+    trigger_ok: bool,
+    advance_per_poll: Duration,
+    clock: std::sync::Arc<TestClock>,
+    call_index: Mutex<usize>,
+    probe_calls: AtomicUsize,
+    trigger_calls: AtomicUsize,
+    seq: std::sync::Arc<AtomicUsize>,
+    max_decision_seq: std::sync::Arc<AtomicUsize>,
+}
+
+impl ScriptedProbe {
+    fn note_decision_seq(&self) {
+        let s = self.seq.fetch_add(1, Ordering::SeqCst);
+        self.max_decision_seq.fetch_max(s, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl WarmBuildCacheProbe for ScriptedProbe {
+    async fn probe(&self, _identity: &WarmCacheIdentity) -> Result<WarmFreshness, WarmProbeError> {
+        self.note_decision_seq();
+        self.probe_calls.fetch_add(1, Ordering::SeqCst);
+        let idx = {
+            let mut guard = self.call_index.lock().expect("probe index");
+            let current = *guard;
+            *guard += 1;
+            current
+        };
+        if idx >= 1 {
+            self.clock.advance_mono(self.advance_per_poll);
+        }
+        let which = idx.min(self.results.len().saturating_sub(1));
+        match self.results[which].as_str() {
+            "fresh" => Ok(WarmFreshness::Fresh),
+            "stale" => Ok(WarmFreshness::Stale),
+            "missing" => Ok(WarmFreshness::Missing),
+            "error" => Err(WarmProbeError("scripted inventory error".to_owned())),
+            other => panic!("unknown scripted probe result {other}"),
+        }
+    }
+
+    async fn trigger(
+        &self,
+        _identity: &WarmCacheIdentity,
+    ) -> Result<(), djinn_runtime::WarmerError> {
+        self.note_decision_seq();
+        self.trigger_calls.fetch_add(1, Ordering::SeqCst);
+        if self.trigger_ok {
+            Ok(())
+        } else {
+            Err(djinn_runtime::WarmerError::Backend(
+                "scripted warmer error".to_owned(),
+            ))
+        }
+    }
+}
+
+fn decision_label(decision: WarmDispatchDecision) -> &'static str {
+    match decision {
+        WarmDispatchDecision::Bypass => "bypass",
+        WarmDispatchDecision::FreshImmediate => "fresh_immediate",
+        WarmDispatchDecision::WaitedFresh { .. } => "waited_fresh",
+        WarmDispatchDecision::ColdDispatch {
+            reason: super::ColdReason::Timeout,
+        } => "cold_timeout",
+        WarmDispatchDecision::ColdDispatch {
+            reason: super::ColdReason::InventoryError,
+        } => "cold_inventory_error",
+        WarmDispatchDecision::ColdDispatch {
+            reason: super::ColdReason::WarmerError,
+        } => "cold_warmer_error",
+    }
+}
+
+#[tokio::test]
+async fn warm_dispatch_gate_v1_contract() {
+    let fixture: Value = serde_json::from_str(FIXTURE).expect("warm_dispatch_gate_v1.json parses");
+    let wait_bound =
+        Duration::from_millis(fixture["wait_bound_ms"].as_u64().expect("wait_bound_ms"));
+    let poll_interval = Duration::from_millis(
+        fixture["poll_interval_ms"]
+            .as_u64()
+            .expect("poll_interval_ms"),
+    );
+    let gate = WarmDispatchGate::new(wait_bound, poll_interval);
+
+    for case in fixture["cases"].as_array().expect("cases") {
+        let scenario = case["scenario"].as_str().expect("scenario");
+        let compile_mode = match case["compile_mode"].as_str().expect("compile_mode") {
+            "compile" => CompileMode::Compile,
+            "none" => CompileMode::None,
+            other => panic!("unknown compile_mode {other}"),
+        };
+        let results: Vec<String> = case["probe_results"]
+            .as_array()
+            .expect("probe_results")
+            .iter()
+            .map(|v| v.as_str().expect("probe result").to_owned())
+            .collect();
+        let trigger_ok = case["trigger"].as_str().expect("trigger") == "ok";
+        let advance_per_poll = Duration::from_millis(
+            case["advance_per_poll_ms"]
+                .as_u64()
+                .expect("advance_per_poll"),
+        );
+
+        let clock = std::sync::Arc::new(TestClock::new(SystemTime::UNIX_EPOCH, Instant::now()));
+        let seq = std::sync::Arc::new(AtomicUsize::new(1));
+        let max_decision_seq = std::sync::Arc::new(AtomicUsize::new(0));
+        let probe = ScriptedProbe {
+            results,
+            trigger_ok,
+            advance_per_poll,
+            clock: std::sync::Arc::clone(&clock),
+            call_index: Mutex::new(0),
+            probe_calls: AtomicUsize::new(0),
+            trigger_calls: AtomicUsize::new(0),
+            seq: std::sync::Arc::clone(&seq),
+            max_decision_seq: std::sync::Arc::clone(&max_decision_seq),
+        };
+        let identity = WarmCacheIdentity {
+            project_id: format!("rmxn-gate-{scenario}"),
+            environment_identity: "img-abc:toolchain-1:mold-jobs-1".to_owned(),
+        };
+
+        // Model the dispatch loop: the warm decision completes and records its
+        // metric BEFORE the caller allocates the pod exactly once.
+        let decision = gate
+            .decide_and_record(compile_mode, &probe, &identity, clock.as_ref())
+            .await;
+
+        let allocate_calls = AtomicUsize::new(0);
+        let allocate_after_decision = AtomicUsize::new(0);
+        {
+            allocate_calls.fetch_add(1, Ordering::SeqCst);
+            let s = seq.fetch_add(1, Ordering::SeqCst);
+            // Allocation must be sequenced strictly after every probe/trigger
+            // the decision performed.
+            if s > max_decision_seq.load(Ordering::SeqCst) {
+                allocate_after_decision.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        // Decision shape and closed telemetry labels match the fixture.
+        assert_eq!(
+            decision_label(decision),
+            case["expected_decision"]
+                .as_str()
+                .expect("expected_decision"),
+            "scenario {scenario}: unexpected decision"
+        );
+        let (outcome, reason) = decision.telemetry_labels();
+        assert_eq!(
+            outcome.as_label(),
+            case["expected_outcome"].as_str().expect("expected_outcome"),
+            "scenario {scenario}: unexpected outcome label"
+        );
+        assert_eq!(
+            reason.as_label(),
+            case["expected_reason"].as_str().expect("expected_reason"),
+            "scenario {scenario}: unexpected reason label"
+        );
+
+        // Probe/trigger call counts: proves the fresh path skips the trigger,
+        // no-compile skips everything, and the wait is bounded (a bounded
+        // number of re-probes, never unbounded).
+        assert_eq!(
+            probe.probe_calls.load(Ordering::SeqCst) as u64,
+            case["expected_probe_calls"]
+                .as_u64()
+                .expect("expected_probe_calls"),
+            "scenario {scenario}: unexpected probe call count (unbounded wait?)"
+        );
+        assert_eq!(
+            probe.trigger_calls.load(Ordering::SeqCst) as u64,
+            case["expected_trigger_calls"]
+                .as_u64()
+                .expect("expected_trigger_calls"),
+            "scenario {scenario}: unexpected trigger call count"
+        );
+
+        // Allocation happens exactly once, strictly after the decision.
+        assert_eq!(
+            allocate_calls.load(Ordering::SeqCst),
+            1,
+            "scenario {scenario}: must allocate exactly once (cold dispatch still allocates)"
+        );
+        assert_eq!(
+            allocate_after_decision.load(Ordering::SeqCst),
+            1,
+            "scenario {scenario}: allocation must be sequenced after the warm decision"
+        );
+
+        // A non-fresh initial observation must never yield a fresh-immediate
+        // decision — identity mismatch can never be treated as fresh.
+        if scenario == "identity_mismatch_is_never_treated_as_fresh" {
+            assert!(
+                !matches!(decision, WarmDispatchDecision::FreshImmediate),
+                "identity mismatch must never be treated as fresh"
+            );
+            assert!(
+                !decision.is_warm_hit(),
+                "identity mismatch is not a warm hit"
+            );
+        }
+    }
+}

--- a/server/crates/djinn-coordinator/tests/fixtures/warm_dispatch/warm_dispatch_gate_v1.json
+++ b/server/crates/djinn-coordinator/tests/fixtures/warm_dispatch/warm_dispatch_gate_v1.json
@@ -1,0 +1,115 @@
+{
+  "contract": "frozen pre-pod-allocation warm build-cache dispatch gate (ri23 Part 2)",
+  "wait_bound_ms": 45000,
+  "poll_interval_ms": 5,
+  "cases": [
+    {
+      "scenario": "fresh_allocates_immediately",
+      "compile_mode": "compile",
+      "probe_results": ["fresh"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 0,
+      "expected_decision": "fresh_immediate",
+      "expected_outcome": "hit",
+      "expected_reason": "fresh",
+      "expected_probe_calls": 1,
+      "expected_trigger_calls": 0
+    },
+    {
+      "scenario": "no_compile_bypasses_gate",
+      "compile_mode": "none",
+      "probe_results": ["fresh"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 0,
+      "expected_decision": "bypass",
+      "expected_outcome": "fallback",
+      "expected_reason": "no_compile",
+      "expected_probe_calls": 0,
+      "expected_trigger_calls": 0
+    },
+    {
+      "scenario": "missing_waits_then_fresh",
+      "compile_mode": "compile",
+      "probe_results": ["missing", "fresh"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 0,
+      "expected_decision": "waited_fresh",
+      "expected_outcome": "hit",
+      "expected_reason": "missing",
+      "expected_probe_calls": 2,
+      "expected_trigger_calls": 1
+    },
+    {
+      "scenario": "stale_waits_then_fresh",
+      "compile_mode": "compile",
+      "probe_results": ["stale", "fresh"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 0,
+      "expected_decision": "waited_fresh",
+      "expected_outcome": "hit",
+      "expected_reason": "stale",
+      "expected_probe_calls": 2,
+      "expected_trigger_calls": 1
+    },
+    {
+      "scenario": "timeout_cold_dispatches_after_bound",
+      "compile_mode": "compile",
+      "probe_results": ["missing", "missing"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 45000,
+      "expected_decision": "cold_timeout",
+      "expected_outcome": "cold",
+      "expected_reason": "timeout",
+      "expected_probe_calls": 2,
+      "expected_trigger_calls": 1
+    },
+    {
+      "scenario": "inventory_error_on_initial_probe_cold_dispatches",
+      "compile_mode": "compile",
+      "probe_results": ["error"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 0,
+      "expected_decision": "cold_inventory_error",
+      "expected_outcome": "cold",
+      "expected_reason": "inventory_error",
+      "expected_probe_calls": 1,
+      "expected_trigger_calls": 0
+    },
+    {
+      "scenario": "inventory_error_during_poll_cold_dispatches",
+      "compile_mode": "compile",
+      "probe_results": ["missing", "error"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 0,
+      "expected_decision": "cold_inventory_error",
+      "expected_outcome": "cold",
+      "expected_reason": "inventory_error",
+      "expected_probe_calls": 2,
+      "expected_trigger_calls": 1
+    },
+    {
+      "scenario": "warmer_error_cold_dispatches",
+      "compile_mode": "compile",
+      "probe_results": ["missing"],
+      "trigger": "error",
+      "advance_per_poll_ms": 0,
+      "expected_decision": "cold_warmer_error",
+      "expected_outcome": "cold",
+      "expected_reason": "warmer_error",
+      "expected_probe_calls": 1,
+      "expected_trigger_calls": 1
+    },
+    {
+      "scenario": "identity_mismatch_is_never_treated_as_fresh",
+      "compile_mode": "compile",
+      "probe_results": ["stale", "stale"],
+      "trigger": "ok",
+      "advance_per_poll_ms": 45000,
+      "expected_decision": "cold_timeout",
+      "expected_outcome": "cold",
+      "expected_reason": "timeout",
+      "expected_probe_calls": 2,
+      "expected_trigger_calls": 1
+    }
+  ]
+}

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -57,6 +57,9 @@ const CARGO_WARM_STEP_OUTCOMES: [&str; 3] = ["ok", "failed", "spawn_error"];
 const CARGO_WARM_STEP_WORKSPACE_PATH_HASH: &str = "djinn_cargo_warm_step_workspace_path_hash";
 const CARGO_WARM_STEP_FRESH_COUNT: &str = "djinn_cargo_warm_step_fresh_count";
 const CARGO_WARM_STEP_COMPILING_COUNT: &str = "djinn_cargo_warm_step_compiling_count";
+const WARM_CACHE_DECISION_TOTAL: &str = "djinn_warm_cache_decision_total";
+const WARM_CACHE_COLD_RATE: &str = "djinn_warm_cache_cold_rate";
+const WARM_CACHE_COLD_RATE_ALERT_FIRING: &str = "djinn_warm_cache_cold_rate_alert_firing";
 const CARGO_WARM_INCREMENTAL_PRUNE_TOTAL: &str = "djinn_cargo_warm_incremental_prune_total";
 const CARGO_WARM_INCREMENTAL_PRUNED_BYTES_TOTAL: &str =
     "djinn_cargo_warm_incremental_pruned_bytes_total";
@@ -956,6 +959,240 @@ pub mod cargo_target_seed {
     }
 }
 
+/// Warm build-cache dispatch-gate telemetry (proposal ri23 Part 2).
+///
+/// The coordinator runs a bounded warm build-cache freshness gate before pod
+/// allocation. Every gate decision is emitted here as a single
+/// `(project_id, outcome, reason)` counter increment, and every decision also
+/// feeds a process-global cold-rate alert whose firing state is exposed as a
+/// gauge. The `outcome` and `reason` label spaces are CLOSED enums so the
+/// series cardinality stays bounded by `project_id` alone.
+///
+/// Ownership boundary: the warm substrate owns inventory / warming / freshness
+/// / eviction. This module only labels the decision the coordinator already
+/// made; it never reads or mutates warm state.
+pub mod warm_cache {
+    use std::sync::{Mutex, OnceLock};
+
+    /// Closed outcome classification for a warm-dispatch gate decision.
+    ///
+    /// - `Hit`: the warm cache was fresh for the resolved environment identity
+    ///   (either immediately or after a bounded wait) and the run allocated
+    ///   against it.
+    /// - `Cold`: the gate reached its bound or observed an error and
+    ///   cold-dispatched (allocated without a warm cache).
+    /// - `Fallback`: the stack has no compile step, so the gate was bypassed.
+    ///   A bypass is deliberately NOT a cold dispatch.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum Outcome {
+        Hit,
+        Cold,
+        Fallback,
+    }
+
+    /// Closed reason classification paired with an [`Outcome`].
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum Reason {
+        /// Warm cache was fresh on the first probe (paired with `Hit`).
+        Fresh,
+        /// Warm cache was stale, then became fresh within the bound (`Hit`).
+        Stale,
+        /// Warm cache was missing, then became fresh within the bound (`Hit`).
+        Missing,
+        /// Bounded wait elapsed without the cache going fresh (`Cold`).
+        Timeout,
+        /// The warm inventory probe returned an error (`Cold`).
+        InventoryError,
+        /// The single-flight warm trigger returned an error (`Cold`).
+        WarmerError,
+        /// The stack has no compile step; the gate was bypassed (`Fallback`).
+        NoCompile,
+    }
+
+    /// Every `Outcome` variant, for exhaustive label enumeration in tests.
+    pub const ALL_OUTCOMES: [Outcome; 3] = [Outcome::Hit, Outcome::Cold, Outcome::Fallback];
+
+    /// Every `Reason` variant, for exhaustive label enumeration in tests.
+    pub const ALL_REASONS: [Reason; 7] = [
+        Reason::Fresh,
+        Reason::Stale,
+        Reason::Missing,
+        Reason::Timeout,
+        Reason::InventoryError,
+        Reason::WarmerError,
+        Reason::NoCompile,
+    ];
+
+    pub const DECISION_TOTAL: &str = super::WARM_CACHE_DECISION_TOTAL;
+    pub const COLD_RATE: &str = super::WARM_CACHE_COLD_RATE;
+    pub const COLD_RATE_ALERT_FIRING: &str = super::WARM_CACHE_COLD_RATE_ALERT_FIRING;
+
+    impl Outcome {
+        pub const fn as_label(self) -> &'static str {
+            match self {
+                Self::Hit => "hit",
+                Self::Cold => "cold",
+                Self::Fallback => "fallback",
+            }
+        }
+    }
+
+    impl Reason {
+        pub const fn as_label(self) -> &'static str {
+            match self {
+                Self::Fresh => "fresh",
+                Self::Stale => "stale",
+                Self::Missing => "missing",
+                Self::Timeout => "timeout",
+                Self::InventoryError => "inventory_error",
+                Self::WarmerError => "warmer_error",
+                Self::NoCompile => "no_compile",
+            }
+        }
+    }
+
+    /// Record exactly one warm-dispatch gate decision for a project.
+    ///
+    /// Increments the `(project_id, outcome, reason)` counter and feeds the
+    /// process-global cold-rate alert (which re-emits its gauges). Exactly one
+    /// counter series moves per call, so a caller that emits per decision can
+    /// never double-count or leave a series dark.
+    pub fn record_decision(project_id: &str, outcome: Outcome, reason: Reason) {
+        metrics::counter!(
+            super::WARM_CACHE_DECISION_TOTAL,
+            "project_id" => project_id.to_owned(),
+            "outcome" => outcome.as_label(),
+            "reason" => reason.as_label(),
+        )
+        .increment(1);
+
+        if let Ok(mut alert) = global_alert().lock() {
+            alert.observe(outcome);
+            alert.evaluate();
+        }
+    }
+
+    /// Hysteresis configuration for the cold-rate alert.
+    #[derive(Clone, Copy, Debug)]
+    pub struct ColdRateAlertConfig {
+        /// Fire when the cold rate is at or above this fraction.
+        pub fire_at: f64,
+        /// Clear a firing alert once the cold rate is at or below this fraction.
+        /// Must be `<= fire_at` so the alert does not flap.
+        pub clear_at: f64,
+        /// Minimum observed decisions before the alert is allowed to fire.
+        pub min_samples: u64,
+    }
+
+    impl Default for ColdRateAlertConfig {
+        fn default() -> Self {
+            Self {
+                fire_at: 0.5,
+                clear_at: 0.2,
+                min_samples: 20,
+            }
+        }
+    }
+
+    /// A transition returned by [`ColdRateAlert::evaluate`].
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum AlertTransition {
+        /// The firing state did not change on this evaluation.
+        Unchanged,
+        /// The alert transitioned from clear to firing.
+        Fired,
+        /// The alert transitioned from firing to clear.
+        Cleared,
+    }
+
+    /// Stateful cold-rate alert with hysteresis.
+    ///
+    /// Pure and self-contained: `observe` accumulates decisions and `evaluate`
+    /// applies the hysteresis and emits the `cold_rate` / `alert_firing`
+    /// gauges. Tests drive an owned instance deterministically; production
+    /// feeds a single process-global instance from [`record_decision`].
+    #[derive(Clone, Copy, Debug)]
+    pub struct ColdRateAlert {
+        config: ColdRateAlertConfig,
+        cold: u64,
+        total: u64,
+        firing: bool,
+    }
+
+    impl ColdRateAlert {
+        pub fn new(config: ColdRateAlertConfig) -> Self {
+            Self {
+                config,
+                cold: 0,
+                total: 0,
+                firing: false,
+            }
+        }
+
+        pub fn with_default_config() -> Self {
+            Self::new(ColdRateAlertConfig::default())
+        }
+
+        /// Accumulate one decision. Only `Outcome::Cold` moves the cold count;
+        /// `Fallback` (no-compile bypass) counts toward the total but never as
+        /// cold, so a no-compile stack can never drive the alert.
+        pub fn observe(&mut self, outcome: Outcome) {
+            self.total = self.total.saturating_add(1);
+            if matches!(outcome, Outcome::Cold) {
+                self.cold = self.cold.saturating_add(1);
+            }
+        }
+
+        /// Current cold fraction; zero before any decision is observed.
+        pub fn cold_rate(&self) -> f64 {
+            if self.total == 0 {
+                0.0
+            } else {
+                self.cold as f64 / self.total as f64
+            }
+        }
+
+        pub fn firing(&self) -> bool {
+            self.firing
+        }
+
+        /// Apply the hysteresis rule and emit the alert gauges. Returns the
+        /// transition (if any) so a caller can log or test edge crossings.
+        pub fn evaluate(&mut self) -> AlertTransition {
+            let rate = self.cold_rate();
+            let transition = if self.firing {
+                if rate <= self.config.clear_at {
+                    self.firing = false;
+                    AlertTransition::Cleared
+                } else {
+                    AlertTransition::Unchanged
+                }
+            } else if self.total >= self.config.min_samples && rate >= self.config.fire_at {
+                self.firing = true;
+                AlertTransition::Fired
+            } else {
+                AlertTransition::Unchanged
+            };
+            emit_cold_rate_gauges(rate, self.firing);
+            transition
+        }
+    }
+
+    fn emit_cold_rate_gauges(rate: f64, firing: bool) {
+        metrics::gauge!(super::WARM_CACHE_COLD_RATE).set(rate);
+        metrics::gauge!(super::WARM_CACHE_COLD_RATE_ALERT_FIRING).set(if firing {
+            1.0
+        } else {
+            0.0
+        });
+    }
+
+    fn global_alert() -> &'static Mutex<ColdRateAlert> {
+        static GLOBAL: OnceLock<Mutex<ColdRateAlert>> = OnceLock::new();
+        GLOBAL.get_or_init(|| Mutex::new(ColdRateAlert::with_default_config()))
+    }
+}
+
 /// Render the current registry in Prometheus text format.
 ///
 /// Calling this before `init()` is supported: it initializes the recorder first
@@ -1370,6 +1607,20 @@ fn register_metrics() {
         CARGO_WARM_BASE_FRESHNESS_SECONDS,
         "Seconds elapsed while producing the most recent warm Cargo target base for a project."
     );
+    metrics::describe_counter!(
+        WARM_CACHE_DECISION_TOTAL,
+        "Warm build-cache dispatch-gate decisions partitioned by project_id and the closed outcome (hit, cold, fallback) and reason (fresh, stale, missing, timeout, inventory_error, warmer_error, no_compile) label spaces."
+    );
+    metrics::describe_gauge!(
+        WARM_CACHE_COLD_RATE,
+        "Fraction of warm build-cache dispatch-gate decisions that cold-dispatched, driving the cold-rate alert."
+    );
+    metrics::describe_gauge!(
+        WARM_CACHE_COLD_RATE_ALERT_FIRING,
+        "Whether the warm build-cache cold-rate alert is firing: 1 firing, 0 clear."
+    );
+    metrics::gauge!(WARM_CACHE_COLD_RATE).set(0.0);
+    metrics::gauge!(WARM_CACHE_COLD_RATE_ALERT_FIRING).set(0.0);
     metrics::describe_counter!(
         CARGO_WARM_STEP_TOTAL,
         "Cargo warm-step invocations partitioned by bounded project_id, step, and outcome labels. The free-form cargo argv is intentionally NOT a label; correlate with the djinn_cargo_warm_step workspace path hash gauge and the worker's structured tracing event for full context."

--- a/server/crates/djinn-telemetry/tests/fixtures/warm_cache/warm_cache_metrics_v1.json
+++ b/server/crates/djinn-telemetry/tests/fixtures/warm_cache/warm_cache_metrics_v1.json
@@ -1,0 +1,24 @@
+{
+  "contract": "frozen warm build-cache dispatch-gate telemetry (ri23 Part 2)",
+  "decision_metric": "djinn_warm_cache_decision_total",
+  "decision_labels": ["project_id", "outcome", "reason"],
+  "cold_rate_gauge": "djinn_warm_cache_cold_rate",
+  "alert_firing_gauge": "djinn_warm_cache_cold_rate_alert_firing",
+  "outcomes": ["hit", "cold", "fallback"],
+  "reasons": ["fresh", "stale", "missing", "timeout", "inventory_error", "warmer_error", "no_compile"],
+  "decision_cases": [
+    {"scenario": "fresh", "outcome": "hit", "reason": "fresh"},
+    {"scenario": "stale", "outcome": "hit", "reason": "stale"},
+    {"scenario": "missing", "outcome": "hit", "reason": "missing"},
+    {"scenario": "timeout", "outcome": "cold", "reason": "timeout"},
+    {"scenario": "inventory_error", "outcome": "cold", "reason": "inventory_error"},
+    {"scenario": "warmer_error", "outcome": "cold", "reason": "warmer_error"},
+    {"scenario": "no_compile", "outcome": "fallback", "reason": "no_compile"}
+  ],
+  "alert": {
+    "config": {"fire_at": 0.5, "clear_at": 0.2, "min_samples": 10},
+    "below_min_samples": {"cold": 9, "total": 9, "expected_firing": false},
+    "fire": {"cold": 8, "hit": 2, "expected_rate": 0.8, "expected_firing": true},
+    "recover": {"hit": 80, "expected_firing": false}
+  }
+}

--- a/server/crates/djinn-telemetry/tests/warm_cache_metrics_contract.rs
+++ b/server/crates/djinn-telemetry/tests/warm_cache_metrics_contract.rs
@@ -1,0 +1,260 @@
+//! Contract test for the warm build-cache dispatch-gate telemetry surface
+//! (proposal ri23 Part 2), driven by the frozen
+//! `fixtures/warm_cache/warm_cache_metrics_v1.json` fixture.
+//!
+//! The fixture is normative: it pins the metric name, the closed
+//! `outcome`/`reason` label spaces, the per-scenario outcome/reason mapping,
+//! and the cold-rate alert fire/recovery behaviour. A test here fails (nonzero)
+//! for a missing/extra/unbounded label, a counter that stays dark, a duplicate
+//! emission, a no-compile decision counted as cold, or an alert that fails to
+//! fire or clear.
+
+use djinn_telemetry::render_isolated;
+use djinn_telemetry::warm_cache::{
+    self, AlertTransition, ColdRateAlert, ColdRateAlertConfig, Outcome, Reason,
+};
+use serde_json::Value;
+
+const FIXTURE: &str = include_str!("fixtures/warm_cache/warm_cache_metrics_v1.json");
+
+fn fixture() -> Value {
+    serde_json::from_str(FIXTURE).expect("warm_cache_metrics_v1.json parses")
+}
+
+fn outcome_from_label(label: &str) -> Outcome {
+    warm_cache::ALL_OUTCOMES
+        .into_iter()
+        .find(|o| o.as_label() == label)
+        .unwrap_or_else(|| panic!("unknown outcome label {label}"))
+}
+
+fn reason_from_label(label: &str) -> Reason {
+    warm_cache::ALL_REASONS
+        .into_iter()
+        .find(|r| r.as_label() == label)
+        .unwrap_or_else(|| panic!("unknown reason label {label}"))
+}
+
+/// The enum label spaces must equal the fixture's enumerations exactly. A
+/// missing or extra variant on either side fails, keeping the series bounded.
+#[test]
+fn outcome_and_reason_label_spaces_match_the_fixture_exactly() {
+    let fx = fixture();
+
+    let fixture_outcomes: Vec<String> = fx["outcomes"]
+        .as_array()
+        .expect("outcomes array")
+        .iter()
+        .map(|v| v.as_str().expect("outcome string").to_owned())
+        .collect();
+    let enum_outcomes: Vec<String> = warm_cache::ALL_OUTCOMES
+        .iter()
+        .map(|o| o.as_label().to_owned())
+        .collect();
+    assert_eq!(
+        enum_outcomes, fixture_outcomes,
+        "Outcome label space must match the fixture exactly (no missing/extra labels)"
+    );
+
+    let fixture_reasons: Vec<String> = fx["reasons"]
+        .as_array()
+        .expect("reasons array")
+        .iter()
+        .map(|v| v.as_str().expect("reason string").to_owned())
+        .collect();
+    let enum_reasons: Vec<String> = warm_cache::ALL_REASONS
+        .iter()
+        .map(|r| r.as_label().to_owned())
+        .collect();
+    assert_eq!(
+        enum_reasons, fixture_reasons,
+        "Reason label space must match the fixture exactly (no missing/extra labels)"
+    );
+}
+
+/// Each scenario records exactly one `(project_id, outcome, reason)` series with
+/// value 1, exactly the three expected label keys, and no other series for the
+/// project. This catches dark counters, duplicate emission, and stray labels.
+#[test]
+fn each_scenario_emits_exactly_one_bounded_decision_series() {
+    let fx = fixture();
+    let metric = fx["decision_metric"].as_str().expect("decision_metric");
+    let cases = fx["decision_cases"].as_array().expect("decision_cases");
+
+    for case in cases {
+        let scenario = case["scenario"].as_str().expect("scenario");
+        let outcome = outcome_from_label(case["outcome"].as_str().expect("outcome"));
+        let reason = reason_from_label(case["reason"].as_str().expect("reason"));
+        let project_id = format!("warm-cache-contract-{scenario}");
+
+        let ((), rendered) =
+            render_isolated(|| warm_cache::record_decision(&project_id, outcome, reason));
+
+        let series: Vec<&str> = rendered
+            .lines()
+            .filter(|line| line.starts_with(metric) && line.contains(&project_id))
+            .collect();
+        assert_eq!(
+            series.len(),
+            1,
+            "scenario {scenario} must emit exactly one decision series, got: {series:?}"
+        );
+        let line = series[0];
+        assert!(
+            line.contains(&format!("outcome=\"{}\"", outcome.as_label()))
+                && line.contains(&format!("reason=\"{}\"", reason.as_label())),
+            "scenario {scenario} series missing expected outcome/reason: {line}"
+        );
+        assert!(
+            line.trim_end().ends_with(" 1"),
+            "scenario {scenario} must increment exactly once (no duplicate emission): {line}"
+        );
+
+        // Exactly the three expected label keys — no extra/unbounded labels.
+        let label_block = line
+            .split_once('{')
+            .and_then(|(_, rest)| rest.split_once('}'))
+            .map(|(labels, _)| labels)
+            .unwrap_or("");
+        let keys: Vec<&str> = label_block
+            .split(',')
+            .filter_map(|kv| kv.split_once('=').map(|(k, _)| k))
+            .collect();
+        assert_eq!(
+            keys,
+            vec!["project_id", "outcome", "reason"],
+            "scenario {scenario} must carry exactly the bounded label keys: {line}"
+        );
+    }
+}
+
+/// A no-compile bypass maps to `fallback`, never `cold`, at both the label layer
+/// and the alert layer: any number of fallback decisions must never fire the
+/// cold-rate alert.
+#[test]
+fn no_compile_is_fallback_and_never_drives_the_alert() {
+    let fx = fixture();
+    let no_compile = fx["decision_cases"]
+        .as_array()
+        .expect("decision_cases")
+        .iter()
+        .find(|c| c["scenario"].as_str() == Some("no_compile"))
+        .expect("no_compile case present");
+    assert_eq!(no_compile["outcome"].as_str(), Some("fallback"));
+    assert_ne!(
+        no_compile["outcome"].as_str(),
+        Some("cold"),
+        "no-compile must never be counted cold"
+    );
+
+    let mut alert = ColdRateAlert::new(ColdRateAlertConfig {
+        fire_at: 0.5,
+        clear_at: 0.2,
+        min_samples: 5,
+    });
+    for _ in 0..100 {
+        alert.observe(Outcome::Fallback);
+        alert.evaluate();
+    }
+    assert!(
+        !alert.firing(),
+        "fallback (no-compile) decisions must never drive the cold-rate alert"
+    );
+    assert_eq!(alert.cold_rate(), 0.0);
+}
+
+/// The cold-rate alert must stay clear below the sample floor, fire once the
+/// cold rate crosses `fire_at`, and clear again once it falls to `clear_at`.
+#[test]
+fn cold_rate_alert_fires_and_recovers_per_fixture() {
+    let fx = fixture();
+    let alert_fx = &fx["alert"];
+    let cfg = &alert_fx["config"];
+    let config = ColdRateAlertConfig {
+        fire_at: cfg["fire_at"].as_f64().expect("fire_at"),
+        clear_at: cfg["clear_at"].as_f64().expect("clear_at"),
+        min_samples: cfg["min_samples"].as_u64().expect("min_samples"),
+    };
+    let mut alert = ColdRateAlert::new(config);
+
+    // Below the sample floor: a 100% cold rate must NOT fire.
+    let below = &alert_fx["below_min_samples"];
+    for _ in 0..below["cold"].as_u64().expect("below cold") {
+        alert.observe(Outcome::Cold);
+    }
+    assert_eq!(alert.evaluate(), AlertTransition::Unchanged);
+    assert!(
+        !alert.firing(),
+        "alert must not fire below the min_samples floor"
+    );
+
+    // Cross the fire threshold.
+    let fire = &alert_fx["fire"];
+    for _ in 0..fire["cold"].as_u64().expect("fire cold") {
+        alert.observe(Outcome::Cold);
+    }
+    for _ in 0..fire["hit"].as_u64().expect("fire hit") {
+        alert.observe(Outcome::Hit);
+    }
+    let transition = alert.evaluate();
+    assert_eq!(
+        transition,
+        AlertTransition::Fired,
+        "alert must fire once the cold rate crosses fire_at"
+    );
+    assert!(alert.firing());
+
+    // Drive the rate back down until it clears.
+    let recover = &alert_fx["recover"];
+    for _ in 0..recover["hit"].as_u64().expect("recover hit") {
+        alert.observe(Outcome::Hit);
+    }
+    let transition = alert.evaluate();
+    assert_eq!(
+        transition,
+        AlertTransition::Cleared,
+        "alert must clear once the cold rate falls to clear_at"
+    );
+    assert!(!alert.firing());
+}
+
+/// The alert emits both gauges on every evaluation, so a firing state is always
+/// observable in the Prometheus surface (fire and clear).
+#[test]
+fn cold_rate_alert_emits_firing_gauge_on_fire_and_clear() {
+    let (_, rendered_fire) = render_isolated(|| {
+        let mut alert = ColdRateAlert::new(ColdRateAlertConfig {
+            fire_at: 0.5,
+            clear_at: 0.2,
+            min_samples: 2,
+        });
+        alert.observe(Outcome::Cold);
+        alert.observe(Outcome::Cold);
+        alert.evaluate();
+    });
+    assert!(
+        rendered_fire
+            .lines()
+            .any(|l| l.starts_with(warm_cache::COLD_RATE_ALERT_FIRING)
+                && l.trim_end().ends_with(" 1")),
+        "firing gauge must be 1 while the alert fires:\n{rendered_fire}"
+    );
+
+    let (_, rendered_clear) = render_isolated(|| {
+        let mut alert = ColdRateAlert::new(ColdRateAlertConfig {
+            fire_at: 0.5,
+            clear_at: 0.2,
+            min_samples: 2,
+        });
+        alert.observe(Outcome::Hit);
+        alert.observe(Outcome::Hit);
+        alert.evaluate();
+    });
+    assert!(
+        rendered_clear
+            .lines()
+            .any(|l| l.starts_with(warm_cache::COLD_RATE_ALERT_FIRING)
+                && l.trim_end().ends_with(" 0")),
+        "firing gauge must be 0 while the alert is clear:\n{rendered_clear}"
+    );
+}


### PR DESCRIPTION
## Summary

ri23 Part 2 (epic fwqb). Two coupled pieces:

1. **Pre-pod-allocation warm build-cache freshness gate** (`djinn-coordinator/src/dispatch/warm_dispatch_gate.rs`) mirroring the bounded-wait / single-flight / timeout-best-effort shape of `InProcessGraphWarmer::await_fresh`:
   - fresh matching cache → allocate immediately;
   - `CompileMode::None` (no-compile) stack → bypass;
   - missing/stale → single-flight warm trigger + poll only to the configured bound;
   - timeout / inventory-error / warmer-error → cold-dispatch exactly once + a bounded `project_id`+`reason` metric.
   Wired into `task_dispatch.rs` before build admission behind an `Option` probe seam (`None` until the warm substrate exposes a coordinator-facing probe, mirroring the `graph_warmer` precedent).

2. **Lit up the dark per-project seed counters**: the worker seed decision (`djinn-agent-worker/src/main.rs`) now calls `cargo_metrics::record_seed_hit` / `record_seed_cold` with `project_id` + bounded reason, removing the zero-caller dark path.

3. **Telemetry** (`djinn-telemetry` `warm_cache` module): closed `outcome` (hit/cold/fallback) and `reason` (fresh/stale/missing/timeout/inventory_error/warmer_error/no_compile) label spaces, a per-project decision counter, and a cold-rate alert with hysteresis (fire/recover gauges).

The warm substrate keeps ownership of inventory / warming / freshness / eviction / seeding; this only READS facts, gates dispatch, and labels telemetry. Distinct pre-allocation seam from `1bnj`'s runtime `prepare_build_cache`.

## Tests (normative fixtures + named contract tests)
- `warm_dispatch_gate_v1.json` + `warm_dispatch_gate_v1_contract` (djinn-coordinator): allocation strictly after the decision, fresh allocates immediately, no-compile bypasses, bounded wait, timeout/inventory-error/warmer-error each cold-dispatch and allocate exactly once, identity-mismatch never treated as fresh.
- `warm_cache_metrics_v1.json` + contract tests (djinn-telemetry): closed label spaces, one bounded series per decision (no dark/duplicate/extra labels), no-compile is fallback (never cold), cold-rate alert fire + recovery.
- `record_seed_result_lights_per_project_hit_and_cold_counters` (djinn-agent-worker).

## Gates
fmt clean; clippy on touched crates clean for changed code; `SQLX_OFFLINE=1 cargo check --workspace --all-targets` clean; file-size + raw-SQL-boundary guards pass; no Cargo.toml changes (no hakari needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)