### PR TITLE
fix(build-lease): Degrade a lost lease queue to unleased execution instead of killing the command

### DIFF
--- a/server/crates/djinn-agent/src/extension/tests/shell_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/shell_dispatch_tests.rs
@@ -29,8 +29,18 @@ struct BrokerShellLauncher {
 struct BrokerShellState {
     stdout: Vec<u8>,
     stderr: Vec<u8>,
-    status: ExitStatus,
+    /// `None` while the remote child is still running.
+    status: Option<ExitStatus>,
+    /// The child finishes on its own once it has been sampled this many times.
+    exit_after_samples: usize,
+    exit_code: i32,
+    samples: usize,
+    /// Reported CPU usage: above the runner's escalation threshold this child
+    /// is build-shaped and reaches the lease authority.
+    cpu_usage_usec: u64,
     identities: Vec<TaskInvocationLeaseIdentity>,
+    lifts: usize,
+    killed_while_running: usize,
     empties: usize,
     cleanups: usize,
 }
@@ -43,8 +53,35 @@ impl BrokerShellLauncher {
             state: Arc::new(Mutex::new(BrokerShellState {
                 stdout: stdout.to_vec(),
                 stderr: stderr.to_vec(),
-                status: ExitStatus::from_raw(code << 8),
+                status: Some(ExitStatus::from_raw(code << 8)),
+                exit_after_samples: 0,
+                exit_code: code,
+                samples: 0,
+                cpu_usage_usec: 0,
                 identities: Vec::new(),
+                lifts: 0,
+                killed_while_running: 0,
+                empties: 0,
+                cleanups: 0,
+            })),
+        }
+    }
+
+    /// A still-running, CPU-heavy child: the runner escalates it to the lease
+    /// authority and it finishes on its own a few polls later.
+    fn escalating(stdout: &[u8], stderr: &[u8], code: i32) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(BrokerShellState {
+                stdout: stdout.to_vec(),
+                stderr: stderr.to_vec(),
+                status: None,
+                exit_after_samples: 3,
+                exit_code: code,
+                samples: 0,
+                cpu_usage_usec: 1_000_000,
+                identities: Vec::new(),
+                lifts: 0,
+                killed_while_running: 0,
                 empties: 0,
                 cleanups: 0,
             })),
@@ -79,22 +116,47 @@ impl ProcessHandle for BrokerShellHandle {
     }
 
     fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
-        Ok(Some(self.state.lock().unwrap().status))
-    }
-
-    fn wait(&mut self) -> io::Result<ExitStatus> {
         Ok(self.state.lock().unwrap().status)
     }
 
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        self.state
+            .lock()
+            .unwrap()
+            .status
+            .ok_or_else(|| io::Error::other("remote child is still running"))
+    }
+
     fn sample_cpu(&mut self) -> io::Result<CpuStat> {
-        Ok(CpuStat::default())
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut state = self.state.lock().unwrap();
+        state.samples += 1;
+        if state.exit_after_samples > 0 && state.samples >= state.exit_after_samples {
+            let code = state.exit_code;
+            state
+                .status
+                .get_or_insert_with(|| ExitStatus::from_raw(code << 8));
+        }
+        Ok(CpuStat {
+            usage_usec: state.cpu_usage_usec,
+            ..CpuStat::default()
+        })
     }
 
     fn fenced_lift(&mut self, _: &LeaseFencingToken) -> io::Result<()> {
+        self.state.lock().unwrap().lifts += 1;
         Ok(())
     }
 
     fn kill(&mut self) -> io::Result<()> {
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut state = self.state.lock().unwrap();
+        if state.status.is_none() {
+            state.killed_while_running += 1;
+            state.status = Some(ExitStatus::from_raw(9));
+        }
         Ok(())
     }
 
