### PR TITLE
ymx9: Give every dispatch attempt its own admission generation

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -323,9 +323,25 @@ pub struct BuildAdmissionController {
     creator_server_epoch: String,
     permits: Mutex<HashMap<WarmAdmissionPermit, PermitState>>,
     permits_by_key: Mutex<HashMap<String, WarmAdmissionPermit>>,
+    /// The permit for each work item's CURRENT admission generation.
+    ///
+    /// A journal generation is one object lifecycle, so a second dispatch
+    /// attempt for the same work reserves a new generation whose number the
+    /// caller does not know. Lifecycle callbacks that only carry the work
+    /// identity — a session start that has just learned its runtime UID —
+    /// resolve their permit here rather than recomputing a generation from a
+    /// caller-side counter that no longer identifies the attempt.
+    permits_by_work: Mutex<HashMap<String, WarmAdmissionPermit>>,
     /// Runtime task-run IDs are learned when a session starts. This binding
     /// prevents a delayed terminal callback from selecting a later generation.
     permits_by_task_run: Mutex<HashMap<String, WarmAdmissionPermit>>,
+    /// Durable lifecycle transitions the journal accepted / rejected. Exposed
+    /// as bounded telemetry so a fleet-wide rejection rate is observable
+    /// without log scraping, and retained in-process so the readiness surface
+    /// can report the last rejection reason verbatim.
+    accepted_transitions: AtomicU64,
+    rejected_transitions: AtomicU64,
+    last_transition_rejection: Mutex<Option<String>>,
     unclassified_observations: Mutex<u64>,
     would_defer_observations: Mutex<u64>,
     /// Bounded observe-only disk would-defer signal (proposal nquz, phase 1).
@@ -394,7 +410,11 @@ impl BuildAdmissionController {
             creator_server_epoch: creator_server_epoch.into(),
             permits: Mutex::new(HashMap::new()),
             permits_by_key: Mutex::new(HashMap::new()),
+            permits_by_work: Mutex::new(HashMap::new()),
             permits_by_task_run: Mutex::new(HashMap::new()),
+            accepted_transitions: AtomicU64::new(0),
+            rejected_transitions: AtomicU64::new(0),
+            last_transition_rejection: Mutex::new(None),
             unclassified_observations: Mutex::new(0),
             would_defer_observations: Mutex::new(0),
             disk_would_defer_observations: Mutex::new(0),
@@ -798,13 +818,41 @@ impl BuildAdmissionController {
                 return Ok(BuildAdmissionDecision::Unclassified);
             }
         };
-        let key = AdmissionJournalKey {
+        let mut key = AdmissionJournalKey {
             domain: request.domain,
             work_id: request.work_id,
             generation: request.generation,
         };
-        let permit_key = permit_key(&key);
         let durable = self.mode() != BuildAdmissionMode::Off;
+        // The caller's generation is a floor, not the identity. A second
+        // dispatch attempt for the same work is a second object with its own
+        // Kubernetes UID and terminal release, so the journal — not the
+        // caller's counter — decides which generation this attempt reserves.
+        // Resolving BEFORE the in-memory permit lookup is what stops a retired
+        // generation's permit from being replayed as an idempotent hit and
+        // then colliding with that generation's recorded UID.
+        if durable {
+            match self
+                .journal
+                .resolve_dispatch_generation(key.domain, &key.work_id, key.generation)
+                .await
+            {
+                Ok(generation) => key.generation = generation,
+                Err(error) => {
+                    if self.mode() != BuildAdmissionMode::Observe {
+                        return Err(unavailable(error));
+                    }
+                    tracing::warn!(%error, "build admission generation resolution unavailable; permitting without journal telemetry");
+                    self.mark_journal_unhealthy();
+                    self.publish_metrics().await;
+                    let permit_key = permit_key(&key);
+                    return self
+                        .permit_without_reservation(key, permit_key, request.object_name)
+                        .await;
+                }
+            }
+        }
+        let permit_key = permit_key(&key);
         let idempotent_permit = self.permits_by_key.lock().await.get(&permit_key).cloned();
         if let Some(permit) = idempotent_permit {
             return Ok(BuildAdmissionDecision::Permitted {
@@ -906,6 +954,7 @@ impl BuildAdmissionController {
             }
         }
         let permit = WarmAdmissionPermit::new();
+        let work_key = work_key(&key);
         let state = PermitState {
             key: key.clone(),
             creator_server_epoch: self.creator_server_epoch.clone(),
@@ -919,6 +968,10 @@ impl BuildAdmissionController {
             .lock()
             .await
             .insert(permit_key, permit.clone());
+        self.permits_by_work
+            .lock()
+            .await
+            .insert(work_key, permit.clone());
         // A durable Reserved row occupies immediately; do not wait for a
         // later cap denial or terminal release to refresh the gauge.
         self.publish_metrics().await;
@@ -937,6 +990,7 @@ impl BuildAdmissionController {
         object_name: String,
     ) -> Result<BuildAdmissionDecision, WarmAdmissionError> {
         let permit = WarmAdmissionPermit::new();
+        let work_key = work_key(&key);
         self.permits.lock().await.insert(
             permit.clone(),
             PermitState {
@@ -952,10 +1006,60 @@ impl BuildAdmissionController {
             .lock()
             .await
             .insert(permit_key, permit.clone());
+        self.permits_by_work
+            .lock()
+            .await
+            .insert(work_key, permit.clone());
         Ok(BuildAdmissionDecision::Permitted {
             permit,
             idempotent: false,
         })
+    }
+
+    /// The permit for a work item's current admission generation, in any state.
+    ///
+    /// This is the lookup for lifecycle callbacks that carry only the work
+    /// identity. It is deliberately generation-free: after a retry the current
+    /// generation is a journal fact, not a caller-side counter.
+    pub async fn current_permit_for_work(
+        &self,
+        domain: AdmissionDomain,
+        work_id: &str,
+    ) -> Option<WarmAdmissionPermit> {
+        self.permits_by_work
+            .lock()
+            .await
+            .get(&work_key(&AdmissionJournalKey {
+                domain,
+                work_id: work_id.to_owned(),
+                generation: 0,
+            }))
+            .cloned()
+    }
+
+    /// The permit for this task's current admission generation.
+    pub async fn current_task_run_permit(&self, task_id: &str) -> Option<WarmAdmissionPermit> {
+        self.current_permit_for_work(AdmissionDomain::TaskObservation, task_id)
+            .await
+    }
+
+    /// Durable lifecycle transitions the journal accepted since process start.
+    #[must_use]
+    pub fn accepted_transition_count(&self) -> u64 {
+        self.accepted_transitions.load(Ordering::Acquire)
+    }
+
+    /// Durable lifecycle transitions the journal rejected since process start.
+    /// A rate approaching the accepted count means the journal is refusing the
+    /// observations it would have to trust when the mode is armed to Enforce.
+    #[must_use]
+    pub fn rejected_transition_count(&self) -> u64 {
+        self.rejected_transitions.load(Ordering::Acquire)
+    }
+
+    /// The most recent rejection diagnostic, verbatim.
+    pub async fn last_transition_rejection(&self) -> Option<String> {
+        self.last_transition_rejection.lock().await.clone()
     }
 
     /// A missing or unknown task role is a fail-closed classification result.
@@ -1189,6 +1293,31 @@ impl BuildAdmissionController {
         }
     }
 
+    /// Count one durable lifecycle transition by outcome.
+    ///
+    /// The WARN stays exactly as loud as it was; this makes the SAME fact
+    /// countable. A process whose rejected series equals its total is a
+    /// journal that would mis-account every grant if the mode were armed, and
+    /// that is now visible as a ratio rather than only as log volume.
+    async fn record_transition_outcome(&self, accepted: bool, error: Option<&WarmAdmissionError>) {
+        if accepted {
+            self.accepted_transitions.fetch_add(1, Ordering::AcqRel);
+        } else {
+            self.rejected_transitions.fetch_add(1, Ordering::AcqRel);
+            if let Some(error) = error {
+                *self.last_transition_rejection.lock().await = Some(error.to_string());
+            }
+        }
+        if self.process_metrics_enabled() {
+            let mode = match self.mode() {
+                BuildAdmissionMode::Off => "off",
+                BuildAdmissionMode::Observe => "observe",
+                BuildAdmissionMode::Enforce => "enforce",
+            };
+            djinn_telemetry::build_admission::record_transition(mode, self.cap, accepted);
+        }
+    }
+
     async fn transition_permit(
         &self,
         permit: &WarmAdmissionPermit,
@@ -1250,6 +1379,8 @@ impl BuildAdmissionController {
                 .map_err(unavailable),
         };
         let transition_durable = result.is_ok();
+        self.record_transition_outcome(transition_durable, result.as_ref().err())
+            .await;
         if let Err(error) = result {
             if self.mode() != BuildAdmissionMode::Observe {
                 return Err(error);
@@ -1427,6 +1558,7 @@ impl BuildAdmissionController {
         {
             let mut permits = self.permits.lock().await;
             let mut by_key = self.permits_by_key.lock().await;
+            let mut by_work = self.permits_by_work.lock().await;
             for row in &recovery.active_rows {
                 if !seed_filter(row) {
                     continue;
@@ -1442,6 +1574,10 @@ impl BuildAdmissionController {
                         permit
                     }
                 };
+                // A recovered row is the work item's current generation, so a
+                // lifecycle callback that arrives after restart resolves to it
+                // exactly as it would have before the restart.
+                by_work.insert(work_key(&row.key), permit.clone());
                 permits.insert(
                     permit,
                     PermitState {
@@ -1508,6 +1644,13 @@ fn permit_key(key: &AdmissionJournalKey) -> String {
     admission_generation_key(key)
 }
 
+/// Generation-free identity for one work item. Shares the `{domain:?}:{work_id}:`
+/// prefix with [`admission_generation_key`] so the deferred-queue prefix scans
+/// and this map agree on what "the same work" means.
+fn work_key(key: &AdmissionJournalKey) -> String {
+    format!("{:?}:{}", key.domain, key.work_id)
+}
+
 /// Canonical string identity for one admission generation.
 ///
 /// This is the single source of truth for the `generation_key` used by the
@@ -1518,6 +1661,12 @@ fn permit_key(key: &AdmissionJournalKey) -> String {
 /// MUST format their key through this function so the two byte-match. It is the
 /// same `{domain:?}:{work_id}:{generation}` form used for in-memory permit
 /// bookkeeping.
+///
+/// The generation component is a JOURNAL fact. A producer that formats a key
+/// from a caller-side counter (a task's `reopen_count`) only byte-matches while
+/// that task has had one dispatch attempt per reopen; a retried attempt reserves
+/// its own generation. Any producer of the required set must read the generation
+/// from the journal row rather than recompute it.
 #[must_use]
 pub fn admission_generation_key(key: &AdmissionJournalKey) -> String {
     format!("{:?}:{}:{}", key.domain, key.work_id, key.generation)
@@ -1721,6 +1870,245 @@ mod tests {
         async fn job_uid(&self, _namespace: &str, _job_name: &str) -> Option<String> {
             Some("warm-uid".into())
         }
+    }
+
+    /// Kubernetes assigns a fresh UID to every Job object it creates, even when
+    /// the deterministic object name is identical. This watcher reproduces that:
+    /// each observed warm lifecycle reports its own immutable UID.
+    struct FreshUidPerJobWatcher {
+        observed: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl WarmJobWatcher for FreshUidPerJobWatcher {
+        async fn wait_terminal(&self, _namespace: &str, _job_name: &str) -> WarmTerminalOutcome {
+            WarmTerminalOutcome::Succeeded
+        }
+
+        async fn job_uid(&self, _namespace: &str, _job_name: &str) -> Option<String> {
+            let n = self.observed.fetch_add(1, Ordering::SeqCst) + 1;
+            Some(format!("warm-uid-{n}"))
+        }
+    }
+
+    struct CountingWarmDispatcher {
+        posts: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl WarmJobDispatcher for CountingWarmDispatcher {
+        async fn dispatch(
+            &self,
+            _namespace: &str,
+            _job: WarmJobManifest,
+        ) -> Result<String, String> {
+            self.posts.fetch_add(1, Ordering::SeqCst);
+            Ok("warm-job".into())
+        }
+    }
+
+    async fn await_terminal_generations(
+        journal: &AdmissionJournalRepository,
+        work_id: &str,
+        expected: usize,
+    ) -> Vec<AdmissionJournalRow> {
+        for _ in 0..600 {
+            let history = journal
+                .list_history(AdmissionDomain::WarmBuild, work_id)
+                .await
+                .unwrap();
+            if history.len() >= expected
+                && history
+                    .iter()
+                    .all(|row| row.state == AdmissionState::Terminal)
+            {
+                return history;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        journal
+            .list_history(AdmissionDomain::WarmBuild, work_id)
+            .await
+            .unwrap()
+    }
+
+    /// Regression (ymx9): two real graph-warm Job lifecycles for the same
+    /// project revision must each own a journal generation carrying that Job's
+    /// own Kubernetes UID.
+    ///
+    /// This drives the production `K8sGraphWarmer` create → observe → terminal
+    /// sequence through the production `BuildAdmissionController` and the
+    /// production `AdmissionJournalRepository` in the mode production actually
+    /// runs (`Observe`). Before the fix, the second lifecycle reused the first
+    /// lifecycle's retired row, so every observation transition was rejected —
+    /// `cannot mark create started from Terminal` followed by two
+    /// `Kubernetes UID does not match admission row` rejections.
+    #[tokio::test]
+    async fn repeated_warm_lifecycles_record_one_generation_per_kubernetes_uid() {
+        let db = Database::open_in_memory().unwrap();
+        let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+        let controller = Arc::new(BuildAdmissionController::new(
+            Arc::clone(&journal),
+            BuildAdmissionMode::Observe,
+            4,
+            "epoch",
+        ));
+        let project_id = seed_project_with_ready_image(&db, "warm-uid-regression").await;
+        let work_id = djinn_k8s::warm_work_id(&project_id, "unknown");
+        let posts = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(AtomicUsize::new(0));
+        let warmer = K8sGraphWarmer::with_dispatcher(
+            KubernetesConfig::for_testing(),
+            db,
+            Arc::new(CountingWarmDispatcher {
+                posts: Arc::clone(&posts),
+            }),
+            Arc::new(FreshUidPerJobWatcher {
+                observed: Arc::clone(&observed),
+            }),
+        )
+        .with_warm_admission(controller.clone());
+
+        warmer.trigger(&project_id).await;
+        let history = await_terminal_generations(&journal, &work_id, 1).await;
+        assert_eq!(history.len(), 1, "the first warm records one generation");
+
+        warmer.trigger(&project_id).await;
+        let history = await_terminal_generations(&journal, &work_id, 2).await;
+
+        assert_eq!(posts.load(Ordering::SeqCst), 2, "both warm lifecycles POST");
+        assert_eq!(
+            history.len(),
+            2,
+            "a second warm Job is a second object lifecycle and must own its own \
+             admission generation instead of reusing the retired row"
+        );
+        let uids: Vec<Option<&str>> = history
+            .iter()
+            .map(|row| row.object_uid.as_deref())
+            .collect();
+        assert_eq!(
+            uids,
+            vec![Some("warm-uid-1"), Some("warm-uid-2")],
+            "every generation persists the exact Kubernetes UID its own Live and \
+             Terminal observations supplied"
+        );
+        assert!(
+            history
+                .iter()
+                .all(|row| row.state == AdmissionState::Terminal),
+            "both generations reach Terminal through the observed UID"
+        );
+        assert_eq!(
+            controller.rejected_transition_count(),
+            0,
+            "Observe mode must emit successful journal observations, not a 100% \
+             rejection rate; last rejection: {:?}",
+            controller.last_transition_rejection().await
+        );
+        assert!(
+            controller.accepted_transition_count() >= 6,
+            "each warm lifecycle records CreateStarted, Live and Terminal"
+        );
+        assert_eq!(controller.last_transition_rejection().await, None);
+    }
+
+    /// Regression (ymx9): the create observation and the terminal observation
+    /// are independent messages, so a create report can arrive after the
+    /// generation is already retired. That has a defined idempotent outcome —
+    /// the terminal row is retained, occupancy is not resurrected — while a
+    /// transition addressed to a superseded generation is still rejected.
+    #[tokio::test]
+    async fn late_create_observation_is_idempotent_while_stale_generations_stay_rejected() {
+        let controller = controller(BuildAdmissionMode::Enforce, 4);
+        controller.mark_ready();
+        let first = WarmAdmission::admit(&controller, warm("late-create"))
+            .await
+            .unwrap();
+        controller
+            .transition(&first, WarmAdmissionTransition::CreateStarted)
+            .await
+            .unwrap();
+        controller
+            .transition(
+                &first,
+                WarmAdmissionTransition::Live {
+                    uid: "uid-one".into(),
+                },
+            )
+            .await
+            .unwrap();
+        controller
+            .transition(
+                &first,
+                WarmAdmissionTransition::Terminal {
+                    uid: "uid-one".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // The create outcome finally lands, after the terminal one.
+        controller
+            .transition(
+                &first,
+                WarmAdmissionTransition::CreateUnknown {
+                    diagnostic: "create response arrived after the job terminated".into(),
+                },
+            )
+            .await
+            .expect("a late create observation resolves idempotently");
+        let history = controller
+            .journal()
+            .list_history(AdmissionDomain::WarmBuild, "late-create")
+            .await
+            .unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(
+            history[0].state,
+            AdmissionState::Terminal,
+            "a late create observation must not resurrect a retired generation"
+        );
+        assert_eq!(
+            controller
+                .journal()
+                .count_task_or_warm_occupancy()
+                .await
+                .unwrap(),
+            0,
+            "a late create observation must not re-occupy capacity"
+        );
+
+        // A second attempt supersedes the retired generation. Every transition
+        // still addressed to the old one is rejected, loudly.
+        let second = WarmAdmission::admit(&controller, warm("late-create"))
+            .await
+            .unwrap();
+        assert_ne!(first, second, "a new attempt gets a new permit");
+        controller
+            .transition(&second, WarmAdmissionTransition::CreateStarted)
+            .await
+            .unwrap();
+        let stale = controller
+            .transition(
+                &first,
+                WarmAdmissionTransition::Terminal {
+                    uid: "uid-one".into(),
+                },
+            )
+            .await
+            .expect_err("a superseded generation cannot transition");
+        assert!(
+            stale.to_string().contains("stale admission generation"),
+            "unexpected diagnostic: {stale}"
+        );
+        assert!(controller.rejected_transition_count() >= 1);
+        assert!(
+            controller
+                .last_transition_rejection()
+                .await
+                .is_some_and(|reason| reason.contains("stale admission generation"))
+        );
     }
 
     #[tokio::test]
@@ -2920,6 +3308,65 @@ mod tests {
         assert_no_identity_labels(
             &rendered,
             "djinn_build_admission_unknown_classification_total",
+        );
+    }
+
+    /// AC4 (ymx9): accepted and rejected journal transitions are separate
+    /// bounded series, so a 100% rejection rate is a ratio an alert can read
+    /// instead of a log volume an operator has to notice.
+    #[tokio::test]
+    async fn telemetry_transition_counter_separates_accepted_from_rejected() {
+        let _guard = telemetry_guard();
+        djinn_telemetry::init().unwrap();
+
+        let c = controller(BuildAdmissionMode::Observe, 4);
+        c.enable_process_metrics_for_test();
+        let permit = WarmAdmission::admit(&c, warm("counted")).await.unwrap();
+        c.transition(&permit, WarmAdmissionTransition::CreateStarted)
+            .await
+            .unwrap();
+        c.transition(&permit, WarmAdmissionTransition::Live { uid: "uid".into() })
+            .await
+            .unwrap();
+        // Observe never denies dispatch, so this rejection is only visible as
+        // a counter and a WARN — never as a changed decision.
+        c.transition(
+            &permit,
+            WarmAdmissionTransition::Terminal {
+                uid: "other-uid".into(),
+            },
+        )
+        .await
+        .expect("Observe does not turn a rejected transition into a denial");
+
+        let rendered = djinn_telemetry::render().unwrap();
+        let labels = |outcome| {
+            [
+                ("effective_mode", "observe"),
+                ("effective_cap", "4"),
+                ("outcome", outcome),
+            ]
+        };
+        assert!(
+            sample_value(
+                &rendered,
+                "djinn_build_admission_transition_total",
+                &labels("accepted")
+            ) >= 2.0
+        );
+        assert!(
+            sample_value(
+                &rendered,
+                "djinn_build_admission_transition_total",
+                &labels("rejected")
+            ) >= 1.0
+        );
+        assert_no_identity_labels(&rendered, "djinn_build_admission_transition_total");
+        assert_eq!(c.rejected_transition_count(), 1);
+        assert!(
+            c.last_transition_rejection()
+                .await
+                .is_some_and(|reason| reason.contains("Kubernetes UID does not match"))
         );
     }
 

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -790,6 +790,13 @@ impl CoordinatorActor {
 
     /// Mark a runtime task-run live and bind its UID to this exact generation.
     /// Terminal events must use this UID binding rather than a task-ID lookup.
+    ///
+    /// The permit is resolved from the task's CURRENT admission generation, not
+    /// from a caller-side counter: a second dispatch attempt at the same
+    /// `reopen_count` reserves its own generation, and binding a fresh runtime
+    /// UID onto the retired generation is exactly what made every observation
+    /// transition fail the UID fence. `generation` remains the fallback for a
+    /// permit that predates this process's work-scoped bookkeeping.
     pub(crate) async fn live_task_run_build_admission(
         &self,
         task_id: &str,
@@ -799,7 +806,11 @@ impl CoordinatorActor {
         let Some(controller) = self.admission_controller() else {
             return;
         };
-        let Some(permit) = controller.task_run_permit(task_id, generation).await else {
+        let permit = match controller.current_task_run_permit(task_id).await {
+            Some(permit) => Some(permit),
+            None => controller.task_run_permit(task_id, generation).await,
+        };
+        let Some(permit) = permit else {
             return;
         };
         if let Err(error) = controller
@@ -9498,5 +9509,137 @@ mod build_admission_route_tests {
                 .is_none(),
             "stale generation callback must not emit a release notification"
         );
+    }
+
+    /// Drive one full task-run attempt through the production admission route:
+    /// reserve + CreateStarted, the pool-outcome transition, the session-started
+    /// Live observation, and the session-terminal release.
+    async fn drive_task_run_attempt(
+        actor: &mut CoordinatorActor,
+        db: &djinn_db::Database,
+        fixture: &Wnd1DispatchFixture,
+        task_id: &str,
+        reopen_count: i64,
+        task_run_id: &str,
+    ) {
+        let permit = actor
+            .begin_task_run_build_admission(
+                "worker",
+                task_id,
+                reopen_count,
+                format!("task-run-{task_id}-{reopen_count}"),
+            )
+            .await
+            .expect("admission permits the attempt");
+        actor.finish_task_run_build_admission(permit, true).await;
+
+        let session_repo =
+            djinn_db::SessionRepository::new(db.clone(), djinn_core::events::EventBus::noop());
+        let mut session = session_repo
+            .create(djinn_db::CreateSessionParams {
+                project_id: &fixture.project_id,
+                task_id: Some(task_id),
+                model: &fixture.model_id,
+                agent_type: "worker",
+                metadata_json: None,
+                task_run_id: None,
+                pricing: None,
+                cost_basis: None,
+            })
+            .await
+            .expect("create attempt session");
+        session.task_run_id = Some(task_run_id.to_owned());
+        session.status = "running".to_owned();
+        actor
+            .handle_event(DjinnEventEnvelope {
+                entity_type: "session",
+                action: "started",
+                payload: serde_json::to_value(&session).expect("serialize started"),
+                id: None,
+                project_id: None,
+                from_sync: false,
+            })
+            .await;
+        session.status = "completed".to_owned();
+        actor
+            .handle_event(DjinnEventEnvelope {
+                entity_type: "session",
+                action: "completed",
+                payload: serde_json::to_value(&session).expect("serialize terminal"),
+                id: None,
+                project_id: None,
+                from_sync: false,
+            })
+            .await;
+    }
+
+    /// Regression (ymx9): a task retried at the same `reopen_count` is a second
+    /// task-run object with its own runtime UID, and must own its own admission
+    /// generation.
+    ///
+    /// Both attempts run the production admission route end to end — the same
+    /// `begin`/`finish`/session-event path `dispatch_ready_tasks` uses — in the
+    /// mode production runs (`Observe`). Before the fix the second attempt
+    /// inherited the first attempt's retired row, so its create observation was
+    /// rejected with `cannot mark create unknown from Terminal` and both of its
+    /// UID-bearing observations with `Kubernetes UID does not match admission
+    /// row`, leaving the second runtime UID unrecorded.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn retried_attempts_at_one_reopen_count_each_record_their_own_runtime_uid() {
+        let db = crate::test_helpers::create_test_db();
+        let (events_tx, _events_rx) = tokio::sync::broadcast::channel(256);
+        let fixture = seed_wnd1_ready_worker_tasks(&db, WND1_READY_TASK_COUNT).await;
+        let journal = route_journal(&db);
+        let controller = route_controller(&journal, BuildAdmissionMode::Observe, 4);
+        let (runtime, _started_rx, _completed_rx) = AdmissionRouteRuntime::new(journal.clone());
+        let mut actor = build_route_actor(&db, &events_tx, &runtime, 2);
+        actor.build_admission = Some(controller.clone());
+
+        let task_id = fixture.task_ids[0].clone();
+        close_all_except(&db, &fixture, &task_id).await;
+
+        // Two dispatch attempts of the SAME task at the SAME reopen_count: the
+        // ordinary retry shape after a failed or interrupted first attempt.
+        for task_run_id in ["task-run-uid-first", "task-run-uid-second"] {
+            drive_task_run_attempt(&mut actor, &db, &fixture, &task_id, 0, task_run_id).await;
+        }
+
+        let history = journal
+            .list_history(AdmissionDomain::TaskObservation, &task_id)
+            .await
+            .expect("read generation history");
+        assert_eq!(
+            history.len(),
+            2,
+            "each dispatch attempt is its own object lifecycle and its own generation"
+        );
+        assert_eq!(
+            history
+                .iter()
+                .map(|row| (row.key.generation, row.object_uid.as_deref(), row.state))
+                .collect::<Vec<_>>(),
+            vec![
+                (0, Some("task-run-uid-first"), AdmissionState::Terminal),
+                (1, Some("task-run-uid-second"), AdmissionState::Terminal),
+            ],
+            "the UID persisted at Live is the UID the terminal observation \
+             released, per attempt"
+        );
+        assert_eq!(
+            journal
+                .count_task_or_warm_occupancy()
+                .await
+                .expect("count occupancy"),
+            0,
+            "both attempts released their own occupancy"
+        );
+        assert_eq!(
+            controller.rejected_transition_count(),
+            0,
+            "Observe mode must emit successful journal observations; last \
+             rejection: {:?}",
+            controller.last_transition_rejection().await
+        );
+        assert!(controller.accepted_transition_count() >= 8);
     }
 }

--- a/server/crates/djinn-db/src/repositories/admission_journal.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal.rs
@@ -360,6 +360,15 @@ impl AdmissionJournalRepository {
         Ok(result)
     }
 
+    /// Record an ambiguous create outcome for this generation.
+    ///
+    /// A create report can legitimately arrive after the generation already
+    /// reached its terminal outcome — the dispatch side effect and the
+    /// lifecycle observation are separate messages with no ordering guarantee.
+    /// A late create report is therefore a defined idempotent no-op that
+    /// retains the terminal row: ambiguity about a create can never resurrect
+    /// occupancy that a terminal observation already released. Stale
+    /// generations are still rejected by [`current_row_for_update`].
     pub async fn mark_create_unknown(
         &self,
         key: &AdmissionJournalKey,
@@ -371,7 +380,7 @@ impl AdmissionJournalRepository {
             AdmissionState::CreateInFlight => {
                 update_state(&mut tx, key, "create_unknown", None).await?
             }
-            AdmissionState::CreateUnknown => row,
+            AdmissionState::CreateUnknown | AdmissionState::Terminal => row,
             state => return Err(invalid_state("mark create unknown", state)),
         };
         tx.commit().await?;
@@ -604,6 +613,62 @@ impl AdmissionJournalRepository {
         rows.into_iter().map(TryInto::try_into).collect()
     }
 
+    /// Resolve the generation a dispatch attempt must reserve for `work_id`.
+    ///
+    /// A generation is one object lifecycle: exactly one create, at most one
+    /// Kubernetes UID, one terminal release. A caller-supplied generation (a
+    /// task's `reopen_count`, or the warm path's fixed generation) is therefore
+    /// only a *floor*, never the identity itself — a second dispatch attempt at
+    /// the same floor is a second object with its own UID and must not inherit
+    /// the retired row's recorded UID.
+    ///
+    /// Resolution, under the same per-work advisory lock the mutations take:
+    /// * no retained row — the requested generation, so first-ever dispatch
+    ///   keeps the caller's numbering,
+    /// * latest retained generation nonterminal — that generation, so a
+    ///   duplicate dispatch or a restart resumes the in-flight row idempotently
+    ///   instead of double-reserving capacity,
+    /// * latest retained generation terminal — one past it, so a new attempt
+    ///   always starts from a row with no object UID.
+    ///
+    /// The result is never below `requested`, keeping the journal generation
+    /// aligned with a caller counter that advances faster than dispatch does.
+    /// Allocation intentionally does not insert a row: callers must reserve the
+    /// returned generation through [`Self::reserve`] or
+    /// [`Self::reserve_observed`].
+    pub async fn resolve_dispatch_generation(
+        &self,
+        domain: AdmissionDomain,
+        work_id: &str,
+        requested: i64,
+    ) -> DbResult<i64> {
+        if requested < 0 {
+            return Err(DbError::InvalidData(
+                "admission generation must be non-negative".into(),
+            ));
+        }
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        lock_work(&mut tx, domain, work_id).await?;
+        let latest: Option<(i64, String)> = sqlx::query_as(
+            "SELECT generation, state FROM admission_journal \
+             WHERE domain = $1 AND work_id = $2 ORDER BY generation DESC LIMIT 1",
+        )
+        .bind(domain.as_str())
+        .bind(work_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        let resolved = match latest {
+            None => requested,
+            Some((generation, state)) => match AdmissionState::parse(&state)? {
+                AdmissionState::Terminal => generation.saturating_add(1),
+                _ => generation,
+            },
+        };
+        Ok(resolved.max(requested))
+    }
+
     /// Allocate the next generation only if the latest retained generation is terminal.
     ///
     /// Allocation intentionally does not insert a row: callers must reserve the
@@ -772,439 +837,5 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use super::*;
-
-    fn input(domain: AdmissionDomain, work_id: &str, generation: i64) -> ReserveAdmissionInput {
-        ReserveAdmissionInput {
-            key: AdmissionJournalKey {
-                domain,
-                work_id: work_id.into(),
-                generation,
-            },
-            workload_kind: match domain {
-                AdmissionDomain::TaskObservation => AdmissionWorkloadKind::Task,
-                AdmissionDomain::WarmBuild => AdmissionWorkloadKind::Warm,
-                AdmissionDomain::InvocationBuild => AdmissionWorkloadKind::Invocation,
-            },
-            creator_server_epoch: "epoch-1".into(),
-            object_name: format!("admission-{work_id}-{generation}"),
-        }
-    }
-
-    fn create_started(input: &ReserveAdmissionInput) -> CreateStartedInput {
-        CreateStartedInput {
-            key: input.key.clone(),
-            creator_server_epoch: input.creator_server_epoch.clone(),
-            object_name: input.object_name.clone(),
-        }
-    }
-
-    fn uid_input(input: &ReserveAdmissionInput, object_uid: &str) -> UidFencedAdmissionInput {
-        UidFencedAdmissionInput {
-            key: input.key.clone(),
-            object_uid: object_uid.into(),
-        }
-    }
-
-    async fn set_state(db: &Database, key: &AdmissionJournalKey, state: &str) {
-        sqlx::query(
-            "UPDATE admission_journal SET state = $1, terminal_at = \
-             CASE WHEN $1 = 'terminal' THEN now() ELSE NULL END WHERE domain = $2 AND work_id = $3 AND generation = $4",
-        )
-        .bind(state)
-        .bind(key.domain.as_str())
-        .bind(&key.work_id)
-        .bind(key.generation)
-        .execute(db.pool())
-        .await
-        .unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn cap_one_concurrent_reservation_has_one_winner() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = Arc::new(AdmissionJournalRepository::new(db));
-        let first = {
-            let repo = Arc::clone(&repo);
-            tokio::spawn(async move {
-                repo.reserve(&input(AdmissionDomain::TaskObservation, "a", 0), 1)
-                    .await
-                    .unwrap()
-            })
-        };
-        let second = {
-            let repo = Arc::clone(&repo);
-            tokio::spawn(async move {
-                repo.reserve(&input(AdmissionDomain::WarmBuild, "b", 0), 1)
-                    .await
-                    .unwrap()
-            })
-        };
-        let results = [first.await.unwrap(), second.await.unwrap()];
-        assert_eq!(
-            results
-                .iter()
-                .filter(|r| matches!(r, ReserveAdmissionResult::Reserved { .. }))
-                .count(),
-            1
-        );
-        assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
-    }
-
-    #[tokio::test]
-    async fn duplicate_reservation_is_idempotent() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db);
-        let input = input(AdmissionDomain::TaskObservation, "same", 0);
-        assert!(matches!(
-            repo.reserve(&input, 1).await.unwrap(),
-            ReserveAdmissionResult::Reserved {
-                idempotent: false,
-                ..
-            }
-        ));
-        assert!(matches!(
-            repo.reserve(&input, 1).await.unwrap(),
-            ReserveAdmissionResult::Reserved {
-                idempotent: true,
-                ..
-            }
-        ));
-        assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
-    }
-
-    #[tokio::test]
-    async fn all_occupying_states_count_but_terminal_history_does_not() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db.clone());
-        for (index, state) in [
-            "reserved",
-            "create_in_flight",
-            "create_unknown",
-            "live",
-            "terminal",
-        ]
-        .iter()
-        .enumerate()
-        {
-            let input = input(
-                AdmissionDomain::TaskObservation,
-                &format!("work-{index}"),
-                0,
-            );
-            repo.reserve(&input, 10).await.unwrap();
-            set_state(&db, &input.key, state).await;
-        }
-        assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 4);
-        let history = repo
-            .list_history(AdmissionDomain::TaskObservation, "work-4")
-            .await
-            .unwrap();
-        assert_eq!(history[0].state, AdmissionState::Terminal);
-    }
-
-    #[tokio::test]
-    async fn reservation_domains_are_separate_but_task_warm_share_cap() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db);
-        assert!(matches!(
-            repo.reserve(&input(AdmissionDomain::InvocationBuild, "same", 0), 0)
-                .await
-                .unwrap(),
-            ReserveAdmissionResult::Reserved { .. }
-        ));
-        assert!(matches!(
-            repo.reserve(&input(AdmissionDomain::TaskObservation, "same", 0), 1)
-                .await
-                .unwrap(),
-            ReserveAdmissionResult::Reserved { .. }
-        ));
-        assert!(matches!(
-            repo.reserve(&input(AdmissionDomain::WarmBuild, "same", 0), 1)
-                .await
-                .unwrap(),
-            ReserveAdmissionResult::Denied { .. }
-        ));
-    }
-
-    #[tokio::test]
-    async fn next_generation_requires_terminal_predecessor() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db.clone());
-        let input = input(AdmissionDomain::TaskObservation, "history", 0);
-        assert_eq!(
-            repo.allocate_next_generation(AdmissionDomain::TaskObservation, "history")
-                .await
-                .unwrap(),
-            0
-        );
-        repo.reserve(&input, 1).await.unwrap();
-        assert!(matches!(
-            repo.allocate_next_generation(AdmissionDomain::TaskObservation, "history")
-                .await,
-            Err(DbError::InvalidTransition(_))
-        ));
-        set_state(&db, &input.key, "terminal").await;
-        assert_eq!(
-            repo.allocate_next_generation(AdmissionDomain::TaskObservation, "history")
-                .await
-                .unwrap(),
-            1
-        );
-    }
-
-    #[tokio::test]
-    async fn definitive_and_ambiguous_create_failures_have_distinct_occupancy() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db);
-        let reserved = input(AdmissionDomain::TaskObservation, "definitive-reserved", 0);
-        let in_flight = input(AdmissionDomain::TaskObservation, "definitive-flight", 0);
-        let ambiguous = input(AdmissionDomain::TaskObservation, "ambiguous", 0);
-        for reservation in [&reserved, &in_flight, &ambiguous] {
-            repo.reserve(reservation, 3).await.unwrap();
-        }
-
-        assert_eq!(
-            repo.mark_definitive_create_failure(&reserved.key)
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::Terminal
-        );
-        assert_eq!(
-            repo.mark_definitive_create_failure(&reserved.key)
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::Terminal
-        );
-        repo.mark_create_started(&create_started(&in_flight))
-            .await
-            .unwrap();
-        assert_eq!(
-            repo.mark_definitive_create_failure(&in_flight.key)
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::Terminal
-        );
-
-        repo.mark_create_started(&create_started(&ambiguous))
-            .await
-            .unwrap();
-        assert_eq!(
-            repo.mark_create_started(&create_started(&ambiguous))
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::CreateInFlight
-        );
-        assert_eq!(
-            repo.mark_create_unknown(&ambiguous.key)
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::CreateUnknown
-        );
-        assert_eq!(
-            repo.mark_create_unknown(&ambiguous.key)
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::CreateUnknown
-        );
-        // LIST absence is deliberately not an input to this repository: ambiguity occupies.
-        assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
-        assert_eq!(repo.list_active_rows().await.unwrap()[0].key, ambiguous.key);
-        assert_eq!(
-            repo.mark_live(&uid_input(&ambiguous, "uid-ambiguous"))
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::Live
-        );
-    }
-
-    #[tokio::test]
-    async fn cancellation_is_reserved_only_and_idempotent() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db);
-        let cancelled = input(AdmissionDomain::TaskObservation, "cancelled", 0);
-        let posted = input(AdmissionDomain::TaskObservation, "posted", 0);
-        repo.reserve(&cancelled, 2).await.unwrap();
-        repo.reserve(&posted, 2).await.unwrap();
-        assert_eq!(
-            repo.cancel_reserved(&cancelled.key).await.unwrap().state,
-            AdmissionState::Terminal
-        );
-        assert_eq!(
-            repo.cancel_reserved(&cancelled.key).await.unwrap().state,
-            AdmissionState::Terminal
-        );
-        repo.mark_create_started(&create_started(&posted))
-            .await
-            .unwrap();
-        assert!(matches!(
-            repo.cancel_reserved(&posted.key).await,
-            Err(DbError::InvalidTransition(_))
-        ));
-        assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
-    }
-
-    #[tokio::test]
-    async fn stale_generations_and_mismatched_uids_cannot_release_current_work() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db);
-        let first = input(AdmissionDomain::TaskObservation, "fenced", 0);
-        repo.reserve(&first, 1).await.unwrap();
-        repo.mark_create_started(&create_started(&first))
-            .await
-            .unwrap();
-        repo.mark_live(&uid_input(&first, "uid-first"))
-            .await
-            .unwrap();
-        repo.mark_terminal(&TerminalAdmissionInput {
-            key: first.key.clone(),
-            object_uid: Some("uid-first".into()),
-        })
-        .await
-        .unwrap();
-
-        let second = input(AdmissionDomain::TaskObservation, "fenced", 1);
-        repo.reserve(&second, 1).await.unwrap();
-        repo.mark_create_started(&create_started(&second))
-            .await
-            .unwrap();
-        repo.mark_live(&uid_input(&second, "uid-current"))
-            .await
-            .unwrap();
-        assert!(matches!(
-            repo.mark_live(&uid_input(&first, "uid-first")).await,
-            Err(DbError::InvalidTransition(_))
-        ));
-        assert!(matches!(
-            repo.mark_terminal(&TerminalAdmissionInput {
-                key: second.key.clone(),
-                object_uid: Some("wrong-uid".into()),
-            })
-            .await,
-            Err(DbError::InvalidTransition(_))
-        ));
-        assert_eq!(
-            repo.mark_live(&uid_input(&second, "uid-current"))
-                .await
-                .unwrap()
-                .state,
-            AdmissionState::Live
-        );
-        assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
-        for _ in 0..2 {
-            assert_eq!(
-                repo.mark_terminal(&TerminalAdmissionInput {
-                    key: second.key.clone(),
-                    object_uid: Some("uid-current".into()),
-                })
-                .await
-                .unwrap()
-                .state,
-                AdmissionState::Terminal
-            );
-        }
-        assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 0);
-    }
-
-    #[tokio::test]
-    async fn predecessor_recovery_retires_only_reserved_and_retains_ambiguous_work() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db);
-        let reserved = input(AdmissionDomain::TaskObservation, "recover-reserved", 0);
-        let flight = input(AdmissionDomain::TaskObservation, "recover-flight", 0);
-        let unknown = input(AdmissionDomain::TaskObservation, "recover-unknown", 0);
-        let live = input(AdmissionDomain::TaskObservation, "recover-live", 0);
-        let mut successor = input(AdmissionDomain::TaskObservation, "recover-successor", 0);
-        successor.creator_server_epoch = "epoch-2".into();
-        for reservation in [&reserved, &flight, &unknown, &live, &successor] {
-            repo.reserve(reservation, 5).await.unwrap();
-        }
-        repo.mark_create_started(&create_started(&flight))
-            .await
-            .unwrap();
-        repo.mark_create_started(&create_started(&unknown))
-            .await
-            .unwrap();
-        repo.mark_create_unknown(&unknown.key).await.unwrap();
-        repo.mark_create_started(&create_started(&live))
-            .await
-            .unwrap();
-        repo.mark_live(&uid_input(&live, "uid-live")).await.unwrap();
-
-        let report = repo.recover_predecessor_epoch("epoch-1").await.unwrap();
-        assert_eq!(report.retired_reserved, 1);
-        assert_eq!(report.marked_create_unknown, 1);
-        let states = report
-            .active_rows
-            .iter()
-            .map(|row| (row.key.work_id.as_str(), row.state))
-            .collect::<Vec<_>>();
-        assert_eq!(
-            states,
-            vec![
-                ("recover-flight", AdmissionState::CreateUnknown),
-                ("recover-live", AdmissionState::Live),
-                ("recover-successor", AdmissionState::Reserved),
-                ("recover-unknown", AdmissionState::CreateUnknown),
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn recover_all_predecessors_retires_every_predecessor_epoch_atomically() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = AdmissionJournalRepository::new(db);
-        // Two distinct predecessor epochs plus the current replacement epoch.
-        let mut pred_a = input(AdmissionDomain::WarmBuild, "pred-a-reserved", 0);
-        pred_a.creator_server_epoch = "epoch-a".into();
-        let mut pred_a_flight = input(AdmissionDomain::WarmBuild, "pred-a-flight", 0);
-        pred_a_flight.creator_server_epoch = "epoch-a".into();
-        let mut pred_b = input(AdmissionDomain::WarmBuild, "pred-b-reserved", 0);
-        pred_b.creator_server_epoch = "epoch-b".into();
-        let mut current = input(AdmissionDomain::WarmBuild, "current-reserved", 0);
-        current.creator_server_epoch = "replacement-epoch".into();
-        for reservation in [&pred_a, &pred_a_flight, &pred_b, &current] {
-            repo.reserve(reservation, 10).await.unwrap();
-        }
-        repo.mark_create_started(&create_started(&pred_a_flight))
-            .await
-            .unwrap();
-
-        // recover_all_predecessors processes every epoch except the current one.
-        let report = repo
-            .recover_all_predecessors("replacement-epoch")
-            .await
-            .unwrap();
-        assert_eq!(
-            report.retired_reserved, 2,
-            "both predecessor Reserved retired"
-        );
-        assert_eq!(
-            report.marked_create_unknown, 1,
-            "the single predecessor CreateInFlight converted to CreateUnknown"
-        );
-        // The current-epoch Reserved row is untouched.
-        let states = report
-            .active_rows
-            .iter()
-            .map(|row| (row.key.work_id.as_str(), row.state))
-            .collect::<Vec<_>>();
-        assert_eq!(
-            states,
-            vec![
-                ("current-reserved", AdmissionState::Reserved),
-                ("pred-a-flight", AdmissionState::CreateUnknown),
-            ]
-        );
-    }
-}
+#[path = "admission_journal_tests.rs"]
+mod tests;

--- a/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
@@ -1,0 +1,500 @@
+//! PostgreSQL contract tests for the durable admission journal.
+
+use std::sync::Arc;
+
+use super::*;
+
+fn input(domain: AdmissionDomain, work_id: &str, generation: i64) -> ReserveAdmissionInput {
+    ReserveAdmissionInput {
+        key: AdmissionJournalKey {
+            domain,
+            work_id: work_id.into(),
+            generation,
+        },
+        workload_kind: match domain {
+            AdmissionDomain::TaskObservation => AdmissionWorkloadKind::Task,
+            AdmissionDomain::WarmBuild => AdmissionWorkloadKind::Warm,
+            AdmissionDomain::InvocationBuild => AdmissionWorkloadKind::Invocation,
+        },
+        creator_server_epoch: "epoch-1".into(),
+        object_name: format!("admission-{work_id}-{generation}"),
+    }
+}
+
+fn create_started(input: &ReserveAdmissionInput) -> CreateStartedInput {
+    CreateStartedInput {
+        key: input.key.clone(),
+        creator_server_epoch: input.creator_server_epoch.clone(),
+        object_name: input.object_name.clone(),
+    }
+}
+
+fn uid_input(input: &ReserveAdmissionInput, object_uid: &str) -> UidFencedAdmissionInput {
+    UidFencedAdmissionInput {
+        key: input.key.clone(),
+        object_uid: object_uid.into(),
+    }
+}
+
+async fn set_state(db: &Database, key: &AdmissionJournalKey, state: &str) {
+    sqlx::query(
+        "UPDATE admission_journal SET state = $1, terminal_at = \
+         CASE WHEN $1 = 'terminal' THEN now() ELSE NULL END WHERE domain = $2 AND work_id = $3 AND generation = $4",
+    )
+    .bind(state)
+    .bind(key.domain.as_str())
+    .bind(&key.work_id)
+    .bind(key.generation)
+    .execute(db.pool())
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cap_one_concurrent_reservation_has_one_winner() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = Arc::new(AdmissionJournalRepository::new(db));
+    let first = {
+        let repo = Arc::clone(&repo);
+        tokio::spawn(async move {
+            repo.reserve(&input(AdmissionDomain::TaskObservation, "a", 0), 1)
+                .await
+                .unwrap()
+        })
+    };
+    let second = {
+        let repo = Arc::clone(&repo);
+        tokio::spawn(async move {
+            repo.reserve(&input(AdmissionDomain::WarmBuild, "b", 0), 1)
+                .await
+                .unwrap()
+        })
+    };
+    let results = [first.await.unwrap(), second.await.unwrap()];
+    assert_eq!(
+        results
+            .iter()
+            .filter(|r| matches!(r, ReserveAdmissionResult::Reserved { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn duplicate_reservation_is_idempotent() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+    let input = input(AdmissionDomain::TaskObservation, "same", 0);
+    assert!(matches!(
+        repo.reserve(&input, 1).await.unwrap(),
+        ReserveAdmissionResult::Reserved {
+            idempotent: false,
+            ..
+        }
+    ));
+    assert!(matches!(
+        repo.reserve(&input, 1).await.unwrap(),
+        ReserveAdmissionResult::Reserved {
+            idempotent: true,
+            ..
+        }
+    ));
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn all_occupying_states_count_but_terminal_history_does_not() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db.clone());
+    for (index, state) in [
+        "reserved",
+        "create_in_flight",
+        "create_unknown",
+        "live",
+        "terminal",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let input = input(
+            AdmissionDomain::TaskObservation,
+            &format!("work-{index}"),
+            0,
+        );
+        repo.reserve(&input, 10).await.unwrap();
+        set_state(&db, &input.key, state).await;
+    }
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 4);
+    let history = repo
+        .list_history(AdmissionDomain::TaskObservation, "work-4")
+        .await
+        .unwrap();
+    assert_eq!(history[0].state, AdmissionState::Terminal);
+}
+
+#[tokio::test]
+async fn reservation_domains_are_separate_but_task_warm_share_cap() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+    assert!(matches!(
+        repo.reserve(&input(AdmissionDomain::InvocationBuild, "same", 0), 0)
+            .await
+            .unwrap(),
+        ReserveAdmissionResult::Reserved { .. }
+    ));
+    assert!(matches!(
+        repo.reserve(&input(AdmissionDomain::TaskObservation, "same", 0), 1)
+            .await
+            .unwrap(),
+        ReserveAdmissionResult::Reserved { .. }
+    ));
+    assert!(matches!(
+        repo.reserve(&input(AdmissionDomain::WarmBuild, "same", 0), 1)
+            .await
+            .unwrap(),
+        ReserveAdmissionResult::Denied { .. }
+    ));
+}
+
+#[tokio::test]
+async fn dispatch_generation_resolves_per_object_lifecycle() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db.clone());
+    let resolve = async |requested| {
+        repo.resolve_dispatch_generation(AdmissionDomain::TaskObservation, "attempts", requested)
+            .await
+            .unwrap()
+    };
+
+    // No retained row: the caller's own numbering is kept.
+    assert_eq!(resolve(0).await, 0);
+    assert_eq!(resolve(3).await, 3);
+
+    // A nonterminal generation is resumed, never double-reserved, so a
+    // duplicate dispatch or a restart is idempotent.
+    let first = input(AdmissionDomain::TaskObservation, "attempts", 0);
+    repo.reserve(&first, 4).await.unwrap();
+    assert_eq!(resolve(0).await, 0);
+    set_state(&db, &first.key, "live").await;
+    assert_eq!(resolve(0).await, 0);
+
+    // A retired generation is never reused: the next attempt is a new
+    // object with its own UID, so it needs a row that has none yet.
+    set_state(&db, &first.key, "terminal").await;
+    assert_eq!(resolve(0).await, 1);
+
+    // A caller counter that has run ahead of dispatch is still a floor.
+    assert_eq!(resolve(7).await, 7);
+    assert!(
+        repo.resolve_dispatch_generation(AdmissionDomain::TaskObservation, "attempts", -1)
+            .await
+            .is_err()
+    );
+}
+
+/// A create outcome that arrives after the generation is already retired is
+/// a defined no-op: the terminal row and its released capacity stand.
+#[tokio::test]
+async fn late_create_unknown_after_terminal_retains_the_terminal_row() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db.clone());
+    let input = input(AdmissionDomain::WarmBuild, "late", 0);
+    repo.reserve(&input, 1).await.unwrap();
+    repo.mark_create_started(&create_started(&input))
+        .await
+        .unwrap();
+    repo.mark_live(&uid_input(&input, "uid")).await.unwrap();
+    repo.mark_terminal(&TerminalAdmissionInput {
+        key: input.key.clone(),
+        object_uid: Some("uid".into()),
+    })
+    .await
+    .unwrap();
+
+    let row = repo
+        .mark_create_unknown(&input.key)
+        .await
+        .expect("a late create observation is idempotent");
+    assert_eq!(row.state, AdmissionState::Terminal);
+    assert_eq!(row.object_uid.as_deref(), Some("uid"));
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn next_generation_requires_terminal_predecessor() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db.clone());
+    let input = input(AdmissionDomain::TaskObservation, "history", 0);
+    assert_eq!(
+        repo.allocate_next_generation(AdmissionDomain::TaskObservation, "history")
+            .await
+            .unwrap(),
+        0
+    );
+    repo.reserve(&input, 1).await.unwrap();
+    assert!(matches!(
+        repo.allocate_next_generation(AdmissionDomain::TaskObservation, "history")
+            .await,
+        Err(DbError::InvalidTransition(_))
+    ));
+    set_state(&db, &input.key, "terminal").await;
+    assert_eq!(
+        repo.allocate_next_generation(AdmissionDomain::TaskObservation, "history")
+            .await
+            .unwrap(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn definitive_and_ambiguous_create_failures_have_distinct_occupancy() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+    let reserved = input(AdmissionDomain::TaskObservation, "definitive-reserved", 0);
+    let in_flight = input(AdmissionDomain::TaskObservation, "definitive-flight", 0);
+    let ambiguous = input(AdmissionDomain::TaskObservation, "ambiguous", 0);
+    for reservation in [&reserved, &in_flight, &ambiguous] {
+        repo.reserve(reservation, 3).await.unwrap();
+    }
+
+    assert_eq!(
+        repo.mark_definitive_create_failure(&reserved.key)
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::Terminal
+    );
+    assert_eq!(
+        repo.mark_definitive_create_failure(&reserved.key)
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::Terminal
+    );
+    repo.mark_create_started(&create_started(&in_flight))
+        .await
+        .unwrap();
+    assert_eq!(
+        repo.mark_definitive_create_failure(&in_flight.key)
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::Terminal
+    );
+
+    repo.mark_create_started(&create_started(&ambiguous))
+        .await
+        .unwrap();
+    assert_eq!(
+        repo.mark_create_started(&create_started(&ambiguous))
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::CreateInFlight
+    );
+    assert_eq!(
+        repo.mark_create_unknown(&ambiguous.key)
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::CreateUnknown
+    );
+    assert_eq!(
+        repo.mark_create_unknown(&ambiguous.key)
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::CreateUnknown
+    );
+    // LIST absence is deliberately not an input to this repository: ambiguity occupies.
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+    assert_eq!(repo.list_active_rows().await.unwrap()[0].key, ambiguous.key);
+    assert_eq!(
+        repo.mark_live(&uid_input(&ambiguous, "uid-ambiguous"))
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::Live
+    );
+}
+
+#[tokio::test]
+async fn cancellation_is_reserved_only_and_idempotent() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+    let cancelled = input(AdmissionDomain::TaskObservation, "cancelled", 0);
+    let posted = input(AdmissionDomain::TaskObservation, "posted", 0);
+    repo.reserve(&cancelled, 2).await.unwrap();
+    repo.reserve(&posted, 2).await.unwrap();
+    assert_eq!(
+        repo.cancel_reserved(&cancelled.key).await.unwrap().state,
+        AdmissionState::Terminal
+    );
+    assert_eq!(
+        repo.cancel_reserved(&cancelled.key).await.unwrap().state,
+        AdmissionState::Terminal
+    );
+    repo.mark_create_started(&create_started(&posted))
+        .await
+        .unwrap();
+    assert!(matches!(
+        repo.cancel_reserved(&posted.key).await,
+        Err(DbError::InvalidTransition(_))
+    ));
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn stale_generations_and_mismatched_uids_cannot_release_current_work() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+    let first = input(AdmissionDomain::TaskObservation, "fenced", 0);
+    repo.reserve(&first, 1).await.unwrap();
+    repo.mark_create_started(&create_started(&first))
+        .await
+        .unwrap();
+    repo.mark_live(&uid_input(&first, "uid-first"))
+        .await
+        .unwrap();
+    repo.mark_terminal(&TerminalAdmissionInput {
+        key: first.key.clone(),
+        object_uid: Some("uid-first".into()),
+    })
+    .await
+    .unwrap();
+
+    let second = input(AdmissionDomain::TaskObservation, "fenced", 1);
+    repo.reserve(&second, 1).await.unwrap();
+    repo.mark_create_started(&create_started(&second))
+        .await
+        .unwrap();
+    repo.mark_live(&uid_input(&second, "uid-current"))
+        .await
+        .unwrap();
+    assert!(matches!(
+        repo.mark_live(&uid_input(&first, "uid-first")).await,
+        Err(DbError::InvalidTransition(_))
+    ));
+    assert!(matches!(
+        repo.mark_terminal(&TerminalAdmissionInput {
+            key: second.key.clone(),
+            object_uid: Some("wrong-uid".into()),
+        })
+        .await,
+        Err(DbError::InvalidTransition(_))
+    ));
+    assert_eq!(
+        repo.mark_live(&uid_input(&second, "uid-current"))
+            .await
+            .unwrap()
+            .state,
+        AdmissionState::Live
+    );
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+    for _ in 0..2 {
+        assert_eq!(
+            repo.mark_terminal(&TerminalAdmissionInput {
+                key: second.key.clone(),
+                object_uid: Some("uid-current".into()),
+            })
+            .await
+            .unwrap()
+            .state,
+            AdmissionState::Terminal
+        );
+    }
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn predecessor_recovery_retires_only_reserved_and_retains_ambiguous_work() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+    let reserved = input(AdmissionDomain::TaskObservation, "recover-reserved", 0);
+    let flight = input(AdmissionDomain::TaskObservation, "recover-flight", 0);
+    let unknown = input(AdmissionDomain::TaskObservation, "recover-unknown", 0);
+    let live = input(AdmissionDomain::TaskObservation, "recover-live", 0);
+    let mut successor = input(AdmissionDomain::TaskObservation, "recover-successor", 0);
+    successor.creator_server_epoch = "epoch-2".into();
+    for reservation in [&reserved, &flight, &unknown, &live, &successor] {
+        repo.reserve(reservation, 5).await.unwrap();
+    }
+    repo.mark_create_started(&create_started(&flight))
+        .await
+        .unwrap();
+    repo.mark_create_started(&create_started(&unknown))
+        .await
+        .unwrap();
+    repo.mark_create_unknown(&unknown.key).await.unwrap();
+    repo.mark_create_started(&create_started(&live))
+        .await
+        .unwrap();
+    repo.mark_live(&uid_input(&live, "uid-live")).await.unwrap();
+
+    let report = repo.recover_predecessor_epoch("epoch-1").await.unwrap();
+    assert_eq!(report.retired_reserved, 1);
+    assert_eq!(report.marked_create_unknown, 1);
+    let states = report
+        .active_rows
+        .iter()
+        .map(|row| (row.key.work_id.as_str(), row.state))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        states,
+        vec![
+            ("recover-flight", AdmissionState::CreateUnknown),
+            ("recover-live", AdmissionState::Live),
+            ("recover-successor", AdmissionState::Reserved),
+            ("recover-unknown", AdmissionState::CreateUnknown),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn recover_all_predecessors_retires_every_predecessor_epoch_atomically() {
+    let db = Database::open_in_memory().unwrap();
+    let repo = AdmissionJournalRepository::new(db);
+    // Two distinct predecessor epochs plus the current replacement epoch.
+    let mut pred_a = input(AdmissionDomain::WarmBuild, "pred-a-reserved", 0);
+    pred_a.creator_server_epoch = "epoch-a".into();
+    let mut pred_a_flight = input(AdmissionDomain::WarmBuild, "pred-a-flight", 0);
+    pred_a_flight.creator_server_epoch = "epoch-a".into();
+    let mut pred_b = input(AdmissionDomain::WarmBuild, "pred-b-reserved", 0);
+    pred_b.creator_server_epoch = "epoch-b".into();
+    let mut current = input(AdmissionDomain::WarmBuild, "current-reserved", 0);
+    current.creator_server_epoch = "replacement-epoch".into();
+    for reservation in [&pred_a, &pred_a_flight, &pred_b, &current] {
+        repo.reserve(reservation, 10).await.unwrap();
+    }
+    repo.mark_create_started(&create_started(&pred_a_flight))
+        .await
+        .unwrap();
+
+    // recover_all_predecessors processes every epoch except the current one.
+    let report = repo
+        .recover_all_predecessors("replacement-epoch")
+        .await
+        .unwrap();
+    assert_eq!(
+        report.retired_reserved, 2,
+        "both predecessor Reserved retired"
+    );
+    assert_eq!(
+        report.marked_create_unknown, 1,
+        "the single predecessor CreateInFlight converted to CreateUnknown"
+    );
+    // The current-epoch Reserved row is untouched.
+    let states = report
+        .active_rows
+        .iter()
+        .map(|row| (row.key.work_id.as_str(), row.state))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        states,
+        vec![
+            ("current-reserved", AdmissionState::Reserved),
+            ("pred-a-flight", AdmissionState::CreateUnknown),
+        ]
+    );
+}

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -247,6 +247,8 @@ const BUILD_ADMISSION_JOURNAL_DEGRADED: &str = "djinn_build_admission_journal_de
 const BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH: &str = "djinn_build_admission_create_unknown_health";
 const BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL: &str =
     "djinn_build_admission_shadow_invocation_total";
+const BUILD_ADMISSION_TRANSITION_TOTAL: &str = "djinn_build_admission_transition_total";
+const BUILD_ADMISSION_TRANSITION_OUTCOMES: [&str; 2] = ["accepted", "rejected"];
 const BUILD_ADMISSION_HANDOFF_WARNING: &str = "djinn_build_admission_handoff_warning";
 const BUILD_ADMISSION_HANDOFF_WARNING_REASONS: [&str; 3] =
     ["unexpected_overlap", "stale_epoch", "epoch_unreadable"];
@@ -2263,6 +2265,12 @@ fn register_metrics() {
         BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL,
         "Shadow-mode v1 invocation decisions the launcher observed but did not act on."
     );
+    metrics::describe_counter!(
+        BUILD_ADMISSION_TRANSITION_TOTAL,
+        "Durable admission-journal lifecycle transitions by outcome. A rejected \
+         share near one means the journal is refusing every observation and \
+         cannot be trusted as a grant authority."
+    );
     for metric in [
         BUILD_ADMISSION_INVENTORY_DEGRADED,
         BUILD_ADMISSION_JOURNAL_DEGRADED,
@@ -3390,6 +3398,23 @@ pub mod build_admission {
     pub fn increment_would_defer(effective_mode: &'static str, effective_cap: i64) {
         metrics::counter!(super::BUILD_ADMISSION_WOULD_DEFER_TOTAL, "effective_mode" => effective_mode, "effective_cap" => effective_cap.to_string()).increment(1);
     }
+    /// Record the outcome of one durable admission-journal lifecycle transition.
+    ///
+    /// `outcome` is a two-valued closed enumeration (`accepted` / `rejected`),
+    /// so a fleet running Observe can be checked for a 100% rejection rate —
+    /// the shape that makes the journal unsafe to arm as a grant authority —
+    /// without reading a single log line.
+    pub fn record_transition(effective_mode: &'static str, effective_cap: i64, accepted: bool) {
+        let cap = effective_cap.to_string();
+        let outcome = if accepted { "accepted" } else { "rejected" };
+        // Both series exist as soon as either is written, so a zero-rejection
+        // process is distinguishable from an unreported one.
+        for candidate in super::BUILD_ADMISSION_TRANSITION_OUTCOMES {
+            metrics::counter!(super::BUILD_ADMISSION_TRANSITION_TOTAL, "effective_mode" => effective_mode, "effective_cap" => cap.clone(), "outcome" => candidate)
+                .increment(u64::from(candidate == outcome));
+        }
+    }
+
     /// Record one bounded unknown-classification event.
     pub fn increment_unknown_classification(effective_mode: &'static str, effective_cap: i64) {
         metrics::counter!(super::BUILD_ADMISSION_UNKNOWN_CLASSIFICATION_TOTAL, "effective_mode" => effective_mode, "effective_cap" => effective_cap.to_string()).increment(1);


### PR DESCRIPTION
## The defect

`DJINN_BUILD_ADMISSION_MODE=observe` on the deployed v0.7.4 rejected **100% of durable admission-journal transitions** over 24h — 37 WARNs from `djinn_coordinator::build_admission`, zero successful observations:

- 23x `Kubernetes UID does not match admission row`
- 12x `cannot mark create unknown from Terminal`
- 2x `stale admission generation 1 for <uuid>`

The same journal is the **grant authority** once the mode is armed to `enforce`, so it could not be armed. This was the blocking defect for the goxi admission-epoch cutover.

## Root cause

The admission journal key is `(domain, work_id, generation)`, and both dispatch paths derive `generation` from a caller-side counter that does not advance per attempt: the task path from `task.reopen_count`, the warm path from a hard-coded `1`.

A generation is one *object lifecycle*: one create, one Kubernetes/runtime UID, one terminal release. A retried task attempt at the same `reopen_count` — or a re-warm of the same project revision — therefore reused the previous attempt's already-**retired** row. Worse, the retained in-memory permit for that key was returned as an "idempotent" hit, so the new attempt never got a reservation at all. Every subsequent observation then hit that row's recorded UID fence.

Per repeat cycle that is exactly: **1x `cannot mark create started/unknown from Terminal` + 2x `Kubernetes UID does not match admission row`** — the 2:1 ratio observed in production (23:12).

Note on the hypothesis in the task: the UIDs were **not** two independently computed values. Both paths already supply a single value to both Live and Terminal (the warm Job UID from `WarmJobWatcher::job_uid`, the task-run UID from the session-started binding). The identity that collided was the journal *generation*. Also, the `warm admission unavailable:` prefix is the shared `WarmAdmissionError` Display, not proof of the warm path — the task-run path produces it too, and both paths carry the identical defect.

## The fix

- **`AdmissionJournalRepository::resolve_dispatch_generation`** — the caller's generation becomes a *floor*; the journal decides the identity. No retained row keeps the caller's numbering; a nonterminal latest generation is resumed idempotently (duplicate dispatch / restart resume); a terminal latest generation yields the next one. `admit` resolves **before** the in-memory permit lookup, which is what stops a retired permit from being replayed.
- **`permits_by_work`** — lifecycle callbacks that carry only the work identity (a session start that has just learned its runtime UID) resolve to the current generation instead of recomputing it from `reopen_count`. Seeded from recovery so a restart resolves identically.
- **`mark_create_unknown` from `Terminal` is a defined idempotent no-op** — the create outcome and the terminal outcome are independent messages with no ordering guarantee; ambiguity about a create must never resurrect occupancy a terminal observation already released. Stale-generation transitions remain rejected, and the WARN is unchanged in level and text.
- **`djinn_build_admission_transition_total{effective_mode,effective_cap,outcome}`** — accepted vs rejected, both series written together so a zero-rejection process is distinguishable from an unreported one. A 100% rejection rate is now a ratio an alert reads, not log volume someone has to notice.

## Verification

Both regression tests drive the **production** sequences in the mode production runs (`Observe`), and both fail on current main with the production error text:

- `repeated_warm_lifecycles_record_one_generation_per_kubernetes_uid` — two real `K8sGraphWarmer` create→observe→terminal lifecycles for one project revision, through the production `BuildAdmissionController` and `AdmissionJournalRepository`. On main: `left: 1, right: 2` generations, with the WARNs reproduced verbatim, including `warm admission unavailable: invalid transition: Kubernetes UID does not match admission row` twice.
- `retried_attempts_at_one_reopen_count_each_record_their_own_runtime_uid` — two task-run attempts at one `reopen_count` through the actual `begin`/`finish`/`live`/`terminal` dispatch route and real `session.started` / `session.completed` events. Asserts each generation persists the exact runtime UID its own Live *and* Terminal observations supplied (AC2), and that zero transitions were rejected.
- `late_create_observation_is_idempotent_while_stale_generations_stay_rejected` and `late_create_unknown_after_terminal_retains_the_terminal_row` cover AC3 at controller and repository level, including that a superseded generation still gets `stale admission generation`.
- `telemetry_transition_counter_separates_accepted_from_rejected` covers AC4 with bounded labels.

`cargo test -p djinn-coordinator --lib build_admission` (99 tests), `-p djinn-db --lib admission_journal` (12), `-p djinn-k8s --lib` (242) all pass. Workspace `cargo check --all-targets`, `cargo fmt`, clippy on the changed crates, boundary check and file-size guard clean. The `djinn-db` admission-journal tests moved to a sibling `admission_journal_tests.rs` (existing house pattern) — the file was 164 bytes under the size guard.

## Follow-up (not in this PR)

`supervisor_impl/stage.rs` formats its handoff `generation_key` from `task.reopen_count`. Nothing in production produces the matching `required_generations` set yet, but once one does it must read the generation from the journal row, not recompute it — a retried attempt now has its own generation. Noted in the `admission_generation_key` doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)