### PR TITLE
fix(jqvg): stop repository code reading the credential Secret and SA token

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
  "djinn-git",
  "djinn-provider",
  "djinn-runtime",
+ "djinn-sandbox",
  "djinn-stack",
  "djinn-supervisor",
  "djinn-workspace",

--- a/server/crates/djinn-agent/src/commands.rs
+++ b/server/crates/djinn-agent/src/commands.rs
@@ -30,6 +30,15 @@ pub async fn run_commands(
 
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg(&spec.command).current_dir(working_dir);
+        // jqvg: these hooks are operator-configured, but what they run is the
+        // repository's own build tooling — a `build.rs`, an npm `postinstall`,
+        // a Makefile target — so repository-controlled code executes here just
+        // as it does under the agent shell. This path deliberately does NOT go
+        // through the full sandbox (setup hooks may legitimately write outside
+        // the worktree), so arm only the read-denial layer: it withholds the
+        // credential Secret and the projected ServiceAccount token and changes
+        // nothing else about how the command runs.
+        crate::sandbox::confidential::deny_confidential_reads(&mut cmd);
 
         let output = spawn_command(cmd, duration)
             .await

--- a/server/crates/djinn-agent/src/sandbox/mod.rs
+++ b/server/crates/djinn-agent/src/sandbox/mod.rs
@@ -15,6 +15,8 @@ pub use djinn_sandbox::*;
 #[cfg(target_os = "linux")]
 #[allow(unused_imports)]
 pub use djinn_sandbox::chat_shell;
+#[allow(unused_imports)]
+pub use djinn_sandbox::confidential;
 #[cfg(target_os = "linux")]
 #[allow(unused_imports)]
 pub use djinn_sandbox::linux;

--- a/server/crates/djinn-k8s/Cargo.toml
+++ b/server/crates/djinn-k8s/Cargo.toml
@@ -34,6 +34,9 @@ workspace-hack.workspace = true
 [dev-dependencies]
 async-trait = "0.1"
 djinn-provider = { path = "../djinn-provider" }
+# jqvg drift guard only: the secret mount paths rendered here must stay covered
+# by the shell sandbox's confidential-path denylist.
+djinn-sandbox = { path = "../djinn-sandbox" }
 serde_yaml = "0.9"
 http = "1"
 http-body-util = "0.1"

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -506,6 +506,16 @@ pub fn build_task_run_job(
 
     let pod_spec = PodSpec {
         service_account_name: Some(config.service_account.clone()),
+        // jqvg: the task-run Pod runs repository-controlled code (agent shell
+        // commands, `build.rs`, test targets, npm `postinstall`). Nothing in
+        // this Pod speaks to the apiserver — the worker's only authenticated
+        // peer is djinn-server, reached with the audience-bound projected token
+        // on VOLUME_AUTH_TOKEN below — so the default ServiceAccount token has
+        // no legitimate reader here and only supplies a leak with real
+        // apiserver blast radius. Turning automount off removes that file from
+        // the container filesystem entirely, which is strictly stronger than
+        // the sandbox-level read denial that also covers `/var/run/secrets`.
+        automount_service_account_token: Some(false),
         restart_policy: Some("Never".to_string()),
         init_containers,
         containers: vec![container],
@@ -1512,6 +1522,15 @@ mod tests {
             "task grkq: no launcher ⇒ no initContainers for a service-less run"
         );
         assert_eq!(pod.share_process_namespace, None);
+
+        // jqvg: nothing in the task-run Pod speaks to the apiserver, and the
+        // Pod runs repository-controlled code. The apiserver-capable default
+        // ServiceAccount token must not be projected into it at all.
+        assert_eq!(
+            pod.automount_service_account_token,
+            Some(false),
+            "jqvg: the task-run Pod must not automount the apiserver ServiceAccount token"
+        );
 
         // spec → Secret volume with the right name + key-to-path mapping.
         let spec_volume = &volumes[0];
@@ -3684,5 +3703,34 @@ mod tests {
         assert_eq!(cfg.warm_cpu_limit, "4");
         assert_eq!(cfg.warm_memory_request, "2Gi");
         assert_eq!(cfg.warm_memory_limit, "6Gi");
+    }
+
+    /// jqvg drift guard. Every secret this module projects into the worker
+    /// container must sit beneath a root the shell sandbox withholds
+    /// `ReadFile` on, otherwise repository-controlled code can read it again.
+    /// This coupling did not exist when the credential mount was added, which
+    /// is a large part of why the exposure went unnoticed.
+    #[test]
+    fn projected_secret_mounts_stay_covered_by_the_sandbox_denylist() {
+        use std::path::Path;
+
+        for secret in [
+            SPEC_MOUNT_FILE,
+            CREDENTIALS_MOUNT_FILE,
+            TOKEN_MOUNT_FILE,
+            // No longer automounted (see `automount_service_account_token`),
+            // but keep it in the denylist's remit so re-enabling automount
+            // cannot silently re-expose it to a sandboxed shell.
+            "/var/run/secrets/kubernetes.io/serviceaccount/token",
+        ] {
+            assert!(
+                djinn_sandbox::confidential::CONFIDENTIAL_ROOTS
+                    .iter()
+                    .any(|root| Path::new(secret).starts_with(root)),
+                "{secret} is projected into the worker container but is not beneath any \
+                 djinn_sandbox::confidential::CONFIDENTIAL_ROOTS entry — a sandboxed \
+                 shell could read it"
+            );
+        }
     }
 }

--- a/server/crates/djinn-sandbox/src/chat_shell.rs
+++ b/server/crates/djinn-sandbox/src/chat_shell.rs
@@ -32,8 +32,13 @@
 //!    `kernel.unprivileged_userns_clone=0`, or we're running inside a
 //!    container that already dropped the cap), we fall through — the other
 //!    layers still apply. See [`NAMESPACE_PROBE`] for the detection logic.
-//! 5. **Landlock v3.** `AccessFs::ReadFile | ReadDir | Execute` on `/`, and
+//! 5. **Landlock v3.** `AccessFs::ReadDir | Execute` on `/` plus `ReadFile`
+//!    on everything except [`crate::confidential::CONFIDENTIAL_ROOTS`], and
 //!    no write rules anywhere. Applied via `restrict_self()` in the child.
+//!    Withholding `ReadFile` on the confidential mounts is task jqvg: a
+//!    blanket `ReadFile` on `/` let a chat `cat` reach the task-run Pod's
+//!    credential Secret and projected ServiceAccount token, and Landlock is
+//!    additive so the exception cannot be carved out of a `/` grant.
 //! 6. **Seccomp-bpf.** Errno-denies a hard deny list covering ptrace,
 //!    module loading, pivot_root, bpf, perf_event_open, and friends.
 //! 7. **rlimits.** `RLIMIT_AS=512 MiB`, `RLIMIT_CPU=20s`,
@@ -211,6 +216,16 @@ impl ChatShellSandbox {
         let cwd = resolve_cwd(&self.clone_root, req.cwd.as_deref())?;
 
         let namespaces_ok = probe_namespaces();
+
+        // File-content reads are granted over everything EXCEPT the task-run
+        // Pod's credential/token mounts (task jqvg). Computed here in the
+        // parent because it walks the filesystem with `read_dir`; `pre_exec`
+        // only opens the resulting paths.
+        let read_file_cover =
+            crate::confidential::read_file_cover(&crate::confidential::present_confidential_roots(
+                crate::confidential::CONFIDENTIAL_ROOTS,
+            ));
+
         let mut cmd = Command::new(&req.argv[0]);
         cmd.args(&req.argv[1..])
             .current_dir(&cwd)
@@ -245,7 +260,7 @@ impl ChatShellSandbox {
                 if namespaces_ok {
                     enter_namespaces()?;
                 }
-                apply_landlock()?;
+                apply_landlock(&read_file_cover)?;
                 apply_seccomp()?;
                 apply_rlimits()?;
                 Ok(())
@@ -480,21 +495,36 @@ fn enter_namespaces() -> io::Result<()> {
     Ok(())
 }
 
-fn apply_landlock() -> io::Result<()> {
+fn apply_landlock(read_file_cover: &[PathBuf]) -> io::Result<()> {
     let abi = ABI::V3;
     let full = AccessFs::from_all(abi);
     let read_exec = AccessFs::Execute | AccessFs::ReadFile | AccessFs::ReadDir;
+    // Traverse, list and execute stay granted on all of `/`; only file-content
+    // reads are withheld, and only beneath the confidential mounts (jqvg).
+    let traverse_exec = AccessFs::Execute | AccessFs::ReadDir;
 
     let root = PathFd::new("/")
         .map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e.to_string()))?;
 
-    let ruleset = Ruleset::default()
+    let mut ruleset = Ruleset::default()
         .handle_access(full)
         .map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e.to_string()))?
         .create()
         .map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e.to_string()))?
