### PR TITLE
fix(goxi): opt the cgroup launcher out of the AppArmor profile that denies mount(2)

### DIFF
--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -64,20 +64,28 @@ buildAdmission:
 #
 #   required  (default) — render the cgroup-launcher sidecar. The launcher
 #                         establishes its own delegated cgroup v2 root at
-#                         startup, which needs `SYS_ADMIN` for the duration of
-#                         that bootstrap; it drops the capability irreversibly
-#                         before the broker accepts any work, and the pod runs
-#                         with `hostUsers: false` so even that window is inside
-#                         a user namespace.
+#                         startup, which needs `SYS_ADMIN` plus an AppArmor
+#                         opt-out for the duration of that bootstrap; it drops
+#                         the capability irreversibly out of its bounding set
+#                         before the broker accepts any work, which is the only
+#                         layer under it and is verified at runtime.
 #   disabled            — explicit local/development compatibility: no sidecar,
 #                         cgroup leaf, or lease; shell commands run in-process
 #                         at the pod's own quota.
 #
 # Requires a cgroup-v2 node whose kubelet offers the `cpu` controller to
-# container cgroups, and (for `hostUsers: false`) a runtime with user-namespace
-# support — Kubernetes 1.33+. Every precondition fails CLOSED: an unusable
-# render is refused at dispatch before a Job is submitted, and a launcher that
-# cannot establish its delegation exits non-zero before binding its socket.
+# container cgroups. The launcher container is rendered with
+# `appArmorProfile: Unconfined`, because the container runtime's default
+# AppArmor profile carries a flat `deny mount,` and denies the launcher's
+# `mount(2)` with EACCES even though CAP_SYS_ADMIN is held — that is what took
+# v0.7.5 down on its first armed task pod. The opt-out is scoped to that one
+# container; seccomp stays RuntimeDefault, and the pod is deliberately NOT
+# user-namespaced (`hostUsers: false` leaves the launcher's own cgroup owned by
+# an unmapped uid, which breaks the delegation one step after the mount).
+#
+# Every precondition fails CLOSED: an unusable render is refused at dispatch
+# before a Job is submitted, and a launcher that cannot establish its delegation
+# exits non-zero before binding its socket.
 cgroupLauncher:
   # Production task-runs must use the brokered invocation-leaf path. Set this
   # explicitly to `disabled` only for local/development environments where the

--- a/server/crates/djinn-cgroup-launcher/src/bootstrap.rs
+++ b/server/crates/djinn-cgroup-launcher/src/bootstrap.rs
@@ -32,8 +32,16 @@
 //! **and bounding** sets — irreversibly, before the broker binds its socket and
 //! therefore before the pod can accept a single unit of work. No user-controlled
 //! code ever executes while the capability is held: the only thing running in
-//! that window is this function. `hostUsers: false` on the Pod is the second
-//! layer, confining even that window to a user namespace.
+//! that window is this function.
+//!
+//! That drop is the ONLY layer under the capability, and it therefore has to
+//! hold on its own. `hostUsers: false` was once rendered as a second layer, on
+//! the reasoning that a user namespace puts the non-namespaced sysctls out of
+//! reach; it was removed because it does not work. Kubernetes user namespaces do
+//! not delegate the container's cgroup to the mapped user, so the launcher's own
+//! root stays owned by an unmapped uid and [`Bootstrap::vacate_root`] cannot
+//! create the holding leaf — the mount succeeds and the delegation then fails
+//! with `EACCES`. See `djinn_k8s::launcher::pod_host_users` for the measurement.
 //!
 //! This is also the honest implementation of goxi's "allowPrivilegeEscalation
 //! false AFTER INITIALIZATION", which is not expressible as a Pod field — a

