### PR TITLE
fix(build-lease): render invocation lease deadlines as absolute epoch milliseconds

### DIFF
--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -163,14 +163,21 @@ impl ShellLaunchContext {
         })
     }
 
+    /// How long an escalating shell command may wait in the build-lease queue
+    /// before the coordinator gives up on it. These are RELATIVE timeouts; the
+    /// runner converts them to the absolute epoch-millisecond deadlines the
+    /// coordinator compares against its wall clock.
+    const QUEUE_TIMEOUT: Duration = Duration::from_secs(30);
+    const LAUNCH_TIMEOUT: Duration = Duration::from_secs(60);
+
     pub(crate) fn invocation(&self, timeout: Duration) -> LeaseInvocationConfig {
         LeaseInvocationConfig {
             task_id: self.task_id.clone(),
             task_run_id: self.task_run_id.clone(),
             pod_uid: self.pod_uid.clone(),
             cpu_usage_threshold_usec: 250_000,
-            queue_deadline_ms: 30_000,
-            launch_deadline_ms: 60_000,
+            queue_timeout: Self::QUEUE_TIMEOUT,
+            launch_timeout: Self::LAUNCH_TIMEOUT,
             timeout,
         }
     }

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -367,8 +367,20 @@ pub(crate) struct LeaseInvocationConfig {
     pub task_run_id: String,
     pub pod_uid: String,
     pub cpu_usage_threshold_usec: u64,
-    pub queue_deadline_ms: i64,
-    pub launch_deadline_ms: i64,
+    /// How long this invocation may sit in the durable queue before the
+    /// coordinator terminalizes it as `deadline_expired`.
+    ///
+    /// Deliberately a [`Duration`] and not a bare `i64`: the wire contract
+    /// ([`LeaseDeadlines`]) carries ABSOLUTE epoch milliseconds, and a caller
+    /// that wrote its intended timeout there produced a 1970 deadline that
+    /// expired every task-invocation lease on arrival. The conversion to an
+    /// absolute instant happens once, in [`LeaseInvocationRunner::lease_deadlines`],
+    /// against this runner's clock at the moment the queue request is issued —
+    /// so a config value can no longer be mistaken for a timestamp.
+    pub queue_timeout: Duration,
+    /// How long a granted lease may remain unlaunched before the coordinator
+    /// marks it `suspect`. Same units contract as [`Self::queue_timeout`].
+    pub launch_timeout: Duration,
     pub timeout: Duration,
 }
 
@@ -422,6 +434,27 @@ impl LeaseInvocationRunner {
         self.journal = Some(journal);
         self
     }
