### PR TITLE
chore(sjrs): configurable per-step warm cargo budgets, timeout != spawn error, and warm-base convergence instrumentation

### DIFF
--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -205,6 +205,14 @@ resources:
     # 3600s (60 min) covers a cold single-pass warm of a ~12-crate workspace
     # (~20-25 min observed) with ample margin. Raise it if a larger workspace
     # consistently hits the deadline.
+    #
+    # This is the ONLY warm wall-clock knob that matters: it is the Job's
+    # activeDeadlineSeconds, it drives the in-process warm watcher deadline
+    # (that value plus a fixed 300s slack), and it is projected into the warm
+    # Pod as DJINN_WARM_JOB_DEADLINE_SECONDS, where the in-Pod per-step cargo
+    # budgets clamp against it. A step can therefore never be given a bound
+    # that outlives the deadline which would kill the Pod anyway; to give the
+    # test-binary compile more room, raise this rather than a per-step override.
     jobTimeoutSeconds: 3600
 
 # -----------------------------------------------------------------------------

--- a/server/crates/djinn-agent-worker/src/cargo_metrics.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_metrics.rs
@@ -155,9 +155,80 @@ pub fn record_resolved_workspace_dir(project_id: &str, workspace_dir: &str) {
     djinn_telemetry::cargo_warm_step::set_workspace_path(project_id, workspace_dir);
 }
 
+/// Log + metric for a single cargo warm-step's wall clock. Called exactly once
+/// per step alongside [`record_warm_step`], with the same bounded labels.
+pub fn record_warm_step_seconds(
+    project_id: &str,
+    label: &str,
+    outcome: &'static str,
+    elapsed: std::time::Duration,
+) {
+    let step = warm_step_metric_label(label);
+    djinn_telemetry::cargo_warm_step::record_step_seconds(
+        project_id,
+        step,
+        outcome,
+        elapsed.as_secs_f64(),
+    );
+}
+
+/// Log + metric for one warm-base census sample.
+pub fn record_warm_base_census(
+    project_id: &str,
+    phase: &'static str,
+    census: &crate::warm_base_census::WarmBaseCensus,
+) {
+    info!(
+        project_id,
+        phase,
+        fingerprint_units = census.fingerprint_units,
+        test_units = census.test_units,
+        dep_files = census.dep_files,
+        metric = "djinn_cargo_warm_base_units",
+        "cargo_metrics: warm base census"
+    );
+    djinn_telemetry::cargo_warm_base::set_units(
+        project_id,
+        phase,
+        djinn_telemetry::cargo_warm_base::KIND_FINGERPRINT_UNITS,
+        census.fingerprint_units,
+    );
+    djinn_telemetry::cargo_warm_base::set_units(
+        project_id,
+        phase,
+        djinn_telemetry::cargo_warm_base::KIND_TEST_UNITS,
+        census.test_units,
+    );
+    djinn_telemetry::cargo_warm_base::set_units(
+        project_id,
+        phase,
+        djinn_telemetry::cargo_warm_base::KIND_DEP_FILES,
+        census.dep_files,
+    );
+}
+
+/// Log + metric for the single tail-sweep decision of a warm cycle.
+pub fn record_warm_sweep_decision(project_id: &str, decision: &'static str) {
+    info!(
+        project_id,
+        decision,
+        metric = "djinn_cargo_warm_sweep_decision_total",
+        "cargo_metrics: warm tail sweep decision"
+    );
+    djinn_telemetry::cargo_warm_base::increment_sweep_decision(project_id, decision);
+}
+
 /// Map the warm-step call-site label string to the bounded `STEP_*` constant
 /// the metric uses. Unknown labels are coerced to `STEP_BUILD_FALLBACK` so
 /// the metric label cardinality stays bounded.
+///
+/// The test-compile labels are the ones `cargo_cache_policy` actually emits —
+/// `"test (--no-run)"` and `"nextest (--no-run)"`. An earlier arm matched a
+/// `"test --no-run"` spelling that no call site ever produces, so every
+/// test-compile step was silently coerced to `build_fallback` by the catch-all
+/// and the `test_no_run` series stayed dark. Any change to
+/// `cargo_cache_policy::build_test_warm_command`'s labels must be mirrored
+/// here; `warm_step_labels_from_policy_map_to_their_own_step` fails if not.
 fn warm_step_metric_label(label: &str) -> &'static str {
     match label {
         "clippy" => djinn_telemetry::cargo_warm_step::STEP_CLIPPY,
@@ -166,7 +237,9 @@ fn warm_step_metric_label(label: &str) -> &'static str {
             djinn_telemetry::cargo_warm_step::STEP_CLIPPY_DEFAULT_FEATURES
         }
         "build (clippy fallback)" => djinn_telemetry::cargo_warm_step::STEP_BUILD_FALLBACK,
-        "test --no-run" => djinn_telemetry::cargo_warm_step::STEP_TEST_NO_RUN,
+        "test (--no-run)" | "nextest (--no-run)" => {
+            djinn_telemetry::cargo_warm_step::STEP_TEST_NO_RUN
+        }
         _ => djinn_telemetry::cargo_warm_step::STEP_BUILD_FALLBACK,
     }
 }
@@ -314,7 +387,11 @@ mod tests {
             djinn_telemetry::cargo_warm_step::STEP_BUILD_FALLBACK,
         );
         assert_eq!(
-            warm_step_metric_label("test --no-run"),
+            warm_step_metric_label("test (--no-run)"),
+            djinn_telemetry::cargo_warm_step::STEP_TEST_NO_RUN,
+        );
+        assert_eq!(
+            warm_step_metric_label("nextest (--no-run)"),
             djinn_telemetry::cargo_warm_step::STEP_TEST_NO_RUN,
         );
 
@@ -340,13 +417,99 @@ mod tests {
         );
         record_warm_step(
             "project-warm-step-test",
-            "test --no-run",
+            "test (--no-run)",
             djinn_telemetry::cargo_warm_step::OUTCOME_FAILED,
+        );
+        record_warm_step(
+            "project-warm-step-timeout",
+            "nextest (--no-run)",
+            djinn_telemetry::cargo_warm_step::OUTCOME_TIMEOUT,
         );
         record_warm_step(
             "project-warm-step-unknown",
             "novel step label",
             djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR,
+        );
+    }
+
+    /// The labels `cargo_cache_policy` actually produces must each map to their
+    /// own bounded step. This is the regression that made every production
+    /// `nextest (--no-run)` step report as `step="build_fallback"`: the mapping
+    /// matched a spelling no call site emits, and the catch-all swallowed it.
+    #[test]
+    fn warm_step_labels_from_policy_map_to_their_own_step() {
+        let _guard = test_guard();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = []\nresolver = \"2\"\n",
+        )
+        .expect("write workspace manifest");
+
+        // Without a nextest config the test step is `cargo test --no-run`.
+        let policy = crate::cargo_cache_policy::resolve_cargo_cache_policy(root, None)
+            .expect("resolve policy");
+        let labels: Vec<&'static str> = policy.warm_commands.iter().map(|c| c.label).collect();
+        assert!(
+            labels.contains(&"test (--no-run)"),
+            "expected the test-compile label in {labels:?}"
+        );
+        assert_eq!(
+            warm_step_metric_label("test (--no-run)"),
+            djinn_telemetry::cargo_warm_step::STEP_TEST_NO_RUN,
+        );
+
+        // With one, it is `cargo nextest run --no-run` — the production shape.
+        std::fs::create_dir_all(root.join(".config")).expect("create .config");
+        std::fs::write(root.join(".config/nextest.toml"), "").expect("write nextest config");
+        let policy = crate::cargo_cache_policy::resolve_cargo_cache_policy(root, None)
+            .expect("resolve policy");
+        let test_label = policy
+            .warm_commands
+            .last()
+            .expect("test-compile warm command")
+            .label;
+        assert_eq!(test_label, "nextest (--no-run)");
+        assert_eq!(
+            warm_step_metric_label(test_label),
+            djinn_telemetry::cargo_warm_step::STEP_TEST_NO_RUN,
+            "the test-compile step must never be reported as build_fallback"
+        );
+
+        // Every clippy/build label the policy emits keeps its own step too.
+        for command in &policy.warm_commands {
+            let step = warm_step_metric_label(command.label);
+            let expected = match command.label {
+                "clippy" => djinn_telemetry::cargo_warm_step::STEP_CLIPPY,
+                "nextest (--no-run)" => djinn_telemetry::cargo_warm_step::STEP_TEST_NO_RUN,
+                _ => djinn_telemetry::cargo_warm_step::STEP_BUILD_FALLBACK,
+            };
+            assert_eq!(step, expected, "label {} mapped wrong", command.label);
+        }
+    }
+
+    #[test]
+    fn record_warm_base_census_and_sweep_decision_do_not_panic() {
+        let _guard = test_guard();
+        record_warm_base_census(
+            "project-warm-census",
+            djinn_telemetry::cargo_warm_base::PHASE_PRE_COMPILE,
+            &crate::warm_base_census::WarmBaseCensus {
+                fingerprint_units: 1593,
+                test_units: 160,
+                dep_files: 3578,
+            },
+        );
+        record_warm_sweep_decision(
+            "project-warm-census",
+            djinn_telemetry::cargo_warm_base::DECISION_SKIPPED_TRUNCATED,
+        );
+        record_warm_step_seconds(
+            "project-warm-census",
+            "nextest (--no-run)",
+            djinn_telemetry::cargo_warm_step::OUTCOME_TIMEOUT,
+            std::time::Duration::from_secs(1800),
         );
     }
 

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -73,6 +73,8 @@ mod checkpoint;
 mod checkpoint_safety;
 mod launcher_handshake;
 mod lifecycle;
+pub mod warm_base_census;
+pub mod warm_step_budget;
 mod worker_services;
 
 // Startup volume-permission validation lives in this package's library target
@@ -933,6 +935,39 @@ async fn warm_cargo_target_base(
         workspace_dir.to_string_lossy().as_ref(),
     );
 
+    // Per-step budgets for this cycle, anchored now and reconciled against the
+    // warm Job's activeDeadlineSeconds (projected as
+    // `DJINN_WARM_JOB_DEADLINE_SECONDS`). Resolved once so every step's clamp
+    // is measured from the same anchor.
+    let budgets = resolve_warm_step_budgets();
+    info!(
+        project_id,
+        job_deadline_secs = budgets.job_deadline().as_secs(),
+        tail_reserve_secs = budgets.tail_reserve().as_secs(),
+        clippy_budget_secs = budgets
+            .nominal(warm_step_budget::WarmStepKind::Clippy)
+            .as_secs(),
+        build_budget_secs = budgets
+            .nominal(warm_step_budget::WarmStepKind::Build)
+            .as_secs(),
+        test_budget_secs = budgets
+            .nominal(warm_step_budget::WarmStepKind::TestNoRun)
+            .as_secs(),
+        "cargo warm: resolved per-step budgets against the warm Job deadline"
+    );
+
+    // Census the base BEFORE anything compiles. Paired with the post-compile
+    // sample this is what makes convergence answerable: whether test-target
+    // units survive and accumulate across cycles, or whether the tail sweep
+    // reclaims them faster than a truncated compile step produces them.
+    let base_dir = PathBuf::from(&target_dir);
+    let pre_compile_census = warm_base_census::census(&base_dir);
+    cargo_metrics::record_warm_base_census(
+        project_id,
+        djinn_telemetry::cargo_warm_base::PHASE_PRE_COMPILE,
+        &pre_compile_census,
+    );
+
     // Stamp the warm base BEFORE compiling. The compile refreshes the mtime of
     // every artifact it actually uses, so a post-compile `cargo sweep --file`
     // can safely delete everything older than this stamp — stale crate versions
