### PR TITLE
chore(hevr): ri23 Part 3 — per-project build_resources overrides

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "kube",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",

--- a/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
@@ -332,6 +332,7 @@ mod tests {
             cargo_cache_policy: None,
             agent_mcp_defaults: Default::default(),
             global_skills: vec![],
+            build_resources: None,
         }
     }
 

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -3484,7 +3484,7 @@ mod inflight_ledger_tests {
 
     pub(super) const WND1_READY_TASK_COUNT: usize = 10;
     pub(super) const WND1_STABLE_MODEL_ID: &str = "test/mock";
-    const WND1_DISPATCH_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+    pub(super) const WND1_DISPATCH_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
     pub(super) const WND1_CONTROLLED_RUNTIME_GUARD: Duration = Duration::from_secs(60);
 
     pub(super) struct Wnd1DispatchFixture {
@@ -3844,7 +3844,18 @@ mod inflight_ledger_tests {
             .sum()
     }
 
-    async fn wait_for_pool_to_forget_task(pool: &djinn_slot::SlotPoolHandle, task_id: &str) {
+    /// Block until the pool has released a task's slot mapping.
+    ///
+    /// `SlotPoolHandle::kill_session` only *sends* the kill; the pool actor
+    /// drops `task_to_slot` later, when the slot's own `Killed`/`Free` event
+    /// arrives through `handle_event`. The same asymmetry applies to a runner
+    /// that completes on its own. Any test that asserts "the pool forgot this
+    /// task" therefore has to wait for that event rather than read the mapping
+    /// straight after the command returns.
+    pub(super) async fn wait_for_pool_to_forget_task(
+        pool: &djinn_slot::SlotPoolHandle,
+        task_id: &str,
+    ) {
         let deadline = tokio::time::Instant::now() + WND1_DISPATCH_SETTLE_TIMEOUT;
         loop {
             if !pool
@@ -8005,6 +8016,7 @@ mod build_admission_route_tests {
     use super::inflight_ledger_tests::{
         WND1_CONTROLLED_RUNTIME_GUARD, WND1_READY_TASK_COUNT, WND1_STABLE_MODEL_ID,
         Wnd1DispatchFixture, configure_wnd1_user_max_sessions, seed_wnd1_ready_worker_tasks,
+        wait_for_pool_to_forget_task,
     };
     use super::*;
     use crate::build_admission::{BuildAdmissionController, BuildAdmissionMode};
@@ -8989,10 +9001,15 @@ mod build_admission_route_tests {
         // already have removed the mapping, in which case TaskNotFound is the
         // expected deterministic outcome.
         let _ = actor.pool.kill_session(&task_id).await;
-        assert!(
-            !actor.pool.has_session(&task_id).await.expect("check pool"),
-            "runner completion must remove the first controlled session"
-        );
+        // Runner completion must remove the first controlled session — but that
+        // removal is event-driven, not synchronous with `kill_session`: the
+        // completed-callback fires before the runner future returns, and the
+        // pool drops `task_to_slot` only once the slot's `Killed`/`Free` event
+        // reaches `handle_event`. Reading the mapping immediately therefore
+        // races the pool actor under load. Wait for the event instead — the
+        // retry below also depends on the mapping being gone, since
+        // `dispatch_ready_tasks` skips any task the pool still holds.
+        wait_for_pool_to_forget_task(&actor.pool, &task_id).await;
         actor
             .clear_planned_dispatch_completion(&task_id, "ambiguous retry fixture settlement")
             .await;

--- a/server/crates/djinn-k8s/Cargo.toml
+++ b/server/crates/djinn-k8s/Cargo.toml
@@ -34,6 +34,7 @@ workspace-hack.workspace = true
 [dev-dependencies]
 async-trait = "0.1"
 djinn-provider = { path = "../djinn-provider" }
+serde_yaml = "0.9"
 http = "1"
 http-body-util = "0.1"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/server/crates/djinn-k8s/src/build_resources.rs
+++ b/server/crates/djinn-k8s/src/build_resources.rs
@@ -1,0 +1,420 @@
+//! Resolution + render of per-project [`build_resources`] overrides.
+//!
+//! [`djinn_stack::resources::BuildResources`] carries optional per-project CPU
+//! and memory overrides. This module combines them with the deployment-wide
+//! defaults from [`KubernetesConfig`] — task-run and warm Pods resolved
+//! **independently** — enforces the hard invariants, and produces the
+//! [`ResourceRequirements`] rendered into the Job/Pod spec.
+//!
+//! Resolution fails closed: after defaults and overrides combine, each kind's
+//! request must not exceed its limit, and every quantity must sit within any
+//! administrator-configured per-kind minimum/maximum. A malformed, zero,
+//! negative, request-above-limit, below-minimum, or above-maximum value
+//! returns an error so the caller never creates a Job — values are never
+//! clamped. When a project sets no override and the deployment configures no
+//! bounds, the resolved requirements are byte-identical to
+//! [`crate::launcher::worker_resources`] / the warm default, so the default
+//! render path is unchanged.
+//!
+//! [`build_resources`]: djinn_stack::resources::BuildResources
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::ResourceRequirements;
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity as K8sQuantity;
+use serde::{Deserialize, Serialize};
+
+use djinn_stack::resources::{BuildResourceOverrides, Quantity};
+
+use crate::config::KubernetesConfig;
+use crate::launcher::RoleResourceClass;
+
+/// Administrator-configured per-kind hard bounds for a Pod kind's CPU and
+/// memory. Every bound is optional; `None` leaves that axis unbounded. Bounds
+/// are enforced at resolution time: a resolved request below a minimum or a
+/// resolved limit above a maximum fails closed.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceBounds {
+    /// Minimum acceptable CPU request.
+    #[serde(default)]
+    pub cpu_min: Option<String>,
+    /// Maximum acceptable CPU limit.
+    #[serde(default)]
+    pub cpu_max: Option<String>,
+    /// Minimum acceptable memory request.
+    #[serde(default)]
+    pub memory_min: Option<String>,
+    /// Maximum acceptable memory limit.
+    #[serde(default)]
+    pub memory_max: Option<String>,
+}
+
+/// Why a `build_resources` resolution failed. Every variant means "reject the
+/// config and do not create a Job".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    /// A resolved quantity was malformed, zero, or negative.
+    InvalidQuantity { field: String, value: String },
+    /// A configured administrator bound was itself not a valid quantity.
+    InvalidBound { field: String, value: String },
+    /// The resolved request exceeds the resolved limit for a resource axis.
+    RequestExceedsLimit {
+        resource: String,
+        request: String,
+        limit: String,
+    },
+    /// The resolved request is below the administrator minimum.
+    BelowMinimum {
+        resource: String,
+        value: String,
+        min: String,
+    },
+    /// The resolved limit is above the administrator maximum.
+    AboveMaximum {
+        resource: String,
+        value: String,
+        max: String,
+    },
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidQuantity { field, value } => {
+                write!(f, "{field}: {value:?} is not a valid resource quantity")
+            }
+            Self::InvalidBound { field, value } => {
+                write!(
+                    f,
+                    "{field}: configured bound {value:?} is not a valid quantity"
+                )
+            }
+            Self::RequestExceedsLimit {
+                resource,
+                request,
+                limit,
+            } => write!(f, "{resource}: request {request:?} exceeds limit {limit:?}"),
+            Self::BelowMinimum {
+                resource,
+                value,
+                min,
+            } => write!(f, "{resource}: request {value:?} is below minimum {min:?}"),
+            Self::AboveMaximum {
+                resource,
+                value,
+                max,
+            } => write!(f, "{resource}: limit {value:?} is above maximum {max:?}"),
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+/// Resolve the task-run Pod's resources: role-classed CPU request default
+/// (light vs build-capable), shared CPU-limit / memory defaults, the optional
+/// per-project `task` overrides, and the deployment's task bounds.
+pub fn resolve_task_run_resources(
+    config: &KubernetesConfig,
+    class: RoleResourceClass,
+    overrides: Option<&BuildResourceOverrides>,
+    bounds: &ResourceBounds,
+) -> Result<ResourceRequirements, ResolveError> {
+    resolve(
+        pick(cpu_request_of(overrides), class.cpu_request(config)),
+        pick(cpu_limit_of(overrides), &config.cpu_limit),
+        pick(memory_request_of(overrides), &config.memory_request),
+        pick(memory_limit_of(overrides), &config.memory_limit),
+        bounds,
+    )
+}
+
+/// Resolve the warm Pod's resources from the warm deployment defaults, the
+/// optional per-project `warm` overrides, and the deployment's warm bounds.
+pub fn resolve_warm_resources(
+    config: &KubernetesConfig,
+    overrides: Option<&BuildResourceOverrides>,
+    bounds: &ResourceBounds,
+) -> Result<ResourceRequirements, ResolveError> {
+    resolve(
+        pick(cpu_request_of(overrides), &config.warm_cpu_request),
+        pick(cpu_limit_of(overrides), &config.warm_cpu_limit),
+        pick(memory_request_of(overrides), &config.warm_memory_request),
+        pick(memory_limit_of(overrides), &config.warm_memory_limit),
+        bounds,
+    )
+}
+
+/// Overwrite the primary container's resources on an already-built Job with the
+/// resolved requirements. Targets the `worker` (task-run) or `warmer` (warm)
+/// container.
+pub fn apply_resolved_resources(job: &mut Job, resources: ResourceRequirements) {
+    if let Some(spec) = job.spec.as_mut()
+        && let Some(pod) = spec.template.spec.as_mut()
+        && let Some(container) = pod
+            .containers
+            .iter_mut()
+            .find(|c| c.name == "worker" || c.name == "warmer")
+    {
+        container.resources = Some(resources);
+    }
+}
+
+fn cpu_request_of(o: Option<&BuildResourceOverrides>) -> Option<&str> {
+    o.and_then(|o| o.cpu_request.as_deref())
+}
+fn cpu_limit_of(o: Option<&BuildResourceOverrides>) -> Option<&str> {
+    o.and_then(|o| o.cpu_limit.as_deref())
+}
+fn memory_request_of(o: Option<&BuildResourceOverrides>) -> Option<&str> {
+    o.and_then(|o| o.memory_request.as_deref())
+}
+fn memory_limit_of(o: Option<&BuildResourceOverrides>) -> Option<&str> {
+    o.and_then(|o| o.memory_limit.as_deref())
+}
+
+/// Override wins over the deployment default; the winner is trimmed to its
+/// canonical (whitespace-free) Quantity form for the render.
+fn pick<'a>(over: Option<&'a str>, default: &'a str) -> &'a str {
+    over.unwrap_or(default).trim()
+}
+
+fn resolve(
+    cpu_request: &str,
+    cpu_limit: &str,
+    memory_request: &str,
+    memory_limit: &str,
+    bounds: &ResourceBounds,
+) -> Result<ResourceRequirements, ResolveError> {
+    check_axis(
+        "cpu",
+        cpu_request,
+        cpu_limit,
+        bounds.cpu_min.as_deref(),
+        bounds.cpu_max.as_deref(),
+    )?;
+    check_axis(
+        "memory",
+        memory_request,
+        memory_limit,
+        bounds.memory_min.as_deref(),
+        bounds.memory_max.as_deref(),
+    )?;
+    Ok(ResourceRequirements {
+        requests: Some(BTreeMap::from([
+            ("cpu".to_string(), K8sQuantity(cpu_request.to_string())),
+            (
+                "memory".to_string(),
+                K8sQuantity(memory_request.to_string()),
+            ),
+        ])),
+        limits: Some(BTreeMap::from([
+            ("cpu".to_string(), K8sQuantity(cpu_limit.to_string())),
+            ("memory".to_string(), K8sQuantity(memory_limit.to_string())),
+        ])),
+        ..ResourceRequirements::default()
+    })
+}
+
+fn check_axis(
+    resource: &str,
+    request: &str,
+    limit: &str,
+    min: Option<&str>,
+    max: Option<&str>,
+) -> Result<(), ResolveError> {
+    let req = parse_positive(resource, "request", request)?;
+    let lim = parse_positive(resource, "limit", limit)?;
+    if req > lim {
+        return Err(ResolveError::RequestExceedsLimit {
+            resource: resource.to_string(),
+            request: request.to_string(),
+            limit: limit.to_string(),
+        });
+    }
+    if let Some(min) = min {
+        let min_q = parse_bound(resource, "min", min)?;
+        if req < min_q {
+            return Err(ResolveError::BelowMinimum {
+                resource: resource.to_string(),
+                value: request.to_string(),
+                min: min.to_string(),
+            });
+        }
+    }
+    if let Some(max) = max {
+        let max_q = parse_bound(resource, "max", max)?;
+        if lim > max_q {
+            return Err(ResolveError::AboveMaximum {
+                resource: resource.to_string(),
+                value: limit.to_string(),
+                max: max.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn parse_positive(resource: &str, role: &str, value: &str) -> Result<Quantity, ResolveError> {
+    match Quantity::parse(value) {
+        Some(q) if q.is_positive() => Ok(q),
+        _ => Err(ResolveError::InvalidQuantity {
+            field: format!("{resource}_{role}"),
+            value: value.to_string(),
+        }),
+    }
+}
+
+fn parse_bound(resource: &str, role: &str, value: &str) -> Result<Quantity, ResolveError> {
+    Quantity::parse(value).ok_or_else(|| ResolveError::InvalidBound {
+        field: format!("{resource}_{role}"),
+        value: value.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> KubernetesConfig {
+        KubernetesConfig::for_testing()
+    }
+
+    fn req(rr: &ResourceRequirements, key: &str) -> String {
+        rr.requests.as_ref().unwrap().get(key).unwrap().0.clone()
+    }
+    fn lim(rr: &ResourceRequirements, key: &str) -> String {
+        rr.limits.as_ref().unwrap().get(key).unwrap().0.clone()
+    }
+
+    #[test]
+    fn unset_task_inherits_role_classed_defaults() {
+        let c = cfg();
+        let rr = resolve_task_run_resources(
+            &c,
+            RoleResourceClass::BuildCapable,
+            None,
+            &ResourceBounds::default(),
+        )
+        .expect("defaults resolve");
+        assert_eq!(req(&rr, "cpu"), c.cpu_request);
+        assert_eq!(lim(&rr, "cpu"), c.cpu_limit);
+        assert_eq!(req(&rr, "memory"), c.memory_request);
+        assert_eq!(lim(&rr, "memory"), c.memory_limit);
+
+        let light = resolve_task_run_resources(
+            &c,
+            RoleResourceClass::Light,
+            None,
+            &ResourceBounds::default(),
+        )
+        .expect("light defaults resolve");
+        assert_eq!(req(&light, "cpu"), c.light_cpu_request);
+    }
+
+    #[test]
+    fn task_and_warm_resolve_independently() {
+        let c = cfg();
+        let br = BuildResourceOverrides {
+            cpu_request: Some("2".into()),
+            cpu_limit: Some("2".into()),
+            memory_request: Some("3Gi".into()),
+            memory_limit: Some("3Gi".into()),
+        };
+        // Only the task block is set; warm must fall back to warm defaults.
+        let task = resolve_task_run_resources(
+            &c,
+            RoleResourceClass::BuildCapable,
+            Some(&br),
+            &ResourceBounds::default(),
+        )
+        .unwrap();
+        let warm = resolve_warm_resources(&c, None, &ResourceBounds::default()).unwrap();
+        assert_eq!(req(&task, "memory"), "3Gi");
+        assert_eq!(req(&warm, "memory"), c.warm_memory_request);
+        assert_ne!(req(&task, "memory"), req(&warm, "memory"));
+    }
+
+    #[test]
+    fn request_above_limit_after_defaults_combine_rejects() {
+        let c = cfg();
+        // Only cpu_request overridden, to above the default cpu_limit ("4").
+        let br = BuildResourceOverrides {
+            cpu_request: Some("8".into()),
+            ..Default::default()
+        };
+        let err = resolve_task_run_resources(
+            &c,
+            RoleResourceClass::BuildCapable,
+            Some(&br),
+            &ResourceBounds::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ResolveError::RequestExceedsLimit { .. }));
+    }
+
+    #[test]
+    fn below_min_and_above_max_reject() {
+        let c = cfg();
+        let bounds = ResourceBounds {
+            cpu_min: Some("2".into()),
+            cpu_max: Some("8".into()),
+            memory_min: Some("1Gi".into()),
+            memory_max: Some("16Gi".into()),
+        };
+        let below = BuildResourceOverrides {
+            cpu_request: Some("1".into()),
+            cpu_limit: Some("4".into()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            resolve_task_run_resources(&c, RoleResourceClass::BuildCapable, Some(&below), &bounds),
+            Err(ResolveError::BelowMinimum { .. })
+        ));
+        let above = BuildResourceOverrides {
+            cpu_request: Some("4".into()),
+            cpu_limit: Some("16".into()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            resolve_task_run_resources(&c, RoleResourceClass::BuildCapable, Some(&above), &bounds),
+            Err(ResolveError::AboveMaximum { .. })
+        ));
+    }
+
+    #[test]
+    fn apply_overwrites_primary_container() {
+        let c = cfg();
+        let id = uuid::Uuid::nil();
+        let mut job = crate::job::build_task_run_job(
+            &c,
+            &id,
+            "proj",
+            "secret",
+            "img:tag",
+            &[],
+            None,
+            false,
+            None,
+        );
+        let br = BuildResourceOverrides {
+            cpu_request: Some("2".into()),
+            cpu_limit: Some("3".into()),
+            memory_request: Some("5Gi".into()),
+            memory_limit: Some("6Gi".into()),
+        };
+        let rr = resolve_task_run_resources(
+            &c,
+            RoleResourceClass::BuildCapable,
+            Some(&br),
+            &ResourceBounds::default(),
+        )
+        .unwrap();
+        apply_resolved_resources(&mut job, rr);
+        let container = &job.spec.unwrap().template.spec.unwrap().containers[0];
+        let res = container.resources.as_ref().unwrap();
+        assert_eq!(res.requests.as_ref().unwrap().get("cpu").unwrap().0, "2");
+        assert_eq!(res.limits.as_ref().unwrap().get("memory").unwrap().0, "6Gi");
+    }
+}

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -176,6 +176,20 @@ pub struct KubernetesConfig {
     /// misconfigured node profile fails closed at dispatch BEFORE any user code
     /// executes. Overridable via `DJINN_K8S_CGROUP_DELEGATION_PROFILE`.
     pub cgroup_delegation_profile: String,
+    /// Administrator-configured hard bounds for per-project `build_resources`
+    /// overrides on the **task-run** Pod. Empty (the default) leaves every axis
+    /// unbounded — a per-project override is only bounded by request ≤ limit.
+    /// A resolved request below `cpu_min`/`memory_min` or a resolved limit above
+    /// `cpu_max`/`memory_max` fails closed at resolution (no Job created).
+    /// Overridable via `DJINN_K8S_TASK_{CPU,MEMORY}_{MIN,MAX}`.
+    #[serde(default)]
+    pub task_resource_bounds: crate::build_resources::ResourceBounds,
+    /// Administrator-configured hard bounds for per-project `build_resources`
+    /// overrides on the **warm** Pod. Same semantics as
+    /// [`Self::task_resource_bounds`]; overridable via
+    /// `DJINN_K8S_WARM_{CPU,MEMORY}_{MIN,MAX}`.
+    #[serde(default)]
+    pub warm_resource_bounds: crate::build_resources::ResourceBounds,
     /// Volume-ownership mode used for the workspace/cache/mirror surfaces. v1
     /// requires `"fsgroup-on-root-mismatch"`
     /// ([`crate::launcher::VOLUME_OWNERSHIP_ON_ROOT_MISMATCH`]): `fsGroup =
@@ -235,6 +249,11 @@ impl KubernetesConfig {
             // to anything the launcher's runtime readiness check would reject.
             cgroup_delegation_profile: crate::launcher::CGROUP_PROFILE_V2_CPU_ONLY.into(),
             volume_ownership_mode: crate::launcher::VOLUME_OWNERSHIP_ON_ROOT_MISMATCH.into(),
+            // Unbounded by default: per-project build_resources overrides are
+            // gated only by request <= limit until an operator configures the
+            // per-kind DJINN_K8S_{TASK,WARM}_{CPU,MEMORY}_{MIN,MAX} envs.
+            task_resource_bounds: crate::build_resources::ResourceBounds::default(),
+            warm_resource_bounds: crate::build_resources::ResourceBounds::default(),
         }
     }
 
@@ -421,6 +440,18 @@ impl KubernetesConfig {
         if let Ok(v) = std::env::var("DJINN_K8S_VOLUME_OWNERSHIP_MODE") {
             cfg.volume_ownership_mode = v;
         }
+        // Per-project build_resources hard bounds (per Pod kind, per resource).
+        // Unset leaves the axis unbounded. Empty strings are ignored so an
+        // operator can clear a bound by exporting the var empty.
+        let bound = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+        cfg.task_resource_bounds.cpu_min = bound("DJINN_K8S_TASK_CPU_MIN");
+        cfg.task_resource_bounds.cpu_max = bound("DJINN_K8S_TASK_CPU_MAX");
+        cfg.task_resource_bounds.memory_min = bound("DJINN_K8S_TASK_MEMORY_MIN");
+        cfg.task_resource_bounds.memory_max = bound("DJINN_K8S_TASK_MEMORY_MAX");
+        cfg.warm_resource_bounds.cpu_min = bound("DJINN_K8S_WARM_CPU_MIN");
+        cfg.warm_resource_bounds.cpu_max = bound("DJINN_K8S_WARM_CPU_MAX");
+        cfg.warm_resource_bounds.memory_min = bound("DJINN_K8S_WARM_MEMORY_MIN");
+        cfg.warm_resource_bounds.memory_max = bound("DJINN_K8S_WARM_MEMORY_MAX");
         cfg
     }
 }

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -728,16 +728,46 @@ impl WarmDispatch {
             return;
         }
 
-        let cargo_cache_policy: Option<djinn_stack::environment::CargoCachePolicy> = {
+        let (cargo_cache_policy, warm_build_resources): (
+            Option<djinn_stack::environment::CargoCachePolicy>,
+            Option<djinn_stack::resources::BuildResourceOverrides>,
+        ) = {
             let repo =
                 ProjectRepository::new(self.db.clone(), djinn_core::events::EventBus::noop());
             match repo.get_environment_config(project_id).await {
                 Ok(Some(raw)) => {
-                    serde_json::from_str::<djinn_stack::environment::EnvironmentConfig>(&raw)
-                        .ok()
-                        .and_then(|cfg| cfg.cargo_cache_policy)
+                    match serde_json::from_str::<djinn_stack::environment::EnvironmentConfig>(&raw)
+                    {
+                        Ok(cfg) => (
+                            cfg.cargo_cache_policy,
+                            cfg.build_resources.and_then(|b| b.warm),
+                        ),
+                        Err(_) => (None, None),
+                    }
                 }
-                _ => None,
+                _ => (None, None),
+            }
+        };
+
+        // Resolve per-project build_resources overrides for the warm Pod. A
+        // bad override fails closed: no warm Job is created this cycle.
+        let resolved_warm_resources = match crate::build_resources::resolve_warm_resources(
+            &self.config,
+            warm_build_resources.as_ref(),
+            &self.config.warm_resource_bounds,
+        ) {
+            Ok(resources) => resources,
+            Err(error) => {
+                warn!(
+                    project_id,
+                    %error,
+                    "K8sGraphWarmer: build_resources resolution failed; skipping warm Job"
+                );
+                let mut guard = self.in_flight.lock().await;
+                if let Some(n) = guard.remove(project_id) {
+                    n.notify_waiters();
+                }
+                return;
             }
         };
 
@@ -800,6 +830,7 @@ impl WarmDispatch {
                 cargo_cache_policy.as_ref(),
             ),
         };
+        crate::build_resources::apply_resolved_resources(&mut job, resolved_warm_resources);
         stamp_admission_identity(&mut job, &admission_request);
         let namespace = self.config.namespace.clone();
         let permit = match (lease_grant.as_ref(), self.admission.as_ref()) {

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -5,6 +5,7 @@
 //! typed configuration, and empty trait-impl shell — real cluster wiring
 //! arrives in PR 3.
 
+pub mod build_resources;
 pub mod config;
 pub mod env_config;
 pub mod graph_warmer;
@@ -21,6 +22,10 @@ pub mod token_review;
 pub mod warm_job;
 pub mod workload_inventory;
 
+pub use build_resources::{
+    ResolveError, ResourceBounds, apply_resolved_resources, resolve_task_run_resources,
+    resolve_warm_resources,
+};
 pub use config::KubernetesConfig;
 pub use env_config::{
     ENV_CONFIG_KEY, ENV_CONFIG_MOUNT_DIR, ENV_CONFIG_MOUNT_FILE, VOLUME_ENV_CONFIG,

--- a/server/crates/djinn-k8s/src/runtime.rs
+++ b/server/crates/djinn-k8s/src/runtime.rs
@@ -676,7 +676,28 @@ impl SessionRuntime for KubernetesRuntime {
         //     role-classed CPU request (light vs build-capable). `None` (an
         //     empty sequence) fails safe to build-capable in the renderer.
         let role = spec.flow.role_sequence().first().copied();
-        let job = build_task_run_job_with_read_sources(
+        // Resolve per-project build_resources overrides for the task-run Pod
+        // BEFORE the Job is built: a malformed / request-above-limit /
+        // out-of-bounds override fails closed here so no Job is ever created.
+        let role_class = crate::launcher::RoleResourceClass::for_role(role);
+        let resolved_task_resources = match crate::build_resources::resolve_task_run_resources(
+            &self.config,
+            role_class,
+            effective_env_config
+                .build_resources
+                .as_ref()
+                .and_then(|b| b.task.as_ref()),
+            &self.config.task_resource_bounds,
+        ) {
+            Ok(resources) => resources,
+            Err(error) => {
+                self.drop_pending(&task_run_id_str).await;
+                return Err(RuntimeError::Prepare(format!(
+                    "build_resources resolution failed for task-run: {error}"
+                )));
+            }
+        };
+        let mut job = build_task_run_job_with_read_sources(
             &self.config,
             &task_run_id,
             &spec.project_id,
@@ -688,6 +709,7 @@ impl SessionRuntime for KubernetesRuntime {
             role,
             read_source_cache_sub_path.as_deref(),
         );
+        crate::build_resources::apply_resolved_resources(&mut job, resolved_task_resources);
         let jobs: Api<Job> = Api::namespaced(self.client.clone(), ns);
         let created_job = match jobs.create(&PostParams::default(), &job).await {
             Ok(j) => j,

--- a/server/crates/djinn-k8s/tests/build_resources_contract.rs
+++ b/server/crates/djinn-k8s/tests/build_resources_contract.rs
@@ -1,0 +1,248 @@
+//! Contract test for per-project `build_resources` overrides (ri23 Part 3).
+//!
+//! Drives the `build_resources_v1.yaml` fixture through the public resolver
+//! and render surface of `djinn-k8s`, proving:
+//!
+//! * unset per-kind fields inherit the deployment defaults;
+//! * valid distinct task and warm CPU + memory quantities render **unchanged**
+//!   into their corresponding Job/Pod specs;
+//! * malformed, zero/negative, request-above-limit, below-minimum, and
+//!   above-maximum values reject at resolution — so no Job is ever built;
+//! * task and warm resolve independently;
+//! * production retains the 4-vCPU deployment default.
+
+use djinn_k8s::build_resources::{ResolveError, ResourceBounds};
+use djinn_k8s::launcher::RoleResourceClass;
+use djinn_k8s::{
+    KubernetesConfig, apply_resolved_resources, resolve_task_run_resources, resolve_warm_resources,
+};
+use djinn_stack::resources::BuildResourceOverrides;
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::ResourceRequirements;
+use serde::Deserialize;
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    name: String,
+    kind: Kind,
+    expect: Expect,
+    #[serde(default)]
+    overrides: Option<BuildResourceOverrides>,
+    #[serde(default)]
+    bounds: Option<ResourceBounds>,
+    #[serde(default)]
+    expected: Option<Expected>,
+    #[serde(default)]
+    inherits_defaults: bool,
+    #[serde(default)]
+    reject_kind: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Kind {
+    Task,
+    Warm,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Expect {
+    Ok,
+    Reject,
+}
+
+#[derive(Debug, Deserialize)]
+struct Expected {
+    cpu_request: String,
+    cpu_limit: String,
+    memory_request: String,
+    memory_limit: String,
+}
+
+fn resolve(config: &KubernetesConfig, case: &Case) -> Result<ResourceRequirements, ResolveError> {
+    let bounds = case.bounds.clone().unwrap_or_default();
+    match case.kind {
+        Kind::Task => resolve_task_run_resources(
+            config,
+            RoleResourceClass::BuildCapable,
+            case.overrides.as_ref(),
+            &bounds,
+        ),
+        Kind::Warm => resolve_warm_resources(config, case.overrides.as_ref(), &bounds),
+    }
+}
+
+fn get(rr: &ResourceRequirements, section: &str, key: &str) -> String {
+    let map = match section {
+        "requests" => rr.requests.as_ref(),
+        _ => rr.limits.as_ref(),
+    };
+    map.unwrap().get(key).unwrap().0.clone()
+}
+
+/// Render the resolved requirements into a real Job of the case's kind, then
+/// return the primary container's resources — proving the quantities land on
+/// the actual k8s spec, not just the resolver output.
+fn render_into_job(
+    config: &KubernetesConfig,
+    kind: Kind,
+    rr: ResourceRequirements,
+) -> ResourceRequirements {
+    let mut job: Job = match kind {
+        Kind::Task => djinn_k8s::job::build_task_run_job(
+            config,
+            &Uuid::nil(),
+            "proj",
+            "secret",
+            "img:tag",
+            &[],
+            None,
+            false,
+            None,
+        ),
+        Kind::Warm => djinn_k8s::build_warm_job(config, "proj", "img:tag", None),
+    };
+    apply_resolved_resources(&mut job, rr);
+    job.spec
+        .unwrap()
+        .template
+        .spec
+        .unwrap()
+        .containers
+        .into_iter()
+        .find(|c| c.name == "worker" || c.name == "warmer")
+        .unwrap()
+        .resources
+        .unwrap()
+}
+
+fn reject_variant(err: &ResolveError) -> &'static str {
+    match err {
+        ResolveError::InvalidQuantity { .. } => "invalid_quantity",
+        ResolveError::InvalidBound { .. } => "invalid_bound",
+        ResolveError::RequestExceedsLimit { .. } => "request_exceeds_limit",
+        ResolveError::BelowMinimum { .. } => "below_minimum",
+        ResolveError::AboveMaximum { .. } => "above_maximum",
+    }
+}
+
+#[test]
+fn build_resources_v1_contract() {
+    let raw = include_str!("fixtures/build_resources_v1.yaml");
+    let fixture: Fixture = serde_yaml::from_str(raw).expect("fixture parses");
+    let config = KubernetesConfig::for_testing();
+
+    // Production retains the 4-vCPU deployment default.
+    assert_eq!(config.cpu_limit, "4", "task-run cpu limit default");
+    assert_eq!(config.warm_cpu_limit, "4", "warm cpu limit default");
+
+    for case in &fixture.cases {
+        let outcome = resolve(&config, case);
+        match case.expect {
+            Expect::Reject => {
+                let err = outcome
+                    .as_ref()
+                    .err()
+                    .unwrap_or_else(|| panic!("case {}: expected reject, got Ok", case.name));
+                if let Some(expected_kind) = &case.reject_kind {
+                    assert_eq!(
+                        reject_variant(err),
+                        expected_kind,
+                        "case {}: wrong reject variant",
+                        case.name
+                    );
+                }
+                // Reject means no Job: we never reach render_into_job.
+            }
+            Expect::Ok => {
+                let rr =
+                    outcome.unwrap_or_else(|e| panic!("case {}: expected Ok, got {e}", case.name));
+
+                if case.inherits_defaults {
+                    let (cr, cl, mr, ml) = match case.kind {
+                        Kind::Task => (
+                            &config.cpu_request,
+                            &config.cpu_limit,
+                            &config.memory_request,
+                            &config.memory_limit,
+                        ),
+                        Kind::Warm => (
+                            &config.warm_cpu_request,
+                            &config.warm_cpu_limit,
+                            &config.warm_memory_request,
+                            &config.warm_memory_limit,
+                        ),
+                    };
+                    assert_eq!(&get(&rr, "requests", "cpu"), cr, "{}", case.name);
+                    assert_eq!(&get(&rr, "limits", "cpu"), cl, "{}", case.name);
+                    assert_eq!(&get(&rr, "requests", "memory"), mr, "{}", case.name);
+                    assert_eq!(&get(&rr, "limits", "memory"), ml, "{}", case.name);
+                }
+
+                // Render into the real Job and assert the quantities land there
+                // unchanged.
+                let rendered = render_into_job(&config, case.kind, rr);
+                if let Some(exp) = &case.expected {
+                    assert_eq!(
+                        get(&rendered, "requests", "cpu"),
+                        exp.cpu_request,
+                        "{}: cpu request",
+                        case.name
+                    );
+                    assert_eq!(
+                        get(&rendered, "limits", "cpu"),
+                        exp.cpu_limit,
+                        "{}: cpu limit",
+                        case.name
+                    );
+                    assert_eq!(
+                        get(&rendered, "requests", "memory"),
+                        exp.memory_request,
+                        "{}: memory request",
+                        case.name
+                    );
+                    assert_eq!(
+                        get(&rendered, "limits", "memory"),
+                        exp.memory_limit,
+                        "{}: memory limit",
+                        case.name
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Task and warm resolve independently: overriding one kind never perturbs the
+/// other, which stays on its own deployment default.
+#[test]
+fn task_and_warm_resolve_independently() {
+    let config = KubernetesConfig::for_testing();
+    let task_only = BuildResourceOverrides {
+        cpu_request: Some("2".into()),
+        cpu_limit: Some("2".into()),
+        memory_request: Some("7Gi".into()),
+        memory_limit: Some("7Gi".into()),
+    };
+    let task = resolve_task_run_resources(
+        &config,
+        RoleResourceClass::BuildCapable,
+        Some(&task_only),
+        &ResourceBounds::default(),
+    )
+    .expect("task resolves");
+    let warm =
+        resolve_warm_resources(&config, None, &ResourceBounds::default()).expect("warm resolves");
+
+    assert_eq!(get(&task, "requests", "memory"), "7Gi");
+    // Warm ignored the task override entirely.
+    assert_eq!(get(&warm, "requests", "memory"), config.warm_memory_request);
+    assert_eq!(get(&warm, "limits", "cpu"), config.warm_cpu_limit);
+}

--- a/server/crates/djinn-k8s/tests/fixtures/build_resources_v1.yaml
+++ b/server/crates/djinn-k8s/tests/fixtures/build_resources_v1.yaml
@@ -1,0 +1,152 @@
+# build_resources_v1 — contract cases for per-project build_resources overrides.
+#
+# Each case resolves one Pod kind (`kind: task | warm`) against the
+# deployment defaults from `KubernetesConfig::for_testing()`, optional
+# per-kind admin `bounds`, and the given `overrides`.
+#
+# expect:
+#   ok      — resolution succeeds; if `expected` is present the rendered
+#             request/limit quantities must match it byte-for-byte; if
+#             `inherits_defaults` is true the rendered quantities must equal the
+#             deployment defaults for that kind.
+#   reject  — resolution MUST fail (no Job is created); `reject_kind` names the
+#             ResolveError variant expected.
+cases:
+  # Unset fields inherit the deployment defaults for each kind.
+  - name: task_unset_inherits_defaults
+    kind: task
+    expect: ok
+    inherits_defaults: true
+
+  - name: warm_unset_inherits_defaults
+    kind: warm
+    expect: ok
+    inherits_defaults: true
+
+  # A partial override inherits the deployment default for the unset fields
+  # while the set field renders unchanged.
+  - name: task_partial_override_inherits_rest
+    kind: task
+    overrides:
+      memory_limit: "8Gi"
+    expect: ok
+
+  # Valid distinct task quantities render unchanged into the task spec.
+  - name: task_distinct_valid_renders_unchanged
+    kind: task
+    overrides:
+      cpu_request: "2"
+      cpu_limit: "3"
+      memory_request: "5Gi"
+      memory_limit: "6Gi"
+    expect: ok
+    expected:
+      cpu_request: "2"
+      cpu_limit: "3"
+      memory_request: "5Gi"
+      memory_limit: "6Gi"
+
+  # Valid distinct warm quantities render unchanged into the warm spec — and
+  # are distinct from the task numbers above (kinds resolve independently).
+  - name: warm_distinct_valid_renders_unchanged
+    kind: warm
+    overrides:
+      cpu_request: "6"
+      cpu_limit: "6"
+      memory_request: "10Gi"
+      memory_limit: "12Gi"
+    expect: ok
+    expected:
+      cpu_request: "6"
+      cpu_limit: "6"
+      memory_request: "10Gi"
+      memory_limit: "12Gi"
+
+  # Millicore + binary-SI forms round-trip unchanged.
+  - name: task_millicore_and_mi_render_unchanged
+    kind: task
+    overrides:
+      cpu_request: "500m"
+      cpu_limit: "1500m"
+      memory_request: "512Mi"
+      memory_limit: "1024Mi"
+    expect: ok
+    expected:
+      cpu_request: "500m"
+      cpu_limit: "1500m"
+      memory_request: "512Mi"
+      memory_limit: "1024Mi"
+
+  # Malformed quantity → reject, no Job.
+  - name: task_malformed_rejects
+    kind: task
+    overrides:
+      cpu_request: "not-a-quantity"
+    expect: reject
+    reject_kind: invalid_quantity
+
+  # Zero / negative are non-positive → reject.
+  - name: task_zero_rejects
+    kind: task
+    overrides:
+      memory_request: "0"
+    expect: reject
+    reject_kind: invalid_quantity
+
+  - name: warm_negative_rejects
+    kind: warm
+    overrides:
+      cpu_limit: "-1"
+    expect: reject
+    reject_kind: invalid_quantity
+
+  # Request above limit after defaults+overrides combine → reject. Only the
+  # request is overridden (to above the "4" default cpu_limit).
+  - name: task_request_above_limit_rejects
+    kind: task
+    overrides:
+      cpu_request: "8"
+    expect: reject
+    reject_kind: request_exceeds_limit
+
+  # Below the admin minimum → reject.
+  - name: task_below_minimum_rejects
+    kind: task
+    bounds:
+      cpu_min: "2"
+    overrides:
+      cpu_request: "1"
+      cpu_limit: "4"
+    expect: reject
+    reject_kind: below_minimum
+
+  # Above the admin maximum → reject.
+  - name: warm_above_maximum_rejects
+    kind: warm
+    bounds:
+      memory_max: "8Gi"
+    overrides:
+      memory_request: "4Gi"
+      memory_limit: "16Gi"
+    expect: reject
+    reject_kind: above_maximum
+
+  # Within configured bounds → ok.
+  - name: task_within_bounds_ok
+    kind: task
+    bounds:
+      cpu_min: "1"
+      cpu_max: "8"
+      memory_min: "1Gi"
+      memory_max: "16Gi"
+    overrides:
+      cpu_request: "2"
+      cpu_limit: "4"
+      memory_request: "4Gi"
+      memory_limit: "8Gi"
+    expect: ok
+    expected:
+      cpu_request: "2"
+      cpu_limit: "4"
+      memory_request: "4Gi"
+      memory_limit: "8Gi"

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -5004,6 +5004,18 @@
                 "type": "string"
               },
               "default": []
+            },
+            "build_resources": {
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`].",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
             }
           },
           "additionalProperties": false
@@ -5692,6 +5704,76 @@
             "label",
             "args"
           ]
+        },
+        "BuildResources": {
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "type": "object",
+          "properties": {
+            "task": {
+              "description": "Overrides applied to the task-run Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "warm": {
+              "description": "Overrides applied to the warm-job Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
+        },
+        "BuildResourceOverrides": {
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "type": "object",
+          "properties": {
+            "cpu_request": {
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "cpu_limit": {
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_request": {
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_limit": {
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -5948,6 +6030,18 @@
                 "type": "string"
               },
               "default": []
+            },
+            "build_resources": {
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`].",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
             }
           },
           "additionalProperties": false
@@ -6636,6 +6730,76 @@
             "label",
             "args"
           ]
+        },
+        "BuildResources": {
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "type": "object",
+          "properties": {
+            "task": {
+              "description": "Overrides applied to the task-run Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "warm": {
+              "description": "Overrides applied to the warm-job Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
+        },
+        "BuildResourceOverrides": {
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "type": "object",
+          "properties": {
+            "cpu_request": {
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "cpu_limit": {
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_request": {
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_limit": {
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -6834,6 +6998,18 @@
                 "type": "string"
               },
               "default": []
+            },
+            "build_resources": {
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`].",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
             }
           },
           "additionalProperties": false
@@ -7522,6 +7698,76 @@
             "label",
             "args"
           ]
+        },
+        "BuildResources": {
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "type": "object",
+          "properties": {
+            "task": {
+              "description": "Overrides applied to the task-run Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "warm": {
+              "description": "Overrides applied to the warm-job Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
+        },
+        "BuildResourceOverrides": {
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "type": "object",
+          "properties": {
+            "cpu_request": {
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "cpu_limit": {
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_request": {
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_limit": {
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -13249,6 +13495,18 @@
                 "type": "string"
               },
               "default": []
+            },
+            "build_resources": {
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`].",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
             }
           },
           "additionalProperties": false
@@ -13937,6 +14195,76 @@
             "label",
             "args"
           ]
+        },
+        "BuildResources": {
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "type": "object",
+          "properties": {
+            "task": {
+              "description": "Overrides applied to the task-run Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "warm": {
+              "description": "Overrides applied to the warm-job Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
+        },
+        "BuildResourceOverrides": {
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "type": "object",
+          "properties": {
+            "cpu_request": {
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "cpu_limit": {
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_request": {
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_limit": {
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -14111,6 +14439,18 @@
                 "type": "string"
               },
               "default": []
+            },
+            "build_resources": {
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`].",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
             }
           },
           "additionalProperties": false
@@ -14799,6 +15139,76 @@
             "label",
             "args"
           ]
+        },
+        "BuildResources": {
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "type": "object",
+          "properties": {
+            "task": {
+              "description": "Overrides applied to the task-run Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "warm": {
+              "description": "Overrides applied to the warm-job Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
+        },
+        "BuildResourceOverrides": {
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "type": "object",
+          "properties": {
+            "cpu_request": {
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "cpu_limit": {
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_request": {
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_limit": {
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -14947,6 +15357,18 @@
                 "type": "string"
               },
               "default": []
+            },
+            "build_resources": {
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`].",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
             }
           },
           "additionalProperties": false
@@ -15635,6 +16057,76 @@
             "label",
             "args"
           ]
+        },
+        "BuildResources": {
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "type": "object",
+          "properties": {
+            "task": {
+              "description": "Overrides applied to the task-run Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "warm": {
+              "description": "Overrides applied to the warm-job Pod.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
+        },
+        "BuildResourceOverrides": {
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "type": "object",
+          "properties": {
+            "cpu_request": {
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "cpu_limit": {
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_request": {
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "memory_limit": {
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            }
+          },
+          "additionalProperties": false
         }
       },
       "type": "object",

--- a/server/crates/djinn-stack/src/environment.rs
+++ b/server/crates/djinn-stack/src/environment.rs
@@ -92,6 +92,14 @@ pub enum EnvironmentConfigError {
     },
     #[error("{field}: duplicate name after normalization: {name:?}")]
     DuplicateName { field: String, name: String },
+    #[error("{field}: value {value:?} is not a valid Kubernetes resource quantity")]
+    InvalidQuantity { field: String, value: String },
+    #[error("{field}: request {request:?} exceeds limit {limit:?}")]
+    RequestExceedsLimit {
+        field: String,
+        request: String,
+        limit: String,
+    },
 }
 
 pub type EnvResult<T> = std::result::Result<T, EnvironmentConfigError>;
@@ -163,6 +171,13 @@ pub struct EnvironmentConfig {
     /// is a registered skill identifier.
     #[serde(default)]
     pub global_skills: Vec<String>,
+    /// Optional per-project CPU/memory overrides for the task-run and warm
+    /// Pods, layered over the deployment-wide defaults. `None` (the default)
+    /// keeps every kind on its deployment default. Task and warm blocks resolve
+    /// independently; the resolved quantities are rendered into the k8s Job/Pod
+    /// specs by `djinn-k8s`. See [`crate::resources::BuildResources`].
+    #[serde(default)]
+    pub build_resources: Option<crate::resources::BuildResources>,
 }
 
 impl EnvironmentConfig {
@@ -180,6 +195,7 @@ impl EnvironmentConfig {
             cargo_cache_policy: default_cargo_cache_policy(),
             agent_mcp_defaults: BTreeMap::new(),
             global_skills: Vec::new(),
+            build_resources: None,
         }
     }
 
@@ -337,6 +353,9 @@ impl EnvironmentConfig {
         self.lifecycle.validate()?;
         if let Some(policy) = &self.cargo_cache_policy {
             policy.validate()?;
+        }
+        if let Some(build_resources) = &self.build_resources {
+            build_resources.validate()?;
         }
         Ok(())
     }

--- a/server/crates/djinn-stack/src/lib.rs
+++ b/server/crates/djinn-stack/src/lib.rs
@@ -16,6 +16,7 @@ pub mod frameworks;
 pub mod heuristics;
 pub mod languages;
 pub mod manifests;
+pub mod resources;
 pub mod schema;
 pub mod slug;
 pub mod test_runners;

--- a/server/crates/djinn-stack/src/resources.rs
+++ b/server/crates/djinn-stack/src/resources.rs
@@ -1,0 +1,341 @@
+//! Per-project build resource overrides + Kubernetes Quantity parsing.
+//!
+//! `EnvironmentConfig.build_resources` lets a project raise or lower the CPU
+//! and memory a task-run or warm Pod is provisioned with, on top of the
+//! deployment-wide defaults. Task-run and warm blocks resolve *independently*:
+//! neither inherits the other's overrides, and any field left unset inherits
+//! its deployment default (see `djinn-k8s` for the resolution + render step).
+//!
+//! This module owns the shape (`BuildResources` / `BuildResourceOverrides`),
+//! the write-time validation (parse, positivity, and per-block
+//! request ≤ limit), and an exact-rational [`Quantity`] parser reused by the
+//! `djinn-k8s` resolver for the resolution-time bound checks. Values are the
+//! same strings the Kubernetes Quantity parser accepts (e.g. `"4"`, `"300m"`,
+//! `"8Gi"`); malformed, zero, or negative values are rejected, never clamped.
+
+use std::cmp::Ordering;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::environment::{EnvResult, EnvironmentConfigError};
+
+/// Optional per-project CPU/memory overrides for the task-run and warm Pods.
+///
+/// The whole object is optional on `EnvironmentConfig`; each inner block is
+/// optional; each field within a block is optional. Anything unset inherits
+/// the deployment default at resolution time. The two blocks are resolved
+/// separately — a `task` override never affects `warm` and vice-versa.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BuildResources {
+    /// Overrides applied to the task-run Pod.
+    #[serde(default)]
+    pub task: Option<BuildResourceOverrides>,
+    /// Overrides applied to the warm-job Pod.
+    #[serde(default)]
+    pub warm: Option<BuildResourceOverrides>,
+}
+
+impl BuildResources {
+    /// Validate both blocks. Called from [`crate::environment::EnvironmentConfig::validate`]
+    /// before any config write.
+    pub(crate) fn validate(&self) -> EnvResult<()> {
+        if let Some(task) = &self.task {
+            task.validate("build_resources.task")?;
+        }
+        if let Some(warm) = &self.warm {
+            warm.validate("build_resources.warm")?;
+        }
+        Ok(())
+    }
+}
+
+/// CPU + memory request/limit overrides for one Pod kind. Every field is an
+/// optional Kubernetes Quantity string; `None` inherits the deployment default.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BuildResourceOverrides {
+    /// CPU request override (e.g. `"4"`, `"500m"`).
+    #[serde(default)]
+    pub cpu_request: Option<String>,
+    /// CPU limit override.
+    #[serde(default)]
+    pub cpu_limit: Option<String>,
+    /// Memory request override (e.g. `"8Gi"`, `"512Mi"`).
+    #[serde(default)]
+    pub memory_request: Option<String>,
+    /// Memory limit override.
+    #[serde(default)]
+    pub memory_limit: Option<String>,
+}
+
+impl BuildResourceOverrides {
+    /// Write-time validation: every present field must parse as a positive
+    /// Quantity, and where both a request and its limit are present *in this
+    /// block* the request must not exceed the limit. Cross-default checks
+    /// (request ≤ limit after combining with the deployment default, and admin
+    /// min/max bounds) run at resolution time in `djinn-k8s`, which has the
+    /// deployment context this module lacks.
+    fn validate(&self, field: &str) -> EnvResult<()> {
+        let cpu_request = validate_quantity(field, "cpu_request", &self.cpu_request)?;
+        let cpu_limit = validate_quantity(field, "cpu_limit", &self.cpu_limit)?;
+        let memory_request = validate_quantity(field, "memory_request", &self.memory_request)?;
+        let memory_limit = validate_quantity(field, "memory_limit", &self.memory_limit)?;
+
+        if let (Some(req), Some(lim)) = (cpu_request, cpu_limit)
+            && req > lim
+        {
+            return Err(EnvironmentConfigError::RequestExceedsLimit {
+                field: format!("{field}.cpu"),
+                request: self.cpu_request.clone().unwrap_or_default(),
+                limit: self.cpu_limit.clone().unwrap_or_default(),
+            });
+        }
+        if let (Some(req), Some(lim)) = (memory_request, memory_limit)
+            && req > lim
+        {
+            return Err(EnvironmentConfigError::RequestExceedsLimit {
+                field: format!("{field}.memory"),
+                request: self.memory_request.clone().unwrap_or_default(),
+                limit: self.memory_limit.clone().unwrap_or_default(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Parse an optional quantity field, rejecting malformed / zero / negative
+/// values. Returns `None` for an unset field (inherits the default).
+fn validate_quantity(
+    block: &str,
+    field: &str,
+    value: &Option<String>,
+) -> EnvResult<Option<Quantity>> {
+    match value {
+        None => Ok(None),
+        Some(raw) => match Quantity::parse(raw) {
+            Some(q) if q.is_positive() => Ok(Some(q)),
+            _ => Err(EnvironmentConfigError::InvalidQuantity {
+                field: format!("{block}.{field}"),
+                value: raw.clone(),
+            }),
+        },
+    }
+}
+
+/// A parsed Kubernetes resource Quantity, kept as an exact rational
+/// (`value = num / den`, with `den > 0`) so requests, limits, and admin bounds
+/// compare without floating-point error across the full CPU (millicores) and
+/// memory (bytes) range.
+///
+/// Accepts the common Kubernetes suffixes: decimal SI (`n`, `u`, `m`, `k`,
+/// `M`, `G`, `T`, `P`) and binary SI (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`),
+/// plus a bare or decimal number. Scientific notation and the ambiguous `E`
+/// (Exa) suffix are intentionally not accepted — no djinn resource quantity
+/// uses them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Quantity {
+    num: i128,
+    den: i128,
+}
+
+impl Quantity {
+    /// Parse a Kubernetes Quantity string. Returns `None` if the string is not
+    /// a syntactically valid quantity. A syntactically valid but non-positive
+    /// value (`"0"`, `"-1"`) parses; callers gate on [`Self::is_positive`].
+    pub fn parse(input: &str) -> Option<Self> {
+        let s = input.trim();
+        if s.is_empty() {
+            return None;
+        }
+        // The numeric prefix is the leading run of digits, sign, and decimal
+        // point; everything after it is the suffix.
+        let split = s
+            .find(|c: char| !(c.is_ascii_digit() || c == '.' || c == '+' || c == '-'))
+            .unwrap_or(s.len());
+        let (num_part, suffix) = s.split_at(split);
+        let (mant_num, mant_den) = parse_decimal(num_part)?;
+        let (suf_num, suf_den) = suffix_multiplier(suffix)?;
+        let num = mant_num.checked_mul(suf_num)?;
+        let den = mant_den.checked_mul(suf_den)?;
+        if den == 0 {
+            return None;
+        }
+        Some(Self { num, den }.reduced())
+    }
+
+    /// Whether the quantity is strictly greater than zero.
+    pub fn is_positive(&self) -> bool {
+        self.num > 0
+    }
+
+    fn reduced(self) -> Self {
+        let g = gcd(self.num.abs(), self.den.abs()).max(1);
+        Self {
+            num: self.num / g,
+            den: self.den / g,
+        }
+    }
+}
+
+impl PartialOrd for Quantity {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Quantity {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // den and other.den are both > 0, so the cross-multiplied comparison
+        // preserves ordering. Values stay well within i128.
+        (self.num * other.den).cmp(&(other.num * self.den))
+    }
+}
+
+/// Multiplier for a Kubernetes quantity suffix as an exact `(numerator,
+/// denominator)` rational. `None` for an unrecognized suffix.
+fn suffix_multiplier(suffix: &str) -> Option<(i128, i128)> {
+    Some(match suffix {
+        "" => (1, 1),
+        "n" => (1, 1_000_000_000),
+        "u" => (1, 1_000_000),
+        "m" => (1, 1_000),
+        "k" => (1_000, 1),
+        "M" => (1_000_000, 1),
+        "G" => (1_000_000_000, 1),
+        "T" => (1_000_000_000_000, 1),
+        "P" => (1_000_000_000_000_000, 1),
+        "Ki" => (1i128 << 10, 1),
+        "Mi" => (1i128 << 20, 1),
+        "Gi" => (1i128 << 30, 1),
+        "Ti" => (1i128 << 40, 1),
+        "Pi" => (1i128 << 50, 1),
+        "Ei" => (1i128 << 60, 1),
+        _ => return None,
+    })
+}
+
+/// Parse the numeric prefix (optional sign, digits, optional single decimal
+/// point) into an exact `(numerator, denominator)` rational.
+fn parse_decimal(s: &str) -> Option<(i128, i128)> {
+    let (neg, rest) = match s.strip_prefix('-') {
+        Some(r) => (true, r),
+        None => (false, s.strip_prefix('+').unwrap_or(s)),
+    };
+    let mut parts = rest.split('.');
+    let int_part = parts.next().unwrap_or("");
+    let frac_part = parts.next().unwrap_or("");
+    if parts.next().is_some() {
+        return None; // more than one decimal point
+    }
+    if int_part.is_empty() && frac_part.is_empty() {
+        return None;
+    }
+    if !int_part.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if !frac_part.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let combined = format!("{int_part}{frac_part}");
+    let mut num: i128 = combined.parse().ok()?;
+    let den: i128 = 10i128.checked_pow(u32::try_from(frac_part.len()).ok()?)?;
+    if neg {
+        num = -num;
+    }
+    Some((num, den))
+}
+
+fn gcd(mut a: i128, mut b: i128) -> i128 {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(s: &str) -> Quantity {
+        Quantity::parse(s).unwrap_or_else(|| panic!("{s} should parse"))
+    }
+
+    #[test]
+    fn parses_plain_millis_and_binary_si() {
+        assert!(q("4") == q("4000m"));
+        assert!(q("1") == q("1000m"));
+        assert!(q("1.5") > q("1"));
+        assert!(q("300m") < q("1"));
+        assert!(q("8Gi") > q("4Gi"));
+        assert!(q("1Gi") == q("1024Mi"));
+        assert!(q("1Mi") == q("1024Ki"));
+        assert!(q("2Gi") > q("2G")); // binary > decimal
+    }
+
+    #[test]
+    fn rejects_malformed() {
+        for bad in [
+            "", "  ", "abc", "4x", "1.2.3", "Gi", "m", "4 Gi", "1e3", "4E",
+        ] {
+            assert!(Quantity::parse(bad).is_none(), "{bad} must not parse");
+        }
+    }
+
+    #[test]
+    fn parses_but_flags_non_positive() {
+        assert!(!q("0").is_positive());
+        assert!(!q("0Gi").is_positive());
+        assert!(!q("-1").is_positive());
+        assert!(q("1m").is_positive());
+    }
+
+    #[test]
+    fn validate_accepts_unset_and_valid() {
+        let ov = BuildResourceOverrides {
+            cpu_request: Some("2".into()),
+            cpu_limit: Some("4".into()),
+            memory_request: None,
+            memory_limit: Some("8Gi".into()),
+        };
+        ov.validate("build_resources.task")
+            .expect("valid overrides");
+        BuildResourceOverrides::default()
+            .validate("build_resources.warm")
+            .expect("empty overrides valid");
+    }
+
+    #[test]
+    fn validate_rejects_malformed_and_request_above_limit() {
+        let malformed = BuildResourceOverrides {
+            cpu_request: Some("nonsense".into()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            malformed.validate("build_resources.task"),
+            Err(EnvironmentConfigError::InvalidQuantity { .. })
+        ));
+
+        let zero = BuildResourceOverrides {
+            memory_limit: Some("0".into()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            zero.validate("build_resources.task"),
+            Err(EnvironmentConfigError::InvalidQuantity { .. })
+        ));
+
+        let inverted = BuildResourceOverrides {
+            cpu_request: Some("4".into()),
+            cpu_limit: Some("2".into()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            inverted.validate("build_resources.task"),
+            Err(EnvironmentConfigError::RequestExceedsLimit { .. })
+        ));
+    }
+}

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -4852,6 +4852,76 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$defs": {
+        "BuildResourceOverrides": {
+          "additionalProperties": false,
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "properties": {
+            "cpu_limit": {
+              "default": null,
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu_request": {
+              "default": null,
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_limit": {
+              "default": null,
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_request": {
+              "default": null,
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "BuildResources": {
+          "additionalProperties": false,
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "properties": {
+            "task": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the task-run Pod."
+            },
+            "warm": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the warm-job Pod."
+            }
+          },
+          "type": "object"
+        },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
           "oneOf": [
@@ -4984,6 +5054,18 @@ expression: signatures
               "default": {},
               "description": "Per-agent-role MCP server defaults. The key is a role\nname (e.g. `\"worker\"`, `\"chat\"`) or `\"*\"` for the fallback applied to\nany role with no explicit entry. The value is the list of MCP server\nnames (from root `mcp.json`) that sessions for that role should\nconnect to by default. Specialist role assignments override these.",
               "type": "object"
+            },
+            "build_resources": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`]."
             },
             "cargo_cache_policy": {
               "anyOf": [
@@ -5755,6 +5837,76 @@ expression: signatures
     },
     "output_schema": {
       "$defs": {
+        "BuildResourceOverrides": {
+          "additionalProperties": false,
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "properties": {
+            "cpu_limit": {
+              "default": null,
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu_request": {
+              "default": null,
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_limit": {
+              "default": null,
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_request": {
+              "default": null,
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "BuildResources": {
+          "additionalProperties": false,
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "properties": {
+            "task": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the task-run Pod."
+            },
+            "warm": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the warm-job Pod."
+            }
+          },
+          "type": "object"
+        },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
           "oneOf": [
@@ -5887,6 +6039,18 @@ expression: signatures
               "default": {},
               "description": "Per-agent-role MCP server defaults. The key is a role\nname (e.g. `\"worker\"`, `\"chat\"`) or `\"*\"` for the fallback applied to\nany role with no explicit entry. The value is the list of MCP server\nnames (from root `mcp.json`) that sessions for that role should\nconnect to by default. Specialist role assignments override these.",
               "type": "object"
+            },
+            "build_resources": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`]."
             },
             "cargo_cache_policy": {
               "anyOf": [
@@ -6678,6 +6842,76 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$defs": {
+        "BuildResourceOverrides": {
+          "additionalProperties": false,
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "properties": {
+            "cpu_limit": {
+              "default": null,
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu_request": {
+              "default": null,
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_limit": {
+              "default": null,
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_request": {
+              "default": null,
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "BuildResources": {
+          "additionalProperties": false,
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "properties": {
+            "task": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the task-run Pod."
+            },
+            "warm": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the warm-job Pod."
+            }
+          },
+          "type": "object"
+        },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
           "oneOf": [
@@ -6810,6 +7044,18 @@ expression: signatures
               "default": {},
               "description": "Per-agent-role MCP server defaults. The key is a role\nname (e.g. `\"worker\"`, `\"chat\"`) or `\"*\"` for the fallback applied to\nany role with no explicit entry. The value is the list of MCP server\nnames (from root `mcp.json`) that sessions for that role should\nconnect to by default. Specialist role assignments override these.",
               "type": "object"
+            },
+            "build_resources": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`]."
             },
             "cargo_cache_policy": {
               "anyOf": [
@@ -13053,6 +13299,76 @@ expression: signatures
     },
     "output_schema": {
       "$defs": {
+        "BuildResourceOverrides": {
+          "additionalProperties": false,
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "properties": {
+            "cpu_limit": {
+              "default": null,
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu_request": {
+              "default": null,
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_limit": {
+              "default": null,
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_request": {
+              "default": null,
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "BuildResources": {
+          "additionalProperties": false,
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "properties": {
+            "task": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the task-run Pod."
+            },
+            "warm": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the warm-job Pod."
+            }
+          },
+          "type": "object"
+        },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
           "oneOf": [
@@ -13185,6 +13501,18 @@ expression: signatures
               "default": {},
               "description": "Per-agent-role MCP server defaults. The key is a role\nname (e.g. `\"worker\"`, `\"chat\"`) or `\"*\"` for the fallback applied to\nany role with no explicit entry. The value is the list of MCP server\nnames (from root `mcp.json`) that sessions for that role should\nconnect to by default. Specialist role assignments override these.",
               "type": "object"
+            },
+            "build_resources": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`]."
             },
             "cargo_cache_policy": {
               "anyOf": [
@@ -13914,6 +14242,76 @@ expression: signatures
     },
     "output_schema": {
       "$defs": {
+        "BuildResourceOverrides": {
+          "additionalProperties": false,
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "properties": {
+            "cpu_limit": {
+              "default": null,
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu_request": {
+              "default": null,
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_limit": {
+              "default": null,
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_request": {
+              "default": null,
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "BuildResources": {
+          "additionalProperties": false,
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "properties": {
+            "task": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the task-run Pod."
+            },
+            "warm": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the warm-job Pod."
+            }
+          },
+          "type": "object"
+        },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
           "oneOf": [
@@ -14046,6 +14444,18 @@ expression: signatures
               "default": {},
               "description": "Per-agent-role MCP server defaults. The key is a role\nname (e.g. `\"worker\"`, `\"chat\"`) or `\"*\"` for the fallback applied to\nany role with no explicit entry. The value is the list of MCP server\nnames (from root `mcp.json`) that sessions for that role should\nconnect to by default. Specialist role assignments override these.",
               "type": "object"
+            },
+            "build_resources": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`]."
             },
             "cargo_cache_policy": {
               "anyOf": [
@@ -14749,6 +15159,76 @@ expression: signatures
     "concurrent_safe": false,
     "input_schema": {
       "$defs": {
+        "BuildResourceOverrides": {
+          "additionalProperties": false,
+          "description": "CPU + memory request/limit overrides for one Pod kind. Every field is an\noptional Kubernetes Quantity string; `None` inherits the deployment default.",
+          "properties": {
+            "cpu_limit": {
+              "default": null,
+              "description": "CPU limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cpu_request": {
+              "default": null,
+              "description": "CPU request override (e.g. `\"4\"`, `\"500m\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_limit": {
+              "default": null,
+              "description": "Memory limit override.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "memory_request": {
+              "default": null,
+              "description": "Memory request override (e.g. `\"8Gi\"`, `\"512Mi\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "BuildResources": {
+          "additionalProperties": false,
+          "description": "Optional per-project CPU/memory overrides for the task-run and warm Pods.\n\nThe whole object is optional on `EnvironmentConfig`; each inner block is\noptional; each field within a block is optional. Anything unset inherits\nthe deployment default at resolution time. The two blocks are resolved\nseparately — a `task` override never affects `warm` and vice-versa.",
+          "properties": {
+            "task": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the task-run Pod."
+            },
+            "warm": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResourceOverrides"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Overrides applied to the warm-job Pod."
+            }
+          },
+          "type": "object"
+        },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
           "oneOf": [
@@ -14881,6 +15361,18 @@ expression: signatures
               "default": {},
               "description": "Per-agent-role MCP server defaults. The key is a role\nname (e.g. `\"worker\"`, `\"chat\"`) or `\"*\"` for the fallback applied to\nany role with no explicit entry. The value is the list of MCP server\nnames (from root `mcp.json`) that sessions for that role should\nconnect to by default. Specialist role assignments override these.",
               "type": "object"
+            },
+            "build_resources": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildResources"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Optional per-project CPU/memory overrides for the task-run and warm\nPods, layered over the deployment-wide defaults. `None` (the default)\nkeeps every kind on its deployment default. Task and warm blocks resolve\nindependently; the resolved quantities are rendered into the k8s Job/Pod\nspecs by `djinn-k8s`. See [`crate::resources::BuildResources`]."
             },
             "cargo_cache_policy": {
               "anyOf": [

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -2592,6 +2592,14 @@ export namespace ImageCreateInputSchema {
   [k: string]: string[]
   }
   /**
+   * Optional per-project CPU/memory overrides for the task-run and warm
+   * Pods, layered over the deployment-wide defaults. `None` (the default)
+   * keeps every kind on its deployment default. Task and warm blocks resolve
+   * independently; the resolved quantities are rendered into the k8s Job/Pod
+   * specs by `djinn-k8s`. See [`crate::resources::BuildResources`].
+   */
+  build_resources?: (BuildResources | null)
+  /**
    * Project-level override for Cargo target-cache warming/running policy.
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
@@ -2640,6 +2648,46 @@ export namespace ImageCreateInputSchema {
    */
   system_packages?: string[]
   workspaces?: Workspace[]
+  }
+  /**
+   * Optional per-project CPU/memory overrides for the task-run and warm Pods.
+   * 
+   * The whole object is optional on `EnvironmentConfig`; each inner block is
+   * optional; each field within a block is optional. Anything unset inherits
+   * the deployment default at resolution time. The two blocks are resolved
+   * separately — a `task` override never affects `warm` and vice-versa.
+   */
+  export interface BuildResources {
+  /**
+   * Overrides applied to the task-run Pod.
+   */
+  task?: (BuildResourceOverrides | null)
+  /**
+   * Overrides applied to the warm-job Pod.
+   */
+  warm?: (BuildResourceOverrides | null)
+  }
+  /**
+   * CPU + memory request/limit overrides for one Pod kind. Every field is an
+   * optional Kubernetes Quantity string; `None` inherits the deployment default.
+   */
+  export interface BuildResourceOverrides {
+  /**
+   * CPU limit override.
+   */
+  cpu_limit?: string
+  /**
+   * CPU request override (e.g. `"4"`, `"500m"`).
+   */
+  cpu_request?: string
+  /**
+   * Memory limit override.
+   */
+  memory_limit?: string
+  /**
+   * Memory request override (e.g. `"8Gi"`, `"512Mi"`).
+   */
+  memory_request?: string
   }
   /**
    * Explicit Cargo target-cache policy used when auto-detection is overridden.
@@ -2971,6 +3019,14 @@ export namespace ImageListOutputSchema {
   [k: string]: string[]
   }
   /**
+   * Optional per-project CPU/memory overrides for the task-run and warm
+   * Pods, layered over the deployment-wide defaults. `None` (the default)
+   * keeps every kind on its deployment default. Task and warm blocks resolve
+   * independently; the resolved quantities are rendered into the k8s Job/Pod
+   * specs by `djinn-k8s`. See [`crate::resources::BuildResources`].
+   */
+  build_resources?: (BuildResources | null)
+  /**
    * Project-level override for Cargo target-cache warming/running policy.
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
@@ -3019,6 +3075,46 @@ export namespace ImageListOutputSchema {
    */
   system_packages?: string[]
   workspaces?: Workspace[]
+  }
+  /**
+   * Optional per-project CPU/memory overrides for the task-run and warm Pods.
+   * 
+   * The whole object is optional on `EnvironmentConfig`; each inner block is
+   * optional; each field within a block is optional. Anything unset inherits
+   * the deployment default at resolution time. The two blocks are resolved
+   * separately — a `task` override never affects `warm` and vice-versa.
+   */
+  export interface BuildResources {
+  /**
+   * Overrides applied to the task-run Pod.
+   */
+  task?: (BuildResourceOverrides | null)
+  /**
+   * Overrides applied to the warm-job Pod.
+   */
+  warm?: (BuildResourceOverrides | null)
+  }
+  /**
+   * CPU + memory request/limit overrides for one Pod kind. Every field is an
+   * optional Kubernetes Quantity string; `None` inherits the deployment default.
+   */
+  export interface BuildResourceOverrides {
+  /**
+   * CPU limit override.
+   */
+  cpu_limit?: string
+  /**
+   * CPU request override (e.g. `"4"`, `"500m"`).
+   */
+  cpu_request?: string
+  /**
+   * Memory limit override.
+   */
+  memory_limit?: string
+  /**
+   * Memory request override (e.g. `"8Gi"`, `"512Mi"`).
+   */
+  memory_request?: string
   }
   /**
    * Explicit Cargo target-cache policy used when auto-detection is overridden.
@@ -3326,6 +3422,14 @@ export namespace ImageUpdateInputSchema {
   [k: string]: string[]
   }
   /**
+   * Optional per-project CPU/memory overrides for the task-run and warm
+   * Pods, layered over the deployment-wide defaults. `None` (the default)
+   * keeps every kind on its deployment default. Task and warm blocks resolve
+   * independently; the resolved quantities are rendered into the k8s Job/Pod
+   * specs by `djinn-k8s`. See [`crate::resources::BuildResources`].
+   */
+  build_resources?: (BuildResources | null)
+  /**
    * Project-level override for Cargo target-cache warming/running policy.
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
@@ -3374,6 +3478,46 @@ export namespace ImageUpdateInputSchema {
    */
   system_packages?: string[]
   workspaces?: Workspace[]
+  }
+  /**
+   * Optional per-project CPU/memory overrides for the task-run and warm Pods.
+   * 
+   * The whole object is optional on `EnvironmentConfig`; each inner block is
+   * optional; each field within a block is optional. Anything unset inherits
+   * the deployment default at resolution time. The two blocks are resolved
+   * separately — a `task` override never affects `warm` and vice-versa.
+   */
+  export interface BuildResources {
+  /**
+   * Overrides applied to the task-run Pod.
+   */
+  task?: (BuildResourceOverrides | null)
+  /**
+   * Overrides applied to the warm-job Pod.
+   */
+  warm?: (BuildResourceOverrides | null)
+  }
+  /**
+   * CPU + memory request/limit overrides for one Pod kind. Every field is an
+   * optional Kubernetes Quantity string; `None` inherits the deployment default.
+   */
+  export interface BuildResourceOverrides {
+  /**
+   * CPU limit override.
+   */
+  cpu_limit?: string
+  /**
+   * CPU request override (e.g. `"4"`, `"500m"`).
+   */
+  cpu_request?: string
+  /**
+   * Memory limit override.
+   */
+  memory_limit?: string
+  /**
+   * Memory request override (e.g. `"8Gi"`, `"512Mi"`).
+   */
+  memory_request?: string
   }
   /**
    * Explicit Cargo target-cache policy used when auto-detection is overridden.
@@ -5937,6 +6081,14 @@ export namespace ProjectEnvironmentConfigGetOutputSchema {
   [k: string]: string[]
   }
   /**
+   * Optional per-project CPU/memory overrides for the task-run and warm
+   * Pods, layered over the deployment-wide defaults. `None` (the default)
+   * keeps every kind on its deployment default. Task and warm blocks resolve
+   * independently; the resolved quantities are rendered into the k8s Job/Pod
+   * specs by `djinn-k8s`. See [`crate::resources::BuildResources`].
+   */
+  build_resources?: (BuildResources | null)
+  /**
    * Project-level override for Cargo target-cache warming/running policy.
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
@@ -5985,6 +6137,46 @@ export namespace ProjectEnvironmentConfigGetOutputSchema {
    */
   system_packages?: string[]
   workspaces?: Workspace[]
+  }
+  /**
+   * Optional per-project CPU/memory overrides for the task-run and warm Pods.
+   * 
+   * The whole object is optional on `EnvironmentConfig`; each inner block is
+   * optional; each field within a block is optional. Anything unset inherits
+   * the deployment default at resolution time. The two blocks are resolved
+   * separately — a `task` override never affects `warm` and vice-versa.
+   */
+  export interface BuildResources {
+  /**
+   * Overrides applied to the task-run Pod.
+   */
+  task?: (BuildResourceOverrides | null)
+  /**
+   * Overrides applied to the warm-job Pod.
+   */
+  warm?: (BuildResourceOverrides | null)
+  }
+  /**
+   * CPU + memory request/limit overrides for one Pod kind. Every field is an
+   * optional Kubernetes Quantity string; `None` inherits the deployment default.
+   */
+  export interface BuildResourceOverrides {
+  /**
+   * CPU limit override.
+   */
+  cpu_limit?: string
+  /**
+   * CPU request override (e.g. `"4"`, `"500m"`).
+   */
+  cpu_request?: string
+  /**
+   * Memory limit override.
+   */
+  memory_limit?: string
+  /**
+   * Memory request override (e.g. `"8Gi"`, `"512Mi"`).
+   */
+  memory_request?: string
   }
   /**
    * Explicit Cargo target-cache policy used when auto-detection is overridden.
@@ -6276,6 +6468,14 @@ export namespace ProjectEnvironmentConfigResetOutputSchema {
   [k: string]: string[]
   }
   /**
+   * Optional per-project CPU/memory overrides for the task-run and warm
+   * Pods, layered over the deployment-wide defaults. `None` (the default)
+   * keeps every kind on its deployment default. Task and warm blocks resolve
+   * independently; the resolved quantities are rendered into the k8s Job/Pod
+   * specs by `djinn-k8s`. See [`crate::resources::BuildResources`].
+   */
+  build_resources?: (BuildResources | null)
+  /**
    * Project-level override for Cargo target-cache warming/running policy.
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
@@ -6324,6 +6524,46 @@ export namespace ProjectEnvironmentConfigResetOutputSchema {
    */
   system_packages?: string[]
   workspaces?: Workspace[]
+  }
+  /**
+   * Optional per-project CPU/memory overrides for the task-run and warm Pods.
+   * 
+   * The whole object is optional on `EnvironmentConfig`; each inner block is
+   * optional; each field within a block is optional. Anything unset inherits
+   * the deployment default at resolution time. The two blocks are resolved
+   * separately — a `task` override never affects `warm` and vice-versa.
+   */
+  export interface BuildResources {
+  /**
+   * Overrides applied to the task-run Pod.
+   */
+  task?: (BuildResourceOverrides | null)
+  /**
+   * Overrides applied to the warm-job Pod.
+   */
+  warm?: (BuildResourceOverrides | null)
+  }
+  /**
+   * CPU + memory request/limit overrides for one Pod kind. Every field is an
+   * optional Kubernetes Quantity string; `None` inherits the deployment default.
+   */
+  export interface BuildResourceOverrides {
+  /**
+   * CPU limit override.
+   */
+  cpu_limit?: string
+  /**
+   * CPU request override (e.g. `"4"`, `"500m"`).
+   */
+  cpu_request?: string
+  /**
+   * Memory limit override.
+   */
+  memory_limit?: string
+  /**
+   * Memory request override (e.g. `"8Gi"`, `"512Mi"`).
+   */
+  memory_request?: string
   }
   /**
    * Explicit Cargo target-cache policy used when auto-detection is overridden.
@@ -6608,6 +6848,14 @@ export namespace ProjectEnvironmentConfigSetInputSchema {
   [k: string]: string[]
   }
   /**
+   * Optional per-project CPU/memory overrides for the task-run and warm
+   * Pods, layered over the deployment-wide defaults. `None` (the default)
+   * keeps every kind on its deployment default. Task and warm blocks resolve
+   * independently; the resolved quantities are rendered into the k8s Job/Pod
+   * specs by `djinn-k8s`. See [`crate::resources::BuildResources`].
+   */
+  build_resources?: (BuildResources | null)
+  /**
    * Project-level override for Cargo target-cache warming/running policy.
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
@@ -6656,6 +6904,46 @@ export namespace ProjectEnvironmentConfigSetInputSchema {
    */
   system_packages?: string[]
   workspaces?: Workspace[]
+  }
+  /**
+   * Optional per-project CPU/memory overrides for the task-run and warm Pods.
+   * 
+   * The whole object is optional on `EnvironmentConfig`; each inner block is
+   * optional; each field within a block is optional. Anything unset inherits
+   * the deployment default at resolution time. The two blocks are resolved
+   * separately — a `task` override never affects `warm` and vice-versa.
+   */
+  export interface BuildResources {
+  /**
+   * Overrides applied to the task-run Pod.
+   */
+  task?: (BuildResourceOverrides | null)
+  /**
+   * Overrides applied to the warm-job Pod.
+   */
+  warm?: (BuildResourceOverrides | null)
+  }
+  /**
+   * CPU + memory request/limit overrides for one Pod kind. Every field is an
+   * optional Kubernetes Quantity string; `None` inherits the deployment default.
+   */
+  export interface BuildResourceOverrides {
+  /**
+   * CPU limit override.
+   */
+  cpu_limit?: string
+  /**
+   * CPU request override (e.g. `"4"`, `"500m"`).
+   */
+  cpu_request?: string
+  /**
+   * Memory limit override.
+   */
+  memory_limit?: string
+  /**
+   * Memory request override (e.g. `"8Gi"`, `"512Mi"`).
+   */
+  memory_request?: string
   }
   /**
    * Explicit Cargo target-cache policy used when auto-detection is overridden.


### PR DESCRIPTION
Implements ri23 Part 3: per-project build_resources overrides over deployment defaults, rendered into the task-run and warm k8s Job/Pod specs. Task and warm resolve independently.

djinn-stack: BuildResources/BuildResourceOverrides on EnvironmentConfig + exact-rational Quantity parser; write-time validate rejects malformed/zero/negative/in-block request-above-limit (never clamps).

djinn-k8s: resolve_task_run_resources (role-classed) and resolve_warm_resources combine defaults + per-project overrides + admin per-kind min/max bounds; fail closed at resolution (request-above-limit after combine, below-min, above-max) so no Job is created; apply_resolved_resources renders onto the primary container. Bounds via new DJINN_K8S_{TASK,WARM}_{CPU,MEMORY}_{MIN,MAX} envs, unbounded default. Role classification + env-override precedence preserved; 4-vCPU default retained; 09no remains global admission owner.

Tests: build_resources_v1.yaml fixture + build_resources_contract test cover default inheritance, unchanged render of distinct task/warm quantities, and reject-without-Job for malformed/request-above-limit/below-min/above-max.

Gates: fmt, clippy, focused tests, SQLX_OFFLINE workspace check clean; hakari no-op.

Generated with Claude Code
