### PR TITLE
fix(7deu): make the per-invocation CPU lease actually govern CPU, and arm it

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -560,6 +560,12 @@ jobs:
       # fewer than this many actually execute, so a lane that quietly runs zero
       # tests can never be mistaken for a proven kernel boundary.
       ZF13_EXPECTED_PROOFS: "3"
+      # Number of `#[ignore]`d proofs `delegated_cpu_lease_lifecycle.rs`
+      # declares. That suite is the ONLY place the CPU lease is proven to
+      # actually govern CPU — measured on `cpu.stat` over a wall-clock window
+      # rather than by reading `cpu.max` back — so a run that executes zero of
+      # its proofs must fail rather than look green (task 7deu).
+      LEASE_LIFECYCLE_EXPECTED_PROOFS: "1"
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install
@@ -604,6 +610,7 @@ jobs:
           # only the finished binary is then run with elevated privilege.
           cargo test -p djinn-cgroup-launcher \
             --test kernel_boundary_under_rendered_context \
+            --test delegated_cpu_lease_lifecycle \
             --no-run --message-format=json > "$RUNNER_TEMP/build.json"
           binary=$(jq -r 'select(.executable != null and .target.name == "kernel_boundary_under_rendered_context") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
           if [ -z "$binary" ] || [ ! -x "$binary" ]; then
@@ -611,6 +618,12 @@ jobs:
             exit 1
           fi
           echo "binary=$binary" >> "$GITHUB_OUTPUT"
+          lease=$(jq -r 'select(.executable != null and .target.name == "delegated_cpu_lease_lifecycle") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
+          if [ -z "$lease" ] || [ ! -x "$lease" ]; then
+            echo "::error::could not locate the built CPU-lease lifecycle proof binary"
+            exit 1
+          fi
+          echo "lease=$lease" >> "$GITHUB_OUTPUT"
       - name: Prove the kernel boundary under the rendered security context
         run: |
           set -euo pipefail
@@ -636,6 +649,32 @@ jobs:
             exit 1
           fi
           echo "::notice::launcher kernel boundary proven: $passed/$ZF13_EXPECTED_PROOFS privileged proofs executed"
+      - name: Prove the per-invocation CPU lease actually governs CPU
+        run: |
+          set -euo pipefail
+          # Task 7deu. The same privileged cgroup-v2 container, running the
+          # ONLY suite that measures behaviour rather than configuration: the
+          # launcher mounts its own delegated cgroup2 root, drops CAP_SYS_ADMIN
+          # and proves it can no longer mount, spawns a real child into an
+          # invocation leaf, and measures `cpu.stat usage_usec` over a
+          # wall-clock window unleased and then lifted. Reading `cpu.max` back
+          # cannot see any of the defects this replaces — an ancestor CPU limit
+          # clamping every leaf, or a clone flag that truncated to zero so the
+          # child was never in the cgroup at all.
+          #
+          # --test-threads 1 because the proof's capability drop is irreversible
+          # and process-wide.
+          docker run --rm --privileged --cgroupns=private \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            ubuntu:24.04 \
+            bash -c 'mkdir -p /workspace && exec "$0" --ignored --test-threads 1 --nocapture' \
+            "${{ steps.build.outputs.lease }}" 2>&1 | tee "$RUNNER_TEMP/lease.log"
+          passed=$(sed -n 's/^test result: ok\. \([0-9]*\) passed.*/\1/p' "$RUNNER_TEMP/lease.log" | tail -1)
+          if [ "${passed:-0}" != "$LEASE_LIFECYCLE_EXPECTED_PROOFS" ]; then
+            echo "::error::the CPU-lease lifecycle lane executed ${passed:-0} proofs but $LEASE_LIFECYCLE_EXPECTED_PROOFS are declared; the lease is NOT proven to govern CPU by this run"
+            exit 1
+          fi
+          echo "::notice::per-invocation CPU lease proven: $passed/$LEASE_LIFECYCLE_EXPECTED_PROOFS privileged proofs executed"
   server-aarch64-check:
     name: Server aarch64 Check
     needs: preflight

--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -427,6 +427,15 @@ spec:
               value: {{ .Values.resources.warm.limits.memory | quote }}
             - name: DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS
               value: {{ .Values.resources.warm.jobTimeoutSeconds | quote }}
+            # Per-invocation CPU lease. `required` renders the cgroup-launcher
+            # sidecar onto every task-run Pod; `disabled` (the default) renders
+            # no launcher surface at all. The server refuses to dispatch an
+            # armed render it could not satisfy, so a mis-set value fails closed
+            # at dispatch rather than producing pods whose sidecar cannot start.
+            # See `deploy/helm/djinn/values.yaml` and
+            # `djinn_k8s::launcher::CgroupLauncherMode`.
+            - name: DJINN_K8S_CGROUP_LAUNCHER_MODE
+              value: {{ .Values.cgroupLauncher.mode | quote }}
             # Pod scheduling for task-run + warm Jobs. JSON-encoded so the
             # controller can deserialize directly into k8s_openapi types
             # without bringing a YAML parser into the dispatch path. The

--- a/deploy/helm/djinn/values.schema.json
+++ b/deploy/helm/djinn/values.schema.json
@@ -29,6 +29,14 @@
         "maxBuildTaskRuns": { "type": "integer", "minimum": 1, "maximum": 64 }
       }
     },
+    "cgroupLauncher": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": { "type": "string", "enum": ["disabled", "required"] }
+      }
+    },
     "server": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -49,6 +49,39 @@ buildAdmission:
   maxBuildTaskRuns: 3
 
 # -----------------------------------------------------------------------------
+# Per-invocation CPU lease (cgroup launcher)
+# -----------------------------------------------------------------------------
+# The other half of the throughput semaphore. `buildAdmission` bounds HOW MANY
+# task-runs may build concurrently; this bounds how much CPU each one gets while
+# it is building, per invocation rather than per pod.
+#
+# Why per-invocation: a static pod cap strands capacity. A worker holds its slot
+# through LLM streaming while compiling nothing, planners never compile at all,
+# and different repositories compile at very different speeds. With the launcher
+# armed, every shell command starts in its own cgroup leaf throttled to 250m and
+# is lifted to the pod's full CPU limit only once it demonstrates it is actually
+# CPU-hungry.
+#
+#   disabled  (default) — no sidecar, no cgroup leaf, no lease. Shell commands
+#                         run in-process in the worker at the pod's own quota.
+#                         This is the behaviour that shipped before task 7deu.
+#   required            — render the cgroup-launcher sidecar. The launcher
+#                         establishes its own delegated cgroup v2 root at
+#                         startup, which needs `SYS_ADMIN` for the duration of
+#                         that bootstrap; it drops the capability irreversibly
+#                         before the broker accepts any work, and the pod runs
+#                         with `hostUsers: false` so even that window is inside
+#                         a user namespace.
+#
+# Requires a cgroup-v2 node whose kubelet offers the `cpu` controller to
+# container cgroups, and (for `hostUsers: false`) a runtime with user-namespace
+# support — Kubernetes 1.33+. Every precondition fails CLOSED: an unusable
+# render is refused at dispatch before a Job is submitted, and a launcher that
+# cannot establish its delegation exits non-zero before binding its socket.
+cgroupLauncher:
+  mode: disabled
+
+# -----------------------------------------------------------------------------
 # Server deployment
 # -----------------------------------------------------------------------------
 # Keep this availability-first rolling update for off/observe. When enabling

--- a/server/crates/djinn-agent-worker/src/launcher_handshake.rs
+++ b/server/crates/djinn-agent-worker/src/launcher_handshake.rs
@@ -236,8 +236,8 @@ mod tests {
     use djinn_cgroup_launcher::child::WorkerDumpability;
     use djinn_cgroup_launcher::transport::UnixBrokerServer;
     use djinn_cgroup_launcher::{
-        CgroupFs, CgroupMode, ChildProcess, CloneIntoCgroup, CommandSpec, Error, Invocation,
-        Launcher, LauncherConfig, Readiness,
+        CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher,
+        LauncherConfig, Readiness, SpawnIntoCgroup,
     };
 
     /// A dumpability double that reports the worker as already non-dumpable
@@ -268,27 +268,27 @@ mod tests {
             })
         }
         fn create_direct_child(&mut self, _: &str) -> Result<RawFd, Error> {
-            Err(Error::CloneDenied)
+            Err(Error::SpawnDenied)
         }
         fn write_leaf(&mut self, _: RawFd, _: &str, _: &str) -> Result<(), Error> {
-            Err(Error::CloneDenied)
+            Err(Error::SpawnDenied)
         }
         fn read_leaf(&mut self, _: RawFd, _: &str) -> Result<String, Error> {
-            Err(Error::CloneDenied)
+            Err(Error::SpawnDenied)
         }
         fn remove_leaf(&mut self, _: RawFd, _: &str) -> Result<(), Error> {
             Ok(())
         }
     }
     struct NoClone;
-    impl CloneIntoCgroup for NoClone {
-        fn clone_into_cgroup(
+    impl SpawnIntoCgroup for NoClone {
+        fn spawn_into_cgroup(
             &mut self,
             _: RawFd,
             _: &Invocation,
             _: &CommandSpec,
         ) -> Result<ChildProcess, Error> {
-            Err(Error::CloneDenied)
+            Err(Error::SpawnDenied)
         }
     }
 
@@ -339,7 +339,7 @@ mod tests {
             let launcher = Launcher::new(
                 FakeFs { owner_uid },
                 NoClone,
-                LauncherConfig::new(None, owner_uid).expect("launcher config"),
+                LauncherConfig::new(None, None, owner_uid).expect("launcher config"),
             )
             .expect("launcher readiness");
             let broker = Broker::new(launcher, config, OsNonceSource).expect("broker");

--- a/server/crates/djinn-agent/src/process_broker.rs
+++ b/server/crates/djinn-agent/src/process_broker.rs
@@ -217,25 +217,69 @@ fn command_spec(command: Command) -> io::Result<CommandSpec> {
         .get_current_dir()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "command cwd is required"))?;
     let cwd = text(cwd.as_os_str(), "cwd")?;
-    let environment = command
-        .get_envs()
-        .filter_map(|(key, value)| {
-            value.map(|value| {
-                Ok((
-                    text(key, "environment key")?,
-                    text(value, "environment value")?,
-                ))
-            })
-        })
-        .collect::<io::Result<Vec<_>>>()?;
     let spec = CommandSpec {
         program,
         argv,
         cwd,
-        environment,
+        environment: child_environment(&command)?,
     };
     spec.validate().map_err(broker_error)?;
     Ok(spec)
+}
+
+/// The environment a brokered child is given.
+///
+/// # Why the worker's own environment has to be forwarded (task 7deu, defect 2)
+///
+/// The launcher execs the child with **exactly** the environment in the
+/// [`CommandSpec`] — never the broker's. That is the right isolation property,
+/// but `Command::get_envs()` returns only the variables a caller explicitly set
+/// on the command, not the ones the process inherited. Under the in-process
+/// path the child inherits the pod's environment; under the broker path it got
+/// nothing. So a brokered build ran with no `CARGO_TARGET_DIR` (a cold build, in
+/// the wrong directory, missing the warm cache), no `CARGO_BUILD_RUSTFLAGS` (no
+/// mold linker), no `RUSTUP_HOME`, and no `CARGO_BUILD_JOBS` — the last of which
+/// silently reverted the load-103 fix.
+///
+/// Compilation is 60-90% of task wall clock, so that is not a rough edge; it is
+/// the feature making the thing it governs dramatically slower.
+///
+/// The fix keeps the allow-list closed and forwards through it:
+/// `djinn_cgroup_launcher::is_allowed_environment_key` is the single predicate,
+/// applied here as a convenience and re-applied inside the privileged broker by
+/// `CommandSpec::validate`, which is the actual control. Explicit per-command
+/// values win over inherited ones; the launcher then overrides the parallelism
+/// pins with values derived from the quota the leaf will really run at, because
+/// only it knows that.
+fn child_environment(command: &Command) -> io::Result<Vec<(String, String)>> {
+    use std::collections::BTreeMap;
+
+    let mut environment: BTreeMap<String, String> = std::env::vars()
+        .filter(|(key, _)| djinn_cgroup_launcher::is_allowed_environment_key(key))
+        .collect();
+
+    for (key, value) in command.get_envs() {
+        let key = key.to_str().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "environment key must be UTF-8")
+        })?;
+        match value {
+            // `Command::env_remove` is represented as a `None` value.
+            None => {
+                environment.remove(key);
+            }
+            Some(value) => {
+                let value = value.to_str().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "environment value must be UTF-8",
+                    )
+                })?;
+                environment.insert(key.to_owned(), value.to_owned());
+            }
+        }
+    }
+
+    Ok(environment.into_iter().collect())
 }
 
 #[cfg(test)]
@@ -277,5 +321,74 @@ impl ProcessHandle for std::process::Child {
 
     fn cleanup(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod broker_environment_tests {
+    use super::*;
+
+    /// The pod's build environment must survive the broker hop, or a brokered
+    /// build runs cold, in the wrong target directory, without mold — the exact
+    /// regression that made routing through the launcher a net loss.
+    #[test]
+    fn the_inherited_build_environment_reaches_the_child() {
+        // SAFETY: single-threaded test, and both keys are test-local.
+        unsafe {
+            std::env::set_var("CARGO_TARGET_DIR", "/cache/cargo-target/proj/mold-jobs-4");
+            std::env::set_var("DJINN_BROKER_ENV_TEST_SECRET", "kept");
+            std::env::set_var("AWS_SECRET_ACCESS_KEY", "must-not-leak");
+        }
+
+        let mut command = Command::new("/bin/sh");
+        command.current_dir("/workspace");
+        let spec = command_spec(command).expect("spec");
+        let value = |key: &str| {
+            spec.environment
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.as_str())
+        };
+
+        assert_eq!(
+            value("CARGO_TARGET_DIR"),
+            Some("/cache/cargo-target/proj/mold-jobs-4"),
+            "the warm cache directory must reach a brokered build"
+        );
+        // The allow-list is still closed: an unlisted key is not forwarded.
+        assert_eq!(value("AWS_SECRET_ACCESS_KEY"), None);
+
+        unsafe {
+            std::env::remove_var("CARGO_TARGET_DIR");
+            std::env::remove_var("DJINN_BROKER_ENV_TEST_SECRET");
+            std::env::remove_var("AWS_SECRET_ACCESS_KEY");
+        }
+    }
+
+    /// An explicitly-set value wins over the inherited one, and `env_remove`
+    /// really removes rather than being ignored.
+    #[test]
+    fn explicit_command_environment_overrides_and_removes() {
+        // SAFETY: single-threaded test, test-local key.
+        unsafe { std::env::set_var("RUST_LOG", "inherited") };
+
+        let mut command = Command::new("/bin/sh");
+        command.current_dir("/workspace");
+        command.env("RUST_LOG", "explicit");
+        command.env("CARGO_INCREMENTAL", "0");
+        command.env_remove("TERM");
+        let spec = command_spec(command).expect("spec");
+        let value = |key: &str| {
+            spec.environment
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.as_str())
+        };
+
+        assert_eq!(value("RUST_LOG"), Some("explicit"));
+        assert_eq!(value("CARGO_INCREMENTAL"), Some("0"));
+        assert_eq!(value("TERM"), None);
+
+        unsafe { std::env::remove_var("RUST_LOG") };
     }
 }

