### PR TITLE
chore(ij6g): project the catalog wrapper image manifest into the server

### DIFF
--- a/deploy/helm/djinn/templates/_helpers.tpl
+++ b/deploy/helm/djinn/templates/_helpers.tpl
@@ -295,3 +295,21 @@ the PVC template and point the Deployment volume at the caller-provided name.
 {{- printf "%s-projects" (include "djinn.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+ij6g: the catalog wrapper image manifest, normalized to JSON.
+
+`serviceWrappers.imageManifest` accepts either the JSON string that
+`server/docker/build-wrapper-images.sh` writes or the equivalent YAML mapping.
+A mapping is re-encoded so the file the server reads is always JSON; a string
+is emitted verbatim (surrounding whitespace trimmed) so the operator-supplied
+bytes — the digests above all — reach the server unaltered.
+*/}}
+{{- define "djinn.wrapperImageManifest.json" -}}
+{{- $manifest := .Values.serviceWrappers.imageManifest -}}
+{{- if kindIs "string" $manifest -}}
+{{- trim $manifest -}}
+{{- else -}}
+{{- toJson $manifest -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/djinn/templates/configmap-wrapper-manifest.yaml
+++ b/deploy/helm/djinn/templates/configmap-wrapper-manifest.yaml
@@ -1,0 +1,25 @@
+{{- /*
+ij6g: catalog wrapper image manifest.
+
+Rendered ONLY when `serviceWrappers.imageManifest` is set. The file is mounted
+read-only into the server container and named by DJINN_WRAPPER_IMAGE_MANIFEST
+(see deployment-server.yaml); the image controller's boot reconcile records the
+identities into `service_presets`. Absent value => no ConfigMap, no env var,
+and strict service verification stays fail-closed rather than resolving a
+wrapper image with no verified digest.
+
+The value may be the manifest JSON as a string (what
+`server/docker/build-wrapper-images.sh` writes) or the equivalent YAML mapping;
+a mapping is re-encoded with `toJson` so the on-disk file is always JSON.
+*/ -}}
+{{- if .Values.serviceWrappers.imageManifest }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "djinn.fullname" . }}-wrapper-manifest
+  namespace: {{ include "djinn.namespace" . }}
+  labels:
+    {{- include "djinn.server.labels" . | nindent 4 }}
+data:
+  wrapper-image-manifest.json: {{ include "djinn.wrapperImageManifest.json" . | quote }}
+{{- end }}

--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -63,6 +63,7 @@ spec:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret-github-app: {{ include (print $.Template.BasePath "/secret-github-app.yaml") . | sha256sum }}
         checksum/secret-vault-key: {{ include (print $.Template.BasePath "/secret-vault-key.yaml") . | sha256sum }}
+        checksum/configmap-wrapper-manifest: {{ include (print $.Template.BasePath "/configmap-wrapper-manifest.yaml") . | sha256sum }}
       labels:
         {{- include "djinn.server.selectorLabels" . | nindent 8 }}
     spec:
@@ -442,6 +443,16 @@ spec:
             {{- end }}
             - name: DJINN_VAULT_KEY_PATH
               value: /var/run/secrets/djinn/vault.key
+            {{- if .Values.serviceWrappers.imageManifest }}
+            # ij6g: path of the projected catalog wrapper image manifest. The
+            # image controller reads it once at boot and records each
+            # `{wrapper_image}@{digest}` into `service_presets`. Omitted (with
+            # its ConfigMap + volume) when no manifest is configured, so strict
+            # service verification stays fail-closed instead of resolving a
+            # wrapper image with no verified digest.
+            - name: DJINN_WRAPPER_IMAGE_MANIFEST
+              value: /var/run/djinn/wrapper/wrapper-image-manifest.json
+            {{- end }}
             {{- if $githubAppConfigAttempted }}
             - name: GITHUB_APP_PRIVATE_KEY_PATH
               value: /var/run/secrets/djinn/github-app/private-key.pem
@@ -544,6 +555,11 @@ spec:
               mountPath: /var/run/secrets/djinn/github-app
               readOnly: true
             {{- end }}
+            {{- if .Values.serviceWrappers.imageManifest }}
+            - name: wrapper-manifest
+              mountPath: /var/run/djinn/wrapper
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.resources.server | nindent 12 }}
           lifecycle:
