### PR TITLE
fix(8hrv): classify nextest TRY-n FAIL lines in shard failure summaries

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -142,6 +142,8 @@ jobs:
         run: node --test scripts/ci-qa-smoke-workflow.test.mjs
       - name: Verify release image validation contract
         run: node --test scripts/ci-release-image-validation.test.mjs
+      - name: Verify shard failure summary contract
+        run: node --test scripts/ci-shard-failure-summary.test.mjs
       - name: Verify retirement manifest generator contract
         run: node --test scripts/test-djinn-retirement-manifest.mjs
       - name: Run retirement manifest strict reconciliation guard
@@ -1234,38 +1236,31 @@ jobs:
         # is therefore the durable source of truth for "which lane/test failed".
         # Not gated on shard.active: a shard can also fail before shard
         # resolution (build/migration/setup), and those must surface too. The
-        # nextest log is simply absent there, so the generic branch fires.
+        # nextest log is simply absent there, and the annotation then reports
+        # that observation — it does NOT name a layer it cannot see.
         if: failure()
         run: |
           set -uo pipefail
-          shard_name="${{ matrix.shard }}"
-          log="$RUNNER_TEMP/nextest-run.log"
-          failed_tests=""
-          if [ -f "$log" ]; then
-            # nextest prints one `    FAIL [   0.005s] <binary-id> <test-name>`
-            # line per failing test; strip the leading marker + timing bracket
-            # to leave `<binary-id> <test-name>`.
-            failed_tests=$(grep -E '^[[:space:]]*FAIL \[' "$log" \
-              | sed -E 's/^[[:space:]]*FAIL \[[^]]*\][[:space:]]+//' \
-              | sort -u || true)
-          fi
-          if [ -n "$failed_tests" ]; then
-            echo "::error title=Server Test ${shard_name} failed::$(printf '%s' "$failed_tests" | paste -sd'; ' -)"
-            {
-              echo "### Server Test ${shard_name} — FAILED"
-              echo
-              echo "Failing tests:"
-              echo
-              printf '%s\n' "$failed_tests" | sed 's/^/- `/;s/$/`/'
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::error title=Server Test ${shard_name} failed::shard concluded failure without nextest FAIL lines (build, migration, or setup step); see this job's log."
-            {
-              echo "### Server Test ${shard_name} — FAILED"
-              echo
-              echo "This shard failed before producing nextest FAIL lines (e.g. a build, migration, or setup step). See this job's log for the failing step."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          # The parsing lives in a checked-in script, NOT in an inline
+          # grep/sed here, because the inline version could not be tested and
+          # was wrong in both of the ways that matter (task 8hrv):
+          #   * it grepped `^[[:space:]]*FAIL \[`, but every profile used here
+          #     inherits [profile.ci] retries, so a real failure prints
+          #     `TRY 3 FAIL [...]` and never a bare `FAIL` line; and
+          #   * nextest colorizes on CI, so the status token arrives as
+          #     `\e[31;1m  TRY 3 FAIL\e[0m [   0.483s]` — the anchor and the
+          #     space before `[` are both wrong even without retries.
+          # It therefore always fell through to a generic message that
+          # ASSERTED "build, migration, or setup step". Nineteen sessions on
+          # task rwpk were sent after a build problem that did not exist; the
+          # failure was an assertion in
+          # djinn-provider::stream_event_consumer_audit. The script is
+          # exercised by scripts/ci-shard-failure-summary.test.mjs against
+          # captured nextest output from that very run.
+          node "$GITHUB_WORKSPACE/scripts/ci-shard-failure-summary.mjs" \
+            --shard "${{ matrix.shard }}" \
+            --log "$RUNNER_TEMP/nextest-run.log" \
+            --summary "$GITHUB_STEP_SUMMARY"
       - name: Upload retained shard timing data
         if: always() && steps.shard.outputs.active == 'true'
         uses: actions/upload-artifact@v4

--- a/scripts/ci-shard-failure-summary.mjs
+++ b/scripts/ci-shard-failure-summary.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Run-level failure summary for the Server Test shards (quality-gate.yml).
+ *
+ * The shard step that used to do this inline grepped `^[[:space:]]*FAIL \[`.
+ * That pattern misses what nextest actually writes, and the fallback branch it
+ * fell through to did not merely say nothing — it asserted a cause:
+ * "shard concluded failure without nextest FAIL lines (build, migration, or
+ * setup step)". Nineteen remediation sessions on task rwpk were sent to hunt a
+ * build problem that never existed; the real failure was an ordinary assertion
+ * in djinn-provider::stream_event_consumer_audit.
+ *
+ * Two things break the old pattern. Both were confirmed against a real captured
+ * shard log (run 30149467240, job 89657358613) and against cargo-nextest
+ * 0.9.133 locally:
+ *
+ *   1. Retries. The `pull-request`/`merge-group`/`full-validation` profiles all
+ *      inherit `[profile.ci]`'s `retries = { count = 2, ... }` (see
+ *      server/.config/nextest.toml), so a genuinely failing test never prints a
+ *      bare `FAIL` line at all — every attempt, including the final one and its
+ *      repeat in the Summary block, is prefixed: `TRY 3 FAIL [   0.483s] ...`.
+ *   2. Color. nextest emits SGR escapes on CI, and they wrap the status token
+ *      together with its indentation: `<ESC>[31;1m  TRY 3 FAIL<ESC>[0m [   0.483s]`.
+ *      So even a no-retry `FAIL` line does not start with whitespace-then-FAIL
+ *      and does not have a space between `FAIL` and `[`. The old pattern could
+ *      not have matched an un-retried failure on CI either.
+ *
+ * Observed status-line grammar (nextest 0.9.133), after escapes are stripped:
+ *
+ *     [indent]{TRY <n> }?<STATUS> [<duration>] {(<progress>) }?<binary-id> <test-name>
+ *
+ * The progress counter — `(2477/2842)` on a settled attempt, `(───)` while the
+ * count is still unknown — is why stripping only the timing bracket left the
+ * old sed emitting `(2477/2842) binary test` as the "test id". It is optional
+ * here because older nextest releases do not print it.
+ *
+ * Failure statuses observed: FAIL, SIGABRT, TIMEOUT. SIG<NAME> is matched
+ * generically and LEAK-FAIL is included by name; both are terminal failures in
+ * the same grammar. PASS/LEAK lines are parsed too, but only to *retract* a
+ * candidate: a flaky test prints `TRY 1 FAIL` and then `TRY 2 PASS`, and
+ * reporting it as this shard's failing test would be the same misattribution
+ * pointed the other way.
+ *
+ * Usage:
+ *   node scripts/ci-shard-failure-summary.mjs --shard <name> --log <path> \
+ *     [--summary <path>]
+ *
+ * Prints the `::error::` annotation to stdout and, when --summary names a file,
+ * appends the job-page summary block to it.
+ */
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+
+/**
+ * SGR/CSI escape sequences, as nextest writes them when it forces color on CI.
+ * Built from a char code so no invisible ESC byte is checked into this source.
+ */
+const ANSI_ESCAPE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[ -/]*[@-~]`, 'g');
+
+/**
+ * {<runner timestamp> }?[indent]{TRY <n> }?<STATUS> [<duration>] {(<progress>) }?<rest>
+ *
+ * The workflow feeds the tee'd runner-side log, which has no timestamps. The
+ * optional ISO prefix is for the other log a human ever has in hand — the one
+ * downloaded from the Actions API, where every line is timestamp-prefixed — so
+ * the same parser can be pointed at it while debugging.
+ */
+const STATUS_LINE =
+  /^(?:\d{4}-\d{2}-\d{2}T[\d:.]+Z )?\s*(?:TRY\s+\d+\s+)?([A-Z][A-Z-]*)\s+\[[^\]]*\]\s+(?:\([^)]*\)\s+)?(\S.*?)\s*$/;
+
+/** Terminal failure statuses. LEAK-FAIL precedes FAIL so it is not split. */
+const FAILURE_STATUS = /^(?:LEAK-FAIL|FAIL|TIMEOUT|SIG[A-Z]+)$/;
+
+/** Statuses that mean the test ultimately succeeded on that attempt. */
+const SUCCESS_STATUS = /^(?:PASS|LEAK)$/;
+
+export function stripAnsi(text) {
+  return String(text).replace(ANSI_ESCAPE, '');
+}
+
+/**
+ * Parse one nextest status line into `{ status, id }`, or null if the line is
+ * not a status line. `id` is the normalized `<binary-id> <test-name>`.
+ */
+export function parseStatusLine(line) {
+  const match = STATUS_LINE.exec(stripAnsi(line));
+  if (match === null) return null;
+  const status = match[1];
+  if (!FAILURE_STATUS.test(status) && !SUCCESS_STATUS.test(status)) return null;
+  const id = match[2].replace(/\s+/g, ' ');
+  if (id.length === 0) return null;
+  return { status, id };
+}
+
+/**
+ * Failing test IDs in the order nextest first reported them, deduplicated.
+ * A test that later reports PASS/LEAK on a retry is not a failure of this run.
+ */
+export function extractFailedTests(logText) {
+  const failed = [];
+  const seen = new Set();
+  const recovered = new Set();
+  for (const line of stripAnsi(logText).split('\n')) {
+    const parsed = parseStatusLine(line);
+    if (parsed === null) continue;
+    if (SUCCESS_STATUS.test(parsed.status)) {
+      recovered.add(parsed.id);
+      continue;
+    }
+    if (seen.has(parsed.id)) continue;
+    seen.add(parsed.id);
+    failed.push(parsed.id);
+  }
+  return failed.filter((id) => !recovered.has(id));
+}
+
+/**
+ * Render the run-level annotation and the job-page summary block.
+ *
+ * The no-failure-lines wording states only what was observed. The previous
+ * wording concluded the cause ("build, migration, or setup step") from the
+ * absence of matches, which is exactly the claim that cost nineteen sessions;
+ * absence of failure lines is evidence about the log, not about the step.
+ */
+export function renderShardFailure({ shardName, logPath, logText }) {
+  const shard = `Server Test ${shardName}`;
+  const failedTests = typeof logText === 'string' ? extractFailedTests(logText) : [];
+
+  if (failedTests.length > 0) {
+    return {
+      failedTests,
+      annotation: `::error title=${shard} failed::${failedTests.join('; ')}`,
+      summary: [
+        `### ${shard} — FAILED`,
+        '',
+        'Failing tests:',
+        '',
+        ...failedTests.map((id) => `- \`${id}\``),
+        '',
+      ].join('\n'),
+    };
+  }
+
+  const observed = typeof logText === 'string'
+    ? `nextest ran and its log (${logPath}) contains no failure status lines (FAIL / TRY n FAIL / TIMEOUT / SIG*)`
+    : `no nextest log was produced at ${logPath}`;
+  return {
+    failedTests,
+    annotation: `::error title=${shard} failed::${shard} failed and ${observed}; the failing step is the last red step in this job's log.`,
+    summary: [
+      `### ${shard} — FAILED`,
+      '',
+      `Observed: ${observed}.`,
+      '',
+      "This does not identify which layer failed — check the last red step in this job's log.",
+      '',
+    ].join('\n'),
+  };
+}
+
+function parseArgs(argv) {
+  const args = { shard: '', log: '', summary: '' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === '--shard' || flag === '--log' || flag === '--summary') {
+      if (value === undefined) throw new Error(`ci-shard-failure-summary: ${flag} needs a value`);
+      args[flag.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`ci-shard-failure-summary: unexpected argument ${JSON.stringify(flag)}`);
+  }
+  if (args.shard === '') throw new Error('ci-shard-failure-summary: --shard is required');
+  if (args.log === '') throw new Error('ci-shard-failure-summary: --log is required');
+  return args;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  const logText = existsSync(args.log) ? readFileSync(args.log, 'utf8') : undefined;
+  const { annotation, summary } = renderShardFailure({
+    shardName: args.shard,
+    logPath: args.log,
+    logText,
+  });
+  process.stdout.write(`${annotation}\n`);
+  if (args.summary !== '') appendFileSync(args.summary, `${summary}\n`);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/scripts/ci-shard-failure-summary.test.mjs
+++ b/scripts/ci-shard-failure-summary.test.mjs
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+import {
+  extractFailedTests,
+  parseStatusLine,
+  renderShardFailure,
+  stripAnsi,
+} from './ci-shard-failure-summary.mjs';
+
+const SCRIPT = resolve('scripts/ci-shard-failure-summary.mjs');
+const WORKFLOW = resolve('.github/workflows/quality-gate.yml');
+const FIXTURES = resolve('scripts/fixtures/shard-failure');
+
+// The fixtures are slices of the real captured shard log from run 30149467240 /
+// job 89657358613 (task rwpk), timestamps stripped so they match what the
+// workflow's `tee` writes. ANSI escapes are preserved byte-for-byte: nextest
+// colorizes on CI and that is half of why the old grep never matched.
+const fixture = (name) => readFileSync(join(FIXTURES, name), 'utf8');
+
+const ESC = String.fromCharCode(27);
+const AUDIT_TEST =
+  'djinn-provider::stream_event_consumer_audit checked_in_classification_covers_every_production_stream_event_match';
+
+// The pattern the workflow used before task 8hrv, as a POSIX-ERE-equivalent
+// JS regex. It is asserted against the fixtures so the defect cannot come back
+// disguised as a different spelling.
+const OLD_PATTERN = /^[ \t]*FAIL \[/m;
+
+test('TRY-n retry failures are the shape nextest actually emits, and the old pattern misses them', () => {
+  const log = fixture('nextest-try-n-fail.log');
+  assert.equal(OLD_PATTERN.test(log), false, 'fixture must contain no bare FAIL line for the old pattern to find');
+  assert.match(stripAnsi(log), /^\s*TRY 3 FAIL \[/m);
+});
+
+test('a log whose only failure records are TRY-n FAIL is classified as a test failure', () => {
+  const log = fixture('nextest-try-n-fail.log');
+  assert.deepEqual(extractFailedTests(log), [AUDIT_TEST]);
+
+  const { failedTests, annotation, summary } = renderShardFailure({
+    shardName: 'shard-1',
+    logPath: '/tmp/nextest-run.log',
+    logText: log,
+  });
+  assert.deepEqual(failedTests, [AUDIT_TEST]);
+  assert.equal(annotation, `::error title=Server Test shard-1 failed::${AUDIT_TEST}`);
+  assert.match(summary, /Failing tests:/);
+  assert.match(summary, new RegExp(`- \`${AUDIT_TEST}\``.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+
+  // The whole point: the build/migration/setup diagnostic must NOT be chosen.
+  for (const text of [annotation, summary]) {
+    assert.doesNotMatch(text, /build/i);
+    assert.doesNotMatch(text, /migration/i);
+    assert.doesNotMatch(text, /setup/i);
+    assert.doesNotMatch(text, /no failure status lines/);
+  }
+});
+
+test('ordinary FAIL records stay recognized and duplicate IDs are deduplicated', () => {
+  // Each ID appears twice in the fixture: once live, once in the Summary block.
+  const failed = extractFailedTests(fixture('nextest-plain-fail.log'));
+  assert.deepEqual(failed, [
+    'djinn-db repositories::note::tests::rrf_orders_by_fused_rank',
+    AUDIT_TEST,
+  ]);
+  assert.equal(new Set(failed).size, failed.length);
+});
+
+test('a log with no failure record of any kind still selects the generic diagnostic', () => {
+  const log = fixture('nextest-no-failure-lines.log');
+  assert.deepEqual(extractFailedTests(log), []);
+
+  const { failedTests, annotation, summary } = renderShardFailure({
+    shardName: 'shard-2',
+    logPath: '/tmp/nextest-run.log',
+    logText: log,
+  });
+  assert.deepEqual(failedTests, []);
+  assert.match(annotation, /^::error title=Server Test shard-2 failed::/);
+  assert.match(annotation, /contains no failure status lines \(FAIL \/ TRY n FAIL \/ TIMEOUT \/ SIG\*\)/);
+  assert.match(annotation, /last red step in this job's log/);
+  assert.match(summary, /Observed: nextest ran and its log/);
+
+  // The generic branch reports what it observed. It must not assert a cause it
+  // has not established — that claim is what sent nineteen sessions to the
+  // wrong layer.
+  for (const text of [annotation, summary]) {
+    assert.doesNotMatch(text, /build, migration, or setup/i);
+    assert.doesNotMatch(text, /concluded failure without nextest FAIL lines/);
+  }
+});
+
+test('an absent nextest log is reported as an absent log, not as a build failure', () => {
+  const { failedTests, annotation, summary } = renderShardFailure({
+    shardName: 'shard-3',
+    logPath: '/tmp/nextest-run.log',
+    logText: undefined,
+  });
+  assert.deepEqual(failedTests, []);
+  assert.match(annotation, /no nextest log was produced at \/tmp\/nextest-run\.log/);
+  assert.doesNotMatch(annotation, /build, migration, or setup/i);
+  assert.match(summary, /no nextest log was produced/);
+});
+
+test('a retry that recovered is not reported as this shard failing test', () => {
+  assert.deepEqual(extractFailedTests(fixture('nextest-flaky-recovered.log')), []);
+});
+
+test('status-line grammar: failure statuses in, run noise out', () => {
+  const cases = [
+    ['        FAIL [   0.002s] (2/3) nxprobe nxtests::plain_fail', 'nxprobe nxtests::plain_fail'],
+    ['  TRY 3 FAIL [   0.483s] (2477/2842) crate test_name', 'crate test_name'],
+    ['     SIGABRT [   0.003s] (1/3) nxprobe nxtests::aborts', 'nxprobe nxtests::aborts'],
+    ['     TIMEOUT [   1.001s] (3/3) nxprobe nxtests::times_out', 'nxprobe nxtests::times_out'],
+    ['   LEAK-FAIL [   0.004s] (4/9) crate leaky_test', 'crate leaky_test'],
+    // No progress counter: older nextest releases, and the plan-time output.
+    ['        FAIL [   0.005s] crate older_nextest_shape', 'crate older_nextest_shape'],
+    // The Actions-API download prefixes every line with a runner timestamp.
+    ['2026-07-25T07:45:23.7159008Z   TRY 3 FAIL [   0.483s] (2477/2842) crate downloaded_log_shape', 'crate downloaded_log_shape'],
+  ];
+  for (const [line, id] of cases) {
+    assert.deepEqual(extractFailedTests(line), [id], line);
+  }
+
+  const noise = [
+    '     Summary [ 196.905s] 2480/2842 tests run: 2479 passed, 1 failed, 0 skipped',
+    '  Cancelling due to test failure: 3 tests still running',
+    '    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured',
+    '    test checked_in_classification ... FAILED',
+    '        SLOW [>  30.000s] (───) crate slow_test',
+    ' TERMINATING [>   1.000s] (───) nxprobe nxtests::times_out',
+    '        PASS [   0.008s] (1/2) crate passing_test',
+    '        LEAK [   0.008s] (2/2) crate leaky_but_passing_test',
+    '   DELAY 2/3 by   0.625s (───) crate retried_test',
+    'error: test run failed',
+  ];
+  for (const line of noise) {
+    assert.deepEqual(extractFailedTests(line), [], line);
+  }
+});
+
+test('escape sequences and split-color test paths normalize to `<binary-id> <test-name>`', () => {
+  // nextest colors the module path and the `::` separator independently, so the
+  // stripped line must not gain or lose whitespace around them.
+  const line = `${ESC}[32;1m        FAIL${ESC}[0m [   0.008s] (2365/2842) ${ESC}[35;1mdjinn-runtime${ESC}[0m ${ESC}[36mspec::tests${ESC}[0m${ESC}[36m::${ESC}[0m${ESC}[34;1mtask_run_spec_roundtrips${ESC}[0m`;
+  assert.equal(
+    stripAnsi(line),
+    '        FAIL [   0.008s] (2365/2842) djinn-runtime spec::tests::task_run_spec_roundtrips',
+  );
+  assert.deepEqual(parseStatusLine(line), {
+    status: 'FAIL',
+    id: 'djinn-runtime spec::tests::task_run_spec_roundtrips',
+  });
+});
+
+test('CLI prints the annotation and appends the job summary block', () => {
+  const workdir = mkdtempSync(join(tmpdir(), 'shard-failure-'));
+  const summaryPath = join(workdir, 'step-summary.md');
+  const stdout = execFileSync('node', [
+    SCRIPT,
+    '--shard', 'shard-1',
+    '--log', join(FIXTURES, 'nextest-try-n-fail.log'),
+    '--summary', summaryPath,
+  ], { encoding: 'utf8' });
+
+  assert.equal(stdout, `::error title=Server Test shard-1 failed::${AUDIT_TEST}\n`);
+  const summary = readFileSync(summaryPath, 'utf8');
+  assert.match(summary, /### Server Test shard-1 — FAILED/);
+  assert.ok(summary.includes(AUDIT_TEST), 'summary names the failing test');
+});
+
+test('CLI treats a missing log as a missing log', () => {
+  const stdout = execFileSync('node', [
+    SCRIPT,
+    '--shard', 'shard-4',
+    '--log', join(FIXTURES, 'does-not-exist.log'),
+  ], { encoding: 'utf8' });
+  assert.match(stdout, /no nextest log was produced at/);
+  assert.doesNotMatch(stdout, /build, migration, or setup/i);
+});
+
+test('the shard step delegates to this script and the old pattern is gone', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  assert.ok(
+    workflow.includes('scripts/ci-shard-failure-summary.mjs'),
+    'the shard failure step must call the tested parser',
+  );
+  assert.ok(
+    workflow.includes('node --test scripts/ci-shard-failure-summary.test.mjs'),
+    'preflight must run this contract',
+  );
+  assert.equal(
+    workflow.includes("grep -E '^[[:space:]]*FAIL \\['"),
+    false,
+    'the untestable inline grep must not come back',
+  );
+  assert.equal(
+    workflow.includes('shard concluded failure without nextest FAIL lines'),
+    false,
+    'the cause-asserting diagnostic must not come back',
+  );
+});

--- a/scripts/fixtures/shard-failure/nextest-flaky-recovered.log
+++ b/scripts/fixtures/shard-failure/nextest-flaky-recovered.log
@@ -1,0 +1,8 @@
+[32;1m Nextest run[0m ID [1mb4689864-1a40-4b1b-9312-5497a9c5f809[0m with nextest profile: [1mpull-request[0m
+[32;1m    Starting[0m [1m2842[0m tests across [1m110[0m binaries ([1m8481[0m tests and [1m50[0m binaries [33;1mskipped[0m, including [1m8473[0m tests and [1m50[0m binaries via [1mprofile.pull-request.default-filter[0m)
+[32;1m        PASS[0m [   0.011s] (2363/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mfailed_outcome_throttle_without_retry_after_bincode_roundtrip[0m
+[35;1m  TRY 1 FAIL[0m [   0.526s] (─────────) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+[33;1m   DELAY 2/3[0m by   0.625s (─────────) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+[33;1m  TRY 2 PASS[0m [   0.501s] (12/2842) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+────────────
+[32;1m     Summary[0m [ 196.905s] [1m2842[0m tests run: [1m2842[0m [32;1mpassed[0m ([1m1[0m [33;1mflaky[0m), [1m0[0m [33;1mskipped[0m

--- a/scripts/fixtures/shard-failure/nextest-no-failure-lines.log
+++ b/scripts/fixtures/shard-failure/nextest-no-failure-lines.log
@@ -1,0 +1,6 @@
+   Compiling djinn-server v0.6.0 (/home/runner/work/djinn/djinn/server/crates/djinn-server)
+error: linking with `cc` failed: exit status: 1
+  = note: /usr/bin/ld: final link failed: No space left on device
+
+error: could not compile `djinn-server` (lib test) due to 1 previous error
+[31;1merror[0m: command [1mcargo test --no-run[0m exited with code 101

--- a/scripts/fixtures/shard-failure/nextest-plain-fail.log
+++ b/scripts/fixtures/shard-failure/nextest-plain-fail.log
@@ -1,0 +1,11 @@
+[32;1m Nextest run[0m ID [1mb4689864-1a40-4b1b-9312-5497a9c5f809[0m with nextest profile: [1mpull-request[0m
+[32;1m    Starting[0m [1m2842[0m tests across [1m110[0m binaries ([1m8481[0m tests and [1m50[0m binaries [33;1mskipped[0m, including [1m8473[0m tests and [1m50[0m binaries via [1mprofile.pull-request.default-filter[0m)
+[32;1m        PASS[0m [   0.011s] (2363/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mfailed_outcome_throttle_without_retry_after_bincode_roundtrip[0m
+[31;1m        FAIL[0m [   0.104s] (11/2842) [35;1mdjinn-db[0m [34;1mrepositories::note::tests::rrf_orders_by_fused_rank[0m
+[32;1m        PASS[0m [   0.007s] (2364/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mtask_run_report_bincode_roundtrip[0m
+[31;1m        FAIL[0m [   0.483s] (12/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+────────────
+[31;1m     Summary[0m [ 196.905s] [1m2480[0m/[1m2842[0m tests run: [1m2479[0m [32;1mpassed[0m ([1m1[0m [33;1mleaky[0m), [1m1[0m [31;1mfailed[0m, [1m8481[0m [33;1mskipped[0m
+[31;1m        FAIL[0m [   0.104s] (11/2842) [35;1mdjinn-db[0m [34;1mrepositories::note::tests::rrf_orders_by_fused_rank[0m
+[31;1m        FAIL[0m [   0.483s] (12/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[31;1merror[0m: test run failed

--- a/scripts/fixtures/shard-failure/nextest-try-n-fail.log
+++ b/scripts/fixtures/shard-failure/nextest-try-n-fail.log
@@ -1,0 +1,49 @@
+[32;1m Nextest run[0m ID [1mb4689864-1a40-4b1b-9312-5497a9c5f809[0m with nextest profile: [1mpull-request[0m
+[32;1m    Starting[0m [1m2842[0m tests across [1m110[0m binaries ([1m8481[0m tests and [1m50[0m binaries [33;1mskipped[0m, including [1m8473[0m tests and [1m50[0m binaries via [1mprofile.pull-request.default-filter[0m)
+[32;1m        PASS[0m [   0.011s] (2363/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mfailed_outcome_throttle_without_retry_after_bincode_roundtrip[0m
+[32;1m        PASS[0m [   0.007s] (2364/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mtask_run_report_bincode_roundtrip[0m
+[35;1m  TRY 1 FAIL[0m [   0.526s] (─────────) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[35;1m [0m [35;1mstdout[0m [35;1m───[0m
+
+    running 1 test
+    test checked_in_classification_covers_every_production_stream_event_match ... FAILED
+
+    failures:
+
+    failures:
+        checked_in_classification_covers_every_production_stream_event_match
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.52s
+    [0m
+[35;1m [0m [35;1mstderr[0m [35;1m───[0m
+[35;1m  TRY 2 FAIL[0m [   0.491s] (─────────) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[31;1m  TRY 3 FAIL[0m [   0.483s] (2477/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[31;1m [0m [31;1mstdout[0m [31;1m───[0m
+
+    running 1 test
+    test checked_in_classification_covers_every_production_stream_event_match ... FAILED
+
+    failures:
+
+    failures:
+        checked_in_classification_covers_every_production_stream_event_match
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.48s
+    [0m
+[31;1m [0m [31;1mstderr[0m [31;1m───[0m
+
+    [0m[31;1mthread 'checked_in_classification_covers_every_production_stream_event_match' (25382) panicked at crates/djinn-provider/tests/stream_event_consumer_audit.rs:228:5:[0m
+    [31;1massertion `left == right` failed: update the classification fixture for every production StreamEvent match site; this audit is not behavioral coverage[0m
+      left: {"server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs::await_report_from_stream#1", "server/crates/djinn-agent/src/direct_services.rs::append_direct_response_event#1", "server/crates/djinn-compaction/src/summarizer.rs::call_llm_for_summary#1", "server/crates/djinn-k8s/src/runtime.rs::record_arbiter_session_termination#1", "server/crates/djinn-provider/src/completion.rs::collect_completion#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::apply_persistence_event#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::consume_provider_stream#1", "server/src/server/chat/handler.rs::drain_provider_turn#1", "server/src/server/chat/handler.rs::generate_chat_title#1"}
+     right: {"server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs::await_report_from_stream#1", "server/crates/djinn-agent/src/direct_services.rs::append_direct_response_event#1", "server/crates/djinn-compaction/src/summarizer.rs::call_llm_for_summary#1", "server/crates/djinn-provider/src/completion.rs::collect_completion#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::apply_persistence_event#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::consume_provider_stream#1", "server/src/server/chat/handler.rs::drain_provider_turn#1", "server/src/server/chat/handler.rs::generate_chat_title#1"}
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
+
+[31;1m  Cancelling[0m due to [31;1mtest failure[0m: [1m3[0m tests still running
+[32;1m        PASS[0m [   0.614s] (2478/2842) [35;1mdjinn-server[0m [36mserver::chat::tests::compaction[0m[36m::[0m[34;1mnewer_boundary_with_stale_tail_hash_falls_back[0m
+[32;1m        PASS[0m [   0.740s] (2479/2842) [35;1mdjinn-server[0m [36mserver::chat::compaction_boundary::tests[0m[36m::[0m[34;1mrecord_and_complete_chat_compaction_boundary[0m
+[32;1m        PASS[0m [   0.733s] (2480/2842) [35;1mdjinn-server[0m [36mserver::chat::tests::interruption[0m[36m::[0m[34;1mhttp_completion_aggregates_consumes_and_does_not_reinject_notices[0m
+────────────
+[31;1m     Summary[0m [ 196.905s] [1m2480[0m/[1m2842[0m tests run: [1m2479[0m [32;1mpassed[0m ([1m1[0m [33;1mleaky[0m), [1m1[0m [31;1mfailed[0m, [1m8481[0m [33;1mskipped[0m
+[31;1m  TRY 3 FAIL[0m [   0.483s] (2477/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[33;1mwarning[0m: [1m362[0m/[1m2842[0m tests were not run due to [33;1mtest failure[0m (run with [1m--no-fail-fast[0m to run all tests, or run with [1m--max-fail[0m)
+[31;1merror[0m: test run failed


### PR DESCRIPTION
## The defect

The Server Test shard's `Surface shard failure at run level` step looked for failing
tests with:

```sh
grep -E '^[[:space:]]*FAIL \[' "$log" | sed -E 's/^[[:space:]]*FAIL \[[^]]*\][[:space:]]+//' | sort -u
```

On no match it emitted, as a run-level annotation:

> Server Test shard-1 failed — shard concluded failure without nextest FAIL lines
> (build, migration, or setup step); see this job's log.

That annotation is what the board surfaces as the failure evidence (wnqw / #2561).
So every remediation attempt on task `rwpk` (#2565) was told, authoritatively and
wrongly, that the failure was in a build/migration/setup step. **Nineteen sessions**
hunted a build problem that never existed. The real failure was an ordinary
assertion in `djinn-provider::stream_event_consumer_audit`
(`checked_in_classification_covers_every_production_stream_event_match`).

## Why the pattern could not match

Confirmed against the real captured shard log (run `30149467240`, job `89657358613`)
and against `cargo-nextest 0.9.133` locally. Real bytes from that log:

```
^[[31;1m  TRY 3 FAIL^[[0m [   0.483s] (2477/2842) ^[[35;1mdjinn-provider::stream_event_consumer_audit^[[0m ^[[34;1mchecked_in_...^[[0m
```

1. **Retries.** `pull-request`, `merge-group` and `full-validation` all inherit
   `[profile.ci]`'s `retries = { count = 2, ... }`, so a genuinely failing test never
   prints a bare `FAIL` line — every attempt, including the final one and its repeat
   in the `Summary` block, is prefixed `TRY <n> FAIL`.
2. **Color.** nextest colorizes on CI, and the SGR escape wraps the status token
   *together with its indentation*. So even an un-retried `FAIL` line neither starts
   with whitespace-then-`FAIL` nor has a space between `FAIL` and `[`. The old
   pattern could not have matched an un-retried failure on CI either.
3. The old `sed` also left nextest's progress counter (`(2477/2842)`, or `(───)`
   before the count settles) inside the "test id" it emitted.

## The fix

* Parsing moves to `scripts/ci-shard-failure-summary.mjs` (testable; the inline
  grep was not). It strips ANSI, accepts `{TRY <n> }?<STATUS> [<duration>]
  {(<progress>) }?<binary-id> <test-name>`, and normalizes to
  `<binary-id> <test-name>`.
* Failure statuses: `FAIL`, `LEAK-FAIL`, `TIMEOUT`, `SIG*` (`FAIL`, `SIGABRT` and
  `TIMEOUT` were reproduced locally). `PASS`/`LEAK` lines are parsed only to
  *retract* a candidate, so a flaky `TRY 1 FAIL` → `TRY 2 PASS` is not reported as
  this shard's failing test — that would be the same misattribution pointed the
  other way.
* The generic branch now states **what it observed**, not what it means: either
  "nextest ran and its log (<path>) contains no failure status lines
  (FAIL / TRY n FAIL / TIMEOUT / SIG*)" or "no nextest log was produced at <path>",
  followed by "the failing step is the last red step in this job's log."
* `scripts/ci-shard-failure-summary.test.mjs` (11 tests) runs in `preflight`, with
  fixtures under `scripts/fixtures/shard-failure/` sliced from that real log, ANSI
  bytes preserved.

## Both directions are asserted

| Fixture | Assertion |
| --- | --- |
| `nextest-try-n-fail.log` (only `TRY n FAIL` records) | yields exactly the audit test ID; annotation and summary must contain no `build`/`migration`/`setup` wording, and the old pattern is asserted **not** to match the fixture |
| `nextest-no-failure-lines.log` (no failure record of any kind) | yields `[]`; the generic branch **is** selected; must not contain "build, migration, or setup" or the old sentence |
| absent log (no file) | generic branch, reported as "no nextest log was produced at <path>" |
| `nextest-plain-fail.log` (un-retried `FAIL`, each ID twice: live + `Summary`) | both IDs recognized, deduplicated, first-seen order |
| `nextest-flaky-recovered.log` (`TRY 1 FAIL` → `TRY 2 PASS`) | yields `[]` |

Plus a grammar table: `SIGABRT`/`TIMEOUT`/`LEAK-FAIL`/no-counter/timestamp-prefixed
lines in; `Summary`, `Cancelling`, `test result: FAILED.`, `SLOW`, `TERMINATING`,
`PASS`, `LEAK`, `DELAY` out.

## Verification

* `node --test scripts/ci-shard-failure-summary.test.mjs` → 11/11.
* The **full 6497-line real CI job log** (all its apt/cargo/GH noise, 2480 `PASS`
  lines and panic bodies) fed to the script yields exactly one ID:
  `djinn-provider::stream_event_consumer_audit checked_in_classification_covers_every_production_stream_event_match`.
* The rendered step body was executed locally in all three branches
  (test-failure log / no-failure-lines log / absent log) with `GITHUB_WORKSPACE`,
  `RUNNER_TEMP` and `GITHUB_STEP_SUMMARY` set, checking the shell quoting and the
  appended step-summary block.
* `actionlint` 1.7.12 (the pinned CI version) clean; workflow parses as YAML;
  sibling workflow-contract suites (`ci-changed-scope`, `ci-cache-policy`,
  `ci-qa-smoke-workflow`, `ci-release-image-validation`, `ci-nextest-plan`) 80/80.
* No Rust touched, so the Rust gates are untouched by this change.

Scope is the shard failure extraction only. The `StreamEvent` audit tokenizer
itself (`ud7q`) is deliberately not in here.

Closes 8hrv.