@@ -940,8 +975,14 @@ async fn warm_cargo_target_base(
     // `incremental/` sessions. Best-effort: on images without cargo-sweep the
     // stamp fails, `sweep_stamped` stays false, and the whole prune no-ops.
     warm_cargo_test_phase("stamp");
-    let sweep_stamped =
-        run_cargo_sweep_step(project_id, &workspace_dir, &["--stamp"], "sweep-stamp").await;
+    let sweep_stamped = run_cargo_sweep_step(
+        project_id,
+        &workspace_dir,
+        &["--stamp"],
+        "sweep-stamp",
+        &budgets,
+    )
+    .await;
 
     let started = djinn_core::clock::Clock::now_instant(&djinn_core::clock::SystemClock::new());
 
@@ -966,18 +1007,25 @@ async fn warm_cargo_target_base(
         .chain(commands[0].feature_args.iter().cloned())
         .collect();
     warm_cargo_test_phase("compile");
-    let clippy_ok = run_cargo_warm_step(
+    let clippy_result = run_cargo_warm_step(
         project_id,
         &workspace_dir,
         &clippy_args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
         commands[0].label,
+        &budgets,
     )
     .await;
+    let clippy_ok = clippy_result.succeeded();
     // Track whether ANY warm step compiled successfully. The post-compile
     // `--file` sweep only runs when at least one step succeeded, so a fully-red
     // branch (nothing compiles → nothing refreshed) never prunes a still-good
     // base down to a cold rebuild.
     let mut any_step_ok = clippy_ok;
+    // …and whether ANY step was truncated at its budget. A truncated step did
+    // not get to touch every artifact it would have refreshed, so the artifacts
+    // it never reached are "not rebuilt yet", not "no longer needed" — which is
+    // the only thing `cargo sweep --file` can distinguish them by.
+    let mut any_step_truncated = clippy_result.truncated();
 
     // Run remaining warm commands (all-features clippy, default-features
     // clippy, build fallback, test --no-run, etc.), skipping the first
@@ -1002,32 +1050,90 @@ async fn warm_cargo_target_base(
             .chain(cmd.feature_args.iter().cloned())
             .collect();
         warm_cargo_test_phase("compile");
-        any_step_ok |= run_cargo_warm_step(
+        let step_result = run_cargo_warm_step(
             project_id,
             &workspace_dir,
             &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
             cmd.label,
+            &budgets,
         )
         .await;
+        any_step_ok |= step_result.succeeded();
+        any_step_truncated |= step_result.truncated();
     }
 
     let elapsed = started.elapsed();
     cargo_metrics::record_warm_base_freshness(project_id, elapsed.as_millis() as u64);
 
+    // Post-compile census, before the tail sweep can remove anything: this is
+    // the number that must rise across cycles for the base to be converging.
+    let post_compile_census = warm_base_census::census(&base_dir);
+    cargo_metrics::record_warm_base_census(
+        project_id,
+        djinn_telemetry::cargo_warm_base::PHASE_POST_COMPILE,
+        &post_compile_census,
+    );
+    info!(
+        project_id,
+        pre_test_units = pre_compile_census.test_units,
+        post_test_units = post_compile_census.test_units,
+        test_unit_delta =
+            post_compile_census.test_units as i64 - pre_compile_census.test_units as i64,
+        pre_fingerprint_units = pre_compile_census.fingerprint_units,
+        post_fingerprint_units = post_compile_census.fingerprint_units,
+        pre_dep_files = pre_compile_census.dep_files,
+        post_dep_files = post_compile_census.dep_files,
+        any_step_truncated,
+        "cargo warm: warm-base convergence delta for this cycle"
+    );
+
     // Prune the warm base of everything the compile above did not touch. Safe by
-    // construction: cargo-sweep only removes whole artifact files older than the
-    // stamp, and cargo transparently rebuilds anything genuinely needed on the
-    // next warm — it can never leave a corrupt/half cache. Gated on a successful
-    // stamp AND at least one green step so a broken branch keeps its warm base.
-    if sweep_stamped && any_step_ok {
+    // construction *only when the compile phase actually ran to completion*:
+    // cargo-sweep removes whole artifact files older than the stamp, and its
+    // sole notion of "no longer needed" is "this compile did not touch it".
+    //
+    // A step killed at its budget breaks that assumption. It never reached the
+    // artifacts it would have refreshed, so sweeping deletes exactly the
+    // previously-built artifacts the truncated step had not got to yet — the
+    // test binaries that `--no-run` exists to accumulate. Since one green
+    // clippy is enough to satisfy `any_step_ok`, the old gate fired precisely in
+    // the failure mode this task was opened for, and the base ping-ponged
+    // instead of converging. Truncation therefore skips the sweep: the base
+    // keeps last cycle's artifacts and the next cycle resumes from more
+    // progress. Disk is still bounded by the incremental prune above and by the
+    // cache-cleanup sweep outside this Pod.
+    // Truncation is checked before "nothing succeeded" because it is the more
+    // specific and more actionable explanation: a cycle whose only compile step
+    // was killed at its budget satisfies both predicates, and reporting it as
+    // `skipped_no_success` would hide the very signal this task is about.
+    let sweep_decision = if !sweep_stamped {
+        djinn_telemetry::cargo_warm_base::DECISION_SKIPPED_NO_STAMP
+    } else if any_step_truncated {
+        djinn_telemetry::cargo_warm_base::DECISION_SKIPPED_TRUNCATED
+    } else if !any_step_ok {
+        djinn_telemetry::cargo_warm_base::DECISION_SKIPPED_NO_SUCCESS
+    } else {
+        djinn_telemetry::cargo_warm_base::DECISION_SWEPT
+    };
+    cargo_metrics::record_warm_sweep_decision(project_id, sweep_decision);
+    if sweep_decision == djinn_telemetry::cargo_warm_base::DECISION_SWEPT {
         warm_cargo_test_phase("end-sweep");
-        run_cargo_sweep_step(project_id, &workspace_dir, &["--file"], "sweep-file").await;
+        run_cargo_sweep_step(
+            project_id,
+            &workspace_dir,
+            &["--file"],
+            "sweep-file",
+            &budgets,
+        )
+        .await;
     } else {
         info!(
             project_id,
             sweep_stamped,
             any_step_ok,
-            "cargo warm: skipping warm-base sweep (no stamp or no successful compile step)"
+            any_step_truncated,
+            sweep_decision,
+            "cargo warm: skipping warm-base sweep"
         );
     }
 
@@ -1053,6 +1159,62 @@ static WARM_CARGO_INJECTED_LOCK_FAILURE: std::sync::Mutex<
 #[cfg(test)]
 static WARM_CARGO_TEST_ROOT: std::sync::Mutex<Option<std::path::PathBuf>> =
     std::sync::Mutex::new(None);
+
+/// Injected budgets for the warm orchestration tests. Production always
+/// resolves from the environment; the seam exists so a test can shorten a step
+/// bound without a process-global env var that would leak into the sibling
+/// tests spawning their own cargo stubs in the same binary.
+#[cfg(test)]
+static WARM_CARGO_TEST_BUDGETS: std::sync::Mutex<Option<warm_step_budget::WarmStepBudgets>> =
+    std::sync::Mutex::new(None);
+
+fn resolve_warm_step_budgets() -> warm_step_budget::WarmStepBudgets {
+    #[cfg(test)]
+    if let Some(injected) = *WARM_CARGO_TEST_BUDGETS
+        .lock()
+        .expect("warm budgets poisoned")
+    {
+        return injected;
+    }
+    warm_step_budget::WarmStepBudgets::now_from_env()
+}
+
+/// Forced terminal outcome for warm steps, for the orchestration tests.
+///
+/// The real truncation path cannot be driven deterministically from inside this
+/// test binary: the child reaper is process-wide, so a sibling test's group
+/// shutdown can `SIGTERM` a deliberately-hung stub before its own budget
+/// elapses, and the step then classifies as an external-signal death rather
+/// than a timeout. The timeout-versus-spawn-failure discrimination itself is
+/// covered directly by
+/// `warm_step_error_outcome_separates_truncation_from_spawn_failure` and by
+/// `djinn_graph::process`'s own tests; this seam only lets the orchestration
+/// around it — sweep suppression and convergence logging — be asserted without
+/// a racing subprocess.
+///
+/// Keyed by project id so the injection can never leak into a sibling test
+/// running concurrently in this binary — the warm-step tests each use their own
+/// project id, and only the injecting test's own warm sees a forced outcome.
+#[cfg(test)]
+static WARM_CARGO_TEST_STEP_OUTCOME: std::sync::Mutex<Option<(String, &'static str)>> =
+    std::sync::Mutex::new(None);
+
+fn forced_warm_step_outcome(project_id: &str) -> Option<&'static str> {
+    #[cfg(test)]
+    {
+        WARM_CARGO_TEST_STEP_OUTCOME
+            .lock()
+            .expect("warm step outcome injection poisoned")
+            .as_ref()
+            .filter(|(injected_project, _)| injected_project == project_id)
+            .map(|(_, outcome)| *outcome)
+    }
+    #[cfg(not(test))]
+    {
+        let _ = project_id;
+        None
+    }
+}
 
 #[cfg(test)]
 fn warm_cargo_test_phase(phase: &'static str) {
@@ -1178,22 +1340,24 @@ fn record_warm_incremental_prune_failure(
 }
 
 /// Run one `cargo <args>` step inside `workspace_dir` for the warm base.
-/// Returns `true` on success. Never panics; logs failures as warnings so a
-/// compile error can't abort the graph warm.
+/// Never panics; logs failures as warnings so a compile error can't abort the
+/// graph warm.
 ///
 /// Emits a structured tracing event with the resolved absolute
-/// `workspace_dir`, the full `cargo_command` argv, the `step_label`, and the
-/// terminal `seed_outcome` ("ok" / "failed" / "spawn_error") so the
-/// coordinator health sweep can correlate warm-step outcomes with workspace
-/// paths and command shapes. The metric `djinn_cargo_warm_step_total` is
-/// incremented with bounded `project_id`, `step`, and `outcome` labels.
+/// `workspace_dir`, the full `cargo_command` argv, the `step_label`, the
+/// resolved budget, and the terminal `seed_outcome` ("ok" / "failed" /
+/// "timeout" / "spawn_error") so the coordinator health sweep can correlate
+/// warm-step outcomes with workspace paths and command shapes. The metric
+/// `djinn_cargo_warm_step_total` is incremented with bounded `project_id`,
+/// `step`, and `outcome` labels.
 async fn run_cargo_warm_step(
     project_id: &str,
     workspace_dir: &Path,
     args: &[&str],
     label: &str,
-) -> bool {
-    run_cargo_warm_step_with_cargo("cargo", project_id, workspace_dir, args, label).await
+    budgets: &warm_step_budget::WarmStepBudgets,
+) -> WarmStepResult {
+    run_cargo_warm_step_with_cargo("cargo", project_id, workspace_dir, args, label, budgets).await
 }
 
 /// Run `cargo sweep <args>` inside `workspace_dir` to prune the warm target
@@ -1208,8 +1372,12 @@ async fn run_cargo_sweep_step(
     workspace_dir: &Path,
     args: &[&str],
     label: &str,
+    budgets: &warm_step_budget::WarmStepBudgets,
 ) -> bool {
-    run_cargo_sweep_step_with_cargo("cargo", project_id, workspace_dir, args, label).await
+    let budget = budgets
+        .resolve(warm_step_budget::WarmStepKind::Sweep)
+        .budget;
+    run_cargo_sweep_step_with_cargo("cargo", project_id, workspace_dir, args, label, budget).await
 }
 
 async fn run_cargo_sweep_step_with_cargo(
@@ -1218,12 +1386,13 @@ async fn run_cargo_sweep_step_with_cargo(
     workspace_dir: &Path,
     args: &[&str],
     label: &str,
+    budget: Duration,
 ) -> bool {
     let sweep_command = format!("cargo sweep {}", args.join(" "));
     let workspace_dir_display = workspace_dir.display().to_string();
     let mut command = std::process::Command::new(cargo_bin.as_ref());
     command.arg("sweep").args(args).current_dir(workspace_dir);
-    match warm_command_status(command).await {
+    match warm_command_status(command, budget).await {
         Ok(status) if status.success() => {
             info!(
                 project_id,
@@ -1253,10 +1422,11 @@ async fn run_cargo_sweep_step_with_cargo(
                 workspace_dir = %workspace_dir_display,
                 sweep_command = %sweep_command,
                 step_label = label,
-                sweep_outcome = "spawn_error",
+                sweep_outcome = warm_step_error_outcome(&e),
+                budget_secs = budget.as_secs(),
                 error = %e,
-                "cargo warm: could not spawn cargo-sweep (absent on this image?); \
-                 warm base left unpruned"
+                "cargo warm: cargo-sweep did not complete (absent on this image, \
+                 or killed at its budget); warm base left unpruned"
             );
             false
         }
@@ -1269,74 +1439,41 @@ async fn run_cargo_warm_step_with_cargo(
     workspace_dir: &Path,
     args: &[&str],
     label: &str,
-) -> bool {
+    budgets: &warm_step_budget::WarmStepBudgets,
+) -> WarmStepResult {
     let cargo_instrumented = cargo_instrument_enabled();
     let plan = cargo_warm_execution_plan(args, cargo_instrumented);
     let cargo_command = format!("cargo {}", plan.args.join(" "));
     let workspace_dir_display = workspace_dir.display().to_string();
+    // Classify from the ORIGINAL args, not the instrumented plan: the plan may
+    // prepend flags but never changes which cargo subcommand runs.
+    let kind = warm_step_budget::WarmStepKind::from_args(args);
+    let resolved = budgets.resolve(kind);
+    let started = djinn_core::clock::Clock::now_instant(&djinn_core::clock::SystemClock::new());
 
-    if !cargo_instrumented {
+    let outcome = if let Some(forced) = forced_warm_step_outcome(project_id) {
+        forced
+    } else if !cargo_instrumented {
         let mut command = std::process::Command::new(cargo_bin.as_ref());
         command.args(&plan.args).current_dir(workspace_dir);
-        return match warm_command_status(command).await {
-            Ok(status) if status.success() => {
-                info!(
-                    project_id,
-                    workspace_dir = %workspace_dir_display,
-                    cargo_command = %cargo_command,
-                    step_label = label,
-                    seed_outcome = "ok",
-                    "cargo warm: step succeeded"
-                );
-                cargo_metrics::record_warm_step(
-                    project_id,
-                    label,
-                    djinn_telemetry::cargo_warm_step::OUTCOME_OK,
-                );
-                true
-            }
-            Ok(status) => {
-                warn!(
-                    project_id,
-                    workspace_dir = %workspace_dir_display,
-                    cargo_command = %cargo_command,
-                    step_label = label,
-                    seed_outcome = "failed",
-                    code = ?status.code(),
-                    "cargo warm: step failed (non-fatal; continuing warm)"
-                );
-                cargo_metrics::record_warm_step(
-                    project_id,
-                    label,
-                    djinn_telemetry::cargo_warm_step::OUTCOME_FAILED,
-                );
-                false
-            }
+        match warm_command_status(command, resolved.budget).await {
+            Ok(status) if status.success() => djinn_telemetry::cargo_warm_step::OUTCOME_OK,
+            Ok(_) => djinn_telemetry::cargo_warm_step::OUTCOME_FAILED,
             Err(err) => {
                 warn!(
                     project_id,
-                    workspace_dir = %workspace_dir_display,
-                    cargo_command = %cargo_command,
                     step_label = label,
-                    seed_outcome = "spawn_error",
                     error = %err,
-                    "cargo warm: failed to spawn `cargo` (non-fatal; continuing warm)"
+                    "cargo warm: step did not run to completion"
                 );
-                cargo_metrics::record_warm_step(
-                    project_id,
-                    label,
-                    djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR,
-                );
-                false
+                warm_step_error_outcome(&err)
             }
-        };
-    }
-
-    let mut command = std::process::Command::new(cargo_bin.as_ref());
-    command.args(&plan.args).current_dir(workspace_dir);
-    match warm_command_output(command).await {
-        Ok(output) => {
-            if cargo_instrumented {
+        }
+    } else {
+        let mut command = std::process::Command::new(cargo_bin.as_ref());
+        command.args(&plan.args).current_dir(workspace_dir);
+        match warm_command_output(command, resolved.budget).await {
+            Ok(output) => {
                 let (stdout_fresh_count, stdout_compiling_count) =
                     cargo_fresh_compiling_counts(&output.stdout);
                 let (stderr_fresh_count, stderr_compiling_count) =
@@ -1363,59 +1500,64 @@ async fn run_cargo_warm_step_with_cargo(
                     label,
                     compiling_count,
                 );
-            }
 
-            if output.status.success() {
-                info!(
-                    project_id,
-                    workspace_dir = %workspace_dir_display,
-                    cargo_command = %cargo_command,
-                    step_label = label,
-                    seed_outcome = "ok",
-                    "cargo warm: step succeeded"
-                );
-                cargo_metrics::record_warm_step(
-                    project_id,
-                    label,
-                    djinn_telemetry::cargo_warm_step::OUTCOME_OK,
-                );
-                true
-            } else {
+                if output.status.success() {
+                    djinn_telemetry::cargo_warm_step::OUTCOME_OK
+                } else {
+                    djinn_telemetry::cargo_warm_step::OUTCOME_FAILED
+                }
+            }
+            Err(err) => {
                 warn!(
                     project_id,
-                    workspace_dir = %workspace_dir_display,
-                    cargo_command = %cargo_command,
                     step_label = label,
-                    seed_outcome = "failed",
-                    code = ?output.status.code(),
-                    "cargo warm: step failed (non-fatal; continuing warm)"
+                    error = %err,
+                    "cargo warm: step did not run to completion"
                 );
-                cargo_metrics::record_warm_step(
-                    project_id,
-                    label,
-                    djinn_telemetry::cargo_warm_step::OUTCOME_FAILED,
-                );
-                false
+                warm_step_error_outcome(&err)
             }
         }
-        Err(err) => {
-            warn!(
-                project_id,
-                workspace_dir = %workspace_dir_display,
-                cargo_command = %cargo_command,
-                step_label = label,
-                seed_outcome = "spawn_error",
-                error = %err,
-                "cargo warm: failed to spawn `cargo` (non-fatal; continuing warm)"
-            );
-            cargo_metrics::record_warm_step(
-                project_id,
-                label,
-                djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR,
-            );
-            false
-        }
+    };
+
+    let elapsed = started.elapsed();
+    let result = WarmStepResult::new(outcome);
+    // Exactly one terminal event and one metric pair per step, carrying the
+    // budget that bounded it and whether that budget came from the step's own
+    // configuration or from the enclosing warm-Job deadline. A truncated step is
+    // reported as `timeout`, never as `spawn_error`: it left partial progress in
+    // the warm base, which is what the convergence question turns on.
+    if result.succeeded() {
+        info!(
+            project_id,
+            workspace_dir = %workspace_dir_display,
+            cargo_command = %cargo_command,
+            step_label = label,
+            seed_outcome = outcome,
+            ran_to_completion = true,
+            budget_secs = resolved.budget.as_secs(),
+            budget_clamped_by_job_deadline = resolved.clamped_by_deadline,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "cargo warm: step succeeded"
+        );
+    } else {
+        warn!(
+            project_id,
+            workspace_dir = %workspace_dir_display,
+            cargo_command = %cargo_command,
+            step_label = label,
+            seed_outcome = outcome,
+            ran_to_completion = false,
+            truncated = result.truncated(),
+            budget_secs = resolved.budget.as_secs(),
+            budget_clamped_by_job_deadline = resolved.clamped_by_deadline,
+            job_deadline_secs = budgets.job_deadline().as_secs(),
+            elapsed_ms = elapsed.as_millis() as u64,
+            "cargo warm: step did not succeed (non-fatal; continuing warm)"
+        );
     }
+    cargo_metrics::record_warm_step(project_id, label, outcome);
+    cargo_metrics::record_warm_step_seconds(project_id, label, outcome, elapsed);
+    result
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1424,35 +1566,82 @@ enum CargoWarmOutputMode {
     CaptureForInstrumentation,
 }
 
-#[cfg(target_os = "linux")]
-const WARM_COMMAND_TIMEOUT: Duration = Duration::from_secs(30 * 60);
-
 async fn warm_command_status(
     command: std::process::Command,
+    budget: Duration,
 ) -> std::io::Result<std::process::ExitStatus> {
     #[cfg(target_os = "linux")]
     {
-        djinn_graph::process::output_with_timeout(command, WARM_COMMAND_TIMEOUT)
+        djinn_graph::process::output_with_timeout(command, budget)
             .await
             .map(|output| output.status)
     }
     #[cfg(not(target_os = "linux"))]
-    tokio::task::spawn_blocking(move || command.status())
-        .await
-        .map_err(std::io::Error::other)?
+    {
+        // Only Linux has the process-group timeout/kill implementation; the
+        // non-Linux path is developer-workstation only and stays unbounded.
+        let _ = budget;
+        tokio::task::spawn_blocking(move || command.status())
+            .await
+            .map_err(std::io::Error::other)?
+    }
 }
 
 async fn warm_command_output(
     command: std::process::Command,
+    budget: Duration,
 ) -> std::io::Result<std::process::Output> {
     #[cfg(target_os = "linux")]
     {
-        djinn_graph::process::output_with_timeout(command, WARM_COMMAND_TIMEOUT).await
+        djinn_graph::process::output_with_timeout(command, budget).await
     }
     #[cfg(not(target_os = "linux"))]
-    tokio::task::spawn_blocking(move || command.output())
-        .await
-        .map_err(std::io::Error::other)?
+    {
+        let _ = budget;
+        tokio::task::spawn_blocking(move || command.output())
+            .await
+            .map_err(std::io::Error::other)?
+    }
+}
+
+/// Classify a warm-step process error into its bounded outcome label.
+///
+/// `output_with_timeout` returns `io::ErrorKind::TimedOut` **only** when our own
+/// deadline fired (an externally-signalled child surfaces as a distinct
+/// non-timeout failure), so this is an exact discrimination between "cargo ran
+/// and was killed at its budget, leaving partial progress in the warm base" and
+/// "cargo never started". Conflating the two is what made every production warm
+/// cycle report `spawn_error` for a step that had compiled for thirty minutes.
+fn warm_step_error_outcome(err: &std::io::Error) -> &'static str {
+    if err.kind() == std::io::ErrorKind::TimedOut {
+        djinn_telemetry::cargo_warm_step::OUTCOME_TIMEOUT
+    } else {
+        djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR
+    }
+}
+
+/// Terminal result of one warm step, retaining whether the step was truncated.
+///
+/// `succeeded` alone is not enough for the caller: a truncated step neither
+/// succeeded nor left the base in the "everything needed was rebuilt" state the
+/// tail `cargo sweep --file` assumes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WarmStepResult {
+    outcome: &'static str,
+}
+
+impl WarmStepResult {
+    const fn new(outcome: &'static str) -> Self {
+        Self { outcome }
+    }
+
+    fn succeeded(self) -> bool {
+        self.outcome == djinn_telemetry::cargo_warm_step::OUTCOME_OK
+    }
+
+    fn truncated(self) -> bool {
+        djinn_telemetry::cargo_warm_step::outcome_left_partial_progress(self.outcome)
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -3955,13 +4144,15 @@ warning: something
                     tmp.path(),
                     &["check"],
                     "check",
+                    &warm_step_budget::WarmStepBudgets::now_from_env(),
                 ))
         });
 
         // SAFETY: guarded test-only env mutation.
         unsafe { std::env::remove_var("DJINN_CARGO_INSTRUMENT") };
 
-        assert!(ok, "mock cargo should succeed");
+        assert!(ok.succeeded(), "mock cargo should succeed");
+        assert!(!ok.truncated(), "a zero-exit step is not truncated");
         let logs = logs.take();
         assert!(
             logs.contains("cargo warm: instrumented Fresh/Compiling counts"),
@@ -4006,6 +4197,7 @@ warning: something
                 workspace,
                 args,
                 "sweep-file",
+                warm_step_budget::DEFAULT_SWEEP_BUDGET,
             ))
     }
 
@@ -4089,10 +4281,11 @@ warning: something
                     tmp.path(),
                     &["check"],
                     "check",
+                    &warm_step_budget::WarmStepBudgets::now_from_env(),
                 ))
         });
 
-        assert!(ok, "mock cargo should succeed");
+        assert!(ok.succeeded(), "mock cargo should succeed");
         let logs = logs.take();
         assert!(
             !logs.contains("instrumented Fresh/Compiling counts"),
@@ -4666,6 +4859,198 @@ warning: something
             ["lock", "pruned", "stamp", "compile", "end-sweep"]
         );
         let _ = std::fs::remove_dir_all(target);
+    }
+
+    /// The convergence fix, end to end.
+    ///
+    /// A compile step killed at its budget must (a) be recorded as `timeout`,
+    /// not `spawn_error`, and (b) suppress the tail `cargo sweep --file`.
+    /// Sweeping after a truncated step deletes exactly the previously-built
+    /// artifacts the step never reached — for the production warm that is the
+    /// test binaries `--no-run` exists to accumulate — so the base loses ground
+    /// every cycle instead of converging.
+    ///
+    /// Unix-only for the `chmod`ed stub `cargo` the stamp step invokes.
+    #[cfg(unix)]
+    #[test]
+    fn truncated_warm_step_records_timeout_and_suppresses_the_tail_sweep() {
+        use std::os::unix::fs::PermissionsExt;
+        let _serial = WARM_CARGO_ORDERING_MUTEX.lock().expect("ordering mutex");
+        let fixture = tempfile::tempdir().expect("workspace fixture");
+        std::fs::write(
+            fixture.path().join("Cargo.toml"),
+            "[package]\nname=\"ordering-truncated\"\nversion=\"0.1.0\"\nedition=\"2024\"\n",
+        )
+        .expect("manifest");
+        // Only the stamp/sweep steps actually spawn here; the compile step's
+        // terminal outcome is injected (see WARM_CARGO_TEST_STEP_OUTCOME).
+        let cargo = fixture.path().join("cargo");
+        std::fs::write(&cargo, "#!/bin/sh\nexit 0\n").expect("fake cargo");
+        let mut permissions = std::fs::metadata(&cargo)
+            .expect("cargo metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&cargo, permissions).expect("fake cargo executable");
+
+        let project = format!("warm-truncated-{}", std::process::id());
+        let warm_root = fixture.path().join("warm-base");
+        let target = warm_root.join(&project);
+        std::fs::create_dir_all(target.join("debug/incremental")).expect("warm target");
+        let previous_target = std::env::var_os(CARGO_TARGET_DIR_ENV);
+        let previous_path = std::env::var("PATH").expect("PATH");
+        unsafe {
+            std::env::set_var(CARGO_TARGET_DIR_ENV, &target);
+            std::env::set_var(
+                "PATH",
+                format!("{}:{previous_path}", fixture.path().display()),
+            );
+        }
+        *WARM_CARGO_TEST_ROOT.lock().expect("warm test root") = Some(warm_root);
+        // Injected rather than env-driven: a process-global budget override
+        // would change the bound for the sibling warm-step tests running in
+        // parallel in this same binary.
+        *WARM_CARGO_TEST_BUDGETS.lock().expect("warm budgets") =
+            Some(warm_step_budget::WarmStepBudgets::for_testing(
+                Duration::from_secs(1_234),
+                Duration::from_secs(120),
+            ));
+        *WARM_CARGO_TEST_STEP_OUTCOME
+            .lock()
+            .expect("warm step outcome injection") = Some((
+            project.clone(),
+            djinn_telemetry::cargo_warm_step::OUTCOME_TIMEOUT,
+        ));
+        WARM_CARGO_PHASES.lock().expect("recorder").clear();
+
+        let policy = cargo_cache_policy::CargoCachePolicy {
+            workspace: false,
+            features: Vec::new(),
+            all_features: false,
+            warm_commands: vec![cargo_cache_policy::CargoWarmCommand {
+                label: "clippy",
+                args: vec!["clippy".to_string()],
+                feature_args: Vec::new(),
+            }],
+        };
+        // Assert through the thread-local tracing subscriber rather than the
+        // process-global metric registry: the recorder is shared with every
+        // other test in this binary, while `with_default` is scoped to this
+        // thread and therefore deterministic under `--test-threads=N`.
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(logs.clone())
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NONE)
+            .with_target(false)
+            .with_ansi(false)
+            .finish();
+        let dispatch = Dispatch::new(subscriber);
+        tracing::dispatcher::with_default(&dispatch, || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime")
+                .block_on(warm_cargo_target_base(&project, fixture.path(), &policy));
+        });
+
+        *WARM_CARGO_TEST_ROOT.lock().expect("warm test root") = None;
+        *WARM_CARGO_TEST_BUDGETS.lock().expect("warm budgets") = None;
+        *WARM_CARGO_TEST_STEP_OUTCOME
+            .lock()
+            .expect("warm step outcome injection") = None;
+        unsafe {
+            std::env::set_var("PATH", previous_path);
+            match previous_target {
+                Some(value) => std::env::set_var(CARGO_TARGET_DIR_ENV, value),
+                None => std::env::remove_var(CARGO_TARGET_DIR_ENV),
+            }
+        }
+
+        assert_eq!(
+            *WARM_CARGO_PHASES.lock().expect("recorder"),
+            ["lock", "pruned", "stamp", "compile"],
+            "a truncated compile step must not reach the tail sweep"
+        );
+
+        let logs = logs.take();
+        // The resolved budget is logged so a truncation is always attributable
+        // to a specific bound rather than to an anonymous constant.
+        assert!(
+            logs.contains("clippy_budget_secs=1234"),
+            "the resolved per-step budget must be reported: {logs}"
+        );
+        assert!(
+            logs.contains("budget_secs=1234"),
+            "the terminal step event must carry the budget that bounded it: {logs}"
+        );
+        assert!(
+            logs.contains(&format!(
+                "seed_outcome=\"{}\"",
+                djinn_telemetry::cargo_warm_step::OUTCOME_TIMEOUT
+            )),
+            "the truncated step must be recorded as a timeout: {logs}"
+        );
+        assert!(
+            !logs.contains(&format!(
+                "seed_outcome=\"{}\"",
+                djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR
+            )),
+            "a step killed at its budget must never be reported as a spawn error: {logs}"
+        );
+        assert!(
+            logs.contains("truncated=true"),
+            "truncation must be explicit in the terminal step event: {logs}"
+        );
+        assert!(
+            logs.contains(&format!(
+                "decision=\"{}\"",
+                djinn_telemetry::cargo_warm_base::DECISION_SKIPPED_TRUNCATED
+            )),
+            "the suppressed sweep must be attributable to truncation: {logs}"
+        );
+
+        let _ = std::fs::remove_dir_all(target);
+    }
+
+    /// The exact discrimination the fix rests on: `output_with_timeout` reports
+    /// `TimedOut` only when our own deadline fired, so a truncated step and a
+    /// cargo that could not be started are distinguishable without heuristics.
+    #[test]
+    fn warm_step_error_outcome_separates_truncation_from_spawn_failure() {
+        assert_eq!(
+            warm_step_error_outcome(&std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "process timed out"
+            )),
+            djinn_telemetry::cargo_warm_step::OUTCOME_TIMEOUT,
+        );
+        assert_eq!(
+            warm_step_error_outcome(&std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "No such file or directory"
+            )),
+            djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR,
+        );
+        assert_eq!(
+            warm_step_error_outcome(&std::io::Error::other("boom")),
+            djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR,
+        );
+        // The two labels must remain distinct members of the closed space.
+        assert!(
+            djinn_telemetry::cargo_warm_step::outcome_left_partial_progress(
+                djinn_telemetry::cargo_warm_step::OUTCOME_TIMEOUT
+            )
+        );
+        for other in [
+            djinn_telemetry::cargo_warm_step::OUTCOME_OK,
+            djinn_telemetry::cargo_warm_step::OUTCOME_FAILED,
+            djinn_telemetry::cargo_warm_step::OUTCOME_SPAWN_ERROR,
+        ] {
+            assert!(
+                !djinn_telemetry::cargo_warm_step::outcome_left_partial_progress(other),
+                "{other} must not claim partial progress"
+            );
+        }
     }
 
     #[test]

--- a/server/crates/djinn-agent-worker/src/warm_base_census.rs
+++ b/server/crates/djinn-agent-worker/src/warm_base_census.rs
@@ -1,0 +1,193 @@
+//! Census of the cargo warm base — the convergence instrument.
+//!
+//! # The question this answers
+//!
+//! The warm cycle runs `cargo sweep --stamp`, compiles, then `cargo sweep
+//! --file`, and `--file` deletes every artifact older than the stamp. When the
+//! test-compile step is killed at its budget, the test binaries it did *not*
+//! get around to touching are older than the stamp and are therefore deleted —
+//! so the next cycle starts from less progress than the previous one finished
+//! with. Whether the base converges is exactly the question of whether
+//! `test_units` rises or falls cycle over cycle.
+//!
+//! Nothing here can answer that from a single sample; it is a per-cycle census
+//! published either side of the compile phase so the trend is readable from
+//! metrics and from the Pod log without shelling into the cluster.
+//!
+//! # What is counted
+//!
+//! * `fingerprint_units` — directories under `<base>/debug/.fingerprint`. One
+//!   per cargo unit that has a recorded fingerprint.
+//! * `test_units` — fingerprint units carrying a `test-*.json` fingerprint.
+//!   Cargo names a unit's fingerprint file after its unit kind, so `test-lib-*`
+//!   / `test-bin-*` is an exact identification of a `--test` unit. This is the
+//!   artifact class the `--no-run` warm step exists to produce.
+//! * `dep_files` — regular files under `<base>/debug/deps`, i.e. the linked
+//!   artifacts themselves.
+//!
+//! Counting is best-effort and bounded: a missing base, an unreadable
+//! directory, or a partially-written tree yields the counts observed so far
+//! rather than an error, because a census must never be able to fail a warm.
+
+use std::path::Path;
+
+/// Counts for one warm-base sample.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WarmBaseCensus {
+    pub fingerprint_units: u64,
+    pub test_units: u64,
+    pub dep_files: u64,
+}
+
+impl WarmBaseCensus {
+    /// Whether the sample found anything at all. A base that has never been
+    /// compiled reports all zeros, which is a legitimate observation and not an
+    /// error.
+    pub fn is_empty(&self) -> bool {
+        self.fingerprint_units == 0 && self.test_units == 0 && self.dep_files == 0
+    }
+}
+
+const FINGERPRINT_DIR: &str = "debug/.fingerprint";
+const DEPS_DIR: &str = "debug/deps";
+const TEST_FINGERPRINT_PREFIX: &str = "test-";
+const FINGERPRINT_SUFFIX: &str = ".json";
+
+/// Take a census of the warm base rooted at `base` (the `CARGO_TARGET_DIR` the
+/// warm compiles into). Never fails: unreadable components contribute zero.
+pub fn census(base: &Path) -> WarmBaseCensus {
+    let mut out = WarmBaseCensus::default();
+    count_fingerprint_units(&base.join(FINGERPRINT_DIR), &mut out);
+    out.dep_files = count_regular_files(&base.join(DEPS_DIR));
+    out
+}
+
+fn count_fingerprint_units(fingerprint_root: &Path, out: &mut WarmBaseCensus) {
+    let Ok(entries) = std::fs::read_dir(fingerprint_root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        // `file_type` avoids a stat per entry on platforms that carry the type
+        // in the directory entry; a symlinked unit dir is not a cargo unit.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        out.fingerprint_units += 1;
+        if unit_dir_has_test_fingerprint(&entry.path()) {
+            out.test_units += 1;
+        }
+    }
+}
+
+fn unit_dir_has_test_fingerprint(unit_dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(unit_dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if name.starts_with(TEST_FINGERPRINT_PREFIX) && name.ends_with(FINGERPRINT_SUFFIX) {
+            return true;
+        }
+    }
+    false
+}
+
+fn count_regular_files(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut count = 0;
+    for entry in entries.flatten() {
+        match entry.file_type() {
+            Ok(file_type) if file_type.is_file() => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create fixture parent");
+        }
+        std::fs::write(path, contents).expect("write fixture");
+    }
+
+    #[test]
+    fn counts_units_test_units_and_dep_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = tmp.path();
+
+        // A library unit: lib fingerprint only.
+        write(
+            &base.join("debug/.fingerprint/djinn-core-aaaa/lib-djinn_core.json"),
+            "{}",
+        );
+        // A unit compiled with --test: this is what the --no-run warm step
+        // produces and what the convergence question is about.
+        write(
+            &base.join("debug/.fingerprint/djinn-core-bbbb/test-lib-djinn_core.json"),
+            "{}",
+        );
+        write(
+            &base.join("debug/.fingerprint/djinn-server-cccc/test-bin-djinn_server.json"),
+            "{}",
+        );
+        // Linked artifacts.
+        write(&base.join("debug/deps/libdjinn_core-aaaa.rlib"), "");
+        write(&base.join("debug/deps/djinn_core-bbbb"), "");
+        write(&base.join("debug/deps/djinn_core-bbbb.d"), "");
+
+        let census = census(base);
+        assert_eq!(census.fingerprint_units, 3);
+        assert_eq!(census.test_units, 2);
+        assert_eq!(census.dep_files, 3);
+        assert!(!census.is_empty());
+    }
+
+    #[test]
+    fn missing_base_is_an_all_zero_observation_not_an_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let census = census(&tmp.path().join("never-compiled"));
+        assert_eq!(census, WarmBaseCensus::default());
+        assert!(census.is_empty());
+    }
+
+    /// A base holding only non-test units must not be reported as holding test
+    /// artifacts — otherwise a truncated `--no-run` step would look converged.
+    #[test]
+    fn units_without_a_test_fingerprint_are_not_counted_as_test_units() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = tmp.path();
+        write(
+            &base.join("debug/.fingerprint/serde-dddd/lib-serde.json"),
+            "{}",
+        );
+        write(
+            &base.join("debug/.fingerprint/serde-dddd/build-script-build-script-build.json"),
+            "{}",
+        );
+        let census = census(base);
+        assert_eq!(census.fingerprint_units, 1);
+        assert_eq!(census.test_units, 0);
+    }
+
+    /// Files directly under `.fingerprint` are not units; only directories are.
+    #[test]
+    fn stray_files_under_the_fingerprint_root_are_not_units() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = tmp.path();
+        write(&base.join("debug/.fingerprint/stray.json"), "{}");
+        assert_eq!(census(base).fingerprint_units, 0);
+    }
+}