-        .add_rule(PathBeneath::new(root, read_exec))
+        .add_rule(PathBeneath::new(root, traverse_exec))
         .map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e.to_string()))?;
+
+    // `read_file_cover` is `["/"]` on any host without the Pod secret mounts,
+    // which reproduces the previous blanket read grant exactly. A path that
+    // vanished since the parent enumerated it is skipped — we cannot log from
+    // `pre_exec`, and a missing path grants nothing.
+    for path in read_file_cover {
+        if let Ok(fd) = PathFd::new(path) {
+            ruleset = ruleset
+                .add_rule(PathBeneath::new(fd, read_exec))
+                .map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e.to_string()))?;
+        }
+    }
 
     ruleset
         .restrict_self()

--- a/server/crates/djinn-sandbox/src/confidential.rs
+++ b/server/crates/djinn-sandbox/src/confidential.rs
@@ -1,0 +1,249 @@
+// Confidential filesystem paths that repository-controlled code must never read.
+//
+// jqvg: the agent shell sandbox's Landlock policy is WRITE-confinement only —
+// it grants `ReadFile` across the whole of `/`. The task-run Pod mounts the
+// org's provider credentials and the projected ServiceAccount token into the
+// same container that runs `bash -lc`, so any agent shell command, `build.rs`,
+// test, Makefile target, or npm `postinstall` could read them.
+//
+// Landlock is purely additive within a ruleset layer: the kernel walks from the
+// accessed dentry towards the mount root and any matching rule that grants the
+// requested access satisfies the layer. A deeper, narrower rule therefore
+// cannot subtract from a broader ancestor grant — you cannot carve an exception
+// out of `PathBeneath("/", ReadFile)`.
+//
+// What you CAN do is never grant the ancestor in the first place. This module
+// computes, mechanically from the confidential paths themselves, the set of
+// paths that must be granted `ReadFile` so that the entire filesystem stays
+// readable EXCEPT the confidential subtrees. For every strict ancestor of a
+// confidential path, every sibling that is not itself on a confidential path is
+// granted individually; the ancestors themselves are not. That is a denylist
+// derived from a constant, not a hand-maintained read allowlist: nothing can be
+// "missed" except by adding a new secret without adding it here, which the
+// drift tests around `CONFIDENTIAL_ROOTS` guard.
+//
+// Directory listing (`ReadDir`) and `Execute` stay granted on `/` by the
+// callers, so `ls /`, path traversal, and every toolchain binary keep working.
+// Neither leaks file CONTENT: a filename is not the secret, and `Execute` on a
+// non-executable blob is not reachable and would not surface its bytes to the
+// caller anyway.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Directories inside the task-run Pod whose *contents* must be unreadable to
+/// any process the agent spawns.
+///
+/// These mirror the mount paths rendered by `djinn_k8s::job`; a drift test in
+/// that crate asserts the two stay in step.
+///
+/// * `/var/run/djinn` — `djinn_k8s::job::SPEC_MOUNT_DIR`, the per-task-run
+///   Secret volume. Carries `credentials.bin` (the org's resolved provider
+///   credentials), `spec.bin`, `environment.json` and `service_metadata.json`.
+///   The whole directory is excluded rather than just `credentials.bin`, so a
+///   future key added to the same Secret is covered by construction.
+/// * `/var/run/secrets` — the parent of `djinn_k8s::job::TOKEN_MOUNT_DIR`.
+///   Covers both the djinn-audience projected ServiceAccount token
+///   (`tokens/djinn`) and, on clusters that still automount it, the
+///   kube-apiserver ServiceAccount token under `kubernetes.io/serviceaccount/`.
+///   The two have very different blast radii — the djinn-audience token only
+///   authenticates the worker to djinn-server for its own task-run, while the
+///   automounted one is accepted by the apiserver — so the token half is also
+///   addressed at the manifest: `job.rs` sets `automountServiceAccountToken:
+///   false`, removing the apiserver-capable token from the Pod entirely.
+///
+/// A path that does not exist on the running host is skipped: there is nothing
+/// to protect, and the cover degenerates to the historical blanket `/` grant.
+pub const CONFIDENTIAL_ROOTS: &[&str] = &["/var/run/djinn", "/var/run/secrets"];
+
+/// Resolve the confidential roots that actually exist, as canonical paths.
+///
+/// Canonicalization is load-bearing. On most modern images `/var/run` is a
+/// symlink to `/run`, so `/var/run/djinn` and `/run/djinn` are the same inode.
+/// Landlock matches on the resolved dentry rather than on the path string, so
+/// the cover must be computed over canonical paths or the exclusion would sit
+/// on the wrong branch of the tree and grant the secret back through the other
+/// name.
+///
+/// Runs in the parent process before `fork`: it allocates and touches the
+/// filesystem, neither of which is async-signal-safe.
+pub fn present_confidential_roots(roots: &[&str]) -> Vec<PathBuf> {
+    roots
+        .iter()
+        .filter_map(|raw| std::fs::canonicalize(raw).ok())
+        .collect()
+}
+
+/// Compute the paths that must be granted `ReadFile` so the whole filesystem
+/// stays readable except beneath `confidential_roots`.
+///
+/// Returns `["/"]` when there is nothing to exclude, which reproduces the
+/// historical blanket grant exactly (dev hosts, the macOS path, any image that
+/// does not mount the Pod secrets).
+///
+/// Fails closed: an ancestor directory that cannot be listed contributes no
+/// grants rather than falling back to a blanket `/`, so a hostile or broken
+/// filesystem cannot silently reopen the hole.
+///
+/// Runs in the parent process before `fork` — `read_dir` allocates.
+pub fn read_file_cover(confidential_roots: &[PathBuf]) -> Vec<PathBuf> {
+    let root = Path::new("/");
+
+    // Drop anything that is not a usable exclusion, then drop entries that are
+    // already inside another exclusion. Without that second pass a nested pair
+    // such as `/run/secrets` + `/run/secrets/tokens` would make `/run/secrets`
+    // an "ancestor", and its other children would be granted straight back.
+    let mut candidates: Vec<PathBuf> = confidential_roots
+        .iter()
+        .filter(|path| path.is_absolute() && path.as_path() != root)
+        .cloned()
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+    let excluded: BTreeSet<PathBuf> = candidates
+        .iter()
+        .filter(|path| {
+            !candidates
+                .iter()
+                .any(|other| other != *path && path.starts_with(other))
+        })
+        .cloned()
+        .collect();
+
+    if excluded.is_empty() {
+        return vec![root.to_path_buf()];
+    }
+
+    // Every strict ancestor of an excluded path loses its blanket grant and is
+    // re-covered entry by entry below. `/` is always in this set.
+    let mut ancestors: BTreeSet<PathBuf> = BTreeSet::new();
+    for path in &excluded {
+        let mut current = path.parent();
+        while let Some(dir) = current {
+            ancestors.insert(dir.to_path_buf());
+            current = dir.parent();
+        }
+    }
+
+    let mut cover: Vec<PathBuf> = Vec::new();
+    for dir in &ancestors {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            // Fail closed: grant nothing out of a directory we cannot enumerate.
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if ancestors.contains(&path) || excluded.contains(&path) {
+                continue;
+            }
+            cover.push(path);
+        }
+    }
+    cover.sort();
+    cover.dedup();
+    cover
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `/var/run/djinn` and `/var/run/secrets` are the two mount points
+    /// `djinn_k8s::job` renders into the worker container. If either constant
+    /// moves, this crate must move with it.
+    #[test]
+    fn confidential_roots_cover_the_pod_secret_mounts() {
+        // Mirrors `djinn_k8s::job::CREDENTIALS_MOUNT_FILE` and
+        // `djinn_k8s::job::TOKEN_MOUNT_FILE`.
+        for secret in [
+            "/var/run/djinn/credentials.bin",
+            "/var/run/djinn/spec.bin",
+            "/var/run/secrets/tokens/djinn",
+            "/var/run/secrets/kubernetes.io/serviceaccount/token",
+        ] {
+            assert!(
+                CONFIDENTIAL_ROOTS
+                    .iter()
+                    .any(|root| Path::new(secret).starts_with(root)),
+                "{secret} must sit beneath a confidential root"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_exclusions_reproduce_the_blanket_root_grant() {
+        assert_eq!(read_file_cover(&[]), vec![PathBuf::from("/")]);
+        // A bare `/` is not a usable exclusion and must not blank the cover.
+        assert_eq!(
+            read_file_cover(&[PathBuf::from("/")]),
+            vec![PathBuf::from("/")]
+        );
+    }
+
+    /// The cover must contain every sibling of every ancestor of the excluded
+    /// path, and none of the ancestors themselves.
+    #[test]
+    fn cover_grants_siblings_and_withholds_ancestors() {
+        let fixture = tempfile::tempdir_in("/var/tmp").expect("fixture root");
+        let base = fixture
+            .path()
+            .canonicalize()
+            .expect("canonical fixture root");
+        let secret_dir = base.join("run/secret");
+        let peer_dir = base.join("run/peer");
+        std::fs::create_dir_all(&secret_dir).expect("secret dir");
+        std::fs::create_dir_all(&peer_dir).expect("peer dir");
+        let sibling_file = base.join("sibling.txt");
+        std::fs::write(&sibling_file, "public").expect("sibling file");
+
+        let cover = read_file_cover(std::slice::from_ref(&secret_dir));
+
+        assert!(
+            !cover.contains(&secret_dir),
+            "excluded path must not appear"
+        );
+        assert!(
+            cover.contains(&peer_dir),
+            "sibling directory must be granted"
+        );
+        assert!(
+            cover.contains(&sibling_file),
+            "sibling file must be granted"
+        );
+        assert!(
+            !cover.contains(&base.join("run")),
+            "ancestor must not be granted as a subtree"
+        );
+        assert!(!cover.contains(&base), "ancestor must not be granted");
+        assert!(
+            !cover.contains(&PathBuf::from("/")),
+            "the blanket root grant must be gone once anything is excluded"
+        );
+        // Unrelated top-level entries stay readable.
+        assert!(cover.contains(&PathBuf::from("/etc")));
+    }
+
+    /// A nested pair must collapse to the broader exclusion, otherwise the
+    /// inner directory's siblings get granted back out of the outer one.
+    #[test]
+    fn nested_exclusions_collapse_to_the_broadest() {
+        let fixture = tempfile::tempdir_in("/var/tmp").expect("fixture root");
+        let base = fixture
+            .path()
+            .canonicalize()
+            .expect("canonical fixture root");
+        let outer = base.join("secrets");
+        let inner = outer.join("tokens");
+        let leaked = outer.join("other");
+        std::fs::create_dir_all(&inner).expect("inner dir");
+        std::fs::create_dir_all(&leaked).expect("peer inside outer");
+
+        let cover = read_file_cover(&[inner, outer.clone()]);
+
+        assert!(!cover.contains(&outer));
+        assert!(
+            !cover.contains(&leaked),
+            "a sibling INSIDE the broader exclusion must stay excluded"
+        );
+    }
+}

--- a/server/crates/djinn-sandbox/src/confidential.rs
+++ b/server/crates/djinn-sandbox/src/confidential.rs
@@ -144,6 +144,78 @@ pub fn read_file_cover(confidential_roots: &[PathBuf]) -> Vec<PathBuf> {
     cover
 }
 
+/// Arm a Landlock layer on `cmd` that denies reading file CONTENT beneath the
+/// confidential roots, and restricts **nothing else**.
+///
+/// This is for the command paths that are not under the full shell sandbox —
+/// notably project setup hooks, which are operator-configured but invoke the
+/// repository's own build tooling, so `build.rs`, an npm `postinstall` or a
+/// Makefile target still executes repository-controlled code there. Applying
+/// the full [`crate::linux::LandlockSandbox`] would additionally impose
+/// write-confinement and could break a hook that legitimately writes outside
+/// the worktree; this layer handles only `ReadFile`, so every other access
+/// stays exactly as it was. Landlock layers intersect, so it also composes
+/// safely with the full sandbox if both are ever applied.
+///
+/// No-op when Landlock is unavailable, or when no confidential root exists on
+/// this host — both cases leave the command's behaviour byte-identical.
+#[cfg(target_os = "linux")]
+pub fn deny_confidential_reads(cmd: &mut std::process::Command) {
+    deny_confidential_reads_beneath(cmd, &present_confidential_roots(CONFIDENTIAL_ROOTS));
+}
+
+/// [`deny_confidential_reads`] with an explicit root set, so tests can exercise
+/// the real layer against a fixture tree.
+#[cfg(target_os = "linux")]
+pub(crate) fn deny_confidential_reads_beneath(
+    cmd: &mut std::process::Command,
+    confidential_roots: &[PathBuf],
+) {
+    use landlock::{AccessFs, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr};
+    use std::os::unix::process::CommandExt;
+
+    if !crate::probe_landlock() {
+        return;
+    }
+    // Computed in the parent: `read_dir` allocates and is not
+    // async-signal-safe. `pre_exec` only opens the resulting paths.
+    let cover = read_file_cover(confidential_roots);
+    if cover.len() == 1 && cover[0] == Path::new("/") {
+        // Nothing to protect on this host — do not arm a layer at all.
+        return;
+    }
+
+    // Safety: `pre_exec` runs in the forked child. The closure only performs
+    // Landlock syscalls and `open(2)` via `PathFd::new`, both async-signal-safe.
+    unsafe {
+        cmd.pre_exec(move || {
+            let to_io =
+                |e: std::io::Error| std::io::Error::new(std::io::ErrorKind::PermissionDenied, e);
+            let mut ruleset = Ruleset::default()
+                .handle_access(AccessFs::ReadFile)
+                .map_err(|e| to_io(std::io::Error::other(e.to_string())))?
+                .create()
+                .map_err(|e| to_io(std::io::Error::other(e.to_string())))?;
+            for path in &cover {
+                if let Ok(fd) = PathFd::new(path) {
+                    ruleset = ruleset
+                        .add_rule(PathBeneath::new(fd, AccessFs::ReadFile))
+                        .map_err(|e| to_io(std::io::Error::other(e.to_string())))?;
+                }
+            }
+            ruleset
+                .restrict_self()
+                .map_err(|e| to_io(std::io::Error::other(e.to_string())))?;
+            Ok(())
+        });
+    }
+}
+
+/// Non-Linux hosts have no Landlock; the task-run Pod is Linux-only, so this is
+/// a no-op that keeps call sites free of `cfg` noise.
+#[cfg(not(target_os = "linux"))]
+pub fn deny_confidential_reads(_cmd: &mut std::process::Command) {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,6 +293,59 @@ mod tests {
         );
         // Unrelated top-level entries stay readable.
         assert!(cover.contains(&PathBuf::from("/etc")));
+    }
+
+    /// The standalone read-denial layer must block the secret and leave
+    /// everything else — including writes outside the worktree, which the full
+    /// shell sandbox would deny — completely alone.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn read_denial_layer_blocks_the_secret_and_nothing_else() {
+        if !crate::probe_landlock() {
+            return;
+        }
+        // Outside every writable root the full sandbox grants, so no broader
+        // rule can hand `ReadFile` back. See the matching note in `linux.rs`.
+        let fixture = tempfile::tempdir_in(std::env::current_dir().expect("test directory"))
+            .expect("fixture");
+        let base = fixture.path().canonicalize().expect("canonical fixture");
+        let secret_dir = base.join("var/run/djinn");
+        std::fs::create_dir_all(&secret_dir).expect("secret dir");
+        let secret = secret_dir.join("credentials.bin");
+        std::fs::write(&secret, "LAYER-CANARY").expect("secret");
+        let neighbour = base.join("var/run/neighbour.txt");
+        std::fs::write(&neighbour, "NEIGHBOUR").expect("neighbour");
+        let roots = vec![secret_dir, base.join("var/run/secrets")];
+
+        let run = |script: &str, arg: &Path| {
+            let mut cmd = std::process::Command::new("sh");
+            cmd.args(["-c", script, "--"]).arg(arg);
+            deny_confidential_reads_beneath(&mut cmd, &roots);
+            cmd.output().expect("child should spawn")
+        };
+
+        let denied = run("cat \"$1\"", &secret);
+        assert!(!denied.status.success(), "the layer must deny the secret");
+        assert!(
+            !String::from_utf8_lossy(&denied.stdout).contains("LAYER-CANARY"),
+            "the canary leaked through the read-denial layer"
+        );
+
+        let allowed = run("cat \"$1\"", &neighbour);
+        assert!(
+            allowed.status.success(),
+            "a neighbouring read must still work: {}",
+            String::from_utf8_lossy(&allowed.stderr)
+        );
+
+        // The layer handles only `ReadFile`, so an ordinary write outside any
+        // worktree — which the full sandbox would deny — must still succeed.
+        let scratch = base.join("scratch.txt");
+        assert!(
+            run("printf ok > \"$1\"", &scratch).status.success(),
+            "the read-denial layer must not impose write confinement"
+        );
+        assert!(scratch.exists());
     }
 
     /// A nested pair must collapse to the broader exclusion, otherwise the

--- a/server/crates/djinn-sandbox/src/lib.rs
+++ b/server/crates/djinn-sandbox/src/lib.rs
@@ -8,6 +8,11 @@ use std::sync::LazyLock;
 
 use anyhow::Result;
 
+/// Filesystem paths that repository-controlled code must never be able to read
+/// (the per-task-run credential Secret and the projected ServiceAccount token).
+/// Consumed by both Linux Landlock backends.
+pub mod confidential;
+
 /// Strict reusable-final-verification launcher. Unlike [`SANDBOX`], this
 /// module never selects the heuristic fallback backend.
 #[cfg(target_os = "linux")]

--- a/server/crates/djinn-sandbox/src/linux.rs
+++ b/server/crates/djinn-sandbox/src/linux.rs
@@ -13,12 +13,13 @@ use landlock::{
     ABI, Access, AccessFs, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr,
 };
 
+use crate::confidential;
 use crate::{Sandbox, SandboxScope, djinn_cache_dir, git_dir, git_metadata_dir};
 
 /// Landlock-based filesystem sandbox for Linux ≥ 5.13.
 ///
-/// Restricts the agent child process to read-everywhere, write only to the
-/// task worktree, its git metadata directory, `/var/tmp`, a dedicated djinn
+/// Restricts the agent child process to read-almost-everywhere, write only to
+/// the task worktree, its git metadata directory, `/var/tmp`, a dedicated djinn
 /// agent scratch dir (`$XDG_CACHE_HOME/djinn` or `$HOME/.cache/djinn`), the
 /// shared cross-task cache PVC (`/cache`, where toolchain caches like
 /// `GOMODCACHE`/`GOCACHE`/sccache live, task-run Cargo targets use private
@@ -27,10 +28,36 @@ use crate::{Sandbox, SandboxScope, djinn_cache_dir, git_dir, git_metadata_dir};
 /// nodes. `/tmp` is intentionally not
 /// writable: on typical Linux it's tmpfs, and allowing writes there caused a
 /// 3.8 GB cargo-artifact leak into RAM-backed storage.
+///
+/// "Almost" everywhere: file CONTENT reads are withheld beneath
+/// [`confidential::CONFIDENTIAL_ROOTS`] — the per-task-run Secret mount that
+/// carries the org's provider credentials, and the projected ServiceAccount
+/// token mount (task jqvg). Directory listing and execute stay granted on all
+/// of `/`.
 pub struct LandlockSandbox;
 
 impl Sandbox for LandlockSandbox {
     fn apply(&self, scope: SandboxScope<'_>, cmd: &mut std::process::Command) -> Result<()> {
+        self.apply_with_confidential_roots(
+            scope,
+            cmd,
+            &confidential::present_confidential_roots(confidential::CONFIDENTIAL_ROOTS),
+        )
+    }
+}
+
+impl LandlockSandbox {
+    /// [`Sandbox::apply`] with an explicit set of unreadable roots.
+    ///
+    /// Production always passes [`confidential::CONFIDENTIAL_ROOTS`]; tests
+    /// pass a fixture tree so the denial can be exercised for real on a host
+    /// where the Pod's `/var/run/djinn` mount does not exist.
+    pub(crate) fn apply_with_confidential_roots(
+        &self,
+        scope: SandboxScope<'_>,
+        cmd: &mut std::process::Command,
+        confidential_roots: &[PathBuf],
+    ) -> Result<()> {
         use std::os::unix::process::CommandExt;
 
         scope.validate()?;
@@ -64,6 +91,13 @@ impl Sandbox for LandlockSandbox {
         // construction runs post-fork in pre_exec.
         let cache_dir_for_rule = prepare_cache_dir();
 
+        // Same reasoning for the confidential-path cover: computing it walks
+        // the filesystem with `read_dir`, which allocates. Resolve it here in
+        // the parent so `pre_exec` only has to open the resulting paths.
+        // Recomputed per spawn so a directory that appears mid-run is picked
+        // up on the next command rather than being silently ungranted.
+        let read_file_cover = confidential::read_file_cover(confidential_roots);
+
         // Safety: pre_exec runs in the forked child process. The closure only
         // performs Landlock syscalls and open(2) calls, both of which are
         // async-signal-safe per POSIX.
@@ -73,6 +107,7 @@ impl Sandbox for LandlockSandbox {
                     writable_worktree.as_deref(),
                     git_meta.as_deref(),
                     cache_dir_for_rule.as_deref(),
+                    &read_file_cover,
                 )
                 .map_err(|e| io::Error::new(io::ErrorKind::PermissionDenied, e.to_string()))
             });
@@ -113,6 +148,7 @@ fn apply_policy(
     worktree: Option<&Path>,
     git_meta: Option<&Path>,
     cache_dir: Option<&Path>,
+    read_file_cover: &[PathBuf],
 ) -> anyhow::Result<()> {
     // Use V3 (Linux 5.19+). The probe in mod.rs verified the kernel supports
     // Landlock; V3 covers all practical kernels in 2026.
@@ -121,6 +157,12 @@ fn apply_policy(
 
     // Read-only subset: allow read and execute, deny all write operations.
     let read_exec = AccessFs::Execute | AccessFs::ReadFile | AccessFs::ReadDir;
+
+    // Everything the blanket `/` grant may still carry once file-content reads
+    // are withheld from the confidential mounts: traversal, directory listing
+    // and execute. None of these expose the bytes of a secret file, and
+    // dropping them would break `ls /` and every toolchain lookup.
+    let traverse_exec = AccessFs::Execute | AccessFs::ReadDir;
 
     // Cargo shared build cache: {CARGO_HOME}/build/ (default ~/.cargo/build/).
     // Agents need write access so `cargo test`/`cargo clippy` can use the shared
@@ -133,8 +175,10 @@ fn apply_policy(
     let mut ruleset = Ruleset::default()
         .handle_access(full_access)?
         .create()?
-        // Read + execute access everywhere on the filesystem.
-        .add_rule(PathBeneath::new(PathFd::new("/")?, read_exec))?
+        // Traverse, list and execute everywhere on the filesystem. File-content
+        // reads are granted separately from `read_file_cover` below, which
+        // covers all of `/` minus the confidential mounts (task jqvg).
+        .add_rule(PathBeneath::new(PathFd::new("/")?, traverse_exec))?
         // Full access to /var/tmp (disk-backed) and /dev/null et al.
         // /tmp is intentionally excluded: on Linux it's typically tmpfs and
         // writes there can silently consume RAM.
@@ -142,6 +186,23 @@ fn apply_policy(
         .add_rule(PathBeneath::new(PathFd::new("/dev/null")?, full_access))?
         .add_rule(PathBeneath::new(PathFd::new("/dev/zero")?, full_access))?
         .add_rule(PathBeneath::new(PathFd::new("/dev/urandom")?, full_access))?;
+
+    // File-content reads. `read_file_cover` is `["/"]` on any host without the
+    // Pod secret mounts, which reproduces the historical blanket grant exactly;
+    // in the task-run Pod it is every entry of every ancestor of the
+    // confidential mounts, minus those mounts. A path that vanished between the
+    // parent's `read_dir` and this `open` is skipped rather than failing the
+    // spawn — we cannot log from `pre_exec`, and a missing path grants nothing.
+    //
+    // NOTE: the `full_access` rules below (worktree, /var/tmp, /cache, the
+    // scratch dir, the cargo build dir, `.git/`) include `ReadFile`, so a
+    // confidential root nested beneath one of them would be granted back.
+    // `confidential_roots_do_not_overlap_writable_sandbox_roots` guards that.
+    for path in read_file_cover {
+        if let Ok(fd) = PathFd::new(path) {
+            ruleset = ruleset.add_rule(PathBeneath::new(fd, read_exec))?;
+        }
+    }
 
     if let Some(worktree) = worktree {
         ruleset = ruleset.add_rule(PathBeneath::new(PathFd::new(worktree)?, full_access))?;
@@ -209,6 +270,23 @@ mod tests {
         cmd.args(["-c", "printf x > \"$1\"", "--"]).arg(path);
         LandlockSandbox
             .apply(scope, &mut cmd)
+            .expect("scope should configure Landlock");
+        cmd.output().expect("sandboxed shell should spawn")
+    }
+
+    /// Run `sh -c <script>` under the real sandbox policy with an explicit
+    /// confidential-root set, exactly as production does with
+    /// [`confidential::CONFIDENTIAL_ROOTS`].
+    fn run_sandboxed(
+        scope: SandboxScope<'_>,
+        confidential_roots: &[PathBuf],
+        script: &str,
+        arg: &Path,
+    ) -> std::process::Output {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", script, "--"]).arg(arg);
+        LandlockSandbox
+            .apply_with_confidential_roots(scope, &mut cmd, confidential_roots)
             .expect("scope should configure Landlock");
         cmd.output().expect("sandboxed shell should spawn")
     }
@@ -290,5 +368,187 @@ mod tests {
             "Landlock must retain task-worktree write access"
         );
         assert!(worktree_content.exists());
+    }
+
+    const CREDENTIAL_CANARY: &str = "PROVIDER-CREDENTIAL-CANARY-jqvg";
+    const TOKEN_CANARY: &str = "SERVICE-ACCOUNT-TOKEN-CANARY-jqvg";
+
+    /// jqvg — the regression this whole change exists for.
+    ///
+    /// This does NOT assert on configuration. It builds a fixture with the same
+    /// shape as the task-run Pod's secret mounts, applies the real production
+    /// `apply_policy` through the real `LandlockSandbox`, spawns a real
+    /// `sh -c 'cat ...'`, and fails if the bytes come back. Before this change
+    /// the blanket `PathBeneath("/", ReadFile)` grant let both reads through.
+    #[test]
+    fn shell_sandbox_denies_reading_confidential_mount_contents() {
+        if !crate::probe_landlock() {
+            return;
+        }
+
+        // The fixture must live outside every writable root the policy grants
+        // (`/var/tmp`, `/cache`, the worktree, the cargo build dir, the scratch
+        // dir): those rules carry `ReadFile` and would grant the secret back
+        // through a broader ancestor. The crate directory satisfies that, and
+        // is where the read-source test already puts its fixtures.
+        let fixture = tempfile::tempdir_in(std::env::current_dir().expect("test directory"))
+            .expect("confidential fixture");
+        let root = fixture.path().canonicalize().expect("canonical fixture");
+
+        // Mirror the Pod layout: `/var/run/djinn` + `/var/run/secrets/tokens`.
+        let credentials_dir = root.join("var/run/djinn");
+        let token_dir = root.join("var/run/secrets/tokens");
+        std::fs::create_dir_all(&credentials_dir).expect("credentials mount");
+        std::fs::create_dir_all(&token_dir).expect("token mount");
+        let credentials = credentials_dir.join("credentials.bin");
+        let token = token_dir.join("djinn");
+        std::fs::write(&credentials, CREDENTIAL_CANARY).expect("credentials");
+        std::fs::write(&token, TOKEN_CANARY).expect("token");
+
+        // A neighbour of both mounts, one level up: it must stay readable, or
+        // the exclusion is over-broad.
+        let neighbour = root.join("var/run/neighbour.txt");
+        std::fs::write(&neighbour, "NEIGHBOUR").expect("neighbour");
+
+        let confidential_roots = vec![credentials_dir.clone(), root.join("var/run/secrets")];
+        let worktree = tempfile::tempdir_in("/var/tmp").expect("worktree");
+        let scope = SandboxScope::Worktree(worktree.path());
+
+        for (label, secret, canary) in [
+            ("provider credentials", &credentials, CREDENTIAL_CANARY),
+            ("projected ServiceAccount token", &token, TOKEN_CANARY),
+        ] {
+            let direct = run_sandboxed(scope, &confidential_roots, "cat \"$1\"", secret);
+            assert!(
+                !direct.status.success(),
+                "sandboxed shell read the {label} at {}",
+                secret.display()
+            );
+            assert!(
+                !String::from_utf8_lossy(&direct.stdout).contains(canary),
+                "the {label} canary leaked to a sandboxed shell"
+            );
+
+            // Landlock matches the resolved dentry, not the path string, so the
+            // `/proc/self/root` magic symlink must not launder the read.
+            let laundered = PathBuf::from("/proc/self/root")
+                .join(secret.strip_prefix("/").expect("absolute secret path"));
+            let via_proc = run_sandboxed(scope, &confidential_roots, "cat \"$1\"", &laundered);
+            assert!(
+                !String::from_utf8_lossy(&via_proc.stdout).contains(canary),
+                "the {label} canary leaked via /proc/self/root"
+            );
+        }
+
+        // Legitimate reads must survive. A neighbour inside the excluded dirs'
+        // parent, and a workspace file — plus the fact that `sh` itself
+        // executed at all, which needs `Execute` and `ReadFile` on the
+        // interpreter and its shared libraries.
+        let allowed = run_sandboxed(scope, &confidential_roots, "cat \"$1\"", &neighbour);
+        assert!(
+            allowed.status.success(),
+            "sandboxed shell lost a legitimate read next to the secret mounts: {}",
+            String::from_utf8_lossy(&allowed.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&allowed.stdout), "NEIGHBOUR");
+
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let source_read = run_sandboxed(scope, &confidential_roots, "cat \"$1\"", &manifest);
+        assert!(
+            source_read.status.success(),
+            "sandboxed shell lost a legitimate workspace read: {}",
+            String::from_utf8_lossy(&source_read.stderr)
+        );
+        assert!(String::from_utf8_lossy(&source_read.stdout).contains("djinn-sandbox"));
+
+        // Directory listing stays granted everywhere, including at `/` and
+        // inside the excluded mount — a filename is not the secret.
+        for dir in ["/", "/usr"] {
+            let listing = run_sandboxed(scope, &confidential_roots, "ls \"$1\"", Path::new(dir));
+            assert!(
+                listing.status.success(),
+                "sandboxed shell lost `ls {dir}`: {}",
+                String::from_utf8_lossy(&listing.stderr)
+            );
+        }
+
+        // Writes to the secret mounts stay denied, as before.
+        assert!(
+            !run_sandboxed(
+                scope,
+                &confidential_roots,
+                "printf x > \"$1\"",
+                &credentials
+            )
+            .status
+            .success(),
+            "Landlock must still deny writes to the credential mount"
+        );
+    }
+
+    /// The same denial, asserted against the REAL production mount paths on
+    /// any host that actually has them — which includes the task-run Pod djinn
+    /// verifies in, where `/var/run/djinn/credentials.bin` is the org's live
+    /// credential bundle. Self-skips elsewhere; the fixture test above carries
+    /// the guarantee on a developer laptop and in a plain CI container.
+    #[test]
+    fn shell_sandbox_denies_reading_the_real_pod_secret_mounts() {
+        if !crate::probe_landlock() {
+            return;
+        }
+        let roots = confidential::present_confidential_roots(confidential::CONFIDENTIAL_ROOTS);
+        if roots.is_empty() {
+            return;
+        }
+
+        let worktree = tempfile::tempdir_in("/var/tmp").expect("worktree");
+        let scope = SandboxScope::Worktree(worktree.path());
+
+        // Mirrors `djinn_k8s::job::{CREDENTIALS_MOUNT_FILE, TOKEN_MOUNT_FILE}`.
+        for secret in [
+            "/var/run/djinn/credentials.bin",
+            "/var/run/secrets/tokens/djinn",
+        ] {
+            let path = Path::new(secret);
+            if !path.exists() {
+                continue;
+            }
+            let output = run_sandboxed(scope, &roots, "cat \"$1\"", path);
+            assert!(
+                !output.status.success(),
+                "sandboxed shell read the live secret at {secret}"
+            );
+            assert!(
+                output.stdout.is_empty(),
+                "sandboxed shell got {} bytes out of the live secret at {secret}",
+                output.stdout.len()
+            );
+        }
+
+        // The same environment must still serve an ordinary read.
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        assert!(
+            run_sandboxed(scope, &roots, "cat \"$1\"", &manifest)
+                .status
+                .success(),
+            "the production confidential-root set broke an ordinary read"
+        );
+    }
+
+    /// A confidential root nested under one of the policy's `full_access`
+    /// roots would be granted `ReadFile` back through that broader rule. The
+    /// production set must never overlap them.
+    #[test]
+    fn confidential_roots_do_not_overlap_writable_sandbox_roots() {
+        let writable = ["/var/tmp", "/cache", "/tmp"];
+        for root in confidential::CONFIDENTIAL_ROOTS {
+            for writable_root in writable {
+                assert!(
+                    !Path::new(root).starts_with(writable_root),
+                    "{root} sits under the writable sandbox root {writable_root}, \
+                     whose full-access rule would grant ReadFile back"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## The defect (live in production)

The shell sandbox's Landlock policy was **write-confinement only**. `linux.rs` granted
`Execute | ReadFile | ReadDir` on all of `/`, and the task-run Pod mounts

- `/var/run/djinn/credentials.bin` — the org's resolved provider credentials
- `/var/run/secrets/tokens/djinn` — the projected ServiceAccount token
- `/var/run/secrets/kubernetes.io/serviceaccount/token` — the automounted apiserver token

into the **same container that runs `bash -lc`**. So every agent shell command, and every
piece of repository-controlled code that executes during a build — `build.rs`, a test, a
Makefile target, an npm `postinstall` — could read all three. Both secret volumes render
`default_mode: 0444`.

The goxi launcher's UID 1000/1001 split was carrying this vector via
`ChildMounts::isolated()`, but the launcher has never functioned in production. The
protection was designed, attested as met, and never once in effect. **This fix does not
depend on it.**

## Why not just narrow the Landlock read grant

Landlock is purely additive within a ruleset layer: the kernel walks from the accessed
dentry towards the mount root and any matching rule granting the requested access
satisfies the layer. A deeper, narrower rule cannot subtract from a broader ancestor
grant, so you cannot carve an exception out of `PathBeneath("/", ReadFile)`. And an
explicit read *allowlist* is the wrong shape — agents legitimately read toolchains, the
cargo registry, system headers and the workspace, so one missed subtree is a support
burden.

## What this does instead

Never issue the blanket grant, and derive the exclusion mechanically from the secret
paths themselves.

- `/` keeps `Execute | ReadDir`. Traversal, `ls /`, every binary lookup and every
  shared-library load work exactly as before. Neither leaks file *content* — a filename
  is not the secret.
- `ReadFile` is granted over a **cover**: for each strict ancestor of a confidential
  root, every sibling that is not itself on a confidential path. In the Pod that is the
  entries of `/` and of `/run`, roughly 30 rules. It is a denylist derived from a
  constant (`djinn_sandbox::confidential::CONFIDENTIAL_ROOTS`), not a hand-maintained
  allowlist, so no subtree can be "missed".
- Roots are **canonicalized first**: `/var/run` is normally a symlink to `/run`, and
  Landlock matches the resolved dentry, so the exclusion would otherwise sit on the wrong
  branch and grant the secret back under the other name.
- The cover is computed in the **parent** (`read_dir` allocates); `pre_exec` only opens
  the resulting paths, preserving the existing async-signal-safety contract.
- With no confidential root present the cover degenerates to `["/"]`, reproducing the
  previous policy byte for byte on dev hosts and on any image without the Pod mounts.
- Fails closed: an ancestor that cannot be enumerated contributes no grants rather than
  falling back to a blanket `/`.

Both Landlock backends that granted `/` are covered — the agent shell (`linux.rs`) and
the chat shell (`chat_shell.rs`). `final_verification.rs` was already allowlist-based and
is untouched.

## The three secrets, handled separately

| Item | Lifetime | Blast radius | Treatment |
|---|---|---|---|
| Provider credentials | per task-run | the org's LLM/provider keys | read once at worker startup before any user code runs; now unreadable to every child via the cover |
| djinn-audience projected token | 1h, kubelet-rotated | authenticates the worker to djinn-server for its own task-run | must stay a file (it bootstraps the very RPC channel a credentials-over-RPC design would need, and the kubelet rotates it in place), so it is covered by the same exclusion |
| Default apiserver ServiceAccount token | 1h | real Kubernetes API access | **removed from the Pod entirely** — `automountServiceAccountToken: false`. Nothing in the task-run Pod speaks to the apiserver; the worker's only authenticated peer is djinn-server. Still inside the denylist's remit so re-enabling automount cannot silently re-expose it. |

`default_mode: 0444` is deliberately left alone. A mode change is worthless here: the Pod
sets `fsGroup: 1000` and the worker container `runAsUser/runAsGroup: 1000`, so the secret
files are group-owned by exactly the gid the sandboxed child runs as. `0440` would be
just as readable.

## Tests

The mandatory test **attempts the read** under the real policy; it does not assert on
configuration.

`shell_sandbox_denies_reading_confidential_mount_contents` builds a fixture with the
Pod's mount shape, applies the production `apply_policy` through the real
`LandlockSandbox`, spawns a real `sh -c 'cat ...'`, and fails if the canary bytes come
back — for both the credentials and the token, and also via the `/proc/self/root` magic
symlink (Landlock is inode-based, so that must not launder the read). The same test
asserts positively that a neighbouring file, a workspace file, and `ls /` still work, and
that writes stay denied.

`shell_sandbox_denies_reading_the_real_pod_secret_mounts` runs the identical attempt
against the **live** `/var/run/djinn/credentials.bin` and `/var/run/secrets/tokens/djinn`
whenever they exist — which is the case in the task-run Pod djinn verifies in. It
self-skips elsewhere.

`projected_secret_mounts_stay_covered_by_the_sandbox_denylist` (in `djinn-k8s`) fails if
a mount path rendered by `job.rs` ever stops being covered by the sandbox denylist. That
coupling did not exist before, which is a large part of why this shipped.

### Verified by reverting the fix

Restoring `PathBeneath("/", read_exec)` makes the new test fail with
`sandboxed shell read the provider credentials at .../var/run/djinn/credentials.bin`.

### Legitimate reads are unaffected — controlled A/B

The same script run under the new cover and under the historical blanket grant, differing
only in the confidential-root set:

```
                          with exclusion        control (old policy)
ls /                      bin boot dev etc      bin boot dev etc
cargo --version           1.96.0                1.96.0
rustc --version           1.96.0                1.96.0
git --version             2.54.0                2.54.0
head /usr/include/stdio.h ok                    ok
real `cargo build` + run  BUILT-AND-RAN probe   BUILT-AND-RAN probe
git rev-parse             ok                    ok
cat <credentials>         DENIED                SECRETLEAKED
```

Every legitimate operation is byte-identical. The only difference is the secret read.

## Gates

`SQLX_OFFLINE=1 cargo check --workspace --all-targets` clean · `cargo fmt --all --check`
clean · clippy `-D warnings` clean on `djinn-sandbox` / `djinn-k8s` / `djinn-agent` ·
`djinn-sandbox` 63 pass, `djinn-k8s` 239 pass, `djinn-agent` 1387 pass ·
`cargo hakari generate && manage-deps` no changes · file-size guard 0 oversized.

## Known residual, out of scope

`configure_private_dep_access` writes the GitHub App installation token into the global
git config so the child's builds can fetch private transitive deps. That token is
*intentionally* in-band for the child and cannot be withheld without a credential-helper
proxy. It is scoped to one project and expires hourly, unlike the provider credentials.
Worth a follow-up, not this PR.

## Second commit: the unsandboxed setup-hook path

While auditing for bypasses I found `djinn_agent::commands::run_commands` spawns `sh -c`
with **no sandbox at all**. Its only caller is the slot lifecycle's pre-verification setup
hooks. The hook strings are operator-configured, but what they run is the repository's own
build tooling — a `build.rs`, an npm `postinstall`, a Makefile target — so
repository-controlled code executes there exactly as it does under the agent shell, and it
could read both secrets.

Routing it through the full `LandlockSandbox` would also impose write confinement, a real
behaviour change for a hook that legitimately writes outside the worktree. Instead there is
now `confidential::deny_confidential_reads`: a Landlock layer that handles **only**
`AccessFs::ReadFile` and grants it over the same cover. The confidential mounts become
unreadable; writes, exec and directory listing are byte-identical. Landlock layers
intersect, so it composes safely with the full sandbox. No-op when Landlock is unavailable
or no confidential root exists.

Its test spawns a real `sh -c 'cat ...'`, asserts the canary does not come back, asserts a
neighbouring read still works, and asserts that a **write outside any worktree** — which
the full sandbox would deny — still succeeds, pinning the "restricts nothing else"
property.