@@ -340,6 +402,60 @@ async fn shell_dispatch_broker_backed_cargo_records_exactly_one_observation() {
     assert_eq!(broker.identities[0].task_id, "trusted-task");
     assert_eq!(broker.identities[0].task_run_id, "trusted-task-run");
     assert!(!broker.identities[0].invocation_id.is_empty());
+    assert_eq!((broker.empties, broker.cleanups), (1, 1));
+}
+
+/// Workspace composition: a shell command that loses the build-lease queue must
+/// come back as an ordinary shell result, not as
+/// "failed to run shell command: lease invocation failed: ...".
+///
+/// This drives the whole production seam - `call_shell` -> `ShellLaunchContext`
+/// -> `LeaseInvocationRunner` -> the real `DirectServices` lease authority over
+/// a real durable repository - with the deadlines
+/// `ShellLaunchContext::invocation` actually renders. Contention makes the
+/// command slow (it stays at the broker's unleased quota, never lifted), never
+/// dead.
+#[tokio::test]
+async fn shell_dispatch_lease_queue_timeout_returns_the_command_result_not_an_error() {
+    let (worktree, mut state) = setup("shell-lease-degrade-");
+    let launcher = BrokerShellLauncher::escalating(b"degraded stdout\n", b"", 0);
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        Arc::new(crate::direct_services::DirectServices::new(
+            state.clone(),
+            CancellationToken::new(),
+        )),
+        Arc::new(launcher.clone()),
+        Arc::new(SystemClock::new()),
+    ));
+    state.shell_launch = Some(crate::context::ShellLaunchContext::for_test(
+        runner,
+        "degrade-task".into(),
+        "degrade-task-run".into(),
+        "degrade-pod-uid".into(),
+    ));
+
+    let response = call_shell(
+        &state,
+        &shell_args("cargo build"),
+        worktree.path(),
+        None,
+        &crate::extension::ToolCancellation::never(),
+    )
+    .await
+    .expect("a lost lease queue must not fail the shell tool call");
+
+    assert_eq!(response["ok"], serde_json::json!(true));
+    assert_eq!(response["exit_code"], serde_json::json!(0));
+    assert_eq!(response["stdout"], serde_json::json!("degraded stdout\n"));
+    let broker = launcher.state.lock().unwrap();
+    assert_eq!(
+        broker.killed_while_running, 0,
+        "the queued command must keep running, not be killed"
+    );
+    assert_eq!(
+        broker.lifts, 0,
+        "a degraded command stays at the unleased quota"
+    );
     assert_eq!((broker.empties, broker.cleanups), (1, 1));
 }
 

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -372,13 +372,19 @@ pub(crate) struct LeaseInvocationConfig {
     pub timeout: Duration,
 }
 
+/// A lease response that stops the invocation.
+///
+/// There is deliberately no wait-timeout variant: losing the queue is
+/// contention, not a failure, and contention degrades to unleased execution
+/// (see [`lease_failure`]) instead of killing the command. Only responses that
+/// mean the lease authority cannot be used coherently at all — an identity
+/// conflict, or repeated unavailability — end the invocation here.
 #[derive(Debug)]
 #[allow(dead_code)] // consumed by this runner now and workspace lease wiring next
 pub(crate) enum LeaseInvocationError {
     Process(ProcessRunError),
     Launcher(io::Error),
     LeaseIdentityConflict,
-    LeaseWaitTimeout,
     LeaseUnavailable,
 }
 
