### PR TITLE
chore(opyp): Gate pass recording on provisioning success and add database-backed service regressions

### DIFF
--- a/server/crates/djinn-sandbox/src/final_verification_execution.rs
+++ b/server/crates/djinn-sandbox/src/final_verification_execution.rs
@@ -983,4 +983,209 @@ mod tests {
             "identities, fingerprints, command evidence, and structured reasons exclude credentials"
         );
     }
+
+    /// A provisioner that mints a fresh, empty attempt-scoped service store on
+    /// every `create` and exposes its lease id in the command environment. The
+    /// injected launcher records the row count it observed before writing, so
+    /// two forced executions can prove each attempt saw fresh empty state.
+    struct FreshStateProvisioner {
+        nonce: String,
+        store: Arc<Mutex<BTreeMap<String, Vec<String>>>>,
+        created: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl CatalogServiceProvisioner for FreshStateProvisioner {
+        fn preset_id(&self) -> &str {
+            "preset-postgres-18"
+        }
+        fn create<'a>(
+            &'a self,
+            attempt: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<ServiceLease, ServiceProvisioningError>> + Send + 'a>>
+        {
+            let lease_id = format!("db-{attempt}-{}", self.nonce);
+            let store = Arc::clone(&self.store);
+            let created = Arc::clone(&self.created);
+            Box::pin(async move {
+                // Fresh, empty state for this attempt's lease.
+                store.lock().unwrap().insert(lease_id.clone(), Vec::new());
+                created.lock().unwrap().push(lease_id.clone());
+                Ok(ServiceLease {
+                    lease_id: lease_id.clone(),
+                    environment: BTreeMap::from([("DB_LEASE".to_string(), lease_id)]),
+                })
+            })
+        }
+        fn ready<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), ServiceProvisioningError>> + Send + 'a>>
+        {
+            Box::pin(async { Ok(()) })
+        }
+        fn delete<'a>(
+            &'a self,
+            lease: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), ServiceProvisioningError>> + Send + 'a>>
+        {
+            let store = Arc::clone(&self.store);
+            Box::pin(async move {
+                store.lock().unwrap().remove(lease);
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn two_forced_executions_each_observe_fresh_attempt_scoped_service_state() {
+        let store = Arc::new(Mutex::new(BTreeMap::<String, Vec<String>>::new()));
+        let created = Arc::new(Mutex::new(Vec::<String>::new()));
+        let observed_rows = Arc::new(Mutex::new(Vec::<usize>::new()));
+
+        for run in 0..2 {
+            let worktree = git_worktree();
+            let mut command = descriptor("check");
+            command.environment_names = vec!["DB_LEASE".into()];
+            let mut input = identity_input(vec![command], Vec::new());
+            input.input_manifest.environment_names = vec!["DB_LEASE".into()];
+            let mut request = request(worktree.path(), input.clone(), static_resolver(input));
+            request.service_provisioners = vec![Arc::new(FreshStateProvisioner {
+                nonce: format!("run-{run}"),
+                store: Arc::clone(&store),
+                created: Arc::clone(&created),
+            })];
+            let store_for_launch = Arc::clone(&store);
+            let observed = Arc::clone(&observed_rows);
+            let evidence = execute_with_fake_provisioners(request, move |launch, _| {
+                let lease = launch
+                    .environment
+                    .get("DB_LEASE")
+                    .cloned()
+                    .expect("attempt command receives its fresh service lease");
+                let mut store = store_for_launch.lock().unwrap();
+                let rows = store.entry(lease).or_default();
+                // Observe the state BEFORE this attempt mutates it.
+                observed.lock().unwrap().push(rows.len());
+                rows.push("attempt-row".into());
+                Ok(succeeded())
+            })
+            .await;
+            assert!(evidence.eligible(), "run {run} must be a reusable pass");
+        }
+
+        assert_eq!(
+            *observed_rows.lock().unwrap(),
+            vec![0, 0],
+            "each forced execution must observe fresh, empty attempt-scoped state"
+        );
+        let created = created.lock().unwrap();
+        assert_eq!(created.len(), 2);
+        assert_ne!(
+            created[0], created[1],
+            "each attempt is provisioned with a distinct fresh lease"
+        );
+        assert!(
+            store.lock().unwrap().is_empty(),
+            "every attempt-scoped service lease is torn down after execution"
+        );
+    }
+
+    /// A provisioner that fails at a chosen lifecycle phase, used to prove a
+    /// service lifecycle failure is a typed infrastructure outcome that runs no
+    /// command and computes no fingerprint or identity.
+    struct PhaseFailingProvisioner {
+        phase: ServiceProvisioningPhase,
+    }
+
+    impl CatalogServiceProvisioner for PhaseFailingProvisioner {
+        fn preset_id(&self) -> &str {
+            "preset-postgres-18"
+        }
+        fn create<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<ServiceLease, ServiceProvisioningError>> + Send + 'a>>
+        {
+            let phase = self.phase;
+            Box::pin(async move {
+                if phase == ServiceProvisioningPhase::Create {
+                    Err(ServiceProvisioningError {
+                        phase: ServiceProvisioningPhase::Create,
+                        code: ServiceProvisioningCode::Rejected,
+                    })
+                } else {
+                    Ok(ServiceLease {
+                        lease_id: "lease".into(),
+                        environment: BTreeMap::new(),
+                    })
+                }
+            })
+        }
+        fn ready<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), ServiceProvisioningError>> + Send + 'a>>
+        {
+            let phase = self.phase;
+            Box::pin(async move {
+                if phase == ServiceProvisioningPhase::Readiness {
+                    Err(ServiceProvisioningError {
+                        phase: ServiceProvisioningPhase::Readiness,
+                        code: ServiceProvisioningCode::Timeout,
+                    })
+                } else {
+                    Ok(())
+                }
+            })
+        }
+        fn delete<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), ServiceProvisioningError>> + Send + 'a>>
+        {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn service_create_and_readiness_failures_are_typed_infrastructure_outcomes() {
+        for (phase, expected_code) in [
+            (
+                ServiceProvisioningPhase::Create,
+                ServiceProvisioningCode::Rejected,
+            ),
+            (
+                ServiceProvisioningPhase::Readiness,
+                ServiceProvisioningCode::Timeout,
+            ),
+        ] {
+            let worktree = git_worktree();
+            let input = identity_input(vec![descriptor("check")], Vec::new());
+            let mut request = request(worktree.path(), input.clone(), static_resolver(input));
+            request.service_provisioners = vec![Arc::new(PhaseFailingProvisioner { phase })];
+
+            // `execute_final_verification` provisions before it computes any
+            // fingerprint or launches any command, so a create/readiness failure
+            // short-circuits with a typed service outcome and no evidence.
+            let evidence = execute_final_verification(request).await;
+
+            assert_eq!(
+                evidence.eligibility_reason,
+                Some(FinalVerificationIneligibilityReason::ServiceProvisioning {
+                    phase,
+                    code: expected_code,
+                }),
+                "a {phase:?} failure must surface as a typed service-provisioning outcome"
+            );
+            assert!(
+                evidence.commands.is_empty(),
+                "no command runs when provisioning fails"
+            );
+            assert!(
+                evidence.fingerprint_f0.is_none() && evidence.pre_environment_identity.is_none(),
+                "provisioning failure computes no fingerprint or identity"
+            );
+            assert!(!evidence.eligible());
+        }
+    }
 }

--- a/server/crates/djinn-slot/src/final_verification.rs
+++ b/server/crates/djinn-slot/src/final_verification.rs
@@ -21,8 +21,15 @@ use djinn_sandbox::final_verification_execution::{
     FinalVerificationExecutionEvidence, FinalVerificationExecutionRequest,
     execute_final_verification,
 };
+use djinn_sandbox::service_provisioning::{ServiceProvisioningCode, ServiceProvisioningPhase};
 use time::format_description::well_known::Rfc3339;
 use tokio_util::sync::CancellationToken;
+
+mod provisioning_gate;
+use provisioning_gate::{
+    emit_service_provisioning_outcome, provisioning_outcome_label, provisioning_phase_label,
+    service_provisioning_failure,
+};
 
 use crate::final_verification_agent::{
     AgentRunCapture, CoordinateResult, check_from_command, selection_surface,
@@ -111,6 +118,17 @@ pub enum FinalVerificationRecordingOutcome {
     Ineligible {
         verification_attempt_id: String,
         reason: String,
+    },
+    /// A cataloged service could not be resolved, created, made ready, proxied,
+    /// or torn down. This is a bounded infrastructure outcome, deliberately
+    /// distinct from a worktree command/check failure: the attempt is ineligible
+    /// and no pass may be persisted, but the cause is the service lifecycle, not
+    /// the authored tree. `phase`/`code` are bounded enums; no URL, credential,
+    /// tenant name, or raw backend error is carried.
+    InfrastructureIneligible {
+        verification_attempt_id: String,
+        phase: ServiceProvisioningPhase,
+        code: ServiceProvisioningCode,
     },
     Error {
         verification_attempt_id: String,
@@ -203,6 +221,15 @@ pub(crate) async fn verify_completion_intent(
         FinalVerificationRecordingOutcome::Ineligible { reason, .. } => Err(format!(
             "Final verification rejected this {submit_tool_label} request: {reason}. Fix the worktree and resubmit."
         )),
+        FinalVerificationRecordingOutcome::InfrastructureIneligible { phase, code, .. } => {
+            Err(format!(
+                "Final verification could not provision the required catalog services \
+                 ({phase}/{outcome}) for this {submit_tool_label} request. This is an \
+                 infrastructure error, not a worktree problem; retry once services are available.",
+                phase = provisioning_phase_label(phase),
+                outcome = provisioning_outcome_label(code),
+            ))
+        }
         FinalVerificationRecordingOutcome::Error { detail, .. } => Err(format!(
             "Final verification could not complete: {detail}. Inspect the worktree and resubmit."
         )),
@@ -464,11 +491,28 @@ pub(crate) async fn coordinate_final_verification_core(
         // string. This is a read of the one execution — never a second run.
         capture.checks = evidence.commands.iter().map(check_from_command).collect();
         capture.ineligibility = evidence.eligibility_reason.clone();
+        // Emit exactly one bounded provisioning outcome, plus a structured audit
+        // summary, for any attempt whose plan declared catalog services. This is
+        // the single coordinator point that observes the executed evidence for a
+        // serviced plan (success, command failure, or provisioning failure).
+        emit_service_provisioning_outcome(&request, &verification_attempt_id, &material, &evidence);
         if request.cancellation.is_cancelled() {
             Err(ineligible_outcome(
                 &verification_attempt_id,
                 "cancelled during execution",
             ))
+        } else if let Some((phase, code)) = service_provisioning_failure(&evidence) {
+            // Infrastructure ineligibility is a bounded outcome distinct from a
+            // command/check failure. It flows through the Err path below, which
+            // releases the invocation lease and returns without ever reaching
+            // `persist_evidence` — no passing row can be written.
+            Err(
+                FinalVerificationRecordingOutcome::InfrastructureIneligible {
+                    verification_attempt_id: verification_attempt_id.clone(),
+                    phase,
+                    code,
+                },
+            )
         } else if !evidence.eligible() {
             Err(ineligible_outcome(
                 &verification_attempt_id,
@@ -1056,6 +1100,26 @@ fn emit_outcome(
                 "final verification recording completed"
             )
         }
+        FinalVerificationRecordingOutcome::InfrastructureIneligible {
+            verification_attempt_id,
+            phase,
+            code,
+        } => {
+            // Infrastructure ineligibility records no passing row, so it counts
+            // as an ineligible writer outcome; the bounded provisioning phase/code
+            // ride the structured audit fields, never the record metric labels.
+            let _ = djinn_telemetry::final_verification::increment_record(
+                djinn_telemetry::final_verification::RECORD_INELIGIBLE,
+            );
+            tracing::info!(
+                recording_outcome = "infrastructure_ineligible",
+                task_id = %request.task_id, task_run_id = %request.task_run_id,
+                verification_attempt_id = %verification_attempt_id,
+                provisioning_phase = provisioning_phase_label(*phase),
+                provisioning_outcome = provisioning_outcome_label(*code),
+                "final verification recording completed"
+            )
+        }
         FinalVerificationRecordingOutcome::Error {
             verification_attempt_id,
             detail,
@@ -1158,5 +1222,7 @@ mod tests {
 
 #[cfg(test)]
 mod recording_tests;
+#[cfg(test)]
+mod service_provisioning_tests;
 #[cfg(test)]
 mod telemetry_contract_tests;

--- a/server/crates/djinn-slot/src/final_verification/provisioning_gate.rs
+++ b/server/crates/djinn-slot/src/final_verification/provisioning_gate.rs
@@ -1,0 +1,139 @@
+//! Bounded catalog-service provisioning helpers for the final-verification
+//! coordinator: classify a service-lifecycle failure distinctly from a
+//! command/check failure, derive the coarse bounded `service_type` label, and
+//! emit exactly one bounded provisioning metric plus one structured audit
+//! summary per serviced attempt.
+
+use djinn_sandbox::final_verification_execution::{
+    FinalVerificationExecutionEvidence, FinalVerificationIneligibilityReason,
+};
+use djinn_sandbox::service_provisioning::{ServiceProvisioningCode, ServiceProvisioningPhase};
+
+use super::{FinalVerificationCoordinatorRequest, FinalVerificationResolvedMaterial};
+
+/// Return the bounded provisioning `(phase, code)` when the execution evidence
+/// is ineligible specifically because of the catalog-service lifecycle, so the
+/// coordinator can surface a typed infrastructure outcome distinct from a
+/// command/check failure. Any other (or no) ineligibility returns `None`.
+pub(super) fn service_provisioning_failure(
+    evidence: &FinalVerificationExecutionEvidence,
+) -> Option<(ServiceProvisioningPhase, ServiceProvisioningCode)> {
+    match &evidence.eligibility_reason {
+        Some(FinalVerificationIneligibilityReason::ServiceProvisioning { phase, code }) => {
+            Some((*phase, *code))
+        }
+        _ => None,
+    }
+}
+
+/// Coarse, bounded classification of a plan's declared catalog services for the
+/// provisioning metric's `service_type` label. Preset identifiers are never used
+/// as labels directly (they are project-defined and unbounded); this collapses
+/// them to a fixed enum. Distinct types collapse to `multiple`; an empty plan to
+/// `none`.
+pub(super) fn classify_service_type(material: &FinalVerificationResolvedMaterial) -> &'static str {
+    use djinn_telemetry::final_verification as tel;
+    let mut seen: Option<&'static str> = None;
+    for provisioner in &material.execution_request.service_provisioners {
+        let preset = provisioner.preset_id().to_ascii_lowercase();
+        let classified = if preset.contains("postgres") {
+            tel::PROVISION_SERVICE_POSTGRES
+        } else if preset.contains("redis") {
+            tel::PROVISION_SERVICE_REDIS
+        } else if preset.contains("rabbitmq") || preset.contains("amqp") {
+            tel::PROVISION_SERVICE_RABBITMQ
+        } else {
+            tel::PROVISION_SERVICE_OTHER
+        };
+        match seen {
+            None => seen = Some(classified),
+            Some(existing) if existing == classified => {}
+            Some(_) => return tel::PROVISION_SERVICE_MULTIPLE,
+        }
+    }
+    seen.unwrap_or(tel::PROVISION_SERVICE_NONE)
+}
+
+pub(super) fn provisioning_phase_label(phase: ServiceProvisioningPhase) -> &'static str {
+    use djinn_telemetry::final_verification as tel;
+    match phase {
+        ServiceProvisioningPhase::Resolve => tel::PROVISION_PHASE_RESOLVE,
+        ServiceProvisioningPhase::Proxy => tel::PROVISION_PHASE_PROXY,
+        ServiceProvisioningPhase::Create => tel::PROVISION_PHASE_CREATE,
+        ServiceProvisioningPhase::Readiness => tel::PROVISION_PHASE_READINESS,
+        ServiceProvisioningPhase::Teardown => tel::PROVISION_PHASE_TEARDOWN,
+    }
+}
+
+pub(super) fn provisioning_outcome_label(code: ServiceProvisioningCode) -> &'static str {
+    use djinn_telemetry::final_verification as tel;
+    match code {
+        ServiceProvisioningCode::Unavailable => tel::PROVISION_OUTCOME_UNAVAILABLE,
+        ServiceProvisioningCode::ProtocolMismatch => tel::PROVISION_OUTCOME_PROTOCOL_MISMATCH,
+        ServiceProvisioningCode::Timeout => tel::PROVISION_OUTCOME_TIMEOUT,
+        ServiceProvisioningCode::Rejected => tel::PROVISION_OUTCOME_REJECTED,
+        ServiceProvisioningCode::InvalidResponse => tel::PROVISION_OUTCOME_INVALID_RESPONSE,
+    }
+}
+
+/// Emit exactly one bounded provisioning metric and one structured audit summary
+/// for an attempt whose plan declared catalog services. Serviceless plans emit
+/// nothing (no provisioning occurred). Success (evidence not blocked by the
+/// service lifecycle) records `complete`/`ok`; a service failure records the
+/// failing bounded `phase`/`outcome`. The metric carries only bounded enum
+/// labels; task/run/attempt/fingerprint/environment identifiers are confined to
+/// the structured audit event and are never metric labels.
+pub(super) fn emit_service_provisioning_outcome(
+    request: &FinalVerificationCoordinatorRequest,
+    attempt_id: &str,
+    material: &FinalVerificationResolvedMaterial,
+    evidence: &FinalVerificationExecutionEvidence,
+) {
+    use djinn_telemetry::final_verification as tel;
+    if material.execution_request.service_provisioners.is_empty() {
+        return;
+    }
+    let service_type = classify_service_type(material);
+    let (phase, outcome) = match service_provisioning_failure(evidence) {
+        Some((phase, code)) => (
+            provisioning_phase_label(phase),
+            provisioning_outcome_label(code),
+        ),
+        // Provisioning + teardown both succeeded whenever the evidence is not
+        // blocked by the service lifecycle, even if a command later failed.
+        None => (tel::PROVISION_PHASE_COMPLETE, tel::PROVISION_OUTCOME_OK),
+    };
+    if tel::increment_provisioning(phase, outcome, service_type).is_err() {
+        tracing::warn!(
+            provisioning_phase = phase,
+            provisioning_outcome = outcome,
+            service_type = service_type,
+            task_id = %request.task_id,
+            task_run_id = %request.task_run_id,
+            verification_attempt_id = %attempt_id,
+            "service provisioning telemetry emission failed"
+        );
+    }
+    // The one structured attempt summary. Fingerprint and environment identity
+    // are present only when execution progressed past provisioning; a pure
+    // provisioning failure leaves them empty rather than fabricating a value.
+    let fingerprint = evidence
+        .fingerprint_f0
+        .as_ref()
+        .map_or("", |digest| digest.fingerprint.as_str());
+    let environment_identity_digest = evidence
+        .pre_environment_identity
+        .as_ref()
+        .map_or("", |identity| identity.digest.as_str());
+    tracing::info!(
+        provisioning_phase = phase,
+        provisioning_outcome = outcome,
+        service_type = service_type,
+        task_id = %request.task_id,
+        task_run_id = %request.task_run_id,
+        verification_attempt_id = %attempt_id,
+        verification_input_fingerprint = %fingerprint,
+        environment_identity_digest = %environment_identity_digest,
+        "final verification service provisioning attempt completed"
+    );
+}

--- a/server/crates/djinn-slot/src/final_verification/service_provisioning_tests.rs
+++ b/server/crates/djinn-slot/src/final_verification/service_provisioning_tests.rs
@@ -1,0 +1,804 @@
+//! Coordinator-boundary regressions for catalog-service provisioning.
+//!
+//! These prove the authoritative recording coordinator treats a service
+//! lifecycle failure as a typed infrastructure-ineligible outcome distinct from
+//! a command/check failure, that no such outcome can reach pass persistence, and
+//! that provisioning telemetry stays bounded with identifiers confined to the
+//! structured audit event. A Postgres-backed reuse case proves a matching hit
+//! returns the stored pass without provisioning or executing anything.
+
+use std::future::Future;
+use std::io::Write;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use djinn_core::canonical_verify::EnvironmentIdentityV1;
+use djinn_core::models::Task;
+use djinn_db::repositories::settings::SettingsRepository;
+use djinn_db::repositories::task_run::{CreateTaskRunParams, TaskRunRepository};
+use djinn_db::repositories::verify_run::{
+    RecordEligibleFinalVerificationPassParams, RequiredFinalVerificationCommand,
+    VerifyRunRepository,
+};
+use djinn_git::{
+    VerificationInputFingerprint, compute_verification_input_fingerprint, run_git_command_in,
+};
+use djinn_sandbox::final_verification_execution::{
+    FinalVerificationCommandEvidence, FinalVerificationExecutionEvidence,
+    FinalVerificationIneligibilityReason,
+};
+use djinn_sandbox::service_provisioning::{
+    CatalogServiceProvisioner, ServiceLease, ServiceProvisioningCode, ServiceProvisioningError,
+    ServiceProvisioningPhase,
+};
+use tokio_util::sync::CancellationToken;
+
+use super::provisioning_gate::classify_service_type;
+use super::*;
+use crate::host::{ResolvedMcpTools, SlotHostCallbacks};
+use crate::reply_loop_completion_intent_tests::reuse_material;
+
+// ---------------------------------------------------------------------------
+// Provisioner + probe fixtures
+// ---------------------------------------------------------------------------
+
+/// Counts every lifecycle call so tests can prove a reuse hit provisions
+/// nothing and a serviced run provisions exactly once.
+#[derive(Default)]
+struct ProvisionCounts {
+    create: AtomicUsize,
+    ready: AtomicUsize,
+    delete: AtomicUsize,
+}
+
+struct TrackingProvisioner {
+    preset: String,
+    counts: Arc<ProvisionCounts>,
+}
+
+impl CatalogServiceProvisioner for TrackingProvisioner {
+    fn preset_id(&self) -> &str {
+        &self.preset
+    }
+    fn create<'a>(
+        &'a self,
+        _: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<ServiceLease, ServiceProvisioningError>> + Send + 'a>>
+    {
+        self.counts.create.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async {
+            Ok(ServiceLease {
+                lease_id: "lease".into(),
+                environment: Default::default(),
+            })
+        })
+    }
+    fn ready<'a>(
+        &'a self,
+        _: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ServiceProvisioningError>> + Send + 'a>> {
+        self.counts.ready.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(()) })
+    }
+    fn delete<'a>(
+        &'a self,
+        _: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ServiceProvisioningError>> + Send + 'a>> {
+        self.counts.delete.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn tracking_material(
+    preset: &str,
+    checks: &[&str],
+) -> (FinalVerificationResolvedMaterial, Arc<ProvisionCounts>) {
+    let counts = Arc::new(ProvisionCounts::default());
+    let mut material = bare_material(checks);
+    material.execution_request.service_provisioners = vec![Arc::new(TrackingProvisioner {
+        preset: preset.to_owned(),
+        counts: Arc::clone(&counts),
+    })];
+    (material, counts)
+}
+
+/// Material whose resolver panics (injected evidence only) but which can carry
+/// service provisioners. Mirrors `recording_tests::material`.
+fn bare_material(checks: &[&str]) -> FinalVerificationResolvedMaterial {
+    FinalVerificationResolvedMaterial {
+        execution_request: FinalVerificationExecutionRequest {
+            worktree: std::path::PathBuf::new(),
+            resolve_environment_identity: Arc::new(|| panic!("injected evidence only")),
+            fingerprint_config: djinn_git::VerificationInputFingerprintConfig::default(),
+            tool_runtime: vec![],
+            read_only_external_mounts: vec![],
+            output_directories: vec![],
+            catalog_loopback_endpoints: vec![],
+            service_provisioners: vec![],
+        },
+        verify_source: djinn_core::models::VerifySource::Worker,
+        required_checks: checks.iter().map(|c| (*c).to_owned()).collect(),
+        diff_fingerprint: "audit-diff".into(),
+    }
+}
+
+fn command(id: &str) -> FinalVerificationCommandEvidence {
+    FinalVerificationCommandEvidence {
+        descriptor: djinn_core::canonical_verify::CanonicalCommandDescriptorV1 {
+            check_id: id.into(),
+            executable: "hermetic-tool".into(),
+            argv: vec![id.into()],
+            working_directory: ".".into(),
+            environment_names: vec![],
+            timeout_seconds: 60,
+            descriptor_revision: 1,
+        },
+        started_at_unix_millis: 10,
+        completed_at_unix_millis: 11,
+        exit_code: Some(0),
+        timed_out: false,
+    }
+}
+
+fn fingerprint(value: &str) -> djinn_git::VerificationInputDigestV1 {
+    djinn_git::VerificationInputDigestV1 {
+        version: 1,
+        fingerprint: value.into(),
+        canonical_stream_len: value.len() as u64,
+        merge_base: Some("base".into()),
+        head: "head".into(),
+        tracked_entry_count: 1,
+        extra_entry_count: 0,
+    }
+}
+
+fn identity(value: &str) -> EnvironmentIdentityV1 {
+    EnvironmentIdentityV1 {
+        schema_version: 1,
+        canonicalization_version: 1,
+        canonical_json: format!(r#"{{"environment":"{value}"}}"#),
+        digest: format!("identity-{value}"),
+    }
+}
+
+fn passing_evidence(value: &str) -> FinalVerificationExecutionEvidence {
+    FinalVerificationExecutionEvidence {
+        manifest_version: 1,
+        pre_environment_identity: Some(identity("stable")),
+        post_environment_identity: Some(identity("stable")),
+        fingerprint_f0: Some(fingerprint(value)),
+        fingerprint_f1: Some(fingerprint(value)),
+        commands: vec![command("lint"), command("test")],
+        eligibility_reason: None,
+    }
+}
+
+/// Evidence shaped exactly like the sandbox `service_error_evidence`: no
+/// fingerprint, identity, or command, only a typed provisioning ineligibility.
+fn provisioning_failure_evidence(
+    phase: ServiceProvisioningPhase,
+    code: ServiceProvisioningCode,
+) -> FinalVerificationExecutionEvidence {
+    FinalVerificationExecutionEvidence {
+        manifest_version: 0,
+        pre_environment_identity: None,
+        post_environment_identity: None,
+        fingerprint_f0: None,
+        fingerprint_f1: None,
+        commands: vec![],
+        eligibility_reason: Some(FinalVerificationIneligibilityReason::ServiceProvisioning {
+            phase,
+            code,
+        }),
+    }
+}
+
+struct ServiceProbe {
+    material: FinalVerificationResolvedMaterial,
+    evidence: Mutex<Option<FinalVerificationExecutionEvidence>>,
+    events: Arc<Mutex<Vec<&'static str>>>,
+    lease_acquisitions: AtomicUsize,
+    executions: AtomicUsize,
+}
+
+impl ServiceProbe {
+    fn new(material: FinalVerificationResolvedMaterial) -> Self {
+        Self {
+            material,
+            evidence: Mutex::new(None),
+            events: Arc::new(Mutex::new(Vec::new())),
+            lease_acquisitions: AtomicUsize::new(0),
+            executions: AtomicUsize::new(0),
+        }
+    }
+    fn with_evidence(mut self, evidence: FinalVerificationExecutionEvidence) -> Self {
+        self.evidence = Mutex::new(Some(evidence));
+        self
+    }
+    fn events(&self) -> Vec<&'static str> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+struct ProbeLease {
+    events: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl FinalVerificationInvocationLease for ProbeLease {
+    fn release<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async {
+            self.events.lock().unwrap().push("lease-release");
+            Ok(())
+        })
+    }
+}
+
+impl SlotHostCallbacks for ServiceProbe {
+    fn final_verification_outcome_for_test(
+        &self,
+        _request: &FinalVerificationCoordinatorRequest,
+    ) -> Option<FinalVerificationRecordingOutcome> {
+        None
+    }
+    fn final_verification_evidence_for_test(
+        &self,
+        _request: &FinalVerificationCoordinatorRequest,
+    ) -> Option<FinalVerificationExecutionEvidence> {
+        self.events.lock().unwrap().push("evidence");
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        self.evidence.lock().unwrap().clone()
+    }
+    fn resolve_final_verification<'a>(
+        &'a self,
+        _task_id: &'a str,
+        _task_run_id: &'a str,
+        _verification_attempt_id: &'a str,
+        _verify_run_id: &'a str,
+        _ctx: &'a SlotContext,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<Option<FinalVerificationResolvedMaterial>, String>>
+                + Send
+                + 'a,
+        >,
+    > {
+        self.events.lock().unwrap().push("resolve");
+        let material = self.material.clone();
+        Box::pin(async move { Ok(Some(material)) })
+    }
+    fn acquire_final_verification_lease<'a>(
+        &'a self,
+        _task_id: &'a str,
+        _task_run_id: &'a str,
+        _verification_attempt_id: &'a str,
+        _ctx: &'a SlotContext,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<Box<dyn FinalVerificationInvocationLease>, String>>
+                + Send
+                + 'a,
+        >,
+    > {
+        self.events.lock().unwrap().push("lease-acquire");
+        self.lease_acquisitions.fetch_add(1, Ordering::SeqCst);
+        let events = Arc::clone(&self.events);
+        Box::pin(async move {
+            Ok(Box::new(ProbeLease { events }) as Box<dyn FinalVerificationInvocationLease>)
+        })
+    }
+    fn interrupt_paused_worker_session<'a>(
+        &'a self,
+        _task_id: &'a str,
+        _ctx: &'a SlotContext,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async {})
+    }
+    fn resolve_mcp_tools<'a>(
+        &'a self,
+        _worktree_path: &'a str,
+        _role_name: &'a str,
+        _ctx: &'a SlotContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedMcpTools, String>> + Send + 'a>> {
+        Box::pin(async { Err("not implemented in test".into()) })
+    }
+    fn render_prompt(
+        &self,
+        _role_name: &str,
+        _task: &Task,
+        _context_json: &serde_json::Value,
+    ) -> String {
+        String::new()
+    }
+    fn initial_user_message<'a>(
+        &'a self,
+        _task_id: &'a str,
+        _ctx: &'a SlotContext,
+    ) -> Pin<Box<dyn Future<Output = String> + Send + 'a>> {
+        Box::pin(async { String::new() })
+    }
+    fn build_mcp_state(&self, _ctx: &SlotContext) -> djinn_control_plane::McpState {
+        panic!("build_mcp_state not needed in service provisioning tests")
+    }
+    fn require_project_id_for_task_ops<'a>(
+        &'a self,
+        _project: &'a str,
+        _ctx: &'a SlotContext,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<String, djinn_control_plane::tools::task_tools::ErrorResponse>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async {
+            Err(djinn_control_plane::tools::task_tools::ErrorResponse {
+                error: "not implemented".into(),
+            })
+        })
+    }
+    fn resolve_provider_credential<'a>(
+        &'a self,
+        _provider_id: &'a str,
+        _ctx: &'a SlotContext,
+    ) -> Pin<Box<dyn Future<Output = Result<crate::helpers::ProviderCredential, String>> + Send + 'a>>
+    {
+        Box::pin(async { Err("not implemented in test".into()) })
+    }
+    fn run_task_dispatch<'a>(
+        &'a self,
+        _task_id: String,
+        _project_path: String,
+        _model_id: String,
+        _ctx: SlotContext,
+        _kill: CancellationToken,
+        _pause: CancellationToken,
+        _resume_lifecycle_metadata: Option<serde_json::Value>,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+    fn touch_activity_rpc<'a>(
+        &'a self,
+        _task_id: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+    fn flush_session_tokens_rpc<'a>(
+        &'a self,
+        _session_id: String,
+        _tokens_in: i64,
+        _tokens_out: i64,
+        _cache_read: i64,
+        _cache_write: i64,
+    ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+struct Rig {
+    ctx: SlotContext,
+    request: FinalVerificationCoordinatorRequest,
+    probe: Arc<ServiceProbe>,
+}
+
+async fn build_rig(probe: ServiceProbe) -> Rig {
+    let db = crate::test_helpers::create_test_db();
+    let project = crate::test_helpers::create_test_project(&db).await;
+    let epic = crate::test_helpers::create_test_epic(&db, &project.id).await;
+    let task = crate::test_helpers::create_test_task(&db, &project.id, &epic.id).await;
+    let run = uuid::Uuid::now_v7().to_string();
+    TaskRunRepository::new(db.clone())
+        .create(CreateTaskRunParams {
+            id: &run,
+            project_id: &project.id,
+            task_id: &task.id,
+            trigger_type: "dispatch",
+            status: Some("running"),
+            workspace_path: None,
+            mirror_ref: None,
+            dispatch_group_id: None,
+        })
+        .await
+        .unwrap();
+    let probe = Arc::new(probe);
+    let ctx = crate::test_helpers::agent_context_from_db_with_callbacks(db, probe.clone());
+    let request = FinalVerificationCoordinatorRequest {
+        task_id: task.id,
+        task_run_id: run,
+        cancellation: CancellationToken::new(),
+    };
+    Rig {
+        ctx,
+        request,
+        probe,
+    }
+}
+
+async fn recorded_rows(ctx: &SlotContext, task_run_id: &str) -> usize {
+    VerifyRunRepository::new(ctx.db.clone())
+        .list_for_task_run(task_run_id)
+        .await
+        .unwrap()
+        .len()
+}
+
+// ---------------------------------------------------------------------------
+// service_type classification (bounded label)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn service_type_classification_is_bounded() {
+    use djinn_telemetry::final_verification as tel;
+    let (postgres, _) = tracking_material("preset-postgres-18", &["a"]);
+    assert_eq!(
+        classify_service_type(&postgres),
+        tel::PROVISION_SERVICE_POSTGRES
+    );
+    let (redis, _) = tracking_material("preset-redis-7", &["a"]);
+    assert_eq!(classify_service_type(&redis), tel::PROVISION_SERVICE_REDIS);
+    let (rabbit, _) = tracking_material("preset-rabbitmq-4", &["a"]);
+    assert_eq!(
+        classify_service_type(&rabbit),
+        tel::PROVISION_SERVICE_RABBITMQ
+    );
+    let (other, _) = tracking_material("preset-clickhouse", &["a"]);
+    assert_eq!(classify_service_type(&other), tel::PROVISION_SERVICE_OTHER);
+    // Empty plan classifies as `none`; distinct types collapse to `multiple`.
+    assert_eq!(
+        classify_service_type(&bare_material(&["a"])),
+        tel::PROVISION_SERVICE_NONE
+    );
+    let mut multiple = bare_material(&["a"]);
+    multiple.execution_request.service_provisioners = vec![
+        Arc::new(TrackingProvisioner {
+            preset: "preset-postgres-18".into(),
+            counts: Arc::new(ProvisionCounts::default()),
+        }),
+        Arc::new(TrackingProvisioner {
+            preset: "preset-redis-7".into(),
+            counts: Arc::new(ProvisionCounts::default()),
+        }),
+    ];
+    assert_eq!(
+        classify_service_type(&multiple),
+        tel::PROVISION_SERVICE_MULTIPLE
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC1 / AC3: provisioning failure is infrastructure-ineligible, records no row
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn service_provisioning_failure_is_infrastructure_ineligible_and_records_no_row() {
+    let cases = [
+        (
+            ServiceProvisioningPhase::Resolve,
+            ServiceProvisioningCode::Unavailable,
+        ),
+        (
+            ServiceProvisioningPhase::Proxy,
+            ServiceProvisioningCode::Unavailable,
+        ),
+        (
+            ServiceProvisioningPhase::Create,
+            ServiceProvisioningCode::Rejected,
+        ),
+        (
+            ServiceProvisioningPhase::Readiness,
+            ServiceProvisioningCode::Timeout,
+        ),
+        (
+            ServiceProvisioningPhase::Teardown,
+            ServiceProvisioningCode::Rejected,
+        ),
+    ];
+    for (phase, code) in cases {
+        let (material, _counts) = tracking_material("preset-postgres-18", &["lint", "test"]);
+        let probe =
+            ServiceProbe::new(material).with_evidence(provisioning_failure_evidence(phase, code));
+        let rig = build_rig(probe).await;
+        let outcome = coordinate_final_verification(rig.request.clone(), &rig.ctx).await;
+        let FinalVerificationRecordingOutcome::InfrastructureIneligible {
+            phase: got_phase,
+            code: got_code,
+            ..
+        } = outcome
+        else {
+            panic!("phase {phase:?} must be infrastructure-ineligible, got {outcome:?}");
+        };
+        assert_eq!(
+            (got_phase, got_code),
+            (phase, code),
+            "bounded phase/code carried through"
+        );
+        // The lease is acquired then released; persistence is never reached.
+        assert_eq!(
+            rig.probe.events(),
+            vec!["resolve", "lease-acquire", "evidence", "lease-release"],
+            "phase {phase:?}"
+        );
+        assert_eq!(
+            recorded_rows(&rig.ctx, &rig.request.task_run_id).await,
+            0,
+            "phase {phase:?} must record no passing verify-run row"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC5 continuity: a serviced plan still records exactly one pass on success
+// and emits a bounded `complete`/`ok` provisioning outcome.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn serviced_forced_execution_records_one_pass() {
+    let (material, _counts) = tracking_material("preset-postgres-18", &["lint", "test"]);
+    let probe = ServiceProbe::new(material).with_evidence(passing_evidence("serviced-pass"));
+    let rig = build_rig(probe).await;
+
+    let outcome = coordinate_final_verification(rig.request.clone(), &rig.ctx).await;
+    assert!(
+        matches!(outcome, FinalVerificationRecordingOutcome::Stored { .. }),
+        "serviced success must store one pass, got {outcome:?}"
+    );
+    assert_eq!(
+        rig.probe.events(),
+        vec!["resolve", "lease-acquire", "evidence", "lease-release"],
+    );
+    assert_eq!(recorded_rows(&rig.ctx, &rig.request.task_run_id).await, 1);
+}
+
+// ---------------------------------------------------------------------------
+// AC4: provisioning telemetry is bounded; identifiers stay in the audit event
+// ---------------------------------------------------------------------------
+
+/// Count the emitted provisioning samples (value `1`), independent of label
+/// ordering in the rendered exposition.
+fn provisioning_sample_lines(rendered: &str) -> Vec<&str> {
+    rendered
+        .lines()
+        .filter(|line| {
+            line.starts_with("verify_service_provisioning_total{") && line.ends_with(" 1")
+        })
+        .collect()
+}
+
+/// True when exactly one emitted provisioning sample carries all three bounded
+/// labels, regardless of the order the exporter renders them in.
+fn has_provisioning_sample(rendered: &str, phase: &str, outcome: &str, service_type: &str) -> bool {
+    provisioning_sample_lines(rendered).iter().any(|line| {
+        line.contains(&format!("phase=\"{phase}\""))
+            && line.contains(&format!("outcome=\"{outcome}\""))
+            && line.contains(&format!("service_type=\"{service_type}\""))
+    })
+}
+
+#[test]
+fn provisioning_metric_labels_are_bounded_and_identifiers_never_leak() {
+    let request = FinalVerificationCoordinatorRequest {
+        task_id: "task-id-must-not-be-a-label".into(),
+        task_run_id: "run-id-must-not-be-a-label".into(),
+        cancellation: CancellationToken::new(),
+    };
+    let (material, _) = tracking_material("preset-postgres-18", &["lint", "test"]);
+    let failure = provisioning_failure_evidence(
+        ServiceProvisioningPhase::Create,
+        ServiceProvisioningCode::Rejected,
+    );
+    let success = passing_evidence("fingerprint-must-not-be-a-label");
+
+    let ((), rendered) = djinn_telemetry::render_isolated(|| {
+        emit_service_provisioning_outcome(
+            &request,
+            "attempt-id-must-not-be-a-label",
+            &material,
+            &failure,
+        );
+        emit_service_provisioning_outcome(
+            &request,
+            "attempt-id-must-not-be-a-label",
+            &material,
+            &success,
+        );
+    });
+    assert_eq!(
+        provisioning_sample_lines(&rendered).len(),
+        2,
+        "exactly two bounded provisioning samples were emitted: {rendered}"
+    );
+    assert!(
+        has_provisioning_sample(&rendered, "create", "rejected", "postgres"),
+        "a create/rejected/postgres sample must be present: {rendered}"
+    );
+    assert!(
+        has_provisioning_sample(&rendered, "complete", "ok", "postgres"),
+        "a complete/ok/postgres sample must be present: {rendered}"
+    );
+    for identifier in [
+        "task-id-must-not-be-a-label",
+        "run-id-must-not-be-a-label",
+        "attempt-id-must-not-be-a-label",
+        "fingerprint-must-not-be-a-label",
+        "identity-stable",
+    ] {
+        assert!(
+            !rendered.contains(identifier),
+            "identifier {identifier} must never appear in a metric label"
+        );
+    }
+
+    // The structured audit event does carry the identifiers.
+    let events = capture_events(|| {
+        emit_service_provisioning_outcome(
+            &request,
+            "attempt-id-must-not-be-a-label",
+            &material,
+            &success,
+        )
+    });
+    for identifier in [
+        "task-id-must-not-be-a-label",
+        "run-id-must-not-be-a-label",
+        "attempt-id-must-not-be-a-label",
+        "fingerprint-must-not-be-a-label",
+        "identity-stable",
+    ] {
+        assert!(
+            events.contains(identifier),
+            "audit event must carry {identifier}: {events}"
+        );
+    }
+}
+
+// A minimal tracing capture, mirroring the telemetry-contract test helper.
+#[derive(Clone, Default)]
+struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+struct CapturedLogsWriter(Arc<Mutex<Vec<u8>>>);
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = CapturedLogsWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        CapturedLogsWriter(Arc::clone(&self.0))
+    }
+}
+impl Write for CapturedLogsWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+fn capture_events(f: impl FnOnce()) -> String {
+    let logs = CapturedLogs::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(logs.clone())
+        .with_ansi(false)
+        .with_target(false)
+        .finish();
+    let dispatch = tracing::dispatcher::Dispatch::new(subscriber);
+    let guard = tracing::dispatcher::set_default(&dispatch);
+    f();
+    drop(guard);
+    String::from_utf8(logs.0.lock().unwrap().clone()).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// AC2: a matching reuse returns the stored pass without provisioning or
+// executing anything (Postgres-backed).
+// ---------------------------------------------------------------------------
+
+async fn init_verifiable_repo(prefix: &str) -> tempfile::TempDir {
+    let tree = crate::test_helpers::test_tempdir(prefix);
+    run_git_command_in(tree.path(), vec!["init".into()])
+        .await
+        .expect("git init");
+    for args in [
+        vec!["config", "--local", "user.email", "test@test.com"],
+        vec!["config", "--local", "user.name", "Test User"],
+        vec!["config", "--local", "commit.gpgsign", "false"],
+    ] {
+        run_git_command_in(tree.path(), args.into_iter().map(String::from).collect())
+            .await
+            .expect("git config");
+    }
+    std::fs::write(tree.path().join("authored.txt"), "state").unwrap();
+    for args in [
+        vec!["add", "authored.txt"],
+        vec!["commit", "-m", "init"],
+        vec!["branch", "-m", "main"],
+    ] {
+        run_git_command_in(tree.path(), args.into_iter().map(String::from).collect())
+            .await
+            .expect("git populate");
+    }
+    tree
+}
+
+#[tokio::test]
+async fn matching_reuse_returns_stored_pass_without_provisioning_or_execution() {
+    let tree = init_verifiable_repo("reuse-services-").await;
+    let mut material = reuse_material(tree.path().into());
+    let counts = Arc::new(ProvisionCounts::default());
+    material.execution_request.service_provisioners = vec![Arc::new(TrackingProvisioner {
+        preset: "preset-postgres-18".into(),
+        counts: Arc::clone(&counts),
+    })];
+
+    let fingerprint =
+        match compute_verification_input_fingerprint(&material.execution_request.worktree)
+            .await
+            .unwrap()
+        {
+            VerificationInputFingerprint::Available(digest) => digest.fingerprint,
+            VerificationInputFingerprint::Unavailable(reason) => panic!("fingerprint: {reason}"),
+        };
+    let identity = EnvironmentIdentityV1::derive(
+        (material.execution_request.resolve_environment_identity)().unwrap(),
+    )
+    .unwrap();
+
+    let probe = ServiceProbe::new(material.clone());
+    let rig = build_rig(probe).await;
+    let task = rig.ctx.load_task(&rig.request.task_id).await.unwrap();
+    SettingsRepository::new(rig.ctx.db.clone(), rig.ctx.event_bus.clone())
+        .set(
+            &format!("project.{}.verify_run_reuse_enabled", task.project_id),
+            "true",
+        )
+        .await
+        .unwrap();
+
+    let required_commands = [
+        RequiredFinalVerificationCommand {
+            descriptor_id: "format",
+        },
+        RequiredFinalVerificationCommand {
+            descriptor_id: "slot-clippy",
+        },
+    ];
+    let ordered_commands = serde_json::json!([
+        {"descriptor_id":"format","result":"pass","passed":true},
+        {"descriptor_id":"slot-clippy","result":"pass","passed":true}
+    ]);
+    let covered_checks = serde_json::json!(["format", "slot-clippy"]);
+    let identity_json = serde_json::from_str(&identity.canonical_json).unwrap();
+    VerifyRunRepository::new(rig.ctx.db.clone())
+        .record_eligible_final_verification_pass(RecordEligibleFinalVerificationPassParams {
+            id: "reuse-services-row",
+            task_run_id: &rig.request.task_run_id,
+            verify_source: "worker",
+            verify_run_id: "seeded-run",
+            verification_attempt_id: "seeded-attempt",
+            required_commands: &required_commands,
+            ordered_commands: &ordered_commands,
+            covered_checks: &covered_checks,
+            required_checks: &material.required_checks,
+            verification_input_fingerprint: &fingerprint,
+            manifest_version: "manifest-v1",
+            environment_identity_json: &identity_json,
+            environment_identity_digest: &identity.digest,
+            environment_identity_version: "identity-v1",
+            completed_at: "2099-02-02T03:04:05Z",
+            diff_fingerprint: &material.diff_fingerprint,
+        })
+        .await
+        .unwrap();
+
+    let outcome = coordinate_final_verification(rig.request.clone(), &rig.ctx).await;
+    let FinalVerificationRecordingOutcome::Reused { evidence, .. } = outcome else {
+        panic!("matching reuse must return the stored pass, got {outcome:?}");
+    };
+    assert_eq!(evidence.persisted_run_id, "reuse-services-row");
+    // No provisioning, no lease, no execution occurred on the reuse hit.
+    assert_eq!(counts.create.load(Ordering::SeqCst), 0);
+    assert_eq!(counts.ready.load(Ordering::SeqCst), 0);
+    assert_eq!(counts.delete.load(Ordering::SeqCst), 0);
+    assert_eq!(rig.probe.lease_acquisitions.load(Ordering::SeqCst), 0);
+    assert_eq!(rig.probe.executions.load(Ordering::SeqCst), 0);
+    assert_eq!(rig.probe.events(), vec!["resolve", "resolve"]);
+    assert_eq!(recorded_rows(&rig.ctx, &rig.request.task_run_id).await, 1);
+}

--- a/server/crates/djinn-slot/src/final_verification_agent.rs
+++ b/server/crates/djinn-slot/src/final_verification_agent.rs
@@ -288,6 +288,15 @@ pub async fn coordinate_final_verification_for_agent(
         FinalVerificationRecordingOutcome::Error { detail, .. } => {
             AgentRunVerificationOutcome::Error { detail }
         }
+        // A service-provisioning failure is an infrastructure outcome distinct
+        // from a real check failure, so it maps to the tool's `Error` result
+        // (bucketed with other infrastructure errors) with a bounded detail that
+        // carries no URL, credential, tenant name, or raw backend error.
+        FinalVerificationRecordingOutcome::InfrastructureIneligible { phase, code, .. } => {
+            AgentRunVerificationOutcome::Error {
+                detail: format!("catalog service provisioning failed ({phase:?}/{code:?})"),
+            }
+        }
         FinalVerificationRecordingOutcome::NotConfigured { .. } => {
             AgentRunVerificationOutcome::NotConfigured
         }

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -89,6 +89,30 @@ const RUN_VERIFICATION_SELECTION_TOTAL: &str = "run_verification_selection_total
 const RUN_VERIFICATION_SELECTIONS: [&str; 2] = ["full", "subset"];
 const RUN_VERIFICATION_CHECK_TOTAL: &str = "run_verification_check_total";
 const RUN_VERIFICATION_CHECK_RESULTS: [&str; 2] = ["pass", "fail"];
+// Catalog service provisioning for one final-verification attempt whose plan
+// declares services. Every label is a bounded enum: the lifecycle `phase`, the
+// terminal `outcome`, and a coarse `service_type` classification. Task, run,
+// attempt, fingerprint, and environment identifiers stay in the structured
+// audit event emitted next to this counter, never as metric labels.
+const VERIFY_SERVICE_PROVISIONING_TOTAL: &str = "verify_service_provisioning_total";
+const VERIFY_SERVICE_PROVISIONING_PHASES: [&str; 6] = [
+    "resolve",
+    "proxy",
+    "create",
+    "readiness",
+    "teardown",
+    "complete",
+];
+const VERIFY_SERVICE_PROVISIONING_OUTCOMES: [&str; 6] = [
+    "ok",
+    "unavailable",
+    "protocol-mismatch",
+    "timeout",
+    "rejected",
+    "invalid-response",
+];
+const VERIFY_SERVICE_PROVISIONING_SERVICE_TYPES: [&str; 6] =
+    ["postgres", "redis", "rabbitmq", "other", "multiple", "none"];
 // Build-drift soft gate (ri23). Both metrics carry only fixed, enumerated
 // label values; project/session/command/key identifiers stay in structured
 // tracing fields next to these counters.
@@ -377,6 +401,32 @@ pub mod final_verification {
     pub const CHECK_PASS: &str = "pass";
     pub const CHECK_FAIL: &str = "fail";
 
+    /// Bounded catalog-service provisioning lifecycle phases for one attempt.
+    /// `COMPLETE` is the success terminal (create + readiness + teardown all
+    /// succeeded); the others name the phase that failed.
+    pub const PROVISION_PHASE_RESOLVE: &str = "resolve";
+    pub const PROVISION_PHASE_PROXY: &str = "proxy";
+    pub const PROVISION_PHASE_CREATE: &str = "create";
+    pub const PROVISION_PHASE_READINESS: &str = "readiness";
+    pub const PROVISION_PHASE_TEARDOWN: &str = "teardown";
+    pub const PROVISION_PHASE_COMPLETE: &str = "complete";
+
+    /// Bounded catalog-service provisioning terminal outcomes.
+    pub const PROVISION_OUTCOME_OK: &str = "ok";
+    pub const PROVISION_OUTCOME_UNAVAILABLE: &str = "unavailable";
+    pub const PROVISION_OUTCOME_PROTOCOL_MISMATCH: &str = "protocol-mismatch";
+    pub const PROVISION_OUTCOME_TIMEOUT: &str = "timeout";
+    pub const PROVISION_OUTCOME_REJECTED: &str = "rejected";
+    pub const PROVISION_OUTCOME_INVALID_RESPONSE: &str = "invalid-response";
+
+    /// Bounded coarse service-type classification for the provisioning label.
+    pub const PROVISION_SERVICE_POSTGRES: &str = "postgres";
+    pub const PROVISION_SERVICE_REDIS: &str = "redis";
+    pub const PROVISION_SERVICE_RABBITMQ: &str = "rabbitmq";
+    pub const PROVISION_SERVICE_OTHER: &str = "other";
+    pub const PROVISION_SERVICE_MULTIPLE: &str = "multiple";
+    pub const PROVISION_SERVICE_NONE: &str = "none";
+
     /// An injected recorder failure used to prove telemetry is best-effort.
     #[derive(Debug)]
     pub struct EmissionError;
@@ -430,12 +480,45 @@ pub mod final_verification {
         metrics::counter!(super::RUN_VERIFICATION_CHECK_TOTAL, "result" => result).increment(count);
     }
 
+    /// Increment the one catalog-service provisioning outcome for a
+    /// final-verification attempt whose plan declares services. Best-effort:
+    /// a telemetry failure never changes the coordinator's recording decision.
+    /// All three labels are bounded enums; identifiers stay in the structured
+    /// audit event emitted alongside this counter.
+    pub fn increment_provisioning(
+        phase: &'static str,
+        outcome: &'static str,
+        service_type: &'static str,
+    ) -> Result<(), EmissionError> {
+        #[cfg(feature = "test-support")]
+        PROVISIONING_EMISSION_ATTEMPTS.with(|attempts| attempts.set(attempts.get() + 1));
+        if injected_failure() {
+            return Err(EmissionError);
+        }
+        metrics::counter!(
+            super::VERIFY_SERVICE_PROVISIONING_TOTAL,
+            "phase" => phase,
+            "outcome" => outcome,
+            "service_type" => service_type,
+        )
+        .increment(1);
+        Ok(())
+    }
+
     #[cfg(feature = "test-support")]
     thread_local! {
         static FAIL_NEXT_EMISSION: Cell<bool> = const { Cell::new(false) };
         static LOOKUP_EMISSION_ATTEMPTS: Cell<usize> = const { Cell::new(0) };
         static RECORD_EMISSION_ATTEMPTS: Cell<usize> = const { Cell::new(0) };
         static TOOL_EMISSION_ATTEMPTS: Cell<usize> = const { Cell::new(0) };
+        static PROVISIONING_EMISSION_ATTEMPTS: Cell<usize> = const { Cell::new(0) };
+    }
+
+    /// Return catalog-service provisioning emissions since the failure seam was
+    /// armed (includes the injected failure, exposing duplicates).
+    #[cfg(feature = "test-support")]
+    pub fn provisioning_emission_attempts_for_test() -> usize {
+        PROVISIONING_EMISSION_ATTEMPTS.with(Cell::get)
     }
 
     /// Return `run_verification` tool-attempt emissions since the failure seam
@@ -452,6 +535,7 @@ pub mod final_verification {
         LOOKUP_EMISSION_ATTEMPTS.with(|attempts| attempts.set(0));
         RECORD_EMISSION_ATTEMPTS.with(|attempts| attempts.set(0));
         TOOL_EMISSION_ATTEMPTS.with(|attempts| attempts.set(0));
+        PROVISIONING_EMISSION_ATTEMPTS.with(|attempts| attempts.set(0));
     }
 
     /// Return lookup/record attempts since the failure seam was armed.
@@ -1222,6 +1306,23 @@ fn register_metrics() {
     );
     for result in RUN_VERIFICATION_CHECK_RESULTS {
         metrics::counter!(RUN_VERIFICATION_CHECK_TOTAL, "result" => result).absolute(0);
+    }
+    metrics::describe_counter!(
+        VERIFY_SERVICE_PROVISIONING_TOTAL,
+        "Catalog service provisioning outcomes for final-verification attempts, partitioned by bounded phase, outcome, and service_type."
+    );
+    for phase in VERIFY_SERVICE_PROVISIONING_PHASES {
+        for outcome in VERIFY_SERVICE_PROVISIONING_OUTCOMES {
+            for service_type in VERIFY_SERVICE_PROVISIONING_SERVICE_TYPES {
+                metrics::counter!(
+                    VERIFY_SERVICE_PROVISIONING_TOTAL,
+                    "phase" => phase,
+                    "outcome" => outcome,
+                    "service_type" => service_type,
+                )
+                .absolute(0);
+            }
+        }
     }
     metrics::describe_counter!(
         BUILD_DRIFT_DECISIONS_TOTAL,

--- a/server/crates/djinn-telemetry/src/panic_capture.rs
+++ b/server/crates/djinn-telemetry/src/panic_capture.rs
@@ -104,6 +104,7 @@ const PREVIOUS_HOOK_MARKER: &str = "previous-hook-large-write:";
 
 #[cfg(test)]
 #[test]
+#[allow(clippy::print_stderr)]
 fn chained_large_hook() {
     // `install` is process-global. Exercise it in a separate libtest process
     // so this fixture can install a deliberately large previous hook.
@@ -180,6 +181,9 @@ fn chained_large_hook() {
 
 #[cfg(test)]
 #[inline(never)]
+// `black_box` deliberately wraps the recursive unit call to keep the deep frame
+// stack intact for the fixture; the unit argument is the point, not a mistake.
+#[allow(clippy::unit_arg)]
 fn deep_panic(depth: usize) {
     if depth == 0 {
         panic!("panic capture fixture");


### PR DESCRIPTION
Completes epic xy15 (proposal jvpm) at the coordinator boundary.

## What
- Carry the sandbox catalog-service provisioning `phase`/`code` through execution evidence into `coordinate_final_verification` and surface a resolve/create/readiness/proxy/teardown failure as a bounded, typed `FinalVerificationRecordingOutcome::InfrastructureIneligible` — distinct from a worktree command/check failure.
- Preserve the invariant that `persist_evidence` / `VerifyRunRepository::record_eligible_final_verification_pass` is reachable only after successful service teardown: the infrastructure-ineligible outcome flows through the lease-release path and never writes a passing row.
- Format the outcome as an infrastructure error on the completion-intent path (not "fix the worktree"); the agent `run_verification` tool maps it to a bounded `Error`.
- Emit a bounded provisioning metric `verify_service_provisioning_total` with enum-only `phase`/`outcome`/`service_type` labels plus one structured attempt summary carrying task/run/attempt/fingerprint/environment identifiers in audit fields only (never URLs/credentials/tenant names/raw errors). Provisioning-gate helpers live in a new `final_verification` submodule to keep the coordinator within the file-size guard.
- gm8w selection/fingerprint semantics and czd9's single-writer invariant are preserved.

## Coverage
Coordinator (Postgres-backed): infrastructure-ineligible with no verify-run row for every phase; matching reuse returns the stored pass without provisioning or execution; serviced forced execution records one pass; provisioning telemetry is bounded with no identifier leakage into labels (identifiers in the audit event); `service_type` classification is bounded. Sandbox: two forced executions each observe fresh attempt-scoped service state; create/readiness failures are typed infrastructure outcomes with no command or fingerprint.

Also adds two `#[allow]` attributes to the pre-existing `panic_capture` test fixture so `clippy -D warnings` stays clean on the touched crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)