### PR TITLE
chore(1bnj): prepare_build_cache worker tool and configuration-aware verification surface

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/conditional_verification_surface_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/conditional_verification_surface_tests.rs
@@ -1,0 +1,159 @@
+//! Rendered-surface guards for the configuration-aware `run_verification`
+//! surface and the unconditional `prepare_build_cache` worker tool (epic 1bnj).
+//!
+//! Both the configured (non-empty final-verification plan) and empty-plan cases
+//! are covered for Worker and Reviewer, at the schema-surface level and in the
+//! rendered prompt prose.
+
+use djinn_core::events::EventBus;
+use djinn_db::Database;
+use djinn_mcp_extension::tool_defs::{tool_schemas_reviewer, tool_schemas_worker};
+use djinn_roles::prompts::retain_conditional_verification_tools;
+
+use super::test_support::create_project_epic_task;
+use crate::AgentType;
+use crate::prompts::{TaskContext, render_prompt_for_role};
+
+fn tool_names(schemas: &[serde_json::Value]) -> Vec<String> {
+    schemas
+        .iter()
+        .filter_map(|s| s.get("name").and_then(|n| n.as_str()).map(str::to_string))
+        .collect()
+}
+
+/// Resolve the live per-project tool surface for a role the way the supervisor
+/// stage does: canonical schema set with the conditional verification tool
+/// stripped when the plan is empty.
+fn live_surface(schemas: Vec<serde_json::Value>, configured: bool) -> Vec<String> {
+    let mut schemas = schemas;
+    retain_conditional_verification_tools(&mut schemas, configured);
+    tool_names(&schemas)
+}
+
+#[test]
+fn worker_surface_gates_run_verification_but_always_has_prepare_build_cache() {
+    let configured = live_surface(tool_schemas_worker(), true);
+    assert!(
+        configured.iter().any(|n| n == "run_verification"),
+        "configured worker must advertise run_verification"
+    );
+    assert!(
+        configured.iter().any(|n| n == "prepare_build_cache"),
+        "configured worker must advertise prepare_build_cache"
+    );
+
+    let empty = live_surface(tool_schemas_worker(), false);
+    assert!(
+        !empty.iter().any(|n| n == "run_verification"),
+        "empty-plan worker must NOT advertise run_verification"
+    );
+    assert!(
+        empty.iter().any(|n| n == "prepare_build_cache"),
+        "prepare_build_cache renders for the worker regardless of gate configuration"
+    );
+}
+
+#[test]
+fn reviewer_surface_gates_run_verification_and_never_has_prepare_build_cache() {
+    let configured = live_surface(tool_schemas_reviewer(), true);
+    assert!(
+        configured.iter().any(|n| n == "run_verification"),
+        "configured reviewer must advertise run_verification"
+    );
+    assert!(
+        !configured.iter().any(|n| n == "prepare_build_cache"),
+        "prepare_build_cache is a worker-only tool"
+    );
+
+    let empty = live_surface(tool_schemas_reviewer(), false);
+    assert!(
+        !empty.iter().any(|n| n == "run_verification"),
+        "empty-plan reviewer must NOT advertise run_verification"
+    );
+}
+
+async fn make_task() -> djinn_core::models::Task {
+    let db = Database::ephemeral().await.expect("ephemeral database");
+    let events = EventBus::noop();
+    create_project_epic_task(&db, &events, "1bnj epic", "Conditional surface").await
+}
+
+fn ctx(final_verification_configured: bool) -> TaskContext {
+    TaskContext {
+        project_path: "proj".into(),
+        workspace_path: "/workspace/wt".into(),
+        diff: None,
+        commits: None,
+        start_commit: None,
+        end_commit: None,
+        conflict_files: None,
+        merge_base_branch: None,
+        merge_target_branch: None,
+        merge_failure_context: None,
+        setup_commands: None,
+        activity: None,
+        worker_summary: None,
+        worker_concerns: None,
+        epic_context: None,
+        knowledge_context: None,
+        code_graph_context: None,
+        reviewer_diff_context: None,
+        ci_blocking_directive: None,
+        worker_resume_note: None,
+        arbiter_directive: None,
+        final_verification_configured,
+    }
+}
+
+#[tokio::test]
+async fn worker_prompt_prose_is_configuration_aware() {
+    crate::init_tool_schema_registry();
+    let task = make_task().await;
+
+    let configured = render_prompt_for_role(AgentType::Worker.role_config(), &task, &ctx(true));
+    assert!(
+        configured.contains("## Final Verification"),
+        "configured worker prompt must recommend iterating with run_verification"
+    );
+    assert!(
+        configured.contains("not credited"),
+        "configured worker prompt must explain shell builds are permitted but not credited"
+    );
+    assert!(
+        configured.contains("- `run_verification()`"),
+        "configured worker tools section must list run_verification"
+    );
+
+    let empty = render_prompt_for_role(AgentType::Worker.role_config(), &task, &ctx(false));
+    assert!(
+        !empty.contains("## Final Verification"),
+        "empty-plan worker prompt must render legacy language with no gate claim"
+    );
+    assert!(
+        !empty.contains("- `run_verification()`"),
+        "empty-plan worker tools section must omit run_verification"
+    );
+    // prepare_build_cache is present in both cases.
+    assert!(empty.contains("- `prepare_build_cache()`"));
+    assert!(configured.contains("- `prepare_build_cache()`"));
+}
+
+#[tokio::test]
+async fn reviewer_prompt_prose_is_configuration_aware() {
+    crate::init_tool_schema_registry();
+    let task = make_task().await;
+
+    let configured = render_prompt_for_role(AgentType::Reviewer.role_config(), &task, &ctx(true));
+    assert!(
+        configured.contains("## Independent Verification"),
+        "configured reviewer prompt must expose independent rerun guidance"
+    );
+    assert!(configured.contains("- `run_verification()`"));
+
+    let empty = render_prompt_for_role(AgentType::Reviewer.role_config(), &task, &ctx(false));
+    assert!(
+        !empty.contains("## Independent Verification"),
+        "empty-plan reviewer prompt must render legacy language with no gate claim"
+    );
+    assert!(!empty.contains("- `run_verification()`"));
+}

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/memory_intent_planner_replay_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/memory_intent_planner_replay_tests.rs
@@ -254,6 +254,7 @@ async fn assemble(
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: planner,
+        final_verification_configured: false,
     })
     .await
 }

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context.rs
@@ -1107,6 +1107,7 @@ pub(crate) async fn assemble_prompt_context(inputs: PromptContextInputs<'_>) -> 
         extension_diagnostics,
         cancellation,
         memory_intent_planner,
+        final_verification_configured,
     } = inputs;
     let uncancelled = CancellationToken::new();
     let cancellation = cancellation.unwrap_or(&uncancelled);