--- a/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
@@ -144,7 +144,7 @@ fn assert_rendered_required_job_contract() {
     let contract = rendered_contract();
     for (key, expected) in [
         ("seccomp_profile", "RuntimeDefault"),
-        ("launcher_host_users", "false"),
+        ("launcher_apparmor_profile", "Unconfined"),
         ("worker_allow_privilege_escalation", "false"),
         ("launcher_allow_privilege_escalation", "false"),
         ("launcher_capabilities_drop", "ALL"),

--- a/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
+++ b/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
@@ -41,7 +41,16 @@ launcher_read_only_root_filesystem=true
 launcher_capabilities_drop=ALL
 launcher_capabilities_add=SETUID,SETGID,SETPCAP,SYS_ADMIN,SYS_RESOURCE
 launcher_bootstrap_only_capabilities=SYS_ADMIN,SYS_RESOURCE
-launcher_host_users=false
+
+# The runtime's default AppArmor profile carries a flat `deny mount,` and denies
+# with EACCES, which is what took v0.7.5 down on its first task pod while
+# CAP_SYS_ADMIN was demonstrably present. `Unconfined` on this container only is
+# what makes the launcher's `mount(2)` reachable; seccomp `Unconfined` was
+# measured and does NOT unblock it, so `seccomp_profile` below stays
+# RuntimeDefault. The pod deliberately does NOT set `hostUsers: false`: a user
+# namespace leaves the launcher's own cgroup owned by an unmapped uid, so the
+# delegation fails one step after the mount.
+launcher_apparmor_profile=Unconfined
 
 # Launcher-spawned child: applied at runtime by `child::prepare_child`, not by
 # the Pod manifest (there is no manifest field for a process the kubelet never

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -535,12 +535,12 @@ pub fn build_task_run_job(
         // then see the worker's `/proc` entries — so it is set only when the
         // launcher is actually rendered (task grkq).
         share_process_namespace: renders_launcher.then_some(true),
-        // User namespaces (GA since k8s 1.33). Set ONLY when the launcher is
-        // armed, because only then does a container in this pod hold
-        // CAP_SYS_ADMIN — and only for the launcher's bootstrap phase. Mapping
-        // it into a user namespace puts the non-namespaced sysctls that make it
-        // a node-wide escape primitive (`/proc/sys/kernel/core_pattern`) out of
-        // reach. See `launcher::pod_host_users`.
+        // Always None. A user namespace would map the launcher's bootstrap
+        // CAP_SYS_ADMIN away from the non-namespaced sysctls that make it a
+        // node-wide escape primitive, which is why this was once Some(false) —
+        // but it also leaves the launcher's own cgroup owned by an unmapped uid,
+        // so the delegation fails one step after the mount. Measured on the real
+        // node; see `launcher::pod_host_users`.
         host_users: pod_host_users(config.cgroup_launcher_mode),
         // v1 leases security contract (qut0). The per-container securityContexts
         // set the UIDs now (worker=1000, launcher=0); the pod context ties
@@ -3756,8 +3756,10 @@ mod tests {
             "only the launcher may see the cgroup mountpoint"
         );
 
-        // User namespaces confine the launcher's bootstrap CAP_SYS_ADMIN.
-        assert_eq!(armed.host_users, Some(false));
+        // NOT user-namespaced: `hostUsers: false` leaves the launcher's own
+        // cgroup owned by an unmapped uid, which breaks the delegation one step
+        // after the mount. See `launcher::pod_host_users`.
+        assert_eq!(armed.host_users, None);
     }
 
     /// AC1: distinct worker/child UIDs, artifact GID, fsGroup/setgid ownership,

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -29,7 +29,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use k8s_openapi::api::core::v1::{
-    Capabilities, Container, EmptyDirVolumeSource, EnvVar, PodSecurityContext,
+    AppArmorProfile, Capabilities, Container, EmptyDirVolumeSource, EnvVar, PodSecurityContext,
     ResourceRequirements, SeccompProfile, SecurityContext, Volume, VolumeMount,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
@@ -171,10 +171,18 @@ pub const LAUNCHER_CGROUP_ROOT: &str = "/run/djinn-cgroup";
 ///   placement, and only then releases the child to `execve`. `fork(2)` and
 ///   `write(2)` are not intercepted by any profile in use, so goxi's "allowlist
 ///   for cgroup setup and clone3" needs no `Localhost` profile — which matters,
-///   because no seccomp delivery mechanism exists in the deployment repo.
-/// * [`VOLUME_LAUNCHER_CGROUP`] supplies the writable mountpoint (not the
-///   delegation), and [`pod_host_users`] confines the capability window to a user
-///   namespace.
+///   because no seccomp delivery mechanism exists in the deployment repo. This
+///   was measured, not assumed: `seccompProfile: Unconfined` does **not** unblock
+///   the mount.
+/// * `appArmorProfile: Unconfined` on the launcher container is what does. The
+///   runtime's default AppArmor profile carries a flat `deny mount,` and denies
+///   with `EACCES` — the errno that took v0.7.5 down on its first task pod. See
+///   [`launcher_security_context`] for the one-variable-at-a-time evidence and an
+///   honest account of the confinement this gives up.
+/// * [`VOLUME_LAUNCHER_CGROUP`] supplies the writable mountpoint, not the
+///   delegation. [`pod_host_users`] is deliberately unset: a user namespace
+///   leaves the launcher's own cgroup owned by an unmapped uid, which breaks the
+///   delegation one step after the mount.
 ///
 /// A `hostPath` onto a node subtree is still NOT the route: the pod's private
 /// cgroup namespace is mounted `nsdelegate`, so a target outside that namespace
@@ -371,6 +379,60 @@ pub const LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES: &[&str] = &["SYS_ADMIN", "SYS_RE
 /// (`child::prepare_child`); `allowPrivilegeEscalation: false` here matches that
 /// intent for the launcher process itself (dropping to the child uid still works
 /// under NNP).
+///
+/// # Why `appArmorProfile: Unconfined` (task 22rj follow-up, v0.7.5 rollback)
+///
+/// Arming the launcher in production failed on the very first task pod with
+/// `mount(2)` returning **errno 13 (EACCES)** while `CAP_SYS_ADMIN` was
+/// demonstrably present (`CapEff: 00000000012001c0`). The capability was never
+/// what was missing.
+///
+/// Measured on the production node (Ubuntu 24.04, k3s v1.35.5, cgroup v2), one
+/// variable at a time, with the rest of this security context held fixed:
+///
+/// | variant                                     | `mount("cgroup2", ...)` |
+/// |---------------------------------------------|-------------------------|
+/// | baseline (RuntimeDefault seccomp, default AppArmor) | `EACCES`        |
+/// | `seccompProfile: Unconfined`                | **still `EACCES`**      |
+/// | `appArmorProfile: Unconfined`               | **succeeds**            |
+///
+/// containerd applies its built-in `cri-containerd.apparmor.d` profile to every
+/// container that does not opt out, and that profile contains a flat
+/// `deny mount,`. AppArmor's `sb_mount` hook denies with `EACCES`, which is
+/// exactly the errno observed; seccomp denies with `EPERM` and in any case the
+/// runtime default permits `mount` once `CAP_SYS_ADMIN` is held. Note that the
+/// denial leaves **no audit record**: AppArmor `deny` rules are silent unless
+/// written `audit deny`, so an empty `dmesg | grep DENIED` is not evidence of
+/// absence — the isolation table above is the evidence.
+///
+/// So goxi's "clone3 seccomp allowlist" was aimed at the wrong axis, and task
+/// 22rj's "RuntimeDefault seccomp" acceptance criterion is not wrong in value —
+/// `RuntimeDefault` genuinely is correct and is retained here — it is simply
+/// irrelevant to the failure. Neither contract mentioned AppArmor at all.
+///
+/// ## What this gives up, honestly
+///
+/// The container runtime's default AppArmor confinement on this one container:
+/// principally `deny mount,` (which is the point) and the profile's write denials
+/// on `/proc/sys/**`, `/sys/**`, `/proc/sysrq-trigger` and
+/// `/proc/kernel/core_pattern`. During the bootstrap window this process
+/// therefore holds a genuinely unconfined `CAP_SYS_ADMIN`.
+///
+/// That window is bounded by construction and the bound is asserted, not
+/// asserted-about: `bootstrap::run` mounts, vacates, delegates and then
+/// `capset`s `CAP_SYS_ADMIN`/`CAP_SYS_RESOURCE` out of the permitted, effective,
+/// inheritable **and bounding** sets before the broker binds its socket. No
+/// user-controlled code executes while the capability is held — the only code
+/// running is that function. Verified on the node against the real launcher
+/// binary: once the container reaches `Running`, `/proc/1/status` reports
+/// `CapEff: 00000000000001c0` and `CapBnd: 00000000000001c0` — `SETUID`,
+/// `SETGID`, `SETPCAP` and nothing more.
+///
+/// A `Localhost` profile allowing only `mount fstype=cgroup2` would be tighter,
+/// but it must be preloaded on every node before the pod starts and the deploy
+/// repo has no mechanism to place one; a missing profile fails the pod closed,
+/// which is precisely the outage this is fixing. That hardening is a follow-up,
+/// not a prerequisite.
 pub fn launcher_security_context() -> SecurityContext {
     SecurityContext {
         run_as_user: Some(LAUNCHER_UID),
@@ -380,7 +442,18 @@ pub fn launcher_security_context() -> SecurityContext {
         read_only_root_filesystem: Some(true),
         capabilities: Some(launcher_capabilities()),
         seccomp_profile: Some(runtime_default_seccomp()),
+        app_armor_profile: Some(unconfined_apparmor()),
         ..SecurityContext::default()
+    }
+}
+
+/// The `Unconfined` AppArmor profile the launcher container needs so `mount(2)`
+/// is reachable at all. See [`launcher_security_context`] for the measurement
+/// that establishes this is the axis that actually blocks the mount.
+fn unconfined_apparmor() -> AppArmorProfile {
+    AppArmorProfile {
+        type_: "Unconfined".to_string(),
+        ..AppArmorProfile::default()
     }
 }
 
@@ -470,26 +543,47 @@ pub fn launcher_cgroup_mount() -> VolumeMount {
     }
 }
 
-/// Whether the Pod runs in a user namespace.
+/// Whether the Pod runs in a user namespace. Always [`None`] — read below
+/// before setting this to `Some(false)` again.
 ///
-/// `hostUsers: false` (user namespaces, GA since Kubernetes 1.33) maps the
-/// launcher's bootstrap `CAP_SYS_ADMIN` into a user namespace, where the
-/// non-namespaced sysctls that make it an escape primitive —
-/// `/proc/sys/kernel/core_pattern` above all — are unreachable. It is the second
-/// layer under the launcher's own `capset` drop, not a replacement for it.
+/// # `hostUsers: false` breaks the delegated cgroup root (v0.7.5 rollback)
 ///
-/// Only meaningful when the launcher is armed: without the sidecar no container
-/// in the pod holds a capability worth confining, and `hostUsers: false` has a
-/// real cost (idmapped volume mounts, a runtime that must support it), so it is
-/// not imposed on the default rendering.
+/// This previously returned `Some(false)` whenever the launcher was armed, on
+/// the reasoning that a user namespace maps the bootstrap `CAP_SYS_ADMIN` away
+/// from the non-namespaced sysctls that make it an escape primitive. That
+/// reasoning is sound, but the setting carried a doc comment reading "NOT
+/// VERIFIED ON A NON-NESTED NODE" — kind-in-docker cannot nest user namespaces,
+/// so it had never once been exercised. It does not work.
 ///
-/// NOT VERIFIED ON A NON-NESTED NODE. kind-in-docker cannot nest user
-/// namespaces — sandbox creation fails mounting sysfs — so this could not be
-/// exercised locally. Both failure modes are fail-closed: a runtime that does
-/// not support it refuses the Pod, and a user namespace that broke the cgroup
-/// chain would fail the launcher's startup readiness before the broker binds.
-pub fn pod_host_users(mode: CgroupLauncherMode) -> Option<bool> {
-    mode.renders_sidecar().then_some(false)
+/// Measured on the production node against the real launcher binary, with
+/// `appArmorProfile: Unconfined` already applied so the mount itself succeeds,
+/// varying only this field:
+///
+/// | `hostUsers` | outcome                                                        |
+/// |-------------|----------------------------------------------------------------|
+/// | `false`     | mount succeeds, then `mkdir` of the `init` leaf fails `EACCES`  |
+/// | unset       | full bootstrap: mount, vacate, `+cpu` delegation, capability drop |
+///
+/// The cause is not fixable from the manifest. Kubernetes user namespaces
+/// (KEP-127) do **not** delegate the container's cgroup to the mapped user: the
+/// cgroup directory stays owned by real host `root`, which is unmapped inside
+/// the pod's user namespace. The launcher's own root therefore appears owned by
+/// an unmapped uid and is unwritable, so `vacate_root` cannot create the `init`
+/// holding leaf and `delegate_cpu` never runs. The container cannot chown its
+/// way out — the inode owner is precisely what is unmapped.
+///
+/// The confinement this gives up is real and is stated plainly in
+/// [`launcher_security_context`]: the bootstrap `CAP_SYS_ADMIN` is a host
+/// capability for the duration of the mount. It is bounded by the launcher's own
+/// irreversible `capset` drop before the broker binds, which is asserted against
+/// `/proc/1/status` on the real node rather than assumed. Note this is not a
+/// regression against the pod as it actually shipped: before goxi was armed the
+/// launcher was `Disabled` and this field was already unset.
+///
+/// Kept as a named function rather than deleted so the reasoning has somewhere
+/// to live and the render guard has one thing to assert.
+pub fn pod_host_users(_mode: CgroupLauncherMode) -> Option<bool> {
+    None
 }
 
 /// Worker-side mount of the IPC volume so the worker can dial the broker socket
@@ -827,10 +921,30 @@ pub fn validate_enforcement_render(config: &KubernetesConfig) -> Result<(), Rend
                          clamps every invocation leaf to it and makes the lease a no-op",
             });
         }
-        if pod_host_users(config.cgroup_launcher_mode) != Some(false) {
+        // A user namespace leaves the launcher's own cgroup owned by an unmapped
+        // uid, so the init leaf cannot be created and the delegation never
+        // happens. Measured on the real node; see `pod_host_users`.
+        if pod_host_users(config.cgroup_launcher_mode) == Some(false) {
             return Err(RenderValidationError::ArmedRenderCannotDelegate {
-                reason: "the pod does not set hostUsers: false, so the launcher's bootstrap \
-                         CAP_SYS_ADMIN would be a host-level capability",
+                reason: "the pod sets hostUsers: false, which leaves the launcher's own cgroup \
+                         owned by an uid unmapped inside the user namespace, so the delegated \
+                         root cannot be written",
+            });
+        }
+        // The container runtime's default AppArmor profile carries a flat
+        // `deny mount,` and denies with EACCES. Without opting out, the
+        // launcher's first syscall fails and the pod fails closed. This is
+        // defect 2, asserted on the render rather than trusted.
+        let apparmor_unconfined = container
+            .security_context
+            .as_ref()
+            .and_then(|context| context.app_armor_profile.as_ref())
+            .is_some_and(|profile| profile.type_ == "Unconfined");
+        if !apparmor_unconfined {
+            return Err(RenderValidationError::ArmedRenderCannotDelegate {
+                reason: "the launcher container does not set appArmorProfile: Unconfined, so the \
+                         runtime's default profile denies mount(2) with EACCES and the delegated \
+                         root is never established",
             });
         }
         // 5. The lease must map onto a quota the launcher crate accepts, or a

--- a/server/crates/djinn-k8s/src/launcher_tests.rs
+++ b/server/crates/djinn-k8s/src/launcher_tests.rs
@@ -207,12 +207,17 @@ fn the_lease_quota_is_derived_from_the_declared_pod_cpu_limit() {
     );
 }
 
-/// `hostUsers: false` only when the launcher is armed — it is the second
-/// layer under the launcher's own capability drop, and it has a real cost.
+/// A user namespace is never requested, armed or not.
+///
+/// `hostUsers: false` leaves the launcher's own cgroup owned by a uid that is
+/// unmapped inside the namespace, so the `init` holding leaf cannot be created
+/// and the `+cpu` delegation never happens — measured on the production node,
+/// see [`pod_host_users`]. This is the guard against restoring it for the
+/// confinement argument, which is sound but unimplementable here.
 #[test]
-fn user_namespaces_are_requested_exactly_when_the_launcher_is_armed() {
+fn user_namespaces_are_never_requested_because_they_break_the_delegation() {
     assert_eq!(pod_host_users(CgroupLauncherMode::Disabled), None);
-    assert_eq!(pod_host_users(CgroupLauncherMode::Required), Some(false));
+    assert_eq!(pod_host_users(CgroupLauncherMode::Required), None);
 }
 
 /// The armed sidecar mounts a writable directory at the cgroup root path.
@@ -462,10 +467,13 @@ fn rendered_security_context_matches_the_adversarial_proof_fixture() {
             LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES.join(","),
         ),
         (
-            "launcher_host_users",
-            pod.host_users
-                .expect("the required render sets hostUsers")
-                .to_string(),
+            "launcher_apparmor_profile",
+            launcher
+                .app_armor_profile
+                .as_ref()
+                .expect("the required render pins the launcher's AppArmor profile")
+                .type_
+                .clone(),
         ),
         ("child_run_as_user", CHILD_UID.to_string()),
         ("child_run_as_group", ARTIFACT_GID.to_string()),

--- a/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
+++ b/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
@@ -273,9 +273,10 @@ fn the_default_rendering_has_the_mandatory_launcher_surface() {
         "the mandatory launcher cgroup mountpoint volume must be declared"
     );
     assert_eq!(
-        pod.host_users,
-        Some(false),
-        "the mandatory launcher bootstrap must be user-namespaced"
+        pod.host_users, None,
+        "the mandatory launcher must NOT be user-namespaced: hostUsers: false leaves its own \
+         cgroup owned by an uid unmapped inside the namespace, so the init leaf cannot be \
+         created and the +cpu delegation never happens"
     );
 }
 
@@ -385,17 +386,26 @@ fn the_armed_launcher_container_has_no_cpu_limit_and_a_real_memory_limit() {
     );
 }
 
-/// The armed pod runs in a user namespace, and the launcher's capabilities are
-/// spelled the way the API server accepts.
+/// The launcher opts out of the AppArmor profile that denies `mount(2)`, keeps
+/// the runtime-default seccomp profile, is not user-namespaced, and spells its
+/// capabilities the way the API server accepts.
+///
+/// The AppArmor assertion is the rendered-contract half of the v0.7.5 rollback:
+/// the runtime's default profile carries a flat `deny mount,` and denies with
+/// `EACCES`, which is what failed the very first armed task pod while
+/// `CAP_SYS_ADMIN` was demonstrably present. Measured one variable at a time on
+/// the production node, `seccompProfile: Unconfined` does NOT unblock the mount
+/// and `appArmorProfile: Unconfined` does — so this test pins both: the AppArmor
+/// opt-out must be present AND seccomp must stay `RuntimeDefault`, so a future
+/// change cannot "fix" the wrong axis and quietly relax seccomp too.
 #[test]
 fn the_armed_pod_confines_the_bootstrap_capability() {
     let job = render();
     let pod = pod_of(&job);
     assert_eq!(
-        pod.host_users,
-        Some(false),
-        "hostUsers: false maps the launcher's bootstrap CAP_SYS_ADMIN into a user namespace, \
-         where the non-namespaced sysctls that make it an escape primitive are unreachable"
+        pod.host_users, None,
+        "hostUsers: false leaves the launcher's own cgroup owned by an uid unmapped inside the \
+         user namespace, so the delegated root cannot be written"
     );
 
     let launcher = pod
@@ -415,7 +425,26 @@ fn the_armed_pod_confines_the_bootstrap_capability() {
             .seccomp_profile
             .as_ref()
             .map(|profile| profile.type_.as_str()),
-        Some("RuntimeDefault")
+        Some("RuntimeDefault"),
+        "seccomp is NOT the axis that blocked the mount; relaxing it too would give up \
+         confinement for nothing"
+    );
+    assert_eq!(
+        security
+            .app_armor_profile
+            .as_ref()
+            .map(|profile| profile.type_.as_str()),
+        Some("Unconfined"),
+        "the runtime's default AppArmor profile denies mount(2) with EACCES, so without this \
+         opt-out the launcher fails on its first syscall and the armed pod fails closed"
+    );
+    assert!(
+        security
+            .app_armor_profile
+            .as_ref()
+            .is_none_or(|profile| profile.localhost_profile.is_none()),
+        "localhostProfile must be unset for type Unconfined, and no node-preloaded profile is \
+         shipped by the deploy repo"
     );
     let added = security
         .capabilities
@@ -446,6 +475,29 @@ fn the_armed_pod_confines_the_bootstrap_capability() {
             );
         }
     }
