### PR TITLE
chore(pwrr): Validate mounted volume ownership at startup and declare the permission contract

### DIFF
--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -87,10 +87,39 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      # hostPath / PVC volumes land owned by root:root, but djinn-server runs
-      # as uid 10001. fsGroup only helps for CSI-backed PVCs, not hostPath, so
-      # we chown the three writable mounts up-front in a root initContainer.
-      # Idempotent — re-runs every pod start with negligible cost.
+      # The server writes these volumes as uid {{ .Values.storage.ownership.ownerUid }},
+      # while task-run and warm Job Pods write the SAME volumes as uid/gid 1000
+      # (and the launcher-spawned child as uid 1001, primary group 1000). Give
+      # the server supplementary membership in the artifact group so it can
+      # overwrite and unlink what those Pods create.
+      #
+      # Deliberately NOT `fsGroup`: fsGroup couples group membership to the
+      # kubelet's ownership pass, which on a root-gid mismatch is an UNBOUNDED
+      # recursive chown of the whole volume at mount time — minutes of stalled
+      # pod start on a large cache. `supplementalGroups` grants the same
+      # membership with zero filesystem work; the volume roots are normalized
+      # explicitly below instead.
+      securityContext:
+        supplementalGroups:
+          - {{ .Values.storage.ownership.artifactGid }}
+      {{- if .Values.storage.ownership.normalizeRoots }}
+      # Declare the ownership contract on the volume ROOTS so a fresh install
+      # produces conforming volumes (task pwrr / goxi):
+      #   * group = artifactGid  → shared by server, worker and child;
+      #   * g+w                  → all three can create/overwrite/unlink;
+      #   * setgid on the dir    → new files INHERIT the artifact group rather
+      #                            than the creating process's primary group.
+      #
+      # hostPath / PVC volumes land owned by root:root and fsGroup does nothing
+      # for hostPath at all, so this runs in a root initContainer. It is
+      # idempotent, O(1) and NON-RECURSIVE by design: it touches the three roots
+      # only. Contents that predate the contract need the one-time remediation
+      # in docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md — a recursive chown here
+      # would stall every pod start.
+      #
+      # Normalizing the root also makes the task-run/warm Pods'
+      # `fsGroupChangePolicy: OnRootMismatch` a guaranteed no-op instead of a
+      # surprise recursive pass.
       initContainers:
         - name: fix-volume-perms
           image: {{ .Values.image.server | quote }}
@@ -105,8 +134,8 @@ spec:
               set -eu
               for d in /var/lib/djinn/mirrors /var/lib/djinn/cache /var/lib/djinn/projects; do
                 mkdir -p "$d"
-                chown 10001:10001 "$d"
-                chmod 0775 "$d"
+                chown {{ .Values.storage.ownership.ownerUid }}:{{ .Values.storage.ownership.artifactGid }} "$d"
+                chmod {{ .Values.storage.ownership.dirMode }} "$d"
               done
           volumeMounts:
             - name: mirrors
@@ -115,6 +144,9 @@ spec:
               mountPath: /var/lib/djinn/cache
             - name: projects
               mountPath: /var/lib/djinn/projects
+      {{- else }}
+      initContainers:
+      {{- end }}
         # Apply pending SQL migrations before the server boots.
         #
         # This was a separate `pre-install,pre-upgrade` Helm hook Job, but a

--- a/deploy/helm/djinn/tests/volume-ownership-render.sh
+++ b/deploy/helm/djinn/tests/volume-ownership-render.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Exact Helm render contract for the shared-volume ownership guarantee (pwrr).
+#
+# The mirrors/cache/projects volumes are written by the server (uid 10001) AND
+# by task-run/warm Job Pods (uid/gid 1000 + child uid 1001, group 1000). The
+# chart must therefore render, on a fresh install:
+#   * supplementary membership in the artifact GID on the server pod — and NOT
+#     `fsGroup`, whose kubelet ownership pass is an unbounded recursive chown;
+#   * a root initContainer that normalizes the three volume ROOTS to
+#     `ownerUid:artifactGid` with setgid + group-write, non-recursively.
+#
+# Usage: bash deploy/helm/djinn/tests/volume-ownership-render.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+require_tool() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: required test tool '$1' is not installed" >&2; exit 1; }; }
+require_tool helm
+require_tool python3
+TMPDIR_RENDER=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_RENDER"' EXIT
+
+render() {
+    helm template volume-ownership-test "$CHART_DIR" \
+        --set-string migration.designatedOperatorSecret=volume-ownership-test-operator \
+        "$@" > "$TMPDIR_RENDER/manifest.yaml"
+}
+
+assert_contract() {
+    python3 - "$TMPDIR_RENDER/manifest.yaml" "$@" <<'PY'
+import sys
+import yaml
+
+manifest, expect_init = sys.argv[1], sys.argv[2] == "with-init"
+docs = [d for d in yaml.safe_load_all(open(manifest, encoding="utf-8")) if d]
+deps = [
+    d
+    for d in docs
+    if d.get("kind") == "Deployment" and "server" in d["metadata"]["name"]
+]
+assert len(deps) == 1, f"expected exactly one server Deployment, got {len(deps)}"
+spec = deps[0]["spec"]["template"]["spec"]
+
+sc = spec.get("securityContext") or {}
+assert sc.get("supplementalGroups") == [1000], f"bad supplementalGroups: {sc}"
+assert "fsGroup" not in sc, "fsGroup must not be set: it triggers a recursive chown"
+
+inits = {c["name"]: c for c in (spec.get("initContainers") or [])}
+if not expect_init:
+    assert "fix-volume-perms" not in inits, "normalizeRoots=false must drop the initContainer"
+    assert "migrate" in inits, "the remaining initContainers must still render"
+    print("OK: normalizeRoots=false renders without fix-volume-perms")
+    sys.exit(0)
+
+fix = inits.get("fix-volume-perms")
+assert fix is not None, f"fix-volume-perms missing, got {list(inits)}"
+assert fix["securityContext"]["runAsUser"] == 0, "root is required to chown the roots"
+script = fix["command"][-1]
+assert "chown 10001:1000 " in script, f"root ownership not declared: {script}"
+assert "chmod 2775 " in script, f"setgid + group-write not declared: {script}"
+assert " -R" not in script and "-R " not in script, "the normalization must never recurse"
+for root in ("mirrors", "cache", "projects"):
+    assert f"/var/lib/djinn/{root}" in script, f"{root} root not normalized"
+    assert any(
+        m["mountPath"] == f"/var/lib/djinn/{root}" for m in fix["volumeMounts"]
+    ), f"{root} not mounted into the initContainer"
+print("OK: fresh install declares the artifact-GID / g+w / setgid contract")
+PY
+}
+
+render
+assert_contract with-init
+
+render --set storage.ownership.normalizeRoots=false
+assert_contract without-init
+
+echo "PASS: volume ownership render contract"

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -214,6 +214,38 @@ resources:
 # writes mirror clones and task-run Job Pods read from them. The cache PVC is
 # similarly RWX so cargo/pnpm/pip caches survive across task runs.
 storage:
+  # ---------------------------------------------------------------------------
+  # Volume ownership contract (task pwrr / goxi)
+  # ---------------------------------------------------------------------------
+  # The mirrors/cache/projects volumes are written by TWO identities: the server
+  # (uid `ownerUid`) and the task-run + warm Job Pods (uid/gid 1000, plus the
+  # launcher-spawned child at uid 1001 with primary group 1000). They can only
+  # share those volumes if everything on them is group-owned by `artifactGid`
+  # and group-writable, with setgid on directories so newly created files
+  # INHERIT that group instead of the creator's.
+  #
+  # The chart guarantees this for a fresh install by normalizing the three
+  # volume ROOTS in the `fix-volume-perms` initContainer (O(1), non-recursive)
+  # and by giving the server pod supplementary membership in `artifactGid`.
+  # The worker binary re-validates the mounted result at startup and fails
+  # readiness if it does not hold — see
+  # `docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md` for the one-time remediation of
+  # volumes that predate this contract.
+  ownership:
+    # GID that owns every artifact on the shared volumes. MUST equal
+    # `djinn_cgroup_launcher::child::ARTIFACT_GID` (the fsGroup the task-run and
+    # warm Pod renders pin). Changing it here without changing the binary
+    # constant breaks the contract in both directions.
+    artifactGid: 1000
+    # UID the djinn-server process runs as; it stays the owner of the volume
+    # roots so the server keeps unrestricted access to its own directories.
+    ownerUid: 10001
+    # Mode applied to the volume roots: setgid + rwxrwxr-x.
+    dirMode: "2775"
+    # Normalize the volume roots on every server pod start. Idempotent and O(1)
+    # — it touches the three roots only, never their contents. Disable only if
+    # an external process owns volume provisioning.
+    normalizeRoots: true
   # Mirrors are shared between the server (writer) and image-build + task-run
   # Jobs (readers). In prod this requires RWX storage; on single-node clusters
   # like kind, RWO PVCs work because RWO is enforced per-node, not per-pod.

--- a/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
+++ b/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
@@ -13,19 +13,23 @@ They can only share those volumes under one contract:
 
 * **group ownership = `1000`** (`ARTIFACT_GID`, `djinn_cgroup_launcher::child`)
   on every directory and file;
