### PR TITLE
chore(ufdq): Wire the would_throttle shadow observation arm

### DIFF
--- a/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
+++ b/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
@@ -176,17 +176,33 @@ The phase machine is a strict forward cycle, so you cannot advance
 and no v1 quota is lifted. Re-arm shadow/overlap later to resume. A full reverse
 rollback (`rollback_overlap`) is only defined from `invocation_primary`.
 
-## Shadow-mode observability gap (deferred to `u2oz`)
+## Reading the shadow window
 
-In `shadow` every user spawn traverses the broker, but the runtime currently
-records only the `would_escalate` shadow-invocation decision
-(`djinn_telemetry::build_admission::record_shadow_invocation`, called from
-`server/crates/djinn-agent/src/process.rs`). The complementary `would_throttle`
-decision (v1 *would* have kept the quota throttled because the reference cap is
-already met) is **not** emitted: a shadow request that the invocation authority
-would have denied is not distinguished, because shadow still takes a real lease
-grant rather than a non-enforcing would-decision. This does not weaken v0 (shadow
-never lifts and never denies) and does not affect the executor's shadow arm,
-which correctly sets `v1 = shadow`. Wiring the `would_throttle` branch requires a
-non-enforcing broker capacity check on the shadow request path and belongs with
-the cross-component work in `u2oz`.
+In `shadow` the runtime records both arms of
+`djinn_telemetry::build_admission::record_shadow_invocation`
+(`djinn_build_admission_shadow_invocation_total`, label `decision`), from
+`server/crates/djinn-agent/src/process.rs`:
+
+- `would_escalate` — the spawn crossed the escalation threshold and reached a
+  valid matching durable bind, so v1 *would* have lifted the quota. It stays
+  throttled under v0.
+- `would_throttle` — the spawn ran to terminal without ever crossing
+  `cpu_usage_threshold_usec`, so it was never escalated to the lease authority
+  and v1 would have left it throttled.
+
+The two arms are mutually exclusive (escalation requires a grant, which requires
+queueing), so
+`would_escalate / (would_escalate + would_throttle)` over the window is the
+fraction of observed invocations a cutover would escalate. Both are observation
+only: shadow never lifts `cpu.max` and never denies.
+
+### Remaining gap (deferred to `u2oz`)
+
+`would_throttle` covers invocations that never escalated, not the narrower case
+of a shadow request the invocation authority would have *denied because the
+reference cap is already met* — shadow still takes a real lease grant rather
+than a non-enforcing would-decision, so cap-denial is not distinguished.
+Measuring that needs a non-enforcing broker capacity check on the shadow request
+path and belongs with the cross-component work in `u2oz`. It does not weaken v0
+and does not affect the executor's shadow arm, which correctly sets
+`v1 = shadow`.

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -620,7 +620,10 @@ impl LeaseInvocationRunner {
                                         // irreversible lift occurs, so no
                                         // fence-before-lift journal write is
                                         // required; `fence` is still reconciled
-                                        // to terminal below.
+                                        // to terminal below. The complementary
+                                        // `would_throttle` arm is recorded after
+                                        // the loop for invocations that never
+                                        // crossed the escalation threshold.
                                         djinn_telemetry::build_admission::record_shadow_invocation(
                                             true,
                                         );
@@ -686,6 +689,28 @@ impl LeaseInvocationRunner {
             journal
                 .clear(&identity)
                 .map_err(LeaseInvocationError::Launcher)?;
+        }
+        // The shadow measurement baseline, and the complement of the
+        // `would_escalate` arm recorded at the bind above: this invocation ran
+        // to terminal without ever crossing `cpu_usage_threshold_usec`
+        // (`queued` is false), so it was never escalated to the lease authority
+        // and v1 would have left it throttled. Recording only the escalating
+        // arm would make the ratio that decides cutover safety ("of all
+        // observed invocations, what fraction would v1 have escalated?")
+        // unanswerable. The two arms are mutually exclusive: escalation
+        // requires a grant, which requires `queued`.
+        //
+        // Observation only. The epoch is read once, after the child is terminal
+        // and the durable lease is reconciled, and a read failure projects to
+        // `Unleased` — nothing here can lift cpu.max, mint a fence, or move
+        // lease state.
+        if !queued
+            && matches!(
+                self.services.invocation_lift_decision().await,
+                InvocationLiftDecision::Shadow
+            )
+        {
+            djinn_telemetry::build_admission::record_shadow_invocation(false);
         }
         if let Some(error) = lease_error {
             Err(error)

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -1286,5 +1286,121 @@ async fn ac4_unresolved_state_without_fence_abandons_at_most_once() {
     assert!(services.release_fences.lock().unwrap().is_empty());
 }
 
+/// Both shadow-observation arms come from real invocation paths, so the shadow
+/// window produces a ratio rather than a single half of one.
+///
+/// `would_escalate` is produced by an invocation that crossed the escalation
+/// threshold and reached a valid matching bind under a shadow epoch;
+/// `would_throttle` by one that ran to terminal below the threshold and was
+/// never escalated. Neither counter is incremented by the test: each is emitted
+/// by driving `LeaseInvocationRunner` end to end. The whole scenario shares one
+/// current-thread runtime because the isolated recorder is thread-local.
+#[test]
+fn shadow_epoch_emits_both_would_throttle_arms_from_production_paths() {
+    let (_, rendered) = djinn_telemetry::render_isolated(|| {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime builds");
+        runtime.block_on(async {
+            // ── Escalating arm: shadow epoch + a valid matching bind. ──────
+            let services = Arc::new(ScriptedServices::new(
+                vec![granted(7)],
+                vec![status(LeaseState::Active, Some(7))],
+                vec![status(LeaseState::Active, Some(7)); 20],
+            ));
+            services.set_lift_decision(djinn_supervisor::services::InvocationLiftDecision::Shadow);
+            services
+                .release
+                .lock()
+                .unwrap()
+                .push_back(LeaseResult::Released {
+                    candidate_cleanup: false,
+                });
+            let launcher = Arc::new(ScriptedLauncher::default());
+            let cancel = CancellationToken::new();
+            let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+            let run_cancel = cancel.clone();
+            let run =
+                tokio::spawn(async move { runner.output(command(), config(), run_cancel).await });
+            wait_for(&services.status_calls, 3).await;
+            cancel.cancel();
+            run.await.unwrap().unwrap();
+            assert_eq!(services.grant_calls.load(Ordering::SeqCst), 1);
+            assert!(
+                launcher.lifts.lock().unwrap().is_empty(),
+                "the escalating shadow arm must still never lift cpu.max"
+            );
+
+            // ── Non-escalating arm: the child never crosses the escalation
+            // threshold, so the lease authority is never contacted at all. ──
+            let services = Arc::new(ScriptedServices::new(vec![], vec![], vec![]));
+            services.set_lift_decision(djinn_supervisor::services::InvocationLiftDecision::Shadow);
+            let launcher = Arc::new(BrokerBackedLauncher::running(0));
+            let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+            let cancel = CancellationToken::new();
+            let run_cancel = cancel.clone();
+            let run =
+                tokio::spawn(async move { runner.output(command(), config(), run_cancel).await });
+            for _ in 0..10_000 {
+                if launcher.state.lock().unwrap().samples > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert!(
+                launcher.state.lock().unwrap().samples > 0,
+                "the below-threshold child was never sampled"
+            );
+            cancel.cancel();
+            run.await.unwrap().unwrap();
+            assert_eq!(
+                services.queue_calls.load(Ordering::SeqCst),
+                0,
+                "a below-threshold invocation never escalates"
+            );
+            assert_eq!(services.grant_calls.load(Ordering::SeqCst), 0);
+        });
+    });
+
+    let samples: Vec<&str> = rendered
+        .lines()
+        .filter(|line| line.starts_with("djinn_build_admission_shadow_invocation_total{"))
+        .collect();
+    assert_eq!(
+        samples.len(),
+        2,
+        "both shadow arms emit exactly one bounded series each:\n{rendered}"
+    );
+    for (decision, sample) in [("would_escalate", 1), ("would_throttle", 1)]
+        .into_iter()
+        .map(|(decision, value)| {
+            (
+                decision,
+                format!(
+                    "djinn_build_admission_shadow_invocation_total{{decision=\"{decision}\"}} {value}"
+                ),
+            )
+        })
+    {
+        assert!(
+            rendered.lines().any(|line| line == sample),
+            "missing the {decision} arm in:\n{rendered}"
+        );
+    }
+    // No new cardinality: `decision` remains the only label on the family.
+    for sample in samples {
+        let labels = sample
+            .split_once('{')
+            .and_then(|(_, rest)| rest.split_once('}'))
+            .map(|(labels, _)| labels)
+            .expect("rendered sample carries a label block");
+        assert!(
+            labels.starts_with("decision=\"") && !labels.contains(','),
+            "shadow invocation samples carry only the bounded decision label: {labels}"
+        );
+    }
+}
+
 #[path = "process_lease_recovery_tests.rs"]
 mod recovery_tests;

--- a/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
@@ -449,10 +449,11 @@ fn epoch_and_admission_telemetry_labels_stay_bounded_and_carry_no_identifiers() 
             }
         }
 
-        // Shadow-mode escalation/throttle observations. Only `would_escalate`
-        // has a production caller today (the complementary `would_throttle`
-        // branch is deferred with the shadow broker check); both label values
-        // are asserted so the family stays closed when it is wired.
+        // Shadow-mode escalation/throttle observations. Both arms have a
+        // production caller in the agent's lease runner: `would_escalate` at a
+        // valid bind under a shadow epoch, `would_throttle` for an invocation
+        // that finished below the escalation threshold. Both label values are
+        // asserted here so the family stays closed.
         djinn_telemetry::build_admission::record_shadow_invocation(true);
         djinn_telemetry::build_admission::record_shadow_invocation(false);
 


### PR DESCRIPTION
`record_shadow_invocation(false)` had no production caller. Shadow mode recorded only the invocations it would have escalated, so the ratio that decides cutover safety — of all invocations observed under a shadow epoch, what fraction would v1 have escalated? — was unanswerable, and a post-deploy shadow window would have produced no decision-grade data.

**Change.** The lease runner now records the complementary arm on its real terminal path: an invocation that ran to terminal without ever crossing `cpu_usage_threshold_usec` was never escalated to the lease authority, so under a shadow epoch v1 would have kept it throttled. The two arms are mutually exclusive — escalation requires a grant, which requires queueing — so no invocation is double-counted.

Observation only. The epoch is read once, after the child is terminal and the durable lease is reconciled, and a read failure projects to `Unleased`. Lift semantics, the escalation threshold, and transition-writer behavior are untouched; shadow still never lifts `cpu.max`.

**Tests.** `shadow_epoch_emits_both_would_throttle_arms_from_production_paths` drives `LeaseInvocationRunner` end to end twice under a shadow epoch — once crossing the threshold to a valid matching bind, once staying below it — and asserts both arms rendered exactly one series each, with `decision` still the only label. Neither counter is incremented by the test itself. The ujvz telemetry contract test already pinned both label values, so cardinality is unchanged; its stale "no production caller" note is corrected.

Gates: fmt, clippy (`djinn-agent`, `djinn-coordinator`, `--tests`), djinn-agent `process::` suite, djinn-coordinator `build_admission*`, `djinn-agent-worker` `cancel_path` + `in_pod_drive`, and `SQLX_OFFLINE=1 cargo check --workspace --all-targets` all clean. No `Cargo.toml` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)