### PR TITLE
fix(nurw): put safe.directory in protected scope so mirror clones work cross-uid

### DIFF
--- a/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
+++ b/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
@@ -49,14 +49,46 @@ matching group. Therefore mirror ownership is not a readiness requirement and
 operators must not recursively `chown /mirror` to uid `1000` merely to satisfy
 Git.
 
-Every Djinn-managed git process injects `safe.directory=*` through
-`GIT_CONFIG_COUNT=1`, `GIT_CONFIG_KEY_0=safe.directory`, and
-`GIT_CONFIG_VALUE_0=*`. Environment variables are required rather than a
-`git -c` flag because the inner process spawned by `git clone --local` inherits
-the environment but not its parent's command-line flags. This makes the
-2026-07-25 operational `chown /mirror/<project>.git` mitigation unnecessary
-for newly created, restored, and freshly provisioned mirrors; retain the group,
-mode, setgid, and umask contract above instead.
+Every Djinn-managed git process injects `safe.directory=*` through a **config
+file** in protected (system) scope: `djinn_git::git_command` writes
+`$TMPDIR/djinn-git-<euid>/gitconfig` once per process and exports
+`GIT_CONFIG_SYSTEM` pointing at it. The warm Job's shell wrapper does the same
+with its own file. This makes the 2026-07-25 operational
+`chown /mirror/<project>.git` mitigation unnecessary for newly created,
+restored, and freshly provisioned mirrors; retain the group, mode, setgid, and
+umask contract above instead.
+
+**Do not** switch this back to `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/
+`GIT_CONFIG_VALUE_0`, and not to `git -c` either. Both are *command* scope, and
+`git clone --local` does ref discovery through an inner `git-upload-pack` child
+that git spawns with those variables **stripped** — visible in `GIT_TRACE` as
+`trace: run_command: unset GIT_CONFIG_COUNT GIT_DIR; git-upload-pack '<src>'`.
+Measured on git 2.47.3 (the deployed server image) with uid 10001 cloning a
+root-owned repository, `git clone --local --shared` fails with "detected dubious
+ownership" under both command-scope forms and succeeds with `GIT_CONFIG_SYSTEM`.
+The command-scope form is honoured by a git process that reads it *directly*,
+which is why it looked correct, and it had in fact never worked for a mirror
+clone in any released version — the check simply never fired while the server
+owned the mirror.
+
+`GIT_CONFIG_SYSTEM` rather than `GIT_CONFIG_GLOBAL`: `configure_private_dep_access`
+stores the GitHub installation token as a `url.<...>.insteadOf` rewrite with
+`git config --global`, and the agent's build tools (cargo, go, pnpm) read it back
+from `$HOME/.gitconfig` with Djinn nowhere in the loop. Redirecting global scope
+would send that write to a file nothing else reads and silently break
+private-dependency fetches. System scope is additive, so `$HOME/.gitconfig` and
+the XDG config keep being read exactly as before.
+
+**Stopgap that is no longer needed.** On 2026-07-25, with v0.7.3 deployed,
+`git config --global --add safe.directory "*"` was run by hand inside the running
+server pod to unwedge PR creation (120 dubious-ownership errors and 40
+`supervisor_pr_open failed` in 20 minutes). That was ephemeral — lost on every
+pod restart, which is how the outage resurfaced after the rollout replaced the
+pod — and it widened trust for every process sharing that uid, permanently, in a
+file on disk. The generated file above replaces it: it is process-scoped, and it
+is re-created on every start. Do not re-apply the manual command; if dubious
+ownership reappears, the config file is missing or unwritable, and the server
+logs `could not materialize the system-scope safe.directory config` at `WARN`.
 
 Violating it does not produce a crash. It produces a **silent freeze**: the warm
 Job's cargo phase is best-effort (lock-unavailable, step failure and timeout only
@@ -203,3 +235,10 @@ gap loud instead of silent.
 - `deploy/helm/djinn/tests/volume-ownership-render.sh` — the render contract.
 - `server/crates/djinn-k8s/src/launcher.rs` — `pod_security_context()` and the
   worker/child/launcher uid contract.
+- `server/crates/djinn-git/src/lib.rs` — the generated protected-scope
+  `safe.directory` config, with the measurements behind it.
+- `server/crates/djinn-git/src/lib_tests.rs` — regression tests that assert which
+  scope git resolves the rule in and what the inner child of
+  `git clone --local` sees. "A clone of a foreign-owned repo succeeds" is not
+  sufficient: git >= 2.48 accepts it either way, so that assertion passes on a
+  modern developer/CI git while production is wedged.

--- a/server/crates/djinn-git/src/lib.rs
+++ b/server/crates/djinn-git/src/lib.rs
@@ -52,27 +52,282 @@ fn lower_process_priority(cmd: &mut tokio::process::Command) {
     }
 }
 
-/// Set GIT_CONFIG_COUNT=1 + GIT_CONFIG_KEY_0/VALUE_0 on a `std::process::Command`
-/// so git accepts any repo regardless of cross-UID ownership. Env vars (not
-/// `-c` flag) so that inner git subprocesses spawned by `git clone --local`
-/// also inherit the rule.
+// ─── safe.directory: protected-scope trust for cross-UID repositories ───────
+//
+// git refuses to operate on a repository owned by a different uid ("detected
+// dubious ownership") unless `safe.directory` lists it. djinn shares
+// repositories across two identities on purpose — the server (uid 10001) and
+// the worker / warm Job (uid 1000) both clone the same `/mirror` PVC — so
+// whichever identity does not own the mirror needs that exception.
+//
+// The exception has to arrive as a config **file** pointed at by
+// `GIT_CONFIG_SYSTEM`. Injecting it as `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`
+// (or as `git -c`) does not work. Measured on git 2.47.3 — the version in the
+// deployed server image — with uid 10001 cloning a root-owned repository:
+//
+//     git clone --local --shared <foreign-owned repo> <dst>
+//       GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0=*
+//                                                     -> dubious ownership, FAILS
+//       git -c safe.directory='*'                     -> dubious ownership, FAILS
+//       GIT_CONFIG_SYSTEM=<file holding safe.directory> -> clone succeeds
+//
+// The reason is visible in `GIT_TRACE`: `git clone --local` does ref discovery
+// through an inner `git-upload-pack` child, and git *strips* the command-scope
+// variables from that child's environment —
+//
+//     trace: run_command: unset GIT_CONFIG_COUNT GIT_DIR; git-upload-pack '<src>'
+//
+// — so the outer process is trusted while the child that actually opens the
+// repository is not. `GIT_CONFIG_SYSTEM` is not in that stripped set and system
+// scope is protected configuration, so the rule survives into the child.
+//
+// This is why the env form had never worked in any released version (nurw): it
+// only appeared to work while the server owned the mirror and no check fired,
+// and it broke the instant the mirror was chowned to uid 1000 for the workers.
+// Note that a test which only asserts "a clone of a foreign-owned repo
+// succeeds" does not pin this down — on git >= 2.48 that clone succeeds either
+// way. The regression tests therefore assert what the *inner child* resolves;
+// see `lib_tests.rs`.
+//
+// SYSTEM rather than GLOBAL scope, deliberately: `configure_private_dep_access`
+// stores the GitHub installation token as a `url.<...>.insteadOf` rewrite with
+// `git config --global`, and the agent's own build tools (cargo, go, pnpm) read
+// it back out of `$HOME/.gitconfig` with djinn nowhere in the loop. Pointing
+// `GIT_CONFIG_GLOBAL` at a djinn-owned file would redirect that write into a
+// file those tools never read and would silently break private-dependency
+// fetches. System scope is purely additive: `$HOME/.gitconfig` and the XDG
+// config keep being read exactly as before, and `git config --global` keeps
+// writing where it always did.
+
+/// Basename of the generated config inside [`generated_config_dir`].
+const GENERATED_CONFIG_BASENAME: &str = "gitconfig";
+
+/// The `safe.directory` value djinn writes.
+///
+/// `*` (trust every repository) rather than an explicit list of mirror roots.
+/// The reasoning:
+///
+/// * The check only fires for repositories owned by *another* uid. Everything
+///   djinn creates for itself — task workspaces, ephemeral clones, read-source
+///   caches — is owned by the creating process, so `*` grants nothing there.
+///   The only foreign-owned repositories in play are the mirror / cache volumes
+///   that djinn deliberately shares between its two service identities.
+/// * The generated file is exported only to git subprocesses djinn spawns. It is
+///   never written into `/etc/gitconfig` or any `$HOME/.gitconfig`, so unlike
+///   the `git config --global --add safe.directory "*"` that was applied by hand
+///   inside the running pod, it does not widen trust for other processes sharing
+///   that uid, and it disappears with the process.
+/// * An explicit list would have to name paths this crate cannot see: mirror and
+///   cache roots are deployment-configured, and tests and local development use
+///   per-run temporary directories. Threading that configuration into the lowest
+///   git seam would leave a path that fails closed — a wedged mirror clone —
+///   every time a new shared location appears, which is precisely the silent
+///   failure mode this whole change exists to remove.
+const SAFE_DIRECTORY_VALUE: &str = "*";
+
+/// Effective uid of this process.
+fn effective_uid() -> u32 {
+    // SAFETY: `geteuid` is always successful and takes no arguments.
+    unsafe { libc::geteuid() }
+}
+
+/// `{TMPDIR}/djinn-git-{euid}`, created private to this uid.
+///
+/// `TMPDIR` rather than `$HOME`: the server pod's home directory is not
+/// guaranteed writable, while a writable temp dir is a precondition for git
+/// itself. An existing directory is accepted only when it is a real directory
+/// owned by us that no other user can write, so a pre-planted path in a shared
+/// `/tmp` cannot be used to feed arbitrary git configuration into djinn.
+fn generated_config_dir() -> std::io::Result<PathBuf> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt};
+
+    let dir = std::env::temp_dir().join(format!("djinn-git-{}", effective_uid()));
+    match std::fs::DirBuilder::new().mode(0o755).create(&dir) {
+        Ok(()) => return Ok(dir),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(err) => return Err(err),
+    }
+    // `symlink_metadata`: never follow a symlink another user may have planted.
+    let metadata = std::fs::symlink_metadata(&dir)?;
+    if !metadata.is_dir() || metadata.uid() != effective_uid() || metadata.mode() & 0o022 != 0 {
+        return Err(std::io::Error::other(format!(
+            "{} is not a directory owned by uid {} and writable only by it",
+            dir.display(),
+            effective_uid()
+        )));
+    }
+    Ok(dir)
+}
+
+/// Is `GIT_CONFIG_NOSYSTEM` asking git to ignore system configuration?
+///
+/// Mirrors git's own boolean env handling closely enough for this purpose:
+/// present and not an explicit false.
+fn system_config_suppressed() -> bool {
+    match std::env::var("GIT_CONFIG_NOSYSTEM") {
+        Ok(value) => !matches!(value.trim(), "" | "0" | "false" | "no" | "off"),
+        Err(_) => false,
+    }
+}
+
+/// The system config the generated file must chain to, so that pointing
+/// `GIT_CONFIG_SYSTEM` at our file does not silently drop real system settings.
+///
+/// Returns `None` when the caller asked for no system config at all, so that
+/// intent is preserved and only `safe.directory` is added on top. Never returns
+/// `generated` itself, which would be a self-include loop.
+fn system_config_to_chain(generated: &Path) -> Option<PathBuf> {
+    if system_config_suppressed() {
+        return None;
+    }
+    let inherited = std::env::var_os("GIT_CONFIG_SYSTEM").map(PathBuf::from);
+    let candidate = match inherited {
+        Some(path) if path != generated => path,
+        // Either unset, or already pointing at our own generated file because a
+        // parent djinn process exported it; chain to the real system config.
+        _ => PathBuf::from("/etc/gitconfig"),
+    };
+    candidate.is_file().then_some(candidate)
+}
+
+/// Quote a path as a git config value (git unescapes `\\` and `\"` inside `"`).
+fn quote_config_value(path: &Path) -> String {
+    let mut quoted = String::from("\"");
+    for ch in path.to_string_lossy().chars() {
+        if ch == '\\' || ch == '"' {
+            quoted.push('\\');
+        }
+        quoted.push(ch);
+    }
+    quoted.push('"');
+    quoted
+}
+
+/// Body of the generated system-scope config, chaining to `chain` when present.
+fn generated_config_contents(chain: Option<&Path>) -> String {
+    let mut contents = String::from(
+        "# Generated by djinn-git. Do not edit; rewritten on every process start.\n\
+         #\n\
+         # Exists so `safe.directory` lands in protected (system) configuration,\n\
+         # which is the only scope git honours for it in the inner `git-upload-pack`\n\
+         # child of `git clone --local`. See the comment in djinn-git/src/lib.rs.\n",
+    );
+    if let Some(chain) = chain {
+        contents.push_str("[include]\n\tpath = ");
+        contents.push_str(&quote_config_value(chain));
+        contents.push('\n');
+    }
+    contents.push_str("[safe]\n\tdirectory = ");
+    contents.push_str(SAFE_DIRECTORY_VALUE);
+    contents.push('\n');
+    contents
+}
+
+/// Write `contents` to `path` atomically, world-readable.
+///
+/// World-readable because the pointer is inherited by descendants that may run
+/// under a different uid (the launcher-spawned child); the file holds only a
+/// `safe.directory` rule and an include path, never a secret.
+fn write_generated_config(path: &Path, contents: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let staging = path.with_file_name(format!(
+        "{GENERATED_CONFIG_BASENAME}.{}.tmp",
+        std::process::id()
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o644)
+        .open(&staging)?;
+    file.write_all(contents.as_bytes())?;
+    drop(file);
+    std::fs::rename(&staging, path)
+}
+
+fn materialize_generated_config() -> std::io::Result<PathBuf> {
+    let path = generated_config_dir()?.join(GENERATED_CONFIG_BASENAME);
+    let contents = generated_config_contents(system_config_to_chain(&path).as_deref());
+    write_generated_config(&path, &contents)?;
+    Ok(path)
+}
+
+static GENERATED_CONFIG: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+
+/// Path of djinn's generated system-scope git config, materialized on first use.
+///
+/// `None` only when no writable location could be found, in which case callers
+/// fall back to the weaker command-scope injection.
+pub fn safe_directory_config_path() -> Option<&'static Path> {
+    GENERATED_CONFIG
+        .get_or_init(|| match materialize_generated_config() {
+            Ok(path) => Some(path),
+            Err(err) => {
+                tracing::warn!(
+                    %err,
+                    "could not materialize the system-scope safe.directory config; \
+                     falling back to command-scope injection, which git strips from \
+                     the inner child of `git clone --local` — clones of a mirror owned \
+                     by another uid will fail"
+                );
+                None
+            }
+        })
+        .as_deref()
+}
+
+/// Environment that makes git trust repositories shared across djinn's uids.
+///
+/// `(key, value)` pairs to set, plus keys to remove. `GIT_CONFIG_NOSYSTEM` has
+/// to go: it would make git ignore the very file we are pointing it at, and the
+/// generated file already honours that intent by not chaining to
+/// `/etc/gitconfig` when it was set.
+fn safe_directory_env() -> (Vec<(&'static str, String)>, &'static [&'static str]) {
+    match safe_directory_config_path() {
+        Some(path) => (
+            vec![("GIT_CONFIG_SYSTEM", path.display().to_string())],
+            &["GIT_CONFIG_NOSYSTEM"],
+        ),
+        None => (
+            vec![
+                ("GIT_CONFIG_COUNT", "1".to_string()),
+                ("GIT_CONFIG_KEY_0", "safe.directory".to_string()),
+                ("GIT_CONFIG_VALUE_0", SAFE_DIRECTORY_VALUE.to_string()),
+            ],
+            &[],
+        ),
+    }
+}
+
+/// Apply [`safe_directory_env`] to a `std::process::Command`.
 fn apply_safe_directory_env_std(cmd: &mut std::process::Command) {
-    cmd.env("GIT_CONFIG_COUNT", "1");
-    cmd.env("GIT_CONFIG_KEY_0", "safe.directory");
-    cmd.env("GIT_CONFIG_VALUE_0", "*");
+    let (set, remove) = safe_directory_env();
+    for (key, value) in set {
+        cmd.env(key, value);
+    }
+    for key in remove {
+        cmd.env_remove(key);
+    }
 }
 
 /// Build a git command that trusts repositories shared by the server and worker.
 ///
-/// The configuration is deliberately injected through environment variables,
-/// rather than a `-c` flag, because `git clone --local` starts an inner git
-/// process that inherits its environment but not the outer command's flags.
+/// The trust rule is injected as a `GIT_CONFIG_SYSTEM` config *file* rather than
+/// a `-c` flag or `GIT_CONFIG_*` entry, because `git clone --local` starts an
+/// inner git process that inherits the environment with the command-scope
+/// variables stripped. See the module comment above for the measurements.
 /// All production git subprocesses must start at this constructor.
 pub fn git_command() -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new("git");
-    cmd.env("GIT_CONFIG_COUNT", "1");
-    cmd.env("GIT_CONFIG_KEY_0", "safe.directory");
-    cmd.env("GIT_CONFIG_VALUE_0", "*");
+    let (set, remove) = safe_directory_env();
+    for (key, value) in set {
+        cmd.env(key, value);
+    }
+    for key in remove {
+        cmd.env_remove(key);
+    }
     cmd
 }
 

--- a/server/crates/djinn-git/src/lib.rs
+++ b/server/crates/djinn-git/src/lib.rs
@@ -247,10 +247,15 @@ fn write_generated_config(path: &Path, contents: &str) -> std::io::Result<()> {
     std::fs::rename(&staging, path)
 }
 
+/// (Re-)write the generated config at exactly `path`.
+fn materialize_generated_config_at(path: &Path) -> std::io::Result<()> {
+    let contents = generated_config_contents(system_config_to_chain(path).as_deref());
+    write_generated_config(path, &contents)
+}
+
 fn materialize_generated_config() -> std::io::Result<PathBuf> {
     let path = generated_config_dir()?.join(GENERATED_CONFIG_BASENAME);
-    let contents = generated_config_contents(system_config_to_chain(&path).as_deref());
-    write_generated_config(&path, &contents)?;
+    materialize_generated_config_at(&path)?;
     Ok(path)
 }
 
@@ -261,7 +266,7 @@ static GENERATED_CONFIG: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceL
 /// `None` only when no writable location could be found, in which case callers
 /// fall back to the weaker command-scope injection.
 pub fn safe_directory_config_path() -> Option<&'static Path> {
-    GENERATED_CONFIG
+    let path = GENERATED_CONFIG
         .get_or_init(|| match materialize_generated_config() {
             Ok(path) => Some(path),
             Err(err) => {
@@ -275,7 +280,28 @@ pub fn safe_directory_config_path() -> Option<&'static Path> {
                 None
             }
         })
-        .as_deref()
+        .as_deref()?;
+
+    // Self-heal. A temp-directory reaper (`systemd-tmpfiles-clean` ages `/tmp`
+    // out from under long-lived processes) can delete the file, and git ignores a
+    // `GIT_CONFIG_SYSTEM` that does not exist *silently* — which would bring the
+    // dubious-ownership failure back days into a server's uptime with nothing in
+    // the logs. One `stat` per git spawn is free next to the fork/exec.
+    if !path.is_file() {
+        match materialize_generated_config_at(path) {
+            Ok(()) => tracing::info!(
+                config = %path.display(),
+                "re-created the system-scope safe.directory config after it disappeared"
+            ),
+            Err(err) => tracing::warn!(
+                %err,
+                config = %path.display(),
+                "the system-scope safe.directory config disappeared and could not be \
+                 re-created; clones of a mirror owned by another uid will fail"
+            ),
+        }
+    }
+    Some(path)
 }
 
 /// Environment that makes git trust repositories shared across djinn's uids.

--- a/server/crates/djinn-git/src/lib_tests.rs
+++ b/server/crates/djinn-git/src/lib_tests.rs
@@ -369,6 +369,32 @@ fn generated_config_chains_to_the_real_system_config() {
     );
 }
 
+/// git ignores a `GIT_CONFIG_SYSTEM` pointing at a missing file silently, so a
+/// temp reaper deleting the generated config would resurrect the outage days into
+/// a server's uptime with nothing in the logs. Writing it must be repeatable and
+/// must restore a deleted file.
+#[test]
+fn generated_config_is_rewritten_when_it_disappears() {
+    let dir = tempfile::tempdir().expect("create config dir");
+    let path = dir.path().join("gitconfig");
+
+    crate::materialize_generated_config_at(&path).expect("first write");
+    let first = std::fs::read_to_string(&path).expect("config must exist after the first write");
+
+    std::fs::remove_file(&path).expect("simulate a temp-directory reaper");
+    crate::materialize_generated_config_at(&path).expect("rewrite after deletion");
+
+    let second = std::fs::read_to_string(&path).expect("config must be restored");
+    assert_eq!(
+        first, second,
+        "the rewrite must reproduce the same trust configuration"
+    );
+    assert!(
+        second.contains("[safe]\n\tdirectory = *\n"),
+        "the restored file must carry the trust rule, got {second:?}"
+    );
+}
+
 // ── run_git_command_with_timeout: Timeout ───────────────────────────────────
 
 /// Verifies that `run_git_command_with_timeout` returns `GitError::Timeout`

--- a/server/crates/djinn-git/src/lib_tests.rs
+++ b/server/crates/djinn-git/src/lib_tests.rs
@@ -13,8 +13,9 @@ use crate::test_support::{checkout_branch, init_repo_with_main_commit, write_and
 use crate::{
     GitError, delete_branch, head_commit_sha, is_non_fast_forward_error,
     is_retryable_git_command_error, is_transient_network_error, rebase_with_retry, retry_delay,
-    rev_list_count, run_git_command, run_git_command_in, run_git_command_in_with_env,
-    run_git_command_with_timeout, run_git_command_with_timeout_in, unmerged_files,
+    rev_list_count, run_git_command, run_git_command_in, run_git_command_in_allow_failure,
+    run_git_command_in_with_env, run_git_command_with_timeout, run_git_command_with_timeout_in,
+    unmerged_files,
 };
 
 // ── Helper ──────────────────────────────────────────────────────────────────
@@ -88,14 +89,141 @@ async fn run_git_command_missing_remote_returns_command_failed() {
     }
 }
 
-/// A uid-1000 worker must clone a uid-10001 mirror. When the test runner can
-/// change ownership, make the fixture's actual `.git` directory foreign and
-/// verify the local clone succeeds through the configured command seam. An
-/// unprivileged local developer cannot create a foreign-owned inode, so that
-/// environment leaves this integration regression to the privileged CI lane.
+// ── safe.directory: cross-UID repository trust (nurw) ───────────────────────
+//
+// git honours `safe.directory` only from protected *file* configuration, and
+// strips command-scope config (`-c`, `GIT_CONFIG_COUNT`/`KEY_0`/`VALUE_0`) from
+// the inner `git-upload-pack` child that `git clone --local` spawns. The
+// previous injection form was therefore a no-op for exactly the operation djinn
+// depends on, and every mirror clone failed once the mirror was owned by the
+// other identity.
+//
+// Note what is NOT a sufficient regression test: "cloning a foreign-owned
+// repository succeeds". git >= 2.48 accepts `clone --local --shared` of a
+// foreign-owned repository regardless of `safe.directory`, so on a modern
+// developer/CI git that assertion passes with the broken mechanism too — the
+// same way the previous test passed while production was wedged. The two tests
+// below instead assert, version-independently, *which scope git resolves the
+// rule in* and *what the stripped-environment child sees*.
+
+/// The scope git resolves `safe.directory` in must be protected file
+/// configuration (`system`/`global`), never `command`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn safe_directory_resolves_in_protected_file_scope() {
+    let fixture = init_repo_with_main_commit();
+
+    let out = run_git_command_in_allow_failure(
+        fixture.path(),
+        vec![
+            "config".into(),
+            "--show-scope".into(),
+            "--get-all".into(),
+            "safe.directory".into(),
+        ],
+    )
+    .await
+    .expect("spawning git must succeed");
+
+    assert!(
+        out.is_success(),
+        "git resolved no safe.directory at all, so a repository owned by the other \
+         djinn identity is rejected outright; stdout: {:?} stderr: {:?}",
+        out.stdout,
+        out.stderr
+    );
+    let scopes: Vec<&str> = out
+        .stdout
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .collect();
+    assert!(
+        scopes
+            .iter()
+            .any(|scope| matches!(*scope, "system" | "global")),
+        "safe.directory must come from protected file configuration (system/global). \
+         `command` scope is stripped from the inner `git-upload-pack` child of \
+         `git clone --local`, which is what made every mirror clone fail. scopes: {scopes:?}"
+    );
+}
+
+/// The property the previous env-var form was chosen for, and did not deliver:
+/// the inner git process spawned by `git clone --local` must resolve the trust
+/// rule too. Substituting `--upload-pack` with a shim that records what that
+/// child sees observes it directly, on any git version, without privileges.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inner_child_of_a_local_clone_resolves_the_trust_rule() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let source = init_repo_with_main_commit();
+    let scratch = tempfile::tempdir().expect("create scratch dir");
+    let record = scratch.path().join("child-view");
+    let shim = scratch.path().join("upload-pack-shim.sh");
+    std::fs::write(
+        &shim,
+        "#!/bin/sh\n\
+         git config --show-scope --get-all safe.directory > \"$DJINN_TEST_RECORD\" 2>&1\n\
+         exec git upload-pack \"$@\"\n",
+    )
+    .expect("write upload-pack shim");
+    std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755))
+        .expect("make shim executable");
+
+    let destination = scratch.path().join("clone");
+    run_git_command_in_with_env(
+        scratch.path(),
+        vec![
+            "clone".into(),
+            "--local".into(),
+            "--shared".into(),
+            "--upload-pack".into(),
+            shim.display().to_string(),
+            source.path().display().to_string(),
+            destination.display().to_string(),
+        ],
+        vec![(
+            "DJINN_TEST_RECORD".to_string(),
+            record.display().to_string(),
+        )],
+    )
+    .await
+    .expect("clone through the upload-pack shim must succeed");
+    assert!(
+        destination.join(".git").is_dir(),
+        "clone must be materialized"
+    );
+
+    let child_view = std::fs::read_to_string(&record)
+        .expect("the inner upload-pack child must have recorded its config view");
+    let scope = child_view.split_whitespace().next().unwrap_or_default();
+    assert!(
+        matches!(scope, "system" | "global"),
+        "the inner `git-upload-pack` child of `git clone --local` must resolve \
+         safe.directory in protected file scope. git strips command-scope config from \
+         this child (`trace: run_command: unset GIT_CONFIG_COUNT ...`), so a `-c` or \
+         GIT_CONFIG_* injection leaves it with nothing and cloning a mirror owned by \
+         the other djinn identity fails with \"detected dubious ownership\". \
+         child saw: {child_view:?}"
+    );
+    assert!(
+        child_view.contains('*'),
+        "the child must inherit the trust value itself, got {child_view:?}"
+    );
+}
+
+/// Cloning a repository owned by another uid must work: the server (uid 10001)
+/// and the worker / warm Job (uid 1000) both clone the same mirror, so either
+/// can be the non-owner.
+///
+/// The ownership boundary is created for real with `chown` when the runner is
+/// privileged, otherwise simulated with git's own
+/// `GIT_TEST_ASSUME_DIFFERENT_OWNER`. Either way a *control* clone — carrying
+/// only the pre-fix command-scope injection — runs first: if the control
+/// succeeds, this environment cannot express the failure and there is nothing to
+/// assert, so the test says so instead of passing vacuously. The two tests above
+/// are the version-independent gate.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn local_clone_succeeds_when_repository_is_owned_by_a_different_uid() {
-    use std::os::unix::{ffi::OsStrExt, fs::MetadataExt};
+    use std::os::unix::fs::MetadataExt;
 
     let source = init_repo_with_main_commit();
     let source_git = source.path().join(".git");
@@ -104,46 +232,140 @@ async fn local_clone_succeeds_when_repository_is_owned_by_a_different_uid() {
         .uid();
     let foreign_uid = if current_uid == 10001 { 10002 } else { 10001 };
 
-    // CI's privileged test lane exercises the real ownership boundary. The
-    // task-run image intentionally runs tests as uid 1000, where chown is not
-    // available; returning there avoids turning a capability limitation into a
-    // false test failure.
-    if unsafe {
-        libc::chown(
-            source_git.as_os_str().as_bytes().as_ptr().cast(),
+    let source_git_c =
+        std::ffi::CString::new(source_git.as_os_str().as_encoded_bytes()).expect("path has no NUL");
+    // SAFETY: `source_git_c` is a live NUL-terminated C string.
+    let chowned = unsafe { libc::chown(source_git_c.as_ptr(), foreign_uid, u32::MAX) } == 0;
+    if chowned {
+        assert_eq!(
+            std::fs::metadata(&source_git)
+                .expect("stat foreign-owned source git dir")
+                .uid(),
             foreign_uid,
-            u32::MAX,
-        )
-    } != 0
-    {
-        return;
+            "fixture must be owned by a uid other than the cloning process"
+        );
     }
-    assert_eq!(
-        std::fs::metadata(&source_git)
-            .expect("stat foreign-owned source git dir")
-            .uid(),
-        foreign_uid,
-        "fixture must be owned by a uid other than the cloning process"
-    );
 
-    let destination_parent = tempfile::tempdir().expect("create clone destination parent");
-    let destination = destination_parent.path().join("clone");
-    run_git_command_in_with_env(
-        destination_parent.path(),
+    // Keep the runner's own ~/.gitconfig out of the result either way: an
+    // ambient `safe.directory` there would silently decide the outcome.
+    let home = tempfile::tempdir().expect("create isolated home");
+    let mut trigger = vec![
+        ("HOME".to_string(), home.path().display().to_string()),
+        (
+            "XDG_CONFIG_HOME".to_string(),
+            home.path().join("xdg").display().to_string(),
+        ),
+    ];
+    if !chowned {
+        trigger.push((
+            "GIT_TEST_ASSUME_DIFFERENT_OWNER".to_string(),
+            "1".to_string(),
+        ));
+    }
+
+    let scratch = tempfile::tempdir().expect("create clone destination parent");
+    let clone_args = |destination: &std::path::Path| {
         vec![
-            "clone".into(),
-            "--local".into(),
+            "clone".to_string(),
+            "--local".to_string(),
+            "--shared".to_string(),
             source.path().display().to_string(),
             destination.display().to_string(),
-        ],
-        Vec::new(),
-    )
-    .await
-    .expect("safe.directory must permit cloning a foreign-owned source repository");
+        ]
+    };
 
+    // Control: the pre-fix mechanism, spawned outside the seam on purpose.
+    let control_destination = scratch.path().join("control");
+    let mut control = tokio::process::Command::new("git");
+    control
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "safe.directory")
+        .env("GIT_CONFIG_VALUE_0", "*")
+        .env_remove("GIT_CONFIG_SYSTEM")
+        .args(clone_args(&control_destination))
+        .current_dir(scratch.path());
+    for (key, value) in &trigger {
+        control.env(key, value);
+    }
+    let control_out = control.output().await.expect("spawn control clone");
+    if control_out.status.success() {
+        // No ownership rejection is reachable here (unprivileged runner on a git
+        // that accepts `--local --shared` under the simulation), so a successful
+        // clone below would prove nothing.
+        return;
+    }
+
+    let destination = scratch.path().join("clone");
+    run_git_command_in_with_env(scratch.path(), clone_args(&destination), trigger)
+        .await
+        .expect(
+            "the seam must clone a repository owned by another uid — the control clone \
+             carrying only the pre-fix command-scope injection was rejected here",
+        );
     assert!(
         destination.join(".git").is_dir(),
         "clone must be materialized"
+    );
+}
+
+/// `configure_private_dep_access` stores the GitHub installation token as a
+/// `url.<...>.insteadOf` rewrite with `git config --global`, and the agent's own
+/// build tools read it back from `$HOME/.gitconfig` without djinn in the loop.
+/// The trust rule must therefore not be injected as `GIT_CONFIG_GLOBAL`, which
+/// would redirect that write into a djinn-private file nothing else reads.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn global_config_writes_still_land_in_the_home_config() {
+    let fixture = init_repo_with_main_commit();
+    let home = tempfile::tempdir().expect("create isolated home");
+    let env = vec![("HOME".to_string(), home.path().display().to_string())];
+
+    run_git_command_in_with_env(
+        fixture.path(),
+        vec![
+            "config".into(),
+            "--global".into(),
+            "--add".into(),
+            "url.https://x-access-token:token@github.com/owner/.insteadOf".into(),
+            "https://github.com/owner/".into(),
+        ],
+        env,
+    )
+    .await
+    .expect("`git config --global` must succeed through the seam");
+
+    let home_config = std::fs::read_to_string(home.path().join(".gitconfig")).expect(
+        "`git config --global` must keep writing $HOME/.gitconfig; redirecting global \
+         scope would break private-dependency access for cargo/go/pnpm, which read that \
+         file directly",
+    );
+    assert!(
+        home_config.contains("insteadOf"),
+        "the rewrite must be in $HOME/.gitconfig, got {home_config:?}"
+    );
+}
+
+/// Pointing `GIT_CONFIG_SYSTEM` at a generated file shadows the real
+/// `/etc/gitconfig`, so the generated file has to chain to it.
+#[test]
+fn generated_config_chains_to_the_real_system_config() {
+    let chained = crate::generated_config_contents(Some(std::path::Path::new("/etc/git\"conf ig")));
+    assert!(
+        chained.contains("[include]\n\tpath = \"/etc/git\\\"conf ig\"\n"),
+        "the chained path must be quoted and escaped, got {chained:?}"
+    );
+    assert!(
+        chained.contains("[safe]\n\tdirectory = *\n"),
+        "the trust rule must be present, got {chained:?}"
+    );
+
+    let standalone = crate::generated_config_contents(None);
+    assert!(
+        !standalone.contains("[include]"),
+        "with no system config to chain to there must be no include, got {standalone:?}"
+    );
+    assert!(
+        standalone.contains("[safe]\n\tdirectory = *\n"),
+        "the trust rule must be present, got {standalone:?}"
     );
 }
 

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -558,8 +558,11 @@ pub fn build_task_run_job(
         // before cutover so the root gid already matches and the recursive pass
         // is skipped. See the matching notes in `launcher.rs` and `config.rs`.
         //
-        // (The legacy uid-10001 / git "dubious ownership" concern is now covered
-        // by the `safe.directory=*` GIT_CONFIG_* envs set in build_task_run_env.)
+        // (The legacy uid-10001 / git "dubious ownership" concern is covered by
+        // the protected system-scope `safe.directory` config that
+        // `djinn_git::git_command` exports — not by the GIT_CONFIG_* envs in
+        // build_task_run_env, which git strips from the inner child of
+        // `git clone --local`. See nurw and djinn-git/src/lib.rs.)
         security_context: Some(pod_security_context()),
         ..PodSpec::default()
     };
@@ -743,11 +746,16 @@ fn build_task_run_env(
     // image runs as root by default (USER reset by language-toolchain
     // layers), so the worker process sees the /mirror dir as
     // 10001:10001 — git 2.35.2+ rejects that with "dubious ownership"
-    // unless safe.directory is set. We inject the env vars at the Pod
-    // level so the worker process inherits them; the worker's Rust code
-    // also sets them per-Command (run_git_command), but the Pod-level
-    // env is the belt-and-suspenders that guarantees any subprocess
-    // tree gets them.
+    // unless safe.directory is set.
+    //
+    // These Pod-level vars cover a *direct* git invocation in the Pod and
+    // nothing more. They are NOT what makes the mirror clone work: git strips
+    // command-scope config from the inner `git-upload-pack` child that
+    // `git clone --local` spawns, so this form is a no-op for exactly that
+    // operation (nurw — it wedged every PR open on v0.7.3). Mirror clones are
+    // trusted by `djinn_git::git_command`, which exports a protected
+    // system-scope config file that survives into the child; see the
+    // measurements in djinn-git/src/lib.rs.
     env.push(env_var("GIT_CONFIG_COUNT", "1"));
     env.push(env_var("GIT_CONFIG_KEY_0", "safe.directory"));
     env.push(env_var("GIT_CONFIG_VALUE_0", "*"));

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -115,12 +115,16 @@ pub fn build_warm_job(
 # dirs / 644 files, which the worker's startup contract check rejects. See
 # `djinn_agent_worker::volume_contract`.
 umask 0002
-# The mirror is server-owned (uid 10001) while this pod runs as uid 1000.
-# Keep this in inherited environment variables, not `git -c`, so any nested
-# git process receives the same trust rule.
-export GIT_CONFIG_COUNT=1
-export GIT_CONFIG_KEY_0=safe.directory
-export GIT_CONFIG_VALUE_0='*'
+# The mirror is server-owned (uid 10001) while this pod runs as uid 1000, so git
+# needs a `safe.directory` exception for it. It must be a config FILE in protected
+# scope: git honours safe.directory only from system/global files in the inner
+# `git-upload-pack` child of `git clone --local`, and strips command-scope config
+# from that child. SYSTEM, not GLOBAL, so `git config --global` (the private-dep
+# url.insteadOf token rewrite) keeps writing $HOME/.gitconfig where cargo/go/pnpm
+# read it. See djinn-git/src/lib.rs and the volume-ownership runbook (nurw).
+export GIT_CONFIG_SYSTEM={WORKSPACE_MOUNT_DIR}/.djinn-gitconfig
+unset GIT_CONFIG_NOSYSTEM
+printf '[safe]\n\tdirectory = *\n' > "$GIT_CONFIG_SYSTEM"
 UPSTREAM_URL="$(git -C "{mirror_path}" config remote.origin.url)"
 git clone --depth 1000 --single-branch "$UPSTREAM_URL" "{project_root}"
 # Install JS deps before indexing so scip-typescript can resolve
@@ -593,22 +597,30 @@ mod tests {
         assert_eq!(cmd[1], "-c");
         assert!(cmd[2].contains("git clone"), "bash -c script: {}", cmd[2]);
         // The read-only mirror is server-owned while the warmer runs as the
-        // worker uid. The shell must export, rather than locally configure,
-        // safe.directory so every git child inherits it.
+        // worker uid, so the shell needs a safe.directory exception for it. It
+        // must be an exported config FILE: git honours safe.directory only from
+        // protected file scope in the inner child of `git clone --local` and
+        // strips GIT_CONFIG_COUNT/KEY_0/VALUE_0 from that child (nurw).
         for setting in [
-            "export GIT_CONFIG_COUNT=1",
-            "export GIT_CONFIG_KEY_0=safe.directory",
-            "export GIT_CONFIG_VALUE_0='*'",
+            "export GIT_CONFIG_SYSTEM=/workspace/.djinn-gitconfig",
+            "unset GIT_CONFIG_NOSYSTEM",
+            r#"printf '[safe]\n\tdirectory = *\n' > "$GIT_CONFIG_SYSTEM""#,
         ] {
             assert!(
                 cmd[2].contains(setting),
-                "warm shell must export {setting}: {}",
+                "warm shell must set up the trust file with {setting}: {}",
                 cmd[2]
             );
         }
         assert!(
+            !cmd[2].contains("export GIT_CONFIG_COUNT"),
+            "command-scope config is stripped from the inner child of `git clone --local`, \
+             so it must not be the mechanism: {}",
+            cmd[2]
+        );
+        assert!(
             !cmd[2].contains("git config --global --add safe.directory"),
-            "safe.directory must be inherited instead of persisted globally: {}",
+            "safe.directory must be inherited instead of persisted into $HOME/.gitconfig: {}",
             cmd[2]
         );
         // Warm clone must give the coupling index enough history to walk


### PR DESCRIPTION
## The bug

djinn shares its mirror between two identities on purpose — the server (uid 10001) and the worker/warm Job (uid 1000) both clone it — so whichever one does not own the mirror needs a git `safe.directory` exception. It was injected as `GIT_CONFIG_COUNT=1` / `GIT_CONFIG_KEY_0=safe.directory` / `GIT_CONFIG_VALUE_0=*`, which **never worked for the operation that needs it, in any released version**. It only looked correct while the server owned the mirror and no ownership check ever fired. Chowning the mirror to uid 1000 for the workers surfaced it: 120 dubious-ownership errors and 40 `supervisor_pr_open failed` in 20 minutes on deployed v0.7.3, blocking PR creation for every task.

## Why it never worked

Measured on git 2.47.3 — the version in the deployed server image — with uid 10001 cloning a root-owned repository:

```
git clone --local --shared <foreign-owned repo> <dst>
  GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0=*
                                                  -> dubious ownership, FAILS
  git -c safe.directory='*'                       -> dubious ownership, FAILS
  GIT_CONFIG_SYSTEM=<file holding safe.directory>  -> clone succeeds