+
+    // The AppArmor opt-out is a real reduction in confinement, so it must be
+    // scoped to the one container that actually needs to call mount(2). Nothing
+    // else in the pod — the worker above all, which is where user-controlled
+    // code runs — may inherit it.
+    let unconfined: Vec<&str> = pod
+        .containers
+        .iter()
+        .chain(pod.init_containers.iter().flatten())
+        .filter(|container| container.name != LAUNCHER_CONTAINER_NAME)
+        .filter(|container| {
+            container
+                .security_context
+                .as_ref()
+                .and_then(|context| context.app_armor_profile.as_ref())
+                .is_some_and(|profile| profile.type_ == "Unconfined")
+        })
+        .map(|container| container.name.as_str())
+        .collect();
+    assert!(
+        unconfined.is_empty(),
+        "only the launcher may opt out of AppArmor confinement, but {unconfined:?} also did"
+    );
 }
 
 /// The launcher mode round-trips through its config string and refuses typos, so


### PR DESCRIPTION
## The blocker

Arming the goxi cgroup launcher in production (v0.7.5) failed on the very first task pod and was rolled back within 25 minutes:

```
djinn-cgroup-launcher: could not mount a private cgroup2 filesystem at /run/djinn-cgroup (errno 13)
```

errno 13 is **EACCES**, and `CAP_SYS_ADMIN` was demonstrably present (`CapEff: 00000000012001c0`). The capability was never what was missing.