@@ -609,5 +625,13 @@ spec:
             # can read the file. The Secret is namespace-scoped + only
             # mounted into this Pod, so "world-readable" inside the
             # container is fine.
+            defaultMode: 0444
+        {{- end }}
+        {{- if .Values.serviceWrappers.imageManifest }}
+        - name: wrapper-manifest
+          configMap:
+            name: {{ include "djinn.fullname" . }}-wrapper-manifest
+            # 0444 so the non-root djinn user can read it regardless of which
+            # uid the image runs as.
             defaultMode: 0444
         {{- end }}

--- a/deploy/helm/djinn/tests/wrapper-manifest-render.sh
+++ b/deploy/helm/djinn/tests/wrapper-manifest-render.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# ij6g: exact Helm render contract for the catalog wrapper image manifest.
+#
+# Two properties are load-bearing and are asserted here:
+#   1. Unset `serviceWrappers.imageManifest` renders NO ConfigMap, NO volume
+#      and NO DJINN_WRAPPER_IMAGE_MANIFEST — strict service verification then
+#      stays fail-closed rather than resolving a wrapper with no verified
+#      digest.
+#   2. A configured manifest reaches the server container BYTE-FOR-BYTE as
+#      JSON. The digests in it are the registry's, so any mangling here would
+#      either fail the identity validation in `set_wrapper_identity` or, worse,
+#      record a wrapper image nobody can pull.
+#
+# Usage: bash deploy/helm/djinn/tests/wrapper-manifest-render.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+require_tool() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: required test tool '$1' is not installed" >&2; exit 1; }; }
+require_tool helm
+require_tool python3
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+MOUNT_PATH="/var/run/djinn/wrapper/wrapper-image-manifest.json"
+DIGEST_PG="sha256:$(printf 'a%.0s' $(seq 64))"
+DIGEST_REDIS="sha256:$(printf 'b%.0s' $(seq 64))"
+
+echo "=== unset: no ConfigMap, no env, no volume ==="
+helm template wrapper-test "$CHART_DIR" \
+    --set-string migration.designatedOperatorSecret=wrapper-test-operator \
+    > "$TMP/none.yaml"
+for needle in "DJINN_WRAPPER_IMAGE_MANIFEST" "wrapper-image-manifest.json" "name: wrapper-manifest"; do
+    if grep -q -- "$needle" "$TMP/none.yaml"; then
+        echo "FAIL: default render must not contain '$needle'" >&2
+        exit 1
+    fi
+done
+
+echo "=== configured (YAML mapping): exact JSON reaches the server ==="
+cat > "$TMP/values-map.yaml" <<EOF
+migration:
+  designatedOperatorSecret: wrapper-test-operator
+serviceWrappers:
+  imageManifest:
+    entries:
+      - preset_id: preset-postgres-18
+        wrapper_image: ghcr.io/djinnos/djinn-postgres-wrapper
+        image_digest: "$DIGEST_PG"
+      - preset_id: preset-redis-7
+        wrapper_image: ghcr.io/djinnos/djinn-redis-wrapper
+        image_digest: "$DIGEST_REDIS"
+EOF
+helm template wrapper-test "$CHART_DIR" -f "$TMP/values-map.yaml" > "$TMP/map.yaml"
+
+echo "=== configured (JSON string): identical projection ==="
+cat > "$TMP/values-str.yaml" <<EOF
+migration:
+  designatedOperatorSecret: wrapper-test-operator
+serviceWrappers:
+  imageManifest: |
+    {"entries":[{"preset_id":"preset-postgres-18","wrapper_image":"ghcr.io/djinnos/djinn-postgres-wrapper","image_digest":"$DIGEST_PG"},{"preset_id":"preset-redis-7","wrapper_image":"ghcr.io/djinnos/djinn-redis-wrapper","image_digest":"$DIGEST_REDIS"}]}
+EOF
+helm template wrapper-test "$CHART_DIR" -f "$TMP/values-str.yaml" > "$TMP/str.yaml"
+
+MOUNT_PATH="$MOUNT_PATH" DIGEST_PG="$DIGEST_PG" DIGEST_REDIS="$DIGEST_REDIS" \
+python3 - "$TMP/map.yaml" "$TMP/str.yaml" <<'PY'
+import json
+import os
+import sys
+
+try:
+    import yaml
+except ImportError:  # PyYAML is not guaranteed on every runner
+    yaml = None
+
+mount_path = os.environ["MOUNT_PATH"]
+expected = {
+    "entries": [
+        {
+            "preset_id": "preset-postgres-18",
+            "wrapper_image": "ghcr.io/djinnos/djinn-postgres-wrapper",
+            "image_digest": os.environ["DIGEST_PG"],
+        },
+        {
+            "preset_id": "preset-redis-7",
+            "wrapper_image": "ghcr.io/djinnos/djinn-redis-wrapper",
+            "image_digest": os.environ["DIGEST_REDIS"],
+        },
+    ]
+}
+
+
+def projected_json(path):
+    """The single `wrapper-image-manifest.json:` ConfigMap value, decoded."""
+    values = []
+    for line in open(path, encoding="utf-8").read().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("wrapper-image-manifest.json:"):
+            raw = stripped.split(":", 1)[1].strip()
+            assert raw.startswith('"'), f"manifest must render as a quoted scalar, got {raw[:40]}"
+            values.append(json.loads(raw) if yaml is None else yaml.safe_load(raw))
+    assert len(values) == 1, f"expected exactly one manifest entry in {path}, got {len(values)}"
+    return json.loads(values[0])
+
+
+def asserts_common(path):
+    text = open(path, encoding="utf-8").read()
+    assert projected_json(path) == expected, f"{path}: manifest content differs from the values"
+    assert f"value: {mount_path}" in text, f"{path}: env must point at {mount_path}"
+    assert "mountPath: /var/run/djinn/wrapper" in text, f"{path}: manifest volume is not mounted"
+    assert "name: wrapper-test-djinn-wrapper-manifest" in text, f"{path}: ConfigMap is not referenced"
+
+
+for manifest_path in sys.argv[1:]:
+    asserts_common(manifest_path)
+
+print("OK: wrapper manifest render contract holds for mapping and string forms")
+PY

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -476,6 +476,32 @@ env:
   # evaluation; production remains organization-only by default.
   allowUserInstallations: false
 
