### PR TITLE
fix(grkq): stop rendering an unusable mandatory cgroup-launcher; restore the real unleased fallback

### DIFF
--- a/server/crates/djinn-agent-worker/src/launcher_handshake.rs
+++ b/server/crates/djinn-agent-worker/src/launcher_handshake.rs
@@ -25,12 +25,23 @@
 //! ## Detection-gated fallback (never block pod startup)
 //!
 //! The IPC mount is the parent directory of the credential path. When it is
-//! absent — an old rendering without the sidecar, or a local/non-pod run — the
-//! handshake is skipped and the caller keeps the unleased in-process broker path
-//! UNCHANGED. Any failure AFTER detection (write error, the socket never binds,
-//! a credential/peer rejection, a readiness failure) is a typed, bounded outcome
-//! that also falls back to the in-process path. The handshake never returns an
-//! unbounded wait and never propagates an error that would fail pod startup.
+//! absent — the launcher is not rendered (the default since task grkq), an old
+//! rendering without the sidecar, or a local/non-pod run — the handshake is
+//! skipped. Any failure AFTER detection (write error, the socket never binds, a
+//! credential/peer rejection, a readiness failure) is a typed, bounded outcome
+//! that folds into the same result. The handshake never returns an unbounded
+//! wait and never propagates an error that would fail pod startup.
+//!
+//! ## What the fallback actually is
+//!
+//! Anything other than [`LauncherHandshake::Connected`] leaves
+//! `AgentContext::shell_launch` as `None`, and the shell handler then runs the
+//! command **in-process in the worker** (`process::output_with_kill_cancellable`)
+//! at whatever quota the pod itself has — i.e. unleased, with no cgroup leaf and
+//! no lease lift. There is no "in-process broker": earlier revisions of this
+//! comment said so, and worse, the in-process arm was compiled only under
+//! `#[cfg(test)]`, so in production this "fallback" made every shell command
+//! fail. Both are fixed; if you change the shell handler, keep this accurate.
 
 use std::fs::File;
 use std::io::Read;
@@ -59,17 +70,17 @@ const CONNECT_POLL: Duration = Duration::from_millis(100);
 const CONNECT_ATTEMPTS: u32 = 300;
 
 /// Typed, bounded outcome of the launcher handshake. Every variant other than
-/// [`LauncherHandshake::Connected`] routes the worker to the unleased in-process
-/// broker path unchanged.
+/// [`LauncherHandshake::Connected`] routes the worker to unleased, in-process
+/// shell execution (see the module docs).
 pub enum LauncherHandshake {
     /// The sidecar is present and authenticated us: the broker client is live
     /// and readiness has been accepted.
     Connected(Box<UnixBrokerClient>),
-    /// No IPC mount / sidecar (old rendering, or a local/non-pod run). Use the
-    /// in-process path unchanged.
+    /// No IPC mount / sidecar — the launcher is not rendered, this is an old
+    /// rendering, or a local/non-pod run. Shells run in-process, unleased.
     AbsentMount,
-    /// The mount was present but the handshake failed. Fail closed to the
-    /// in-process path; the reason is carried for logging.
+    /// The mount was present but the handshake failed. Fail closed to unleased
+    /// in-process execution; the reason is carried for logging.
     FailedClosed(HandshakeError),
 }
 

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -260,8 +260,8 @@ struct WorkerDefaultArgs {
     /// cgroup-launcher control socket the sidecar binds inside the shared IPC
     /// mount. Env name and default match qut0's render (`DJINN_LAUNCHER_SOCKET`
     /// / `djinn_k8s::launcher::LAUNCHER_SOCKET_PATH`). The worker connects here
-    /// after writing its handshake; an absent mount falls back to the in-process
-    /// broker path (see [`launcher_handshake`]).
+    /// after writing its handshake; an absent mount means shells run in-process
+    /// and unleased (see [`launcher_handshake`]).
     #[arg(
         long,
         env = "DJINN_LAUNCHER_SOCKET",
@@ -1970,15 +1970,19 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
     .with_context(|| format!("dial djinn-server at {server_addr}"))?;
     info!(server = %server_addr, "tcp connection up, RPC handshake accepted");
 
-    // Detection-gated launcher handshake (task ab05). qut0 renders a mandatory
-    // cgroup-launcher sidecar whose serve loop waits for a worker handshake
-    // (private credential + worker PID in the shared IPC mount) before it binds
-    // its control socket. The worker writes that handshake and dials the socket
-    // here. When the mount/sidecar is absent (old rendering, or a local/non-pod
-    // run) — or when the handshake fails closed for any reason — the worker uses
-    // the unleased in-process broker path UNCHANGED (`shell_launch = None`); the
-    // handshake never blocks pod startup. Run the blocking write/connect on a
-    // blocking thread so the async runtime is never stalled.
+    // Detection-gated launcher handshake (task ab05). When a cgroup-launcher
+    // sidecar is rendered, its serve loop waits for a worker handshake (private
+    // credential + worker PID in the shared IPC mount) before it binds its
+    // control socket. The worker writes that handshake and dials the socket here.
+    //
+    // When the mount/sidecar is absent — which is the DEFAULT since task grkq,
+    // and also covers old renderings and local/non-pod runs — or when the
+    // handshake fails closed for any reason, `shell_launch` stays `None` and the
+    // shell handler executes commands IN-PROCESS at the pod's own quota
+    // (unleased, no cgroup leaf, no lease lift). That is a real, supported
+    // production path, not a stub. The handshake never blocks pod startup. Run
+    // the blocking write/connect on a blocking thread so the async runtime is
+    // never stalled.
     let launcher_socket = args.launcher_socket.clone();
     let launcher_credential_path = args.launcher_credential_path.clone();
     let handshake = tokio::task::spawn_blocking(move || {
@@ -2009,7 +2013,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
         launcher_handshake::LauncherHandshake::AbsentMount => {
             info!(
                 socket = %args.launcher_socket.display(),
-                "no cgroup-launcher IPC mount; using in-process broker shell path"
+                "no cgroup-launcher IPC mount; shell commands run in-process, unleased"
             );
             None
         }
@@ -2017,7 +2021,7 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
             warn!(
                 error = %error,
                 socket = %args.launcher_socket.display(),
-                "cgroup-launcher handshake failed; falling back to in-process broker shell path"
+                "cgroup-launcher handshake failed; degrading to unleased in-process shell execution"
             );
             None
         }

--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -412,7 +412,13 @@ pub struct AgentContext {
     /// variables at `AgentContext` construction time via
     /// [`ReconciliationSweepConfig::from_env`].
     pub reconciliation_sweep: ReconciliationSweepConfig,
-    /// Missing in host/test contexts. Production shell dispatch fails closed.
+    /// The broker-backed, leased shell launch context.
+    ///
+    /// `None` in host/test contexts, and in any worker whose cgroup-launcher
+    /// sidecar is absent or whose handshake failed — which is the default
+    /// rendering since task grkq. `None` does NOT disable shell dispatch: the
+    /// handler then runs commands in-process at the pod's own quota (unleased,
+    /// no cgroup leaf, no lease lift).
     pub shell_launch: Option<ShellLaunchContext>,
     /// Explicitly injected configuration for the optional session-start memory
     /// intent planner. It remains disabled by default, but keeping it on the

--- a/server/crates/djinn-agent/src/extension/handlers/workspace.rs
+++ b/server/crates/djinn-agent/src/extension/handlers/workspace.rs
@@ -217,8 +217,22 @@ pub(crate) async fn call_shell(
     let clock = SystemClock::new();
     let started = clock.now_instant();
 
-    // Cargo classification is observation-only. Every production shell uses
-    // the immutable broker-backed task-run launch context.
+    // Cargo classification is observation-only.
+    //
+    // Two real execution paths, and BOTH must work in production (task grkq):
+    //
+    //   * `Some(launch)` — the cgroup-launcher sidecar came up and the worker
+    //     completed its handshake, so the command is launched by the broker into
+    //     a delegated cgroup leaf and is eligible for a CPU lease lift.
+    //   * `None` — no launcher (it is not rendered by default, the pod predates
+    //     it, this is a local/non-pod run, or the handshake failed closed). The
+    //     command runs in-process at whatever quota the pod itself has, i.e.
+    //     unleased. This arm used to be `#[cfg(test)]`-only, with production
+    //     returning "broker-backed shell launch context is not configured" —
+    //     which turned any launcher problem into EVERY shell command failing,
+    //     while the surrounding doc comments claimed a fallback existed. It is
+    //     now a genuine production path; degrading to unleased execution is the
+    //     documented contract.
     let runner_result = if let Some(launch) = state.shell_launch.as_ref() {
         launch
             .runner()
@@ -235,21 +249,18 @@ pub(crate) async fn call_shell(
                 )))
             })
     } else {
-        #[cfg(test)]
-        {
-            crate::process::output_with_kill_cancellable(
-                cmd,
-                Duration::from_millis(timeout_ms),
-                child_token,
-            )
-            .await
-        }
-        #[cfg(not(test))]
-        {
-            Err(crate::process::ProcessRunError::Spawn(
-                std::io::Error::other("broker-backed shell launch context is not configured"),
-            ))
-        }
+        // Put the child in its own process group BEFORE spawning. The in-process
+        // runner's timeout/cancellation cleanup signals `-pgid`, so without this
+        // the child shares the worker's group and the whole TERM/grace/KILL
+        // sequence targets a process group that does not exist — a timed-out or
+        // cancelled command would simply keep running.
+        crate::process::isolate_process_group(&mut cmd);
+        crate::process::output_with_kill_cancellable(
+            cmd,
+            Duration::from_millis(timeout_ms),
+            child_token,
+        )
+        .await
     };
 
     // Structurally finish exactly one cargo observation from the single

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -616,7 +616,14 @@ impl LeaseInvocationRunner {
                                         // Reaching a valid bind means v1 would
                                         // have escalated (lifted); record the
                                         // bounded shadow observation but leave
-                                        // cpu.max throttled under v0. No
+                                        // cpu.max throttled under v0.
+                                        //
+                                        // Shadow CLAMPS. The leaf stays at the
+                                        // broker's 250m unleased quota for the
+                                        // whole command — arming shadow makes
+                                        // leased builds slower, never faster. It
+                                        // is an observation mode; see
+                                        // `evaluate_invocation_lift`. No
                                         // irreversible lift occurs, so no
                                         // fence-before-lift journal write is
                                         // required; `fence` is still reconciled

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -375,6 +375,20 @@ pub enum Error {
     InvalidQuota(u16),
     #[error("cgroup v2 is required (v1 and hybrid mounts are unsupported)")]
     NotCgroupV2,
+    #[error(
+        "delegated cgroup root {path} is not a cgroup2 filesystem (statfs f_type {actual:#x}, \
+         expected {expected:#x}); nothing mounted a delegated cgroup v2 subtree there"
+    )]
+    DelegatedRootIsNotCgroupFs {
+        path: String,
+        actual: i64,
+        expected: i64,
+    },
+    #[error(
+        "clone3(CLONE_INTO_CGROUP) is unreachable in this sandbox (errno {errno}); the only \
+         child-spawn seam is denied, so no command could ever be launched"
+    )]
+    Clone3Unavailable { errno: i32 },
     #[error("delegated cgroup root is read-only")]
     ReadOnlyDelegation,
     #[error("delegated cgroup owner {actual} differs from launcher uid {expected}")]
@@ -448,6 +462,14 @@ impl NativeCgroupFs {
         #[cfg(unix)]
         let root_writable = metadata.permissions().mode() & 0o222 != 0
             && metadata.permissions().mode() & 0o022 == 0;
+        // Prove the delegated root IS a cgroup2 tree BEFORE reading any control
+        // file. Without this, a root that is any other filesystem (an emptyDir,
+        // a tmpfs, a plain directory) surfaces only as a bare `ENOENT` from the
+        // `cgroup.subtree_control` read below — an opaque `Io` error that says
+        // nothing about the delegation actually being absent. Task grkq: that
+        // exact opacity is what turned "nothing mounts a cgroup2 tree here" into
+        // an unexplained sidecar CrashLoopBackOff.
+        assert_cgroup2_filesystem(&root_path)?;
         let controllers = fs::read_to_string(root_path.join("cgroup.subtree_control"))?
             .split_ascii_whitespace()
             .map(str::to_owned)
@@ -562,6 +584,45 @@ impl CgroupFs for NativeCgroupFs {
     }
 }
 
