### PR TITLE
nquz: Arm the observe-only disk dimension at coordinator startup

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -220,13 +220,14 @@ pub enum BuildAdmissionDecision {
 }
 
 /// Observe-only disk-capacity adapter for build admission (proposal nquz,
-/// phase 1 — DARK).
+/// phase 1 — OBSERVE).
 ///
 /// A source, when installed, returns what disk admission WOULD do for a build
-/// request — never denying and never allocating. In this phase no production
-/// path installs a source, so the disk dimension is inert; it exists so the
-/// observe substrate and its tests can measure the future policy. The concrete
-/// decision logic lives in [`crate::disk_admission`].
+/// request — never denying and never allocating. `observe` is consulted only
+/// AFTER a permit has been issued, so an installed source can add telemetry but
+/// can never turn a permit into a denial. The production source is composed by
+/// `crate::run_dir_observe`; the concrete decision logic lives in
+/// [`crate::disk_admission`].
 #[async_trait]
 pub trait DiskCapacitySource: Send + Sync {
     /// Return the observed disk decision for a build request, or `None` when no
@@ -330,8 +331,7 @@ pub struct BuildAdmissionController {
     would_defer_observations: Mutex<u64>,
     /// Bounded observe-only disk would-defer signal (proposal nquz, phase 1).
     ///
-    /// DARK by default: it only advances when a [`DiskCapacitySource`] has been
-    /// installed, which no production path does in this phase. The disk
+    /// Advances only when a [`DiskCapacitySource`] has been installed. The disk
     /// dimension NEVER changes an admission decision — it records what disk
     /// admission WOULD do.
     disk_would_defer_observations: Mutex<u64>,
@@ -610,8 +610,8 @@ impl BuildAdmissionController {
 
     /// Install the observe-only disk-capacity source (proposal nquz).
     ///
-    /// Phase-1 production never calls this; it exists so the dark disk dimension
-    /// and its tests can run. Installing a source can only add telemetry — it
+    /// Called by the coordinator's startup composition in
+    /// `crate::run_dir_observe`. Installing a source can only add telemetry — it
     /// can never turn a permit into a denial.
     pub fn set_disk_capacity_source(&self, source: Arc<dyn DiskCapacitySource>) {
         *self
@@ -739,8 +739,8 @@ impl BuildAdmissionController {
             });
         }
         // Capture an observe-only copy before any field of `request` is moved.
-        // Only cloned when the dark disk dimension is armed (never in phase-1
-        // production), so the default path pays nothing.
+        // Only cloned when the disk dimension is armed, so a controller with
+        // no source installed pays nothing.
         let disk_observe_request = self
             .disk_capacity_source()
             .is_some()

--- a/server/crates/djinn-coordinator/src/disk_admission.rs
+++ b/server/crates/djinn-coordinator/src/disk_admission.rs
@@ -102,12 +102,16 @@ pub struct DiskObservation {
     pub projected_reservation_bytes: u64,
 }
 
-/// Per-volume disk-admission configuration. Phase-1 defaults are inert
-/// placeholders: nothing consumes them for a live decision yet.
+/// Per-volume disk-admission configuration. Observe mode consumes these to
+/// classify samples and to compute what enforce WOULD reserve; nothing here
+/// changes a grant.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DiskAdmissionConfig {
     pub cache_budget_bytes: u64,
     pub critical_free_bytes: u64,
+    /// The warning floor used by [`DiskCapacityState::classify`]. Must be at
+    /// least `critical_free_bytes`; a smaller configured value is raised to it.
+    pub warning_free_bytes: u64,
     pub emergency_headroom_bytes: u64,
     pub per_lease_growth_bytes: u64,
     pub max_sample_age: Duration,
@@ -118,24 +122,68 @@ pub const DEFAULT_EMERGENCY_HEADROOM_BYTES: u64 = 10 * 1024 * 1024 * 1024;
 /// 90 seconds, the proposal's freshness bound for a capacity sample.
 pub const DEFAULT_MAX_SAMPLE_AGE: Duration = Duration::from_secs(90);
 
+const GIB: u64 = 1024 * 1024 * 1024;
+
+/// Environment overrides. Every value is optional; a malformed value keeps the
+/// default rather than failing coordinator startup (observe must never be a
+/// boot hazard).
+pub const CACHE_BUDGET_BYTES_ENV: &str = "DJINN_RUN_DIR_CACHE_BUDGET_BYTES";
+pub const CRITICAL_FREE_BYTES_ENV: &str = "DJINN_RUN_DIR_CRITICAL_FREE_BYTES";
+pub const WARNING_FREE_BYTES_ENV: &str = "DJINN_RUN_DIR_WARNING_FREE_BYTES";
+pub const EMERGENCY_HEADROOM_BYTES_ENV: &str = "DJINN_RUN_DIR_EMERGENCY_HEADROOM_BYTES";
+pub const PER_LEASE_GROWTH_BYTES_ENV: &str = "DJINN_RUN_DIR_PER_LEASE_GROWTH_BYTES";
+pub const MAX_SAMPLE_AGE_SECS_ENV: &str = "DJINN_RUN_DIR_MAX_SAMPLE_AGE_SECS";
+
 impl Default for DiskAdmissionConfig {
     fn default() -> Self {
         Self {
-            cache_budget_bytes: 200 * 1024 * 1024 * 1024,
-            critical_free_bytes: 20 * 1024 * 1024 * 1024,
+            cache_budget_bytes: 200 * GIB,
+            critical_free_bytes: 20 * GIB,
+            warning_free_bytes: 40 * GIB,
             emergency_headroom_bytes: DEFAULT_EMERGENCY_HEADROOM_BYTES,
-            per_lease_growth_bytes: 4 * 1024 * 1024 * 1024,
+            per_lease_growth_bytes: 4 * GIB,
             max_sample_age: DEFAULT_MAX_SAMPLE_AGE,
         }
     }
 }
 
+fn env_u64(name: &str) -> Option<u64> {
+    std::env::var(name).ok()?.trim().parse::<u64>().ok()
+}
+
 impl DiskAdmissionConfig {
+    /// Read the per-volume observe configuration from the environment,
+    /// defaulting every unset or malformed value.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+        Self {
+            cache_budget_bytes: env_u64(CACHE_BUDGET_BYTES_ENV)
+                .unwrap_or(defaults.cache_budget_bytes),
+            critical_free_bytes: env_u64(CRITICAL_FREE_BYTES_ENV)
+                .unwrap_or(defaults.critical_free_bytes),
+            warning_free_bytes: env_u64(WARNING_FREE_BYTES_ENV)
+                .unwrap_or(defaults.warning_free_bytes),
+            emergency_headroom_bytes: env_u64(EMERGENCY_HEADROOM_BYTES_ENV)
+                .unwrap_or(defaults.emergency_headroom_bytes),
+            per_lease_growth_bytes: env_u64(PER_LEASE_GROWTH_BYTES_ENV)
+                .unwrap_or(defaults.per_lease_growth_bytes),
+            max_sample_age: env_u64(MAX_SAMPLE_AGE_SECS_ENV)
+                .map_or(defaults.max_sample_age, Duration::from_secs),
+        }
+    }
+
     /// The effective emergency headroom for a volume: at least the configured
     /// value, and never less than 5% of filesystem capacity.
     #[must_use]
     pub fn effective_emergency_headroom(&self, total_bytes: u64) -> u64 {
         self.emergency_headroom_bytes.max(total_bytes / 20)
+    }
+
+    /// The warning floor, never below the critical floor.
+    #[must_use]
+    pub fn effective_warning_free_bytes(&self) -> u64 {
+        self.warning_free_bytes.max(self.critical_free_bytes)
     }
 }
 

