### PR TITLE
chore(ujvz): Versioned admission-epoch transition test matrix

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
@@ -1,0 +1,618 @@
+//! Versioned admission-epoch transition matrix (ujvz): disruptions.
+//!
+//! Stale and reordered watch deliveries, partial configuration updates, and
+//! missing acknowledgements. Each disruption is applied to a real durable epoch
+//! and asserted against the same two invariants the cutover scenarios use (see
+//! [`crate::build_admission_epoch_support`]), plus the bounded-label contract
+//! for the telemetry this rollout emits.
+
+use std::collections::BTreeSet;
+
+use djinn_db::{
+    AdmissionHandoffAuthority, AdmissionHandoffPhase, AdmissionHandoffRow, V0Mode, V1Mode,
+};
+use djinn_supervisor::services::{InvocationLiftDecision, evaluate_invocation_lift};
+
+use crate::build_admission::{
+    BuildAdmissionMode, BuildAdmissionReadiness, MAX_ADMISSION_CAP, MIN_ADMISSION_CAP,
+    task_run_generation_key,
+};
+use crate::build_admission_epoch_support::EpochWorld;
+use crate::build_admission_handoff::{
+    EmergencyAuthorityDecision, HandoffState, HandoffWarningReason, InvocationAuthorityObservation,
+    evaluate_handoff,
+};
+use crate::build_admission_transition::TransitionError;
+
+fn armed_generations() -> Vec<String> {
+    vec![
+        task_run_generation_key("task-alpha", 0),
+        task_run_generation_key("task-beta", 2),
+    ]
+}
+
+/// Reach a committed forward overlap: both authorities enforce, both
+/// acknowledged, with a concrete reference cap.
+async fn overlapping_world(cap: i64) -> EpochWorld {
+    let world = EpochWorld::new();
+    world.observe("disruption_baseline").await;
+    let epoch = world.row().await.epoch;
+    world.executor.arm_shadow(epoch, cap).await.unwrap();
+    world.observe("disruption_shadow").await;
+    let epoch = world.row().await.epoch;
+    world.executor.arm_overlap(epoch, cap).await.unwrap();
+    world.observe("disruption_overlap_modes").await;
+    let epoch = world.row().await.epoch;
+    world.executor.enter_forward_overlap(epoch).await.unwrap();
+    world.observe("disruption_forward_overlap").await;
+    world
+}
+
+/// A watch consumer that cached an older row cannot act on it: every mutation
+/// carrying a stale epoch is fenced, and re-reading is the only way forward.
+/// Reordered deliveries therefore cannot commit a state the durable row does
+/// not already permit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stale_and_reordered_watch_deliveries_are_fenced_and_never_release_v0() {
+    let world = overlapping_world(3).await;
+
+    // A watch delivery captured while the shadow was armed, replayed late.
+    let stale_shadow = AdmissionHandoffRow {
+        phase: AdmissionHandoffPhase::EmergencyPrimary,
+        epoch: 1,
+        emergency_ack_epoch: Some(1),
+        invocation_ack_epoch: None,
+        v0_mode: V0Mode::Enforce,
+        v1_mode: V1Mode::Shadow,
+        cap: Some(3),
+        updated_at: "stale-delivery".into(),
+    };
+    // A delivery from the future that this process has not committed.
+    let current = world.row().await;
+    let unseen_future = AdmissionHandoffRow {
+        phase: AdmissionHandoffPhase::InvocationPrimary,
+        epoch: current.epoch + 5,
+        emergency_ack_epoch: None,
+        invocation_ack_epoch: Some(current.epoch + 5),
+        v0_mode: V0Mode::Observe,
+        v1_mode: V1Mode::Enforce,
+        cap: Some(3),
+        updated_at: "reordered-delivery".into(),
+    };
+
+    // Read in isolation, a reordered delivery can look permissive…
+    assert_eq!(
+        evaluate_invocation_lift(Ok(Some(unseen_future.clone()))),
+        InvocationLiftDecision::Lift
+    );
+    // …but every mutation it could motivate is fenced against the durable row.
+    for epoch in [stale_shadow.epoch, unseen_future.epoch] {
+        assert!(matches!(
+            world.executor.set_cap(epoch, 2).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+        assert!(matches!(
+            world.executor.arm_overlap(epoch, 2).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+        assert!(matches!(
+            world.executor.commit_invocation_primary(epoch, &[]).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+        for authority in [
+            AdmissionHandoffAuthority::Emergency,
+            AdmissionHandoffAuthority::Invocation,
+        ] {
+            assert!(
+                world.handoff.acknowledge(authority, epoch).await.is_err(),
+                "an acknowledgement for epoch {epoch} is not current"
+            );
+        }
+        assert!(
+            world
+                .handoff
+                .record_generation_ack(epoch, &armed_generations()[0])
+                .await
+                .is_err(),
+            "a generation acknowledgement for epoch {epoch} is not current"
+        );
+        assert!(
+            world
+                .handoff
+                .advance(epoch, AdmissionHandoffPhase::InvocationPrimary, &[])
+                .await
+                .is_err()
+        );
+    }
+
+    // Nothing moved, and the committed state still holds both invariants.
+    let after = world.observe("after_reordered_deliveries").await;
+    assert_eq!(after.row, current, "no fenced attempt mutated the row");
+    assert!(after.v0_enforcing && after.v1_enforcing);
+
+    // The v1 authority binds to the epoch it actually observed, not to any
+    // delivery: a stale delivery cannot make it act on a superseded cap.
+    assert_eq!(after.row.cap, Some(3));
+    assert_ne!(after.row.epoch, stale_shadow.epoch);
+    assert_ne!(after.row.epoch, unseen_future.epoch);
+}
+
+/// Applying acknowledgements out of order (invocation before emergency, or an
+/// authority re-acknowledging a superseded epoch) never opens an edge early.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reordered_acknowledgements_never_open_an_edge_early() {
+    let world = EpochWorld::new();
+    world.observe("reorder_baseline").await;
+    let epoch = world.row().await.epoch;
+    world.executor.arm_overlap(epoch, 2).await.unwrap();
+
+    // The invocation authority acknowledges first; the emergency ack the
+    // EmergencyPrimary edge actually requires is still missing.
+    world.invocation_acks().await;
+    let epoch = world.row().await.epoch;
+    assert!(matches!(
+        world.executor.enter_forward_overlap(epoch).await,
+        Err(TransitionError::AwaitingEmergencyAck { .. })
+    ));
+    assert!(
+        world
+            .handoff
+            .advance(epoch, AdmissionHandoffPhase::ForwardOverlap, &[])
+            .await
+            .is_err(),
+        "the durable edge requires the outgoing primary authority"
+    );
+    let blocked = world.observe("invocation_acked_first").await;
+    assert_eq!(blocked.row.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert!(blocked.v0_enforcing);
+
+    // Now the edge opens, and the superseded epoch's acknowledgements are dead.
+    let epoch = world.row().await.epoch;
+    let overlap = world.executor.enter_forward_overlap(epoch).await.unwrap();
+    assert!(
+        world
+            .handoff
+            .acknowledge(AdmissionHandoffAuthority::Invocation, epoch)
+            .await
+            .is_err(),
+        "the pre-advance epoch can no longer be acknowledged"
+    );
+    assert_eq!(overlap.phase, AdmissionHandoffPhase::ForwardOverlap);
+    let committed = world.observe("reordered_overlap").await;
+    assert!(committed.v0_enforcing && committed.v1_enforcing);
+}
+
+/// A configuration update that lands partially — modes written without the
+/// acknowledgements that make them authoritative, or an illegal combination
+/// written outside the operator executor — always fails closed onto v0.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn partial_config_updates_fail_closed_onto_the_emergency_authority() {
+    let world = overlapping_world(3).await;
+
+    // 1. An out-of-range cap never reaches the durable row.
+    let before = world.row().await;
+    for cap in [0, MAX_ADMISSION_CAP + 1] {
+        assert!(matches!(
+            world.executor.set_cap(before.epoch, cap).await,
+            Err(TransitionError::InvalidConfig(_))
+        ));
+    }
+    assert_eq!(world.row().await, before, "a rejected cap changed nothing");
+
+    // 2. A legal cap change re-collects acknowledgements; the window between
+    //    the write and the acks is an incomplete epoch that lifts nothing.
+    let recapped = world.executor.set_cap(before.epoch, 2).await.unwrap();
+    assert_eq!(recapped.cap, Some(2));
+    assert_ne!(
+        recapped.emergency_ack_epoch,
+        Some(recapped.epoch),
+        "the mode/cap write cleared the v0 acknowledgement"
+    );
+    assert_eq!(
+        evaluate_invocation_lift(Ok(Some(recapped.clone()))),
+        InvocationLiftDecision::Unleased,
+        "a partially acknowledged epoch never lifts v1"
+    );
+    let recapped_state = world.observe("cap_changed").await;
+    assert_eq!(recapped_state.cap, 2, "the lowered cap is now in force");
+    assert!(recapped_state.v0_enforcing);
+
+    // 3. The illegal both-non-enforcing combination written straight to the
+    //    durable row (an operator editing modes outside the executor) fails
+    //    closed in BOTH projections.
+    let epoch = world.row().await.epoch;
+    assert!(matches!(
+        world.executor.arm_rollback(epoch, 2).await,
+        Err(TransitionError::InvalidTransition(_))
+    ));
+    world
+        .handoff
+        .set_modes_and_cap(epoch, V0Mode::Observe, V1Mode::Shadow, Some(2))
+        .await
+        .unwrap();
+    let illegal = world.row().await;
+    let snapshot = evaluate_handoff(
+        Ok(Some(illegal.clone())),
+        BuildAdmissionMode::Enforce,
+        true,
+        BuildAdmissionReadiness::Healthy,
+        InvocationAuthorityObservation::default(),
+    );
+    assert_eq!(snapshot.state, HandoffState::IllegalModeCombo);
+    assert_eq!(
+        snapshot.emergency,
+        EmergencyAuthorityDecision::RequiredFailClosed
+    );
+    assert_eq!(
+        evaluate_invocation_lift(Ok(Some(illegal))),
+        InvocationLiftDecision::Unleased
+    );
+    let observed = world.observe("illegal_mode_combo").await;
+    assert!(
+        observed.v0_enforcing && !observed.v1_enforcing,
+        "an illegal combination leaves the emergency authority in charge"
+    );
+    assert_eq!(world.leader_mode(), BuildAdmissionMode::Enforce);
+}
+
+/// Every phase's required acknowledgements gate its edge, and the durable state
+/// stays safe while the edge is closed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn missing_acknowledgements_block_every_edge_including_invocation_primary() {
+    let armed = armed_generations();
+
+    // ── EmergencyPrimary needs the v0 acknowledgement. ────────────────────
+    let world = EpochWorld::new();
+    let epoch = world.row().await.epoch;
+    assert!(matches!(
+        world.executor.enter_forward_overlap(epoch).await,
+        Err(TransitionError::AwaitingEmergencyAck { epoch: 0 })
+    ));
+
+    // ── ForwardOverlap needs both authorities plus every live generation. ─
+    let world = overlapping_world(3).await;
+    let epoch = world.row().await.epoch;
+    // The armed live set has not acknowledged: the edge is closed and reports
+    // only how many are missing, never which.
+    let error = world
+        .executor
+        .commit_invocation_primary(epoch, &armed)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        TransitionError::AwaitingGenerationAcks { missing: 2, .. }
+    ));
+    let message = error.to_string();
+    for key in &armed {
+        assert!(
+            !message.contains(key),
+            "a blocked-edge error must not carry generation identities"
+        );
+    }
+    // The durable edge is closed too, not merely the executor's guard.
+    assert!(
+        world
+            .handoff
+            .advance(epoch, AdmissionHandoffPhase::InvocationPrimary, &armed)
+            .await
+            .is_err()
+    );
+    let blocked = world.observe("missing_generation_acks").await;
+    assert_eq!(blocked.row.phase, AdmissionHandoffPhase::ForwardOverlap);
+    assert!(blocked.v0_enforcing && blocked.v1_enforcing);
+
+    // A live generation that acknowledges a superseded epoch does not count.
+    world
+        .handoff
+        .record_generation_ack(epoch, &armed[0])
+        .await
+        .unwrap();
+    assert!(
+        !world
+            .handoff
+            .generation_ack_complete(epoch, &armed)
+            .await
+            .unwrap()
+    );
+    world.generations_ack(&armed[1..]).await;
+    assert!(
+        world
+            .handoff
+            .generation_ack_complete(epoch, &armed)
+            .await
+            .unwrap()
+    );
+
+    // ── InvocationPrimary needs the v1 acknowledgement to leave. ──────────
+    let epoch = world.row().await.epoch;
+    world
+        .executor
+        .commit_invocation_primary(epoch, &armed)
+        .await
+        .unwrap();
+    world.observe("committed_primary").await;
+    let epoch = world.row().await.epoch;
+    world.executor.arm_rollback(epoch, 3).await.unwrap();
+    // v0 has not re-acknowledged the rollback epoch yet.
+    let epoch = world.row().await.epoch;
+    assert!(matches!(
+        world.executor.enter_rollback_overlap(epoch).await,
+        Err(TransitionError::HaltedV0Unconfirmed { .. })
+    ));
+    let halted = world.observe("rollback_awaiting_v0").await;
+    assert!(halted.v0_enforcing, "the halt kept v0 enforcing");
+
+    // ── RollbackOverlap needs both authorities to leave. ──────────────────
+    let epoch = world.row().await.epoch;
+    world.executor.enter_rollback_overlap(epoch).await.unwrap();
+    let epoch = world.row().await.epoch;
+    assert!(matches!(
+        world.executor.complete_rollback(epoch).await,
+        Err(TransitionError::AwaitingEmergencyAck { .. })
+    ));
+    let overlap = world.observe("rollback_overlap_awaiting_v0").await;
+    assert!(overlap.v0_enforcing && overlap.v1_enforcing);
+    let epoch = world.row().await.epoch;
+    world.executor.complete_rollback(epoch).await.unwrap();
+    let done = world.observe("rollback_done").await;
+    assert!(done.v0_enforcing && !done.v1_enforcing);
+}
+
+/// Extract the label block of every rendered sample line for `metric`.
+fn label_blocks(rendered: &str, metric: &str) -> Vec<String> {
+    rendered
+        .lines()
+        .filter(|line| !line.starts_with('#'))
+        .filter(|line| line.starts_with(metric))
+        .map(|line| {
+            line.split_once('{')
+                .and_then(|(_, rest)| rest.split_once('}'))
+                .map_or_else(String::new, |(labels, _)| labels.to_owned())
+        })
+        .collect()
+}
+
+/// Split one rendered label block into `(key, value)` pairs.
+fn label_pairs(block: &str) -> Vec<(String, String)> {
+    if block.is_empty() {
+        return Vec::new();
+    }
+    block
+        .split(',')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| {
+            let (key, value) = pair.split_once('=').unwrap();
+            (key.trim().to_owned(), value.trim_matches('"').to_owned())
+        })
+        .collect()
+}
+
+/// Every metric this rollout emits carries only closed-enumeration labels, and
+/// identifiers stay in logs and traces.
+///
+/// The v1 lease family (`operation` / `consumer` / `state` / `outcome`, which is
+/// where abandon, warm bind, timeout, and occupancy live) has its own
+/// exhaustive contract test beside the service:
+/// `crate::build_lease::tests::production_metrics_use_only_bounded_typed_labels`.
+/// This test covers the epoch/handoff, shadow-escalation, admission-health, and
+/// run-dir reclamation families, which had no label contract.
+#[test]
+fn epoch_and_admission_telemetry_labels_stay_bounded_and_carry_no_identifiers() {
+    // Identity-bearing inputs held by the code that emits, so a leak would show.
+    const WORK_ID: &str = "ujvz-work-secret-7f91";
+    const POD_UID: &str = "ujvz-pod-secret-7f91";
+    let generation = task_run_generation_key("ujvz-task-secret-7f91", 4);
+
+    let (reasons, rendered) = djinn_telemetry::render_isolated(|| {
+        // Drive the handoff warning family through the coordinator's own
+        // bounded projection rather than through literal strings.
+        let mut reasons = BTreeSet::new();
+        for row in [
+            Err(()),
+            Ok(None),
+            Ok(Some(AdmissionHandoffRow {
+                phase: AdmissionHandoffPhase::ForwardOverlap,
+                epoch: 41,
+                emergency_ack_epoch: Some(40),
+                invocation_ack_epoch: Some(41),
+                v0_mode: V0Mode::Enforce,
+                v1_mode: V1Mode::Enforce,
+                cap: Some(3),
+                updated_at: WORK_ID.into(),
+            })),
+            Ok(Some(AdmissionHandoffRow {
+                phase: AdmissionHandoffPhase::EmergencyPrimary,
+                epoch: 41,
+                emergency_ack_epoch: Some(41),
+                invocation_ack_epoch: None,
+                v0_mode: V0Mode::Enforce,
+                v1_mode: V1Mode::Off,
+                cap: Some(3),
+                updated_at: POD_UID.into(),
+            })),
+        ] {
+            let snapshot = evaluate_handoff(
+                row,
+                BuildAdmissionMode::Enforce,
+                true,
+                BuildAdmissionReadiness::Healthy,
+                InvocationAuthorityObservation { enforcing: true },
+            );
+            let reason =
+                snapshot.warning_reason(true, InvocationAuthorityObservation { enforcing: true });
+            djinn_telemetry::build_admission::set_handoff_warning(
+                reason.map(HandoffWarningReason::as_str),
+            );
+            if let Some(reason) = reason {
+                reasons.insert(reason.as_str());
+            }
+        }
+
+        // Shadow-mode escalation/throttle observations. Only `would_escalate`
+        // has a production caller today (the complementary `would_throttle`
+        // branch is deferred with the shadow broker check); both label values
+        // are asserted so the family stays closed when it is wired.
+        djinn_telemetry::build_admission::record_shadow_invocation(true);
+        djinn_telemetry::build_admission::record_shadow_invocation(false);
+
+        for mode in ["enforce", "observe", "off"] {
+            djinn_telemetry::build_admission::set_health(mode, 3, true, true, true);
+            djinn_telemetry::build_admission::increment_would_defer(mode, 3);
+            djinn_telemetry::build_admission::increment_unknown_classification(mode, 3);
+        }
+
+        // Occupancy and queue-wait telemetry for the same admissions.
+        djinn_telemetry::build_slot_occupancy::set_slots_in_use(2);
+        djinn_telemetry::build_slot_occupancy::set_slots_queued(1);
+        for outcome in [
+            djinn_telemetry::build_slot_queue::OUTCOME_ADMITTED,
+            djinn_telemetry::build_slot_queue::OUTCOME_CANCELLED,
+            djinn_telemetry::build_slot_queue::OUTCOME_SHUTDOWN,
+        ] {
+            djinn_telemetry::build_slot_queue::record_wait_seconds(
+                outcome,
+                std::time::Duration::from_millis(5),
+            );
+        }
+
+        // Reclamation / unleased run-dir families.
+        for state in [
+            djinn_telemetry::run_dir::STATE_RESERVED,
+            djinn_telemetry::run_dir::STATE_READY_ACTIVE,
+            djinn_telemetry::run_dir::STATE_RECLAIMABLE,
+            djinn_telemetry::run_dir::STATE_QUARANTINED_UNOWNED,
+        ] {
+            djinn_telemetry::run_dir::set_state_count(state, 1);
+        }
+        for tier in [
+            djinn_telemetry::run_dir::RECLAIM_TIER_RECLAIMABLE,
+            djinn_telemetry::run_dir::RECLAIM_TIER_READY_IDLE,
+            djinn_telemetry::run_dir::RECLAIM_TIER_WARM_BASE_AUX,
+        ] {
+            djinn_telemetry::run_dir::increment_reclaim(tier, 1, 1024);
+        }
+        djinn_telemetry::run_dir::increment_queue_reason(
+            djinn_telemetry::run_dir::QUEUE_REASON_DISK_PRESSURE,
+        );
+        djinn_telemetry::run_dir::increment_quota_failure(
+            djinn_telemetry::run_dir::QUOTA_FAILURE_PROBE_UNAVAILABLE,
+        );
+        reasons
+    });
+
+    // The bounded projection produced exactly the contract reasons.
+    assert_eq!(
+        reasons,
+        BTreeSet::from(["unexpected_overlap", "stale_epoch", "epoch_unreadable"])
+    );
+
+    let bounded: [(&str, &[&str]); 9] = [
+        (
+            "reason",
+            &[
+                "unexpected_overlap",
+                "stale_epoch",
+                "epoch_unreadable",
+                "disk_pressure",
+                "probe_unavailable",
+            ],
+        ),
+        ("effective_mode", &["enforce", "observe", "off"]),
+        ("decision", &["would_escalate", "would_throttle"]),
+        (
+            "outcome",
+            &["admitted", "cancelled", "shutdown", "seeded", "reseeded"],
+        ),
+        (
+            "state",
+            &[
+                "absent",
+                "reserved",
+                "seeding",
+                "ready_active",
+                "ready_idle",
+                "reclaimable",
+                "reclaiming",
+                "quarantined_unowned",
+            ],
+        ),
+        ("tier", &["reclaimable", "ready_idle", "warm_base_aux"]),
+        // Numeric, not identities: histogram bucket bounds and quantiles.
+        ("le", &[]),
+        ("quantile", &[]),
+        ("effective_cap", &[]),
+    ];
+    let allowed_keys: BTreeSet<&str> = bounded.iter().map(|(key, _)| *key).collect();
+
+    let mut seen_keys = BTreeSet::new();
+    for line in rendered.lines() {
+        if line.starts_with('#') || !line.starts_with("djinn_") {
+            continue;
+        }
+        let Some((_, rest)) = line.split_once('{') else {
+            continue;
+        };
+        let Some((block, _)) = rest.split_once('}') else {
+            continue;
+        };
+        for (key, value) in label_pairs(block) {
+            assert!(
+                allowed_keys.contains(key.as_str()),
+                "unbounded label key `{key}` in `{line}`"
+            );
+            seen_keys.insert(key.clone());
+            match key.as_str() {
+                // Histogram bucket boundaries and quantiles are numeric.
+                "le" | "quantile" => {
+                    assert!(value == "+Inf" || value.parse::<f64>().is_ok());
+                }
+                // The reference cap is bounded by the configuration validator.
+                "effective_cap" => {
+                    let cap: i64 = value.parse().unwrap();
+                    assert!((MIN_ADMISSION_CAP..=MAX_ADMISSION_CAP).contains(&cap));
+                }
+                other => {
+                    let (_, allowed) = bounded.iter().find(|(key, _)| *key == other).unwrap();
+                    assert!(
+                        allowed.contains(&value.as_str()),
+                        "unbounded value `{value}` for label `{other}`"
+                    );
+                }
+            }
+        }
+    }
+    assert!(
+        seen_keys.contains("reason") && seen_keys.contains("decision"),
+        "the handoff and shadow families must actually have rendered"
+    );
+
+    // No identifier reaches a label, by value or by key.
+    for identifier in [WORK_ID, POD_UID, generation.as_str()] {
+        assert!(
+            !rendered.contains(identifier),
+            "identifier `{identifier}` leaked into telemetry"
+        );
+    }
+    for key in [
+        "work_id=",
+        "uid=",
+        "epoch=",
+        "task_id=",
+        "session_id=",
+        "project_id=",
+        "user_id=",
+        "generation=",
+        "pod_uid=",
+    ] {
+        assert!(
+            !rendered.contains(key),
+            "identity label `{key}` was emitted"
+        );
+    }
+    // The handoff warning family is exactly three series, all present.
+    assert_eq!(
+        label_blocks(&rendered, "djinn_build_admission_handoff_warning").len(),
+        3
+    );
+}