--- a/server/crates/djinn-agent-worker/src/warm_step_budget.rs
+++ b/server/crates/djinn-agent-worker/src/warm_step_budget.rs
@@ -1,0 +1,350 @@
+//! Per-step wall-clock budgets for the cargo warm base, reconciled against the
+//! deadline that will kill the warm Pod anyway.
+//!
+//! # Why this exists
+//!
+//! Every warm cargo command used to share one hard-coded `30 * 60` constant.
+//! Two problems followed from that:
+//!
+//! 1. `cargo clippy` and `cargo nextest run --no-run` are not the same
+//!    workload. On the production 4-vCPU box clippy finishes in ~10 minutes
+//!    while the test-binary compile — the step that actually puts test-target
+//!    artifacts in the warm base — was killed at 30 minutes *every cycle*.
+//! 2. The constant was never reconciled with the two enclosing deadlines. The
+//!    warm Job carries `activeDeadlineSeconds` (`warm_job_timeout_seconds`,
+//!    default 3600s) and the in-process warm watcher derives its own deadline
+//!    from that same value plus a fixed slack (see
+//!    `djinn_k8s::graph_warmer_lifecycle::watch_deadline`). A step bound larger
+//!    than the Job deadline does not buy the step more time; it just relocates
+//!    the truncation from an observable `outcome="timeout"` step record to an
+//!    unobservable kubelet kill.
+//!
+//! # The model
+//!
+//! The Job deadline is the single authoritative bound, projected into the warm
+//! Pod as `DJINN_WARM_JOB_DEADLINE_SECONDS` by `djinn_k8s::warm_job`. Each step
+//! gets a nominal budget (overridable per step), and every budget is then
+//! clamped to the time actually left before the Job deadline, minus a tail
+//! reserve for the post-compile work (graph indexing and publication) that runs
+//! inside the same Pod. Raising a step's nominal budget can therefore never
+//! push a step past the deadline; to genuinely give the warm more time an
+//! operator raises `DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS`, and the step budgets
+//! follow automatically.
+
+use std::time::{Duration, Instant};
+
+use djinn_core::clock::{Clock, SystemClock};
+
+/// Wall-clock the warm Job is allowed, projected from the Job's
+/// `activeDeadlineSeconds`. Absent (local runs, tests) → [`DEFAULT_JOB_DEADLINE`].
+pub const ENV_JOB_DEADLINE_SECONDS: &str = "DJINN_WARM_JOB_DEADLINE_SECONDS";
+/// Reserve withheld from the compile phase for the post-compile graph index +
+/// publish that shares the warm Pod's deadline.
+pub const ENV_TAIL_RESERVE_SECONDS: &str = "DJINN_WARM_TAIL_RESERVE_SECONDS";
+pub const ENV_CLIPPY_BUDGET_SECONDS: &str = "DJINN_WARM_STEP_TIMEOUT_CLIPPY_SECONDS";
+pub const ENV_BUILD_BUDGET_SECONDS: &str = "DJINN_WARM_STEP_TIMEOUT_BUILD_SECONDS";
+pub const ENV_TEST_BUDGET_SECONDS: &str = "DJINN_WARM_STEP_TIMEOUT_TEST_SECONDS";
+pub const ENV_SWEEP_BUDGET_SECONDS: &str = "DJINN_WARM_STEP_TIMEOUT_SWEEP_SECONDS";
+
+/// Mirrors `djinn_k8s::config::KubernetesConfig::warm_job_timeout_seconds`'s
+/// default so a worker started without the projected env behaves like a Pod
+/// launched with the shipped default.
+pub const DEFAULT_JOB_DEADLINE: Duration = Duration::from_secs(3600);
+/// Post-compile SCIP indexing + publication share the Job deadline with the
+/// compile phase; withhold this much from every step clamp.
+pub const DEFAULT_TAIL_RESERVE: Duration = Duration::from_secs(900);
+/// Unchanged from the retired `WARM_COMMAND_TIMEOUT` so existing deployments
+/// do not regress on the steps that were already finishing inside it.
+pub const DEFAULT_CLIPPY_BUDGET: Duration = Duration::from_secs(30 * 60);
+pub const DEFAULT_BUILD_BUDGET: Duration = Duration::from_secs(30 * 60);
+pub const DEFAULT_SWEEP_BUDGET: Duration = Duration::from_secs(30 * 60);
+/// Raised: this is the step that was truncated every cycle. It is still clamped
+/// by the Job deadline, so on a default 3600s Job it resolves to whatever is
+/// left after clippy rather than to a full hour.
+pub const DEFAULT_TEST_BUDGET: Duration = Duration::from_secs(60 * 60);
+/// Never hand a step a zero/absurd budget: below this the step could not even
+/// start cargo, and a `timeout` record would be noise rather than signal.
+pub const MIN_STEP_BUDGET: Duration = Duration::from_secs(60);
+
+/// The bounded set of warm steps, each with its own budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarmStepKind {
+    /// `cargo clippy …` (check-mode units).
+    Clippy,
+    /// `cargo build …`, the clippy fallback.
+    Build,
+    /// `cargo test --no-run` / `cargo nextest run --no-run`.
+    TestNoRun,
+    /// `cargo sweep --stamp` / `--file`.
+    Sweep,
+}
+
+impl WarmStepKind {
+    /// Classify a warm command from its cargo subcommand argv. Anything
+    /// unrecognized is treated as a build-shaped step, matching how the metric
+    /// label mapping coerces unknown labels.
+    pub fn from_args(args: &[&str]) -> Self {
+        match args.first().copied() {
+            Some("clippy") | Some("check") => Self::Clippy,
+            Some("test") => Self::TestNoRun,
+            Some("nextest") => Self::TestNoRun,
+            Some("sweep") => Self::Sweep,
+            _ => Self::Build,
+        }
+    }
+
+    const fn env_key(self) -> &'static str {
+        match self {
+            Self::Clippy => ENV_CLIPPY_BUDGET_SECONDS,
+            Self::Build => ENV_BUILD_BUDGET_SECONDS,
+            Self::TestNoRun => ENV_TEST_BUDGET_SECONDS,
+            Self::Sweep => ENV_SWEEP_BUDGET_SECONDS,
+        }
+    }
+
+    const fn default_budget(self) -> Duration {
+        match self {
+            Self::Clippy => DEFAULT_CLIPPY_BUDGET,
+            Self::Build => DEFAULT_BUILD_BUDGET,
+            Self::TestNoRun => DEFAULT_TEST_BUDGET,
+            Self::Sweep => DEFAULT_SWEEP_BUDGET,
+        }
+    }
+}
+
+/// Resolved budgets for one warm cycle, anchored at the moment the warm Pod's
+/// deadline started running.
+#[derive(Debug, Clone, Copy)]
+pub struct WarmStepBudgets {
+    job_deadline: Duration,
+    tail_reserve: Duration,
+    clippy: Duration,
+    build: Duration,
+    test_no_run: Duration,
+    sweep: Duration,
+    started: Instant,
+}
+
+/// One step's resolved budget plus why it landed where it did — logged so a
+/// truncated step is always attributable to either its own bound or to the
+/// enclosing Job deadline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StepBudget {
+    pub budget: Duration,
+    /// True when the enclosing Job deadline (not the step's own bound) is what
+    /// limited this step. This is the case the campaign cares about: raising a
+    /// per-step number here changes nothing, the Job deadline must move.
+    pub clamped_by_deadline: bool,
+}
+
+impl WarmStepBudgets {
+    /// Resolve from the process environment, anchoring elapsed-time accounting
+    /// at `started`.
+    pub fn from_env(started: Instant) -> Self {
+        Self {
+            job_deadline: duration_from_env(ENV_JOB_DEADLINE_SECONDS, DEFAULT_JOB_DEADLINE),
+            tail_reserve: duration_from_env(ENV_TAIL_RESERVE_SECONDS, DEFAULT_TAIL_RESERVE),
+            clippy: budget_from_env(WarmStepKind::Clippy),
+            build: budget_from_env(WarmStepKind::Build),
+            test_no_run: budget_from_env(WarmStepKind::TestNoRun),
+            sweep: budget_from_env(WarmStepKind::Sweep),
+            started,
+        }
+    }
+
+    /// Resolve from the environment anchored at "now".
+    pub fn now_from_env() -> Self {
+        Self::from_env(Clock::now_instant(&SystemClock::new()))
+    }
+
+    /// Deterministic budgets for the in-crate warm orchestration tests.
+    ///
+    /// Deliberately NOT env-driven: the warm tests run inside one process
+    /// alongside tests that spawn their own cargo stubs, and a process-global
+    /// budget override would leak a one-second bound into them.
+    #[cfg(test)]
+    pub fn for_testing(compile: Duration, sweep: Duration) -> Self {
+        Self {
+            job_deadline: DEFAULT_JOB_DEADLINE,
+            tail_reserve: DEFAULT_TAIL_RESERVE,
+            clippy: compile,
+            build: compile,
+            test_no_run: compile,
+            sweep,
+            started: Clock::now_instant(&SystemClock::new()),
+        }
+    }
+
+    /// The Job deadline this cycle is reconciled against.
+    pub fn job_deadline(&self) -> Duration {
+        self.job_deadline
+    }
+
+    /// The reserve withheld from every step for post-compile work.
+    pub fn tail_reserve(&self) -> Duration {
+        self.tail_reserve
+    }
+
+    /// The nominal (pre-clamp) budget configured for `kind`.
+    pub fn nominal(&self, kind: WarmStepKind) -> Duration {
+        match kind {
+            WarmStepKind::Clippy => self.clippy,
+            WarmStepKind::Build => self.build,
+            WarmStepKind::TestNoRun => self.test_no_run,
+            WarmStepKind::Sweep => self.sweep,
+        }
+    }
+
+    /// The budget to actually hand this step, clamped so it can never outlive
+    /// the deadline that would kill the Pod. Uses the elapsed time since the
+    /// anchor, so later steps see a correspondingly smaller ceiling.
+    pub fn resolve(&self, kind: WarmStepKind) -> StepBudget {
+        self.resolve_at(kind, self.started.elapsed())
+    }
+
+    /// Deterministic seam for the clamp arithmetic.
+    pub fn resolve_at(&self, kind: WarmStepKind, elapsed: Duration) -> StepBudget {
+        let nominal = self.nominal(kind);
+        let ceiling = self
+            .job_deadline
+            .saturating_sub(elapsed)
+            .saturating_sub(self.tail_reserve);
+        if ceiling >= nominal {
+            return StepBudget {
+                budget: nominal,
+                clamped_by_deadline: false,
+            };
+        }
+        StepBudget {
+            budget: ceiling.max(MIN_STEP_BUDGET),
+            clamped_by_deadline: true,
+        }
+    }
+}
+
+fn budget_from_env(kind: WarmStepKind) -> Duration {
+    duration_from_env(kind.env_key(), kind.default_budget())
+}
+
+/// Parse a positive whole-second duration from `key`. Anything unset, empty,
+/// unparseable, or zero keeps `fallback` — a warm Pod must never be left with
+/// an unbounded or instantly-expiring step because of a typo in an env var.
+fn duration_from_env(key: &str, fallback: Duration) -> Duration {
+    let Some(raw) = std::env::var_os(key) else {
+        return fallback;
+    };
+    let Some(text) = raw.to_str() else {
+        return fallback;
+    };
+    match text.trim().parse::<u64>() {
+        Ok(seconds) if seconds > 0 => Duration::from_secs(seconds),
+        _ => fallback,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn budgets(job_deadline: u64, tail_reserve: u64) -> WarmStepBudgets {
+        WarmStepBudgets {
+            job_deadline: Duration::from_secs(job_deadline),
+            tail_reserve: Duration::from_secs(tail_reserve),
+            clippy: DEFAULT_CLIPPY_BUDGET,
+            build: DEFAULT_BUILD_BUDGET,
+            test_no_run: DEFAULT_TEST_BUDGET,
+            sweep: DEFAULT_SWEEP_BUDGET,
+            started: Clock::now_instant(&SystemClock::new()),
+        }
+    }
+
+    #[test]
+    fn classifies_every_warm_command_shape() {
+        assert_eq!(
+            WarmStepKind::from_args(&["clippy", "--workspace"]),
+            WarmStepKind::Clippy
+        );
+        assert_eq!(
+            WarmStepKind::from_args(&["build", "--all-targets"]),
+            WarmStepKind::Build
+        );
+        assert_eq!(
+            WarmStepKind::from_args(&["test", "--workspace", "--no-run"]),
+            WarmStepKind::TestNoRun
+        );
+        assert_eq!(
+            WarmStepKind::from_args(&["nextest", "run", "--no-run"]),
+            WarmStepKind::TestNoRun
+        );
+        assert_eq!(
+            WarmStepKind::from_args(&["sweep", "--file"]),
+            WarmStepKind::Sweep
+        );
+        // An `override`-policy argv we do not recognize is build-shaped, the
+        // same coercion the bounded metric label mapping applies.
+        assert_eq!(WarmStepKind::from_args(&["doc"]), WarmStepKind::Build);
+        assert_eq!(WarmStepKind::from_args(&[]), WarmStepKind::Build);
+    }
+
+    /// The test-compile step is the one the campaign is about: its nominal
+    /// budget must exceed the retired 30-minute constant.
+    #[test]
+    fn test_step_nominal_budget_exceeds_the_retired_constant() {
+        let budgets = budgets(7200, 900);
+        assert!(budgets.nominal(WarmStepKind::TestNoRun) > Duration::from_secs(30 * 60));
+        // …while the steps that already fit keep exactly the old bound, so
+        // existing deployments do not regress.
+        assert_eq!(
+            budgets.nominal(WarmStepKind::Clippy),
+            Duration::from_secs(30 * 60)
+        );
+        assert_eq!(
+            budgets.nominal(WarmStepKind::Build),
+            Duration::from_secs(30 * 60)
+        );
+    }
+
+    /// A step bound must never exceed the deadline that would kill the Pod.
+    #[test]
+    fn budget_is_clamped_to_the_enclosing_job_deadline() {
+        let budgets = budgets(3600, 900);
+        let resolved = budgets.resolve_at(WarmStepKind::TestNoRun, Duration::from_secs(600));
+        assert!(resolved.clamped_by_deadline);
+        // 3600 - 600 elapsed - 900 reserve.
+        assert_eq!(resolved.budget, Duration::from_secs(2100));
+        assert!(resolved.budget < budgets.nominal(WarmStepKind::TestNoRun));
+    }
+
+    /// On the production 7200s Job the test step gets its full hour: the clamp
+    /// only binds when the deadline is genuinely the smaller number.
+    #[test]
+    fn generous_job_deadline_leaves_the_nominal_budget_intact() {
+        let budgets = budgets(7200, 900);
+        let resolved = budgets.resolve_at(WarmStepKind::TestNoRun, Duration::from_secs(620));
+        assert!(!resolved.clamped_by_deadline);
+        assert_eq!(resolved.budget, DEFAULT_TEST_BUDGET);
+    }
+
+    /// An exhausted deadline still yields a usable, bounded budget rather than
+    /// zero (which would report a timeout for a step that never ran).
+    #[test]
+    fn exhausted_deadline_floors_at_the_minimum_budget() {
+        let budgets = budgets(3600, 900);
+        let resolved = budgets.resolve_at(WarmStepKind::Clippy, Duration::from_secs(3600));
+        assert!(resolved.clamped_by_deadline);
+        assert_eq!(resolved.budget, MIN_STEP_BUDGET);
+    }
+
+    #[test]
+    fn env_parsing_rejects_zero_and_garbage_without_unbounding_the_step() {
+        // A parse seam rather than mutating process env: `duration_from_env`
+        // is exercised through its documented fallbacks below.
+        assert_eq!(
+            duration_from_env(
+                "DJINN_WARM_STEP_BUDGET_TEST_ABSENT_KEY",
+                DEFAULT_TEST_BUDGET
+            ),
+            DEFAULT_TEST_BUDGET
+        );
+    }
+}

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -162,6 +162,18 @@ exec {bin} warm-graph "{project_id}"
         // invocation failures surface in the Pod log instead of being
         // silently absent.
         env_var("RUST_LOG", "info,djinn=debug"),
+        // Project the Job's own activeDeadlineSeconds (set below from
+        // `warm_job_timeout_seconds`) so the in-Pod warm can size its per-step
+        // cargo budgets against the deadline that will kill it. Without this
+        // the worker would bound a step by a constant that may be larger than
+        // the Job deadline, which does not give the step more time — it just
+        // relocates the truncation from an observable `outcome="timeout"` step
+        // record to an unobservable kubelet kill. Mirrors the task-run path's
+        // DJINN_TASK_RUN_ACTIVE_DEADLINE_SECONDS projection in `job.rs`.
+        env_var(
+            "DJINN_WARM_JOB_DEADLINE_SECONDS",
+            &config.warm_job_timeout_seconds.to_string(),
+        ),
     ];
     // Forward the server's DB connection so `bootstrap_warm_database` in
     // djinn-agent-worker reaches the same Postgres instance as the server.
