### PR TITLE
fix(8hrv): classify nextest TRY-n FAIL lines in shard failure summaries

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -142,6 +142,8 @@ jobs:
         run: node --test scripts/ci-qa-smoke-workflow.test.mjs
       - name: Verify release image validation contract
         run: node --test scripts/ci-release-image-validation.test.mjs
+      - name: Verify shard failure summary contract
+        run: node --test scripts/ci-shard-failure-summary.test.mjs
       - name: Verify retirement manifest generator contract
         run: node --test scripts/test-djinn-retirement-manifest.mjs
       - name: Run retirement manifest strict reconciliation guard
@@ -1234,38 +1236,34 @@ jobs:
         # is therefore the durable source of truth for "which lane/test failed".
         # Not gated on shard.active: a shard can also fail before shard
         # resolution (build/migration/setup), and those must surface too. The
-        # nextest log is simply absent there, so the generic branch fires.
+        # nextest log is simply absent there, and the annotation then says so —
+        # it does not name a layer it cannot see.
         if: failure()
+        env:
+          SHARD_NAME: ${{ matrix.shard }}
         run: |
           set -uo pipefail
-          shard_name="${{ matrix.shard }}"
-          log="$RUNNER_TEMP/nextest-run.log"
-          failed_tests=""
-          if [ -f "$log" ]; then
-            # nextest prints one `    FAIL [   0.005s] <binary-id> <test-name>`
-            # line per failing test; strip the leading marker + timing bracket
-            # to leave `<binary-id> <test-name>`.
-            failed_tests=$(grep -E '^[[:space:]]*FAIL \[' "$log" \
-              | sed -E 's/^[[:space:]]*FAIL \[[^]]*\][[:space:]]+//' \
-              | sort -u || true)
-          fi
-          if [ -n "$failed_tests" ]; then
-            echo "::error title=Server Test ${shard_name} failed::$(printf '%s' "$failed_tests" | paste -sd'; ' -)"
-            {
-              echo "### Server Test ${shard_name} — FAILED"
-              echo
-              echo "Failing tests:"
-              echo
-              printf '%s\n' "$failed_tests" | sed 's/^/- `/;s/$/`/'
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::error title=Server Test ${shard_name} failed::shard concluded failure without nextest FAIL lines (build, migration, or setup step); see this job's log."
-            {
-              echo "### Server Test ${shard_name} — FAILED"
-              echo
-              echo "This shard failed before producing nextest FAIL lines (e.g. a build, migration, or setup step). See this job's log for the failing step."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          # The parsing lives in a checked-in, tested script instead of an
+          # inline grep/sed, because the inline version could not be tested and
+          # was wrong in both of the ways that matter (task 8hrv). It grepped
+          # `^[[:space:]]*FAIL \[`, but:
+          #   * every profile this job uses inherits [profile.ci] retries
+          #     (server/.config/nextest.toml), so a real failure prints
+          #     `TRY 3 FAIL [...]` and never a bare `FAIL` line; and
+          #   * CARGO_TERM_COLOR: always (top of this workflow) makes nextest
+          #     colorize into the pipe, so the status token arrives as
+          #     `\e[31;1m        FAIL\e[0m [   0.002s]` — the leading anchor and
+          #     the space before `[` are both wrong even without retries.
+          # It therefore always fell through to a message that ASSERTED "build,
+          # migration, or setup step". Nineteen sessions on task rwpk were sent
+          # after a build problem that did not exist; the failure was an
+          # assertion in djinn-provider::stream_event_consumer_audit. The script
+          # is exercised by scripts/ci-shard-failure-summary.test.mjs against
+          # captured output from that very run.
+          node "$GITHUB_WORKSPACE/scripts/ci-shard-failure-summary.mjs" \
+            --shard "$SHARD_NAME" \
+            --log "$RUNNER_TEMP/nextest-run.log" \
+            --summary "$GITHUB_STEP_SUMMARY"
       - name: Upload retained shard timing data
         if: always() && steps.shard.outputs.active == 'true'
         uses: actions/upload-artifact@v4

--- a/scripts/ci-shard-failure-summary.mjs
+++ b/scripts/ci-shard-failure-summary.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Run-level failure summary for the Server Test shards (quality-gate.yml).
+ *
+ * WHY THIS IS A SCRIPT AND NOT AN INLINE grep
+ *
+ * The shard step used to grep `^[[:space:]]*FAIL \[` out of the tee'd nextest
+ * log, and when that found nothing it emitted a message that *asserted a
+ * cause*: "shard concluded failure without nextest FAIL lines (build,
+ * migration, or setup step)". That annotation is what the board surfaces as
+ * failure evidence, so nineteen remediation sessions on task rwpk were told,
+ * authoritatively and wrongly, to go look at a build/migration/setup step. The
+ * real failure was an ordinary assertion in
+ * `djinn-provider::stream_event_consumer_audit`.
+ *
+ * Two independent reasons the old pattern could not match. Both confirmed
+ * against the captured shard log of run 30149467240 (job 89657358613) and
+ * reproduced locally with cargo-nextest 0.9.133:
+ *
+ *   1. Retries. `pull-request`, `merge-group` and `full-validation` all inherit
+ *      `[profile.ci]`'s `retries = { count = 2, ... }` (server/.config/nextest.toml),
+ *      so a genuinely failing test never prints a bare `FAIL` line — every
+ *      attempt, the final one, and its repeat in the Summary block are all
+ *      prefixed: `TRY 3 FAIL [   0.483s] ...`.
+ *   2. Color. quality-gate.yml sets `CARGO_TERM_COLOR: always` workflow-wide, so
+ *      nextest emits SGR escapes even into a pipe, and they wrap the status
+ *      token together with its indentation:
+ *      `<ESC>[31;1m        FAIL<ESC>[0m [   0.002s]`. The old pattern's
+ *      `^[[:space:]]*` anchor and its space before `[` are therefore both wrong
+ *      even for an un-retried failure.
+ *
+ * Status-line grammar (nextest 0.9.133), after escapes are stripped:
+ *
+ *     [indent]{TRY <n> }?<STATUS> [<duration>] {(<progress>) }?<binary-id> <test-name>
+ *
+ * The progress counter — `(2477/2842)` once the total is settled, `(───)` while
+ * it is not — is why stripping only the timing bracket left the old sed
+ * emitting `(2477/2842) <binary-id> <test-name>` as the "test id". It is
+ * optional in the pattern because older nextest releases omit it.
+ *
+ * Escapes also wrap each segment of a test path independently
+ * (`<ESC>[36mspec::tests<ESC>[0m<ESC>[36m::<ESC>[0m<ESC>[34;1mfoo<ESC>[0m`), so
+ * stripping them is what reassembles `spec::tests::foo`.
+ *
+ * PASS/LEAK lines are parsed too, but only to *retract* a candidate: a flaky
+ * test prints `TRY 1 FAIL` and then `TRY 2 PASS`, and blaming this shard's
+ * failure on it would be the same misattribution pointed the other way.
+ *
+ * Usage:
+ *   node scripts/ci-shard-failure-summary.mjs --shard <name> --log <path> \
+ *     [--summary <path>]
+ *
+ * Writes the `::error::` annotation to stdout and, when --summary names a file,
+ * appends the job-page summary block to it.
+ */
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+
+/**
+ * SGR/CSI escape sequences.
+ *
+ * Two spellings are accepted: the real ESC byte, which is what nextest writes
+ * and what the workflow parses, and the two-character `^[` transliteration that
+ * `cat -v`-style captures leave behind (the log a human downloads and pastes
+ * often went through one). ESC is built from a char code so no invisible byte
+ * is checked into this source.
+ */
+const ANSI_ESCAPE = new RegExp(`(?:${String.fromCharCode(27)}|\\^\\[)\\[[0-9;?]*[ -/]*[@-~]`, 'g');
+
+/**
+ * {<log decoration> }?[indent]{TRY <n> }?<STATUS> [<duration>] {(<progress>) }?<rest>
+ *
+ * The workflow feeds the tee'd runner-side log, which carries no decoration.
+ * The optional prefixes are for the copies a human ever has in hand, so the
+ * same parser can be pointed at them while debugging: the log archive
+ * downloaded from Actions prefixes every line with an ISO timestamp, and
+ * `gh run view --log` prefixes `<job name>\t<step name>\t<ISO timestamp> `.
+ */
+const STATUS_LINE = new RegExp(
+  '^(?:[^\\t]*\\t[^\\t]*\\t)?' + // gh run view --log job/step decoration
+    '(?:\\d{4}-\\d{2}-\\d{2}T[\\d:.]+Z )?' + // Actions log-archive timestamp
+    '\\s*(?:TRY\\s+\\d+\\s+)?' + // retry attempt marker
+    '([A-Z][A-Z-]*)\\s+' + // status token
+    '\\[[^\\]]*\\]\\s+' + // [   0.483s]
+    '(?:\\([^)]*\\)\\s+)?' + // (2477/2842) or (───), when present
+    '(\\S.*?)\\s*$', // <binary-id> <test-name>
+);
+
+/** Terminal failure statuses. LEAK-FAIL precedes FAIL so it is not truncated. */
+const FAILURE_STATUS = /^(?:LEAK-FAIL|FAIL|TIMEOUT|ABORT|SIG[A-Z]+)$/;
+
+/** Statuses meaning the test ultimately succeeded on that attempt. */
+const SUCCESS_STATUS = /^(?:PASS|LEAK)$/;
+
+/** The first `error:` line nextest/cargo wrote, if any — observed, not construed. */
+const ERROR_LINE = /^\s*error(?:\[[A-Za-z0-9]+\])?:\s*(\S.*?)\s*$/;
+
+/** How many trailing log lines the job-page summary quotes when no test failed. */
+const TAIL_LINES = 15;
+
+/** Per-line cap on quoted log text: a panic dump can be one enormous line. */
+const MAX_QUOTED_CHARS = 400;
+
+export function stripAnsi(text) {
+  return String(text).replace(ANSI_ESCAPE, '');
+}
+
+function clamp(line, limit = MAX_QUOTED_CHARS) {
+  return line.length <= limit ? line : `${line.slice(0, limit)}… (truncated)`;
+}
+
+/**
+ * Parse one nextest status line into `{ status, id }`, or null when the line is
+ * not a status line. `id` is the normalized `<binary-id> <test-name>`.
+ */
+export function parseStatusLine(line) {
+  const match = STATUS_LINE.exec(stripAnsi(line));
+  if (match === null) return null;
+  const status = match[1];
+  if (!FAILURE_STATUS.test(status) && !SUCCESS_STATUS.test(status)) return null;
+  const id = match[2].replace(/\s+/g, ' ');
+  if (id.length === 0) return null;
+  return { status, id };
+}
+
+/**
+ * Failing test IDs in the order nextest first reported them, deduplicated.
+ * A test that later reports PASS/LEAK on a retry did not fail this run.
+ */
+export function extractFailedTests(logText) {
+  const failed = [];
+  const seen = new Set();
+  const recovered = new Set();
+  for (const line of stripAnsi(logText).split('\n')) {
+    const parsed = parseStatusLine(line);
+    if (parsed === null) continue;
+    if (SUCCESS_STATUS.test(parsed.status)) {
+      recovered.add(parsed.id);
+      continue;
+    }
+    if (seen.has(parsed.id)) continue;
+    seen.add(parsed.id);
+    failed.push(parsed.id);
+  }
+  return failed.filter((id) => !recovered.has(id));
+}
+
+/** The first `error:` line in the log, or null. Quoted verbatim as evidence. */
+export function firstErrorLine(logText) {
+  for (const line of stripAnsi(logText).split('\n')) {
+    const match = ERROR_LINE.exec(line);
+    if (match !== null) return clamp(match[1]);
+  }
+  return null;
+}
+
+/** The last non-empty lines of the log, escapes stripped, for the summary block. */
+export function logTail(logText, limit = TAIL_LINES) {
+  return stripAnsi(logText)
+    .split('\n')
+    .map((line) => line.replace(/\s+$/, ''))
+    .filter((line) => line !== '')
+    .slice(-limit)
+    .map((line) => clamp(line));
+}
+
+/**
+ * Render the run-level annotation and the job-page summary block.
+ *
+ * The no-failing-test branch reports only what it observed — whether a log
+ * exists, that it holds no failure status line, and the first `error:` line it
+ * does hold. It deliberately does not name a layer. Concluding "build,
+ * migration, or setup step" from the absence of matches is a claim about the
+ * log dressed up as a claim about the run, and that is the claim that cost
+ * nineteen sessions.
+ */
+export function renderShardFailure({ shardName, logPath, logText }) {
+  const shard = `Server Test ${shardName}`;
+  const haveLog = typeof logText === 'string';
+  const failedTests = haveLog ? extractFailedTests(logText) : [];
+
+  if (failedTests.length > 0) {
+    return {
+      failedTests,
+      annotation: `::error title=${shard} failed::${failedTests.join('; ')}`,
+      summary: [
+        `### ${shard} — FAILED`,
+        '',
+        'Failing tests:',
+        '',
+        ...failedTests.map((id) => `- \`${id}\``),
+        '',
+      ].join('\n'),
+    };
+  }
+
+  const observed = haveLog
+    ? `nextest ran and its log (${logPath}) holds no failure status line (FAIL / TRY n FAIL / TIMEOUT / SIG*)`
+    : `no nextest log was produced at ${logPath}`;
+  const errorLine = haveLog ? firstErrorLine(logText) : null;
+  const evidence = errorLine === null ? '' : ` First error line in that log: "${errorLine}".`;
+  const tail = haveLog ? logTail(logText) : [];
+
+  return {
+    failedTests,
+    annotation:
+      `::error title=${shard} failed::${observed}.${evidence}` +
+      " This does not identify which step failed — read the last red step in this job's log.",
+    summary: [
+      `### ${shard} — FAILED`,
+      '',
+      `Observed: ${observed}.`,
+      // Not wrapped in backticks: cargo error text routinely contains them
+      // (`linking with \`cc\` failed`) and nesting them breaks the rendering.
+      ...(errorLine === null ? [] : ['', `First \`error:\` line in that log: ${errorLine}`]),
+      '',
+      "This does not identify which step failed — read the last red step in this job's log.",
+      // Four-backtick fence so a log line containing a triple fence cannot end it.
+      ...(tail.length === 0
+        ? []
+        : ['', `Last ${tail.length} log lines:`, '', '````text', ...tail, '````']),
+      '',
+    ].join('\n'),
+  };
+}
+
+function parseArgs(argv) {
+  const args = { shard: '', log: '', summary: '' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === '--shard' || flag === '--log' || flag === '--summary') {
+      if (value === undefined) throw new Error(`ci-shard-failure-summary: ${flag} needs a value`);
+      args[flag.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`ci-shard-failure-summary: unexpected argument ${JSON.stringify(flag)}`);
+  }
+  if (args.shard === '') throw new Error('ci-shard-failure-summary: --shard is required');
+  if (args.log === '') throw new Error('ci-shard-failure-summary: --log is required');
+  return args;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  const logText = existsSync(args.log) ? readFileSync(args.log, 'utf8') : undefined;
+  const { annotation, summary } = renderShardFailure({
+    shardName: args.shard,
+    logPath: args.log,
+    logText,
+  });
+  process.stdout.write(`${annotation}\n`);
+  if (args.summary !== '') appendFileSync(args.summary, `${summary}\n`);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/scripts/ci-shard-failure-summary.test.mjs
+++ b/scripts/ci-shard-failure-summary.test.mjs
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+import {
+  extractFailedTests,
+  firstErrorLine,
+  parseStatusLine,
+  renderShardFailure,
+  stripAnsi,
+} from './ci-shard-failure-summary.mjs';
+
+const SCRIPT = resolve('scripts/ci-shard-failure-summary.mjs');
+const WORKFLOW = resolve('.github/workflows/quality-gate.yml');
+const FIXTURES = resolve('scripts/fixtures/shard-failure');
+
+// Fixture provenance, so a future reader knows what is evidence and what is
+// construction:
+//   * nextest-try-n-fail.log             — whole lines lifted verbatim from the
+//     captured shard log of run 30149467240 / job 89657358613 (the run that
+//     misled task rwpk), with the capture decoration removed so the bytes match
+//     what the workflow's `tee` writes, and the escapes restored to real ESC.
+//   * nextest-try-n-fail-gh-log-capture.log — the same lines in the form an
+//     operator actually holds: `gh run view --log` job/step/timestamp
+//     decoration, escapes left in `^[` transliterated form.
+//   * the remaining three are constructed, but every status line in them is a
+//     shape reproduced locally from cargo-nextest 0.9.133 with
+//     CARGO_TERM_COLOR=always (un-retried FAIL, DELAY, TRY n PASS, Summary).
+// The ANSI escapes matter: nextest colorizes on CI because quality-gate.yml
+// sets CARGO_TERM_COLOR workflow-wide, and that is half of why the old grep
+// never matched.
+const fixture = (name) => readFileSync(join(FIXTURES, name), 'utf8');
+
+const ESC = String.fromCharCode(27);
+const AUDIT_TEST =
+  'djinn-provider::stream_event_consumer_audit checked_in_classification_covers_every_production_stream_event_match';
+
+// The pattern the workflow used before task 8hrv, as a POSIX-ERE-equivalent JS
+// regex, asserted against the fixtures so the defect cannot come back wearing a
+// different spelling.
+const OLD_PATTERN = /^[ \t]*FAIL \[/m;
+
+test('the old pattern cannot match what nextest actually emits', () => {
+  // Not just the retry prefix: the escape sequence wraps the indentation and
+  // the status token together, so an un-retried FAIL misses the anchor too.
+  assert.equal(OLD_PATTERN.test(fixture('nextest-try-n-fail.log')), false);
+  assert.equal(OLD_PATTERN.test(fixture('nextest-plain-fail.log')), false);
+  assert.match(stripAnsi(fixture('nextest-try-n-fail.log')), /^\s*TRY 3 FAIL \[/m);
+  assert.match(stripAnsi(fixture('nextest-plain-fail.log')), /^\s*FAIL \[/m);
+});
+
+test('a log whose only failure records are TRY-n FAIL classifies as a test failure', () => {
+  const log = fixture('nextest-try-n-fail.log');
+  assert.deepEqual(extractFailedTests(log), [AUDIT_TEST]);
+
+  const { failedTests, annotation, summary } = renderShardFailure({
+    shardName: 'shard-1',
+    logPath: '/tmp/nextest-run.log',
+    logText: log,
+  });
+  assert.deepEqual(failedTests, [AUDIT_TEST]);
+  assert.equal(annotation, `::error title=Server Test shard-1 failed::${AUDIT_TEST}`);
+  assert.match(summary, /Failing tests:/);
+  assert.ok(summary.includes(`- \`${AUDIT_TEST}\``), 'summary names the failing test');
+
+  // The whole point of task 8hrv: the build/migration/setup diagnostic must not
+  // be selected for this log.
+  for (const text of [annotation, summary]) {
+    assert.doesNotMatch(text, /build/i);
+    assert.doesNotMatch(text, /migration/i);
+    assert.doesNotMatch(text, /setup/i);
+    assert.doesNotMatch(text, /holds no failure status line/);
+  }
+});
+
+test('the same failure classifies identically from a `gh run view --log` capture', () => {
+  // Decorated lines, `^[`-transliterated escapes — the copy a human or agent
+  // debugging the run has in hand.
+  const log = fixture('nextest-try-n-fail-gh-log-capture.log');
+  assert.ok(log.includes('\tUNKNOWN STEP\t'), 'fixture keeps the capture decoration');
+  assert.equal(log.includes(ESC), false, 'fixture keeps the transliterated escapes');
+  assert.deepEqual(extractFailedTests(log), [AUDIT_TEST]);
+});
+
+test('ordinary FAIL records stay recognized and duplicate IDs stay deduplicated', () => {
+  // Each ID appears twice in the fixture: once live, once in the Summary block.
+  const log = fixture('nextest-plain-fail.log');
+  const failed = extractFailedTests(log);
+  assert.deepEqual(failed, [
+    'djinn-db repositories::note::tests::rrf_orders_by_fused_rank',
+    AUDIT_TEST,
+  ]);
+  assert.equal(new Set(failed).size, failed.length);
+  assert.match(renderShardFailure({
+    shardName: 'shard-0',
+    logPath: '/tmp/nextest-run.log',
+    logText: log,
+  }).annotation, /^::error title=Server Test shard-0 failed::djinn-db [^;]+; djinn-provider::/);
+});
+
+test('a log with no failure record of any kind still selects the generic diagnostic', () => {
+  const log = fixture('nextest-no-failure-lines.log');
+  assert.deepEqual(extractFailedTests(log), []);
+
+  const { failedTests, annotation, summary } = renderShardFailure({
+    shardName: 'shard-2',
+    logPath: '/tmp/nextest-run.log',
+    logText: log,
+  });
+  assert.deepEqual(failedTests, []);
+  assert.match(annotation, /^::error title=Server Test shard-2 failed::/);
+  assert.match(
+    annotation,
+    /holds no failure status line \(FAIL \/ TRY n FAIL \/ TIMEOUT \/ SIG\*\)/,
+  );
+  assert.match(annotation, /read the last red step in this job's log/);
+  assert.match(summary, /Observed: nextest ran and its log/);
+
+  // It reports what it observed, quoted from the log, instead of concluding a
+  // layer. The old wording asserted "build, migration, or setup step" from the
+  // absence of matches, and that assertion is what sent nineteen sessions to
+  // the wrong layer.
+  assert.equal(firstErrorLine(log), 'linking with `cc` failed: exit status: 1');
+  assert.match(annotation, /First error line in that log: "linking with `cc` failed: exit status: 1"\./);
+  assert.match(summary, /Last 5 log lines:/);
+  assert.match(summary, /No space left on device/);
+  for (const text of [annotation, summary]) {
+    assert.doesNotMatch(text, /build, migration, or setup/i);
+    assert.doesNotMatch(text, /concluded failure without nextest FAIL lines/);
+  }
+});
+
+test('an absent nextest log is reported as an absent log, not as a build failure', () => {
+  const { failedTests, annotation, summary } = renderShardFailure({
+    shardName: 'shard-3',
+    logPath: '/tmp/nextest-run.log',
+    logText: undefined,
+  });
+  assert.deepEqual(failedTests, []);
+  assert.match(annotation, /no nextest log was produced at \/tmp\/nextest-run\.log/);
+  assert.doesNotMatch(annotation, /build, migration, or setup/i);
+  assert.match(summary, /no nextest log was produced/);
+  assert.doesNotMatch(summary, /log lines:/);
+});
+
+test('every annotation is a single line so GitHub renders it as one', () => {
+  for (const logText of [
+    fixture('nextest-try-n-fail.log'),
+    fixture('nextest-plain-fail.log'),
+    fixture('nextest-no-failure-lines.log'),
+    undefined,
+  ]) {
+    const { annotation } = renderShardFailure({
+      shardName: 'shard-1',
+      logPath: '/tmp/nextest-run.log',
+      logText,
+    });
+    assert.equal(annotation.includes('\n'), false, annotation);
+  }
+});
+
+test('quoted log text is clamped so one enormous line cannot flood the annotation', () => {
+  const huge = `error: ${'x'.repeat(5000)}`;
+  const { annotation, summary } = renderShardFailure({
+    shardName: 'shard-5',
+    logPath: '/tmp/nextest-run.log',
+    logText: `   Compiling djinn-server v0.6.0\n${huge}\n`,
+  });
+  assert.match(annotation, /… \(truncated\)/);
+  assert.ok(annotation.length < 1200, `annotation length ${annotation.length}`);
+  assert.match(summary, /… \(truncated\)/);
+});
+
+test('a retry that recovered is not reported as this shard failing', () => {
+  assert.deepEqual(extractFailedTests(fixture('nextest-flaky-recovered.log')), []);
+});
+
+test('status-line grammar: failure statuses in, run noise out', () => {
+  const cases = [
+    ['        FAIL [   0.002s] (2/3) nxprobe nxtests::plain_fail', 'nxprobe nxtests::plain_fail'],
+    ['  TRY 3 FAIL [   0.483s] (2477/2842) crate test_name', 'crate test_name'],
+    ['     SIGABRT [   0.003s] (1/3) nxprobe nxtests::aborts', 'nxprobe nxtests::aborts'],
+    ['     TIMEOUT [   1.001s] (3/3) nxprobe nxtests::times_out', 'nxprobe nxtests::times_out'],
+    ['   LEAK-FAIL [   0.004s] (4/9) crate leaky_test', 'crate leaky_test'],
+    // No progress counter: older nextest releases omit it.
+    ['        FAIL [   0.005s] crate older_nextest_shape', 'crate older_nextest_shape'],
+    // The Actions log archive prefixes every line with a runner timestamp.
+    [
+      '2026-07-25T07:45:23.7159008Z   TRY 3 FAIL [   0.483s] (2477/2842) crate archive_log_shape',
+      'crate archive_log_shape',
+    ],
+    // `gh run view --log` prefixes job and step names as well.
+    [
+      'Server Test (shard-1, 0)\tUNKNOWN STEP\t2026-07-25T07:45:23.7159008Z   TRY 3 FAIL [   0.483s] (2477/2842) crate gh_log_shape',
+      'crate gh_log_shape',
+    ],
+  ];
+  for (const [line, id] of cases) {
+    assert.deepEqual(extractFailedTests(line), [id], line);
+  }
+
+  const noise = [
+    '     Summary [ 196.905s] 2480/2842 tests run: 2479 passed, 1 failed, 0 skipped',
+    '  Cancelling due to test failure: 3 tests still running',
+    '    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured',
+    '    test checked_in_classification ... FAILED',
+    '        SLOW [>  30.000s] (───) crate slow_test',
+    ' TERMINATING [>   1.000s] (───) nxprobe nxtests::times_out',
+    '        PASS [   0.008s] (1/2) crate passing_test',
+    '        LEAK [   0.008s] (2/2) crate leaky_but_passing_test',
+    '   DELAY 2/3 by   0.625s (───) crate retried_test',
+    'error: test run failed',
+  ];
+  for (const line of noise) {
+    assert.deepEqual(extractFailedTests(line), [], line);
+  }
+});
+
+test('escape sequences and split-color test paths normalize to `<binary-id> <test-name>`', () => {
+  // nextest colors the module path and the `::` separator independently, so
+  // stripping must not gain or lose whitespace around them.
+  const line = `${ESC}[31;1m        FAIL${ESC}[0m [   0.008s] (2365/2842) ${ESC}[35;1mdjinn-runtime${ESC}[0m ${ESC}[36mspec::tests${ESC}[0m${ESC}[36m::${ESC}[0m${ESC}[34;1mtask_run_spec_roundtrips${ESC}[0m`;
+  assert.equal(
+    stripAnsi(line),
+    '        FAIL [   0.008s] (2365/2842) djinn-runtime spec::tests::task_run_spec_roundtrips',
+  );
+  assert.deepEqual(parseStatusLine(line), {
+    status: 'FAIL',
+    id: 'djinn-runtime spec::tests::task_run_spec_roundtrips',
+  });
+  // Same line, escapes transliterated by a `cat -v`-style capture.
+  assert.deepEqual(parseStatusLine(line.split(ESC).join('^[')), {
+    status: 'FAIL',
+    id: 'djinn-runtime spec::tests::task_run_spec_roundtrips',
+  });
+});
+
+test('CLI prints the annotation and appends the job summary block', () => {
+  const workdir = mkdtempSync(join(tmpdir(), 'shard-failure-'));
+  const summaryPath = join(workdir, 'step-summary.md');
+  const stdout = execFileSync('node', [
+    SCRIPT,
+    '--shard', 'shard-1',
+    '--log', join(FIXTURES, 'nextest-try-n-fail.log'),
+    '--summary', summaryPath,
+  ], { encoding: 'utf8' });
+
+  assert.equal(stdout, `::error title=Server Test shard-1 failed::${AUDIT_TEST}\n`);
+  const summary = readFileSync(summaryPath, 'utf8');
+  assert.match(summary, /### Server Test shard-1 — FAILED/);
+  assert.ok(summary.includes(AUDIT_TEST), 'summary names the failing test');
+});
+
+test('CLI treats a missing log as a missing log', () => {
+  const stdout = execFileSync('node', [
+    SCRIPT,
+    '--shard', 'shard-4',
+    '--log', join(FIXTURES, 'does-not-exist.log'),
+  ], { encoding: 'utf8' });
+  assert.match(stdout, /no nextest log was produced at/);
+  assert.doesNotMatch(stdout, /build, migration, or setup/i);
+});
+
+test('the shard step delegates to this script and the old pattern is gone', () => {
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  assert.ok(
+    workflow.includes('scripts/ci-shard-failure-summary.mjs'),
+    'the shard failure step must call the tested parser',
+  );
+  assert.ok(
+    workflow.includes('node --test scripts/ci-shard-failure-summary.test.mjs'),
+    'preflight must run this contract',
+  );
+  assert.equal(
+    workflow.includes("grep -E '^[[:space:]]*FAIL \\['"),
+    false,
+    'the untestable inline grep must not come back',
+  );
+  assert.equal(
+    workflow.includes('shard concluded failure without nextest FAIL lines'),
+    false,
+    'the cause-asserting diagnostic must not come back',
+  );
+});

--- a/scripts/fixtures/shard-failure/nextest-flaky-recovered.log
+++ b/scripts/fixtures/shard-failure/nextest-flaky-recovered.log
@@ -1,0 +1,8 @@
+[32;1m Nextest run[0m ID [1mb4689864-1a40-4b1b-9312-5497a9c5f809[0m with nextest profile: [1mpull-request[0m
+[32;1m    Starting[0m [1m2842[0m tests across [1m110[0m binaries ([1m8481[0m tests and [1m50[0m binaries [33;1mskipped[0m, including [1m8473[0m tests and [1m50[0m binaries via [1mprofile.pull-request.default-filter[0m)
+[32;1m        PASS[0m [   0.011s] (2363/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mfailed_outcome_throttle_without_retry_after_bincode_roundtrip[0m
+[35;1m  TRY 1 FAIL[0m [   0.526s] (─────────) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+[33;1m   DELAY 2/3[0m by   0.625s (─────────) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+[33;1m  TRY 2 PASS[0m [   0.501s] (12/2842) [35;1mdjinn-server[0m [36mserver::chat::tests::handler[0m[36m::[0m[34;1mcompletions_rejects_non_uuid_session[0m
+────────────
+[32;1m     Summary[0m [ 196.905s] [1m2842[0m tests run: [1m2842[0m [32;1mpassed[0m ([1m1[0m [33;1mflaky[0m), [1m0[0m [33;1mskipped[0m

--- a/scripts/fixtures/shard-failure/nextest-no-failure-lines.log
+++ b/scripts/fixtures/shard-failure/nextest-no-failure-lines.log
@@ -1,0 +1,6 @@
+   Compiling djinn-server v0.6.0 (/home/runner/work/djinn/djinn/server/crates/djinn-server)
+error: linking with `cc` failed: exit status: 1
+  = note: /usr/bin/ld: final link failed: No space left on device
+
+error: could not compile `djinn-server` (lib test) due to 1 previous error
+[31;1merror[0m: command [1mcargo test --no-run[0m exited with code 101

--- a/scripts/fixtures/shard-failure/nextest-plain-fail.log
+++ b/scripts/fixtures/shard-failure/nextest-plain-fail.log
@@ -1,0 +1,11 @@
+[32;1m Nextest run[0m ID [1mb4689864-1a40-4b1b-9312-5497a9c5f809[0m with nextest profile: [1mpull-request[0m
+[32;1m    Starting[0m [1m2842[0m tests across [1m110[0m binaries ([1m8481[0m tests and [1m50[0m binaries [33;1mskipped[0m, including [1m8473[0m tests and [1m50[0m binaries via [1mprofile.pull-request.default-filter[0m)
+[32;1m        PASS[0m [   0.011s] (2363/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mfailed_outcome_throttle_without_retry_after_bincode_roundtrip[0m
+[31;1m        FAIL[0m [   0.104s] (11/2842) [35;1mdjinn-db[0m [34;1mrepositories::note::tests::rrf_orders_by_fused_rank[0m
+[32;1m        PASS[0m [   0.007s] (2364/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mtask_run_report_bincode_roundtrip[0m
+[31;1m        FAIL[0m [   0.483s] (12/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+────────────
+[31;1m     Summary[0m [ 196.905s] [1m2480[0m/[1m2842[0m tests run: [1m2479[0m [32;1mpassed[0m ([1m1[0m [33;1mleaky[0m), [1m1[0m [31;1mfailed[0m, [1m8481[0m [33;1mskipped[0m
+[31;1m        FAIL[0m [   0.104s] (11/2842) [35;1mdjinn-db[0m [34;1mrepositories::note::tests::rrf_orders_by_fused_rank[0m
+[31;1m        FAIL[0m [   0.483s] (12/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[31;1merror[0m: test run failed

--- a/scripts/fixtures/shard-failure/nextest-try-n-fail-gh-log-capture.log
+++ b/scripts/fixtures/shard-failure/nextest-try-n-fail-gh-log-capture.log
@@ -1,0 +1,39 @@
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:42:07.5059498Z ^[[32;1m Nextest run^[[0m ID ^[[1mb4689864-1a40-4b1b-9312-5497a9c5f809^[[0m with nextest profile: ^[[1mpull-request^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:42:07.5061646Z ^[[32;1m    Starting^[[0m ^[[1m2842^[[0m tests across ^[[1m110^[[0m binaries (^[[1m8481^[[0m tests and ^[[1m50^[[0m binaries ^[[33;1mskipped^[[0m, including ^[[1m8473^[[0m tests and ^[[1m50^[[0m binaries via ^[[1mprofile.pull-request.default-filter^[[0m)
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.5912405Z ^[[32;1m        PASS^[[0m [   0.011s] (2363/2842) ^[[35;1mdjinn-runtime^[[0m ^[[36mspec::tests^[[0m^[[36m::^[[0m^[[34;1mfailed_outcome_throttle_without_retry_after_bincode_roundtrip^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.5920889Z ^[[32;1m        PASS^[[0m [   0.007s] (2364/2842) ^[[35;1mdjinn-runtime^[[0m ^[[36mspec::tests^[[0m^[[36m::^[[0m^[[34;1mtask_run_report_bincode_roundtrip^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6822315Z ^[[35;1m  TRY 1 FAIL^[[0m [   0.526s] (─────────) ^[[35;1mdjinn-provider::stream_event_consumer_audit^[[0m ^[[34;1mchecked_in_classification_covers_every_production_stream_event_match^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6847668Z ^[[35;1m ^[[0m ^[[35;1mstdout^[[0m ^[[35;1m───^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6848273Z     running 1 test
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6849397Z     test checked_in_classification_covers_every_production_stream_event_match ... FAILED
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6850489Z     failures:
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6850489Z     failures:
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6851421Z         checked_in_classification_covers_every_production_stream_event_match
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6852621Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.52s
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6853513Z     ^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6854026Z ^[[35;1m ^[[0m ^[[35;1mstderr^[[0m ^[[35;1m───^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:21.6926798Z ^[[35;1m  TRY 2 FAIL^[[0m [   0.491s] (─────────) ^[[35;1mdjinn-provider::stream_event_consumer_audit^[[0m ^[[34;1mchecked_in_classification_covers_every_production_stream_event_match^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7159008Z ^[[31;1m  TRY 3 FAIL^[[0m [   0.483s] (2477/2842) ^[[35;1mdjinn-provider::stream_event_consumer_audit^[[0m ^[[34;1mchecked_in_classification_covers_every_production_stream_event_match^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7161828Z ^[[31;1m ^[[0m ^[[31;1mstdout^[[0m ^[[31;1m───^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6848273Z     running 1 test
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6849397Z     test checked_in_classification_covers_every_production_stream_event_match ... FAILED
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6850489Z     failures:
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6850489Z     failures:
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6851421Z         checked_in_classification_covers_every_production_stream_event_match
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:21.6936291Z     test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.48s
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6853513Z     ^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7167471Z ^[[31;1m ^[[0m ^[[31;1mstderr^[[0m ^[[31;1m───^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7169094Z     ^[[0m^[[31;1mthread 'checked_in_classification_covers_every_production_stream_event_match' (25382) panicked at crates/djinn-provider/tests/stream_event_consumer_audit.rs:228:5:^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6858049Z     ^[[31;1massertion `left == right` failed: update the classification fixture for every production StreamEvent match site; this audit is not behavioral coverage^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6862925Z       left: {"server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs::await_report_from_stream#1", "server/crates/djinn-agent/src/direct_services.rs::append_direct_response_event#1", "server/crates/djinn-compaction/src/summarizer.rs::call_llm_for_summary#1", "server/crates/djinn-k8s/src/runtime.rs::record_arbiter_session_termination#1", "server/crates/djinn-provider/src/completion.rs::collect_completion#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::apply_persistence_event#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::consume_provider_stream#1", "server/src/server/chat/handler.rs::drain_provider_turn#1", "server/src/server/chat/handler.rs::generate_chat_title#1"}
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6867388Z      right: {"server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs::await_report_from_stream#1", "server/crates/djinn-agent/src/direct_services.rs::append_direct_response_event#1", "server/crates/djinn-compaction/src/summarizer.rs::call_llm_for_summary#1", "server/crates/djinn-provider/src/completion.rs::collect_completion#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::apply_persistence_event#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::consume_provider_stream#1", "server/src/server/chat/handler.rs::drain_provider_turn#1", "server/src/server/chat/handler.rs::generate_chat_title#1"}
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:20.6870682Z     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7183523Z ^[[31;1m  Cancelling^[[0m due to ^[[31;1mtest failure^[[0m: ^[[1m3^[[0m tests still running
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7593940Z ^[[32;1m        PASS^[[0m [   0.614s] (2478/2842) ^[[35;1mdjinn-server^[[0m ^[[36mserver::chat::tests::compaction^[[0m^[[36m::^[[0m^[[34;1mnewer_boundary_with_stale_tail_hash_falls_back^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7667962Z ^[[32;1m        PASS^[[0m [   0.740s] (2479/2842) ^[[35;1mdjinn-server^[[0m ^[[36mserver::chat::compaction_boundary::tests^[[0m^[[36m::^[[0m^[[34;1mrecord_and_complete_chat_compaction_boundary^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:24.4086863Z ^[[32;1m        PASS^[[0m [   0.733s] (2480/2842) ^[[35;1mdjinn-server^[[0m ^[[36mserver::chat::tests::interruption^[[0m^[[36m::^[[0m^[[34;1mhttp_completion_aggregates_consumes_and_does_not_reinject_notices^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:42:07.5052495Z ────────────
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:24.4089717Z ^[[31;1m     Summary^[[0m [ 196.905s] ^[[1m2480^[[0m/^[[1m2842^[[0m tests run: ^[[1m2479^[[0m ^[[32;1mpassed^[[0m (^[[1m1^[[0m ^[[33;1mleaky^[[0m), ^[[1m1^[[0m ^[[31;1mfailed^[[0m, ^[[1m8481^[[0m ^[[33;1mskipped^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:23.7159008Z ^[[31;1m  TRY 3 FAIL^[[0m [   0.483s] (2477/2842) ^[[35;1mdjinn-provider::stream_event_consumer_audit^[[0m ^[[34;1mchecked_in_classification_covers_every_production_stream_event_match^[[0m
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:24.4092534Z ^[[33;1mwarning^[[0m: ^[[1m362^[[0m/^[[1m2842^[[0m tests were not run due to ^[[33;1mtest failure^[[0m (run with ^[[1m--no-fail-fast^[[0m to run all tests, or run with ^[[1m--max-fail^[[0m)
+Server Test (shard-1, 0)	UNKNOWN STEP	2026-07-25T07:45:24.4140498Z ^[[31;1merror^[[0m: test run failed

--- a/scripts/fixtures/shard-failure/nextest-try-n-fail.log
+++ b/scripts/fixtures/shard-failure/nextest-try-n-fail.log
@@ -1,0 +1,49 @@
+[32;1m Nextest run[0m ID [1mb4689864-1a40-4b1b-9312-5497a9c5f809[0m with nextest profile: [1mpull-request[0m
+[32;1m    Starting[0m [1m2842[0m tests across [1m110[0m binaries ([1m8481[0m tests and [1m50[0m binaries [33;1mskipped[0m, including [1m8473[0m tests and [1m50[0m binaries via [1mprofile.pull-request.default-filter[0m)
+[32;1m        PASS[0m [   0.011s] (2363/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mfailed_outcome_throttle_without_retry_after_bincode_roundtrip[0m
+[32;1m        PASS[0m [   0.007s] (2364/2842) [35;1mdjinn-runtime[0m [36mspec::tests[0m[36m::[0m[34;1mtask_run_report_bincode_roundtrip[0m
+[35;1m  TRY 1 FAIL[0m [   0.526s] (─────────) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[35;1m [0m [35;1mstdout[0m [35;1m───[0m
+
+    running 1 test
+    test checked_in_classification_covers_every_production_stream_event_match ... FAILED
+
+    failures:
+
+    failures:
+        checked_in_classification_covers_every_production_stream_event_match
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.52s
+    [0m
+[35;1m [0m [35;1mstderr[0m [35;1m───[0m
+[35;1m  TRY 2 FAIL[0m [   0.491s] (─────────) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[31;1m  TRY 3 FAIL[0m [   0.483s] (2477/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[31;1m [0m [31;1mstdout[0m [31;1m───[0m
+
+    running 1 test
+    test checked_in_classification_covers_every_production_stream_event_match ... FAILED
+
+    failures:
+
+    failures:
+        checked_in_classification_covers_every_production_stream_event_match
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.48s
+    [0m
+[31;1m [0m [31;1mstderr[0m [31;1m───[0m
+
+    [0m[31;1mthread 'checked_in_classification_covers_every_production_stream_event_match' (25382) panicked at crates/djinn-provider/tests/stream_event_consumer_audit.rs:228:5:[0m
+    [31;1massertion `left == right` failed: update the classification fixture for every production StreamEvent match site; this audit is not behavioral coverage[0m
+      left: {"server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs::await_report_from_stream#1", "server/crates/djinn-agent/src/direct_services.rs::append_direct_response_event#1", "server/crates/djinn-compaction/src/summarizer.rs::call_llm_for_summary#1", "server/crates/djinn-k8s/src/runtime.rs::record_arbiter_session_termination#1", "server/crates/djinn-provider/src/completion.rs::collect_completion#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::apply_persistence_event#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::consume_provider_stream#1", "server/src/server/chat/handler.rs::drain_provider_turn#1", "server/src/server/chat/handler.rs::generate_chat_title#1"}
+     right: {"server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs::await_report_from_stream#1", "server/crates/djinn-agent/src/direct_services.rs::append_direct_response_event#1", "server/crates/djinn-compaction/src/summarizer.rs::call_llm_for_summary#1", "server/crates/djinn-provider/src/completion.rs::collect_completion#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::apply_persistence_event#1", "server/crates/djinn-slot/src/reply_loop/streaming.rs::consume_provider_stream#1", "server/src/server/chat/handler.rs::drain_provider_turn#1", "server/src/server/chat/handler.rs::generate_chat_title#1"}
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace[0m
+
+[31;1m  Cancelling[0m due to [31;1mtest failure[0m: [1m3[0m tests still running
+[32;1m        PASS[0m [   0.614s] (2478/2842) [35;1mdjinn-server[0m [36mserver::chat::tests::compaction[0m[36m::[0m[34;1mnewer_boundary_with_stale_tail_hash_falls_back[0m
+[32;1m        PASS[0m [   0.740s] (2479/2842) [35;1mdjinn-server[0m [36mserver::chat::compaction_boundary::tests[0m[36m::[0m[34;1mrecord_and_complete_chat_compaction_boundary[0m
+[32;1m        PASS[0m [   0.733s] (2480/2842) [35;1mdjinn-server[0m [36mserver::chat::tests::interruption[0m[36m::[0m[34;1mhttp_completion_aggregates_consumes_and_does_not_reinject_notices[0m
+────────────
+[31;1m     Summary[0m [ 196.905s] [1m2480[0m/[1m2842[0m tests run: [1m2479[0m [32;1mpassed[0m ([1m1[0m [33;1mleaky[0m), [1m1[0m [31;1mfailed[0m, [1m8481[0m [33;1mskipped[0m
+[31;1m  TRY 3 FAIL[0m [   0.483s] (2477/2842) [35;1mdjinn-provider::stream_event_consumer_audit[0m [34;1mchecked_in_classification_covers_every_production_stream_event_match[0m
+[33;1mwarning[0m: [1m362[0m/[1m2842[0m tests were not run due to [33;1mtest failure[0m (run with [1m--no-fail-fast[0m to run all tests, or run with [1m--max-fail[0m)
+[31;1merror[0m: test run failed


### PR DESCRIPTION
## The defect

The Server Test shard's `Surface shard failure at run level` step grepped the tee'd nextest log for `^[[:space:]]*FAIL \[`. When that matched nothing it emitted a message that **asserted a cause**:

> Server Test shard-1 failed — shard concluded failure without nextest FAIL lines (build, migration, or setup step); see this job's log.

That annotation is what the board surfaces as failure evidence (wnqw / #2561 added annotation capture), so nineteen remediation sessions on task `rwpk` (#2565) were told — authoritatively and wrongly — that the failure was in a build/migration/setup step. The real failure was an ordinary assertion at `shard1.log:4258`:

```
djinn-provider::stream_event_consumer_audit
  checked_in_classification_covers_every_production_stream_event_match
assertion `left == right` failed
```

## Why the pattern could not match

Two independent reasons, both confirmed against the captured shard log of run `30149467240` / job `89657358613` and reproduced locally with `cargo-nextest 0.9.133`:

1. **Retries.** `pull-request`, `merge-group` and `full-validation` all inherit `[profile.ci]`'s `retries = { count = 2, ... }` (`server/.config/nextest.toml`), so a genuinely failing test never prints a bare `FAIL` line. Every attempt, the final one, and its repeat in the Summary block are prefixed:

   ```
   TRY 3 FAIL [   0.483s] (2477/2842) djinn-provider::stream_event_consumer_audit checked_in_…
   ```

2. **Color.** `quality-gate.yml` sets `CARGO_TERM_COLOR: always` workflow-wide, so nextest colorizes into the pipe and the escape wraps the *indentation together with the status token*:

   ```
   \e[31;1m        FAIL\e[0m [   0.002s] (1/3) crate test_name
   ```

   The old pattern's leading `^[[:space:]]*` anchor and its space before `[` are therefore both wrong even for an un-retried failure — the inline grep could never have matched on CI at all.

A third latent bug: nextest prints a progress counter after the timing bracket (`(2477/2842)`, or `(───)` before the total settles). The old `sed` stripped only the timing bracket, so had it ever matched it would have emitted `(2477/2842) <binary-id> <test-name>` as the test id.

## Pattern before → after

Before (inline in the workflow, untestable):

```sh
grep -E '^[[:space:]]*FAIL \[' "$log" \
  | sed -E 's/^[[:space:]]*FAIL \[[^]]*\][[:space:]]+//' \
  | sort -u
```

After — `scripts/ci-shard-failure-summary.mjs`, escapes stripped first, then:

```
^{<log decoration> }?[indent]{TRY <n> }?<STATUS> [<duration>] {(<progress>) }?<binary-id> <test-name>
```

with `STATUS ∈ {FAIL, LEAK-FAIL, TIMEOUT, ABORT, SIG*}` counted as a failure and `{PASS, LEAK}` used only to **retract** a candidate (a flaky test prints `TRY 1 FAIL` then `TRY 2 PASS`; blaming the shard on it is the same misattribution pointed the other way). First-report order is kept and duplicates removed. `LEAK-FAIL`, `SIGABRT`, `SIGSEGV` were verified to exist as status tokens in the pinned nextest build.

The parsing lives in a checked-in script rather than inline shell precisely because the inline version could not be tested and was wrong in two ways at once.

## Message rewording

The generic branch no longer names a layer it cannot see. It reports what it observed, and quotes evidence:

```
::error title=Server Test shard-2 failed::nextest ran and its log (…/nextest-run.log) holds no
failure status line (FAIL / TRY n FAIL / TIMEOUT / SIG*). First error line in that log: "linking
with `cc` failed: exit status: 1". This does not identify which step failed — read the last red
step in this job's log.
```

The job-page summary adds a bounded, fenced tail of the last 15 non-empty log lines. Quoted text is clamped at 400 chars per line. An absent log is reported as an absent log, not as a build failure.

## Fixtures — both directions

`scripts/ci-shard-failure-summary.test.mjs` runs in preflight (`node --test`) with fixtures under `scripts/fixtures/shard-failure/`:

| direction | fixture | asserts |
| --- | --- | --- |
| TRY-n only ⇒ **test failure** | `nextest-try-n-fail.log` | yields exactly `djinn-provider::stream_event_consumer_audit checked_in_…`; annotation and summary contain no `build`/`migration`/`setup` text at all, and the generic diagnostic is not selected |
| same, operator's copy | `nextest-try-n-fail-gh-log-capture.log` | identical classification from `gh run view --log` bytes (job/step/timestamp decoration, `^[` transliterated escapes) |
| no FAIL of any kind ⇒ **generic** | `nextest-no-failure-lines.log` | empty failing set, generic wording selected, first `error:` line quoted, log tail present, and the old cause-asserting phrasing absent |
| ordinary FAIL + dedup | `nextest-plain-fail.log` | two ids in report order, each present twice in the log (live + Summary), deduplicated |
| flaky recovered | `nextest-flaky-recovered.log` | `TRY 1 FAIL` + `TRY 2 PASS` ⇒ empty failing set |
| absent log | – | reported as an absent log |

The first two fixtures are whole lines lifted **verbatim** from the captured shard log of the misleading run — provenance was verified line-by-line against the capture, and the test file documents which fixtures are captured and which are constructed. The remaining three are constructed, but every status line in them is a shape reproduced locally from `cargo-nextest 0.9.133` with `CARGO_TERM_COLOR=always`.

The test also pins the workflow contract: the shard step must call the script, preflight must run the test, and neither the old grep nor the phrase `shard concluded failure without nextest FAIL lines` may come back.

## Verification

- `node --test scripts/ci-shard-failure-summary.test.mjs` — 14/14 pass.
- End-to-end against the **full 6497-line captured shard log**: emits exactly the one true failing test, no false positives.
- Against three logs produced locally by `cargo-nextest 0.9.133` (`--profile ci`, `--profile pull-request`, and `--retries 0` with color forced): correct in all three, including flaky retraction.
- `actionlint` clean on `quality-gate.yml`; YAML parses.
- No Rust touched, so the workspace gates are unaffected.

Closes `8hrv`.