--- a/server/crates/djinn-coordinator/src/disk_admission_tests.rs
+++ b/server/crates/djinn-coordinator/src/disk_admission_tests.rs
@@ -11,6 +11,7 @@ fn config() -> DiskAdmissionConfig {
     DiskAdmissionConfig {
         cache_budget_bytes: 100 * GIB,
         critical_free_bytes: 20 * GIB,
+        warning_free_bytes: 40 * GIB,
         emergency_headroom_bytes: 10 * GIB,
         per_lease_growth_bytes: 4 * GIB,
         max_sample_age: Duration::from_secs(90),

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -122,6 +122,10 @@ pub async fn record_supervisor_rework_reopen(
 
 pub mod resource_monitor;
 pub mod roles;
+/// Production wiring that arms the observe-only disk dimension at coordinator
+/// startup: run-dir reconciliation, the live capacity adapter, and the quota
+/// probe.
+pub mod run_dir_observe;
 pub mod run_dir_reconcile;
 pub mod supervisor_impl;
 pub mod task_merge;

--- a/server/crates/djinn-coordinator/src/run_dir_observe.rs
+++ b/server/crates/djinn-coordinator/src/run_dir_observe.rs
@@ -1,0 +1,832 @@
+//! Production wiring for the observe-only disk dimension (proposal nquz,
+//! phase 1 — OBSERVE).
+//!
+//! Phase 1 shipped three pure pieces and no call sites: the run-dir ledger
+//! ([`djinn_db::RunDirRepository`]), the reconciliation planner
+//! ([`crate::run_dir_reconcile`]), and the disk evaluator plus quota probe
+//! ([`crate::disk_admission`]). This module is the executor that composes them
+//! at coordinator startup and installs the capacity adapter on the production
+//! [`BuildAdmissionController`].
+//!
+//! # What this module may NOT do
+//!
+//! Observe mode is read-only with respect to the filesystem and to admission:
+//!
+//! - it never creates, renames, deletes, or truncates anything on the volume —
+//!   the only writes it performs at all are `run_dirs` ledger rows;
+//! - it never reserves bytes, assigns a quota, or allocates a temp/final path;
+//! - it never changes a grant. [`DiskCapacitySource::observe`] is consulted by
+//!   `build_admission` only AFTER a permit has been issued, and its return value
+//!   feeds telemetry alone.
+//!
+//! Unknown, malformed, symlinked, unreadable, and unresolved entries become
+//! [`RunDirState::QuarantinedUnowned`] and are left untouched on disk. The whole
+//! executor is idempotent: [`djinn_db::RunDirRepository::upsert_reconciled`]
+//! leaves a pre-existing `(volume_id, pod_uid)` row alone, so a rerun observes
+//! the same ledger.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use djinn_core::clock::Clock;
+use djinn_db::{
+    BuildLeaseRepository, BuildLeaseRow, BuildLeaseState, Database, RunDirRepository, RunDirState,
+};
+
+use crate::build_admission::{
+    BuildAdmissionController, BuildWorkloadKind, DiskCapacitySource, TaskRunRole,
+};
+use crate::cargo_warm_base_gc::{CapacitySnapshot, FilesystemCapacity, StatvfsFilesystemCapacity};
+use crate::disk_admission::{
+    CapacitySample, DiskAdmissionConfig, DiskAdmissionRequest, DiskCapacityState, DiskObservation,
+    LedgerTotals, QuotaSupport, QuotaUnavailableReason, evaluate_disk_admission_observe,
+    probe_project_quota,
+};
+use crate::run_dir_reconcile::{
+    ReconcileInventoryEntry, ResolvedOwnership, RunDirOwnershipResolver, plan_reconciliation,
+};
+
+/// Single configured volume ID for the pre-`8ixk` (single-volume) phase. When
+/// node-keyed pools land, the same ledger activates with `volume_id =
+/// node_volume_id`; until then every row on this coordinator shares this ID.
+pub const DEFAULT_VOLUME_ID: &str = "cargo-target-runs";
+pub const VOLUME_ID_ENV: &str = "DJINN_RUN_DIR_VOLUME_ID";
+
+/// The configured single-volume ID, defaulting to [`DEFAULT_VOLUME_ID`].
+#[must_use]
+pub fn volume_id_from_env() -> String {
+    std::env::var(VOLUME_ID_ENV)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_VOLUME_ID.to_owned())
+}
+
+// ── Filesystem inventory seam ───────────────────────────────────────────────
+
+/// One volume scan: the per-directory entries the planner consumes, plus the
+/// bytes held by top-level non-directory debris. Debris is not a run dir and
+/// therefore has no ledger row, but it DOES occupy the volume, so it is
+/// reported as unowned bytes rather than silently dropped from accounting.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunDirInventory {
+    pub entries: Vec<ReconcileInventoryEntry>,
+    pub loose_file_bytes: u64,
+}
+
+/// Read-only inventory of the configured runs root.
+///
+/// A seam so startup tests can drive an unreadable or adversarial volume
+/// deterministically. Implementations MUST NOT mutate the filesystem.
+pub trait RunDirInventorySource: Send + Sync {
+    fn inventory(&self, root: &Path) -> Result<RunDirInventory, String>;
+}
+
+/// The production inventory: [`djinn_core::cargo_target_runs`] measurement,
+/// `st_blocks`-based, inode-deduplicated, never following symlinks.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FilesystemRunDirInventory;
+
+/// A well-formed run dir is named by a task-run UUID. Anything else — debris,
+/// a rename, an operator scratch dir — is malformed and quarantined.
+fn is_task_run_dir_name(name: &str) -> bool {
+    uuid::Uuid::parse_str(name).is_ok()
+}
+
+impl RunDirInventorySource for FilesystemRunDirInventory {
+    fn inventory(&self, root: &Path) -> Result<RunDirInventory, String> {
+        let scan = djinn_core::cargo_target_runs::inventory_cargo_target_runs(root)
+            .map_err(|error| error.to_string())?;
+        let mut entries: Vec<ReconcileInventoryEntry> = Vec::new();
+        let mut seen: Vec<String> = Vec::new();
+
+        // Measurable, contained directories. A non-UUID name is malformed even
+        // though the inventory accepted it as a candidate.
+        for candidate in &scan.candidates {
+            let Ok(name) = std::str::from_utf8(&candidate.name) else {
+                continue;
+            };
+            let malformed = !is_task_run_dir_name(name);
+            let measured =
+                djinn_core::cargo_target_runs::measure_run_dir_allocated_bytes(root, name)
+                    .ok()
+                    .flatten()
+                    .unwrap_or(0);
+            seen.push(name.to_owned());
+            entries.push(ReconcileInventoryEntry {
+                dir_name: name.to_owned(),
+                measured_bytes: measured,
+                final_path: root.join(name).to_string_lossy().into_owned(),
+                malformed,
+            });
+        }
+
+        // Symlinked, malformed-name, and unreadable top-level entries. These are
+        // ALWAYS quarantined; an unreadable subtree measures as zero tracked
+        // bytes rather than being mistaken for a small directory.
+        for issue in scan.protected.iter().chain(scan.errors.iter()) {
+            let Some(raw) = issue.top_level_name.as_deref() else {
+                continue;
+            };
+            let Ok(name) = std::str::from_utf8(raw) else {
+                continue;
+            };
+            if seen.iter().any(|existing| existing == name) {
+                continue;
+            }
+            seen.push(name.to_owned());
+            entries.push(ReconcileInventoryEntry {
+                dir_name: name.to_owned(),
+                measured_bytes: 0,
+                final_path: root.join(name).to_string_lossy().into_owned(),
+                malformed: true,
+            });
+        }
+
+        entries.sort_by(|left, right| left.dir_name.cmp(&right.dir_name));
+        Ok(RunDirInventory {
+            entries,
+            loose_file_bytes: scan.top_level_non_directory_allocated_bytes,
+        })
+    }
+}
+
+// ── Authoritative ownership resolution ──────────────────────────────────────
+
+/// Resolve run directories from durable pod-UID evidence.
+///
+/// `build_leases.bound_pod_uid` is the only pod UID this database durably
+/// records: the schema constraint admits it solely in the pod-bound and terminal
+/// states and only the fencing-token `bind` path writes it. A directory with no
+/// matching bound lease has NO authoritative owner and is quarantined — which is
+/// exactly the mixed-version behaviour the rollout section requires while
+/// workers still eager-seed.
+#[derive(Clone, Debug, Default)]
+pub struct LeaseOwnershipResolver {
+    by_task_run: HashMap<String, ResolvedOwnership>,
+}
+
+/// A task-invocation lease's `immutable_identity` is `task:<task>:<run>:<inv>`.
+/// Extract the task-run ID, which is also the run directory's name.
+#[must_use]
+pub fn task_run_id_from_immutable_identity(identity: &str) -> Option<&str> {
+    let mut parts = identity.split(':');
+    if parts.next()? != "task" {
+        return None;
+    }
+    let _task_id = parts.next()?;
+    let task_run_id = parts.next()?;
+    (!task_run_id.is_empty()).then_some(task_run_id)
+}
+
+impl LeaseOwnershipResolver {
+    /// Build the resolver from pod-bound task-invocation leases.
+    ///
+    /// Reconciliation asserts only two of the three authoritative states:
+    /// terminal leases become [`RunDirState::Reclaimable`] (the pod-UID terminal
+    /// proof landed) and every other pod-bound state becomes
+    /// [`RunDirState::ReadyActive`]. [`RunDirState::ReadyIdle`] is deliberately
+    /// never asserted here: the durable ledger carries no lease-recency evidence
+    /// across a restart, and `ready_active` is the strictly more protected of
+    /// the two.
+    #[must_use]
+    pub fn from_lease_rows(rows: &[BuildLeaseRow], project_ids: &HashMap<String, String>) -> Self {
+        let mut by_task_run: HashMap<String, ResolvedOwnership> = HashMap::new();
+        for row in rows {
+            let Some(pod_uid) = row.bound_pod_uid.as_deref() else {
+                continue;
+            };
+            if pod_uid.trim().is_empty() {
+                continue;
+            }
+            let Some(task_run_id) = task_run_id_from_immutable_identity(&row.immutable_identity)
+            else {
+                continue;
+            };
+            let state = match row.state {
+                BuildLeaseState::Terminal => RunDirState::Reclaimable,
+                BuildLeaseState::Bound | BuildLeaseState::Active | BuildLeaseState::Suspect => {
+                    RunDirState::ReadyActive
+                }
+                // Queued/Granted/Launching cannot carry a bound pod UID; if the
+                // constraint ever loosened, refuse to claim ownership.
+                BuildLeaseState::Queued | BuildLeaseState::Granted | BuildLeaseState::Launching => {
+                    continue;
+                }
+            };
+            by_task_run.insert(
+                task_run_id.to_owned(),
+                ResolvedOwnership {
+                    pod_uid: pod_uid.to_owned(),
+                    task_run_id: task_run_id.to_owned(),
+                    project_id: project_ids.get(task_run_id).cloned(),
+                    base_fingerprint: None,
+                    state,
+                },
+            );
+        }
+        Self { by_task_run }
+    }
+}
+
+impl RunDirOwnershipResolver for LeaseOwnershipResolver {
+    fn resolve(&self, dir_name: &str) -> Option<ResolvedOwnership> {
+        self.by_task_run.get(dir_name).cloned()
+    }
+}
+
+// ── Startup reconciliation executor ─────────────────────────────────────────
+
+/// Bounded outcome of one startup reconciliation. Every field is a count or a
+/// byte total — no task-run, pod-UID, or project identifier appears here, so the
+/// report is safe to publish as telemetry.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunDirReconcileReport {
+    pub scanned: usize,
+    pub resolved: usize,
+    pub quarantined: usize,
+    pub resolved_bytes: u64,
+    pub quarantined_bytes: u64,
+    /// Bytes held by top-level non-directory debris; unowned, never deleted.
+    pub loose_file_bytes: u64,
+    /// Ledger upserts that failed. Reconciliation is best effort: a failed row
+    /// is retried on the next startup, never worked around by a deletion.
+    pub upsert_errors: usize,
+    /// The volume could not be inventoried at all (missing root, unreadable).
+    pub inventory_failed: bool,
+}
+
+impl RunDirReconcileReport {
+    /// Total bytes on the volume that reconciliation could not attribute to an
+    /// authoritative owner. Enforce activation requires this to be zero.
+    #[must_use]
+    pub fn unowned_bytes(&self) -> u64 {
+        self.quarantined_bytes.saturating_add(self.loose_file_bytes)
+    }
+}
+
+/// Inventory the configured volume, resolve ownership from durable evidence,
+/// and apply the reconciliation plan to the run-dir ledger.
+///
+/// Idempotent and non-destructive: no directory is created, moved, or removed,
+/// and a rerun re-observes the same rows because `upsert_reconciled` never
+/// overwrites an existing `(volume_id, pod_uid)`.
+pub async fn reconcile_run_dirs_at_startup(
+    db: &Database,
+    root: &Path,
+    volume_id: &str,
+    inventory_source: &dyn RunDirInventorySource,
+) -> RunDirReconcileReport {
+    let inventory = match inventory_source.inventory(root) {
+        Ok(inventory) => inventory,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                root = %root.display(),
+                "run_dir_observe: volume inventory unavailable; ledger left unchanged"
+            );
+            return RunDirReconcileReport {
+                inventory_failed: true,
+                ..RunDirReconcileReport::default()
+            };
+        }
+    };
+
+    let resolver = build_lease_resolver(db, &inventory.entries).await;
+    let plan = plan_reconciliation(volume_id, &inventory.entries, &resolver);
+
+    let ledger = RunDirRepository::new(db.clone());
+    let mut upsert_errors = 0_usize;
+    for upsert in &plan.upserts {
+        if let Err(error) = ledger.upsert_reconciled(upsert).await {
+            upsert_errors += 1;
+            tracing::warn!(
+                %error,
+                state = upsert.state.as_str(),
+                "run_dir_observe: reconciled run-dir upsert failed; retried at next startup"
+            );
+        }
+    }
+
+    let report = RunDirReconcileReport {
+        scanned: inventory.entries.len(),
+        resolved: plan.resolved_count,
+        quarantined: plan.quarantined_count,
+        resolved_bytes: plan.resolved_bytes,
+        quarantined_bytes: plan.quarantined_bytes,
+        loose_file_bytes: inventory.loose_file_bytes,
+        upsert_errors,
+        inventory_failed: false,
+    };
+    tracing::info!(
+        root = %root.display(),
+        scanned = report.scanned,
+        resolved = report.resolved,
+        quarantined = report.quarantined,
+        resolved_bytes = report.resolved_bytes,
+        unowned_bytes = report.unowned_bytes(),
+        upsert_errors = report.upsert_errors,
+        "run_dir_observe: startup reconciliation complete (observe-only; nothing deleted)"
+    );
+    report
+}
+
+/// Compose the authoritative resolver from durable lease evidence, enriched with
+/// each resolved run's project ID. A failed read yields an empty resolver, which
+/// quarantines everything — the fail-safe direction.
+async fn build_lease_resolver(
+    db: &Database,
+    entries: &[ReconcileInventoryEntry],
+) -> LeaseOwnershipResolver {
+    let rows = match BuildLeaseRepository::new(db.clone())
+        .list_pod_bound_task_invocations()
+        .await
+    {
+        Ok(rows) => rows,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "run_dir_observe: pod-bound lease evidence unavailable; every dir stays unowned"
+            );
+            return LeaseOwnershipResolver::default();
+        }
+    };
+    let task_runs = djinn_db::TaskRunRepository::new(db.clone());
+    let mut project_ids: HashMap<String, String> = HashMap::new();
+    for entry in entries {
+        if entry.malformed {
+            continue;
+        }
+        if let Ok(Some(record)) = task_runs.get(&entry.dir_name).await {
+            project_ids.insert(entry.dir_name.clone(), record.project_id);
+        }
+    }
+    LeaseOwnershipResolver::from_lease_rows(&rows, &project_ids)
+}
+
+/// Publish the bounded run-dir gauges for one volume.
+///
+/// Labels are the closed [`RunDirState`] family only; the reconciliation report
+/// contributes unowned debris bytes that have no ledger row.
+pub async fn publish_run_dir_telemetry(
+    db: &Database,
+    volume_id: &str,
+    loose_file_bytes: u64,
+) -> Result<(), String> {
+    let totals = RunDirRepository::new(db.clone())
+        .volume_state_totals(volume_id)
+        .await
+        .map_err(|error| error.to_string())?;
+    let mut reserved_total = 0_u64;
+    let mut unowned_total = loose_file_bytes;
+    for state in RunDirState::ALL {
+        let row = totals.iter().find(|row| row.state == state);
+        let count = row.map_or(0, |row| row.count.max(0) as u64);
+        let measured = row.map_or(0, |row| row.measured_bytes.max(0) as u64);
+        reserved_total =
+            reserved_total.saturating_add(row.map_or(0, |row| row.reserved_bytes.max(0) as u64));
+        if state == RunDirState::QuarantinedUnowned {
+            unowned_total = unowned_total.saturating_add(measured);
+        }
+        djinn_telemetry::run_dir::set_state_count(metric_state_label(state), count);
+        djinn_telemetry::run_dir::set_state_allocated_bytes(metric_state_label(state), measured);
+    }
+    djinn_telemetry::run_dir::set_reserved_bytes(reserved_total);
+    djinn_telemetry::run_dir::set_unowned_bytes(unowned_total);
+    Ok(())
+}
+
+/// Map a ledger state onto its bounded telemetry label. The `&'static str`
+/// constants come from `djinn-telemetry`, keeping the label domain closed.
+#[must_use]
+pub fn metric_state_label(state: RunDirState) -> &'static str {
+    use djinn_telemetry::run_dir as m;
+    match state {
+        RunDirState::Absent => m::STATE_ABSENT,
+        RunDirState::Reserved => m::STATE_RESERVED,
+        RunDirState::Seeding => m::STATE_SEEDING,
+        RunDirState::ReadyActive => m::STATE_READY_ACTIVE,
+        RunDirState::ReadyIdle => m::STATE_READY_IDLE,
+        RunDirState::Reclaimable => m::STATE_RECLAIMABLE,
+        RunDirState::Reclaiming => m::STATE_RECLAIMING,
+        RunDirState::QuarantinedUnowned => m::STATE_QUARANTINED_UNOWNED,
+    }
+}
+
+// ── Quota probe ─────────────────────────────────────────────────────────────
+
+/// The startup quota-probe result and what it permits.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QuotaProbeReport {
+    pub support: QuotaSupport,
+    /// True when this volume may never be armed for `enforce`. Observe mode is
+    /// unaffected: an unavailable probe is recorded, not a startup failure.
+    pub enforce_prohibited: bool,
+}
+
+/// Probe the volume for filesystem project-quota support and record the result.
+///
+/// Read-only. Enforce mode is prohibited without working project quotas, but
+/// observe-mode startup MUST NOT fail on an unavailable probe — the whole point
+/// of observe is to run on volumes that cannot yet be enforced.
+pub fn report_quota_probe(root: &Path) -> QuotaProbeReport {
+    record_quota_support(root, probe_project_quota(root))
+}
+
+/// Classify and record an already-obtained quota answer.
+///
+/// Split out from [`report_quota_probe`] so both branches are reachable in a
+/// test: the live probe reads `/proc/mounts`, which a test cannot make report
+/// `prjquota` on demand.
+#[must_use]
+pub fn record_quota_support(root: &Path, support: QuotaSupport) -> QuotaProbeReport {
+    match &support {
+        QuotaSupport::Available => {
+            tracing::info!(
+                root = %root.display(),
+                "run_dir_observe: project quotas available; a future enforce is permitted"
+            );
+            QuotaProbeReport {
+                support,
+                enforce_prohibited: false,
+            }
+        }
+        QuotaSupport::Unavailable { reason } => {
+            djinn_telemetry::run_dir::increment_quota_failure(reason.as_metric());
+            tracing::warn!(
+                root = %root.display(),
+                reason = ?reason,
+                "run_dir_observe: project quotas unavailable; observe continues, enforce prohibited"
+            );
+            QuotaProbeReport {
+                support,
+                enforce_prohibited: true,
+            }
+        }
+    }
+}
+
+/// Bounded log/diagnostic label for a quota outcome.
+#[must_use]
+pub fn quota_metric_label(support: &QuotaSupport) -> &'static str {
+    match support {
+        QuotaSupport::Available => "available",
+        QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoMatchingMount,
+        } => "no_matching_mount",
+        QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoQuotaMountOption,
+        } => "no_quota_mount_option",
+        QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::MountsUnreadable,
+        } => "mounts_unreadable",
+    }
+}
+
+// ── Live capacity adapter ───────────────────────────────────────────────────
+
+/// Monotonic clock seam so sample-staleness is deterministically testable.
+pub trait ObserveClock: Send + Sync {
+    fn now(&self) -> Instant;
+}
+
+/// Production clock, delegating to the shared [`djinn_core::clock::Clock`]
+/// abstraction rather than reading the wall clock directly.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemObserveClock;
+
+impl ObserveClock for SystemObserveClock {
+    fn now(&self) -> Instant {
+        djinn_core::clock::SystemClock::new().now_instant()
+    }
+}
+
+/// Adapts the coordinator's existing [`FilesystemCapacity`] snapshot to the
+/// observe-only [`DiskCapacitySource`] that `build_admission` consults.
+///
+/// The adapter is read-only and never denies. A live probe produces a fresh
+/// sample; a failed probe falls back to the last good snapshot with its true
+/// age (which the evaluator treats as stale once it passes `max_sample_age`);
+/// with no history at all the sample is `Unknown`.
+pub struct CoordinatorDiskCapacitySource {
+    volume_id: String,
+    root: PathBuf,
+    config: DiskAdmissionConfig,
+    capacity: Arc<dyn FilesystemCapacity>,
+    ledger: Arc<RunDirRepository>,
+    clock: Arc<dyn ObserveClock>,
+    /// Conservative per-request seed projection: the largest authoritative run
+    /// dir observed at startup reconciliation, or 0 with no history. The
+    /// evaluator rounds it up by 10% before adding the growth allowance.
+    projected_seed_bytes: u64,
+    last_good: Mutex<Option<(CapacitySnapshot, Instant)>>,
+}
+
+impl CoordinatorDiskCapacitySource {
+    #[must_use]
+    pub fn new(
+        volume_id: String,
+        root: PathBuf,
+        config: DiskAdmissionConfig,
+        capacity: Arc<dyn FilesystemCapacity>,
+        ledger: Arc<RunDirRepository>,
+        clock: Arc<dyn ObserveClock>,
+        projected_seed_bytes: u64,
+    ) -> Self {
+        Self {
+            volume_id,
+            root,
+            config,
+            capacity,
+            ledger,
+            clock,
+            projected_seed_bytes,
+            last_good: Mutex::new(None),
+        }
+    }
+
+    /// The production adapter over `statvfs` and the durable ledger.
+    #[must_use]
+    pub fn production(
+        volume_id: String,
+        root: PathBuf,
+        config: DiskAdmissionConfig,
+        db: &Database,
+        projected_seed_bytes: u64,
+    ) -> Self {
+        Self::new(
+            volume_id,
+            root,
+            config,
+            Arc::new(StatvfsFilesystemCapacity),
+            Arc::new(RunDirRepository::new(db.clone())),
+            Arc::new(SystemObserveClock),
+            projected_seed_bytes,
+        )
+    }
+
+    /// Take (or age) a capacity sample for the volume.
+    pub fn sample(&self) -> CapacitySample {
+        let now = self.clock.now();
+        match self.capacity.capacity(&self.root) {
+            Ok(snapshot) => {
+                if let Ok(mut last) = self.last_good.lock() {
+                    *last = Some((snapshot, now));
+                }
+                CapacitySample {
+                    free_bytes: snapshot.available_bytes,
+                    total_bytes: snapshot.total_bytes,
+                    state: DiskCapacityState::classify(
+                        snapshot.available_bytes,
+                        self.config.critical_free_bytes,
+                        self.config.effective_warning_free_bytes(),
+                    ),
+                    age: Duration::ZERO,
+                }
+            }
+            Err(error) => {
+                let previous = self.last_good.lock().ok().and_then(|last| *last);
+                match previous {
+                    Some((snapshot, at)) => {
+                        tracing::debug!(
+                            %error,
+                            "run_dir_observe: capacity probe failed; ageing the last good sample"
+                        );
+                        CapacitySample {
+                            free_bytes: snapshot.available_bytes,
+                            total_bytes: snapshot.total_bytes,
+                            state: DiskCapacityState::classify(
+                                snapshot.available_bytes,
+                                self.config.critical_free_bytes,
+                                self.config.effective_warning_free_bytes(),
+                            ),
+                            age: now.saturating_duration_since(at),
+                        }
+                    }
+                    None => {
+                        tracing::debug!(
+                            %error,
+                            "run_dir_observe: capacity probe failed with no history; sample unknown"
+                        );
+                        CapacitySample {
+                            free_bytes: 0,
+                            total_bytes: 0,
+                            state: DiskCapacityState::Unknown,
+                            age: Duration::ZERO,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn ledger_totals(&self) -> Option<LedgerTotals> {
+        match self.ledger.volume_state_totals(&self.volume_id).await {
+            Ok(totals) => {
+                let mut tracked_measured_bytes = 0_u64;
+                let mut outstanding_reserved_bytes = 0_u64;
+                for row in totals {
+                    tracked_measured_bytes =
+                        tracked_measured_bytes.saturating_add(row.measured_bytes.max(0) as u64);
+                    outstanding_reserved_bytes =
+                        outstanding_reserved_bytes.saturating_add(row.reserved_bytes.max(0) as u64);
+                }
+                Some(LedgerTotals {
+                    tracked_measured_bytes,
+                    outstanding_reserved_bytes,
+                })
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "run_dir_observe: ledger totals unavailable; skipping this observation"
+                );
+                None
+            }
+        }
+    }
+}
+
+/// Whether a workload actually runs the project's compile/test toolchain.
+///
+/// Light and explicitly non-build workloads never consult disk admission and
+/// never seed. `build_admission` already routes them through
+/// `permit_without_reservation`, which does not observe; this is the second,
+/// independent guard so a future routing change cannot silently start charging
+/// orchestration-only work against a disk budget.
+#[must_use]
+pub fn workload_consults_disk(kind: BuildWorkloadKind) -> bool {
+    match kind {
+        BuildWorkloadKind::GraphWarmJob => true,
+        BuildWorkloadKind::TaskRun { role } => {
+            role.resource_class() != djinn_runtime::RoleResourceClass::Light
+        }
+        BuildWorkloadKind::NonBuild { .. } => false,
+    }
+}
+
+/// Light roles, restated for the guard test so a role reclassification cannot
+/// silently change what consults disk.
+#[must_use]
+pub fn is_light_role(role: TaskRunRole) -> bool {
+    role.resource_class() == djinn_runtime::RoleResourceClass::Light
+}
+
+#[async_trait]
+impl DiskCapacitySource for CoordinatorDiskCapacitySource {
+    async fn observe(
+        &self,
+        request: &crate::build_admission::BuildAdmissionRequest,
+    ) -> Option<DiskObservation> {
+        if !workload_consults_disk(request.kind) {
+            return None;
+        }
+        let ledger = self.ledger_totals().await?;
+        let sample = self.sample();
+        // Phase 1 has no run-dir lease binding yet, so no request can claim a
+        // zero-growth reuse of an already-ready directory. `false` is the
+        // conservative reading: every observation is priced as a new
+        // reservation.
+        let disk_request = DiskAdmissionRequest {
+            projected_seed_bytes: self.projected_seed_bytes,
+            reuses_ready_dir: false,
+        };
+        Some(evaluate_disk_admission_observe(
+            &self.config,
+            &sample,
+            &ledger,
+            &disk_request,
+        ))
+    }
+}
+
+// ── Composition ─────────────────────────────────────────────────────────────
+
+/// Everything one coordinator startup needs to arm the observe-only disk
+/// dimension. The seams exist so the production composition below can be driven
+/// deterministically in tests without a second implementation.
+pub struct RunDirObserveSeams {
+    pub root: PathBuf,
+    pub volume_id: String,
+    pub config: DiskAdmissionConfig,
+    pub inventory: Arc<dyn RunDirInventorySource>,
+    pub capacity: Arc<dyn FilesystemCapacity>,
+    pub clock: Arc<dyn ObserveClock>,
+}
+
+impl RunDirObserveSeams {
+    /// The production composition: the server pod's mount of the shared cache
+    /// PVC, a real `st_blocks` inventory, and a real `statvfs` capacity probe.
+    #[must_use]
+    pub fn production() -> Self {
+        Self {
+            root: djinn_core::paths::cargo_target_runs_root(),
+            volume_id: volume_id_from_env(),
+            config: DiskAdmissionConfig::from_env(),
+            inventory: Arc::new(FilesystemRunDirInventory),
+            capacity: Arc::new(StatvfsFilesystemCapacity),
+            clock: Arc::new(SystemObserveClock),
+        }
+    }
+}
+
+/// Bounded outcome of arming the observe-only disk dimension.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RunDirObserveReport {
+    pub reconcile: RunDirReconcileReport,
+    pub quota: QuotaProbeReport,
+    /// The conservative per-request seed projection installed on the capacity
+    /// source (bytes, pre-rounding).
+    pub projected_seed_bytes: u64,
+}
+
+/// Run startup reconciliation, probe quotas, publish bounded telemetry, and
+/// install the capacity source on the supplied controller.
+///
+/// This is the whole observe-mode activation. It performs no filesystem
+/// mutation and cannot change an admission outcome: installing a source only
+/// adds telemetry to the already-granted path.
+pub async fn arm_disk_observation(
+    db: &Database,
+    controller: &BuildAdmissionController,
+    seams: RunDirObserveSeams,
+) -> RunDirObserveReport {
+    let reconcile =
+        reconcile_run_dirs_at_startup(db, &seams.root, &seams.volume_id, seams.inventory.as_ref())
+            .await;
+    let quota = report_quota_probe(&seams.root);
+
+    if let Err(error) =
+        publish_run_dir_telemetry(db, &seams.volume_id, reconcile.loose_file_bytes).await
+    {
+        tracing::warn!(%error, "run_dir_observe: run-dir telemetry publish failed");
+    }
+
+    // Conservative seed projection: the largest authoritative run dir seen this
+    // startup. With no authoritative history the projection is zero and the
+    // reservation is the growth allowance alone.
+    let projected_seed_bytes = largest_authoritative_run_dir_bytes(db, &seams.volume_id).await;
+
+    let source = CoordinatorDiskCapacitySource::new(
+        seams.volume_id.clone(),
+        seams.root.clone(),
+        seams.config,
+        Arc::clone(&seams.capacity),
+        Arc::new(RunDirRepository::new(db.clone())),
+        Arc::clone(&seams.clock),
+        projected_seed_bytes,
+    );
+    controller.set_disk_capacity_source(Arc::new(source));
+
+    tracing::info!(
+        volume_id = %seams.volume_id,
+        root = %seams.root.display(),
+        resolved = reconcile.resolved,
+        quarantined = reconcile.quarantined,
+        unowned_bytes = reconcile.unowned_bytes(),
+        quota = quota_metric_label(&quota.support),
+        enforce_prohibited = quota.enforce_prohibited,
+        projected_seed_bytes,
+        "run_dir_observe: disk observation armed (observe-only; grants unaffected)"
+    );
+
+    RunDirObserveReport {
+        reconcile,
+        quota,
+        projected_seed_bytes,
+    }
+}
+
+/// The largest measured bytes among authoritative ready rows on a volume.
+async fn largest_authoritative_run_dir_bytes(db: &Database, volume_id: &str) -> u64 {
+    match RunDirRepository::new(db.clone())
+        .list_by_volume(volume_id)
+        .await
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .filter(|row| {
+                matches!(
+                    row.state,
+                    RunDirState::ReadyActive | RunDirState::ReadyIdle | RunDirState::Reclaimable
+                )
+            })
+            .map(|row| row.measured_bytes.max(0) as u64)
+            .max()
+            .unwrap_or(0),
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "run_dir_observe: seed projection unavailable; defaulting to growth allowance only"
+            );
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "run_dir_observe_tests.rs"]
+mod tests;

--- a/server/crates/djinn-coordinator/src/run_dir_observe_tests.rs
+++ b/server/crates/djinn-coordinator/src/run_dir_observe_tests.rs
@@ -1,0 +1,754 @@
+//! Tests for the observe-mode disk wiring.
+//!
+//! These drive the SAME functions the coordinator's startup path composes
+//! ([`arm_disk_observation`] and [`reconcile_run_dirs_at_startup`]) against a
+//! real temporary volume, a real ephemeral Postgres, and a real
+//! [`BuildAdmissionController`]. Only the capacity probe and the clock are
+//! substituted, because a test cannot make a real filesystem report critical
+//! pressure or age a monotonic instant.
+
+use std::collections::HashMap;
+use std::os::unix::fs::symlink;
+use std::sync::Arc;
+
+use djinn_db::{
+    AdmissionJournalRepository, BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository,
+    BuildLeaseState, Database, GrantNextBuildLeaseResult, QueueBuildLeaseInput,
+    QueueBuildLeaseResult, RunDirRepository, RunDirState,
+};
+
+use super::*;
+use crate::build_admission::{
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, BuildAdmissionRequest,
+    BuildWorkloadKind, LIGHT_ROLE_AUDIT_REASON, TaskRunRole,
+};
+
+const GIB: u64 = 1024 * 1024 * 1024;
+const VOLUME: &str = "test-volume";
+
+const LIVE_RUN: &str = "11111111-1111-1111-1111-111111111111";
+const UNRESOLVED_RUN: &str = "33333333-3333-3333-3333-333333333333";
+const MALFORMED_DIR: &str = "not-a-uuid";
+
+// ── Fakes for the two seams a test cannot drive for real ────────────────────
+
+struct FixedCapacity(Result<CapacitySnapshot, String>);
+
+impl FilesystemCapacity for FixedCapacity {
+    fn capacity(&self, _path: &Path) -> Result<CapacitySnapshot, String> {
+        self.0.clone()
+    }
+}
+
+/// A clock that reports a fixed offset past its construction instant, so a
+/// fallback sample can be aged deterministically.
+struct OffsetClock {
+    base: Instant,
+    offset: Duration,
+}
+
+impl ObserveClock for OffsetClock {
+    fn now(&self) -> Instant {
+        self.base + self.offset
+    }
+}
+
+fn config() -> DiskAdmissionConfig {
+    DiskAdmissionConfig {
+        cache_budget_bytes: 100 * GIB,
+        critical_free_bytes: 20 * GIB,
+        warning_free_bytes: 40 * GIB,
+        emergency_headroom_bytes: 10 * GIB,
+        per_lease_growth_bytes: 4 * GIB,
+        max_sample_age: Duration::from_secs(90),
+    }
+}
+
+/// One volume with an authoritative run dir, an unresolved run dir, a malformed
+/// directory name, a symlink, and top-level debris.
+fn fixture_volume() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    for name in [LIVE_RUN, UNRESOLVED_RUN, MALFORMED_DIR] {
+        std::fs::create_dir(root.join(name)).unwrap();
+        std::fs::write(root.join(name).join("payload"), vec![7_u8; 4096]).unwrap();
+    }
+    symlink(root.join(LIVE_RUN), root.join("dangling-link")).unwrap();
+    std::fs::write(root.join("debris.log"), vec![1_u8; 2048]).unwrap();
+    dir
+}
+
+fn controller(db: &Database) -> BuildAdmissionController {
+    BuildAdmissionController::new(
+        Arc::new(AdmissionJournalRepository::new(db.clone())),
+        BuildAdmissionMode::Observe,
+        4,
+        "epoch",
+    )
+}
+
+fn worker_request(id: &str) -> BuildAdmissionRequest {
+    BuildAdmissionRequest {
+        domain: djinn_db::AdmissionDomain::TaskObservation,
+        work_id: id.to_owned(),
+        generation: 0,
+        object_name: format!("job-{id}"),
+        kind: BuildWorkloadKind::TaskRun {
+            role: TaskRunRole::Worker,
+        },
+    }
+}
+
+/// Drive a task-invocation lease all the way to pod-bound through the real
+/// repository API, so the resolver reads exactly what the production `bind`
+/// path writes.
+async fn bind_lease(db: &Database, task_run_id: &str, pod_uid: &str) -> BuildLeaseKey {
+    let repo = BuildLeaseRepository::new(db.clone());
+    let key = BuildLeaseKey {
+        consumer_kind: BuildLeaseConsumerKind::TaskInvocation,
+        consumer_id: format!("inv-{task_run_id}"),
+    };
+    let queued = repo
+        .queue(&QueueBuildLeaseInput {
+            key: key.clone(),
+            immutable_identity: format!("task:task-1:{task_run_id}:inv-{task_run_id}"),
+            queue_deadline: None,
+            launch_deadline: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(queued, QueueBuildLeaseResult::Queued { .. }));
+    let granted = repo
+        .grant_next(4, "2026-07-25T00:00:00Z", None)
+        .await
+        .unwrap();
+    let GrantNextBuildLeaseResult::Granted(row) = granted else {
+        panic!("the queued lease must be grantable");
+    };
+    let token = row.fencing_token.unwrap();
+    let bound = repo.bind(&key, token, pod_uid, None).await.unwrap();
+    assert_eq!(bound.state, BuildLeaseState::Bound);
+    assert_eq!(bound.bound_pod_uid.as_deref(), Some(pod_uid));
+    key
+}
+
+// ── Inventory ───────────────────────────────────────────────────────────────
+
+#[test]
+fn inventory_classifies_run_dirs_symlinks_and_malformed_names() {
+    let volume = fixture_volume();
+    let inventory = FilesystemRunDirInventory
+        .inventory(volume.path())
+        .expect("a readable volume inventories");
+
+    let by_name: HashMap<&str, &ReconcileInventoryEntry> = inventory
+        .entries
+        .iter()
+        .map(|entry| (entry.dir_name.as_str(), entry))
+        .collect();
+
+    assert!(
+        !by_name[LIVE_RUN].malformed,
+        "a UUID run dir is well formed"
+    );
+    assert!(by_name[LIVE_RUN].measured_bytes > 0, "bytes are measured");
+    assert!(
+        by_name[MALFORMED_DIR].malformed,
+        "a non-UUID directory name is malformed"
+    );
+    assert!(
+        by_name["dangling-link"].malformed,
+        "a top-level symlink is never a run dir"
+    );
+    assert!(
+        inventory.loose_file_bytes > 0,
+        "top-level debris is accounted as unowned bytes, not dropped"
+    );
+}
+
+#[test]
+fn inventory_of_a_missing_root_is_an_error_not_an_empty_volume() {
+    let missing = tempfile::tempdir().unwrap();
+    let root = missing.path().join("never-created");
+    assert!(FilesystemRunDirInventory.inventory(&root).is_err());
+}
+
+// ── Ownership resolution ────────────────────────────────────────────────────
+
+#[test]
+fn immutable_identity_parsing_extracts_only_the_task_run_id() {
+    assert_eq!(
+        task_run_id_from_immutable_identity("task:t-1:run-9:inv-3"),
+        Some("run-9")
+    );
+    assert_eq!(task_run_id_from_immutable_identity("warm:p:w:g"), None);
+    assert_eq!(task_run_id_from_immutable_identity("task:t-1"), None);
+    assert_eq!(task_run_id_from_immutable_identity("task:t-1::inv"), None);
+}
+
+// ── Startup reconciliation against the production path ──────────────────────
+
+#[tokio::test]
+async fn startup_reconciliation_resolves_authoritative_quarantines_the_rest_and_deletes_nothing() {
+    let db = Database::open_in_memory().unwrap();
+    let volume = fixture_volume();
+    bind_lease(&db, LIVE_RUN, "pod-live-uid").await;
+
+    let report = reconcile_run_dirs_at_startup(
+        &db,
+        volume.path(),
+        VOLUME,
+        &FilesystemRunDirInventory as &dyn RunDirInventorySource,
+    )
+    .await;
+
+    assert!(!report.inventory_failed);
+    assert_eq!(report.upsert_errors, 0);
+    assert_eq!(report.resolved, 1, "only the bound lease resolves");
+    assert_eq!(
+        report.quarantined, 3,
+        "unresolved UUID, malformed name, and symlink all quarantine"
+    );
+    assert!(report.resolved_bytes > 0);
+    assert!(report.unowned_bytes() > 0);
+
+    let ledger = RunDirRepository::new(db.clone());
+    // The authoritative row is keyed by the POD UID from the durable lease, not
+    // by the untrusted directory name.
+    let live = ledger
+        .get(&djinn_db::RunDirKey {
+            volume_id: VOLUME.into(),
+            pod_uid: "pod-live-uid".into(),
+        })
+        .await
+        .unwrap()
+        .expect("the authoritative run dir is reconciled");
+    assert_eq!(live.state, RunDirState::ReadyActive);
+    assert_eq!(live.task_run_id.as_deref(), Some(LIVE_RUN));
+    assert_eq!(live.reserved_bytes, 0, "observe reserves no bytes");
+    assert!(live.quota_id.is_none(), "observe assigns no quota");
+    assert!(
+        live.temp_path.is_none(),
+        "observe creates no temp directory"
+    );
+
+    for unowned in [UNRESOLVED_RUN, MALFORMED_DIR, "dangling-link"] {
+        let row = ledger
+            .get(&djinn_db::RunDirKey {
+                volume_id: VOLUME.into(),
+                pod_uid: unowned.into(),
+            })
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{unowned} must be recorded"));
+        assert_eq!(row.state, RunDirState::QuarantinedUnowned);
+        assert_eq!(row.task_run_id, None, "no untrusted task-run binding");
+        assert_eq!(row.reserved_bytes, 0);
+    }
+
+    // Nothing on the volume was touched: every directory, the symlink, and the
+    // debris file all survive reconciliation.
+    for name in [
+        LIVE_RUN,
+        UNRESOLVED_RUN,
+        MALFORMED_DIR,
+        "dangling-link",
+        "debris.log",
+    ] {
+        assert!(
+            std::fs::symlink_metadata(volume.path().join(name)).is_ok(),
+            "{name} must be left untouched on disk"
+        );
+    }
+}
+
+#[tokio::test]
+async fn startup_reconciliation_is_idempotent_across_reruns() {
+    let db = Database::open_in_memory().unwrap();
+    let volume = fixture_volume();
+    bind_lease(&db, LIVE_RUN, "pod-live-uid").await;
+
+    let first = reconcile_run_dirs_at_startup(
+        &db,
+        volume.path(),
+        VOLUME,
+        &FilesystemRunDirInventory as &dyn RunDirInventorySource,
+    )
+    .await;
+    // Growing the directory between runs must not rewrite the committed row.
+    std::fs::write(
+        volume.path().join(LIVE_RUN).join("more"),
+        vec![3_u8; 65_536],
+    )
+    .unwrap();
+    let second = reconcile_run_dirs_at_startup(
+        &db,
+        volume.path(),
+        VOLUME,
+        &FilesystemRunDirInventory as &dyn RunDirInventorySource,
+    )
+    .await;
+
+    assert_eq!(first.resolved, second.resolved);
+    assert_eq!(first.quarantined, second.quarantined);
+    assert_eq!(second.upsert_errors, 0);
+    let rows = RunDirRepository::new(db.clone())
+        .list_by_volume(VOLUME)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 4, "a rerun adds no duplicate rows");
+    let live = rows
+        .iter()
+        .find(|row| row.key.pod_uid == "pod-live-uid")
+        .unwrap();
+    assert_eq!(
+        live.measured_bytes as u64, first.resolved_bytes,
+        "the committed row is preserved, not overwritten"
+    );
+}
+
+#[tokio::test]
+async fn a_terminal_lease_reconciles_as_reclaimable_never_deleted() {
+    let db = Database::open_in_memory().unwrap();
+    let volume = fixture_volume();
+    let key = bind_lease(&db, LIVE_RUN, "pod-terminal-uid").await;
+    let repo = BuildLeaseRepository::new(db.clone());
+    let row = repo.get(&key).await.unwrap().unwrap();
+    repo.release(&key, row.fencing_token.unwrap(), None)
+        .await
+        .unwrap();
+
+    reconcile_run_dirs_at_startup(
+        &db,
+        volume.path(),
+        VOLUME,
+        &FilesystemRunDirInventory as &dyn RunDirInventorySource,
+    )
+    .await;
+
+    let reclaimable = RunDirRepository::new(db.clone())
+        .get(&djinn_db::RunDirKey {
+            volume_id: VOLUME.into(),
+            pod_uid: "pod-terminal-uid".into(),
+        })
+        .await
+        .unwrap()
+        .expect("terminal pod proof reconciles");
+    assert_eq!(reclaimable.state, RunDirState::Reclaimable);
+    assert!(
+        volume.path().join(LIVE_RUN).exists(),
+        "reclaimable is a ledger state, not a deletion"
+    );
+}
+
+#[tokio::test]
+async fn an_unreadable_volume_leaves_the_ledger_untouched() {
+    let db = Database::open_in_memory().unwrap();
+    let root = std::path::Path::new("/nonexistent/djinn/run-dirs");
+    let report = reconcile_run_dirs_at_startup(
+        &db,
+        root,
+        VOLUME,
+        &FilesystemRunDirInventory as &dyn RunDirInventorySource,
+    )
+    .await;
+    assert!(report.inventory_failed);
+    assert_eq!(report.scanned, 0);
+    assert!(
+        RunDirRepository::new(db)
+            .list_by_volume(VOLUME)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+// ── Capacity sampling ───────────────────────────────────────────────────────
+
+fn source_with(
+    db: &Database,
+    capacity: Result<CapacitySnapshot, String>,
+    offset: Duration,
+) -> CoordinatorDiskCapacitySource {
+    CoordinatorDiskCapacitySource::new(
+        VOLUME.to_owned(),
+        std::path::PathBuf::from("/cache/cargo-target-runs"),
+        config(),
+        Arc::new(FixedCapacity(capacity)),
+        Arc::new(RunDirRepository::new(db.clone())),
+        Arc::new(OffsetClock {
+            base: Instant::now(),
+            offset,
+        }),
+        8 * GIB,
+    )
+}
+
+fn snapshot(available: u64) -> CapacitySnapshot {
+    CapacitySnapshot {
+        total_bytes: 500 * GIB,
+        available_bytes: available,
+    }
+}
+
+#[tokio::test]
+async fn live_samples_classify_healthy_warning_and_critical() {
+    let db = Database::open_in_memory().unwrap();
+    for (available, expected) in [
+        (400 * GIB, DiskCapacityState::Healthy),
+        (30 * GIB, DiskCapacityState::Warning),
+        (5 * GIB, DiskCapacityState::Critical),
+    ] {
+        let sample = source_with(&db, Ok(snapshot(available)), Duration::ZERO).sample();
+        assert_eq!(sample.state, expected, "available={available}");
+        assert_eq!(sample.age, Duration::ZERO, "a live probe is fresh");
+    }
+}
+
+#[tokio::test]
+async fn a_failed_probe_with_no_history_is_unknown_and_would_defer() {
+    let db = Database::open_in_memory().unwrap();
+    let source = source_with(&db, Err("statvfs failed".into()), Duration::ZERO);
+    let sample = source.sample();
+    assert_eq!(sample.state, DiskCapacityState::Unknown);
+
+    let observation = source
+        .observe(&worker_request("unknown-sample"))
+        .await
+        .expect("a build workload always yields an observation");
+    assert_eq!(
+        observation.would_defer,
+        Some(crate::disk_admission::DiskQueueReason::DiskCapacityUnknown)
+    );
+}
+
+#[tokio::test]
+async fn a_stale_fallback_sample_ages_past_the_freshness_bound() {
+    let db = Database::open_in_memory().unwrap();
+    // Alternate a good probe then a failing one: the source keeps the good
+    // snapshot and reports its true age.
+    struct FlakyCapacity {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+    impl FilesystemCapacity for FlakyCapacity {
+        fn capacity(&self, _path: &Path) -> Result<CapacitySnapshot, String> {
+            if self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                Ok(CapacitySnapshot {
+                    total_bytes: 500 * GIB,
+                    available_bytes: 400 * GIB,
+                })
+            } else {
+                Err("statvfs failed".into())
+            }
+        }
+    }
+    struct SteppingClock {
+        base: Instant,
+        step: std::sync::atomic::AtomicUsize,
+    }
+    impl ObserveClock for SteppingClock {
+        fn now(&self) -> Instant {
+            let step = self.step.fetch_add(1, std::sync::atomic::Ordering::SeqCst) as u64;
+            self.base + Duration::from_secs(step * 200)
+        }
+    }
+
+    let source = CoordinatorDiskCapacitySource::new(
+        VOLUME.to_owned(),
+        std::path::PathBuf::from("/cache/cargo-target-runs"),
+        config(),
+        Arc::new(FlakyCapacity {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        }),
+        Arc::new(RunDirRepository::new(db.clone())),
+        Arc::new(SteppingClock {
+            base: Instant::now(),
+            step: std::sync::atomic::AtomicUsize::new(0),
+        }),
+        8 * GIB,
+    );
+
+    let fresh = source.sample();
+    assert_eq!(fresh.state, DiskCapacityState::Healthy);
+    assert_eq!(fresh.age, Duration::ZERO);
+
+    let stale = source.sample();
+    assert_eq!(
+        stale.state,
+        DiskCapacityState::Healthy,
+        "the retained snapshot keeps its classification"
+    );
+    assert!(
+        stale.age > config().max_sample_age,
+        "the retained snapshot is aged past the freshness bound"
+    );
+
+    // A stale sample that would reserve new bytes is a typed unknown-capacity
+    // defer, not an optimistic grant.
+    let observation = source
+        .observe(&worker_request("stale-sample"))
+        .await
+        .unwrap();
+    assert_eq!(
+        observation.would_defer,
+        Some(crate::disk_admission::DiskQueueReason::DiskCapacityUnknown)
+    );
+}
+
+#[tokio::test]
+async fn critical_pressure_would_defer_with_the_disk_pressure_reason() {
+    let db = Database::open_in_memory().unwrap();
+    let source = source_with(&db, Ok(snapshot(5 * GIB)), Duration::ZERO);
+    let observation = source.observe(&worker_request("critical")).await.unwrap();
+    assert_eq!(
+        observation.would_defer,
+        Some(crate::disk_admission::DiskQueueReason::DiskPressure)
+    );
+    assert!(observation.projected_reservation_bytes > 0);
+}
+
+#[tokio::test]
+async fn a_healthy_sample_within_budget_would_not_defer() {
+    let db = Database::open_in_memory().unwrap();
+    let source = source_with(&db, Ok(snapshot(400 * GIB)), Duration::ZERO);
+    let observation = source.observe(&worker_request("healthy")).await.unwrap();
+    assert_eq!(observation.would_defer, None);
+}
+
+#[tokio::test]
+async fn light_and_non_build_workloads_never_consult_disk() {
+    let db = Database::open_in_memory().unwrap();
+    let source = source_with(&db, Ok(snapshot(5 * GIB)), Duration::ZERO);
+    for role in [
+        TaskRunRole::Planner,
+        TaskRunRole::Reviewer,
+        TaskRunRole::Lead,
+        TaskRunRole::Advocate,
+        TaskRunRole::Adversary,
+        TaskRunRole::Judge,
+    ] {
+        assert!(is_light_role(role), "{role:?} must classify as light");
+        let mut request = worker_request("light");
+        request.kind = BuildWorkloadKind::TaskRun { role };
+        assert!(
+            source.observe(&request).await.is_none(),
+            "{role:?} must never consult disk admission"
+        );
+    }
+    let mut non_build = worker_request("non-build");
+    non_build.kind = BuildWorkloadKind::NonBuild {
+        audit_reason: LIGHT_ROLE_AUDIT_REASON,
+    };
+    assert!(source.observe(&non_build).await.is_none());
+}
+
+// ── Quota probe ─────────────────────────────────────────────────────────────
+
+#[test]
+fn an_available_quota_permits_a_future_enforce() {
+    // The production probe reads /proc/mounts, which a test cannot make
+    // advertise `prjquota`; drive the exact answer the parser would return.
+    let mounts = "/dev/sdb1 /cache xfs rw,relatime,prjquota 0 0\n";
+    let support = crate::disk_admission::parse_project_quota_support(
+        mounts,
+        Path::new("/cache/cargo-target-runs"),
+    );
+    assert_eq!(support, QuotaSupport::Available);
+    let report = record_quota_support(Path::new("/cache/cargo-target-runs"), support);
+    assert!(
+        !report.enforce_prohibited,
+        "a working project quota is the prerequisite enforce needs"
+    );
+}
+
+#[test]
+fn a_quota_answer_of_unavailable_prohibits_enforce() {
+    let report = record_quota_support(
+        Path::new("/cache/cargo-target-runs"),
+        QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoQuotaMountOption,
+        },
+    );
+    assert!(report.enforce_prohibited);
+}
+
+#[test]
+fn an_unavailable_quota_probe_prohibits_enforce_without_failing_observe() {
+    // A tmpfs/ext4 test volume carries no project-quota mount option, which is
+    // exactly the production condition today.
+    let volume = tempfile::tempdir().unwrap();
+    let report = report_quota_probe(volume.path());
+    match report.support {
+        QuotaSupport::Available => assert!(!report.enforce_prohibited),
+        QuotaSupport::Unavailable { .. } => assert!(
+            report.enforce_prohibited,
+            "an unavailable probe must prohibit a future enforce"
+        ),
+    }
+}
+
+// ── Full production composition ─────────────────────────────────────────────
+
+fn seams_for(
+    volume: &tempfile::TempDir,
+    capacity: Result<CapacitySnapshot, String>,
+) -> RunDirObserveSeams {
+    RunDirObserveSeams {
+        root: volume.path().to_path_buf(),
+        volume_id: VOLUME.to_owned(),
+        config: config(),
+        inventory: Arc::new(FilesystemRunDirInventory),
+        capacity: Arc::new(FixedCapacity(capacity)),
+        clock: Arc::new(SystemObserveClock),
+    }
+}
+
+#[tokio::test]
+async fn arming_observation_records_pressure_without_changing_any_grant() {
+    let db = Database::open_in_memory().unwrap();
+    let volume = fixture_volume();
+    bind_lease(&db, LIVE_RUN, "pod-live-uid").await;
+    let controller = controller(&db);
+
+    // Baseline: the same request is permitted with the disk dimension dark.
+    let before = controller.admit(worker_request("grant-a")).await.unwrap();
+    assert!(matches!(before, BuildAdmissionDecision::Permitted { .. }));
+    assert_eq!(controller.disk_would_defer_observation_count().await, 0);
+
+    let report =
+        arm_disk_observation(&db, &controller, seams_for(&volume, Ok(snapshot(GIB)))).await;
+    assert_eq!(report.reconcile.resolved, 1);
+    assert!(
+        report.projected_seed_bytes > 0,
+        "history feeds the projection"
+    );
+
+    // Armed, under critical pressure: the grant is IDENTICAL and only the
+    // observe counter advances.
+    let after = controller.admit(worker_request("grant-b")).await.unwrap();
+    assert!(
+        matches!(after, BuildAdmissionDecision::Permitted { .. }),
+        "disk observation must never change a grant outcome"
+    );
+    assert_eq!(
+        controller.disk_would_defer_observation_count().await,
+        1,
+        "critical pressure is recorded as a would-defer"
+    );
+
+    // And no reservation, quota, temp dir, or deletion resulted.
+    for row in RunDirRepository::new(db.clone())
+        .list_by_volume(VOLUME)
+        .await
+        .unwrap()
+    {
+        assert_eq!(row.reserved_bytes, 0);
+        assert!(row.quota_id.is_none());
+        assert!(row.temp_path.is_none());
+    }
+    assert!(volume.path().join(LIVE_RUN).exists());
+    assert!(volume.path().join(UNRESOLVED_RUN).exists());
+    assert!(volume.path().join(MALFORMED_DIR).exists());
+}
+
+#[tokio::test]
+async fn arming_observation_on_a_healthy_volume_records_nothing() {
+    let db = Database::open_in_memory().unwrap();
+    let volume = fixture_volume();
+    let controller = controller(&db);
+    arm_disk_observation(
+        &db,
+        &controller,
+        seams_for(&volume, Ok(snapshot(400 * GIB))),
+    )
+    .await;
+    let decision = controller.admit(worker_request("healthy")).await.unwrap();
+    assert!(matches!(decision, BuildAdmissionDecision::Permitted { .. }));
+    assert_eq!(controller.disk_would_defer_observation_count().await, 0);
+}
+
+#[tokio::test]
+async fn arming_observation_survives_a_missing_volume() {
+    let db = Database::open_in_memory().unwrap();
+    let controller = controller(&db);
+    let seams = RunDirObserveSeams {
+        root: std::path::PathBuf::from("/nonexistent/djinn/run-dirs"),
+        volume_id: VOLUME.to_owned(),
+        config: config(),
+        inventory: Arc::new(FilesystemRunDirInventory),
+        capacity: Arc::new(FixedCapacity(Err("no such volume".into()))),
+        clock: Arc::new(SystemObserveClock),
+    };
+    let report = arm_disk_observation(&db, &controller, seams).await;
+    assert!(report.reconcile.inventory_failed);
+    // Observe-mode startup is not a boot hazard: admission still works.
+    let decision = controller.admit(worker_request("missing")).await.unwrap();
+    assert!(matches!(decision, BuildAdmissionDecision::Permitted { .. }));
+}
+
+// ── Bounded telemetry ───────────────────────────────────────────────────────
+
+#[test]
+fn state_labels_are_the_closed_telemetry_family() {
+    let labels: Vec<&'static str> = RunDirState::ALL
+        .iter()
+        .copied()
+        .map(metric_state_label)
+        .collect();
+    assert_eq!(labels.len(), 8);
+    for (state, label) in RunDirState::ALL.iter().zip(labels.iter()) {
+        assert_eq!(*label, state.as_str(), "label must match the ledger state");
+        assert!(
+            !label.contains('-') && label.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+            "bounded label `{label}` must be a plain snake_case constant"
+        );
+    }
+    // No identifier ever becomes a label value.
+    assert!(!labels.contains(&LIVE_RUN));
+}
+
+#[test]
+fn quota_labels_are_bounded() {
+    for label in [
+        quota_metric_label(&QuotaSupport::Available),
+        quota_metric_label(&QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoMatchingMount,
+        }),
+        quota_metric_label(&QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::NoQuotaMountOption,
+        }),
+        quota_metric_label(&QuotaSupport::Unavailable {
+            reason: QuotaUnavailableReason::MountsUnreadable,
+        }),
+    ] {
+        assert!(label.chars().all(|c| c.is_ascii_lowercase() || c == '_'));
+    }
+    assert_eq!(
+        QuotaUnavailableReason::NoQuotaMountOption.as_metric(),
+        "probe_unavailable",
+        "every unavailable reason collapses to one bounded metric label"
+    );
+}
+
+#[tokio::test]
+async fn telemetry_publish_reads_only_bounded_ledger_totals() {
+    let db = Database::open_in_memory().unwrap();
+    let volume = fixture_volume();
+    bind_lease(&db, LIVE_RUN, "pod-live-uid").await;
+    let report = reconcile_run_dirs_at_startup(
+        &db,
+        volume.path(),
+        VOLUME,
+        &FilesystemRunDirInventory as &dyn RunDirInventorySource,
+    )
+    .await;
+    publish_run_dir_telemetry(&db, VOLUME, report.loose_file_bytes)
+        .await
+        .expect("bounded telemetry publishes from ledger totals");
+}
+
+#[test]
+fn volume_id_defaults_to_the_single_configured_volume() {
+    // The default must be stable: it is the bounded `volume` dimension value.
+    assert_eq!(DEFAULT_VOLUME_ID, "cargo-target-runs");
+}

--- a/server/crates/djinn-coordinator/src/run_dir_reconcile.rs
+++ b/server/crates/djinn-coordinator/src/run_dir_reconcile.rs
@@ -29,12 +29,19 @@ pub struct ReconcileInventoryEntry {
 }
 
 /// Authoritative ownership resolved from pod/terminal evidence.
+///
+/// `pod_uid` and `task_run_id` are required — they ARE the authoritative
+/// binding. `project_id` and `base_fingerprint` are optional because a startup
+/// reconciler observes a directory that was published by a previous process and
+/// may hold no durable record of which base it was seeded from; recording
+/// `None` is honest, whereas inventing a fingerprint would corrupt the seed
+/// projection that reads it back.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedOwnership {
     pub pod_uid: String,
     pub task_run_id: String,
-    pub project_id: String,
-    pub base_fingerprint: String,
+    pub project_id: Option<String>,
+    pub base_fingerprint: Option<String>,
     pub state: RunDirState,
 }
 