@@ -1344,6 +1345,7 @@ pub(crate) async fn assemble_prompt_context(inputs: PromptContextInputs<'_>) -> 
             ci_blocking_directive: ci_blocking_directive.clone(),
             worker_resume_note: worker_resume_note.map(str::to_string),
             arbiter_directive: arbiter_directive.map(str::to_string),
+            final_verification_configured,
         },
     );
     let system_prompt_with_extensions =
@@ -1598,6 +1600,10 @@ mod tests;
 #[cfg(test)]
 #[path = "rendered_surface_guard_tests.rs"]
 mod rendered_surface_guard_tests;
+
+#[cfg(test)]
+#[path = "conditional_verification_surface_tests.rs"]
+mod conditional_verification_surface_tests;
 
 #[cfg(test)]
 #[path = "attempt_history_prompt_tests.rs"]

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context/types.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context/types.rs
@@ -152,4 +152,8 @@ pub(crate) struct PromptContextInputs<'a> {
     /// of the broad, reusable `AgentContext`.
     pub cancellation: Option<&'a CancellationToken>,
     pub memory_intent_planner: Option<MemoryIntentPlannerInvocation<'a>>,
+    /// `true` when the resolved project `lifecycle.final_verification` plan is
+    /// non-empty. Drives the conditional Worker/Reviewer `run_verification`
+    /// surface and prompt guidance (epic 1bnj).
+    pub final_verification_configured: bool,
 }

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/prompt_context_tests.rs
@@ -1044,6 +1044,7 @@ async fn concurrent_assembly_is_deterministic() {
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await;
 
@@ -1066,6 +1067,7 @@ async fn concurrent_assembly_is_deterministic() {
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await;
 
@@ -1393,6 +1395,7 @@ async fn ci_blocking_appears_before_resume_context_in_prompt() {
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await;
 
@@ -1543,6 +1546,7 @@ async fn resume_context_section_in_canonical_order_with_skills_and_sources() {
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await;
 
@@ -1804,6 +1808,7 @@ async fn resume_context_deterministic_with_discontinuity_metadata() {
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await;
 
@@ -1826,6 +1831,7 @@ async fn resume_context_deterministic_with_discontinuity_metadata() {
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await;
 
@@ -2043,6 +2049,7 @@ macro_rules! planner_assembly_inputs {
             extension_diagnostics: &[],
             cancellation: None,
             memory_intent_planner: $planner,
+            final_verification_configured: false,
         }
     };
 }

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/rendered_surface_guard_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/rendered_surface_guard_tests.rs
@@ -196,6 +196,9 @@ async fn runtime_and_serialized_surfaces_reject_project_local_djinn_paths() {
         ci_blocking_directive: None,
         worker_resume_note: None,
         arbiter_directive: None,
+        // Exercise the configured-plan surface so the guard also scans the
+        // rendered `run_verification` guidance for path leakage.
+        final_verification_configured: true,
     };
     for agent_type in AGENT_TYPES {
         let rendered = render_prompt_for_role(agent_type.role_config(), &task, &task_context);

--- a/server/crates/djinn-agent/src/actors/slot/lifecycle/test_support.rs
+++ b/server/crates/djinn-agent/src/actors/slot/lifecycle/test_support.rs
@@ -143,6 +143,7 @@ pub(crate) async fn assemble_for_role_with_extension_diagnostics(
         extension_diagnostics,
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await
 }
@@ -177,6 +178,7 @@ pub(crate) async fn assemble_for_role_with_mcp_instructions(
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await
 }
@@ -210,6 +212,7 @@ pub(crate) async fn assemble_for_role_with_resume(
         extension_diagnostics: &[],
         cancellation: None,
         memory_intent_planner: None,
+        final_verification_configured: false,
     })
     .await
 }

--- a/server/crates/djinn-agent/src/extension/handlers.rs
+++ b/server/crates/djinn-agent/src/extension/handlers.rs
@@ -54,7 +54,9 @@ mod memory_agent;
 // Retained for test coverage; production dispatch goes through djinn-mcp-extension.
 #[allow(dead_code)]
 mod task_admin;
-// Retained for test coverage; production dispatch goes through djinn-mcp-extension.
+// Stack-neutral build-cache preparation worker tool (epic 1bnj). Handled in
+// this local fallback because it reads the pod build environment directly.
+pub(crate) mod prepare_build_cache;
 #[allow(dead_code)]
 mod task_epic;
 pub(crate) mod verification;
@@ -260,6 +262,14 @@ pub(super) async fn dispatch_tool_call(
                 session_role,
             )
             .await
+        }
+
+        // ── Build-cache preparation (stack-neutral worker tool) ─────────
+        // Resolves the platform warm-cache descriptor from the pod environment
+        // and returns a typed outcome; a ready no-op while eager startup
+        // seeding is still authoritative (epic 1bnj).
+        "prepare_build_cache" => {
+            prepare_build_cache::call_prepare_build_cache(session_task_id).await
         }
 
         // ── Code graph (agent-local bridge) ─────────────────────────────

--- a/server/crates/djinn-agent/src/extension/handlers/prepare_build_cache.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/prepare_build_cache.rs
@@ -1,0 +1,224 @@
+//! Agent-facing `prepare_build_cache` worker-tool handler (epic 1bnj).
+//!
+//! Stack-neutral: this handler resolves the platform warm-cache descriptor for
+//! the current stack, routes it through the pure admission classifier in
+//! [`djinn_core::prepare_build_cache`], and returns exactly one typed outcome
+//! plus one bounded telemetry increment. It never intercepts or blocks shell
+//! commands and never encodes language-specific behaviour in the tool schema —
+//! the Rust cargo target run-dir is resolved here from the pod environment, not
+//! from any tool argument.
+//!
+//! While the worker still eagerly seeds the cargo target run-dir at startup
+//! (nquz first-use / enforce is not yet live), this returns a compatible ready
+//! `noop` rather than duplicating the seed work, preserving the seed
+//! single-flight and disk-reservation invariants owned by the startup path.
+
+use djinn_core::prepare_build_cache::{
+    DiskAdmission, PlatformCache, PrepareBuildCacheOutcome, classify_prepare_build_cache,
+};
+
+/// Environment variable Cargo uses for the per-run private target directory.
+const CARGO_TARGET_DIR_ENV: &str = "CARGO_TARGET_DIR";
+
+/// Opt-in switch that flips the tool off its eager-seed compatibility no-op and
+/// onto the disk-admission seam. Absent / not `"1"` means eager startup seeding
+/// is still authoritative (the state on `main` today), so the tool must be a
+/// ready no-op. Wired ahead of the nquz first-use client so the cutover is a
+/// single env flip.
+const NQUZ_FIRST_USE_ENFORCE_ENV: &str = "DJINN_NQUZ_FIRST_USE_ENFORCE";
+
+/// Resolve the platform warm-cache descriptor for the current stack from the
+/// pod environment. Today only the Rust cargo target run-dir exists; every
+/// other stack resolves to [`PlatformCache::None`] (`not_applicable`).
+fn resolve_platform_cache() -> PlatformCache {
+    let Some(target_dir) = std::env::var(CARGO_TARGET_DIR_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return PlatformCache::None;
+    };
+
+    // A platform warm cache applies only when Cargo's target dir is a private
+    // per-task-run directory under the conventional runs root. A project that
+    // points CARGO_TARGET_DIR elsewhere (or has no warm base) is not applicable.
+    let runs_root = djinn_core::paths::cargo_target_runs_root();
+    if std::path::Path::new(&target_dir).starts_with(&runs_root) {
+        PlatformCache::CargoTargetRunDir {
+            cache_path: target_dir,
+        }
+    } else {
+        PlatformCache::None
+    }
+}
+
+/// `true` while eager startup seeding remains authoritative (nquz enforce off).
+fn eager_seed_active() -> bool {
+    std::env::var(NQUZ_FIRST_USE_ENFORCE_ENV).ok().as_deref() != Some("1")
+}
+
+/// Handle a `prepare_build_cache` tool call.
+///
+/// Returns exactly one typed outcome and emits exactly one bounded telemetry
+/// increment. Identifiers are placed only in the structured `audit` object,
+/// never in telemetry labels.
+pub(crate) async fn call_prepare_build_cache(
+    session_task_id: Option<&str>,
+) -> Result<serde_json::Value, String> {
+    let cache = resolve_platform_cache();
+    let eager = eager_seed_active();
+    // The disk-admission signal is consulted only once eager seeding is retired.
+    // Until the nquz first-use client is wired, fail closed to queued (no
+    // allocation) rather than allocating run-dir bytes speculatively.
+    let disk = DiskAdmission::CapacityUnknown;
+    Ok(build_result(&cache, eager, disk, session_task_id))
+}
+
+/// Pure result shaper: classify, emit exactly one telemetry increment, and
+/// build the typed tool-result payload. Split out from environment resolution
+/// so it can be unit-tested with explicit inputs.
+fn build_result(
+    cache: &PlatformCache,
+    eager_seed_active: bool,
+    disk: DiskAdmission,
+    session_task_id: Option<&str>,
+) -> serde_json::Value {
+    let outcome = classify_prepare_build_cache(cache, eager_seed_active, disk);
+
+    djinn_telemetry::prepare_build_cache::increment_outcome(telemetry_label(&outcome));
+
+    let stack = match cache {
+        PlatformCache::CargoTargetRunDir { .. } => "rust",
+        PlatformCache::None => "none",
+    };
+
+    let mut audit = serde_json::Map::new();
+    if let Some(task_id) = session_task_id {
+        audit.insert(
+            "task_id".to_string(),
+            serde_json::Value::String(task_id.to_string()),
+        );
+    }
+
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "outcome".to_string(),
+        serde_json::Value::String(outcome.outcome_field().to_string()),
+    );
+    payload.insert(
+        "stack".to_string(),
+        serde_json::Value::String(stack.to_string()),
+    );
+
+    let detail = match &outcome {
+        PrepareBuildCacheOutcome::Ready { cache_path } => {
+            payload.insert(
+                "cache_path".to_string(),
+                serde_json::Value::String(cache_path.clone()),
+            );
+            audit.insert(
+                "cache_path".to_string(),
+                serde_json::Value::String(cache_path.clone()),
+            );
+            "Platform build cache is prepared and ready. Build normally; do not override the pre-configured cache paths.".to_string()
+        }
+        PrepareBuildCacheOutcome::Noop { cache_path } => {
+            payload.insert(
+                "cache_path".to_string(),
+                serde_json::Value::String(cache_path.clone()),
+            );
+            audit.insert(
+                "cache_path".to_string(),
+                serde_json::Value::String(cache_path.clone()),
+            );
+            "Platform build cache was already seeded for this run; nothing to do. Build normally against the pre-configured cache paths.".to_string()
+        }
+        PrepareBuildCacheOutcome::Queued { reason } => {
+            payload.insert(
+                "queued_reason".to_string(),
+                serde_json::Value::String(reason.as_str().to_string()),
+            );
+            format!(
+                "Cache preparation was deferred ({}) without allocating cache bytes; build normally and it will be prepared when capacity allows.",
+                reason.as_str()
+            )
+        }
+        PrepareBuildCacheOutcome::NotApplicable => {
+            "This stack has no platform warm cache; nothing to prepare. Build normally.".to_string()
+        }
+    };
+    payload.insert("detail".to_string(), serde_json::Value::String(detail));
+    payload.insert("audit".to_string(), serde_json::Value::Object(audit));
+
+    serde_json::Value::Object(payload)
+}
+
+/// Map a typed outcome onto its bounded telemetry constant.
+fn telemetry_label(outcome: &PrepareBuildCacheOutcome) -> &'static str {
+    use djinn_telemetry::prepare_build_cache as tel;
+    match outcome {
+        PrepareBuildCacheOutcome::Ready { .. } => tel::OUTCOME_READY,
+        PrepareBuildCacheOutcome::Noop { .. } => tel::OUTCOME_NOOP,
+        PrepareBuildCacheOutcome::Queued { .. } => tel::OUTCOME_QUEUED,
+        PrepareBuildCacheOutcome::NotApplicable => tel::OUTCOME_NOT_APPLICABLE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cargo_cache() -> PlatformCache {
+        PlatformCache::CargoTargetRunDir {
+            cache_path: "/cache/cargo-target-runs/task-run-xyz".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_platform_cache_is_not_applicable_and_hides_cache_path() {
+        let value = build_result(
+            &PlatformCache::None,
+            true,
+            DiskAdmission::Ok,
+            Some("task-abc"),
+        );
+        assert_eq!(value["outcome"], "not_applicable");
+        assert_eq!(value["stack"], "none");
+        // Identifiers ride the audit object only, never the top-level payload.
+        assert_eq!(value["audit"]["task_id"], "task-abc");
+        assert!(value.get("cache_path").is_none());
+        assert!(value["audit"].get("cache_path").is_none());
+    }
+
+    #[test]
+    fn eager_active_returns_ready_noop_with_cache_path_contract() {
+        let value = build_result(
+            &cargo_cache(),
+            true,
+            DiskAdmission::CapacityUnknown,
+            Some("t1"),
+        );
+        assert_eq!(value["outcome"], "noop");
+        assert_eq!(value["stack"], "rust");
+        assert_eq!(value["cache_path"], "/cache/cargo-target-runs/task-run-xyz");
+        assert_eq!(
+            value["audit"]["cache_path"],
+            "/cache/cargo-target-runs/task-run-xyz"
+        );
+    }
+
+    #[test]
+    fn eager_retired_disk_pressure_queues_without_cache_path() {
+        let value = build_result(&cargo_cache(), false, DiskAdmission::Pressure, None);
+        assert_eq!(value["outcome"], "queued");
+        assert_eq!(value["queued_reason"], "disk_pressure");
+        // A queued outcome allocates nothing and returns no ready cache-path.
+        assert!(value.get("cache_path").is_none());
+    }
+
+    #[test]
+    fn eager_retired_ok_disk_is_ready() {
+        let value = build_result(&cargo_cache(), false, DiskAdmission::Ok, None);
+        assert_eq!(value["outcome"], "ready");
+        assert_eq!(value["cache_path"], "/cache/cargo-target-runs/task-run-xyz");
+    }
+}

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__worker_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__worker_tool_schemas.snap
@@ -816,6 +816,20 @@ expression: tool_schemas_worker()
     "concurrent_safe": false
   },
   {
+    "name": "prepare_build_cache",
+    "description": "Prepare the platform build cache for this task before you start building, on demand. Stack-neutral: where the platform maintains a warm cache for your stack, this routes cache preparation through the first-use/admission seam and returns a typed outcome WITHOUT you running any build yourself. Outcomes: `ready`/`noop` (the cache is prepared and its path is returned — `noop` means startup already seeded it, so nothing was re-done), `queued` (preparation was deferred under disk pressure or unknown capacity and no cache bytes were allocated), or `not_applicable` (your stack has no platform warm cache). It never intercepts or blocks your shell commands and does not build or submit anything. Call it once up front; re-calling an already-prepared cache is cheap.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    "readOnly": false,
+    "destructive": false,
+    "idempotent": true,
+    "openWorld": false,
+    "concurrent_safe": false
+  },
+  {
     "name": "run_verification",
     "description": "Run the canonical final-verification gate on the current worktree, on demand. It consults first: if an identical tree (same whole-tree fingerprint, manifest, environment, and required coverage) already has a passing run, it returns that evidence instantly WITHOUT executing any commands. Otherwise it runs the required checks hermetically and records the result. Use it to confirm your work passes before you submit — an unchanged tree is never compiled twice, so calling it is cheap on a fresh hit. Returns a typed outcome (hit / ran-pass / ran-fail / rate-limited / error) with per-check results. It does NOT submit your work; call submit_work / submit_review when you are done.",
     "inputSchema": {

--- a/server/crates/djinn-agent/src/prompts/tests.rs
+++ b/server/crates/djinn-agent/src/prompts/tests.rs
@@ -136,6 +136,7 @@ fn make_ctx() -> TaskContext {
         ci_blocking_directive: None,
         worker_resume_note: None,
         arbiter_directive: None,
+        final_verification_configured: false,
     }
 }
 

--- a/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__worker_tools_section_snapshot.snap
+++ b/server/crates/djinn-agent/src/snapshots/djinn_agent__prompts__tests__worker_tools_section_snapshot.snap
@@ -26,5 +26,6 @@ expression: section
 - `memory_write(content, reason, title, type, status?, tags?)`
 - `memory_edit(content, identifier, operation, reason, find_text?, section?, type?)`
 - `request_planner(id, reason)`
+- `prepare_build_cache()`
 - `run_verification()`
 - `submit_work(commit_title, summary, task_id, files_changed?, remaining_concerns?)`

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -976,6 +976,15 @@ pub(crate) async fn execute_stage(
             return Err(StageError::Setup(format!("env_config: {error}")));
         }
     };
+    // Epic 1bnj: resolve whether the project has a non-empty final-verification
+    // plan. Computed once, before `pre_verification` is moved out of the config,
+    // and used both to gate the Worker/Reviewer `run_verification` surface and to
+    // render the configured-vs-legacy prompt guidance.
+    let final_verification_configured = !env_config
+        .lifecycle
+        .final_verification
+        .normalized_commands()
+        .is_empty();
     let SetupContext {
         prompt_setup_commands,
     } = match resolve_setup_context(
@@ -1101,6 +1110,7 @@ pub(crate) async fn execute_stage(
                 .and_then(|metadata| metadata.last_durable_progress_summary.as_deref()),
             planned_note_search: None,
         }),
+        final_verification_configured,
     })
     .await;
 