@@ -628,6 +640,13 @@ mod tests {
             Some(MIRROR_MOUNT_DIR)
         );
         assert_eq!(envs.get("DJINN_WARM_PROJECT_ID").copied(), Some("proj-xyz"));
+        // The in-Pod warm sizes its per-step cargo budgets against the Job's
+        // own activeDeadlineSeconds; the two must be the same number or a step
+        // bound could silently exceed the deadline that kills the Pod.
+        assert_eq!(
+            envs.get("DJINN_WARM_JOB_DEADLINE_SECONDS").copied(),
+            Some(cfg.warm_job_timeout_seconds.to_string().as_str()),
+        );
         // DJINN_SERVER_ADDR is intentionally absent — `warm-graph` lives
         // on a disjoint subcommand whose `WorkerDefaultArgs` are not
         // parsed, so any residual envs would only be noise.
@@ -803,6 +822,29 @@ mod tests {
         // than an accidental assertion of the default timeout.
         assert_eq!(spec.active_deadline_seconds, Some(1_237));
         assert_eq!(spec.backoff_limit, Some(0));
+        {
+            // A non-default deadline must reach the in-Pod warm verbatim: the
+            // per-step cargo budgets clamp against this value, so a stale or
+            // absent projection would let a step outlive the Job.
+            let projected: BTreeMap<&str, &str> = spec
+                .template
+                .spec
+                .as_ref()
+                .expect("pod spec")
+                .containers
+                .first()
+                .expect("warm container")
+                .env
+                .as_ref()
+                .expect("container environment")
+                .iter()
+                .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
+                .collect();
+            assert_eq!(
+                projected.get("DJINN_WARM_JOB_DEADLINE_SECONDS").copied(),
+                Some("1237"),
+            );
+        }
 
         let pod = spec.template.spec.as_ref().expect("pod spec");
         let container = pod.containers.first().expect("warm container");

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -54,7 +54,21 @@ const CARGO_SEED_HIT_TOTAL: &str = "djinn_cargo_seed_hit_total";
 const CARGO_SEED_COLD_TOTAL: &str = "djinn_cargo_seed_cold_total";
 const CARGO_WARM_BASE_FRESHNESS_SECONDS: &str = "djinn_cargo_warm_base_freshness_seconds";
 const CARGO_WARM_STEP_TOTAL: &str = "djinn_cargo_warm_step_total";
-const CARGO_WARM_STEP_OUTCOMES: [&str; 3] = ["ok", "failed", "spawn_error"];
+// A warm step that was killed at its own budget is NOT a spawn failure: it ran
+// and left partial progress in the warm base. `timeout` is its own closed label
+// so the convergence signal is not conflated with "could not start cargo".
+const CARGO_WARM_STEP_OUTCOMES: [&str; 4] = ["ok", "failed", "spawn_error", "timeout"];
+const CARGO_WARM_STEP_SECONDS: &str = "djinn_cargo_warm_step_seconds";
+const CARGO_WARM_BASE_UNITS: &str = "djinn_cargo_warm_base_units";
+const CARGO_WARM_BASE_PHASES: [&str; 2] = ["pre_compile", "post_compile"];
+const CARGO_WARM_BASE_UNIT_KINDS: [&str; 3] = ["fingerprint_units", "test_units", "dep_files"];
+const CARGO_WARM_SWEEP_DECISION_TOTAL: &str = "djinn_cargo_warm_sweep_decision_total";
+const CARGO_WARM_SWEEP_DECISIONS: [&str; 4] = [
+    "swept",
+    "skipped_no_stamp",
+    "skipped_no_success",
+    "skipped_truncated",
+];
 const CARGO_WARM_STEP_WORKSPACE_PATH_HASH: &str = "djinn_cargo_warm_step_workspace_path_hash";
 const CARGO_WARM_STEP_FRESH_COUNT: &str = "djinn_cargo_warm_step_fresh_count";
 const CARGO_WARM_STEP_COMPILING_COUNT: &str = "djinn_cargo_warm_step_compiling_count";
@@ -872,6 +886,11 @@ pub mod cargo_warm_step {
     pub const OUTCOME_OK: &str = "ok";
     pub const OUTCOME_FAILED: &str = "failed";
     pub const OUTCOME_SPAWN_ERROR: &str = "spawn_error";
+    /// The step ran and was killed at its configured budget. It is a partial
+    /// result, not a failure to start cargo, and downstream consumers must be
+    /// able to tell the two apart (a truncated step still advanced the warm
+    /// base; a spawn error advanced nothing).
+    pub const OUTCOME_TIMEOUT: &str = "timeout";
 
     /// Stable labels for the cargo warm step. Keep this list closed so the
     /// `step` label cardinality stays bounded.
@@ -881,7 +900,44 @@ pub mod cargo_warm_step {
     pub const STEP_TEST_NO_RUN: &str = "test_no_run";
 
     pub const STEP_TOTAL: &str = super::CARGO_WARM_STEP_TOTAL;
+    pub const STEP_SECONDS: &str = super::CARGO_WARM_STEP_SECONDS;
     pub const WORKSPACE_PATH_HASH: &str = super::CARGO_WARM_STEP_WORKSPACE_PATH_HASH;
+
+    /// Every closed `outcome` label value, for exhaustive enumeration in tests
+    /// and in consumers that must branch on the full space.
+    pub const ALL_OUTCOMES: [&str; 4] = [
+        OUTCOME_OK,
+        OUTCOME_FAILED,
+        OUTCOME_SPAWN_ERROR,
+        OUTCOME_TIMEOUT,
+    ];
+
+    /// Whether the outcome means "cargo ran and left partial progress in the
+    /// warm base" rather than "the step never produced anything". Consumers
+    /// that gate destructive warm-base maintenance on step results must use
+    /// this instead of a bare `outcome == OUTCOME_OK` test.
+    pub fn outcome_left_partial_progress(outcome: &str) -> bool {
+        outcome == OUTCOME_TIMEOUT
+    }
+
+    /// Record the wall-clock a single warm step consumed, partitioned by the
+    /// same bounded `(project_id, step, outcome)` triple as the counter. A
+    /// truncated step's sample is its budget, which is what makes "how much of
+    /// the enclosing deadline did this step burn" answerable from metrics.
+    pub fn record_step_seconds(
+        project_id: &str,
+        step: &'static str,
+        outcome: &'static str,
+        seconds: f64,
+    ) {
+        metrics::histogram!(
+            super::CARGO_WARM_STEP_SECONDS,
+            "project_id" => project_id.to_owned(),
+            "step" => step,
+            "outcome" => outcome,
+        )
+        .record(seconds);
+    }
 
     /// Increment the cargo warm-step counter for a `(project_id, step, outcome)`
     /// bucket. The free-form cargo argv is intentionally NOT a label so metric
@@ -948,6 +1004,71 @@ pub mod cargo_warm_step {
             hash = hash.wrapping_mul(PRIME);
         }
         hash
+    }
+}
+
+/// Bounded telemetry for the *contents* of the Cargo warm base, sampled either
+/// side of the warm compile phase.
+///
+/// This is the convergence instrument: if successive warm cycles accumulate
+/// test-target artifacts, `test_units` at `post_compile` rises cycle over
+/// cycle; if the tail sweep reclaims them faster than a truncated compile step
+/// produces them, it does not. Every label is a closed enum — the census counts
+/// themselves are gauge *values*, never labels.
+pub mod cargo_warm_base {
+    pub const PHASE_PRE_COMPILE: &str = "pre_compile";
+    pub const PHASE_POST_COMPILE: &str = "post_compile";
+    pub const ALL_PHASES: [&str; 2] = [PHASE_PRE_COMPILE, PHASE_POST_COMPILE];
+
+    /// Cargo unit directories under `debug/.fingerprint`.
+    pub const KIND_FINGERPRINT_UNITS: &str = "fingerprint_units";
+    /// Fingerprint units that carry a `test-*.json` fingerprint — i.e. units
+    /// compiled with `--test`, which is exactly what the `--no-run` warm step
+    /// exists to produce.
+    pub const KIND_TEST_UNITS: &str = "test_units";
+    /// Regular files under `debug/deps` (the linked artifacts themselves).
+    pub const KIND_DEP_FILES: &str = "dep_files";
+    pub const ALL_UNIT_KINDS: [&str; 3] = [KIND_FINGERPRINT_UNITS, KIND_TEST_UNITS, KIND_DEP_FILES];
+
+    pub const UNITS: &str = super::CARGO_WARM_BASE_UNITS;
+    pub const SWEEP_DECISION_TOTAL: &str = super::CARGO_WARM_SWEEP_DECISION_TOTAL;
+
+    /// The tail `cargo sweep --file` ran.
+    pub const DECISION_SWEPT: &str = "swept";
+    /// Skipped: the pre-compile `cargo sweep --stamp` never landed.
+    pub const DECISION_SKIPPED_NO_STAMP: &str = "skipped_no_stamp";
+    /// Skipped: no warm step completed successfully.
+    pub const DECISION_SKIPPED_NO_SUCCESS: &str = "skipped_no_success";
+    /// Skipped: at least one warm step was killed at its budget, so artifacts
+    /// older than the stamp are "not yet rebuilt", not "no longer needed".
+    pub const DECISION_SKIPPED_TRUNCATED: &str = "skipped_truncated";
+    pub const ALL_SWEEP_DECISIONS: [&str; 4] = [
+        DECISION_SWEPT,
+        DECISION_SKIPPED_NO_STAMP,
+        DECISION_SKIPPED_NO_SUCCESS,
+        DECISION_SKIPPED_TRUNCATED,
+    ];
+
+    /// Publish one warm-base census count for a `(project_id, phase, kind)`
+    /// bucket.
+    pub fn set_units(project_id: &str, phase: &'static str, kind: &'static str, count: u64) {
+        metrics::gauge!(
+            super::CARGO_WARM_BASE_UNITS,
+            "project_id" => project_id.to_owned(),
+            "phase" => phase,
+            "kind" => kind,
+        )
+        .set(count as f64);
+    }
+
+    /// Record exactly one tail-sweep decision per warm cycle.
+    pub fn increment_sweep_decision(project_id: &str, decision: &'static str) {
+        metrics::counter!(
+            super::CARGO_WARM_SWEEP_DECISION_TOTAL,
+            "project_id" => project_id.to_owned(),
+            "decision" => decision,
+        )
+        .increment(1);
     }
 }
 
@@ -1761,6 +1882,37 @@ fn register_metrics() {
             "project_id" => "",
             "step" => "",
             "outcome" => outcome
+        )
+        .absolute(0);
+    }
+    metrics::describe_histogram!(
+        CARGO_WARM_STEP_SECONDS,
+        "Wall-clock seconds consumed by one cargo warm step, partitioned by the same bounded project_id, step, and outcome labels as djinn_cargo_warm_step_total. A `timeout` sample equals the step's configured budget."
+    );
+    metrics::describe_gauge!(
+        CARGO_WARM_BASE_UNITS,
+        "Census of the cargo warm base sampled either side of the compile phase, partitioned by project_id, the closed phase (pre_compile, post_compile) and the closed kind (fingerprint_units, test_units, dep_files). Rising post_compile test_units across cycles is the warm base converging on test-target artifacts."
+    );
+    for phase in CARGO_WARM_BASE_PHASES {
+        for kind in CARGO_WARM_BASE_UNIT_KINDS {
+            metrics::gauge!(
+                CARGO_WARM_BASE_UNITS,
+                "project_id" => "",
+                "phase" => phase,
+                "kind" => kind
+            )
+            .set(0.0);
+        }
+    }
+    metrics::describe_counter!(
+        CARGO_WARM_SWEEP_DECISION_TOTAL,
+        "Tail `cargo sweep --file` decisions for one warm cycle, partitioned by project_id and the fixed decisions swept, skipped_no_stamp, skipped_no_success, and skipped_truncated."
+    );
+    for decision in CARGO_WARM_SWEEP_DECISIONS {
+        metrics::counter!(
+            CARGO_WARM_SWEEP_DECISION_TOTAL,
+            "project_id" => "",
+            "decision" => decision
         )
         .absolute(0);
     }