+
+    /// Render the invocation's configured timeouts as the wire deadlines the
+    /// coordinator actually understands.
+    ///
+    /// [`LeaseDeadlines`] carries ABSOLUTE Unix epoch milliseconds: the
+    /// coordinator persists them as timestamps and `expire_deadlines` compares
+    /// them against its own wall clock. Handing it a raw timeout instead placed
+    /// every task-invocation deadline in 1970, so the durable row was
+    /// terminalized as `deadline_expired` before the queue could ever be
+    /// granted and the invocation degraded to the launcher's unleased 250m
+    /// quota for the whole command. The conversion therefore lives here — one
+    /// place, at the moment the request is issued, reading this runner's
+    /// injected clock so it stays deterministic under test.
+    fn lease_deadlines(&self, config: &LeaseInvocationConfig) -> LeaseDeadlines {
+        let now_ms = epoch_ms(self.clock.now());
+        LeaseDeadlines {
+            queue_deadline_ms: deadline_epoch_ms(now_ms, config.queue_timeout),
+            launch_deadline_ms: deadline_epoch_ms(now_ms, config.launch_timeout),
+        }
+    }
+
     pub(crate) async fn output(
         &self,
         cmd: Command,
@@ -429,8 +462,8 @@ impl LeaseInvocationRunner {
         cancel: CancellationToken,
     ) -> Result<LeaseInvocationOutput, LeaseInvocationError> {
         let identity = TaskInvocationLeaseIdentity {
-            task_id: config.task_id,
-            task_run_id: config.task_run_id,
+            task_id: config.task_id.clone(),
+            task_run_id: config.task_run_id.clone(),
             invocation_id: uuid::Uuid::now_v7().to_string(),
         };
         let lease = LeaseIdentity::TaskInvocation(identity.clone());
@@ -478,10 +511,7 @@ impl LeaseInvocationRunner {
                 match await_lease_or_terminal(
                     self.services.queue_lease(LeaseQueueRequest {
                         identity: lease.clone(),
-                        deadlines: LeaseDeadlines {
-                            queue_deadline_ms: config.queue_deadline_ms,
-                            launch_deadline_ms: config.launch_deadline_ms,
-                        },
+                        deadlines: self.lease_deadlines(&config),
                     }),
                     &mut *child,
                     &cancel,
@@ -944,6 +974,28 @@ async fn reconcile_terminal_lease(
 #[cfg_attr(not(test), allow(dead_code))] // consumed by the workspace lease wiring task
 fn started_lease_error(error: io::Error) -> LeaseInvocationError {
     LeaseInvocationError::Process(ProcessRunError::Started(error))
+}
+
+/// Wall-clock instant as Unix epoch milliseconds. A pre-epoch clock reads as 0,
+/// which the deadline contract treats as "no deadline" rather than "expired".
+fn epoch_ms(now: SystemTime) -> i64 {
+    now.duration_since(UNIX_EPOCH).map_or(0, |since| {
+        i64::try_from(since.as_millis()).unwrap_or(i64::MAX)
+    })
+}
+
+/// Project a relative timeout onto the absolute epoch-millisecond instant the
+/// coordinator compares against its own clock.
+///
+/// `Duration::ZERO` renders `0`, which [`LeaseDeadlines`] defines as *no
+/// deadline* (the durable column stays NULL) — the same thing the graph-warm
+/// recovery and worker paths already pass. It is deliberately not "expires
+/// immediately".
+fn deadline_epoch_ms(now_ms: i64, timeout: Duration) -> i64 {
+    if timeout.is_zero() {
+        return 0;
+    }
+    now_ms.saturating_add(i64::try_from(timeout.as_millis()).unwrap_or(i64::MAX))
 }
 /// Classify a lease response that did not produce a usable grant.
 ///

--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -379,12 +379,17 @@ fn wall_clock_ms() -> i64 {
         .as_millis() as i64
 }
 
-/// A runner clock pinned to real wall time. The invocation deadline contract is
-/// absolute epoch milliseconds, so the runner's clock and the coordinator's
-/// clock must agree on "now" for a rendered deadline to be in the future.
-#[allow(clippy::disallowed_methods)] // test-only reference clock for absolute deadlines
-fn wall_clock() -> Arc<TestClock> {
-    Arc::new(TestClock::new(SystemTime::now(), Instant::now()))
+/// A runner clock frozen at an exact, caller-known epoch millisecond. The
+/// invocation deadline contract is absolute epoch milliseconds, so the runner's
+/// clock and the coordinator's clock must agree on "now" for a rendered deadline
+/// to be in the future — and pinning `now` to a value the test already holds
+/// makes the rendered deadline exactly predictable rather than a tolerance band.
+#[allow(clippy::disallowed_methods)] // test-only monotonic seam; the wall side is explicit
+fn clock_pinned_at(now_ms: i64) -> Arc<TestClock> {
+    Arc::new(TestClock::new(
+        std::time::UNIX_EPOCH + Duration::from_millis(now_ms as u64),
+        Instant::now(),
+    ))
 }
 
 /// Drive the durable admission epoch to a committed forward overlap with v1
@@ -489,10 +494,14 @@ async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
     )
     .await;
     let launcher = Arc::new(DegradeLauncher::completing());
+    // The runner's "now". The coordinator keeps its own real clock, so a
+    // correctly rendered deadline must land ahead of it for the lease to be
+    // granted at all.
+    let now_ms = wall_clock_ms();
     let runner = Arc::new(LeaseInvocationRunner::new(
         services,
         launcher.clone(),
-        wall_clock(),
+        clock_pinned_at(now_ms),
     ));
     // The exact config a task pod renders, straight from the production
     // producer — no deadline literal appears in this test.
@@ -502,7 +511,6 @@ async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
         "run".into(),
         "pod".into(),
     );
-    let before_ms = wall_clock_ms();
     let output = runner
         .output(
             command(),
@@ -511,7 +519,6 @@ async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
         )
         .await
         .expect("the rendered deadlines must produce a usable lease");
-    let after_ms = wall_clock_ms();
 
     assert_eq!(output.process.termination, ProcessTermination::Exited);
     assert_eq!(output.process.output.status.code(), Some(0));
@@ -531,24 +538,25 @@ async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
         "the rendered queue deadline must not be in the past"
     );
 
-    // The stored deadline is an absolute instant ~30s from now, not 1970.
-    let queue_deadline_ms = durable_deadline_ms(
-        row.queue_deadline
-            .as_deref()
-            .expect("the queued row retains its deadline"),
+    // The stored deadlines are absolute instants exactly 30s / 60s past the
+    // runner's `now` — not 1970, and not the raw timeouts.
+    assert_eq!(
+        durable_deadline_ms(
+            row.queue_deadline
+                .as_deref()
+                .expect("the queued row retains its deadline"),
+        ),
+        now_ms + 30_000,
+        "the durable queue deadline must be now + 30s"
     );
-    assert!(
-        queue_deadline_ms >= before_ms + 30_000 && queue_deadline_ms <= after_ms + 30_000,
-        "queue deadline {queue_deadline_ms} is not ~30s ahead of [{before_ms}, {after_ms}]"
-    );
-    let launch_deadline_ms = durable_deadline_ms(
-        row.launch_deadline
-            .as_deref()
-            .expect("the granted row retains its launch deadline"),
-    );
-    assert!(
-        launch_deadline_ms >= before_ms + 60_000 && launch_deadline_ms <= after_ms + 60_000,
-        "launch deadline {launch_deadline_ms} is not ~60s ahead of [{before_ms}, {after_ms}]"
+    assert_eq!(
+        durable_deadline_ms(
+            row.launch_deadline
+                .as_deref()
+                .expect("the granted row retains its launch deadline"),
+        ),
+        now_ms + 60_000,
+        "the durable launch deadline must be now + 60s"
     );
 }
 
@@ -580,16 +588,17 @@ fn durable_deadline_ms(value: &str) -> i64 {
 async fn real_lease_authority_queue_timeout_degrades_to_a_successful_command() {
     let db = crate::test_helpers::create_test_db();
     arm_invocation_lift(&db).await;
+    let now_ms = wall_clock_ms();
     // One hour past every deadline this invocation can render.
     let expired_clock = Arc::new(djinn_coordinator::build_lease::ManualLeaseClock::new(
-        wall_clock_ms() + 3_600_000,
+        now_ms + 3_600_000,
     ));
     let services = real_lease_services(&db, expired_clock).await;
     let launcher = Arc::new(DegradeLauncher::completing());
     let runner = Arc::new(LeaseInvocationRunner::new(
         services,
         launcher.clone(),
-        wall_clock(),
+        clock_pinned_at(now_ms),
     ));
     let context = crate::context::ShellLaunchContext::for_test(
         Arc::clone(&runner),

--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -364,33 +364,245 @@ async fn repeated_unavailability_still_fails() {
     assert!(launcher.lifts().is_empty());
 }
 
-/// Production composition seam: the real `DirectServices` lease authority over
-/// a real durable repository, driven by the real runner — no hand-built lease
-/// response anywhere.
+// ---------------------------------------------------------------------------
+// Production composition seam: the real `DirectServices` lease authority over a
+// real durable repository, driven by the real runner — no hand-built lease
+// response anywhere.
+// ---------------------------------------------------------------------------
+
+/// Current wall clock as Unix epoch milliseconds.
+#[allow(clippy::disallowed_methods)] // test-only reference clock for absolute deadlines
+fn wall_clock_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("wall clock")
+        .as_millis() as i64
+}
+
+/// A runner clock pinned to real wall time. The invocation deadline contract is
+/// absolute epoch milliseconds, so the runner's clock and the coordinator's
+/// clock must agree on "now" for a rendered deadline to be in the future.
+#[allow(clippy::disallowed_methods)] // test-only reference clock for absolute deadlines
+fn wall_clock() -> Arc<TestClock> {
+    Arc::new(TestClock::new(SystemTime::now(), Instant::now()))
+}
+
+/// Drive the durable admission epoch to a committed forward overlap with v1
+/// enforcing — the only state in which a bound invocation may lift `cpu.max`.
+/// Every write goes through the real repository, so the arming sequence is the
+/// operator sequence.
+async fn arm_invocation_lift(db: &djinn_db::Database) {
+    use djinn_db::{AdmissionHandoffAuthority, AdmissionHandoffPhase, V0Mode, V1Mode};
+
+    let handoff = djinn_db::AdmissionHandoffRepository::new(db.clone());
+    let row = handoff
+        .seed_baseline()
+        .await
+        .expect("seed the baseline epoch");
+    let row = handoff
+        .set_modes_and_cap(row.epoch, V0Mode::Enforce, V1Mode::Enforce, None)
+        .await
+        .expect("arm v1 enforcement");
+    handoff
+        .acknowledge(AdmissionHandoffAuthority::Emergency, row.epoch)
+        .await
+        .expect("emergency acknowledges the armed epoch");
+    let row = handoff
+        .advance(row.epoch, AdmissionHandoffPhase::ForwardOverlap, &[])
+        .await
+        .expect("enter the forward overlap");
+    handoff
+        .acknowledge(AdmissionHandoffAuthority::Emergency, row.epoch)
+        .await
+        .expect("emergency acknowledges the overlap");
+    handoff
+        .acknowledge(AdmissionHandoffAuthority::Invocation, row.epoch)
+        .await
+        .expect("invocation acknowledges the overlap");
+}
+
+/// Compose the production lease authority over a fresh database with an armed
+/// cap. `lease_clock` is the coordinator's own deadline clock: advancing it past
+/// a rendered deadline is how a test expires one without waiting.
+async fn real_lease_services(
+    db: &djinn_db::Database,
+    lease_clock: Arc<dyn djinn_coordinator::build_lease::LeaseClock>,
+) -> Arc<crate::direct_services::DirectServices> {
+    let build_lease = Arc::new(
+        djinn_coordinator::build_lease::BuildLeaseService::with_seams(
+            Arc::new(djinn_db::BuildLeaseRepository::new(db.clone())),
+            // The cap `DJINN_MAX_BUILD_TASKRUNS` arms in production; without it
+            // `grant_next` short-circuits on `occupied >= cap` and nothing is
+            // ever granted (see `build_lease_cap_arming_tests`).
+            4,
+            lease_clock,
+            Arc::new(djinn_coordinator::build_lease::NoopLeaseTransactionPause),
+            Arc::new(djinn_coordinator::build_lease::MetricsLeaseTelemetry),
+        )
+        .with_handoff_epoch(Arc::new(djinn_db::AdmissionHandoffRepository::new(
+            db.clone(),
+        ))),
+    );
+    Arc::new(crate::direct_services::DirectServices::with_build_lease(
+        crate::test_helpers::agent_context_from_db(db.clone(), CancellationToken::new()),
+        CancellationToken::new(),
+        build_lease,
+    ))
+}
+
+fn durable_row(
+    db: &djinn_db::Database,
+    invocation_id: &str,
+) -> impl std::future::Future<Output = djinn_db::BuildLeaseRow> + use<> {
+    let repository = djinn_db::BuildLeaseRepository::new(db.clone());
+    let key = djinn_db::BuildLeaseKey {
+        consumer_kind: djinn_db::BuildLeaseConsumerKind::TaskInvocation,
+        consumer_id: invocation_id.to_string(),
+    };
+    async move {
+        repository
+            .get(&key)
+            .await
+            .expect("read the durable lease row")
+            .expect("the invocation queued a durable lease row")
+    }
+}
+
+/// The defect this test exists for: `ShellLaunchContext::invocation` rendered
+/// `queue_deadline_ms: 30_000` and `launch_deadline_ms: 60_000` — plainly
+/// intended as 30s and 60s — but [`LeaseDeadlines`] carries ABSOLUTE Unix epoch
+/// milliseconds. `30_000` is therefore `1970-01-01T00:00:30Z`, so the
+/// coordinator terminalized every task-invocation lease as `deadline_expired`
+/// the instant it was queued. Combined with the (correct) degrade to unleased
+/// execution, every escalating shell command would have run at the launcher's
+/// 250m quota forever instead of the leased 4-CPU quota — silently, ~16x slower.
 ///
-/// `queue_deadline_ms` is passed exactly as `ShellLaunchContext::invocation`
-/// passes it (30_000), which the coordinator reads as an absolute epoch
-/// timestamp and therefore treats as already expired. That is the production
-/// path that made every escalating shell command hit a queue timeout: it must
-/// now produce a successful command result at the unleased quota.
+/// The deadlines here are not restated: they come from the production producer
+/// itself, so a regression in `ShellLaunchContext::invocation` fails this test.
+#[tokio::test]
+async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
+    let db = crate::test_helpers::create_test_db();
+    arm_invocation_lift(&db).await;
+    let services = real_lease_services(
+        &db,
+        Arc::new(djinn_coordinator::build_lease::SystemLeaseClock),
+    )
+    .await;
+    let launcher = Arc::new(DegradeLauncher::completing());
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        services,
+        launcher.clone(),
+        wall_clock(),
+    ));
+    // The exact config a task pod renders, straight from the production
+    // producer — no deadline literal appears in this test.
+    let context = crate::context::ShellLaunchContext::for_test(
+        Arc::clone(&runner),
+        "task".into(),
+        "run".into(),
+        "pod".into(),
+    );
+    let before_ms = wall_clock_ms();
+    let output = runner
+        .output(
+            command(),
+            context.invocation(Duration::from_secs(60)),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("the rendered deadlines must produce a usable lease");
+    let after_ms = wall_clock_ms();
+
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(output.process.output.status.code(), Some(0));
+    assert_eq!(launcher.killed_while_running(), 0);
+    // The whole point: the lease was actually granted, bound, and lifted off the
+    // unleased 250m quota. Under the defect this list was always empty.
+    assert_eq!(
+        launcher.lifts().len(),
+        1,
+        "a lease queued with the rendered deadlines must reach the fenced lift"
+    );
+
+    let row = durable_row(&db, &output.identity.invocation_id).await;
+    assert_ne!(
+        row.terminal_reason.as_deref(),
+        Some("deadline_expired"),
+        "the rendered queue deadline must not be in the past"
+    );
+
+    // The stored deadline is an absolute instant ~30s from now, not 1970.
+    let queue_deadline_ms = durable_deadline_ms(
+        row.queue_deadline
+            .as_deref()
+            .expect("the queued row retains its deadline"),
+    );
+    assert!(
+        queue_deadline_ms >= before_ms + 30_000 && queue_deadline_ms <= after_ms + 30_000,
+        "queue deadline {queue_deadline_ms} is not ~30s ahead of [{before_ms}, {after_ms}]"
+    );
+    let launch_deadline_ms = durable_deadline_ms(
+        row.launch_deadline
+            .as_deref()
+            .expect("the granted row retains its launch deadline"),
+    );
+    assert!(
+        launch_deadline_ms >= before_ms + 60_000 && launch_deadline_ms <= after_ms + 60_000,
+        "launch deadline {launch_deadline_ms} is not ~60s ahead of [{before_ms}, {after_ms}]"
+    );
+}
+
+/// Parse a durable deadline column back to epoch milliseconds. `COLS` selects
+/// `queue_deadline::text`, so the value arrives in Postgres' text rendering of
+/// `timestamptz` (`2026-07-25 20:30:00.123456+00`), whose fractional part is
+/// omitted when it is zero.
+fn durable_deadline_ms(value: &str) -> i64 {
+    const FORMAT: &[time::format_description::BorrowedFormatItem<'_>] = time::macros::format_description!(
+        version = 2,
+        "[year]-[month]-[day] [hour]:[minute]:[second][optional [.[subsecond]]][offset_hour sign:mandatory]"
+    );
+    (time::OffsetDateTime::parse(value, FORMAT)
+        .unwrap_or_else(|error| panic!("durable deadline `{value}` is not parseable: {error}"))
+        .unix_timestamp_nanos()
+        / 1_000_000) as i64
+}
+
+/// The degrade path from the lost-queue fix must stay reachable and correct: a
+/// deadline the coordinator's clock has genuinely passed still expires, and the
+/// command still succeeds at the unleased quota rather than dying.
+///
+/// Expiry is constructed explicitly by advancing the coordinator's own deadline
+/// clock an hour past the rendered (absolute, correct) deadline. It deliberately
+/// no longer relies on a relative value being misread as an epoch timestamp —
+/// that was the defect, and once fixed this test would otherwise have asserted
+/// nothing.
 #[tokio::test]
 async fn real_lease_authority_queue_timeout_degrades_to_a_successful_command() {
     let db = crate::test_helpers::create_test_db();
-    let services = Arc::new(crate::direct_services::DirectServices::new(
-        crate::test_helpers::agent_context_from_db(db.clone(), CancellationToken::new()),
-        CancellationToken::new(),
+    arm_invocation_lift(&db).await;
+    // One hour past every deadline this invocation can render.
+    let expired_clock = Arc::new(djinn_coordinator::build_lease::ManualLeaseClock::new(
+        wall_clock_ms() + 3_600_000,
     ));
+    let services = real_lease_services(&db, expired_clock).await;
     let launcher = Arc::new(DegradeLauncher::completing());
-    let runner = LeaseInvocationRunner::new(services, launcher.clone(), clock());
-    // The exact deadlines `ShellLaunchContext::invocation` renders in a task
-    // pod.
-    let production_deadlines = LeaseInvocationConfig {
-        queue_deadline_ms: 30_000,
-        launch_deadline_ms: 60_000,
-        ..config()
-    };
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        services,
+        launcher.clone(),
+        wall_clock(),
+    ));
+    let context = crate::context::ShellLaunchContext::for_test(
+        Arc::clone(&runner),
+        "task".into(),
+        "run".into(),
+        "pod".into(),
+    );
     let output = runner
-        .output(command(), production_deadlines, CancellationToken::new())
+        .output(
+            command(),
+            context.invocation(Duration::from_secs(60)),
+            CancellationToken::new(),
+        )
         .await
         .expect("a real queue timeout must not fail the command");
 
@@ -410,14 +622,34 @@ async fn real_lease_authority_queue_timeout_degrades_to_a_successful_command() {
     // Prove the successful result came through the timeout path rather than a
     // queue that simply never resolved: the durable row this invocation created
     // is terminal for the expired deadline.
-    let row = djinn_db::BuildLeaseRepository::new(db)
-        .get(&djinn_db::BuildLeaseKey {
-            consumer_kind: djinn_db::BuildLeaseConsumerKind::TaskInvocation,
-            consumer_id: output.identity.invocation_id.clone(),
-        })
-        .await
-        .expect("read the durable lease row")
-        .expect("the invocation queued a durable lease row");
+    let row = durable_row(&db, &output.identity.invocation_id).await;
     assert_eq!(row.state, djinn_db::BuildLeaseState::Terminal);
     assert_eq!(row.terminal_reason.as_deref(), Some("deadline_expired"));
+}
+
+/// Unit boundary for the conversion itself: a configured timeout becomes an
+/// absolute instant, and `Duration::ZERO` stays `0` — the contract's "no
+/// deadline", which the graph-warm recovery and worker paths already pass.
+#[test]
+fn timeouts_render_as_absolute_epoch_deadlines() {
+    let now_ms = 1_800_000_000_000_i64;
+    assert_eq!(
+        deadline_epoch_ms(now_ms, Duration::from_secs(30)),
+        now_ms + 30_000
+    );
+    assert_eq!(
+        deadline_epoch_ms(now_ms, Duration::ZERO),
+        0,
+        "zero means no deadline, never an expired one"
+    );
+    assert_eq!(
+        deadline_epoch_ms(i64::MAX, Duration::from_secs(30)),
+        i64::MAX,
+        "the conversion saturates instead of wrapping into the past"
+    );
+    assert_eq!(epoch_ms(std::time::UNIX_EPOCH), 0);
+    assert_eq!(
+        epoch_ms(std::time::UNIX_EPOCH + Duration::from_millis(1_234)),
+        1_234
+    );
 }

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -492,8 +492,8 @@ fn config() -> LeaseInvocationConfig {
         task_run_id: "run".into(),
         pod_uid: "pod".into(),
         cpu_usage_threshold_usec: 1,
-        queue_deadline_ms: 100,
-        launch_deadline_ms: 200,
+        queue_timeout: Duration::from_millis(100),
+        launch_timeout: Duration::from_millis(200),
         timeout: Duration::from_secs(60),
     }
 }

--- a/server/crates/djinn-supervisor/src/services/lease.rs
+++ b/server/crates/djinn-supervisor/src/services/lease.rs
@@ -17,9 +17,27 @@ pub enum LeaseIdentity {
     TaskInvocation(TaskInvocationLeaseIdentity),
     GraphWarm(GraphWarmLeaseIdentity),
 }
+/// Wall-clock lease deadlines, in **absolute Unix epoch milliseconds** — never
+/// durations.
+///
+/// The coordinator stores each field verbatim as a timestamp
+/// (`BuildLeaseService::deadline` → `OffsetDateTime::from_unix_timestamp_nanos`)
+/// and `expire_deadlines` compares those timestamps against its own wall clock.
+/// A relative value therefore does not mean "in 30 seconds": `30_000` is
+/// `1970-01-01T00:00:30Z`, permanently in the past, and every lease queued with
+/// it is terminalized as `deadline_expired` the instant it is enqueued. Producers
+/// must compute `now_ms + timeout_ms` (see `K8sGraphWarmer::spawn_warm_job` and
+/// `LeaseInvocationRunner::lease_deadlines`).
+///
+/// A non-positive value means **no deadline**: `deadline()` maps it to `None`
+/// and the durable column stays NULL, so the lease never expires on that edge.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LeaseDeadlines {
+    /// Absolute epoch-millisecond instant after which a still-queued lease is
+    /// terminalized as `deadline_expired`. Non-positive means no deadline.
     pub queue_deadline_ms: i64,
+    /// Absolute epoch-millisecond instant after which a granted-but-unlaunched
+    /// lease is marked `suspect`. Non-positive means no deadline.
     pub launch_deadline_ms: i64,
 }
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## The defect

`ShellLaunchContext::invocation` hardcoded `queue_deadline_ms: 30_000` and `launch_deadline_ms: 60_000` — plainly intended as "30 seconds" and "60 seconds". But `LeaseDeadlines` carries **absolute Unix epoch milliseconds**: the coordinator stores each field verbatim as a timestamp (`deadline()` → `OffsetDateTime::from_unix_timestamp_nanos`) and `expire_deadlines` compares it against its own wall clock.

`30_000` therefore meant `1970-01-01T00:00:30Z` — permanently in the past. Every task-invocation lease was terminalized as `deadline_expired` the instant it was enqueued.

## Why it matters now

Nothing had noticed because the cgroup launcher is not armed yet. Once it is, every shell command crossing the CPU threshold requests an invocation lease. With this defect each one is born already expired, so — thanks to the degrade that landed in #2596 — it would have silently dropped to the launcher's unleased **250m** quota and never lifted to the 4-CPU lease. Roughly 16x slower compiles, with no error anywhere. The degrade fix is what makes this *silent* rather than fatal, which is exactly what would have let it ship unnoticed.

## Producer audit

| Producer | Value passed | Verdict |
|---|---|---|
| `djinn-agent/src/context.rs` `ShellLaunchContext::invocation` | `30_000` / `60_000` | **the defect** — relative, read as 1970 |
| `djinn-k8s/src/graph_warmer.rs` `spawn_warm_job` | `now_ms + warm_job_timeout_seconds * 1000` | correct (absolute) — the reference |
| `djinn-coordinator/src/graph_warm_lease.rs` recovery | `0` / parsed epoch ms from the durable row | correct (absolute; `0` = no deadline) |
| `djinn-agent-worker/src/worker_services.rs` (tests) | `0`, and `now_ms - 1` for the expired case | correct (absolute) |
| `djinn-coordinator/src/build_admission_epoch_support.rs` (matrix harness) | `0` / `0` | no deadline |
| `djinn-supervisor` `wire.rs` / `server.rs` (tests) | fixtures | n/a |

`0` (any non-positive value) means **no deadline**: `deadline()` maps it to `None` and the durable column stays NULL. That behaviour is unchanged.

Two of three real producers already pass absolute values, so the producer is fixed rather than the coordinator's interpretation.

## The fix

- `LeaseInvocationConfig` now carries `queue_timeout` / `launch_timeout` as **`Duration`** instead of bare `i64` milliseconds. A `Duration` cannot be mistaken for an epoch timestamp, so the exact confusion that caused this defect is no longer expressible at the site where it happened. This is crate-private, so nothing fans out across the RPC/proto surface — renaming the wire fields would have changed the serde field names between a rolling server and worker for no additional safety.
- `LeaseInvocationRunner::lease_deadlines` performs the one conversion, at the moment the queue request is issued, against the runner's injected clock. `Duration::ZERO` renders `0` (no deadline), never "already expired"; the conversion saturates rather than wrapping into the past.
- `LeaseDeadlines` now documents the unit explicitly on the type and on both fields, including what a non-positive value means.

## Tests

Every new test drives the real `DirectServices` lease authority over a real durable repository with an armed cap and a committed forward-overlap admission epoch, and takes its deadlines from `ShellLaunchContext::invocation` itself rather than restating them — so a regression in the producer fails the test.

- **`rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift`** — asserts the lease is granted, bound, and reaches exactly one `fenced_lift`; that the durable row is not `deadline_expired`; and that the stored `queue_deadline` / `launch_deadline` land ~30s / ~60s ahead of wall clock rather than in 1970.
- **`real_lease_authority_queue_timeout_degrades_to_a_successful_command`** — from #2596, this relied on the defect to produce its timeout (its comment said the deadline "is therefore treated as already expired"), so it would have quietly stopped testing anything. It now expires its deadline explicitly by advancing the coordinator's own deadline clock an hour past the rendered (correct, absolute) deadline. The #2596 degrade path stays covered.
- **`timeouts_render_as_absolute_epoch_deadlines`** — pins the conversion itself, including the zero and saturation edges.

**Confirmed the regression fails against the pre-fix behaviour.** With the conversion neutralised back to `timeout.as_millis()`:

```
rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift ... FAILED
  assertion `left == right` failed: a lease queued with the rendered deadlines
  must reach the fenced lift
  left: 0
 right: 1
timeouts_render_as_absolute_epoch_deadlines ... FAILED
```

`lifts` empty is precisely the production symptom: the command runs at 250m and never lifts. The degrade test still passed under the neutralised build, confirming it now tests the degrade rather than the defect.

## Adjacent finding (not fixed here)

`BuildLeaseRepository`'s `COLS` selects `queue_deadline::text`, which renders Postgres' `timestamptz` text format (`2026-07-25 20:30:00+00`), but `build_lease.rs::ms()` parses it as RFC3339 and returns `0` on failure. So the `deadlines` echoed back inside `LeaseStatus` / `LeaseGrant` are always `0`. Expiry itself is unaffected (it is evaluated in SQL against the stored column), and no consumer currently reads those echoed values, so this is left alone rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)