@@ -1203,6 +1213,15 @@ pub(crate) async fn execute_stage(
     } else {
         crate::roles::tool_schemas_for(agent_type)
     };
+    // Epic 1bnj: the canonical Worker/Reviewer schema sets advertise
+    // `run_verification` unconditionally; strip it from the live per-project
+    // surface when the resolved project has no final-verification plan so the
+    // model never sees a gate tool that would fail at submit. `prepare_build_cache`
+    // is untouched — it renders for the Worker regardless of gate configuration.
+    djinn_roles::prompts::retain_conditional_verification_tools(
+        &mut tools,
+        final_verification_configured,
+    );
     if let Some(ref registry) = mcp_registry {
         tools.extend_from_slice(registry.tool_schemas());
         // Append native MCP resource tools only when at least one connected

--- a/server/crates/djinn-core/src/lib.rs
+++ b/server/crates/djinn-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod liveness;
 pub mod message;
 pub mod models;
 pub mod paths;
+pub mod prepare_build_cache;
 pub mod refinement_liveness;
 pub mod run_progress;
 pub mod test_paths;

--- a/server/crates/djinn-core/src/prepare_build_cache.rs
+++ b/server/crates/djinn-core/src/prepare_build_cache.rs
@@ -1,0 +1,245 @@
+//! Stack-neutral admission/classification core for the `prepare_build_cache`
+//! worker tool (epic 1bnj, proposal jvpm).
+//!
+//! This module owns the pure decision logic that maps a resolved platform
+//! warm-cache descriptor plus the current admission signals onto a single
+//! typed outcome. It performs no filesystem work and allocates no run-dir
+//! bytes: queued outcomes (`disk_pressure`, `disk_capacity_unknown`) are
+//! returned WITHOUT touching the target run-dir, preserving the seed
+//! single-flight and disk-reservation invariants owned by the worker startup
+//! seed path and the future nquz first-use client.
+//!
+//! The public tool schema is stack-neutral; the Rust cargo target run-dir is
+//! the only platform cache that exists today, but the classifier is written so
+//! any future stack cache slots in without changing the tool surface.
+//!
+//! ## Compatibility no-op while eager seeding is active
+//!
+//! nquz first-use / enforce is not yet live on `main` (the observe-mode core
+//! landed in #2537). While the worker still eagerly seeds the cargo target
+//! run-dir at startup, this tool must NOT duplicate that work: it returns a
+//! compatible `Noop` (ready) outcome pointing at the already-seeded run-dir.
+//! Only once eager seeding is retired does the classifier route through the
+//! disk-admission seam and return `Ready`/`Queued`.
+
+/// A resolved platform warm-cache descriptor for the current stack.
+///
+/// Stack-neutral by construction: adding a new stack cache is a new variant,
+/// not a change to the tool schema or the worker-facing outcome contract.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PlatformCache {
+    /// Rust cargo warm-target per-run seed directory. `cache_path` is the
+    /// worker's private `CARGO_TARGET_DIR` (a run-dir under the cargo target
+    /// runs root), which is the cache-path contract returned to the agent.
+    CargoTargetRunDir { cache_path: String },
+    /// The stack has no platform warm cache; preparation is not applicable.
+    None,
+}
+
+/// Disk-admission signal consulted only when eager seeding is retired.
+///
+/// The classifier never allocates run-dir bytes to compute this; callers pass
+/// the already-observed admission state. `CapacityUnknown` is distinct from
+/// `Pressure` so operators can tell a measured-full disk apart from a disk
+/// whose capacity could not be measured.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum DiskAdmission {
+    /// Enough headroom to seed a fresh run-dir.
+    Ok,
+    /// Measured disk pressure: seeding is deferred (queued) without allocating.
+    Pressure,
+    /// Disk capacity could not be determined: fail closed to queued without
+    /// allocating.
+    CapacityUnknown,
+}
+
+/// Reason a preparation was queued rather than made ready.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum QueuedReason {
+    DiskPressure,
+    DiskCapacityUnknown,
+}
+
+impl QueuedReason {
+    /// Stable wire label for the queued reason (audit / structured fields).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DiskPressure => "disk_pressure",
+            Self::DiskCapacityUnknown => "disk_capacity_unknown",
+        }
+    }
+}
+
+/// The single typed outcome returned per `prepare_build_cache` call.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PrepareBuildCacheOutcome {
+    /// The platform cache was seeded/admitted and is ready. `cache_path` is the
+    /// cache-path contract the agent may rely on.
+    Ready { cache_path: String },
+    /// Compatibility no-op: eager seeding already prepared the cache at worker
+    /// startup, so this call did no work. `cache_path` still returns the
+    /// ready cache-path contract.
+    Noop { cache_path: String },
+    /// Preparation was deferred without allocating any run-dir bytes.
+    Queued { reason: QueuedReason },
+    /// The stack has no platform warm cache.
+    NotApplicable,
+}
+
+impl PrepareBuildCacheOutcome {
+    /// Bounded telemetry label for this outcome. Exactly one of these is
+    /// emitted per call; `error` is emitted by the handler for internal
+    /// failures and is intentionally not represented here.
+    pub const fn telemetry_label(&self) -> &'static str {
+        match self {
+            Self::Ready { .. } => "ready",
+            Self::Noop { .. } => "noop",
+            Self::Queued { .. } => "queued",
+            Self::NotApplicable => "not-applicable",
+        }
+    }
+
+    /// Machine-readable `outcome` field for the tool result payload.
+    pub const fn outcome_field(&self) -> &'static str {
+        match self {
+            Self::Ready { .. } => "ready",
+            Self::Noop { .. } => "noop",
+            Self::Queued { .. } => "queued",
+            Self::NotApplicable => "not_applicable",
+        }
+    }
+}
+
+/// Classify a `prepare_build_cache` call into exactly one typed outcome.
+///
+/// Pure: performs no filesystem work and allocates no run-dir bytes. The
+/// queued branches return without side effects, preserving the disk-reservation
+/// and seed single-flight invariants (the actual reservation/seed is owned by
+/// the worker startup path today, and by the nquz first-use client once eager
+/// seeding is retired).
+///
+/// - No platform cache -> [`PrepareBuildCacheOutcome::NotApplicable`].
+/// - Platform cache present while eager seeding is active ->
+///   [`PrepareBuildCacheOutcome::Noop`] (do not duplicate seed work).
+/// - Platform cache present, eager seeding retired -> route through the
+///   disk-admission seam: `Ok` -> `Ready`, `Pressure`/`CapacityUnknown` ->
+///   `Queued` (no allocation).
+pub fn classify_prepare_build_cache(
+    cache: &PlatformCache,
+    eager_seed_active: bool,
+    disk: DiskAdmission,
+) -> PrepareBuildCacheOutcome {
+    let cache_path = match cache {
+        PlatformCache::None => return PrepareBuildCacheOutcome::NotApplicable,
+        PlatformCache::CargoTargetRunDir { cache_path } => cache_path.clone(),
+    };
+
+    if eager_seed_active {
+        // Eager startup seeding already prepared the run-dir; returning a
+        // compatible ready no-op avoids duplicating (and re-locking) the seed.
+        return PrepareBuildCacheOutcome::Noop { cache_path };
+    }
+
+    match disk {
+        DiskAdmission::Ok => PrepareBuildCacheOutcome::Ready { cache_path },
+        DiskAdmission::Pressure => PrepareBuildCacheOutcome::Queued {
+            reason: QueuedReason::DiskPressure,
+        },
+        DiskAdmission::CapacityUnknown => PrepareBuildCacheOutcome::Queued {
+            reason: QueuedReason::DiskCapacityUnknown,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cargo_cache() -> PlatformCache {
+        PlatformCache::CargoTargetRunDir {
+            cache_path: "/cache/cargo-target-runs/task-run-123".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_platform_cache_is_not_applicable_regardless_of_signals() {
+        for eager in [true, false] {
+            for disk in [
+                DiskAdmission::Ok,
+                DiskAdmission::Pressure,
+                DiskAdmission::CapacityUnknown,
+            ] {
+                let outcome = classify_prepare_build_cache(&PlatformCache::None, eager, disk);
+                assert_eq!(outcome, PrepareBuildCacheOutcome::NotApplicable);
+                assert_eq!(outcome.telemetry_label(), "not-applicable");
+                assert_eq!(outcome.outcome_field(), "not_applicable");
+            }
+        }
+    }
+
+    #[test]
+    fn eager_seeding_active_returns_ready_noop_without_consulting_disk() {
+        // Even under disk pressure, the eager-seed compatibility path is a
+        // ready no-op: the startup seed already reserved and prepared the dir.
+        for disk in [
+            DiskAdmission::Ok,
+            DiskAdmission::Pressure,
+            DiskAdmission::CapacityUnknown,
+        ] {
+            let outcome = classify_prepare_build_cache(&cargo_cache(), true, disk);
+            assert_eq!(
+                outcome,
+                PrepareBuildCacheOutcome::Noop {
+                    cache_path: "/cache/cargo-target-runs/task-run-123".to_string(),
+                }
+            );
+            assert_eq!(outcome.telemetry_label(), "noop");
+            assert_eq!(outcome.outcome_field(), "noop");
+        }
+    }
+
+    #[test]
+    fn eager_retired_ok_disk_is_ready_with_cache_path_contract() {
+        let outcome = classify_prepare_build_cache(&cargo_cache(), false, DiskAdmission::Ok);
+        assert_eq!(
+            outcome,
+            PrepareBuildCacheOutcome::Ready {
+                cache_path: "/cache/cargo-target-runs/task-run-123".to_string(),
+            }
+        );
+        assert_eq!(outcome.telemetry_label(), "ready");
+        assert_eq!(outcome.outcome_field(), "ready");
+    }
+
+    #[test]
+    fn eager_retired_disk_pressure_queues_without_allocation() {
+        let outcome = classify_prepare_build_cache(&cargo_cache(), false, DiskAdmission::Pressure);
+        assert_eq!(
+            outcome,
+            PrepareBuildCacheOutcome::Queued {
+                reason: QueuedReason::DiskPressure,
+            }
+        );
+        assert_eq!(outcome.telemetry_label(), "queued");
+        assert_eq!(outcome.outcome_field(), "queued");
+        if let PrepareBuildCacheOutcome::Queued { reason } = outcome {
+            assert_eq!(reason.as_str(), "disk_pressure");
+        }
+    }
+
+    #[test]
+    fn eager_retired_capacity_unknown_queues_fail_closed() {
+        let outcome =
+            classify_prepare_build_cache(&cargo_cache(), false, DiskAdmission::CapacityUnknown);
+        assert_eq!(
+            outcome,
+            PrepareBuildCacheOutcome::Queued {
+                reason: QueuedReason::DiskCapacityUnknown,
+            }
+        );
+        assert_eq!(outcome.telemetry_label(), "queued");
+        if let PrepareBuildCacheOutcome::Queued { reason } = outcome {
+            assert_eq!(reason.as_str(), "disk_capacity_unknown");
+        }
+    }
+}

--- a/server/crates/djinn-mcp-extension/src/tests/schema_tests.rs
+++ b/server/crates/djinn-mcp-extension/src/tests/schema_tests.rs
@@ -92,6 +92,7 @@ fn expected_safety_tuple(name: &str) -> Option<(bool, bool, bool, bool)> {
         | "epic_close"
         | "proposal_ac_set"
         | "run_verification"
+        | "prepare_build_cache"
         | "proposal_debate_resolve" => Some(idempotent_mutation),
         "task_create"
         | "epic_create"

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__worker_tool_names.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__worker_tool_names.snap
@@ -27,6 +27,7 @@ expression: names
   "memory_write",
   "memory_edit",
   "request_planner",
+  "prepare_build_cache",
   "run_verification",
   "submit_work"
 ]

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__worker_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__worker_tool_schemas.snap
@@ -816,6 +816,20 @@ expression: tool_schemas_worker()
     "concurrent_safe": false
   },
   {
+    "name": "prepare_build_cache",
+    "description": "Prepare the platform build cache for this task before you start building, on demand. Stack-neutral: where the platform maintains a warm cache for your stack, this routes cache preparation through the first-use/admission seam and returns a typed outcome WITHOUT you running any build yourself. Outcomes: `ready`/`noop` (the cache is prepared and its path is returned — `noop` means startup already seeded it, so nothing was re-done), `queued` (preparation was deferred under disk pressure or unknown capacity and no cache bytes were allocated), or `not_applicable` (your stack has no platform warm cache). It never intercepts or blocks your shell commands and does not build or submit anything. Call it once up front; re-calling an already-prepared cache is cheap.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    "readOnly": false,
+    "destructive": false,
+    "idempotent": true,
+    "openWorld": false,
+    "concurrent_safe": false
+  },
+  {
     "name": "run_verification",
     "description": "Run the canonical final-verification gate on the current worktree, on demand. It consults first: if an identical tree (same whole-tree fingerprint, manifest, environment, and required coverage) already has a passing run, it returns that evidence instantly WITHOUT executing any commands. Otherwise it runs the required checks hermetically and records the result. Use it to confirm your work passes before you submit — an unchanged tree is never compiled twice, so calling it is cheap on a fresh hit. Returns a typed outcome (hit / ran-pass / ran-fail / rate-limited / error) with per-check results. It does NOT submit your work; call submit_work / submit_review when you are done.",
     "inputSchema": {

--- a/server/crates/djinn-mcp-extension/src/tool_defs.rs
+++ b/server/crates/djinn-mcp-extension/src/tool_defs.rs
@@ -85,6 +85,27 @@ pub fn tool_run_verification() -> RmcpTool {
     )
 }
 
+pub fn tool_prepare_build_cache() -> RmcpTool {
+    RmcpTool::new(
+        "prepare_build_cache".to_string(),
+        "Prepare the platform build cache for this task before you start building, on demand. \
+         Stack-neutral: where the platform maintains a warm cache for your stack, this routes \
+         cache preparation through the first-use/admission seam and returns a typed outcome \
+         WITHOUT you running any build yourself. Outcomes: `ready`/`noop` (the cache is prepared \
+         and its path is returned — `noop` means startup already seeded it, so nothing was \
+         re-done), `queued` (preparation was deferred under disk pressure or unknown capacity \
+         and no cache bytes were allocated), or `not_applicable` (your stack has no platform \
+         warm cache). It never intercepts or blocks your shell commands and does not build or \
+         submit anything. Call it once up front; re-calling an already-prepared cache is cheap."
+            .to_string(),
+        object!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        }),
+    )
+}
+
 pub fn tool_shell() -> RmcpTool {
     RmcpTool::new(
         "shell".to_string(),
@@ -480,9 +501,22 @@ pub fn tool_schemas_worker() -> Vec<serde_json::Value> {
         mutation(),
     ));
     tool_values.push(serialize_tool(tool_request_planner(), mutation()));
+    // Stack-neutral build-cache preparation. Present for the Worker regardless
+    // of gate configuration — it routes through the worker-side first-use /
+    // admission seam and returns a typed outcome. Idempotent: re-preparing an
+    // already-ready cache only consults.
+    tool_values.push(serialize_tool(
+        tool_prepare_build_cache(),
+        idempotent_mutation(),
+    ));
     // On-demand canonical final-verification gate (consult-first reuse). Runs
     // and may record a passing row, but re-running an unchanged tree only
     // consults, so it is classified idempotent.
+    //
+    // NOTE: the canonical schema set advertises `run_verification`; the live
+    // Worker/Reviewer surface and the rendered prompt strip it when the
+    // resolved `lifecycle.final_verification` plan is empty (see
+    // `djinn_roles::prompts::retain_conditional_verification_tools`).
     tool_values.push(serialize_tool(
         tool_run_verification(),
         idempotent_mutation(),

--- a/server/crates/djinn-mcp-extension/tests/fixtures/tool_surface_baseline.json
+++ b/server/crates/djinn-mcp-extension/tests/fixtures/tool_surface_baseline.json
@@ -1639,6 +1639,20 @@
   },
   {
     "concurrent_safe": false,
+    "description": "Prepare the platform build cache for this task before you start building, on demand. Stack-neutral: where the platform maintains a warm cache for your stack, this routes cache preparation through the first-use/admission seam and returns a typed outcome WITHOUT you running any build yourself. Outcomes: `ready`/`noop` (the cache is prepared and its path is returned — `noop` means startup already seeded it, so nothing was re-done), `queued` (preparation was deferred under disk pressure or unknown capacity and no cache bytes were allocated), or `not_applicable` (your stack has no platform warm cache). It never intercepts or blocks your shell commands and does not build or submit anything. Call it once up front; re-calling an already-prepared cache is cheap.",
+    "destructive": false,
+    "idempotent": true,
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {},
+      "type": "object"
+    },
+    "name": "prepare_build_cache",
+    "openWorld": false,
+    "readOnly": false
+  },
+  {
+    "concurrent_safe": false,
     "description": "Amend a proposal's acceptance-criteria spec with audited revision semantics. Each amendment targets a zero-based criterion index with operation `rewrite`, `drop`, or `waive`; requires a non-empty reason. Bumps proposal revision, retains sign-offs. Use proposal_ac_set for met-flag reconciliation only.",
     "destructive": false,
     "idempotent": false,

--- a/server/crates/djinn-roles/src/prompts/dev.md
+++ b/server/crates/djinn-roles/src/prompts/dev.md
@@ -33,6 +33,7 @@ Your sole job is to write working code that satisfies the acceptance criteria. I
 7. **Verify completeness** — ensure ALL acceptance criteria are met, ALL code changes written and saved. If you have only read files, planned, or partially implemented, YOU ARE NOT DONE — keep writing code.
 8. **Submit work** — call `submit_work(task_id="{{task_id}}", summary="...")` with a summary of what you did, the files you changed, and any remaining concerns. **This is the only way to end your session. Do NOT call submit_work until all implementation is complete.**
 
+{{verification_guidance_section}}
 ## Rules
 
 - **Honesty guard:** Do not claim recovery, cleanup, retry, reset, auto-healing, or "fixed the state" actions unless a real tool call in this session performed that action. Describe only what you actually did and what the tools actually returned. If you only observed an error or changed code, say that; do not narrate an unperformed heal.

--- a/server/crates/djinn-roles/src/prompts/mod.rs
+++ b/server/crates/djinn-roles/src/prompts/mod.rs
@@ -143,6 +143,73 @@ pub struct TaskContext {
     /// injected into planner/reviewer/lead/architect prompts.  `None` when
     /// there is no active monitored reopen or the role does not receive it.
     pub arbiter_directive: Option<String>,
+
+    // ── Final-verification plan (epic 1bnj) ────────────────────────────────────
+    /// `true` when the resolved project `lifecycle.final_verification` plan is
+    /// non-empty. Drives the conditional agent surface: Worker/Reviewer prompts
+    /// render `run_verification` guidance and the tool is kept in the rendered
+    /// tools section only when this is `true`. Empty-plan projects render legacy
+    /// prompt language and make no claim that a gate runs at submit.
+    pub final_verification_configured: bool,
+}
+
+// ─── Conditional final-verification surface (epic 1bnj) ─────────────────────────
+
+/// Tool name gated on a non-empty resolved `lifecycle.final_verification` plan.
+///
+/// The canonical Worker/Reviewer schema sets advertise this tool
+/// unconditionally (so the reviewed baseline and snapshots capture the full
+/// surface); the live per-project surface and the rendered prompt strip it when
+/// the resolved plan is empty via [`retain_conditional_verification_tools`].
+pub const CONDITIONAL_VERIFICATION_TOOL: &str = "run_verification";
+
+/// Remove the on-demand `run_verification` tool from a role's rendered tool
+/// surface when the resolved project has no `lifecycle.final_verification`
+/// plan configured.
+///
+/// Single source of truth shared by the live MCP tool surface (supervisor
+/// stage) and the rendered prompt tools section so the two cannot drift.
+/// `prepare_build_cache` is intentionally never touched here — it renders for
+/// the Worker unconditionally.
+pub fn retain_conditional_verification_tools(
+    schemas: &mut Vec<serde_json::Value>,
+    final_verification_configured: bool,
+) {
+    if !final_verification_configured {
+        schemas.retain(|schema| {
+            schema.get("name").and_then(|name| name.as_str()) != Some(CONDITIONAL_VERIFICATION_TOOL)
+        });
+    }
+}
+
+/// Render the role-specific `run_verification` guidance block.
+///
+/// Non-empty only for the Worker and Reviewer roles when the resolved plan is
+/// configured. Empty-plan projects (and every other role) render nothing, so
+/// the legacy prompt language stands with no claim that a gate runs at submit.
+fn verification_guidance_section(role_name: &str, final_verification_configured: bool) -> String {
+    if !final_verification_configured {
+        return String::new();
+    }
+    match role_name {
+        "worker" => "## Final Verification\n\n\
+             This project has a configured final-verification gate. Iterate against it: call \
+             `run_verification` to run the canonical gate on the current worktree on demand and \
+             confirm your tree passes before you `submit_work`. It consults a passing result for \
+             an unchanged tree first, so an unchanged tree is never recompiled and calling it is \
+             cheap. Running `cargo`/build/test shell commands yourself for debugging is permitted, \
+             but such manual runs are not credited — only `run_verification` records gate evidence \
+             for the required checks.\n"
+            .to_string(),
+        "reviewer" => "## Independent Verification\n\n\
+             This project has a configured final-verification gate. You may independently re-run it \
+             with `run_verification` to confirm the submitted tree passes on demand — it reuses a \
+             passing result for an unchanged authored tree and executes the checks only when the \
+             tree has changed. Use it to corroborate the worker's submission rather than trusting \
+             it blind.\n"
+            .to_string(),
+        _ => String::new(),
+    }
 }
 
 // ─── Renderer ─────────────────────────────────────────────────────────────────
@@ -178,9 +245,21 @@ pub fn render_prompt_for_role(
         .unwrap_or("");
     out = out.replace("{{role_mode_section}}", mode_section);
 
-    // Dynamic tools section from role schemas
-    let tools_md = format_tools_section(&(tool_schemas)());
+    // Dynamic tools section from role schemas. The canonical schema set
+    // advertises `run_verification` unconditionally; strip it here when the
+    // resolved project has no final-verification plan so the rendered surface
+    // matches the live per-project MCP surface.
+    let mut schemas = (tool_schemas)();
+    retain_conditional_verification_tools(&mut schemas, ctx.final_verification_configured);
+    let tools_md = format_tools_section(&schemas);
     out = out.replace("{{tools_section}}", &tools_md);
+
+    // Role-specific `run_verification` guidance, rendered only for configured
+    // projects (Worker/Reviewer). The placeholder vanishes cleanly for
+    // empty-plan projects and every other role.
+    let verification_guidance =
+        verification_guidance_section(config.name, ctx.final_verification_configured);
+    out = out.replace("{{verification_guidance_section}}", &verification_guidance);
 
     // Task fields
     out = out.replace("{{task_id}}", &task.id);

--- a/server/crates/djinn-roles/src/prompts/task-reviewer.md
+++ b/server/crates/djinn-roles/src/prompts/task-reviewer.md
@@ -73,6 +73,7 @@ These patterns are **intentional** and should not be reported as defects unless 
 
 {{reviewer_diff_context_section}}
 
+{{verification_guidance_section}}
 ## Out-of-Workspace AC
 
 If a criterion requires changes to code that lives **outside this workspace** (another project, service, or codebase), mark it as **MET** — the worker cannot fulfil it from here. Add a FEEDBACK note describing where the work belongs so the lead can remove the AC.

--- a/server/crates/djinn-roles/src/prompts/tests.rs
+++ b/server/crates/djinn-roles/src/prompts/tests.rs
@@ -99,6 +99,7 @@ fn make_ctx() -> TaskContext {
         ci_blocking_directive: None,
         worker_resume_note: None,
         arbiter_directive: None,
+        final_verification_configured: false,
     }
 }
 

--- a/server/crates/djinn-slot/src/reply_loop/tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop/tests.rs
@@ -337,6 +337,10 @@ impl ReplyLoopHarness {
             ci_blocking_directive: None,
             worker_resume_note: None,
             arbiter_directive: None,
+            // Render the full canonical surface (incl. run_verification) for the
+            // shared worker-prompt harness so signature-coverage assertions see
+            // every worker tool.
+            final_verification_configured: true,
         };
         let system_prompt = djinn_roles::prompts::render_prompt_for_role(
             role_config,
@@ -5191,6 +5195,7 @@ async fn rendered_worker_prompt_uses_signature_only_tool_section() {
         ci_blocking_directive: None,
         worker_resume_note: None,
         arbiter_directive: None,
+        final_verification_configured: true,
     };
     let system_prompt = djinn_roles::prompts::render_prompt_for_role(
         role_config,

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -49,6 +49,7 @@ const BOARD_HEALTH_MISMATCH_COALESCED_TOTAL: &str = "djinn_board_health_mismatch
 const BOARD_HEALTH_MISMATCH_PASS_AGE_SECONDS: &str = "djinn_board_health_mismatch_pass_age_seconds";
 const BOARD_HEALTH_MISMATCH_OUTCOMES_TOTAL: &str = "djinn_board_health_mismatch_outcomes_total";
 const CARGO_TARGET_SEED_TOTAL: &str = "djinn_cargo_target_seed_total";
+const PREPARE_BUILD_CACHE_TOTAL: &str = "djinn_prepare_build_cache_total";
 const CARGO_SEED_HIT_TOTAL: &str = "djinn_cargo_seed_hit_total";
 const CARGO_SEED_COLD_TOTAL: &str = "djinn_cargo_seed_cold_total";
 const CARGO_WARM_BASE_FRESHNESS_SECONDS: &str = "djinn_cargo_warm_base_freshness_seconds";
@@ -1040,6 +1041,34 @@ pub mod cargo_target_seed {
             "fallback_reason" => reason
         )
         .increment(1);
+    }
+}
+
+/// Agent-facing `prepare_build_cache` worker-tool telemetry (epic 1bnj).
+///
+/// Exactly one counter increment is emitted per tool call. The `outcome` label
+/// space is a CLOSED enum (`ready`, `noop`, `queued`, `not-applicable`,
+/// `error`) so series cardinality stays bounded. Identifiers (task-run id,
+/// resolved cache path) are carried in the tool result's structured audit
+/// fields, never as metric labels.
+pub mod prepare_build_cache {
+    /// Ready after admission/seed for a stack with a platform warm cache.
+    pub const OUTCOME_READY: &str = "ready";
+    /// Compatibility ready no-op while eager startup seeding is still active.
+    pub const OUTCOME_NOOP: &str = "noop";
+    /// Deferred (disk pressure / capacity unknown) without allocating bytes.
+    pub const OUTCOME_QUEUED: &str = "queued";
+    /// Stack has no platform warm cache.
+    pub const OUTCOME_NOT_APPLICABLE: &str = "not-applicable";
+    /// Internal failure preparing the cache.
+    pub const OUTCOME_ERROR: &str = "error";
+
+    /// Emit exactly one bounded outcome for a `prepare_build_cache` call.
+    ///
+    /// Callers pass one of the `OUTCOME_*` constants; free-form labels are not
+    /// accepted so the series stays bounded.
+    pub fn increment_outcome(outcome: &'static str) {
+        metrics::counter!(super::PREPARE_BUILD_CACHE_TOTAL, "outcome" => outcome).increment(1);
     }
 }
 


### PR DESCRIPTION
Implements epic 1bnj (proposal jvpm).

## prepare_build_cache Worker tool
- Stack-neutral tool, present for the Worker regardless of gate config. Empty-object schema; no language-specific behaviour in the public surface.
- Routes cache preparation through the worker-side first-use/admission seam. Pure classifier in `djinn-core::prepare_build_cache` maps a resolved platform cache + admission signals onto one typed outcome (`ready`/`noop`/`queued`/`not_applicable`), never allocating run-dir bytes on the queued branches (preserves seed single-flight + disk reservation invariants).
- While eager startup seeding remains authoritative (nquz enforce not yet live), returns a compatible `ready` no-op rather than duplicating seed work. Rust cargo target run-dir is the only platform cache today; other stacks resolve to `not_applicable`.
- Exactly one bounded telemetry outcome per call (`ready`/`noop`/`queued`/`not-applicable`/`error`); identifiers ride the structured `audit` object only.

## Configuration-aware run_verification surface
- The canonical Worker/Reviewer schema sets still advertise `run_verification` (so goldens capture the full surface); the live per-project MCP surface and the rendered prompt strip it when the resolved `lifecycle.final_verification` plan is empty, via `retain_conditional_verification_tools` (single source shared by the supervisor stage and the prompt renderer). `prepare_build_cache` is never stripped.
- Configured Worker prompt recommends iterating with `run_verification` and explains shell builds are permitted but not credited; configured Reviewer prompt exposes independent-rerun guidance. Empty-plan projects render legacy language with no gate claim.

## Goldens + tests
- Regenerated every derived tool-schema golden: `tool_surface_baseline.json` (via `regenerate_tool_surface_baseline`), mcp-extension worker snapshots (names + schemas), djinn-agent worker snapshots (tools section + extension schemas), and the safety-tuple table.
- New rendered-surface guards cover both configured and empty-plan cases for Worker and Reviewer (schema surface + prompt prose). Pure classifier + handler unit tests cover every outcome.

Gates: fmt clean, clippy clean on touched crates, focused tests green, `cargo check --workspace --all-targets` clean, no Cargo.toml changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)