@@ -108,8 +115,8 @@ pub fn plan_reconciliation(
                         pod_uid: owned.pod_uid,
                     },
                     task_run_id: Some(owned.task_run_id),
-                    project_id: Some(owned.project_id),
-                    base_fingerprint: Some(owned.base_fingerprint),
+                    project_id: owned.project_id,
+                    base_fingerprint: owned.base_fingerprint,
                     state: owned.state,
                     measured_bytes: entry.measured_bytes as i64,
                     final_path: Some(entry.final_path.clone()),

--- a/server/crates/djinn-coordinator/src/run_dir_reconcile_tests.rs
+++ b/server/crates/djinn-coordinator/src/run_dir_reconcile_tests.rs
@@ -44,8 +44,8 @@ fn fixture_resolver() -> MapResolver {
         ResolvedOwnership {
             pod_uid: "pod-live".to_owned(),
             task_run_id: "run-live".to_owned(),
-            project_id: "proj-1".to_owned(),
-            base_fingerprint: "fp-1".to_owned(),
+            project_id: Some("proj-1".to_owned()),
+            base_fingerprint: Some("fp-1".to_owned()),
             state: RunDirState::ReadyActive,
         },
     );
@@ -54,8 +54,8 @@ fn fixture_resolver() -> MapResolver {
         ResolvedOwnership {
             pod_uid: "pod-terminal".to_owned(),
             task_run_id: "run-terminal".to_owned(),
-            project_id: "proj-1".to_owned(),
-            base_fingerprint: "fp-1".to_owned(),
+            project_id: Some("proj-1".to_owned()),
+            base_fingerprint: Some("fp-1".to_owned()),
             state: RunDirState::Reclaimable,
         },
     );
