### PR TITLE
docs(iz2z): Declare djinn-stack as the language-knowledge seam and contract PlatformCache

### DIFF
--- a/server/crates/djinn-core/src/prepare_build_cache.rs
+++ b/server/crates/djinn-core/src/prepare_build_cache.rs
@@ -26,6 +26,29 @@
 ///
 /// Stack-neutral by construction: adding a new stack cache is a new variant,
 /// not a change to the tool schema or the worker-facing outcome contract.
+///
+/// # Declaration contract
+///
+/// Every language-specific platform cache MUST be declared as a variant of this
+/// enum, here in `djinn-core`. Consumer crates MUST NOT introduce their own
+/// language or toolchain branches to describe a cache — they only `match` on
+/// the variants declared here, and each arm maps a variant onto an
+/// already-generic value. The intended shape is the total match in the
+/// `prepare_build_cache` handler in `djinn-agent`:
+///
+/// ```ignore
+/// let stack = match cache {
+///     PlatformCache::CargoTargetRunDir { .. } => "rust",
+///     PlatformCache::None => "none",
+/// };
+/// ```
+///
+/// Adding a Python or Node warm cache is therefore a new variant here plus a
+/// new arm in each such match, which the compiler's exhaustiveness check makes
+/// impossible to miss. It is never a new `if language == ...` in a consumer
+/// crate. Keeping the discriminator in this enum is what lets the generic
+/// crates stay language-agnostic; see the `djinn-stack` crate documentation for
+/// the wider language-knowledge seam this belongs to.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PlatformCache {
     /// Rust cargo warm-target per-run seed directory. `cache_path` is the

--- a/server/crates/djinn-stack/src/lib.rs
+++ b/server/crates/djinn-stack/src/lib.rs
@@ -9,6 +9,29 @@
 //!
 //! Downstream wiring (mirror-fetcher hook, MCP tool, DB column) lands
 //! in PR 2; this crate is standalone and pure-function.
+//!
+//! # The language-knowledge seam
+//!
+//! `djinn-stack` is the platform's single declared language-knowledge crate.
+//! Language, package-manager, framework, test-runner, and manifest knowledge
+//! belongs here — in [`languages`], [`frameworks`], [`test_runners`], and
+//! [`manifests`] — and anything that varies per project belongs in that
+//! project's [`environment::EnvironmentConfig`].
+//!
+//! Generic platform crates — `djinn-agent`, `djinn-mcp-extension`,
+//! `djinn-coordinator`, `djinn-agent-worker`, `djinn-telemetry`, `djinn-k8s` —
+//! MUST NOT acquire their own language branches. When one of them needs to
+//! behave differently for a language, toolchain, or build tool, the
+//! discriminator is declared here or resolved from per-project configuration,
+//! and the generic crate consumes the already-resolved value.
+//!
+//! This is a review contract, not a lint, and deliberately so. A keyword or
+//! confinement check over the generic crates was prototyped and measured
+//! against ~1000 merged PRs: it fired on 42 of them and found a single true
+//! positive that ordinary design review had already removed, while `main`
+//! legitimately carries approved toolchain branching inside those same crates.
+//! Enforcement therefore lives in review and in this seam, not in a guard with
+//! a standing exclusion list. See ri23 AC6 for the measurement and the record.
 
 pub mod detect;
 pub mod environment;


### PR DESCRIPTION
Implements the amended ri23 AC6. Documentation only — no behavior change, no new check, no exclusion list.

## What changed

- `djinn-stack/src/lib.rs` — crate-level doc declaring `djinn-stack` as the platform's single language-knowledge crate. Language, package-manager, framework, test-runner, and manifest knowledge belongs here (or in a project's `EnvironmentConfig`); the generic platform crates must not acquire their own language branches.
- `djinn-core/src/prepare_build_cache.rs` — declaration contract on `PlatformCache`: every language-specific platform cache is a variant of that enum in `djinn-core`, and consumers only `match` on it. Cites the existing `CargoTargetRunDir { .. } => "rust"` handler arm as the intended shape, and notes that exhaustiveness checking is what makes a new variant impossible to miss.

## Why the policy corpus was not built

AC6 originally called for `platform_genericity_v1.toml` plus a contract script failing when production logic in seven crates branches on Cargo, qdrant, a language, toolchain, or feature name. I built the preferred confinement variant (diff-scoped to added lines, seam allowlist, comment and lint-attribute noise filtered) and replayed it over ~1000 merged PRs (history deepened to 1118 commits, 2026-07-03..07-24):

- Naive keyword form: 78/1000 PRs fire.
- Confinement form with an 8-entry seam allowlist: still 42/1000 fire, across 24+ further production files.
- True positives: one — `coordinator/src/preapproval_gate.rs` (#1561), which hardcoded `cargo clippy --features qdrant`. It was already gone from main, removed by ordinary design review (gm8w's per-project canonical plan), not by any guard. PR-level precision ~2.4%.

AC6 was also unsatisfiable against main on four counts: it contradicts its own "must pass on main" gate (`workspace_helpers.rs` does `if base == "cargo"`, `command_classifier.rs` dispatches `"cargo" | "npm" | "pnpm" | "yarn"`, `tripwires/policy.rs` lists `**/Cargo.toml` and `**/go.mod`, and `djinn_telemetry::cargo_invocation` exists — all approved); it names `djinn-stack`, which *is* the language-detection registry; it omits `djinn-core`, where the only hardcoded Cargo enum variant lives, while covering the consumers that merely match on it; and its per-region exclusion requirement cannot be met by a diff-scoped shell script that sees added lines without block context. `qdrant` appears in the seven crates only in four comment and help-string lines.

Enforcement therefore lives in review and in this seam, which is what these two doc contracts record.

## Gates

`cargo fmt --all` clean; `SQLX_OFFLINE=1 cargo check --workspace --all-targets` clean; clippy on the touched crates is identical to the unmodified baseline (6 pre-existing errors, all in files this PR does not touch); every intra-doc link added here resolves under `-D rustdoc::broken_intra_doc_links`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
