### PR TITLE
chore(a32o): Make a freshly seeded admission epoch self-open

### DIFF
--- a/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
+++ b/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
@@ -37,6 +37,7 @@ actor or HTTP listener starts.
 
 ```
 djinn-server epoch show                  # print the durable row + derived state
+djinn-server epoch seed                  # create the row when it is ABSENT (idempotent)
 djinn-server epoch advance --cap N       # perform the next safe FORWARD step
 djinn-server epoch set-cap --cap N        # change the reference cap (epoch-fenced)
 djinn-server epoch rollback --cap N        # perform the next safe ROLLBACK step
@@ -166,6 +167,38 @@ Enforcement must never be enabled without kernel isolation and inventory proofs.
   then retry. A `LeaseContainmentFailed` node must be drained or fixed before it
   can host v1-enforcing spawns; until then the epoch keeps v1 unleased on that
   node fail-closed.
+
+### 6. Absent row (no epoch at all)
+
+Deleting the singleton is the immediate remediation for a wedged handoff, so a
+deployment can legitimately be running with **no** row. This is safe but is one
+step below baseline: `evaluate_handoff` maps `Ok(None)` to
+`HandoffState::MissingRow` / `EmergencyAuthorityDecision::ConfiguredStandalone`,
+which retains the configured standalone v0 mode and never denies — and the whole
+v1 rollout is dormant, so shadow cannot be armed and no would-throttle ratio
+accumulates.
+
+- **Detect:** `epoch show` prints `admission handoff row: <absent>`.
+- **Recover:** `djinn-server epoch seed`. It creates the `emergency_primary`
+  baseline (`v0 = enforce, v1 = off`, cap unset) **born acknowledged for its own
+  epoch**, so the deployment lands on the complete v0 baseline instead of the
+  fail-closed incomplete-epoch state, and `epoch advance` is immediately usable.
+  The command is idempotent: an existing row is reported and left untouched, so
+  it can never disturb a live rollout.
+- **Roll back:** `DELETE FROM admission_handoff WHERE name = 'build';` and
+  restart the coordinator returns the deployment to the dormant standalone
+  behaviour above. This is the one supported raw-SQL escape hatch, and it exists
+  precisely because startup must never re-create the row implicitly — no
+  migration or startup path does.
+- **Expect on the next start:** a seeded row requires v0, so startup promotes
+  even a configured `observe`/`off` controller to a fail-closed `enforce`
+  (`require_enforcement`) and admission stays closed through
+  `JournalRecoveryIncomplete` → `InventoryPending` → `TopologyPending` until the
+  coordinator wins the advisory lock. `confirm_build_admission_topology` then
+  opens the topology gate and writes the emergency ack in the same seam; the
+  periodic handoff loop re-drives it every 5 minutes. Denials logged as
+  `occupancy 0 reached cap N` during that window are the ordinary fail-closed
+  startup state, not a full ledger.
 
 ## Aborting a forward overlap
 

--- a/server/crates/djinn-coordinator/src/build_admission_transition.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_transition.rs
@@ -145,6 +145,18 @@ impl AdmissionTransitionExecutor {
         self.repo.read().await.map_err(map_db)
     }
 
+    /// Create the durable row at its v0-enforcing baseline, born acknowledged
+    /// for its own epoch.
+    ///
+    /// A deployment whose row was removed (the documented remediation for a
+    /// wedged handoff) has no rollout state at all: startup keeps the configured
+    /// standalone v0 mode and no epoch can be armed. This is the only step that
+    /// creates the row, and it is idempotent — an existing row is returned
+    /// untouched, so it can never overwrite a live rollout.
+    pub async fn seed(&self) -> Result<AdmissionHandoffRow, TransitionError> {
+        self.repo.seed_baseline().await.map_err(map_db)
+    }
+
     /// Read the current row and fail fast if it no longer matches the epoch the
     /// operator observed — a stale-epoch attempt returns `InvalidTransition`
     /// before any mutation is issued.

--- a/server/crates/djinn-db/src/repositories/admission_handoff.rs
+++ b/server/crates/djinn-db/src/repositories/admission_handoff.rs
@@ -183,6 +183,38 @@ impl AdmissionHandoffRepository {
         row.map(TryInto::try_into).transpose()
     }
 
+    /// Create the `build` singleton at its baseline, born acknowledged for its
+    /// own epoch.
+    ///
+    /// Seeding is idempotent: an already present row is returned untouched, so
+    /// this can never overwrite a live rollout state. The emergency
+    /// acknowledgement is written *with* the row rather than left NULL because
+    /// an unacknowledged `emergency_primary` row is an incomplete epoch — a
+    /// fail-closed state the deployment then has to climb back out of on the
+    /// coordinator leader's handoff tick. Born acknowledged, the seed lands
+    /// directly on the v0-enforcing baseline; it never weakens anything,
+    /// because that baseline still requires the emergency authority.
+    ///
+    /// This is the only writer that creates the row, and it is deliberately
+    /// operator-driven: startup maps an absent row to the configured standalone
+    /// mode, which is the documented remediation for a wedged deployment, so no
+    /// startup path may re-create it implicitly.
+    pub async fn seed_baseline(&self) -> DbResult<AdmissionHandoffRow> {
+        self.db.ensure_initialized().await?;
+        sqlx::query(
+            "INSERT INTO admission_handoff \
+                 (name, phase, epoch, emergency_ack_epoch, v0_mode, v1_mode) \
+             VALUES ($1, 'emergency_primary', 0, 0, 'enforce', 'off') \
+             ON CONFLICT (name) DO NOTHING",
+        )
+        .bind(HANDOFF_NAME)
+        .execute(self.db.pool())
+        .await?;
+        self.read().await?.ok_or_else(|| {
+            DbError::InvalidData("admission handoff singleton absent after seeding".into())
+        })
+    }
+
     /// Remove the singleton to exercise startup behavior for installations
     /// where no durable handoff has been created.
     #[cfg(any(test, feature = "test-support"))]
@@ -526,6 +558,37 @@ mod tests {
         assert_eq!(row.epoch, 0);
         assert_eq!(row.emergency_ack_epoch, None);
         assert_eq!(row.invocation_ack_epoch, None);
+    }
+
+    /// Re-seeding a deployment whose row was deleted (the documented wedge
+    /// remediation) must produce the v0-enforcing baseline that is already
+    /// acknowledged for its own epoch, and must never disturb an existing row.
+    #[tokio::test]
+    async fn seeding_recreates_an_acknowledged_baseline_and_never_overwrites() {
+        let repo = repository().await;
+        repo.delete_for_test().await.unwrap();
+        assert!(repo.read().await.unwrap().is_none());
+
+        let seeded = repo.seed_baseline().await.unwrap();
+        assert_eq!(seeded.phase, AdmissionHandoffPhase::EmergencyPrimary);
+        assert_eq!(seeded.epoch, 0);
+        assert_eq!(seeded.v0_mode, V0Mode::Enforce);
+        assert_eq!(seeded.v1_mode, V1Mode::Off);
+        assert_eq!(seeded.cap, None);
+        assert_eq!(
+            seeded.emergency_ack_epoch,
+            Some(seeded.epoch),
+            "the seed is born acknowledged, so it is never an incomplete epoch"
+        );
+        assert_eq!(seeded.invocation_ack_epoch, None);
+
+        // An in-flight rollout must survive a repeated seed untouched.
+        let armed = repo
+            .set_modes_and_cap(seeded.epoch, V0Mode::Enforce, V1Mode::Shadow, Some(5))
+            .await
+            .unwrap();
+        let reseeded = repo.seed_baseline().await.unwrap();
+        assert_eq!(reseeded, armed, "seeding is idempotent, never destructive");
     }
 
     #[tokio::test]

--- a/server/src/admin.rs
+++ b/server/src/admin.rs
@@ -12,6 +12,12 @@
 //! from the current durable state and reports what it did or what it is waiting
 //! on, so an operator (or the runbook) re-runs the command as controller and
 //! generation acknowledgements land.
+//!
+//! `seed` is the one step that creates the durable row rather than transitioning
+//! it. Startup deliberately never re-creates an absent row — mapping absence to
+//! the configured standalone v0 mode is the documented remediation for a wedged
+//! handoff — so restoring the rollout after that remediation is an explicit
+//! operator action rather than an implicit deploy-time side effect.
 
 use std::fmt::Write as _;
 use std::sync::Arc;
@@ -37,6 +43,9 @@ pub enum AdminCommand {
 pub enum EpochAction {
     /// Print the durable epoch row and its derived handoff state.
     Show,
+    /// Create the durable epoch row at its v0-enforcing baseline when it is
+    /// absent. Idempotent: an existing row is reported and left untouched.
+    Seed,
     /// Perform the next safe FORWARD step: arm shadow → arm overlap → enter
     /// overlap → commit invocation-primary → observe v0.
     Advance {
@@ -89,6 +98,16 @@ async fn run_epoch_action(
         EpochAction::Show => {
             let row = exec.show().await.map_err(|e| e.to_string())?;
             Ok(render_show(row.as_ref()))
+        }
+        EpochAction::Seed => {
+            if let Some(row) = exec.show().await.map_err(|e| e.to_string())? {
+                return Ok(format!(
+                    "seed: already present, left untouched\n{}",
+                    render_show(Some(&row))
+                ));
+            }
+            let row = exec.seed().await.map_err(|e| e.to_string())?;
+            Ok(format!("seed: applied\n{}", render_show(Some(&row))))
         }
         EpochAction::SetCap { cap } => {
             let row = require_row(exec).await?;
@@ -226,4 +245,57 @@ fn render_show(row: Option<&AdmissionHandoffRow>) -> String {
             .map_or_else(|| "<none>".to_string(), |e| e.to_string())
     );
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `epoch seed` is the operator surface that restores a deployment whose row
+    /// was deleted, and it must land on a complete (already acknowledged) v0
+    /// baseline so the next `advance` is not blocked waiting for an ack that
+    /// only a healthy coordinator leader can write.
+    #[tokio::test]
+    async fn seed_creates_an_acknowledged_baseline_and_is_idempotent() {
+        let db = Database::open_in_memory().expect("test database");
+        let repo = Arc::new(AdmissionHandoffRepository::new(db));
+        repo.read().await.expect("initialize fixture");
+        repo.delete_for_test().await.expect("remove row");
+
+        let rendered = run_admin_command_with(&repo, EpochAction::Seed)
+            .await
+            .expect("seed applies");
+        assert!(rendered.starts_with("seed: applied"), "{rendered}");
+        let seeded = repo.read().await.expect("read").expect("seeded row");
+        assert_eq!(seeded.phase, AdmissionHandoffPhase::EmergencyPrimary);
+        assert_eq!(seeded.v0_mode, V0Mode::Enforce);
+        assert_eq!(seeded.v1_mode, V1Mode::Off);
+        assert_eq!(seeded.emergency_ack_epoch, Some(seeded.epoch));
+
+        let rendered = run_admin_command_with(&repo, EpochAction::Seed)
+            .await
+            .expect("repeat seed reports the existing row");
+        assert!(rendered.starts_with("seed: already present"), "{rendered}");
+        assert_eq!(repo.read().await.expect("read").expect("row"), seeded);
+
+        // The acknowledged baseline is immediately armable: the shadow step no
+        // longer has to wait for a coordinator tick to complete the epoch.
+        let rendered = run_admin_command_with(
+            &repo,
+            EpochAction::Advance {
+                cap: Some(3),
+                generations: Vec::new(),
+            },
+        )
+        .await
+        .expect("arm shadow");
+        assert!(rendered.starts_with("arm-shadow: applied"), "{rendered}");
+    }
+
+    async fn run_admin_command_with(
+        repo: &Arc<AdmissionHandoffRepository>,
+        action: EpochAction,
+    ) -> Result<String, String> {
+        run_epoch_action(&AdmissionTransitionExecutor::new(repo.clone()), action).await
+    }
 }

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -4421,6 +4421,145 @@ mod build_admission_config_tests {
         assert!(admission.is_ready());
     }
 
+    /// Regression for the 2026-07-19 admission-handoff seed wedge.
+    ///
+    /// Migration 129 seeds `('build', 'emergency_primary', 0)` with no
+    /// acknowledgement, which `evaluate_handoff` classifies as `IncompleteEpoch`
+    /// → `RequiredFailClosed`: startup promotes even a configured-Observe
+    /// controller to a fail-closed Enforce. The wedge was that nothing in
+    /// production could then complete that epoch — `mark_topology_ready` had no
+    /// production call site, so readiness parked at `TopologyPending` forever,
+    /// the seeded epoch was never acknowledged, and every dispatch was denied
+    /// until an operator deleted the row by hand.
+    ///
+    /// A freshly seeded row must now self-open with no manual intervention: the
+    /// ordered startup gates run, coordinator leadership confirms the
+    /// single-active topology, and that same seam writes the first emergency
+    /// acknowledgement, leaving a healthy enforcing v0 baseline that admits work
+    /// and survives a restart.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn freshly_seeded_handoff_epoch_self_opens_without_operator_intervention() {
+        use djinn_agent::actors::coordinator::BuildAdmissionReadiness;
+        use djinn_coordinator::build_admission::BuildAdmissionDecision;
+
+        // This walks the real startup seams, which publish the process-global
+        // admission gauges; serialize against the other tests that read them.
+        let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let db = Database::open_in_memory().expect("test database");
+        let state = state_for_admission_config_with_db(
+            db.clone(),
+            BuildAdmissionConfig {
+                mode: BuildAdmissionMode::Observe,
+                cap: 3,
+            },
+        );
+        let repository = handoff_repository(&state);
+        let seeded = repository.read().await.expect("read").expect("seeded row");
+        assert_eq!(seeded.phase, AdmissionHandoffPhase::EmergencyPrimary);
+        assert_eq!(
+            seeded.emergency_ack_epoch, None,
+            "the migration seeds an unacknowledged epoch"
+        );
+
+        // The durable row is read before recovery. An incomplete epoch is
+        // fail-closed, so the configured-Observe controller is promoted to
+        // Enforce with every startup gate reset.
+        state.initialize_build_admission_handoff().await;
+        let controller = admission(&state).clone();
+        assert_eq!(
+            controller.mode(),
+            BuildAdmissionMode::Enforce,
+            "an incomplete durable epoch promotes the configured standalone mode"
+        );
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::JournalRecoveryIncomplete
+        );
+
+        // Journal recovery and the Kubernetes inventory advance their own gates
+        // and must not acknowledge anything: only a fully healthy controller may.
+        state.initialize_build_admission_recovery().await;
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::InventoryPending
+        );
+        *state.inner.graph_warmer.write().await =
+            Some(Arc::new(build_in_process_graph_warmer(state.clone())));
+        state.initialize_build_admission_inventory().await;
+        assert_eq!(
+            controller.readiness(),
+            BuildAdmissionReadiness::TopologyPending
+        );
+        assert_eq!(
+            repository
+                .read()
+                .await
+                .expect("read")
+                .expect("row")
+                .emergency_ack_epoch,
+            None,
+            "no gate short of topology may acknowledge the seeded epoch"
+        );
+
+        // Winning the coordinator advisory lock is the single-active topology
+        // gate AND the production writer of the first acknowledgement.
+        state.confirm_build_admission_topology().await;
+        assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+        assert_eq!(controller.mode(), BuildAdmissionMode::Enforce);
+        assert_eq!(
+            repository
+                .read()
+                .await
+                .expect("read")
+                .expect("row")
+                .emergency_ack_epoch,
+            Some(seeded.epoch),
+            "coordinator leadership acknowledges the seeded epoch without an operator"
+        );
+
+        // The completed epoch is the enforcing v0 baseline: it admits real work
+        // rather than denying it at the fail-closed readiness gate.
+        let decision = controller
+            .admit_task_run(
+                Some("worker"),
+                AdmissionDomain::TaskObservation,
+                "seeded-epoch-task".to_owned(),
+                0,
+                "seeded-epoch-job".to_owned(),
+            )
+            .await
+            .expect("admission decision");
+        assert!(
+            matches!(decision, BuildAdmissionDecision::Permitted { .. }),
+            "a self-opened epoch admits work: {decision:?}"
+        );
+
+        // A restart re-reads the now-acknowledged row and stays the enforcing
+        // baseline instead of falling back into the incomplete-epoch state.
+        let restarted = state_for_admission_config_with_db(
+            db,
+            BuildAdmissionConfig {
+                mode: BuildAdmissionMode::Observe,
+                cap: 3,
+            },
+        );
+        restarted.initialize_build_admission_handoff().await;
+        assert_eq!(admission(&restarted).mode(), BuildAdmissionMode::Enforce);
+        assert_eq!(
+            repository
+                .read()
+                .await
+                .expect("read")
+                .expect("row")
+                .emergency_ack_epoch,
+            Some(seeded.epoch),
+            "the acknowledged epoch survives a restart untouched"
+        );
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn replacement_recovery_restores_distinct_active_and_durable_ready_identities() {


### PR DESCRIPTION
## Verdict: the 2026-07-19 seed wedge is no longer reachable

Both landed defects now have production openers, so a freshly seeded
`admission_handoff` row completes its own epoch without an operator.

1. **Topology gate.** `mark_topology_ready()` is called from
   `AppState::confirm_build_admission_topology()`, which `become_leader()`
   invokes on winning the coordinator advisory lock (`main.rs` runs
   `initialize()` first, so journal recovery and the Kubernetes inventory
   have already advanced their gates). Readiness reaches `Healthy` instead
   of parking at `TopologyPending`.
2. **First acknowledgement.** The same seam calls
   `finalize_build_admission_handoff`, which writes the emergency ack for
   the exact current epoch; `start_handoff_warning_loop` re-drives it every
   5 minutes, so a later epoch bump is also acknowledged without a restart.
   `evaluate_handoff` receives the controller's *effective* mode — already
   promoted to `Enforce` by `require_enforcement()` — so `ack_allowed` is
   satisfied on an Observe/Off-configured deployment, which the pitfall
   recorded as impossible.

The still-open code fix from that pitfall can be closed.

## Changes

- **Regression test** (`server/src/server/state/mod.rs`): walks the real
  startup order on a migration-seeded row (unacknowledged, `emergency_primary`,
  epoch 0) under a configured-Observe deployment, asserting each gate in turn,
  that no gate short of topology acknowledges, that leadership writes the ack,
  that the controller then admits a real task run, and that a restart keeps it.
  Verified to have teeth: removing either `mark_topology_ready()` or the ack
  write makes it fail.
- **`epoch seed` operator action** (`server/src/admin.rs`,
  `build_admission_transition.rs`, `djinn-db`): a deployment whose row was
  removed by the documented `DELETE row` remediation has no way back except
  raw SQL. The new step is idempotent (an existing row is reported and left
  untouched) and the seed is born acknowledged for its own epoch, so it lands
  directly on the v0-enforcing baseline rather than transiting the fail-closed
  incomplete-epoch state. Startup still never re-creates an absent row —
  mapping absence to the configured standalone mode is the escape hatch.

No fail-closed state was made permissive: the seeded baseline is still
`RequiredFailClosed`, so v0 remains the enforcing authority.

## Verification

`cargo fmt --all`; clippy on djinn-server/djinn-db/djinn-coordinator `--tests`
(no new findings); `djinn-coordinator` `build_admission*` suites incl. the ujvz
epoch matrices (87 passed); `djinn-server` admission/handoff suites (14 passed);
`djinn-db` `admission_handoff` suites (8 passed), all against the local `:5433`
test Postgres; `SQLX_OFFLINE=1 cargo check --workspace --all-targets` clean.
No production system was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