```

The mechanism is **not** "git ignores the environment" — a git process that reads those variables directly does honour them, which is exactly why the form looked plausible. It is that `git clone --local` does ref discovery through an inner `git-upload-pack` child, and git spawns that child with the command-scope variables **stripped**. Visible in `GIT_TRACE`:

```
trace: run_command: unset GIT_CONFIG_COUNT GIT_DIR; git-upload-pack '<src>'
```

So the outer process was trusted and the child that actually opens the repository was not. The old comment's reasoning ("env vars, not `-c`, so the inner process inherits them") is right about inheritance and wrong about these particular variables.

## The fix

`djinn_git::git_command` writes `$TMPDIR/djinn-git-<euid>/gitconfig` once per process and exports `GIT_CONFIG_SYSTEM` at it. System scope is protected configuration, so `safe.directory` is honoured, and the variable is not in the set git strips, so the rule survives into the inner child. The generated file chains to the real `/etc/gitconfig` with `[include]`, so pointing at it shadows nothing. The warm Job's shell wrapper does the same with its own file.

**`GIT_CONFIG_SYSTEM` rather than the recommended `GIT_CONFIG_GLOBAL`.** `configure_private_dep_access` stores the GitHub installation token as a `url.<...>.insteadOf` rewrite with `git config --global`, and the agent's build tools (cargo, go, pnpm) read it back from `$HOME/.gitconfig` with djinn nowhere in the loop. Redirecting global scope would send that write into a djinn-private file nothing else reads and silently break private-dependency fetches — the same class of silent failure this PR exists to remove. System scope is additive: `$HOME/.gitconfig` and the XDG config keep being read exactly as before, and `git config --global` keeps writing where it always did. Both properties are verified, the second by a test.

Holds for **both identities** with no chown: neither the file nor the mechanism depends on who owns the mirror.

## `*` vs. explicit mirror roots

Kept `*`, deliberately:

- The check only fires for repositories owned by *another* uid. Everything djinn creates for itself — task workspaces, ephemeral clones, read-source caches — is owned by its creator, so `*` grants nothing there. The only foreign-owned repositories in play are the volumes djinn deliberately shares between its two service identities.
- The file is exported only to git subprocesses djinn spawns and disappears with the process. Unlike the `git config --global --add safe.directory "*"` applied by hand in the pod, it does not widen trust for other processes sharing that uid, and it is not persisted on disk.
- An explicit list would have to name paths this crate cannot see (deployment-configured mirror/cache roots, per-run test temp dirs) and would fail closed — a wedged mirror clone — every time a new shared location appeared.

## Tests

The previous regression test asserted that cloning a foreign-owned repository succeeds, and **passed while production was broken**, for two independent reasons: it `return`s silently when the runner cannot `chown`, and on git >= 2.48 `clone --local --shared` of a foreign-owned repository succeeds regardless of `safe.directory`, so the assertion holds with the broken mechanism too. Replaced with three tests that discriminate on any git version:

- `safe_directory_resolves_in_protected_file_scope` — asks git itself, through the seam, which scope it resolved the rule in. Pre-fix: `command`.
- `inner_child_of_a_local_clone_resolves_the_trust_rule` — substitutes `--upload-pack` with a shim that records what the stripped-environment child sees, observing the inheritance property directly. Pre-fix the child sees nothing. Hermetic, unprivileged, version-independent.
- `local_clone_succeeds_when_repository_is_owned_by_a_different_uid` — real `chown` when privileged, `GIT_TEST_ASSUME_DIFFERENT_OWNER` otherwise, and runs a **control** clone carrying only the pre-fix injection first. If the control succeeds the environment cannot express the failure, so the test says so rather than passing vacuously.

Plus `global_config_writes_still_land_in_the_home_config`, which guards the private-dep-access property, and a unit test for the `[include]` chaining and value quoting.

**Proof, not just green.** The compiled test binary was run inside `debian:trixie-slim` (git 2.47.3, the deployed image's git) as root against a genuinely foreign-owned repository. Pre-fix, all three fail and reproduce the production stderr verbatim:

```
fatal: detected dubious ownership in repository at '/tmp/.tmpTsEBor/.git'
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
```

With the fix, all pass. The same mutation (forcing the fallback branch) also fails the two hermetic tests on the local git 2.54, confirming they discriminate where the old test does not.

## Also

- `job.rs`: the Pod-level `GIT_CONFIG_*` env is left in place — it does cover a *direct* git invocation in the Pod — but the two comments claiming it is what makes mirror clones work are corrected. Note that these vars are not in the cgroup-launcher's env allowlist either, so they never reached the launcher-spawned child.
- Runbook: records the hand-applied `git config --global --add safe.directory "*"` as an ephemeral stopgap, says not to re-apply it, and states the `WARN` line to look for if dubious ownership ever reappears.

## Gates

`SQLX_OFFLINE=1 cargo check --workspace --all-targets`, `cargo fmt --all --check`, clippy `-D warnings` on djinn-k8s (`--all-targets`) and djinn-git (`--lib`), djinn-git 77 / djinn-k8s 241 / djinn-workspace 115 tests, `cargo hakari verify`, file-size guard, raw-SQL boundary, git boundary — all pass.

`cargo clippy -p djinn-git --all-targets` reports 7 `await_holding_lock` errors in `verification_input_tests.rs`; verified pre-existing on `origin/main` with my changes stashed, untouched by this PR.
