### PR TITLE
chore(zf13): Adversarially prove the launcher kernel boundary under the rendered Pod security context

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -453,6 +453,104 @@ jobs:
           }
       - name: Clippy
         run: cargo clippy --all-targets --features qdrant -- -D warnings
+  launcher-kernel-boundary:
+    name: Launcher Kernel Boundary
+    needs: preflight
+    # The proofs need uid 0, real UID separation, a shared PID namespace,
+    # cgroup-v2 delegation and an installable seccomp filter — none of which the
+    # ordinary sharded test lane has. This is the ONLY lane that executes goxi
+    # AC2, so it must never be optional: the suite's always-on guard test
+    # (`the_privileged_lane_is_wired_and_this_proof_cannot_silently_skip`) reads
+    # this file back and fails if the job, its `--ignored` invocation, or the
+    # ZF13_EXPECTED_PROOFS declaration below disappears.
+    if: needs.preflight.outputs.serverTest == 'true' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: server
+    env:
+      SQLX_OFFLINE: "true"
+      # Number of `#[ignore]`d proofs the suite declares. The run below fails if
+      # fewer than this many actually execute, so a lane that quietly runs zero
+      # tests can never be mistaken for a proven kernel boundary.
+      ZF13_EXPECTED_PROOFS: "3"
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install
+        working-directory: server
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # djinn-cgroup-launcher depends only on libc + thiserror, so this lane
+          # compiles one small crate; it shares the server-test family purely to
+          # reuse an already-warm registry rather than to seed a new one.
+          workspaces: server
+          shared-key: server-test
+          cache-on-failure: true
+          cache-all-crates: true
+          save-if: false
+        id: rust-cache
+      - name: Log cache family and restore status
+        run: |-
+          echo "cache-family=server-test"
+          echo "shared-key=server-test"
+          echo "runner-os=${{ runner.os }}"
+          echo "rustc=$(rustc --version || echo 'unknown')"
+          echo "cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+          echo "::notice::cache-family=server-test shared-key=server-test cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
+      - name: Assert the runner can host the proof
+        run: |
+          set -euo pipefail
+          # Fail here, loudly, rather than let the suite decide it "cannot run".
+          if ! docker info >/dev/null 2>&1; then
+            echo "::error::no container runtime on this runner; the launcher kernel boundary cannot be proven"
+            exit 1
+          fi
+          if [ "$(docker info --format '{{.CgroupVersion}}')" != "2" ]; then
+            echo "::error::the container runtime is not on cgroup v2; the launcher readiness contract rejects v1/hybrid"
+            exit 1
+          fi
+          docker pull --quiet ubuntu:24.04
+      - name: Build the privileged proof binary (unprivileged)
+        id: build
+        run: |
+          set -euo pipefail
+          # Built as the normal user so no root-owned artifacts land in target/;
+          # only the finished binary is then run with elevated privilege.
+          cargo test -p djinn-cgroup-launcher \
+            --test kernel_boundary_under_rendered_context \
+            --no-run --message-format=json > "$RUNNER_TEMP/build.json"
+          binary=$(jq -r 'select(.executable != null and .target.name == "kernel_boundary_under_rendered_context") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
+          if [ -z "$binary" ] || [ ! -x "$binary" ]; then
+            echo "::error::could not locate the built kernel-boundary proof binary"
+            exit 1
+          fi
+          echo "binary=$binary" >> "$GITHUB_OUTPUT"
+      - name: Prove the kernel boundary under the rendered security context
+        run: |
+          set -euo pipefail
+          # A privileged cgroup-v2 container is the closest analogue of the
+          # rendered enforcement Pod a hosted runner can offer: real uid 0, a
+          # private cgroup namespace whose cpu controller the suite can delegate
+          # exactly as the launcher requires, one shared PID namespace for the
+          # worker and its launched child, and /workspace (the rendered
+          # CommandSpec cwd) present. The image matches the runner's userspace,
+          # so the binary built above runs unmodified.
+          #
+          # --test-threads 1 keeps the harness single-threaded, so the worker
+          # fork and the clone3-into-cgroup adversary behave as they do in the
+          # rendered pod.
+          docker run --rm --privileged --cgroupns=private \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            ubuntu:24.04 \
+            bash -c 'mkdir -p /workspace && exec "$0" --ignored --test-threads 1 --nocapture' \
+            "${{ steps.build.outputs.binary }}" 2>&1 | tee "$RUNNER_TEMP/zf13.log"
+          passed=$(sed -n 's/^test result: ok\. \([0-9]*\) passed.*/\1/p' "$RUNNER_TEMP/zf13.log" | tail -1)
+          if [ "${passed:-0}" != "$ZF13_EXPECTED_PROOFS" ]; then
+            echo "::error::the launcher kernel-boundary lane executed ${passed:-0} proofs but $ZF13_EXPECTED_PROOFS are declared; goxi AC2 is NOT proven by this run"
+            exit 1
+          fi
+          echo "::notice::launcher kernel boundary proven: $passed/$ZF13_EXPECTED_PROOFS privileged proofs executed"
   server-aarch64-check:
     name: Server aarch64 Check
     needs: preflight

--- a/server/crates/djinn-cgroup-launcher/src/transport.rs
+++ b/server/crates/djinn-cgroup-launcher/src/transport.rs
@@ -1,7 +1,7 @@
 //! Bounded Unix socket transport for authenticated broker controls.
 use crate::{
     CgroupFs, CloneIntoCgroup, CommandSpec, CpuStat, Error, Invocation,
-    broker::{Broker, ConnectionId, ControlNonce, NonceSource, SocketPeer},
+    broker::{Broker, ConnectionId, ControlNonce, NonceSource, SocketPeer, WORKER_GID, WORKER_UID},
     child::WorkerReadinessAssertion,
 };
 use std::{
@@ -58,6 +58,7 @@ impl<F: CgroupFs, S: CloneIntoCgroup, N: NonceSource> UnixBrokerServer<F, S, N> 
         }
         let listener = UnixListener::bind(&path)?;
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        restrict_socket_to_worker(&path)?;
         Ok(Self {
             broker,
             listener: Some(listener),
@@ -187,6 +188,32 @@ impl<F, S, N> Drop for UnixBrokerServer<F, S, N> {
             let _ = fs::remove_file(path);
         }
     }
+}
+
+/// Hand the 0600 control socket to the worker identity when the broker runs
+/// privileged.
+///
+/// `connect(2)` on a filesystem-backed Unix socket requires WRITE permission on
+/// the socket inode. In the rendered Pod the launcher is uid 0 and the worker is
+/// [`WORKER_UID`], so a root-owned 0600 socket is unreachable by the very peer
+/// the broker exists to serve — while a laxer mode would open it to the
+/// launcher-spawned child (uid 1001). Owner-only, worker-owned is the single
+/// mode that admits exactly the worker: the child is refused by the kernel at
+/// `connect`, before a byte of the protocol is read. Proven by
+/// `tests/kernel_boundary_under_rendered_context.rs`.
+///
+/// Unprivileged embeddings (tests, local runs) already own the socket they just
+/// created, so there is nothing to hand over and this is a no-op.
+fn restrict_socket_to_worker(path: &Path) -> Result<(), Error> {
+    if unsafe { libc::geteuid() } != 0 {
+        return Ok(());
+    }
+    let raw = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
+        .map_err(|_| Error::UnsafeSocketPath)?;
+    if unsafe { libc::chown(raw.as_ptr(), WORKER_UID, WORKER_GID) } != 0 {
+        return Err(Error::Io(std::io::Error::last_os_error()));
+    }
+    Ok(())
 }
 
 pub struct UnixBrokerClient {
@@ -962,6 +989,35 @@ mod tests {
             assert_eq!(counts.leaves.load(Ordering::SeqCst), 1);
             assert_eq!(counts.clones.load(Ordering::SeqCst), 1);
         }
+    }
+
+    /// Unprivileged embeddings already own their socket, so handing it to the
+    /// worker identity is a no-op that must never weaken the 0600 mode. The
+    /// privileged half (root hands a 0600 socket to uid 1000, which is what
+    /// admits the worker and refuses the uid-1001 child at `connect`) is proven
+    /// in `tests/kernel_boundary_under_rendered_context.rs`.
+    #[test]
+    fn worker_socket_ownership_is_a_no_op_when_unprivileged_and_never_relaxes_mode() {
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let dir = std::env::var_os("CARGO_TARGET_TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("djinn-launcher-socket-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("broker.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        restrict_socket_to_worker(&path).unwrap();
+        assert_eq!(
+            fs::symlink_metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "the control socket must stay owner-only"
+        );
+        drop(listener);
+        let _ = fs::remove_dir_all(&dir);
     }
 
     fn create_wire(program: &str, cwd: &str, environment: &[(&str, &str)]) -> Vec<u8> {

--- a/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
@@ -3,17 +3,21 @@
 //!
 //! Everything here is driven through fake cgroup-filesystem, clone, peer, and
 //! nonce seams so kernel behaviour is modelled deterministically. No test needs
-//! privileged Kubernetes or cgroup access. The one privilege-dependent
-//! assertion (distinct-UID setgid artifact editing) always runs its unprivileged
-//! mechanism proof and additionally runs the real distinct-UID edit — asserting,
-//! never silently passing — when the environment can switch identity.
+//! privileged Kubernetes or cgroup access.
 //!
-//! Rendered security-context and cluster-wide cap/warm-consumer assertions live
-//! in sibling epics 9y1a/23or, not here.
+//! The privilege-dependent half — a real UID-1001 child attacking a real,
+//! non-dumpable UID-1000 worker, and the distinct-UID setgid artifact edit that
+//! used to sit behind a `geteuid() == 0` check here and therefore never
+//! executed — now lives in `tests/kernel_boundary_under_rendered_context.rs`
+//! (task zf13, goxi AC2), which runs in the privileged
+//! `launcher-kernel-boundary` CI lane and FAILS rather than skips when that
+//! environment is unavailable. What remains below is the unprivileged mechanism
+//! proof, which runs everywhere.
+//!
+//! Cluster-wide cap/warm-consumer assertions live in sibling epics 9y1a/23or.
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
-use std::ffi::CString;
 use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -564,7 +568,9 @@ fn ac3_incompatible_readiness_profiles_and_missing_worker_readiness_fail_closed(
         owner_uid: 7,
         delegated_controllers: BTreeSet::from(["cpu".to_owned()]),
     };
-    let cases: Vec<(Readiness, fn(&Error) -> bool)> = vec![
+    /// One unsupported readiness profile and the error it must fail closed with.
+    type RejectedProfile = (Readiness, fn(&Error) -> bool);
+    let cases: Vec<RejectedProfile> = vec![
         (
             Readiness {
                 mode: CgroupMode::V1,
@@ -658,18 +664,17 @@ fn set_mode(path: &Path, mode: u32) {
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).expect("set mode");
 }
 
-/// Whether this process can switch to arbitrary worker/child identities. Only
-/// then is the real distinct-UID mutual edit exercised; the mechanism proof
-/// below always runs.
-fn can_switch_identity() -> bool {
-    unsafe { libc::geteuid() == 0 }
-}
-
 /// The child boundary sets GID = ARTIFACT_GID (1000) and umask 0002 so that a
 /// setgid artifact directory yields group-owned, group-writable files that the
 /// distinct worker (UID 1000) and child (UID 1001) — both in group 1000 — can
-/// mutually edit. This proves the mechanism unconditionally and, where the
-/// environment permits identity switching, the real cross-UID edit as well.
+/// mutually edit.
+///
+/// This proves the MECHANISM unconditionally, with the process's own gid, so it
+/// runs everywhere. The real cross-UID edit at the rendered identities is
+/// proven by
+/// `kernel_boundary_under_rendered_context::setgid_artifacts_stay_mutually_editable_across_the_distinct_worker_and_child_uids`,
+/// which executes in the privileged lane and fails loudly there rather than
+/// skipping — the gap that left this half of the AC unproven.
 #[test]
 fn ac3_setgid_gid1000_umask0002_enables_distinct_uid_mutual_edit() {
     // The identities that make mutual editing possible: two distinct UIDs that
@@ -716,89 +721,5 @@ fn ac3_setgid_gid1000_umask0002_enables_distinct_uid_mutual_edit() {
         );
     }
 
-    // Privileged proof: two real processes at the distinct worker/child UIDs,
-    // both in artifact group 1000, mutually edit each other's setgid artifacts.
-    if can_switch_identity() {
-        let dir = base.join("cross-uid");
-        std::fs::create_dir(&dir).expect("cross-uid dir");
-        set_mode(&dir, 0o2775);
-        chown(&dir, WORKER_UID, ARTIFACT_GID);
-
-        // Worker (uid 1000) creates an artifact; child (uid 1001) edits it.
-        let worker_artifact = dir.join("worker-owned.txt");
-        assert_eq!(create_as(&worker_artifact, WORKER_UID, ARTIFACT_GID), 0);
-        assert_eq!(append_as(&worker_artifact, CHILD_UID, ARTIFACT_GID), 0);
-
-        // And the reverse: child creates, worker edits.
-        let child_artifact = dir.join("child-owned.txt");
-        assert_eq!(create_as(&child_artifact, CHILD_UID, ARTIFACT_GID), 0);
-        assert_eq!(append_as(&child_artifact, WORKER_UID, ARTIFACT_GID), 0);
-    }
-
     let _ = std::fs::remove_dir_all(&base);
-}
-
-fn chown(path: &Path, uid: u32, gid: u32) {
-    let c = CString::new(path.as_os_str().to_str().expect("utf8 path")).expect("cstring");
-    let rc = unsafe { libc::chown(c.as_ptr(), uid, gid) };
-    assert_eq!(rc, 0, "chown must succeed when privileged");
-}
-
-/// Fork a child that becomes (uid, gid) under umask 0002 and O_CREAT-writes the
-/// file. Returns the child's exit code (0 on success). Only async-signal-safe
-/// libc calls run post-fork.
-fn create_as(path: &Path, uid: u32, gid: u32) -> i32 {
-    run_as(
-        path,
-        uid,
-        gid,
-        libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
-    )
-}
-
-/// Fork a child that becomes (uid, gid) and appends to an existing file,
-/// proving a distinct same-group UID can edit another identity's artifact.
-fn append_as(path: &Path, uid: u32, gid: u32) -> i32 {
-    run_as(path, uid, gid, libc::O_WRONLY | libc::O_APPEND)
-}
-
-fn run_as(path: &Path, uid: u32, gid: u32, open_flags: i32) -> i32 {
-    let c_path = CString::new(path.as_os_str().to_str().expect("utf8 path")).expect("cstring");
-    let payload = b"edit\n";
-    let pid = unsafe { libc::fork() };
-    assert!(pid >= 0, "fork must succeed");
-    if pid == 0 {
-        // Child: only async-signal-safe syscalls from here on.
-        unsafe {
-            libc::umask(0o002);
-            let group = [gid];
-            if libc::setgroups(1, group.as_ptr()) != 0 {
-                libc::_exit(101);
-            }
-            if libc::setresgid(gid, gid, gid) != 0 {
-                libc::_exit(102);
-            }
-            if libc::setresuid(uid, uid, uid) != 0 {
-                libc::_exit(103);
-            }
-            let fd = libc::open(c_path.as_ptr(), open_flags, 0o666);
-            if fd < 0 {
-                libc::_exit(104);
-            }
-            let written = libc::write(fd, payload.as_ptr().cast(), payload.len());
-            libc::close(fd);
-            if written != payload.len() as isize {
-                libc::_exit(105);
-            }
-            libc::_exit(0);
-        }
-    }
-    let mut status = 0;
-    let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
-    assert_eq!(waited, pid, "waitpid must reap the child");
-    if libc::WIFEXITED(status) {
-        libc::WEXITSTATUS(status)
-    } else {
-        -1
-    }
 }

--- a/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
+++ b/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
@@ -1,0 +1,54 @@
+# Rendered enforcement Pod security context (djinn board task zf13, goxi AC2).
+#
+# This file is the CONTRACT between the manifest renderer and the adversarial
+# kernel-boundary proof:
+#
+#   * `djinn-k8s` owns the render. Its test
+#     `rendered_security_context_matches_the_adversarial_proof_fixture`
+#     rebuilds the real `worker_security_context` / `launcher_security_context`
+#     / `pod_security_context` / `validate_enforcement_render` values and
+#     asserts they equal every line below, so this fixture can never drift
+#     from what is actually rendered onto a task-run Pod.
+#
+#   * `djinn-cgroup-launcher`'s privileged suite
+#     (`tests/kernel_boundary_under_rendered_context.rs`) READS this file and
+#     drives its real UID-1001 attacker against a real UID-1000 worker under
+#     exactly these identities. It cannot depend on `djinn-k8s` (that would be
+#     a dependency cycle), so the fixture carries the rendered context across.
+#
+# Any change to the rendered security context MUST be made here too, or the
+# djinn-k8s test fails. Format is `key=value`; `#` lines and blanks ignored.
+
+# Worker container: the trusted, non-dumpable identity the child attacks.
+worker_run_as_user=1000
+worker_run_as_group=1000
+worker_run_as_non_root=true
+worker_allow_privilege_escalation=false
+worker_capabilities_drop=ALL
+
+# Launcher sidecar: privileged broker, minimal capabilities, read-only rootfs.
+launcher_run_as_user=0
+launcher_run_as_group=0
+launcher_allow_privilege_escalation=false
+launcher_read_only_root_filesystem=true
+launcher_capabilities_drop=ALL
+launcher_capabilities_add=SETUID,SETGID,SETPCAP
+
+# Launcher-spawned child: applied at runtime by `child::prepare_child`, not by
+# the Pod manifest (there is no manifest field for a process the kubelet never
+# sees). The render ties `fsGroup` to the same artifact GID.
+child_run_as_user=1001
+child_run_as_group=1000
+child_umask=0002
+
+# Pod-level: artifact group ownership for the shared workspace/cache volumes.
+pod_fs_group=1000
+pod_fs_group_change_policy=OnRootMismatch
+
+# Shared container hardening + the delegation contract the launcher revalidates
+# at runtime (`Readiness::validate`) before it serves a single control.
+seccomp_profile=RuntimeDefault
+launcher_expected_uid=0
+unleased_millicores=250
+cgroup_delegation_profile=cgroup-v2-cpu-only
+volume_ownership_mode=fsgroup-on-root-mismatch

--- a/server/crates/djinn-cgroup-launcher/tests/kernel_boundary_under_rendered_context.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/kernel_boundary_under_rendered_context.rs
@@ -1,0 +1,483 @@
+//! Adversarial proof of the launcher kernel boundary under the rendered Pod
+//! security context (djinn board task zf13, proposal goxi AC2).
+//!
+//! 7os5 proved the BROKER-facing half of the boundary with fake kernel seams:
+//! wrong peer PID/UID, child and sibling connections, forged own-or-sibling
+//! controls, nonce replay and control-descriptor closure. This file proves the
+//! KERNEL-facing half that no fake seam can establish — a real UID-1001 child,
+//! born by `clone3(CLONE_INTO_CGROUP)` into a real invocation cgroup and taken
+//! through the production `close_range` + `child::prepare_child` boundary,
+//! attacking a real, live, non-dumpable UID-1000 worker and being denied on
+//! every path, with the worker healthy, both invocation quotas untouched and no
+//! unauthorized cgroup created. Positive controls in the same suite prove the
+//! legitimate worker connection still creates its assigned invocation and that
+//! only a matching durable fencing token lifts quota, so the suite cannot pass
+//! by denying everything.
+//!
+//! ## Where these proofs run
+//!
+//! They need uid 0, real UID separation, a shared PID namespace, cgroup-v2
+//! delegation and an installable seccomp filter, so they are `#[ignore]`d for
+//! ordinary unprivileged runs and executed by the dedicated privileged CI lane
+//! (`launcher-kernel-boundary` in `.github/workflows/quality-gate.yml`).
+//!
+//! ## Why they cannot silently skip
+//!
+//! Two mechanisms, both always-on:
+//!
+//! 1. Inside each proof, `require_privileged_environment` PANICS with the
+//!    concrete missing capability. There is no environment probe that returns
+//!    "not applicable" — a degraded host fails the test.
+//! 2. [`the_privileged_lane_is_wired_and_this_proof_cannot_silently_skip`] is
+//!    NOT ignored, so it runs in every ordinary shard. It asserts the lane
+//!    exists, runs this exact binary with `--ignored`, is not
+//!    `continue-on-error`, and declares an expected proof count equal to the
+//!    number of `#[ignore]`d proofs in this file — so adding a proof without
+//!    wiring it, or a lane that executes zero tests, is a red build.
+
+mod rendered_boundary;
+
+use std::path::Path;
+
+use djinn_cgroup_launcher::broker::{WORKER_GID, WORKER_UID};
+use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
+use djinn_cgroup_launcher::{
+    ChildProcess, CloneIntoCgroup, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
+    NativeCgroupFs, UnleasedQuota,
+};
+
+use rendered_boundary::{
+    Attempt, LIFTED_CPU_MAX, RenderedContext, UNLEASED_CPU_MAX, Worker, chown, fixture_path, pipe,
+    read_report, repo_root, require_privileged_environment, run_as, serve_broker, set_mode,
+    unique_slot,
+};
+
+/// The workflow job that must execute the `#[ignore]`d proofs below.
+const PRIVILEGED_LANE_JOB: &str = "launcher-kernel-boundary";
+/// Marker the lane uses to declare how many proofs it expects to execute.
+const EXPECTED_PROOFS_KEY: &str = "ZF13_EXPECTED_PROOFS";
+
+// ═══════════════════ always-on: the lane cannot silently skip ════════════════
+
+#[test]
+fn the_privileged_lane_is_wired_and_this_proof_cannot_silently_skip() {
+    let source = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/kernel_boundary_under_rendered_context.rs"),
+    )
+    .expect("read this test file to count its privileged proofs");
+    // Only attributes at the start of a line; prose mentions are backticked.
+    let declared = source.matches("\n#[ignore").count();
+    assert!(
+        declared > 0,
+        "this file must declare privileged proofs; an empty suite proves nothing"
+    );
+
+    let lane = privileged_lane_block();
+    assert!(
+        lane.contains("--test kernel_boundary_under_rendered_context"),
+        "the privileged lane must run THIS test binary"
+    );
+    assert!(
+        lane.contains("--ignored --test-threads 1"),
+        "the privileged lane must run the `#[ignore]`d proofs serially, not skip past them"
+    );
+    assert!(
+        !lane.contains("continue-on-error"),
+        "the privileged lane may not swallow its own failure; a security proof least of all"
+    );
+    assert!(
+        lane.contains(&format!("{EXPECTED_PROOFS_KEY}: \"{declared}\"")),
+        "the lane must declare `{EXPECTED_PROOFS_KEY}: \"{declared}\"` so a run that \
+         executes fewer than the {declared} declared proofs fails instead of passing"
+    );
+
+    // The fixture the proofs drive their identities from must agree with the
+    // constants this crate enforces at runtime.
+    let context = RenderedContext::load();
+    assert_eq!(context.u32("worker_run_as_user"), WORKER_UID);
+    assert_eq!(context.u32("worker_run_as_group"), WORKER_GID);
+    assert_eq!(context.u32("child_run_as_user"), CHILD_UID);
+    assert_eq!(context.u32("child_run_as_group"), ARTIFACT_GID);
+    assert_eq!(context.u32("pod_fs_group"), ARTIFACT_GID);
+    assert_eq!(context.get("child_umask"), "0002");
+    assert_eq!(
+        context.get("unleased_millicores"),
+        &UnleasedQuota::DEFAULT_MILLICORES.to_string()
+    );
+    assert_ne!(
+        context.u32("worker_run_as_user"),
+        context.u32("child_run_as_user"),
+        "the worker and its launched child must never share a uid"
+    );
+    assert!(
+        fixture_path().is_file(),
+        "the rendered security-context fixture must ship with the suite"
+    );
+}
+
+// ══════════════════════ privileged proof 1: the attacks ══════════════════════
+
+/// A real UID-1001 launched child attacks a real UID-1000 worker and is denied
+/// on every path goxi AC2 names, while the worker stays healthy, both
+/// invocation quotas are unchanged and no unauthorized cgroup is created.
+/// Positive controls run on the same live topology.
+#[ignore = "privileged: needs uid 0, real UID separation, cgroup-v2 delegation and seccomp \
+            (CI job launcher-kernel-boundary)"]
+#[test]
+fn a_uid1001_launched_child_is_denied_on_every_kernel_boundary_path() {
+    let context = RenderedContext::load();
+    let environment = require_privileged_environment(&context);
+
+    // 1. A live, non-dumpable UID-1000 worker, forked while single-threaded.
+    let mut worker = Worker::fork(&environment, &context);
+    let (report_read, report_write) = pipe();
+
+    // 2. The privileged broker over the real Unix transport, and the worker's
+    //    authenticated connection through it (SO_PEERCRED, private credential).
+    let _server = serve_broker(&environment, &context, worker.pid, report_write);
+    worker.send("connect");
+    assert_eq!(
+        worker.expect_line(),
+        "connected",
+        "POSITIVE CONTROL: the legitimate UID-1000 worker must authenticate"
+    );
+
+    // 3. POSITIVE CONTROL: the worker creates its assigned invocations. The
+    //    attack invocation's child is the adversary; the others really exec.
+    assert_eq!(worker.expect_line(), "created");
+    let mut leaves = environment.cgroup_children();
+    leaves.sort();
+    assert_eq!(
+        leaves,
+        ["attack", "execed", "legit"],
+        "exactly the three authorized invocation cgroups exist"
+    );
+    for leaf in ["legit", "attack"] {
+        assert_eq!(
+            environment.quota(leaf),
+            UNLEASED_CPU_MAX,
+            "{leaf} must start at the unleased broker quota"
+        );
+    }
+
+    // 4. The exec'd UID-1001 adversary's own findings, proving the credential
+    //    drop and seccomp filter survive `execve`.
+    let execed: Vec<String> = worker.collect_until("execed-done");
+    let execed: Vec<&str> = execed
+        .iter()
+        .filter_map(|line| line.strip_prefix("execed "))
+        .collect();
+    assert!(
+        !execed.is_empty(),
+        "the exec'd adversary produced no output; the boundary was not exercised"
+    );
+    for probe in ["environ", "maps", "fd", "root", "cwd", "signal", "socket"] {
+        assert!(
+            execed.contains(&format!("{probe}=denied").as_str()),
+            "post-exec adversary reached {probe} on the worker: {execed:?}"
+        );
+    }
+    assert!(
+        execed.contains(&format!("uid={CHILD_UID}").as_str()),
+        "the exec'd child must run as the rendered child uid: {execed:?}"
+    );
+    assert!(
+        execed.contains(&format!("gid={ARTIFACT_GID}").as_str()),
+        "the exec'd child must run in the artifact group: {execed:?}"
+    );
+
+    // 5. The in-cgroup adversary's syscall-level report.
+    let attempts = read_report(report_read);
+    assert_eq!(
+        value(&attempts, "identity_uid").rc,
+        i64::from(CHILD_UID),
+        "the launched child must be the rendered child uid"
+    );
+    assert_eq!(value(&attempts, "identity_gid").rc, i64::from(ARTIFACT_GID));
+    assert_eq!(
+        value(&attempts, "identity_groups").rc,
+        0,
+        "the child must hold no supplementary groups"
+    );
+    assert_eq!(
+        value(&attempts, "identity_umask").rc,
+        0o2,
+        "the child must run under the rendered umask 0002"
+    );
+
+    // Every attack path goxi AC2 names, with the errno that denied it.
+    for (probe, allowed) in [
+        // /proc/<worker-pid>/{root,fd,mem} and the rest of the procfs surface.
+        ("proc_mem", &[libc::EACCES, libc::EPERM][..]),
+        ("proc_environ", &[libc::EACCES, libc::EPERM]),
+        ("proc_maps", &[libc::EACCES, libc::EPERM]),
+        ("proc_root", &[libc::EACCES, libc::EPERM]),
+        ("proc_fd", &[libc::EACCES, libc::EPERM]),
+        ("proc_fd_link", &[libc::EACCES, libc::EPERM, libc::ENOENT]),
+        // ptrace attach/seize.
+        ("ptrace_attach", &[libc::EPERM]),
+        ("ptrace_seize", &[libc::EPERM]),
+        // Cross-process memory read and write.
+        ("process_vm_readv", &[libc::EPERM]),
+        ("process_vm_writev", &[libc::EPERM]),
+        // Signals, stop and injection.
+        ("signal_stop", &[libc::EPERM]),
+        ("signal_kill", &[libc::EPERM]),
+        ("signal_usr1", &[libc::EPERM]),
+        // Control-descriptor enumeration and reuse.
+        ("control_fd_reuse", &[libc::EBADF]),
+        ("pidfd_getfd", &[libc::EPERM, libc::EACCES, libc::ESRCH]),
+        // Broker credential recovery and a broker connection as uid 1001.
+        ("broker_credential_read", &[libc::EACCES, libc::EPERM]),
+        ("broker_socket_connect", &[libc::EACCES, libc::EPERM]),
+        // Unauthorized cgroup creation and quota tampering.
+        ("cgroup_create", &[libc::EACCES, libc::EPERM]),
+        ("cgroup_quota_write", &[libc::EACCES, libc::EPERM]),
+        // Re-privileging.
+        ("regain_uid", &[libc::EPERM]),
+        ("regain_caps", &[libc::EPERM]),
+        ("unshare_userns", &[libc::EPERM]),
+        ("mount_any", &[libc::EPERM]),
+    ] {
+        let attempt = value(&attempts, probe);
+        assert!(
+            attempt.rc < 0,
+            "{probe} SUCCEEDED from the UID-1001 child (rc {}); the kernel boundary is open",
+            attempt.rc
+        );
+        assert!(
+            allowed.contains(&attempt.errno),
+            "{probe} was denied with errno {} but the boundary must deny it with one of \
+             {allowed:?}",
+            attempt.errno
+        );
+    }
+
+    // 6. Invariants: worker healthy, quotas untouched, no new cgroup.
+    assert!(
+        worker.is_alive(),
+        "the worker must survive every attack; it was killed or stopped"
+    );
+    for leaf in ["legit", "attack"] {
+        assert_eq!(
+            environment.quota(leaf),
+            UNLEASED_CPU_MAX,
+            "{leaf}'s invocation quota changed under attack"
+        );
+    }
+    let mut after = environment.cgroup_children();
+    after.sort();
+    assert_eq!(
+        after,
+        ["attack", "execed", "legit"],
+        "an unauthorized cgroup was created under the delegated root"
+    );
+
+    // 7. POSITIVE CONTROL: only a matching durable fencing token lifts quota.
+    worker.send("controls");
+    assert_eq!(
+        worker.expect_line(),
+        "mismatched-fence-rejected true",
+        "a mismatched fencing token must not lift the quota"
+    );
+    assert_eq!(
+        environment.quota("legit"),
+        UNLEASED_CPU_MAX,
+        "a rejected fence must leave the unleased quota in place"
+    );
+    worker.send("lift");
+    assert_eq!(
+        worker.expect_line(),
+        "matching-fence-lifted true",
+        "the matching durable fencing token must lift the quota"
+    );
+    assert_eq!(worker.expect_line(), "controls-done");
+    assert_eq!(
+        environment.quota("legit"),
+        LIFTED_CPU_MAX,
+        "the matching fence must actually write the lifted cpu.max"
+    );
+    assert!(
+        worker.is_alive(),
+        "the worker must still be live after the positive controls"
+    );
+
+    // The still-unleased sibling proves the lift was invocation-scoped.
+    assert_eq!(environment.quota("attack"), UNLEASED_CPU_MAX);
+}
+
+// ════════════════ privileged proof 2: artifact ownership (7os5) ══════════════
+
+/// The setgid GID-1000 + umask-0002 fixture 7os5 could only describe. It now
+/// EXECUTES: two real processes at the distinct rendered worker/child UIDs,
+/// both in the artifact group, mutually edit each other's setgid artifacts.
+#[ignore = "privileged: needs uid 0 to become both uid 1000 and uid 1001 \
+            (CI job launcher-kernel-boundary)"]
+#[test]
+fn setgid_artifacts_stay_mutually_editable_across_the_distinct_worker_and_child_uids() {
+    use std::os::unix::fs::MetadataExt;
+
+    let context = RenderedContext::load();
+    // Deliberately reuses the same fail-loud precondition gate: this proof was
+    // unproven precisely because it was allowed to skip.
+    let _environment = require_privileged_environment(&context);
+
+    let worker_uid = context.u32("worker_run_as_user");
+    let child_uid = context.u32("child_run_as_user");
+    let artifact_gid = context.u32("child_run_as_group");
+    assert_ne!(worker_uid, child_uid, "distinct identities are the point");
+    assert_eq!(artifact_gid, context.u32("pod_fs_group"));
+
+    let base = std::path::PathBuf::from(format!("/tmp/djinn-zf13-artifacts-{}", unique_slot()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir(&base).expect("create artifact base");
+    set_mode(&base, 0o2775); // rwxrwsr-x: setgid, group-writable.
+    chown(&base, worker_uid, artifact_gid);
+
+    let create = libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC;
+    let append = libc::O_WRONLY | libc::O_APPEND;
+
+    // Worker creates, child edits.
+    let worker_owned = base.join("worker-owned.txt");
+    assert_eq!(run_as(&worker_owned, worker_uid, artifact_gid, create), 0);
+    assert_eq!(
+        run_as(&worker_owned, child_uid, artifact_gid, append),
+        0,
+        "the UID-1001 child must be able to edit the worker's artifact"
+    );
+
+    // Child creates, worker edits.
+    let child_owned = base.join("child-owned.txt");
+    assert_eq!(run_as(&child_owned, child_uid, artifact_gid, create), 0);
+    assert_eq!(
+        run_as(&child_owned, worker_uid, artifact_gid, append),
+        0,
+        "the UID-1000 worker must be able to edit the child's artifact"
+    );
+
+    for (path, owner) in [(&worker_owned, worker_uid), (&child_owned, child_uid)] {
+        let metadata = std::fs::metadata(path).expect("artifact metadata");
+        assert_eq!(
+            metadata.uid(),
+            owner,
+            "each artifact keeps its creator's uid"
+        );
+        assert_eq!(
+            metadata.gid(),
+            artifact_gid,
+            "the setgid directory must propagate the artifact group"
+        );
+        assert_ne!(
+            metadata.mode() & 0o020,
+            0,
+            "umask 0002 must leave artifacts group-writable"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+// ═════════ privileged proof 3: incompatible ownership rejects the spawn ══════
+
+/// An incompatible volume/cgroup-ownership mode is refused at readiness, before
+/// any leaf is created and before any child can exec.
+#[ignore = "privileged: needs uid 0 to own and re-own a delegated cgroup root \
+            (CI job launcher-kernel-boundary)"]
+#[test]
+fn an_incompatible_volume_ownership_mode_rejects_the_spawn_before_exec() {
+    let context = RenderedContext::load();
+    let environment = require_privileged_environment(&context);
+
+    /// A clone seam that must never be reached.
+    struct NeverClone;
+    impl CloneIntoCgroup for NeverClone {
+        fn clone_into_cgroup(
+            &mut self,
+            _: std::os::fd::RawFd,
+            _: &Invocation,
+            _: &CommandSpec,
+        ) -> Result<ChildProcess, Error> {
+            panic!("an incompatible ownership mode must never reach the clone seam");
+        }
+    }
+
+    let expected_uid = context.u32("launcher_expected_uid");
+    let foreign_uid = context.u32("worker_run_as_user");
+
+    // 1. Opening the delegated root under an incompatible ownership expectation
+    //    is refused outright — the launcher never even gets a filesystem seam.
+    let error = NativeCgroupFs::open(&environment.root, foreign_uid)
+        .err()
+        .expect("a delegated root owned by another uid must be rejected");
+    assert!(
+        matches!(error, Error::IncompatibleOwnership { .. }),
+        "expected an ownership rejection, got {error:?}"
+    );
+
+    // 2. Even holding an opened root, a launcher configured for a different
+    //    owner fails at construction, so the clone seam is never reached.
+    let fs = NativeCgroupFs::open(&environment.root, expected_uid)
+        .expect("the correctly owned delegated root must be accepted");
+    let error = Launcher::new(
+        fs,
+        NeverClone,
+        LauncherConfig::new(None, foreign_uid).expect("launcher config"),
+    )
+    .err()
+    .expect("an incompatible ownership mode must reject the launcher");
+    assert!(
+        matches!(
+            error,
+            Error::IncompatibleOwnership {
+                expected,
+                actual
+            } if expected == foreign_uid && actual == expected_uid
+        ),
+        "expected an ownership rejection naming both uids, got {error:?}"
+    );
+    assert!(
+        environment.cgroup_children().is_empty(),
+        "no invocation cgroup may be created once ownership is incompatible"
+    );
+
+    // 3. Re-owning the root away from the launcher reproduces the same refusal
+    //    on the shipped path, confirming the check is the ownership check.
+    chown(&environment.root, foreign_uid, 0);
+    assert!(matches!(
+        NativeCgroupFs::open(&environment.root, expected_uid),
+        Err(Error::IncompatibleOwnership { .. })
+    ));
+    chown(&environment.root, expected_uid, 0);
+}
+
+/// The privileged lane's own YAML block, isolated from sibling jobs so this
+/// guard asserts the lane's wiring and never trips over unrelated CI edits.
+fn privileged_lane_block() -> String {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/quality-gate.yml"))
+        .expect("read the CI workflow that must host the privileged lane");
+    let header = format!("\n  {PRIVILEGED_LANE_JOB}:\n");
+    let start = workflow.find(&header).unwrap_or_else(|| {
+        panic!(
+            "no `{PRIVILEGED_LANE_JOB}` job: goxi AC2 would have no executing proof, and an \
+             unproven kernel boundary looks identical to a passing one"
+        )
+    }) + 1;
+    // Everything up to the next sibling job key (exactly two-space indent).
+    let mut block = String::new();
+    for (index, line) in workflow[start..].lines().enumerate() {
+        let sibling_job =
+            line.starts_with("  ") && !line.starts_with("   ") && line.trim_end().ends_with(':');
+        if index > 0 && sibling_job {
+            break;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+    block
+}
+
+fn value(attempts: &std::collections::BTreeMap<String, Attempt>, key: &str) -> Attempt {
+    *attempts
+        .get(key)
+        .unwrap_or_else(|| panic!("the adversary did not report `{key}`: {attempts:?}"))
+}

--- a/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
@@ -1,0 +1,1074 @@
+//! Privileged harness for the adversarial kernel-boundary proof (task zf13,
+//! goxi AC2). `tests/kernel_boundary_under_rendered_context.rs` holds the
+//! assertions; this module only builds the production-shaped topology:
+//!
+//! ```text
+//!   test process (uid 0)  = the launcher sidecar: NativeCgroupFs + Broker +
+//!                           UnixBrokerServer over a real Unix socket
+//!   forked worker (1000)  = the trusted, non-dumpable worker: real
+//!                           SO_PEERCRED authentication, real controls
+//!   launched child (1001) = born by clone3(CLONE_INTO_CGROUP) into the
+//!                           invocation cgroup, then through the production
+//!                           close_range + `child::prepare_child` boundary
+//! ```
+//!
+//! Nothing here silently degrades: every precondition is a panic naming the
+//! missing capability, so an environment that cannot host the proof can never
+//! be mistaken for a boundary that held.
+
+use std::collections::BTreeMap;
+use std::ffi::CString;
+use std::io::{BufRead, BufReader, Write};
+use std::os::fd::{FromRawFd, RawFd};
+use std::path::{Path, PathBuf};
+
+use djinn_cgroup_launcher::broker::{Broker, BrokerConfig, ChildStatus, OsNonceSource};
+use djinn_cgroup_launcher::child::{
+    ChildMounts, NativeChildSyscalls, NativeWorkerDumpability, prepare_child,
+    prepare_worker_readiness,
+};
+use djinn_cgroup_launcher::transport::{UnixBrokerClient, UnixBrokerServer};
+use djinn_cgroup_launcher::{
+    ChildProcess, CloneIntoCgroup, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
+    NativeCgroupFs, NativeClone3,
+};
+
+/// Invocation whose child is the in-cgroup adversary rather than an exec.
+pub const ATTACK_INVOCATION: &str = "zf13-attack";
+/// Invocation the legitimate worker owns; the positive-control target.
+pub const LEGIT_INVOCATION: &str = "zf13-legit";
+/// Invocation that really `execve`s an attacking `/bin/sh`.
+pub const EXECED_INVOCATION: &str = "zf13-execed";
+/// Durable fencing token the worker holds for [`LEGIT_INVOCATION`].
+pub const LEGIT_FENCE: u64 = 0x5a5a_f13d;
+/// `cpu.max` an unleased invocation must carry (250m of a 100ms period).
+pub const UNLEASED_CPU_MAX: &str = "25000 100000";
+/// `cpu.max` after a matching fencing token lifts the quota.
+pub const LIFTED_CPU_MAX: &str = "max 100000";
+
+// ───────────────────────────── rendered context ─────────────────────────────
+
+/// The rendered enforcement-Pod security context, loaded from the fixture that
+/// `djinn-k8s` asserts against its real manifest builders.
+pub struct RenderedContext {
+    values: BTreeMap<String, String>,
+}
+
+impl RenderedContext {
+    pub fn load() -> Self {
+        let path = fixture_path();
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("rendered security-context fixture {path:?}: {e}"));
+        let mut values = BTreeMap::new();
+        for line in raw.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let (key, value) = line
+                .split_once('=')
+                .unwrap_or_else(|| panic!("malformed fixture line: {line}"));
+            values.insert(key.trim().to_owned(), value.trim().to_owned());
+        }
+        Self { values }
+    }
+
+    pub fn get(&self, key: &str) -> &str {
+        self.values
+            .get(key)
+            .unwrap_or_else(|| panic!("rendered security context is missing `{key}`"))
+    }
+
+    pub fn u32(&self, key: &str) -> u32 {
+        self.get(key)
+            .parse()
+            .unwrap_or_else(|e| panic!("rendered `{key}` is not a number: {e}"))
+    }
+}
+
+pub fn fixture_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rendered-security-context.env")
+}
+
+pub fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .canonicalize()
+        .expect("canonicalize repository root")
+}
+
+// ─────────────────────────── privileged preconditions ───────────────────────
+
+/// Refuse to run — loudly — unless this process can actually host the proof.
+///
+/// Every branch panics with the concrete missing capability. There is no early
+/// `return` and no boolean a caller could mistake for success: an unavailable
+/// environment fails the test rather than skipping it.
+pub fn require_privileged_environment(context: &RenderedContext) -> Environment {
+    let euid = unsafe { libc::geteuid() };
+    assert_eq!(
+        euid,
+        context.u32("launcher_expected_uid"),
+        "the adversarial kernel-boundary proof must run as the rendered launcher uid \
+         (uid {euid} cannot create real UID-1000/1001 processes). It runs in the \
+         `launcher-kernel-boundary` CI lane; reproduce it locally with: \
+         `cargo test -p djinn-cgroup-launcher --test kernel_boundary_under_rendered_context \
+         --no-run` then `docker run --rm --privileged --cgroupns=private -v \"$PWD:$PWD\" \
+         ubuntu:24.04 bash -c 'mkdir -p /workspace && exec \"$0\" --ignored --test-threads 1' \
+         <the built test binary>`"
+    );
+
+    let mountinfo = std::fs::read_to_string("/proc/self/mountinfo")
+        .expect("read /proc/self/mountinfo for the cgroup delegation mode");
+    let mounted = |name: &str| {
+        let prefix = format!("{name} ");
+        mountinfo.lines().any(|line| {
+            line.split(" - ")
+                .nth(1)
+                .is_some_and(|tail| tail.starts_with(&prefix))
+        })
+    };
+    assert!(
+        mounted("cgroup2"),
+        "no cgroup2 mount: the rendered delegation profile is {} and the launcher's \
+         readiness contract rejects anything else",
+        context.get("cgroup_delegation_profile")
+    );
+    assert!(
+        !mounted("cgroup"),
+        "a cgroup v1 mount is present, so this host is hybrid and the launcher rejects \
+         it at readiness. The boundary cannot be proven here"
+    );
+    assert!(
+        Path::new("/proc/sys/kernel/seccomp/actions_avail").exists(),
+        "seccomp filtering is unavailable, so the child syscall boundary cannot install"
+    );
+    assert!(
+        Path::new("/workspace").is_dir(),
+        "/workspace is missing: the rendered CommandSpec cwd must exist before a child \
+         can exec (the privileged lane creates it)"
+    );
+
+    let slot = unique_slot();
+    let root = enable_cpu_delegation(&slot);
+    let ipc = PathBuf::from(format!("/tmp/djinn-zf13-{slot}"));
+    let _ = std::fs::remove_dir_all(&ipc);
+    std::fs::create_dir(&ipc).expect("create launcher IPC directory");
+    set_mode(&ipc, 0o755);
+
+    // The worker owns its private credential exactly as the real handshake
+    // publishes it: 0600, worker-owned, so uid 1001 can never read it.
+    let credential = random_bytes(32);
+    let credential_path = ipc.join("credential");
+    std::fs::write(&credential_path, &credential).expect("publish worker credential");
+    set_mode(&credential_path, 0o600);
+    chown(
+        &credential_path,
+        context.u32("worker_run_as_user"),
+        context.u32("worker_run_as_group"),
+    );
+
+    Environment {
+        root,
+        socket: ipc.join("broker.sock"),
+        credential_path,
+        credential,
+        ipc,
+    }
+}
+
+/// Create a delegated cgroup-v2 root owned by uid 0 with exactly the `cpu`
+/// controller enabled — the only profile the launcher's readiness accepts.
+fn enable_cpu_delegation(slot: &str) -> PathBuf {
+    let base = PathBuf::from("/sys/fs/cgroup");
+    let root = base.join(format!("djinn-zf13-{slot}"));
+    let _ = std::fs::remove_dir(&root);
+    std::fs::create_dir(&root).unwrap_or_else(|e| panic!("create delegated cgroup {root:?}: {e}"));
+    if let Err(first) = delegate_cpu(&base, &root) {
+        // cgroup v2 exempts only the TRUE root from the "no internal processes"
+        // rule. On a systemd host `/sys/fs/cgroup` is that root and the first
+        // attempt succeeds; inside a container it is a namespaced view of an
+        // ordinary cgroup that still holds the container's own processes, so
+        // delegation is refused. Roll the parent back first — a cgroup whose
+        // subtree_control is already populated will not let its members move —
+        // then empty it and retry.
+        let _ = std::fs::write(base.join("cgroup.subtree_control"), "-cpu");
+        vacate_cgroup_root(&base);
+        delegate_cpu(&base, &root).unwrap_or_else(|second| {
+            panic!(
+                "cannot delegate the cpu controller to {root:?} ({first}; after vacating the \
+                 cgroup root: {second}); the launcher boundary cannot be proven on this host"
+            )
+        });
+    }
+    root
+}
+
+fn delegate_cpu(base: &Path, root: &Path) -> std::io::Result<()> {
+    let available = std::fs::read_to_string(root.join("cgroup.controllers")).unwrap_or_default();
+    if !available.split_ascii_whitespace().any(|c| c == "cpu") {
+        std::fs::write(base.join("cgroup.subtree_control"), "+cpu")?;
+    }
+    std::fs::write(root.join("cgroup.subtree_control"), "+cpu")
+}
+
+/// Move every process sitting directly in the cgroup root into a holding leaf.
+/// A no-op on a systemd host (the root is already empty).
+fn vacate_cgroup_root(base: &Path) {
+    let holding = base.join("djinn-zf13-holding");
+    let _ = std::fs::create_dir(&holding);
+    let procs = std::fs::read_to_string(base.join("cgroup.procs")).unwrap_or_default();
+    for pid in procs.split_ascii_whitespace() {
+        let _ = std::fs::write(holding.join("cgroup.procs"), pid);
+    }
+}
+
+/// Live, root-owned topology plus best-effort teardown.
+pub struct Environment {
+    pub root: PathBuf,
+    pub ipc: PathBuf,
+    pub socket: PathBuf,
+    pub credential_path: PathBuf,
+    pub credential: Vec<u8>,
+}
+
+impl Environment {
+    /// Direct children of the delegated cgroup root — the authority on whether
+    /// an unauthorized cgroup appeared.
+    pub fn cgroup_children(&self) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(&self.root)
+            .expect("read delegated cgroup root")
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                entry
+                    .file_type()
+                    .ok()?
+                    .is_dir()
+                    .then(|| entry.file_name().to_string_lossy().into_owned())
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// The applied `cpu.max` of one invocation leaf.
+    pub fn quota(&self, leaf: &str) -> String {
+        std::fs::read_to_string(self.root.join(leaf).join("cpu.max"))
+            .unwrap_or_else(|e| panic!("read cpu.max of leaf {leaf}: {e}"))
+            .trim()
+            .to_owned()
+    }
+}
+
+impl Drop for Environment {
+    fn drop(&mut self) {
+        while unsafe { libc::waitpid(-1, std::ptr::null_mut(), libc::WNOHANG) } > 0 {}
+        if self.root.is_dir() {
+            for leaf in self.cgroup_children() {
+                let path = self.root.join(&leaf);
+                let _ = std::fs::write(path.join("cgroup.kill"), "1");
+                for _ in 0..100 {
+                    if std::fs::remove_dir(&path).is_ok() {
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+            }
+        }
+        let _ = std::fs::remove_dir(&self.root);
+        let _ = std::fs::remove_dir_all(&self.ipc);
+    }
+}
+
+// ─────────────────────────────── the worker ─────────────────────────────────
+
+/// A live UID-1000 worker process holding an authenticated broker connection.
+pub struct Worker {
+    pub pid: i32,
+    to_worker: std::fs::File,
+    from_worker: BufReader<std::fs::File>,
+}
+
+impl Worker {
+    /// Fork the worker BEFORE any broker thread exists, so the fork happens in
+    /// a single-threaded process.
+    pub fn fork(environment: &Environment, context: &RenderedContext) -> Self {
+        let (up_read, up_write) = pipe();
+        let (down_read, down_write) = pipe();
+        let uid = context.u32("worker_run_as_user");
+        let gid = context.u32("worker_run_as_group");
+        let socket = environment.socket.clone();
+        let credential = environment.credential.clone();
+
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork the worker: {}", last_error());
+        if pid == 0 {
+            unsafe {
+                libc::close(up_read);
+                libc::close(down_write);
+            }
+            worker_main(uid, gid, &socket, &credential, down_read, up_write);
+        }
+        unsafe {
+            libc::close(up_write);
+            libc::close(down_read);
+        }
+        let mut worker = Self {
+            pid,
+            to_worker: unsafe { std::fs::File::from_raw_fd(down_write) },
+            from_worker: BufReader::new(unsafe { std::fs::File::from_raw_fd(up_read) }),
+        };
+        assert_eq!(
+            worker.expect_line(),
+            "dropped",
+            "the worker must reach the rendered worker identity and be non-dumpable"
+        );
+        worker
+    }
+
+    pub fn send(&mut self, line: &str) {
+        writeln!(self.to_worker, "{line}").expect("signal the worker");
+        self.to_worker.flush().expect("flush worker signal");
+    }
+
+    pub fn expect_line(&mut self) -> String {
+        let mut line = String::new();
+        let read = self
+            .from_worker
+            .read_line(&mut line)
+            .expect("read the worker report");
+        assert!(read > 0, "the worker died before reporting");
+        let line = line.trim_end().to_owned();
+        assert!(
+            !line.starts_with("fail:"),
+            "the legitimate worker could not complete a step it must be able to: {line}"
+        );
+        line
+    }
+
+    /// Collect worker lines until `terminator`, returning the ones before it.
+    pub fn collect_until(&mut self, terminator: &str) -> Vec<String> {
+        let mut lines = Vec::new();
+        loop {
+            let line = self.expect_line();
+            if line == terminator {
+                return lines;
+            }
+            lines.push(line);
+        }
+    }
+
+    /// The worker is still scheduled and still owns its connection.
+    pub fn is_alive(&self) -> bool {
+        unsafe { libc::kill(self.pid, 0) == 0 }
+    }
+}
+
+/// The forked worker: drop to the rendered worker identity, prove
+/// non-dumpability, authenticate, and drive real controls on demand.
+fn worker_main(
+    uid: u32,
+    gid: u32,
+    socket: &Path,
+    credential: &[u8],
+    from_parent: RawFd,
+    to_parent: RawFd,
+) -> ! {
+    let groups = [gid];
+    let dropped = unsafe {
+        libc::setgroups(1, groups.as_ptr()) == 0
+            && libc::setresgid(gid, gid, gid) == 0
+            && libc::setresuid(uid, uid, uid) == 0
+    };
+    let mut out = unsafe { std::fs::File::from_raw_fd(to_parent) };
+    let mut input = BufReader::new(unsafe { std::fs::File::from_raw_fd(from_parent) });
+    macro_rules! say {
+        ($($arg:tt)*) => {{
+            let _ = writeln!(out, $($arg)*);
+            let _ = out.flush();
+        }};
+    }
+    macro_rules! wait_for {
+        ($expected:expr, $code:expr) => {{
+            let mut line = String::new();
+            let _ = input.read_line(&mut line);
+            if line.trim_end() != $expected {
+                unsafe { libc::_exit($code) };
+            }
+        }};
+    }
+    if !dropped {
+        say!("fail:credential drop: {}", last_error());
+        unsafe { libc::_exit(11) };
+    }
+    // A real prctl on a real process: from here the worker is non-dumpable.
+    if prepare_worker_readiness(&mut NativeWorkerDumpability).is_err() {
+        say!("fail:non-dumpable readiness");
+        unsafe { libc::_exit(12) };
+    }
+    say!("dropped");
+    wait_for!("connect", 13);
+
+    let mut client = match UnixBrokerClient::connect_path(socket, credential) {
+        Ok(client) => client,
+        Err(error) => {
+            say!("fail:connect broker as uid {uid}: {error}");
+            unsafe { libc::_exit(14) };
+        }
+    };
+    match prepare_worker_readiness(&mut NativeWorkerDumpability).map(|r| client.ready(r)) {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) | Err(error) => {
+            say!("fail:worker readiness: {error}");
+            unsafe { libc::_exit(15) };
+        }
+    }
+    say!("connected");
+
+    // POSITIVE CONTROL 1: the legitimate connection creates its own invocations.
+    let worker_pid = unsafe { libc::getpid() };
+    for (id, fence, leaf, command) in [
+        (LEGIT_INVOCATION, LEGIT_FENCE, "legit", sleep_command()),
+        (ATTACK_INVOCATION, 7, "attack", sleep_command()),
+        (
+            EXECED_INVOCATION,
+            8,
+            "execed",
+            execed_command(worker_pid, socket),
+        ),
+    ] {
+        let invocation = Invocation {
+            id: id.to_owned(),
+            fence,
+        };
+        if let Err(error) = client.begin(invocation) {
+            say!("fail:begin {id}: {error}");
+            unsafe { libc::_exit(17) };
+        }
+        if let Err(error) = client.create(id, leaf, &command) {
+            say!("fail:create {id}: {error}");
+            unsafe { libc::_exit(18) };
+        }
+    }
+    say!("created");
+
+    // Drain the exec'd adversary's own report through the broker stdout path.
+    let mut execed = Vec::new();
+    for _ in 0..400 {
+        match client.stdout(EXECED_INVOCATION) {
+            Ok((bytes, eof, status)) => {
+                execed.extend(bytes);
+                if eof || !matches!(status, ChildStatus::Running) {
+                    break;
+                }
+            }
+            Err(error) => {
+                say!("fail:execed stdout: {error}");
+                unsafe { libc::_exit(19) };
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    for line in String::from_utf8_lossy(&execed).lines() {
+        let line = line.trim();
+        if !line.is_empty() {
+            say!("execed {line}");
+        }
+    }
+    say!("execed-done");
+
+    wait_for!("controls", 20);
+    // POSITIVE CONTROL 2: only a matching durable fencing token lifts quota.
+    // The two lifts are separated by a parent round-trip so the parent can read
+    // `cpu.max` between them without racing the second write.
+    let mismatched = client.lift(LEGIT_INVOCATION, LEGIT_FENCE ^ 1);
+    say!("mismatched-fence-rejected {}", mismatched.is_err());
+    wait_for!("lift", 21);
+    let matching = client.lift(LEGIT_INVOCATION, LEGIT_FENCE);
+    say!("matching-fence-lifted {}", matching.is_ok());
+    say!("controls-done");
+
+    wait_for!("exit", 0);
+    unsafe { libc::_exit(0) }
+}
+
+fn sleep_command() -> CommandSpec {
+    CommandSpec {
+        program: "/bin/sleep".to_owned(),
+        argv: vec!["45".to_owned()],
+        cwd: "/workspace".to_owned(),
+        environment: vec![],
+    }
+}
+
+/// A genuinely `execve`d adversary. It proves the credential drop and the
+/// seccomp filter survive exec, which an in-process child alone cannot show.
+fn execed_command(worker_pid: i32, socket: &Path) -> CommandSpec {
+    let socket = socket.display();
+    let script = format!(
+        "p={worker_pid}\n\
+         for f in environ maps; do if cat /proc/$p/$f >/dev/null 2>&1; \
+           then echo $f=leaked; else echo $f=denied; fi; done\n\
+         for d in fd root cwd; do if ls /proc/$p/$d >/dev/null 2>&1; \
+           then echo $d=leaked; else echo $d=denied; fi; done\n\
+         if kill -STOP $p 2>/dev/null; then echo signal=leaked; else echo signal=denied; fi\n\
+         if cat {socket} >/dev/null 2>&1; then echo socket=leaked; else echo socket=denied; fi\n\
+         echo uid=$(id -u)\n\
+         echo gid=$(id -g)\n"
+    );
+    CommandSpec {
+        program: "/bin/sh".to_owned(),
+        argv: vec!["-c".to_owned(), script],
+        cwd: "/workspace".to_owned(),
+        environment: vec![("PATH".to_owned(), "/usr/bin:/bin".to_owned())],
+    }
+}
+
+// ─────────────────────────── the launched adversary ─────────────────────────
+
+/// Pre-built, allocation-free attack inputs. Everything the cloned child
+/// touches is constructed in the parent, so the child performs only
+/// async-signal-safe work after `clone3`.
+struct Probes {
+    worker_pid: i32,
+    proc_paths: Vec<(&'static str, CString, i32)>,
+    fd_link: CString,
+    credential: CString,
+    socket: CString,
+    cgroup_procs: CString,
+    unauthorized_cgroup: CString,
+    attack_quota: CString,
+}
+
+/// Clone seam that births a real UID-1001 adversary inside the invocation
+/// cgroup. Every other invocation is delegated to the production
+/// `NativeClone3`, so the legitimate and exec'd children take the shipped path.
+pub struct AdversaryClone {
+    report: RawFd,
+    delegate: NativeClone3,
+    probes: Probes,
+}
+
+impl AdversaryClone {
+    pub fn new(environment: &Environment, worker_pid: i32, report: RawFd) -> Self {
+        let root = environment.root.display();
+        let proc_paths = vec![
+            (
+                "proc_mem",
+                path_cstring(&format!("/proc/{worker_pid}/mem")),
+                libc::O_RDONLY,
+            ),
+            (
+                "proc_environ",
+                path_cstring(&format!("/proc/{worker_pid}/environ")),
+                libc::O_RDONLY,
+            ),
+            (
+                "proc_maps",
+                path_cstring(&format!("/proc/{worker_pid}/maps")),
+                libc::O_RDONLY,
+            ),
+            (
+                "proc_root",
+                path_cstring(&format!("/proc/{worker_pid}/root")),
+                libc::O_RDONLY | libc::O_DIRECTORY,
+            ),
+            (
+                "proc_fd",
+                path_cstring(&format!("/proc/{worker_pid}/fd")),
+                libc::O_RDONLY | libc::O_DIRECTORY,
+            ),
+        ];
+        Self {
+            report,
+            delegate: NativeClone3,
+            probes: Probes {
+                worker_pid,
+                proc_paths,
+                fd_link: path_cstring(&format!("/proc/{worker_pid}/fd/3")),
+                credential: path_cstring(&environment.credential_path.to_string_lossy()),
+                socket: path_cstring(&environment.socket.to_string_lossy()),
+                cgroup_procs: path_cstring("cgroup.procs"),
+                unauthorized_cgroup: path_cstring(&format!("{root}/zf13-pwned")),
+                attack_quota: path_cstring(&format!("{root}/attack/cpu.max")),
+            },
+        }
+    }
+}
+
+impl CloneIntoCgroup for AdversaryClone {
+    fn clone_into_cgroup(
+        &mut self,
+        cgroup: RawFd,
+        invocation: &Invocation,
+        command: &CommandSpec,
+    ) -> Result<ChildProcess, Error> {
+        if invocation.id != ATTACK_INVOCATION {
+            return self.delegate.clone_into_cgroup(cgroup, invocation, command);
+        }
+        let pid = clone3_into_cgroup(cgroup)?;
+        if pid == 0 {
+            attack(&self.probes, self.report, cgroup);
+        }
+        Ok(ChildProcess {
+            pid,
+            stdout: -1,
+            stderr: -1,
+        })
+    }
+}
+
+/// Runs in the freshly cloned child. It crosses the production isolation and
+/// credential boundary exactly as `NativeClone3` does — `close_range` over
+/// every inherited descriptor (sparing only stdio and the report pipe) then
+/// `prepare_child` — and only then attacks the worker.
+fn attack(probes: &Probes, report: RawFd, cgroup: RawFd) -> ! {
+    unsafe {
+        libc::syscall(libc::SYS_close_range, 3_u32, (report - 1) as u32, 0_u32);
+        libc::syscall(libc::SYS_close_range, (report + 1) as u32, u32::MAX, 0_u32);
+    }
+    if prepare_child(&mut NativeChildSyscalls, &[], &ChildMounts::isolated()).is_err() {
+        unsafe { libc::_exit(90) };
+    }
+
+    // Control-descriptor reuse: the launcher's own cgroup descriptor number.
+    emit(report, "control_fd_reuse", unsafe {
+        i64::from(libc::openat(
+            cgroup,
+            probes.cgroup_procs.as_ptr(),
+            libc::O_WRONLY,
+        ))
+    });
+
+    // The identity the boundary itself produced.
+    emit(report, "identity_uid", i64::from(unsafe { libc::getuid() }));
+    emit(report, "identity_gid", i64::from(unsafe { libc::getgid() }));
+    emit(
+        report,
+        "identity_groups",
+        i64::from(unsafe { libc::getgroups(0, std::ptr::null_mut()) }),
+    );
+    let previous = unsafe { libc::umask(0o022) };
+    emit(report, "identity_umask", i64::from(previous));
+    unsafe { libc::umask(previous) };
+
+    // /proc/<worker>/… against a non-dumpable worker.
+    for (key, path, flags) in &probes.proc_paths {
+        emit(
+            report,
+            key,
+            i64::from(unsafe { libc::open(path.as_ptr(), *flags) }),
+        );
+    }
+    let mut link = [0 as libc::c_char; 256];
+    emit(report, "proc_fd_link", unsafe {
+        libc::readlink(probes.fd_link.as_ptr(), link.as_mut_ptr(), link.len()) as i64
+    });
+
+    // Cross-process memory and control.
+    let pid = i64::from(probes.worker_pid);
+    emit(report, "ptrace_attach", unsafe {
+        libc::syscall(
+            libc::SYS_ptrace,
+            libc::PTRACE_ATTACH as i64,
+            pid,
+            0_i64,
+            0_i64,
+        )
+    });
+    emit(report, "ptrace_seize", unsafe {
+        libc::syscall(
+            libc::SYS_ptrace,
+            libc::PTRACE_SEIZE as i64,
+            pid,
+            0_i64,
+            0_i64,
+        )
+    });
+    let mut scratch = [0_u8; 64];
+    let local = libc::iovec {
+        iov_base: scratch.as_mut_ptr().cast(),
+        iov_len: scratch.len(),
+    };
+    let remote = libc::iovec {
+        iov_base: std::ptr::without_provenance_mut(0x1000),
+        iov_len: scratch.len(),
+    };
+    for (key, number) in [
+        ("process_vm_readv", libc::SYS_process_vm_readv),
+        ("process_vm_writev", libc::SYS_process_vm_writev),
+    ] {
+        emit(report, key, unsafe {
+            libc::syscall(
+                number,
+                pid,
+                &raw const local,
+                1_i64,
+                &raw const remote,
+                1_i64,
+                0_i64,
+            )
+        });
+    }
+    for (key, signal) in [
+        ("signal_stop", libc::SIGSTOP),
+        ("signal_kill", libc::SIGKILL),
+        ("signal_usr1", libc::SIGUSR1),
+    ] {
+        emit(
+            report,
+            key,
+            i64::from(unsafe { libc::kill(probes.worker_pid, signal) }),
+        );
+    }
+    let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0_i64) };
+    emit(
+        report,
+        "pidfd_getfd",
+        if pidfd < 0 {
+            pidfd
+        } else {
+            unsafe { libc::syscall(libc::SYS_pidfd_getfd, pidfd, 3_i64, 0_i64) }
+        },
+    );
+
+    // Broker surface: the worker-private credential and the control socket.
+    emit(
+        report,
+        "broker_credential_read",
+        i64::from(unsafe { libc::open(probes.credential.as_ptr(), libc::O_RDONLY) }),
+    );
+    emit(
+        report,
+        "broker_socket_connect",
+        connect_unix(&probes.socket),
+    );
+
+    // Cgroup authority by path, not by the (already closed) descriptor.
+    emit(
+        report,
+        "cgroup_create",
+        i64::from(unsafe { libc::mkdir(probes.unauthorized_cgroup.as_ptr(), 0o755) }),
+    );
+    emit(
+        report,
+        "cgroup_quota_write",
+        i64::from(unsafe { libc::open(probes.attack_quota.as_ptr(), libc::O_WRONLY) }),
+    );
+
+    // Re-privileging attempts the seccomp filter must refuse.
+    for (key, number, argument) in [
+        ("regain_uid", libc::SYS_setresuid, 0_i64),
+        ("regain_caps", libc::SYS_capset, 0),
+        (
+            "unshare_userns",
+            libc::SYS_unshare,
+            i64::from(libc::CLONE_NEWUSER),
+        ),
+        ("mount_any", libc::SYS_mount, 0),
+    ] {
+        emit(report, key, unsafe {
+            libc::syscall(number, argument, 0_i64, 0_i64, 0_i64, 0_i64)
+        });
+    }
+
+    emit(report, "end", 0);
+    unsafe { libc::_exit(0) }
+}
+
+fn connect_unix(path: &CString) -> i64 {
+    let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+    if fd < 0 {
+        return i64::from(fd);
+    }
+    let mut address: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    address.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    for (slot, byte) in address.sun_path.iter_mut().zip(path.as_bytes()) {
+        *slot = *byte as libc::c_char;
+    }
+    let rc = unsafe {
+        libc::connect(
+            fd,
+            (&raw const address).cast(),
+            std::mem::size_of::<libc::sockaddr_un>() as libc::socklen_t,
+        )
+    };
+    let saved = errno_value();
+    unsafe {
+        libc::close(fd);
+        *libc::__errno_location() = saved;
+    }
+    i64::from(rc)
+}
+
+/// `clone3(CLONE_INTO_CGROUP)` — the same birth the production seam performs,
+/// so the adversary really is a direct child of the invocation cgroup.
+fn clone3_into_cgroup(cgroup: RawFd) -> Result<i32, Error> {
+    #[repr(C)]
+    struct Args {
+        flags: u64,
+        pidfd: u64,
+        child_tid: u64,
+        parent_tid: u64,
+        exit_signal: u64,
+        stack: u64,
+        stack_size: u64,
+        tls: u64,
+        set_tid: u64,
+        set_tid_size: u64,
+        cgroup: u64,
+    }
+    let args = Args {
+        flags: libc::CLONE_INTO_CGROUP as u64,
+        pidfd: 0,
+        child_tid: 0,
+        parent_tid: 0,
+        exit_signal: libc::SIGCHLD as u64,
+        stack: 0,
+        stack_size: 0,
+        tls: 0,
+        set_tid: 0,
+        set_tid_size: 0,
+        cgroup: cgroup as u64,
+    };
+    let pid = unsafe {
+        libc::syscall(
+            libc::SYS_clone3,
+            &raw const args,
+            std::mem::size_of::<Args>(),
+        )
+    } as i32;
+    if pid < 0 {
+        return Err(Error::CloneDenied);
+    }
+    Ok(pid)
+}
+
+// ───────────────────────────── broker plumbing ──────────────────────────────
+
+/// Run the real broker over the real Unix transport in a background thread,
+/// exactly as the launcher sidecar's serve loop does.
+pub fn serve_broker(
+    environment: &Environment,
+    context: &RenderedContext,
+    worker_pid: i32,
+    report: RawFd,
+) -> std::thread::JoinHandle<()> {
+    let expected_uid = context.u32("launcher_expected_uid");
+    let unleased: u16 = context
+        .get("unleased_millicores")
+        .parse()
+        .expect("rendered unleased millicores");
+    let fs = NativeCgroupFs::open(&environment.root, expected_uid)
+        .unwrap_or_else(|e| panic!("delegated cgroup readiness: {e}"));
+    let launcher = Launcher::new(
+        fs,
+        AdversaryClone::new(environment, worker_pid, report),
+        LauncherConfig::new(Some(unleased), expected_uid).expect("launcher config"),
+    )
+    .expect("launcher");
+    let broker = Broker::new(
+        launcher,
+        BrokerConfig::worker(
+            u32::try_from(worker_pid).expect("worker pid"),
+            environment.credential.clone(),
+        )
+        .expect("broker config"),
+        OsNonceSource,
+    )
+    .expect("broker");
+    let mut server = UnixBrokerServer::bind(&environment.socket, broker).expect("bind broker");
+    std::thread::spawn(move || {
+        let _ = server.serve_once();
+    })
+}
+
+// ───────────────────────────────── helpers ──────────────────────────────────
+
+/// One reported adversary attempt: the raw return value and errno.
+#[derive(Clone, Copy, Debug)]
+pub struct Attempt {
+    pub rc: i64,
+    pub errno: i32,
+}
+
+/// Read the adversary's report lines until its `end` marker. The write end
+/// stays open for the test's lifetime, so EOF is never the terminator.
+pub fn read_report(read_fd: RawFd) -> BTreeMap<String, Attempt> {
+    let mut reader = BufReader::new(unsafe { std::fs::File::from_raw_fd(read_fd) });
+    let mut attempts = BTreeMap::new();
+    loop {
+        let mut line = String::new();
+        let read = reader
+            .read_line(&mut line)
+            .expect("read the adversary report");
+        assert!(
+            read > 0,
+            "the UID-1001 adversary died before completing its report: {attempts:?}"
+        );
+        let line = line.trim();
+        let (key, value) = line.split_once('=').expect("report line is key=rc:errno");
+        if key == "end" {
+            return attempts;
+        }
+        let (rc, errno) = value.split_once(':').expect("report value is rc:errno");
+        attempts.insert(
+            key.to_owned(),
+            Attempt {
+                rc: rc.parse().expect("report rc"),
+                errno: errno.parse().expect("report errno"),
+            },
+        );
+    }
+}
+
+pub fn pipe() -> (RawFd, RawFd) {
+    let mut fds = [0; 2];
+    assert_eq!(
+        unsafe { libc::pipe(fds.as_mut_ptr()) },
+        0,
+        "create pipe: {}",
+        last_error()
+    );
+    (fds[0], fds[1])
+}
+
+pub fn set_mode(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .unwrap_or_else(|e| panic!("set mode {mode:o} on {path:?}: {e}"));
+}
+
+pub fn chown(path: &Path, uid: u32, gid: u32) {
+    let raw = path_cstring(&path.to_string_lossy());
+    assert_eq!(
+        unsafe { libc::chown(raw.as_ptr(), uid, gid) },
+        0,
+        "chown {path:?} to {uid}:{gid}: {}",
+        last_error()
+    );
+}
+
+pub fn random_bytes(count: usize) -> Vec<u8> {
+    use std::io::Read;
+    let mut bytes = vec![0_u8; count];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(&mut bytes))
+        .expect("read /dev/urandom");
+    bytes
+}
+
+/// Fork a child that becomes `(uid, gid)` under umask 0002 and opens `path`
+/// with `flags`. Returns the child's exit code; only async-signal-safe libc
+/// calls run after the fork.
+pub fn run_as(path: &Path, uid: u32, gid: u32, flags: i32) -> i32 {
+    let raw = path_cstring(&path.to_string_lossy());
+    let payload = b"edit\n";
+    let pid = unsafe { libc::fork() };
+    assert!(pid >= 0, "fork must succeed: {}", last_error());
+    if pid == 0 {
+        unsafe {
+            libc::umask(0o002);
+            let group = [gid];
+            if libc::setgroups(1, group.as_ptr()) != 0 {
+                libc::_exit(101);
+            }
+            if libc::setresgid(gid, gid, gid) != 0 {
+                libc::_exit(102);
+            }
+            if libc::setresuid(uid, uid, uid) != 0 {
+                libc::_exit(103);
+            }
+            let fd = libc::open(raw.as_ptr(), flags, 0o666);
+            if fd < 0 {
+                libc::_exit(104);
+            }
+            let written = libc::write(fd, payload.as_ptr().cast(), payload.len());
+            libc::close(fd);
+            if written != payload.len() as isize {
+                libc::_exit(105);
+            }
+            libc::_exit(0);
+        }
+    }
+    let mut status = 0;
+    assert_eq!(
+        unsafe { libc::waitpid(pid, &mut status, 0) },
+        pid,
+        "waitpid must reap the child"
+    );
+    if libc::WIFEXITED(status) {
+        libc::WEXITSTATUS(status)
+    } else {
+        -1
+    }
+}
+
+/// A per-test-instance path suffix. Distinct even if a runner executes several
+/// proofs inside one process, so two live topologies never collide.
+pub fn unique_slot() -> String {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static NEXT: AtomicU32 = AtomicU32::new(0);
+    format!(
+        "{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn path_cstring(value: &str) -> CString {
+    CString::new(value).expect("path has an interior NUL")
+}
+
+fn errno_value() -> i32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+fn last_error() -> std::io::Error {
+    std::io::Error::last_os_error()
+}
+
+/// Allocation-free `key=rc:errno` line writer for the post-clone child.
+fn emit(fd: RawFd, key: &str, rc: i64) {
+    let errno = if rc < 0 { i64::from(errno_value()) } else { 0 };
+    let mut buffer = [0_u8; 96];
+    let mut length = 0;
+    for byte in key.as_bytes() {
+        buffer[length] = *byte;
+        length += 1;
+    }
+    buffer[length] = b'=';
+    length += 1;
+    length += write_int(&mut buffer[length..], rc);
+    buffer[length] = b':';
+    length += 1;
+    length += write_int(&mut buffer[length..], errno);
+    buffer[length] = b'\n';
+    length += 1;
+    unsafe { libc::write(fd, buffer.as_ptr().cast(), length) };
+}
+
+fn write_int(out: &mut [u8], value: i64) -> usize {
+    let mut digits = [0_u8; 20];
+    let negative = value < 0;
+    let mut magnitude = value.unsigned_abs();
+    let mut count = 0;
+    loop {
+        digits[count] = b'0' + (magnitude % 10) as u8;
+        magnitude /= 10;
+        count += 1;
+        if magnitude == 0 {
+            break;
+        }
+    }
+    let mut written = 0;
+    if negative {
+        out[0] = b'-';
+        written = 1;
+    }
+    for index in (0..count).rev() {
+        out[written] = digits[index];
+        written += 1;
+    }
+    written
+}

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -674,6 +674,132 @@ mod tests {
         }
     }
 
+    /// The adversarial kernel-boundary proof (djinn-cgroup-launcher's
+    /// `tests/kernel_boundary_under_rendered_context.rs`, task zf13/goxi AC2)
+    /// cannot depend on this crate — that would be a dependency cycle — so it
+    /// drives its real UID-1000/1001 processes from a checked-in fixture of the
+    /// rendered security context. This test is what keeps that fixture honest:
+    /// it rebuilds the REAL manifest values and asserts every fixture line, so
+    /// changing the render without updating the fixture fails here instead of
+    /// silently proving a boundary nobody ships.
+    #[test]
+    fn rendered_security_context_matches_the_adversarial_proof_fixture() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env");
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read rendered security-context fixture {path:?}: {e}"));
+        let fixture: BTreeMap<&str, &str> = raw
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .map(|line| {
+                let (key, value) = line.split_once('=').expect("fixture line is key=value");
+                (key.trim(), value.trim())
+            })
+            .collect();
+
+        let worker = worker_security_context();
+        let launcher = launcher_security_context();
+        let pod = pod_security_context();
+        let config = KubernetesConfig::for_testing();
+        let capabilities = |sc: &SecurityContext, take_added: bool| {
+            let caps = sc.capabilities.as_ref().expect("capabilities");
+            let list = if take_added {
+                caps.add.clone().unwrap_or_default()
+            } else {
+                caps.drop.clone().unwrap_or_default()
+            };
+            list.join(",")
+        };
+        let expected: BTreeMap<&str, String> = BTreeMap::from([
+            (
+                "worker_run_as_user",
+                worker.run_as_user.unwrap().to_string(),
+            ),
+            (
+                "worker_run_as_group",
+                worker.run_as_group.unwrap().to_string(),
+            ),
+            (
+                "worker_run_as_non_root",
+                worker.run_as_non_root.unwrap().to_string(),
+            ),
+            (
+                "worker_allow_privilege_escalation",
+                worker.allow_privilege_escalation.unwrap().to_string(),
+            ),
+            ("worker_capabilities_drop", capabilities(&worker, false)),
+            (
+                "launcher_run_as_user",
+                launcher.run_as_user.unwrap().to_string(),
+            ),
+            (
+                "launcher_run_as_group",
+                launcher.run_as_group.unwrap().to_string(),
+            ),
+            (
+                "launcher_allow_privilege_escalation",
+                launcher.allow_privilege_escalation.unwrap().to_string(),
+            ),
+            (
+                "launcher_read_only_root_filesystem",
+                launcher.read_only_root_filesystem.unwrap().to_string(),
+            ),
+            ("launcher_capabilities_drop", capabilities(&launcher, false)),
+            ("launcher_capabilities_add", capabilities(&launcher, true)),
+            ("child_run_as_user", CHILD_UID.to_string()),
+            ("child_run_as_group", ARTIFACT_GID.to_string()),
+            ("child_umask", "0002".to_string()),
+            ("pod_fs_group", pod.fs_group.unwrap().to_string()),
+            (
+                "pod_fs_group_change_policy",
+                pod.fs_group_change_policy.clone().unwrap(),
+            ),
+            (
+                "seccomp_profile",
+                worker.seccomp_profile.as_ref().unwrap().type_.clone(),
+            ),
+            ("launcher_expected_uid", LAUNCHER_UID.to_string()),
+            (
+                "unleased_millicores",
+                LAUNCHER_UNLEASED_MILLICORES.to_string(),
+            ),
+            (
+                "cgroup_delegation_profile",
+                config.cgroup_delegation_profile.clone(),
+            ),
+            (
+                "volume_ownership_mode",
+                config.volume_ownership_mode.clone(),
+            ),
+        ]);
+
+        for (key, value) in &expected {
+            assert_eq!(
+                fixture.get(key).copied(),
+                Some(value.as_str()),
+                "the adversarial proof fixture is stale for `{key}`; update \
+                 crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env"
+            );
+        }
+        let extra: Vec<&&str> = fixture
+            .keys()
+            .filter(|k| !expected.contains_key(*k))
+            .collect();
+        assert!(
+            extra.is_empty(),
+            "the fixture declares keys the render does not produce: {extra:?}"
+        );
+        // The launcher and worker share one seccomp profile; assert it rather
+        // than let the fixture describe only half the contract.
+        assert_eq!(
+            launcher.seccomp_profile.as_ref().unwrap().type_,
+            fixture["seccomp_profile"]
+        );
+        // The render must also actually accept the profile pair it advertises.
+        assert!(validate_enforcement_render(&config).is_ok());
+    }
+
     #[test]
     fn incompatible_volume_ownership_mode_fails_closed() {
         let mut cfg = KubernetesConfig::for_testing();


### PR DESCRIPTION
goxi AC2 was the proposal's only unmet criterion and its security-critical one. The kernel boundary was implemented (`child.rs`) and rendered onto every enforcement Pod (qut0), but never adversarially proven — `ptrace`, `process_vm_readv`, `process_vm_writev` appeared only in the production code that blocks them.

## What this adds

`server/crates/djinn-cgroup-launcher/tests/kernel_boundary_under_rendered_context.rs` stands up the production-shaped topology — root broker over the real Unix transport, a forked non-dumpable UID-1000 worker authenticating by real `SO_PEERCRED`, and a UID-1001 adversary born by `clone3(CLONE_INTO_CGROUP)` into a real invocation cgroup and taken through the production `close_range` + `prepare_child` boundary — and asserts each AC2 path is denied with its errno:

- `/proc/<worker-pid>/{mem,environ,maps,root,fd}` and `fd/3` readlink
- `ptrace` attach and seize; `process_vm_readv`; `process_vm_writev`
- `SIGSTOP` / `SIGKILL` / `SIGUSR1`
- control-descriptor reuse (`EBADF`) and `pidfd_getfd`
- broker credential read; broker `connect()` as uid 1001
- unauthorized cgroup creation and quota tampering
- `setresuid` / `capset` / `unshare(CLONE_NEWUSER)` / `mount`

A separately `execve`d `/bin/sh` adversary proves the credential drop and seccomp filter survive exec. After the sweep: the worker is alive, both invocation quotas are still unleased, and the delegated cgroup's child set is unchanged.

**Positive controls** in the same suite: the legitimate UID-1000 worker authenticates and creates its assigned invocations; a mismatched fencing token leaves `cpu.max` unleased; only the matching durable token lifts it. The suite cannot pass by denying everything.

7os5's setgid GID-1000 / umask-0002 mutual-edit fixture is **re-homed out of its `geteuid() == 0` gate** (where it never executed) into a proof that runs for real, alongside an incompatible-ownership proof that rejects the spawn before the clone seam is reached.

## It cannot silently skip

Each proof calls `require_privileged_environment`, which **panics with the concrete missing capability** rather than returning "not applicable". An always-on guard test reads this workflow back and fails unless the `launcher-kernel-boundary` job exists, runs this binary with `--ignored`, is not `continue-on-error`, and declares `ZF13_EXPECTED_PROOFS` equal to the number of `#[ignore]`d proofs in the file. The lane then fails if fewer proofs execute than declared.

## Defect found and fixed

The proof surfaced a real one: `UnixBrokerServer::bind` left the control socket 0600 owned by root, which `connect(2)` makes unreachable by the UID-1000 worker the broker exists to serve. It is now handed to the worker identity when the broker runs privileged — the same owner-only mode that is what refuses the UID-1001 child at `connect`.

## Fixture

The launcher crate cannot depend on `djinn-k8s` (cycle), so a checked-in `rendered-security-context.env` carries the rendered context across, and a new `djinn-k8s` test rebuilds the real manifest builders and asserts every line, so it cannot drift from what ships.

## Verification

All three privileged proofs were **executed and passed** in a privileged cgroup-v2 container using the exact invocation the new lane runs (`3 passed`), plus the loud-failure path confirmed unprivileged. Repository lane: fmt, clippy on both touched crates `--all-targets`, `SQLX_OFFLINE=1 cargo check --workspace --all-targets`, and the full `djinn-cgroup-launcher` + `djinn-k8s` launcher test suites green. No `Cargo.toml` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
