### PR TITLE
fix(9jrg): make $HOME writable by the uid the pod runs as, and take the durable stash off it

### DIFF
--- a/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
+++ b/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
@@ -91,6 +91,55 @@ the startup check **never repairs** — a recursive `chown` over a 300G cache is
 multi-minute stall on pod start, which is the whole reason
 `fsGroupChangePolicy` is `OnRootMismatch`.
 
+## `$HOME` is part of the startup check too (9jrg)
+
+The volume contract covers the *mounted* surfaces. It did not cover the one
+writable surface that ships inside the image: `$HOME` (`/home/djinn`).
+
+`qut0` moved the Pod to uid/gid `1000` while the image still owned `/home/djinn`
+as `10001:10001` mode `0775`. The group-write bit was there but pointed at a
+group the Pod does not hold, so the Pod fell through to *other* (`r-x`) and could
+not create a single entry under its own home. Nothing checked it. The first
+consumer to notice was the durable output stash — `$HOME/.cache/djinn/output_stash`
+when `XDG_CACHE_HOME` is unset — and it surfaced hours later, inside the reply
+loop, as `create durable blobs: Permission denied (os error 13)` on **every**
+worker and planner session. Because a worker dies before submitting for review,
+the task returns to `open` and no reviewer is ever spawned; after six consecutive
+failures the coordinator escalates to a 1800s cooldown, so planning looks dormant
+rather than failing.
+
+Two changes close it:
+
+| Layer | Mechanism |
+|-------|-----------|
+| Image | `/home/djinn` keeps uid `10001` as its **owner** and is group-owned by the artifact GID `1000` with `2775`. Three identities write it — uid `10001` (server-side path), uid/gid `1000` (worker), uid `1001`/group `1000` (launcher-spawned child) — and only a shared group can hold all three. Changing the owner instead would break the first. Applied in `djinn-image-builder/scripts/base-debian.sh` (project images, `env-config/v11` forces the rebuild) and `server/docker/djinn-agent-runtime-base.Dockerfile`. |
+| Job render | `XDG_CACHE_HOME=/cache/xdg/<project_id>` — the stash and the SCIP indexer cache resolve `$XDG_CACHE_HOME` first, so they no longer depend on the image home at all, and they land on a *persistent* PVC instead of a container layer that dies with the Pod. |
+| Runtime | `volume_contract::check_home_writable` asks the kernel (`access(W_OK|X_OK)`) whether the running identity can create entries in `$HOME`, and fails readiness with the path, observed ownership/mode and running identity. |
+
+The same rule applies to anything the image pre-creates *under* `$HOME` for the
+runtime identity to write. `install-node.sh` scaffolds `$HOME/.local/state` so
+`fnm` can drop its per-shell multishell symlink there; `mkdir` under the build
+umask leaves it `0755`, which stopped working for the same reason the moment the
+runtime identity stopped being the owner. It is now `2775` too. When adding a
+build-time directory the Pod must write, group-own it to `1000` and give it
+`2775` — owner-only modes are only safe for paths nothing writes at runtime.
+
+`$HOME` is deliberately **not** a `VolumeRoot`: it is an image path, the
+artifact-gid/setgid rules do not apply to it, and it is correct for it to stay
+owned by uid `10001`. Only its effective writability is contractual.
+
+A violation looks like:
+
+```
+volume permission contract VIOLATED  kind=home_not_writable path=/home/djinn ...
+```
+
+This fails closed. Task-run and warm Pods only ever start on a `ready` catalog
+image, and the `env-config/v11` salt bump means every catalog image rebuilds
+before it can be `ready` again — so a pre-fix image cannot be dispatched to. If
+one somehow is, the break-glass is the existing, loud
+`DJINN_VOLUME_CONTRACT_MODE=audit`; the correct fix is to let the image rebuild.
+
 ## Symptom → diagnosis
 
 A pod that fails this check logs one line and exits:
@@ -200,6 +249,10 @@ gap loud instead of silent.
   the bounded check.
 - `server/crates/djinn-agent-worker/tests/volume_contract.rs` — deterministic
   proof that each violation fails readiness and a conforming layout passes.
+- `server/crates/djinn-agent-worker/tests/home_contract.rs` — the `$HOME` arm,
+  proved against a directory owned by a **different** uid than the running
+  process (privileged runs fabricate `10001:10001 0775` and `10001:1000 2775`
+  and judge both from a child dropped to uid/gid 1000).
 - `deploy/helm/djinn/tests/volume-ownership-render.sh` — the render contract.
 - `server/crates/djinn-k8s/src/launcher.rs` — `pod_security_context()` and the
   worker/child/launcher uid contract.

--- a/server/crates/djinn-agent-worker/src/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/src/volume_contract.rs
@@ -52,6 +52,35 @@
 //!   the volume *root* would be worthless here: the production near-miss had a
 //!   hand-fixed root over a broken subtree — which is also precisely the state
 //!   that makes kubelet's `OnRootMismatch` heuristic skip its recursive pass.
+//!
+//! ## `$HOME` (task 9jrg)
+//!
+//! The contract above covers the *mounted* surfaces and deliberately left one
+//! writable surface out: the container's own `$HOME`. `qut0` moved the pod to
+//! uid 1000 while the image still owned `/home/djinn` as uid 10001 mode `0775`,
+//! so the pod matched "other" (`r-x`) and could not create a single entry
+//! beneath its own home. Nothing checked it, and the first consumer to notice
+//! was the durable output stash resolving `$HOME/.cache/djinn/output_stash` —
+//! which surfaced hours later as `create durable blobs: Permission denied`
+//! inside the reply loop, killing every worker and planner session.
+//!
+//! [`check_home_writable`] closes that gap: a pod that cannot create entries in
+//! its own `$HOME` fails readiness with the path, the observed ownership/mode
+//! and the running identity, instead of degrading into an opaque `EACCES` in
+//! whichever feature touches `$HOME` first (`fnm`'s multishell state, `gopls`,
+//! `npm`, `git config --global`, `rustup`, and the stash all do).
+//!
+//! It is deliberately NOT expressed as a [`VolumeRoot`]: `$HOME` lives in the
+//! image layer, not on a shared volume, so the artifact-gid/setgid rules do not
+//! apply to it and it is *correct* for it to stay owned by the image's uid
+//! 10001 (the server-side path runs as that uid and writes the same directory).
+//! The only invariant that matters is the effective one — "can the identity
+//! that is actually running create something here" — so the check asks the
+//! kernel (`access(W_OK|X_OK)`) rather than re-deriving permission from mode
+//! bits. The image satisfies it for every identity at once by group-owning
+//! `/home/djinn` to [`ARTIFACT_GID`] with `2775`: uid 10001 writes as owner,
+//! the worker (uid/gid 1000) and the launcher-spawned child (uid 1001, group
+//! 1000) write through the group.
 
 use std::collections::VecDeque;
 use std::fs;