@@ -441,6 +447,12 @@ impl LeaseInvocationRunner {
         let mut deadline = self.clock.now_instant() + config.timeout;
         let (mut queued, mut fence, mut credit_used, mut lease_error) = (false, None, false, None);
         let mut unavailable_responses = 0_u8;
+        // Set once the durable queue ends without capacity for this invocation.
+        // From then on the child runs to its own terminal state at the
+        // launcher's unleased quota and the lease authority is never contacted
+        // again for a grant. See `lease_failure` for why the degrade is
+        // one-way.
+        let mut unleased_degrade = false;
         // This variable is assigned only by `terminal_now` or by a service
         // wait that observed terminal intent. Consequently no later response
         // can authorize a cgroup lift.
@@ -452,7 +464,16 @@ impl LeaseInvocationRunner {
                 break terminal;
             }
             let cpu = child.sample_cpu().map_err(LeaseInvocationError::Launcher)?;
-            let result = if !queued && cpu.usage_usec >= config.cpu_usage_threshold_usec {
+            let result = if unleased_degrade {
+                // Degraded: the child keeps running at the launcher's unleased
+                // quota (250m) until it exits on its own, its command timeout
+                // fires, or it is cancelled. Contention makes a command slow,
+                // never dead — nothing here kills the child, and no further
+                // lease request is issued. The durable record is still
+                // reconciled to terminal after the loop.
+                tokio::task::yield_now().await;
+                continue;
+            } else if !queued && cpu.usage_usec >= config.cpu_usage_threshold_usec {
                 queued = true;
                 match await_lease_or_terminal(
                     self.services.queue_lease(LeaseQueueRequest {
@@ -504,6 +525,7 @@ impl LeaseInvocationRunner {
                         &mut deadline,
                         &mut credit_used,
                         &mut lease_error,
+                        &mut unleased_degrade,
                     );
                     break (
                         child.try_wait().map_err(started_lease_error)?,
@@ -531,7 +553,13 @@ impl LeaseInvocationRunner {
                         status.fencing_token
                     }
                     other => {
-                        lease_failure(other, &mut deadline, &mut credit_used, &mut lease_error);
+                        lease_failure(
+                            other,
+                            &mut deadline,
+                            &mut credit_used,
+                            &mut lease_error,
+                            &mut unleased_degrade,
+                        );
                         None
                     }
                 }
@@ -644,6 +672,7 @@ impl LeaseInvocationRunner {
                                 &mut deadline,
                                 &mut credit_used,
                                 &mut lease_error,
+                                &mut unleased_degrade,
                             ),
                         }
                     }
@@ -655,12 +684,17 @@ impl LeaseInvocationRunner {
                                 &mut deadline,
                                 &mut credit_used,
                                 &mut lease_error,
+                                &mut unleased_degrade,
                             );
                         }
                     }
-                    other => {
-                        lease_failure(other, &mut deadline, &mut credit_used, &mut lease_error)
-                    }
+                    other => lease_failure(
+                        other,
+                        &mut deadline,
+                        &mut credit_used,
+                        &mut lease_error,
+                        &mut unleased_degrade,
+                    ),
                 }
             }
             if lease_error.is_some() {
@@ -911,12 +945,32 @@ async fn reconcile_terminal_lease(
 fn started_lease_error(error: io::Error) -> LeaseInvocationError {
     LeaseInvocationError::Process(ProcessRunError::Started(error))
 }
+/// Classify a lease response that did not produce a usable grant.
+///
+/// Contention is not a failure. A command that cannot get a lease must queue
+/// and be slow, not die: when the durable queue ends without capacity — a wait
+/// timeout, or a terminal record observed before any grant — the invocation
+/// sets `unleased` and the caller keeps the child running at the launcher's
+/// unleased quota. Killing the child there was the old behaviour and it burned
+/// the agent's session on `LeaseWaitTimeout` for work that was merely queued.
+///
+/// The degrade is **one-way**. Every terminal reason, `deadline_expired`
+/// included, is a terminal durable state for this invocation id; the
+/// coordinator can never grant that row again, and this invocation's identity
+/// is immutable (it is journaled before launch and drives watchdog recovery),
+/// so re-escalating would require minting a second lease identity for one
+/// child. Re-escalation is therefore out of reach without a redesign of the
+/// identity/journal contract.
+///
+/// Only responses meaning the lease authority cannot be used coherently at all
+/// — an identity conflict, or repeated unavailability — remain hard errors.
 #[cfg_attr(not(test), allow(dead_code))] // consumed by the workspace lease wiring task
 fn lease_failure(
     result: LeaseResult,
     deadline: &mut std::time::Instant,
     credit_used: &mut bool,
     output: &mut Option<LeaseInvocationError>,
+    unleased: &mut bool,
 ) {
     match result {
         LeaseResult::LeaseIdentityConflict { .. } => {
@@ -929,9 +983,19 @@ fn lease_failure(
             *deadline += Duration::from_millis(u64::from(credit.retry_after_ms));
             *credit_used = true;
         }
-        LeaseResult::LeaseWaitTimeout { .. } => {
-            *output = Some(LeaseInvocationError::LeaseWaitTimeout)
-        }
+        // Queue timeout (credit spent or never issued), and the terminal
+        // records a timed-out queue leaves behind: the coordinator terminalizes
+        // an expired row as `deadline_expired`, which a later status read
+        // reports as a cancelled terminal state. Both mean the same thing —
+        // this invocation will never hold the lease — so both degrade.
+        LeaseResult::LeaseWaitTimeout { .. }
+        | LeaseResult::Cancelled { .. }
+        | LeaseResult::Released { .. }
+        | LeaseResult::Abandoned { .. }
+        | LeaseResult::Status(LeaseStatus {
+            state: LeaseState::Cancelled | LeaseState::Released,
+            ..
+        }) => *unleased = true,
         _ => {}
     }
 }
@@ -1360,6 +1424,7 @@ mod tests {
         let mut deadline = std::time::Instant::now();
         let mut used = false;
         let mut error = None;
+        let mut unleased = false;
         lease_failure(
             LeaseResult::LeaseIdentityConflict {
                 identity: LeaseIdentity::TaskInvocation(test_identity()),
@@ -1367,6 +1432,7 @@ mod tests {
             &mut deadline,
             &mut used,
             &mut error,
+            &mut unleased,
         );
         assert!(matches!(
             error,
@@ -1378,24 +1444,93 @@ mod tests {
             &mut deadline,
             &mut used,
             &mut error,
+            &mut unleased,
         );
         assert!(matches!(
             error,
             Some(LeaseInvocationError::LeaseUnavailable)
         ));
-        error = None;
-        lease_failure(
+        assert!(
+            !unleased,
+            "an unusable lease authority is a failure, never a degrade"
+        );
+    }
+
+    /// A queue that ends without capacity degrades to unleased execution: no
+    /// error is produced for the caller to kill the child with. Every response
+    /// shape a lost queue can take — the timeout itself and the terminal record
+    /// the coordinator leaves behind — degrades identically.
+    #[test]
+    fn lost_queue_responses_degrade_without_error() {
+        for result in [
             LeaseResult::LeaseWaitTimeout {
                 timeout_credit: None,
             },
+            LeaseResult::Cancelled {
+                candidate_cleanup: false,
+            },
+            LeaseResult::Released {
+                candidate_cleanup: false,
+            },
+            LeaseResult::Abandoned {
+                candidate_cleanup: false,
+            },
+            LeaseResult::Status(LeaseStatus {
+                state: LeaseState::Cancelled,
+                fencing_token: None,
+                deadlines: LeaseDeadlines {
+                    queue_deadline_ms: 0,
+                    launch_deadline_ms: 0,
+                },
+                pod_uid: None,
+                candidate_cleanup: false,
+            }),
+        ] {
+            let mut deadline = std::time::Instant::now();
+            let original = deadline;
+            let mut used = true;
+            let mut error = None;
+            let mut unleased = false;
+            lease_failure(
+                result.clone(),
+                &mut deadline,
+                &mut used,
+                &mut error,
+                &mut unleased,
+            );
+            assert!(error.is_none(), "{result:?} must not fail the invocation");
+            assert!(unleased, "{result:?} must degrade to unleased execution");
+            assert_eq!(deadline, original);
+        }
+    }
+
+    /// A queued row that has not lost the queue keeps waiting: no degrade, no
+    /// error. Without this the runner would abandon the lease on its first
+    /// still-queued poll.
+    #[test]
+    fn still_queued_responses_neither_fail_nor_degrade() {
+        let mut deadline = std::time::Instant::now();
+        let mut used = false;
+        let mut error = None;
+        let mut unleased = false;
+        lease_failure(
+            LeaseResult::Status(LeaseStatus {
+                state: LeaseState::Queued,
+                fencing_token: None,
+                deadlines: LeaseDeadlines {
+                    queue_deadline_ms: 0,
+                    launch_deadline_ms: 0,
+                },
+                pod_uid: None,
+                candidate_cleanup: false,
+            }),
             &mut deadline,
             &mut used,
             &mut error,
+            &mut unleased,
         );
-        assert!(matches!(
-            error,
-            Some(LeaseInvocationError::LeaseWaitTimeout)
-        ));
+        assert!(error.is_none());
+        assert!(!unleased);
     }
 
     #[test]
@@ -1410,14 +1545,23 @@ mod tests {
                 retry_after_ms: 25,
             }),
         };
-        lease_failure(credit.clone(), &mut deadline, &mut used, &mut error);
+        let mut unleased = false;
+        lease_failure(
+            credit.clone(),
+            &mut deadline,
+            &mut used,
+            &mut error,
+            &mut unleased,
+        );
         assert_eq!(deadline, original + Duration::from_millis(25));
-        lease_failure(credit, &mut deadline, &mut used, &mut error);
+        assert!(!unleased, "the one credited retry still waits for capacity");
+        lease_failure(credit, &mut deadline, &mut used, &mut error, &mut unleased);
         assert_eq!(deadline, original + Duration::from_millis(25));
-        assert!(matches!(
-            error,
-            Some(LeaseInvocationError::LeaseWaitTimeout)
-        ));
+        assert!(error.is_none());
+        assert!(
+            unleased,
+            "the spent credit degrades to unleased instead of failing"
+        );
     }
 
     #[test]

--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -1,0 +1,423 @@
+//! Contention-degrade tests for [`LeaseInvocationRunner`].
+//!
+//! A command that cannot get a build lease must queue and be slow, never die.
+//! These tests drive the real runner state machine — the same
+//! `LeaseInvocationRunner::output` composition the workspace shell handler
+//! calls — and pin the boundary between a *lost queue* (degrade to unleased
+//! execution, successful command result) and a *broken lease authority*
+//! (still an error). Split out of `process_lease_tests.rs` to stay within the
+//! file-size guard; shares its harness (`ScriptedServices`, `clock`, `status`,
+//! …) via `use super::*`.
+
+use super::*;
+
+/// Launcher double that keeps the cgroup boundary observable for a degraded
+/// invocation. Unlike the harness launchers it never spawns a local process:
+/// the child's lifetime is scripted, so a test can prove the runner let it run
+/// to its own exit instead of killing it.
+///
+/// `fenced_lift` is the only call that can raise the leaf above the broker's
+/// unleased quota, so "the command is slow, not unconstrained" is asserted as
+/// "`lifts` stayed empty". `killed_while_running` records any kill that landed
+/// before the child reached a terminal status, which is exactly the defect the
+/// degrade removes.
+#[derive(Clone)]
+struct DegradeLauncher {
+    state: Arc<Mutex<DegradeState>>,
+}
+
+struct DegradeState {
+    /// The child exits on its own once it has been sampled this many times.
+    /// `None` keeps it running until it is killed.
+    exit_after_samples: Option<usize>,
+    samples: usize,
+    stdout: Vec<u8>,
+    status: Option<std::process::ExitStatus>,
+    lifts: Vec<LeaseFencingToken>,
+    kills: usize,
+    killed_while_running: usize,
+    empties: usize,
+    cleanups: usize,
+}
+
+impl DegradeLauncher {
+    fn new(exit_after_samples: Option<usize>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(DegradeState {
+                exit_after_samples,
+                samples: 0,
+                stdout: b"degraded command output\n".to_vec(),
+                status: None,
+                lifts: Vec::new(),
+                kills: 0,
+                killed_while_running: 0,
+                empties: 0,
+                cleanups: 0,
+            })),
+        }
+    }
+    /// A child that finishes on its own a few polls in.
+    fn completing() -> Self {
+        Self::new(Some(3))
+    }
+    /// A child that never finishes by itself.
+    fn running() -> Self {
+        Self::new(None)
+    }
+    fn lifts(&self) -> Vec<LeaseFencingToken> {
+        self.state.lock().unwrap().lifts.clone()
+    }
+    fn killed_while_running(&self) -> usize {
+        self.state.lock().unwrap().killed_while_running
+    }
+    fn samples(&self) -> usize {
+        self.state.lock().unwrap().samples
+    }
+}
+
+impl CgroupLauncherClient for DegradeLauncher {
+    fn launch(
+        &self,
+        _: Command,
+        _: &TaskInvocationLeaseIdentity,
+    ) -> io::Result<Box<dyn ProcessHandle>> {
+        Ok(Box::new(DegradeHandle {
+            state: self.state.clone(),
+        }))
+    }
+}
+
+struct DegradeHandle {
+    state: Arc<Mutex<DegradeState>>,
+}
+
+impl ProcessHandle for DegradeHandle {
+    fn drain_stdout(&mut self) -> io::Result<Vec<u8>> {
+        Ok(std::mem::take(&mut self.state.lock().unwrap().stdout))
+    }
+    fn drain_stderr(&mut self) -> io::Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+    fn try_wait(&mut self) -> io::Result<Option<std::process::ExitStatus>> {
+        Ok(self.state.lock().unwrap().status)
+    }
+    fn wait(&mut self) -> io::Result<std::process::ExitStatus> {
+        self.state
+            .lock()
+            .unwrap()
+            .status
+            .ok_or_else(|| io::Error::other("scripted child is still running"))
+    }
+    fn sample_cpu(&mut self) -> io::Result<CpuStat> {
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut state = self.state.lock().unwrap();
+        state.samples += 1;
+        if state.exit_after_samples.is_some_and(|n| state.samples >= n) {
+            // Exit code 0 << 8: a clean, self-terminated child. A killed child
+            // would carry the injected signal status instead.
+            state
+                .status
+                .get_or_insert_with(|| std::process::ExitStatus::from_raw(0));
+        }
+        // Always above the runner's escalation threshold: this is a build-shaped
+        // command, so it always reaches the lease authority.
+        Ok(CpuStat {
+            usage_usec: 1_000_000,
+            ..CpuStat::default()
+        })
+    }
+    fn fenced_lift(&mut self, token: &LeaseFencingToken) -> io::Result<()> {
+        self.state.lock().unwrap().lifts.push(token.clone());
+        Ok(())
+    }
+    fn kill(&mut self) -> io::Result<()> {
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut state = self.state.lock().unwrap();
+        state.kills += 1;
+        if state.status.is_none() {
+            state.killed_while_running += 1;
+            state.status = Some(std::process::ExitStatus::from_raw(9));
+        }
+        Ok(())
+    }
+    fn wait_empty(&mut self) -> io::Result<()> {
+        self.state.lock().unwrap().empties += 1;
+        Ok(())
+    }
+    fn cleanup(&mut self) -> io::Result<()> {
+        self.state.lock().unwrap().cleanups += 1;
+        Ok(())
+    }
+}
+
+/// The durable terminal record the coordinator leaves behind for a queue whose
+/// deadline expired: `status` reports a terminalized row as cancelled.
+fn cancelled_terminal_status() -> LeaseResult {
+    status(LeaseState::Cancelled, None)
+}
+
+/// The defect: a queue-wait timeout used to kill the child and return
+/// `Err(LeaseWaitTimeout)`, which surfaced at the workspace shell handler as
+/// "failed to run shell command: lease invocation failed: LeaseWaitTimeout" and
+/// burned the agent's session for work that was merely queued. It must instead
+/// leave the child running at the unleased quota and return its real result.
+#[tokio::test]
+async fn lease_wait_timeout_degrades_to_unleased_not_error() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![LeaseResult::LeaseWaitTimeout {
+            timeout_credit: None,
+        }],
+        vec![],
+        vec![cancelled_terminal_status(); 3],
+    ));
+    let launcher = Arc::new(DegradeLauncher::completing());
+    let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+    let output = runner
+        .output(command(), config(), CancellationToken::new())
+        .await
+        .expect("a queue-wait timeout must not fail the command");
+
+    // The child ran to its own exit and its output survived.
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(output.process.output.status.code(), Some(0));
+    assert_eq!(output.process.output.stdout, b"degraded command output\n");
+    assert_eq!(
+        launcher.killed_while_running(),
+        0,
+        "a timed-out lease wait must never kill a running child"
+    );
+    // Slow, not unconstrained: nothing lifted the leaf off the broker's
+    // unleased quota, and the runner never tried to escalate again.
+    assert!(
+        launcher.lifts().is_empty(),
+        "a degraded invocation must keep the unleased quota"
+    );
+    assert_eq!(services.queue_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        services.grant_calls.load(Ordering::SeqCst),
+        0,
+        "the degrade is one-way: no grant is attempted after the queue is lost"
+    );
+    assert!(launcher.samples() >= 3, "the child kept being driven");
+}
+
+/// The single bounded timeout credit still buys one more wait; only the spent
+/// credit degrades. The runner must not treat the credited retry as a degrade,
+/// or the one retry the coordinator paid for would be skipped.
+#[tokio::test]
+async fn credited_timeout_retries_once_then_degrades() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![LeaseResult::LeaseWaitTimeout {
+            timeout_credit: Some(djinn_supervisor::services::TimeoutCredit {
+                units: 1,
+                retry_after_ms: 0,
+            }),
+        }],
+        vec![],
+        vec![
+            // The credited retry: still nothing, then the terminal record.
+            LeaseResult::LeaseWaitTimeout {
+                timeout_credit: None,
+            },
+            cancelled_terminal_status(),
+            cancelled_terminal_status(),
+            cancelled_terminal_status(),
+        ],
+    ));
+    let launcher = Arc::new(DegradeLauncher::completing());
+    let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+    let output = runner
+        .output(command(), config(), CancellationToken::new())
+        .await
+        .expect("a spent timeout credit degrades instead of failing");
+
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(output.process.output.status.code(), Some(0));
+    assert_eq!(launcher.killed_while_running(), 0);
+    assert!(launcher.lifts().is_empty());
+    assert!(services.status_calls.load(Ordering::SeqCst) >= 1);
+}
+
+/// The response shape production actually produces after a queue deadline
+/// expires: the coordinator terminalizes the row and `status` reports it as a
+/// cancelled terminal state. That is the same lost queue, so it degrades too —
+/// and the runner must stop polling. The scripted status queue holds exactly
+/// one terminal answer; every later poll would fall through to
+/// `LeaseUnavailable`, and three of those still fail the invocation. A
+/// successful result therefore proves the polling stopped at the degrade.
+#[tokio::test]
+async fn terminal_record_before_any_grant_degrades_and_stops_polling() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![LeaseResult::Queued(LeaseStatus {
+            state: LeaseState::Queued,
+            fencing_token: None,
+            deadlines: deadlines(),
+            pod_uid: None,
+            candidate_cleanup: false,
+        })],
+        vec![],
+        vec![cancelled_terminal_status()],
+    ));
+    let launcher = Arc::new(DegradeLauncher::completing());
+    let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+    let output = runner
+        .output(command(), config(), CancellationToken::new())
+        .await
+        .expect("a terminal lease record degrades the invocation");
+
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(output.process.output.status.code(), Some(0));
+    assert_eq!(launcher.killed_while_running(), 0);
+    assert!(launcher.lifts().is_empty());
+    assert_eq!(services.grant_calls.load(Ordering::SeqCst), 0);
+}
+
+/// Degrading must not disarm cancellation: a degraded child is still killed
+/// when the tool call is cancelled, and the run still reports `Cancelled`.
+#[tokio::test]
+async fn cancellation_after_degrade_still_terminates_the_child() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![LeaseResult::LeaseWaitTimeout {
+            timeout_credit: None,
+        }],
+        vec![],
+        vec![cancelled_terminal_status(); 3],
+    ));
+    let launcher = Arc::new(DegradeLauncher::running());
+    let cancel = CancellationToken::new();
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        services.clone(),
+        launcher.clone(),
+        clock(),
+    ));
+    let run_cancel = cancel.clone();
+    let run = tokio::spawn(async move { runner.output(command(), config(), run_cancel).await });
+    // The degraded child keeps being driven; cancel it mid-flight.
+    for _ in 0..10_000 {
+        if launcher.samples() >= 3 && services.queue_calls.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    cancel.cancel();
+    let output = run
+        .await
+        .expect("runner task joins")
+        .expect("cancellation is a clean terminal result");
+
+    assert_eq!(output.process.termination, ProcessTermination::Cancelled);
+    assert_eq!(
+        launcher.killed_while_running(),
+        1,
+        "cancellation must still kill the degraded child"
+    );
+    assert!(launcher.lifts().is_empty());
+}
+
+/// The degrade is scoped to a lost queue. An identity conflict means the lease
+/// authority cannot be used coherently for this invocation at all, and must
+/// still fail rather than silently running unleased.
+#[tokio::test]
+async fn lease_identity_conflict_still_fails() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![LeaseResult::LeaseIdentityConflict {
+            identity: LeaseIdentity::TaskInvocation(TaskInvocationLeaseIdentity {
+                task_id: "task".into(),
+                task_run_id: "run".into(),
+                invocation_id: "conflicting".into(),
+            }),
+        }],
+        vec![],
+        vec![],
+    ));
+    let launcher = Arc::new(DegradeLauncher::running());
+    let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+    let error = runner
+        .output(command(), config(), CancellationToken::new())
+        .await
+        .expect_err("an identity conflict is not contention");
+
+    assert!(matches!(error, LeaseInvocationError::LeaseIdentityConflict));
+    assert!(launcher.lifts().is_empty());
+}
+
+/// Repeated unavailability is a broken authority, not a queue: it must still
+/// fail after the bounded re-read, so a coordinator outage cannot be mistaken
+/// for contention.
+#[tokio::test]
+async fn repeated_unavailability_still_fails() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![LeaseResult::LeaseUnavailable],
+        vec![],
+        vec![LeaseResult::LeaseUnavailable; 8],
+    ));
+    let launcher = Arc::new(DegradeLauncher::running());
+    let runner = LeaseInvocationRunner::new(services.clone(), launcher.clone(), clock());
+    let error = runner
+        .output(command(), config(), CancellationToken::new())
+        .await
+        .expect_err("an unusable lease authority is not contention");
+
+    assert!(matches!(error, LeaseInvocationError::LeaseUnavailable));
+    assert!(launcher.lifts().is_empty());
+}
+
+/// Production composition seam: the real `DirectServices` lease authority over
+/// a real durable repository, driven by the real runner — no hand-built lease
+/// response anywhere.
+///
+/// `queue_deadline_ms` is passed exactly as `ShellLaunchContext::invocation`
+/// passes it (30_000), which the coordinator reads as an absolute epoch
+/// timestamp and therefore treats as already expired. That is the production
+/// path that made every escalating shell command hit a queue timeout: it must
+/// now produce a successful command result at the unleased quota.
+#[tokio::test]
+async fn real_lease_authority_queue_timeout_degrades_to_a_successful_command() {
+    let db = crate::test_helpers::create_test_db();
+    let services = Arc::new(crate::direct_services::DirectServices::new(
+        crate::test_helpers::agent_context_from_db(db.clone(), CancellationToken::new()),
+        CancellationToken::new(),
+    ));
+    let launcher = Arc::new(DegradeLauncher::completing());
+    let runner = LeaseInvocationRunner::new(services, launcher.clone(), clock());
+    // The exact deadlines `ShellLaunchContext::invocation` renders in a task
+    // pod.
+    let production_deadlines = LeaseInvocationConfig {
+        queue_deadline_ms: 30_000,
+        launch_deadline_ms: 60_000,
+        ..config()
+    };
+    let output = runner
+        .output(command(), production_deadlines, CancellationToken::new())
+        .await
+        .expect("a real queue timeout must not fail the command");
+
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(output.process.output.status.code(), Some(0));
+    assert_eq!(output.process.output.stdout, b"degraded command output\n");
+    assert_eq!(
+        launcher.killed_while_running(),
+        0,
+        "the real timeout path must never kill a running child"
+    );
+    assert!(
+        launcher.lifts().is_empty(),
+        "a degraded invocation never lifts the unleased quota"
+    );
+
+    // Prove the successful result came through the timeout path rather than a
+    // queue that simply never resolved: the durable row this invocation created
+    // is terminal for the expired deadline.
+    let row = djinn_db::BuildLeaseRepository::new(db)
+        .get(&djinn_db::BuildLeaseKey {
+            consumer_kind: djinn_db::BuildLeaseConsumerKind::TaskInvocation,
+            consumer_id: output.identity.invocation_id.clone(),
+        })
+        .await
+        .expect("read the durable lease row")
+        .expect("the invocation queued a durable lease row");
+    assert_eq!(row.state, djinn_db::BuildLeaseState::Terminal);
+    assert_eq!(row.terminal_reason.as_deref(), Some("deadline_expired"));
+}

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -1402,5 +1402,7 @@ fn shadow_epoch_emits_both_would_throttle_arms_from_production_paths() {
     }
 }
 