--- a/server/crates/djinn-coordinator/src/build_admission_epoch_matrix_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_epoch_matrix_tests.rs
@@ -1,0 +1,479 @@
+//! Versioned admission-epoch transition matrix (ujvz): the rollout and rollback
+//! state machine driven through the merged operator executor.
+//!
+//! Every scenario drives [`crate::build_admission_transition::AdmissionTransitionExecutor`]
+//! — the same safe-ordering executor operators use — and asserts, at every
+//! committed durable state, that at least one authority still enforces and that
+//! the epoch's reference cap is never exceeded at full speed. See
+//! [`crate::build_admission_epoch_support`] for the two invariants.
+
+use djinn_db::{AdmissionHandoffPhase, V0Mode, V1Mode};
+use djinn_supervisor::services::{InvocationLiftDecision, evaluate_invocation_lift};
+
+use crate::build_admission::BuildAdmissionMode;
+use crate::build_admission_epoch_support::{EpochWorld, assert_restart_is_fail_closed};
+use crate::build_admission_handoff::HandoffState;
+use crate::build_admission_transition::TransitionError;
+
+fn armed_generations() -> Vec<String> {
+    vec![
+        crate::build_admission::task_run_generation_key("task-alpha", 0),
+        crate::build_admission::task_run_generation_key("task-beta", 2),
+    ]
+}
+
+/// The launcher-side projection of the durable row *without* a leader tick, so
+/// the window between two transactions can be inspected exactly as a running
+/// agent would see it.
+async fn raw_lift(world: &EpochWorld) -> InvocationLiftDecision {
+    evaluate_invocation_lift(Ok(Some(world.row().await)))
+}
+
+/// Shadow → overlap → cutover, observing after every durable transaction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn forward_cutover_holds_an_enforcing_authority_and_the_cap_at_every_state() {
+    let world = EpochWorld::new();
+    let cap = 3;
+    let armed = armed_generations();
+
+    // ── Baseline: v0 alone, v1 off. ───────────────────────────────────────
+    let baseline = world.observe("baseline").await;
+    assert_eq!(baseline.row.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert_eq!(baseline.row.v0_mode, V0Mode::Enforce);
+    assert_eq!(baseline.row.v1_mode, V1Mode::Off);
+    assert_eq!(baseline.snapshot.state, HandoffState::EmergencyPrimary);
+    assert_eq!(baseline.lift, InvocationLiftDecision::Unleased);
+    assert!(baseline.v0_enforcing && !baseline.v1_enforcing);
+
+    // ── Shadow: v1 observes, never lifts; v0 remains the sole authority. ──
+    let epoch = world.row().await.epoch;
+    world.executor.arm_shadow(epoch, cap).await.unwrap();
+    assert_eq!(
+        raw_lift(&world).await,
+        InvocationLiftDecision::Unleased,
+        "the freshly armed epoch has no acknowledgement yet, so nothing lifts"
+    );
+    let shadow = world.observe("shadow").await;
+    assert_eq!(shadow.row.v1_mode, V1Mode::Shadow);
+    assert_eq!(shadow.row.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert_eq!(shadow.snapshot.state, HandoffState::Shadow);
+    assert_eq!(
+        shadow.lift,
+        InvocationLiftDecision::Shadow,
+        "shadow observes what v1 would do and never lifts the launcher quota"
+    );
+    assert!(shadow.v0_enforcing && !shadow.v1_enforcing);
+    assert_eq!(shadow.cap, cap);
+
+    // ── Overlap modes armed, phase still v0-primary: v1 still cannot lift. ─
+    let epoch = world.row().await.epoch;
+    world.executor.arm_overlap(epoch, cap).await.unwrap();
+    let armed_modes = world.observe("overlap_modes_armed").await;
+    assert_eq!(armed_modes.row.v1_mode, V1Mode::Enforce);
+    assert_eq!(
+        armed_modes.row.phase,
+        AdmissionHandoffPhase::EmergencyPrimary
+    );
+    assert_eq!(
+        armed_modes.lift,
+        InvocationLiftDecision::Unleased,
+        "arming v1 enforce alone never lifts: the overlap phase is not committed"
+    );
+    assert!(armed_modes.v0_enforcing && !armed_modes.v1_enforcing);
+
+    // ── Forward overlap: both authorities enforce. ────────────────────────
+    let epoch = world.row().await.epoch;
+    world.executor.enter_forward_overlap(epoch).await.unwrap();
+    assert_eq!(
+        raw_lift(&world).await,
+        InvocationLiftDecision::Unleased,
+        "the overlap epoch does not lift before v0 acknowledges it"
+    );
+    let overlap = world.observe("forward_overlap").await;
+    assert_eq!(overlap.row.phase, AdmissionHandoffPhase::ForwardOverlap);
+    assert_eq!(overlap.snapshot.state, HandoffState::ForwardOverlap);
+    assert!(
+        overlap.v0_enforcing && overlap.v1_enforcing,
+        "the forward overlap is the both-enforcing state"
+    );
+
+    // ── The invocation-primary edge is blocked by a missing generation ack. ─
+    let epoch = world.row().await.epoch;
+    let blocked = world
+        .executor
+        .commit_invocation_primary(epoch, &armed)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            blocked,
+            TransitionError::AwaitingGenerationAcks { missing: 2, .. }
+        ),
+        "a missing live-generation acknowledgement blocks invocation_primary: {blocked:?}"
+    );
+    let still_overlap = world.observe("blocked_on_generation_acks").await;
+    assert_eq!(
+        still_overlap.row.phase,
+        AdmissionHandoffPhase::ForwardOverlap
+    );
+    assert!(still_overlap.v0_enforcing);
+
+    // One of two generations acknowledges: still blocked, still both-enforcing.
+    world.generations_ack(&armed[..1]).await;
+    let epoch = world.row().await.epoch;
+    assert!(matches!(
+        world
+            .executor
+            .commit_invocation_primary(epoch, &armed)
+            .await
+            .unwrap_err(),
+        TransitionError::AwaitingGenerationAcks { missing: 1, .. }
+    ));
+    let partial = world.observe("one_generation_acknowledged").await;
+    assert_eq!(partial.row.phase, AdmissionHandoffPhase::ForwardOverlap);
+    assert!(partial.v0_enforcing && partial.v1_enforcing);
+
+    // ── Cutover: every armed generation acknowledges, v0 may be released. ──
+    world.generations_ack(&armed[1..]).await;
+    let epoch = world.row().await.epoch;
+    world
+        .executor
+        .commit_invocation_primary(epoch, &armed)
+        .await
+        .unwrap();
+    let primary = world.observe("invocation_primary").await;
+    assert_eq!(primary.row.phase, AdmissionHandoffPhase::InvocationPrimary);
+    assert_eq!(primary.snapshot.state, HandoffState::InvocationPrimary);
+    assert!(
+        !primary.v0_enforcing && primary.v1_enforcing,
+        "v0 is released exactly once v1 is the committed, lifting authority"
+    );
+    assert_eq!(world.leader_mode(), BuildAdmissionMode::Off);
+
+    // ── Terminal forward step: v0 observes, v1 keeps enforcing the cap. ────
+    let epoch = world.row().await.epoch;
+    world.executor.observe_v0(epoch).await.unwrap();
+    let observed = world.observe("v0_observe").await;
+    assert_eq!(observed.row.v0_mode, V0Mode::Observe);
+    assert_eq!(observed.row.v1_mode, V1Mode::Enforce);
+    assert!(!observed.v0_enforcing && observed.v1_enforcing);
+    assert_eq!(observed.cap, cap);
+}
+
+/// Drive the forward cutover the same way the operator runbook does, leaving
+/// the world at the terminal `v0 = observe` state.
+async fn drive_forward_cutover(world: &EpochWorld, cap: i64, armed: &[String]) {
+    world.observe("cutover_baseline").await;
+    let epoch = world.row().await.epoch;
+    world.executor.arm_shadow(epoch, cap).await.unwrap();
+    world.observe("cutover_shadow").await;
+    let epoch = world.row().await.epoch;
+    world.executor.arm_overlap(epoch, cap).await.unwrap();
+    world.observe("cutover_overlap_modes").await;
+    let epoch = world.row().await.epoch;
+    world.executor.enter_forward_overlap(epoch).await.unwrap();
+    world.observe("cutover_forward_overlap").await;
+    world.generations_ack(armed).await;
+    let epoch = world.row().await.epoch;
+    world
+        .executor
+        .commit_invocation_primary(epoch, armed)
+        .await
+        .unwrap();
+    world.observe("cutover_invocation_primary").await;
+}
+
+/// The rollback ordering proof: v0 is enforcing *and* acknowledged before any
+/// v1 quota is lifted at the rollback epoch, and v1 is never disabled while v0
+/// is unconfirmed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rollback_confirms_v0_before_any_v1_quota_lift_and_never_raises_the_cap() {
+    let world = EpochWorld::new();
+    let armed = armed_generations();
+    drive_forward_cutover(&world, 3, &armed).await;
+    let epoch = world.row().await.epoch;
+    world.executor.observe_v0(epoch).await.unwrap();
+    let released = world.observe("v1_primary").await;
+    assert!(!released.v0_enforcing && released.v1_enforcing);
+
+    // ── Arm the rollback at a same-or-lower cap: v0 re-enforces. ──────────
+    let epoch = world.row().await.epoch;
+    assert!(matches!(
+        world.executor.arm_rollback(epoch, 4).await,
+        Err(TransitionError::CapNotSameOrLower {
+            requested: 4,
+            current: 3
+        })
+    ));
+    let armed_row = world.executor.arm_rollback(epoch, 2).await.unwrap();
+    assert_eq!(armed_row.v0_mode, V0Mode::Enforce);
+    assert_eq!(armed_row.v1_mode, V1Mode::Enforce);
+    assert_eq!(armed_row.cap, Some(2));
+    assert_eq!(
+        raw_lift(&world).await,
+        InvocationLiftDecision::Unleased,
+        "the rollback epoch lifts nothing until it is acknowledged"
+    );
+
+    // ── v0 unconfirmed: the rollback halts, mutating nothing. ─────────────
+    let halted = world
+        .executor
+        .enter_rollback_overlap(armed_row.epoch)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        halted,
+        TransitionError::HaltedV0Unconfirmed { .. }
+    ));
+    let after_halt = world.row().await;
+    assert_eq!(
+        after_halt.epoch, armed_row.epoch,
+        "the halt mutated nothing"
+    );
+    assert_eq!(after_halt.v1_mode, V1Mode::Enforce, "v1 was never disabled");
+
+    // The leader tick confirms v0 (enforcing, healthy, acknowledged).
+    let confirmed = world.observe("rollback_armed").await;
+    assert!(confirmed.v0_enforcing, "v0 re-enforces before the rollback");
+    assert_eq!(confirmed.row.emergency_ack_epoch, Some(confirmed.row.epoch));
+    assert_eq!(confirmed.cap, 2, "the rollback lowered the reference cap");
+
+    // ── Rollback overlap: v1 lifts only after v0 acknowledges this epoch. ─
+    let epoch = world.row().await.epoch;
+    let overlap = world.executor.enter_rollback_overlap(epoch).await.unwrap();
+    assert_eq!(overlap.phase, AdmissionHandoffPhase::RollbackOverlap);
+    assert_eq!(overlap.invocation_ack_epoch, Some(overlap.epoch));
+    assert_ne!(
+        overlap.emergency_ack_epoch,
+        Some(overlap.epoch),
+        "the advance cleared the v0 acknowledgement"
+    );
+    assert_eq!(
+        raw_lift(&world).await,
+        InvocationLiftDecision::Unleased,
+        "no v1 quota is lifted at the rollback overlap before v0 acknowledges it"
+    );
+    let rollback_overlap = world.observe("rollback_overlap").await;
+    assert_eq!(
+        rollback_overlap.snapshot.state,
+        HandoffState::RollbackOverlap
+    );
+    assert_eq!(
+        rollback_overlap.row.emergency_ack_epoch,
+        Some(rollback_overlap.row.epoch),
+        "v0 is acknowledged BEFORE the epoch lifts v1"
+    );
+    assert_eq!(rollback_overlap.lift, InvocationLiftDecision::Lift);
+    assert!(rollback_overlap.v0_enforcing && rollback_overlap.v1_enforcing);
+
+    // ── Complete: v1 is disabled only after v0 is re-confirmed. ───────────
+    let epoch = world.row().await.epoch;
+    let baseline = world.executor.complete_rollback(epoch).await.unwrap();
+    assert_eq!(baseline.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert_eq!(baseline.v0_mode, V0Mode::Enforce);
+    assert_eq!(baseline.v1_mode, V1Mode::Off);
+    assert_eq!(baseline.cap, Some(2), "the rollback never raised the cap");
+    let final_state = world.observe("rollback_complete").await;
+    assert_eq!(final_state.snapshot.state, HandoffState::EmergencyPrimary);
+    assert_eq!(final_state.lift, InvocationLiftDecision::Unleased);
+    assert!(final_state.v0_enforcing && !final_state.v1_enforcing);
+    assert_eq!(world.leader_mode(), BuildAdmissionMode::Enforce);
+}
+
+/// The kill switch runs the same reverse ordering straight from
+/// invocation-primary, where v0 is still durably `Enforce`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn kill_switch_from_invocation_primary_keeps_an_enforcing_authority_throughout() {
+    let world = EpochWorld::new();
+    let armed = armed_generations();
+    drive_forward_cutover(&world, 3, &armed).await;
+
+    let epoch = world.row().await.epoch;
+    world.executor.arm_rollback(epoch, 3).await.unwrap();
+    let armed_state = world.observe("kill_switch_armed").await;
+    assert!(armed_state.v0_enforcing);
+    assert_eq!(armed_state.cap, 3);
+
+    let epoch = world.row().await.epoch;
+    world.executor.enter_rollback_overlap(epoch).await.unwrap();
+    let overlap = world.observe("kill_switch_overlap").await;
+    assert!(overlap.v0_enforcing && overlap.v1_enforcing);
+
+    let epoch = world.row().await.epoch;
+    world.executor.complete_rollback(epoch).await.unwrap();
+    let done = world.observe("kill_switch_complete").await;
+    assert_eq!(done.row.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert_eq!(done.row.v1_mode, V1Mode::Off);
+    assert!(done.v0_enforcing && !done.v1_enforcing);
+}
+
+/// The durable transactions of one complete forward + rollback cycle, in order.
+const CYCLE_STEPS: usize = 15;
+
+/// The phase that must be authoritative after `executed` transactions.
+fn expected_phase(executed: usize) -> AdmissionHandoffPhase {
+    match executed {
+        0..=5 => AdmissionHandoffPhase::EmergencyPrimary,
+        6..=8 => AdmissionHandoffPhase::ForwardOverlap,
+        9..=12 => AdmissionHandoffPhase::InvocationPrimary,
+        13..=14 => AdmissionHandoffPhase::RollbackOverlap,
+        _ => AdmissionHandoffPhase::EmergencyPrimary,
+    }
+}
+
+/// Apply the first `stop_after` durable transactions of the cycle.
+async fn drive_cycle(world: &EpochWorld, stop_after: usize, cap: i64, armed: &[String]) {
+    for step in 0..stop_after {
+        let epoch = world.row().await.epoch;
+        match step {
+            // The leader's live handoff tick is itself a durable transaction.
+            0 | 2 | 4 | 6 | 11 | 13 => {
+                world.leader_tick().await;
+            }
+            1 => world
+                .executor
+                .arm_shadow(epoch, cap)
+                .await
+                .map(drop)
+                .unwrap(),
+            3 => world
+                .executor
+                .arm_overlap(epoch, cap)
+                .await
+                .map(drop)
+                .unwrap(),
+            5 => world
+                .executor
+                .enter_forward_overlap(epoch)
+                .await
+                .map(drop)
+                .unwrap(),
+            7 => world.generations_ack(armed).await,
+            8 => world
+                .executor
+                .commit_invocation_primary(epoch, armed)
+                .await
+                .map(drop)
+                .unwrap(),
+            9 => world.executor.observe_v0(epoch).await.map(drop).unwrap(),
+            10 => world
+                .executor
+                .arm_rollback(epoch, cap - 1)
+                .await
+                .map(drop)
+                .unwrap(),
+            12 => world
+                .executor
+                .enter_rollback_overlap(epoch)
+                .await
+                .map(drop)
+                .unwrap(),
+            _ => world
+                .executor
+                .complete_rollback(epoch)
+                .await
+                .map(drop)
+                .unwrap(),
+        }
+    }
+}
+
+/// Crash and restart between EVERY handoff transaction of the full cycle: the
+/// earlier safe phase stays authoritative, no state is torn, and the restarted
+/// process still holds an enforcing authority under its cap.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn crash_restart_between_every_transaction_keeps_the_earlier_phase_authoritative() {
+    let armed = armed_generations();
+    for executed in 0..=CYCLE_STEPS {
+        let world = EpochWorld::new();
+        drive_cycle(&world, executed, 3, &armed).await;
+        let before = world.row().await;
+        assert_eq!(
+            before.phase,
+            expected_phase(executed),
+            "after {executed} transactions the durable phase is the committed one"
+        );
+
+        // Forced process loss: nothing cooperative runs. A replacement leader
+        // starts fail-closed and reads the durable epoch.
+        let restarted = world.restart();
+        let after = restarted.row().await;
+        assert_eq!(
+            after, before,
+            "a crash between transactions leaves the durable row exactly as committed"
+        );
+        let observation = restarted
+            .observe(&format!("restart_after_{executed}_transactions"))
+            .await;
+        assert_eq!(observation.row.phase, expected_phase(executed));
+        assert_restart_is_fail_closed(&observation);
+    }
+}
+
+/// The operator steps that issue more than one durable write have an internal
+/// window. A crash inside it must still leave the earlier, safe authority in
+/// charge — even when the durable v0 mode has already been relaxed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn crash_inside_a_multi_write_operator_step_leaves_the_safe_authority_in_charge() {
+    let armed = armed_generations();
+
+    // Window 1: `observe_v0` writes the relaxed modes, then re-acknowledges the
+    // invocation authority. A crash between the two leaves v0 = observe on an
+    // incomplete epoch.
+    let world = EpochWorld::new();
+    drive_forward_cutover(&world, 3, &armed).await;
+    let epoch = world.row().await.epoch;
+    world
+        .handoff
+        .set_modes_and_cap(epoch, V0Mode::Observe, V1Mode::Enforce, Some(3))
+        .await
+        .unwrap();
+    assert_eq!(
+        raw_lift(&world).await,
+        InvocationLiftDecision::Unleased,
+        "the half-applied step lifts nothing"
+    );
+    let restarted = world.restart();
+    let observation = restarted.observe("crash_inside_observe_v0").await;
+    assert_eq!(observation.row.v0_mode, V0Mode::Observe);
+    assert!(
+        observation.v0_enforcing,
+        "an incomplete epoch keeps the emergency authority enforcing even when the \
+         durable v0 mode has been relaxed"
+    );
+    assert!(!observation.v1_enforcing);
+
+    // Window 2: `complete_rollback` advances to the v0 baseline and only then
+    // disables v1. A crash between the two leaves both authorities armed.
+    let world = EpochWorld::new();
+    drive_forward_cutover(&world, 3, &armed).await;
+    let epoch = world.row().await.epoch;
+    world.executor.arm_rollback(epoch, 3).await.unwrap();
+    world.observe("rollback_armed_for_window").await;
+    let epoch = world.row().await.epoch;
+    world.executor.enter_rollback_overlap(epoch).await.unwrap();
+    world.observe("rollback_overlap_for_window").await;
+    let epoch = world.row().await.epoch;
+    world
+        .handoff
+        .advance(epoch, AdmissionHandoffPhase::EmergencyPrimary, &[])
+        .await
+        .unwrap();
+    assert_eq!(
+        raw_lift(&world).await,
+        InvocationLiftDecision::Unleased,
+        "the v0 baseline stops v1 lifting the moment the phase commits"
+    );
+    let restarted = world.restart();
+    let observation = restarted.observe("crash_inside_complete_rollback").await;
+    assert_eq!(
+        observation.row.phase,
+        AdmissionHandoffPhase::EmergencyPrimary
+    );
+    assert_eq!(
+        observation.row.v1_mode,
+        V1Mode::Enforce,
+        "v1 is still durably armed; only the phase stopped it lifting"
+    );
+    assert!(observation.v0_enforcing && !observation.v1_enforcing);
+}

