### PR TITLE
Reclaim admission occupancy whose Kubernetes object is provably gone

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -369,6 +369,12 @@ pub struct BuildAdmissionController {
     /// Seeded durable occupancy exceeded the configured cap at recovery.
     /// Cleared when a terminal release brings occupancy back within the cap.
     over_cap: AtomicBool,
+    /// Whether the loud over-cap alarm has already been logged for the current
+    /// episode. Occupancy is republished on every admission and every
+    /// lifecycle transition, so the alarm is edge-triggered: exactly one
+    /// `ERROR` when durable occupancy crosses the cap and exactly one `INFO`
+    /// when it comes back under, instead of one line per publication.
+    over_cap_alarm_active: AtomicBool,
     /// The broad Kubernetes inventory LIST completed successfully.
     inventory_ready: AtomicBool,
     /// The single-active topology gate (coordinator leadership) is held by
@@ -423,6 +429,7 @@ impl BuildAdmissionController {
             journal_healthy: AtomicBool::new(true),
             create_unknown_pending: AtomicU64::new(0),
             over_cap: AtomicBool::new(false),
+            over_cap_alarm_active: AtomicBool::new(false),
             inventory_ready: AtomicBool::new(true),
             topology_ready: AtomicBool::new(true),
             draining: AtomicBool::new(false),
@@ -697,7 +704,10 @@ impl BuildAdmissionController {
         if self.mode() == BuildAdmissionMode::Off {
             djinn_telemetry::build_slot_occupancy::set_slots_in_use(0);
             djinn_telemetry::build_slot_occupancy::set_slots_queued(0);
-            djinn_telemetry::build_admission::set_health(mode, self.cap, false, false, false);
+            djinn_telemetry::build_admission::set_health(
+                mode, self.cap, false, false, false, false,
+            );
+            djinn_telemetry::build_admission::set_stale_rows(mode, self.cap, 0);
             return;
         }
         // Keep individual health gauges independent. `readiness()` is a
@@ -735,6 +745,14 @@ impl BuildAdmissionController {
         } else {
             0
         };
+        // Durable occupancy above the cap is the exact shape that denies every
+        // admission once the cap is armed, and it is invisible in a log stream
+        // that only reports per-transition warnings. Export it as a bounded
+        // gauge and alarm on the edge so it is never something a human has to
+        // discover by reading thousands of warn lines.
+        let over_cap =
+            !journal_snapshot_degraded && i64::try_from(occupied).unwrap_or(i64::MAX) > self.cap;
+        self.report_over_cap_edge(over_cap, occupied);
         djinn_telemetry::build_slot_occupancy::set_slots_in_use(occupied);
         djinn_telemetry::build_slot_occupancy::set_slots_queued(queued);
         djinn_telemetry::build_admission::set_health(
@@ -745,7 +763,89 @@ impl BuildAdmissionController {
                 || !self.journal_recovered.load(Ordering::Acquire)
                 || !self.journal_healthy.load(Ordering::Acquire),
             self.create_unknown_pending.load(Ordering::Acquire) > 0,
+            over_cap,
         );
+    }
+
+    /// Log the over-cap alarm exactly once per episode, in both directions.
+    fn report_over_cap_edge(&self, over_cap: bool, occupancy: usize) {
+        if self
+            .over_cap_alarm_active
+            .compare_exchange(!over_cap, over_cap, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        if over_cap {
+            tracing::error!(
+                occupancy,
+                cap = self.cap,
+                mode = ?self.mode(),
+                "build_admission: durable occupancy exceeds the configured cap; every \
+                 enforced admission will be denied until the excess is released. Run the \
+                 stale-admission-occupancy runbook."
+            );
+        } else {
+            tracing::info!(
+                occupancy,
+                cap = self.cap,
+                "build_admission: durable occupancy is back within the configured cap"
+            );
+        }
+    }
+
+    /// Publish the outcome of one reconciliation pass over durable occupancy.
+    ///
+    /// `stale_rows` is the number of occupying rows whose Kubernetes object the
+    /// pass proved absent, counted BEFORE reclamation, so the gauge reports the
+    /// size of the problem rather than the size of the fix.
+    pub fn publish_reconciliation(&self, stale_rows: usize, reclaimed: usize, fenced: usize) {
+        if stale_rows > 0 || reclaimed > 0 {
+            let level_is_alarm = i64::try_from(stale_rows).unwrap_or(i64::MAX) > self.cap;
+            if level_is_alarm {
+                tracing::error!(
+                    stale_rows,
+                    reclaimed,
+                    fenced,
+                    cap = self.cap,
+                    mode = ?self.mode(),
+                    "build_admission: reconciliation found more occupying rows with absent \
+                     Kubernetes objects than the configured cap; this is the population that \
+                     wedges the board when the cap is armed"
+                );
+            } else {
+                tracing::info!(
+                    stale_rows,
+                    reclaimed,
+                    fenced,
+                    cap = self.cap,
+                    "build_admission: reconciliation released stale durable occupancy"
+                );
+            }
+        }
+        if !self.process_metrics_enabled() {
+            return;
+        }
+        let mode = match self.mode() {
+            BuildAdmissionMode::Off => "off",
+            BuildAdmissionMode::Observe => "observe",
+            BuildAdmissionMode::Enforce => "enforce",
+        };
+        djinn_telemetry::build_admission::set_stale_rows(mode, self.cap, stale_rows as u64);
+        for _ in 0..reclaimed {
+            djinn_telemetry::build_admission::record_transition_outcome(
+                mode,
+                self.cap,
+                djinn_telemetry::build_admission::OUTCOME_RECLAIMED,
+            );
+        }
+        for _ in 0..fenced {
+            djinn_telemetry::build_admission::record_transition_outcome(
+                mode,
+                self.cap,
+                djinn_telemetry::build_admission::OUTCOME_RECLAIM_FENCED,
+            );
+        }
     }
 
     pub async fn admit(
@@ -3870,11 +3970,102 @@ mod tests {
             "djinn_build_admission_inventory_degraded",
             "djinn_build_admission_journal_degraded",
             "djinn_build_admission_create_unknown_health",
+            "djinn_build_admission_occupancy_over_cap",
+            "djinn_build_admission_stale_rows",
             "djinn_build_slots_in_use",
             "djinn_build_slots_queued",
         ] {
             assert_no_identity_labels(&rendered, metric);
         }
+    }
+
+    /// Durable occupancy above the cap must be readable as a bounded gauge, and
+    /// reclamation must report through the same `outcome` family the lifecycle
+    /// transitions report through — not a parallel metric nobody queries.
+    #[tokio::test]
+    async fn telemetry_reports_over_cap_occupancy_and_reclamation_outcomes() {
+        let _guard = telemetry_guard();
+        djinn_telemetry::init().unwrap();
+
+        let controller = controller(BuildAdmissionMode::Enforce, 2);
+        controller.enable_process_metrics_for_test();
+        controller.mark_ready();
+        let labels = [("effective_mode", "enforce"), ("effective_cap", "2")];
+
+        controller.publish_metrics().await;
+        assert_eq!(
+            sample_value(
+                &djinn_telemetry::render().unwrap(),
+                "djinn_build_admission_occupancy_over_cap",
+                &labels
+            ),
+            0.0
+        );
+
+        for index in 0..2 {
+            WarmAdmission::admit(&controller, warm(&format!("over-cap-{index}")))
+                .await
+                .expect("a fresh controller admits up to the cap");
+        }
+        // The cap itself refuses a third reservation, so drive occupancy above
+        // it the way a predecessor epoch does: adopt a durable row directly.
+        controller
+            .journal()
+            .adopt_live(&djinn_db::AdoptLiveAdmissionInput {
+                key: AdmissionJournalKey {
+                    domain: AdmissionDomain::WarmBuild,
+                    work_id: "seeded-over-cap".into(),
+                    generation: 0,
+                },
+                workload_kind: AdmissionWorkloadKind::Warm,
+                creator_server_epoch: "predecessor".into(),
+                object_name: "seeded-over-cap-job".into(),
+                object_uid: "seeded-uid".into(),
+            })
+            .await
+            .unwrap();
+        controller.publish_metrics().await;
+        let rendered = djinn_telemetry::render().unwrap();
+        assert_eq!(
+            sample_value(
+                &rendered,
+                "djinn_build_admission_occupancy_over_cap",
+                &labels
+            ),
+            1.0,
+            "occupancy above the cap must be visible without reading a log"
+        );
+
+        controller.publish_reconciliation(7, 5, 2);
+        let rendered = djinn_telemetry::render().unwrap();
+        assert_eq!(
+            sample_value(&rendered, "djinn_build_admission_stale_rows", &labels),
+            7.0
+        );
+        assert_eq!(
+            sample_value(
+                &rendered,
+                "djinn_build_admission_transition_total",
+                &[
+                    ("effective_mode", "enforce"),
+                    ("effective_cap", "2"),
+                    ("outcome", "reclaimed")
+                ]
+            ),
+            5.0
+        );
+        assert_eq!(
+            sample_value(
+                &rendered,
+                "djinn_build_admission_transition_total",
+                &[
+                    ("effective_mode", "enforce"),
+                    ("effective_cap", "2"),
+                    ("outcome", "reclaim_fenced")
+                ]
+            ),
+            2.0
+        );
     }
 
     struct FakeQueueClock {

--- a/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
@@ -458,7 +458,7 @@ fn epoch_and_admission_telemetry_labels_stay_bounded_and_carry_no_identifiers() 
         djinn_telemetry::build_admission::record_shadow_invocation(false);
 
         for mode in ["enforce", "observe", "off"] {
-            djinn_telemetry::build_admission::set_health(mode, 3, true, true, true);
+            djinn_telemetry::build_admission::set_health(mode, 3, true, true, true, true);
             djinn_telemetry::build_admission::increment_would_defer(mode, 3);
             djinn_telemetry::build_admission::increment_unknown_classification(mode, 3);
         }

--- a/server/crates/djinn-coordinator/src/build_admission_inventory.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory.rs
@@ -129,6 +129,18 @@ fn classify(r: &WorkloadRecord) -> Result<Option<ClassifiedWorkload>, String> {
             object: r.clone(),
         }));
     }
+    // Image builds share the namespace but are not project compiles under the
+    // shared task/warm cap: the image controller dispatches them, they execute
+    // on buildkitd, and they have never carried an admission identity. They
+    // must be RECOGNISED here rather than falling through to the
+    // unclassifiable catch-all below, which marks the inventory gate pending
+    // and would keep Enforce fail-closed for as long as any image is building.
+    if l.get("djinn.app/component")
+        .is_some_and(|value| value == "image-build")
+        || r.name.starts_with("djinn-build-")
+    {
+        return Ok(None);
+    }
     if (r.name.starts_with("djinn-") || l.keys().any(|k| k.starts_with("djinn.app/")))
         && !r.terminal
         && !r.images.is_empty()

--- a/server/crates/djinn-coordinator/src/build_admission_inventory.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory.rs
@@ -1,18 +1,32 @@
 //! Conservative Kubernetes inventory classification and reconciliation.
 use crate::build_admission::{BuildAdmissionController, BuildAdmissionMode};
 use djinn_db::{
-    AdmissionDomain, AdmissionJournalKey, AdmissionRecoveryResult, AdmissionState,
-    AdmissionWorkloadKind, AdoptLiveAdmissionInput, TerminalAdmissionInput,
+    AdmissionDomain, AdmissionJournalKey, AdmissionJournalRow, AdmissionRecoveryResult,
+    AdmissionState, AdmissionWorkloadKind, AdoptLiveAdmissionInput, ReclaimAbsentInput,
+    ReclaimAbsentOutcome, TerminalAdmissionInput,
 };
 use djinn_k8s::{
-    LABEL_ADMISSION_DOMAIN, LABEL_ADMISSION_GENERATION, LABEL_ADMISSION_WORK_ID, UidGetResult,
-    WorkloadInventory, WorkloadRecord, has_canonical_warm_signature,
+    LABEL_ADMISSION_DOMAIN, LABEL_ADMISSION_GENERATION, LABEL_ADMISSION_WORK_ID, ObjectPresence,
+    UidGetResult, WorkloadInventory, WorkloadObjectKind, WorkloadRecord,
+    has_canonical_warm_signature,
 };
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
+    time::Duration,
 };
 use tokio::sync::Mutex;
+
+/// How long an occupying row must sit untouched before its object's absence is
+/// allowed to retire it.
+///
+/// This is a guard, never the reason. A Kubernetes create that a since-dead
+/// process POSTed can still be admitted by the API server shortly after that
+/// process is gone, so a row that was written moments ago is not yet safe to
+/// judge by a LIST/GET. Five minutes is far beyond any create-admission window
+/// and far below the lifetime of the stale populations this reclaims.
+pub const DEFAULT_RECLAIM_SETTLE_WINDOW: Duration = Duration::from_secs(300);
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClassifiedWorkload {
     pub key: AdmissionJournalKey,
@@ -23,7 +37,18 @@ pub struct ClassifiedWorkload {
 pub struct InventoryReport {
     pub adopted: usize,
     pub released: usize,
+    /// Occupying rows in a pre-Live state that were retired because their
+    /// Kubernetes object was proven absent.
+    pub reclaimed: usize,
+    /// Rows whose object was proven absent, counted before any reclamation.
+    /// This is the size of the stale population, not the size of the fix.
+    pub stale: usize,
+    /// Reclamations refused because the row changed after its absence proof.
+    pub fenced: usize,
     pub blockers: Vec<String>,
+}
+fn identity(key: &AdmissionJournalKey) -> String {
+    format!("{:?}:{}:{}", key.domain, key.work_id, key.generation)
 }
 fn domain(v: &str) -> Option<AdmissionDomain> {
     match v {
@@ -115,6 +140,7 @@ fn classify(r: &WorkloadRecord) -> Result<Option<ClassifiedWorkload>, String> {
 pub struct BuildAdmissionReconciler {
     controller: Arc<BuildAdmissionController>,
     inventory: Arc<dyn WorkloadInventory>,
+    settle_window: Duration,
     serial: Mutex<()>,
 }
 impl BuildAdmissionReconciler {
@@ -122,12 +148,61 @@ impl BuildAdmissionReconciler {
         controller: Arc<BuildAdmissionController>,
         inventory: Arc<dyn WorkloadInventory>,
     ) -> Self {
+        Self::with_settle_window(controller, inventory, DEFAULT_RECLAIM_SETTLE_WINDOW)
+    }
+
+    /// Reconcile with an explicit settle window. Tests use a zero window to
+    /// exercise reclamation without sleeping; production uses the default.
+    pub fn with_settle_window(
+        controller: Arc<BuildAdmissionController>,
+        inventory: Arc<dyn WorkloadInventory>,
+        settle_window: Duration,
+    ) -> Self {
         Self {
             controller,
             inventory,
+            settle_window,
             serial: Mutex::new(()),
         }
     }
+    /// Whether a pre-Live occupying row's Kubernetes object is provably gone.
+    ///
+    /// Every clause is a fence that must open; none of them is a heuristic
+    /// about how old the row looks:
+    ///
+    /// * the row's creator epoch is not this process, so no in-process dispatch
+    ///   can still be mid-create for it — the only process that could have
+    ///   finished this create is gone;
+    /// * the row has settled, so the API server can no longer be admitting a
+    ///   create the dead process POSTed;
+    /// * the authoritative LIST that just succeeded contains no object under
+    ///   this row's name, and it did not classify to a live workload;
+    /// * a direct GET, taken now and independently of the LIST snapshot,
+    ///   answers that no object with that name exists. `Uncertain` — a
+    ///   transport or permission failure — is never proof, so a degraded API
+    ///   server leaves every row occupying.
+    async fn is_reclaimable(
+        &self,
+        row: &AdmissionJournalRow,
+        classified: &Option<&ClassifiedWorkload>,
+        listed_names: &HashSet<String>,
+        settled: &HashMap<String, bool>,
+    ) -> bool {
+        if row.creator_server_epoch == self.controller.server_epoch() {
+            return false;
+        }
+        if !settled.get(&identity(&row.key)).copied().unwrap_or(false) {
+            return false;
+        }
+        if classified.is_some() || listed_names.contains(&row.object_name) {
+            return false;
+        }
+        self.inventory
+            .presence(WorkloadObjectKind::Job, &row.object_name)
+            .await
+            == ObjectPresence::Absent
+    }
+
     pub async fn reconcile(&self) -> InventoryReport {
         let _g = self.serial.lock().await;
         if self.controller.mode() == BuildAdmissionMode::Off {
@@ -147,10 +222,15 @@ impl BuildAdmissionReconciler {
         let mut out = InventoryReport::default();
         let mut cs = Vec::new();
         let mut ids = HashSet::new();
+        // Every Job name the authoritative LIST returned, including records
+        // classification skipped or rejected. A row whose object name appears
+        // here is never a reclamation candidate, whatever we could or could not
+        // make of that object's labels.
+        let listed_names: HashSet<String> = records.iter().map(|r| r.name.clone()).collect();
         for r in records {
             match classify(&r) {
                 Ok(Some(c)) => {
-                    let id = format!("{:?}:{}:{}", c.key.domain, c.key.work_id, c.key.generation);
+                    let id = identity(&c.key);
                     if ids.insert(id) {
                         cs.push(c)
                     } else {
@@ -186,7 +266,12 @@ impl BuildAdmissionReconciler {
                 }
             }
         }
-        let active = match self.controller.journal().list_active_rows().await {
+        let active = match self
+            .controller
+            .journal()
+            .list_active_rows_with_settlement(self.settle_window.as_secs() as i64)
+            .await
+        {
             Ok(rows) => rows,
             Err(error) => {
                 self.controller.mark_journal_unhealthy();
@@ -196,51 +281,94 @@ impl BuildAdmissionReconciler {
                 return out;
             }
         };
-        let by: HashMap<_, _> = cs
+        let settled: HashMap<String, bool> = active
             .iter()
-            .map(|c| {
-                (
-                    format!("{:?}:{}:{}", c.key.domain, c.key.work_id, c.key.generation),
-                    c,
-                )
-            })
+            .map(|(row, settled)| (identity(&row.key), *settled))
             .collect();
+        let active: Vec<AdmissionJournalRow> = active.into_iter().map(|(row, _)| row).collect();
+        let by: HashMap<_, _> = cs.iter().map(|c| (identity(&c.key), c)).collect();
         for row in &active {
-            if row.state != AdmissionState::Live {
+            let id = identity(&row.key);
+            if row.state == AdmissionState::Live {
+                let proof = if let Some(c) = by.get(&id) {
+                    c.object.terminal && c.object.uid.as_deref() == row.object_uid.as_deref()
+                } else if let Some(uid) = row.object_uid.as_deref() {
+                    self.inventory
+                        .get_uid(WorkloadObjectKind::Job, &row.object_name, uid)
+                        .await
+                        == UidGetResult::NotFound
+                } else {
+                    false
+                };
+                if proof {
+                    out.stale += 1;
+                    match self
+                        .controller
+                        .journal()
+                        .mark_terminal(&TerminalAdmissionInput {
+                            key: row.key.clone(),
+                            object_uid: row.object_uid.clone(),
+                        })
+                        .await
+                    {
+                        Ok(_) => {
+                            out.released += 1;
+                            self.controller.release_notifier().notify_one();
+                        }
+                        Err(error) => {
+                            self.controller.mark_journal_unhealthy();
+                            out.blockers.push(error.to_string());
+                        }
+                    }
+                }
                 continue;
             }
-            let id = format!(
-                "{:?}:{}:{}",
-                row.key.domain, row.key.work_id, row.key.generation
-            );
-            let proof = if let Some(c) = by.get(&id) {
-                c.object.terminal && c.object.uid.as_deref() == row.object_uid.as_deref()
-            } else if let Some(uid) = row.object_uid.as_deref() {
-                self.inventory
-                    .get_uid(djinn_k8s::WorkloadObjectKind::Job, &row.object_name, uid)
-                    .await
-                    == UidGetResult::NotFound
-            } else {
-                false
+            // Reserved / CreateInFlight / CreateUnknown. Recovery retires
+            // Reserved rows and converts CreateInFlight into occupying
+            // CreateUnknown, and adoption rescues a CreateUnknown row whose
+            // object still exists — but nothing at all terminalizes one whose
+            // object is gone. Those rows occupy the shared cap forever, which
+            // is how a fleet accumulates a stale population large enough to
+            // deny every admission the moment the cap is armed.
+            if !self
+                .is_reclaimable(row, &by.get(&id).copied(), &listed_names, &settled)
+                .await
+            {
+                continue;
+            }
+            out.stale += 1;
+            let input = ReclaimAbsentInput {
+                key: row.key.clone(),
+                observed_state: row.state,
+                observed_creator_server_epoch: row.creator_server_epoch.clone(),
+                observed_object_name: row.object_name.clone(),
+                observed_object_uid: row.object_uid.clone(),
             };
-            if proof {
-                match self
-                    .controller
-                    .journal()
-                    .mark_terminal(&TerminalAdmissionInput {
-                        key: row.key.clone(),
-                        object_uid: row.object_uid.clone(),
-                    })
-                    .await
-                {
-                    Ok(_) => {
-                        out.released += 1;
-                        self.controller.release_notifier().notify_one();
-                    }
-                    Err(error) => {
-                        self.controller.mark_journal_unhealthy();
-                        out.blockers.push(error.to_string());
-                    }
+            match self
+                .controller
+                .journal()
+                .reclaim_absent_object(&input)
+                .await
+            {
+                Ok(ReclaimAbsentOutcome::Reclaimed(_)) => {
+                    out.reclaimed += 1;
+                    self.controller.release_notifier().notify_one();
+                }
+                Ok(ReclaimAbsentOutcome::AlreadyTerminal(_)) => {}
+                Ok(ReclaimAbsentOutcome::Fenced { reason }) => {
+                    out.fenced += 1;
+                    tracing::warn!(
+                        work_id = %row.key.work_id,
+                        generation = row.key.generation,
+                        object = %row.object_name,
+                        %reason,
+                        "build_admission: refused to reclaim an admission row that changed \
+                         after its absence proof"
+                    );
+                }
+                Err(error) => {
+                    self.controller.mark_journal_unhealthy();
+                    out.blockers.push(error.to_string());
                 }
             }
         }
@@ -281,6 +409,11 @@ impl BuildAdmissionReconciler {
         // blockers, but the blockers branch and any adoption under partial
         // inventory still need this explicit publication.
         self.controller.publish_metrics().await;
+        // Publish the size of the stale population itself, loudly when it is
+        // large enough to have wedged the cap. Discovering this by reading
+        // thousands of per-transition warn lines is not an operating model.
+        self.controller
+            .publish_reconciliation(out.stale, out.released + out.reclaimed, out.fenced);
         out
     }
 }

--- a/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
@@ -12,8 +12,8 @@ use djinn_db::{
     ReserveAdmissionInput,
 };
 use djinn_k8s::{
-    LABEL_ADMISSION_DOMAIN, LABEL_ADMISSION_GENERATION, LABEL_ADMISSION_WORK_ID, UidGetResult,
-    WorkloadInventory, WorkloadObjectKind, WorkloadRecord,
+    LABEL_ADMISSION_DOMAIN, LABEL_ADMISSION_GENERATION, LABEL_ADMISSION_WORK_ID, ObjectPresence,
+    UidGetResult, WorkloadInventory, WorkloadObjectKind, WorkloadRecord,
 };
 use futures::FutureExt;
 use tokio::sync::RwLock;
@@ -26,6 +26,7 @@ use crate::{
 struct FakeInventory {
     records: RwLock<Result<Vec<WorkloadRecord>, String>>,
     gets: RwLock<HashMap<(String, String), UidGetResult>>,
+    presence: RwLock<HashMap<String, ObjectPresence>>,
     list_calls: std::sync::atomic::AtomicUsize,
 }
 
@@ -34,6 +35,7 @@ impl FakeInventory {
         Self {
             records: RwLock::new(Ok(records)),
             gets: RwLock::new(HashMap::new()),
+            presence: RwLock::new(HashMap::new()),
             list_calls: std::sync::atomic::AtomicUsize::new(0),
         }
     }
@@ -47,6 +49,10 @@ impl FakeInventory {
             .write()
             .await
             .insert((name.into(), uid.into()), result);
+    }
+
+    async fn presence_returns(&self, name: &str, result: ObjectPresence) {
+        self.presence.write().await.insert(name.into(), result);
     }
 }
 
@@ -65,6 +71,17 @@ impl WorkloadInventory for FakeInventory {
             .get(&(name.into(), uid.into()))
             .copied()
             .unwrap_or(UidGetResult::Uncertain)
+    }
+
+    /// Defaults to `Uncertain`: a probe that was never programmed must never
+    /// be read as proof that an object is gone.
+    async fn presence(&self, _kind: WorkloadObjectKind, name: &str) -> ObjectPresence {
+        self.presence
+            .read()
+            .await
+            .get(name)
+            .cloned()
+            .unwrap_or(ObjectPresence::Uncertain)
     }
 }
 
@@ -328,6 +345,84 @@ async fn authoritative_uid_not_found_releases_and_emits_wakeup() {
 
     assert_eq!(report.released, 1);
     assert!(notified.now_or_never().is_some());
+    assert!(
+        controller
+            .journal()
+            .list_active_rows()
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// A degraded API server answers `Uncertain`, which is not evidence. The row
+/// keeps occupying until a probe can actually answer.
+#[tokio::test]
+async fn uncertain_presence_never_reclaims_a_create_unknown_row() {
+    let controller = controller(BuildAdmissionMode::Enforce, 3);
+    let key = AdmissionJournalKey {
+        domain: AdmissionDomain::TaskObservation,
+        work_id: "uncertain".into(),
+        generation: 4,
+    };
+    controller
+        .journal()
+        .reserve(
+            &ReserveAdmissionInput {
+                key: key.clone(),
+                workload_kind: AdmissionWorkloadKind::Task,
+                creator_server_epoch: "old".into(),
+                object_name: "uncertain-job".into(),
+            },
+            3,
+        )
+        .await
+        .unwrap();
+    controller
+        .journal()
+        .mark_create_started(&CreateStartedInput {
+            key: key.clone(),
+            creator_server_epoch: "old".into(),
+            object_name: "uncertain-job".into(),
+        })
+        .await
+        .unwrap();
+    controller
+        .journal()
+        .recover_predecessor_epoch("old")
+        .await
+        .unwrap();
+
+    let inventory = Arc::new(FakeInventory::new(vec![]));
+    inventory
+        .presence_returns("uncertain-job", ObjectPresence::Uncertain)
+        .await;
+    let report = BuildAdmissionReconciler::with_settle_window(
+        controller.clone(),
+        inventory.clone(),
+        std::time::Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(report.stale, 0, "an unanswerable probe proves nothing");
+    assert_eq!(
+        controller.journal().list_active_rows().await.unwrap()[0].state,
+        AdmissionState::CreateUnknown
+    );
+
+    // The same probe, now able to answer, retires the row.
+    inventory
+        .presence_returns("uncertain-job", ObjectPresence::Absent)
+        .await;
+    let report = BuildAdmissionReconciler::with_settle_window(
+        controller.clone(),
+        inventory,
+        std::time::Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+    assert_eq!(report.reclaimed, 1);
     assert!(
         controller
             .journal()

--- a/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory_tests.rs
@@ -355,6 +355,43 @@ async fn authoritative_uid_not_found_releases_and_emits_wakeup() {
     );
 }
 
+/// An image build shares the namespace with admission workloads. It is not a
+/// project compile under the shared cap, and it must never be mistaken for an
+/// unclassifiable build workload — that marks the inventory gate pending and
+/// keeps Enforce fail-closed for as long as any image is building.
+#[tokio::test]
+async fn image_build_jobs_are_recognised_and_never_block_the_inventory_gate() {
+    let mut image_build = record(
+        "djinn-build-project-abc123",
+        Some("uid-image-build"),
+        &[
+            ("djinn.app/component", "image-build"),
+            ("djinn.app/build", "true"),
+        ],
+    );
+    image_build.commands = vec!["buildctl".into()];
+    let inventory = Arc::new(FakeInventory::new(vec![
+        image_build,
+        labeled("real-work", "uid-work", "work", "0"),
+    ]));
+    let controller = controller(BuildAdmissionMode::Enforce, 3);
+    let report = BuildAdmissionReconciler::new(controller.clone(), inventory)
+        .reconcile()
+        .await;
+
+    assert!(
+        report.blockers.is_empty(),
+        "an image build must not block the gate: {:?}",
+        report.blockers
+    );
+    assert_eq!(report.adopted, 1, "only the admission workload is adopted");
+    assert_ne!(
+        controller.readiness(),
+        BuildAdmissionReadiness::InventoryPending,
+        "the inventory gate must complete while an image is building"
+    );
+}
+
 /// A degraded API server answers `Uncertain`, which is not evidence. The row
 /// keeps occupying until a probe can actually answer.
 #[tokio::test]

--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -1,0 +1,500 @@
+//! Regression coverage for stale durable occupancy whose Kubernetes objects
+//! are gone (production symptom: 318 occupying `admission_journal` rows against
+//! a namespace holding zero Jobs, with `djinn_build_slots_in_use` reading 318
+//! while `kubectl get jobs -A` returned nothing).
+//!
+//! Every stale row in these tests is produced by the production dispatch path —
+//! the concrete `K8sGraphWarmer` driving the production `BuildAdmissionController`
+//! and the production `AdmissionJournalRepository` against a real project row in
+//! a fresh database — and then aged into its stale form by the production
+//! `recover_all_predecessors_and_seed` restart path. Nothing here hand-writes a
+//! journal row and then asks reconciliation to clean it up: the seeding is the
+//! behaviour under test just as much as the reclamation is.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_core::events::EventBus;
+use djinn_db::{
+    AdmissionDomain, AdmissionJournalRepository, AdmissionState, Database, ImageRepository,
+    ProjectRepository,
+};
+use djinn_k8s::{
+    K8sGraphWarmer, KubernetesConfig, ObjectPresence, UidGetResult, WarmAdmission,
+    WarmAdmissionError, WarmAdmissionRequest, WarmJobDispatcher, WarmJobManifest, WarmJobWatcher,
+    WarmTerminalOutcome, WorkloadInventory, WorkloadObjectKind, WorkloadRecord, warm_work_id,
+};
+use djinn_runtime::GraphWarmerService;
+use tokio::sync::RwLock;
+
+use crate::build_admission::{
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, BuildAdmissionReadiness,
+    BuildAdmissionRequest, BuildWorkloadKind,
+};
+use crate::build_admission_inventory::BuildAdmissionReconciler;
+
+const PREDECESSOR_EPOCH: &str = "epoch-before-the-restart";
+const REPLACEMENT_EPOCH: &str = "epoch-after-the-restart";
+
+/// An inventory whose namespace holds exactly the Jobs it was given.
+///
+/// `presence` answers authoritatively from that same set, which is what a live
+/// API server does: an object either exists under a name or it does not.
+struct NamespaceInventory {
+    records: RwLock<Vec<WorkloadRecord>>,
+}
+
+impl NamespaceInventory {
+    fn empty() -> Self {
+        Self {
+            records: RwLock::new(Vec::new()),
+        }
+    }
+
+    fn holding(records: Vec<WorkloadRecord>) -> Self {
+        Self {
+            records: RwLock::new(records),
+        }
+    }
+}
+
+#[async_trait]
+impl WorkloadInventory for NamespaceInventory {
+    async fn list(&self) -> Result<Vec<WorkloadRecord>, String> {
+        Ok(self.records.read().await.clone())
+    }
+
+    async fn get_uid(&self, _kind: WorkloadObjectKind, name: &str, uid: &str) -> UidGetResult {
+        match self
+            .records
+            .read()
+            .await
+            .iter()
+            .find(|record| record.name == name)
+        {
+            Some(record) if record.uid.as_deref() == Some(uid) => UidGetResult::Present,
+            Some(_) => UidGetResult::Uncertain,
+            None => UidGetResult::NotFound,
+        }
+    }
+
+    async fn presence(&self, _kind: WorkloadObjectKind, name: &str) -> ObjectPresence {
+        match self
+            .records
+            .read()
+            .await
+            .iter()
+            .find(|record| record.name == name)
+        {
+            Some(record) => ObjectPresence::Present {
+                uid: record.uid.clone(),
+            },
+            None => ObjectPresence::Absent,
+        }
+    }
+}
+
+/// A dispatcher whose POST response is lost. This is the production shape that
+/// leaves a generation in an ambiguous create state: Kubernetes may or may not
+/// have created the object, so the warmer records `CreateUnknown` rather than a
+/// definitive failure.
+struct LostResponseDispatcher;
+
+#[async_trait]
+impl WarmJobDispatcher for LostResponseDispatcher {
+    async fn dispatch(&self, _namespace: &str, _job: WarmJobManifest) -> Result<String, String> {
+        Err("connection reset by peer while awaiting the create response".into())
+    }
+}
+
+/// A dispatcher that POSTs successfully, paired with a watcher that reports a
+/// UID and then never terminalizes — the process is lost mid-lifecycle.
+struct SucceedingDispatcher;
+
+#[async_trait]
+impl WarmJobDispatcher for SucceedingDispatcher {
+    async fn dispatch(&self, _namespace: &str, _job: WarmJobManifest) -> Result<String, String> {
+        Ok("warm-job".into())
+    }
+}
+
+struct NeverTerminalWatcher {
+    uid: String,
+}
+
+#[async_trait]
+impl WarmJobWatcher for NeverTerminalWatcher {
+    async fn wait_terminal(&self, _namespace: &str, _job_name: &str) -> WarmTerminalOutcome {
+        std::future::pending::<()>().await;
+        unreachable!("the observing process is lost before the Job terminates")
+    }
+
+    async fn job_uid(&self, _namespace: &str, _job_name: &str) -> Option<String> {
+        Some(self.uid.clone())
+    }
+}
+
+async fn seed_project(db: &Database, name: &str) -> String {
+    let projects = ProjectRepository::new(db.clone(), EventBus::noop());
+    let project = projects.create(name, "test", name).await.unwrap();
+    let images = ImageRepository::new(db.clone());
+    let image_id = format!("img-{name}");
+    images.create(&image_id, name, None, "{}").await.unwrap();
+    images
+        .mark_ready(
+            &image_id,
+            &format!("reg.example:5000/djinn-project-{}:abc123", project.id),
+            None,
+        )
+        .await
+        .unwrap();
+    images
+        .set_project_image(&project.id, Some(&image_id))
+        .await
+        .unwrap();
+    project.id
+}
+
+async fn await_state(
+    journal: &AdmissionJournalRepository,
+    work_id: &str,
+    expected: AdmissionState,
+) {
+    for _ in 0..600 {
+        let history = journal
+            .list_history(AdmissionDomain::WarmBuild, work_id)
+            .await
+            .unwrap();
+        if history.last().is_some_and(|row| row.state == expected) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!(
+        "warm work {work_id} never reached {expected:?}: {:?}",
+        journal
+            .list_history(AdmissionDomain::WarmBuild, work_id)
+            .await
+            .unwrap()
+    );
+}
+
+/// Drive real warm dispatches on a doomed process and return the durable shape
+/// production accumulated: `ambiguous` generations left in an unresolved create
+/// and `orphaned` generations left Live with a UID nobody will ever retire.
+///
+/// The returned work ids are the journal's own, not a test fixture's.
+async fn accumulate_production_stale_population(
+    db: &Database,
+    journal: &Arc<AdmissionJournalRepository>,
+    ambiguous: usize,
+    orphaned: usize,
+) -> Vec<String> {
+    let doomed = Arc::new(BuildAdmissionController::new(
+        Arc::clone(journal),
+        // Production ran Observe while this population accumulated.
+        BuildAdmissionMode::Observe,
+        3,
+        PREDECESSOR_EPOCH,
+    ));
+    let mut work_ids = Vec::new();
+    for index in 0..ambiguous {
+        let project_id = seed_project(db, &format!("ambiguous-{index}")).await;
+        let warmer = K8sGraphWarmer::with_dispatcher(
+            KubernetesConfig::for_testing(),
+            db.clone(),
+            Arc::new(LostResponseDispatcher),
+            Arc::new(NeverTerminalWatcher {
+                uid: format!("unused-{index}"),
+            }),
+        )
+        .with_warm_admission(doomed.clone());
+        warmer.trigger(&project_id).await;
+        let work_id = warm_work_id(&project_id, "unknown");
+        await_state(journal, &work_id, AdmissionState::CreateUnknown).await;
+        work_ids.push(work_id);
+    }
+    for index in 0..orphaned {
+        let project_id = seed_project(db, &format!("orphaned-{index}")).await;
+        let warmer = K8sGraphWarmer::with_dispatcher(
+            KubernetesConfig::for_testing(),
+            db.clone(),
+            Arc::new(SucceedingDispatcher),
+            Arc::new(NeverTerminalWatcher {
+                uid: format!("orphan-uid-{index}"),
+            }),
+        )
+        .with_warm_admission(doomed.clone());
+        warmer.trigger(&project_id).await;
+        let work_id = warm_work_id(&project_id, "unknown");
+        await_state(journal, &work_id, AdmissionState::Live).await;
+        work_ids.push(work_id);
+    }
+    work_ids
+}
+
+fn replacement(
+    journal: &Arc<AdmissionJournalRepository>,
+    cap: i64,
+) -> Arc<BuildAdmissionController> {
+    Arc::new(BuildAdmissionController::new(
+        Arc::clone(journal),
+        BuildAdmissionMode::Enforce,
+        cap,
+        REPLACEMENT_EPOCH,
+    ))
+}
+
+fn warm_request(id: &str) -> WarmAdmissionRequest {
+    WarmAdmissionRequest {
+        domain: "ignored".into(),
+        work_id: id.into(),
+        generation: 0,
+        object_name: format!("job-{id}"),
+    }
+}
+
+/// The production build-admission entry point the warm trait wraps, so the
+/// bounded decision (and its occupancy arithmetic) is directly observable.
+fn build_request(id: &str) -> BuildAdmissionRequest {
+    BuildAdmissionRequest {
+        domain: AdmissionDomain::WarmBuild,
+        work_id: id.into(),
+        generation: 0,
+        object_name: format!("job-{id}"),
+        kind: BuildWorkloadKind::GraphWarmJob,
+    }
+}
+
+/// The blocker, end to end: a production-shaped stale population denies every
+/// Enforce admission at cap 3, and startup reconciliation against an authoritative
+/// namespace listing releases it so the board runs again.
+#[tokio::test]
+async fn production_shaped_stale_population_is_reclaimed_and_enforce_admits_at_cap() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    let stale_work = accumulate_production_stale_population(&db, &journal, 4, 2).await;
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        6,
+        "the doomed process left six occupying generations behind"
+    );
+
+    // The process is replaced. This is the real startup recovery path.
+    let controller = replacement(&journal, 3);
+    let report = controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        6,
+        "recovery retires Reserved rows and converts CreateInFlight into occupying \
+         CreateUnknown; it releases none of this population"
+    );
+    assert!(
+        matches!(
+            report.readiness,
+            BuildAdmissionReadiness::CreateUnknownHealth
+                | BuildAdmissionReadiness::SeededOccupancyAboveCap
+        ),
+        "the stale population must trip a startup gate, not pass silently: {:?}",
+        report.readiness
+    );
+    controller.mark_inventory_ready();
+    controller.mark_topology_ready();
+    assert!(
+        !controller.is_ready(),
+        "Enforce cannot arm while the stale population occupies the cap"
+    );
+    let wedged = WarmAdmission::admit(controller.as_ref(), warm_request("blocked-by-stale"))
+        .await
+        .expect_err("this is the production wedge: every admission denied while stale");
+    assert!(
+        matches!(wedged, WarmAdmissionError::Denied { .. }),
+        "unexpected wedge diagnostic: {wedged}"
+    );
+
+    // Startup reconciliation against a namespace that holds no Jobs at all —
+    // the exact production observation.
+    let reconciler = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::ZERO,
+    );
+    let inventory = reconciler.reconcile().await;
+    assert!(
+        inventory.blockers.is_empty(),
+        "unexpected blockers: {:?}",
+        inventory.blockers
+    );
+    assert_eq!(
+        inventory.stale, 6,
+        "every occupying row's object was proven absent"
+    );
+    assert_eq!(inventory.reclaimed, 4, "four ambiguous creates are retired");
+    assert_eq!(inventory.released, 2, "two orphaned Live rows are retired");
+    assert_eq!(inventory.fenced, 0);
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        0,
+        "reconciliation must release the whole stale population"
+    );
+    for work_id in &stale_work {
+        let history = journal
+            .list_history(AdmissionDomain::WarmBuild, work_id)
+            .await
+            .unwrap();
+        assert!(
+            history
+                .iter()
+                .all(|row| row.state == AdmissionState::Terminal),
+            "{work_id} retains a non-terminal generation: {history:?}"
+        );
+    }
+
+    // The board runs again: three concurrent builds admit, the fourth queues.
+    controller.mark_topology_ready();
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::Healthy,
+        "every startup gate must clear once the stale occupancy is gone"
+    );
+    for index in 0..3 {
+        let decision = controller
+            .admit(build_request(&format!("after-{index}")))
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, BuildAdmissionDecision::Permitted { .. }),
+            "admission {index} must be granted at cap 3 after reconciliation: {decision:?}"
+        );
+    }
+    let fourth = controller.admit(build_request("after-3")).await.unwrap();
+    assert!(
+        matches!(
+            fourth,
+            BuildAdmissionDecision::Denied {
+                occupancy: 3,
+                cap: 3
+            }
+        ),
+        "the cap must still bind after reconciliation; reclamation is not a bypass: {fourth:?}"
+    );
+}
+
+/// Reclamation must not become a way to release work that is still running.
+/// Only rows whose object the API server denies the existence of are retired.
+#[tokio::test]
+async fn reclamation_never_releases_work_that_is_still_fenced() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    accumulate_production_stale_population(&db, &journal, 2, 0).await;
+
+    // One of the two ambiguous creates actually landed: the Job exists in the
+    // namespace under the name the journal recorded. Its capacity is real.
+    let rows = journal.list_active_rows().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    let surviving = rows[0].clone();
+    let surviving_job = WorkloadRecord {
+        kind: WorkloadObjectKind::Job,
+        name: surviving.object_name.clone(),
+        uid: Some("the-create-did-land".into()),
+        labels: Default::default(),
+        terminal: false,
+        images: vec!["djinn:test".into()],
+        commands: vec!["djinn-warm".into()],
+    };
+
+    let controller = replacement(&journal, 3);
+    controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::holding(vec![surviving_job])),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+
+    assert_eq!(
+        report.reclaimed, 1,
+        "only the generation whose object is absent may be reclaimed"
+    );
+    let remaining = journal.list_active_rows().await.unwrap();
+    assert_eq!(
+        remaining.len(),
+        1,
+        "the generation whose Job still exists must keep occupying: {remaining:?}"
+    );
+    assert_eq!(remaining[0].key, surviving.key);
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        1,
+        "live work is never released by reconciliation"
+    );
+}
+
+/// A row created by THIS process may be mid-create right now, and an API server
+/// that cannot answer is not evidence of anything. Neither may be reclaimed.
+#[tokio::test]
+async fn current_epoch_and_unsettled_rows_are_never_reclaimed() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+
+    // A live process holds an in-flight create of its own. Its epoch matches
+    // the reconciling controller's, so no Kubernetes evidence can retire it.
+    let controller = replacement(&journal, 3);
+    controller.mark_ready();
+    let project_id = seed_project(&db, "in-flight-now").await;
+    let warmer = K8sGraphWarmer::with_dispatcher(
+        KubernetesConfig::for_testing(),
+        db.clone(),
+        Arc::new(LostResponseDispatcher),
+        Arc::new(NeverTerminalWatcher {
+            uid: "unused".into(),
+        }),
+    )
+    .with_warm_admission(controller.clone());
+    warmer.trigger(&project_id).await;
+    let work_id = warm_work_id(&project_id, "unknown");
+    await_state(&journal, &work_id, AdmissionState::CreateUnknown).await;
+
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+    assert_eq!(
+        report.reclaimed, 0,
+        "a row this process created may still be mid-create"
+    );
+    assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 1);
+
+    // Same rows, seen by a replacement process, but inside the settle window:
+    // the API server could still be admitting a create the dead process POSTed.
+    let successor = Arc::new(BuildAdmissionController::new(
+        Arc::clone(&journal),
+        BuildAdmissionMode::Enforce,
+        3,
+        "a-third-epoch",
+    ));
+    successor.recover_all_predecessors_and_seed().await.unwrap();
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&successor),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::from_secs(3600),
+    )
+    .reconcile()
+    .await;
+    assert_eq!(
+        report.reclaimed, 0,
+        "an unsettled row is not yet safe to judge by a listing"
+    );
+    assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 1);
+}

--- a/server/crates/djinn-coordinator/src/build_lease_cap_arming_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_cap_arming_tests.rs
@@ -43,9 +43,8 @@ async fn an_unarmed_durable_cap_denies_every_graph_warm_lease_forever() {
     // The composition as it shipped: the configured build-slot cap was never
     // handed to the lease service, so the resolution chain bottomed out at the
     // unarmed durable 0.
-    let service = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 0).with_handoff_epoch(handoff),
-    );
+    let service =
+        Arc::new(BuildLeaseService::new(Arc::clone(&repository), 0).with_handoff_epoch(handoff));
     assert!(matches!(service.recover().await, LeaseResult::Status(_)));
     assert_eq!(service.cap(), 0);
 
@@ -86,9 +85,8 @@ async fn an_unarmed_durable_cap_adopts_the_configured_build_slot_cap() {
     let handoff = Arc::new(AdmissionHandoffRepository::new(database.clone()));
     // The fixed composition: the same configured cap the v0 journal controller
     // receives from DJINN_MAX_BUILD_TASKRUNS.
-    let service = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 3).with_handoff_epoch(handoff),
-    );
+    let service =
+        Arc::new(BuildLeaseService::new(Arc::clone(&repository), 3).with_handoff_epoch(handoff));
     assert!(matches!(service.recover().await, LeaseResult::Status(_)));
     assert_eq!(service.cap(), 3);
 
@@ -131,16 +129,18 @@ async fn re_seeding_the_handoff_row_alone_does_not_arm_the_lease() {
     let unconfigured = Arc::new(
         BuildLeaseService::new(Arc::clone(&repository), 0).with_handoff_epoch(Arc::clone(&handoff)),
     );
-    assert!(matches!(unconfigured.recover().await, LeaseResult::Status(_)));
+    assert!(matches!(
+        unconfigured.recover().await,
+        LeaseResult::Status(_)
+    ));
     assert_eq!(
         unconfigured.cap(),
         0,
         "seeding the handoff row is not sufficient to arm the lease"
     );
 
-    let configured = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 3).with_handoff_epoch(handoff),
-    );
+    let configured =
+        Arc::new(BuildLeaseService::new(Arc::clone(&repository), 3).with_handoff_epoch(handoff));
     assert!(matches!(configured.recover().await, LeaseResult::Status(_)));
     assert_eq!(
         configured.cap(),
@@ -170,9 +170,11 @@ async fn an_armed_cap_is_never_overridden_by_the_configured_fallback() {
         .set_modes_and_cap(0, V0Mode::Enforce, V1Mode::Shadow, Some(5))
         .await
         .unwrap();
-    let epoch_armed = Arc::new(
-        BuildLeaseService::new(Arc::clone(&repository), 9).with_handoff_epoch(handoff),
-    );
-    assert!(matches!(epoch_armed.recover().await, LeaseResult::Status(_)));
+    let epoch_armed =
+        Arc::new(BuildLeaseService::new(Arc::clone(&repository), 9).with_handoff_epoch(handoff));
+    assert!(matches!(
+        epoch_armed.recover().await,
+        LeaseResult::Status(_)
+    ));
     assert_eq!(epoch_armed.cap(), 5, "the epoch reference cap wins");
 }

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -200,6 +200,8 @@ mod build_admission_inventory_tests;
 #[cfg(test)]
 mod build_admission_light_role_tests;
 #[cfg(test)]
+mod build_admission_stale_reclaim_tests;
+#[cfg(test)]
 mod build_lease_cap_arming_tests;
 #[cfg(test)]
 mod build_lease_integration_tests;

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -64,8 +64,9 @@ pub use repositories::{
     admission_journal::{
         AdmissionDomain, AdmissionJournalKey, AdmissionJournalRepository, AdmissionJournalRow,
         AdmissionRecoveryResult, AdmissionState, AdmissionWorkloadKind, AdoptLiveAdmissionInput,
-        CreateStartedInput, ObserveAdmissionResult, ReserveAdmissionInput, ReserveAdmissionResult,
-        TerminalAdmissionInput, UidFencedAdmissionInput,
+        CreateStartedInput, ObserveAdmissionResult, ReclaimAbsentInput, ReclaimAbsentOutcome,
+        ReserveAdmissionInput, ReserveAdmissionResult, TerminalAdmissionInput,
+        UidFencedAdmissionInput,
     },
     agent::{
         AgentCreateInput, AgentListQuery, AgentListResult, AgentMetrics, AgentRepository,

--- a/server/crates/djinn-db/src/repositories/admission_journal.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal.rs
@@ -185,6 +185,36 @@ pub struct TerminalAdmissionInput {
     pub object_uid: Option<String>,
 }
 
+/// One occupying generation and the exact identity an absence proof was taken
+/// against.
+///
+/// Reclamation is a compare-and-set, never a blind write: every field below is
+/// re-read under the row lock and must still match, so a row that changed after
+/// the Kubernetes evidence was gathered — it acquired a UID, advanced to Live,
+/// or was re-created by a newer dispatch — is refused rather than terminalized.
+/// This is what keeps the existing fencing semantics intact while still
+/// releasing capacity whose object is provably gone.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReclaimAbsentInput {
+    pub key: AdmissionJournalKey,
+    pub observed_state: AdmissionState,
+    pub observed_creator_server_epoch: String,
+    pub observed_object_name: String,
+    pub observed_object_uid: Option<String>,
+}
+
+/// Outcome of one evidence-fenced reclamation attempt.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReclaimAbsentOutcome {
+    /// The row still matched the proof and was retired to Terminal.
+    Reclaimed(AdmissionJournalRow),
+    /// The row was already Terminal; capacity was released by someone else.
+    AlreadyTerminal(AdmissionJournalRow),
+    /// The row no longer matches the observation the proof was taken against;
+    /// nothing was written.
+    Fenced { reason: String },
+}
+
 /// Atomic predecessor-epoch recovery report.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AdmissionRecoveryResult {
@@ -521,6 +551,42 @@ impl AdmissionJournalRepository {
         active_rows(self.db.pool()).await
     }
 
+    /// Occupying rows, each flagged with whether it has been untouched for at
+    /// least `settle_seconds`.
+    ///
+    /// Settlement is evaluated against the database clock that wrote
+    /// `updated_at`, so it needs no timestamp parsing and no agreement between
+    /// process clocks. It is NOT by itself a reason to release anything: a
+    /// Kubernetes create that a dead process POSTed can still be admitted by
+    /// the API server for a short window after the process is gone, and this
+    /// flag is what stops reconciliation from racing that window. Absence of
+    /// the object remains the only proof.
+    pub async fn list_active_rows_with_settlement(
+        &self,
+        settle_seconds: i64,
+    ) -> DbResult<Vec<(AdmissionJournalRow, bool)>> {
+        if settle_seconds < 0 {
+            return Err(DbError::InvalidData(
+                "settle window must be non-negative".into(),
+            ));
+        }
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query_as::<_, SettlementDbRow>(&format!(
+            "SELECT {JOURNAL_COLUMNS}, (updated_at <= now() - make_interval(secs => $2)) AS settled \
+             FROM admission_journal WHERE state = ANY($1) ORDER BY domain, work_id, generation"
+        ))
+        .bind(OCCUPYING_STATES.as_slice())
+        .bind(settle_seconds as f64)
+        .fetch_all(self.db.pool())
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let settled = row.settled.unwrap_or(false);
+                AdmissionJournalRow::try_from(row.row).map(|row| (row, settled))
+            })
+            .collect()
+    }
+
     pub async fn recover_predecessor_epoch(
         &self,
         predecessor_epoch: &str,
@@ -579,6 +645,62 @@ impl AdmissionJournalRepository {
             marked_create_unknown,
             active_rows: rows,
         })
+    }
+
+    /// Retire one occupying generation whose Kubernetes object is provably gone.
+    ///
+    /// Recovery only terminalizes `reserved` rows and converts `create_in_flight`
+    /// into occupying `create_unknown`. Nothing else in the journal can leave an
+    /// occupying state without a lifecycle callback from the process that
+    /// created the object, so a generation whose object vanished with its
+    /// creator occupies capacity forever. This is the durable half of the
+    /// reconciliation that fixes that; the caller owns the Kubernetes evidence.
+    ///
+    /// The write is fenced by a compare-and-set on the full observed identity
+    /// (state, creator epoch, object name, object UID). Anything that changed
+    /// since the proof was gathered yields [`ReclaimAbsentOutcome::Fenced`] and
+    /// writes nothing, so this can never terminalize a row that might still
+    /// correspond to live work. Unlike the lifecycle mutations it deliberately
+    /// does not require the row to be the latest generation: a superseded
+    /// occupying generation is, by definition, a lifecycle that already ended.
+    pub async fn reclaim_absent_object(
+        &self,
+        input: &ReclaimAbsentInput,
+    ) -> DbResult<ReclaimAbsentOutcome> {
+        if input.observed_state == AdmissionState::Terminal {
+            return Err(DbError::InvalidData(
+                "reclamation evidence must describe an occupying state".into(),
+            ));
+        }
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        lock_work(&mut tx, input.key.domain, &input.key.work_id).await?;
+        let Some(row) = fetch_row_for_update(&mut tx, &input.key).await? else {
+            tx.commit().await?;
+            return Ok(ReclaimAbsentOutcome::Fenced {
+                reason: "admission row no longer exists".into(),
+            });
+        };
+        if row.state == AdmissionState::Terminal {
+            tx.commit().await?;
+            return Ok(ReclaimAbsentOutcome::AlreadyTerminal(row));
+        }
+        if row.state != input.observed_state
+            || row.creator_server_epoch != input.observed_creator_server_epoch
+            || row.object_name != input.observed_object_name
+            || row.object_uid != input.observed_object_uid
+        {
+            let reason = format!(
+                "admission row changed after the absence proof (observed {:?}/{}, found {:?}/{})",
+                input.observed_state, input.observed_object_name, row.state, row.object_name
+            );
+            tx.commit().await?;
+            return Ok(ReclaimAbsentOutcome::Fenced { reason });
+        }
+        let reclaimed =
+            update_state(&mut tx, &input.key, "terminal", row.object_uid.as_deref()).await?;
+        tx.commit().await?;
+        Ok(ReclaimAbsentOutcome::Reclaimed(reclaimed))
     }
 
     /// Count rows that currently occupy task-or-warm capacity.
@@ -705,6 +827,13 @@ impl AdmissionJournalRepository {
 }
 
 #[derive(sqlx::FromRow)]
+struct SettlementDbRow {
+    #[sqlx(flatten)]
+    row: JournalDbRow,
+    settled: Option<bool>,
+}
+
+#[derive(sqlx::FromRow)]
 struct JournalDbRow {
     domain: String,
     work_id: String,
@@ -793,6 +922,24 @@ async fn fetch_row(
 }
 
 const JOURNAL_COLUMNS: &str = "domain, work_id, generation, workload_kind, state, creator_server_epoch, object_name, object_uid, created_at::text, updated_at::text, terminal_at::text";
+
+/// Row-locked fetch of one exact generation, without the latest-generation
+/// requirement [`current_row_for_update`] imposes on lifecycle mutations.
+async fn fetch_row_for_update(
+    tx: &mut Transaction<'_, Postgres>,
+    key: &AdmissionJournalKey,
+) -> DbResult<Option<AdmissionJournalRow>> {
+    let row = sqlx::query_as::<_, JournalDbRow>(&format!(
+        "SELECT {JOURNAL_COLUMNS} FROM admission_journal \
+         WHERE domain = $1 AND work_id = $2 AND generation = $3 FOR UPDATE"
+    ))
+    .bind(key.domain.as_str())
+    .bind(&key.work_id)
+    .bind(key.generation)
+    .fetch_optional(&mut **tx)
+    .await?;
+    row.map(TryInto::try_into).transpose()
+}
 
 fn invalid_state(operation: &str, state: AdmissionState) -> DbError {
     DbError::InvalidTransition(format!("cannot {operation} from {state:?}"))

--- a/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal_tests.rs
@@ -498,3 +498,90 @@ async fn recover_all_predecessors_retires_every_predecessor_epoch_atomically() {
         ]
     );
 }
+
+#[tokio::test]
+async fn reclaim_absent_object_is_fenced_by_the_full_observed_identity() {
+    let repo = AdmissionJournalRepository::new(Database::open_in_memory().unwrap());
+    let reserved = input(AdmissionDomain::WarmBuild, "reclaim", 0);
+    repo.reserve(&reserved, 4).await.unwrap();
+    repo.mark_create_started(&create_started(&reserved))
+        .await
+        .unwrap();
+    repo.recover_all_predecessors("replacement-epoch")
+        .await
+        .unwrap();
+    let row = repo.list_active_rows().await.unwrap().remove(0);
+    assert_eq!(row.state, AdmissionState::CreateUnknown);
+
+    let proof = ReclaimAbsentInput {
+        key: row.key.clone(),
+        observed_state: row.state,
+        observed_creator_server_epoch: row.creator_server_epoch.clone(),
+        observed_object_name: row.object_name.clone(),
+        observed_object_uid: row.object_uid.clone(),
+    };
+
+    // A proof taken against a different state writes nothing.
+    let stale_proof = ReclaimAbsentInput {
+        observed_state: AdmissionState::Reserved,
+        ..proof.clone()
+    };
+    assert!(matches!(
+        repo.reclaim_absent_object(&stale_proof).await.unwrap(),
+        ReclaimAbsentOutcome::Fenced { .. }
+    ));
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+
+    // A proof taken against a different object name writes nothing either: the
+    // absence that was proven was some other object's.
+    let renamed = ReclaimAbsentInput {
+        observed_object_name: "a-different-job".into(),
+        ..proof.clone()
+    };
+    assert!(matches!(
+        repo.reclaim_absent_object(&renamed).await.unwrap(),
+        ReclaimAbsentOutcome::Fenced { .. }
+    ));
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 1);
+
+    // The matching proof retires the row and releases its capacity.
+    assert!(matches!(
+        repo.reclaim_absent_object(&proof).await.unwrap(),
+        ReclaimAbsentOutcome::Reclaimed(_)
+    ));
+    assert_eq!(repo.count_task_or_warm_occupancy().await.unwrap(), 0);
+
+    // Replaying the same proof is an idempotent no-op, not an error.
+    assert!(matches!(
+        repo.reclaim_absent_object(&proof).await.unwrap(),
+        ReclaimAbsentOutcome::AlreadyTerminal(_)
+    ));
+
+    // A retired generation still yields the next one to a new dispatch, so
+    // reclamation composes with generation resolution instead of stranding the
+    // work item on a generation that can never advance.
+    assert_eq!(
+        repo.resolve_dispatch_generation(AdmissionDomain::WarmBuild, "reclaim", 0)
+            .await
+            .unwrap(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn settlement_flags_rows_against_the_database_clock() {
+    let repo = AdmissionJournalRepository::new(Database::open_in_memory().unwrap());
+    let reserved = input(AdmissionDomain::TaskObservation, "settle", 0);
+    repo.reserve(&reserved, 4).await.unwrap();
+
+    let settled_now = repo.list_active_rows_with_settlement(0).await.unwrap();
+    assert_eq!(settled_now.len(), 1);
+    assert!(settled_now[0].1, "a zero window settles immediately");
+
+    let unsettled = repo.list_active_rows_with_settlement(3600).await.unwrap();
+    assert!(
+        !unsettled[0].1,
+        "a row written moments ago is not settled against an hour-long window"
+    );
+    assert!(repo.list_active_rows_with_settlement(-1).await.is_err());
+}

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -1269,6 +1269,21 @@ impl K8sGraphWarmer {
         self.dispatch.admission.clone()
     }
 
+    /// The broad Kubernetes workload inventory backed by this warmer's client.
+    ///
+    /// Build-admission reconciliation needs the same client selection and
+    /// namespace the warmer dispatches into, and the composition root must not
+    /// build a second client. `None` under the test/mock-dispatcher path, which
+    /// owns no live client and therefore has no Kubernetes objects to inventory.
+    pub fn workload_inventory(&self) -> Option<Arc<dyn crate::WorkloadInventory>> {
+        self.client.clone().map(|client| {
+            Arc::new(crate::KubeWorkloadInventory::new(
+                client,
+                self.dispatch.config.namespace.clone(),
+            )) as Arc<dyn crate::WorkloadInventory>
+        })
+    }
+
     /// Override the merge-storm debounce policy (builder style). Production
     /// takes it from the environment via [`Self::new`]; tests use this to
     /// exercise the quiet-window / max-wait / disabled behaviours with short

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -51,8 +51,8 @@ pub use token_review::TokenReviewer;
 pub use warm_job::{build_leased_warm_job, build_warm_job};
 pub use workload_inventory::{
     KubeWorkloadInventory, LABEL_ADMISSION_DOMAIN, LABEL_ADMISSION_GENERATION,
-    LABEL_ADMISSION_WORK_ID, UidGetResult, WorkloadInventory, WorkloadObjectKind, WorkloadRecord,
-    has_canonical_warm_signature,
+    LABEL_ADMISSION_WORK_ID, ObjectPresence, UidGetResult, WorkloadInventory, WorkloadObjectKind,
+    WorkloadRecord, has_canonical_warm_signature,
 };
 
 /// Re-exported `kube::Client` type so non-owner callers can name the

--- a/server/crates/djinn-k8s/src/workload_inventory.rs
+++ b/server/crates/djinn-k8s/src/workload_inventory.rs
@@ -30,10 +30,29 @@ pub enum UidGetResult {
     Uncertain,
 }
 
+/// Authoritative answer to "does an object with this name exist right now?".
+///
+/// Distinct from [`UidGetResult`], which can only be asked about a row that
+/// already recorded a UID. An admission row that never reached Live has no UID
+/// at all, so absence of its object can only be established by name.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ObjectPresence {
+    /// The API server returned an object under this name. `uid` is its
+    /// immutable identity when the metadata carried one.
+    Present { uid: Option<String> },
+    /// The API server answered authoritatively that no such object exists.
+    Absent,
+    /// The probe could not answer. Never treated as proof of anything.
+    Uncertain,
+}
+
 #[async_trait]
 pub trait WorkloadInventory: Send + Sync {
     async fn list(&self) -> Result<Vec<WorkloadRecord>, String>;
     async fn get_uid(&self, kind: WorkloadObjectKind, name: &str, uid: &str) -> UidGetResult;
+
+    /// Probe one named object independently of any recorded UID.
+    async fn presence(&self, kind: WorkloadObjectKind, name: &str) -> ObjectPresence;
 }
 
 pub struct KubeWorkloadInventory {
@@ -107,6 +126,24 @@ impl WorkloadInventory for KubeWorkloadInventory {
             Ok(Some(found)) if found == uid => UidGetResult::Present,
             Ok(None) => UidGetResult::NotFound,
             _ => UidGetResult::Uncertain,
+        }
+    }
+
+    async fn presence(&self, kind: WorkloadObjectKind, name: &str) -> ObjectPresence {
+        let result = match kind {
+            WorkloadObjectKind::Job => Api::<Job>::namespaced(self.client.clone(), &self.namespace)
+                .get_opt(name)
+                .await
+                .map(|v| v.map(|o| o.metadata.uid)),
+            WorkloadObjectKind::Pod => Api::<Pod>::namespaced(self.client.clone(), &self.namespace)
+                .get_opt(name)
+                .await
+                .map(|v| v.map(|o| o.metadata.uid)),
+        };
+        match result {
+            Ok(Some(uid)) => ObjectPresence::Present { uid },
+            Ok(None) => ObjectPresence::Absent,
+            Err(_) => ObjectPresence::Uncertain,
         }
     }
 }

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -247,7 +247,15 @@ const BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH: &str = "djinn_build_admission_creat
 const BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL: &str =
     "djinn_build_admission_shadow_invocation_total";
 const BUILD_ADMISSION_TRANSITION_TOTAL: &str = "djinn_build_admission_transition_total";
-const BUILD_ADMISSION_TRANSITION_OUTCOMES: [&str; 2] = ["accepted", "rejected"];
+// One closed enumeration for every durable journal write attempt: the two
+// lifecycle outcomes plus the two startup-reconciliation outcomes. Extending
+// this family rather than adding a parallel metric keeps a single query able to
+// answer "is the journal accepting writes, and is anything reclaiming stale
+// occupancy" for a whole fleet.
+const BUILD_ADMISSION_TRANSITION_OUTCOMES: [&str; 4] =
+    ["accepted", "rejected", "reclaimed", "reclaim_fenced"];
+const BUILD_ADMISSION_OCCUPANCY_OVER_CAP: &str = "djinn_build_admission_occupancy_over_cap";
+const BUILD_ADMISSION_STALE_ROWS: &str = "djinn_build_admission_stale_rows";
 const BUILD_ADMISSION_HANDOFF_WARNING: &str = "djinn_build_admission_handoff_warning";
 const BUILD_ADMISSION_HANDOFF_WARNING_REASONS: [&str; 3] =
     ["unexpected_overlap", "stale_epoch", "epoch_unreadable"];
@@ -2246,12 +2254,19 @@ fn register_metrics() {
         BUILD_ADMISSION_INVENTORY_DEGRADED,
         BUILD_ADMISSION_JOURNAL_DEGRADED,
         BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH,
+        BUILD_ADMISSION_OCCUPANCY_OVER_CAP,
     ] {
         metrics::describe_gauge!(
             metric,
             "Bounded build-admission health signal; one means degraded."
         );
     }
+    metrics::describe_gauge!(
+        BUILD_ADMISSION_STALE_ROWS,
+        "Occupying admission-journal rows whose Kubernetes object was proven \
+         absent by the last reconciliation pass. A population above the cap is \
+         the shape that wedges every admission once the cap is armed."
+    );
     metrics::describe_gauge!(
         BUILD_ADMISSION_HANDOFF_WARNING,
         "Current bounded emergency-to-invocation admission handoff warning; one means active."
@@ -3352,6 +3367,14 @@ pub mod build_admission {
         }
     }
 
+    /// One durable-write outcome for the closed `outcome` enumeration.
+    pub const OUTCOME_ACCEPTED: &str = "accepted";
+    pub const OUTCOME_REJECTED: &str = "rejected";
+    /// A stale occupying row was terminalized against Kubernetes absence proof.
+    pub const OUTCOME_RECLAIMED: &str = "reclaimed";
+    /// A reclamation was refused because the row no longer matched its proof.
+    pub const OUTCOME_RECLAIM_FENCED: &str = "reclaim_fenced";
+
     /// Set readiness-derived health gauges. `true` means degraded.
     pub fn set_health(
         effective_mode: &'static str,
@@ -3359,11 +3382,19 @@ pub mod build_admission {
         inventory_degraded: bool,
         journal_degraded: bool,
         create_unknown: bool,
+        occupancy_over_cap: bool,
     ) {
         let cap = effective_cap.to_string();
         metrics::gauge!(super::BUILD_ADMISSION_INVENTORY_DEGRADED, "effective_mode" => effective_mode, "effective_cap" => cap.clone()).set(f64::from(inventory_degraded));
         metrics::gauge!(super::BUILD_ADMISSION_JOURNAL_DEGRADED, "effective_mode" => effective_mode, "effective_cap" => cap.clone()).set(f64::from(journal_degraded));
-        metrics::gauge!(super::BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH, "effective_mode" => effective_mode, "effective_cap" => cap).set(f64::from(create_unknown));
+        metrics::gauge!(super::BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH, "effective_mode" => effective_mode, "effective_cap" => cap.clone()).set(f64::from(create_unknown));
+        metrics::gauge!(super::BUILD_ADMISSION_OCCUPANCY_OVER_CAP, "effective_mode" => effective_mode, "effective_cap" => cap).set(f64::from(occupancy_over_cap));
+    }
+
+    /// Set the absolute count of occupying rows whose object was proven absent
+    /// by the last reconciliation pass.
+    pub fn set_stale_rows(effective_mode: &'static str, effective_cap: i64, stale_rows: u64) {
+        metrics::gauge!(super::BUILD_ADMISSION_STALE_ROWS, "effective_mode" => effective_mode, "effective_cap" => effective_cap.to_string()).set(stale_rows as f64);
     }
     /// Record one bounded Observe-mode would-defer event.
     pub fn increment_would_defer(effective_mode: &'static str, effective_cap: i64) {
@@ -3376,10 +3407,26 @@ pub mod build_admission {
     /// the shape that makes the journal unsafe to arm as a grant authority —
     /// without reading a single log line.
     pub fn record_transition(effective_mode: &'static str, effective_cap: i64, accepted: bool) {
+        let outcome = if accepted {
+            OUTCOME_ACCEPTED
+        } else {
+            OUTCOME_REJECTED
+        };
+        record_transition_outcome(effective_mode, effective_cap, outcome);
+    }
+
+    /// Record one durable admission-journal write attempt under the closed
+    /// `outcome` enumeration. `outcome` MUST be one of the `OUTCOME_*`
+    /// constants; reconciliation reports `reclaimed` / `reclaim_fenced` through
+    /// the same family the lifecycle reports `accepted` / `rejected` through.
+    pub fn record_transition_outcome(
+        effective_mode: &'static str,
+        effective_cap: i64,
+        outcome: &'static str,
+    ) {
         let cap = effective_cap.to_string();
-        let outcome = if accepted { "accepted" } else { "rejected" };
-        // Both series exist as soon as either is written, so a zero-rejection
-        // process is distinguishable from an unreported one.
+        // Every series exists as soon as any is written, so a process that has
+        // reclaimed nothing is distinguishable from one that never reported.
         for candidate in super::BUILD_ADMISSION_TRANSITION_OUTCOMES {
             metrics::counter!(super::BUILD_ADMISSION_TRANSITION_TOTAL, "effective_mode" => effective_mode, "effective_cap" => cap.clone(), "outcome" => candidate)
                 .increment(u64::from(candidate == outcome));

--- a/server/docs/operational/stale-admission-occupancy.md
+++ b/server/docs/operational/stale-admission-occupancy.md
@@ -1,0 +1,210 @@
+# Stale Build-Admission Occupancy
+
+The durable admission journal (`admission_journal`) is the grant authority for
+build-producing workloads once `buildAdmission.mode` is armed to `enforce`. Rows
+in `reserved`, `create_in_flight`, `create_unknown` or `live` occupy capacity
+against the shared task/warm cap. Terminal rows are retained as history and
+occupy nothing.
+
+A row leaves an occupying state in exactly three ways:
+
+1. a lifecycle callback from the process that created the object,
+2. startup recovery, which retires predecessor `reserved` rows and converts
+   predecessor `create_in_flight` into occupying `create_unknown`,
+3. startup reconciliation, which retires a row whose Kubernetes object the API
+   server proves does not exist.
+
+Before (3) existed, a row whose object died together with its creating process
+occupied capacity permanently. That is how a fleet accumulates a stale
+population. On 2026-07-25 production held **318** occupying rows while
+`kubectl get jobs -A` returned no Djinn Jobs at all.
+
+## Symptoms
+
+* `djinn_build_slots_in_use` is far above the configured cap while the namespace
+  holds no `djinn-warm-*` or `djinn-taskrun-*` Jobs.
+* `djinn_build_admission_occupancy_over_cap` is `1`.
+* `djinn_build_admission_stale_rows` is above the cap after a reconciliation
+  pass.
+* Readiness reports `CreateUnknownHealth` or `SeededOccupancyAboveCap`, and with
+  `mode=enforce` every admission is denied with the self-contradictory
+  diagnostic `occupancy 0 reached cap 3` (the in-memory occupancy the denial
+  message renders is not the durable occupancy that produced the denial).
+* Server logs carry a single loud line rather than thousands of warnings:
+  `build_admission: durable occupancy exceeds the configured cap`.
+
+## Diagnosis
+
+Read the bounded telemetry; do not query the database.
+
+```promql
+# Durable occupancy vs the armed cap.
+djinn_build_slots_in_use
+max(djinn_build_admission_occupancy_over_cap) by (effective_mode, effective_cap)
+
+# Size of the stale population the last reconciliation pass proved absent.
+djinn_build_admission_stale_rows
+
+# Reconciliation is running and is not being fenced off.
+sum by (outcome) (
+  increase(djinn_build_admission_transition_total{outcome=~"reclaimed|reclaim_fenced"}[1h])
+)
+```
+
+Cross-check against the cluster:
+
+```bash
+kubectl get jobs -n djinn
+kubectl get pods -n djinn -l djinn.app/component=task-run-worker
+```
+
+If `djinn_build_slots_in_use` is large and the namespace holds no matching Jobs,
+the occupancy is stale.
+
+## Normal remediation: let reconciliation run
+
+Startup reconciliation runs on the leader after journal recovery, on every
+process start. It reclaims a row only when **all** of the following hold:
+
+* the row's `creator_server_epoch` differs from the running process's epoch, so
+  no in-process dispatch can still be mid-create for it;
+* the row has been untouched for at least the settle window
+  (`DEFAULT_RECLAIM_SETTLE_WINDOW`, 5 minutes), so the API server can no longer
+  be admitting a create the dead process POSTed;
+* the authoritative Job LIST contains no object under the row's `object_name`;
+* a direct GET for that name answers `Absent`. A GET that fails (`Uncertain`)
+  is never treated as proof, so a degraded API server reclaims nothing.
+
+**Therefore the first remediation is always a rolling restart of the server**,
+which runs a reconciliation pass:
+
+```bash
+kubectl rollout restart deploy/djinn-server -n djinn
+kubectl rollout status deploy/djinn-server -n djinn --timeout=300s
+```
+
+Verify:
+
+```bash
+kubectl logs -n djinn deploy/djinn-server -c djinn-server \
+  | grep 'Kubernetes inventory reconciliation complete'
+```
+
+The line reports `adopted`, `released`, `reclaimed`, `stale`, `fenced` and the
+resulting `readiness`. Then confirm the gauge:
+
+```bash
+curl -s http://<server-pod-ip>:3000/metrics | grep djinn_build_slots_in_use
+```
+
+`djinn_build_slots_in_use` must equal the number of Djinn Jobs actually running.
+
+## Fallback: one-time operator cleanup
+
+Use this **only** when reconciliation cannot run — for example the cluster's API
+server is unreachable so every probe returns `Uncertain`, or the population
+predates the reconciliation path and the cluster no longer has any record of the
+objects. Reconciliation is always preferred because it is evidence-fenced and
+this procedure is not.
+
+### Preconditions (all must hold)
+
+1. `kubectl get jobs -n djinn` lists **no** `djinn-warm-*` and no
+   `djinn-taskrun-*` Jobs. Record the output; it is the evidence for the write.
+2. `kubectl get pods -n djinn` shows no task-run or warm Pods.
+3. Dispatch is paused, so no new row can be created mid-procedure:
+   ```
+   djinn MCP: dispatch_pause
+   ```
+4. A database backup exists for the current point in time.
+
+### Procedure
+
+Take the backup snapshot of the rows first — this **is** the rollback artifact:
+
+```sql
+CREATE TABLE admission_journal_stale_backup_20260725 AS
+SELECT * FROM admission_journal
+WHERE state IN ('reserved', 'create_in_flight', 'create_unknown', 'live');
+```
+
+Confirm the count matches what the metric reported:
+
+```sql
+SELECT count(*) FROM admission_journal_stale_backup_20260725;
+```
+
+Then retire the population, scoping the write by the same evidence:
+
+```sql
+UPDATE admission_journal
+SET state = 'terminal', terminal_at = now(), updated_at = now()
+WHERE state IN ('reserved', 'create_in_flight', 'create_unknown', 'live')
+  AND updated_at < now() - interval '1 hour';
+```
+
+The `updated_at` clause is a floor, not the justification: the justification is
+precondition 1. It exists so a row created while the statement was being typed
+cannot be caught.
+
+Restart the server so the controller re-seeds from the corrected journal:
+
+```bash
+kubectl rollout restart deploy/djinn-server -n djinn
+kubectl rollout status deploy/djinn-server -n djinn --timeout=300s
+```
+
+Resume dispatch:
+
+```
+djinn MCP: dispatch_resume
+```
+
+### Verification
+
+1. `djinn_build_slots_in_use` reads `0` (or the true number of running Jobs).
+2. `djinn_build_admission_occupancy_over_cap` reads `0`.
+3. `djinn_build_admission_create_unknown_health` reads `0`.
+4. The startup log line reports `readiness=Healthy`.
+5. A task dispatches and reaches a running Pod.
+
+### Rollback
+
+If the board misbehaves after the cleanup, restore the exact prior states from
+the backup table and restart:
+
+```sql
+UPDATE admission_journal AS j
+SET state = b.state,
+    terminal_at = b.terminal_at,
+    updated_at = b.updated_at
+FROM admission_journal_stale_backup_20260725 AS b
+WHERE j.domain = b.domain
+  AND j.work_id = b.work_id
+  AND j.generation = b.generation;
+```
+
+```bash
+kubectl rollout restart deploy/djinn-server -n djinn
+```
+
+Restoring re-occupies the capacity, which re-wedges Enforce. Roll the mode back
+to `observe` in the same window if you need the board to keep running while the
+underlying cause is investigated.
+
+Drop the backup table only after a full day of healthy operation:
+
+```sql
+DROP TABLE admission_journal_stale_backup_20260725;
+```
+
+## Why not an age cutoff
+
+An occupying row that looks old is not evidence that its work is finished. A
+warm build is a heavy compile and can legitimately run for a long time, and a
+`live` row for a running Job must keep occupying capacity for exactly as long as
+that Job runs. Every automated release in this system is fenced on the API
+server's answer about a specific object; the settle window only prevents racing
+a create that is still being admitted. The operator procedure above is the sole
+exception, and it substitutes a human-verified `kubectl get jobs` for the
+automated probe.

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1089,6 +1089,12 @@ impl AppState {
     /// inventory succeeds. The in-process runtime has no Kubernetes objects
     /// to inventory, so its (empty) listing trivially completes the gate.
     /// Observe records the same degradation but never denies.
+    ///
+    /// When the runtime owns a live Kubernetes client this runs the full
+    /// [`BuildAdmissionReconciler`] rather than a bare listing: recovery alone
+    /// retires Reserved rows and converts CreateInFlight into occupying
+    /// CreateUnknown, so without a reconciliation pass every occupying row
+    /// whose object died with its creator holds shared capacity permanently.
     async fn initialize_build_admission_inventory(&self) {
         let Some(admission) = self.inner.build_admission.clone() else {
             // Off: no controller, no readiness coupling.
@@ -1104,6 +1110,38 @@ impl AppState {
             );
             return;
         };
+        if let Some(inventory) = warmer
+            .as_any()
+            .downcast_ref::<djinn_k8s::K8sGraphWarmer>()
+            .and_then(djinn_k8s::K8sGraphWarmer::workload_inventory)
+        {
+            let report =
+                djinn_coordinator::build_admission_inventory::BuildAdmissionReconciler::new(
+                    admission.clone(),
+                    inventory,
+                )
+                .reconcile()
+                .await;
+            if report.blockers.is_empty() {
+                tracing::info!(
+                    mode = ?admission.mode(),
+                    adopted = report.adopted,
+                    released = report.released,
+                    reclaimed = report.reclaimed,
+                    stale = report.stale,
+                    fenced = report.fenced,
+                    readiness = ?admission.readiness(),
+                    "build_admission: Kubernetes inventory reconciliation complete"
+                );
+            } else {
+                tracing::error!(
+                    mode = ?admission.mode(),
+                    blockers = ?report.blockers,
+                    "build_admission: Kubernetes inventory reconciliation blocked; Enforce remains fail-closed"
+                );
+            }
+            return;
+        }
         match warmer.list_taskrun_jobs().await {
             Ok(jobs) => {
                 admission.mark_inventory_ready();


### PR DESCRIPTION
Production holds **318** occupying `admission_journal` rows against a namespace containing zero Djinn Jobs. Verified from the server's own bounded telemetry (`djinn_build_slots_in_use 318`, `djinn_build_admission_create_unknown_health 1`, `djinn_build_admission_journal_degraded 1`) and `kubectl get jobs -A`, which returns only the two 48-day-old `helm-install-traefik*` Jobs. Arming `buildAdmission.mode=enforce` at cap 3 today trips both `CreateUnknownHealth` and `SeededOccupancyAboveCap` and denies every admission — the 2026-07-19 wedge shape.

## The population is ongoing, not historical

It is not residue of the generation-reuse defect #2589 fixed. Two structural halves keep producing it:

1. **Recovery has no exit from `create_unknown`.** `recover_all_predecessors` retires predecessor `reserved` rows and converts predecessor `create_in_flight` into occupying `create_unknown`. The only escape from `create_unknown` is `adopt_live`, which requires the object to still exist. A row whose object died with its creating process occupies the shared cap forever, and every restart manufactures more of them.
2. **The reconciler was never wired into production.** `BuildAdmissionReconciler` and `KubeWorkloadInventory` are constructed nowhere outside tests. `initialize_build_admission_inventory` called `warmer.list_taskrun_jobs()` and marked the gate ready — a liveness probe, not a reconciliation. And the reconciler's own release loop only ever considered `state == Live` rows.

#2589 reduces the inflow (fewer UID-fence rejections) but terminalizes nothing. It also sharpens the consequence: `resolve_dispatch_generation` resumes a nonterminal latest generation, so a work item whose latest generation is a permanently stuck `create_unknown` can never advance to a new generation at all.

## What changed

* **`AdmissionJournalRepository::reclaim_absent_object`** — retires one occupying generation under a compare-and-set on its full observed identity (state, creator epoch, object name, object UID). Any drift since the absence proof yields `Fenced` and writes nothing, so this cannot release a row that might still be live work. Composes with #2589: a reclaimed row is Terminal, so `resolve_dispatch_generation` hands the next attempt N+1.
* **`list_active_rows_with_settlement`** — flags rows against the database clock that wrote them. Settlement is a guard, never a reason: a create a since-dead process POSTed can still be admitted briefly, and this stops reconciliation racing that window.
* **`WorkloadInventory::presence`** — answers "does an object with this name exist" independently of any recorded UID, which `get_uid` cannot do for a row that never reached Live. `Uncertain` is never proof.
* **Reconciler** — a pre-Live row is reclaimed only when its creator epoch is not this process's, it has settled, the authoritative LIST holds no object under its name, and a direct GET reports the name absent. `Live` rows keep their existing UID-fenced release path unchanged.
* **Production wiring** — `initialize_build_admission_inventory` now runs the real reconciler against a `KubeWorkloadInventory` built from the warmer's own client and namespace, falling back to the previous listing gate for non-Kubernetes runtimes.

## A latent wedge found while wiring the reconciler

The image controller dispatches `djinn-build-*` Jobs into the same namespace the admission inventory LISTs. They match `classify`'s unclassifiable catch-all (`djinn-` prefix, non-terminal, has images), which pushes a blocker and marks the inventory gate pending. That was harmless only because the reconciler was never wired to production — wiring it as-is would have fail-closed Enforce for as long as any image was building. Image builds are now recognised as a known non-admission workload (they run on buildkitd and have never carried an admission identity), with a regression covering it.

## Guard against silent recurrence

`djinn_build_admission_occupancy_over_cap` and `djinn_build_admission_stale_rows` join the existing bounded health family (`effective_mode`, `effective_cap`). The `outcome` vocabulary of `djinn_build_admission_transition_total` gains `reclaimed` and `reclaim_fenced` — extending #2589's family rather than adding a parallel metric. Over-cap occupancy emits one edge-triggered `ERROR` naming the runbook, and a stale population above the cap emits another; neither is discoverable only by reading thousands of warn lines.

## Testing

`build_admission_stale_reclaim_tests` drives the concrete `K8sGraphWarmer`, the production `BuildAdmissionController` and the production `AdmissionJournalRepository` against real project rows in a fresh database, accumulating the stale shape through real dispatch (a lost POST response producing `create_unknown`; a successful POST whose watcher never terminalizes producing an orphaned `live`). It then ages the population through the real `recover_all_predecessors_and_seed` restart path and reconciles against a namespace holding no Jobs. No row is hand-written.

Asserted: Enforce at cap 3 denies while the population is stale, reconciliation releases all six, readiness reaches `Healthy`, and the cap still binds afterwards (three admit, the fourth is `Denied { occupancy: 3, cap: 3 }`). Negative coverage: a row whose Job still exists keeps occupying; a current-epoch row is never reclaimed; an unsettled row is never reclaimed; an `Uncertain` probe reclaims nothing.

**Verified failing against main** by neutralising the reclamation predicate — 2 of 6 rows released (the pre-existing `Live` path), the four `create_unknown` rows leak, Enforce stays wedged.

## Operator action

`server/docs/operational/stale-admission-occupancy.md`. The normal remediation is a rolling restart, which now runs a reconciliation pass. The one-time SQL cleanup for the existing 318 rows is documented as a fallback with preconditions, verification and rollback. **Not executed against production by this PR.**

## Follow-up (not in this PR)

The warm and task authorities are disjoint pools at enforce — v0 journal for task-runs, v1 lease for warm, cap 3 each, neither aware of the other. A warm Job is a heavy compile and belongs in the same semaphore. Unification should make the v1 lease the single admission authority for both, with the v0 journal retained as the durable fencing ledger rather than a second grant authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