+#[path = "process_lease_degrade_tests.rs"]
+mod lease_degrade_tests;
 #[path = "process_lease_recovery_tests.rs"]
 mod recovery_tests;


### PR DESCRIPTION
## The defect

When a shell command waited for a build lease and lost the queue, djinn **killed the command**. `LeaseWaitTimeout` set `lease_error`, broke the invocation loop, killed the child and returned `Err`, which surfaced at `workspace.rs` as:

```
failed to run shell command: lease invocation failed: LeaseWaitTimeout
```

That is the opposite of the intended semantics. With `cgroupLauncher.mode` armed, every shell command crossing the CPU threshold goes through this path, so any queueing at all would kill real work in every task pod.

There was a second, quieter half of the same bug: after a queue deadline expires the coordinator terminalizes the row as `deadline_expired`, and a later `lease_status` read reports that row as a *cancelled terminal state*, which the runner classified as "nothing to do" — so it busy-polled the lease authority for the rest of the command.

## What changed

`LeaseInvocationRunner` now degrades instead of failing. When the durable queue ends without capacity, the child keeps running at the broker's 250m unleased quota until it exits on its own, its command timeout fires, or it is cancelled, and its real output is returned. No further lease request is issued, and the terminal record is still reconciled after the loop.

Both response shapes a lost queue produces degrade identically: the `LeaseWaitTimeout` itself, and the terminal record a later status read reports.