+# -----------------------------------------------------------------------------
+# Catalog service-wrapper image identities (ij6g)
+# -----------------------------------------------------------------------------
+# `server/docker/build-wrapper-images.sh` builds the three catalog wrapper
+# images (Postgres/Redis/RabbitMQ) and writes a manifest recording the digest
+# buildx ACTUALLY pushed for each one. Paste that manifest here and the chart
+# projects it into the server container as a file, pointing
+# DJINN_WRAPPER_IMAGE_MANIFEST at it. On boot the image controller
+# (`reconcile_wrapper_catalog_from_env`) records each identity into
+# `service_presets`, so strict canonical verification can resolve
+# `{wrapper_image}@{digest}` for attempt-scoped service leases.
+#
+# Accepts either the manifest JSON as a string or the equivalent YAML mapping
+# (`{entries: [{preset_id, wrapper_image, image_digest}, ...]}`); both render
+# to the same JSON file.
+#
+# Digests must be the real `sha256:<64 hex>` the registry returned —
+# `ServicePresetRepository::set_wrapper_identity` rejects mutable or malformed
+# identities before any write, so a placeholder can never become deployable.
+# Empty (the default) renders no ConfigMap and no env var: the controller then
+# leaves wrapper digests unpopulated and strict resolution stays fail-closed.
+# Left null rather than "" so overriding it with the mapping form doesn't make
+# Helm's coalesce warn about replacing a scalar with a table.
+serviceWrappers:
+  imageManifest: null
+
 # Arbitrary extra env injected into the server container. Useful for ad-hoc
 # tuning knobs without re-templating.
 extraEnv: []

--- a/server/docker/build-wrapper-images.sh
+++ b/server/docker/build-wrapper-images.sh
@@ -37,6 +37,19 @@ preset-rabbitmq-4|djinn-rabbitmq-wrapper|djinn-rabbitmq-wrapper|djinn-rabbitmq-w
 echo ">> building catalog wrapper binaries"
 ( cd "$REPO_ROOT/server" && cargo build --release --locked -p djinn-catalog-wrapper )
 