## Decisive evidence

Measured on the production node (Ubuntu 24.04, k3s v1.35.5, cgroup v2), **one variable at a time**, everything else held fixed:

| variant | `mount("cgroup2", ...)` |
|---|---|
| baseline (RuntimeDefault seccomp, default AppArmor) | `EACCES` |
| `seccompProfile: Unconfined` | **still `EACCES`** |
| `appArmorProfile: Unconfined` | **succeeds** |

containerd applies its built-in `cri-containerd.apparmor.d` profile to every container that does not opt out, and that profile carries a flat `deny mount,`. AppArmor's `sb_mount` hook denies with `EACCES`; seccomp denies with `EPERM` and in any case permits `mount` once `CAP_SYS_ADMIN` is held.

The denial leaves **no audit record** — AppArmor `deny` rules are silent unless written `audit deny` — so an empty `dmesg | grep DENIED` was not evidence of absence. The isolation table is the evidence.

## A second, independent blocker

With the mount fixed, bootstrap failed one step later creating the `init` holding leaf, again `EACCES`. The cause is `hostUsers: false`, which carried a doc comment reading *"NOT VERIFIED ON A NON-NESTED NODE"* — kind-in-docker cannot nest user namespaces, so it had never once been exercised.

| `hostUsers` | outcome (AppArmor already fixed) |
|---|---|
| `false` | mount succeeds, then `mkdir` of the `init` leaf fails `EACCES` |
| unset | full bootstrap: mount, vacate, `+cpu` delegation, capability drop |