@@ -83,6 +112,11 @@ pub const CACHE_MOUNT_ROOT: &str = "/cache";
 pub const MIRROR_MOUNT_ROOT: &str = "/mirror";
 /// Contractual workspace mount path.
 pub const WORKSPACE_MOUNT_ROOT: &str = "/workspace";
+
+/// The process's home directory. Set as an explicit image `ENV` (see
+/// `djinn-image-builder`'s `emit_path`) precisely because a pod with no home
+/// inherits `HOME="/"`.
+pub const HOME_ENV: &str = "HOME";
 
 /// Env var selecting the enforcement mode (`enforce` | `audit`).
 pub const MODE_ENV: &str = "DJINN_VOLUME_CONTRACT_MODE";
@@ -276,6 +310,10 @@ pub struct VolumeContract {
     pub stat_budget: usize,
     /// Also assert the process is a member of `required_gid`.
     pub require_process_membership: bool,
+    /// Also assert the running identity can create entries in its own `$HOME`
+    /// (task 9jrg). Independent of `required_gid`: `$HOME` is an image path, not
+    /// a mounted volume, and only its *effective* writability is contractual.
+    pub require_writable_home: bool,
 }
 
 impl Default for VolumeContract {
@@ -286,6 +324,7 @@ impl Default for VolumeContract {
             entries_per_dir: 32,
             stat_budget: 512,
             require_process_membership: true,
+            require_writable_home: true,
         }
     }
 }
@@ -366,6 +405,35 @@ pub enum VolumeContractError {
         supplementary: Vec<u32>,
         required_gid: u32,
     },
+
+    #[error(
+        "volume contract [home]: {HOME_ENV} is unset or empty, so every \
+         $HOME-relative path resolves against \"/\" — which no non-root identity \
+         can write"
+    )]
+    HomeUnset,
+
+    #[error("volume contract [home]: {HOME_ENV}={path} is not a directory")]
+    HomeNotADirectory { path: PathBuf },
+
+    #[error(
+        "volume contract [home]: {path} is owned by {observed_uid}:{observed_gid} \
+         mode {observed_mode:o} and the running identity (uid {process_uid}, gid \
+         {process_gid}, supplementary {supplementary:?}) cannot create entries in \
+         it; every $HOME-relative path this pod writes (the durable output stash, \
+         fnm/npm/rustup/git state) fails with EACCES. Group-own $HOME to a gid \
+         this identity holds with mode 2775 instead of changing its owner — the \
+         server-side path runs as the owning uid and writes the same directory"
+    )]
+    HomeNotWritable {
+        path: PathBuf,
+        observed_uid: u32,
+        observed_gid: u32,
+        observed_mode: u32,
+        process_uid: u32,
+        process_gid: u32,
+        supplementary: Vec<u32>,
+    },
 }
 
 impl VolumeContractError {
@@ -379,6 +447,9 @@ impl VolumeContractError {
             Self::GroupWrite { .. } => "group_write",
             Self::Setgid { .. } => "setgid",
             Self::ProcessGroupMembership { .. } => "process_group_membership",
+            Self::HomeUnset { .. } => "home_unset",
+            Self::HomeNotADirectory { .. } => "home_not_a_directory",
+            Self::HomeNotWritable { .. } => "home_not_writable",
         }
     }
 
@@ -390,8 +461,10 @@ impl VolumeContractError {
             | Self::Stat { path, .. }
             | Self::GroupOwner { path, .. }
             | Self::GroupWrite { path, .. }
-            | Self::Setgid { path, .. } => Some(path.as_path()),
-            Self::ProcessGroupMembership { .. } => None,
+            | Self::Setgid { path, .. }
+            | Self::HomeNotADirectory { path }
+            | Self::HomeNotWritable { path, .. } => Some(path.as_path()),
+            Self::ProcessGroupMembership { .. } | Self::HomeUnset => None,
         }
     }
 }
@@ -593,6 +666,74 @@ fn check_process_membership(required_gid: u32) -> Result<(), VolumeContractError
     })
 }
 