--- a/server/crates/djinn-cgroup-launcher/src/bootstrap.rs
+++ b/server/crates/djinn-cgroup-launcher/src/bootstrap.rs
@@ -1,0 +1,400 @@
+//! Startup bootstrap: the launcher establishes its OWN delegated cgroup v2 root,
+//! then drops the capability that let it.
+//!
+//! # Why the launcher mounts it rather than receiving it (task 7deu)
+//!
+//! A delegated cgroup v2 subtree is not something a Kubernetes *volume source*
+//! can supply. An `emptyDir` is an ordinary directory on the node filesystem
+//! with no `cgroup.subtree_control` and no `cpu.max`; a `hostPath` onto a node
+//! subtree is refused from inside the pod's private, `nsdelegate`d cgroup
+//! namespace. Shipping either is how the sidecar came to CrashLoopBackOff on
+//! every task-run Pod.
+//!
+//! What *does* work — and is what this module does — is the launcher mounting
+//! `cgroup2` inside its own cgroup namespace, where the mount's root IS the
+//! launcher's container cgroup and every invocation leaf is a descendant of it.
+//! The `emptyDir` rendered at the mount path supplies only a writable
+//! **mountpoint**; `readOnlyRootFilesystem: true` forbids creating one on the
+//! image's own rootfs, and `no_new_privs` does not block `mount(2)` (it blocks
+//! *gaining* privilege across `execve`, not using a capability already held).
+//!
+//! # Why the capability does not stay
+//!
+//! `CAP_SYS_ADMIN` is a node-wide escape primitive: with it a process can
+//! `umount` the runtime's `/proc` masks and write `/proc/sys/kernel/core_pattern`,
+//! which is not namespaced. On a host whose `core_pattern` is already a pipe —
+//! the production VPS's is `|/usr/share/apport/apport …` — that is a direct path
+//! to executing a payload as root outside every namespace.
+//!
+//! So the capability exists for exactly one phase. [`Bootstrap::run`] mounts,
+//! delegates, and then [`drop_bootstrap_capabilities`] removes `CAP_SYS_ADMIN`
+//! and `CAP_SYS_RESOURCE` from the launcher's permitted, effective, inheritable
+//! **and bounding** sets — irreversibly, before the broker binds its socket and
+//! therefore before the pod can accept a single unit of work. No user-controlled
+//! code ever executes while the capability is held: the only thing running in
+//! that window is this function. `hostUsers: false` on the Pod is the second
+//! layer, confining even that window to a user namespace.
+//!
+//! This is also the honest implementation of goxi's "allowPrivilegeEscalation
+//! false AFTER INITIALIZATION", which is not expressible as a Pod field — a
+//! container `securityContext` is static. `CAP_SETPCAP` is what makes it real.
+
+use std::ffi::CString;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::Error;
+
+/// Capability numbers (`include/uapi/linux/capability.h`).
+const CAP_SETGID: u32 = 6;
+const CAP_SETUID: u32 = 7;
+const CAP_SETPCAP: u32 = 8;
+const CAP_SYS_ADMIN: u32 = 21;
+const CAP_SYS_RESOURCE: u32 = 24;
+
+/// The only capabilities the launcher keeps once bootstrap is complete: exactly
+/// what `child::prepare_child` needs to move a child across the credential
+/// boundary before `execve`.
+const RETAINED_CAPABILITIES: &[u32] = &[CAP_SETGID, CAP_SETUID, CAP_SETPCAP];
+
+/// The capabilities bootstrap needs and then destroys.
+const BOOTSTRAP_ONLY_CAPABILITIES: &[u32] = &[CAP_SYS_ADMIN, CAP_SYS_RESOURCE];
+
+/// `_LINUX_CAPABILITY_VERSION_3`.
+const CAPABILITY_VERSION_3: u32 = 0x2008_0522;
+
+/// Name of the holding leaf the launcher moves its own process into.
+///
+/// cgroup v2's "no internal process" rule exempts only the true root: a cgroup
+/// may not both contain processes and enable controllers for its children. The
+/// launcher's own init process starts in the mount root, so it has to move out
+/// before `+cpu` can be delegated.
+pub const INIT_LEAF: &str = "init";
+
+/// Controller the delegated root enables for its children — exactly one.
+const DELEGATED_CONTROLLER: &str = "cpu";
+
+#[repr(C)]
+struct CapabilityHeader {
+    version: u32,
+    pid: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct CapabilityData {
+    effective: u32,
+    permitted: u32,
+    inheritable: u32,
+}
+
+/// Establish the delegated cgroup v2 root at `root`.
+///
+/// Idempotent: a launcher restarting inside a container whose mount already
+/// exists re-uses it rather than failing. Every step that cannot be made to
+/// hold is a named error — there is no partial-success path.
+pub struct Bootstrap {
+    root: PathBuf,
+}
+
+impl Bootstrap {
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Mount, vacate, delegate, then drop the bootstrap capabilities.
+    ///
+    /// After this returns `Ok`, the launcher holds only
+    /// [`RETAINED_CAPABILITIES`] and `root` satisfies the full
+    /// [`Readiness`](crate::Readiness) contract.
+    pub fn run(&self) -> Result<(), Error> {
+        self.mount_cgroup2()?;
+        self.vacate_root()?;
+        self.delegate_cpu()?;
+        drop_bootstrap_capabilities()
+    }
+
+    /// Mount a private, read-write `cgroup2` filesystem at `root`.
+    ///
+    /// Inside the pod's private cgroup namespace the mount's root is the
+    /// launcher's own container cgroup, so an invocation leaf created under it
+    /// is a descendant of the namespace root — which is what makes the leaf
+    /// reachable at all under `nsdelegate`.
+    fn mount_cgroup2(&self) -> Result<(), Error> {
+        if !self.root.is_dir() {
+            std::fs::create_dir_all(&self.root).map_err(|error| Error::CgroupMountFailed {
+                path: self.root.display().to_string(),
+                errno: error.raw_os_error().unwrap_or(0),
+            })?;
+        }
+        if crate::is_cgroup2_filesystem(&self.root)? {
+            // Already mounted (launcher restart inside a live container).
+            return Ok(());
+        }
+
+        let target = c_path(&self.root)?;
+        let fstype = CString::new("cgroup2").map_err(|_| Error::UnsafeLeafName)?;
+        let source = CString::new("cgroup2").map_err(|_| Error::UnsafeLeafName)?;
+        // SAFETY: all three pointers are live NUL-terminated strings and `data`
+        // is NULL, which `cgroup2` accepts.
+        let rc = unsafe {
+            libc::mount(
+                source.as_ptr(),
+                target.as_ptr(),
+                fstype.as_ptr(),
+                (libc::MS_NOSUID | libc::MS_NODEV | libc::MS_NOEXEC) as libc::c_ulong,
+                std::ptr::null(),
+            )
+        };
+        if rc != 0 {
+            return Err(Error::CgroupMountFailed {
+                path: self.root.display().to_string(),
+                errno: errno(),
+            });
+        }
+        // Refuse to proceed on a mount that somehow is not cgroup2 rather than
+        // discovering it three control-file reads later.
+        if !crate::is_cgroup2_filesystem(&self.root)? {
+            return Err(Error::CgroupMountFailed {
+                path: self.root.display().to_string(),
+                errno: 0,
+            });
+        }
+        Ok(())
+    }
+
+    /// Move every process sitting directly in the mount root into [`INIT_LEAF`].
+    fn vacate_root(&self) -> Result<(), Error> {
+        let init = self.root.join(INIT_LEAF);
+        if !init.is_dir() {
+            std::fs::create_dir(&init).map_err(|error| Error::CgroupDelegationFailed {
+                detail: "create the init holding leaf",
+                errno: error.raw_os_error().unwrap_or(0),
+            })?;
+        }
+        let procs = std::fs::read_to_string(self.root.join("cgroup.procs")).map_err(|error| {
+            Error::CgroupDelegationFailed {
+                detail: "read the delegated root's cgroup.procs",
+                errno: error.raw_os_error().unwrap_or(0),
+            }
+        })?;
+        let target = init.join("cgroup.procs");
+        for pid in procs.split_ascii_whitespace() {
+            std::fs::write(&target, pid).map_err(|error| Error::CgroupDelegationFailed {
+                detail: "move the launcher's own process into the init leaf",
+                errno: error.raw_os_error().unwrap_or(0),
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Enable exactly the `cpu` controller for the root's children.
+    ///
+    /// Also *disables* anything else already enabled, because the launcher's
+    /// readiness contract requires the delegated controller set to be exactly
+    /// `{cpu}` — a broader delegation would hand the launcher authority it has
+    /// no reason to hold.
+    fn delegate_cpu(&self) -> Result<(), Error> {
+        let control = self.root.join("cgroup.subtree_control");
+        let enabled =
+            std::fs::read_to_string(&control).map_err(|error| Error::CgroupDelegationFailed {
+                detail: "read cgroup.subtree_control",
+                errno: error.raw_os_error().unwrap_or(0),
+            })?;
+        let mut directives: Vec<String> = enabled
+            .split_ascii_whitespace()
+            .filter(|controller| *controller != DELEGATED_CONTROLLER)
+            .map(|controller| format!("-{controller}"))
+            .collect();
+        if !enabled
+            .split_ascii_whitespace()
+            .any(|controller| controller == DELEGATED_CONTROLLER)
+        {
+            directives.push(format!("+{DELEGATED_CONTROLLER}"));
+        }
+        if directives.is_empty() {
+            return Ok(());
+        }
+        std::fs::write(&control, directives.join(" ")).map_err(|error| {
+            Error::CgroupDelegationFailed {
+                // The overwhelmingly common cause is the PARENT (the kubelet's
+                // pod cgroup, outside this namespace) not offering `cpu` to its
+                // children, which shows up as EINVAL here.
+                detail: "enable the cpu controller in cgroup.subtree_control",
+                errno: error.raw_os_error().unwrap_or(0),
+            }
+        })
+    }
+}
+
+/// Irreversibly remove [`BOOTSTRAP_ONLY_CAPABILITIES`], keeping only
+/// [`RETAINED_CAPABILITIES`].
+///
+/// Drops from the bounding set first (so the capability cannot be regained via
+/// a file-capability `execve`), then rewrites permitted/effective/inheritable.
+/// Ordering matters: `PR_CAPBSET_DROP` itself requires `CAP_SETPCAP`, which is
+/// retained, but `CAP_SYS_ADMIN` must still be in the effective set for nothing
+/// — it is not needed here, so the bounding drops happen while both are present
+/// only for simplicity, not necessity.
+pub fn drop_bootstrap_capabilities() -> Result<(), Error> {
+    for capability in BOOTSTRAP_ONLY_CAPABILITIES {
+        // ENODATA/EINVAL for a capability not in the bounding set is not a
+        // failure to drop it — it is already absent.
+        let rc = unsafe {
+            libc::prctl(
+                libc::PR_CAPBSET_DROP,
+                libc::c_ulong::from(*capability),
+                0,
+                0,
+                0,
+            )
+        };
+        if rc != 0 && errno() != libc::EINVAL {
+            return Err(Error::CapabilityDropFailed { errno: errno() });
+        }
+    }
+
+    let retained = capability_mask(RETAINED_CAPABILITIES);
+    let header = CapabilityHeader {
+        version: CAPABILITY_VERSION_3,
+        pid: 0,
+    };
+    let data = [
+        CapabilityData {
+            effective: retained,
+            permitted: retained,
+            inheritable: 0,
+        },
+        CapabilityData::default(),
+    ];
+    // SAFETY: `capset` reads a version-3 header and two data words through live
+    // pointers; both live for the duration of the call.
+    if unsafe { libc::syscall(libc::SYS_capset, &raw const header, data.as_ptr()) } != 0 {
+        return Err(Error::CapabilityDropFailed { errno: errno() });
+    }
+    // Prove it, rather than trust the return value: this is the step that
+    // decides whether a task-run pod carries a node-wide escape primitive.
+    if holds_any_bootstrap_capability()? {
+        return Err(Error::CapabilityDropFailed { errno: 0 });
+    }
+    Ok(())
+}
+
+/// Does this process still hold any of [`BOOTSTRAP_ONLY_CAPABILITIES`] in its
+/// permitted or effective set?
+pub fn holds_any_bootstrap_capability() -> Result<bool, Error> {
+    let header = CapabilityHeader {
+        version: CAPABILITY_VERSION_3,
+        pid: 0,
+    };
+    let mut data = [CapabilityData::default(); 2];
+    // SAFETY: `capget` writes two data words through a live pointer.
+    if unsafe { libc::syscall(libc::SYS_capget, &raw const header, data.as_mut_ptr()) } != 0 {
+        return Err(Error::CapabilityDropFailed { errno: errno() });
+    }
+    let mask = capability_mask(BOOTSTRAP_ONLY_CAPABILITIES);
+    Ok(data[0].permitted & mask != 0 || data[0].effective & mask != 0)
+}
+
+fn capability_mask(capabilities: &[u32]) -> u32 {
+    capabilities
+        .iter()
+        .fold(0_u32, |mask, capability| mask | (1 << capability))
+}
+
+fn c_path(path: &Path) -> Result<CString, Error> {
+    use std::os::unix::ffi::OsStrExt;
+    CString::new(path.as_os_str().as_bytes()).map_err(|_| Error::UnsafeLeafName)
+}
+
+fn errno() -> i32 {
+    io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_retained_set_is_exactly_what_the_credential_boundary_needs() {
+        assert_eq!(
+            RETAINED_CAPABILITIES,
+            &[CAP_SETGID, CAP_SETUID, CAP_SETPCAP]
+        );
+        assert_eq!(
+            capability_mask(RETAINED_CAPABILITIES),
+            (1 << 6) | (1 << 7) | (1 << 8)
+        );
+    }
+
+    /// `CAP_SYS_ADMIN` is the escape primitive; it must never be retained, and
+    /// the retained and bootstrap-only sets must not overlap.
+    #[test]
+    fn the_escape_capability_is_never_retained() {
+        assert!(BOOTSTRAP_ONLY_CAPABILITIES.contains(&CAP_SYS_ADMIN));
+        assert!(BOOTSTRAP_ONLY_CAPABILITIES.contains(&CAP_SYS_RESOURCE));
+        assert_eq!(
+            capability_mask(RETAINED_CAPABILITIES) & capability_mask(BOOTSTRAP_ONLY_CAPABILITIES),
+            0,
+            "a capability cannot be both dropped and retained"
+        );
+    }
+
+    /// The kernel's own numbering. A wrong bit here would silently retain
+    /// `CAP_SYS_ADMIN` while reporting success, which is the exact class of
+    /// defect (a constant that is not the value it claims to be) that made the
+    /// previous clone flag a no-op.
+    #[test]
+    fn capability_numbers_are_the_kernel_values() {
+        assert_eq!(CAP_SETGID, 6);
+        assert_eq!(CAP_SETUID, 7);
+        assert_eq!(CAP_SETPCAP, 8);
+        assert_eq!(CAP_SYS_ADMIN, 21);
+        assert_eq!(CAP_SYS_RESOURCE, 24);
+        assert_eq!(CAPABILITY_VERSION_3, 0x2008_0522);
+    }
+
+    /// An ordinary unprivileged test process holds neither bootstrap
+    /// capability, so the live `capget` path is exercised on every test run.
+    #[test]
+    fn an_unprivileged_process_reports_no_bootstrap_capability() {
+        if unsafe { libc::geteuid() } == 0 {
+            // Running as root (the privileged CI lane): the assertion below
+            // would be about the lane's own capability set, not about this
+            // code, so only exercise the syscall path.
+            holds_any_bootstrap_capability().expect("capget must succeed");
+            return;
+        }
+        assert!(
+            !holds_any_bootstrap_capability().expect("capget must succeed"),
+            "an unprivileged process cannot hold CAP_SYS_ADMIN"
+        );
+    }
+
+    #[test]
+    fn a_non_cgroup_root_fails_the_mount_step_by_name() {
+        // Unprivileged: `mount(2)` is denied, which is exactly the named error
+        // an unarmed launcher must produce rather than an opaque EPERM.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("djinn-bootstrap-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let error = Bootstrap::new(&base)
+            .run()
+            .expect_err("an unprivileged mount must fail");
+        let _ = std::fs::remove_dir_all(&base);
+        match error {
+            Error::CgroupMountFailed { path, errno } => {
+                assert_eq!(path, base.display().to_string());
+                assert_eq!(errno, libc::EPERM);
+            }
+            other => panic!("expected a named mount failure, got: {other}"),
+        }
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/src/broker.rs
+++ b/server/crates/djinn-cgroup-launcher/src/broker.rs
@@ -6,8 +6,8 @@
 use std::{collections::HashMap, fs::File, io::Read, os::fd::RawFd};
 
 use crate::{
-    CgroupFs, ChildProcess, CloneIntoCgroup, CommandSpec, CpuStat, Error, Invocation, Launcher,
-    Leaf, child::WorkerReadinessAssertion,
+    CgroupFs, ChildProcess, CommandSpec, CpuStat, Error, Invocation, Launcher, Leaf,
+    SpawnIntoCgroup, child::WorkerReadinessAssertion,
 };
 
 pub const WORKER_UID: u32 = 1000;
@@ -144,7 +144,7 @@ pub struct Broker<F, S, N = OsNonceSource> {
     active: HashMap<String, ActiveInvocation>,
 }
 
-impl<F: CgroupFs, S: CloneIntoCgroup, N: NonceSource> Broker<F, S, N> {
+impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> Broker<F, S, N> {
     pub fn new(launcher: Launcher<F, S>, config: BrokerConfig, nonces: N) -> Result<Self, Error> {
         Ok(Self {
             launcher,
@@ -516,8 +516,8 @@ mod tests {
         }
     }
     struct Clone;
-    impl CloneIntoCgroup for Clone {
-        fn clone_into_cgroup(
+    impl SpawnIntoCgroup for Clone {
+        fn spawn_into_cgroup(
             &mut self,
             _: RawFd,
             _: &Invocation,
@@ -534,7 +534,7 @@ mod tests {
         let launcher = Launcher::new(
             Fs::ready(),
             Clone,
-            crate::LauncherConfig::new(None, 0).unwrap(),
+            crate::LauncherConfig::new(None, None, 0).unwrap(),
         )
         .unwrap();
         Broker::new(
@@ -693,8 +693,12 @@ mod tests {
     fn duplicate_create_does_not_clone_or_replace_the_active_leaf() {
         let fs = Fs::ready();
         let creates = Rc::clone(&fs.creates);
-        let launcher =
-            Launcher::new(fs, Clone, crate::LauncherConfig::new(None, 0).unwrap()).unwrap();
+        let launcher = Launcher::new(
+            fs,
+            Clone,
+            crate::LauncherConfig::new(None, None, 0).unwrap(),
+        )
+        .unwrap();
         let mut broker = Broker::new(
             launcher,
             BrokerConfig::worker(42, b"private".to_vec()).unwrap(),
@@ -737,8 +741,12 @@ mod tests {
         let fs = Fs::ready();
         let events = Rc::clone(&fs.events);
         *events.borrow_mut() = "populated 1".into();
-        let launcher =
-            Launcher::new(fs, Clone, crate::LauncherConfig::new(None, 0).unwrap()).unwrap();
+        let launcher = Launcher::new(
+            fs,
+            Clone,
+            crate::LauncherConfig::new(None, None, 0).unwrap(),
+        )
+        .unwrap();
         let mut broker = Broker::new(
             launcher,
             BrokerConfig::worker(42, b"private".to_vec()).unwrap(),

--- a/server/crates/djinn-cgroup-launcher/src/env.rs
+++ b/server/crates/djinn-cgroup-launcher/src/env.rs
@@ -1,0 +1,334 @@
+//! The child environment contract: what the broker forwards, and what it pins.
+//!
+//! # Why this module exists (task 7deu, defect 2)
+//!
+//! The launcher execs the child with **exactly** the environment carried in the
+//! [`CommandSpec`](crate::CommandSpec) — never the broker's own. That is the
+//! right isolation property, but it made the broker path silently lossy in two
+//! ways that both land on compilation, which is 60-90% of task wall clock:
+//!
+//! 1. **The pod's build environment never reached the child.** A task-run Pod
+//!    renders `CARGO_TARGET_DIR` (the warm cache), `CARGO_BUILD_RUSTFLAGS` (the
+//!    mold linker), `RUSTUP_HOME`, `SCCACHE_*` and friends. None of them are on
+//!    the old six-key allow-list, and [`CommandSpec::validate`] *rejects* a
+//!    disallowed key rather than stripping it — so a broker-launched build
+//!    either failed outright or ran cold, in a different target directory,
+//!    against a different linker.
+//! 2. **The parallelism pins never reached the child.** `djinn-k8s`'s `job.rs`
+//!    sets `CARGO_BUILD_JOBS`/`NEXTEST_TEST_THREADS` from the pod's own CPU
+//!    limit *because of the load-103 thrash incident*. Routing through the
+//!    broker dropped them, so cargo fell back to `available_parallelism()` —
+//!    which it samples **once, at startup**, from the cgroup it is born in.
+//!    Born in a 250m unleased leaf, that is `1`. Measured: `-j1` is 165s where
+//!    `-j4` is 61s, a 2.7x regression on the dominant cost of every task.
+//!
+//! # The contract
+//!
+//! * The allow-list stays **closed by default**. It is not removed and it is not
+//!   a deny-list: an unlisted key is still rejected by `CommandSpec::validate`.
+//!   What changed is that it now names the build toolchain surface explicitly,
+//!   so the set is auditable rather than accidental.
+//! * The parallelism pins are **derived by the launcher and overridden**, not
+//!   trusted from the caller. See [`parallelism_pins`] for why they are derived
+//!   from the *leased* quota rather than the quota in force at spawn time.
+//!
+//! # Deliberately NOT forwarded
+//!
+//! `LD_PRELOAD`, `LD_AUDIT` and `LD_LIBRARY_PATH` are absent on purpose. The
+//! child crosses a credential boundary (`setresuid` to `CHILD_UID`) immediately
+//! before `execve`, and while `no_new_privs` and the glibc secure-execution
+//! rules already neutralise them there, keeping them off the list means the
+//! boundary does not *depend* on that reasoning.
+
+/// Exact environment keys the broker forwards to a launched child.
+///
+/// Grouped by why each one has to survive the broker hop. Anything not here and
+/// not matched by [`ALLOWED_PREFIXES`] is refused by `CommandSpec::validate`.
+const ALLOWED_KEYS: &[&str] = &[
+    // ── Base shell environment ──────────────────────────────────────────────
+    "HOME",
+    "PATH",
+    "TERM",
+    "LANG",
+    "TZ",
+    "CI",
+    "SHELL",
+    "USER",
+    "LOGNAME",
+    "TMPDIR",
+    // ── Rust toolchain ──────────────────────────────────────────────────────
+    // `CARGO_*`/`RUSTUP_*` arrive via the prefix list; these are the bare names.
+    "RUSTFLAGS",
+    "RUSTDOCFLAGS",
+    "RUSTC",
+    "RUSTC_WRAPPER",
+    "RUSTC_WORKSPACE_WRAPPER",
+    "RUST_BACKTRACE",
+    "RUST_LOG",
+    // ── Go toolchain ────────────────────────────────────────────────────────
+    "GOPATH",
+    "GOCACHE",
+    "GOMODCACHE",
+    "GOFLAGS",
+    "GOPRIVATE",
+    "GONOSUMDB",
+    "GONOSUMCHECK",
+    "GOMAXPROCS",
+    "GOPROXY",
+    "GOSUMDB",
+    "GOTOOLCHAIN",
+    // ── JVM toolchain ───────────────────────────────────────────────────────
+    "JAVA_HOME",
+    "MAVEN_OPTS",
+    "GRADLE_OPTS",
+    "GRADLE_USER_HOME",
+    // ── Node toolchain ──────────────────────────────────────────────────────
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "COREPACK_HOME",
+    // ── Python toolchain ────────────────────────────────────────────────────
+    "PYTHONPATH",
+    "PYTHONUNBUFFERED",
+    "PYTHONDONTWRITEBYTECODE",
+    "VIRTUAL_ENV",
+    // ── C/C++ toolchain and linkers ─────────────────────────────────────────
+    "CC",
+    "CXX",
+    "AR",
+    "LD",
+    "CFLAGS",
+    "CXXFLAGS",
+    "LDFLAGS",
+    "PKG_CONFIG_PATH",
+    "MOLD_JOBS",
+    // ── Build-system parallelism ────────────────────────────────────────────
+    "MAKEFLAGS",
+    "NEXTEST_TEST_THREADS",
+    "RAYON_NUM_THREADS",
+];
+
+/// Key prefixes the broker forwards wholesale.
+///
+/// Every entry is a toolchain namespace whose full key set is defined by an
+/// external tool rather than by this repository, so enumerating exact names
+/// would go stale silently. `DJINN_` is here because the worker and the launcher
+/// share a rendered configuration namespace.
+const ALLOWED_PREFIXES: &[&str] = &[
+    "LC_",
+    "DJINN_",
+    "CARGO_",
+    "RUSTUP_",
+    "SCCACHE_",
+    "NPM_CONFIG_",
+    "PNPM_",
+    "YARN_",
+    "PIP_",
+    "UV_",
+    "POETRY_",
+];
+
+/// Is `key` forwardable to a launched child?
+///
+/// This is the single predicate behind both ends of the hop: the worker filters
+/// its own environment with it before building a [`CommandSpec`](crate::CommandSpec),
+/// and `CommandSpec::validate` re-checks it inside the privileged broker. The
+/// worker-side filter is a convenience; the broker-side check is the control.
+pub fn is_allowed_environment_key(key: &str) -> bool {
+    ALLOWED_KEYS.contains(&key)
+        || ALLOWED_PREFIXES
+            .iter()
+            .any(|prefix| key.starts_with(prefix))
+}
+
+/// Parallelism pin keys the launcher **overrides** on every spawn.
+///
+/// A caller may legitimately send these (the pod renders them), but the value
+/// the child sees is always the launcher's, because only the launcher knows the
+/// quota the leaf will actually run at.
+pub const PINNED_PARALLELISM_KEYS: &[&str] = &[
+    "CARGO_BUILD_JOBS",
+    "NEXTEST_TEST_THREADS",
+    "MAKEFLAGS",
+    "GOMAXPROCS",
+    "RAYON_NUM_THREADS",
+];
+
+/// Job count for a cgroup whose CPU quota is `millicores`.
+///
+/// Floors at 1 and truncates rather than rounds: 4000m is 4 jobs, 1500m is 1.
+/// This is deliberately identical to `djinn_k8s::job::cpu_limit_to_jobs`, which
+/// derives the same number from the pod's CPU limit — the two must agree or a
+/// build would pick a different job count depending on whether it happened to be
+/// brokered.
+pub fn jobs_for_millicores(millicores: u32) -> u32 {
+    (millicores / 1000).max(1)
+}
+
+/// The parallelism pins a child must be born with, derived from `leased_millicores`.
+///
+/// # Why the LEASED quota and not the quota in force at spawn
+///
+/// `available_parallelism()` — and therefore cargo's default `-j`, nextest's
+/// thread count, `mold --threads`, and Go's `GOMAXPROCS` — is read **once, at
+/// process start**, from the cgroup the process is born in. The lease
+/// deliberately changes that cgroup's quota *after* the process is running, and
+/// nothing re-reads it. So there is no static value that is correct in both
+/// regimes, and the choice is which regime to be wrong in:
+///
+/// * Pin from the **unleased** (250m) quota → every build that later gets lifted
+///   runs `-j1` on a 4-core lease. Measured cost: 165s vs 61s, 2.7x, on the
+///   single largest component of task wall clock. Catastrophic.
+/// * Pin from the **leased** quota → a command that is *never* lifted runs with
+///   more threads than its 250m quota. But a command that is never lifted is, by
+///   construction, one that never consumed enough CPU to be detected as heavy —
+///   it is not compute-bound, so oversubscribing its threads costs essentially
+///   nothing, and the CFS quota bounds it regardless.
+///
+/// The asymmetry is not close, so the pin is derived from the leased quota. This
+/// also restores the load-103 fix through the broker path: the child is capped at
+/// the pod's own budget instead of reading the node's core count.
+pub fn parallelism_pins(leased_millicores: u32) -> Vec<(String, String)> {
+    let jobs = jobs_for_millicores(leased_millicores);
+    let count = jobs.to_string();
+    vec![
+        ("CARGO_BUILD_JOBS".to_owned(), count.clone()),
+        ("NEXTEST_TEST_THREADS".to_owned(), count.clone()),
+        // `-j<n>` in MAKEFLAGS is honoured by a bare `make`; it cannot override
+        // an explicit `make -j$(nproc)` in a project's own scripts, and this
+        // does not claim to.
+        ("MAKEFLAGS".to_owned(), format!("-j{count}")),
+        ("GOMAXPROCS".to_owned(), count.clone()),
+        ("RAYON_NUM_THREADS".to_owned(), count),
+    ]
+}
+
+/// Apply the launcher-derived pins over `environment`, replacing any value the
+/// caller supplied for a pinned key and appending the ones it omitted.
+///
+/// Order is stable: caller-supplied keys keep their positions, appended pins
+/// follow in [`PINNED_PARALLELISM_KEYS`] order. Stability matters because the
+/// resulting `envp` is asserted verbatim by the spawn tests.
+pub fn apply_parallelism_pins(environment: &mut Vec<(String, String)>, leased_millicores: u32) {
+    for (key, value) in parallelism_pins(leased_millicores) {
+        match environment
+            .iter_mut()
+            .find(|(existing, _)| *existing == key)
+        {
+            Some(slot) => slot.1 = value,
+            None => environment.push((key, value)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_allow_list_is_closed_by_default() {
+        for denied in [
+            "LD_PRELOAD",
+            "LD_AUDIT",
+            "LD_LIBRARY_PATH",
+            "AWS_SECRET_ACCESS_KEY",
+            "ANTHROPIC_API_KEY",
+            "GITHUB_TOKEN",
+            "SSH_AUTH_SOCK",
+            "",
+            "cargo_build_jobs",
+        ] {
+            assert!(
+                !is_allowed_environment_key(denied),
+                "{denied} must not be forwardable"
+            );
+        }
+    }
+
+    #[test]
+    fn the_build_environment_the_pod_renders_survives_the_broker_hop() {
+        // Exactly the keys `djinn-k8s::job` puts on a task-run worker container
+        // for the build toolchain. If any of these stops being forwardable, a
+        // brokered build runs cold or against the wrong linker.
+        for required in [
+            "CARGO_TARGET_DIR",
+            "CARGO_HOME",
+            "CARGO_BUILD_JOBS",
+            "CARGO_BUILD_RUSTFLAGS",
+            "CARGO_INCREMENTAL",
+            "RUSTUP_HOME",
+            "NEXTEST_TEST_THREADS",
+            "SCCACHE_DIR",
+            "PATH",
+            "HOME",
+        ] {
+            assert!(
+                is_allowed_environment_key(required),
+                "{required} must reach a brokered build"
+            );
+        }
+    }
+
+    #[test]
+    fn every_pinned_key_is_itself_forwardable() {
+        for key in PINNED_PARALLELISM_KEYS {
+            assert!(
+                is_allowed_environment_key(key),
+                "the launcher pins {key}, so it must also be allowed through validation"
+            );
+        }
+    }
+
+    #[test]
+    fn job_count_floors_at_one_and_truncates() {
+        assert_eq!(jobs_for_millicores(0), 1);
+        assert_eq!(jobs_for_millicores(250), 1);
+        assert_eq!(jobs_for_millicores(999), 1);
+        assert_eq!(jobs_for_millicores(1000), 1);
+        assert_eq!(jobs_for_millicores(1500), 1);
+        assert_eq!(jobs_for_millicores(4000), 4);
+        assert_eq!(jobs_for_millicores(12_000), 12);
+    }
+
+    /// The pin must describe the quota the child will RUN at, not the one it is
+    /// born at — that is the whole decision recorded in [`parallelism_pins`].
+    #[test]
+    fn pins_are_derived_from_the_leased_quota_not_the_unleased_one() {
+        let unleased = parallelism_pins(250);
+        let leased = parallelism_pins(4000);
+        assert_eq!(unleased[0], ("CARGO_BUILD_JOBS".into(), "1".into()));
+        assert_eq!(leased[0], ("CARGO_BUILD_JOBS".into(), "4".into()));
+        assert_eq!(leased[2], ("MAKEFLAGS".into(), "-j4".into()));
+        assert_eq!(
+            leased.len(),
+            PINNED_PARALLELISM_KEYS.len(),
+            "every pinned key must be emitted"
+        );
+    }
+
+    #[test]
+    fn pins_override_a_caller_supplied_value_and_keep_position() {
+        let mut environment = vec![
+            ("PATH".to_owned(), "/usr/bin".to_owned()),
+            // A stale pod-level value computed for a different budget.
+            ("CARGO_BUILD_JOBS".to_owned(), "12".to_owned()),
+            ("HOME".to_owned(), "/home/djinn".to_owned()),
+        ];
+        apply_parallelism_pins(&mut environment, 4000);
+
+        assert_eq!(environment[0].0, "PATH");
+        assert_eq!(
+            environment[1],
+            ("CARGO_BUILD_JOBS".to_owned(), "4".to_owned()),
+            "a caller value must be overridden in place, never duplicated"
+        );
+        assert_eq!(environment[2].0, "HOME");
+        let keys: Vec<&str> = environment.iter().map(|(key, _)| key.as_str()).collect();
+        for pinned in PINNED_PARALLELISM_KEYS {
+            assert_eq!(
+                keys.iter().filter(|key| *key == pinned).count(),
+                1,
+                "{pinned} must appear exactly once"
+            );
+        }
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -1,7 +1,7 @@
 //! Fail-closed, cgroup-v2 leaf lifecycle primitives.
 //!
 //! This crate intentionally has no lease transport or process protocol.  The
-//! caller supplies an invocation-local fence and an injectable clone syscall;
+//! caller supplies an invocation-local fence and an injectable spawn syscall;
 //! this boundary only creates and controls one direct child of a validated
 //! delegated cgroup root.
 
@@ -9,12 +9,23 @@ use std::{collections::BTreeSet, ffi::CString, fs, io, os::fd::RawFd, path::Path
 
 use thiserror::Error;
 
+pub mod bootstrap;
 pub mod broker;
 pub mod child;
+pub mod env;
+pub mod spawn;
 pub mod transport;
+
+pub use env::is_allowed_environment_key;
+pub use spawn::{DenySpawn, NativeCgroupSpawn};
 
 const DEFAULT_PERIOD_US: u64 = 100_000;
 
+/// CPU quota an invocation leaf runs at before a lease lifts it.
+///
+/// Deliberately small: an unleased command is throttled hard enough that a
+/// genuinely CPU-hungry one is detectable within a few scheduling periods, and
+/// cheap enough that a light one is unaffected.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct UnleasedQuota(u16);
 
@@ -33,11 +44,7 @@ impl UnleasedQuota {
     }
 
     fn cpu_max(self) -> String {
-        // cpu.max quota is in microseconds per period.  1000m is one CPU.
-        format!(
-            "{} {DEFAULT_PERIOD_US}",
-            u64::from(self.0) * DEFAULT_PERIOD_US / 1000
-        )
+        cpu_max_for(u32::from(self.0))
     }
 }
 
@@ -47,18 +54,92 @@ impl Default for UnleasedQuota {
     }
 }
 
+/// CPU quota an invocation leaf is lifted to when a lease is granted.
+///
+/// # Why a lift is a quota and not `max` (task 7deu, defect 1)
+///
+/// The lift used to write `max`, i.e. remove the leaf's quota entirely, which
+/// was harmless only because an ancestor still clamped it: the launcher
+/// container carried a 250m CPU limit, and under `nsdelegate` the delegated root
+/// IS that container's cgroup. Every build was therefore permanently capped at
+/// 250m no matter what the leaf said — measured at 0.25 core against a leaf set
+/// to four — and `nr_throttled` read 0 in the leaf because the throttling
+/// happened at the parent, which made throttle-based heavy detection
+/// structurally blind.
+///
+/// Removing the container's CPU limit fixes that, but it also removes the only
+/// remaining ceiling. So the ceiling moves to where the work actually is: the
+/// lease grants an explicit quota equal to the pod's own CPU budget. One lifted
+/// build gets exactly the budget the pod declares, and N concurrent lifted
+/// builds are bounded by N × budget — which is what makes the admission cap a
+/// real semaphore instead of an advisory number.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LeasedQuota(u32);
+
+impl LeasedQuota {
+    /// Four cores: the task-run pod's declared CPU limit in production.
+    pub const DEFAULT_MILLICORES: u32 = 4_000;
+    /// Below this a "lease" would not be a lift at all.
+    pub const MIN_MILLICORES: u32 = 1_000;
+    /// A single leaf may never be granted more than one large node's worth.
+    pub const MAX_MILLICORES: u32 = 64_000;
+
+    pub fn new(millicores: u32) -> Result<Self, Error> {
+        if !(Self::MIN_MILLICORES..=Self::MAX_MILLICORES).contains(&millicores) {
+            return Err(Error::InvalidLeasedQuota(millicores));
+        }
+        Ok(Self(millicores))
+    }
+
+    pub fn millicores(self) -> u32 {
+        self.0
+    }
+
+    fn cpu_max(self) -> String {
+        cpu_max_for(self.0)
+    }
+}
+
+impl Default for LeasedQuota {
+    fn default() -> Self {
+        Self(Self::DEFAULT_MILLICORES)
+    }
+}
+
+/// `cpu.max` line for `millicores` over the default 100ms period.
+fn cpu_max_for(millicores: u32) -> String {
+    format!(
+        "{} {DEFAULT_PERIOD_US}",
+        u64::from(millicores) * DEFAULT_PERIOD_US / 1000
+    )
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LauncherConfig {
     pub unleased_quota: UnleasedQuota,
+    pub leased_quota: LeasedQuota,
     pub expected_uid: u32,
 }
 
 impl LauncherConfig {
-    pub fn new(unleased_millicores: Option<u16>, expected_uid: u32) -> Result<Self, Error> {
+    pub fn new(
+        unleased_millicores: Option<u16>,
+        leased_millicores: Option<u32>,
+        expected_uid: u32,
+    ) -> Result<Self, Error> {
+        let unleased =
+            UnleasedQuota::new(unleased_millicores.unwrap_or(UnleasedQuota::DEFAULT_MILLICORES))?;
+        let leased =
+            LeasedQuota::new(leased_millicores.unwrap_or(LeasedQuota::DEFAULT_MILLICORES))?;
+        if u32::from(unleased.millicores()) >= leased.millicores() {
+            return Err(Error::LeaseIsNotALift {
+                unleased: unleased.millicores(),
+                leased: leased.millicores(),
+            });
+        }
         Ok(Self {
-            unleased_quota: UnleasedQuota::new(
-                unleased_millicores.unwrap_or(UnleasedQuota::DEFAULT_MILLICORES),
-            )?,
+            unleased_quota: unleased,
+            leased_quota: leased,
             expected_uid,
         })
     }
@@ -121,13 +202,17 @@ pub struct CommandSpec {
 
 impl CommandSpec {
     pub const MAX_ARGUMENTS: usize = 128;
-    pub const MAX_BYTES: usize = 16 * 1024;
+    /// A task-run Pod renders a real build environment (cargo target dir, mold
+    /// flags, rustup home, sccache, the language toolchains) plus the launcher's
+    /// own pins. The former six-entry ceiling could not carry it.
+    pub const MAX_ENVIRONMENT: usize = 96;
+    pub const MAX_BYTES: usize = 32 * 1024;
 
     pub fn validate(&self) -> Result<(), Error> {
         if !safe_command_path(&self.program, false)
             || !safe_command_path(&self.cwd, true)
             || self.argv.len() > Self::MAX_ARGUMENTS
-            || self.environment.len() > 32
+            || self.environment.len() > Self::MAX_ENVIRONMENT
         {
             return Err(Error::InvalidCommand);
         }
@@ -142,7 +227,8 @@ impl CommandSpec {
             // `execve` receives each entry as `key=value`; accepting either
             // separator or NUL in the key would make that representation
             // malformed or change the key observed by the child.
-            if !allowed_environment(key) || key.contains(['\0', '=']) || value.contains('\0') {
+            if !is_allowed_environment_key(key) || key.contains(['\0', '=']) || value.contains('\0')
+            {
                 return Err(Error::InvalidCommand);
             }
             bytes = bytes.saturating_add(key.len() + value.len());
@@ -164,11 +250,6 @@ fn safe_command_path(path: &str, cwd: bool) -> bool {
                 || path.starts_with("/usr/bin/")
                 || path.starts_with("/workspace/")
         }
-}
-fn allowed_environment(key: &str) -> bool {
-    matches!(key, "HOME" | "PATH" | "TERM" | "LANG" | "TZ" | "CI")
-        || key.starts_with("LC_")
-        || key.starts_with("DJINN_")
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -216,10 +297,14 @@ pub trait CgroupFs {
     fn remove_leaf(&mut self, fd: RawFd, name: &str) -> Result<(), Error>;
 }
 
-pub trait CloneIntoCgroup {
-    /// This is the only child-spawn seam. Implementations must use
-    /// `clone3(CLONE_INTO_CGROUP)` with `target_cgroup_fd` before exec.
-    fn clone_into_cgroup(
+/// The only child-spawn seam.
+///
+/// Implementations must place the child inside `target_cgroup_fd` **and verify
+/// the placement** before the child is allowed to `execve`; see
+/// [`spawn::NativeCgroupSpawn`] for the production `fork` + pipe-handshake +
+/// `cgroup.procs` implementation and why it replaced `clone3`.
+pub trait SpawnIntoCgroup {
+    fn spawn_into_cgroup(
         &mut self,
         target_cgroup_fd: RawFd,
         invocation: &Invocation,
@@ -233,7 +318,7 @@ pub struct Launcher<F, S> {
     config: LauncherConfig,
 }
 
-impl<F: CgroupFs, S: CloneIntoCgroup> Launcher<F, S> {
+impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
     pub fn new(fs: F, syscall: S, config: LauncherConfig) -> Result<Self, Error> {
         fs.readiness()?.validate(config.expected_uid)?;
         Ok(Self {
@@ -241,6 +326,11 @@ impl<F: CgroupFs, S: CloneIntoCgroup> Launcher<F, S> {
             syscall,
             config,
         })
+    }
+
+    /// The quota a lease lifts an invocation leaf to.
+    pub fn leased_quota(&self) -> LeasedQuota {
+        self.config.leased_quota
     }
 
     pub fn create_command(
@@ -251,16 +341,30 @@ impl<F: CgroupFs, S: CloneIntoCgroup> Launcher<F, S> {
     ) -> Result<(Leaf, ChildProcess), Error> {
         validate_leaf_name(name)?;
         command.validate()?;
+
+        // Pin build parallelism from the LEASED quota, not the quota the child
+        // is born at. `available_parallelism()` is sampled once at process
+        // start and never re-read, so a pin taken from the 250m unleased lane
+        // would leave every lifted build stuck at `-j1`. See
+        // `env::parallelism_pins` for the full argument.
+        let mut command = command.clone();
+        env::apply_parallelism_pins(
+            &mut command.environment,
+            self.config.leased_quota.millicores(),
+        );
+        command.validate()?;
+
         let fd = self.fs.create_direct_child(name)?;
         self.fs
             .write_leaf(fd, "cpu.max", &self.config.unleased_quota.cpu_max())?;
-        // Clone is deliberately last: all readiness and leaf setup failures
+        // Spawn is deliberately last: all readiness and leaf setup failures
         // occur before the child can execute.
-        let child = match self.syscall.clone_into_cgroup(fd, &invocation, command) {
+        let child = match self.syscall.spawn_into_cgroup(fd, &invocation, &command) {
             Ok(child) => child,
             Err(error) => {
-                // clone3 failed before a child existed, so this direct child is
-                // necessarily empty. Do not leak a delegated cgroup on refusal.
+                // The spawn seam stands the child down before `execve` on every
+                // failure path, so this direct child is necessarily empty. Do
+                // not leak a delegated cgroup on refusal.
                 let _ = self.fs.remove_leaf(fd, name);
                 return Err(error);
             }
@@ -292,7 +396,7 @@ impl<F: CgroupFs, S: CloneIntoCgroup> Launcher<F, S> {
             return Err(Error::FenceMismatch);
         }
         self.fs
-            .write_leaf(leaf.fd, "cpu.max", &format!("max {DEFAULT_PERIOD_US}"))?;
+            .write_leaf(leaf.fd, "cpu.max", &self.config.leased_quota.cpu_max())?;
         leaf.lifted = true;
         Ok(())
     }
@@ -373,6 +477,13 @@ fn populated_zero(input: &str) -> Result<bool, Error> {
 pub enum Error {
     #[error("unleased CPU quota {0}m is outside 50m..=1000m")]
     InvalidQuota(u16),
+    #[error("leased CPU quota {0}m is outside 1000m..=64000m")]
+    InvalidLeasedQuota(u32),
+    #[error(
+        "the leased quota {leased}m does not lift the unleased quota {unleased}m; a lease that \
+         does not raise the ceiling is not a lease"
+    )]
+    LeaseIsNotALift { unleased: u16, leased: u32 },
     #[error("cgroup v2 is required (v1 and hybrid mounts are unsupported)")]
     NotCgroupV2,
     #[error(
@@ -385,10 +496,25 @@ pub enum Error {
         expected: i64,
     },
     #[error(
-        "clone3(CLONE_INTO_CGROUP) is unreachable in this sandbox (errno {errno}); the only \
-         child-spawn seam is denied, so no command could ever be launched"
+        "could not mount a private cgroup2 filesystem at {path} (errno {errno}); the launcher \
+         establishes its own delegated root and needs CAP_SYS_ADMIN plus a writable mountpoint \
+         to do so"
     )]
-    Clone3Unavailable { errno: i32 },
+    CgroupMountFailed { path: String, errno: i32 },
+    #[error("could not {detail} on the delegated cgroup root (errno {errno})")]
+    CgroupDelegationFailed { detail: &'static str, errno: i32 },
+    #[error(
+        "could not drop the bootstrap capabilities after establishing the delegated cgroup root \
+         (errno {errno}); refusing to serve while CAP_SYS_ADMIN is still held"
+    )]
+    CapabilityDropFailed { errno: i32 },
+    #[error("could not place child {pid} into the invocation cgroup (errno {errno})")]
+    CgroupPlacementFailed { pid: i32, errno: i32 },
+    #[error(
+        "child {pid} is not a member of the invocation cgroup after placement; its CPU would not \
+         be governed by the leaf quota, so it was stood down before exec"
+    )]
+    ChildNotInInvocationCgroup { pid: i32 },
     #[error("delegated cgroup root is read-only")]
     ReadOnlyDelegation,
     #[error("delegated cgroup owner {actual} differs from launcher uid {expected}")]
@@ -397,8 +523,8 @@ pub enum Error {
     OverbroadOrMissingCpuDelegation,
     #[error("leaf name is not a safe direct child")]
     UnsafeLeafName,
-    #[error("clone3(CLONE_INTO_CGROUP) was denied or unsupported")]
-    CloneDenied,
+    #[error("the child-spawn seam refused to start a process")]
+    SpawnDenied,
     #[error("command request is malformed, over-budget, or outside the broker allow-list")]
     InvalidCommand,
     #[error("child process operation failed")]
@@ -589,6 +715,14 @@ impl CgroupFs for NativeCgroupFs {
 /// because its type differs per libc target (`__fsword_t` vs `c_ulong`).
 pub const CGROUP2_SUPER_MAGIC: i64 = 0x6367_7270;
 
+/// Is `path` a cgroup v2 filesystem?
+///
+/// Used both by the readiness contract and by [`bootstrap`], which needs to know
+/// whether a previous launcher instance already established the mount.
+pub fn is_cgroup2_filesystem(path: &Path) -> Result<bool, Error> {
+    Ok(statfs_type(path)? == CGROUP2_SUPER_MAGIC)
+}
+
 /// Fail closed unless `path` really is a cgroup v2 filesystem.
 ///
 /// This is the first readiness check, deliberately ahead of every control-file
@@ -596,6 +730,18 @@ pub const CGROUP2_SUPER_MAGIC: i64 = 0x6367_7270;
 /// later check, and saying so by name is the difference between a diagnosable
 /// startup failure and an opaque `ENOENT`.
 fn assert_cgroup2_filesystem(path: &Path) -> Result<(), Error> {
+    let actual = statfs_type(path)?;
+    if actual != CGROUP2_SUPER_MAGIC {
+        return Err(Error::DelegatedRootIsNotCgroupFs {
+            path: path.display().to_string(),
+            actual,
+            expected: CGROUP2_SUPER_MAGIC,
+        });
+    }
+    Ok(())
+}
+
+fn statfs_type(path: &Path) -> Result<i64, Error> {
     use std::os::unix::ffi::OsStrExt;
 
     let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|_| Error::UnsafeLeafName)?;
@@ -612,15 +758,7 @@ fn assert_cgroup2_filesystem(path: &Path) -> Result<(), Error> {
     // 32-bit targets, so normalizing to `i64` is what makes this compile
     // everywhere. Clippy only sees the target it is running on.
     #[allow(clippy::unnecessary_cast)]
-    let actual = unsafe { buf.assume_init() }.f_type as i64;
-    if actual != CGROUP2_SUPER_MAGIC {
-        return Err(Error::DelegatedRootIsNotCgroupFs {
-            path: path.display().to_string(),
-            actual,
-            expected: CGROUP2_SUPER_MAGIC,
-        });
-    }
-    Ok(())
+    Ok(unsafe { buf.assume_init() }.f_type as i64)
 }
 
 fn safe_control_file(file: &str) -> Result<CString, Error> {
@@ -661,240 +799,6 @@ fn inspect_cgroup_mode() -> Result<CgroupMode, Error> {
         (true, true) => CgroupMode::Hybrid,
         _ => CgroupMode::V1,
     })
-}
-
-/// The production broker supplies a real clone3 implementation. This safe
-/// default makes unsupported/denied kernels fail before any child exec.
-pub struct DenyClone3;
-impl CloneIntoCgroup for DenyClone3 {
-    fn clone_into_cgroup(
-        &mut self,
-        _: RawFd,
-        _: &Invocation,
-        _: &CommandSpec,
-    ) -> Result<ChildProcess, Error> {
-        Err(Error::CloneDenied)
-    }
-}
-
-/// Linux production clone/exec implementation. The child is born in the
-/// target cgroup and crosses the credential/isolation boundary before exec.
-pub struct NativeClone3;
-
-/// `CLONE_INTO_CGROUP` (`include/uapi/linux/sched.h`), as a `u64`.
-///
-/// **Do not replace this with `libc::CLONE_INTO_CGROUP`.** On glibc targets the
-/// `libc` crate declares it as `pub const CLONE_INTO_CGROUP: c_int =
-/// 0x200000000` — a value that does not fit in a 32-bit `c_int`, and which the
-/// crate's blanket `allow(overflowing_literals)` truncates to **0** instead of
-/// rejecting. Using it silently passed `flags: 0` to `clone3`, so the child was
-/// an ordinary fork that stayed in the LAUNCHER's cgroup: the delegated leaf and
-/// the `cpu.max` written on it governed nothing at all. Found while adding the
-/// startup preflight for task grkq. `clone_flag_is_the_kernel_value` guards it.
-const CLONE_INTO_CGROUP: u64 = 0x2_0000_0000;
-
-/// `clone3` argument block. Hoisted to module scope so the startup preflight
-/// and the production spawn path use the SAME layout — a preflight that probed
-/// a different struct would prove nothing about the real call.
-#[repr(C)]
-#[derive(Default)]
-struct CloneArgs {
-    flags: u64,
-    pidfd: u64,
-    child_tid: u64,
-    parent_tid: u64,
-    exit_signal: u64,
-    stack: u64,
-    stack_size: u64,
-    tls: u64,
-    set_tid: u64,
-    set_tid_size: u64,
-    cgroup: u64,
-}
-
-impl NativeClone3 {
-    /// Startup readiness probe: is `clone3(CLONE_INTO_CGROUP)` reachable at all?
-    ///
-    /// The launcher's ONLY child-spawn seam is `clone3` with
-    /// `CLONE_INTO_CGROUP`. A sandbox that denies it (task grkq: the container
-    /// runtime's `RuntimeDefault` seccomp profile answers `clone3` with `ENOSYS`
-    /// so glibc falls back to `clone`, and this call site has no such fallback)
-    /// cannot launch a single command — but without this probe that only shows
-    /// up much later, once per command, as an opaque spawn error. Run it before
-    /// the broker binds its socket so an unusable sandbox fails readiness loudly
-    /// and BEFORE the pod accepts work.
-    ///
-    /// The probe passes a syntactically valid but unopened cgroup descriptor.
-    /// The kernel validates that descriptor before it forks, so:
-    ///   * `EBADF` — the syscall is reachable and no child was created;
-    ///   * anything else (notably `ENOSYS`/`EPERM` from a seccomp filter, or
-    ///     `EINVAL` on a kernel without `CLONE_INTO_CGROUP`) — unavailable.
-    pub fn preflight() -> Result<(), Error> {
-        // A descriptor inside the kernel's accepted range (`cgroup` is rejected
-        // with EINVAL above INT_MAX) that this process has certainly not opened.
-        const UNOPENED_FD: u64 = i32::MAX as u64;
-        let args = CloneArgs {
-            flags: CLONE_INTO_CGROUP,
-            exit_signal: libc::SIGCHLD as u64,
-            cgroup: UNOPENED_FD,
-            ..CloneArgs::default()
-        };
-        // SAFETY: a raw `clone3` with a deliberately invalid `cgroup` descriptor.
-        // The kernel rejects it during argument validation, before `copy_process`
-        // forks, so no child can be created and the `rc == 0` arm is unreachable.
-        let rc = unsafe {
-            libc::syscall(
-                libc::SYS_clone3,
-                &raw const args,
-                std::mem::size_of::<CloneArgs>(),
-            )
-        };
-        if rc == 0 {
-            // Defensive: a child here would be an unowned process. Exit it
-            // immediately rather than letting a preflight leak a process.
-            unsafe { libc::_exit(0) };
-        }
-        let errno = io::Error::last_os_error().raw_os_error().unwrap_or(0);
-        if errno == libc::EBADF {
-            Ok(())
-        } else {
-            Err(Error::Clone3Unavailable { errno })
-        }
-    }
-}
-
-/// Close every non-stdio descriptor with one kernel operation. In particular,
-/// do not enumerate `/proc/self/fd`: `read_dir` owns a descriptor which is
-/// reported by that directory and then closed when the iterator is dropped,
-/// leaving a stale fd for `prepare_child` to fail on.
-fn close_inherited_descriptors(
-    close_range: impl FnOnce(u32, u32) -> Result<(), Error>,
-) -> Result<(), Error> {
-    close_range(3, u32::MAX)
-}
-
-fn native_close_inherited_descriptors(first: u32, last: u32) -> Result<(), Error> {
-    let result = unsafe { libc::syscall(libc::SYS_close_range, first, last, 0_u32) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(Error::Io(io::Error::last_os_error()))
-    }
-}
-
-impl CloneIntoCgroup for NativeClone3 {
-    fn clone_into_cgroup(
-        &mut self,
-        cgroup: RawFd,
-        _: &Invocation,
-        command: &CommandSpec,
-    ) -> Result<ChildProcess, Error> {
-        command.validate()?;
-        let mut out = [0; 2];
-        let mut err = [0; 2];
-        // Child writes remain blocking; pipe capacity provides backpressure.
-        if unsafe { libc::pipe2(out.as_mut_ptr(), libc::O_CLOEXEC) } != 0
-            || unsafe { libc::pipe2(err.as_mut_ptr(), libc::O_CLOEXEC) } != 0
-        {
-            return Err(Error::Io(io::Error::last_os_error()));
-        }
-        let args = CloneArgs {
-            flags: CLONE_INTO_CGROUP,
-            exit_signal: libc::SIGCHLD as u64,
-            cgroup: cgroup as u64,
-            ..CloneArgs::default()
-        };
-        let pid = unsafe {
-            libc::syscall(
-                libc::SYS_clone3,
-                &raw const args,
-                std::mem::size_of::<CloneArgs>(),
-            )
-        } as i32;
-        if pid < 0 {
-            unsafe {
-                libc::close(out[0]);
-                libc::close(out[1]);
-                libc::close(err[0]);
-                libc::close(err[1]);
-            }
-            return Err(Error::CloneDenied);
-        }
-        if pid == 0 {
-            unsafe {
-                libc::close(out[0]);
-                libc::close(err[0]);
-                let null = CString::new("/dev/null").unwrap();
-                let stdin = libc::open(null.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC);
-                if stdin < 0 || libc::dup2(stdin, 0) < 0 {
-                    libc::_exit(127);
-                }
-                libc::close(stdin);
-                libc::dup2(out[1], 1);
-                libc::dup2(err[1], 2);
-                libc::close(out[1]);
-                libc::close(err[1]);
-            }
-            let mut child = child::NativeChildSyscalls;
-            // A close-range operation is race-safe and leaves no procfs
-            // directory iterator descriptor that could become stale before
-            // the credential boundary. Stdio remains the only child surface.
-            if close_inherited_descriptors(native_close_inherited_descriptors)
-                .and_then(|_| {
-                    child::prepare_child(&mut child, &[], &child::ChildMounts::isolated())
-                })
-                .is_err()
-            {
-                unsafe { libc::_exit(127) };
-            }
-            let cwd = CString::new(command.cwd.as_str()).unwrap();
-            if unsafe { libc::chdir(cwd.as_ptr()) } != 0 {
-                unsafe { libc::_exit(127) };
-            }
-            let program = CString::new(command.program.as_str()).unwrap();
-            let args: Vec<CString> = command
-                .argv
-                .iter()
-                .map(|v| CString::new(v.as_str()).unwrap())
-                .collect();
-            let mut argv = Vec::with_capacity(args.len() + 2);
-            argv.push(program.as_ptr().cast_mut());
-            argv.extend(args.iter().map(|v| v.as_ptr().cast_mut()));
-            argv.push(std::ptr::null_mut());
-            // Pass exactly the validated environment, never the broker's.
-            let environment: Vec<CString> = command
-                .environment
-                .iter()
-                .map(|(key, value)| CString::new(format!("{key}={value}")).unwrap())
-                .collect();
-            let mut envp: Vec<*mut libc::c_char> = environment
-                .iter()
-                .map(|value| value.as_ptr().cast_mut())
-                .collect();
-            envp.push(std::ptr::null_mut());
-            unsafe {
-                libc::execve(program.as_ptr(), argv.as_ptr().cast(), envp.as_ptr().cast());
-                libc::_exit(127)
-            }
-        }
-        unsafe {
-            libc::close(out[1]);
-            libc::close(err[1]);
-            for fd in [out[0], err[0]] {
-                let flags = libc::fcntl(fd, libc::F_GETFL);
-                if flags < 0 || libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
-                    libc::close(out[0]);
-                    libc::close(err[0]);
-                    return Err(Error::Io(io::Error::last_os_error()));
-                }
-            }
-        }
-        Ok(ChildProcess {
-            pid,
-            stdout: out[0],
-            stderr: err[0],
-        })
-    }
 }
 
 #[cfg(test)]
@@ -950,23 +854,25 @@ mod tests {
         }
     }
     #[derive(Default)]
-    struct FakeClone {
+    struct FakeSpawn {
         attempts: Vec<(RawFd, Invocation)>,
         exec_calls: Vec<(RawFd, Invocation)>,
+        environments: Vec<Vec<(String, String)>>,
         deny: bool,
     }
-    impl CloneIntoCgroup for FakeClone {
-        fn clone_into_cgroup(
+    impl SpawnIntoCgroup for FakeSpawn {
+        fn spawn_into_cgroup(
             &mut self,
             fd: RawFd,
             inv: &Invocation,
-            _: &CommandSpec,
+            command: &CommandSpec,
         ) -> Result<ChildProcess, Error> {
             self.attempts.push((fd, inv.clone()));
             if self.deny {
-                return Err(Error::CloneDenied);
+                return Err(Error::SpawnDenied);
             }
             self.exec_calls.push((fd, inv.clone()));
+            self.environments.push(command.environment.clone());
             Ok(ChildProcess {
                 pid: 1,
                 stdout: -1,
@@ -974,13 +880,11 @@ mod tests {
             })
         }
     }
-    fn launcher() -> Launcher<FakeFs, FakeClone> {
-        Launcher::new(
-            FakeFs::ready(),
-            FakeClone::default(),
-            LauncherConfig::new(None, 7).unwrap(),
-        )
-        .unwrap()
+    fn config() -> LauncherConfig {
+        LauncherConfig::new(None, None, 7).unwrap()
+    }
+    fn launcher() -> Launcher<FakeFs, FakeSpawn> {
+        Launcher::new(FakeFs::ready(), FakeSpawn::default(), config()).unwrap()
     }
     fn invocation() -> Invocation {
         Invocation {
@@ -996,39 +900,15 @@ mod tests {
             environment: vec![],
         }
     }
-    fn create(l: &mut Launcher<FakeFs, FakeClone>, name: &str) -> Leaf {
+    fn create(l: &mut Launcher<FakeFs, FakeSpawn>, name: &str) -> Leaf {
         l.create_command(name, invocation(), &command()).unwrap().0
-    }
-
-    /// The clone flag must be the kernel's `CLONE_INTO_CGROUP`, and must NOT be
-    /// sourced from `libc`, whose glibc declaration truncates it to 0 (see the
-    /// constant's doc comment). With a zero flag `clone3` degrades to a plain
-    /// fork: the child stays in the launcher's own cgroup, so the delegated leaf
-    /// and its `cpu.max` govern nothing and the containment claim is false.
-    #[test]
-    fn clone_flag_is_the_kernel_value() {
-        assert_eq!(CLONE_INTO_CGROUP, 0x2_0000_0000);
-        assert_ne!(
-            CLONE_INTO_CGROUP, 0,
-            "a zero flag silently turns clone3 into an ordinary fork"
-        );
-        assert_ne!(
-            u64::from(libc::CLONE_INTO_CGROUP as u32),
-            CLONE_INTO_CGROUP,
-            "libc's constant still truncates; keep using the local one"
-        );
     }
 
     #[test]
     fn quota_configuration_has_a_safe_default_and_closed_bounds() {
         assert_eq!(UnleasedQuota::default().millicores(), 250);
-        assert_eq!(
-            LauncherConfig::new(None, 7)
-                .unwrap()
-                .unleased_quota
-                .millicores(),
-            250
-        );
+        assert_eq!(config().unleased_quota.millicores(), 250);
+        assert_eq!(config().leased_quota.millicores(), 4_000);
         assert_eq!(UnleasedQuota::new(50).unwrap().millicores(), 50);
         assert_eq!(UnleasedQuota::new(1000).unwrap().millicores(), 1000);
         assert!(matches!(
@@ -1039,15 +919,95 @@ mod tests {
             UnleasedQuota::new(1001),
             Err(Error::InvalidQuota(1001))
         ));
+        assert!(matches!(
+            LeasedQuota::new(999),
+            Err(Error::InvalidLeasedQuota(999))
+        ));
+        assert!(matches!(
+            LeasedQuota::new(64_001),
+            Err(Error::InvalidLeasedQuota(64_001))
+        ));
+    }
+
+    /// A "lease" that does not raise the ceiling is a configuration error, not
+    /// a quiet no-op: it would leave every detected-heavy build throttled while
+    /// telemetry reported a successful lift.
+    #[test]
+    fn a_lease_that_does_not_lift_is_rejected() {
+        assert!(matches!(
+            LauncherConfig::new(Some(1000), Some(1000), 0),
+            Err(Error::LeaseIsNotALift {
+                unleased: 1000,
+                leased: 1000
+            })
+        ));
+        assert!(LauncherConfig::new(Some(250), Some(1000), 0).is_ok());
+    }
+
+    /// The unleased quota throttles and the lease lifts to the pod budget — as
+    /// `cpu.max` lines, since that is what the kernel reads.
+    #[test]
+    fn quotas_render_as_cpu_max_lines_over_the_default_period() {
+        assert_eq!(UnleasedQuota::default().cpu_max(), "25000 100000");
+        assert_eq!(LeasedQuota::default().cpu_max(), "400000 100000");
+        assert_eq!(
+            LeasedQuota::new(12_000).unwrap().cpu_max(),
+            "1200000 100000"
+        );
     }
 
     #[test]
     fn fresh_invocation_is_passed_with_leaf_fd() {
         let mut l = launcher();
         let leaf = create(&mut l, "invocation-1");
-        let (_, clone) = l.into_parts();
-        assert_eq!(clone.exec_calls, vec![(leaf.fd, invocation())]);
+        let (_, spawn) = l.into_parts();
+        assert_eq!(spawn.exec_calls, vec![(leaf.fd, invocation())]);
     }
+
+    /// The child must be born already knowing the parallelism it will be able
+    /// to use, because nothing re-reads it after the lift.
+    #[test]
+    fn the_child_environment_carries_pins_derived_from_the_leased_quota() {
+        let mut l = Launcher::new(
+            FakeFs::ready(),
+            FakeSpawn::default(),
+            LauncherConfig::new(Some(250), Some(4_000), 7).unwrap(),
+        )
+        .unwrap();
+        create(&mut l, "pinned");
+        let (_, spawn) = l.into_parts();
+        let environment = &spawn.environments[0];
+        let value = |key: &str| {
+            environment
+                .iter()
+                .find(|(name, _)| name == key)
+                .map(|(_, value)| value.as_str())
+                .unwrap_or_else(|| panic!("{key} must be pinned on the child"))
+        };
+        assert_eq!(value("CARGO_BUILD_JOBS"), "4");
+        assert_eq!(value("NEXTEST_TEST_THREADS"), "4");
+        assert_eq!(value("MAKEFLAGS"), "-j4");
+        assert_eq!(value("GOMAXPROCS"), "4");
+    }
+
+    /// A stale pod-level pin must not win over the launcher's derived one: the
+    /// pod cannot know the quota the leaf will actually run at.
+    #[test]
+    fn a_caller_supplied_pin_is_overridden_by_the_launcher() {
+        let mut l = launcher();
+        let mut spec = command();
+        spec.environment = vec![("CARGO_BUILD_JOBS".into(), "12".into())];
+        l.create_command("override", invocation(), &spec).unwrap();
+        let (_, spawn) = l.into_parts();
+        assert_eq!(
+            spawn.environments[0]
+                .iter()
+                .filter(|(key, _)| key == "CARGO_BUILD_JOBS")
+                .collect::<Vec<_>>(),
+            vec![&("CARGO_BUILD_JOBS".to_string(), "4".to_string())]
+        );
+    }
+
     #[test]
     fn lift_is_one_way_and_fenced() {
         let mut l = launcher();
@@ -1062,6 +1022,25 @@ mod tests {
             Err(Error::LiftAlreadyApplied)
         ));
     }
+
+    /// The whole point of the lift, asserted on the bytes written to the leaf:
+    /// unleased is a throttling quota, lifted is the pod's full budget, and
+    /// NEITHER is `max` — an unbounded leaf would let one build take the node.
+    #[test]
+    fn the_lift_writes_the_leased_quota_not_an_unbounded_max() {
+        let mut l = launcher();
+        let mut leaf = create(&mut l, "one");
+        let fd = leaf.fd;
+        assert_eq!(l.fs.files[&(fd, "cpu.max".into())], "25000 100000");
+        l.fenced_lift(&mut leaf, 99).unwrap();
+        let lifted = &l.fs.files[&(fd, "cpu.max".into())];
+        assert_eq!(lifted, "400000 100000");
+        assert!(
+            !lifted.starts_with("max"),
+            "an unbounded lift removes the only remaining ceiling"
+        );
+    }
+
     #[test]
     fn remove_requires_descendant_emptiness() {
         let mut l = launcher();
@@ -1076,17 +1055,14 @@ mod tests {
         l.remove(&leaf).unwrap();
         assert_eq!(l.fs.removed, vec!["one"]);
     }
+
     #[test]
     fn readiness_rejects_all_unsupported_delegation_profiles() {
         for mode in [CgroupMode::V1, CgroupMode::Hybrid] {
             let mut fs = FakeFs::ready();
             fs.readiness.as_mut().unwrap().mode = mode;
             assert!(matches!(
-                Launcher::new(
-                    fs,
-                    FakeClone::default(),
-                    LauncherConfig::new(None, 7).unwrap()
-                ),
+                Launcher::new(fs, FakeSpawn::default(), config()),
                 Err(Error::NotCgroupV2)
             ));
         }
@@ -1098,11 +1074,7 @@ mod tests {
             .delegated_controllers
             .clear();
         assert!(matches!(
-            Launcher::new(
-                missing_cpu,
-                FakeClone::default(),
-                LauncherConfig::new(None, 7).unwrap()
-            ),
+            Launcher::new(missing_cpu, FakeSpawn::default(), config()),
             Err(Error::OverbroadOrMissingCpuDelegation)
         ));
         let mut overbroad = FakeFs::ready();
@@ -1113,31 +1085,19 @@ mod tests {
             .delegated_controllers
             .insert("memory".into());
         assert!(matches!(
-            Launcher::new(
-                overbroad,
-                FakeClone::default(),
-                LauncherConfig::new(None, 7).unwrap()
-            ),
+            Launcher::new(overbroad, FakeSpawn::default(), config()),
             Err(Error::OverbroadOrMissingCpuDelegation)
         ));
         let mut read_only = FakeFs::ready();
         read_only.readiness.as_mut().unwrap().root_writable = false;
         assert!(matches!(
-            Launcher::new(
-                read_only,
-                FakeClone::default(),
-                LauncherConfig::new(None, 7).unwrap()
-            ),
+            Launcher::new(read_only, FakeSpawn::default(), config()),
             Err(Error::ReadOnlyDelegation)
         ));
         let mut wrong_owner = FakeFs::ready();
         wrong_owner.readiness.as_mut().unwrap().owner_uid = 8;
         assert!(matches!(
-            Launcher::new(
-                wrong_owner,
-                FakeClone::default(),
-                LauncherConfig::new(None, 7).unwrap()
-            ),
+            Launcher::new(wrong_owner, FakeSpawn::default(), config()),
             Err(Error::IncompatibleOwnership {
                 expected: 7,
                 actual: 8
@@ -1168,7 +1128,7 @@ mod tests {
     }
 
     #[test]
-    fn malformed_command_is_rejected_before_leaf_or_clone() {
+    fn malformed_command_is_rejected_before_leaf_or_spawn() {
         let mut l = launcher();
         let mut malformed = command();
         malformed.program = "/bin/../sh".into();
@@ -1176,10 +1136,10 @@ mod tests {
             l.create_command("one", invocation(), &malformed),
             Err(Error::InvalidCommand)
         ));
-        let (fs, clone) = l.into_parts();
+        let (fs, spawn) = l.into_parts();
         assert!(fs.created.is_empty());
-        assert!(clone.attempts.is_empty());
-        assert!(clone.exec_calls.is_empty());
+        assert!(spawn.attempts.is_empty());
+        assert!(spawn.exec_calls.is_empty());
     }
 
     #[test]
@@ -1191,82 +1151,42 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct CloseRangePreparedChild {
-        calls: Vec<&'static str>,
-    }
-
-    impl child::ChildSyscalls for CloseRangePreparedChild {
-        fn close(&mut self, _: RawFd) -> Result<(), Error> {
-            Err(Error::ChildPreparation("stale descriptor"))
+    /// The allow-list stays closed: widening it for the build toolchain must
+    /// not have opened it to anything else.
+    #[test]
+    fn command_validation_still_refuses_unlisted_environment_keys() {
+        for key in ["LD_PRELOAD", "ANTHROPIC_API_KEY", "GITHUB_TOKEN"] {
+            let mut malformed = command();
+            malformed.environment = vec![(key.into(), "value".into())];
+            assert!(
+                matches!(malformed.validate(), Err(Error::InvalidCommand)),
+                "{key} must not pass validation"
+            );
         }
-        fn set_groups_empty(&mut self) -> Result<(), Error> {
-            self.calls.push("groups");
-            Ok(())
-        }
-        fn clear_capabilities(&mut self) -> Result<(), Error> {
-            self.calls.push("caps");
-            Ok(())
-        }
-        fn set_gid(&mut self, _: u32) -> Result<(), Error> {
-            self.calls.push("gid");
-            Ok(())
-        }
-        fn set_uid(&mut self, _: u32) -> Result<(), Error> {
-            self.calls.push("uid");
-            Ok(())
-        }
-        fn set_umask(&mut self, _: u32) -> Result<(), Error> {
-            self.calls.push("umask");
-            Ok(())
-        }
-        fn set_no_new_privs(&mut self) -> Result<(), Error> {
-            self.calls.push("nnp");
-            Ok(())
-        }
-        fn install_restricted_seccomp(&mut self) -> Result<(), Error> {
-            self.calls.push("seccomp");
-            Ok(())
-        }
+        let mut build = command();
+        build.environment = vec![("CARGO_TARGET_DIR".into(), "/cache/target".into())];
+        assert!(build.validate().is_ok());
     }
 
     #[test]
-    fn close_range_seam_prepares_child_without_a_stale_procfs_descriptor() {
-        let mut bounds = None;
-        let mut child = CloseRangePreparedChild::default();
-        close_inherited_descriptors(|first, last| {
-            bounds = Some((first, last));
-            Ok(())
-        })
-        .and_then(|_| child::prepare_child(&mut child, &[], &child::ChildMounts::isolated()))
-        .unwrap();
-
-        assert_eq!(bounds, Some((3, u32::MAX)));
-        assert_eq!(
-            child.calls,
-            ["groups", "gid", "uid", "caps", "umask", "nnp", "seccomp"]
-        );
-    }
-
-    #[test]
-    fn denied_clone_never_executes_a_child() {
+    fn denied_spawn_never_executes_a_child() {
         let mut l = Launcher::new(
             FakeFs::ready(),
-            FakeClone {
+            FakeSpawn {
                 deny: true,
-                ..FakeClone::default()
+                ..FakeSpawn::default()
             },
-            LauncherConfig::new(None, 7).unwrap(),
+            config(),
         )
         .unwrap();
         assert!(matches!(
             l.create_command("one", invocation(), &command())
                 .map(|v| v.0),
-            Err(Error::CloneDenied)
+            Err(Error::SpawnDenied)
         ));
-        let (fs, clone) = l.into_parts();
-        assert_eq!(clone.attempts.len(), 1);
-        assert!(clone.exec_calls.is_empty());
+        let (fs, spawn) = l.into_parts();
+        assert_eq!(spawn.attempts.len(), 1);
+        assert!(spawn.exec_calls.is_empty());
         assert_eq!(fs.removed, vec!["one"]);
     }
 }

--- a/server/crates/djinn-cgroup-launcher/src/main.rs
+++ b/server/crates/djinn-cgroup-launcher/src/main.rs
@@ -1,7 +1,7 @@
 //! Packaged entrypoint for the mandatory cgroup-launcher sidecar.
 //!
 //! This binary is deliberately thin: it only *composes* the crate's existing,
-//! separately-tested primitives (`NativeCgroupFs`, `NativeClone3`, `Launcher`,
+//! separately-tested primitives (`NativeCgroupFs`, `NativeCgroupSpawn`, `Launcher`,
 //! `Broker`, `UnixBrokerServer`) into a fail-closed serve loop. It adds no lease
 //! policy and no new syscall surface — the crate's runtime behavior is unchanged;
 //! this file is the packaging seam so the launcher ships as a real binary
@@ -11,9 +11,9 @@
 //! Configuration is read from the environment the Job renders
 //! (`djinn-k8s::launcher`): the delegated cgroup root, control socket path, the
 //! worker-private credential path, the expected delegated-root owner uid, and the
-//! unleased broker quota. Anything missing/invalid, a sandbox that denies the
-//! `clone3(CLONE_INTO_CGROUP)` child-spawn seam, or a delegated cgroup that
-//! fails the [`Readiness`](djinn_cgroup_launcher::Readiness) contract, exits
+//! unleased/leased broker quotas. Anything missing/invalid, a cgroup2 mount the
+//! launcher cannot establish, a capability it cannot drop, or a delegated cgroup
+//! that fails the [`Readiness`](djinn_cgroup_launcher::Readiness) contract, exits
 //! non-zero with a NAMED error BEFORE the broker accepts a single connection.
 //! Every one of those conditions is a readiness failure, never a per-command
 //! error discovered after the pod has taken work (task grkq).
@@ -23,10 +23,11 @@ use std::path::Path;
 use std::process::ExitCode;
 use std::time::Duration;
 
+use djinn_cgroup_launcher::bootstrap::{self, Bootstrap};
 use djinn_cgroup_launcher::broker::{Broker, BrokerConfig, OsNonceSource};
 use djinn_cgroup_launcher::transport::UnixBrokerServer;
 use djinn_cgroup_launcher::{
-    Error as LauncherError, Launcher, LauncherConfig, NativeCgroupFs, NativeClone3,
+    Error as LauncherError, Launcher, LauncherConfig, NativeCgroupFs, NativeCgroupSpawn,
 };
 
 /// Worker→launcher handshake filename (holds the worker PID) written by the
@@ -63,24 +64,38 @@ fn run() -> Result<(), MainError> {
     let unleased: u16 = env_required("DJINN_LAUNCHER_UNLEASED_MILLICORES")?
         .parse()
         .map_err(|_| MainError::InvalidEnv("DJINN_LAUNCHER_UNLEASED_MILLICORES"))?;
+    let leased: u32 = env_required("DJINN_LAUNCHER_LEASED_MILLICORES")?
+        .parse()
+        .map_err(|_| MainError::InvalidEnv("DJINN_LAUNCHER_LEASED_MILLICORES"))?;
 
-    // Readiness gate 1 — the child-spawn seam. `clone3(CLONE_INTO_CGROUP)` is
-    // the launcher's ONLY way to start a command; a sandbox that denies it (a
-    // seccomp profile answering `clone3` with ENOSYS, or a kernel without
-    // CLONE_INTO_CGROUP) can never run anything. Probe it here so that failure
-    // is a loud, named startup failure instead of an opaque per-command spawn
-    // error surfacing after the pod has already accepted work (task grkq).
-    NativeClone3::preflight()?;
+    // Readiness gate 1 — establish the delegated cgroup v2 root, then give up
+    // the capability that allowed it. `Bootstrap::run` mounts cgroup2 inside the
+    // launcher's own cgroup namespace, vacates the mount root into `init/` so
+    // the "no internal process" rule permits delegation, enables exactly `+cpu`,
+    // and finally drops CAP_SYS_ADMIN/CAP_SYS_RESOURCE irreversibly. Everything
+    // here runs before the broker binds, so the capability window contains no
+    // user-controlled code at all (task 7deu, defect 4).
+    Bootstrap::new(&cgroup_root).run()?;
 
-    // Readiness gate 2 — the delegated cgroup root. `NativeCgroupFs::open` runs
+    // Readiness gate 2 — prove the capability really is gone. A launcher that
+    // kept CAP_SYS_ADMIN would hand every task-run pod a node-wide escape
+    // primitive (`/proc/sys/kernel/core_pattern` is not namespaced), so this is
+    // fail-closed rather than advisory.
+    if bootstrap::holds_any_bootstrap_capability()? {
+        return Err(MainError::Launcher(LauncherError::CapabilityDropFailed {
+            errno: 0,
+        }));
+    }
+
+    // Readiness gate 3 — the delegated cgroup root. `NativeCgroupFs::open` runs
     // the full readiness contract (really a cgroup2 filesystem, cgroup-v2 mode,
     // root writable and not group/other-writable, owner == expected uid, exactly
     // the cpu controller delegated) and fails closed, by name, otherwise.
     let fs = NativeCgroupFs::open(&cgroup_root, expected_uid)?;
     let launcher = Launcher::new(
         fs,
-        NativeClone3,
-        LauncherConfig::new(Some(unleased), expected_uid)?,
+        NativeCgroupSpawn,
+        LauncherConfig::new(Some(unleased), Some(leased), expected_uid)?,
     )?;
 
     // Read the worker handshake (private credential + PID) the worker writes into

--- a/server/crates/djinn-cgroup-launcher/src/spawn.rs
+++ b/server/crates/djinn-cgroup-launcher/src/spawn.rs
@@ -1,0 +1,523 @@
+//! The child-spawn seam: `fork` + a pipe handshake + a `cgroup.procs` write.
+//!
+//! # Why not `clone3(CLONE_INTO_CGROUP)` (task 7deu, defect 3)
+//!
+//! The launcher used to be able to start a command exactly one way:
+//! `clone3(CLONE_INTO_CGROUP)`. That made a single syscall's availability a
+//! hard dependency of the entire feature, and it cost real production time:
+//!
+//! * The container runtime's `RuntimeDefault` seccomp profile answers `clone3`
+//!   with `ENOSYS` for containers **without** `CAP_SYS_ADMIN`. Every launcher
+//!   configuration that did not grant that capability could not launch anything,
+//!   and the failure surfaced as an opaque per-command spawn error.
+//! * `libc::CLONE_INTO_CGROUP` is declared `c_int` on glibc with the value
+//!   `0x200000000`, which does not fit; the `libc` crate's blanket
+//!   `allow(overflowing_literals)` truncated it to **0**. The shipped call
+//!   therefore passed no flag at all: an ordinary `fork` whose child stayed in
+//!   the launcher's own cgroup, so the delegated leaf and the `cpu.max` written
+//!   on it governed nothing. The test suite could not see it because the clone
+//!   seam was faked.
+//!
+//! Neither problem exists here. `fork(2)` and `write(2)` are not intercepted by
+//! any seccomp profile in use, there is no flag constant to truncate, and the
+//! placement is verified by reading it back (see [`verify_placement`]) rather
+//! than assumed. This is also what `runc` itself does.
+//!
+//! # The no-unthrottled-interval property is preserved
+//!
+//! goxi correctly insists that a child must never execute work outside its
+//! quota. The ordering here is enforced by construction:
+//!
+//! ```text
+//!   parent: fork ─┬─────────────────────────────────────────────────────────
+//!                 │                                    child: read(sync) ⏸
+//!   parent: write child pid → leaf/cgroup.procs        (blocked, no work)
+//!   parent: read back leaf/cgroup.procs, assert pid    (blocked, no work)
+//!   parent: write 1 byte → sync ───────────────────────▶ child: resumes
+//!                                                       child: prepare_child
+//!                                                       child: execve
+//! ```
+//!
+//! Between `fork` and the go byte the child issues exactly one syscall — a
+//! blocking `read` on an empty pipe — and burns no CPU. If the parent cannot
+//! place it, the sync pipe is closed instead of written: the child observes EOF
+//! and `_exit`s **without ever reaching `execve`**.
+
+use std::ffi::CString;
+use std::io;
+use std::os::fd::RawFd;
+
+use crate::child::{self, ChildMounts};
+use crate::{ChildProcess, CommandSpec, Error, Invocation, SpawnIntoCgroup};
+
+/// Byte the parent writes once the child is confirmed inside the leaf.
+const GO: u8 = b'G';
+
+/// Exit code for a child that was told to stand down before `execve`.
+const EXIT_NOT_PLACED: i32 = 126;
+/// Exit code for a child that failed its own pre-exec preparation.
+const EXIT_PREPARATION_FAILED: i32 = 127;
+
+/// Safe default seam: refuses every spawn.
+///
+/// Used where a launcher must exist but must never start a process — the
+/// readiness-rejection paths, and tests that assert a spawn is not reached.
+pub struct DenySpawn;
+
+impl SpawnIntoCgroup for DenySpawn {
+    fn spawn_into_cgroup(
+        &mut self,
+        _: RawFd,
+        _: &Invocation,
+        _: &CommandSpec,
+    ) -> Result<ChildProcess, Error> {
+        Err(Error::SpawnDenied)
+    }
+}
+
+/// Everything `execve` needs, allocated in the **parent** before `fork`.
+///
+/// After `fork` in a process that may hold locks from other threads, only
+/// async-signal-safe operations are permitted — which excludes every allocation.
+/// The previous implementation built its `CString`s in the child; this one does
+/// not, so the child path is allocation-free.
+struct PreparedExec {
+    program: CString,
+    cwd: CString,
+    dev_null: CString,
+    /// Backing storage for `argv`; must outlive the pointer array.
+    _argv_storage: Vec<CString>,
+    /// Backing storage for `envp`; must outlive the pointer array.
+    _envp_storage: Vec<CString>,
+    argv: Vec<*mut libc::c_char>,
+    envp: Vec<*mut libc::c_char>,
+}
+
+impl PreparedExec {
+    fn new(command: &CommandSpec) -> Result<Self, Error> {
+        let program = CString::new(command.program.as_str()).map_err(|_| Error::InvalidCommand)?;
+        let cwd = CString::new(command.cwd.as_str()).map_err(|_| Error::InvalidCommand)?;
+        let dev_null = CString::new("/dev/null").map_err(|_| Error::InvalidCommand)?;
+
+        let argv_storage: Vec<CString> = command
+            .argv
+            .iter()
+            .map(|value| CString::new(value.as_str()).map_err(|_| Error::InvalidCommand))
+            .collect::<Result<_, _>>()?;
+        let envp_storage: Vec<CString> = command
+            .environment
+            .iter()
+            .map(|(key, value)| {
+                CString::new(format!("{key}={value}")).map_err(|_| Error::InvalidCommand)
+            })
+            .collect::<Result<_, _>>()?;
+
+        let mut argv = Vec::with_capacity(argv_storage.len() + 2);
+        argv.push(program.as_ptr().cast_mut());
+        argv.extend(argv_storage.iter().map(|value| value.as_ptr().cast_mut()));
+        argv.push(std::ptr::null_mut());
+
+        let mut envp: Vec<*mut libc::c_char> = envp_storage
+            .iter()
+            .map(|value| value.as_ptr().cast_mut())
+            .collect();
+        envp.push(std::ptr::null_mut());
+
+        Ok(Self {
+            program,
+            cwd,
+            dev_null,
+            _argv_storage: argv_storage,
+            _envp_storage: envp_storage,
+            argv,
+            envp,
+        })
+    }
+}
+
+/// A pipe pair that closes both ends unless explicitly disarmed.
+struct Pipe {
+    read: RawFd,
+    write: RawFd,
+}
+
+impl Pipe {
+    fn new() -> Result<Self, Error> {
+        let mut fds = [0; 2];
+        // `O_CLOEXEC` so a descriptor can never survive into the exec'd image;
+        // the child still inherits them across `fork`, which is what we want.
+        if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
+            return Err(Error::Io(io::Error::last_os_error()));
+        }
+        Ok(Self {
+            read: fds[0],
+            write: fds[1],
+        })
+    }
+
+    fn take_read(&mut self) -> RawFd {
+        std::mem::replace(&mut self.read, -1)
+    }
+
+    fn close_read(&mut self) {
+        close_if_open(&mut self.read);
+    }
+
+    fn close_write(&mut self) {
+        close_if_open(&mut self.write);
+    }
+}
+
+impl Drop for Pipe {
+    fn drop(&mut self) {
+        self.close_read();
+        self.close_write();
+    }
+}
+
+fn close_if_open(fd: &mut RawFd) {
+    if *fd >= 0 {
+        unsafe { libc::close(*fd) };
+        *fd = -1;
+    }
+}
+
+/// Production spawn seam: the child is placed in `cgroup` and the placement is
+/// verified before it is allowed to `execve`.
+pub struct NativeCgroupSpawn;
+
+impl SpawnIntoCgroup for NativeCgroupSpawn {
+    fn spawn_into_cgroup(
+        &mut self,
+        cgroup: RawFd,
+        _: &Invocation,
+        command: &CommandSpec,
+    ) -> Result<ChildProcess, Error> {
+        command.validate()?;
+        let prepared = PreparedExec::new(command)?;
+
+        let mut out = Pipe::new()?;
+        let mut err = Pipe::new()?;
+        let mut sync = Pipe::new()?;
+
+        // Everything above this line allocates; everything the child touches
+        // below it does not.
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            return Err(Error::SpawnDenied);
+        }
+        if pid == 0 {
+            // SAFETY: post-`fork` child. Only async-signal-safe libc calls and
+            // pre-allocated pointers are used, and every path terminates in
+            // `_exit` or `execve`.
+            unsafe { child_after_fork(&out, &err, &sync, &prepared) };
+        }
+
+        // ── Parent ──────────────────────────────────────────────────────────
+        out.close_write();
+        err.close_write();
+        let sync_read = sync.take_read();
+        unsafe { libc::close(sync_read) };
+
+        // Place the child, then PROVE it is placed. A write that silently did
+        // nothing is exactly the failure mode that shipped last time.
+        if let Err(error) = place_and_verify(cgroup, pid) {
+            // Closing the sync pipe without writing GO makes the child observe
+            // EOF and exit before `execve`: no command runs outside its quota.
+            sync.close_write();
+            reap(pid);
+            return Err(error);
+        }
+
+        let go = [GO];
+        let written = unsafe { libc::write(sync.write, go.as_ptr().cast(), 1) };
+        if written != 1 {
+            let error = Error::Io(io::Error::last_os_error());
+            sync.close_write();
+            reap(pid);
+            return Err(error);
+        }
+        sync.close_write();
+
+        for fd in [out.read, err.read] {
+            let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+            if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
+            {
+                // The child has already been released, so it is running and
+                // owned by nobody unless it is killed here. Returning without
+                // this would leak a process inside a leaf the caller is about
+                // to try to remove — and `remove` requires `populated 0`, so
+                // the leak would strand the reservation too.
+                let error = Error::Io(io::Error::last_os_error());
+                reap(pid);
+                return Err(error);
+            }
+        }
+
+        Ok(ChildProcess {
+            pid,
+            stdout: out.take_read(),
+            stderr: err.take_read(),
+        })
+    }
+}
+
+/// The post-`fork` child. Never returns.
+///
+/// # Safety
+///
+/// Must only be called in a freshly forked child. Every call below is
+/// async-signal-safe and every pointer was allocated by the parent.
+unsafe fn child_after_fork(out: &Pipe, err: &Pipe, sync: &Pipe, prepared: &PreparedExec) -> ! {
+    unsafe {
+        libc::close(out.read);
+        libc::close(err.read);
+        libc::close(sync.write);
+
+        // Stand at the gate. This is the ONLY work the child performs before it
+        // is inside the invocation cgroup, and it consumes no CPU.
+        let mut byte = [0_u8; 1];
+        let read = libc::read(sync.read, byte.as_mut_ptr().cast(), 1);
+        if read != 1 || byte[0] != GO {
+            // EOF (parent could not place us) or a corrupt handshake.
+            libc::_exit(EXIT_NOT_PLACED);
+        }
+        libc::close(sync.read);
+
+        let stdin = libc::open(prepared.dev_null.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC);
+        if stdin < 0 || libc::dup2(stdin, 0) < 0 {
+            libc::_exit(EXIT_PREPARATION_FAILED);
+        }
+        libc::close(stdin);
+        if libc::dup2(out.write, 1) < 0 || libc::dup2(err.write, 2) < 0 {
+            libc::_exit(EXIT_PREPARATION_FAILED);
+        }
+        libc::close(out.write);
+        libc::close(err.write);
+
+        // One kernel operation, no procfs iterator: enumerating `/proc/self/fd`
+        // owns a descriptor that the enumeration itself reports and then closes,
+        // leaving a stale fd for `prepare_child` to fail on.
+        if libc::syscall(libc::SYS_close_range, 3_u32, u32::MAX, 0_u32) != 0 {
+            libc::_exit(EXIT_PREPARATION_FAILED);
+        }
+
+        let mut syscalls = child::NativeChildSyscalls;
+        if child::prepare_child(&mut syscalls, &[], &ChildMounts::isolated()).is_err() {
+            libc::_exit(EXIT_PREPARATION_FAILED);
+        }
+        if libc::chdir(prepared.cwd.as_ptr()) != 0 {
+            libc::_exit(EXIT_PREPARATION_FAILED);
+        }
+        libc::execve(
+            prepared.program.as_ptr(),
+            prepared.argv.as_ptr().cast(),
+            prepared.envp.as_ptr().cast(),
+        );
+        libc::_exit(EXIT_PREPARATION_FAILED)
+    }
+}
+
+/// Write `pid` into `cgroup`'s `cgroup.procs`, then read it back and confirm.
+///
+/// The read-back is the point. A `cpu.max` written on a leaf the child is not
+/// actually in governs nothing, and that failure is invisible from the leaf's
+/// configuration — it only shows up as a build that is mysteriously not
+/// throttled. Verifying membership makes the silent variant impossible.
+fn place_and_verify(cgroup: RawFd, pid: i32) -> Result<(), Error> {
+    write_cgroup_procs(cgroup, pid)?;
+    verify_placement(cgroup, pid)
+}
+
+fn write_cgroup_procs(cgroup: RawFd, pid: i32) -> Result<(), Error> {
+    let name = CString::new("cgroup.procs").map_err(|_| Error::UnsafeLeafName)?;
+    let fd = unsafe {
+        libc::openat(
+            cgroup,
+            name.as_ptr(),
+            libc::O_WRONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(Error::CgroupPlacementFailed {
+            pid,
+            errno: errno(),
+        });
+    }
+    let text = pid.to_string();
+    let bytes = text.as_bytes();
+    let written = unsafe { libc::write(fd, bytes.as_ptr().cast(), bytes.len()) };
+    let error = errno();
+    unsafe { libc::close(fd) };
+    if written != bytes.len() as isize {
+        return Err(Error::CgroupPlacementFailed { pid, errno: error });
+    }
+    Ok(())
+}
+
+/// Read `cgroup.procs` back and require `pid` to be a member.
+fn verify_placement(cgroup: RawFd, pid: i32) -> Result<(), Error> {
+    let name = CString::new("cgroup.procs").map_err(|_| Error::UnsafeLeafName)?;
+    let fd = unsafe {
+        libc::openat(
+            cgroup,
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(Error::CgroupPlacementFailed {
+            pid,
+            errno: errno(),
+        });
+    }
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let count = unsafe { libc::read(fd, chunk.as_mut_ptr().cast(), chunk.len()) };
+        if count < 0 {
+            let error = errno();
+            unsafe { libc::close(fd) };
+            return Err(Error::CgroupPlacementFailed { pid, errno: error });
+        }
+        if count == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..count as usize]);
+    }
+    unsafe { libc::close(fd) };
+
+    let member = String::from_utf8_lossy(&bytes)
+        .split_ascii_whitespace()
+        .any(|entry| entry.parse::<i32>() == Ok(pid));
+    if member {
+        Ok(())
+    } else {
+        Err(Error::ChildNotInInvocationCgroup { pid })
+    }
+}
+
+/// Reap a child that will never exec. Best effort: a child blocked on the sync
+/// pipe exits as soon as it sees EOF, so this returns promptly.
+fn reap(pid: i32) {
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+        let mut status = 0;
+        libc::waitpid(pid, &raw mut status, 0);
+    }
+}
+
+fn errno() -> i32 {
+    io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn command(program: &str) -> CommandSpec {
+        CommandSpec {
+            program: program.to_owned(),
+            argv: vec![],
+            cwd: "/workspace".to_owned(),
+            environment: vec![],
+        }
+    }
+
+    fn invocation() -> Invocation {
+        Invocation {
+            id: "spawn-test".to_owned(),
+            fence: 1,
+        }
+    }
+
+    #[test]
+    fn the_deny_seam_never_starts_a_process() {
+        assert!(matches!(
+            DenySpawn.spawn_into_cgroup(3, &invocation(), &command("/bin/true")),
+            Err(Error::SpawnDenied)
+        ));
+    }
+
+    /// A cgroup descriptor that cannot accept a `cgroup.procs` write must fail
+    /// the spawn **and** leave no process behind, because the child stands at
+    /// the gate until the parent has proven placement.
+    ///
+    /// This is the negative control for the whole seam: if placement were
+    /// assumed rather than verified, this would return a running child.
+    #[test]
+    fn an_unplaceable_child_never_execs_and_leaves_no_process() {
+        // A real directory that is emphatically not a cgroup: `openat` of
+        // `cgroup.procs` inside it fails with ENOENT.
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("djinn-spawn-unplaceable-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("create scratch dir");
+        let raw = CString::new(base.to_string_lossy().as_bytes()).expect("path");
+        let dir = unsafe {
+            libc::open(
+                raw.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+            )
+        };
+        assert!(dir >= 0, "open scratch dir");
+
+        // `/bin/true` would exit 0 instantly if it ever ran; it must not run.
+        let result = NativeCgroupSpawn.spawn_into_cgroup(dir, &invocation(), &command("/bin/true"));
+        unsafe { libc::close(dir) };
+        let _ = std::fs::remove_dir_all(&base);
+
+        match result {
+            Err(Error::CgroupPlacementFailed { errno, .. }) => {
+                assert_eq!(
+                    errno,
+                    libc::ENOENT,
+                    "a non-cgroup directory has no cgroup.procs"
+                );
+            }
+            Err(other) => panic!("expected a named placement failure, got: {other}"),
+            Ok(child) => {
+                reap(child.pid);
+                panic!(
+                    "a child was started into a cgroup it could not be placed in; the \
+                     no-unthrottled-interval property is broken"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_malformed_command_is_rejected_before_any_fork() {
+        let mut malformed = command("/bin/true");
+        malformed.program = "/bin/../sh".to_owned();
+        assert!(matches!(
+            NativeCgroupSpawn.spawn_into_cgroup(-1, &invocation(), &malformed),
+            Err(Error::InvalidCommand)
+        ));
+    }
+
+    /// Every `execve` argument is built before `fork`, so the child path
+    /// performs no allocation. Asserted on the prepared block itself because a
+    /// post-fork allocation is a deadlock, not a test failure.
+    #[test]
+    fn exec_arguments_are_fully_prepared_in_the_parent() {
+        let spec = CommandSpec {
+            program: "/bin/echo".to_owned(),
+            argv: vec!["one".to_owned(), "two".to_owned()],
+            cwd: "/workspace".to_owned(),
+            environment: vec![("PATH".to_owned(), "/usr/bin".to_owned())],
+        };
+        let prepared = PreparedExec::new(&spec).expect("prepare");
+        assert_eq!(prepared.program.to_str().unwrap(), "/bin/echo");
+        assert_eq!(prepared.cwd.to_str().unwrap(), "/workspace");
+        // argv0 + two arguments + NULL.
+        assert_eq!(prepared.argv.len(), 4);
+        assert!(prepared.argv.last().unwrap().is_null());
+        // one entry + NULL.
+        assert_eq!(prepared.envp.len(), 2);
+        assert!(prepared.envp.last().unwrap().is_null());
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/src/transport.rs
+++ b/server/crates/djinn-cgroup-launcher/src/transport.rs
@@ -1,6 +1,6 @@
 //! Bounded Unix socket transport for authenticated broker controls.
 use crate::{
-    CgroupFs, CloneIntoCgroup, CommandSpec, CpuStat, Error, Invocation,
+    CgroupFs, CommandSpec, CpuStat, Error, Invocation, SpawnIntoCgroup,
     broker::{Broker, ConnectionId, ControlNonce, NonceSource, SocketPeer, WORKER_GID, WORKER_UID},
     child::WorkerReadinessAssertion,
 };
@@ -34,7 +34,7 @@ pub struct UnixBrokerServer<F, S, N = crate::broker::OsNonceSource> {
     listener: Option<UnixListener>,
     socket_path: Option<PathBuf>,
 }
-impl<F: CgroupFs, S: CloneIntoCgroup, N: NonceSource> UnixBrokerServer<F, S, N> {
+impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> UnixBrokerServer<F, S, N> {
     pub fn new(broker: Broker<F, S, N>) -> Self {
         Self {
             broker,
@@ -536,7 +536,7 @@ fn cpu_in(x: &[u8]) -> Result<CpuStat, Error> {
 mod tests {
     use super::*;
     use crate::{
-        CgroupMode, ChildProcess, CloneIntoCgroup, Invocation, Launcher, LauncherConfig, Readiness,
+        CgroupMode, ChildProcess, Invocation, Launcher, LauncherConfig, Readiness, SpawnIntoCgroup,
         broker::{BrokerConfig, NonceSource},
     };
     use std::{
@@ -603,8 +603,8 @@ mod tests {
         counts: Counts,
         outcome: Outcome,
     }
-    impl CloneIntoCgroup for ForkClone {
-        fn clone_into_cgroup(
+    impl SpawnIntoCgroup for ForkClone {
+        fn spawn_into_cgroup(
             &mut self,
             _: RawFd,
             _: &Invocation,
@@ -704,15 +704,15 @@ mod tests {
         }
     }
     struct NoClone(Counts);
-    impl CloneIntoCgroup for NoClone {
-        fn clone_into_cgroup(
+    impl SpawnIntoCgroup for NoClone {
+        fn spawn_into_cgroup(
             &mut self,
             _: RawFd,
             _: &Invocation,
             _: &CommandSpec,
         ) -> Result<ChildProcess, Error> {
             self.0.clones.fetch_add(1, Ordering::SeqCst);
-            Err(Error::CloneDenied)
+            Err(Error::SpawnDenied)
         }
     }
     struct TestNonces(u8);
@@ -722,11 +722,11 @@ mod tests {
             Ok(crate::broker::ControlNonce::from_bytes([self.0; 32]))
         }
     }
-    fn broker<S: CloneIntoCgroup>(counts: Counts, clone: S) -> Broker<FakeFs, S, TestNonces> {
+    fn broker<S: SpawnIntoCgroup>(counts: Counts, clone: S) -> Broker<FakeFs, S, TestNonces> {
         let launcher = Launcher::new(
             FakeFs(counts),
             clone,
-            LauncherConfig::new(None, unsafe { libc::geteuid() }).unwrap(),
+            LauncherConfig::new(None, None, unsafe { libc::geteuid() }).unwrap(),
         )
         .unwrap();
         Broker::new(

--- a/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
@@ -23,8 +23,8 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use djinn_cgroup_launcher::{
-    CgroupFs, CgroupMode, ChildProcess, CloneIntoCgroup, CommandSpec, Error, Invocation, Launcher,
-    LauncherConfig, Readiness,
+    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
+    Readiness, SpawnIntoCgroup,
     broker::{
         Broker, BrokerConfig, OsNonceSource, PeerCredentials, UnixPeer, WORKER_GID, WORKER_UID,
     },
@@ -143,8 +143,8 @@ impl FakeClone {
         })))
     }
 }
-impl CloneIntoCgroup for FakeClone {
-    fn clone_into_cgroup(
+impl SpawnIntoCgroup for FakeClone {
+    fn spawn_into_cgroup(
         &mut self,
         _target: RawFd,
         _invocation: &Invocation,
@@ -153,7 +153,7 @@ impl CloneIntoCgroup for FakeClone {
         let mut state = self.0.borrow_mut();
         state.attempts += 1;
         if state.deny {
-            return Err(Error::CloneDenied);
+            return Err(Error::SpawnDenied);
         }
         Ok(ChildProcess {
             pid: 4242,
@@ -200,7 +200,7 @@ fn broker() -> Broker<FakeCgroup, FakeClone, OsNonceSource> {
     let launcher = Launcher::new(
         FakeCgroup::with_owner(0),
         FakeClone::allow(),
-        LauncherConfig::new(None, 0).expect("launcher config"),
+        LauncherConfig::new(None, None, 0).expect("launcher config"),
     )
     .expect("launcher");
     Broker::new(
@@ -244,7 +244,7 @@ fn ac2_daemon_and_double_fork_stay_in_one_cgroup_and_release_gates_on_populated_
     let mut launcher = Launcher::new(
         fs.clone(),
         clone.clone(),
-        LauncherConfig::new(None, 7).expect("config"),
+        LauncherConfig::new(None, None, 7).expect("config"),
     )
     .expect("launcher");
 
@@ -316,7 +316,7 @@ fn ac2_cleanup_after_kill_still_requires_empty_before_unlink() {
     let mut launcher = Launcher::new(
         fs.clone(),
         FakeClone::allow(),
-        LauncherConfig::new(None, 3).expect("config"),
+        LauncherConfig::new(None, None, 3).expect("config"),
     )
     .expect("launcher");
     let (mut leaf, _) = launcher
@@ -620,7 +620,7 @@ fn ac3_incompatible_readiness_profiles_and_missing_worker_readiness_fail_closed(
         let result = Launcher::new(
             FakeCgroup::with_readiness(readiness),
             FakeClone::allow(),
-            LauncherConfig::new(None, 7).expect("config"),
+            LauncherConfig::new(None, None, 7).expect("config"),
         );
         match result {
             Err(error) => assert!(expected(&error), "unexpected error {error:?}"),

--- a/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
@@ -1,0 +1,480 @@
+//! The end-to-end proof that the per-invocation CPU lease actually governs CPU.
+//!
+//! # Why this file exists (task 7deu)
+//!
+//! Every previous test of this component asserted *configuration*. The
+//! containment suite drives a `FakeCgroup` that hard-codes `root_writable:
+//! true` — the exact property that was false in production. The clone seam was
+//! faked, so a flag constant that silently truncated to zero (making every
+//! "contained" child an ordinary fork in the launcher's own cgroup) passed
+//! everything. And the render tests read `cpu.max` back, which reports what was
+//! written, not what the kernel enforces: with a 250m limit on the launcher
+//! container, a leaf configured for four cores measured 0.25 core and reported
+//! `nr_throttled 0`, because the throttling happened at the ancestor.
+//!
+//! So this file asserts **behaviour, measured over a known wall-clock window**:
+//!
+//! 1. the launcher establishes its own delegated cgroup2 root by `mount(2)`;
+//! 2. it drops `CAP_SYS_ADMIN`/`CAP_SYS_RESOURCE` and **cannot mount again**;
+//! 3. a real child, spawned by the production seam, is a member of the
+//!    invocation leaf;
+//! 4. unleased, it burns *approximately the unleased quota* — two-sided, so it
+//!    fails both if the child escaped the cgroup (usage ≈ 0) and if the quota
+//!    did not bite (usage ≈ 2 cores), and `nr_throttled` is non-zero, which is
+//!    what makes throttle-based heavy detection possible at all;
+//! 5. after a fenced lift it burns *multiples more* in the same window and stops
+//!    being throttled;
+//! 6. a sibling leaf with no child accounts for nothing, so the measurement is
+//!    attributing CPU to the right cgroup.
+//!
+//! Nothing here can pass vacuously. There is no `FakeCgroup`, no fake clone, no
+//! environment probe that returns "not applicable", and no assertion on a value
+//! this crate itself wrote.
+//!
+//! # Where it runs
+//!
+//! It needs uid 0 and a real cgroup-v2 hierarchy it may mount and delegate, so
+//! the proof is `#[ignore]`d for ordinary unprivileged runs and executed by the
+//! `launcher-kernel-boundary` CI lane. [`the_lease_lifecycle_lane_is_wired`] is
+//! NOT ignored and fails the ordinary shard if that lane stops running this
+//! binary — a proof nobody executes looks exactly like a proof that passed.
+//!
+//! # Why it is a single proof
+//!
+//! Step 2 is irreversible: once the launcher has `capset`ed `CAP_SYS_ADMIN`
+//! away, nothing later in the same process can mount anything. Splitting this
+//! into several `#[test]`s sharing one process would make all but the first
+//! fail for a reason that has nothing to do with what they assert.
+
+use std::ffi::CString;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use djinn_cgroup_launcher::bootstrap::{Bootstrap, INIT_LEAF, holds_any_bootstrap_capability};
+use djinn_cgroup_launcher::{
+    CommandSpec, CpuStat, Invocation, Launcher, LauncherConfig, LeasedQuota, NativeCgroupFs,
+    NativeCgroupSpawn, UnleasedQuota,
+};
+
+/// The workflow job that must execute the `#[ignore]`d proof below.
+const PRIVILEGED_LANE_JOB: &str = "launcher-kernel-boundary";
+/// Marker the lane uses to declare how many lease proofs it expects to execute.
+const EXPECTED_PROOFS_KEY: &str = "LEASE_LIFECYCLE_EXPECTED_PROOFS";
+
+/// Wall-clock window each measurement is taken over. Long enough that CFS period
+/// boundaries (100ms) average out, short enough to keep the lane quick.
+const WINDOW: Duration = Duration::from_secs(2);
+/// Unleased quota under test: the shipped default.
+const UNLEASED_MILLICORES: u16 = UnleasedQuota::DEFAULT_MILLICORES;
+/// Leased quota under test: the shipped default, four cores.
+const LEASED_MILLICORES: u32 = LeasedQuota::DEFAULT_MILLICORES;
+/// How many busy loops the probe command runs. Two, so that a lifted leaf can
+/// demonstrably exceed one core while staying inside a four-core lease.
+const SPINNERS: u64 = 2;
+
+// ═══════════════════ always-on: the lane cannot silently skip ════════════════
+
+/// The privileged lane must run THIS binary, with `--ignored`, without
+/// swallowing its failure, and must declare how many proofs it expects.
+#[test]
+fn the_lease_lifecycle_lane_is_wired() {
+    let source = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/delegated_cpu_lease_lifecycle.rs"),
+    )
+    .expect("read this test file to count its privileged proofs");
+    // Only attributes at the start of a line; prose mentions are backticked.
+    let declared = source.matches("\n#[ignore").count();
+    assert!(
+        declared > 0,
+        "this file must declare a privileged proof; an empty suite proves nothing"
+    );
+
+    let lane = privileged_lane_block();
+    assert!(
+        lane.contains("--test delegated_cpu_lease_lifecycle"),
+        "the privileged lane must run THIS test binary, or the only behavioural proof that the \
+         lease governs CPU never executes"
+    );
+    assert!(
+        !lane.contains("continue-on-error"),
+        "the privileged lane may not swallow its own failure"
+    );
+    assert!(
+        lane.contains(&format!("{EXPECTED_PROOFS_KEY}: \"{declared}\"")),
+        "the lane must declare `{EXPECTED_PROOFS_KEY}: \"{declared}\"` so a run that executes \
+         fewer than the {declared} declared proofs fails instead of passing"
+    );
+}
+
+/// The quotas this proof measures are the ones the launcher crate ships, so a
+/// change to either default cannot leave the measurement asserting a number
+/// nobody uses.
+#[test]
+fn the_measured_quotas_are_the_shipped_defaults() {
+    assert_eq!(UNLEASED_MILLICORES, 250);
+    assert_eq!(LEASED_MILLICORES, 4_000);
+    // And the lease must actually be a lift, or every expectation below is
+    // meaningless.
+    assert!(u32::from(UNLEASED_MILLICORES) < LEASED_MILLICORES);
+    LauncherConfig::new(Some(UNLEASED_MILLICORES), Some(LEASED_MILLICORES), 0)
+        .expect("the measured configuration must be one the launcher accepts");
+}
+
+// ══════════════════ privileged proof: the lease governs CPU ══════════════════
+
+/// Mount, delegate, drop the capability, throttle, lift — all measured.
+#[ignore = "privileged: needs uid 0 and a cgroup-v2 hierarchy it may mount and delegate \
+            (CI job launcher-kernel-boundary)"]
+#[test]
+fn the_delegated_lease_throttles_and_lifts_measured_on_cpu_stat() {
+    require_root();
+    let root = scratch_dir("lease-lifecycle");
+
+    // ── 1. The launcher establishes its own delegated root ──────────────────
+    //
+    // This is the step an `emptyDir` could never perform and the reason the
+    // sidecar CrashLoopBackOffed on every task-run Pod. It also drops the
+    // bootstrap capabilities on the way out.
+    Bootstrap::new(&root).run().unwrap_or_else(|error| {
+        panic!(
+            "the launcher could not establish its delegated cgroup root at {}: {error}. If this \
+             is `enable the cpu controller`, the host's parent cgroup does not offer `cpu` to \
+             its children and the lease cannot be proven here.",
+            root.display()
+        )
+    });
+
+    // ── 2. …and can no longer mount anything ────────────────────────────────
+    assert!(
+        !holds_any_bootstrap_capability().expect("read this process's capability set"),
+        "CAP_SYS_ADMIN survived bootstrap; a task-run pod holding it has a node-wide escape \
+         primitive (/proc/sys/kernel/core_pattern is not namespaced)"
+    );
+    let second = scratch_dir("post-drop-mount");
+    let errno = try_mount_cgroup2(&second);
+    assert_eq!(
+        errno,
+        Some(libc::EPERM),
+        "after the capability drop a second cgroup2 mount must fail with EPERM; it returned \
+         {errno:?}, so the drop did not take"
+    );
+    let _ = std::fs::remove_dir_all(&second);
+
+    // The launcher's own process is out of the mount root, which is what the
+    // "no internal process" rule requires before `+cpu` can be delegated.
+    assert!(
+        root.join(INIT_LEAF).is_dir(),
+        "bootstrap must vacate the delegated root into an init leaf"
+    );
+    assert_eq!(
+        read_trimmed(&root.join("cgroup.subtree_control")),
+        "cpu",
+        "the delegated root must enable exactly the cpu controller"
+    );
+    assert_eq!(
+        read_trimmed(&root.join("cgroup.procs")),
+        "",
+        "the delegated root must hold no processes of its own"
+    );
+
+    // ── 3. The real launcher, over the real filesystem seam ─────────────────
+    let fs = NativeCgroupFs::open(&root, 0)
+        .expect("the root the launcher just established must satisfy its own readiness contract");
+    let mut launcher = Launcher::new(
+        fs,
+        NativeCgroupSpawn,
+        LauncherConfig::new(Some(UNLEASED_MILLICORES), Some(LEASED_MILLICORES), 0)
+            .expect("launcher config"),
+    )
+    .expect("launcher");
+
+    let invocation = Invocation {
+        id: "lease-lifecycle".to_owned(),
+        fence: 0x7de_u64,
+    };
+    let (mut leaf, child) = launcher
+        .create_command("leased", invocation, &spinner_command())
+        .expect("spawn the probe command into an invocation leaf");
+
+    // A sibling that never gets a child. It is the control for step 6.
+    let idle_invocation = Invocation {
+        id: "idle".to_owned(),
+        fence: 1,
+    };
+    let (idle_leaf, idle_child) = launcher
+        .create_command("idle", idle_invocation, &sleep_command())
+        .expect("spawn the idle control");
+
+    // ── 4. Membership, then the unleased measurement ────────────────────────
+    let members = read_trimmed(&root.join("leased").join("cgroup.procs"));
+    assert!(
+        members
+            .split_ascii_whitespace()
+            .any(|entry| entry.parse::<i32>() == Ok(child.pid)),
+        "child {} is not a member of the invocation leaf (members: {members:?}); its CPU would \
+         be governed by nothing at all",
+        child.pid
+    );
+
+    let unleased = measure(&mut launcher, &leaf, WINDOW);
+    let expected_unleased = quota_usec(u32::from(UNLEASED_MILLICORES), unleased.wall);
+    assert!(
+        unleased.usage_usec > expected_unleased / 2,
+        "the leaf accounted for only {} usec over {:?}; {SPINNERS} busy loops inside a {}m quota \
+         must burn roughly {expected_unleased} usec. A near-zero reading means the child is not \
+         actually in this cgroup — which is exactly what a silently-truncated clone flag looked \
+         like.",
+        unleased.usage_usec,
+        unleased.wall,
+        UNLEASED_MILLICORES
+    );
+    assert!(
+        unleased.usage_usec < expected_unleased * 2,
+        "the leaf accounted for {} usec over {:?}, far above the {}m quota's {expected_unleased} \
+         usec. The quota is not being enforced — which is what an ancestor CPU limit on the \
+         launcher container produced: the leaf said four cores and the kernel gave 0.25.",
+        unleased.usage_usec,
+        unleased.wall,
+        UNLEASED_MILLICORES
+    );
+    assert!(
+        unleased.nr_throttled > 0,
+        "the unleased leaf reported nr_throttled 0. Throttling is happening somewhere else — at \
+         an ancestor — so throttle-based heavy detection is structurally blind, which is the \
+         defect this task exists to remove."
+    );
+
+    // ── 5. The fenced lift, measured the same way ───────────────────────────
+    launcher
+        .fenced_lift(&mut leaf, 0x7de_u64)
+        .expect("a matching fence must lift the quota");
+
+    let leased = measure(&mut launcher, &leaf, WINDOW);
+    assert!(
+        leased.usage_usec > unleased.usage_usec * 3,
+        "after the lift the leaf burned {} usec against {} unleased over comparable windows. A \
+         lift that does not multiply throughput is a lift in name only — the ancestor is still \
+         clamping.",
+        leased.usage_usec,
+        unleased.usage_usec
+    );
+    let ceiling = quota_usec(LEASED_MILLICORES, leased.wall);
+    assert!(
+        leased.usage_usec <= ceiling,
+        "after the lift the leaf burned {} usec, above the {}m lease's {ceiling} usec ceiling \
+         over {:?}. The lift must raise the quota, not remove it: an unbounded leaf lets one \
+         build take the whole node.",
+        leased.usage_usec,
+        LEASED_MILLICORES,
+        leased.wall
+    );
+    assert_eq!(
+        leased.nr_throttled, 0,
+        "{SPINNERS} busy loops cannot saturate a {LEASED_MILLICORES}m lease, so the lifted leaf \
+         must stop being throttled entirely"
+    );
+
+    // The numbers themselves, on the lane's log, so a human reviewing an arm
+    // decision sees measured throughput rather than a green tick. `println!` is
+    // denied workspace-wide, so this goes through `Write` explicitly.
+    {
+        use std::io::Write;
+        let _ = writeln!(
+            std::io::stdout(),
+            "7deu measured: unleased {} usec / nr_throttled {} over {:?}; \
+             leased {} usec / nr_throttled {} over {:?}; ratio {:.2}x",
+            unleased.usage_usec,
+            unleased.nr_throttled,
+            unleased.wall,
+            leased.usage_usec,
+            leased.nr_throttled,
+            leased.wall,
+            leased.usage_usec as f64 / unleased.usage_usec.max(1) as f64,
+        );
+    }
+
+    // ── 6. The control: an idle sibling accounts for essentially nothing ────
+    let idle = measure(&mut launcher, &idle_leaf, Duration::from_millis(250));
+    assert!(
+        idle.usage_usec < expected_unleased / 4,
+        "a leaf whose only child is asleep accounted for {} usec; the measurement is not \
+         attributing CPU to the cgroup that earned it",
+        idle.usage_usec
+    );
+
+    // ── Teardown: cgroup-wide kill, drain, unlink ───────────────────────────
+    for (leaf, pid) in [(&mut leaf, child.pid), (&mut { idle_leaf }, idle_child.pid)] {
+        launcher.kill(leaf).expect("cgroup.kill");
+        let drained = (0..200).any(|_| {
+            if launcher.wait_empty(leaf).is_ok() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+            false
+        });
+        assert!(drained, "leaf {} never reached populated 0", leaf.name());
+        launcher.remove(leaf).expect("remove the drained leaf");
+        reap(pid);
+    }
+}
+
+// ─────────────────────────────── measurement ────────────────────────────────
+
+/// One measured window: the CPU the leaf actually accrued, and how long the
+/// wall clock really ran for.
+struct Measured {
+    usage_usec: u64,
+    nr_throttled: u64,
+    wall: Duration,
+}
+
+/// Sample `cpu.stat`, sleep, sample again, and return the delta.
+///
+/// Deltas, not absolutes: the leaf has already been running while the previous
+/// phase was measured, and the wall clock is the one actually observed rather
+/// than the one requested, so a slow runner widens the expectation instead of
+/// failing it.
+fn measure<F, S>(
+    launcher: &mut Launcher<F, S>,
+    leaf: &djinn_cgroup_launcher::Leaf,
+    window: Duration,
+) -> Measured
+where
+    F: djinn_cgroup_launcher::CgroupFs,
+    S: djinn_cgroup_launcher::SpawnIntoCgroup,
+{
+    let before: CpuStat = launcher.sample(leaf).expect("sample cpu.stat");
+    // Real monotonic time is the point: the whole assertion is CPU consumed per
+    // unit of WALL CLOCK. An injected clock would make the measurement describe
+    // itself rather than the kernel, which is the failure mode this file exists
+    // to eliminate.
+    #[allow(clippy::disallowed_methods)]
+    let started = Instant::now();
+    std::thread::sleep(window);
+    let elapsed = started.elapsed();
+    let after: CpuStat = launcher.sample(leaf).expect("sample cpu.stat");
+    Measured {
+        usage_usec: after.usage_usec.saturating_sub(before.usage_usec),
+        nr_throttled: after.nr_throttled.saturating_sub(before.nr_throttled),
+        wall: elapsed,
+    }
+}
+
+/// CPU microseconds a `millicores` quota permits over `wall`, capped by how much
+/// the probe command could possibly consume ([`SPINNERS`] cores).
+fn quota_usec(millicores: u32, wall: Duration) -> u64 {
+    let wall_usec = wall.as_micros() as u64;
+    let permitted = wall_usec * u64::from(millicores) / 1000;
+    permitted.min(wall_usec * SPINNERS)
+}
+
+// ──────────────────────────────── commands ──────────────────────────────────
+
+/// [`SPINNERS`] shell busy loops. Deliberately a shell builtin loop: no binary
+/// to locate, no allocation, and it saturates whatever quota it is given.
+fn spinner_command() -> CommandSpec {
+    CommandSpec {
+        program: "/bin/sh".to_owned(),
+        argv: vec![
+            "-c".to_owned(),
+            "while : ; do : ; done & while : ; do : ; done".to_owned(),
+        ],
+        cwd: "/workspace".to_owned(),
+        environment: vec![],
+    }
+}
+
+/// A child that exists but consumes nothing — the control for the measurement.
+fn sleep_command() -> CommandSpec {
+    CommandSpec {
+        program: "/bin/sleep".to_owned(),
+        argv: vec!["60".to_owned()],
+        cwd: "/workspace".to_owned(),
+        environment: vec![],
+    }
+}
+
+// ───────────────────────────────── helpers ──────────────────────────────────
+
+fn require_root() {
+    let euid = unsafe { libc::geteuid() };
+    assert_eq!(
+        euid, 0,
+        "the delegated lease proof must run as uid 0 (uid {euid} cannot mount cgroup2). It runs \
+         in the `{PRIVILEGED_LANE_JOB}` CI lane; reproduce it locally with: \
+         `cargo test -p djinn-cgroup-launcher --test delegated_cpu_lease_lifecycle --no-run` \
+         then `docker run --rm --privileged --cgroupns=private -v \"$PWD:$PWD\" ubuntu:24.04 \
+         bash -c 'mkdir -p /workspace && exec \"$0\" --ignored --test-threads 1' <the binary>`"
+    );
+    assert!(
+        Path::new("/workspace").is_dir(),
+        "/workspace is missing: the rendered CommandSpec cwd must exist before a child can exec \
+         (the privileged lane creates it)"
+    );
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let base = PathBuf::from(format!("/tmp/djinn-7deu-{label}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).expect("create scratch dir");
+    base
+}
+
+/// Attempt a `cgroup2` mount and return the errno if it failed.
+fn try_mount_cgroup2(target: &Path) -> Option<i32> {
+    use std::os::unix::ffi::OsStrExt;
+    let target = CString::new(target.as_os_str().as_bytes()).expect("path");
+    let fstype = CString::new("cgroup2").expect("literal");
+    let rc = unsafe {
+        libc::mount(
+            fstype.as_ptr(),
+            target.as_ptr(),
+            fstype.as_ptr(),
+            0,
+            std::ptr::null(),
+        )
+    };
+    (rc != 0).then(|| std::io::Error::last_os_error().raw_os_error().unwrap_or(0))
+}
+
+fn read_trimmed(path: &Path) -> String {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+        .trim()
+        .to_owned()
+}
+
+fn reap(pid: i32) {
+    let mut status = 0;
+    unsafe { libc::waitpid(pid, &raw mut status, libc::WNOHANG) };
+}
+
+/// The privileged lane's own YAML block, isolated from sibling jobs.
+fn privileged_lane_block() -> String {
+    let workflow = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../..")
+            .join(".github/workflows/quality-gate.yml"),
+    )
+    .expect("read the CI workflow that must host the privileged lane");
+    let header = format!("\n  {PRIVILEGED_LANE_JOB}:\n");
+    let start = workflow.find(&header).unwrap_or_else(|| {
+        panic!(
+            "no `{PRIVILEGED_LANE_JOB}` job: the only behavioural proof that the CPU lease \
+             governs CPU would never execute, and an unproven lease looks identical to a \
+             working one"
+        )
+    }) + 1;
+    // Everything up to the next sibling job key (exactly two-space indent).
+    let mut block = String::new();
+    for (index, line) in workflow[start..].lines().enumerate() {
+        let sibling_job =
+            line.starts_with("  ") && !line.starts_with("   ") && line.trim_end().ends_with(':');
+        if index > 0 && sibling_job {
+            break;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+    block
+}

--- a/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
+++ b/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
@@ -26,13 +26,20 @@ worker_run_as_non_root=true
 worker_allow_privilege_escalation=false
 worker_capabilities_drop=ALL
 
-# Launcher sidecar: privileged broker, minimal capabilities, read-only rootfs.
+# Launcher sidecar: privileged broker, read-only rootfs. SYS_ADMIN and
+# SYS_RESOURCE are BOOTSTRAP-ONLY — the launcher `capset`s them out of its
+# permitted, effective, inheritable and bounding sets once the delegated cgroup
+# root is established, before the broker binds its control socket. The names
+# carry no `CAP_` prefix because the API server rejects that spelling alongside
+# allowPrivilegeEscalation: false.
 launcher_run_as_user=0
 launcher_run_as_group=0
 launcher_allow_privilege_escalation=false
 launcher_read_only_root_filesystem=true
 launcher_capabilities_drop=ALL
-launcher_capabilities_add=SETUID,SETGID,SETPCAP
+launcher_capabilities_add=SETUID,SETGID,SETPCAP,SYS_ADMIN,SYS_RESOURCE
+launcher_bootstrap_only_capabilities=SYS_ADMIN,SYS_RESOURCE
+launcher_host_users=false
 
 # Launcher-spawned child: applied at runtime by `child::prepare_child`, not by
 # the Pod manifest (there is no manifest field for a process the kubelet never
@@ -50,5 +57,6 @@ pod_fs_group_change_policy=OnRootMismatch
 seccomp_profile=RuntimeDefault
 launcher_expected_uid=0
 unleased_millicores=250
+leased_millicores=4000
 cgroup_delegation_profile=cgroup-v2-cpu-only
 volume_ownership_mode=fsgroup-on-root-mismatch

--- a/server/crates/djinn-cgroup-launcher/tests/kernel_boundary_under_rendered_context.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/kernel_boundary_under_rendered_context.rs
@@ -42,8 +42,8 @@ use std::path::Path;
 use djinn_cgroup_launcher::broker::{WORKER_GID, WORKER_UID};
 use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
 use djinn_cgroup_launcher::{
-    ChildProcess, CloneIntoCgroup, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
-    NativeCgroupFs, UnleasedQuota,
+    ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig, NativeCgroupFs,
+    SpawnIntoCgroup, UnleasedQuota,
 };
 
 use rendered_boundary::{
@@ -390,8 +390,8 @@ fn an_incompatible_volume_ownership_mode_rejects_the_spawn_before_exec() {
 
     /// A clone seam that must never be reached.
     struct NeverClone;
-    impl CloneIntoCgroup for NeverClone {
-        fn clone_into_cgroup(
+    impl SpawnIntoCgroup for NeverClone {
+        fn spawn_into_cgroup(
             &mut self,
             _: std::os::fd::RawFd,
             _: &Invocation,
@@ -421,7 +421,7 @@ fn an_incompatible_volume_ownership_mode_rejects_the_spawn_before_exec() {
     let error = Launcher::new(
         fs,
         NeverClone,
-        LauncherConfig::new(None, foreign_uid).expect("launcher config"),
+        LauncherConfig::new(None, None, foreign_uid).expect("launcher config"),
     )
     .err()
     .expect("an incompatible ownership mode must reject the launcher");

--- a/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
@@ -7,8 +7,9 @@
 //!                           UnixBrokerServer over a real Unix socket
 //!   forked worker (1000)  = the trusted, non-dumpable worker: real
 //!                           SO_PEERCRED authentication, real controls
-//!   launched child (1001) = born by clone3(CLONE_INTO_CGROUP) into the
-//!                           invocation cgroup, then through the production
+//!   launched child (1001) = forked, placed in the invocation cgroup by a
+//!                           `cgroup.procs` write and released only once the
+//!                           placement holds, then through the production
 //!                           close_range + `child::prepare_child` boundary
 //! ```
 //!
@@ -29,8 +30,8 @@ use djinn_cgroup_launcher::child::{
 };
 use djinn_cgroup_launcher::transport::{UnixBrokerClient, UnixBrokerServer};
 use djinn_cgroup_launcher::{
-    ChildProcess, CloneIntoCgroup, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
-    NativeCgroupFs, NativeClone3,
+    ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig, NativeCgroupFs,
+    NativeCgroupSpawn, SpawnIntoCgroup,
 };
 
 /// Invocation whose child is the in-cgroup adversary rather than an exec.
@@ -44,7 +45,13 @@ pub const LEGIT_FENCE: u64 = 0x5a5a_f13d;
 /// `cpu.max` an unleased invocation must carry (250m of a 100ms period).
 pub const UNLEASED_CPU_MAX: &str = "25000 100000";
 /// `cpu.max` after a matching fencing token lifts the quota.
-pub const LIFTED_CPU_MAX: &str = "max 100000";
+///
+/// Task 7deu: this used to be `"max 100000"`, i.e. no quota at all. That was
+/// only ever harmless because an ancestor still clamped it — the launcher
+/// container's own 250m CPU limit. With that limit removed (it was what made the
+/// whole feature a no-op) an unbounded lift would let one build take the entire
+/// node, so the lift now writes the pod's declared CPU budget.
+pub const LIFTED_CPU_MAX: &str = "400000 100000";
 
 // ───────────────────────────── rendered context ─────────────────────────────
 
@@ -542,10 +549,10 @@ struct Probes {
 
 /// Clone seam that births a real UID-1001 adversary inside the invocation
 /// cgroup. Every other invocation is delegated to the production
-/// `NativeClone3`, so the legitimate and exec'd children take the shipped path.
+/// `NativeCgroupSpawn`, so the legitimate and exec'd children take the shipped path.
 pub struct AdversaryClone {
     report: RawFd,
-    delegate: NativeClone3,
+    delegate: NativeCgroupSpawn,
     probes: Probes,
 }
 
@@ -581,7 +588,7 @@ impl AdversaryClone {
         ];
         Self {
             report,
-            delegate: NativeClone3,
+            delegate: NativeCgroupSpawn,
             probes: Probes {
                 worker_pid,
                 proc_paths,
@@ -596,20 +603,43 @@ impl AdversaryClone {
     }
 }
 
-impl CloneIntoCgroup for AdversaryClone {
-    fn clone_into_cgroup(
+impl SpawnIntoCgroup for AdversaryClone {
+    fn spawn_into_cgroup(
         &mut self,
         cgroup: RawFd,
         invocation: &Invocation,
         command: &CommandSpec,
     ) -> Result<ChildProcess, Error> {
         if invocation.id != ATTACK_INVOCATION {
-            return self.delegate.clone_into_cgroup(cgroup, invocation, command);
+            return self.delegate.spawn_into_cgroup(cgroup, invocation, command);
         }
-        let pid = clone3_into_cgroup(cgroup)?;
+        let (go_read, go_write) = pipe();
+        let pid = unsafe { libc::fork() };
+        if pid < 0 {
+            return Err(Error::SpawnDenied);
+        }
         if pid == 0 {
+            unsafe { libc::close(go_write) };
+            // Stand at the gate exactly as the production child does: no work
+            // whatsoever until the parent has placed us in the invocation
+            // cgroup and said so.
+            let mut byte = [0_u8; 1];
+            let read = unsafe { libc::read(go_read, byte.as_mut_ptr().cast(), 1) };
+            if read != 1 {
+                unsafe { libc::_exit(91) };
+            }
+            unsafe { libc::close(go_read) };
             attack(&self.probes, self.report, cgroup);
         }
+        unsafe { libc::close(go_read) };
+        place_in_cgroup(cgroup, pid).expect("place the adversary in the invocation cgroup");
+        let go = [b'G'];
+        assert_eq!(
+            unsafe { libc::write(go_write, go.as_ptr().cast(), 1) },
+            1,
+            "release the adversary once it is inside the invocation cgroup"
+        );
+        unsafe { libc::close(go_write) };
         Ok(ChildProcess {
             pid,
             stdout: -1,
@@ -619,7 +649,7 @@ impl CloneIntoCgroup for AdversaryClone {
 }
 
 /// Runs in the freshly cloned child. It crosses the production isolation and
-/// credential boundary exactly as `NativeClone3` does — `close_range` over
+/// credential boundary exactly as `NativeCgroupSpawn` does — `close_range` over
 /// every inherited descriptor (sparing only stdio and the report pipe) then
 /// `prepare_child` — and only then attacks the worker.
 fn attack(probes: &Probes, report: RawFd, cgroup: RawFd) -> ! {
@@ -801,47 +831,29 @@ fn connect_unix(path: &CString) -> i64 {
     i64::from(rc)
 }
 
-/// `clone3(CLONE_INTO_CGROUP)` — the same birth the production seam performs,
-/// so the adversary really is a direct child of the invocation cgroup.
-fn clone3_into_cgroup(cgroup: RawFd) -> Result<i32, Error> {
-    #[repr(C)]
-    struct Args {
-        flags: u64,
-        pidfd: u64,
-        child_tid: u64,
-        parent_tid: u64,
-        exit_signal: u64,
-        stack: u64,
-        stack_size: u64,
-        tls: u64,
-        set_tid: u64,
-        set_tid_size: u64,
-        cgroup: u64,
+/// Place `pid` in the invocation cgroup by writing `cgroup.procs` — the same
+/// placement the production seam performs, so the adversary really is a member
+/// of the invocation cgroup and the boundary being proven is the shipped one.
+///
+/// Task 7deu: this used to be `clone3(CLONE_INTO_CGROUP)`. Proving a boundary
+/// with a spawn mechanism production does not use proves the wrong thing, and
+/// the `clone3` flag constant this harness took from `libc` was the one that
+/// silently truncated to zero.
+fn place_in_cgroup(cgroup: RawFd, pid: i32) -> std::io::Result<()> {
+    let name = CString::new("cgroup.procs").expect("literal");
+    let fd = unsafe { libc::openat(cgroup, name.as_ptr(), libc::O_WRONLY | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
     }
-    let args = Args {
-        flags: libc::CLONE_INTO_CGROUP as u64,
-        pidfd: 0,
-        child_tid: 0,
-        parent_tid: 0,
-        exit_signal: libc::SIGCHLD as u64,
-        stack: 0,
-        stack_size: 0,
-        tls: 0,
-        set_tid: 0,
-        set_tid_size: 0,
-        cgroup: cgroup as u64,
-    };
-    let pid = unsafe {
-        libc::syscall(
-            libc::SYS_clone3,
-            &raw const args,
-            std::mem::size_of::<Args>(),
-        )
-    } as i32;
-    if pid < 0 {
-        return Err(Error::CloneDenied);
+    let text = pid.to_string();
+    let written = unsafe { libc::write(fd, text.as_ptr().cast(), text.len()) };
+    let error = std::io::Error::last_os_error();
+    unsafe { libc::close(fd) };
+    if written == text.len() as isize {
+        Ok(())
+    } else {
+        Err(error)
     }
-    Ok(pid)
 }
 
 // ───────────────────────────── broker plumbing ──────────────────────────────
@@ -859,12 +871,16 @@ pub fn serve_broker(
         .get("unleased_millicores")
         .parse()
         .expect("rendered unleased millicores");
+    let leased: u32 = context
+        .get("leased_millicores")
+        .parse()
+        .expect("rendered leased millicores");
     let fs = NativeCgroupFs::open(&environment.root, expected_uid)
         .unwrap_or_else(|e| panic!("delegated cgroup readiness: {e}"));
     let launcher = Launcher::new(
         fs,
         AdversaryClone::new(environment, worker_pid, report),
-        LauncherConfig::new(Some(unleased), expected_uid).expect("launcher config"),
+        LauncherConfig::new(Some(unleased), Some(leased), expected_uid).expect("launcher config"),
     )
     .expect("launcher");
     let broker = Broker::new(

--- a/server/crates/djinn-cgroup-launcher/tests/startup_readiness_contract.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/startup_readiness_contract.rs
@@ -1,20 +1,25 @@
 //! Startup readiness contract, on a real kernel, with no fakes and no gate.
 //!
-//! Task grkq: the launcher's two hard startup preconditions — a delegated root
-//! that really is a cgroup v2 tree, and a reachable `clone3(CLONE_INTO_CGROUP)`
-//! — must fail LOUDLY and BEFORE the broker binds its control socket, rather
-//! than surfacing later as an opaque per-command spawn error.
+//! Task grkq/7deu: the launcher's hard startup preconditions — a delegated root
+//! it can establish, a capability set it can shed, and a spawn seam that really
+//! places a child in the leaf — must fail LOUDLY and BEFORE the broker binds its
+//! control socket, rather than surfacing later as an opaque per-command error.
 //!
 //! The containment suite next door drives a `FakeCgroup`, so it can prove what
 //! the launcher does with a readiness value but never whether the launcher can
 //! *derive* a truthful one from an actual directory. That gap is what let a
 //! non-cgroup "delegated root" ship. These tests close it using the real
-//! `NativeCgroupFs`/`NativeClone3` against real filesystem objects, which needs
-//! no privileges and therefore runs in the ordinary test lane.
+//! `NativeCgroupFs`/`Bootstrap`/`NativeCgroupSpawn` against real filesystem
+//! objects, which needs no privileges and therefore runs in the ordinary test
+//! lane.
 
 use std::path::PathBuf;
 
-use djinn_cgroup_launcher::{CGROUP2_SUPER_MAGIC, Error, NativeCgroupFs, NativeClone3};
+use djinn_cgroup_launcher::bootstrap::Bootstrap;
+use djinn_cgroup_launcher::{
+    CGROUP2_SUPER_MAGIC, CommandSpec, Error, Invocation, NativeCgroupFs, NativeCgroupSpawn,
+    SpawnIntoCgroup,
+};
 
 /// Per-test scratch directory under the crate's test tmpdir.
 struct Scratch(PathBuf);
@@ -93,40 +98,84 @@ fn the_filesystem_type_check_precedes_the_controller_check() {
     );
 }
 
-/// The child-spawn seam is probed at startup. On an ordinary test host `clone3`
-/// is reachable, so the preflight passes — and, critically, it does so WITHOUT
-/// forking: a preflight that leaked a process would be worse than no preflight.
+/// The startup bootstrap is what turns the rendered mountpoint into a delegated
+/// cgroup2 root. Unprivileged, `mount(2)` is denied — and that has to surface as
+/// a NAMED readiness failure naming the path and the errno, not as an opaque
+/// EPERM discovered per-command after the pod has taken work.
+///
+/// Task 7deu: this replaces the `clone3` preflight. The launcher no longer has a
+/// syscall-availability dependency to probe — `fork(2)` and `write(2)` are not
+/// intercepted by any profile in use — so the only startup precondition left is
+/// whether the delegated root can be established at all.
 #[test]
-fn the_clone3_preflight_passes_on_a_reachable_kernel_without_forking() {
-    let before = std::process::id();
-    NativeClone3::preflight().expect(
-        "clone3(CLONE_INTO_CGROUP) must be reachable on the test host; if this fails the \
-         sandbox running the tests denies clone3, which is exactly the condition the \
-         preflight exists to report",
-    );
-    assert_eq!(
-        std::process::id(),
-        before,
-        "the preflight must never fork; a returning child would corrupt the test process"
-    );
+fn an_unprivileged_bootstrap_is_a_named_readiness_failure_carrying_the_errno() {
+    if unsafe { libc::geteuid() } == 0 {
+        // The privileged lane proves the succeeding path; here there is nothing
+        // to assert about a root that is allowed to mount.
+        return;
+    }
+    let scratch = Scratch::new("bootstrap");
+    let root = scratch.0.join("delegated");
+
+    let error = Bootstrap::new(&root)
+        .run()
+        .expect_err("an unprivileged process cannot mount cgroup2");
+
+    match error {
+        Error::CgroupMountFailed { path, errno } => {
+            assert_eq!(path, root.display().to_string());
+            assert_eq!(errno, libc::EPERM);
+            let rendered = Error::CgroupMountFailed { path, errno }.to_string();
+            assert!(
+                rendered.contains("CAP_SYS_ADMIN"),
+                "the operator must be told which capability is missing: {rendered}"
+            );
+        }
+        other => panic!("expected a named mount failure, got: {other}"),
+    }
 }
 
-/// A denied seam is reported as its own named error carrying the errno, so the
-/// operator sees "clone3 is blocked" rather than a generic launch failure. This
-/// is the shape a `seccompProfile: RuntimeDefault` sandbox produces (that
-/// profile answers `clone3` with `ENOSYS`).
+/// The spawn seam verifies cgroup membership instead of assuming it, and a
+/// child it cannot place never reaches `execve`.
+///
+/// This is the always-on, unprivileged half of the no-unthrottled-interval
+/// proof: the privileged lane measures `cpu.stat` on a real leaf, and this
+/// asserts that a failed placement is refused by name rather than producing a
+/// running child whose CPU nothing governs. The shipped `clone3` seam could not
+/// fail this way — it passed a flag that truncated to zero, so every child was
+/// an ordinary fork that silently stayed in the launcher's own cgroup.
 #[test]
-fn a_denied_clone3_is_a_named_readiness_failure_carrying_the_errno() {
-    let denied = Error::Clone3Unavailable {
-        errno: libc::ENOSYS,
+fn a_child_that_cannot_be_placed_is_refused_by_name_and_never_execs() {
+    let scratch = Scratch::new("placement");
+    let raw = std::ffi::CString::new(scratch.0.to_string_lossy().as_bytes()).expect("path");
+    let not_a_cgroup = unsafe {
+        libc::open(
+            raw.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
     };
-    let message = denied.to_string();
-    assert!(
-        message.contains("clone3") && message.contains(&libc::ENOSYS.to_string()),
-        "a denied child-spawn seam must name itself and its errno: {message}"
-    );
-    assert!(
-        message.contains("child-spawn"),
-        "the message must say why it is fatal: {message}"
-    );
+    assert!(not_a_cgroup >= 0, "open the scratch directory");
+
+    let command = CommandSpec {
+        // Would exit 0 instantly if it ever ran.
+        program: "/bin/true".to_owned(),
+        argv: vec![],
+        cwd: "/workspace".to_owned(),
+        environment: vec![],
+    };
+    let invocation = Invocation {
+        id: "readiness".to_owned(),
+        fence: 1,
+    };
+    let result = NativeCgroupSpawn.spawn_into_cgroup(not_a_cgroup, &invocation, &command);
+    unsafe { libc::close(not_a_cgroup) };
+
+    match result {
+        Err(Error::CgroupPlacementFailed { errno, .. }) => assert_eq!(errno, libc::ENOENT),
+        Err(other) => panic!("expected a named placement failure, got: {other}"),
+        Ok(_) => panic!(
+            "a child was started into a directory that is not a cgroup; its CPU would be \
+             governed by nothing at all"
+        ),
+    }
 }

--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -24,6 +24,7 @@ use djinn_k8s::{
     WarmAdmission, WarmAdmissionError, WarmAdmissionPermit, WarmAdmissionRequest,
     WarmAdmissionTransition,
 };
+use djinn_runtime::RoleResourceClass;
 use tokio::sync::{Mutex, Notify};
 
 /// Policy applied at the coordinator admission boundary.
@@ -88,20 +89,41 @@ pub fn validate_admission_config(v0: V0Mode, v1: V1Mode, cap: i64) -> Result<(),
     Ok(())
 }
 
-/// Typed classification captured before dispatch; only the audited bypass weighs zero.
+/// Typed classification captured before dispatch. Two classes weigh zero: the
+/// explicitly audited [`BuildWorkloadKind::NonBuild`] bypass, and a task-run
+/// whose role is [`RoleResourceClass::Light`] (see [`TaskRunRole`]).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BuildWorkloadKind {
     TaskRun {
         role: TaskRunRole,
     },
     GraphWarmJob,
-    /// Explicit, auditable non-build work. This is the only zero-slot class.
+    /// Explicit, auditable non-build work.
     NonBuild {
         audit_reason: &'static str,
     },
 }
 
-/// All currently dispatchable task-run roles are build-producing work.
+/// Audit reason recorded when a Light (orchestration-only) task-run is admitted
+/// without reserving a build slot.
+///
+/// Distinct and greppable on purpose: it is the single string that explains why
+/// an admitted task-run left no journal row behind.
+pub const LIGHT_ROLE_AUDIT_REASON: &str =
+    "light role: orchestration-only, never runs the project toolchain";
+
+/// Every task-run role the coordinator can dispatch.
+///
+/// These roles are NOT uniformly build-producing. Only Worker and Architect
+/// (and Verifier, which is an in-pod stage — see [`TaskRunRole::parse`]) run the
+/// project's compile/test toolchain; Planner, Reviewer, Lead and the refinement
+/// tribunal (Advocate/Adversary/Judge) are orchestration-only. The distinction
+/// is owned by [`djinn_runtime::RoleResourceClass`] — the single classifier
+/// shared with `djinn-k8s` pod sizing — and reached here through
+/// [`TaskRunRole::resource_class`]. Admission consumes a build slot only for
+/// [`RoleResourceClass::BuildCapable`]: with a production cap of 3 on a 12-vCPU
+/// node, charging a Planner or a tribunal round a slot would queue it behind
+/// builds it never competes with and collapse throughput.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TaskRunRole {
     Worker,
@@ -116,6 +138,20 @@ pub enum TaskRunRole {
 
 impl TaskRunRole {
     /// Classify a known coordinator role. Unknown and missing values fail closed.
+    ///
+    /// There is deliberately no `"verifier"` arm. `djinn_runtime::RoleKind`
+    /// carries a `Verifier`, but it is an IN-POD supervisor stage, not a
+    /// coordinator dispatch role: `djinn_roles::AgentType` has no `Verifier`
+    /// variant, `RoleRegistry::new` registers none, and the agent maps
+    /// `RoleKind::Verifier` back onto `AgentType::Worker`
+    /// (`djinn-agent/src/actors/slot/lifecycle/role_overrides.rs`,
+    /// `djinn-agent/src/supervisor_impl/stage.rs`). Every production caller of
+    /// `admit_task_run` passes either a `RoleRegistry` dispatch role, the literal
+    /// `"planner"` (`dispatch/retry.rs`), or a refinement `agent_type`
+    /// (`advocate`/`adversary`/`judge`) — never `"verifier"`. A verifier's
+    /// compile therefore runs inside a Worker task-run that already holds a slot.
+    /// If a verifier ever becomes separately dispatchable it must be added here
+    /// as build-capable; until then adding it would be dead classification.
     #[must_use]
     pub fn parse(value: Option<&str>) -> Option<Self> {
         match value {
@@ -129,6 +165,32 @@ impl TaskRunRole {
             Some("judge") => Some(Self::Judge),
             _ => None,
         }
+    }
+
+    /// Canonical lowercase dispatch-role string; the exact inverse of
+    /// [`Self::parse`], which the round-trip test locks.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Worker => "worker",
+            Self::Reviewer => "reviewer",
+            Self::Lead => "lead",
+            Self::Planner => "planner",
+            Self::Architect => "architect",
+            Self::Advocate => "advocate",
+            Self::Adversary => "adversary",
+            Self::Judge => "judge",
+        }
+    }
+
+    /// Whether this role's task-run may run the project's compile/test toolchain.
+    ///
+    /// Delegates to [`djinn_runtime::RoleResourceClass`] rather than keeping a
+    /// second table here: pod sizing and build admission must never disagree
+    /// about what "light" means.
+    #[must_use]
+    pub fn resource_class(self) -> RoleResourceClass {
+        RoleResourceClass::for_role_name(self.as_str())
     }
 }
 
@@ -683,7 +745,42 @@ impl BuildAdmissionController {
             .disk_capacity_source()
             .is_some()
             .then(|| request.clone());
-        let workload_kind = match request.kind {
+        let kind = request.kind;
+        let workload_kind = match kind {
+            // A Light task-run is orchestration-only: it never runs the
+            // project's compile/test toolchain, so it weighs zero slots. It is
+            // admitted the same way the audited NonBuild bypass is — a permit
+            // with no journal reservation, via `permit_without_reservation` —
+            // which means it can never be Denied at the cap and its terminal
+            // transition is a no-op that cannot touch occupancy (the permit is
+            // recorded `durable: false`, and occupancy is always derived from
+            // the journal, never from in-memory permits). Warm builds and every
+            // build-capable role fall through and reserve normally; an unknown
+            // role never reaches here at all (`admit_task_run` rejects it as
+            // Unclassified before constructing the request).
+            BuildWorkloadKind::TaskRun { role } if !role.resource_class().consumes_build_slot() => {
+                let key = AdmissionJournalKey {
+                    domain: request.domain,
+                    work_id: request.work_id,
+                    generation: request.generation,
+                };
+                let permit_key = permit_key(&key);
+                if let Some(permit) = self.permits_by_key.lock().await.get(&permit_key).cloned() {
+                    return Ok(BuildAdmissionDecision::Permitted {
+                        permit,
+                        idempotent: true,
+                    });
+                }
+                tracing::debug!(
+                    role = role.as_str(),
+                    resource_class = role.resource_class().as_str(),
+                    audit_reason = LIGHT_ROLE_AUDIT_REASON,
+                    "build admission: zero-slot task-run permitted without reservation"
+                );
+                return self
+                    .permit_without_reservation(key, permit_key, request.object_name)
+                    .await;
+            }
             BuildWorkloadKind::TaskRun { .. } => match request.domain {
                 AdmissionDomain::TaskObservation => AdmissionWorkloadKind::Task,
                 AdmissionDomain::InvocationBuild => AdmissionWorkloadKind::Invocation,

--- a/server/crates/djinn-coordinator/src/build_admission_light_role_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_light_role_tests.rs
@@ -1,0 +1,391 @@
+//! Light (orchestration-only) task-run roles must never consume a build slot.
+//!
+//! Task `h1yv` (folded into `7deu`). The production cap is 3 concurrent build
+//! task-runs on a 12-vCPU node. Planners, Reviewers, Leads and the refinement
+//! tribunal (Advocate/Adversary/Judge) never run the project's compile/test
+//! toolchain, so charging them a slot would queue them behind builds they never
+//! compete with and collapse throughput.
+//!
+//! These tests are deterministic: an in-memory journal, an explicit cap, and
+//! durable occupancy read back from the journal rather than inferred.
+
+use std::sync::Arc;
+
+use djinn_db::{AdmissionDomain, AdmissionJournalRepository, Database};
+use djinn_k8s::{WarmAdmission, WarmAdmissionTransition};
+use djinn_runtime::RoleResourceClass;
+
+use crate::build_admission::{
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, TaskRunRole,
+};
+
+/// Every role the coordinator can dispatch, in the order `TaskRunRole` declares
+/// them. Kept in sync with the enum by
+/// [`task_run_role_classification_matches_runtime_resource_class`], whose
+/// exhaustive match fails to compile when a variant is added.
+const ALL_ROLES: &[TaskRunRole] = &[
+    TaskRunRole::Worker,
+    TaskRunRole::Reviewer,
+    TaskRunRole::Lead,
+    TaskRunRole::Planner,
+    TaskRunRole::Architect,
+    TaskRunRole::Advocate,
+    TaskRunRole::Adversary,
+    TaskRunRole::Judge,
+];
+
+/// The role names the light class must cover, spelled as the dispatch layer
+/// spells them: `RoleRegistry` dispatch roles plus refinement `agent_type`s.
+const LIGHT_ROLE_NAMES: &[&str] = &[
+    "planner",
+    "reviewer",
+    "lead",
+    "advocate",
+    "adversary",
+    "judge",
+];
+
+fn controller(mode: BuildAdmissionMode, cap: i64) -> Arc<BuildAdmissionController> {
+    let controller = BuildAdmissionController::new(
+        Arc::new(AdmissionJournalRepository::new(
+            Database::open_in_memory().unwrap(),
+        )),
+        mode,
+        cap,
+        "light-role-test-epoch",
+    );
+    controller.mark_ready();
+    Arc::new(controller)
+}
+
+async fn admit(
+    controller: &BuildAdmissionController,
+    role: Option<&str>,
+    work_id: &str,
+) -> BuildAdmissionDecision {
+    controller
+        .admit_task_run(
+            role,
+            AdmissionDomain::TaskObservation,
+            work_id.to_owned(),
+            0,
+            format!("task-run-{work_id}-0"),
+        )
+        .await
+        .expect("admission decision")
+}
+
+async fn occupancy(controller: &BuildAdmissionController) -> i64 {
+    controller
+        .journal()
+        .count_task_or_warm_occupancy()
+        .await
+        .expect("durable occupancy")
+}
+
+/// THE regression. Cap = 1, a build-capable worker already holds the only slot,
+/// Enforce mode: every light role must still be Permitted. Before the resource
+/// class existed each of these was Denied and left its task queued behind a
+/// build it was never going to compete with.
+#[tokio::test]
+async fn light_roles_are_permitted_while_a_build_holds_the_only_slot() {
+    let controller = controller(BuildAdmissionMode::Enforce, 1);
+
+    let holder = match admit(&controller, Some("worker"), "build-holder").await {
+        BuildAdmissionDecision::Permitted { permit, .. } => permit,
+        other => panic!("a worker must take the only slot, got {other:?}"),
+    };
+    assert_eq!(occupancy(&controller).await, 1);
+
+    // Control: a second build-capable task-run IS denied at the same cap, so
+    // the light permits below are not passing for a trivial reason.
+    assert!(
+        matches!(
+            admit(&controller, Some("worker"), "second-build").await,
+            BuildAdmissionDecision::Denied {
+                occupancy: 1,
+                cap: 1
+            }
+        ),
+        "a second build-capable task-run must be denied at cap 1"
+    );
+    assert!(
+        matches!(
+            admit(&controller, Some("architect"), "second-architect").await,
+            BuildAdmissionDecision::Denied { .. }
+        ),
+        "the architect compiles and must be denied at cap 1"
+    );
+
+    for role in LIGHT_ROLE_NAMES {
+        let decision = admit(&controller, Some(role), &format!("light-{role}")).await;
+        assert!(
+            matches!(decision, BuildAdmissionDecision::Permitted { .. }),
+            "light role {role} must be permitted while the cap is fully consumed, got {decision:?}"
+        );
+        assert_eq!(
+            occupancy(&controller).await,
+            1,
+            "light role {role} must not add durable occupancy"
+        );
+    }
+
+    // The build slot is still exactly the worker's, and releasing it hands the
+    // slot to the next build — the light admissions changed nothing.
+    controller
+        .transition(&holder, WarmAdmissionTransition::CreateStarted)
+        .await
+        .unwrap();
+    controller
+        .transition(
+            &holder,
+            WarmAdmissionTransition::Live {
+                uid: "holder-uid".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+    controller
+        .transition(
+            &holder,
+            WarmAdmissionTransition::Terminal {
+                uid: "holder-uid".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(occupancy(&controller).await, 0);
+    assert!(matches!(
+        admit(&controller, Some("worker"), "second-build").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+}
+
+/// A light permit's full lifecycle — including the terminal transition — must
+/// be a no-op against occupancy. After N light permits are taken and released,
+/// a build-capable admit sees exactly the occupancy it would have seen had the
+/// light permits never existed.
+#[tokio::test]
+async fn light_permit_lifecycle_does_not_corrupt_build_occupancy() {
+    // Reference run: no light traffic at all.
+    let reference = controller(BuildAdmissionMode::Enforce, 2);
+    let _reference_build = match admit(&reference, Some("worker"), "ref-build").await {
+        BuildAdmissionDecision::Permitted { permit, .. } => permit,
+        other => panic!("reference build must be permitted, got {other:?}"),
+    };
+    let expected = occupancy(&reference).await;
+    assert_eq!(expected, 1);
+
+    // Same run, with light permits taken and fully released in between.
+    let controller = controller(BuildAdmissionMode::Enforce, 2);
+    let mut light_permits = Vec::new();
+    for (index, role) in LIGHT_ROLE_NAMES.iter().enumerate() {
+        match admit(&controller, Some(role), &format!("light-{index}")).await {
+            BuildAdmissionDecision::Permitted { permit, .. } => light_permits.push(permit),
+            other => panic!("light role {role} must be permitted, got {other:?}"),
+        }
+    }
+    assert_eq!(
+        occupancy(&controller).await,
+        0,
+        "light permits must reserve nothing"
+    );
+
+    for (index, permit) in light_permits.iter().enumerate() {
+        let uid = format!("light-uid-{index}");
+        // Every transition the dispatch path drives must succeed on a light
+        // permit — it is registered in the controller's permit map, so this is
+        // a clean no-op rather than an UnknownPermit error.
+        controller
+            .transition(permit, WarmAdmissionTransition::CreateStarted)
+            .await
+            .expect("light permit accepts CreateStarted");
+        controller
+            .transition(permit, WarmAdmissionTransition::Live { uid: uid.clone() })
+            .await
+            .expect("light permit accepts Live");
+        controller
+            .transition(permit, WarmAdmissionTransition::Terminal { uid })
+            .await
+            .expect("light permit accepts Terminal");
+    }
+    assert_eq!(
+        occupancy(&controller).await,
+        0,
+        "releasing light permits must not push occupancy negative or leak rows"
+    );
+
+    let _build = match admit(&controller, Some("worker"), "ref-build").await {
+        BuildAdmissionDecision::Permitted { permit, .. } => permit,
+        other => panic!("build must be permitted after light traffic, got {other:?}"),
+    };
+    assert_eq!(
+        occupancy(&controller).await,
+        expected,
+        "light permits must leave build occupancy identical to the reference run"
+    );
+
+    // The remaining slot is still real: one more build fits, a third does not.
+    assert!(matches!(
+        admit(&controller, Some("worker"), "second-build").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+    assert!(
+        matches!(
+            admit(&controller, Some("worker"), "third-build").await,
+            BuildAdmissionDecision::Denied { .. }
+        ),
+        "the zero-slot class must not widen the effective cap"
+    );
+}
+
+/// A light admission is idempotent on the same task generation: a retry returns
+/// the SAME permit rather than minting a second one, matching how a reserved
+/// build-capable permit replays.
+#[tokio::test]
+async fn light_admission_is_idempotent_for_the_same_generation() {
+    let controller = controller(BuildAdmissionMode::Enforce, 1);
+    let first = match admit(&controller, Some("planner"), "planner-task").await {
+        BuildAdmissionDecision::Permitted { permit, idempotent } => {
+            assert!(!idempotent, "the first light admission is not a replay");
+            permit
+        }
+        other => panic!("planner must be permitted, got {other:?}"),
+    };
+    match admit(&controller, Some("planner"), "planner-task").await {
+        BuildAdmissionDecision::Permitted { permit, idempotent } => {
+            assert!(idempotent, "a light retry must report itself as a replay");
+            assert_eq!(permit, first, "a light retry must return the same permit");
+        }
+        other => panic!("planner retry must be permitted, got {other:?}"),
+    }
+    assert_eq!(occupancy(&controller).await, 0);
+}
+
+/// The zero-slot class must not widen by accident: an unknown, empty or missing
+/// role is still Unclassified (fail-safe), never a free pass.
+#[tokio::test]
+async fn unknown_roles_still_fail_safe_and_get_no_free_pass() {
+    let controller = controller(BuildAdmissionMode::Enforce, 1);
+    // Fill the only slot so a "free pass" would be visible as a Permitted.
+    assert!(matches!(
+        admit(&controller, Some("worker"), "build-holder").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+
+    for role in [
+        Some("mystery"),
+        Some("verifier"),
+        Some("Planner"),
+        Some("grooming"),
+        Some(""),
+        None,
+    ] {
+        let decision = admit(&controller, role, "unknown-role-task").await;
+        assert!(
+            matches!(decision, BuildAdmissionDecision::Unclassified),
+            "role {role:?} must stay Unclassified, got {decision:?}"
+        );
+    }
+    assert_eq!(occupancy(&controller).await, 1);
+}
+
+/// Warm graph builds are unchanged: they still consume a slot.
+#[tokio::test]
+async fn graph_warm_jobs_still_consume_a_slot() {
+    let controller = controller(BuildAdmissionMode::Enforce, 1);
+    assert!(matches!(
+        admit(&controller, Some("planner"), "planner-task").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+    WarmAdmission::admit(
+        controller.as_ref(),
+        djinn_k8s::WarmAdmissionRequest {
+            domain: "ignored".into(),
+            work_id: "warm-one".into(),
+            generation: 0,
+            object_name: "warm-one-0".into(),
+        },
+    )
+    .await
+    .expect("the first warm build takes the slot");
+    assert_eq!(occupancy(&controller).await, 1);
+
+    let denied = WarmAdmission::admit(
+        controller.as_ref(),
+        djinn_k8s::WarmAdmissionRequest {
+            domain: "ignored".into(),
+            work_id: "warm-two".into(),
+            generation: 0,
+            object_name: "warm-two-0".into(),
+        },
+    )
+    .await;
+    assert!(
+        denied.is_err(),
+        "a warm build still competes for the cap: {denied:?}"
+    );
+}
+
+/// `TaskRunRole` must agree with `djinn_runtime::RoleResourceClass` for every
+/// variant. The match is exhaustive on purpose: adding a `TaskRunRole` variant
+/// without deciding its resource class fails to compile here rather than
+/// silently inheriting a default.
+#[test]
+fn task_run_role_classification_matches_runtime_resource_class() {
+    for role in ALL_ROLES {
+        let expected = match role {
+            // Runs the project's compile/test toolchain.
+            TaskRunRole::Worker | TaskRunRole::Architect => RoleResourceClass::BuildCapable,
+            // Orchestration-only.
+            TaskRunRole::Reviewer
+            | TaskRunRole::Lead
+            | TaskRunRole::Planner
+            | TaskRunRole::Advocate
+            | TaskRunRole::Adversary
+            | TaskRunRole::Judge => RoleResourceClass::Light,
+        };
+        assert_eq!(
+            role.resource_class(),
+            expected,
+            "{} disagrees with the runtime resource class",
+            role.as_str()
+        );
+        assert_eq!(
+            role.resource_class(),
+            RoleResourceClass::for_role_name(role.as_str()),
+            "{} must delegate to djinn_runtime, not a second local table",
+            role.as_str()
+        );
+        assert_eq!(
+            role.resource_class().consumes_build_slot(),
+            expected == RoleResourceClass::BuildCapable,
+            "{} slot consumption must follow its class",
+            role.as_str()
+        );
+    }
+}
+
+/// `as_str` is the exact inverse of `parse` for every variant, which is what
+/// makes delegating to `RoleResourceClass::for_role_name` sound.
+#[test]
+fn task_run_role_as_str_round_trips_through_parse() {
+    for role in ALL_ROLES {
+        assert_eq!(
+            TaskRunRole::parse(Some(role.as_str())),
+            Some(*role),
+            "{} must round-trip",
+            role.as_str()
+        );
+    }
+    // Every light dispatch-role name the coordinator can emit parses to a
+    // light variant.
+    for name in LIGHT_ROLE_NAMES {
+        let role = TaskRunRole::parse(Some(name)).expect("light role must classify");
+        assert_eq!(
+            role.resource_class(),
+            RoleResourceClass::Light,
+            "{name} must be light"
+        );
+    }
+}

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -8625,10 +8625,18 @@ mod build_admission_route_tests {
 
     // ─── AC1: Retry / planner-escalation route ────────────────────────────
 
-    /// Prove the planner-escalation dispatch route records an admission row
-    /// before the pool create.
+    /// Prove the planner-escalation dispatch route goes through build admission
+    /// and dispatches WITHOUT reserving a build slot.
+    ///
+    /// This test previously asserted the opposite (an occupying row before the
+    /// pool create). Task `h1yv` inverted it: a Planner is
+    /// [`djinn_runtime::RoleResourceClass::Light`] — orchestration-only, it
+    /// never runs the project's compile/test toolchain — so it is admitted with
+    /// a zero-slot permit and leaves no journal row. The route invariant that
+    /// still matters is that the escalation dispatches at all while a scarce cap
+    /// is in force, and that it adds nothing to durable occupancy.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn planner_escalation_route_reserves_before_pool_create() {
+    async fn planner_escalation_route_dispatches_without_consuming_a_build_slot() {
         let db = crate::test_helpers::create_test_db();
         let (events_tx, _events_rx) = tokio::sync::broadcast::channel(256);
         let fixture = seed_wnd1_ready_worker_tasks(&db, WND1_READY_TASK_COUNT).await;
@@ -8677,18 +8685,31 @@ mod build_admission_route_tests {
 
         let snapshot = runtime.snapshot(&dispatched_id);
         assert!(
-            snapshot.row_existed,
-            "planner-escalation route must have an admission row before the \
-             pool create fires"
+            !snapshot.row_existed,
+            "a light planner task-run must reserve no admission row"
+        );
+        assert_eq!(
+            snapshot.occupancy, 0,
+            "a light planner task-run must add nothing to build occupancy"
         );
 
-        // The review task's admission history must show exactly one generation.
+        // The review task leaves no admission history at all: nothing was
+        // reserved, so there is nothing to release.
         let history = journal
             .list_history(AdmissionDomain::TaskObservation, &dispatched_id)
             .await
             .expect("read planner admission history");
-        assert_eq!(history.len(), 1);
-        assert_eq!(history[0].state, AdmissionState::CreateUnknown);
+        assert!(
+            history.is_empty(),
+            "a light planner task-run writes no journal rows, got {history:?}"
+        );
+        assert_eq!(
+            journal
+                .count_task_or_warm_occupancy()
+                .await
+                .expect("read occupancy"),
+            0
+        );
 
         runtime.release(&dispatched_id).await;
     }

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -194,6 +194,8 @@ mod build_admission_integration_tests;
 #[cfg(test)]
 mod build_admission_inventory_tests;
 #[cfg(test)]
+mod build_admission_light_role_tests;
+#[cfg(test)]
 mod build_lease_integration_tests;
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_cap_tests.rs
@@ -10,8 +10,8 @@ use crate::types::{
 use djinn_core::events::{DjinnEventEnvelope, EventBus};
 use djinn_core::models::{Model, Pricing, Provider};
 use djinn_db::{
-    AdmissionDomain, AdmissionJournalRepository, AdmissionState, ProposalCreateInput,
-    ProposalRepository, SessionRepository, TaskRepository, UserRepository, UserSettingsRepository,
+    AdmissionDomain, AdmissionJournalRepository, ProposalCreateInput, ProposalRepository,
+    SessionRepository, TaskRepository, UserRepository, UserSettingsRepository,
 };
 use djinn_provider::catalog::CatalogService;
 use djinn_provider::catalog::health::HealthTracker;
@@ -545,22 +545,21 @@ async fn capacity_free_retry_dispatches_exactly_one_refinement() {
         .recv()
         .await
         .expect("controlled refinement create callback must execute");
-    assert_eq!(
-        create_time_history.len(),
-        1,
-        "one durable generation at create time"
-    );
-    assert_eq!(create_time_history[0].key.work_id, created_task_id);
+    // Task `h1yv`: the tribunal roles (advocate/adversary/judge) are
+    // `djinn_runtime::RoleResourceClass::Light` — orchestration-only, they never
+    // run the project's compile/test toolchain — so build admission grants a
+    // zero-slot permit and writes NO journal row. This assertion previously
+    // demanded one durable generation; the invariant that survives is that a
+    // tribunal round reserves nothing and occupies nothing. The user-model cap
+    // exercised by this test (AC#3) is a separate, still-enforced gate.
     assert!(
-        matches!(
-            create_time_history[0].state,
-            AdmissionState::CreateInFlight | AdmissionState::CreateUnknown
-        ),
-        "CreateStarted must be durable before the refinement pool create callback"
+        create_time_history.is_empty(),
+        "a light tribunal task-run must reserve no admission generation, got {create_time_history:?}"
     );
+    assert!(!created_task_id.is_empty(), "a refinement task was created");
     assert_eq!(
-        create_time_occupancy, 1,
-        "reservation occupies capacity at create time"
+        create_time_occupancy, 0,
+        "a light tribunal task-run occupies no build capacity at create time"
     );
 
     assert!(
@@ -593,17 +592,24 @@ async fn capacity_free_retry_dispatches_exactly_one_refinement() {
         "exactly one refinement task should exist"
     );
 
-    // The durable journal must be CreateStarted before the pool accepts the request.
+    // The durable journal stays empty: a light tribunal round never reserves,
+    // so there is nothing to make CreateStarted and nothing to release.
     let journal_rows = journal
         .list_history(AdmissionDomain::TaskObservation, &refinement_tasks[0].id)
         .await
         .expect("read refinement admission history");
-    assert_eq!(
-        journal_rows.len(),
-        1,
-        "refinement route reserves exactly one generation"
+    assert!(
+        journal_rows.is_empty(),
+        "a light refinement route writes no admission generation, got {journal_rows:?}"
     );
-    assert_eq!(journal_rows[0].state, AdmissionState::CreateUnknown);
+    assert_eq!(
+        journal
+            .count_task_or_warm_occupancy()
+            .await
+            .expect("count admission occupancy"),
+        0,
+        "a light refinement round consumes no build slot",
+    );
 
     // The state machine should have recorded one spawn.
     let state = &actor.active_refinements[&fixture.proposal_id];

--- a/server/crates/djinn-k8s/src/build_resources.rs
+++ b/server/crates/djinn-k8s/src/build_resources.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use djinn_stack::resources::{BuildResourceOverrides, Quantity};
 
 use crate::config::KubernetesConfig;
-use crate::launcher::RoleResourceClass;
+use crate::launcher::{RoleResourceClass, class_cpu_request};
 
 /// Administrator-configured per-kind hard bounds for a Pod kind's CPU and
 /// memory. Every bound is optional; `None` leaves that axis unbounded. Bounds
@@ -122,7 +122,7 @@ pub fn resolve_task_run_resources(
     bounds: &ResourceBounds,
 ) -> Result<ResourceRequirements, ResolveError> {
     resolve(
-        pick(cpu_request_of(overrides), class.cpu_request(config)),
+        pick(cpu_request_of(overrides), class_cpu_request(class, config)),
         pick(cpu_limit_of(overrides), &config.cpu_limit),
         pick(memory_request_of(overrides), &config.memory_request),
         pick(memory_limit_of(overrides), &config.memory_limit),
@@ -150,12 +150,32 @@ pub fn resolve_warm_resources(
 /// resolved requirements. Targets the `worker` (task-run) or `warmer` (warm)
 /// container.
 pub fn apply_resolved_resources(job: &mut Job, resources: ResourceRequirements) {
-    if let Some(spec) = job.spec.as_mut()
-        && let Some(pod) = spec.template.spec.as_mut()
-        && let Some(container) = pod
-            .containers
-            .iter_mut()
-            .find(|c| c.name == "worker" || c.name == "warmer")
+    let Some(pod) = job
+        .spec
+        .as_mut()
+        .and_then(|spec| spec.template.spec.as_mut())
+    else {
+        return;
+    };
+    // The lease ceiling must equal the CPU limit that was actually resolved,
+    // not the deployment default the sidecar was rendered from. A per-project
+    // `build_resources.task.cpu_limit` override lands HERE, after the render,
+    // so without this a project raising its limit to 8 would get a worker
+    // limit of 8 and a lease of 4 — the lease being the only ceiling that
+    // governs a build once the launcher container has no CPU limit of its own.
+    // Doing it at the same point as the override is what makes drift
+    // impossible (task 7deu).
+    if let Some(limit) = resources
+        .limits
+        .as_ref()
+        .and_then(|limits| limits.get("cpu"))
+    {
+        crate::launcher::retune_launcher_lease(pod, &limit.0);
+    }
+    if let Some(container) = pod
+        .containers
+        .iter_mut()
+        .find(|c| c.name == "worker" || c.name == "warmer")
     {
         container.resources = Some(resources);
     }

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -22,8 +22,9 @@ use djinn_supervisor::cargo_target_run_dir;
 
 use crate::config::KubernetesConfig;
 use crate::launcher::{
-    RoleResourceClass, launcher_ipc_volume, launcher_sidecar_container, pod_security_context,
-    worker_launcher_env, worker_launcher_ipc_mount, worker_resources, worker_security_context,
+    RoleResourceClass, launcher_cgroup_mountpoint_volume, launcher_ipc_volume,
+    launcher_sidecar_container, pod_host_users, pod_security_context, worker_launcher_env,
+    worker_launcher_ipc_mount, worker_resources, worker_security_context,
 };
 use crate::sidecar::{
     BackingServiceSpec, control_volume, control_volume_mount, sidecar_conn_env, sidecar_container,
@@ -444,17 +445,17 @@ pub fn build_task_run_job(
         crate::env_config::env_config_volume(project_id),
     ];
     if renders_launcher {
-        // Enforcement volume for the cgroup-launcher sidecar: `launcher-ipc`
-        // (Memory emptyDir) carries the broker control socket + worker-private
-        // credential (worker + launcher only).
-        //
-        // There is deliberately NO `launcher-cgroup` volume. The delegated
-        // cgroup root used to be rendered as a plain emptyDir, which is not a
-        // cgroup2 tree at all. It is not a volume at all in the goxi design:
-        // the launcher mounts cgroup2 itself inside its own cgroup namespace.
-        // See the note in `launcher.rs` where that builder used to live, and
-        // `CgroupLauncherMode` for the measured evidence.
+        // Enforcement volumes for the cgroup-launcher sidecar:
+        //   * `launcher-ipc` — Memory emptyDir carrying the broker control
+        //     socket + worker-private credential (worker + launcher only);
+        //   * `launcher-cgroup` — Memory emptyDir supplying a writable
+        //     MOUNTPOINT, not a delegated cgroup root. The delegation itself is
+        //     established by the launcher's own `mount(2)` inside its cgroup
+        //     namespace; no volume source can supply one, which is what task
+        //     grkq's P0 proved. `readOnlyRootFilesystem: true` is why the
+        //     mountpoint has to come from a volume at all.
         volumes.push(launcher_ipc_volume());
+        volumes.push(launcher_cgroup_mountpoint_volume());
     }
     // Backing-service sidecars share a Memory /dev/shm (Postgres needs more than
     // the 64Mi default). Added only when services are injected so the manifest
@@ -532,6 +533,13 @@ pub fn build_task_run_job(
         // then see the worker's `/proc` entries — so it is set only when the
         // launcher is actually rendered (task grkq).
         share_process_namespace: renders_launcher.then_some(true),
+        // User namespaces (GA since k8s 1.33). Set ONLY when the launcher is
+        // armed, because only then does a container in this pod hold
+        // CAP_SYS_ADMIN — and only for the launcher's bootstrap phase. Mapping
+        // it into a user namespace puts the non-namespaced sysctls that make it
+        // a node-wide escape primitive (`/proc/sys/kernel/core_pattern`) out of
+        // reach. See `launcher::pod_host_users`.
+        host_users: pod_host_users(config.cgroup_launcher_mode),
         // v1 leases security contract (qut0). The per-container securityContexts
         // set the UIDs now (worker=1000, launcher=0); the pod context ties
         // `fsGroup` to the artifact GID (1000) with `fsGroupChangePolicy:
@@ -3480,18 +3488,50 @@ mod tests {
                 .any(|v| v.name == crate::launcher::VOLUME_LAUNCHER_IPC),
             "the IPC volume renders when armed"
         );
-        // P0 REGRESSION GUARD (task grkq): the delegated cgroup root must NEVER
-        // be rendered as a volume again. The emptyDir that used to back it was
-        // not a cgroup2 tree, so the sidecar CrashLoopBackOffed on every pod; no
-        // volume source can supply a delegated cgroup v2 subtree here.
+        // P0 REGRESSION GUARD (tasks grkq → 7deu): the `launcher-cgroup` volume
+        // is a writable MOUNTPOINT, never a delegated cgroup root. An emptyDir
+        // used to be handed to the launcher AS the delegated root, which is not
+        // a cgroup2 tree, so the sidecar CrashLoopBackOffed on every pod. The
+        // volume must therefore be declared (or the volumeMount dangles and the
+        // API server rejects the manifest) AND be mounted only by the launcher,
+        // which then establishes the real delegation with its own `mount(2)`.
+        // `tests/rendered_launcher_delegation.rs` proves the distinction against
+        // the real `NativeCgroupFs`.
+        let cgroup_volume = armed
+            .volumes
+            .iter()
+            .flatten()
+            .find(|v| v.name == crate::launcher::VOLUME_LAUNCHER_CGROUP)
+            .expect("the armed render must declare the cgroup mountpoint volume");
         assert!(
-            armed
-                .volumes
-                .iter()
-                .flatten()
-                .all(|v| v.name != crate::launcher::VOLUME_LAUNCHER_CGROUP),
-            "no `launcher-cgroup` volume may be rendered, even when armed"
+            cgroup_volume.empty_dir.is_some(),
+            "the mountpoint is an emptyDir; it is mounted OVER, not read"
         );
+        assert!(
+            cgroup_volume.host_path.is_none(),
+            "a hostPath cannot supply a usable delegated root under nsdelegate"
+        );
+        let mounters: Vec<&str> = armed
+            .containers
+            .iter()
+            .chain(armed.init_containers.iter().flatten())
+            .filter(|container| {
+                container
+                    .volume_mounts
+                    .iter()
+                    .flatten()
+                    .any(|mount| mount.name == crate::launcher::VOLUME_LAUNCHER_CGROUP)
+            })
+            .map(|container| container.name.as_str())
+            .collect();
+        assert_eq!(
+            mounters,
+            vec![crate::launcher::LAUNCHER_CONTAINER_NAME],
+            "only the launcher may see the cgroup mountpoint"
+        );
+
+        // User namespaces confine the launcher's bootstrap CAP_SYS_ADMIN.
+        assert_eq!(armed.host_users, Some(false));
     }
 
     /// AC1: distinct worker/child UIDs, artifact GID, fsGroup/setgid ownership,
@@ -3555,8 +3595,18 @@ mod tests {
             .expect("launcher securityContext");
         assert_eq!(lsc.run_as_user, Some(0));
         let add = lsc.capabilities.as_ref().unwrap().add.as_ref().unwrap();
-        assert_eq!(add, &["SETUID", "SETGID", "SETPCAP"]);
-        assert!(!add.iter().any(|c| c == "SYS_ADMIN"));
+        // Task 7deu: SYS_ADMIN/SYS_RESOURCE are granted for the launcher's
+        // bootstrap phase ONLY — it `capset`s them away before the broker binds
+        // its socket, so no user-controlled code ever runs while they are held.
+        // See `launcher::launcher_capabilities`.
+        assert_eq!(
+            add,
+            &["SETUID", "SETGID", "SETPCAP", "SYS_ADMIN", "SYS_RESOURCE"]
+        );
+        // The `CAP_`-prefixed spelling is what the API server rejects alongside
+        // `allowPrivilegeEscalation: false`.
+        assert!(!add.iter().any(|c| c.starts_with("CAP_")));
+        assert_eq!(lsc.allow_privilege_escalation, Some(false));
         assert_eq!(
             lsc.seccomp_profile.as_ref().unwrap().type_,
             "RuntimeDefault"
@@ -3631,16 +3681,20 @@ mod tests {
             .find(|c| c.name == crate::launcher::LAUNCHER_CONTAINER_NAME)
             .unwrap();
         assert!(mount_names(launcher).contains(&crate::launcher::VOLUME_LAUNCHER_IPC.to_string()));
-        // Task grkq: no delegated-cgroup volume exists on the pod at all, and no
-        // container mounts one — not even the launcher. A volumeMount naming a
-        // volume the pod does not declare is a manifest the API server rejects,
-        // so both sides had to go together (see `launcher.rs`).
+        // Tasks grkq → 7deu: the cgroup MOUNTPOINT volume is declared and
+        // mounted by the launcher alone. A volumeMount naming a volume the pod
+        // does not declare is a manifest the API server rejects, so both sides
+        // have to move together (see `launcher.rs`). The worker must never see
+        // it: the delegated tree is the launcher's private authority surface.
         assert!(
             pod.volumes
                 .iter()
                 .flatten()
-                .all(|v| v.name != crate::launcher::VOLUME_LAUNCHER_CGROUP),
-            "no `launcher-cgroup` volume may be rendered"
+                .any(|v| v.name == crate::launcher::VOLUME_LAUNCHER_CGROUP),
+            "the armed render must declare the `launcher-cgroup` mountpoint volume"
+        );
+        assert!(
+            mount_names(launcher).contains(&crate::launcher::VOLUME_LAUNCHER_CGROUP.to_string())
         );
         assert!(
             !mount_names(worker).contains(&crate::launcher::VOLUME_LAUNCHER_CGROUP.to_string())

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -2,11 +2,14 @@
 //! cgroup-launcher sidecar, the v1 worker/child/launcher security contract, and
 //! the fail-closed render/startup validation seam.
 //!
-//! The launcher sidecar is **not** unconditionally rendered. See
-//! [`CgroupLauncherMode`] for the measured reason: a Pod holding this module's
-//! security contract cannot obtain a writable, delegated cgroup v2 subtree on a
-//! containerd/k3s cgroup-v2 node without privileges the contract refuses. The
-//! default is [`CgroupLauncherMode::Disabled`].
+//! The launcher sidecar is **not** unconditionally rendered: arming enforcement
+//! is an operator decision ([`CgroupLauncherMode`], default
+//! [`Disabled`](CgroupLauncherMode::Disabled)). The armed path is real and
+//! measured — the launcher establishes its own delegated cgroup v2 root, throttles
+//! an unleased invocation to [`LAUNCHER_UNLEASED_MILLICORES`], and lifts it to the
+//! pod's declared CPU budget on a fenced lease. `djinn-cgroup-launcher`'s
+//! `tests/delegated_cpu_lease_lifecycle.rs` proves that end to end on a real
+//! kernel by measuring `cpu.stat`, not by reading `cpu.max` back.
 //!
 //! This module is *pure*: every function is a deterministic manifest builder or
 //! a `Result`-returning validator. Nothing here talks to a cluster or mutates
@@ -41,8 +44,10 @@ pub use djinn_cgroup_launcher::broker::{WORKER_GID, WORKER_UID};
 // `CHILD_UID` is applied by the launcher when it spawns the child, not in the
 // pod manifest, so it is only referenced by tests/docs on the render side.
 pub use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
-use djinn_cgroup_launcher::{CgroupMode, Error as LauncherError, Readiness, UnleasedQuota};
-use djinn_runtime::RoleKind;
+use djinn_cgroup_launcher::{
+    CgroupMode, Error as LauncherError, LeasedQuota, Readiness, UnleasedQuota,
+};
+pub use djinn_runtime::RoleResourceClass;
 
 use crate::config::KubernetesConfig;
 
@@ -77,12 +82,41 @@ pub const CGROUP_PROFILE_V2_CPU_ONLY: &str = "cgroup-v2-cpu-only";
 /// Supported volume-ownership mode string (fsGroup re-owned OnRootMismatch).
 pub const VOLUME_OWNERSHIP_ON_ROOT_MISMATCH: &str = "fsgroup-on-root-mismatch";
 
-/// Launcher sidecar CPU/memory bounds — a tiny, fixed envelope; the broker does
-/// almost no work of its own. Role-independent ("same broker everywhere").
+/// Launcher sidecar CPU **request**: the broker's own steady footprint, which is
+/// genuinely tiny — it brokers, it does not compute.
+///
+/// This stays small on purpose even though every launched command now runs in
+/// this container's cgroup. A CPU request is a `cpu.weight`, and `cpu.weight` is
+/// a *floor* under contention, not a ceiling: a container only loses share to a
+/// sibling that is continuously runnable, and the worker is not — while a build
+/// runs the worker is streaming LLM tokens and reading the broker socket in
+/// short bursts, so the launcher receives everything the worker does not use.
+/// Node-level fairness is set by the pod's total request, which is unchanged.
 pub const LAUNCHER_CPU_REQUEST: &str = "50m";
-pub const LAUNCHER_CPU_LIMIT: &str = "250m";
+/// Launcher sidecar memory **request**: also the broker's steady footprint.
+/// The build's peak lives in the limit, not the request — the same
+/// request-is-steady/limit-is-peak shape the worker container already uses.
 pub const LAUNCHER_MEMORY_REQUEST: &str = "64Mi";
-pub const LAUNCHER_MEMORY_LIMIT: &str = "128Mi";
+
+// NOTE (task 7deu, defect 1): there is deliberately NO `LAUNCHER_CPU_LIMIT`.
+//
+// This constant used to be "250m", matching goxi's normative resource matrix.
+// It was the single reason the whole feature was a no-op. Under `nsdelegate` the
+// delegated cgroup root IS the launcher container's own cgroup, whose `cpu.max`
+// the kubelet had already set from that limit — so a bigger quota written on an
+// invocation leaf changed nothing, the ancestor still clamped. Measured with the
+// leaf set to a full 4 cores: two spinners over a 5s wall window should burn 10s
+// of CPU; `cpu.stat` reported `usage_usec 1252296`, i.e. 1.25s — exactly 0.25
+// core. Worse, `nr_throttled` read 0 in the leaf because the throttling happened
+// at the parent, which made goxi's throttle-based heavy detection structurally
+// blind. With the limit removed, the same pod reported `nr_throttled 40/40` on
+// the unleased leaf and 1.995 cores of measured post-lift throughput.
+//
+// The ceiling did not disappear, it moved to where the work is: the invocation
+// leaf's own `cpu.max`, unleased at [`LAUNCHER_UNLEASED_MILLICORES`] and lifted
+// to [`launcher_leased_millicores`]. Removing a container CPU limit also makes
+// the kubelet leave the POD cgroup's `cpu.max` unset, which is required — a pod
+// ceiling would reintroduce exactly the ancestor clamp this removes.
 
 /// Volume name for the worker↔launcher IPC surface (broker control socket +
 /// worker-private launcher credential). Memory-backed emptyDir, mounted into the
@@ -97,65 +131,61 @@ pub const LAUNCHER_SOCKET_PATH: &str = "/var/run/djinn/launcher/broker.sock";
 /// Worker-private launcher credential path inside [`LAUNCHER_IPC_DIR`].
 pub const LAUNCHER_CREDENTIAL_PATH: &str = "/var/run/djinn/launcher/credential";
 
-/// Volume name for the launcher's private delegated cgroup root. Mounted into
-/// the launcher container ONLY.
+/// Volume name for the launcher's writable cgroup **mountpoint**.
+///
+/// This is NOT the delegation. It is an `emptyDir` whose only job is to give the
+/// launcher a writable directory to `mount(2)` cgroup2 onto: the container runs
+/// with `readOnlyRootFilesystem: true`, so a mountpoint cannot be created on the
+/// image's own rootfs, and `readOnlyRootFilesystem` does not block creating one
+/// on an emptyDir/tmpfs. The delegated cgroup v2 tree itself is established by
+/// the launcher at startup (`djinn_cgroup_launcher::bootstrap`); no volume
+/// source can supply one, which is what task grkq's P0 proved the hard way.
 pub const VOLUME_LAUNCHER_CGROUP: &str = "launcher-cgroup";
-/// Mount path of [`VOLUME_LAUNCHER_CGROUP`] (the delegated cgroup-v2 root the
-/// launcher opens; owned by [`LAUNCHER_UID`]).
+/// Mount path of [`VOLUME_LAUNCHER_CGROUP`], and the path the launcher mounts
+/// its delegated cgroup-v2 root onto (owned by [`LAUNCHER_UID`]).
 pub const LAUNCHER_CGROUP_ROOT: &str = "/run/djinn-cgroup";
 
 /// Whether an enforcement task-run Pod renders the cgroup-launcher sidecar.
 ///
-/// # Why this is not simply "always on" (task grkq)
+/// # The armed path is real (tasks grkq → 7deu)
 ///
-/// **This is an implementation gap, NOT a Kubernetes limitation.** Delegated
-/// cgroup v2 enforcement is entirely achievable here; the runtime profile the
-/// goxi proposal specifies was simply never built. Do not read this as "cgroup
-/// enforcement is impossible on Kubernetes" — that is false, and measurably so.
+/// This was `Disabled` by default because the runtime profile goxi specifies had
+/// never been built: the render granted no `CAP_SYS_ADMIN`, so the launcher's
+/// very first step — `mount("cgroup2", root, "cgroup2", ...)` — failed with
+/// `EPERM`, and an `emptyDir` sat where the delegated root belonged. Measured on
+/// a real kubelet + containerd node (kind, k8s v1.36.1, cgroup v2), the designed
+/// profile drives the whole lifecycle: mount cgroup2 RW, vacate the root into
+/// `init/`, enable `+cpu` in `cgroup.subtree_control`, create an invocation leaf,
+/// write the unleased `cpu.max`, place a child in it, read `cpu.stat` showing
+/// real throttling, lift, then kill/drain/remove.
 ///
-/// goxi specifies that the launcher runs with `CAP_SYS_ADMIN`,
-/// `CAP_SYS_RESOURCE`, `CAP_SETUID`, `CAP_SETGID`, "the runtime-default seccomp
-/// profile plus an allowlist for cgroup setup and clone3", and "a dedicated
-/// read-write cgroup-v2 mount visible only in the launcher container". What
-/// this module renders is [`launcher_capabilities`] — `drop: ALL` plus only
-/// `SETUID`/`SETGID`/`SETPCAP` — a plain `RuntimeDefault` seccomp profile, and
-/// (previously) an `emptyDir` where the RW cgroup2 mount belongs.
+/// What this module now renders is that profile:
 ///
-/// Measured on a real kubelet + containerd node (kind, k8s v1.36.1, cgroup v2),
-/// three containers differing only in security context:
+/// * [`launcher_capabilities`] adds `SYS_ADMIN` and `SYS_RESOURCE` to the
+///   launcher container, and the launcher **gives them back** — it `capset`s
+///   them away permanently once the mount and delegation are established, before
+///   the broker binds its socket. No user-controlled code ever runs while they
+///   are held.
+/// * `seccompProfile: RuntimeDefault` is sufficient. The launcher no longer uses
+///   `clone3`: it forks, places the child by writing `cgroup.procs`, verifies the
+///   placement, and only then releases the child to `execve`. `fork(2)` and
+///   `write(2)` are not intercepted by any profile in use, so goxi's "allowlist
+///   for cgroup setup and clone3" needs no `Localhost` profile — which matters,
+///   because no seccomp delivery mechanism exists in the deployment repo.
+/// * [`VOLUME_LAUNCHER_CGROUP`] supplies the writable mountpoint (not the
+///   delegation), and [`pod_host_users`] confines the capability window to a user
+///   namespace.
 ///
-/// * **With the designed profile** — `CAP_SYS_ADMIN` + `CAP_SYS_RESOURCE`, and
-///   the launcher establishing its own cgroup2 mount inside its own cgroup
-///   namespace — the entire launcher lifecycle works: `mount -t cgroup2` RW,
-///   vacate the root into `init/`, enable `+cpu` in `cgroup.subtree_control`,
-///   create an invocation leaf, write the 250m unleased `cpu.max`,
-///   `clone3(CLONE_INTO_CGROUP)` a child into it (confirmed present in the
-///   leaf's `cgroup.procs`), read `cpu.stat` showing real throttling
-///   (`nr_throttled 4`), lift to `max`, then kill/drain/remove.
-/// * **With `seccompProfile: RuntimeDefault` and those capabilities** — the
-///   same lifecycle succeeds. The container runtime's default profile denies
-///   `clone3` with `ENOSYS` only for containers WITHOUT `CAP_SYS_ADMIN`; with it,
-///   `clone3` is permitted. So goxi's "allowlist for clone3" needs no `Localhost`
-///   seccomp profile at all — `RuntimeDefault` suffices once the capability is
-///   granted.
-/// * **With the profile this module actually renders** — the very first step,
-///   `mount("none", root, "cgroup2", ...)`, fails with `EPERM`.
+/// A `hostPath` onto a node subtree is still NOT the route: the pod's private
+/// cgroup namespace is mounted `nsdelegate`, so a target outside that namespace
+/// root is unreachable. The design mounts inside the launcher's own cgroup
+/// namespace, where an invocation leaf IS a descendant of the namespace root.
 ///
-/// The single blocking divergence is therefore `CAP_SYS_ADMIN`. A `hostPath`
-/// onto a node subtree is NOT the route (the pod's private cgroup namespace is
-/// mounted `nsdelegate`, so `clone3(CLONE_INTO_CGROUP)` into a target outside
-/// that namespace root fails with `ENOENT`) — but that is a property of the
-/// workaround, not of the design, which mounts inside the launcher's own cgroup
-/// namespace where an invocation leaf IS a descendant of the namespace root.
-///
-/// Until the designed profile is rendered — capability set, chart runtime-profile
-/// plumbing, and the launcher-established cgroup2 mount — the default is
-/// [`Disabled`](CgroupLauncherMode::Disabled): no sidecar, no launcher volume,
-/// no launcher env, and the worker executes shells in-process at the unleased
-/// quota. [`Required`](CgroupLauncherMode::Required) is the arming switch, and
-/// [`validate_enforcement_render`] rejects it fail-closed at dispatch rather
-/// than shipping a Pod whose sidecar cannot start. That gate is what a follow-up
-/// flips once the runtime profile lands.
+/// The default remains [`Disabled`](CgroupLauncherMode::Disabled) — arming
+/// enforcement is an operator decision, taken with
+/// `DJINN_K8S_CGROUP_LAUNCHER_MODE=required` — and
+/// [`validate_enforcement_render`] still fails closed at dispatch if the render
+/// this build produces could not actually satisfy the launcher's contract.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CgroupLauncherMode {
@@ -163,8 +193,8 @@ pub enum CgroupLauncherMode {
     /// in-process in the worker, unleased. This is the default.
     #[default]
     Disabled,
-    /// Arm the mandatory sidecar. Currently unsatisfiable in this topology and
-    /// rejected by [`validate_enforcement_render`].
+    /// Arm the sidecar: the launcher establishes its delegated cgroup root and
+    /// every shell command runs in a per-invocation leaf under a CPU lease.
     Required,
 }
 
@@ -194,54 +224,17 @@ impl CgroupLauncherMode {
     }
 }
 
-/// v1 resource class a task-run Pod is provisioned under, derived from the role
-/// that executes the run. Only the CPU **request** differs between the two — the
-/// CPU limit, both memory bounds, and the launcher/broker contract are identical
-/// ("role changes REQUESTS only — same limits, same broker everywhere").
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RoleResourceClass {
-    /// Orchestration-only roles that never run the project's compile/test
-    /// toolchain: Planner, Reviewer, Lead, every Refinement sub-role, and
-    /// grooming (a Planner-driven flow). Fractional-core CPU request.
-    Light,
-    /// Roles that may compile/build/test: Worker, Verifier, Architect, and any
-    /// retry/resume of those. Full-core CPU request. Also the FAIL-SAFE default
-    /// for a missing/unknown/newly-added role.
-    BuildCapable,
-}
-
-impl RoleResourceClass {
-    /// Classify the role that executes a task-run.
-    ///
-    /// Deliberately a catch-all (`_ => BuildCapable`) rather than an exhaustive
-    /// match on [`RoleKind`]: an unrecognized, missing (`None`), or
-    /// newly-introduced role must **fail safe to build-capable** so a pod that
-    /// might compile is never under-provisioned. Only the explicitly-listed
-    /// light roles are ever classed light.
-    pub fn for_role(role: Option<RoleKind>) -> Self {
-        match role {
-            Some(
-                RoleKind::Planner | RoleKind::Reviewer | RoleKind::Lead | RoleKind::Refinement,
-            ) => Self::Light,
-            _ => Self::BuildCapable,
-        }
-    }
-
-    /// The CPU request quantity string for this class, sourced from the
-    /// (env-overridable) config.
-    pub fn cpu_request<'a>(&self, config: &'a KubernetesConfig) -> &'a str {
-        match self {
-            Self::Light => &config.light_cpu_request,
-            Self::BuildCapable => &config.cpu_request,
-        }
-    }
-
-    /// Stable telemetry/label string.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Light => "light",
-            Self::BuildCapable => "build-capable",
-        }
+/// The CPU request quantity string for `class`, sourced from the
+/// (env-overridable) config.
+///
+/// The classifier itself is [`RoleResourceClass`], which lives in
+/// `djinn-runtime` so `djinn-coordinator`'s build-admission cap and this crate's
+/// pod sizing can never disagree about which roles compile. Only the mapping
+/// onto *this* crate's config lives here.
+pub fn class_cpu_request(class: RoleResourceClass, config: &KubernetesConfig) -> &str {
+    match class {
+        RoleResourceClass::Light => &config.light_cpu_request,
+        RoleResourceClass::BuildCapable => &config.cpu_request,
     }
 }
 
@@ -256,7 +249,7 @@ pub fn worker_resources(
         requests: Some(BTreeMap::from([
             (
                 "cpu".to_string(),
-                Quantity(class.cpu_request(config).to_string()),
+                Quantity(class_cpu_request(class, config).to_string()),
             ),
             (
                 "memory".to_string(),
@@ -309,16 +302,52 @@ pub fn worker_security_context() -> SecurityContext {
     }
 }
 
-/// Minimal capability set the launcher keeps. It runs as root but drops
-/// everything except the three it needs to move the child across the credential
-/// boundary before exec:
+/// Capability set the launcher container is granted at admission.
+///
+/// Three of the five are permanent, and two of them are not:
+///
 ///   * `SETUID`/`SETGID` — `setresuid(1001)` / `setresgid(1000)` +
 ///     `setgroups(0)` to drop the child to [`CHILD_UID`]/[`ARTIFACT_GID`];
-///   * `SETPCAP` — clear the child's capability bounding/ambient set.
+///   * `SETPCAP` — clear the child's capability bounding/ambient set, and
+///     `capset` the launcher's OWN set down after bootstrap (below);
+///   * `SYS_ADMIN` — `mount(2)` the delegated cgroup2 filesystem. **Bootstrap
+///     only.**
+///   * `SYS_RESOURCE` — cgroup limit management on the delegated tree.
+///     **Bootstrap only.**
 ///
-/// It needs no `SYS_ADMIN`: cgroup control is confined to the *delegated* root
-/// mounted at [`LAUNCHER_CGROUP_ROOT`] (owned by uid 0), and the child is born
-/// there via `clone3(CLONE_INTO_CGROUP)` with no mount/namespace ops.
+/// # The two bootstrap capabilities do not survive startup
+///
+/// `CAP_SYS_ADMIN` is a node-wide escape primitive: with it a process can
+/// `umount` the runtime's `/proc` masks and write `/proc/sys/kernel/core_pattern`,
+/// which is not namespaced. The production node's `core_pattern` is already a
+/// pipe, so that is a direct route to executing a payload as root outside every
+/// namespace. Granting it to a pod that runs arbitrary repository code would be
+/// indefensible.
+///
+/// It is not granted to such a pod. `djinn_cgroup_launcher::bootstrap` mounts,
+/// delegates, and then `capset`s both bootstrap capabilities out of the
+/// permitted, effective, inheritable AND bounding sets — verifying the drop with
+/// `capget` and refusing to serve if it did not take — all **before** the broker
+/// binds its control socket. The only code that runs while they are held is that
+/// bootstrap function. The worker container never has them
+/// ([`worker_security_context`] drops ALL), and the launched child never has
+/// them (`child::prepare_child` clears its capabilities and installs a seccomp
+/// filter denying `mount`/`unshare`/`setns` before `execve`).
+///
+/// This is also the only real implementation of goxi's "allowPrivilegeEscalation
+/// false AFTER INITIALIZATION": a container `securityContext` is static, so the
+/// phase change cannot be a Pod field. `CAP_SETPCAP` is what makes it
+/// expressible, and it is runtime behaviour rather than a manifest line.
+///
+/// # Why the names have no `CAP_` prefix
+///
+/// The Kubernetes API rejects `capabilities.add: ["CAP_SYS_ADMIN"]` together
+/// with `allowPrivilegeEscalation: false` — validation string-matches the
+/// literal `"CAP_SYS_ADMIN"`. The conventional, and universally used, spelling
+/// is the bare `"SYS_ADMIN"`, which is accepted; goxi's manifest as literally
+/// written is API-invalid. Keeping `allowPrivilegeEscalation: false` is the
+/// stronger posture and it is what the launcher actually needs — it drops
+/// privilege, it never gains any across `execve`.
 fn launcher_capabilities() -> Capabilities {
     Capabilities {
         drop: Some(vec!["ALL".to_string()]),
@@ -326,9 +355,15 @@ fn launcher_capabilities() -> Capabilities {
             "SETUID".to_string(),
             "SETGID".to_string(),
             "SETPCAP".to_string(),
+            "SYS_ADMIN".to_string(),
+            "SYS_RESOURCE".to_string(),
         ]),
     }
 }
+
+/// Capabilities the launcher holds only during bootstrap and then `capset`s
+/// away. Named here so the render and the runtime drop assert one list.
+pub const LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES: &[&str] = &["SYS_ADMIN", "SYS_RESOURCE"];
 
 /// Container-level security context for the launcher sidecar. Root, minimal
 /// caps, restricted seccomp, read-only rootfs (it only writes the delegated
@@ -391,23 +426,72 @@ pub fn launcher_ipc_volume() -> Volume {
     }
 }
 
-// NOTE (task grkq): there is deliberately NO `launcher_cgroup_volume()` here.
-//
-// This function used to return `EmptyDirVolumeSource::default()` for
-// [`VOLUME_LAUNCHER_CGROUP`]. An emptyDir is an ordinary directory on the node
-// filesystem, so `/run/djinn-cgroup` had no `cgroup.subtree_control` and the
-// launcher's `NativeCgroupFs::open` failed with a bare ENOENT on every pod —
-// CrashLoopBackOff for the sidecar, no broker socket, and (before the fallback
-// was restored) a hard failure for every single shell command in every task run.
-//
-// It is not replaced by a hostPath: as documented on [`CgroupLauncherMode`], a
-// hostPath cannot supply a *usable* delegated root either, because the pod's
-// private cgroup namespace plus `nsdelegate` refuse `clone3(CLONE_INTO_CGROUP)`
-// into anything outside it. Rendering a volume source that provably cannot
-// satisfy the launcher's readiness contract is worse than rendering none: it
-// re-creates exactly the failure this task exists to remove. When a real
-// node-level delegation mechanism exists, add the volume source together with
-// the render validation that proves it is a cgroup2 tree.
+/// The launcher's writable cgroup **mountpoint** — not the delegation.
+///
+/// # Read this before "fixing" it back into a delegated root (task grkq)
+///
+/// A previous `launcher_cgroup_volume()` returned an `EmptyDirVolumeSource` and
+/// the launcher was expected to `open` it as its delegated cgroup root. An
+/// emptyDir is an ordinary directory on the node filesystem: no
+/// `cgroup.subtree_control`, no `cpu.max`, none of the cgroup2 control files.
+/// The sidecar died in `NativeCgroupFs::open` on every task-run Pod, the broker
+/// socket never bound, and every shell command in every task run failed.
+///
+/// This volume is NOT that. It supplies exactly one thing: a directory the
+/// launcher is allowed to write a *mountpoint* into, because
+/// `readOnlyRootFilesystem: true` forbids creating one on the image rootfs
+/// (`readOnlyRootFilesystem` does not extend to emptyDir/tmpfs volumes). The
+/// delegated cgroup v2 tree is then established by the launcher itself, with
+/// `mount(2)`, inside its own cgroup namespace — see
+/// `djinn_cgroup_launcher::bootstrap`. `tests/rendered_launcher_delegation.rs`
+/// asserts precisely this distinction: the rendered volume must materialize into
+/// something the launcher can mount ONTO, and must NOT be accepted as a
+/// delegated root on its own.
+///
+/// Memory-backed so the mountpoint never touches disk; it holds no data, only a
+/// directory inode that a filesystem is mounted over.
+pub fn launcher_cgroup_mountpoint_volume() -> Volume {
+    Volume {
+        name: VOLUME_LAUNCHER_CGROUP.to_string(),
+        empty_dir: Some(EmptyDirVolumeSource {
+            medium: Some("Memory".to_string()),
+            size_limit: Some(Quantity("1Mi".to_string())),
+        }),
+        ..Volume::default()
+    }
+}
+
+/// Launcher-side mount of [`launcher_cgroup_mountpoint_volume`]. Rendered into
+/// the launcher container ONLY — never the worker, and never a backing service.
+pub fn launcher_cgroup_mount() -> VolumeMount {
+    VolumeMount {
+        name: VOLUME_LAUNCHER_CGROUP.to_string(),
+        mount_path: LAUNCHER_CGROUP_ROOT.to_string(),
+        ..VolumeMount::default()
+    }
+}
+
+/// Whether the Pod runs in a user namespace.
+///
+/// `hostUsers: false` (user namespaces, GA since Kubernetes 1.33) maps the
+/// launcher's bootstrap `CAP_SYS_ADMIN` into a user namespace, where the
+/// non-namespaced sysctls that make it an escape primitive —
+/// `/proc/sys/kernel/core_pattern` above all — are unreachable. It is the second
+/// layer under the launcher's own `capset` drop, not a replacement for it.
+///
+/// Only meaningful when the launcher is armed: without the sidecar no container
+/// in the pod holds a capability worth confining, and `hostUsers: false` has a
+/// real cost (idmapped volume mounts, a runtime that must support it), so it is
+/// not imposed on the default rendering.
+///
+/// NOT VERIFIED ON A NON-NESTED NODE. kind-in-docker cannot nest user
+/// namespaces — sandbox creation fails mounting sysfs — so this could not be
+/// exercised locally. Both failure modes are fail-closed: a runtime that does
+/// not support it refuses the Pod, and a user namespace that broke the cgroup
+/// chain would fail the launcher's startup readiness before the broker binds.
+pub fn pod_host_users(mode: CgroupLauncherMode) -> Option<bool> {
+    mode.renders_sidecar().then_some(false)
+}
 
 /// Worker-side mount of the IPC volume so the worker can dial the broker socket
 /// and read its private credential.
@@ -451,16 +535,21 @@ pub fn launcher_sidecar_container(config: &KubernetesConfig, project_image_tag: 
                 "DJINN_LAUNCHER_UNLEASED_MILLICORES",
                 &LAUNCHER_UNLEASED_MILLICORES.to_string(),
             ),
+            // The quota a granted lease lifts an invocation leaf to, and the
+            // number the launcher derives the child's `CARGO_BUILD_JOBS` /
+            // `NEXTEST_TEST_THREADS` / `MAKEFLAGS` / `GOMAXPROCS` pins from.
+            // Sourced from the pod's own declared CPU limit so a brokered build
+            // picks exactly the parallelism an unbrokered one would.
+            env_var(
+                "DJINN_LAUNCHER_LEASED_MILLICORES",
+                &launcher_leased_millicores(config).to_string(),
+            ),
         ]),
-        // IPC only. There is deliberately no mount at [`LAUNCHER_CGROUP_ROOT`]:
-        // the delegated root is not something a *volume source* can supply — in
-        // the goxi design the launcher mounts cgroup2 there ITSELF, inside its
-        // own cgroup namespace, which needs `CAP_SYS_ADMIN` rather than a volume
-        // (see [`CgroupLauncherMode`]). A volumeMount naming a volume the pod
-        // does not declare is also a manifest the API server rejects outright.
-        // The launcher still reads `DJINN_LAUNCHER_CGROUP_ROOT` and creates the
-        // mount point there when it is granted the capability to do so.
-        volume_mounts: Some(vec![worker_launcher_ipc_mount()]),
+        // The IPC surface, plus the writable mountpoint the launcher mounts its
+        // delegated cgroup2 root onto. The volume supplies the mountpoint only;
+        // see [`launcher_cgroup_mountpoint_volume`] for why that distinction is
+        // the entire difference between this working and CrashLoopBackOff.
+        volume_mounts: Some(vec![worker_launcher_ipc_mount(), launcher_cgroup_mount()]),
         security_context: Some(launcher_security_context()),
         resources: Some(ResourceRequirements {
             requests: Some(BTreeMap::from([
@@ -473,17 +562,79 @@ pub fn launcher_sidecar_container(config: &KubernetesConfig, project_image_tag: 
                     Quantity(LAUNCHER_MEMORY_REQUEST.to_string()),
                 ),
             ])),
-            limits: Some(BTreeMap::from([
-                ("cpu".to_string(), Quantity(LAUNCHER_CPU_LIMIT.to_string())),
-                (
-                    "memory".to_string(),
-                    Quantity(LAUNCHER_MEMORY_LIMIT.to_string()),
-                ),
-            ])),
+            // NO CPU LIMIT — see the note where `LAUNCHER_CPU_LIMIT` used to be.
+            // A limit here becomes an ancestor clamp on every invocation leaf and
+            // silently caps every build at the launcher's own quota.
+            //
+            // The MEMORY limit is the worker's, not a sidecar's: when the
+            // launcher is armed every command runs in this container's cgroup,
+            // so the build's memory peak lands here. The old 128Mi would have
+            // OOM-killed the first `cargo build`. Memory has no equivalent of the
+            // CPU problem — a memory limit is a ceiling, not a rate, and the
+            // build needs a real one.
+            limits: Some(BTreeMap::from([(
+                "memory".to_string(),
+                Quantity(config.memory_limit.clone()),
+            )])),
             ..ResourceRequirements::default()
         }),
         ..Container::default()
     }
+}
+
+/// Re-point the rendered launcher's lease ceiling at `cpu_limit`.
+///
+/// The sidecar is rendered from the deployment default, but a per-project
+/// `build_resources.task.cpu_limit` override is applied to the built Job
+/// afterwards. This keeps the lease equal to the CPU limit the pod actually
+/// carries; see [`crate::build_resources::apply_resolved_resources`], which is
+/// the only caller and applies both in one place so they cannot drift.
+///
+/// A limit that does not map onto a usable lease quota leaves the rendered
+/// value in place rather than writing something unbounded: the render-time gate
+/// in [`validate_enforcement_render`] has already refused to arm such a config,
+/// so this is the belt to that braces.
+pub fn retune_launcher_lease(pod: &mut k8s_openapi::api::core::v1::PodSpec, cpu_limit: &str) {
+    let Some(millicores) = parse_cpu_millicores(cpu_limit) else {
+        return;
+    };
+    let value = millicores.to_string();
+    for container in pod.init_containers.iter_mut().flatten() {
+        if container.name != LAUNCHER_CONTAINER_NAME {
+            continue;
+        }
+        for env in container.env.iter_mut().flatten() {
+            if env.name == "DJINN_LAUNCHER_LEASED_MILLICORES" {
+                env.value = Some(value.clone());
+            }
+        }
+    }
+}
+
+/// The CPU quota (millicores) a granted lease lifts an invocation leaf to.
+///
+/// Derived from the pod's declared CPU limit, so the ceiling a build actually
+/// runs under is the ceiling the manifest advertises. Parsing mirrors
+/// `crate::job::cpu_limit_to_jobs`: a bare number is cores, an `m` suffix is
+/// millicores, and anything unparseable falls back to the launcher crate's own
+/// default rather than to something unbounded.
+pub fn launcher_leased_millicores(config: &KubernetesConfig) -> u32 {
+    parse_cpu_millicores(&config.cpu_limit).unwrap_or(LeasedQuota::DEFAULT_MILLICORES)
+}
+
+fn parse_cpu_millicores(quantity: &str) -> Option<u32> {
+    let quantity = quantity.trim();
+    match quantity.strip_suffix('m') {
+        Some(millis) => millis.parse::<u32>().ok(),
+        None => quantity
+            .parse::<f64>()
+            .ok()
+            .filter(|cores| cores.is_finite() && *cores >= 0.0)
+            .map(|cores| (cores * 1000.0) as u32),
+    }
+    .filter(|millicores| {
+        (LeasedQuota::MIN_MILLICORES..=LeasedQuota::MAX_MILLICORES).contains(millicores)
+    })
 }
 
 /// Fail-closed render/startup validation for an enforcement task-run.
@@ -515,16 +666,20 @@ pub enum RenderValidationError {
         expected: &'static str,
     },
     #[error(
-        "cgroup launcher mode is `required`, but the launcher security context this build renders \
-         cannot obtain a delegated cgroup v2 subtree: it lacks CAP_SYS_ADMIN, so the launcher's \
-         own `mount -t cgroup2` fails with EPERM. This is an unbuilt runtime profile, not a \
-         platform limit — the goxi profile (CAP_SYS_ADMIN + CAP_SYS_RESOURCE, with the launcher \
-         mounting cgroup2 inside its own cgroup namespace) drives the full leaf lifecycle \
-         successfully, and RuntimeDefault seccomp already permits clone3 once CAP_SYS_ADMIN is \
-         granted. Run with DJINN_K8S_CGROUP_LAUNCHER_MODE=disabled (the default) until the \
-         designed profile is rendered. See djinn_k8s::launcher::CgroupLauncherMode."
+        "cgroup launcher mode is `required`, but the launcher container this build renders cannot \
+         establish a delegated cgroup v2 subtree: {reason}. Arming enforcement with this render \
+         would submit a Pod whose sidecar fails startup readiness, so it is refused before the Job \
+         exists. Run with DJINN_K8S_CGROUP_LAUNCHER_MODE=disabled (the default) until the render \
+         is repaired. See djinn_k8s::launcher::CgroupLauncherMode."
     )]
-    CgroupDelegationUnavailable,
+    ArmedRenderCannotDelegate { reason: &'static str },
+    #[error(
+        "cgroup launcher mode is `required`, but the pod CPU limit {limit} does not map onto a \
+         usable lease quota ({min}m..={max}m). The lease is what bounds a lifted build now that \
+         the launcher container carries no CPU limit; without a valid one a single build would be \
+         bounded only by the node."
+    )]
+    UnsupportedLeaseQuota { limit: String, min: u32, max: u32 },
 }
 
 /// Map a supported/unsupported cgroup-delegation profile string onto the
@@ -605,15 +760,96 @@ pub fn validate_enforcement_render(config: &KubernetesConfig) -> Result<(), Rend
         });
     }
 
-    // 4. The launcher may only be ARMED if this topology can actually deliver a
-    //    delegated cgroup v2 subtree. It cannot (see `CgroupLauncherMode`), so
-    //    `required` fails closed at dispatch — before a Job is submitted and
-    //    therefore before any pod can come up with a sidecar that cannot start.
-    //    This is the render-time half of the readiness contract; the launcher
-    //    binary enforces the runtime half (`NativeClone3::preflight` +
-    //    `NativeCgroupFs::open`) before it binds its control socket.
+    // 4. The launcher may only be ARMED if the container THIS BUILD renders can
+    //    actually establish the delegation. These are not tautologies about the
+    //    code a few lines up: they are the exact preconditions whose absence
+    //    produced a CrashLoopBackOff sidecar on every task-run Pod, re-derived
+    //    from the rendered manifest so a future edit that removes one fails
+    //    closed at dispatch — before a Job is submitted, and therefore before
+    //    any pod can come up with a sidecar that cannot start. This is the
+    //    render-time half of the readiness contract; the launcher binary
+    //    enforces the runtime half (`bootstrap::Bootstrap::run`, the capability
+    //    drop, and `NativeCgroupFs::open`) before it binds its control socket.
     if config.cgroup_launcher_mode.renders_sidecar() {
-        return Err(RenderValidationError::CgroupDelegationUnavailable);
+        let container = launcher_sidecar_container(config, "render-validation");
+        let security = container.security_context.as_ref().ok_or(
+            RenderValidationError::ArmedRenderCannotDelegate {
+                reason: "the launcher container has no securityContext at all",
+            },
+        )?;
+        let added: Vec<&str> = security
+            .capabilities
+            .as_ref()
+            .and_then(|caps| caps.add.as_deref())
+            .unwrap_or_default()
+            .iter()
+            .map(String::as_str)
+            .collect();
+        if !added.contains(&"SYS_ADMIN") {
+            return Err(RenderValidationError::ArmedRenderCannotDelegate {
+                reason: "the launcher container is not granted SYS_ADMIN, so its own \
+                         `mount -t cgroup2` fails with EPERM",
+            });
+        }
+        // The `CAP_`-prefixed spelling is what the API server rejects alongside
+        // `allowPrivilegeEscalation: false`. Catching it here turns a 422 at
+        // submission into a named refusal.
+        if added
+            .iter()
+            .any(|capability| capability.starts_with("CAP_"))
+        {
+            return Err(RenderValidationError::ArmedRenderCannotDelegate {
+                reason: "a capability is spelled with the `CAP_` prefix; the API server rejects \
+                         `CAP_SYS_ADMIN` together with allowPrivilegeEscalation: false",
+            });
+        }
+        let mounts_cgroup_root = container
+            .volume_mounts
+            .iter()
+            .flatten()
+            .any(|mount| mount.mount_path == LAUNCHER_CGROUP_ROOT);
+        if !mounts_cgroup_root {
+            return Err(RenderValidationError::ArmedRenderCannotDelegate {
+                reason: "no writable volume is mounted at the cgroup root path, and \
+                         readOnlyRootFilesystem forbids creating the mountpoint on the rootfs",
+            });
+        }
+        // A CPU limit on the launcher container becomes an ancestor clamp on
+        // every invocation leaf: the whole feature silently degrades to that
+        // limit. This is defect 1, asserted on the render rather than trusted.
+        let has_cpu_limit = container
+            .resources
+            .as_ref()
+            .and_then(|resources| resources.limits.as_ref())
+            .is_some_and(|limits| limits.contains_key("cpu"));
+        if has_cpu_limit {
+            return Err(RenderValidationError::ArmedRenderCannotDelegate {
+                reason: "the launcher container declares a CPU limit, which under nsdelegate \
+                         clamps every invocation leaf to it and makes the lease a no-op",
+            });
+        }
+        if pod_host_users(config.cgroup_launcher_mode) != Some(false) {
+            return Err(RenderValidationError::ArmedRenderCannotDelegate {
+                reason: "the pod does not set hostUsers: false, so the launcher's bootstrap \
+                         CAP_SYS_ADMIN would be a host-level capability",
+            });
+        }
+        // 5. The lease must map onto a quota the launcher crate accepts, or a
+        //    lifted build has no ceiling at all.
+        if parse_cpu_millicores(&config.cpu_limit).is_none() {
+            return Err(RenderValidationError::UnsupportedLeaseQuota {
+                limit: config.cpu_limit.clone(),
+                min: LeasedQuota::MIN_MILLICORES,
+                max: LeasedQuota::MAX_MILLICORES,
+            });
+        }
+        LeasedQuota::new(launcher_leased_millicores(config)).map_err(|_| {
+            RenderValidationError::UnsupportedLeaseQuota {
+                limit: config.cpu_limit.clone(),
+                min: LeasedQuota::MIN_MILLICORES,
+                max: LeasedQuota::MAX_MILLICORES,
+            }
+        })?;
     }
 
     Ok(())
@@ -628,316 +864,5 @@ fn env_var(name: &str, value: &str) -> EnvVar {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn every_role_kind_maps_to_a_resource_class() {
-        // Light: orchestration-only roles.
-        for role in [
-            RoleKind::Planner,
-            RoleKind::Reviewer,
-            RoleKind::Lead,
-            RoleKind::Refinement,
-        ] {
-            assert_eq!(
-                RoleResourceClass::for_role(Some(role)),
-                RoleResourceClass::Light,
-                "{role:?} must be light"
-            );
-        }
-        // Build-capable: roles that may compile.
-        for role in [RoleKind::Worker, RoleKind::Verifier, RoleKind::Architect] {
-            assert_eq!(
-                RoleResourceClass::for_role(Some(role)),
-                RoleResourceClass::BuildCapable,
-                "{role:?} must be build-capable"
-            );
-        }
-    }
-
-    #[test]
-    fn missing_role_fails_safe_to_build_capable() {
-        assert_eq!(
-            RoleResourceClass::for_role(None),
-            RoleResourceClass::BuildCapable
-        );
-    }
-
-    #[test]
-    fn light_and_build_capable_share_limits_but_not_cpu_request() {
-        let cfg = KubernetesConfig::for_testing();
-        let light = worker_resources(&cfg, RoleResourceClass::Light);
-        let build = worker_resources(&cfg, RoleResourceClass::BuildCapable);
-
-        // CPU request differs by class.
-        assert_eq!(
-            light.requests.as_ref().unwrap().get("cpu").unwrap().0,
-            cfg.light_cpu_request
-        );
-        assert_eq!(
-            build.requests.as_ref().unwrap().get("cpu").unwrap().0,
-            cfg.cpu_request
-        );
-        assert_ne!(
-            light.requests.as_ref().unwrap().get("cpu"),
-            build.requests.as_ref().unwrap().get("cpu"),
-        );
-
-        // Limits + memory identical across classes ("same limits everywhere").
-        assert_eq!(light.limits, build.limits);
-        assert_eq!(
-            light.requests.as_ref().unwrap().get("memory"),
-            build.requests.as_ref().unwrap().get("memory"),
-        );
-        assert_eq!(
-            light.limits.as_ref().unwrap().get("cpu").unwrap().0,
-            cfg.cpu_limit
-        );
-        assert_eq!(
-            light.limits.as_ref().unwrap().get("memory").unwrap().0,
-            cfg.memory_limit
-        );
-    }
-
-    #[test]
-    fn worker_and_launcher_have_distinct_uids_matching_the_launcher_contract() {
-        let worker = worker_security_context();
-        let launcher = launcher_security_context();
-        assert_eq!(worker.run_as_user, Some(i64::from(WORKER_UID)));
-        assert_eq!(worker.run_as_user, Some(1000));
-        assert_eq!(launcher.run_as_user, Some(LAUNCHER_UID));
-        assert_eq!(launcher.run_as_user, Some(0));
-        assert_ne!(worker.run_as_user, launcher.run_as_user);
-        // Child + artifact contract constants come straight from the crate.
-        assert_eq!(CHILD_UID, 1001);
-        assert_eq!(ARTIFACT_GID, 1000);
-    }
-
-    #[test]
-    fn worker_security_context_is_restricted() {
-        let sc = worker_security_context();
-        assert_eq!(sc.allow_privilege_escalation, Some(false));
-        assert_eq!(sc.run_as_non_root, Some(true));
-        assert_eq!(
-            sc.capabilities.as_ref().unwrap().drop.as_deref(),
-            Some(&["ALL".to_string()][..])
-        );
-        assert_eq!(sc.seccomp_profile.as_ref().unwrap().type_, "RuntimeDefault");
-    }
-
-    #[test]
-    fn launcher_keeps_only_minimal_capabilities() {
-        let caps = launcher_capabilities();
-        assert_eq!(caps.drop.as_deref(), Some(&["ALL".to_string()][..]));
-        let add = caps.add.expect("launcher adds minimal caps");
-        assert_eq!(add, vec!["SETUID", "SETGID", "SETPCAP"]);
-        // Never privileged, never SYS_ADMIN.
-        assert!(!add.iter().any(|c| c == "SYS_ADMIN"));
-        let sc = launcher_security_context();
-        assert_eq!(sc.privileged, None);
-        assert_eq!(sc.allow_privilege_escalation, Some(false));
-        assert_eq!(sc.read_only_root_filesystem, Some(true));
-    }
-
-    #[test]
-    fn pod_security_context_ties_fsgroup_to_artifact_gid_on_root_mismatch() {
-        let sc = pod_security_context();
-        assert_eq!(sc.fs_group, Some(i64::from(ARTIFACT_GID)));
-        assert_eq!(sc.fs_group, Some(1000));
-        assert_eq!(sc.fs_group_change_policy.as_deref(), Some("OnRootMismatch"));
-        // The legacy pod-wide uid override is gone from the pod context.
-        assert_eq!(sc.run_as_user, None);
-    }
-
-    #[test]
-    fn launcher_sidecar_reuses_worker_image_with_launcher_entrypoint() {
-        let cfg = KubernetesConfig::for_testing();
-        let image = "registry.example/proj:tag";
-        let c = launcher_sidecar_container(&cfg, image);
-        assert_eq!(c.name, LAUNCHER_CONTAINER_NAME);
-        // Same image as the worker, different entrypoint (real packaged binary).
-        assert_eq!(c.image.as_deref(), Some(image));
-        assert_eq!(c.command.as_deref(), Some(&[LAUNCHER_BIN.to_string()][..]));
-        assert_eq!(c.restart_policy.as_deref(), Some("Always"));
-        // Tiny fixed envelope.
-        let req = c.resources.as_ref().unwrap().requests.as_ref().unwrap();
-        assert_eq!(req.get("cpu").unwrap().0, LAUNCHER_CPU_REQUEST);
-        assert_eq!(req.get("memory").unwrap().0, LAUNCHER_MEMORY_REQUEST);
-        let lim = c.resources.as_ref().unwrap().limits.as_ref().unwrap();
-        assert_eq!(lim.get("cpu").unwrap().0, LAUNCHER_CPU_LIMIT);
-        assert_eq!(lim.get("memory").unwrap().0, LAUNCHER_MEMORY_LIMIT);
-    }
-
-    #[test]
-    fn valid_config_passes_render_validation() {
-        let cfg = KubernetesConfig::for_testing();
-        assert!(validate_enforcement_render(&cfg).is_ok());
-    }
-
-    #[test]
-    fn unknown_cgroup_profile_fails_closed() {
-        let mut cfg = KubernetesConfig::for_testing();
-        cfg.cgroup_delegation_profile = "cgroup-v3-experimental".to_string();
-        assert!(matches!(
-            validate_enforcement_render(&cfg),
-            Err(RenderValidationError::UnsupportedCgroupProfile { .. })
-        ));
-    }
-
-    #[test]
-    fn recognized_but_nonconforming_cgroup_profiles_are_rejected_by_the_launcher_contract() {
-        for profile in [
-            "cgroup-v1",
-            "cgroup-v2-hybrid",
-            "cgroup-v2-overbroad",
-            "cgroup-v2-readonly",
-        ] {
-            let mut cfg = KubernetesConfig::for_testing();
-            cfg.cgroup_delegation_profile = profile.to_string();
-            assert!(
-                matches!(
-                    validate_enforcement_render(&cfg),
-                    Err(RenderValidationError::RejectedCgroupProfile { .. })
-                ),
-                "{profile} must be rejected by the launcher readiness contract"
-            );
-        }
-    }
-
-    /// The adversarial kernel-boundary proof (djinn-cgroup-launcher's
-    /// `tests/kernel_boundary_under_rendered_context.rs`, task zf13/goxi AC2)
-    /// cannot depend on this crate — that would be a dependency cycle — so it
-    /// drives its real UID-1000/1001 processes from a checked-in fixture of the
-    /// rendered security context. This test is what keeps that fixture honest:
-    /// it rebuilds the REAL manifest values and asserts every fixture line, so
-    /// changing the render without updating the fixture fails here instead of
-    /// silently proving a boundary nobody ships.
-    #[test]
-    fn rendered_security_context_matches_the_adversarial_proof_fixture() {
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env");
-        let raw = std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("read rendered security-context fixture {path:?}: {e}"));
-        let fixture: BTreeMap<&str, &str> = raw
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty() && !line.starts_with('#'))
-            .map(|line| {
-                let (key, value) = line.split_once('=').expect("fixture line is key=value");
-                (key.trim(), value.trim())
-            })
-            .collect();
-
-        let worker = worker_security_context();
-        let launcher = launcher_security_context();
-        let pod = pod_security_context();
-        let config = KubernetesConfig::for_testing();
-        let capabilities = |sc: &SecurityContext, take_added: bool| {
-            let caps = sc.capabilities.as_ref().expect("capabilities");
-            let list = if take_added {
-                caps.add.clone().unwrap_or_default()
-            } else {
-                caps.drop.clone().unwrap_or_default()
-            };
-            list.join(",")
-        };
-        let expected: BTreeMap<&str, String> = BTreeMap::from([
-            (
-                "worker_run_as_user",
-                worker.run_as_user.unwrap().to_string(),
-            ),
-            (
-                "worker_run_as_group",
-                worker.run_as_group.unwrap().to_string(),
-            ),
-            (
-                "worker_run_as_non_root",
-                worker.run_as_non_root.unwrap().to_string(),
-            ),
-            (
-                "worker_allow_privilege_escalation",
-                worker.allow_privilege_escalation.unwrap().to_string(),
-            ),
-            ("worker_capabilities_drop", capabilities(&worker, false)),
-            (
-                "launcher_run_as_user",
-                launcher.run_as_user.unwrap().to_string(),
-            ),
-            (
-                "launcher_run_as_group",
-                launcher.run_as_group.unwrap().to_string(),
-            ),
-            (
-                "launcher_allow_privilege_escalation",
-                launcher.allow_privilege_escalation.unwrap().to_string(),
-            ),
-            (
-                "launcher_read_only_root_filesystem",
-                launcher.read_only_root_filesystem.unwrap().to_string(),
-            ),
-            ("launcher_capabilities_drop", capabilities(&launcher, false)),
-            ("launcher_capabilities_add", capabilities(&launcher, true)),
-            ("child_run_as_user", CHILD_UID.to_string()),
-            ("child_run_as_group", ARTIFACT_GID.to_string()),
-            ("child_umask", "0002".to_string()),
-            ("pod_fs_group", pod.fs_group.unwrap().to_string()),
-            (
-                "pod_fs_group_change_policy",
-                pod.fs_group_change_policy.clone().unwrap(),
-            ),
-            (
-                "seccomp_profile",
-                worker.seccomp_profile.as_ref().unwrap().type_.clone(),
-            ),
-            ("launcher_expected_uid", LAUNCHER_UID.to_string()),
-            (
-                "unleased_millicores",
-                LAUNCHER_UNLEASED_MILLICORES.to_string(),
-            ),
-            (
-                "cgroup_delegation_profile",
-                config.cgroup_delegation_profile.clone(),
-            ),
-            (
-                "volume_ownership_mode",
-                config.volume_ownership_mode.clone(),
-            ),
-        ]);
-
-        for (key, value) in &expected {
-            assert_eq!(
-                fixture.get(key).copied(),
-                Some(value.as_str()),
-                "the adversarial proof fixture is stale for `{key}`; update \
-                 crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env"
-            );
-        }
-        let extra: Vec<&&str> = fixture
-            .keys()
-            .filter(|k| !expected.contains_key(*k))
-            .collect();
-        assert!(
-            extra.is_empty(),
-            "the fixture declares keys the render does not produce: {extra:?}"
-        );
-        // The launcher and worker share one seccomp profile; assert it rather
-        // than let the fixture describe only half the contract.
-        assert_eq!(
-            launcher.seccomp_profile.as_ref().unwrap().type_,
-            fixture["seccomp_profile"]
-        );
-        // The render must also actually accept the profile pair it advertises.
-        assert!(validate_enforcement_render(&config).is_ok());
-    }
-
-    #[test]
-    fn incompatible_volume_ownership_mode_fails_closed() {
-        let mut cfg = KubernetesConfig::for_testing();
-        cfg.volume_ownership_mode = "chown-recursive-always".to_string();
-        assert!(matches!(
-            validate_enforcement_render(&cfg),
-            Err(RenderValidationError::IncompatibleVolumeOwnership { .. })
-        ));
-    }
-}
+#[path = "launcher_tests.rs"]
+mod tests;

--- a/server/crates/djinn-k8s/src/launcher_tests.rs
+++ b/server/crates/djinn-k8s/src/launcher_tests.rs
@@ -1,0 +1,544 @@
+//! Unit tests for [`crate::launcher`]: the rendered v1 security contract, the
+//! role-classed resource envelope, the launcher's bootstrap capability set, and
+//! the fail-closed render validation.
+//!
+//! Split out of `launcher.rs` to keep that file inside the repository's per-file
+//! size guard. It is `#[path]`-included as a private child module, so it still
+//! sees the module's private items (`launcher_capabilities`,
+//! `parse_cpu_millicores`) exactly as an inline `mod tests` would.
+
+use super::*;
+
+use djinn_runtime::RoleKind;
+
+/// The classifier itself is proven exhaustively in `djinn-runtime` (one
+/// home, shared with the coordinator's build-admission cap). What this crate
+/// owns is the mapping onto ITS config, so that is what is asserted here.
+#[test]
+fn the_resource_class_maps_onto_this_crates_cpu_requests() {
+    let cfg = KubernetesConfig::for_testing();
+    assert_eq!(
+        class_cpu_request(RoleResourceClass::Light, &cfg),
+        cfg.light_cpu_request
+    );
+    assert_eq!(
+        class_cpu_request(RoleResourceClass::BuildCapable, &cfg),
+        cfg.cpu_request
+    );
+    // The re-export is the same type the coordinator admits against; a
+    // second local copy is exactly the drift this move exists to prevent.
+    assert_eq!(
+        RoleResourceClass::for_role(Some(RoleKind::Planner)),
+        RoleResourceClass::Light
+    );
+    assert_eq!(
+        RoleResourceClass::for_role(Some(RoleKind::Worker)),
+        RoleResourceClass::BuildCapable
+    );
+}
+
+#[test]
+fn missing_role_fails_safe_to_build_capable() {
+    assert_eq!(
+        RoleResourceClass::for_role(None),
+        RoleResourceClass::BuildCapable
+    );
+}
+
+#[test]
+fn light_and_build_capable_share_limits_but_not_cpu_request() {
+    let cfg = KubernetesConfig::for_testing();
+    let light = worker_resources(&cfg, RoleResourceClass::Light);
+    let build = worker_resources(&cfg, RoleResourceClass::BuildCapable);
+
+    // CPU request differs by class.
+    assert_eq!(
+        light.requests.as_ref().unwrap().get("cpu").unwrap().0,
+        cfg.light_cpu_request
+    );
+    assert_eq!(
+        build.requests.as_ref().unwrap().get("cpu").unwrap().0,
+        cfg.cpu_request
+    );
+    assert_ne!(
+        light.requests.as_ref().unwrap().get("cpu"),
+        build.requests.as_ref().unwrap().get("cpu"),
+    );
+
+    // Limits + memory identical across classes ("same limits everywhere").
+    assert_eq!(light.limits, build.limits);
+    assert_eq!(
+        light.requests.as_ref().unwrap().get("memory"),
+        build.requests.as_ref().unwrap().get("memory"),
+    );
+    assert_eq!(
+        light.limits.as_ref().unwrap().get("cpu").unwrap().0,
+        cfg.cpu_limit
+    );
+    assert_eq!(
+        light.limits.as_ref().unwrap().get("memory").unwrap().0,
+        cfg.memory_limit
+    );
+}
+
+#[test]
+fn worker_and_launcher_have_distinct_uids_matching_the_launcher_contract() {
+    let worker = worker_security_context();
+    let launcher = launcher_security_context();
+    assert_eq!(worker.run_as_user, Some(i64::from(WORKER_UID)));
+    assert_eq!(worker.run_as_user, Some(1000));
+    assert_eq!(launcher.run_as_user, Some(LAUNCHER_UID));
+    assert_eq!(launcher.run_as_user, Some(0));
+    assert_ne!(worker.run_as_user, launcher.run_as_user);
+    // Child + artifact contract constants come straight from the crate.
+    assert_eq!(CHILD_UID, 1001);
+    assert_eq!(ARTIFACT_GID, 1000);
+}
+
+#[test]
+fn worker_security_context_is_restricted() {
+    let sc = worker_security_context();
+    assert_eq!(sc.allow_privilege_escalation, Some(false));
+    assert_eq!(sc.run_as_non_root, Some(true));
+    assert_eq!(
+        sc.capabilities.as_ref().unwrap().drop.as_deref(),
+        Some(&["ALL".to_string()][..])
+    );
+    assert_eq!(sc.seccomp_profile.as_ref().unwrap().type_, "RuntimeDefault");
+}
+
+/// The launcher is granted exactly the five capabilities it needs, spelled
+/// the way the API server accepts, and is never `privileged`.
+#[test]
+fn launcher_capabilities_are_exactly_the_designed_set() {
+    let caps = launcher_capabilities();
+    assert_eq!(caps.drop.as_deref(), Some(&["ALL".to_string()][..]));
+    let add = caps.add.expect("launcher adds capabilities");
+    assert_eq!(
+        add,
+        vec!["SETUID", "SETGID", "SETPCAP", "SYS_ADMIN", "SYS_RESOURCE"]
+    );
+    // `privileged: true` would grant everything and defeat the bootstrap
+    // drop entirely; it must never appear.
+    let sc = launcher_security_context();
+    assert_eq!(sc.privileged, None);
+    assert_eq!(sc.read_only_root_filesystem, Some(true));
+}
+
+/// The Kubernetes API server rejects the literal string `CAP_SYS_ADMIN` in
+/// `capabilities.add` when `allowPrivilegeEscalation` is false. goxi's
+/// manifest as written uses that spelling and is therefore API-invalid; the
+/// conventional bare name is accepted. A regression here is a 422 at Job
+/// submission, which is a much worse place to find out.
+#[test]
+fn capabilities_use_the_api_accepted_spelling_alongside_no_privilege_escalation() {
+    let sc = launcher_security_context();
+    assert_eq!(sc.allow_privilege_escalation, Some(false));
+    for capability in sc.capabilities.unwrap().add.unwrap() {
+        assert!(
+            !capability.starts_with("CAP_"),
+            "{capability} uses the CAP_-prefixed spelling the API server rejects \
+             alongside allowPrivilegeEscalation: false"
+        );
+    }
+}
+
+/// The bootstrap capabilities are named in one place and are exactly the
+/// ones the launcher crate drops at runtime. If the render adds a
+/// bootstrap-only capability the runtime does not shed, a task-run pod ships
+/// holding it — which for SYS_ADMIN is a node-wide escape primitive.
+#[test]
+fn every_bootstrap_only_capability_is_one_the_launcher_drops_at_runtime() {
+    let add = launcher_capabilities().add.unwrap();
+    for capability in LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES {
+        assert!(
+            add.iter().any(|granted| granted == capability),
+            "{capability} is declared bootstrap-only but is not granted"
+        );
+    }
+    // The permanent set is what `child::prepare_child` needs and nothing
+    // more; anything else granted must be on the bootstrap-only list.
+    let permanent: Vec<&String> = add
+        .iter()
+        .filter(|granted| !LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES.contains(&granted.as_str()))
+        .collect();
+    assert_eq!(permanent, vec!["SETUID", "SETGID", "SETPCAP"]);
+}
+
+/// Defect 1, asserted on the manifest: a CPU limit on the launcher container
+/// is an ancestor clamp on every invocation leaf. Measured at 0.25 core
+/// against a leaf set to four, with `nr_throttled` reading 0 in the leaf
+/// because the throttling happened at the parent.
+#[test]
+fn the_launcher_container_declares_no_cpu_limit() {
+    let cfg = KubernetesConfig::for_testing();
+    let c = launcher_sidecar_container(&cfg, "registry.example/proj:tag");
+    let limits = c.resources.unwrap().limits.unwrap();
+    assert!(
+        !limits.contains_key("cpu"),
+        "a CPU limit here silently caps every build at it, whatever the leaf says: {limits:?}"
+    );
+    // The memory limit is the pod's build budget, not a sidecar's: every
+    // command now runs in this container's cgroup, so the build's memory
+    // peak lands here. The old 128Mi would OOM-kill the first cargo build.
+    assert_eq!(limits.get("memory").unwrap().0, cfg.memory_limit);
+}
+
+/// The lease ceiling comes from the pod's own declared CPU limit, so the
+/// bound a build runs under is the bound the manifest advertises.
+#[test]
+fn the_lease_quota_is_derived_from_the_declared_pod_cpu_limit() {
+    let mut cfg = KubernetesConfig::for_testing();
+    assert_eq!(cfg.cpu_limit, "4");
+    assert_eq!(launcher_leased_millicores(&cfg), 4_000);
+    cfg.cpu_limit = "12000m".to_string();
+    assert_eq!(launcher_leased_millicores(&cfg), 12_000);
+    // Out of range or unparseable falls back to the crate default rather
+    // than to anything unbounded.
+    cfg.cpu_limit = "not-a-quantity".to_string();
+    assert_eq!(
+        launcher_leased_millicores(&cfg),
+        LeasedQuota::DEFAULT_MILLICORES
+    );
+    cfg.cpu_limit = "500m".to_string();
+    assert_eq!(
+        launcher_leased_millicores(&cfg),
+        LeasedQuota::DEFAULT_MILLICORES
+    );
+}
+
+/// `hostUsers: false` only when the launcher is armed — it is the second
+/// layer under the launcher's own capability drop, and it has a real cost.
+#[test]
+fn user_namespaces_are_requested_exactly_when_the_launcher_is_armed() {
+    assert_eq!(pod_host_users(CgroupLauncherMode::Disabled), None);
+    assert_eq!(pod_host_users(CgroupLauncherMode::Required), Some(false));
+}
+
+/// The armed sidecar mounts a writable directory at the cgroup root path.
+/// Without it `readOnlyRootFilesystem: true` makes the launcher's own
+/// `mount(2)` fail at the mountpoint, before it ever reaches the kernel.
+#[test]
+fn the_launcher_mounts_a_writable_mountpoint_at_the_cgroup_root() {
+    let cfg = KubernetesConfig::for_testing();
+    let c = launcher_sidecar_container(&cfg, "registry.example/proj:tag");
+    let mount = c
+        .volume_mounts
+        .unwrap()
+        .into_iter()
+        .find(|mount| mount.mount_path == LAUNCHER_CGROUP_ROOT)
+        .expect("the launcher must mount a writable cgroup mountpoint");
+    assert_eq!(mount.name, VOLUME_LAUNCHER_CGROUP);
+    assert_ne!(
+        mount.read_only,
+        Some(true),
+        "a read-only mountpoint cannot be mounted over"
+    );
+    // And the volume that backs it must be declared, or the API server
+    // rejects the manifest for a dangling volumeMount.
+    let volume = launcher_cgroup_mountpoint_volume();
+    assert_eq!(volume.name, VOLUME_LAUNCHER_CGROUP);
+    assert!(volume.empty_dir.is_some());
+}
+
+#[test]
+fn pod_security_context_ties_fsgroup_to_artifact_gid_on_root_mismatch() {
+    let sc = pod_security_context();
+    assert_eq!(sc.fs_group, Some(i64::from(ARTIFACT_GID)));
+    assert_eq!(sc.fs_group, Some(1000));
+    assert_eq!(sc.fs_group_change_policy.as_deref(), Some("OnRootMismatch"));
+    // The legacy pod-wide uid override is gone from the pod context.
+    assert_eq!(sc.run_as_user, None);
+}
+
+#[test]
+fn launcher_sidecar_reuses_worker_image_with_launcher_entrypoint() {
+    let cfg = KubernetesConfig::for_testing();
+    let image = "registry.example/proj:tag";
+    let c = launcher_sidecar_container(&cfg, image);
+    assert_eq!(c.name, LAUNCHER_CONTAINER_NAME);
+    // Same image as the worker, different entrypoint (real packaged binary).
+    assert_eq!(c.image.as_deref(), Some(image));
+    assert_eq!(c.command.as_deref(), Some(&[LAUNCHER_BIN.to_string()][..]));
+    assert_eq!(c.restart_policy.as_deref(), Some("Always"));
+    // Requests stay the broker's steady footprint (see the constants);
+    // limits are asserted by `the_launcher_container_declares_no_cpu_limit`.
+    let req = c.resources.as_ref().unwrap().requests.as_ref().unwrap();
+    assert_eq!(req.get("cpu").unwrap().0, LAUNCHER_CPU_REQUEST);
+    assert_eq!(req.get("memory").unwrap().0, LAUNCHER_MEMORY_REQUEST);
+    // The lease ceiling reaches the launcher as env, or it would fall back
+    // to a default that has nothing to do with this pod's budget.
+    let env = c.env.as_ref().unwrap();
+    let value = |name: &str| {
+        env.iter()
+            .find(|var| var.name == name)
+            .and_then(|var| var.value.clone())
+            .unwrap_or_else(|| panic!("{name} must be rendered on the launcher"))
+    };
+    assert_eq!(value("DJINN_LAUNCHER_UNLEASED_MILLICORES"), "250");
+    assert_eq!(value("DJINN_LAUNCHER_LEASED_MILLICORES"), "4000");
+    assert_eq!(value("DJINN_LAUNCHER_CGROUP_ROOT"), LAUNCHER_CGROUP_ROOT);
+}
+
+#[test]
+fn valid_config_passes_render_validation() {
+    let cfg = KubernetesConfig::for_testing();
+    assert!(validate_enforcement_render(&cfg).is_ok());
+}
+
+/// The armed render now PASSES validation — that is the point of this task.
+/// It is not a weakened gate: the individual preconditions below still fail
+/// closed, and the launcher's own startup readiness is unchanged.
+#[test]
+fn the_armed_render_passes_validation() {
+    let mut cfg = KubernetesConfig::for_testing();
+    cfg.cgroup_launcher_mode = CgroupLauncherMode::Required;
+    validate_enforcement_render(&cfg)
+        .expect("the armed render must be dispatchable; it is the shipped enforcement path");
+}
+
+/// A pod CPU limit that cannot become a lease quota is refused while armed,
+/// because the lease is the only ceiling left once the launcher container
+/// has no CPU limit of its own.
+#[test]
+fn an_armed_render_with_an_unusable_lease_quota_fails_closed() {
+    for limit in ["500m", "not-a-quantity", "128"] {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.cgroup_launcher_mode = CgroupLauncherMode::Required;
+        cfg.cpu_limit = limit.to_string();
+        assert!(
+            matches!(
+                validate_enforcement_render(&cfg),
+                Err(RenderValidationError::UnsupportedLeaseQuota { .. })
+            ),
+            "cpu_limit {limit} must not arm enforcement"
+        );
+        // Disarmed, the same config still dispatches: the lease ceiling only
+        // matters when something is actually leasing.
+        cfg.cgroup_launcher_mode = CgroupLauncherMode::Disabled;
+        assert!(validate_enforcement_render(&cfg).is_ok());
+    }
+}
+
+#[test]
+fn unknown_cgroup_profile_fails_closed() {
+    let mut cfg = KubernetesConfig::for_testing();
+    cfg.cgroup_delegation_profile = "cgroup-v3-experimental".to_string();
+    assert!(matches!(
+        validate_enforcement_render(&cfg),
+        Err(RenderValidationError::UnsupportedCgroupProfile { .. })
+    ));
+}
+
+#[test]
+fn recognized_but_nonconforming_cgroup_profiles_are_rejected_by_the_launcher_contract() {
+    for profile in [
+        "cgroup-v1",
+        "cgroup-v2-hybrid",
+        "cgroup-v2-overbroad",
+        "cgroup-v2-readonly",
+    ] {
+        let mut cfg = KubernetesConfig::for_testing();
+        cfg.cgroup_delegation_profile = profile.to_string();
+        assert!(
+            matches!(
+                validate_enforcement_render(&cfg),
+                Err(RenderValidationError::RejectedCgroupProfile { .. })
+            ),
+            "{profile} must be rejected by the launcher readiness contract"
+        );
+    }
+}
+
+/// The adversarial kernel-boundary proof (djinn-cgroup-launcher's
+/// `tests/kernel_boundary_under_rendered_context.rs`, task zf13/goxi AC2)
+/// cannot depend on this crate — that would be a dependency cycle — so it
+/// drives its real UID-1000/1001 processes from a checked-in fixture of the
+/// rendered security context. This test is what keeps that fixture honest:
+/// it rebuilds the REAL manifest values and asserts every fixture line, so
+/// changing the render without updating the fixture fails here instead of
+/// silently proving a boundary nobody ships.
+#[test]
+fn rendered_security_context_matches_the_adversarial_proof_fixture() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read rendered security-context fixture {path:?}: {e}"));
+    let fixture: BTreeMap<&str, &str> = raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            let (key, value) = line.split_once('=').expect("fixture line is key=value");
+            (key.trim(), value.trim())
+        })
+        .collect();
+
+    let worker = worker_security_context();
+    let launcher = launcher_security_context();
+    let pod = pod_security_context();
+    let config = KubernetesConfig::for_testing();
+    let capabilities = |sc: &SecurityContext, take_added: bool| {
+        let caps = sc.capabilities.as_ref().expect("capabilities");
+        let list = if take_added {
+            caps.add.clone().unwrap_or_default()
+        } else {
+            caps.drop.clone().unwrap_or_default()
+        };
+        list.join(",")
+    };
+    let expected: BTreeMap<&str, String> = BTreeMap::from([
+        (
+            "worker_run_as_user",
+            worker.run_as_user.unwrap().to_string(),
+        ),
+        (
+            "worker_run_as_group",
+            worker.run_as_group.unwrap().to_string(),
+        ),
+        (
+            "worker_run_as_non_root",
+            worker.run_as_non_root.unwrap().to_string(),
+        ),
+        (
+            "worker_allow_privilege_escalation",
+            worker.allow_privilege_escalation.unwrap().to_string(),
+        ),
+        ("worker_capabilities_drop", capabilities(&worker, false)),
+        (
+            "launcher_run_as_user",
+            launcher.run_as_user.unwrap().to_string(),
+        ),
+        (
+            "launcher_run_as_group",
+            launcher.run_as_group.unwrap().to_string(),
+        ),
+        (
+            "launcher_allow_privilege_escalation",
+            launcher.allow_privilege_escalation.unwrap().to_string(),
+        ),
+        (
+            "launcher_read_only_root_filesystem",
+            launcher.read_only_root_filesystem.unwrap().to_string(),
+        ),
+        ("launcher_capabilities_drop", capabilities(&launcher, false)),
+        ("launcher_capabilities_add", capabilities(&launcher, true)),
+        (
+            "launcher_bootstrap_only_capabilities",
+            LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES.join(","),
+        ),
+        (
+            "launcher_host_users",
+            pod_host_users(CgroupLauncherMode::Required)
+                .expect("the armed render sets hostUsers")
+                .to_string(),
+        ),
+        ("child_run_as_user", CHILD_UID.to_string()),
+        ("child_run_as_group", ARTIFACT_GID.to_string()),
+        ("child_umask", "0002".to_string()),
+        ("pod_fs_group", pod.fs_group.unwrap().to_string()),
+        (
+            "pod_fs_group_change_policy",
+            pod.fs_group_change_policy.clone().unwrap(),
+        ),
+        (
+            "seccomp_profile",
+            worker.seccomp_profile.as_ref().unwrap().type_.clone(),
+        ),
+        ("launcher_expected_uid", LAUNCHER_UID.to_string()),
+        (
+            "unleased_millicores",
+            LAUNCHER_UNLEASED_MILLICORES.to_string(),
+        ),
+        (
+            "leased_millicores",
+            launcher_leased_millicores(&config).to_string(),
+        ),
+        (
+            "cgroup_delegation_profile",
+            config.cgroup_delegation_profile.clone(),
+        ),
+        (
+            "volume_ownership_mode",
+            config.volume_ownership_mode.clone(),
+        ),
+    ]);
+
+    for (key, value) in &expected {
+        assert_eq!(
+            fixture.get(key).copied(),
+            Some(value.as_str()),
+            "the adversarial proof fixture is stale for `{key}`; update \
+             crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env"
+        );
+    }
+    let extra: Vec<&&str> = fixture
+        .keys()
+        .filter(|k| !expected.contains_key(*k))
+        .collect();
+    assert!(
+        extra.is_empty(),
+        "the fixture declares keys the render does not produce: {extra:?}"
+    );
+    // The launcher and worker share one seccomp profile; assert it rather
+    // than let the fixture describe only half the contract.
+    assert_eq!(
+        launcher.seccomp_profile.as_ref().unwrap().type_,
+        fixture["seccomp_profile"]
+    );
+    // The render must also actually accept the profile pair it advertises.
+    assert!(validate_enforcement_render(&config).is_ok());
+}
+
+#[test]
+fn incompatible_volume_ownership_mode_fails_closed() {
+    let mut cfg = KubernetesConfig::for_testing();
+    cfg.volume_ownership_mode = "chown-recursive-always".to_string();
+    assert!(matches!(
+        validate_enforcement_render(&cfg),
+        Err(RenderValidationError::IncompatibleVolumeOwnership { .. })
+    ));
+}
+
+/// A per-project CPU-limit override must move the lease with it. The lease is
+/// the only ceiling that governs a build once the launcher container has no CPU
+/// limit of its own, so a worker limit of 8 with a lease of 4 would silently
+/// halve every build on that project.
+#[test]
+fn a_resolved_cpu_limit_override_retunes_the_lease() {
+    use k8s_openapi::api::core::v1::PodSpec;
+
+    let cfg = KubernetesConfig::for_testing();
+    let mut pod = PodSpec {
+        init_containers: Some(vec![launcher_sidecar_container(
+            &cfg,
+            "registry.example/proj:tag",
+        )]),
+        ..PodSpec::default()
+    };
+    let leased = |pod: &PodSpec| {
+        pod.init_containers
+            .iter()
+            .flatten()
+            .find(|c| c.name == LAUNCHER_CONTAINER_NAME)
+            .and_then(|c| c.env.as_ref())
+            .and_then(|env| {
+                env.iter()
+                    .find(|var| var.name == "DJINN_LAUNCHER_LEASED_MILLICORES")
+            })
+            .and_then(|var| var.value.clone())
+            .expect("the launcher carries a lease ceiling")
+    };
+
+    assert_eq!(leased(&pod), "4000");
+    retune_launcher_lease(&mut pod, "8");
+    assert_eq!(leased(&pod), "8000");
+    retune_launcher_lease(&mut pod, "6500m");
+    assert_eq!(leased(&pod), "6500");
+    // A limit that cannot become a lease quota leaves the rendered value alone
+    // rather than writing something unbounded.
+    retune_launcher_lease(&mut pod, "250m");
+    assert_eq!(leased(&pod), "6500");
+    retune_launcher_lease(&mut pod, "not-a-quantity");
+    assert_eq!(leased(&pod), "6500");
+}

--- a/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
+++ b/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
@@ -26,11 +26,22 @@
 //!
 //! # Why it is not `#[ignore]`d and needs no privileges
 //!
-//! It runs the REAL `djinn_cgroup_launcher::NativeCgroupFs::open` and the REAL
-//! `NativeClone3::preflight` against a REAL kernel — no fakes — but every check
-//! is a `statfs`/`openat`/`clone3`-argument-validation on a directory this test
-//! owns. There is nothing to gate, so it runs in the ordinary
+//! It runs the REAL `djinn_cgroup_launcher::NativeCgroupFs::open` against a REAL
+//! kernel — no fakes — but every check is a `statfs`/`openat` on a directory
+//! this test owns. There is nothing to gate, so it runs in the ordinary
 //! `cargo test -p djinn-k8s` lane where a human sees it, on every PR.
+//!
+//! # What changed for task 7deu
+//!
+//! The volume rendered at `/run/djinn-cgroup` is back — but as a writable
+//! MOUNTPOINT, not as a delegated root. That distinction is the whole lesson of
+//! the P0, so it is asserted in both directions:
+//! [`the_rendered_cgroup_root_is_a_mountpoint_and_never_a_delegated_root`]
+//! requires the volume to materialize AND requires `NativeCgroupFs::open` on it
+//! to FAIL. The delegation is established by the launcher's own `mount(2)`; that
+//! end-to-end chain — mount, delegate, throttle, lift, measured on `cpu.stat` —
+//! is proven in `djinn-cgroup-launcher`'s privileged lane, which is the only
+//! place a real cgroup2 hierarchy exists.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -144,53 +155,65 @@ fn materialize(volume: &Volume, scratch: &Path) -> Option<PathBuf> {
     None
 }
 
-/// **The contract.** For the manifest this crate actually renders: either the
-/// launcher is not rendered at all, or the delegated cgroup root it mounts
-/// materializes into a filesystem the real launcher accepts.
+/// **The contract.** The volume rendered at [`LAUNCHER_CGROUP_ROOT`] is a
+/// writable MOUNTPOINT, and it must never be mistaken for the delegation.
 ///
-/// Run against BOTH modes, so arming the launcher in the future cannot quietly
-/// reintroduce a root that is not a cgroup2 tree.
+/// Both halves matter, and both are asserted against the real launcher code on
+/// a real kernel:
+///
+/// * it must materialize into a directory at all (a source that cannot be
+///   materialized locally cannot be mounted onto in a pod either), and
+/// * `NativeCgroupFs::open` on it must **FAIL**, by name. That failure is the
+///   proof that the launcher's own `mount(2)` is load-bearing. If this ever
+///   started passing, someone would have handed the launcher a "delegated root"
+///   that is not one — which is exactly the P0 that CrashLoopBackOffed the
+///   sidecar on every task-run Pod.
 #[test]
-fn every_rendered_delegated_cgroup_root_is_a_real_cgroup2_tree() {
+fn the_rendered_cgroup_root_is_a_mountpoint_and_never_a_delegated_root() {
     let scratch = Scratch::new("delegated-root");
+    let job = render(CgroupLauncherMode::Required);
+    let pod = pod_of(&job);
 
-    for mode in [CgroupLauncherMode::Disabled, CgroupLauncherMode::Required] {
-        let job = render(mode);
-        let pod = pod_of(&job);
+    let mounted = volumes_mounted_at(pod, LAUNCHER_CGROUP_ROOT);
+    assert_eq!(
+        mounted.len(),
+        1,
+        "exactly one container mounts the cgroup root, and it is the launcher"
+    );
+    let (container, volume) = mounted[0];
+    assert_eq!(container, LAUNCHER_CONTAINER_NAME);
 
-        for (container, volume) in volumes_mounted_at(pod, LAUNCHER_CGROUP_ROOT) {
-            let root = materialize(volume, scratch.path()).unwrap_or_else(|| {
-                panic!(
-                    "{mode:?}: container {container} mounts a delegated cgroup root at \
-                     {LAUNCHER_CGROUP_ROOT} from volume {} whose source cannot be a cgroup2 \
-                     hierarchy",
-                    volume.name
-                )
-            });
+    let root = materialize(volume, scratch.path()).unwrap_or_else(|| {
+        panic!(
+            "the cgroup mountpoint is rendered from volume {}, whose source cannot be \
+             materialized into a directory the launcher could mount onto",
+            volume.name
+        )
+    });
 
-            // The real launcher code, on a real kernel, against the volume this
-            // crate really renders. No fake, no fixture, no ignore gate.
-            if let Err(error) = NativeCgroupFs::open(&root, LAUNCHER_UID as u32) {
-                panic!(
-                    "{mode:?}: the rendered delegated cgroup root for container {container} \
-                     (volume {}) is not usable by the launcher: {error}. A task-run Pod with \
-                     this rendering CrashLoopBackOffs its cgroup-launcher sidecar on startup.",
-                    volume.name
-                );
-            }
+    let error = NativeCgroupFs::open(&root, LAUNCHER_UID as u32)
+        .err()
+        .expect(
+            "the rendered volume must NOT satisfy the delegated-root contract on its own; if it \
+         does, the launcher's own mount(2) is not what establishes the delegation and the \
+         readiness check proves nothing",
+        );
+    match error {
+        LauncherError::DelegatedRootIsNotCgroupFs {
+            expected, actual, ..
+        } => {
+            assert_eq!(expected, CGROUP2_SUPER_MAGIC);
+            assert_ne!(actual, CGROUP2_SUPER_MAGIC);
         }
+        other => panic!("expected a named non-cgroup2 readiness failure, got: {other}"),
     }
 }
 
 /// Prove the check above has teeth: the exact volume source that shipped the P0
-/// is rejected, by name, by the same code path the contract test runs.
-///
-/// Without this, `every_rendered_delegated_cgroup_root_is_a_real_cgroup2_tree`
-/// could pass vacuously (it does pass vacuously today — nothing mounts that path
-/// any more) and nobody would know whether it can fail at all.
+/// is rejected, by name, by the same code path.
 #[test]
 fn the_emptydir_delegated_root_that_shipped_the_p0_is_rejected_by_name() {
-    let scratch = Scratch::new("delegated-root");
+    let scratch = Scratch::new("shipped-p0");
     // Byte-for-byte the volume `launcher_cgroup_volume()` used to return.
     let shipped = Volume {
         name: VOLUME_LAUNCHER_CGROUP.to_string(),
@@ -246,36 +269,43 @@ fn the_default_rendering_has_no_launcher_surface() {
             .iter()
             .flatten()
             .any(|volume| volume.name == VOLUME_LAUNCHER_CGROUP),
-        "the delegated cgroup volume must not be declared by default"
+        "the cgroup mountpoint volume must not be declared by default"
+    );
+    assert_eq!(
+        pod.host_users, None,
+        "user namespaces are only requested when there is a capability to confine"
     );
 }
 
-/// Even when the mode is armed, no `launcher-cgroup` volume is rendered.
+/// A `hostPath` is still not the route, armed or not.
 ///
-/// A delegated cgroup v2 subtree is not something a *volume source* can supply
-/// at all: in the goxi design the launcher establishes its own cgroup2 mount
-/// inside its own cgroup namespace (which needs `CAP_SYS_ADMIN`, not a volume).
-/// This is the guard against "fix" attempts that re-add an emptyDir, or reach
-/// for a hostPath — which `nsdelegate` refuses across the pod's private cgroup
-/// namespace anyway.
+/// The pod's private cgroup namespace is mounted `nsdelegate`, so a target
+/// outside that namespace root is unreachable no matter what the manifest says.
+/// This is the guard against "fix" attempts that reach for one.
 #[test]
-fn arming_the_launcher_still_renders_no_bogus_cgroup_volume() {
-    let pod = render(CgroupLauncherMode::Required);
-    let pod = pod_of(&pod);
-    assert!(
-        !pod.volumes
-            .iter()
-            .flatten()
-            .any(|volume| volume.name == VOLUME_LAUNCHER_CGROUP),
-        "no volume source can supply a delegated cgroup v2 subtree in this topology"
-    );
+fn no_host_path_is_ever_rendered_for_the_cgroup_root() {
+    for mode in [CgroupLauncherMode::Disabled, CgroupLauncherMode::Required] {
+        let job = render(mode);
+        let pod = pod_of(&job);
+        for (container, volume) in volumes_mounted_at(pod, LAUNCHER_CGROUP_ROOT) {
+            assert!(
+                volume.host_path.is_none(),
+                "{mode:?}: container {container} mounts a hostPath at the cgroup root; \
+                 nsdelegate refuses a target outside the pod's cgroup namespace"
+            );
+        }
+    }
 }
 
-/// The render-time half of the readiness contract: arming the launcher fails
-/// closed at dispatch, before a Job is submitted, rather than after a pod has
-/// come up with a sidecar that cannot start.
+/// The armed render is dispatchable — that is the deliverable — and the
+/// preconditions that make it dispatchable are individually load-bearing.
+///
+/// This replaces a gate that unconditionally refused the armed mode while the
+/// runtime profile did not exist. The refusal has not been deleted, it has been
+/// made specific: each check rejects a render that would produce a sidecar which
+/// cannot start, and does so BEFORE the Job is submitted.
 #[test]
-fn arming_the_launcher_fails_render_validation_before_any_job_is_submitted() {
+fn the_armed_render_is_dispatchable_and_every_precondition_still_fails_closed() {
     let mut config = KubernetesConfig::for_testing();
     assert!(
         validate_enforcement_render(&config).is_ok(),
@@ -283,24 +313,106 @@ fn arming_the_launcher_fails_render_validation_before_any_job_is_submitted() {
     );
 
     config.cgroup_launcher_mode = CgroupLauncherMode::Required;
-    let error = validate_enforcement_render(&config)
-        .expect_err("an unsatisfiable delegation must fail closed");
+    validate_enforcement_render(&config)
+        .expect("the armed render is the shipped enforcement path and must dispatch");
+
+    // The lease is the only ceiling left once the launcher container carries no
+    // CPU limit, so a pod CPU limit that cannot become one is refused.
+    let mut unusable = config.clone();
+    unusable.cpu_limit = "500m".to_string();
+    let error = validate_enforcement_render(&unusable)
+        .expect_err("a lease quota below the launcher crate's floor must fail closed");
     assert!(
-        matches!(error, RenderValidationError::CgroupDelegationUnavailable),
-        "expected CgroupDelegationUnavailable, got: {error}"
+        matches!(error, RenderValidationError::UnsupportedLeaseQuota { .. }),
+        "expected UnsupportedLeaseQuota, got: {error}"
     );
-    // The operator has to be told what to do, not just that it failed — and the
-    // message must not misrepresent an unbuilt runtime profile as a platform
-    // limit, because that is how a solvable gap gets remembered as impossible.
     let message = error.to_string();
-    for expected in [
-        "CAP_SYS_ADMIN",
-        "not a platform limit",
-        "DJINN_K8S_CGROUP_LAUNCHER_MODE=disabled",
-    ] {
+    assert!(
+        message.contains("bounded only by the node"),
+        "the operator must be told what is at stake: {message}"
+    );
+
+    // Disarmed, the same config still dispatches: the lease ceiling only
+    // matters when something is actually leasing.
+    unusable.cgroup_launcher_mode = CgroupLauncherMode::Disabled;
+    assert!(validate_enforcement_render(&unusable).is_ok());
+}
+
+/// Defect 1, on the manifest the API server would receive: the launcher
+/// container must declare NO CPU limit.
+///
+/// Under `nsdelegate` the delegated root IS the launcher's container cgroup, so
+/// a limit here is an ancestor clamp on every invocation leaf. Measured with the
+/// leaf at four cores and a 250m container limit: `usage_usec 1252296` over a 5s
+/// window — 0.25 core — with `nr_throttled` reading 0 in the leaf because the
+/// throttling happened at the parent. Removing it took the same pod to
+/// `nr_throttled 40/40` unleased and 1.995 measured cores after the lift.
+#[test]
+fn the_armed_launcher_container_has_no_cpu_limit_and_a_real_memory_limit() {
+    let config = KubernetesConfig::for_testing();
+    let job = render(CgroupLauncherMode::Required);
+    let pod = pod_of(&job);
+    let launcher = pod
+        .init_containers
+        .iter()
+        .flatten()
+        .find(|container| container.name == LAUNCHER_CONTAINER_NAME)
+        .expect("the armed render includes the launcher sidecar");
+
+    let limits = launcher
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.limits.as_ref())
+        .expect("the launcher declares limits");
+    assert!(
+        !limits.contains_key("cpu"),
+        "a CPU limit on the launcher clamps every invocation leaf to it: {limits:?}"
+    );
+    // Every command now runs in this container's cgroup, so the build's memory
+    // peak lands here — a sidecar-sized memory limit would OOM-kill the first
+    // `cargo build`.
+    assert_eq!(limits.get("memory").unwrap().0, config.memory_limit);
+}
+
+/// The armed pod runs in a user namespace, and the launcher's capabilities are
+/// spelled the way the API server accepts.
+#[test]
+fn the_armed_pod_confines_the_bootstrap_capability() {
+    let job = render(CgroupLauncherMode::Required);
+    let pod = pod_of(&job);
+    assert_eq!(
+        pod.host_users,
+        Some(false),
+        "hostUsers: false maps the launcher's bootstrap CAP_SYS_ADMIN into a user namespace, \
+         where the non-namespaced sysctls that make it an escape primitive are unreachable"
+    );
+
+    let launcher = pod
+        .init_containers
+        .iter()
+        .flatten()
+        .find(|container| container.name == LAUNCHER_CONTAINER_NAME)
+        .expect("the armed render includes the launcher sidecar");
+    let security = launcher
+        .security_context
+        .as_ref()
+        .expect("launcher securityContext");
+    assert_eq!(security.allow_privilege_escalation, Some(false));
+    assert_eq!(security.privileged, None);
+    let added = security
+        .capabilities
+        .as_ref()
+        .and_then(|caps| caps.add.as_deref())
+        .unwrap_or_default();
+    assert!(
+        added.iter().any(|capability| capability == "SYS_ADMIN"),
+        "the launcher cannot mount its delegated root without SYS_ADMIN: {added:?}"
+    );
+    for capability in added {
         assert!(
-            message.contains(expected),
-            "the rejection must explain {expected}: {message}"
+            !capability.starts_with("CAP_"),
+            "{capability} uses the spelling the API server rejects alongside \
+             allowPrivilegeEscalation: false"
         );
     }
 }

--- a/server/crates/djinn-runtime/src/lib.rs
+++ b/server/crates/djinn-runtime/src/lib.rs
@@ -35,8 +35,8 @@ pub use handle::RunHandle;
 pub use session_runtime::{InfraDeathLogTailCapture, RuntimeError, SessionRuntime};
 pub use spec::{
     LoopGuardKind, LoopGuardTrip, ProviderFailureClass, ResumeLifecycleMetadata,
-    ResumeSelectionReason, ResumeSourceKind, RoleKind, SupervisorFlow, TaskRunOutcome,
-    TaskRunReport, TaskRunSpec, role_sequence,
+    ResumeSelectionReason, ResumeSourceKind, RoleKind, RoleResourceClass, SupervisorFlow,
+    TaskRunOutcome, TaskRunReport, TaskRunSpec, role_sequence,
 };
 pub use stream::{BiStream, STAGE_STEP_FIRST_TURN, StreamEvent, StreamFrame, stage_step};
 pub use warmer::{GraphWarmerService, TaskrunJobRef, WarmerError};

--- a/server/crates/djinn-runtime/src/spec.rs
+++ b/server/crates/djinn-runtime/src/spec.rs
@@ -90,6 +90,84 @@ impl RoleKind {
     }
 }
 
+/// Whether a role's task-run may run the project's compile/test toolchain.
+///
+/// # Why this lives in `djinn-runtime` and not where it is used
+///
+/// Two layers need the same answer and must never disagree:
+///
+/// * `djinn-k8s` sizes the pod — a Light role gets a fractional-core CPU
+///   request because it will never compile.
+/// * `djinn-coordinator` admits the task-run — a Light role must NOT consume one
+///   of the scarce build slots, or the cap starves Planners and Refinement
+///   tribunals behind builds they were never going to compete with.
+///
+/// Before this existed, `build_admission.rs` recorded the assumption in a
+/// comment ("All currently dispatchable task-run roles are build-producing
+/// work") and `djinn-k8s` recorded the opposite in code. `djinn-core`'s
+/// `is_test_path` is the precedent: one classifier, one home, no drift.
+///
+/// `djinn-core` would also have worked as a home, but `RoleKind` already lives
+/// here and both consumers already depend on this crate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum RoleResourceClass {
+    /// Orchestration-only roles that never run the project's compile/test
+    /// toolchain: Planner, Reviewer, Lead, every Refinement sub-role, and
+    /// grooming (a Planner-driven flow). Fractional-core CPU request, and no
+    /// build-admission slot.
+    Light,
+    /// Roles that may compile/build/test: Worker, Verifier, Architect, and any
+    /// retry/resume of those. Full-core CPU request, and one build slot. Also
+    /// the FAIL-SAFE default for a missing/unknown/newly-added role.
+    BuildCapable,
+}
+
+impl RoleResourceClass {
+    /// Classify the role that executes a task-run.
+    ///
+    /// Deliberately a catch-all (`_ => BuildCapable`) rather than an exhaustive
+    /// match: an unrecognized, missing (`None`), or newly-introduced role must
+    /// **fail safe to build-capable** so a pod that might compile is never
+    /// under-provisioned and never escapes the admission cap. Only the
+    /// explicitly-listed light roles are ever classed light.
+    pub fn for_role(role: Option<RoleKind>) -> Self {
+        match role {
+            Some(
+                RoleKind::Planner | RoleKind::Reviewer | RoleKind::Lead | RoleKind::Refinement,
+            ) => Self::Light,
+            _ => Self::BuildCapable,
+        }
+    }
+
+    /// Classify by role NAME, for the layers that carry a role as a string.
+    ///
+    /// The coordinator's dispatch path names the concrete refinement sub-roles
+    /// (`advocate`, `adversary`, `judge`) that [`RoleKind`] collapses into
+    /// `Refinement`, so they are listed here explicitly. Matching is
+    /// case-insensitive and, like [`Self::for_role`], anything unrecognized
+    /// fails safe to build-capable.
+    pub fn for_role_name(role: &str) -> Self {
+        match role.trim().to_ascii_lowercase().as_str() {
+            "planner" | "reviewer" | "lead" | "refinement" | "advocate" | "adversary" | "judge"
+            | "grooming" => Self::Light,
+            _ => Self::BuildCapable,
+        }
+    }
+
+    /// Does a task-run of this class consume a build-admission slot?
+    pub fn consumes_build_slot(self) -> bool {
+        matches!(self, Self::BuildCapable)
+    }
+
+    /// Stable telemetry/label string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Light => "light",
+            Self::BuildCapable => "build-capable",
+        }
+    }
+}
+
 /// Template for a task-run's role sequence.
 ///
 /// `NewTask` is the canonical "work" flow: plan, execute, review, verify,


### PR DESCRIPTION
Task `7deu`. Makes the per-invocation CPU lease actually govern CPU, then arms it. Builds on #2559 (grkq).

## The four defects, and what each measured

### 1. The delegated root IS the launcher's own container cgroup

`LAUNCHER_CPU_LIMIT = "250m"` was the single reason the whole feature was a no-op. Under `nsdelegate` the delegated root is the launcher container's cgroup, whose `cpu.max` the kubelet had already set from that limit, so a larger quota on an invocation leaf changed nothing.

| | before | after |
| --- | --- | --- |
| leaf set to 4 cores, 2 spinners, 5s window | `usage_usec 1252296` (0.25 core) | — |
| unleased leaf, 2s window | — | `505620` usec (0.253 core, target 0.25) |
| `nr_throttled` unleased | `0` (throttling happened at the parent) | `20` |
| leased leaf, 2s window | — | `3994452` usec (1.997 cores), `nr_throttled 0` |

`nr_throttled 0` is why the proposal's throttle-based heavy detection was structurally blind. The container CPU limit is removed; the ceiling moves to the leaf, and **the lift now writes the pod's declared CPU budget as an explicit quota rather than `max`** — with no ancestor clamp, an unbounded leaf would let one build take the node. The launcher's memory limit becomes the worker's, because the build's peak now lands in that container and `128Mi` would have OOM-killed the first `cargo build`. Its CPU *request* stays at `50m`: `cpu.weight` is a floor under contention, not a ceiling, and the worker is not continuously runnable during a build — so **the bin-packing fixture is arithmetically unchanged**, it sums requests and no request moved.

### 2. Parallelism, and a much larger environment problem

`available_parallelism()` is sampled once at exec, so a build born in the 250m lane picks `-j1` — 165s against 61s for `-j4`.

Found while fixing it: the launcher execs with **exactly** the `CommandSpec` environment, and `Command::get_envs()` returns only explicitly-set variables. The old six-key allow-list carried none of the pod's build environment, so a brokered build ran with no `CARGO_TARGET_DIR` (cold, wrong directory, no warm cache), no `CARGO_BUILD_RUSTFLAGS` (no mold), no `RUSTUP_HOME`. That is a bigger own-goal than `-j1`.

The allow-list **stays closed by default** and now names the build-toolchain surface explicitly; the worker forwards its own environment through the same predicate (`is_allowed_environment_key`), which the privileged broker re-checks.

**The decision:** the launcher derives `CARGO_BUILD_JOBS` / `NEXTEST_TEST_THREADS` / `MAKEFLAGS` / `GOMAXPROCS` from the **leased** quota, not the quota the child is born at, and overrides whatever the caller sent. There is no static value correct in both regimes, so the question is which to be wrong in. Pinning from the unleased lane costs 2.7x on every lifted build. Pinning from the leased quota only over-threads a command that is *never* lifted — which is by construction one that never consumed enough CPU to be detected heavy, so it is not compute-bound, and the CFS quota bounds it regardless. Lifting-before-exec is strictly better than lifting mid-flight, which cannot repair an already-sampled value.

### 3. clone3 removed

It made a syscall's availability a hard dependency (`RuntimeDefault` `ENOSYS`es it without `CAP_SYS_ADMIN`), and `libc::CLONE_INTO_CGROUP` had already truncated to `0`, turning it into a plain fork whose child stayed in the launcher's cgroup.

Replaced with fork + pipe handshake + `cgroup.procs` write + **read-back verification**. Between fork and the go byte the child issues exactly one syscall — a blocking `read` on an empty pipe — and burns no CPU; if placement fails the pipe is closed instead of written and the child `_exit`s without reaching `execve`. Verifying membership rather than assuming it makes the "silently not contained" variant impossible.

I chose fork over keeping a correctly-typed `clone3`: it removes a syscall-availability dependency entirely, and the containment property is now *verified* rather than delegated to a flag constant that had already been wrong once.

### 4. CAP_SYS_ADMIN does not survive startup

The launcher mounts its own delegated cgroup2 root, vacates into `init/`, enables `+cpu`, then `capset`s `SYS_ADMIN`/`SYS_RESOURCE` out of its permitted, effective, inheritable **and bounding** sets, verifies with `capget`, and refuses to serve if the drop did not take — all before the broker binds, so no user-controlled code ever runs while they are held. `hostUsers: false` confines even that window.

This is also the only real implementation of "allowPrivilegeEscalation false AFTER INITIALIZATION", which is not expressible as a Pod field. Capability names use the bare spelling (`SYS_ADMIN`), because the API server rejects `CAP_SYS_ADMIN` alongside `allowPrivilegeEscalation: false`; a render-time gate now catches the invalid spelling too.

**Not verified on a non-nested node.** kind-in-docker cannot nest user namespaces. Both failure modes are fail-closed: an unsupporting runtime refuses the Pod, and a broken cgroup chain fails launcher readiness before the broker binds.

## Also

- **Light roles no longer consume a build slot** (task `h1yv`). `RoleResourceClass` moves to `djinn-runtime` so pod sizing and admission cannot disagree; Planner/Reviewer/Lead/Advocate/Adversary/Judge get a zero-slot permit. With cap 3 they would otherwise queue behind builds they never compete with.
- **Chart plumbing**: `cgroupLauncher.mode` (`disabled` default), schema-validated, so enforcement can actually be armed. `buildAdmission.maxBuildTaskRuns: 3` was already there.
- **`validate_enforcement_render`** no longer blanket-rejects the armed mode. The refusal is now specific: missing `SYS_ADMIN`, `CAP_`-prefixed spelling, missing mountpoint, a CPU limit on the launcher, absent `hostUsers`, or a pod CPU limit that cannot become a lease quota each fail closed at dispatch.

## Testing

The existing suite ran against a `FakeCgroup` that hard-codes `root_writable: true` — the exact property that was false in production — and a `FakeClone` that ignored its flag. Both hid real defects.

New `tests/delegated_cpu_lease_lifecycle.rs` (privileged lane) runs the real `Bootstrap`/`NativeCgroupFs`/`NativeCgroupSpawn` on a real kernel and asserts **behaviour over a wall-clock window**, never a `cpu.max` read-back. It fails if the child escapes the cgroup (usage ~0), if the quota does not bite (usage ~2 cores), if `nr_throttled` is 0 unleased, if the lift does not multiply throughput, if it exceeds the lease ceiling, or if the capability drop did not take. Verified locally: `1 passed`, with the numbers in the table above.

The always-on lane guard fails the ordinary shard if CI stops running it. `rendered_launcher_delegation.rs` is extended rather than duplicated, and now asserts the mountpoint/delegation distinction in **both** directions — the volume must materialize, and `NativeCgroupFs::open` on it must FAIL.

The zf13 adversary harness was converted from `clone3` to the shipped fork+place path, so it proves the boundary that actually ships.

## Not done

`hostUsers: false` and defects 1–2 are unverified on the production k3s node — I did not touch production. Recommend arming `cgroupLauncher.mode=required` on one node and watching launcher startup logs before enabling `buildAdmission.mode=enforce`.

Amends proposal `goxi`: the launcher resource row, the capability spelling, the unexpressible allowPrivilegeEscalation clause, the clone3 spawn description, and the parallelism-pin decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
