### PR TITLE
chore(cl0m): Verify workspace-hack in the merge queue

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -430,12 +430,22 @@ jobs:
           echo "rustc=$(rustc --version || echo 'unknown')"
           echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
           echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+      # Runs in BOTH lanes on purpose. #771 skipped hakari in the merge queue
+      # to save CI minutes, but that made workspace-hack freshness a PR-lane-only
+      # invariant: a PR that changed Cargo.toml without regenerating
+      # workspace-hack could pass its own lane, be re-based by the queue, and
+      # land stale on main — after which the NEXT, innocent PR failed
+      # "Server Clippy" with "workspace-hack is out of date" (observed twice on
+      # 2026-07-24: #2527, #2531). `cargo hakari verify` is metadata-only (no
+      # build) and the install is a prebuilt binary, so the queue cost is
+      # seconds inside a job whose Clippy step dominates. On failure the
+      # `::error::` below is emitted before the job concludes, so the run-level
+      # annotation names this cause even when the fail-fast watcher then
+      # cancels the sibling shards.
       - uses: taiki-e/install-action@v2
-        if: github.event_name != 'merge_group'
         with:
           tool: cargo-hakari
       - name: Verify workspace-hack (hakari)
-        if: github.event_name != 'merge_group'
         run: |
           cargo hakari verify || {
             echo "::error::workspace-hack is out of date. Run 'cargo hakari generate && cargo hakari manage-deps' locally."


### PR DESCRIPTION
`.github/workflows/quality-gate.yml` guarded both the `cargo-hakari` install and
the "Verify workspace-hack (hakari)" step with `if: github.event_name != 'merge_group'`
(added in #771 purely to save CI minutes). That made workspace-hack freshness a
PR-lane-only invariant.

Failure mode this produces: a PR that changes `Cargo.toml` without regenerating
workspace-hack passes its own lane, gets re-based by the merge queue, and lands
stale on main unverified. The next, unrelated PR then fails **Server Clippy**
with "workspace-hack is out of date" — misattributing the breakage to an innocent
branch and costing a full diagnose/fix/re-CI cycle. Observed twice on 2026-07-24
(#2527, #2531), neither of which had touched dependencies.

Fix: drop the `merge_group` exclusion from both steps so the queue enforces the
same invariant as the PR lane. They must move together — verify needs install's
binary.

Notes:
- Cost: `cargo hakari verify` is metadata-only (no build; ~0.5s locally) and the
  install is a prebuilt binary via `taiki-e/install-action`. Both sit inside
  `server-clippy`, whose `cargo clippy --all-targets` step dominates, so
  merge-queue wall clock is not materially affected.
- Attribution: on failure the step's `::error::` is emitted before the job
  concludes, so it becomes a run-level annotation naming this cause even when
  the fail-fast watcher subsequently cancels sibling shards. `server-clippy`
  itself keeps its `failure` conclusion (the watcher only fires on already
  concluded failures).
- No other step changed; the rest of `server-clippy` (toolchain, rust-cache,
  Clippy) was already unguarded, so the merge_group lane has everything the
  new steps need. PR-lane behavior is identical.
- Verified: `actionlint -shellcheck= -pyflakes=` clean, YAML parses, all 83
  `scripts/*.test.mjs` workflow tests pass, and `cargo hakari verify` reports
  "workspace-hack works correctly" on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