Kubernetes user namespaces (KEP-127) do not delegate the container's cgroup to the mapped user: it stays owned by real host root, unmapped inside the pod. Not fixable from the manifest, and not a regression against what shipped — the field was unset while the launcher was `Disabled`.

## Why not the alternatives

**Consume an already-delegated path instead of mounting** would have been strictly better, so it was tested rather than assumed. Both routes are dead:

- The kubelet-supplied `/sys/fs/cgroup` is mounted **`ro`** inside the container. No `mkdir`, no `subtree_control`. Only `privileged: true` makes it rw — worse than this fix.
- A `hostPath` of the node cgroup tree mounts `rw` but `mkdir` returns `EACCES`: `nsdelegate` refuses writes outside the container's own cgroup-namespace root. (The existing `bootstrap.rs` doc comment claimed this; it was verified, not trusted.)

**A `Localhost` profile** allowing only `mount fstype=cgroup2` would be tighter, but must be preloaded on every node and the deploy repo has no mechanism to place one. A missing profile fails the pod closed — precisely the outage being fixed. Logged as follow-up hardening.

## What this gives up, plainly

The runtime's default AppArmor confinement on the one container that needs `mount(2)` (principally `deny mount,` plus write denials on `/proc/sys/**`, `/sys/**`, `core_pattern`), and the user-namespace mapping of its bootstrap `CAP_SYS_ADMIN`.