-* **group-write (`g+w`)** on every directory, and on every file its owner can
-  write — so any of the three can create, overwrite, and unlink what another
-  produced. Files that are read-only for their owner too (git loose objects and
-  packfiles at `444`, cargo registry sources carrying the tarball's modes) are
-  immutable by design: they are replaced through the directory, so they are not
-  a violation;
+* **group-write (`g+w`)** on every directory — that is what lets any of the
+  three create, replace, and unlink what another produced — and on every file
+  that its owner can write and that is not executable. Two shapes a correct tree
+  legitimately produces are exempt: owner-read-only files (`444` git loose
+  objects and packfiles, cargo registry sources carrying the crate tarball's
+  modes) and executables (`git clone` copies the template hooks with the
+  template's own mode, so `.git/hooks/*.sample` is `755` in every fresh clone).
+  Both are replaced through the directory rather than written in place, and
+  neither can hide the `644` shape that caused the incident;
 * **setgid (`g+s`) on every directory** — so files created there *inherit* the
   artifact group instead of the creating process's primary group. On Linux a
   directory created inside a setgid directory inherits the bit as well, so
   normalizing the volume ROOT propagates it to everything created afterwards;
 * **umask `0002`** in every process that writes these volumes, so new files land
   `664` and new directories `775`. The launcher-spawned child already set it;
-  the worker process and the warm Job's clone wrapper now do too. Without it a
+  `djinn-server` (which clones the mirrors), the worker process, and the warm
+  Job's clone wrapper now do too. Without it a
   process silently writes `755`/`644` into a perfectly conforming volume and
   breaks it from the inside — which is how the frozen warm base kept
   reappearing.

--- a/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
+++ b/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
@@ -1,0 +1,153 @@
+# Shared-volume ownership contract — runbook
+
+The `mirrors`, `cache`, and `projects` volumes are written by **three
+identities**:
+
+| Identity | Who | Where |
+|----------|-----|-------|
+| uid `10001` | `djinn-server` | `/var/lib/djinn/{mirrors,cache,projects}` |
+| uid/gid `1000` | task-run + warm Job worker | `/workspace`, `/cache`, `/mirror` |
+| uid `1001`, primary group `1000` | the launcher-spawned child (compiles, tests) | `/workspace`, `/cache` |
+
+They can only share those volumes under one contract:
+
+* **group ownership = `1000`** (`ARTIFACT_GID`, `djinn_cgroup_launcher::child`)
+  on every directory and file;
+* **group-write (`g+w`)** on every directory and file — so any of the three can
+  create, overwrite, and unlink what another produced;
+* **setgid (`g+s`) on every directory** — so files created there *inherit* the
+  artifact group instead of the creating process's primary group.
+
+Violating it does not produce a crash. It produces a **silent freeze**: the warm
+Job's cargo phase is best-effort (lock-unavailable, step failure and timeout only
+`WARN`) while the Job reports success from the graph phase, so a cache the warm
+pod cannot write shows up as *green warm Jobs over a permanently frozen build
+base*. This happened while preparing the v0.7.0 deploy — 13,512 files owned by
+`10001` with dirs `755` / files `644` — and was caught by hand.
+
+## What enforces it now
+
+| Layer | Mechanism |
+|-------|-----------|
+| Fresh install | The chart's `fix-volume-perms` initContainer normalizes the three volume **roots** to `ownerUid:artifactGid` with `chmod 2775` (setgid + `g+w`). O(1), idempotent, **never recursive**. |
+| Server access | The server pod gets `securityContext.supplementalGroups: [1000]` — membership in the artifact group with zero filesystem work. |
+| Worker/warm pods | The Pod render pins `fsGroup: 1000` + `fsGroupChangePolicy: OnRootMismatch` and runs as uid/gid `1000` (task-run **and** warm — they share `/cache`). |
+| Runtime | `djinn-agent-worker` validates the **actually mounted** roots at startup (`volume_contract`) and fails readiness with a typed error naming the path and observed-versus-required ownership/mode. |
+
+The startup check stats the workspace, the git metadata (`<workspace>/.git` and
+the mirror root), and every configured cache root — `/cache`,
+`/cache/cargo-target`, `/cache/cargo-target-runs`, `CARGO_HOME`, `SCCACHE_DIR`,
+`CARGO_TARGET_DIR`, plus the warm Job's own Cargo warm-base variant. It also
+asserts the process is a member of gid `1000`; a conforming volume is useless to
+a pod that is not in the group.
+
+It is **bounded**: depth 3, 32 entries per directory, 512 `lstat`s total. It
+checks a *sample of the subtree*, not just the root, because the exact
+production near-miss had a hand-fixed root over a broken subtree. It **never
+repairs** — a recursive `chown` over a 300G cache is a multi-minute stall on pod
+start, which is the whole reason `fsGroupChangePolicy` is `OnRootMismatch`.
+
+## Symptom → diagnosis
+
+A pod that fails this check logs one line and exits:
+
+```
+volume permission contract VIOLATED  kind=group_write path=/cache/cargo-target/<project>/mold-jobs-8 ...
+```
+
+```bash
+kubectl -n djinn logs job/<warm-job> | grep 'volume permission contract'
+kubectl -n djinn get pods --field-selector=status.phase=Failed
+```
+
+Confirm from the volume side (`stat` on the offending path):
+
+```bash
+kubectl -n djinn exec deploy/djinn -- \
+  stat -c '%n uid=%u gid=%g mode=%a' \
+  /var/lib/djinn/cache /var/lib/djinn/cache/cargo-target
+```
+
+Conforming output is `gid=1000` and a mode beginning with `2` (setgid) and
+carrying group-write: `2775` for directories, `664` for files.
+
+## One-time remediation for pre-existing volumes
+
+Volumes provisioned before this contract (or restored from a backup taken before
+it) carry the old ownership throughout their **contents**. The chart only
+normalizes the roots, so those need a single operator pass. Run it once, with the
+server scaled down and no task-run or warm Jobs in flight:
+
+```bash
+NS=djinn
+
+# 1. Quiesce: stop new Jobs and drain the ones running.
+kubectl -n "$NS" scale deploy/djinn --replicas=0
+kubectl -n "$NS" delete jobs -l app.kubernetes.io/component=graph-warm --ignore-not-found
+kubectl -n "$NS" delete jobs -l app.kubernetes.io/component=task-run  --ignore-not-found
+
+# 2. One-shot root pod that mounts the same claims and normalizes them.
+kubectl -n "$NS" run volume-ownership-fix --rm -i --restart=Never \
+  --image=busybox:1.36 \
+  --overrides='{"spec":{"securityContext":{"runAsUser":0},"containers":[{"name":"fix","image":"busybox:1.36","command":["sh","-c","set -eu; for d in /mnt/mirrors /mnt/cache /mnt/projects; do chgrp -R 1000 \"$d\"; chmod -R g+w \"$d\"; find \"$d\" -type d -exec chmod g+s {} +; done; echo done"],"volumeMounts":[{"name":"mirrors","mountPath":"/mnt/mirrors"},{"name":"cache","mountPath":"/mnt/cache"},{"name":"projects","mountPath":"/mnt/projects"}]}],"volumes":[{"name":"mirrors","persistentVolumeClaim":{"claimName":"djinn-mirrors"}},{"name":"cache","persistentVolumeClaim":{"claimName":"djinn-cache"}},{"name":"projects","persistentVolumeClaim":{"claimName":"djinn-projects"}}]}}'
+
+# 3. Bring the server back; the startup check now passes.
+kubectl -n "$NS" scale deploy/djinn --replicas=1
+```
+
+Substitute the real claim names (`kubectl -n "$NS" get pvc`) — they differ when
+`storage.*.existingClaim` is set. On a large cache this takes minutes; that is
+exactly why it is an operator action and not something a pod does at startup.
+
+Cheaper alternative when only the cache is broken: delete the Cargo warm base
+(`/cache/cargo-target`, `/cache/cargo-target-runs`) and let the next warm Job
+rebuild it under the correct ownership. It costs one cold warm cycle and no
+`chown` walk.
+
+### Break-glass
+
+`DJINN_VOLUME_CONTRACT_MODE=audit` in the worker's environment downgrades the
+failure to a loud `ERROR` log and lets the pod proceed over a known-broken
+volume. It is a rollout-window escape hatch, **not** a fallback — nothing
+reverts to the legacy uid, and the underlying breakage is still there. Outside
+Kubernetes (no `KUBERNETES_SERVICE_HOST`) the check is `off`: there are no
+pod-mounted volumes to validate.
+
+## Why an explicit initContainer instead of relying on `fsGroup`
+
+`fsGroup` + `fsGroupChangePolicy: OnRootMismatch` looks like it already
+guarantees this. It does not, for four reasons:
+
+1. **The trigger is a heuristic on the volume root.** The kubelet skips the
+   recursive pass when the root's gid already matches the fsGroup *and* the root
+   carries the expected setgid/permission bits. A root that was fixed by hand —
+   precisely what happened here — makes the kubelet skip while the entire
+   subtree stays wrong. The failure mode is exactly the silent one.
+2. **When it does trigger, it is unbounded.** A root mismatch on a 300G cache
+   means a full recursive `chown` at mount time, before any container starts:
+   minutes of stalled pod start on every affected volume.
+3. **It does not apply to every volume type.** `fsGroup` is a no-op for
+   `hostPath` (what a single-node k3s install uses) and its behaviour varies
+   across CSI drivers and `RunAsAny`-style policies.
+4. **It couples membership to filesystem work.** All the server pod needs is to
+   be *in* the group; `supplementalGroups` grants that with no ownership pass at
+   all.
+
+So the chart uses the explicit path: a root initContainer that normalizes only
+the three volume **roots** (deterministic, O(1), driver-independent), plus
+setgid so everything created below them inherits the group, plus
+`supplementalGroups` for the server. `fsGroup: 1000` stays on the task-run and
+warm Pod renders — with the roots already conforming, `OnRootMismatch` is a
+guaranteed no-op there rather than a surprise recursive pass — and it is never
+set to `Always`. The startup validator is the backstop that makes any remaining
+gap loud instead of silent.
+
+## Related
+
+- `server/crates/djinn-agent-worker/src/volume_contract.rs` — the contract and
+  the bounded check.
+- `server/crates/djinn-agent-worker/tests/volume_contract.rs` — deterministic
+  proof that each violation fails readiness and a conforming layout passes.
+- `deploy/helm/djinn/tests/volume-ownership-render.sh` — the render contract.
+- `server/crates/djinn-k8s/src/launcher.rs` — `pod_security_context()` and the
+  worker/child/launcher uid contract.

--- a/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
+++ b/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
@@ -13,10 +13,22 @@ They can only share those volumes under one contract:
 
 * **group ownership = `1000`** (`ARTIFACT_GID`, `djinn_cgroup_launcher::child`)
   on every directory and file;
-* **group-write (`g+w`)** on every directory and file — so any of the three can
-  create, overwrite, and unlink what another produced;
+* **group-write (`g+w`)** on every directory, and on every file its owner can
+  write — so any of the three can create, overwrite, and unlink what another
+  produced. Files that are read-only for their owner too (git loose objects and
+  packfiles at `444`, cargo registry sources carrying the tarball's modes) are
+  immutable by design: they are replaced through the directory, so they are not
+  a violation;
 * **setgid (`g+s`) on every directory** — so files created there *inherit* the
-  artifact group instead of the creating process's primary group.
+  artifact group instead of the creating process's primary group. On Linux a
+  directory created inside a setgid directory inherits the bit as well, so
+  normalizing the volume ROOT propagates it to everything created afterwards;
+* **umask `0002`** in every process that writes these volumes, so new files land
+  `664` and new directories `775`. The launcher-spawned child already set it;
+  the worker process and the warm Job's clone wrapper now do too. Without it a
+  process silently writes `755`/`644` into a perfectly conforming volume and
+  breaks it from the inside — which is how the frozen warm base kept
+  reappearing.
 
 Violating it does not produce a crash. It produces a **silent freeze**: the warm
 Job's cargo phase is best-effort (lock-unavailable, step failure and timeout only
@@ -70,6 +82,14 @@ kubectl -n djinn exec deploy/djinn -- \
 
 Conforming output is `gid=1000` and a mode beginning with `2` (setgid) and
 carrying group-write: `2775` for directories, `664` for files.
+
+## Before upgrading to the version that enforces this
+
+The check fails closed. A cluster whose volumes predate the contract will see
+its first post-upgrade task-run and warm Pods exit at startup with the log line
+above **instead of** silently running against a frozen cache. Run the
+remediation below in the same maintenance window as the upgrade — or run it
+first, since it is safe on a conforming volume.
 
 ## One-time remediation for pre-existing volumes
 

--- a/docs/deploy/configuration.md
+++ b/docs/deploy/configuration.md
@@ -160,6 +160,28 @@ storage:
 `accessMode` is immutable on an existing PVC — moving RWO → RWX means
 recreating/migrating the claim.
 
+### Ownership contract
+
+All three volumes are written by the server (uid `10001`) *and* by task-run /
+warm Job Pods (uid/gid `1000`, plus the launcher-spawned child at uid `1001`
+with primary group `1000`). Sharing them requires group ownership by the
+artifact GID, group-write, and setgid on directories so new files inherit the
+group:
+
+```yaml
+storage:
+  ownership:
+    artifactGid: 1000     # must match ARTIFACT_GID in the worker binary
+    ownerUid: 10001       # djinn-server's uid; stays the owner of the roots
+    dirMode: "2775"       # setgid + rwxrwxr-x
+    normalizeRoots: true  # O(1), non-recursive initContainer on every pod start
+```
+
+A fresh install is conforming out of the box. The worker validates the mounted
+result at startup and **fails readiness** if it is not — volumes that predate
+this contract need a one-time remediation pass. See the
+[shared-volume ownership contract runbook](../VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md).
+
 ## Secrets
 
 Every secret supports two delivery modes: inline values (rendered into a

--- a/server/crates/djinn-agent-worker/src/lib.rs
+++ b/server/crates/djinn-agent-worker/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod cargo_incremental_prune;
 pub mod cargo_target_seed;
+pub mod volume_contract;
 
 #[cfg(test)]
 mod tests {

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -342,6 +342,18 @@ async fn run() -> Result<()> {
         warn!(%error, "failed to initialize worker telemetry recorder");
     }
 
+    // Everything this process creates on the shared volumes must stay
+    // group-writable for the launcher-spawned child (uid 1001, group 1000) —
+    // the child already sets `umask 0002`, the worker inherited the container
+    // default 022 and was silently writing 755/644 into the cargo warm base.
+    // Applied before any filesystem work and before the startup contract check.
+    let previous_umask = volume_contract::apply_artifact_umask();
+    info!(
+        previous_umask = format!("{previous_umask:04o}"),
+        umask = format!("{:04o}", volume_contract::ARTIFACT_UMASK),
+        "applied artifact umask"
+    );
+
     let cli = Cli::parse();
 
     match cli.cmd {

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -75,6 +75,11 @@ mod launcher_handshake;
 mod lifecycle;
 mod worker_services;
 
+// Startup volume-permission validation lives in this package's library target
+// so the deterministic filesystem tests in `tests/volume_contract.rs` drive the
+// exact code the binary runs.
+use djinn_agent_worker::volume_contract;
+
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -1790,6 +1795,15 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
         "worker starting"
     );
 
+    // 0. Readiness: the volumes we were actually given must satisfy the
+    //    artifact-GID / group-write / setgid contract the Pod render only
+    //    *declares*. Fails closed before any work is claimed; never falls back
+    //    to the legacy uid and never repairs (see `volume_contract`).
+    volume_contract::enforce_at_startup(
+        "task-run",
+        &volume_contract::task_run_roots(&args.workspace_path),
+    )?;
+
     // 1. Slurp the TaskRunSpec off the mounted Secret file.
     let spec_bytes = tokio::fs::read(&args.spec_path)
         .await
@@ -2787,6 +2801,18 @@ async fn run_warm_graph(project_id: &str) -> Result<()> {
 /// keeping the body separate makes every return flow through that cleanup while
 /// preserving the historical non-Linux path exactly.
 async fn run_warm_graph_body(project_id: &str) -> Result<()> {
+    // Readiness first. The warm Job shares `/cache` with every task-run, and
+    // its cargo phase is best-effort by design: a non-conforming cache would
+    // otherwise surface as a GREEN warm Job over a permanently frozen warm
+    // base. Fail closed here so the breakage is loud and located.
+    let warm_project_root = std::env::var("DJINN_PROJECT_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(volume_contract::WORKSPACE_MOUNT_ROOT));
+    volume_contract::enforce_at_startup(
+        "warm-graph",
+        &volume_contract::warm_roots(&warm_project_root, project_id),
+    )?;
+
     let db = bootstrap_warm_database().await?;
     let ctx = WorkerWarmContext {
         db,

--- a/server/crates/djinn-agent-worker/src/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/src/volume_contract.rs
@@ -1,0 +1,633 @@
+//! Startup validation of the **mounted-volume permission contract**.
+//!
+//! `qut0` moved the task-run Pod from uid 10001 to uid/gid [`WORKER_UID`]/
+//! [`ARTIFACT_GID`] (1000/1000) with `fsGroup: 1000` +
+//! `fsGroupChangePolicy: OnRootMismatch`. That render only *declares* the
+//! contract; nothing ever inspected the filesystem that actually got mounted.
+//! When the live `djinn-cache` PVC held 13,512 files owned by 10001 with dirs
+//! 755 / files 644 (no group-write anywhere), a uid-1000 pod could not create,
+//! unlink, or overwrite anything in its own Cargo warm base — and because the
+//! warm Job's cargo phase is best-effort (lock-unavailable, step failure and
+//! timeout only WARN) while the Job reports success from the graph phase, the
+//! result would have been *green warm Jobs over a permanently frozen cache*.
+//!
+//! `goxi`'s design names the missing piece: "Startup validates ownership/mode
+//! on the workspace, git metadata, and configured cache roots and fails
+//! readiness rather than falling back to UID 1000 if the volume driver cannot
+//! preserve this contract." This module is that check.
+//!
+//! ## The contract
+//!
+//! For every mounted root the pod writes through:
+//!   * group ownership is [`ARTIFACT_GID`] — so the worker (gid 1000) and the
+//!     launcher-spawned child (primary group 1000) share every artifact;
+//!   * directories carry **group-write** *and* **setgid**, so files created by
+//!     either identity inherit the artifact group instead of the creator's;
+//!   * files carry **group-write**, so the other identity can overwrite them;
+//!   * the process itself is a member of [`ARTIFACT_GID`] (primary or
+//!     supplementary) — a conforming volume is useless to a pod that is not in
+//!     the group.
+//!
+//! ## What it deliberately does NOT do
+//!
+//! * **No repair.** Not even a bounded one. A recursive `chown` over a 300G
+//!   cache is a multi-minute stall on pod start; avoiding exactly that is why
+//!   the render pins `fsGroupChangePolicy: OnRootMismatch`. Remediation is a
+//!   one-shot operator action (see `docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md`)
+//!   plus the chart's O(1) `fix-volume-perms` init container.
+//! * **No fallback to the legacy uid.** A violation fails readiness with a
+//!   typed error naming the path and observed-versus-required ownership/mode.
+//! * **No unbounded scan.** The walk is capped by depth, per-directory sample
+//!   size, and a global stat budget ([`VolumeContract`] defaults: 3 / 32 /
+//!   512), so a conforming volume costs a few hundred `lstat`s. Checking only
+//!   the volume *root* would be worthless here: the production near-miss had a
+//!   hand-fixed root over a broken subtree — which is also precisely the state
+//!   that makes kubelet's `OnRootMismatch` heuristic skip its recursive pass.
+
+use std::collections::VecDeque;
+use std::fs;
+use std::io;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use thiserror::Error;
+use tracing::{info, warn};
+
+pub use djinn_cgroup_launcher::child::ARTIFACT_GID;
+
+use crate::cargo_target_seed::{RUN_TARGET_ROOT, WARM_BASE_ROOT, warm_base_dir_for_current_jobs};
+
+/// setgid bit — new files under the directory inherit its group.
+const MODE_SETGID: u32 = 0o2000;
+/// Group-write bit.
+const MODE_GROUP_WRITE: u32 = 0o020;
+/// Permission bits we report on (mode & this) — keeps log lines readable.
+const MODE_MASK: u32 = 0o7777;
+
+/// Mount path of the shared cache PVC inside every djinn Pod.
+pub const CACHE_MOUNT_ROOT: &str = "/cache";
+/// Mount path of the git-mirror PVC (the pod's git metadata).
+pub const MIRROR_MOUNT_ROOT: &str = "/mirror";
+/// Contractual workspace mount path.
+pub const WORKSPACE_MOUNT_ROOT: &str = "/workspace";
+
+/// Env var selecting the enforcement mode (`enforce` | `audit`).
+pub const MODE_ENV: &str = "DJINN_VOLUME_CONTRACT_MODE";
+/// Always injected by the kubelet into a Pod; absent everywhere else.
+pub const IN_CLUSTER_ENV: &str = "KUBERNETES_SERVICE_HOST";
+
+/// How a contract violation is handled at startup.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ContractMode {
+    /// Fail readiness. The in-cluster default.
+    Enforce,
+    /// Log the same typed error at ERROR level and continue. Break-glass for a
+    /// rollout window only — it is loud, operator-selected, and never a
+    /// fallback to the legacy uid.
+    Audit,
+    /// Not running against pod-mounted volumes; nothing to enforce.
+    Off,
+}
+
+impl ContractMode {
+    /// Resolve from the environment.
+    ///
+    /// Outside Kubernetes there is no mounted-volume contract to enforce (the
+    /// worker binary is also spawned directly by integration tests against
+    /// tempdirs), so the default is [`ContractMode::Off`]. In-cluster the
+    /// default is [`ContractMode::Enforce`]; [`MODE_ENV`] overrides in both
+    /// directions.
+    pub fn from_env() -> Self {
+        let explicit = std::env::var(MODE_ENV).ok();
+        match explicit.as_deref().map(str::trim) {
+            Some("enforce") => Self::Enforce,
+            Some("audit") => Self::Audit,
+            Some("off") => Self::Off,
+            Some(other) if !other.is_empty() => {
+                warn!(
+                    value = other,
+                    env = MODE_ENV,
+                    "unrecognized volume-contract mode; failing closed to enforce-when-in-cluster"
+                );
+                Self::default_for_environment()
+            }
+            _ => Self::default_for_environment(),
+        }
+    }
+
+    fn default_for_environment() -> Self {
+        if std::env::var_os(IN_CLUSTER_ENV).is_some() {
+            Self::Enforce
+        } else {
+            Self::Off
+        }
+    }
+
+    /// Log label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Enforce => "enforce",
+            Self::Audit => "audit",
+            Self::Off => "off",
+        }
+    }
+}
+
+/// Whether an absent root is a violation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RootPresence {
+    /// The root must exist — its absence means the volume was not mounted.
+    Required,
+    /// Absence is fine (a fresh cache PVC has no `cargo-target` yet); if it
+    /// exists it must conform.
+    OptionalWhenAbsent,
+}
+
+/// One mounted root to validate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VolumeRoot {
+    /// Human label used in errors and logs (`workspace`, `cache`, …).
+    pub label: String,
+    /// The real, mounted path.
+    pub path: PathBuf,
+    pub presence: RootPresence,
+}
+
+impl VolumeRoot {
+    pub fn required(label: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            label: label.into(),
+            path: path.into(),
+            presence: RootPresence::Required,
+        }
+    }
+
+    pub fn optional(label: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            label: label.into(),
+            path: path.into(),
+            presence: RootPresence::OptionalWhenAbsent,
+        }
+    }
+}
+
+/// The contract plus the bounds of the sampling walk.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VolumeContract {
+    /// Group every mounted artifact must belong to.
+    pub required_gid: u32,
+    /// Directory levels below each root that are sampled (0 = root only).
+    pub max_depth: usize,
+    /// Entries sampled per directory.
+    pub entries_per_dir: usize,
+    /// Hard cap on `lstat`s across all roots.
+    pub stat_budget: usize,
+    /// Also assert the process is a member of `required_gid`.
+    pub require_process_membership: bool,
+}
+
+impl Default for VolumeContract {
+    fn default() -> Self {
+        Self {
+            required_gid: ARTIFACT_GID,
+            max_depth: 3,
+            entries_per_dir: 32,
+            stat_budget: 512,
+            require_process_membership: true,
+        }
+    }
+}
+
+/// Outcome of a passing validation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct VolumeContractReport {
+    pub roots_checked: usize,
+    pub roots_absent: usize,
+    pub entries_sampled: usize,
+    pub budget_exhausted: bool,
+}
+
+/// Typed startup failure. Every variant names the offending path and the
+/// observed-versus-required ownership/mode.
+#[derive(Debug, Error)]
+pub enum VolumeContractError {
+    #[error("volume contract [{label}]: required root {path} is not mounted")]
+    MissingRoot { label: String, path: PathBuf },
+
+    #[error("volume contract [{label}]: {path} is not a directory")]
+    NotADirectory { label: String, path: PathBuf },
+
+    #[error("volume contract [{label}]: cannot stat {path}: {source}")]
+    Stat {
+        label: String,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+
+    #[error(
+        "volume contract [{label}]: {path} is group-owned by gid {observed_gid} \
+         but the artifact contract requires gid {required_gid} \
+         (observed mode {observed_mode:o}, uid {observed_uid})"
+    )]
+    GroupOwner {
+        label: String,
+        path: PathBuf,
+        observed_gid: u32,
+        observed_uid: u32,
+        observed_mode: u32,
+        required_gid: u32,
+    },
+
+    #[error(
+        "volume contract [{label}]: {path} ({kind}) has mode {observed_mode:o} \
+         with no group-write bit; the artifact contract requires g+w so gid \
+         {required_gid} can create, overwrite and unlink here"
+    )]
+    GroupWrite {
+        label: String,
+        path: PathBuf,
+        kind: &'static str,
+        observed_mode: u32,
+        required_gid: u32,
+    },
+
+    #[error(
+        "volume contract [{label}]: directory {path} has mode {observed_mode:o} \
+         with no setgid bit; the artifact contract requires setgid so files \
+         created here inherit gid {required_gid}"
+    )]
+    Setgid {
+        label: String,
+        path: PathBuf,
+        observed_mode: u32,
+        required_gid: u32,
+    },
+
+    #[error(
+        "volume contract: process runs as gid {process_gid} with supplementary \
+         groups {supplementary:?}; artifact gid {required_gid} is not among \
+         them, so conforming volumes are still unwritable"
+    )]
+    ProcessGroupMembership {
+        process_gid: u32,
+        supplementary: Vec<u32>,
+        required_gid: u32,
+    },
+}
+
+impl VolumeContractError {
+    /// Stable label for logs/metrics.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::MissingRoot { .. } => "missing_root",
+            Self::NotADirectory { .. } => "not_a_directory",
+            Self::Stat { .. } => "stat_failed",
+            Self::GroupOwner { .. } => "group_owner",
+            Self::GroupWrite { .. } => "group_write",
+            Self::Setgid { .. } => "setgid",
+            Self::ProcessGroupMembership { .. } => "process_group_membership",
+        }
+    }
+
+    /// Offending path, when the violation has one.
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::MissingRoot { path, .. }
+            | Self::NotADirectory { path, .. }
+            | Self::Stat { path, .. }
+            | Self::GroupOwner { path, .. }
+            | Self::GroupWrite { path, .. }
+            | Self::Setgid { path, .. } => Some(path.as_path()),
+            Self::ProcessGroupMembership { .. } => None,
+        }
+    }
+}
+
+/// Validate `roots` against `contract`. Pure filesystem reads; never mutates.
+pub fn validate(
+    contract: &VolumeContract,
+    roots: &[VolumeRoot],
+) -> Result<VolumeContractReport, VolumeContractError> {
+    let mut report = VolumeContractReport::default();
+
+    if contract.require_process_membership {
+        check_process_membership(contract.required_gid)?;
+    }
+
+    for root in roots {
+        let meta = match fs::symlink_metadata(&root.path) {
+            Ok(meta) => meta,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => match root.presence {
+                RootPresence::Required => {
+                    return Err(VolumeContractError::MissingRoot {
+                        label: root.label.clone(),
+                        path: root.path.clone(),
+                    });
+                }
+                RootPresence::OptionalWhenAbsent => {
+                    report.roots_absent += 1;
+                    continue;
+                }
+            },
+            Err(source) => {
+                return Err(VolumeContractError::Stat {
+                    label: root.label.clone(),
+                    path: root.path.clone(),
+                    source,
+                });
+            }
+        };
+
+        if !meta.is_dir() {
+            return Err(VolumeContractError::NotADirectory {
+                label: root.label.clone(),
+                path: root.path.clone(),
+            });
+        }
+
+        report.roots_checked += 1;
+        report.entries_sampled += 1;
+        check_metadata(contract, &root.label, &root.path, &meta, true)?;
+        walk_sample(contract, root, &mut report)?;
+    }
+
+    Ok(report)
+}
+
+/// Bounded breadth-first sample below `root`. Symlinks are never followed and
+/// never checked — the contract is about the volume's own inodes.
+fn walk_sample(
+    contract: &VolumeContract,
+    root: &VolumeRoot,
+    report: &mut VolumeContractReport,
+) -> Result<(), VolumeContractError> {
+    if contract.max_depth == 0 {
+        return Ok(());
+    }
+
+    let mut queue: VecDeque<(PathBuf, usize)> = VecDeque::new();
+    queue.push_back((root.path.clone(), 0));
+
+    while let Some((dir, depth)) = queue.pop_front() {
+        if report.entries_sampled >= contract.stat_budget {
+            report.budget_exhausted = true;
+            return Ok(());
+        }
+
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            // A directory we cannot list is itself a contract failure only if
+            // its own mode/ownership said otherwise, which `check_metadata`
+            // already asserted; anything else here (races with a concurrent
+            // prune, for instance) must not wedge startup.
+            Err(_) => continue,
+        };
+
+        for entry in entries.take(contract.entries_per_dir) {
+            let Ok(entry) = entry else { continue };
+            if report.entries_sampled >= contract.stat_budget {
+                report.budget_exhausted = true;
+                return Ok(());
+            }
+
+            let path = entry.path();
+            let meta = match fs::symlink_metadata(&path) {
+                Ok(meta) => meta,
+                // Vanished between listing and stat — not a contract signal.
+                Err(_) => continue,
+            };
+            if meta.file_type().is_symlink() {
+                continue;
+            }
+
+            report.entries_sampled += 1;
+            let is_dir = meta.is_dir();
+            check_metadata(contract, &root.label, &path, &meta, is_dir)?;
+
+            if is_dir && depth + 1 < contract.max_depth {
+                queue.push_back((path, depth + 1));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_metadata(
+    contract: &VolumeContract,
+    label: &str,
+    path: &Path,
+    meta: &fs::Metadata,
+    is_dir: bool,
+) -> Result<(), VolumeContractError> {
+    let mode = meta.mode() & MODE_MASK;
+    let gid = meta.gid();
+
+    if gid != contract.required_gid {
+        return Err(VolumeContractError::GroupOwner {
+            label: label.to_string(),
+            path: path.to_path_buf(),
+            observed_gid: gid,
+            observed_uid: meta.uid(),
+            observed_mode: mode,
+            required_gid: contract.required_gid,
+        });
+    }
+
+    if mode & MODE_GROUP_WRITE == 0 {
+        return Err(VolumeContractError::GroupWrite {
+            label: label.to_string(),
+            path: path.to_path_buf(),
+            kind: if is_dir { "directory" } else { "file" },
+            observed_mode: mode,
+            required_gid: contract.required_gid,
+        });
+    }
+
+    if is_dir && mode & MODE_SETGID == 0 {
+        return Err(VolumeContractError::Setgid {
+            label: label.to_string(),
+            path: path.to_path_buf(),
+            observed_mode: mode,
+            required_gid: contract.required_gid,
+        });
+    }
+
+    Ok(())
+}
+
+/// Assert the process can actually use a conforming volume.
+fn check_process_membership(required_gid: u32) -> Result<(), VolumeContractError> {
+    let process_gid = current_gid();
+    let supplementary = supplementary_groups();
+    if process_gid == required_gid || supplementary.contains(&required_gid) {
+        return Ok(());
+    }
+    Err(VolumeContractError::ProcessGroupMembership {
+        process_gid,
+        supplementary,
+        required_gid,
+    })
+}
+
+/// Effective gid of this process.
+pub fn current_gid() -> u32 {
+    // SAFETY: `getegid` takes no arguments, cannot fail, and touches no memory.
+    unsafe { libc::getegid() }
+}
+
+/// Supplementary group list of this process.
+pub fn supplementary_groups() -> Vec<u32> {
+    // SAFETY: the first call only queries the count (null buffer is the
+    // documented probe form); the second fills a buffer sized by that count and
+    // the returned length bounds the truncation below.
+    unsafe {
+        let count = libc::getgroups(0, std::ptr::null_mut());
+        if count <= 0 {
+            return Vec::new();
+        }
+        let mut buf: Vec<libc::gid_t> = vec![0; count as usize];
+        let filled = libc::getgroups(count, buf.as_mut_ptr());
+        if filled <= 0 {
+            return Vec::new();
+        }
+        buf.truncate(filled as usize);
+        buf
+    }
+}
+
+/// Mounted roots a **task-run** Pod must be able to write.
+pub fn task_run_roots(workspace: &Path) -> Vec<VolumeRoot> {
+    let mut roots = vec![VolumeRoot::required("workspace", workspace)];
+    roots.push(VolumeRoot::optional("git-metadata", workspace.join(".git")));
+    roots.extend(git_mirror_roots());
+    roots.extend(cache_roots());
+    roots
+}
+
+/// Mounted roots the **warm Job** must be able to write. Same shared `/cache`
+/// as the task-runs, plus this pod's own Cargo warm base variant — the exact
+/// directory the near-miss froze.
+pub fn warm_roots(project_root: &Path, project_id: &str) -> Vec<VolumeRoot> {
+    let mut roots = vec![VolumeRoot::required("workspace", project_root)];
+    roots.push(VolumeRoot::optional(
+        "git-metadata",
+        project_root.join(".git"),
+    ));
+    roots.extend(git_mirror_roots());
+    roots.extend(cache_roots());
+    roots.push(VolumeRoot::optional(
+        "cargo-warm-base",
+        warm_base_dir_for_current_jobs(project_id),
+    ));
+    roots
+}
+
+fn git_mirror_roots() -> Vec<VolumeRoot> {
+    let mirror = std::env::var("DJINN_MIRROR_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(MIRROR_MOUNT_ROOT));
+    vec![VolumeRoot::optional("git-mirror", mirror)]
+}
+
+/// Every configured cache root, including the Cargo warm-base parent and the
+/// per-run target parent. All optional-when-absent: a fresh PVC has none of
+/// them yet, and the mount root itself is the required anchor.
+fn cache_roots() -> Vec<VolumeRoot> {
+    let mut roots = vec![
+        VolumeRoot::optional("cache-mount", CACHE_MOUNT_ROOT),
+        VolumeRoot::optional("cargo-warm-base-root", WARM_BASE_ROOT),
+        VolumeRoot::optional("cargo-target-run-root", RUN_TARGET_ROOT),
+    ];
+    for (label, env) in [
+        ("cargo-home", "CARGO_HOME"),
+        ("sccache-dir", "SCCACHE_DIR"),
+        ("cargo-target-dir", "CARGO_TARGET_DIR"),
+    ] {
+        if let Ok(value) = std::env::var(env) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                roots.push(VolumeRoot::optional(label, PathBuf::from(trimmed)));
+            }
+        }
+    }
+    roots
+}
+
+/// Run the check at startup for `context` (`task-run` / `warm-graph`), honouring
+/// [`ContractMode`]. Returns `Err` only when the mode is
+/// [`ContractMode::Enforce`] — the caller propagates it and the pod fails.
+pub fn enforce_at_startup(context: &str, roots: &[VolumeRoot]) -> Result<(), VolumeContractError> {
+    enforce_with(
+        context,
+        &VolumeContract::default(),
+        roots,
+        ContractMode::from_env(),
+    )
+}
+
+/// [`enforce_at_startup`] with the contract and mode supplied explicitly.
+// Approved boundary for `Instant::now`: the elapsed value is observational only
+// — it lands in one startup log line so operators can confirm the check costs
+// milliseconds ([`EXPECTED_MAX_DURATION`]). No control flow reads it.
+#[allow(clippy::disallowed_methods)]
+pub fn enforce_with(
+    context: &str,
+    contract: &VolumeContract,
+    roots: &[VolumeRoot],
+    mode: ContractMode,
+) -> Result<(), VolumeContractError> {
+    if mode == ContractMode::Off {
+        return Ok(());
+    }
+
+    let started = Instant::now();
+    let outcome = validate(contract, roots);
+    let elapsed = started.elapsed();
+
+    match outcome {
+        Ok(report) => {
+            info!(
+                context,
+                mode = mode.as_str(),
+                required_gid = contract.required_gid,
+                roots_checked = report.roots_checked,
+                roots_absent = report.roots_absent,
+                entries_sampled = report.entries_sampled,
+                budget_exhausted = report.budget_exhausted,
+                elapsed_ms = elapsed.as_millis() as u64,
+                "volume permission contract satisfied"
+            );
+            Ok(())
+        }
+        Err(error) => {
+            let path = error
+                .path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            tracing::error!(
+                context,
+                mode = mode.as_str(),
+                kind = error.kind(),
+                path = %path,
+                required_gid = contract.required_gid,
+                elapsed_ms = elapsed.as_millis() as u64,
+                error = %error,
+                "volume permission contract VIOLATED"
+            );
+            match mode {
+                ContractMode::Enforce => Err(error),
+                // Loud, operator-selected, and explicitly not a fallback to the
+                // legacy uid: the pod proceeds with a known-broken cache.
+                ContractMode::Audit | ContractMode::Off => Ok(()),
+            }
+        }
+    }
+}
+
+/// Wall-clock budget the check is expected to stay inside on a conforming
+/// volume. Documentation-only — nothing enforces it — but it pins the intent
+/// that this is a few hundred `lstat`s, not a scan.
+pub const EXPECTED_MAX_DURATION: Duration = Duration::from_millis(250);

--- a/server/crates/djinn-agent-worker/src/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/src/volume_contract.rs
@@ -23,7 +23,12 @@
 //!     launcher-spawned child (primary group 1000) share every artifact;
 //!   * directories carry **group-write** *and* **setgid**, so files created by
 //!     either identity inherit the artifact group instead of the creator's;
-//!   * files carry **group-write**, so the other identity can overwrite them;
+//!   * files that their owner can write carry **group-write**, so the other
+//!     identity can overwrite them in place (files that are read-only for their
+//!     owner too — git objects, cargo registry sources — are immutable by
+//!     design and are replaced through the directory, not written);
+//!   * the process runs with umask `0002` ([`apply_artifact_umask`]) so
+//!     everything it creates keeps satisfying the above;
 //!   * the process itself is a member of [`ARTIFACT_GID`] (primary or
 //!     supplementary) — a conforming volume is useless to a pod that is not in
 //!     the group.
@@ -62,6 +67,9 @@ use crate::cargo_target_seed::{RUN_TARGET_ROOT, WARM_BASE_ROOT, warm_base_dir_fo
 const MODE_SETGID: u32 = 0o2000;
 /// Group-write bit.
 const MODE_GROUP_WRITE: u32 = 0o020;
+/// Owner-write bit — a file without it is immutable by design (git objects,
+/// cargo registry sources) rather than mis-permissioned.
+const MODE_OWNER_WRITE: u32 = 0o200;
 /// Permission bits we report on (mode & this) — keeps log lines readable.
 const MODE_MASK: u32 = 0o7777;
 
@@ -436,7 +444,16 @@ fn check_metadata(
         });
     }
 
-    if mode & MODE_GROUP_WRITE == 0 {
+    // Group-write is required wherever the OWNER can write. A file that is
+    // read-only for its owner too is immutable by design, not a permission
+    // regression: git stores loose objects and packfiles `444`, and cargo lays
+    // down registry sources with the modes recorded in the crate tarball. Those
+    // are replaced by unlink+create, which needs write on the DIRECTORY — which
+    // is checked unconditionally. Keying on the owner-write bit therefore still
+    // catches the exact production shape (dirs 755, files 644) without
+    // rejecting legitimately read-only artifacts.
+    let owner_writable = mode & MODE_OWNER_WRITE != 0;
+    if (is_dir || owner_writable) && mode & MODE_GROUP_WRITE == 0 {
         return Err(VolumeContractError::GroupWrite {
             label: label.to_string(),
             path: path.to_path_buf(),
@@ -496,6 +513,31 @@ pub fn supplementary_groups() -> Vec<u32> {
         buf.truncate(filled as usize);
         buf
     }
+}
+
+/// Process umask that keeps the contract true for everything this process
+/// creates: `0o002` clears only "other"-write, so new directories land `775`
+/// and new files `664` instead of `755`/`644`.
+pub const ARTIFACT_UMASK: libc::mode_t = 0o002;
+
+/// Apply [`ARTIFACT_UMASK`] to this process and return the previous mask.
+///
+/// This is the *other half* of the contract, and it was missing: the
+/// launcher-spawned child already sets `umask 0002`
+/// (`djinn_cgroup_launcher::child::prepare_child`), but the worker process
+/// itself inherited the container's default `022`. Everything the worker
+/// created on the shared volumes — the Cargo warm base above all — therefore
+/// landed group-READABLE but not group-WRITABLE, so the child (uid 1001, group
+/// 1000) could not overwrite it even on a perfectly conforming volume. Setgid
+/// on the directories fixes the *group*; only the umask fixes the *mode*.
+///
+/// Must run before any filesystem work, and before [`enforce_at_startup`] so a
+/// first-run pod that creates its own cache subtree creates it conforming.
+pub fn apply_artifact_umask() -> libc::mode_t {
+    // SAFETY: `umask` takes a mode, cannot fail, and touches no memory. It is
+    // process-global, which is exactly the intent, and is applied once at
+    // startup before any worker thread does filesystem work.
+    unsafe { libc::umask(ARTIFACT_UMASK) }
 }
 
 /// Mounted roots a **task-run** Pod must be able to write.

--- a/server/crates/djinn-agent-worker/src/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/src/volume_contract.rs
@@ -23,10 +23,12 @@
 //!     launcher-spawned child (primary group 1000) share every artifact;
 //!   * directories carry **group-write** *and* **setgid**, so files created by
 //!     either identity inherit the artifact group instead of the creator's;
-//!   * files that their owner can write carry **group-write**, so the other
-//!     identity can overwrite them in place (files that are read-only for their
-//!     owner too — git objects, cargo registry sources — are immutable by
-//!     design and are replaced through the directory, not written);
+//!   * files that their owner can write, and that are not executable, carry
+//!     **group-write** so the other identity can overwrite them in place. The
+//!     two exclusions cover the shapes a correct tree legitimately produces —
+//!     `444` git objects / cargo registry sources, and the `755`
+//!     `.git/hooks/*.sample` every clone copies from git's templates — neither
+//!     of which can hide the `644` production shape this exists to catch;
 //!   * the process runs with umask `0002` ([`apply_artifact_umask`]) so
 //!     everything it creates keeps satisfying the above;
 //!   * the process itself is a member of [`ARTIFACT_GID`] (primary or
@@ -70,6 +72,10 @@ const MODE_GROUP_WRITE: u32 = 0o020;
 /// Owner-write bit — a file without it is immutable by design (git objects,
 /// cargo registry sources) rather than mis-permissioned.
 const MODE_OWNER_WRITE: u32 = 0o200;
+/// Any execute bit — git copies its template hooks with the template's own
+/// mode, so `.git/hooks/*.sample` is 755 in every fresh clone whatever the
+/// umask.
+const MODE_ANY_EXEC: u32 = 0o111;
 /// Permission bits we report on (mode & this) — keeps log lines readable.
 const MODE_MASK: u32 = 0o7777;
 
@@ -444,16 +450,25 @@ fn check_metadata(
         });
     }
 
-    // Group-write is required wherever the OWNER can write. A file that is
-    // read-only for its owner too is immutable by design, not a permission
-    // regression: git stores loose objects and packfiles `444`, and cargo lays
-    // down registry sources with the modes recorded in the crate tarball. Those
-    // are replaced by unlink+create, which needs write on the DIRECTORY — which
-    // is checked unconditionally. Keying on the owner-write bit therefore still
-    // catches the exact production shape (dirs 755, files 644) without
-    // rejecting legitimately read-only artifacts.
+    // Directories are checked unconditionally: write permission on the
+    // DIRECTORY is what actually lets the other identity create, replace and
+    // unlink entries, and its absence is what froze the warm base.
+    //
+    // Files are checked when they are owner-writable and not executable.
+    // The two exclusions are not laxity, they are the two shapes a correct tree
+    // legitimately produces:
+    //   * owner-read-only (`444`) — git loose objects and packfiles, cargo
+    //     registry sources carrying the crate tarball's modes. Immutable by
+    //     design and replaced through the directory, never written in place.
+    //   * executable (`755`) — `git init`/`clone` copies the template hooks
+    //     with the template's own mode, so every fresh clone contains
+    //     `.git/hooks/*.sample` at 755 regardless of umask.
+    // Neither shape can mask the failure this exists to catch: the production
+    // volume was dirs `755` (caught on the directory rule) over files `644` —
+    // owner-writable, non-executable, and still caught here.
     let owner_writable = mode & MODE_OWNER_WRITE != 0;
-    if (is_dir || owner_writable) && mode & MODE_GROUP_WRITE == 0 {
+    let executable = mode & MODE_ANY_EXEC != 0;
+    if (is_dir || (owner_writable && !executable)) && mode & MODE_GROUP_WRITE == 0 {
         return Err(VolumeContractError::GroupWrite {
             label: label.to_string(),
             path: path.to_path_buf(),

--- a/server/crates/djinn-agent-worker/tests/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/tests/volume_contract.rs
@@ -121,6 +121,47 @@ fn missing_group_write_on_a_nested_file_fails() {
     assert_eq!(err.kind(), "group_write");
 }
 
+/// git loose objects/packfiles are `444` and cargo lays down registry sources
+/// with the tarball's modes. Those are immutable by design and are replaced
+/// through the (group-writable) directory, so they must not be read as a
+/// permission regression.
+#[test]
+fn owner_read_only_files_are_not_a_group_write_violation() {
+    let dir = conforming_tree();
+    chmod(&dir.path().join("sub").join("file"), 0o444);
+    validate(&contract(), &root_of(&dir)).expect("444 artifacts are immutable, not misowned");
+
+    // …but an owner-writable file without group-write still fails: that is the
+    // production 644 shape.
+    chmod(&dir.path().join("sub").join("file"), 0o644);
+    let err = validate(&contract(), &root_of(&dir)).expect_err("644 must still fail");
+    assert_eq!(err.kind(), "group_write");
+}
+
+/// The umask is the other half of the contract: without it the worker creates
+/// 755/644 into a conforming volume and breaks it from the inside.
+#[test]
+fn the_artifact_umask_makes_new_files_conforming() {
+    use djinn_agent_worker::volume_contract::{ARTIFACT_UMASK, apply_artifact_umask};
+
+    let previous = apply_artifact_umask();
+    let dir = TempDir::new().expect("tempdir");
+    chmod(dir.path(), DIR_CONFORMING);
+    let nested = dir.path().join("created");
+    fs::create_dir(&nested).expect("mkdir");
+    fs::write(nested.join("artifact"), b"x").expect("write");
+
+    // setgid on the parent propagates the group AND the setgid bit to the new
+    // directory; the umask supplies the group-write bits.
+    let report = validate(&contract(), &root_of(&dir))
+        .expect("everything created under the artifact umask conforms");
+    assert!(report.entries_sampled >= 3);
+    assert_eq!(ARTIFACT_UMASK, 0o002);
+
+    // SAFETY: restore the harness's umask; same contract as the setter.
+    unsafe { libc::umask(previous) };
+}
+
 #[test]
 fn missing_group_write_on_a_directory_fails() {
     let dir = conforming_tree();

--- a/server/crates/djinn-agent-worker/tests/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/tests/volume_contract.rs
@@ -1,0 +1,312 @@
+//! Deterministic filesystem tests for the startup volume-permission contract.
+//!
+//! Ownership cannot be changed without privilege, so the tests pin the required
+//! gid to the process's own gid for the conforming cases and to a deliberately
+//! foreign gid for the ownership-violation case. Mode violations are built with
+//! real `chmod`s on a tempdir, so every assertion runs against the same code the
+//! worker and warm Job execute at startup.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use djinn_agent_worker::volume_contract::{
+    ContractMode, VolumeContract, VolumeContractError, VolumeRoot, current_gid, enforce_with,
+    validate,
+};
+use tempfile::TempDir;
+
+/// Conforming directory mode: setgid + group-write.
+const DIR_CONFORMING: u32 = 0o2775;
+/// Conforming file mode: group-write.
+const FILE_CONFORMING: u32 = 0o664;
+
+fn contract() -> VolumeContract {
+    VolumeContract {
+        required_gid: current_gid(),
+        // Ownership is fixed by the harness, and the process obviously belongs
+        // to its own gid; the membership arm has its own test below.
+        require_process_membership: false,
+        ..VolumeContract::default()
+    }
+}
+
+fn chmod(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).expect("chmod");
+}
+
+/// A conforming root: `<root>/{sub/,sub/file,file}` all group-writable, dirs
+/// setgid.
+fn conforming_tree() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    let root = dir.path();
+    let sub = root.join("sub");
+    fs::create_dir(&sub).expect("mkdir sub");
+    fs::write(root.join("file"), b"a").expect("write file");
+    fs::write(sub.join("file"), b"b").expect("write nested file");
+    chmod(&sub.join("file"), FILE_CONFORMING);
+    chmod(&root.join("file"), FILE_CONFORMING);
+    chmod(&sub, DIR_CONFORMING);
+    chmod(root, DIR_CONFORMING);
+    dir
+}
+
+fn root_of(dir: &TempDir) -> Vec<VolumeRoot> {
+    vec![VolumeRoot::required("workspace", dir.path())]
+}
+
+#[test]
+fn conforming_volume_passes_and_samples_the_subtree() {
+    let dir = conforming_tree();
+    let report = validate(&contract(), &root_of(&dir)).expect("conforming volume must pass");
+    assert_eq!(report.roots_checked, 1);
+    assert_eq!(report.roots_absent, 0);
+    // Root + `sub` + two files.
+    assert!(
+        report.entries_sampled >= 4,
+        "expected the bounded walk to reach the subtree, sampled {}",
+        report.entries_sampled
+    );
+    assert!(!report.budget_exhausted);
+}
+
+#[test]
+fn foreign_group_owner_fails_and_names_the_path() {
+    let dir = conforming_tree();
+    let foreign = current_gid().wrapping_add(4242);
+    let contract = VolumeContract {
+        required_gid: foreign,
+        require_process_membership: false,
+        ..VolumeContract::default()
+    };
+    let err = validate(&contract, &root_of(&dir)).expect_err("foreign gid must fail readiness");
+    match &err {
+        VolumeContractError::GroupOwner {
+            path,
+            observed_gid,
+            required_gid,
+            ..
+        } => {
+            assert_eq!(path, dir.path());
+            assert_eq!(*observed_gid, current_gid());
+            assert_eq!(*required_gid, foreign);
+        }
+        other => panic!("expected GroupOwner, got {other:?}"),
+    }
+    assert_eq!(err.kind(), "group_owner");
+    let rendered = err.to_string();
+    assert!(rendered.contains(&dir.path().display().to_string()));
+    assert!(rendered.contains(&foreign.to_string()));
+}
+
+#[test]
+fn missing_group_write_on_a_nested_file_fails() {
+    let dir = conforming_tree();
+    let victim = dir.path().join("sub").join("file");
+    chmod(&victim, 0o644);
+    let err = validate(&contract(), &root_of(&dir)).expect_err("644 file must fail readiness");
+    match &err {
+        VolumeContractError::GroupWrite {
+            path,
+            kind,
+            observed_mode,
+            ..
+        } => {
+            assert_eq!(path, &victim);
+            assert_eq!(*kind, "file");
+            assert_eq!(*observed_mode, 0o644);
+        }
+        other => panic!("expected GroupWrite, got {other:?}"),
+    }
+    assert_eq!(err.kind(), "group_write");
+}
+
+#[test]
+fn missing_group_write_on_a_directory_fails() {
+    let dir = conforming_tree();
+    // 2755: setgid present, group-write gone — the production shape was 755.
+    chmod(&dir.path().join("sub"), 0o2755);
+    let err = validate(&contract(), &root_of(&dir)).expect_err("2755 dir must fail readiness");
+    match &err {
+        VolumeContractError::GroupWrite { kind, path, .. } => {
+            assert_eq!(*kind, "directory");
+            assert_eq!(path, &dir.path().join("sub"));
+        }
+        other => panic!("expected GroupWrite, got {other:?}"),
+    }
+}
+
+#[test]
+fn missing_setgid_on_a_directory_fails() {
+    let dir = conforming_tree();
+    chmod(&dir.path().join("sub"), 0o0775);
+    let err = validate(&contract(), &root_of(&dir)).expect_err("non-setgid dir must fail");
+    match &err {
+        VolumeContractError::Setgid {
+            path,
+            observed_mode,
+            ..
+        } => {
+            assert_eq!(path, &dir.path().join("sub"));
+            assert_eq!(*observed_mode, 0o0775);
+        }
+        other => panic!("expected Setgid, got {other:?}"),
+    }
+    assert_eq!(err.kind(), "setgid");
+}
+
+/// The exact production near-miss: the volume ROOT was hand-fixed (which is
+/// also what makes kubelet's `OnRootMismatch` skip its recursive pass) while
+/// the 13,512-file subtree stayed 755/644. A root-only check would pass this.
+#[test]
+fn conforming_root_over_a_non_conforming_subtree_still_fails() {
+    let dir = TempDir::new().expect("tempdir");
+    let sub = dir.path().join("cargo-target");
+    fs::create_dir(&sub).expect("mkdir");
+    fs::write(sub.join("artifact"), b"x").expect("write");
+    chmod(&sub.join("artifact"), 0o644);
+    chmod(&sub, 0o755);
+    chmod(dir.path(), DIR_CONFORMING);
+
+    let err = validate(&contract(), &root_of(&dir)).expect_err("broken subtree must fail");
+    assert_eq!(err.kind(), "group_write");
+    assert_eq!(err.path(), Some(sub.as_path()));
+}
+
+#[test]
+fn missing_required_root_fails_but_absent_optional_roots_are_skipped() {
+    let dir = conforming_tree();
+    let absent = dir.path().join("not-mounted");
+
+    let err = validate(
+        &contract(),
+        &[VolumeRoot::required("cache", absent.clone())],
+    )
+    .expect_err("unmounted required root must fail");
+    assert_eq!(err.kind(), "missing_root");
+    assert_eq!(err.path(), Some(absent.as_path()));
+
+    let report = validate(
+        &contract(),
+        &[
+            VolumeRoot::required("workspace", dir.path()),
+            VolumeRoot::optional("cargo-warm-base", absent),
+        ],
+    )
+    .expect("absent optional root is not a violation");
+    assert_eq!(report.roots_checked, 1);
+    assert_eq!(report.roots_absent, 1);
+}
+
+#[test]
+fn the_walk_is_bounded_by_depth_and_budget() {
+    let dir = TempDir::new().expect("tempdir");
+    // Conforming down to depth 3, broken at depth 5.
+    let mut cursor = dir.path().to_path_buf();
+    chmod(&cursor, DIR_CONFORMING);
+    for level in 0..6 {
+        cursor = cursor.join(format!("l{level}"));
+        fs::create_dir(&cursor).expect("mkdir level");
+        chmod(&cursor, if level >= 4 { 0o0755 } else { DIR_CONFORMING });
+    }
+
+    let bounded = VolumeContract {
+        max_depth: 3,
+        ..contract()
+    };
+    validate(&bounded, &root_of(&dir)).expect("violations below max_depth are out of scope");
+
+    let deep = VolumeContract {
+        max_depth: 8,
+        ..contract()
+    };
+    validate(&deep, &root_of(&dir)).expect_err("a deeper walk sees the violation");
+
+    // A budget of one stat can only cover the root itself.
+    let starved = VolumeContract {
+        max_depth: 8,
+        stat_budget: 1,
+        ..contract()
+    };
+    let report = validate(&starved, &root_of(&dir)).expect("budget stops the walk");
+    assert!(report.budget_exhausted);
+    assert_eq!(report.entries_sampled, 1);
+}
+
+#[test]
+fn enforce_fails_closed_while_audit_and_off_do_not() {
+    let dir = conforming_tree();
+    chmod(&dir.path().join("sub"), 0o0775);
+    let roots = root_of(&dir);
+    let contract = contract();
+
+    assert!(
+        enforce_with("task-run", &contract, &roots, ContractMode::Enforce).is_err(),
+        "enforce must fail readiness"
+    );
+    assert!(
+        enforce_with("task-run", &contract, &roots, ContractMode::Audit).is_ok(),
+        "audit is a loud break-glass, not a failure"
+    );
+    assert!(
+        enforce_with("task-run", &contract, &roots, ContractMode::Off).is_ok(),
+        "off short-circuits entirely"
+    );
+}
+
+#[test]
+fn conforming_volume_passes_through_enforce() {
+    let dir = conforming_tree();
+    assert!(
+        enforce_with(
+            "warm-graph",
+            &contract(),
+            &root_of(&dir),
+            ContractMode::Enforce
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn process_group_membership_is_asserted_before_any_stat() {
+    let dir = conforming_tree();
+    let unreachable_gid = u32::MAX - 7;
+    let contract = VolumeContract {
+        required_gid: unreachable_gid,
+        require_process_membership: true,
+        ..VolumeContract::default()
+    };
+    let err = validate(&contract, &root_of(&dir)).expect_err("non-member process must fail");
+    assert_eq!(err.kind(), "process_group_membership");
+
+    let member = VolumeContract {
+        required_gid: current_gid(),
+        require_process_membership: true,
+        ..VolumeContract::default()
+    };
+    validate(&member, &root_of(&dir)).expect("own gid is always a member");
+}
+
+#[test]
+fn the_check_never_mutates_the_volume() {
+    let dir = conforming_tree();
+    let sub = dir.path().join("sub");
+    chmod(&sub, 0o0775);
+    let before = fs::symlink_metadata(&sub)
+        .expect("stat")
+        .permissions()
+        .mode();
+
+    let _ = validate(&contract(), &root_of(&dir));
+    let _ = enforce_with("task-run", &contract(), &root_of(&dir), ContractMode::Audit);
+
+    let after = fs::symlink_metadata(&sub)
+        .expect("stat")
+        .permissions()
+        .mode();
+    assert_eq!(
+        before, after,
+        "startup validation must never repair the volume"
+    );
+}

--- a/server/crates/djinn-agent-worker/tests/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/tests/volume_contract.rs
@@ -131,8 +131,13 @@ fn owner_read_only_files_are_not_a_group_write_violation() {
     chmod(&dir.path().join("sub").join("file"), 0o444);
     validate(&contract(), &root_of(&dir)).expect("444 artifacts are immutable, not misowned");
 
-    // …but an owner-writable file without group-write still fails: that is the
-    // production 644 shape.
+    // …and `git init` copies its template hooks with the template's own mode,
+    // so `.git/hooks/*.sample` is 755 in every fresh clone whatever the umask.
+    chmod(&dir.path().join("sub").join("file"), 0o755);
+    validate(&contract(), &root_of(&dir)).expect("executables are replaced, not written in place");
+
+    // …but an owner-writable, non-executable file without group-write still
+    // fails: that is the production 644 shape.
     chmod(&dir.path().join("sub").join("file"), 0o644);
     let err = validate(&contract(), &root_of(&dir)).expect_err("644 must still fail");
     assert_eq!(err.kind(), "group_write");

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -26,7 +26,9 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use thiserror::Error;
 
-use djinn_cgroup_launcher::broker::{WORKER_GID, WORKER_UID};
+// Re-exported so every pod render that shares the cache volumes (task-run in
+// `job.rs`, warm in `warm_job.rs`) pins the SAME worker identity from one place.
+pub use djinn_cgroup_launcher::broker::{WORKER_GID, WORKER_UID};
 // Re-export the child/artifact contract constants so djinn-k8s consumers (and
 // intra-doc links here) see the same UIDs the launcher enforces at runtime.
 // `CHILD_UID` is applied by the launcher when it spawns the child, not in the

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -109,6 +109,12 @@ pub fn build_warm_job(
     // for the broader warm-cost discussion.
     let cmd = format!(
         r#"set -euo pipefail
+# Everything this Pod creates on the shared volumes must stay group-writable for
+# the other identity that reads/writes them (the launcher-spawned child, uid
+# 1001 primary group 1000). The container default 022 would give the clone 755
+# dirs / 644 files, which the worker's startup contract check rejects. See
+# `djinn_agent_worker::volume_contract`.
+umask 0002
 git config --global --add safe.directory "{mirror_path}"
 UPSTREAM_URL="$(git -C "{mirror_path}" config remote.origin.url)"
 git clone --depth 1000 --single-branch "$UPSTREAM_URL" "{project_root}"

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -275,14 +275,20 @@ exec {bin} warm-graph "{project_id}"
         volumes: Some(volumes),
         node_selector,
         tolerations,
-        // Run as uid 10001 like task-runs (job.rs). The warm pod shares the
-        // /cache cargo target PVC with workers; without this it runs as root
-        // and writes root-owned cargo artifacts the worker (uid 10001) can't
-        // overwrite, corrupting the shared cache.
+        // The warm pod shares the /cache cargo target PVC with task-runs, so it
+        // MUST carry the same identity and the same volume-ownership contract
+        // qut0 put on the task-run pod — otherwise the two halves of the shared
+        // cache write as different owners and neither can overwrite the other
+        // (task pwrr: the warm pod was still pinned to the legacy 10001 after
+        // task-runs moved to 1000). `fsGroup = ARTIFACT_GID` with
+        // `OnRootMismatch` gives the warm process membership in the artifact
+        // group without an unbounded recursive chown on every pod start; the
+        // worker binary re-validates the mounted result at startup
+        // (`djinn_agent_worker::volume_contract`) and fails closed.
         security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
-            run_as_user: Some(10001),
-            run_as_group: Some(10001),
-            ..Default::default()
+            run_as_user: Some(i64::from(crate::launcher::WORKER_UID)),
+            run_as_group: Some(i64::from(crate::launcher::WORKER_GID)),
+            ..crate::launcher::pod_security_context()
         }),
         ..PodSpec::default()
     };
@@ -507,12 +513,28 @@ mod tests {
 
         let pod = spec.template.spec.as_ref().expect("pod");
         assert_eq!(pod.restart_policy.as_deref(), Some("Never"));
-        // Must run as uid 10001 like task-runs to share the /cache cargo target
-        // PVC without writing root-owned artifacts workers can't overwrite.
+        // Must carry the SAME identity and volume-ownership contract as a
+        // task-run pod: both write the shared /cache cargo target PVC, so a
+        // divergent uid/fsGroup leaves artifacts neither side can overwrite.
+        let psc = pod.security_context.as_ref().expect("pod security context");
         assert_eq!(
-            pod.security_context.as_ref().and_then(|s| s.run_as_user),
-            Some(10001),
+            psc.run_as_user,
+            Some(i64::from(crate::launcher::WORKER_UID)),
             "warm pod must run as the worker uid to share the cargo cache safely"
+        );
+        assert_eq!(
+            psc.run_as_group,
+            Some(i64::from(crate::launcher::WORKER_GID))
+        );
+        assert_eq!(
+            psc.fs_group,
+            Some(i64::from(crate::launcher::ARTIFACT_GID)),
+            "warm pod must join the artifact group that owns the shared cache"
+        );
+        assert_eq!(
+            psc.fs_group_change_policy.as_deref(),
+            Some("OnRootMismatch"),
+            "never Always: an unbounded recursive chown would stall warm pod start"
         );
         assert_eq!(
             pod.service_account_name.as_deref(),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -95,6 +95,17 @@ fn main() {
     // Install before CLI parsing and Tokio construction so startup panics are durable.
     djinn_telemetry::panic_capture::install();
 
+    // The server shares `mirrors`, `cache` and `projects` with the task-run and
+    // warm Job Pods, which write them as gid 1000 (task pwrr). Everything this
+    // process creates there must therefore stay group-writable: with the
+    // container default umask 022 a freshly cloned mirror lands 755/644 and the
+    // Pods' startup volume-contract check rejects it. 0002 clears only
+    // "other"-write, so new directories are 775 and new files 664; the setgid
+    // bit the chart puts on the volume roots supplies the group.
+    // SAFETY: `umask` takes a mode, cannot fail, and touches no memory. Applied
+    // once here, before any filesystem work or thread spawns.
+    unsafe { libc::umask(0o002) };
+
     if let Err(error) = djinn_server::allocator::validate_malloc_conf_from_env() {
         tracing::error!(%error, "invalid MALLOC_CONF");
         eprintln!("invalid MALLOC_CONF: {error}");


### PR DESCRIPTION
Found while preparing the v0.7.0 deploy. `qut0` moved the task-run Pod from uid 10001 to uid/gid 1000 with `fsGroup: 1000` + `fsGroupChangePolicy: OnRootMismatch`, but that render only *declares* the contract — nothing ever inspected the filesystem that got mounted. The live `djinn-cache` PVC held 13,512 files owned by 10001 with dirs `755` / files `644`, which a uid-1000 warm Job cannot create, unlink or overwrite. Because the warm Job's cargo phase is best-effort (lock-unavailable, step failure and timeout only WARN) while the Job reports success from the graph phase, that state surfaces as **green warm Jobs over a permanently frozen build base**. It was hand-patched pre-deploy; a fresh volume, a restored backup or a different volume driver reintroduces it.

`goxi`'s design already specified the fix and it was never implemented. This is it.

## Runtime

New `djinn_agent_worker::volume_contract`, enforced at startup by **both** entrypoints (`run_task_run` and `run_warm_graph_body` — the warm Job shares `/cache`). It stats the real mounted workspace, git metadata (`<workspace>/.git` + the mirror root) and every configured cache root — `/cache`, `/cache/cargo-target`, `/cache/cargo-target-runs`, `CARGO_HOME`, `SCCACHE_DIR`, `CARGO_TARGET_DIR`, plus the warm Job's own Cargo warm-base variant — and asserts:

* group ownership = `ARTIFACT_GID`;
* group-write on directories, and on files their owner can write;
* setgid on directories, so new files inherit the artifact group;
* the process is a member of the artifact group (primary or supplementary).

A violation fails readiness with a typed error naming the path and the observed-versus-required ownership/mode. **No** fallback to the legacy uid, and **no** repair — not even a bounded one. The walk is capped at depth 3 / 32 entries per directory / 512 `lstat`s, so it samples the subtree without becoming a scan: a root-only check would have passed the exact production state, whose root had been fixed by hand over a broken subtree.

Outside Kubernetes the check is off (no pod-mounted volumes to validate, and the binary is spawned directly by the in-pod integration tests). `DJINN_VOLUME_CONTRACT_MODE=audit` is a documented, loud break-glass for a rollout window — not a fallback.

## Render

The warm Pod was still pinned to the legacy `10001:10001` with no `fsGroup` while task-runs moved to 1000 — two identities writing one shared cache. It now carries the same worker identity and the same `fsGroup` + `OnRootMismatch` contract.

## Chart

`storage.ownership` declares the contract (`artifactGid` / `ownerUid` / `dirMode` / `normalizeRoots`). The `fix-volume-perms` initContainer normalizes the three volume **roots** to `ownerUid:artifactGid` with setgid + group-write — O(1), idempotent, never recursive — and the server pod gets `supplementalGroups: [1000]` rather than `fsGroup`.

**initContainer over `fsGroup`, and why:** `OnRootMismatch`'s trigger is a heuristic on the volume root's gid *and* mode bits, so a hand-fixed root makes the kubelet skip while the whole subtree stays wrong (exactly the near-miss); when it *does* fire it is an unbounded recursive chown at mount time (minutes of stalled pod start on a large cache); it is a no-op for `hostPath` and varies by CSI driver; and all the server needs is group *membership*, which `supplementalGroups` grants with zero filesystem work. `fsGroup` stays on the task-run/warm renders — with the roots normalized, `OnRootMismatch` is a guaranteed no-op there — and is never `Always`.

## The other half: umask

Validating against real volumes surfaced two gaps that would have made the check a foot-gun:

* Only the launcher-spawned child set `umask 0002`. The worker process and the warm Job's clone wrapper inherited the container default `022`, so everything they wrote to the shared volumes landed `755`/`644` — group-readable, not group-writable. A conforming volume was broken from the inside on first write, which is how the frozen warm base kept reappearing. Both now apply `umask 0002` before any filesystem work; setgid on the volume root propagates the group *and* the setgid bit to everything created below it.
* Group-write on **files** is required only where the owner can write. git loose objects and packfiles are `444` and cargo lays down registry sources with the tarball's modes — immutable by design, replaced through the (unconditionally checked) directory. The rule still catches the exact production shape of dirs `755` / files `644`.

## Rollout

The check fails closed, so a cluster whose volumes predate the contract will see its first post-upgrade pods exit at startup **instead of** silently running against a frozen cache. The runbook's remediation is safe to run on a conforming volume and should go in the same maintenance window.

## Tests

* `server/crates/djinn-agent-worker/tests/volume_contract.rs` — 14 deterministic filesystem tests: each violation (foreign group owner, missing group-write on a file and on a directory, missing setgid, unmounted required root) fails readiness naming the path; a conforming layout passes; a conforming root over a broken subtree still fails; the walk respects depth and stat budget; enforce fails closed while audit/off do not; the check never mutates the volume.
* `deploy/helm/djinn/tests/volume-ownership-render.sh` — render contract: `supplementalGroups` present, `fsGroup` absent, initContainer normalizes all three roots non-recursively.
* `docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md` — diagnosis, the one-time remediation for pre-existing volumes (and the cheaper "delete the warm base" alternative), the break-glass, and the rationale above.

Gates: `cargo fmt --all`, clippy on `djinn-agent-worker` + `djinn-k8s` `--tests --all-targets`, `SQLX_OFFLINE=1 cargo check --workspace --all-targets`, `cancel_path` + `in_pod_drive` green, size guard clean, chart renders with default and local values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