**Degrade semantics: one-way.** Every terminal reason, `deadline_expired` included, is terminal for this invocation id — the coordinator can never grant that row again — and the invocation identity is immutable (journaled before launch, and it drives watchdog recovery). Re-escalating would mean minting a second lease identity for one child, which is out of reach without redesigning the identity/journal contract.

Unchanged, and covered by tests:

- the single bounded timeout credit still buys its one extra wait;
- `LeaseIdentityConflict` and repeated `LeaseUnavailable` are still hard errors — only a *lost queue* degrades;
- cancellation still kills the child and still reports `Cancelled`.

`LeaseInvocationError::LeaseWaitTimeout` is removed, so no code path can return that error any more.

## Tests

Everything drives the real `LeaseInvocationRunner` composition. Two tests use the real `DirectServices` lease authority over a real durable repository rather than a hand-built lease response:

- `real_lease_authority_queue_timeout_degrades_to_a_successful_command` — passes the deadlines `ShellLaunchContext::invocation` actually renders, asserts the command succeeded **and** that the durable row ended `Terminal`/`deadline_expired`, so the success provably came through the timeout path.
- `shell_dispatch_lease_queue_timeout_returns_the_command_result_not_an_error` — the whole production seam, `call_shell` -> `ShellLaunchContext` -> runner -> real lease authority: the tool call returns an ordinary shell result, not a `lease invocation failed` error.

Plus, on the runner: `lease_wait_timeout_degrades_to_unleased_not_error`, `credited_timeout_retries_once_then_degrades`, `terminal_record_before_any_grant_degrades_and_stops_polling` (its scripted status queue holds exactly one terminal answer, so a success proves the polling stopped), `cancellation_after_degrade_still_terminates_the_child`, `lease_identity_conflict_still_fails`, `repeated_unavailability_still_fails`.

Every degrade test asserts the child was **not** killed while running (a kill landing on a live child is recorded separately by the launcher double) and that `fenced_lift` was never called, so the degraded command stays at the unleased quota — slow, not unconstrained.

Mutation-checked: reverting the degrade to an error fails exactly the seven degrade assertions and leaves the two failure tests green.

`build_lease.rs` (PR #2593) and `build_admission.rs` (PR #2589) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