The window is bounded by the launcher's own irreversible `capset` drop before the broker binds, and no user-controlled code runs inside it. The opt-out is scoped to the launcher container only — the worker, where user code actually runs, keeps full confinement, and a test asserts nothing else is unconfined.

## Verification against the real kernel

Not a rendered-manifest assertion alone, and not a fake. The **real launcher binary** was run on the production node under this exact security context:

- container reaches `Running`; cgroup2 mounted at `/run/djinn-cgroup`
- `cgroup.subtree_control` = `cpu` — exactly the delegated set
- root `cgroup.procs` empty, launcher moved into `init/`
- `/proc/1/status`: `CapEff`/`CapBnd` = `00000000000001c0` — `SETUID`, `SETGID`, `SETPCAP` and nothing more, so `SYS_ADMIN`/`SYS_RESOURCE` are gone from the **bounding** set before the broker serves

The rendered securityContext was then dumped from this code and matches that probe field for field.

## On task 22rj's acceptance criterion

goxi's "clone3 seccomp allowlist" and 22rj's "RuntimeDefault seccomp" AC both name the **seccomp axis**. `RuntimeDefault` is correct in value and is retained. It is simply **irrelevant** to this failure — neither contract mentioned AppArmor at all. The lesson is "the AC asserted the wrong axis", not "the wrong value".

## Guards added

The armed render now fails closed if the launcher container lacks `appArmorProfile: Unconfined`, or if the pod sets `hostUsers: false`. The rendered-contract test pins both, keeps seccomp at `RuntimeDefault` so a future change cannot relax the wrong axis, and asserts no container other than the launcher is unconfined.

Note the privileged `launcher-kernel-boundary` CI lane cannot catch the AppArmor axis — it does not run under the containerd default profile. The rendered-contract guard plus node verification is what covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