@@ -123,8 +123,8 @@ fn malformed_entry_is_quarantined_even_if_resolvable() {
         ResolvedOwnership {
             pod_uid: "pod-x".to_owned(),
             task_run_id: "run-x".to_owned(),
-            project_id: "proj-1".to_owned(),
-            base_fingerprint: "fp-1".to_owned(),
+            project_id: Some("proj-1".to_owned()),
+            base_fingerprint: Some("fp-1".to_owned()),
             state: RunDirState::ReadyActive,
         },
     );
@@ -145,8 +145,8 @@ fn non_authoritative_resolved_state_is_quarantined() {
         ResolvedOwnership {
             pod_uid: "pod-live".to_owned(),
             task_run_id: "run-live".to_owned(),
-            project_id: "proj-1".to_owned(),
-            base_fingerprint: "fp-1".to_owned(),
+            project_id: Some("proj-1".to_owned()),
+            base_fingerprint: Some("fp-1".to_owned()),
             state: RunDirState::Seeding,
         },
     );

--- a/server/crates/djinn-db/src/repositories/build_lease.rs
+++ b/server/crates/djinn-db/src/repositories/build_lease.rs
@@ -229,6 +229,27 @@ impl BuildLeaseRepository {
         Ok(row)
     }
 
+    /// Every task-invocation lease that has been fenced onto a concrete pod.
+    ///
+    /// `bound_pod_uid` is the ONLY durable pod-UID evidence this database holds:
+    /// the schema's `build_leases_bound_uid_check` constraint permits it solely
+    /// in the pod-bound and terminal states, and it is written exclusively by
+    /// the fencing-token `bind` path. Run-dir reconciliation (proposal nquz)
+    /// therefore reads it as authoritative ownership; every directory without a
+    /// matching row stays quarantined. Read-only and lock-free: it is a startup
+    /// inventory query, never part of a lease decision.
+    pub async fn list_pod_bound_task_invocations(&self) -> DbResult<Vec<BuildLeaseRow>> {
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query_as::<_, DbRow>(&format!(
+            "SELECT {COLS} FROM build_leases \
+             WHERE consumer_kind='task_invocation' AND bound_pod_uid IS NOT NULL \
+             ORDER BY consumer_id"
+        ))
+        .fetch_all(self.db.pool())
+        .await?;
+        rows.into_iter().map(BuildLeaseRow::try_from).collect()
+    }
+
     /// Atomically consume the one retry credit attached to a committed queue
     /// deadline. False covers both replay and non-timeout terminal rows.
     pub async fn consume_timeout_credit(&self, key: &BuildLeaseKey) -> DbResult<bool> {

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -26,6 +26,7 @@ use djinn_agent::roles::RoleRegistry;
 use djinn_agent::runtime_bridge::{K8sTokenReviewValidator, RuntimeKind, runtime_kind};
 use djinn_coordinator::build_lease::BuildLeaseService;
 use djinn_coordinator::graph_warm_lease::BuildLeaseGraphWarmAdapter;
+use djinn_coordinator::run_dir_observe::{RunDirObserveSeams, arm_disk_observation};
 use djinn_core::clock::{Clock, SystemClock as SystemClockTrait};
 use djinn_core::models::KnowledgeInjectionConfig;
 use djinn_db::{
@@ -999,6 +1000,37 @@ impl AppState {
                 admission.publish_metrics().await;
             }
         }
+    }
+
+    /// Arm the observe-only disk dimension of build admission (proposal nquz,
+    /// phase 1).
+    ///
+    /// Leader-only, and deliberately so: it writes `run_dirs` ledger rows and
+    /// reads the cache PVC that only the active coordinator owns. It performs no
+    /// filesystem mutation whatsoever — every unresolved, malformed, symlinked,
+    /// or unreadable entry is recorded `quarantined_unowned` and left on disk —
+    /// and it cannot change an admission outcome, because the capacity source it
+    /// installs is consulted only after a permit has already been issued.
+    ///
+    /// An unavailable project-quota probe is recorded (a future `enforce` is
+    /// prohibited on that volume) but never fails startup: observe mode exists
+    /// precisely to run on volumes that cannot yet be enforced.
+    async fn initialize_run_dir_disk_observation(&self) {
+        self.initialize_run_dir_disk_observation_with(RunDirObserveSeams::production())
+            .await;
+    }
+
+    /// Seam-bearing implementation of [`Self::initialize_run_dir_disk_observation`].
+    ///
+    /// Startup regressions drive a deterministic volume, capacity probe, and
+    /// clock through the exact production composition rather than a parallel
+    /// implementation.
+    async fn initialize_run_dir_disk_observation_with(
+        &self,
+        seams: RunDirObserveSeams,
+    ) -> Option<djinn_coordinator::run_dir_observe::RunDirObserveReport> {
+        let admission = self.inner.build_admission.clone()?;
+        Some(arm_disk_observation(self.db(), &admission, seams).await)
     }
 
     /// Restore task identities that were durably ready when the previous
