### PR TITLE
fix(release): build and stage the cgroup-launcher binary for the runtime image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ name: Release
 #   djinn-image-builder       — BuildKit wrapper used by image-controller
 #   djinn-agent-runtime-base  — heavy base: rustup, sccache, mold, LSPs
 #   djinn-agent-runtime       — thin top: runtime-base + djinn-agent-worker
+#                               + djinn-cgroup-launcher
 #
 # Triggers:
 #   * tag push `v*`             — publishes SemVer tags (`:1.2.3`, `:1.2`, `:1`)
@@ -17,10 +18,10 @@ name: Release
 #                                 just double-built the tagged commit).
 #   * workflow_dispatch         — manual rebuild with optional explicit tag.
 #
-# Binaries (djinn-server, djinn-agent-worker) build in dedicated jobs so
-# they can share Swatinem/rust-cache; the image jobs COPY the pre-built
-# artifact. runtime FROMs runtime-base at the current commit's sha tag
-# so the two stay coherent.
+# Binaries (djinn-server, djinn-agent-worker, djinn-cgroup-launcher) build in
+# dedicated jobs so they can share Swatinem/rust-cache; the image jobs COPY
+# the pre-built artifacts. runtime FROMs runtime-base at the current commit's
+# sha tag so the two stay coherent.
 
 on:
   push:
@@ -269,6 +270,13 @@ jobs:
       # reusing every shared non-qdrant artifact already on disk.
       - name: Cargo build worker
         run: cargo build --release --locked -p djinn-agent-worker
+      # The cgroup-launcher sidecar binary ships in the SAME runtime image as
+      # the worker (see server/docker/djinn-agent-runtime.Dockerfile), so it
+      # has to be staged here too or the runtime image build fails resolving
+      # `COPY djinn-cgroup-launcher`. Tiny crate (libc + thiserror), and its
+      # deps are already on disk from the worker build — seconds, not minutes.
+      - name: Cargo build cgroup launcher
+        run: cargo build --release --locked -p djinn-cgroup-launcher
       - name: Wait for and fetch UI dist for the server embed
         env:
           GH_TOKEN: ${{ github.token }}
@@ -310,6 +318,8 @@ jobs:
           strip ../stage/djinn-server
           cp target/release/djinn-agent-worker ../stage/djinn-agent-worker
           strip ../stage/djinn-agent-worker
+          cp target/release/djinn-cgroup-launcher ../stage/djinn-cgroup-launcher
+          strip ../stage/djinn-cgroup-launcher
       - uses: actions/upload-artifact@v4
         with:
           name: djinn-server-bin
@@ -320,6 +330,12 @@ jobs:
         with:
           name: djinn-agent-worker-bin
           path: stage/djinn-agent-worker
+          retention-days: 1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: djinn-cgroup-launcher-bin
+          path: stage/djinn-cgroup-launcher
           retention-days: 1
           if-no-files-found: error
 
@@ -364,9 +380,9 @@ jobs:
 
   runtime:
     name: djinn-agent-runtime
-    # Needs the pre-built worker binary and the base image at the same
-    # commit's sha tag (FROM arg below) — without both, the runtime image
-    # would either be missing the binary or built on a stale base.
+    # Needs the pre-built worker + cgroup-launcher binaries and the base image
+    # at the same commit's sha tag (FROM arg below) — without all of them, the
+    # runtime image would either be missing a binary or built on a stale base.
     needs: [runtime-base, binaries]
     runs-on: ubuntu-24.04
     steps:
@@ -376,6 +392,13 @@ jobs:
           name: djinn-agent-worker-bin
           path: .
       - run: chmod +x djinn-agent-worker
+      # Lands at the context root as ./djinn-cgroup-launcher, which is exactly
+      # what djinn-agent-runtime.Dockerfile's COPY expects.
+      - uses: actions/download-artifact@v4
+        with:
+          name: djinn-cgroup-launcher-bin
+          path: .
+      - run: chmod +x djinn-cgroup-launcher
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The v0.7.0 tag push failed in `release.yml` → `djinn-agent-runtime` ([run 30129980009](https://github.com/djinnos/djinn/actions/runs/30129980009)):

```
ERROR: failed to compute cache key: ... "/djinn-cgroup-launcher": not found
```

Root cause: PR #2533 (qut0) added `COPY djinn-cgroup-launcher /usr/local/bin/djinn-cgroup-launcher` to `server/docker/djinn-agent-runtime.Dockerfile` and wired the new binary into the Tilt path (`scripts/tilt/build-binaries.sh`, `wrap-agent-runtime-image.sh`) and the image-builder Dockerfile renderer — but not into `release.yml`, which has its own independent binary-build job. That job built only `djinn-agent-worker` and `djinn-server` and uploaded two artifacts, so the launcher binary was simply absent from the runtime image build context.

Fix, following the existing conventions of the `binaries` job:

- new `Cargo build cgroup launcher` step (`cargo build --release --locked -p djinn-cgroup-launcher`), after the worker build,
- staged + stripped alongside the other two binaries,
- uploaded as the `djinn-cgroup-launcher-bin` artifact,
- downloaded in the `djinn-agent-runtime` job into the context root (`./djinn-cgroup-launcher`) + `chmod +x`, exactly where the Dockerfile's COPY looks.

No Dockerfile, image tag, or job-structure changes. Checked the rest of the release path: `djinn-server`, `djinn-image-builder`, `djinn-buildkitd` and the wrapper Dockerfiles do not reference the launcher, and the per-project image gets it via `COPY --from=<agent-worker image>` in `djinn-image-builder/src/dockerfile.rs`, so the runtime image was the only gap.

Verified: workflow parses (`yaml.safe_load`) and passes `actionlint`; `cargo build --release --locked -p djinn-cgroup-launcher` produces `server/target/release/djinn-cgroup-launcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)