+# The build context is the tracked `server/docker/` directory, so each binary
+# is staged INTO the working tree. A failed `docker buildx build` (e.g. a push
+# denied for a token missing `write:packages`) aborts under `set -e` before the
+# per-iteration cleanup, leaving a multi-megabyte untracked binary behind and
+# the repo dirty. Clean up on ANY exit instead.
+staged=""
+metafile=""
+cleanup() {
+    [ -z "$staged" ] || rm -f "$staged"
+    [ -z "$metafile" ] || rm -f "$metafile"
+}
+trap cleanup EXIT
+
 entries=""
 for row in $WRAPPERS; do
     [ -n "$row" ] || continue
@@ -48,7 +61,8 @@ for row in $WRAPPERS; do
     ref="$wrapper_image:$TAG"
 
     echo ">> staging $bin"
-    cp "$REPO_ROOT/server/target/release/$bin" "$SCRIPT_DIR/$bin"
+    staged="$SCRIPT_DIR/$bin"
+    cp "$REPO_ROOT/server/target/release/$bin" "$staged"
 
     metafile=$(mktemp)
     if [ "$PUSH" = "1" ]; then
@@ -71,7 +85,9 @@ for row in $WRAPPERS; do
         echo ">> building (no push) $ref"
         docker build --file "$SCRIPT_DIR/$dockerfile" --tag "$ref" "$SCRIPT_DIR"
     fi
-    rm -f "$metafile" "$SCRIPT_DIR/$bin"
+    rm -f "$metafile" "$staged"
+    staged=""
+    metafile=""
 done
 
 if [ "$PUSH" = "1" ]; then


### PR DESCRIPTION
## Why

`reconcile_wrapper_catalog_from_env` reads `DJINN_WRAPPER_IMAGE_MANIFEST` as a **file path**, and the chart had no way to put a file into the server container — no `extraVolumes` hook, no wrapper values, nothing (`grep -ri wrapper deploy/helm/djinn` returned zero hits). So the only supported channel for catalog wrapper digests was unreachable from a Helm deploy: `service_presets` keeps NULL digests (migration 150 having correctly NULLed migration 147's fabricated ones) and strict canonical service verification stays fail-closed. A canonical plan that needs fresh attempt-scoped Postgres/Redis/RabbitMQ state cannot record a reusable pass — which is the headline benefit jvpm exists to deliver.

Found while doing the operator half of `plans/OPERATOR-FOLLOWUPS-v0.7.0.md` §2, whose step 2 ("render the manifest through the deploy's values template") assumed a chart hook that does not exist.

## What

`serviceWrappers.imageManifest`, accepted either as the JSON string `server/docker/build-wrapper-images.sh` writes or as the equivalent YAML mapping:

- set → ConfigMap rendered, mounted read-only at `/var/run/djinn/wrapper`, `DJINN_WRAPPER_IMAGE_MANIFEST` points at the file, and a pod-template checksum annotation rolls the server when the digests change;
- unset (default) → nothing rendered. No ConfigMap, no volume, no env var; boot reconcile stays the documented no-op and strict resolution stays fail-closed rather than trusting an unverified digest.

`deploy/helm/djinn/tests/wrapper-manifest-render.sh` pins both halves, including that the manifest bytes reach the container unmangled — a mangled digest either trips `set_wrapper_identity`'s validation or, worse, records a wrapper image nobody can pull.

Also: the build script stages each wrapper binary **into** the tracked `server/docker/` build context, and a failed `docker buildx build --push` aborts under `set -e` before the per-iteration `rm`, leaving a multi-megabyte untracked binary in the working tree (hit this for real on a push denied for a token missing `write:packages`). Cleanup moves to an EXIT trap.

## Verification

```
helm lint deploy/helm/djinn
helm lint deploy/helm/djinn --values deploy/helm/djinn/values.local.yaml
bash deploy/helm/djinn/tests/wrapper-manifest-render.sh
PUSH=0 REGISTRY=local/test TAG=trap-check server/docker/build-wrapper-images.sh   # all three images build; tree stays clean
```

Also rendered end to end through the VPS deploy's `values.vps.yaml.j2` (ansible vars → values → chart) and confirmed the projected JSON matches the input entries exactly.

## Operator note

The deploy-side wiring is committed in `djinn-vps-deploy` (`djinn_wrapper_image_manifest_entries`) with an **empty** entries list: the wrapper images are not yet in ghcr because the local ghcr credential lacks `write:packages`. A chart older than this PR ignores the value, so the deploy repo is safe to carry ahead of it.