@@ -2225,6 +2257,12 @@ impl AppState {
         // open Enforce admission, so standby pods stay fail-closed with
         // `TopologyPending` (and their dispatch subsystems never start).
         self.confirm_build_admission_topology().await;
+
+        // Observe-only disk dimension (proposal nquz). Runs after the topology
+        // gate because it writes the shared run-dir ledger and inventories the
+        // shared cache PVC — leader-only work. It never mutates the volume and
+        // never changes a grant.
+        self.initialize_run_dir_disk_observation().await;
 
         let retention_config = ImageControllerConfig::from_env();
         if let Err(error) = self.run_zot_retention_preflight(&retention_config).await {
@@ -4438,6 +4476,291 @@ mod build_admission_config_tests {
         state.confirm_build_admission_topology().await;
         assert_eq!(admission.readiness(), BuildAdmissionReadiness::Healthy);
         assert!(admission.is_ready());
+    }
+
+    // ── Observe-only disk dimension (proposal nquz) ────────────────────
+
+    /// A capacity probe the test controls. Only the `statvfs` syscall and the
+    /// monotonic clock are substituted; the volume, the ledger, the controller,
+    /// and the startup seam itself are all the production ones.
+    struct FixedCapacity(djinn_coordinator::cargo_warm_base_gc::CapacitySnapshot);
+
+    impl djinn_coordinator::cargo_warm_base_gc::FilesystemCapacity for FixedCapacity {
+        fn capacity(
+            &self,
+            _path: &std::path::Path,
+        ) -> Result<djinn_coordinator::cargo_warm_base_gc::CapacitySnapshot, String> {
+            Ok(self.0)
+        }
+    }
+
+    const NQUZ_GIB: u64 = 1024 * 1024 * 1024;
+
+    fn run_dir_seams(
+        root: std::path::PathBuf,
+        available_bytes: u64,
+    ) -> djinn_coordinator::run_dir_observe::RunDirObserveSeams {
+        djinn_coordinator::run_dir_observe::RunDirObserveSeams {
+            root,
+            volume_id: "startup-volume".to_owned(),
+            config: djinn_coordinator::disk_admission::DiskAdmissionConfig {
+                cache_budget_bytes: 100 * NQUZ_GIB,
+                critical_free_bytes: 20 * NQUZ_GIB,
+                warning_free_bytes: 40 * NQUZ_GIB,
+                emergency_headroom_bytes: 10 * NQUZ_GIB,
+                per_lease_growth_bytes: 4 * NQUZ_GIB,
+                max_sample_age: std::time::Duration::from_secs(90),
+            },
+            inventory: Arc::new(djinn_coordinator::run_dir_observe::FilesystemRunDirInventory),
+            capacity: Arc::new(FixedCapacity(
+                djinn_coordinator::cargo_warm_base_gc::CapacitySnapshot {
+                    total_bytes: 500 * NQUZ_GIB,
+                    available_bytes,
+                },
+            )),
+            clock: Arc::new(djinn_coordinator::run_dir_observe::SystemObserveClock),
+        }
+    }
+
+    fn task_run_admission_request(
+        work_id: &str,
+    ) -> djinn_coordinator::build_admission::BuildAdmissionRequest {
+        djinn_coordinator::build_admission::BuildAdmissionRequest {
+            domain: AdmissionDomain::TaskObservation,
+            work_id: work_id.to_owned(),
+            generation: 0,
+            object_name: format!("djinn-taskrun-{work_id}"),
+            kind: djinn_coordinator::build_admission::BuildWorkloadKind::TaskRun {
+                role: djinn_coordinator::build_admission::TaskRunRole::Worker,
+            },
+        }
+    }
+
+    /// The whole point of the observe phase: the coordinator's real startup
+    /// seam inventories the volume, writes ledger rows, and installs the
+    /// capacity source — and NOTHING about dispatch changes.
+    ///
+    /// The volume is deliberately at critical pressure, which is the strongest
+    /// signal enforce would ever act on. The grant must be byte-identical to the
+    /// pre-arming grant, no directory may be created or removed, and no run-dir
+    /// row may carry a reservation, quota, or temp path.
+    #[tokio::test]
+    async fn run_dir_disk_observation_startup_never_changes_a_grant_or_the_volume() {
+        use djinn_coordinator::build_admission::BuildAdmissionDecision;
+
+        let state = state_for_admission_config(BuildAdmissionConfig {
+            mode: BuildAdmissionMode::Observe,
+            cap: 4,
+        });
+        let admission = state
+            .inner
+            .build_admission
+            .as_ref()
+            .expect("Observe composes a controller")
+            .clone();
+
+        let volume = tempfile::tempdir().expect("temp volume");
+        let run_dir = "11111111-1111-1111-1111-111111111111";
+        std::fs::create_dir(volume.path().join(run_dir)).expect("run dir");
+        std::fs::write(
+            volume.path().join(run_dir).join("payload"),
+            vec![9_u8; 4096],
+        )
+        .expect("payload");
+        std::fs::create_dir(volume.path().join("operator-scratch")).expect("malformed dir");
+
+        // Baseline grant with the disk dimension still dark.
+        let before = admission
+            .admit(task_run_admission_request("before"))
+            .await
+            .expect("observe admits");
+        assert!(matches!(before, BuildAdmissionDecision::Permitted { .. }));
+        assert_eq!(admission.disk_would_defer_observation_count().await, 0);
+
+        // The production startup seam, driven with a critical volume.
+        let report = state
+            .initialize_run_dir_disk_observation_with(run_dir_seams(
+                volume.path().to_path_buf(),
+                NQUZ_GIB,
+            ))
+            .await
+            .expect("a composed controller arms observation");
+
+        assert!(!report.reconcile.inventory_failed);
+        assert_eq!(report.reconcile.scanned, 2);
+        assert_eq!(
+            report.reconcile.resolved, 0,
+            "with no pod-bound lease evidence, nothing may be claimed as owned"
+        );
+        assert_eq!(report.reconcile.quarantined, 2);
+        assert!(
+            report.reconcile.unowned_bytes() > 0,
+            "quarantined bytes still count against the volume"
+        );
+
+        // The grant after arming is identical; only the observe counter moved.
+        let after = admission
+            .admit(task_run_admission_request("after"))
+            .await
+            .expect("observe admits");
+        assert!(
+            matches!(after, BuildAdmissionDecision::Permitted { .. }),
+            "installing a disk capacity source must never turn a permit into a denial"
+        );
+        assert_eq!(
+            admission.disk_would_defer_observation_count().await,
+            1,
+            "critical pressure is recorded once, as telemetry only"
+        );
+
+        // No reservation, quota, or temp/final materialization anywhere.
+        let rows = djinn_db::RunDirRepository::new(state.db().clone())
+            .list_by_volume("startup-volume")
+            .await
+            .expect("ledger readable");
+        assert_eq!(rows.len(), 2);
+        for row in &rows {
+            assert_eq!(row.state, djinn_db::RunDirState::QuarantinedUnowned);
+            assert_eq!(row.reserved_bytes, 0, "observe reserves no bytes");
+            assert!(row.quota_id.is_none(), "observe assigns no quota");
+            assert!(row.temp_path.is_none(), "observe creates no temp directory");
+        }
+
+        // The volume is untouched: nothing deleted, nothing added.
+        let mut names: Vec<String> = std::fs::read_dir(volume.path())
+            .expect("volume readable")
+            .filter_map(|entry| Some(entry.ok()?.file_name().to_string_lossy().into_owned()))
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![run_dir.to_owned(), "operator-scratch".to_owned()]
+        );
+    }
+
+    /// A rerun of the startup seam is idempotent: the same rows, no duplicates,
+    /// and still no deletion.
+    #[tokio::test]
+    async fn run_dir_disk_observation_startup_is_idempotent() {
+        let state = state_for_admission_config(BuildAdmissionConfig {
+            mode: BuildAdmissionMode::Observe,
+            cap: 4,
+        });
+        let volume = tempfile::tempdir().expect("temp volume");
+        std::fs::create_dir(volume.path().join("22222222-2222-2222-2222-222222222222"))
+            .expect("run dir");
+
+        let first = state
+            .initialize_run_dir_disk_observation_with(run_dir_seams(
+                volume.path().to_path_buf(),
+                400 * NQUZ_GIB,
+            ))
+            .await
+            .expect("armed");
+        let second = state
+            .initialize_run_dir_disk_observation_with(run_dir_seams(
+                volume.path().to_path_buf(),
+                400 * NQUZ_GIB,
+            ))
+            .await
+            .expect("armed");
+        assert_eq!(first.reconcile.quarantined, second.reconcile.quarantined);
+
+        let rows = djinn_db::RunDirRepository::new(state.db().clone())
+            .list_by_volume("startup-volume")
+            .await
+            .expect("ledger readable");
+        assert_eq!(rows.len(), 1, "a rerun must not duplicate ledger rows");
+        assert!(
+            volume
+                .path()
+                .join("22222222-2222-2222-2222-222222222222")
+                .exists()
+        );
+    }
+
+    /// A missing or unreadable volume, and a quota probe that reports
+    /// unavailable, must NOT fail observe-mode startup. Production runs on a
+    /// volume with no `prjquota` mount option today.
+    #[tokio::test]
+    async fn unavailable_quota_and_missing_volume_do_not_fail_observe_startup() {
+        let state = state_for_admission_config(BuildAdmissionConfig {
+            mode: BuildAdmissionMode::Observe,
+            cap: 4,
+        });
+        let admission = state
+            .inner
+            .build_admission
+            .as_ref()
+            .expect("Observe composes a controller")
+            .clone();
+
+        let report = state
+            .initialize_run_dir_disk_observation_with(run_dir_seams(
+                std::path::PathBuf::from("/nonexistent/djinn/cargo-target-runs"),
+                400 * NQUZ_GIB,
+            ))
+            .await
+            .expect("armed even with no volume");
+        assert!(report.reconcile.inventory_failed);
+        assert!(
+            report.quota.enforce_prohibited,
+            "a volume with no project quota may never be armed for enforce"
+        );
+
+        // Startup completed and admission still works.
+        assert!(matches!(
+            admission
+                .admit(task_run_admission_request("after-missing-volume"))
+                .await
+                .expect("observe admits"),
+            djinn_coordinator::build_admission::BuildAdmissionDecision::Permitted { .. }
+        ));
+    }
+
+    /// The production composition must inventory the path the server pod
+    /// actually mounts. A seam that pointed at the Job-pod `/cache` path would
+    /// silently reconcile an empty volume forever.
+    #[test]
+    fn production_seams_target_the_server_pod_cache_mount() {
+        let seams = djinn_coordinator::run_dir_observe::RunDirObserveSeams::production();
+        assert_eq!(seams.root, djinn_core::paths::cargo_target_runs_root());
+        assert_eq!(
+            seams.volume_id,
+            djinn_coordinator::run_dir_observe::volume_id_from_env()
+        );
+    }
+
+    /// Leader-only composition: the ledger write and the PVC scan belong to the
+    /// single lock-holding coordinator, so the seam must be reachable from
+    /// `become_leader` and from nowhere in the every-pod `initialize` path.
+    #[test]
+    fn run_dir_disk_observation_is_composed_only_in_become_leader() {
+        let source = include_str!("mod.rs");
+        // Assembled at runtime so this assertion does not match its own literal
+        // inside the file it reads.
+        let call = format!("self.initialize_run_dir_disk_{}().await", "observation");
+        let call = call.as_str();
+        assert_eq!(
+            source.matches(call).count(),
+            1,
+            "exactly one production call site"
+        );
+        let leader = source
+            .find("pub async fn become_leader")
+            .expect("become_leader exists");
+        let observation = source.find(call).expect("call site exists");
+        assert!(
+            observation > leader,
+            "disk observation must be armed inside become_leader"
+        );
+        let initialize = source
+            .find("pub async fn initialize(&self)")
+            .expect("initialize exists");
+        assert!(
+            !source[initialize..leader].contains(call),
+            "standby pods must never arm disk observation"
+        );
     }
 
     /// Regression for the 2026-07-19 admission-handoff seed wedge.


### PR DESCRIPTION
## What this changes

Proposal `nquz` phase 1 (PR #2537 / `09c80ed9f`) shipped migration 151, `RunDirRepository`, allocated-byte measurement, the pure reconciliation planner, the disk evaluator, and the project-quota probe — **with no production call sites**. Nothing called `set_disk_capacity_source`, nothing ran the quota probe, and no executor ever reconciled the volume. The entire dimension was dead code in production.

This PR is the wiring, not a second implementation. No new schema, repository, or capacity model.

### A. Startup reconciliation executor — `djinn-coordinator/src/run_dir_observe.rs`

- `FilesystemRunDirInventory` scans the configured runs root using the existing `djinn_core::cargo_target_runs` measurement (`st_blocks`, inode-deduplicated, never follows symlinks). Non-UUID names, top-level symlinks, and unreadable subtrees are marked malformed; top-level debris is reported as unowned bytes rather than dropped from accounting.
- `LeaseOwnershipResolver` resolves ownership **only** from `build_leases.bound_pod_uid` — the single durable pod-UID record this database holds (the `build_leases_bound_uid_check` constraint admits it solely in the pod-bound/terminal states, and only the fencing-token `bind` path writes it). A terminal lease reconciles as `reclaimable`; a pod-bound lease as `ready_active`.
  - `ready_idle` is deliberately never asserted by reconciliation: the ledger carries no lease-recency evidence across a restart, and `ready_active` is the strictly more protected state.
- Everything unresolved, malformed, symlinked, or unreadable becomes `quarantined_unowned` and is **left untouched on disk**. Idempotent across reruns via `upsert_reconciled`.
- Bounded state/byte/reservation/unowned observations are published from ledger totals.

Today in production this quarantines everything, because build leases are not yet in use — which is exactly the mixed-version behaviour the proposal's rollout section requires while workers still eager-seed. The authoritative path is proven by a test that drives a lease to pod-bound through the real repository API.

### B. Live capacity + quota probes as observations

- `CoordinatorDiskCapacitySource` adapts the coordinator's existing `FilesystemCapacity`/`statvfs` snapshot to the existing `DiskCapacitySource`. A live probe is fresh; a failed probe ages the last good snapshot (which the evaluator treats as stale past `max_sample_age`); with no history the sample is `Unknown`.
- Light and explicitly non-build workloads never consult disk (a second, independent guard on top of the `permit_without_reservation` routing).
- The quota probe runs at startup. `Unavailable` records that a future `enforce` is prohibited and **never fails observe-mode startup** — production's cache volume has no `prjquota` mount option today.

### Production call site

`AppState::initialize_run_dir_disk_observation`, composed in `become_leader` after the topology gate: it writes the shared run-dir ledger and reads the shared cache PVC, so it is leader-only work. A composition test asserts exactly one call site, inside `become_leader` and not in the every-pod `initialize` path.

## Observe-only boundary

No grant result, durable admission transition, run-dir reservation, temp/final directory, quota assignment, GC action, deletion, or filesystem mutation results from a disk observation. `build_admission.rs` consults the source only *after* a permit has already been issued; the diff in that file is **comments only** (the old comments claimed no production path installs a source).

Out of scope, as required: eager seeding in `djinn-agent-worker`, enforcement, first-use seeding, and the incremental-cap benchmark.

## Testing

Tests exercise the production composition — the real startup seam, a real `BuildAdmissionController`, a real temporary volume, and a real ephemeral Postgres ledger. Only `statvfs` and the monotonic clock are substituted, because a test cannot make a real filesystem report critical pressure or age a monotonic instant.

Covered: an authoritative UUID run dir; an unresolved UUID dir; malformed and symlinked entries; a terminal lease; a missing/unreadable volume; idempotent reruns; healthy / warning / critical / stale / unknown capacity samples; quota available and unavailable; light and non-build workloads never consulting disk. Assertions prove grant outcomes are unchanged, no run-dir row carries a reservation, quota, or temp path, and nothing on the volume is created or removed. Telemetry assertions use the closed `RunDirState` label family only — no task-run, pod-UID, or project ID ever becomes a label value.

`cargo test -p djinn-coordinator --lib run_dir_observe` — 23 passed.
`cargo test -p djinn-server --lib` (new startup tests) — 5 passed.

## Acceptance criteria

This is the observe-only subset of `nquz`. It does not on its own satisfy any of the 12 ACs, all of which are written against enforce-mode behaviour (byte-safety transactions, seed atomicity, acquire/reclaim exclusion, GC ordering, the benchmark). It supplies the observe substrate those later phases build on, and it makes the rollout section's reconciliation and quarantine semantics real in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)