### PR TITLE
fix(opsu): render DJINN_TASK_RUN_POD_UID into the task-run Job and guard the renderer/binary contract

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1190,6 +1190,7 @@ dependencies = [
  "djinn-db",
  "djinn-git",
  "djinn-graph",
+ "djinn-k8s",
  "djinn-provider",
  "djinn-runtime",
  "djinn-slot",

--- a/server/crates/djinn-agent-worker/Cargo.toml
+++ b/server/crates/djinn-agent-worker/Cargo.toml
@@ -51,6 +51,12 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 djinn-agent = { path = "../djinn-agent", features = ["test-support"] }
+# Tests only, and deliberately: `src/rendered_job_env_contract.rs` renders the
+# real task-run/warm Job manifests and checks them against this binary's real
+# clap definition. Already in the graph transitively (djinn-agent depends on it),
+# so this edge costs no extra compilation. NEVER promote it to [dependencies] —
+# the worker must not carry a Kubernetes client into the Pod.
+djinn-k8s = { path = "../djinn-k8s" }
 djinn-db = { path = "../djinn-db", features = ["test-support"] }
 djinn-graph = { path = "../djinn-graph", features = ["test-support"] }
 futures = "0.3"

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -290,6 +290,18 @@ struct WorkerDefaultArgs {
     workspace_path: PathBuf,
 }
 
+/// READ THIS BEFORE ADDING A REQUIRED ARGUMENT ABOVE.
+///
+/// Nothing on the command line supplies these — the Pod runs
+/// `djinn-agent-worker task-run` with no flags — so every required argument must
+/// be rendered into the container environment by `djinn_k8s::job`. Task opsu's
+/// P0 was a required argument (`--task-run-pod-uid`, #2513) that no renderer ever
+/// supplied: every task-run Pod in production exited 2 in argv parsing.
+/// [`rendered_job_env_contract`] derives the required set from the clap
+/// definition above and fails when the rendered Job cannot satisfy it.
+#[cfg(test)]
+mod rendered_job_env_contract;
+
 /// Local [`djinn_graph::WarmContext`] implementation for the worker binary.
 ///
 /// Mirrors the subset of `djinn-server::AppState::minimal_for_warm_only`

--- a/server/crates/djinn-agent-worker/src/rendered_job_env_contract.rs
+++ b/server/crates/djinn-agent-worker/src/rendered_job_env_contract.rs
@@ -1,0 +1,244 @@
+//! The coverage whose absence hid task opsu's P0.
+//!
+//! # What went wrong, and why nothing caught it
+//!
+//! Task 9whk (#2513) added `--task-run-pod-uid` to [`crate::WorkerDefaultArgs`]
+//! as a REQUIRED argument with no default. Nothing in `djinn-k8s` ever rendered
+//! `DJINN_TASK_RUN_POD_UID` into the task-run Job. Because the worker's `command`
+//! is `["djinn-agent-worker", "task-run"]` with every value supplied through the
+//! container environment, clap had nowhere else to find it, so every task-run Pod
+//! in production died in argv parsing (`exit 2`) before a single line of worker
+//! code ran.
+//!
+//! The three suites that touch this binary all passed:
+//!   * `djinn-agent-worker`'s integration tests (`rpc_roundtrip`, `in_pod_drive`,
+//!     `cancel_path`) spawn the binary themselves and set `DJINN_TASK_RUN_POD_UID`
+//!     on the command they build — they assert the worker's behaviour GIVEN a
+//!     satisfied argv, never that anything supplies it;
+//!   * `djinn-k8s`'s `job.rs` unit tests assert the env vars someone remembered to
+//!     name, one `assert_eq!` per variable — a hand-written list, which is exactly
+//!     what rots when the binary grows a new requirement;
+//!   * nothing anywhere compared the two.
+//!
+//! # What this file asserts
+//!
+//! The join neither side could make alone: it lives in the binary crate, so it can
+//! read the REAL clap definition, and it dev-depends on `djinn-k8s`, so it can
+//! render the REAL production manifest. The required set is DERIVED from clap on
+//! every run — adding a required argument to `WorkerDefaultArgs` fails this test
+//! until the renderer supplies it, with no list to remember to update.
+//!
+//! Both entry points the cluster actually launches are covered: the env-driven
+//! `task-run` Job and the argv-driven `warm-graph` Job.
+
+use std::collections::BTreeMap;
+
+use clap::{CommandFactory, Parser};
+use uuid::Uuid;
+
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::job::build_task_run_job;
+use djinn_k8s::warm_job::{WARM_COMMAND_BIN, build_warm_job};
+
+use crate::Cli;
+
+/// An argument the process cannot start without: clap marked it required and no
+/// default value can stand in for a missing one.
+fn must_be_supplied(arg: &clap::Arg) -> bool {
+    arg.is_required_set() && arg.get_default_values().is_empty()
+}
+
+/// The arguments of one subcommand that a launcher is obliged to supply,
+/// straight out of the parser the binary really runs.
+fn unsatisfiable_without(subcommand: &str) -> Vec<clap::Arg> {
+    let cli = Cli::command();
+    let sub = cli
+        .get_subcommands()
+        .find(|sub| sub.get_name() == subcommand)
+        .unwrap_or_else(|| {
+            panic!("djinn-agent-worker has no `{subcommand}` subcommand; a renderer launches it")
+        });
+    sub.get_arguments()
+        .filter(|arg| must_be_supplied(arg))
+        .cloned()
+        .collect()
+}
+
+/// **The contract, task-run path.** Every argument the `task-run` subcommand
+/// cannot start without is reachable from the environment the production Job
+/// renders.
+///
+/// The manifest is walked by field access alone so this file names no Kubernetes
+/// types: the k8s capability boundary (`scripts/check-k8s-boundary.sh`) keeps
+/// that surface inside `djinn-k8s`, and a rendered manifest is all this needs.
+#[test]
+fn every_required_task_run_argument_is_rendered_into_the_job() {
+    let job = build_task_run_job(
+        &KubernetesConfig::for_testing(),
+        &Uuid::now_v7(),
+        "proj-opsu",
+        "djinn-taskrun-opsu",
+        "registry.example/djinn-project:opsu",
+        &[],
+        None,
+        false,
+        None,
+    );
+    let pod = job
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("rendered task-run Job has a pod spec");
+    let worker = pod
+        .containers
+        .iter()
+        .find(|container| container.name == "worker")
+        .expect("rendered task-run Job has a worker container");
+
+    // Guard the premise: this test only proves anything while the worker is
+    // launched as `task-run` with no flags on the command line.
+    assert_eq!(
+        worker.command.as_deref(),
+        Some([WARM_COMMAND_BIN.to_string(), "task-run".to_string()].as_slice()),
+        "the worker container's command changed; this contract assumes every value \
+         arrives through the environment"
+    );
+
+    // `name -> can this env entry actually deliver a value`. A `valueFrom` entry
+    // (downward API, secret, configMap) carries no literal at render time but is
+    // resolved by the kubelet before the process starts, so it counts.
+    let rendered: BTreeMap<&str, bool> = worker
+        .env
+        .iter()
+        .flatten()
+        .map(|entry| {
+            let satisfied =
+                entry.value.as_deref().is_some_and(|v| !v.is_empty()) || entry.value_from.is_some();
+            (entry.name.as_str(), satisfied)
+        })
+        .collect();
+
+    let required = unsatisfiable_without("task-run");
+    // Non-vacuity: if the derivation ever stops seeing clap's required set, this
+    // test passes without checking anything — which is the exact failure mode it
+    // exists to prevent.
+    assert!(
+        !required.is_empty(),
+        "derived no required task-run arguments from the clap definition; the contract below \
+         would pass vacuously"
+    );
+
+    for arg in required {
+        let id = arg
+            .get_long()
+            .map(str::to_owned)
+            .unwrap_or_else(|| arg.get_id().as_str().to_owned());
+        let env = arg.get_env().unwrap_or_else(|| {
+            panic!(
+                "`--{id}` is required but reads no environment variable. The task-run Pod runs \
+                 `djinn-agent-worker task-run` with NO flags, so nothing can ever supply it and \
+                 every task-run Pod exits 2 in argv parsing."
+            )
+        });
+        let env = env.to_str().expect("env var names are UTF-8");
+
+        match rendered.get(env) {
+            Some(true) => {}
+            Some(false) => panic!(
+                "the task-run Job renders {env} (for required `--{id}`) with neither a value nor \
+                 a valueFrom; the worker sees an empty string and clap rejects it."
+            ),
+            None => panic!(
+                "the task-run Job does not render {env}, which the worker REQUIRES for `--{id}`. \
+                 Every task-run Pod dispatched with this manifest exits 2 before running any \
+                 worker code. Add it to `build_task_run_env` in djinn-k8s/src/job.rs."
+            ),
+        }
+    }
+}
+
+/// **The contract, warm path.** The warm Pod supplies its arguments positionally
+/// on a shell command line rather than through the environment, so assert the
+/// stronger thing directly: the exact argv the warm Pod `exec`s parses with the
+/// binary's real parser, with no environment at all.
+#[test]
+fn the_warm_pod_argv_parses_with_the_real_parser() {
+    let job = build_warm_job(
+        &KubernetesConfig::for_testing(),
+        "proj-opsu",
+        "registry.example/djinn-project:opsu",
+        None,
+    );
+    let pod = job
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("rendered warm Job has a pod spec");
+    let script = pod.containers[0]
+        .command
+        .as_deref()
+        .and_then(|command| command.last())
+        .expect("warm Pod runs a shell script");
+
+    let exec_line = script
+        .lines()
+        .find(|line| line.starts_with(&format!("exec {WARM_COMMAND_BIN}")))
+        .unwrap_or_else(|| panic!("warm Pod script never execs {WARM_COMMAND_BIN}:\n{script}"));
+
+    let argv = split_shell_words(exec_line.trim_start_matches("exec "));
+    Cli::try_parse_from(&argv).unwrap_or_else(|error| {
+        panic!(
+            "the warm Pod's own command line does not parse: {argv:?}\n{error}\nEvery warm Pod \
+             dispatched with this manifest exits 2 before warming anything."
+        )
+    });
+
+    // The argv path only proves the warm subcommand is satisfiable because none
+    // of its required arguments hide behind the environment. If that changes,
+    // the warm Job's env needs the same treatment as the task-run Job's.
+    for arg in unsatisfiable_without("warm-graph") {
+        assert!(
+            arg.is_positional(),
+            "required warm-graph argument `{}` is not positional; the warm Pod's shell \
+             command supplies positionals only, so it must be rendered into the Pod env",
+            arg.get_id()
+        );
+    }
+}
+
+/// Minimal double-quote-aware tokenizer: enough for the argv this crate's own
+/// renderer emits (`exec <bin> warm-graph "<project id>"`), and it deliberately
+/// refuses anything more exotic rather than guessing at shell semantics.
+fn split_shell_words(line: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut quoted = false;
+    let mut started = false;
+    for ch in line.chars() {
+        match ch {
+            '"' => {
+                quoted = !quoted;
+                started = true;
+            }
+            c if c.is_whitespace() && !quoted => {
+                if started {
+                    words.push(std::mem::take(&mut current));
+                    started = false;
+                }
+            }
+            '$' | '`' | '\\' | '\'' => panic!(
+                "warm Pod argv contains shell metacharacters this contract will not interpret: \
+                 {line}"
+            ),
+            c => {
+                current.push(c);
+                started = true;
+            }
+        }
+    }
+    assert!(!quoted, "unbalanced quote in warm Pod argv: {line}");
+    if started {
+        words.push(current);
+    }
+    words
+}

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -10,9 +10,10 @@ use std::collections::BTreeMap;
 
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
-    Container, EmptyDirVolumeSource, EnvVar, KeyToPath, PersistentVolumeClaimVolumeSource, PodSpec,
-    PodTemplateSpec, ProjectedVolumeSource, SecretVolumeSource, ServiceAccountTokenProjection,
-    Toleration, Volume, VolumeMount, VolumeProjection,
+    Container, EmptyDirVolumeSource, EnvVar, EnvVarSource, KeyToPath, ObjectFieldSelector,
+    PersistentVolumeClaimVolumeSource, PodSpec, PodTemplateSpec, ProjectedVolumeSource,
+    SecretVolumeSource, ServiceAccountTokenProjection, Toleration, Volume, VolumeMount,
+    VolumeProjection,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use uuid::Uuid;
@@ -703,6 +704,13 @@ fn build_task_run_env(
         env_var("DJINN_CREDENTIALS_PATH", CREDENTIALS_MOUNT_FILE),
         env_var("DJINN_TOKEN_PATH", TOKEN_MOUNT_FILE),
         env_var("DJINN_TASK_RUN_ID", task_run_id_str),
+        // The worker REQUIRES this (clap, no default) and uses it as the
+        // immutable fence for the durable invocation journal and for the
+        // watchdog's exact-Pod termination, which matches it against
+        // `pod.metadata.uid` (see `runtime::exact_taskrun_pod_name`). It is the
+        // POD's own UID, not the Job's, so it can only come from the downward
+        // API at admission — no host-side value exists when the Job is built.
+        downward_api_env_var("DJINN_TASK_RUN_POD_UID", "metadata.uid"),
         // TMPDIR points the supervisor's TempDir::new() (used by
         // mirror.clone_ephemeral) at the writable /workspace emptyDir
         // instead of the container's tmpfs root, which has stricter
@@ -995,6 +1003,23 @@ fn env_var(name: &str, value: &str) -> EnvVar {
     }
 }
 
+/// Env var sourced from the Pod's own object metadata at admission (downward
+/// API). Values that only exist once the apiserver has created the Pod — its
+/// UID above all — cannot be baked into the manifest the dispatcher renders.
+fn downward_api_env_var(name: &str, field_path: &str) -> EnvVar {
+    EnvVar {
+        name: name.to_string(),
+        value_from: Some(EnvVarSource {
+            field_ref: Some(ObjectFieldSelector {
+                field_path: field_path.to_string(),
+                ..ObjectFieldSelector::default()
+            }),
+            ..EnvVarSource::default()
+        }),
+        ..EnvVar::default()
+    }
+}
+
 fn volume_mount(name: &str, mount_path: &str, read_only: Option<bool>) -> VolumeMount {
     VolumeMount {
         name: name.to_string(),
@@ -1249,7 +1274,9 @@ mod tests {
             .as_ref()
             .expect("container.env set")
             .iter()
-            .map(|e| (e.name.as_str(), e.value.as_deref().expect("env value")))
+            // Downward-API vars (DJINN_TASK_RUN_POD_UID) carry `valueFrom`, not
+            // `value`; asserted by djinn-agent-worker's `rendered_job_env_contract`.
+            .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
             .collect()
     }
 
@@ -1427,12 +1454,7 @@ mod tests {
             .as_ref()
             .expect("container.env set")
             .iter()
-            .map(|e| {
-                (
-                    e.name.as_str(),
-                    e.value.as_deref().expect("env value present"),
-                )
-            })
+            .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
             .collect();
         assert_eq!(
             envs.get("DJINN_SERVER_ADDR").copied(),
@@ -1467,6 +1489,34 @@ mod tests {
             envs.get("DJINN_TASK_RUN_DEADLINE_SECONDS").copied(),
             Some(cfg.task_run_active_deadline_seconds.to_string().as_str())
         );
+        // The worker requires the Pod's OWN immutable UID (it fences the durable
+        // invocation journal, and the watchdog matches it against
+        // `pod.metadata.uid`). It cannot be a literal — the UID does not exist
+        // until the apiserver admits the Pod — so it MUST come from the downward
+        // API. Rendering it as anything else (metadata.name, the Job UID) breaks
+        // exact-Pod termination silently. Task opsu: it was missing entirely and
+        // every task-run Pod exited 2 in argv parsing.
+        let pod_uid = container
+            .env
+            .as_ref()
+            .expect("container.env set")
+            .iter()
+            .find(|e| e.name == "DJINN_TASK_RUN_POD_UID")
+            .expect("DJINN_TASK_RUN_POD_UID is required by the worker binary");
+        assert!(
+            pod_uid.value.is_none(),
+            "a Pod UID cannot be known when the manifest is rendered"
+        );
+        assert_eq!(
+            pod_uid
+                .value_from
+                .as_ref()
+                .and_then(|source| source.field_ref.as_ref())
+                .map(|field| field.field_path.as_str()),
+            Some("metadata.uid"),
+            "the worker's Pod UID must come from the downward API"
+        );
+
         // DB env vars are gated on the corresponding config fields being
         // `Some`. `for_testing()` leaves them `None`, so they should be
         // absent here — see `forwards_db_env_vars_when_configured` for
@@ -1665,7 +1715,9 @@ mod tests {
             .as_ref()
             .expect("container.env set")
             .iter()
-            .map(|e| (e.name.as_str(), e.value.as_deref().expect("env value")))
+            // Downward-API vars (DJINN_TASK_RUN_POD_UID) carry `valueFrom`, not
+            // `value`; asserted by djinn-agent-worker's `rendered_job_env_contract`.
+            .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
             .collect();
 
         assert_eq!(
@@ -1707,7 +1759,9 @@ mod tests {
             .as_ref()
             .expect("container.env set")
             .iter()
-            .map(|e| (e.name.as_str(), e.value.as_deref().expect("env value")))
+            // Downward-API vars (DJINN_TASK_RUN_POD_UID) carry `valueFrom`, not
+            // `value`; asserted by djinn-agent-worker's `rendered_job_env_contract`.
+            .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
             .collect();
 
         assert_eq!(envs.get("CARGO_HOME").copied(), Some("/cache/cargo"));


### PR DESCRIPTION
## The P0

Every task-run Pod exited 2, ~0s after start, the moment dispatch resumed:

```
applied artifact umask previous_umask="0022" umask="0002"
error: the following required arguments were not provided:
  --task-run-pod-uid <TASK_RUN_POD_UID>
```

#2513 (task 9whk) made `--task-run-pod-uid` a **required** argument of the worker's
`task-run` subcommand. Nothing ever rendered `DJINN_TASK_RUN_POD_UID`. The worker
container's command is `["djinn-agent-worker", "task-run"]` with every value arriving
through the environment, so clap had nowhere to find it and the process died in argv
parsing before any worker code ran. Latent since #2513 only because global dispatch was
paused across that whole window.

## The fix

`build_task_run_env` now renders `DJINN_TASK_RUN_POD_UID` from the downward API
(`valueFrom.fieldRef.fieldPath: metadata.uid`) — the same construct the warm-lease gate
container already uses.

**Pod UID, not Job UID — confirmed against the consumer, not the name.** The value flows
to `ShellLaunchContext::broker_backed` → `InvocationJournal::new(dir, pod_uid)` (the
journal's fence) and to the watchdog's `terminate_taskrun_pod_exact`, which authorizes
its one destructive operation via `exact_taskrun_pod_name(pod, pod_uid, job_uid)` —
literally `pod.metadata.uid == pod_uid`, with the Job UID read separately off the Job
object. A Job UID here would fail every match and disarm exact-Pod termination silently.

## The guard

Second renderer/binary mismatch tonight (grkq/#2559 was the first), invisible for the
same reason both times: the worker's own tests build the argv they spawn
(`rpc_roundtrip`, `in_pod_drive`, `cancel_path` all set this variable themselves), the
renderer's tests assert a hand-written list of env vars, and nothing compared the two.

`djinn-agent-worker/src/rendered_job_env_contract.rs` closes exactly that gap. It lives
in the binary crate — the only place the real clap definition is reachable — and
dev-depends on `djinn-k8s` to render the real production manifests:

* **task-run** — the required set is DERIVED from clap on every run (`is_required_set()`
  minus anything with a default), never restated. A new required argument fails this test
  until the renderer supplies it. A required argument with **no** `env` fails too: nothing
  on that command line can ever satisfy it. A non-vacuity assertion prevents the test
  passing by deriving an empty set.
* **warm-graph** — the warm Pod passes its argument positionally, so the exact argv it
  `exec`s is parsed with the binary's real parser, with no environment at all.

Verified to have teeth: deleting the new env var makes it fail with
*"the task-run Job does not render DJINN_TASK_RUN_POD_UID, which the worker REQUIRES for
`--task-run-pod-uid`"*. A pointer comment sits next to `WorkerDefaultArgs` in `main.rs`,
where someone adding the next required argument will read it.

The `djinn-k8s` unit test additionally pins the *source*: `value` absent, `fieldPath ==
metadata.uid`. The contract test alone would accept a `valueFrom` pointing anywhere.

## Full enumeration of both rendered paths

| subcommand | required args | supplied? |
|---|---|---|
| `task-run` | `DJINN_SERVER_ADDR`, `DJINN_TASK_RUN_ID`, `DJINN_TASK_RUN_POD_UID` | yes, after this PR. Every other argument (`spec_path`, `credentials_path`, `token_path`, `launcher_socket`, `launcher_credential_path`, `workspace_path`) has a clap default |
| `warm-graph` | positional `project_id` | yes — `warm_job.rs` already emits `exec <bin> warm-graph "<id>"` |
| `compare-graph-artifacts` | 3 flags | n/a — no manifest renders it (operator-invoked) |

Those are the only two launch sites in the repo; nothing in `deploy/` runs the worker
binary directly. **No warm-path defect found.**

## Gates

`SQLX_OFFLINE=1 cargo check --workspace --all-targets`, `cargo fmt --all --check`,
`cargo clippy -p djinn-k8s -p djinn-agent-worker --all-targets -- -D warnings`,
`cargo test -p djinn-k8s` (231 + 6 + 2 pass), the new contract tests, file-size /
raw-SQL / k8s-boundary guards, and `cargo hakari generate && manage-deps` (no changes).

Rebased on `c26ec9537` (7deu) — no overlap with its hunks in `job.rs`.

Closes opsu.