+/// `statfs.f_type` of a cgroup v2 hierarchy (`CGROUP2_SUPER_MAGIC`, see
+/// `include/uapi/linux/magic.h`). Hard-coded rather than taken from `libc`
+/// because its type differs per libc target (`__fsword_t` vs `c_ulong`).
+pub const CGROUP2_SUPER_MAGIC: i64 = 0x6367_7270;
+
+/// Fail closed unless `path` really is a cgroup v2 filesystem.
+///
+/// This is the first readiness check, deliberately ahead of every control-file
+/// read: a delegated root that is not a cgroup2 mount can never satisfy any
+/// later check, and saying so by name is the difference between a diagnosable
+/// startup failure and an opaque `ENOENT`.
+fn assert_cgroup2_filesystem(path: &Path) -> Result<(), Error> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|_| Error::UnsafeLeafName)?;
+    let mut buf = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    // SAFETY: `c_path` is a NUL-terminated path and `buf` is a live, correctly
+    // sized `statfs` allocation; `statfs` only writes through it on success.
+    if unsafe { libc::statfs(c_path.as_ptr(), buf.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error().into());
+    }
+    // SAFETY: `statfs` returned 0, so it initialized `buf`.
+    //
+    // The cast is load-bearing even where it is a no-op: `statfs.f_type` is
+    // `__fsword_t` (i64) on 64-bit glibc but `c_ulong` on musl and `i32` on
+    // 32-bit targets, so normalizing to `i64` is what makes this compile
+    // everywhere. Clippy only sees the target it is running on.
+    #[allow(clippy::unnecessary_cast)]
+    let actual = unsafe { buf.assume_init() }.f_type as i64;
+    if actual != CGROUP2_SUPER_MAGIC {
+        return Err(Error::DelegatedRootIsNotCgroupFs {
+            path: path.display().to_string(),
+            actual,
+            expected: CGROUP2_SUPER_MAGIC,
+        });
+    }
+    Ok(())
+}
+
 fn safe_control_file(file: &str) -> Result<CString, Error> {
     if file.contains('/') || file.contains('\0') {
         return Err(Error::UnsafeLeafName);
@@ -620,6 +681,88 @@ impl CloneIntoCgroup for DenyClone3 {
 /// target cgroup and crosses the credential/isolation boundary before exec.
 pub struct NativeClone3;
 
+/// `CLONE_INTO_CGROUP` (`include/uapi/linux/sched.h`), as a `u64`.
+///
+/// **Do not replace this with `libc::CLONE_INTO_CGROUP`.** On glibc targets the
+/// `libc` crate declares it as `pub const CLONE_INTO_CGROUP: c_int =
+/// 0x200000000` — a value that does not fit in a 32-bit `c_int`, and which the
+/// crate's blanket `allow(overflowing_literals)` truncates to **0** instead of
+/// rejecting. Using it silently passed `flags: 0` to `clone3`, so the child was
+/// an ordinary fork that stayed in the LAUNCHER's cgroup: the delegated leaf and
+/// the `cpu.max` written on it governed nothing at all. Found while adding the
+/// startup preflight for task grkq. `clone_flag_is_the_kernel_value` guards it.
+const CLONE_INTO_CGROUP: u64 = 0x2_0000_0000;
+
+/// `clone3` argument block. Hoisted to module scope so the startup preflight
+/// and the production spawn path use the SAME layout — a preflight that probed
+/// a different struct would prove nothing about the real call.
+#[repr(C)]
+#[derive(Default)]
+struct CloneArgs {
+    flags: u64,
+    pidfd: u64,
+    child_tid: u64,
+    parent_tid: u64,
+    exit_signal: u64,
+    stack: u64,
+    stack_size: u64,
+    tls: u64,
+    set_tid: u64,
+    set_tid_size: u64,
+    cgroup: u64,
+}
+
+impl NativeClone3 {
+    /// Startup readiness probe: is `clone3(CLONE_INTO_CGROUP)` reachable at all?
+    ///
+    /// The launcher's ONLY child-spawn seam is `clone3` with
+    /// `CLONE_INTO_CGROUP`. A sandbox that denies it (task grkq: the container
+    /// runtime's `RuntimeDefault` seccomp profile answers `clone3` with `ENOSYS`
+    /// so glibc falls back to `clone`, and this call site has no such fallback)
+    /// cannot launch a single command — but without this probe that only shows
+    /// up much later, once per command, as an opaque spawn error. Run it before
+    /// the broker binds its socket so an unusable sandbox fails readiness loudly
+    /// and BEFORE the pod accepts work.
+    ///
+    /// The probe passes a syntactically valid but unopened cgroup descriptor.
+    /// The kernel validates that descriptor before it forks, so:
+    ///   * `EBADF` — the syscall is reachable and no child was created;
+    ///   * anything else (notably `ENOSYS`/`EPERM` from a seccomp filter, or
+    ///     `EINVAL` on a kernel without `CLONE_INTO_CGROUP`) — unavailable.
+    pub fn preflight() -> Result<(), Error> {
+        // A descriptor inside the kernel's accepted range (`cgroup` is rejected
+        // with EINVAL above INT_MAX) that this process has certainly not opened.
+        const UNOPENED_FD: u64 = i32::MAX as u64;
+        let args = CloneArgs {
+            flags: CLONE_INTO_CGROUP,
+            exit_signal: libc::SIGCHLD as u64,
+            cgroup: UNOPENED_FD,
+            ..CloneArgs::default()
+        };
+        // SAFETY: a raw `clone3` with a deliberately invalid `cgroup` descriptor.
+        // The kernel rejects it during argument validation, before `copy_process`
+        // forks, so no child can be created and the `rc == 0` arm is unreachable.
+        let rc = unsafe {
+            libc::syscall(
+                libc::SYS_clone3,
+                &raw const args,
+                std::mem::size_of::<CloneArgs>(),
+            )
+        };
+        if rc == 0 {
+            // Defensive: a child here would be an unowned process. Exit it
+            // immediately rather than letting a preflight leak a process.
+            unsafe { libc::_exit(0) };
+        }
+        let errno = io::Error::last_os_error().raw_os_error().unwrap_or(0);
+        if errno == libc::EBADF {
+            Ok(())
+        } else {
+            Err(Error::Clone3Unavailable { errno })
+        }
+    }
+}
+
 /// Close every non-stdio descriptor with one kernel operation. In particular,
 /// do not enumerate `/proc/self/fd`: `read_dir` owns a descriptor which is
 /// reported by that directory and then closed when the iterator is dropped,
@@ -655,38 +798,17 @@ impl CloneIntoCgroup for NativeClone3 {
         {
             return Err(Error::Io(io::Error::last_os_error()));
         }
-        #[repr(C)]
-        struct Args {
-            flags: u64,
-            pidfd: u64,
-            child_tid: u64,
-            parent_tid: u64,
-            exit_signal: u64,
-            stack: u64,
-            stack_size: u64,
-            tls: u64,
-            set_tid: u64,
-            set_tid_size: u64,
-            cgroup: u64,
-        }
-        let args = Args {
-            flags: libc::CLONE_INTO_CGROUP as u64,
-            pidfd: 0,
-            child_tid: 0,
-            parent_tid: 0,
+        let args = CloneArgs {
+            flags: CLONE_INTO_CGROUP,
             exit_signal: libc::SIGCHLD as u64,
-            stack: 0,
-            stack_size: 0,
-            tls: 0,
-            set_tid: 0,
-            set_tid_size: 0,
             cgroup: cgroup as u64,
+            ..CloneArgs::default()
         };
         let pid = unsafe {
             libc::syscall(
                 libc::SYS_clone3,
                 &raw const args,
-                std::mem::size_of::<Args>(),
+                std::mem::size_of::<CloneArgs>(),
             )
         } as i32;
         if pid < 0 {
@@ -876,6 +998,25 @@ mod tests {
     }
     fn create(l: &mut Launcher<FakeFs, FakeClone>, name: &str) -> Leaf {
         l.create_command(name, invocation(), &command()).unwrap().0
+    }
+
+    /// The clone flag must be the kernel's `CLONE_INTO_CGROUP`, and must NOT be
+    /// sourced from `libc`, whose glibc declaration truncates it to 0 (see the
+    /// constant's doc comment). With a zero flag `clone3` degrades to a plain
+    /// fork: the child stays in the launcher's own cgroup, so the delegated leaf
+    /// and its `cpu.max` govern nothing and the containment claim is false.
+    #[test]
+    fn clone_flag_is_the_kernel_value() {
+        assert_eq!(CLONE_INTO_CGROUP, 0x2_0000_0000);
+        assert_ne!(
+            CLONE_INTO_CGROUP, 0,
+            "a zero flag silently turns clone3 into an ordinary fork"
+        );
+        assert_ne!(
+            u64::from(libc::CLONE_INTO_CGROUP as u32),
+            CLONE_INTO_CGROUP,
+            "libc's constant still truncates; keep using the local one"
+        );
     }
 
     #[test]

--- a/server/crates/djinn-cgroup-launcher/src/main.rs
+++ b/server/crates/djinn-cgroup-launcher/src/main.rs
@@ -11,9 +11,12 @@
 //! Configuration is read from the environment the Job renders
 //! (`djinn-k8s::launcher`): the delegated cgroup root, control socket path, the
 //! worker-private credential path, the expected delegated-root owner uid, and the
-//! unleased broker quota. Anything missing/invalid, or a delegated cgroup that
+//! unleased broker quota. Anything missing/invalid, a sandbox that denies the
+//! `clone3(CLONE_INTO_CGROUP)` child-spawn seam, or a delegated cgroup that
 //! fails the [`Readiness`](djinn_cgroup_launcher::Readiness) contract, exits
-//! non-zero BEFORE the broker accepts a single connection.
+//! non-zero with a NAMED error BEFORE the broker accepts a single connection.
+//! Every one of those conditions is a readiness failure, never a per-command
+//! error discovered after the pod has taken work (task grkq).
 
 use std::io::Write;
 use std::path::Path;
@@ -61,9 +64,18 @@ fn run() -> Result<(), MainError> {
         .parse()
         .map_err(|_| MainError::InvalidEnv("DJINN_LAUNCHER_UNLEASED_MILLICORES"))?;
 
-    // Open + validate the delegated cgroup root. `NativeCgroupFs::open` runs the
-    // full readiness contract (cgroup-v2, root writable, owner == expected uid,
-    // exactly the cpu controller delegated) and fails closed otherwise.
+    // Readiness gate 1 — the child-spawn seam. `clone3(CLONE_INTO_CGROUP)` is
+    // the launcher's ONLY way to start a command; a sandbox that denies it (a
+    // seccomp profile answering `clone3` with ENOSYS, or a kernel without
+    // CLONE_INTO_CGROUP) can never run anything. Probe it here so that failure
+    // is a loud, named startup failure instead of an opaque per-command spawn
+    // error surfacing after the pod has already accepted work (task grkq).
+    NativeClone3::preflight()?;
+
+    // Readiness gate 2 — the delegated cgroup root. `NativeCgroupFs::open` runs
+    // the full readiness contract (really a cgroup2 filesystem, cgroup-v2 mode,
+    // root writable and not group/other-writable, owner == expected uid, exactly
+    // the cpu controller delegated) and fails closed, by name, otherwise.
     let fs = NativeCgroupFs::open(&cgroup_root, expected_uid)?;
     let launcher = Launcher::new(
         fs,

--- a/server/crates/djinn-cgroup-launcher/tests/startup_readiness_contract.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/startup_readiness_contract.rs
@@ -1,0 +1,132 @@
+//! Startup readiness contract, on a real kernel, with no fakes and no gate.
+//!
+//! Task grkq: the launcher's two hard startup preconditions — a delegated root
+//! that really is a cgroup v2 tree, and a reachable `clone3(CLONE_INTO_CGROUP)`
+//! — must fail LOUDLY and BEFORE the broker binds its control socket, rather
+//! than surfacing later as an opaque per-command spawn error.
+//!
+//! The containment suite next door drives a `FakeCgroup`, so it can prove what
+//! the launcher does with a readiness value but never whether the launcher can
+//! *derive* a truthful one from an actual directory. That gap is what let a
+//! non-cgroup "delegated root" ship. These tests close it using the real
+//! `NativeCgroupFs`/`NativeClone3` against real filesystem objects, which needs
+//! no privileges and therefore runs in the ordinary test lane.
+
+use std::path::PathBuf;
+
+use djinn_cgroup_launcher::{CGROUP2_SUPER_MAGIC, Error, NativeCgroupFs, NativeClone3};
+
+/// Per-test scratch directory under the crate's test tmpdir.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("grkq-readiness-{label}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("create scratch dir");
+        Self(base)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// A plain directory — which is exactly what an `emptyDir` volume gives a
+/// container — is refused by NAME, not as a bare `ENOENT` from groping for a
+/// control file that was never going to be there.
+#[test]
+fn a_delegated_root_that_is_not_cgroup2_is_refused_by_name() {
+    let scratch = Scratch::new("not-cgroupfs");
+
+    let error = NativeCgroupFs::open(&scratch.0, 0)
+        .err()
+        .expect("a plain directory is not a delegated cgroup v2 root");
+
+    match error {
+        Error::DelegatedRootIsNotCgroupFs {
+            path,
+            actual,
+            expected,
+        } => {
+            assert_eq!(expected, CGROUP2_SUPER_MAGIC);
+            assert_ne!(actual, CGROUP2_SUPER_MAGIC);
+            assert_eq!(path, scratch.0.display().to_string());
+            // The message has to name the path an operator would go look at.
+            let rendered = Error::DelegatedRootIsNotCgroupFs {
+                path,
+                actual,
+                expected,
+            }
+            .to_string();
+            assert!(
+                rendered.contains("cgroup2"),
+                "the failure must say what was expected: {rendered}"
+            );
+        }
+        other => panic!("expected DelegatedRootIsNotCgroupFs, got: {other}"),
+    }
+}
+
+/// The filesystem-type check runs BEFORE any control-file read, so a root that
+/// is not cgroup2 can never be misreported as, say, a missing `cpu` delegation.
+#[test]
+fn the_filesystem_type_check_precedes_the_controller_check() {
+    let scratch = Scratch::new("precedence");
+    // Plant a plausible-looking `cgroup.subtree_control` in a NON-cgroup
+    // directory. If the type check ran second, this would be read and the
+    // launcher would report a controller/ownership problem instead of the
+    // truth: nothing mounted a cgroup2 hierarchy here.
+    std::fs::write(scratch.0.join("cgroup.subtree_control"), "cpu\n").expect("plant control file");
+
+    assert!(
+        matches!(
+            NativeCgroupFs::open(&scratch.0, 0),
+            Err(Error::DelegatedRootIsNotCgroupFs { .. })
+        ),
+        "a forged control file must not be able to disguise a non-cgroup2 root"
+    );
+}
+
+/// The child-spawn seam is probed at startup. On an ordinary test host `clone3`
+/// is reachable, so the preflight passes — and, critically, it does so WITHOUT
+/// forking: a preflight that leaked a process would be worse than no preflight.
+#[test]
+fn the_clone3_preflight_passes_on_a_reachable_kernel_without_forking() {
+    let before = std::process::id();
+    NativeClone3::preflight().expect(
+        "clone3(CLONE_INTO_CGROUP) must be reachable on the test host; if this fails the \
+         sandbox running the tests denies clone3, which is exactly the condition the \
+         preflight exists to report",
+    );
+    assert_eq!(
+        std::process::id(),
+        before,
+        "the preflight must never fork; a returning child would corrupt the test process"
+    );
+}
+
+/// A denied seam is reported as its own named error carrying the errno, so the
+/// operator sees "clone3 is blocked" rather than a generic launch failure. This
+/// is the shape a `seccompProfile: RuntimeDefault` sandbox produces (that
+/// profile answers `clone3` with `ENOSYS`).
+#[test]
+fn a_denied_clone3_is_a_named_readiness_failure_carrying_the_errno() {
+    let denied = Error::Clone3Unavailable {
+        errno: libc::ENOSYS,
+    };
+    let message = denied.to_string();
+    assert!(
+        message.contains("clone3") && message.contains(&libc::ENOSYS.to_string()),
+        "a denied child-spawn seam must name itself and its errno: {message}"
+    );
+    assert!(
+        message.contains("child-spawn"),
+        "the message must say why it is fatal: {message}"
+    );
+}

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -5,6 +5,8 @@ use std::collections::BTreeMap;
 use k8s_openapi::api::core::v1::Toleration;
 use serde::{Deserialize, Serialize};
 
+use crate::launcher::CgroupLauncherMode;
+
 /// Configuration for `KubernetesRuntime`.
 ///
 /// Loaded once at djinn-server boot and cloned into the runtime. Fields
@@ -197,6 +199,21 @@ pub struct KubernetesConfig {
     /// Any other mode fails render validation. Overridable via
     /// `DJINN_K8S_VOLUME_OWNERSHIP_MODE`.
     pub volume_ownership_mode: String,
+    /// Whether a task-run Pod renders the cgroup-launcher sidecar.
+    ///
+    /// Defaults to [`CgroupLauncherMode::Disabled`]: no sidecar, no launcher
+    /// volumes, no launcher env, and the worker runs shell commands in-process
+    /// at the unleased quota. `required` is retained as the arming switch but is
+    /// currently rejected by [`crate::launcher::validate_enforcement_render`],
+    /// because the launcher security context this build renders lacks the
+    /// `CAP_SYS_ADMIN` the goxi runtime profile specifies, so the launcher
+    /// cannot establish its own cgroup2 mount. That is an unbuilt profile, not a
+    /// platform limit: with the designed capabilities the full leaf lifecycle
+    /// works (task grkq — see [`CgroupLauncherMode`] for the measured evidence).
+    /// Overridable via `DJINN_K8S_CGROUP_LAUNCHER_MODE`; an unrecognized value is
+    /// ignored with a warning rather than silently flipping enforcement.
+    #[serde(default)]
+    pub cgroup_launcher_mode: CgroupLauncherMode,
 }
 
 impl KubernetesConfig {
@@ -249,6 +266,10 @@ impl KubernetesConfig {
             // to anything the launcher's runtime readiness check would reject.
             cgroup_delegation_profile: crate::launcher::CGROUP_PROFILE_V2_CPU_ONLY.into(),
             volume_ownership_mode: crate::launcher::VOLUME_OWNERSHIP_ON_ROOT_MISMATCH.into(),
+            // Disabled by default: the rendered pod cannot obtain a delegated
+            // cgroup v2 subtree without privileges this contract refuses, so a
+            // mandatory sidecar would CrashLoopBackOff on every task run.
+            cgroup_launcher_mode: CgroupLauncherMode::Disabled,
             // Unbounded by default: per-project build_resources overrides are
             // gated only by request <= limit until an operator configures the
             // per-kind DJINN_K8S_{TASK,WARM}_{CPU,MEMORY}_{MIN,MAX} envs.
@@ -293,6 +314,7 @@ impl KubernetesConfig {
     /// | `DJINN_K8S_TOLERATIONS` | `tolerations` | `[]` (parsed as a JSON array of k8s `Toleration` objects) |
     /// | `DJINN_K8S_CGROUP_DELEGATION_PROFILE` | `cgroup_delegation_profile` | `cgroup-v2-cpu-only` |
     /// | `DJINN_K8S_VOLUME_OWNERSHIP_MODE` | `volume_ownership_mode` | `fsgroup-on-root-mismatch` |
+    /// | `DJINN_K8S_CGROUP_LAUNCHER_MODE` | `cgroup_launcher_mode` | `disabled` (`required` is currently rejected at render validation) |
     ///
     /// `DJINN_DATABASE_URL` is read from djinn-server's own environment (the
     /// Helm chart projects it via `envFrom: configMap djinn-config`) and
@@ -439,6 +461,17 @@ impl KubernetesConfig {
         }
         if let Ok(v) = std::env::var("DJINN_K8S_VOLUME_OWNERSHIP_MODE") {
             cfg.volume_ownership_mode = v;
+        }
+        if let Ok(v) = std::env::var("DJINN_K8S_CGROUP_LAUNCHER_MODE") {
+            match CgroupLauncherMode::parse(&v) {
+                Some(mode) => cfg.cgroup_launcher_mode = mode,
+                // Keep the safe default rather than guessing: a typo must never
+                // arm (or silently disarm) the enforcement sidecar.
+                None => tracing::warn!(
+                    value = %v,
+                    "DJINN_K8S_CGROUP_LAUNCHER_MODE is not `disabled` or `required` — keeping default"
+                ),
+            }
         }
         // Per-project build_resources hard bounds (per Pod kind, per resource).
         // Unset leaves the axis unbounded. Empty strings are ignored so an

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -22,9 +22,8 @@ use djinn_supervisor::cargo_target_run_dir;
 
 use crate::config::KubernetesConfig;
 use crate::launcher::{
-    RoleResourceClass, launcher_cgroup_volume, launcher_ipc_volume, launcher_sidecar_container,
-    pod_security_context, worker_launcher_env, worker_launcher_ipc_mount, worker_resources,
-    worker_security_context,
+    RoleResourceClass, launcher_ipc_volume, launcher_sidecar_container, pod_security_context,
+    worker_launcher_env, worker_launcher_ipc_mount, worker_resources, worker_security_context,
 };
 use crate::sidecar::{
     BackingServiceSpec, control_volume, control_volume_mount, sidecar_conn_env, sidecar_container,
@@ -241,8 +240,16 @@ pub fn build_task_run_job(
     let mut worker_env = build_task_run_env(config, &task_run_id_str, project_id, policy);
     worker_env.extend(effective_services.iter().flat_map(sidecar_conn_env));
     // Broker socket + worker-private credential paths so the worker can dial the
-    // mandatory cgroup-launcher sidecar.
-    worker_env.extend(worker_launcher_env());
+    // cgroup-launcher sidecar — only when that sidecar is actually rendered.
+    //
+    // Task grkq: these MUST NOT be emitted when the launcher is disabled. The
+    // worker's handshake is detection-gated on the IPC mount existing; projecting
+    // the paths (and the mount) without a sidecar would make it wait out the full
+    // 30s connect window on every pod start before falling back.
+    let renders_launcher = config.cgroup_launcher_mode.renders_sidecar();
+    if renders_launcher {
+        worker_env.extend(worker_launcher_env());
+    }
 
     // The private control emptyDir is added only when a wrapper sidecar is
     // injected, and mounted only into the worker and the wrapper sidecars — never
@@ -270,11 +277,13 @@ pub fn build_task_run_job(
         // comment above for why this narrow exception is safe.
         volume_mount(VOLUME_WORKSPACE, WORKSPACE_MOUNT_DIR, None),
         crate::env_config::env_config_volume_mount(),
-        // Broker control socket + worker-private launcher credential. Shared
-        // with the mandatory cgroup-launcher sidecar only; never mounted into a
-        // backing sidecar, and closed off from the launcher-spawned child.
-        worker_launcher_ipc_mount(),
     ];
+    if renders_launcher {
+        // Broker control socket + worker-private launcher credential. Shared
+        // with the cgroup-launcher sidecar only; never mounted into a backing
+        // sidecar, and closed off from the launcher-spawned child.
+        worker_volume_mounts.push(worker_launcher_ipc_mount());
+    }
     if any_wrapper {
         worker_volume_mounts.push(control_volume_mount());
     }
@@ -409,14 +418,20 @@ pub fn build_task_run_job(
             ..Volume::default()
         },
         crate::env_config::env_config_volume(project_id),
-        // Enforcement volumes for the mandatory cgroup-launcher sidecar. Always
-        // present on a task-run pod: the launcher is mandatory. `launcher-ipc`
-        // (Memory emptyDir) carries the broker control socket + worker-private
-        // credential (worker + launcher only); `launcher-cgroup` is the
-        // launcher's private delegated cgroup root (launcher only).
-        launcher_ipc_volume(),
-        launcher_cgroup_volume(),
     ];
+    if renders_launcher {
+        // Enforcement volume for the cgroup-launcher sidecar: `launcher-ipc`
+        // (Memory emptyDir) carries the broker control socket + worker-private
+        // credential (worker + launcher only).
+        //
+        // There is deliberately NO `launcher-cgroup` volume. The delegated
+        // cgroup root used to be rendered as a plain emptyDir, which is not a
+        // cgroup2 tree at all. It is not a volume at all in the goxi design:
+        // the launcher mounts cgroup2 itself inside its own cgroup namespace.
+        // See the note in `launcher.rs` where that builder used to live, and
+        // `CgroupLauncherMode` for the measured evidence.
+        volumes.push(launcher_ipc_volume());
+    }
     // Backing-service sidecars share a Memory /dev/shm (Postgres needs more than
     // the 64Mi default). Added only when services are injected so the manifest
     // is byte-identical to the pre-feature shape for service-less projects.
@@ -431,22 +446,32 @@ pub fn build_task_run_job(
         volumes.push(control_volume());
     }
 
-    // The mandatory cgroup-launcher is a native sidecar (initContainer +
-    // restartPolicy: Always): it comes up before the worker (which dials its
-    // broker socket) and is torn down when the worker exits, so the Job still
-    // reaches Completed. It is ALWAYS present — including for evidence spikes —
-    // because enforcement is not optional.
+    // The cgroup-launcher is a native sidecar (initContainer + restartPolicy:
+    // Always): it comes up before the worker (which dials its broker socket) and
+    // is torn down when the worker exits, so the Job still reaches Completed.
+    //
+    // Task grkq: it is rendered ONLY when `cgroup_launcher_mode` arms it. It was
+    // previously unconditional, but its delegated cgroup root was an emptyDir,
+    // so the sidecar died in `NativeCgroupFs::open` on every pod and the broker
+    // socket never bound. `validate_enforcement_render` currently rejects the
+    // armed mode outright, so in practice no task-run pod renders it — see
+    // `CgroupLauncherMode` for the measured reason.
     //
     // Each declared backing service is then ALSO a native sidecar, appended
     // AFTER the launcher.  For evidence-spike runs, `effective_services` is
-    // empty so no product databases start, but the launcher stays.
-    let mut init_container_vec = vec![launcher_sidecar_container(config, project_image_tag)];
+    // empty so no product databases start.
+    let mut init_container_vec = Vec::new();
+    if renders_launcher {
+        init_container_vec.push(launcher_sidecar_container(config, project_image_tag));
+    }
     init_container_vec.extend(
         effective_services
             .iter()
             .map(|s| sidecar_container(config, s)),
     );
-    let init_containers = Some(init_container_vec);
+    // Emit no `initContainers` key at all when nothing is injected, restoring the
+    // pre-enforcement shape for a service-less project with the launcher off.
+    let init_containers = (!init_container_vec.is_empty()).then_some(init_container_vec);
 
     // Pin Pods to a dedicated NodePool when the operator has configured one.
     // Both fields stay `None` if the corresponding config entry is empty so
@@ -467,10 +492,12 @@ pub fn build_task_run_job(
         // RPC frame (TerminalReport) before SIGKILL — K8s default 30s is
         // tight when the supervisor is mid-stream over a slow link.
         termination_grace_period_seconds: Some(config.task_run_termination_grace_period_seconds),
-        // shareProcessNamespace lets the launcher sidecar see the worker process
-        // (PID auth via SO_PEERCRED / the broker's worker_pid contract) so it can
-        // authenticate the worker and clone children into the delegated cgroup.
-        share_process_namespace: Some(true),
+        // shareProcessNamespace exists ONLY so the launcher sidecar can see the
+        // worker process (PID auth via SO_PEERCRED / the broker's `worker_pid`
+        // contract). It is a real widening — every backing-service sidecar can
+        // then see the worker's `/proc` entries — so it is set only when the
+        // launcher is actually rendered (task grkq).
+        share_process_namespace: renders_launcher.then_some(true),
         // v1 leases security contract (qut0). The per-container securityContexts
         // set the UIDs now (worker=1000, launcher=0); the pod context ties
         // `fsGroup` to the artifact GID (1000) with `fsGroupChangePolicy:
@@ -1007,17 +1034,18 @@ mod tests {
         let job = wrapper_job();
         let pod = pod_of(&job);
         let inits = pod.init_containers.as_ref().expect("init containers set");
-        // The mandatory cgroup-launcher sidecar renders first, followed by one
-        // wrapper sidecar per service type.
+        // Task grkq: the cgroup-launcher sidecar is OFF by default, so the init
+        // containers are exactly one wrapper sidecar per service type.
         assert_eq!(
             inits.len(),
-            4,
-            "mandatory launcher sidecar + one wrapper sidecar per service type"
+            3,
+            "one wrapper sidecar per service type (no launcher by default)"
         );
-        assert_eq!(
-            inits[0].name,
-            crate::launcher::LAUNCHER_CONTAINER_NAME,
-            "the mandatory cgroup-launcher sidecar renders first"
+        assert!(
+            !inits
+                .iter()
+                .any(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME),
+            "the cgroup-launcher sidecar is disabled by default (task grkq)"
         );
 
         for (svc, port, socket) in [
@@ -1404,10 +1432,11 @@ mod tests {
         );
 
         // Volume mounts: 5 from the pre-env-config layout + the
-        // environment-config mount (P4) + the launcher IPC mount (qut0 leases v1).
+        // environment-config mount (P4). Task grkq: the launcher IPC mount is
+        // NOT rendered by default — `cgroup_launcher_mode` is `Disabled`.
         let mounts = container.volume_mounts.as_ref().expect("volume_mounts set");
-        assert_eq!(mounts.len(), 7, "expected 7 volume mounts");
-        let expected_mounts: [(&str, &str, Option<bool>); 7] = [
+        assert_eq!(mounts.len(), 6, "expected 6 volume mounts");
+        let expected_mounts: [(&str, &str, Option<bool>); 6] = [
             (VOLUME_SPEC, SPEC_MOUNT_DIR, Some(true)),
             (VOLUME_AUTH_TOKEN, TOKEN_MOUNT_DIR, Some(true)),
             (VOLUME_MIRROR, MIRROR_MOUNT_DIR, Some(false)),
@@ -1418,11 +1447,6 @@ mod tests {
                 crate::env_config::ENV_CONFIG_MOUNT_DIR,
                 Some(true),
             ),
-            (
-                crate::launcher::VOLUME_LAUNCHER_IPC,
-                crate::launcher::LAUNCHER_IPC_DIR,
-                None,
-            ),
         ];
         for (mount, (exp_name, exp_path, exp_ro)) in mounts.iter().zip(expected_mounts.iter()) {
             assert_eq!(&mount.name, exp_name);
@@ -1430,9 +1454,11 @@ mod tests {
             assert_eq!(mount.read_only, *exp_ro);
         }
 
-        // Volumes mirror the mount list, plus the launcher-only cgroup volume.
+        // Volumes mirror the mount list exactly. Task grkq: neither the launcher
+        // IPC volume nor a `launcher-cgroup` volume is rendered by default (the
+        // latter can never be rendered — no volume source is a cgroup2 tree).
         let volumes = pod.volumes.as_ref().expect("volumes set");
-        assert_eq!(volumes.len(), 8, "expected 8 volumes");
+        assert_eq!(volumes.len(), 6, "expected 6 volumes");
         let expected_volume_names = [
             VOLUME_SPEC,
             VOLUME_AUTH_TOKEN,
@@ -1440,12 +1466,25 @@ mod tests {
             VOLUME_CACHE,
             VOLUME_WORKSPACE,
             crate::env_config::VOLUME_ENV_CONFIG,
-            crate::launcher::VOLUME_LAUNCHER_IPC,
-            crate::launcher::VOLUME_LAUNCHER_CGROUP,
         ];
         for (volume, expected_name) in volumes.iter().zip(expected_volume_names.iter()) {
             assert_eq!(&volume.name, expected_name);
         }
+        for absent in [
+            crate::launcher::VOLUME_LAUNCHER_IPC,
+            crate::launcher::VOLUME_LAUNCHER_CGROUP,
+        ] {
+            assert!(
+                volumes.iter().all(|v| v.name != absent),
+                "task grkq: {absent} must not be rendered with the launcher disabled"
+            );
+        }
+        // No sidecars at all for a service-less run with the launcher off.
+        assert!(
+            pod.init_containers.is_none(),
+            "task grkq: no launcher ⇒ no initContainers for a service-less run"
+        );
+        assert_eq!(pod.share_process_namespace, None);
 
         // spec → Secret volume with the right name + key-to-path mapping.
         let spec_volume = &volumes[0];
@@ -2319,14 +2358,12 @@ mod tests {
             .as_ref()
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec");
-        // The mandatory launcher sidecar is ALWAYS present; with no backing
-        // services it is the ONLY init container and there is no svc-dshm volume.
-        let bare_inits = bare_pod
-            .init_containers
-            .as_ref()
-            .expect("launcher sidecar is always an init container");
-        assert_eq!(bare_inits.len(), 1, "no services ⇒ launcher sidecar only");
-        assert_eq!(bare_inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
+        // Task grkq: the launcher sidecar is off by default, so a service-less
+        // run renders NO init containers at all and no svc-dshm volume.
+        assert!(
+            bare_pod.init_containers.is_none(),
+            "no services + launcher disabled ⇒ no initContainers"
+        );
         assert!(
             !bare_pod
                 .volumes
@@ -2355,13 +2392,12 @@ mod tests {
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec");
 
-        // Native sidecars in initContainers: the mandatory launcher first, then
-        // the backing service after it.
+        // Native sidecars in initContainers. Task grkq: the launcher is off by
+        // default, so the backing service is the only init container.
         let inits = pod.init_containers.as_ref().expect("init_containers set");
-        assert_eq!(inits.len(), 2);
-        assert_eq!(inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
-        assert_eq!(inits[1].name, "svc-postgres");
-        assert_eq!(inits[1].restart_policy.as_deref(), Some("Always"));
+        assert_eq!(inits.len(), 1);
+        assert_eq!(inits[0].name, "svc-postgres");
+        assert_eq!(inits[0].restart_policy.as_deref(), Some("Always"));
 
         // Connection env var exported to the worker container.
         let worker = &pod.containers[0];
@@ -2661,21 +2697,18 @@ mod tests {
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec set");
 
-        // The mandatory launcher sidecar is still present (enforcement is not
-        // optional), but NO backing-service sidecar is injected.
-        let inits = pod
-            .init_containers
-            .as_ref()
-            .expect("launcher sidecar is always present");
-        assert_eq!(
-            inits.len(),
-            1,
-            "evidence-spike must inject only the launcher, no backing services"
-        );
-        assert_eq!(inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
+        // NO backing-service sidecar is injected. Task grkq: the launcher is off
+        // by default too, so an evidence spike renders no init containers at all.
         assert!(
-            !inits.iter().any(|c| c.name.starts_with("svc-")),
+            pod.init_containers
+                .iter()
+                .flatten()
+                .all(|c| !c.name.starts_with("svc-")),
             "evidence-spike must not inject backing-service sidecars"
+        );
+        assert!(
+            pod.init_containers.is_none(),
+            "evidence-spike with the launcher disabled renders no initContainers"
         );
 
         // No svc-dshm volume.
@@ -2742,11 +2775,11 @@ mod tests {
             .and_then(|s| s.template.spec.as_ref())
             .expect("pod spec set");
 
-        // Launcher + backing-service sidecar both injected for normal runs.
+        // The backing-service sidecar IS injected for normal runs. Task grkq:
+        // the launcher is off by default, so it is the only init container.
         let inits = pod.init_containers.as_ref().expect("init_containers set");
-        assert_eq!(inits.len(), 2);
-        assert_eq!(inits[0].name, crate::launcher::LAUNCHER_CONTAINER_NAME);
-        assert_eq!(inits[1].name, "svc-postgres");
+        assert_eq!(inits.len(), 1);
+        assert_eq!(inits[0].name, "svc-postgres");
 
         // Connection env var IS present.
         let worker = &pod.containers[0];
@@ -3210,6 +3243,15 @@ mod tests {
         )
     }
 
+    /// Task grkq: a config with the cgroup-launcher explicitly ARMED. The
+    /// default (`CgroupLauncherMode::Disabled`) renders no sidecar at all, so
+    /// every launcher-shaped render assertion has to opt in through this.
+    fn armed_launcher_config() -> KubernetesConfig {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.cgroup_launcher_mode = crate::launcher::CgroupLauncherMode::Required;
+        cfg
+    }
+
     fn worker_cpu_request(job: &Job) -> String {
         let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
         pod.containers[0]
@@ -3283,33 +3325,96 @@ mod tests {
         );
     }
 
-    /// AC1/AC3: the mandatory launcher sidecar renders on every task pod with
-    /// shareProcessNamespace, reusing the worker image with the packaged
-    /// launcher binary as its entrypoint.
+    /// Task grkq (P0): the cgroup-launcher sidecar is OFF by default and only
+    /// renders when `cgroup_launcher_mode` arms it. The disabled arm proves no
+    /// launcher container, volume, mount or env leaks into an ordinary task pod
+    /// (and `shareProcessNamespace` stays unset); the armed arm proves the
+    /// sidecar still renders correctly — WITHOUT ever re-introducing a
+    /// `launcher-cgroup` volume, which is the regression this task removed.
     #[test]
-    fn mandatory_launcher_sidecar_with_share_process_namespace() {
+    fn launcher_sidecar_and_share_process_namespace_are_off_by_default_and_render_when_armed() {
         let image = "registry.example/proj:tag";
-        let job = build_task_run_job(
-            &KubernetesConfig::for_testing(),
-            &Uuid::now_v7(),
-            "proj-xyz",
-            "djinn-taskrun-role",
-            image,
-            &[],
-            None,
-            false,
-            Some(RoleKind::Worker),
-        );
-        let pod = job.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
-        assert_eq!(pod.share_process_namespace, Some(true));
+        let build = |cfg: &KubernetesConfig| {
+            build_task_run_job(
+                cfg,
+                &Uuid::now_v7(),
+                "proj-xyz",
+                "djinn-taskrun-role",
+                image,
+                &[],
+                None,
+                false,
+                Some(RoleKind::Worker),
+            )
+        };
 
-        let launcher = pod
-            .init_containers
+        // ---- Disabled (the default) -------------------------------------
+        let default_job = build(&KubernetesConfig::for_testing());
+        let pod = default_job
+            .spec
             .as_ref()
             .unwrap()
-            .iter()
-            .find(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
-            .expect("launcher sidecar present");
+            .template
+            .spec
+            .as_ref()
+            .unwrap();
+        assert!(
+            pod.init_containers
+                .iter()
+                .flatten()
+                .all(|c| c.name != crate::launcher::LAUNCHER_CONTAINER_NAME),
+            "no launcher sidecar by default"
+        );
+        for absent in [
+            crate::launcher::VOLUME_LAUNCHER_IPC,
+            crate::launcher::VOLUME_LAUNCHER_CGROUP,
+        ] {
+            assert!(
+                pod.volumes.iter().flatten().all(|v| v.name != absent),
+                "{absent} must not be rendered by default"
+            );
+        }
+        let worker = &pod.containers[0];
+        assert!(
+            worker
+                .volume_mounts
+                .iter()
+                .flatten()
+                .all(|m| m.mount_path != crate::launcher::LAUNCHER_IPC_DIR),
+            "worker must not mount the launcher IPC dir by default"
+        );
+        for env_name in ["DJINN_LAUNCHER_SOCKET", "DJINN_LAUNCHER_CREDENTIAL_PATH"] {
+            assert!(
+                worker.env.iter().flatten().all(|e| e.name != env_name),
+                "{env_name} must not be exported to the worker by default"
+            );
+        }
+        assert_eq!(
+            pod.share_process_namespace, None,
+            "shareProcessNamespace exists only for the launcher; unset by default"
+        );
+
+        // ---- Required (explicitly armed) --------------------------------
+        let armed_job = build(&armed_launcher_config());
+        let armed = armed_job
+            .spec
+            .as_ref()
+            .unwrap()
+            .template
+            .spec
+            .as_ref()
+            .unwrap();
+        assert_eq!(armed.share_process_namespace, Some(true));
+        let inits = armed
+            .init_containers
+            .as_ref()
+            .expect("armed launcher renders an init container");
+        assert_eq!(
+            inits[0].name,
+            crate::launcher::LAUNCHER_CONTAINER_NAME,
+            "the launcher sidecar renders first when armed"
+        );
+        let launcher = &inits[0];
         assert_eq!(
             launcher.image.as_deref(),
             Some(image),
@@ -3321,6 +3426,26 @@ mod tests {
             "runs the packaged launcher binary — no fabricated image ref"
         );
         assert_eq!(launcher.restart_policy.as_deref(), Some("Always"));
+        assert!(
+            armed
+                .volumes
+                .iter()
+                .flatten()
+                .any(|v| v.name == crate::launcher::VOLUME_LAUNCHER_IPC),
+            "the IPC volume renders when armed"
+        );
+        // P0 REGRESSION GUARD (task grkq): the delegated cgroup root must NEVER
+        // be rendered as a volume again. The emptyDir that used to back it was
+        // not a cgroup2 tree, so the sidecar CrashLoopBackOffed on every pod; no
+        // volume source can supply a delegated cgroup v2 subtree here.
+        assert!(
+            armed
+                .volumes
+                .iter()
+                .flatten()
+                .all(|v| v.name != crate::launcher::VOLUME_LAUNCHER_CGROUP),
+            "no `launcher-cgroup` volume may be rendered, even when armed"
+        );
     }
 
     /// AC1: distinct worker/child UIDs, artifact GID, fsGroup/setgid ownership,
@@ -3349,13 +3474,35 @@ mod tests {
         );
 
         // Launcher container: uid 0, minimal caps only, restricted seccomp.
-        let launcher = pod
+        // Task grkq: the launcher only renders when armed, so its half of the
+        // contract is asserted against an armed config. The worker/pod half
+        // above is unconditional and stays on the default config.
+        let armed_job = build_task_run_job(
+            &armed_launcher_config(),
+            &Uuid::now_v7(),
+            "proj-xyz",
+            "djinn-taskrun-role",
+            "registry.example/proj:tag",
+            &[],
+            None,
+            false,
+            Some(RoleKind::Worker),
+        );
+        let armed_pod = armed_job
+            .spec
+            .as_ref()
+            .unwrap()
+            .template
+            .spec
+            .as_ref()
+            .unwrap();
+        let launcher = armed_pod
             .init_containers
             .as_ref()
             .unwrap()
             .iter()
             .find(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
-            .unwrap();
+            .expect("armed launcher sidecar present");
         let lsc = launcher
             .security_context
             .as_ref()
@@ -3384,12 +3531,14 @@ mod tests {
         assert_eq!(psc.run_as_user, None);
     }
 
-    /// AC1/AC2: credential + delegated-cgroup mount isolation. The IPC surface
-    /// is shared only by worker + launcher; the delegated cgroup is launcher-only;
-    /// no backing sidecar can touch either (no workspace/broker access).
+    /// AC1/AC2: credential mount isolation, asserted against an ARMED launcher
+    /// config (task grkq: nothing launcher-shaped renders by default). The IPC
+    /// surface is shared only by worker + launcher, no backing sidecar can touch
+    /// it (nor the workspace/mirror), and NO delegated-cgroup volume is rendered
+    /// at all — that volume was the P0 CrashLoopBackOff and it is gone for good.
     #[test]
-    fn launcher_credential_and_cgroup_mounts_are_isolated() {
-        let cfg = KubernetesConfig::for_testing();
+    fn launcher_credential_mounts_are_isolated_and_no_cgroup_volume_is_rendered() {
+        let cfg = armed_launcher_config();
         let postgres = BackingServiceSpec {
             service_type: "postgres".into(),
             image: "postgres:18-alpine".into(),
@@ -3436,9 +3585,16 @@ mod tests {
             .find(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
             .unwrap();
         assert!(mount_names(launcher).contains(&crate::launcher::VOLUME_LAUNCHER_IPC.to_string()));
-        // Delegated cgroup: launcher only (not the worker).
+        // Task grkq: no delegated-cgroup volume exists on the pod at all, and no
+        // container mounts one — not even the launcher. A volumeMount naming a
+        // volume the pod does not declare is a manifest the API server rejects,
+        // so both sides had to go together (see `launcher.rs`).
         assert!(
-            mount_names(launcher).contains(&crate::launcher::VOLUME_LAUNCHER_CGROUP.to_string())
+            pod.volumes
+                .iter()
+                .flatten()
+                .all(|v| v.name != crate::launcher::VOLUME_LAUNCHER_CGROUP),
+            "no `launcher-cgroup` volume may be rendered"
         );
         assert!(
             !mount_names(worker).contains(&crate::launcher::VOLUME_LAUNCHER_CGROUP.to_string())

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -1,6 +1,12 @@
-//! Enforcement-pod rendering: role-classed resources, the mandatory
+//! Enforcement-pod rendering: role-classed resources, the (mode-gated)
 //! cgroup-launcher sidecar, the v1 worker/child/launcher security contract, and
 //! the fail-closed render/startup validation seam.
+//!
+//! The launcher sidecar is **not** unconditionally rendered. See
+//! [`CgroupLauncherMode`] for the measured reason: a Pod holding this module's
+//! security contract cannot obtain a writable, delegated cgroup v2 subtree on a
+//! containerd/k3s cgroup-v2 node without privileges the contract refuses. The
+//! default is [`CgroupLauncherMode::Disabled`].
 //!
 //! This module is *pure*: every function is a deterministic manifest builder or
 //! a `Result`-returning validator. Nothing here talks to a cluster or mutates
@@ -24,6 +30,7 @@ use k8s_openapi::api::core::v1::{
     ResourceRequirements, SeccompProfile, SecurityContext, Volume, VolumeMount,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 // Re-exported so every pod render that shares the cache volumes (task-run in
@@ -96,6 +103,96 @@ pub const VOLUME_LAUNCHER_CGROUP: &str = "launcher-cgroup";
 /// Mount path of [`VOLUME_LAUNCHER_CGROUP`] (the delegated cgroup-v2 root the
 /// launcher opens; owned by [`LAUNCHER_UID`]).
 pub const LAUNCHER_CGROUP_ROOT: &str = "/run/djinn-cgroup";
+
+/// Whether an enforcement task-run Pod renders the cgroup-launcher sidecar.
+///
+/// # Why this is not simply "always on" (task grkq)
+///
+/// **This is an implementation gap, NOT a Kubernetes limitation.** Delegated
+/// cgroup v2 enforcement is entirely achievable here; the runtime profile the
+/// goxi proposal specifies was simply never built. Do not read this as "cgroup
+/// enforcement is impossible on Kubernetes" — that is false, and measurably so.
+///
+/// goxi specifies that the launcher runs with `CAP_SYS_ADMIN`,
+/// `CAP_SYS_RESOURCE`, `CAP_SETUID`, `CAP_SETGID`, "the runtime-default seccomp
+/// profile plus an allowlist for cgroup setup and clone3", and "a dedicated
+/// read-write cgroup-v2 mount visible only in the launcher container". What
+/// this module renders is [`launcher_capabilities`] — `drop: ALL` plus only
+/// `SETUID`/`SETGID`/`SETPCAP` — a plain `RuntimeDefault` seccomp profile, and
+/// (previously) an `emptyDir` where the RW cgroup2 mount belongs.
+///
+/// Measured on a real kubelet + containerd node (kind, k8s v1.36.1, cgroup v2),
+/// three containers differing only in security context:
+///
+/// * **With the designed profile** — `CAP_SYS_ADMIN` + `CAP_SYS_RESOURCE`, and
+///   the launcher establishing its own cgroup2 mount inside its own cgroup
+///   namespace — the entire launcher lifecycle works: `mount -t cgroup2` RW,
+///   vacate the root into `init/`, enable `+cpu` in `cgroup.subtree_control`,
+///   create an invocation leaf, write the 250m unleased `cpu.max`,
+///   `clone3(CLONE_INTO_CGROUP)` a child into it (confirmed present in the
+///   leaf's `cgroup.procs`), read `cpu.stat` showing real throttling
+///   (`nr_throttled 4`), lift to `max`, then kill/drain/remove.
+/// * **With `seccompProfile: RuntimeDefault` and those capabilities** — the
+///   same lifecycle succeeds. The container runtime's default profile denies
+///   `clone3` with `ENOSYS` only for containers WITHOUT `CAP_SYS_ADMIN`; with it,
+///   `clone3` is permitted. So goxi's "allowlist for clone3" needs no `Localhost`
+///   seccomp profile at all — `RuntimeDefault` suffices once the capability is
+///   granted.
+/// * **With the profile this module actually renders** — the very first step,
+///   `mount("none", root, "cgroup2", ...)`, fails with `EPERM`.
+///
+/// The single blocking divergence is therefore `CAP_SYS_ADMIN`. A `hostPath`
+/// onto a node subtree is NOT the route (the pod's private cgroup namespace is
+/// mounted `nsdelegate`, so `clone3(CLONE_INTO_CGROUP)` into a target outside
+/// that namespace root fails with `ENOENT`) — but that is a property of the
+/// workaround, not of the design, which mounts inside the launcher's own cgroup
+/// namespace where an invocation leaf IS a descendant of the namespace root.
+///
+/// Until the designed profile is rendered — capability set, chart runtime-profile
+/// plumbing, and the launcher-established cgroup2 mount — the default is
+/// [`Disabled`](CgroupLauncherMode::Disabled): no sidecar, no launcher volume,
+/// no launcher env, and the worker executes shells in-process at the unleased
+/// quota. [`Required`](CgroupLauncherMode::Required) is the arming switch, and
+/// [`validate_enforcement_render`] rejects it fail-closed at dispatch rather
+/// than shipping a Pod whose sidecar cannot start. That gate is what a follow-up
+/// flips once the runtime profile lands.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CgroupLauncherMode {
+    /// No sidecar, no launcher volumes, no launcher env. Shell commands run
+    /// in-process in the worker, unleased. This is the default.
+    #[default]
+    Disabled,
+    /// Arm the mandatory sidecar. Currently unsatisfiable in this topology and
+    /// rejected by [`validate_enforcement_render`].
+    Required,
+}
+
+impl CgroupLauncherMode {
+    /// Stable config/telemetry string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Required => "required",
+        }
+    }
+
+    /// Parse the `DJINN_K8S_CGROUP_LAUNCHER_MODE` value. Unknown values are
+    /// rejected rather than silently defaulting, so a typo can neither arm nor
+    /// disarm enforcement by accident.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "disabled" => Some(Self::Disabled),
+            "required" => Some(Self::Required),
+            _ => None,
+        }
+    }
+
+    /// Does this mode render the sidecar and its volumes?
+    pub fn renders_sidecar(&self) -> bool {
+        matches!(self, Self::Required)
+    }
+}
 
 /// v1 resource class a task-run Pod is provisioned under, derived from the role
 /// that executes the run. Only the CPU **request** differs between the two — the
@@ -294,14 +391,23 @@ pub fn launcher_ipc_volume() -> Volume {
     }
 }
 
-/// The launcher's private delegated cgroup root volume (launcher-only).
-pub fn launcher_cgroup_volume() -> Volume {
-    Volume {
-        name: VOLUME_LAUNCHER_CGROUP.to_string(),
-        empty_dir: Some(EmptyDirVolumeSource::default()),
-        ..Volume::default()
-    }
-}
+// NOTE (task grkq): there is deliberately NO `launcher_cgroup_volume()` here.
+//
+// This function used to return `EmptyDirVolumeSource::default()` for
+// [`VOLUME_LAUNCHER_CGROUP`]. An emptyDir is an ordinary directory on the node
+// filesystem, so `/run/djinn-cgroup` had no `cgroup.subtree_control` and the
+// launcher's `NativeCgroupFs::open` failed with a bare ENOENT on every pod —
+// CrashLoopBackOff for the sidecar, no broker socket, and (before the fallback
+// was restored) a hard failure for every single shell command in every task run.
+//
+// It is not replaced by a hostPath: as documented on [`CgroupLauncherMode`], a
+// hostPath cannot supply a *usable* delegated root either, because the pod's
+// private cgroup namespace plus `nsdelegate` refuse `clone3(CLONE_INTO_CGROUP)`
+// into anything outside it. Rendering a volume source that provably cannot
+// satisfy the launcher's readiness contract is worse than rendering none: it
+// re-creates exactly the failure this task exists to remove. When a real
+// node-level delegation mechanism exists, add the volume source together with
+// the render validation that proves it is a cgroup2 tree.
 
 /// Worker-side mount of the IPC volume so the worker can dial the broker socket
 /// and read its private credential.
@@ -346,14 +452,15 @@ pub fn launcher_sidecar_container(config: &KubernetesConfig, project_image_tag: 
                 &LAUNCHER_UNLEASED_MILLICORES.to_string(),
             ),
         ]),
-        volume_mounts: Some(vec![
-            worker_launcher_ipc_mount(),
-            VolumeMount {
-                name: VOLUME_LAUNCHER_CGROUP.to_string(),
-                mount_path: LAUNCHER_CGROUP_ROOT.to_string(),
-                ..VolumeMount::default()
-            },
-        ]),
+        // IPC only. There is deliberately no mount at [`LAUNCHER_CGROUP_ROOT`]:
+        // the delegated root is not something a *volume source* can supply — in
+        // the goxi design the launcher mounts cgroup2 there ITSELF, inside its
+        // own cgroup namespace, which needs `CAP_SYS_ADMIN` rather than a volume
+        // (see [`CgroupLauncherMode`]). A volumeMount naming a volume the pod
+        // does not declare is also a manifest the API server rejects outright.
+        // The launcher still reads `DJINN_LAUNCHER_CGROUP_ROOT` and creates the
+        // mount point there when it is granted the capability to do so.
+        volume_mounts: Some(vec![worker_launcher_ipc_mount()]),
         security_context: Some(launcher_security_context()),
         resources: Some(ResourceRequirements {
             requests: Some(BTreeMap::from([
@@ -407,6 +514,17 @@ pub enum RenderValidationError {
         mode: String,
         expected: &'static str,
     },
+    #[error(
+        "cgroup launcher mode is `required`, but the launcher security context this build renders \
+         cannot obtain a delegated cgroup v2 subtree: it lacks CAP_SYS_ADMIN, so the launcher's \
+         own `mount -t cgroup2` fails with EPERM. This is an unbuilt runtime profile, not a \
+         platform limit — the goxi profile (CAP_SYS_ADMIN + CAP_SYS_RESOURCE, with the launcher \
+         mounting cgroup2 inside its own cgroup namespace) drives the full leaf lifecycle \
+         successfully, and RuntimeDefault seccomp already permits clone3 once CAP_SYS_ADMIN is \
+         granted. Run with DJINN_K8S_CGROUP_LAUNCHER_MODE=disabled (the default) until the \
+         designed profile is rendered. See djinn_k8s::launcher::CgroupLauncherMode."
+    )]
+    CgroupDelegationUnavailable,
 }
 
 /// Map a supported/unsupported cgroup-delegation profile string onto the
@@ -485,6 +603,17 @@ pub fn validate_enforcement_render(config: &KubernetesConfig) -> Result<(), Rend
             mode: config.volume_ownership_mode.clone(),
             expected: VOLUME_OWNERSHIP_ON_ROOT_MISMATCH,
         });
+    }
+
+    // 4. The launcher may only be ARMED if this topology can actually deliver a
+    //    delegated cgroup v2 subtree. It cannot (see `CgroupLauncherMode`), so
+    //    `required` fails closed at dispatch — before a Job is submitted and
+    //    therefore before any pod can come up with a sidecar that cannot start.
+    //    This is the render-time half of the readiness contract; the launcher
+    //    binary enforces the runtime half (`NativeClone3::preflight` +
+    //    `NativeCgroupFs::open`) before it binds its control socket.
+    if config.cgroup_launcher_mode.renders_sidecar() {
+        return Err(RenderValidationError::CgroupDelegationUnavailable);
     }
 
     Ok(())

--- a/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
+++ b/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
@@ -1,0 +1,326 @@
+//! The coverage whose absence hid task grkq's P0.
+//!
+//! # What went wrong, and why nothing caught it
+//!
+//! `launcher_cgroup_volume()` rendered the cgroup-launcher's "private delegated
+//! cgroup root" as a plain `emptyDir`. An emptyDir is an ordinary directory on
+//! the node filesystem — it has no `cgroup.subtree_control`, no `cpu.max`, none
+//! of the cgroup2 control files the launcher opens. So on every task-run Pod the
+//! sidecar died in `NativeCgroupFs::open`, the broker socket never bound, the
+//! worker handshake never completed, and (because the in-process fallback the
+//! comments promised was `#[cfg(test)]`-only) every shell command in every task
+//! run failed.
+//!
+//! Three test suites existed and none could see it:
+//!   * `djinn-k8s`'s own `job.rs`/`launcher.rs` unit tests assert the manifest as
+//!     a *struct* — an `EmptyDirVolumeSource` is a perfectly well-formed volume,
+//!     so every assertion passed;
+//!   * `djinn-cgroup-launcher`'s containment suite drives a `FakeCgroup`, which
+//!     is a `HashMap` and therefore satisfies any readiness the test wants;
+//!   * `djinn-k8s/tests/kind_smoke.rs` is `#[ignore]`d behind `DJINN_TEST_KIND`,
+//!     nothing in CI sets it, and it asserts nothing about the launcher anyway.
+//!
+//! The missing link was always the same: **nobody ever took the volume source
+//! this crate actually renders, materialized it the way a kubelet would, and
+//! handed it to the real launcher code.** That is exactly what this file does.
+//!
+//! # Why it is not `#[ignore]`d and needs no privileges
+//!
+//! It runs the REAL `djinn_cgroup_launcher::NativeCgroupFs::open` and the REAL
+//! `NativeClone3::preflight` against a REAL kernel — no fakes — but every check
+//! is a `statfs`/`openat`/`clone3`-argument-validation on a directory this test
+//! owns. There is nothing to gate, so it runs in the ordinary
+//! `cargo test -p djinn-k8s` lane where a human sees it, on every PR.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::{EmptyDirVolumeSource, PodSpec, Volume};
+use uuid::Uuid;
+
+use djinn_cgroup_launcher::{CGROUP2_SUPER_MAGIC, Error as LauncherError, NativeCgroupFs};
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::job::build_task_run_job;
+use djinn_k8s::launcher::{
+    CgroupLauncherMode, LAUNCHER_CGROUP_ROOT, LAUNCHER_CONTAINER_NAME, LAUNCHER_UID,
+    RenderValidationError, VOLUME_LAUNCHER_CGROUP, validate_enforcement_render,
+};
+
+/// Render the real task-run Job under `mode`.
+fn render(mode: CgroupLauncherMode) -> Job {
+    let mut config = KubernetesConfig::for_testing();
+    config.cgroup_launcher_mode = mode;
+    build_task_run_job(
+        &config,
+        &Uuid::now_v7(),
+        "proj-grkq",
+        "djinn-taskrun-grkq",
+        "registry.example/djinn-project:grkq",
+        &[],
+        None,
+        false,
+        None,
+    )
+}
+
+fn pod_of(job: &Job) -> &PodSpec {
+    job.spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("rendered Job has a pod spec")
+}
+
+/// A private scratch directory under the crate's test tmpdir. Deliberately not
+/// `tempfile`: this crate does not carry it as a dev-dependency, and adding one
+/// for a `mkdir` would drag the whole workspace-hack regeneration along.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("grkq-{label}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("create scratch dir");
+        Self(base)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Every `(container_name, volume)` pair that mounts `mount_path`.
+fn volumes_mounted_at<'a>(pod: &'a PodSpec, mount_path: &str) -> Vec<(&'a str, &'a Volume)> {
+    let volumes = pod.volumes.as_deref().unwrap_or_default();
+    pod.containers
+        .iter()
+        .chain(pod.init_containers.iter().flatten())
+        .flat_map(|container| {
+            container
+                .volume_mounts
+                .iter()
+                .flatten()
+                .filter(|mount| mount.mount_path == mount_path)
+                .map(move |mount| (container.name.as_str(), mount.name.as_str()))
+        })
+        .map(|(container, volume_name)| {
+            let volume = volumes
+                .iter()
+                .find(|volume| volume.name == volume_name)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{container} mounts volume {volume_name}, which the pod does not declare"
+                    )
+                });
+            (container, volume)
+        })
+        .collect()
+}
+
+/// Materialize a rendered volume source the way a kubelet would, and return the
+/// directory the container would see. `None` means "this source cannot be
+/// materialized locally", which for our purposes is itself an answer.
+fn materialize(volume: &Volume, scratch: &Path) -> Option<PathBuf> {
+    if volume.empty_dir.is_some() {
+        // An emptyDir is a fresh, empty directory on the node: for a `medium:
+        // Memory` volume a tmpfs, otherwise the node's own filesystem. Neither
+        // is a cgroup2 hierarchy, which is the entire point.
+        let dir = scratch.join(&volume.name);
+        std::fs::create_dir_all(&dir).expect("materialize emptyDir");
+        return Some(dir);
+    }
+    if let Some(host_path) = volume.host_path.as_ref() {
+        return Some(PathBuf::from(&host_path.path));
+    }
+    None
+}
+
+/// **The contract.** For the manifest this crate actually renders: either the
+/// launcher is not rendered at all, or the delegated cgroup root it mounts
+/// materializes into a filesystem the real launcher accepts.
+///
+/// Run against BOTH modes, so arming the launcher in the future cannot quietly
+/// reintroduce a root that is not a cgroup2 tree.
+#[test]
+fn every_rendered_delegated_cgroup_root_is_a_real_cgroup2_tree() {
+    let scratch = Scratch::new("delegated-root");
+
+    for mode in [CgroupLauncherMode::Disabled, CgroupLauncherMode::Required] {
+        let job = render(mode);
+        let pod = pod_of(&job);
+
+        for (container, volume) in volumes_mounted_at(pod, LAUNCHER_CGROUP_ROOT) {
+            let root = materialize(volume, scratch.path()).unwrap_or_else(|| {
+                panic!(
+                    "{mode:?}: container {container} mounts a delegated cgroup root at \
+                     {LAUNCHER_CGROUP_ROOT} from volume {} whose source cannot be a cgroup2 \
+                     hierarchy",
+                    volume.name
+                )
+            });
+
+            // The real launcher code, on a real kernel, against the volume this
+            // crate really renders. No fake, no fixture, no ignore gate.
+            if let Err(error) = NativeCgroupFs::open(&root, LAUNCHER_UID as u32) {
+                panic!(
+                    "{mode:?}: the rendered delegated cgroup root for container {container} \
+                     (volume {}) is not usable by the launcher: {error}. A task-run Pod with \
+                     this rendering CrashLoopBackOffs its cgroup-launcher sidecar on startup.",
+                    volume.name
+                );
+            }
+        }
+    }
+}
+
+/// Prove the check above has teeth: the exact volume source that shipped the P0
+/// is rejected, by name, by the same code path the contract test runs.
+///
+/// Without this, `every_rendered_delegated_cgroup_root_is_a_real_cgroup2_tree`
+/// could pass vacuously (it does pass vacuously today — nothing mounts that path
+/// any more) and nobody would know whether it can fail at all.
+#[test]
+fn the_emptydir_delegated_root_that_shipped_the_p0_is_rejected_by_name() {
+    let scratch = Scratch::new("delegated-root");
+    // Byte-for-byte the volume `launcher_cgroup_volume()` used to return.
+    let shipped = Volume {
+        name: VOLUME_LAUNCHER_CGROUP.to_string(),
+        empty_dir: Some(EmptyDirVolumeSource::default()),
+        ..Volume::default()
+    };
+    let root = materialize(&shipped, scratch.path()).expect("emptyDir materializes");
+
+    let error = NativeCgroupFs::open(&root, LAUNCHER_UID as u32)
+        .err()
+        .expect("an emptyDir can never satisfy the launcher readiness contract");
+
+    // Named, not an opaque ENOENT from reading `cgroup.subtree_control`. The
+    // opacity was half of why this took a production outage to find.
+    match error {
+        LauncherError::DelegatedRootIsNotCgroupFs {
+            expected, actual, ..
+        } => {
+            assert_eq!(expected, CGROUP2_SUPER_MAGIC);
+            assert_ne!(
+                actual, CGROUP2_SUPER_MAGIC,
+                "an emptyDir must not report itself as cgroup2"
+            );
+        }
+        other => panic!("expected a named non-cgroup2 readiness failure, got: {other}"),
+    }
+}
+
+/// The default rendering carries no launcher surface whatsoever — not the
+/// sidecar, not the cgroup volume, and not a `/run/djinn-cgroup` mount.
+#[test]
+fn the_default_rendering_has_no_launcher_surface() {
+    let job = render(CgroupLauncherMode::Disabled);
+    let pod = pod_of(&job);
+
+    let containers: BTreeSet<&str> = pod
+        .containers
+        .iter()
+        .chain(pod.init_containers.iter().flatten())
+        .map(|container| container.name.as_str())
+        .collect();
+    assert!(
+        !containers.contains(LAUNCHER_CONTAINER_NAME),
+        "the launcher sidecar must not render by default: {containers:?}"
+    );
+
+    assert!(
+        volumes_mounted_at(pod, LAUNCHER_CGROUP_ROOT).is_empty(),
+        "nothing may mount a delegated cgroup root by default"
+    );
+    assert!(
+        !pod.volumes
+            .iter()
+            .flatten()
+            .any(|volume| volume.name == VOLUME_LAUNCHER_CGROUP),
+        "the delegated cgroup volume must not be declared by default"
+    );
+}
+
+/// Even when the mode is armed, no `launcher-cgroup` volume is rendered.
+///
+/// A delegated cgroup v2 subtree is not something a *volume source* can supply
+/// at all: in the goxi design the launcher establishes its own cgroup2 mount
+/// inside its own cgroup namespace (which needs `CAP_SYS_ADMIN`, not a volume).
+/// This is the guard against "fix" attempts that re-add an emptyDir, or reach
+/// for a hostPath — which `nsdelegate` refuses across the pod's private cgroup
+/// namespace anyway.
+#[test]
+fn arming_the_launcher_still_renders_no_bogus_cgroup_volume() {
+    let pod = render(CgroupLauncherMode::Required);
+    let pod = pod_of(&pod);
+    assert!(
+        !pod.volumes
+            .iter()
+            .flatten()
+            .any(|volume| volume.name == VOLUME_LAUNCHER_CGROUP),
+        "no volume source can supply a delegated cgroup v2 subtree in this topology"
+    );
+}
+
+/// The render-time half of the readiness contract: arming the launcher fails
+/// closed at dispatch, before a Job is submitted, rather than after a pod has
+/// come up with a sidecar that cannot start.
+#[test]
+fn arming_the_launcher_fails_render_validation_before_any_job_is_submitted() {
+    let mut config = KubernetesConfig::for_testing();
+    assert!(
+        validate_enforcement_render(&config).is_ok(),
+        "the default (disabled) config must dispatch"
+    );
+
+    config.cgroup_launcher_mode = CgroupLauncherMode::Required;
+    let error = validate_enforcement_render(&config)
+        .expect_err("an unsatisfiable delegation must fail closed");
+    assert!(
+        matches!(error, RenderValidationError::CgroupDelegationUnavailable),
+        "expected CgroupDelegationUnavailable, got: {error}"
+    );
+    // The operator has to be told what to do, not just that it failed — and the
+    // message must not misrepresent an unbuilt runtime profile as a platform
+    // limit, because that is how a solvable gap gets remembered as impossible.
+    let message = error.to_string();
+    for expected in [
+        "CAP_SYS_ADMIN",
+        "not a platform limit",
+        "DJINN_K8S_CGROUP_LAUNCHER_MODE=disabled",
+    ] {
+        assert!(
+            message.contains(expected),
+            "the rejection must explain {expected}: {message}"
+        );
+    }
+}
+
+/// The launcher mode round-trips through its config string and refuses typos, so
+/// a malformed `DJINN_K8S_CGROUP_LAUNCHER_MODE` can neither arm nor disarm
+/// enforcement by accident.
+#[test]
+fn launcher_mode_parses_exactly_its_two_documented_values() {
+    for mode in [CgroupLauncherMode::Disabled, CgroupLauncherMode::Required] {
+        assert_eq!(CgroupLauncherMode::parse(mode.as_str()), Some(mode));
+    }
+    assert_eq!(CgroupLauncherMode::default(), CgroupLauncherMode::Disabled);
+    assert!(!CgroupLauncherMode::Disabled.renders_sidecar());
+    assert!(CgroupLauncherMode::Required.renders_sidecar());
+    for typo in ["Required", "enabled", "", "requried"] {
+        assert_eq!(
+            CgroupLauncherMode::parse(typo),
+            None,
+            "{typo:?} must not parse"
+        );
+    }
+}

--- a/server/crates/djinn-supervisor/src/services/invocation_admission.rs
+++ b/server/crates/djinn-supervisor/src/services/invocation_admission.rs
@@ -30,6 +30,22 @@ use crate::services::lease::InvocationLiftDecision;
 /// The caller additionally requires a matching durable fencing token before it
 /// acts on a [`InvocationLiftDecision::Lift`]; this function never authorizes a
 /// lift on epoch alone.
+///
+/// # Shadow CLAMPS — it does not speed anything up
+///
+/// Read this before arming `v1 = shadow` in production. Only
+/// [`InvocationLiftDecision::Lift`] ever raises `cpu.max`. `Shadow` binds the
+/// invocation and records telemetry (the "would throttle" arms) and then leaves
+/// the leaf pinned at the broker's unleased quota —
+/// `UnleasedQuota::DEFAULT_MILLICORES`, i.e. **250m** — for the whole command.
+/// `Unleased` is a literal no-op with the same effect. So a rollout that seeds
+/// the epoch and arms shadow makes every leased build slower, not faster: it is
+/// an observation mode whose entire purpose is to measure what enforcement
+/// *would* do. This is correct by design and asserted by
+/// `shadow_epoch_binds_but_never_lifts` and `unleased_epoch_binds_but_never_lifts`
+/// in `djinn-agent`'s `process/tests/process_lease_tests.rs` — do not "fix" it.
+/// Only `v1 = enforce` with a fully acknowledged
+/// `ForwardOverlap`/`InvocationPrimary`/`RollbackOverlap` phase lifts the quota.
 #[must_use]
 pub fn evaluate_invocation_lift(
     row: Result<Option<AdmissionHandoffRow>, ()>,


### PR DESCRIPTION
Fixes board task `grkq` (P0). Dispatch is paused; this is what unpauses it.

## The defect

`launcher_cgroup_volume()` rendered the cgroup-launcher's "private delegated cgroup root" as a plain `emptyDir`. An emptyDir is an ordinary directory on the node filesystem — it has no `cgroup.subtree_control` — so `NativeCgroupFs::open` returned `ENOENT` on every task-run pod. The sidecar is a native sidecar (`initContainer` + `restartPolicy: Always`), so that was CrashLoopBackOff, the broker socket never bound, the worker handshake never completed, and `state.shell_launch` stayed `None`.

The in-process fallback that `launcher_handshake.rs` and `worker/main.rs` promised in their doc comments was compiled **only under `#[cfg(test)]`**. In production the `#[cfg(not(test))]` arm returned `broker-backed shell launch context is not configured`. Net effect: every `call_shell` in every task run failed.

## Part 1 — why the launcher cannot be mandatory *as implemented*

**Conclusion up front: the securityContext we actually render cannot obtain a delegated cgroup v2 subtree, because it diverges from the runtime profile the goxi proposal specifies. The launcher stops being unconditionally mandatory until that profile is built.**

This is a divergence between proposal and implementation, **not** a limitation of Kubernetes. The goxi proposal is explicit that the launcher runs with:

> "CAP_SYS_ADMIN, CAP_SYS_RESOURCE, CAP_SETUID, and CAP_SETGID … the runtime-default seccomp profile **plus an allowlist for cgroup setup and clone3** … A **dedicated read-write cgroup-v2 mount** is visible only in the launcher container."

What shipped is `drop: ["ALL"]` + `add: ["SETUID","SETGID","SETPCAP"]` with a plain `seccompProfile: RuntimeDefault` and an `emptyDir` where the RW cgroup2 mount should be. Three specific divergences:

| goxi specifies | as implemented | consequence |
|---|---|---|
| `CAP_SYS_ADMIN` (+ `CAP_SYS_RESOURCE`) | neither | the launcher cannot establish its own RW cgroup2 mount |
| RuntimeDefault **plus an allowlist for cgroup setup and `clone3`** | plain RuntimeDefault | the only child-spawn seam is denied |
| a dedicated RW cgroup-v2 mount, launcher-only | `emptyDir` | the delegated root is not a cgroup filesystem at all |

I measured each on a real kubelet + containerd cgroup-v2 node (kind, k8s v1.36.1) using exactly the securityContext `launcher_security_context()` renders. **Read the three findings below as "what the as-implemented profile does", not as "what Kubernetes permits".**

**Wall 1 — the container's own `/sys/fs/cgroup` is read-only.**

```
1366 1365 0:32 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw,nsdelegate,...
### own cgroup.subtree_control:          <- empty; no controller delegated
### mkdir in own cgroup:
mkdir: cannot create directory '/sys/fs/cgroup/probe': Read-only file system
### rendered delegated root /run/djinn-cgroup (emptyDir):
btrfs                                    <- the node filesystem, not cgroup2
### NativeCgroupFs::open's first read:
cat: /run/djinn-cgroup/cgroup.subtree_control: No such file or directory
```

Making it writable needs `CAP_SYS_ADMIN` — which goxi specifies and we do not grant. I confirmed the `CAP_SYS_ADMIN` route works (`mount -o remount,rw /sys/fs/cgroup` succeeds, `mkdir` then succeeds), so this wall is entirely self-inflicted by the missing capability.

**Wall 2 — a hostPath onto a pre-delegated node subtree does not work.** With a root-owned, `cpu`-delegated host subtree bind-mounted in, the launcher *can* `mkdir` a leaf and write `cpu.max` — but `clone3(CLONE_INTO_CGROUP)` into it fails with **ENOENT**, because the v2 hierarchy is mounted `nsdelegate` and the target is not a descendant of the pod's private cgroup-namespace root.

Note this wall only bites the *hostPath* workaround, which is not what goxi asks for. goxi specifies a dedicated RW cgroup2 mount **inside the launcher container**, where the pod's own cgroup *is* the namespace root and an invocation leaf beneath it *is* a descendant — so `nsdelegate` is satisfied by construction. I reached for hostPath only because the capability needed for the designed mount was absent.

**Wall 3 — `seccompProfile: RuntimeDefault` denies `clone3` outright.** Independent of cgroups. Measured in-cluster, one pod, two containers differing only in seccomp:

```
seccompProfile=RuntimeDefault -> clone3 rc=-1 errno=38 (Function not implemented) => DENIED
seccompProfile=Unconfined     -> clone3 rc=-1 errno=22 (reachable; argument validation)
```

The container runtime's default profile answers `clone3` with `ENOSYS` so glibc falls back to `clone`. `clone3(CLONE_INTO_CGROUP)` is the launcher's *only* child-spawn seam and has no fallback. goxi explicitly calls for RuntimeDefault **plus an allowlist for `clone3`**; we render plain RuntimeDefault, so our own manifest denies the seam. This is the clearest of the three divergences.

### The designed profile works — measured

I re-ran the **full** launcher lifecycle on the same kind cluster with the goxi runtime profile (`CAP_SYS_ADMIN` + `CAP_SYS_RESOURCE`, launcher establishing its own cgroup2 mount inside its own cgroup namespace). Three containers, differing only in securityContext:

```
################ designed (SYS_ADMIN + SYS_RESOURCE, seccomp Unconfined) ########
STEP 1: mount -t cgroup2 ... OK: cgroup2 mounted read-write by the launcher itself
STEP 2: cgroup.controllers: cpuset cpu io memory hugetlb pids rdma misc dmem
STEP 3: OK: launcher process moved to init/          (no-internal-processes rule)
STEP 4: subtree_control(after): cpu
STEP 5: cpu.max(unleased): 25000 100000              (the 250m unleased quota)
STEP 6: OK: clone3 returned child pid=14
STEP 7: leaf cgroup.procs: 14                        <- child IS in the leaf
        leaf cpu.stat: usage_usec 114147 ... nr_periods 4 nr_throttled 4
                       throttled_usec 284821         <- the quota really throttles
STEP 8: cpu.max(lifted): max 100000                  (fenced lift)
STEP 9: leaf cgroup.events: populated 0 ; rmdir leaf: OK
RESULT: FULL LAUNCHER LIFECYCLE SUCCEEDED UNDER THE DESIGNED PROFILE   exit 0

######## designed caps + seccompProfile: RuntimeDefault ########################
... identical; clone3 pid=14, nr_throttled 4, lift OK
RESULT: FULL LAUNCHER LIFECYCLE SUCCEEDED UNDER THE DESIGNED PROFILE   exit 0

######## as-implemented (drop ALL + SETUID/SETGID/SETPCAP) #####################
STEP 1: FAIL: mount cgroup2 errno=1 (Operation not permitted)          exit 1
```

**So goxi is implementable, and the single blocking divergence is `CAP_SYS_ADMIN`.** Two corrections to my own analysis fall out:

- **Wall 3 is weaker than I claimed.** `seccompProfile: RuntimeDefault` denies `clone3` only for containers *without* `CAP_SYS_ADMIN`; with the capability, the runtime's default profile permits it. goxi's "allowlist for cgroup setup and clone3" therefore needs **no `Localhost` seccomp profile at all** — one less thing for the follow-up to build.
- **Wall 2 was an artifact of my workaround.** `nsdelegate` bites a hostPath from *outside* the pod's cgroup namespace. The designed mount is established *inside* it, where an invocation leaf is a descendant of the namespace root by construction.

A follow-up PR needs: the capability set on the launcher container, chart plumbing for the runtime profile (goxi: "the chart rejects an unrecognized runtime profile"), the launcher creating its own cgroup2 mount + `init/` vacate + `+cpu` enable at startup, and flipping the `validate_enforcement_render` gate. **Nothing in this PR should be read as "cgroup enforcement is impossible on Kubernetes" — it is demonstrably not.**

**Decided:** the launcher is off by default *tonight*, because the sidecar we currently render cannot start and is killing every task run. That is a rollback to a working state, not a verdict on the design.

Security posture of the default:

- No `CAP_SYS_ADMIN`, no `privileged`, no hostPath onto the node cgroup hierarchy — because none of them are rendered at all, not because they were weighed and rejected. Arming the designed profile is a follow-up decision with its own tradeoff (CAP_SYS_ADMIN is broad, and the proposal accepts it in exchange for launcher-only pod-subtree ownership).
- `shareProcessNamespace: true` is now rendered **only** when the launcher is armed. It existed solely for the launcher's `SO_PEERCRED` PID auth and is a real widening — with it set, every backing-service sidecar can read the worker's `/proc` entries. Default renders are therefore strictly narrower than before this PR.
- What is given up: task-run shell commands are not CPU-quota-enforced per invocation. They remain bounded by the pod's own `cpu.limit`, the same posture as before the enforcement epic landed. No isolation that previously worked is lost — the launcher never once worked in production.

`CgroupLauncherMode::Required` is kept as the arming switch. `validate_enforcement_render` rejects it fail-closed at dispatch today, with an error naming the divergences; that gate is exactly what a follow-up PR flips once the chart plumbs the runtime profile, the Localhost seccomp profile, the capability set and the mount.

## Part 2 — the readiness contract is now enforced

**Render time** (`validate_enforcement_render`, called from `runtime.rs::prepare` before the Job is submitted, i.e. before any pod exists): arming an unsatisfiable delegation fails closed with `RenderValidationError::CgroupDelegationUnavailable`.

**Runtime**, before the broker binds its socket and therefore before the pod can accept work:

- `NativeClone3::preflight()` — probes `clone3(CLONE_INTO_CGROUP)` with a syntactically valid but unopened cgroup descriptor. The kernel validates it before forking, so `EBADF` means reachable and anything else (notably `ENOSYS` from a seccomp filter) becomes a named `Error::Clone3Unavailable { errno }`. This is the check that would have caught wall 3 on day one.
- `assert_cgroup2_filesystem()` — `statfs` the delegated root and require `CGROUP2_SUPER_MAGIC` **before** any control-file read. Previously a non-cgroup root surfaced as a bare `Io(ENOENT)` from groping for `cgroup.subtree_control`; that opacity is half of why this took an outage to diagnose. It now reads: *"delegated cgroup root /run/djinn-cgroup is not a cgroup2 filesystem (statfs f_type 0x9123683e, expected 0x63677270)"*.

The existing v1/hybrid, missing-CPU-controller, read-only and overbroad-delegation checks in `Readiness::validate` are unchanged; they now run behind a filesystem-type check that a planted control file cannot fool.

## Part 3 — the silent lie is gone

The `#[cfg(test)]` / `#[cfg(not(test))]` split in `workspace.rs` is removed. The in-process arm is now a genuine production path: a launcher failure degrades to **unleased in-process execution** instead of killing every command.

I also restored `isolate_process_group(&mut cmd)`, which `9whk` (#2513) dropped along with the unconditional call. Without it the child shares the worker's process group while `output_with_kill_cancellable` signals `-pgid` using `child.id()` — so the whole TERM/grace/KILL/reap sequence targets a process group that does not exist, and a timed-out or cancelled command would simply keep running.

Every doc comment claiming an "in-process broker path" is corrected. There is no in-process broker; there is unleased in-process execution, and the comments now say so.

## Bonus defect found while adding the preflight

`libc::CLONE_INTO_CGROUP` is declared on glibc targets as `pub const CLONE_INTO_CGROUP: c_int = 0x200000000` — a value that does not fit in a 32-bit `c_int`, and which the crate's blanket `allow(overflowing_literals)` **truncates to 0** instead of rejecting. The production spawn path was passing `flags: 0`, so `clone3` degraded to an ordinary fork: the child stayed in the launcher's own cgroup, and the delegated leaf plus the `cpu.max` written on it governed nothing. Now sourced from a local `u64` constant with a guard test. zf13's privileged kernel lane still passes 3/3 with the corrected flag, verified locally through its own `docker run --privileged --cgroupns=private` harness.

## Part 4 — coverage

`server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs` takes the volume source `build_task_run_job` **actually renders**, materializes it the way a kubelet would, and hands it to the real `djinn_cgroup_launcher::NativeCgroupFs::open` on a real kernel. No `FakeCgroup`, no `#[ignore]`, no `DJINN_TEST_KIND` gate — it runs in the ordinary `cargo test -p djinn-k8s` lane on every PR, where a human sees it.

The contract is two-armed and checked under **both** modes: either the launcher is not rendered, or its delegated cgroup root materializes into a usable cgroup v2 tree. `the_emptydir_delegated_root_that_shipped_the_p0_is_rejected_by_name` proves the check has teeth by running the byte-for-byte volume that shipped the outage through the same code path.

It already earned its keep: it caught that an armed render still emitted a `volumeMount` for the deleted `launcher-cgroup` volume — a dangling reference the API server would reject.

`server/crates/djinn-cgroup-launcher/tests/startup_readiness_contract.rs` covers the runtime half: the named non-cgroup2 failure, type-check precedence against a planted control file, and the clone3 preflight passing without forking.

## Out of scope, as instructed

`evaluate_invocation_lift` returning `Unleased` for an absent row and `Shadow` for `V1Mode::Shadow` — neither lifting `cpu.max` — is unchanged. `unleased_epoch_binds_but_never_lifts` and `shadow_epoch_binds_but_never_lifts` still pass untouched. I only **documented** that shadow **clamps**: it pins the leaf at the 250m unleased quota for the whole command, so arming it makes leased builds slower, never faster. Nobody should arm it expecting a performance win.

## Gates

- `SQLX_OFFLINE=1 cargo check --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `cargo clippy -p djinn-cgroup-launcher -p djinn-k8s -p djinn-agent -p djinn-agent-worker --all-targets -- -D warnings` — clean. The `djinn-supervisor` `MutexGuard`-across-await lints are pre-existing on main; my only change in that crate is a doc comment.
- `cargo test -p djinn-k8s -p djinn-cgroup-launcher` — 279 passed, 0 failed
- `cargo test -p djinn-agent --lib` — 1387 passed; `-p djinn-agent-worker --lib` — 32 passed
- zf13 privileged kernel lane via its own harness — 3/3
- file-size guard and raw-SQL boundary guard clean; no `Cargo.toml` changed, so no hakari regeneration

No Helm rendering is touched, so `deploy/helm/djinn/tests/build-admission-topology.sh` — already red on main from the unrelated `server.strategy` schema issue, board task `swo6` — is unaffected by this PR.

## Deploy note

The default is `disabled`, so no operator action is required. But the fix only takes effect for pods rendered by a **server** carrying this change: existing v0.7.0 pods keep the broken rendering until the server is redeployed.