--- a/server/crates/djinn-coordinator/src/build_admission_epoch_support.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_epoch_support.rs
@@ -333,6 +333,11 @@ impl EpochWorld {
             "{label}: v0 admitted {occupancy} above the epoch cap {cap}"
         );
         assert_eq!(
+            occupancy, cap,
+            "{label}: the burst exceeded the cap in contenders, so a healthy \
+             enforcing v0 must fill it exactly — never fewer, never more"
+        );
+        assert_eq!(
             i64::try_from(permits.len()).unwrap(),
             occupancy,
             "{label}: every v0 permit is durably accounted"
@@ -430,6 +435,10 @@ impl EpochWorld {
         assert_eq!(
             granted, snapshot.occupied,
             "{label}: every v1 grant is durably accounted"
+        );
+        assert_eq!(
+            snapshot.occupied, cap,
+            "{label}: the FIFO fills the epoch cap exactly — never fewer, never more"
         );
 
         // Releasing an occupied lease drains the FIFO into the next queued row,

--- a/server/crates/djinn-coordinator/src/build_admission_epoch_support.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_epoch_support.rs
@@ -1,0 +1,526 @@
+//! Shared harness for the versioned admission-epoch transition matrix (ujvz).
+//!
+//! The matrix drives the *merged* pieces of the rollout and re-implements none
+//! of them:
+//!
+//! - [`AdmissionTransitionExecutor`] (twqh) is the only operator-facing writer
+//!   of durable phase/mode/cap transitions.
+//! - [`evaluate_handoff`] (icvs) is the v0 (emergency) side projection the
+//!   coordinator leader applies on every live handoff tick.
+//! - [`evaluate_invocation_lift`] (keoq) is the v1 (invocation) side projection
+//!   the agent/launcher applies before it lifts the reserved quota.
+//! - [`BuildAdmissionController`] and [`BuildLeaseService`] are the two real
+//!   cap-enforcing authorities.
+//!
+//! # The two invariants asserted at every observed committed state
+//!
+//! 1. **At least one enforcing authority.** `v0_enforcing || v1_enforcing`,
+//!    where `v0_enforcing` is the emergency controller's state *after* one
+//!    leader tick (the tick is what releases or re-closes v0) and
+//!    `v1_enforcing` is the launcher projection actually authorizing the v1
+//!    regime for this epoch. The sharp edge of the proof is the companion
+//!    assertion that [`EmergencyAuthorityDecision::MayDisable`] — the sole v0
+//!    release point — never occurs unless v1 is genuinely lifting.
+//! 2. **The cap is never exceeded at full speed.** Every enforcing authority is
+//!    driven with a concurrent burst larger than the epoch's reference cap, and
+//!    warm consumers plus above-unleased task trees
+//!    (`count_task_or_warm_occupancy`, which deliberately excludes the
+//!    below-the-lease invocation children) never exceed it.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use djinn_db::{
+    AdmissionDomain, AdmissionHandoffAuthority, AdmissionHandoffRepository, AdmissionHandoffRow,
+    AdmissionJournalRepository, BuildLeaseRepository, Database,
+};
+use djinn_k8s::{WarmAdmission, WarmAdmissionRequest, WarmAdmissionTransition};
+use djinn_supervisor::services::{
+    GraphWarmLeaseIdentity, InvocationLiftDecision, LeaseAbandonRequest, LeaseDeadlines,
+    LeaseIdentity, LeaseQueueRequest, LeaseReleaseRequest, LeaseResult, LeaseState,
+    LeaseStatusRequest, evaluate_invocation_lift,
+};
+use tokio::sync::Barrier;
+
+use crate::build_admission::{
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode,
+};
+use crate::build_admission_handoff::{
+    EmergencyAuthorityDecision, HandoffSnapshot, InvocationAuthorityObservation, evaluate_handoff,
+};
+use crate::build_admission_transition::AdmissionTransitionExecutor;
+use crate::build_lease::{
+    BuildLeaseService, ManualLeaseClock, NoopLeaseTelemetry, NoopLeaseTransactionPause,
+};
+
+/// Reference cap used when the durable row inherits the controller default
+/// (`cap = NULL`). The seeded row carries no cap, so the baseline observation
+/// still needs a concrete number to burst against.
+pub(crate) const INHERITED_CAP: i64 = 3;
+
+/// One observed committed durable state plus both authority projections.
+#[derive(Clone, Debug)]
+pub(crate) struct EpochObservation {
+    pub(crate) label: String,
+    pub(crate) row: AdmissionHandoffRow,
+    pub(crate) snapshot: HandoffSnapshot,
+    pub(crate) lift: InvocationLiftDecision,
+    /// The emergency controller still enforces after the leader tick.
+    pub(crate) v0_enforcing: bool,
+    /// The invocation authority is live for this epoch (v1 mode enforcing and
+    /// the launcher projection authorizes the lift).
+    pub(crate) v1_enforcing: bool,
+    /// Reference cap in force for this epoch.
+    pub(crate) cap: i64,
+}
+
+/// A deterministic world holding one durable epoch row, one admission journal,
+/// one lease ledger, and the leader's in-memory emergency controller.
+pub(crate) struct EpochWorld {
+    db: Database,
+    pub(crate) handoff: Arc<AdmissionHandoffRepository>,
+    pub(crate) journal: Arc<AdmissionJournalRepository>,
+    pub(crate) leases: Arc<BuildLeaseRepository>,
+    pub(crate) executor: AdmissionTransitionExecutor,
+    /// The coordinator leader's emergency controller. Its mode is driven only
+    /// by [`Self::leader_tick`], exactly as `finalize_build_admission_handoff`
+    /// drives it in the server.
+    leader: BuildAdmissionController,
+}
+
+/// Process-global burst counter. Worlds share the journal across a restart, so
+/// burst identities must stay unique for the whole test binary or a replayed
+/// index would collide with a retained terminal row.
+static BURST_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+
+fn next_burst() -> usize {
+    BURST_SEQUENCE.fetch_add(1, Ordering::SeqCst)
+}
+
+impl EpochWorld {
+    pub(crate) fn new() -> Self {
+        let db = Database::open_in_memory().unwrap();
+        let handoff = Arc::new(AdmissionHandoffRepository::new(db.clone()));
+        Self {
+            journal: Arc::new(AdmissionJournalRepository::new(db.clone())),
+            leases: Arc::new(BuildLeaseRepository::new(db.clone())),
+            executor: AdmissionTransitionExecutor::new(Arc::clone(&handoff)),
+            leader: BuildAdmissionController::new(
+                Arc::new(AdmissionJournalRepository::new(db.clone())),
+                BuildAdmissionMode::Enforce,
+                INHERITED_CAP,
+                "ujvz-leader",
+            ),
+            handoff,
+            db,
+        }
+    }
+
+    /// Simulate a coordinator restart: the durable state is untouched and a new
+    /// process comes up with a fresh, fail-closed emergency controller.
+    pub(crate) fn restart(&self) -> Self {
+        let handoff = Arc::new(AdmissionHandoffRepository::new(self.db.clone()));
+        let leader = BuildAdmissionController::new_closed(
+            Arc::new(AdmissionJournalRepository::new(self.db.clone())),
+            INHERITED_CAP,
+            "ujvz-leader-restarted",
+        );
+        // Journal recovery, Kubernetes inventory, and the single-active
+        // topology gate all complete before the leader reads the epoch.
+        leader.mark_ready();
+        Self {
+            db: self.db.clone(),
+            journal: Arc::clone(&self.journal),
+            leases: Arc::clone(&self.leases),
+            executor: AdmissionTransitionExecutor::new(Arc::clone(&handoff)),
+            leader,
+            handoff,
+        }
+    }
+
+    pub(crate) async fn row(&self) -> AdmissionHandoffRow {
+        self.handoff.read().await.unwrap().unwrap()
+    }
+
+    pub(crate) fn leader_mode(&self) -> BuildAdmissionMode {
+        self.leader.mode()
+    }
+
+    /// One live handoff tick of the coordinator leader, mirroring
+    /// `finalize_build_admission_handoff`: read the durable row, project it,
+    /// release or re-close the emergency controller, and acknowledge the exact
+    /// current epoch when the policy allows it.
+    pub(crate) async fn leader_tick(&self) -> HandoffSnapshot {
+        let snapshot = self.project().await;
+        match snapshot.emergency {
+            EmergencyAuthorityDecision::MayDisable => {
+                self.leader.disable();
+                return snapshot;
+            }
+            EmergencyAuthorityDecision::RequiredFailClosed
+                if self.leader.mode() != BuildAdmissionMode::Enforce =>
+            {
+                // A durable row that still requires v0 re-closes a released
+                // controller and re-runs its startup gates before it may
+                // acknowledge anything.
+                self.leader.require_enforcement();
+                self.leader.mark_ready();
+            }
+            EmergencyAuthorityDecision::RequiredFailClosed
+            | EmergencyAuthorityDecision::ConfiguredStandalone => {}
+        }
+        let snapshot = self.project().await;
+        if snapshot.emergency_acknowledgement_allowed
+            && let Some(row) = snapshot
+                .row
+                .as_ref()
+                .filter(|row| row.emergency_ack_epoch != Some(row.epoch))
+        {
+            self.handoff
+                .acknowledge(AdmissionHandoffAuthority::Emergency, row.epoch)
+                .await
+                .unwrap();
+            return self.project().await;
+        }
+        snapshot
+    }
+
+    /// Project the durable row through the emergency-side policy with the
+    /// invocation observation taken from the launcher-side projection, so the
+    /// two independent authority readings are never invented by the test.
+    async fn project(&self) -> HandoffSnapshot {
+        let row = self.handoff.read().await.unwrap();
+        let lift = evaluate_invocation_lift(Ok(row.clone()));
+        evaluate_handoff(
+            Ok(row),
+            self.leader.mode(),
+            self.leader.mode() == BuildAdmissionMode::Enforce,
+            self.leader.readiness(),
+            InvocationAuthorityObservation {
+                enforcing: lift == InvocationLiftDecision::Lift,
+            },
+        )
+    }
+
+    /// Observe one committed durable state and assert both invariants.
+    pub(crate) async fn observe(&self, label: &str) -> EpochObservation {
+        let snapshot = self.leader_tick().await;
+        let row = self.row().await;
+        let lift = evaluate_invocation_lift(Ok(Some(row.clone())));
+        let v0_enforcing = self.leader.mode() == BuildAdmissionMode::Enforce;
+        let v1_enforcing = row.v1_mode.is_enforcing() && lift == InvocationLiftDecision::Lift;
+        let cap = row.cap.unwrap_or(INHERITED_CAP);
+
+        assert_eq!(
+            snapshot.emergency == EmergencyAuthorityDecision::MayDisable,
+            !v0_enforcing,
+            "{label}: the emergency controller is released exactly at MayDisable"
+        );
+        if snapshot.emergency == EmergencyAuthorityDecision::MayDisable {
+            assert!(
+                v1_enforcing,
+                "{label}: v0 was released while v1 was not enforcing (lift={lift:?}, \
+                 v1_mode={:?})",
+                row.v1_mode
+            );
+        }
+        assert!(
+            v0_enforcing || v1_enforcing,
+            "{label}: no enforcing authority at phase {:?} epoch {} (v0={:?}, v1={:?}, \
+             state={:?}, lift={lift:?})",
+            row.phase,
+            row.epoch,
+            row.v0_mode,
+            row.v1_mode,
+            snapshot.state,
+        );
+        // Bounded telemetry: the warning family is the three contract reasons
+        // and nothing derived from an identifier or an epoch number.
+        let gauges = snapshot.warning_gauges(
+            v0_enforcing,
+            InvocationAuthorityObservation {
+                enforcing: v1_enforcing,
+            },
+        );
+        assert!(
+            gauges.unexpected_overlap + gauges.stale_epoch + gauges.epoch_unreadable <= 1,
+            "{label}: at most one bounded handoff warning reason is ever active"
+        );
+
+        if v0_enforcing {
+            self.assert_v0_cap_holds_at_full_speed(label, cap).await;
+        }
+        if v1_enforcing {
+            self.assert_v1_cap_holds_at_full_speed(label, cap, row.epoch)
+                .await;
+        }
+
+        EpochObservation {
+            label: label.to_owned(),
+            row,
+            snapshot,
+            lift,
+            v0_enforcing,
+            v1_enforcing,
+            cap,
+        }
+    }
+
+    /// Drive the v0 emergency controller with a concurrent burst larger than
+    /// the epoch cap and assert warm consumers plus above-unleased task trees
+    /// never exceed it. The journal is returned to zero occupancy afterwards so
+    /// a later, lower cap starts from a clean ledger.
+    async fn assert_v0_cap_holds_at_full_speed(&self, label: &str, cap: i64) {
+        let burst = next_burst();
+        let controller = Arc::new(BuildAdmissionController::new(
+            Arc::clone(&self.journal),
+            BuildAdmissionMode::Enforce,
+            cap,
+            format!("ujvz-burst-{burst}"),
+        ));
+        let contenders = usize::try_from(cap).unwrap() + 2;
+        let barrier = Arc::new(Barrier::new(contenders + 1));
+        let mut attempts = Vec::new();
+        for index in 0..contenders {
+            let controller = Arc::clone(&controller);
+            let barrier = Arc::clone(&barrier);
+            attempts.push(tokio::spawn(async move {
+                barrier.wait().await;
+                if index % 2 == 0 {
+                    let work_id = format!("burst-{burst}-task-{index}");
+                    match controller
+                        .admit_task_run(
+                            Some("worker"),
+                            AdmissionDomain::TaskObservation,
+                            work_id,
+                            0,
+                            format!("burst-{burst}-run-{index}"),
+                        )
+                        .await
+                        .unwrap()
+                    {
+                        BuildAdmissionDecision::Permitted { permit, .. } => Some(permit),
+                        BuildAdmissionDecision::Denied { .. } => None,
+                        BuildAdmissionDecision::Unclassified => {
+                            panic!("classified worker role must not be unclassified")
+                        }
+                    }
+                } else {
+                    WarmAdmission::admit(
+                        controller.as_ref(),
+                        WarmAdmissionRequest {
+                            domain: "ignored".into(),
+                            work_id: format!("burst-{burst}-warm-{index}"),
+                            generation: 0,
+                            object_name: format!("burst-{burst}-warm-object-{index}"),
+                        },
+                    )
+                    .await
+                    .ok()
+                }
+            }));
+        }
+        barrier.wait().await;
+        let mut permits = Vec::new();
+        for attempt in attempts {
+            if let Some(permit) = attempt.await.unwrap() {
+                permits.push(permit);
+            }
+        }
+        let occupancy = self.journal.count_task_or_warm_occupancy().await.unwrap();
+        assert!(
+            occupancy <= cap,
+            "{label}: v0 admitted {occupancy} above the epoch cap {cap}"
+        );
+        assert_eq!(
+            i64::try_from(permits.len()).unwrap(),
+            occupancy,
+            "{label}: every v0 permit is durably accounted"
+        );
+
+        // A below-the-lease invocation child never counts against the parent's
+        // cap, which is what "above-unleased task trees" means here.
+        let BuildAdmissionDecision::Permitted { permit: child, .. } = controller
+            .admit_task_run(
+                Some("worker"),
+                AdmissionDomain::InvocationBuild,
+                format!("burst-{burst}-child"),
+                0,
+                format!("burst-{burst}-child-job"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("{label}: an invocation child must not be blocked by the parent cap");
+        };
+        assert_eq!(
+            self.journal.count_task_or_warm_occupancy().await.unwrap(),
+            occupancy,
+            "{label}: invocation children stay below the lease and outside the cap"
+        );
+        permits.push(child);
+
+        for permit in permits {
+            controller
+                .transition(
+                    &permit,
+                    WarmAdmissionTransition::DefinitiveFailure {
+                        diagnostic: "burst teardown".into(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            self.journal.count_task_or_warm_occupancy().await.unwrap(),
+            0,
+            "{label}: the burst released every slot it took"
+        );
+    }
+
+    /// Drive the v1 lease authority the same way. Recovery reads the durable
+    /// epoch (and its reference cap) before the service opens, so the assertion
+    /// also proves the observed epoch is the committed one.
+    async fn assert_v1_cap_holds_at_full_speed(&self, label: &str, cap: i64, epoch: i64) {
+        let burst = next_burst();
+        let service = BuildLeaseService::with_seams(
+            Arc::clone(&self.leases),
+            0,
+            Arc::new(ManualLeaseClock::new(100)),
+            Arc::new(NoopLeaseTransactionPause),
+            Arc::new(NoopLeaseTelemetry),
+        )
+        .with_handoff_epoch(Arc::clone(&self.handoff));
+        assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+        assert_eq!(
+            service.observed_epoch(),
+            Some(epoch),
+            "{label}: the v1 service observes the committed epoch before it opens"
+        );
+
+        let contenders = usize::try_from(cap).unwrap() + 2;
+        let mut queued = Vec::new();
+        let mut granted = 0_i64;
+        for index in 0..contenders {
+            let identity = LeaseIdentity::GraphWarm(GraphWarmLeaseIdentity {
+                project_id: "ujvz-project".into(),
+                warm_request_id: format!("lease-burst-{burst}-{index}"),
+                graph_revision: "ujvz-revision".into(),
+            });
+            let result = service
+                .queue(LeaseQueueRequest {
+                    identity: identity.clone(),
+                    deadlines: LeaseDeadlines {
+                        queue_deadline_ms: 0,
+                        launch_deadline_ms: 0,
+                    },
+                })
+                .await;
+            if matches!(result, LeaseResult::Granted(_)) {
+                granted += 1;
+            }
+            queued.push(identity);
+        }
+        let snapshot = self.leases.snapshot().await.unwrap();
+        assert!(
+            snapshot.occupied <= cap,
+            "{label}: v1 occupied {} above the epoch cap {cap}",
+            snapshot.occupied
+        );
+        assert_eq!(
+            granted, snapshot.occupied,
+            "{label}: every v1 grant is durably accounted"
+        );
+
+        // Releasing an occupied lease drains the FIFO into the next queued row,
+        // so teardown repeats until every contender is terminal. An occupied
+        // lease needs its fencing token; the abandon contract only removes a
+        // still-queued row.
+        for _ in 0..=contenders {
+            let mut remaining = false;
+            for identity in &queued {
+                let LeaseResult::Status(status) = service
+                    .status(LeaseStatusRequest {
+                        identity: identity.clone(),
+                    })
+                    .await
+                else {
+                    continue;
+                };
+                if matches!(status.state, LeaseState::Cancelled | LeaseState::Released) {
+                    continue;
+                }
+                remaining = true;
+                let identity = identity.clone();
+                if let Some(fencing_token) = status.fencing_token {
+                    let _ = service
+                        .release(LeaseReleaseRequest {
+                            identity,
+                            fencing_token,
+                            candidate_cleanup: false,
+                        })
+                        .await;
+                } else {
+                    let _ = service
+                        .abandon(LeaseAbandonRequest {
+                            identity,
+                            candidate_cleanup: false,
+                        })
+                        .await;
+                }
+            }
+            if !remaining {
+                break;
+            }
+        }
+        assert_eq!(
+            self.leases.snapshot().await.unwrap().occupied,
+            0,
+            "{label}: the lease burst released every slot it took"
+        );
+    }
+
+    /// The invocation authority acknowledges the current epoch, as the operator
+    /// executor does while it drives a transition.
+    pub(crate) async fn invocation_acks(&self) {
+        let row = self.row().await;
+        self.handoff
+            .acknowledge(AdmissionHandoffAuthority::Invocation, row.epoch)
+            .await
+            .unwrap();
+    }
+
+    /// Every live generation acknowledges the current epoch.
+    pub(crate) async fn generations_ack(&self, generations: &[String]) {
+        let row = self.row().await;
+        for key in generations {
+            self.handoff
+                .record_generation_ack(row.epoch, key)
+                .await
+                .unwrap();
+        }
+    }
+}
+
+/// Assert that a controller reconstructed from the durable state agrees with
+/// the harness reading — used by the crash/restart scenarios to prove the
+/// earlier safe phase stays authoritative across process loss.
+pub(crate) fn assert_restart_is_fail_closed(observation: &EpochObservation) {
+    let label = &observation.label;
+    assert!(
+        observation.v0_enforcing || observation.v1_enforcing,
+        "{label}: a restart left no enforcing authority"
+    );
+    if !observation.v0_enforcing {
+        assert_eq!(
+            observation.lift,
+            InvocationLiftDecision::Lift,
+            "{label}: v0 stays released only while v1 is genuinely lifting"
+        );
+    }
+    assert_ne!(
+        observation.snapshot.state,
+        crate::build_admission_handoff::HandoffState::EpochUnreadable,
+        "{label}: the durable epoch is readable after a restart"
+    );
+}

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -184,6 +184,12 @@ pub use djinn_orchestration_types::coordinator::PR_REVIEW_FEEDBACK_EVENT;
 // ─── Test modules ────────────────────────────────────────────────────────
 
 #[cfg(test)]
+mod build_admission_epoch_disruption_tests;
+#[cfg(test)]
+mod build_admission_epoch_matrix_tests;
+#[cfg(test)]
+mod build_admission_epoch_support;
+#[cfg(test)]
 mod build_admission_integration_tests;
 #[cfg(test)]
 mod build_admission_inventory_tests;


### PR DESCRIPTION
Discharge goxi AC7 for epic 23or: prove the admission-epoch rollout/rollback
state machine holds **at least one enforcing authority at every observed
committed state** and **never admits above the epoch cap at full speed**, under
every disruption, with bounded-label telemetry.

The matrix drives the merged pieces and re-implements none of them:
`AdmissionTransitionExecutor` (twqh) is the only transition writer,
`evaluate_handoff` (icvs) is the v0 projection applied by a simulated
coordinator leader tick (mirroring `finalize_build_admission_handoff`), and
`evaluate_invocation_lift` (keoq) is the v1 launcher projection. The two
real cap-enforcing authorities — `BuildAdmissionController` and
`BuildLeaseService` — are driven for real.

**Harness** (`build_admission_epoch_support.rs`): an `EpochWorld` over one
durable epoch row, admission journal and lease ledger. Every observation runs a
leader tick and then asserts (a) `v0_enforcing || v1_enforcing`, with the sharp
companion assertion that `MayDisable` — the sole v0 release point — never occurs
unless v1 genuinely lifts, and (b) a concurrent burst larger than the epoch cap
leaves warm consumers plus above-unleased task trees
(`count_task_or_warm_occupancy`, excluding below-the-lease invocation children)
at or below the cap, on both authorities; the v1 burst also asserts the service
observed the committed epoch before it opened.

**Scenarios** (`build_admission_epoch_matrix_tests.rs`): shadow (v1 observes,
never lifts), armed overlap modes (arming alone never lifts), forward overlap
(both enforcing), cutover, terminal `v0 = observe`; the rollback ordering proof
that v0 is enforcing *and* acknowledged before any v1 quota lift and that a
halt on unconfirmed v0 mutates nothing and never disables v1; the kill switch;
crash/restart between every one of the 15 transactions of the full cycle; and
crashes inside the two multi-write operator steps.

**Disruptions** (`build_admission_epoch_disruption_tests.rs`): stale and
reordered watch deliveries (permissive in isolation, fenced against the durable
row), reordered acknowledgements, partial config updates including the illegal
both-non-enforcing combo written outside the executor, missing acknowledgements
per phase including a missing live-generation ack blocking `invocation_primary`
without leaking generation identities, and a bounded-label contract for the
epoch/handoff, shadow-escalation, admission-health, slot-occupancy and
reclamation telemetry (allow-listed keys and values; no identifier reaches a
label). The v1 lease label family keeps its existing exhaustive contract test
beside the service.

Tests only; no production behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