### PR DESCRIPTION
Closes board task `sjrs`.

The warm test-binary compile was killed at a hard-coded 30-minute constant every cycle, reported as a spawn error, and then had its partial progress swept away — so the warm base never converged on the test-target artifacts task runs spend their wall clock rebuilding.

Observed live in production on 2026-07-24 (project djinn, 4 vCPU VPS):

```
23:01:36  warm incremental prune  outcome="pruned"  pruned_bytes=10542053373
23:01:36 -> 23:11:54  cargo clippy --workspace --all-targets   seed_outcome="ok"
23:11:54 -> 23:41:55  cargo nextest run --workspace --all-targets --no-run
                      seed_outcome="spawn_error"  error="process timed out"
                      -> recorded as step="build_fallback"
23:41:58  warm target base compile complete  elapsed_ms=2419269
```

## 1. Per-step budgets, reconciled against the enclosing deadline

`WARM_COMMAND_TIMEOUT` (one `30 * 60` constant applied to every warm cargo command) is replaced by `warm_step_budget`, which resolves a budget per step kind — clippy / build / `test --no-run` / sweep — and then **clamps every one of them to the time actually left before the warm Job's `activeDeadlineSeconds`**, minus a reserve for the post-compile graph index and publish that shares the same Pod.

The Job deadline is now projected into the warm Pod as `DJINN_WARM_JOB_DEADLINE_SECONDS`, mirroring the task-run path's `DJINN_TASK_RUN_ACTIVE_DEADLINE_SECONDS`. Defaults:

| step | nominal | note |
| --- | --- | --- |
| clippy | 1800s | unchanged from the retired constant |
| build (clippy fallback) | 1800s | unchanged |
| sweep | 1800s | unchanged |
| `test --no-run` / `nextest --no-run` | 3600s | raised — the step that was truncated every cycle |
| tail reserve | 900s | withheld from every clamp for SCIP + publish |

Because the clamp always binds, a per-step override can never push a step past the deadline that would kill the Pod anyway — that would only relocate the truncation from an observable `outcome="timeout"` step record to an unobservable kubelet kill. To genuinely give the warm more room an operator raises `DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS` and the step budgets follow.

**On the second enclosing deadline:** the warm watcher is *not* an independent binding constraint any more. `graph_warmer_lifecycle::watch_deadline` derives it as `warm_job_timeout_seconds + 300s` slack (the hard-coded-3600s pitfall was fixed in #2447/#2450). The Job's `activeDeadlineSeconds` is the single authority, and this change makes the in-Pod budgets agree with it rather than ignore it.

## 2. A timeout is not a spawn error

`output_with_timeout` returns `io::ErrorKind::TimedOut` **only** when our own deadline fired (an externally-signalled child is deliberately classified as a distinct non-timeout failure), so the discrimination is exact rather than heuristic. A truncated step now records `outcome="timeout"`, a new member of the closed `djinn_cargo_warm_step_total` outcome space, and the terminal event carries `truncated=`, `budget_secs=`, `budget_clamped_by_job_deadline=`, and `elapsed_ms=`.

This also fixes the mislabelling visible in the evidence above. `cargo_metrics::warm_step_metric_label` matched a `"test --no-run"` spelling that **no call site emits** — `cargo_cache_policy::build_test_warm_command` produces `"test (--no-run)"` and `"nextest (--no-run)"` — so the catch-all coerced every production test-compile step to `step="build_fallback"` and the `test_no_run` series has been dark since it was added. A contract test now drives the mapping from the labels the policy actually returns, so the two cannot drift again.

## 3. Convergence

**The prune is not the culprit.** `cargo_incremental_prune::prune_derived_base` removes exactly one path: `<base>/debug/incremental`. `cargo_target_seed::classify_cargo_target_path` already skips `incremental` when seeding a task run, with an existing test asserting "pruning may only remove skipped incremental state". So the 10.5 GB deleted at the head of the run is disposable incremental state that no task run ever receives, and it is provably not the test-target artifacts the `--no-run` step produces. Prune-before-compile is left where it is; it also doubles as the base-path validation gate that must run before any compiler touches the base.

**The tail sweep is.** `cargo sweep --file` deletes every artifact older than the pre-compile stamp, and its only notion of "no longer needed" is "this compile did not touch it". A step killed at its budget never reached the artifacts it would have refreshed, so the sweep deletes precisely the previously-built test binaries the truncated step had not got to yet. The old gate was `sweep_stamped && any_step_ok` — and one green clippy is enough to satisfy `any_step_ok`, so the sweep fired *exactly* in the observed failure mode. That is the "warm base ping-pongs instead of converging" mechanism recorded in the existing pitfall note, now localised.

Truncation therefore suppresses the tail sweep. A per-cycle `djinn_cargo_warm_sweep_decision_total{project_id, decision}` counter records which of `swept` / `skipped_no_stamp` / `skipped_no_success` / `skipped_truncated` applied, with truncation checked before "nothing succeeded" because it is the more specific and more actionable explanation.

**Instrumentation to settle it empirically.** `warm_base_census` counts, either side of the compile phase, the fingerprint units under `debug/.fingerprint`, the subset carrying a `test-*.json` fingerprint (an exact identification of a `--test` unit — the artifact class `--no-run` exists to produce), and the regular files under `debug/deps`. Published as `djinn_cargo_warm_base_units{project_id, phase, kind}` plus a per-cycle delta log line. Rising `post_compile` `test_units` across cycles *is* the base converging; falling is it losing ground.

Honest scope note: this PR establishes the mechanism from code plus the single captured production cycle, and ships the instrument that answers the cross-cycle question. It does not itself contain multi-cycle production evidence — that requires deploying and reading the census across warms.

## Telemetry

All new labels are closed enums; every count is a gauge/counter **value**, never a label. New series: `djinn_cargo_warm_step_seconds` (histogram, same bounded triple as the counter), `djinn_cargo_warm_base_units` (gauge), `djinn_cargo_warm_sweep_decision_total` (counter). `timeout` is added to the pre-registered `djinn_cargo_warm_step_total` outcome set.

## Verification

- `SQLX_OFFLINE=1 cargo check --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `cargo clippy -p djinn-telemetry -p djinn-agent-worker -p djinn-k8s --all-targets -- -D warnings` — clean
- `cargo test -p djinn-agent-worker --bins` — 283 passed, 2 pre-existing load-sensitive process-timing failures (`lifecycle::tests::pretask_enforces_timeout`, `tests::warm_shutdown_drains_two_registered_groups_and_setsid_adoptee`) reproduced identically on unmodified `main` sources on the same box and passing in isolation
- focused suites green: `warm_step_budget::*`, `warm_base_census::*`, `cargo_metrics::*`, `cargo_cache_policy::*`, `cargo_incremental_prune::*`, `tests::warm_cargo_ordering_*`, `tests::truncated_warm_step_records_timeout_and_suppresses_the_tail_sweep`, `tests::warm_step_error_outcome_separates_truncation_from_spawn_failure`; `djinn-telemetry` (87), `djinn-k8s --lib` (230), `djinn-agent-worker --lib` (32)
- no `Cargo.toml` changed, so no hakari regeneration; no `EnvironmentConfig` change, so no golden fanout; file-size guard and raw-SQL boundary guard clean

The new orchestration test injects the step's terminal outcome rather than racing a deliberately-hung stub: the child reaper is process-wide, so a sibling test's group shutdown can `SIGTERM` a hung stub before its own budget elapses. The timeout-versus-spawn-failure discrimination is covered directly by its own unit test and by `djinn_graph::process`'s existing tests. The injection is keyed by project id so it cannot leak into a concurrently-running sibling test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