+/// `$HOME` as the running process sees it, `None` when unset or empty.
+pub fn home_from_env() -> Option<PathBuf> {
+    std::env::var_os(HOME_ENV)
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+}
+
+/// Assert the running identity can create entries in `home` (task 9jrg).
+///
+/// The question is effective, not declarative, so it is answered by the kernel:
+/// `access(W_OK|X_OK)` on the directory is exactly the permission `mkdir` and
+/// `create_dir_all` need, and it accounts for the owner/group/other selection,
+/// supplementary groups, POSIX ACLs and a read-only mount — none of which mode
+/// bits alone can settle. Mode and ownership are read only to *report* the
+/// violation. Nothing is created: a probe file would have to be written into a
+/// directory whose writability is exactly what is in doubt, and on the passing
+/// path it would litter `$HOME` on every pod start.
+pub fn check_home_writable(home: Option<&Path>) -> Result<(), VolumeContractError> {
+    let Some(home) = home else {
+        return Err(VolumeContractError::HomeUnset);
+    };
+
+    let meta = fs::metadata(home).map_err(|source| VolumeContractError::Stat {
+        label: "home".to_string(),
+        path: home.to_path_buf(),
+        source,
+    })?;
+    if !meta.is_dir() {
+        return Err(VolumeContractError::HomeNotADirectory {
+            path: home.to_path_buf(),
+        });
+    }
+
+    if can_create_entries_in(home) {
+        return Ok(());
+    }
+
+    Err(VolumeContractError::HomeNotWritable {
+        path: home.to_path_buf(),
+        observed_uid: meta.uid(),
+        observed_gid: meta.gid(),
+        observed_mode: meta.mode() & MODE_MASK,
+        process_uid: current_uid(),
+        process_gid: current_gid(),
+        supplementary: supplementary_groups(),
+    })
+}
+
+/// `access(dir, W_OK | X_OK)` — the kernel's own answer to "may this identity
+/// create, rename and unlink entries here".
+fn can_create_entries_in(dir: &Path) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    let Ok(c_path) = std::ffi::CString::new(dir.as_os_str().as_bytes()) else {
+        // A path with an interior NUL cannot name a real directory.
+        return false;
+    };
+    // SAFETY: `access` reads the NUL-terminated path we just built and returns a
+    // status code; it mutates nothing and the CString outlives the call.
+    unsafe { libc::access(c_path.as_ptr(), libc::W_OK | libc::X_OK) == 0 }
+}
+
+/// Effective uid of this process.
+pub fn current_uid() -> u32 {
+    // SAFETY: `geteuid` takes no arguments, cannot fail, and touches no memory.
+    unsafe { libc::geteuid() }
+}
+
 /// Effective gid of this process.
 pub fn current_gid() -> u32 {
     // SAFETY: `getegid` takes no arguments, cannot fail, and touches no memory.
@@ -733,7 +874,14 @@ pub fn enforce_with(
     }
 
     let started = Instant::now();
-    let outcome = validate(contract, roots);
+    // `$HOME` first: it is a single `stat` + `access`, it is the surface the pod
+    // needs before it can do anything at all, and a violation there explains
+    // failures the volume walk cannot (task 9jrg).
+    let outcome = if contract.require_writable_home {
+        check_home_writable(home_from_env().as_deref()).and_then(|()| validate(contract, roots))
+    } else {
+        validate(contract, roots)
+    };
     let elapsed = started.elapsed();
 
     match outcome {

--- a/server/crates/djinn-agent-worker/tests/home_contract.rs
+++ b/server/crates/djinn-agent-worker/tests/home_contract.rs
@@ -1,0 +1,371 @@
+//! Startup readiness for an unwritable `$HOME` (task 9jrg).
+//!
+//! The production failure: `qut0` moved the task-run Pod to uid/gid 1000 while
+//! the image kept `/home/djinn` at `10001:10001 0775`. The pod therefore matched
+//! the "other" class (`r-x`) on its own `$HOME` and could not create a single
+//! entry there. The durable output stash resolves
+//! `$HOME/.cache/djinn/output_stash` when `XDG_CACHE_HOME` is unset, so every
+//! worker and planner session died on `create durable blobs: Permission denied`
+//! — hours after start, inside the reply loop, with nothing pointing at
+//! ownership.
+//!
+//! **Every test here runs against a directory owned by a uid that is NOT the
+//! running process's.** A test that owns the directory it probes proves nothing:
+//! the owner class carries `rwx` in `0775`, so the check passes for the wrong
+//! reason. That is the exact gap that let this, `ej9c` and `4hfr` ship.
+//!
+//! Two arms, chosen by privilege, and one of them ALWAYS runs:
+//!
+//! 1. **Unprivileged** — probes a real directory the filesystem already has
+//!    owned by another uid with no group/other write (`/` and friends). Runs on
+//!    any CI runner. It can prove the failure but not the fix, because an
+//!    unprivileged process cannot fabricate "owned by 10001, group 1000".
+//! 2. **Privileged** — builds both shapes for real (`10001:10001 0775`, the
+//!    outage, and `10001:1000 2775`, the image fix), then `fork`s a child that
+//!    drops to the pod's uid/gid 1000 and runs the check and a genuine
+//!    `create_dir_all` of the stash path from that identity. Needs root to
+//!    `chown`, so it runs in a container but not on a GitHub runner.
+
+use std::fs;
+use std::io;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+
+use djinn_agent_worker::volume_contract::{
+    ContractMode, VolumeContract, VolumeContractError, check_home_writable, current_uid,
+    enforce_with, home_from_env,
+};
+use tempfile::TempDir;
+
+/// Owner of `/home/djinn` in the image — the identity the server-side path runs
+/// as, which is why the fix must not change it.
+const IMAGE_HOME_UID: u32 = 10001;
+/// `djinn_cgroup_launcher::child::ARTIFACT_GID`.
+const ARTIFACT_GID: u32 = 1000;
+/// uid/gid the task-run Pod runs as since `qut0`.
+const POD_UID: u32 = 1000;
+/// The shape that caused the outage.
+const BROKEN_HOME_MODE: u32 = 0o775;
+/// The shape the image now bakes: group-write for the artifact GID, setgid so
+/// entries created here keep the shared group.
+const FIXED_HOME_MODE: u32 = 0o2775;
+
+/// The stash path the reply loop failed to create, relative to `$HOME`.
+const STASH_RELATIVE: &str = ".cache/djinn/output_stash/blobs";
+
+/// Contract that isolates the `$HOME` arm: no roots to walk, no membership
+/// assertion, so the only thing left to fail is `$HOME`.
+fn home_only_contract() -> VolumeContract {
+    VolumeContract {
+        require_process_membership: false,
+        require_writable_home: true,
+        ..VolumeContract::default()
+    }
+}
+
+/// A directory that already exists, is owned by a uid other than ours, and
+/// grants neither group nor other write — the production `$HOME` shape, borrowed
+/// rather than fabricated so the unprivileged arm can run it.
+fn foreign_owned_unwritable_dir() -> Option<PathBuf> {
+    ["/", "/usr", "/etc", "/opt"]
+        .iter()
+        .map(Path::new)
+        .find(|path| {
+            let Ok(meta) = fs::metadata(path) else {
+                return false;
+            };
+            meta.uid() != current_uid() && meta.mode() & 0o022 == 0
+        })
+        .map(Path::to_path_buf)
+}
+
+#[test]
+// Test diagnostic: which arm ran decides what was proven, and a run that does
+// not say so is indistinguishable from a silent skip.
+#[allow(clippy::print_stderr)]
+fn a_home_owned_by_another_uid_with_no_group_write_fails_readiness() {
+    match foreign_owned_unwritable_dir() {
+        Some(home) => {
+            eprintln!(
+                "9jrg home contract: unprivileged arm against {} (uid {})",
+                home.display(),
+                current_uid()
+            );
+            unprivileged_arm(&home)
+        }
+        None => {
+            eprintln!("9jrg home contract: privileged arm (fabricating both real shapes)");
+            assert_eq!(
+                current_uid(),
+                0,
+                "no foreign-owned unwritable directory found and we are not root: \
+                 this test would prove nothing, so it must not pass"
+            );
+            privileged_arm();
+        }
+    }
+}
+
+/// The check must reject a `$HOME` owned by someone else, and the rejection must
+/// match what the filesystem actually does to the stash write.
+fn unprivileged_arm(home: &Path) {
+    let observed = fs::metadata(home).expect("stat foreign home");
+    assert_ne!(
+        observed.uid(),
+        current_uid(),
+        "arm precondition: the probed directory must be owned by another uid"
+    );
+
+    let error = check_home_writable(Some(home)).expect_err("unwritable $HOME must be rejected");
+    match &error {
+        VolumeContractError::HomeNotWritable {
+            path,
+            observed_uid,
+            process_uid,
+            ..
+        } => {
+            assert_eq!(path, home);
+            assert_eq!(*observed_uid, observed.uid());
+            assert_eq!(*process_uid, current_uid());
+            assert_ne!(
+                observed_uid, process_uid,
+                "the error must record that the owner is a different identity"
+            );
+        }
+        other => panic!("expected HomeNotWritable, got {other:?}"),
+    }
+    assert_eq!(error.kind(), "home_not_writable");
+    assert_eq!(error.path(), Some(home));
+
+    // The check's verdict must match the kernel's: the very write that killed
+    // every session has to fail here for the same reason.
+    let stash = home.join(STASH_RELATIVE);
+    let denied = fs::create_dir_all(&stash)
+        .expect_err("creating the durable stash under a foreign-owned home must fail");
+    assert_eq!(
+        denied.kind(),
+        io::ErrorKind::PermissionDenied,
+        "expected the production EACCES at {}, got {denied}",
+        stash.display()
+    );
+
+    // ... and readiness must fail closed on it, before any volume is walked.
+    let outcome = in_forked_child(|| {
+        // SAFETY: single-threaded forked child; nothing else reads the env.
+        unsafe { std::env::set_var("HOME", home) };
+        match enforce_with(
+            "task-run",
+            &home_only_contract(),
+            &[],
+            ContractMode::Enforce,
+        ) {
+            Err(VolumeContractError::HomeNotWritable { .. }) => 0,
+            Err(_) => 2,
+            Ok(()) => 3,
+        }
+    });
+    assert_eq!(
+        outcome, 0,
+        "enforce_with must fail closed with HomeNotWritable (exit {outcome})"
+    );
+}
+
+/// With `chown` available, reproduce both real shapes and judge them from the
+/// pod's own identity.
+fn privileged_arm() {
+    let dir = TempDir::new().expect("tempdir");
+
+    // The outage shape: owned by the image's uid, group-owned by it too, 0775.
+    let broken = dir.path().join("broken-home");
+    fs::create_dir(&broken).expect("mkdir broken home");
+    chown(&broken, IMAGE_HOME_UID, IMAGE_HOME_UID);
+    chmod(&broken, BROKEN_HOME_MODE);
+
+    // The fix: same owner (the server-side path still needs it), group-owned by
+    // the artifact GID with setgid.
+    let fixed = dir.path().join("fixed-home");
+    fs::create_dir(&fixed).expect("mkdir fixed home");
+    chown(&fixed, IMAGE_HOME_UID, ARTIFACT_GID);
+    chmod(&fixed, FIXED_HOME_MODE);
+
+    // The tempdir itself must be traversable by the dropped child.
+    chmod(dir.path(), 0o755);
+
+    let broken_outcome = in_forked_child_as(POD_UID, ARTIFACT_GID, || {
+        let rejected = matches!(
+            check_home_writable(Some(&broken)),
+            Err(VolumeContractError::HomeNotWritable { .. })
+        );
+        let denied = fs::create_dir_all(broken.join(STASH_RELATIVE))
+            .is_err_and(|e| e.kind() == io::ErrorKind::PermissionDenied);
+        match (rejected, denied) {
+            (true, true) => 0,
+            (false, _) => 2,
+            (_, false) => 3,
+        }
+    });
+    assert_eq!(
+        broken_outcome, 0,
+        "uid {POD_UID} must be refused by {IMAGE_HOME_UID}:{IMAGE_HOME_UID} \
+         {BROKEN_HOME_MODE:o} and must fail the real stash write (exit {broken_outcome})"
+    );
+
+    let fixed_outcome = in_forked_child_as(POD_UID, ARTIFACT_GID, || {
+        let accepted = check_home_writable(Some(&fixed)).is_ok();
+        let created = fs::create_dir_all(fixed.join(STASH_RELATIVE)).is_ok();
+        match (accepted, created) {
+            (true, true) => 0,
+            (false, _) => 2,
+            (_, false) => 3,
+        }
+    });
+    assert_eq!(
+        fixed_outcome, 0,
+        "uid {POD_UID} in gid {ARTIFACT_GID} must be accepted by \
+         {IMAGE_HOME_UID}:{ARTIFACT_GID} {FIXED_HOME_MODE:o} and must complete the \
+         real stash write (exit {fixed_outcome})"
+    );
+}
+
+#[test]
+fn an_unset_home_is_a_violation_because_every_relative_path_lands_in_slash() {
+    let error = check_home_writable(None).expect_err("unset $HOME must be rejected");
+    assert!(matches!(error, VolumeContractError::HomeUnset));
+    assert_eq!(error.kind(), "home_unset");
+    assert_eq!(error.path(), None);
+}
+
+#[test]
+fn a_home_that_is_not_a_directory_is_a_violation() {
+    let dir = TempDir::new().expect("tempdir");
+    let file = dir.path().join("not-a-dir");
+    fs::write(&file, b"x").expect("write");
+    let error = check_home_writable(Some(&file)).expect_err("a file is not a home");
+    assert!(matches!(
+        error,
+        VolumeContractError::HomeNotADirectory { .. }
+    ));
+    assert_eq!(error.kind(), "home_not_a_directory");
+}
+
+#[test]
+fn a_missing_home_is_reported_as_a_stat_failure_naming_the_path() {
+    let dir = TempDir::new().expect("tempdir");
+    let missing = dir.path().join("no-such-home");
+    let error = check_home_writable(Some(&missing)).expect_err("absent $HOME must be rejected");
+    assert_eq!(error.kind(), "stat_failed");
+    assert_eq!(error.path(), Some(missing.as_path()));
+}
+
+#[test]
+fn a_writable_home_passes_and_the_check_creates_nothing() {
+    let dir = TempDir::new().expect("tempdir");
+    check_home_writable(Some(dir.path())).expect("an owned home must pass");
+    assert_eq!(
+        fs::read_dir(dir.path()).expect("read_dir").count(),
+        0,
+        "the readiness probe must not write into $HOME"
+    );
+}
+
+#[test]
+fn opting_out_skips_the_home_arm_entirely() {
+    let contract = VolumeContract {
+        require_process_membership: false,
+        require_writable_home: false,
+        ..VolumeContract::default()
+    };
+    let home = foreign_owned_unwritable_dir();
+    let outcome = in_forked_child(|| {
+        match &home {
+            // SAFETY: single-threaded forked child.
+            Some(path) => unsafe { std::env::set_var("HOME", path) },
+            // SAFETY: same.
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        match enforce_with("task-run", &contract, &[], ContractMode::Enforce) {
+            Ok(()) => 0,
+            Err(_) => 2,
+        }
+    });
+    assert_eq!(
+        outcome, 0,
+        "with require_writable_home=false the home arm must not run (exit {outcome})"
+    );
+}
+
+#[test]
+fn the_environment_resolver_rejects_an_empty_home() {
+    let outcome = in_forked_child(|| {
+        // SAFETY: single-threaded forked child.
+        unsafe { std::env::set_var("HOME", "") };
+        if home_from_env().is_some() {
+            return 2;
+        }
+        // SAFETY: same.
+        unsafe { std::env::set_var("HOME", "/tmp") };
+        if home_from_env().as_deref() != Some(Path::new("/tmp")) {
+            return 3;
+        }
+        0
+    });
+    assert_eq!(outcome, 0, "home_from_env mis-resolved (exit {outcome})");
+}
+
+fn chmod(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).expect("chmod");
+}
+
+/// `chown` must run BEFORE `chmod`: changing ownership clears setgid.
+fn chown(path: &Path, uid: u32, gid: u32) {
+    let raw = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).expect("path");
+    // SAFETY: `lchown` reads the NUL-terminated path and returns a status code;
+    // it never follows the final symlink and mutates no Rust-owned memory.
+    let rc = unsafe { libc::lchown(raw.as_ptr(), uid, gid) };
+    assert_eq!(
+        rc,
+        0,
+        "lchown {} to {uid}:{gid}: {}",
+        path.display(),
+        io::Error::last_os_error()
+    );
+}
+
+/// Run `body` in a forked child, returning its exit status. Used to keep `HOME`
+/// mutations and uid drops out of the test process.
+fn in_forked_child(body: impl FnOnce() -> i32) -> i32 {
+    // SAFETY: the test process is single-threaded here; the child only touches
+    // its own env and filesystem and leaves via `_exit`, so no parent atexit
+    // handler or allocator lock is inherited into an inconsistent state.
+    let pid = unsafe { libc::fork() };
+    assert!(pid >= 0, "fork: {}", io::Error::last_os_error());
+    if pid == 0 {
+        let code = body();
+        // SAFETY: terminate the child without unwinding through parent state.
+        unsafe { libc::_exit(code) };
+    }
+    let mut status = 0;
+    // SAFETY: reaping the child just forked above.
+    unsafe { libc::waitpid(pid, &mut status, 0) };
+    libc::WEXITSTATUS(status)
+}
+
+/// [`in_forked_child`] with the child dropped to `uid`/`gid` first — the only
+/// way to judge a foreign-owned directory as the identity that must write it.
+fn in_forked_child_as(uid: u32, gid: u32, body: impl FnOnce() -> i32) -> i32 {
+    in_forked_child(|| {
+        // SAFETY: privilege drop in a single-threaded child; each call is checked
+        // and the order (groups, gid, then uid) is required because dropping the
+        // uid first would forfeit the privilege the other two need.
+        let groups = [gid as libc::gid_t];
+        let dropped = unsafe {
+            libc::setgroups(1, groups.as_ptr()) == 0
+                && libc::setgid(gid) == 0
+                && libc::setuid(uid) == 0
+        };
+        if !dropped {
+            return 4;
+        }
+        body()
+    })
+}

--- a/server/crates/djinn-image-builder/scripts/base-debian.sh
+++ b/server/crates/djinn-image-builder/scripts/base-debian.sh
@@ -69,17 +69,39 @@ rm -rf /var/lib/apt/lists/*
 
 mkdir -p /opt/djinn/bin /etc/profile.d /etc/djinn
 
-# Runtime user. The task-run/warm Pods run as runAsUser=10001, but this image
-# (FROM debian:trixie-slim) otherwise has no matching passwd entry or home
-# directory, so $HOME resolves to "/" and every $HOME-relative path the agent
-# uses — its Landlock scratch dir (~/.cache/djinn), the LSP auto-install dir
-# (~/.local/share/djinn/bin, used for gopls/rust-analyzer/npm servers), and
-# Go's default GOCACHE (~/.cache/go-build) — lands in root-owned / and fails
-# with EACCES. Create the user + a writable home so HOME=/home/djinn (set as
-# an ENV in the generated Dockerfile) is actually usable. The `|| true`s keep
-# the build idempotent if the uid/gid ever pre-exist on a newer base.
+# Runtime user. This image (FROM debian:trixie-slim) otherwise has no matching
+# passwd entry or home directory, so $HOME resolves to "/" and every
+# $HOME-relative path the agent uses — its Landlock scratch dir (~/.cache/djinn),
+# the LSP auto-install dir (~/.local/share/djinn/bin, used for
+# gopls/rust-analyzer/npm servers), and Go's default GOCACHE (~/.cache/go-build)
+# — lands in root-owned / and fails with EACCES. Create the user + a writable
+# home so HOME=/home/djinn (set as an ENV in the generated Dockerfile) is
+# actually usable. The `|| true`s keep the build idempotent if the uid/gid ever
+# pre-exist on a newer base.
 groupadd --system --gid 10001 djinn 2>/dev/null || true
 useradd --system --uid 10001 --gid 10001 --home-dir /home/djinn --shell /usr/sbin/nologin djinn 2>/dev/null || true
 mkdir -p /home/djinn
-chown 10001:10001 /home/djinn
-chmod 0775 /home/djinn
+
+# THREE identities write this home, and only a group can hold all three (9jrg):
+#   * uid 10001 — the image's own `djinn` user; the server-side path runs as it.
+#   * uid/gid 1000 — the task-run/warm Pod since `qut0` (`runAsUser: 1000`,
+#     `fsGroup: 1000`), the artifact GID the volume-ownership contract enforces.
+#   * uid 1001, group 1000 — the cgroup-launcher-spawned child that runs the
+#     agent's shell commands.
+# It was `10001:10001 0775`. The group-write bit was already there — it was
+# pointed at the WRONG group, one the pod does not hold — so uid 1000 fell through
+# to "other" (r-x) and could not create ANYTHING under its own $HOME.
+# `$HOME/.cache/djinn/output_stash` was the first consumer to notice, and every
+# worker and planner session died on `create durable blobs: Permission denied`;
+# fnm's multishell state, gopls, `git config --global` and `npm` all sit on the
+# same wall.
+#
+# Keep the OWNER as 10001 — changing it would break the identity that legitimately
+# owns this path on the server side — and re-point the GROUP at the artifact GID
+# so the group bits apply to the two identities that need them. setgid so anything
+# created here keeps the shared gid instead of the creator's private one, matching
+# the mounted-volume contract's directory mode.
+# 1000 is `djinn_cgroup_launcher::child::ARTIFACT_GID`; the numeric form is
+# deliberate — the gid needs no passwd/group entry in this image to be usable.
+chown 10001:1000 /home/djinn
+chmod 2775 /home/djinn

--- a/server/crates/djinn-image-builder/scripts/install-node.sh
+++ b/server/crates/djinn-image-builder/scripts/install-node.sh
@@ -117,4 +117,11 @@ if [ -d /home/djinn ]; then
     rm -rf /home/djinn/.local/state/fnm_multishells 2>/dev/null || true
     mkdir -p /home/djinn/.local/state
     chown -R --reference=/home/djinn /home/djinn/.local
+    # ...and the MODE, not just the owner (9jrg). `mkdir` under the build umask
+    # leaves these 0755, and since `qut0` the runtime identity (uid/gid 1000) is
+    # NOT the owner of /home/djinn — it reaches these dirs through the artifact
+    # group. Without g+w this block no longer achieves the thing it exists for:
+    # fnm cannot create its multishell dir and `fnm env` fails on every login.
+    # setgid to match /home/djinn so anything created keeps the shared gid.
+    chmod 2775 /home/djinn/.local /home/djinn/.local/state
 fi

--- a/server/crates/djinn-image-builder/src/hash.rs
+++ b/server/crates/djinn-image-builder/src/hash.rs
@@ -117,7 +117,18 @@ pub fn compute_environment_hash(
     // on `agent_worker_ref` missed this whenever that ref was an unversioned
     // tag (`:latest`) or a reused tag — leaving task-run pods on stale agent
     // code after a deploy. Mixing in the version guarantees a rebuild on bump.
-    hasher.update(b"env-config/v10\0");
+    // v10→v11: `/home/djinn` is group-owned by the artifact GID 1000 with setgid
+    // 2775 in base-debian.sh instead of `10001:10001 0775`. Since `qut0` the
+    // task-run/warm Pod runs as uid/gid 1000, so it matched "other" (r-x) on its
+    // own $HOME and could not create anything there — every worker and planner
+    // session died on `create durable blobs: Permission denied` resolving
+    // `$HOME/.cache/djinn/output_stash`, and fnm/gopls/npm/`git config --global`
+    // sat on the same wall (9jrg). The worker now fails readiness loudly on an
+    // unwritable $HOME (`volume_contract::check_home_writable`), which every
+    // cached pre-fix image would trip, so this rebuild is a hard prerequisite,
+    // not an optimization. The script edit already moves script_sha; bump the
+    // salt to document it and guarantee the rebuild.
+    hasher.update(b"env-config/v11\0");
     hasher.update(config_json.as_bytes());
     hasher.update([0u8]);
     hasher.update(script_sha.as_bytes());

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -826,6 +826,46 @@ fn common_cache_env_vars(project_id: &str, cpu_limit: &str) -> Vec<EnvVar> {
     // process count bounded by the node's real capacity.
     let jobs = cpu_limit_to_jobs(cpu_limit).to_string();
     vec![
+        // Generic XDG cache root, rendered for the same reason CARGO_HOME,
+        // SCCACHE_DIR, GOMODCACHE and PNPM_HOME are: `$HOME`-relative stores are
+        // both unwritable and ephemeral in these pods (task 9jrg).
+        //
+        // Unwritable: `qut0` moved these pods to uid/gid 1000 while the image's
+        // /home/djinn stayed uid 10001 mode 0775, so the pod matched "other"
+        // (r-x). The durable output stash resolves
+        // `$XDG_CACHE_HOME/djinn/output_stash`, falling back to
+        // `$HOME/.cache/djinn/output_stash`, so with XDG_CACHE_HOME unset every
+        // worker and planner session died on `create durable blobs: Permission
+        // denied` before it could submit for review. The SCIP indexer cache
+        // (djinn-graph scip_indexer/cache.rs) resolves the same pair.
+        //
+        // Ephemeral: even with the image's ownership fixed, `$HOME/.cache` is a
+        // container layer that dies with the Pod — so a stash the coordinator
+        // GCs on a retention window (`DJINN_OUTPUT_STASH_GC_RETENTION_DAYS`) and
+        // reads back after a restart would never actually survive one. The
+        // `/cache` PVC is persistent, group-owned by the artifact GID with
+        // setgid 2775 (so `create_dir_all` under the worker's 0002 umask
+        // inherits a conforming subtree), verified at startup by the
+        // volume-ownership contract rather than assumed, and inside the agent's
+        // Landlock allowlist — which follows automatically, because the sandbox
+        // derives its djinn cache dir from this very env var.
+        //
+        // Namespaced per project like SCCACHE_DIR/CARGO_TARGET_DIR: the PVC is
+        // shared cluster-wide and stashed blobs are verbatim tool output, which
+        // must not commingle across project boundaries. NOT per task run: the
+        // stash is read back after a restart and expires on a retention window,
+        // so a per-run directory would quietly make the durable stash per-run.
+        //
+        // Retention: the coordinator's stash GC runs in the server process
+        // against the server's OWN root, so it does not sweep this one — nor did
+        // it sweep the pod-side stash before, which lived on a container layer
+        // that died with the Pod. The server mounts this same claim (at
+        // /var/lib/djinn/cache), so extending that sweep to the per-project roots
+        // needs no new volume plumbing.
+        env_var(
+            "XDG_CACHE_HOME",
+            &format!("{CACHE_MOUNT_DIR}/xdg/{project_id}"),
+        ),
         env_var("CARGO_HOME", &format!("{CACHE_MOUNT_DIR}/cargo")),
         // NOTE: we deliberately do NOT force `RUSTC_WRAPPER=sccache` or
         // `CARGO_INCREMENTAL=0` here. The fast path is incremental compilation
@@ -1723,6 +1763,70 @@ mod tests {
         assert_eq!(
             envs.get("DJINN_DATABASE_URL").copied(),
             Some("postgres://djinn@djinn-postgres.djinn.svc:5432/djinn")
+        );
+    }
+
+    /// The durable output stash resolves `$XDG_CACHE_HOME/djinn/output_stash`,
+    /// falling back to `$HOME/.cache/djinn/output_stash`. Since `qut0` the Pod
+    /// runs as uid/gid 1000 while the image's `/home/djinn` is owned by uid
+    /// 10001, so leaving `XDG_CACHE_HOME` unset put the stash on a path the Pod
+    /// cannot create — every worker and planner session died on `create durable
+    /// blobs: Permission denied` (9jrg). It must be rendered, it must sit on the
+    /// persistent PVC (the stash is GC'd on a retention window, so a container
+    /// layer that dies with the Pod is not a home for it), and it must be
+    /// namespaced per project.
+    #[test]
+    fn routes_the_xdg_cache_home_to_the_persistent_pvc_not_the_image_home() {
+        let cfg = KubernetesConfig::for_testing();
+        let task_run_id = Uuid::now_v7();
+
+        let job = build_task_run_job(
+            &cfg,
+            &task_run_id,
+            "proj-xyz",
+            "djinn-taskrun-test",
+            "registry.example:5000/djinn-project-p:abc123def456",
+            &[],
+            None,
+            false,
+            None,
+        );
+        let envs = task_run_job_envs(&job);
+
+        let xdg = envs
+            .get("XDG_CACHE_HOME")
+            .copied()
+            .expect("XDG_CACHE_HOME must be rendered; unset falls back to an unwritable $HOME");
+        assert_eq!(
+            xdg, "/cache/xdg/proj-xyz",
+            "the XDG cache root must live on the persistent /cache PVC, namespaced per project"
+        );
+        assert!(
+            xdg.starts_with(&format!("{CACHE_MOUNT_DIR}/")),
+            "{xdg} must be under the group-1000-writable cache mount"
+        );
+        assert!(
+            !xdg.contains("/home/"),
+            "{xdg} must not resolve under the image home, which uid 1000 cannot write"
+        );
+        assert!(
+            !xdg.contains(&task_run_id.to_string()),
+            "{xdg} must be shared across runs: the stash is read back after a restart \
+             and GC'd on a retention window, so a per-run dir would make it per-run"
+        );
+
+        // Same routing for warm Pods: they run as the same uid against the same
+        // unwritable image home, and the SCIP indexer cache resolves the same
+        // env pair.
+        let warm_env = warm_cache_env_vars("proj-xyz", &cfg.cpu_limit, None);
+        let warm: BTreeMap<&str, &str> = warm_env
+            .iter()
+            .map(|e| (e.name.as_str(), e.value.as_deref().unwrap_or_default()))
+            .collect();
+        assert_eq!(
+            warm.get("XDG_CACHE_HOME").copied(),
+            Some("/cache/xdg/proj-xyz"),
+            "warm and task-run Pods must resolve the same XDG cache root"
         );
     }
 

--- a/server/docker/djinn-agent-runtime-base.Dockerfile
+++ b/server/docker/djinn-agent-runtime-base.Dockerfile
@@ -159,10 +159,19 @@ COPY --from=lsp /usr/local/bin/rust-analyzer /usr/local/bin/rust-analyzer
 
 # Non-root user. Uid/gid 10001 matches the `djinn` user baked into the
 # server image so shared PVCs (mirrors, cache) mount cleanly on both sides.
+# $HOME keeps uid 10001 as its owner but is group-owned by the artifact GID
+# (1000) with setgid 2775, because three identities write it: uid 10001 here and
+# on the server side, uid/gid 1000 for the task-run/warm Pod since `qut0`, and
+# uid 1001/group 1000 for the launcher-spawned child. At 10001:10001 0775 the pod
+# matched "other" (r-x) and could not create a single entry under its own home —
+# `create durable blobs: Permission denied` killed every worker and planner
+# session (9jrg). Mirrors `djinn-image-builder/scripts/base-debian.sh`.
 RUN groupadd --system --gid 10001 djinn \
     && useradd --system --uid 10001 --gid 10001 --home /home/djinn --create-home --shell /usr/sbin/nologin djinn \
     && mkdir -p /workspace /mirror /cache/cargo /cache/pnpm /cache/pip /cache/sccache /cache/rustup /var/run/djinn \
-    && chown -R djinn:djinn /workspace /cache /var/run/djinn /home/djinn
+    && chown -R djinn:djinn /workspace /cache /var/run/djinn /home/djinn \
+    && chown -R 10001:1000 /home/djinn \
+    && chmod 2775 /home/djinn
 
 # Per-run env defaults. Overridable by the Job spec (K8sRuntime) or the
 # docker-run env (LocalDockerRuntime) if a task needs per-task-specific


### PR DESCRIPTION
## P0

Every worker and planner session on deployed v0.7.3 died with
`reply loop error: create durable blobs: Permission denied (os error 13)`
(13 worker + 7 planner in a 40-minute window). Confirmed in a live pod:
`uid=1000 gid=1000`, `HOME=/home/djinn`, `drwxrwxr-x djinn djinn`,
`mkdir /home/djinn/.cache -> Permission denied`.

`qut0` moved task-run Pods to uid/gid 1000 while the image still owned
`/home/djinn` as `10001:10001` mode `0775`. The group-write bit was there but
pointed at a group the Pod does not hold, so the Pod fell through to "other"
(`r-x`) and could not create a single entry under its own `$HOME`. The durable
output stash resolves `$XDG_CACHE_HOME/djinn/output_stash` and falls back to
`$HOME/.cache/djinn/output_stash`; `XDG_CACHE_HOME` was unset in the rendered
Job.

Knock-on: a worker dies before submitting for review, so the task returns to
`open` and no reviewer is ever spawned. Reviewer dispatch was never broken, just
never reached. After six consecutive failures the coordinator escalates to a
1800s cooldown, which makes planning look dormant rather than failing.

## Layer chosen: both, because they answer different questions

**Job render (`djinn-k8s`)** — `XDG_CACHE_HOME=/cache/xdg/<project_id>`.

The env route is not just a permission workaround here. Even with the image's
ownership fixed, `$HOME/.cache` is a **container layer that dies with the Pod**,
so a stash that is read back after a restart and expires on a retention window
(`DJINN_OUTPUT_STASH_GC_RETENTION_DAYS`) had no business living there. `/cache`
is:

- persistent, so cross-run persistence is *gained*, not silently dropped — and
  the dir is deliberately NOT keyed by task run;
- group-owned by the artifact GID with setgid `2775`, so `create_dir_all` under
  the worker's `0002` umask inherits a conforming subtree, and writability is
  **verified** at startup by the volume contract rather than assumed;
- inside the agent's Landlock allowlist automatically — the sandbox derives its
  djinn cache dir from this same env var;
- namespaced per project like `SCCACHE_DIR`/`CARGO_TARGET_DIR`: the PVC is shared
  cluster-wide and stashed blobs are verbatim tool output.

Set in the shared cache-env helper, so warm Pods get it too — the SCIP indexer
cache (`djinn-graph/scip_indexer/cache.rs`) resolves the same env pair and was
silently broken by the same migration.

**Image** — `/home/djinn` keeps uid `10001` as its **owner** and becomes
group-owned by the artifact GID `1000` with setgid `2775`.

This is the reconciliation the dual-uid problem needs. Three identities write
that directory: uid `10001` (the server-side path), uid/gid `1000` (the worker
since `qut0`), and uid `1001`/group `1000` (the launcher-spawned child that runs
the agent's shell commands). Only a shared **group** can hold all three;
`chown`ing to 1000 would have broken the first. This is the fix for the wider
class the task calls out — `fnm`'s multishell state, `gopls`, `npm` and
`git config --global` all sit on the same wall. Applied to both
`base-debian.sh` (project images) and `djinn-agent-runtime-base.Dockerfile`,
with the hash salt bumped to `env-config/v11` so every catalog image rebuilds.

## Readiness check: added

`volume_contract::check_home_writable` asserts the running identity can create
entries in `$HOME`, failing readiness with the path, the observed
ownership/mode, and the running identity (uid, gid, supplementary groups).

`$HOME` is deliberately **not** modelled as a `VolumeRoot`: it is an image path,
the artifact-gid/setgid rules do not apply to it, and it is correct for it to
stay owned by uid 10001. Only its *effective* writability is contractual — so the
check asks the kernel (`access(W_OK|X_OK)`), which accounts for the
owner/group/other selection, supplementary groups, ACLs and a read-only mount.
It creates nothing: a probe file would have to be written into the directory
whose writability is in doubt.

It fails **closed**, and that is safe by construction: Pods only start on a
`ready` catalog image, and the salt bump marks every catalog image `building`
until it rebuilds with the fixed `$HOME`, so a pre-fix image cannot be dispatched
to. `DJINN_VOLUME_CONTRACT_MODE=audit` remains the existing loud break-glass.

## Tests never run as the owner

A test that owns the directory it probes passes for the wrong reason — the owner
class carries `rwx` in `0775`. That is the gap that let this, `ej9c` and `4hfr`
ship, so `tests/home_contract.rs` has two arms and one of them always runs:

- **Unprivileged** (any CI runner): probes a real directory the filesystem
  already has owned by another uid with no group/other write, asserts the typed
  rejection records `observed_uid != process_uid`, and asserts the genuine
  `create_dir_all(".cache/djinn/output_stash/blobs")` fails with the production
  `PermissionDenied` — the check's verdict has to match the kernel's. Then
  asserts `enforce_with` fails closed on it.
- **Privileged** (root in a container): fabricates both real shapes —
  `10001:10001 0775` (the outage) and `10001:1000 2775` (the fix) — and judges
  each from a child `fork`ed and dropped to uid/gid 1000 with supplementary group
  1000, running both the check and a real stash `create_dir_all`. This proves the
  bug *and* the image fix in one test.

If neither arm is possible the test fails rather than passing vacuously.
Verified by mutation: reverting the fixed shape's group to `10001` fails it
(`must be accepted by 10001:1000 2775 ... (exit 2)`), and verified the privileged
arm actually executes (`docker run -u 0 archlinux:base <test-bin>`).

## Follow-up, recorded not hidden

The coordinator's stash GC runs in the server process against the server's own
root and does not sweep the pod-side root. Neither did anything before — the
pod-side stash lived on a container layer that died with the Pod, so it was never
collected *or* persisted. The server mounts this same claim at
`/var/lib/djinn/cache`, so extending that sweep to the per-project roots needs no
new volume plumbing. Noted at the render site and in the runbook.

## Gates

- `SQLX_OFFLINE=1 cargo check --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `cargo clippy -D warnings` on djinn-agent-worker / djinn-k8s / djinn-image-builder — clean
- `cargo nextest`: djinn-k8s + djinn-image-builder 272 passed, djinn-agent-worker 363 passed, djinn-agent 1428 passed, djinn-coordinator 1934 passed
- file-size guard (1500 lines / 51,200 bytes), raw-SQL boundary, k8s boundary, shared-cache rollout (112 checks) — all pass
- no `Cargo.toml` changed, so no hakari regeneration needed

## Deploy note

The server change lands the fix on the next dispatched task-run with no image
rebuild. The `$HOME` readiness check and the image fix arrive together: catalog
images go `building` on the salt bump and Pods will not dispatch until they are
`ready` again.