### PR TITLE
fix(build-lease): Echo real deadlines instead of 0, and correct the light-role audit reason

### DIFF
--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -560,16 +560,15 @@ async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
     );
 }
 
-/// Parse a durable deadline column back to epoch milliseconds. `COLS` selects
-/// `queue_deadline::text`, so the value arrives in Postgres' text rendering of
-/// `timestamptz` (`2026-07-25 20:30:00.123456+00`), whose fractional part is
-/// omitted when it is zero.
+/// Parse a durable deadline column back to epoch milliseconds.
+///
+/// `BuildLeaseRepository`'s shared column list renders every `timestamptz` as
+/// RFC3339 in UTC with millisecond precision, which is the same representation
+/// callers bind on the way in. That is deliberately the only timestamp format
+/// this repository speaks, so this helper is the well-known parser and not a
+/// second, format-specific one.
 fn durable_deadline_ms(value: &str) -> i64 {
-    const FORMAT: &[time::format_description::BorrowedFormatItem<'_>] = time::macros::format_description!(
-        version = 2,
-        "[year]-[month]-[day] [hour]:[minute]:[second][optional [.[subsecond]]][offset_hour sign:mandatory]"
-    );
-    (time::OffsetDateTime::parse(value, FORMAT)
+    (time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
         .unwrap_or_else(|error| panic!("durable deadline `{value}` is not parseable: {error}"))
         .unix_timestamp_nanos()
         / 1_000_000) as i64

--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -104,13 +104,22 @@ pub enum BuildWorkloadKind {
     },
 }
 
-/// Audit reason recorded when a Light (orchestration-only) task-run is admitted
-/// without reserving a build slot.
+/// Audit reason recorded when a Light task-run is admitted without reserving a
+/// build slot.
 ///
 /// Distinct and greppable on purpose: it is the single string that explains why
 /// an admitted task-run left no journal row behind.
-pub const LIGHT_ROLE_AUDIT_REASON: &str =
-    "light role: orchestration-only, never runs the project toolchain";
+///
+/// It states a dispatch-admission prior, NOT a capability boundary. Light roles
+/// are *unlikely* to run the project's compile/test toolchain — measured at 5.5%
+/// of light sessions on 2026-07-25, 8.1% for reviewers alone — which is why
+/// pre-charging them a scarce slot is the wrong trade, not because they cannot
+/// compile. The ones that do compile are governed by the measured, role-agnostic
+/// invocation lease. See [`djinn_runtime::RoleResourceClass`], whose earlier
+/// claim that these roles "never run the project's compile/test toolchain" was
+/// false when written and took 34 days to be caught.
+pub const LIGHT_ROLE_AUDIT_REASON: &str = "light role: not pre-charged a build slot at dispatch (unlikely to compile); \
+     any compile it does run is governed by the invocation lease";
 
 /// Every task-run role the coordinator can dispatch.
 ///

--- a/server/crates/djinn-coordinator/src/build_admission_light_role_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_light_role_tests.rs
@@ -1,10 +1,14 @@
-//! Light (orchestration-only) task-run roles must never consume a build slot.
+//! Light task-run roles must never be pre-charged a build slot at dispatch.
 //!
 //! Task `h1yv` (folded into `7deu`). The production cap is 3 concurrent build
 //! task-runs on a 12-vCPU node. Planners, Reviewers, Leads and the refinement
-//! tribunal (Advocate/Adversary/Judge) never run the project's compile/test
-//! toolchain, so charging them a slot would queue them behind builds they never
-//! compete with and collapse throughput.
+//! tribunal (Advocate/Adversary/Judge) are *unlikely* to run the project's
+//! compile/test toolchain — measured at 5.5% of light sessions — so charging
+//! them a slot 100% of the time would queue them behind builds they almost
+//! never compete with and collapse throughput. This is a dispatch-admission
+//! prior, not a capability boundary: the minority that do compile are governed
+//! by the measured, role-agnostic invocation lease. See
+//! [`djinn_runtime::RoleResourceClass`].
 //!
 //! These tests are deterministic: an in-memory journal, an explicit cap, and
 //! durable occupancy read back from the journal rather than inferred.

--- a/server/crates/djinn-coordinator/src/build_lease_deadline_echo_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_deadline_echo_tests.rs
@@ -1,0 +1,221 @@
+//! The deadlines echoed back to a lease caller must be the deadlines that were
+//! stored.
+//!
+//! These run against the real `BuildLeaseRepository` on a fresh database, so
+//! they exercise the actual SQL projection rather than a hand-built row. The
+//! defect they pin: the shared column list selected `queue_deadline::text`,
+//! which renders PostgreSQL's own `2026-07-25 20:30:00+00` format, while
+//! `build_lease::ms` parses RFC3339 and maps a parse failure to `0`. Because
+//! `0` also means "no deadline" in this contract, every real deadline was
+//! echoed as unbounded and nothing failed loudly.
+//!
+//! Expiry was never affected — it is evaluated in SQL against the stored column
+//! — so only the echo path can catch this. Both halves of the contract are
+//! asserted here: a real deadline echoes its own epoch milliseconds, and a row
+//! stored without a deadline still echoes `0`.
+
+use std::sync::Arc;
+
+use djinn_db::{
+    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseRow, Database,
+};
+use djinn_k8s::GraphWarmLease;
+use djinn_supervisor::services::{
+    GraphWarmLeaseIdentity, LeaseDeadlines, LeaseGrantRequest, LeaseIdentity, LeaseQueueRequest,
+    LeaseResult, LeaseStatusRequest,
+};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::build_lease::{
+    BuildLeaseService, ManualLeaseClock, NoopLeaseTelemetry, NoopLeaseTransactionPause,
+};
+use crate::graph_warm_lease::BuildLeaseGraphWarmAdapter;
+
+/// A fixed 2026 instant on a whole second, so the two deadlines below cover
+/// both a sub-second and an exact-second rendering.
+const NOW_MS: i64 = 1_785_312_000_000;
+/// Deliberately carries a non-zero millisecond component.
+const QUEUE_DEADLINE_MS: i64 = NOW_MS + 30_123;
+/// Deliberately lands on an exact second, where PostgreSQL omits the fraction.
+const LAUNCH_DEADLINE_MS: i64 = NOW_MS + 60_000;
+
+fn warm(id: &str) -> LeaseIdentity {
+    LeaseIdentity::GraphWarm(GraphWarmLeaseIdentity {
+        project_id: "project-id".into(),
+        warm_request_id: id.into(),
+        graph_revision: "graph-revision".into(),
+    })
+}
+
+fn request(id: &str, queue_deadline_ms: i64, launch_deadline_ms: i64) -> LeaseQueueRequest {
+    LeaseQueueRequest {
+        identity: warm(id),
+        deadlines: LeaseDeadlines {
+            queue_deadline_ms,
+            launch_deadline_ms,
+        },
+    }
+}
+
+async fn service(cap: i64) -> (Arc<BuildLeaseService>, Arc<BuildLeaseRepository>) {
+    let repository = Arc::new(BuildLeaseRepository::new(
+        Database::open_in_memory().unwrap(),
+    ));
+    let service = Arc::new(BuildLeaseService::with_seams(
+        Arc::clone(&repository),
+        cap,
+        Arc::new(ManualLeaseClock::new(NOW_MS)),
+        Arc::new(NoopLeaseTransactionPause),
+        Arc::new(NoopLeaseTelemetry),
+    ));
+    assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+    assert!(matches!(service.set_cap(cap).await, LeaseResult::Status(_)));
+    (service, repository)
+}
+
+async fn durable_row(repository: &BuildLeaseRepository, id: &str) -> BuildLeaseRow {
+    repository
+        .get(&BuildLeaseKey {
+            consumer_kind: BuildLeaseConsumerKind::GraphWarm,
+            consumer_id: id.into(),
+        })
+        .await
+        .expect("the durable row must be readable")
+        .expect("the queued lease must exist")
+}
+
+fn parsed_ms(value: &str) -> i64 {
+    (OffsetDateTime::parse(value, &Rfc3339)
+        .unwrap_or_else(|error| panic!("durable deadline `{value}` is not RFC3339: {error}"))
+        .unix_timestamp_nanos()
+        / 1_000_000) as i64
+}
+
+/// A queued row echoes the deadlines it was stored with, through both the queue
+/// response and a later status read.
+#[tokio::test]
+async fn queued_and_status_echo_the_stored_deadlines_rather_than_zero() {
+    let (service, repository) = service(0).await;
+
+    let LeaseResult::Queued(queued) = service
+        .queue(request("echo", QUEUE_DEADLINE_MS, LAUNCH_DEADLINE_MS))
+        .await
+    else {
+        panic!("a zero-cap queue must park the row as queued");
+    };
+    assert_eq!(
+        (
+            queued.deadlines.queue_deadline_ms,
+            queued.deadlines.launch_deadline_ms
+        ),
+        (QUEUE_DEADLINE_MS, LAUNCH_DEADLINE_MS),
+        "the queue response must echo the deadlines it stored, not 0"
+    );
+
+    let LeaseResult::Status(status) = service
+        .status(LeaseStatusRequest {
+            identity: warm("echo"),
+        })
+        .await
+    else {
+        panic!("a queued lease must report status");
+    };
+    assert_eq!(
+        (
+            status.deadlines.queue_deadline_ms,
+            status.deadlines.launch_deadline_ms
+        ),
+        (QUEUE_DEADLINE_MS, LAUNCH_DEADLINE_MS),
+        "a status read must echo the durable deadlines, not 0"
+    );
+
+    // The durable strings themselves are the canonical representation, so the
+    // one parser the coordinator owns round-trips them without loss.
+    let row = durable_row(&repository, "echo").await;
+    let queue_deadline = row.queue_deadline.expect("the queued row retains it");
+    let launch_deadline = row.launch_deadline.expect("the queued row retains it");
+    assert_eq!(parsed_ms(&queue_deadline), QUEUE_DEADLINE_MS);
+    assert_eq!(parsed_ms(&launch_deadline), LAUNCH_DEADLINE_MS);
+}
+
+/// The grant a caller actually launches on carries the same deadlines.
+#[tokio::test]
+async fn a_grant_echoes_the_stored_deadlines_rather_than_zero() {
+    let (service, _) = service(1).await;
+
+    let LeaseResult::Granted(grant) = service
+        .queue(request("granted", QUEUE_DEADLINE_MS, LAUNCH_DEADLINE_MS))
+        .await
+    else {
+        panic!("a lease queued under free capacity must grant");
+    };
+    assert_eq!(
+        (
+            grant.deadlines.queue_deadline_ms,
+            grant.deadlines.launch_deadline_ms
+        ),
+        (QUEUE_DEADLINE_MS, LAUNCH_DEADLINE_MS),
+        "the grant must echo the deadlines it stored, not 0"
+    );
+}
+
+/// The other half of the contract: `0` genuinely means "no deadline", the
+/// column stays NULL, and the echo must keep saying `0`.
+#[tokio::test]
+async fn an_absent_deadline_still_echoes_zero_and_stays_null() {
+    let (service, repository) = service(1).await;
+
+    let LeaseResult::Granted(grant) = service.queue(request("unbounded", 0, 0)).await else {
+        panic!("a lease queued under free capacity must grant");
+    };
+    assert_eq!(
+        (
+            grant.deadlines.queue_deadline_ms,
+            grant.deadlines.launch_deadline_ms
+        ),
+        (0, 0),
+        "an unbounded lease must keep echoing 0"
+    );
+
+    let row = durable_row(&repository, "unbounded").await;
+    assert_eq!(row.queue_deadline, None);
+    assert_eq!(row.launch_deadline, None);
+}
+
+/// Warm recovery is a live consumer that was already reading `0`.
+///
+/// `BuildLeaseGraphWarmAdapter::recoverable` parses the durable launch deadline
+/// with the same RFC3339 parser, so under the defect every warm lease recovered
+/// across a coordinator restart came back unbounded.
+#[tokio::test]
+async fn warm_recovery_reports_the_stored_launch_deadline() {
+    let (service, _) = service(1).await;
+    let LeaseResult::Granted(grant) = service
+        .queue(request("recovered", QUEUE_DEADLINE_MS, LAUNCH_DEADLINE_MS))
+        .await
+    else {
+        panic!("a lease queued under free capacity must grant");
+    };
+    // Only launching/bound/active/suspect rows are recoverable, so acknowledge
+    // the grant before recovering.
+    assert!(matches!(
+        service
+            .grant(LeaseGrantRequest {
+                identity: warm("recovered"),
+                fencing_token: grant.fencing_token,
+            })
+            .await,
+        LeaseResult::Status(_)
+    ));
+
+    let adapter = BuildLeaseGraphWarmAdapter::new(Arc::clone(&service));
+    let recovered = adapter.recoverable().await.expect("recovery must succeed");
+    let entry = recovered
+        .iter()
+        .find(|entry| entry.identity.warm_request_id == "recovered")
+        .expect("the launching warm lease must be recovered");
+    assert_eq!(
+        entry.deadlines.launch_deadline_ms, LAUNCH_DEADLINE_MS,
+        "warm recovery must report the durable launch deadline, not 0"
+    );
+}

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -204,6 +204,8 @@ mod build_admission_stale_reclaim_tests;
 #[cfg(test)]
 mod build_lease_cap_arming_tests;
 #[cfg(test)]
+mod build_lease_deadline_echo_tests;
+#[cfg(test)]
 mod build_lease_integration_tests;
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/server/crates/djinn-db/src/repositories/build_lease.rs
+++ b/server/crates/djinn-db/src/repositories/build_lease.rs
@@ -85,7 +85,11 @@ pub struct BuildLeaseRow {
     pub enqueue_sequence: i64,
     pub fencing_token: Option<i64>,
     pub state: BuildLeaseState,
+    /// RFC3339 UTC with millisecond precision, rendered by the shared column
+    /// list. `None` means the row carries no deadline at all.
     pub queue_deadline: Option<String>,
+    /// RFC3339 UTC with millisecond precision, rendered by the shared column
+    /// list. `None` means the row carries no deadline at all.
     pub launch_deadline: Option<String>,
     pub bound_pod_uid: Option<String>,
     pub candidate_cleanup: Option<serde_json::Value>,
@@ -555,7 +559,29 @@ impl BuildLeaseRepository {
     }
 }
 
-const COLS: &str = "consumer_kind,consumer_id,immutable_identity,enqueue_sequence,fencing_token,state,queue_deadline::text,launch_deadline::text,bound_pod_uid,candidate_cleanup,terminal_reason,timeout_credit_consumed,created_at::text,updated_at::text,granted_at::text,terminal_at::text";
+/// The single projection every read and `RETURNING` clause of this repository
+/// uses.
+///
+/// Every `timestamptz` is rendered as RFC3339 in UTC with millisecond
+/// precision, which is the *only* timestamp representation this repository
+/// emits or accepts: callers bind RFC3339 in (`$n::timestamptz`) and read
+/// RFC3339 back out, so one parser round-trips the values.
+///
+/// A plain `::text` cast would instead yield PostgreSQL's own output format
+/// (`2026-07-25 20:30:00+00`, space-separated, no `T`). That is not RFC3339,
+/// and the coordinator's `build_lease::ms` — the sole reader of the echoed
+/// deadlines — parses RFC3339 and maps a parse failure to `0`. Since `0` is
+/// itself meaningful in that contract ("no deadline"), the cast silently turned
+/// every real deadline into "unbounded" on the way out. Keep the rendering
+/// here; do not add a second parser on the Rust side.
+const COLS: &str = "consumer_kind,consumer_id,immutable_identity,enqueue_sequence,fencing_token,state,\
+    to_char(queue_deadline AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS queue_deadline,\
+    to_char(launch_deadline AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS launch_deadline,\
+    bound_pod_uid,candidate_cleanup,terminal_reason,timeout_credit_consumed,\
+    to_char(created_at AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS created_at,\
+    to_char(updated_at AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS updated_at,\
+    to_char(granted_at AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS granted_at,\
+    to_char(terminal_at AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS terminal_at";
 #[derive(sqlx::FromRow)]
 struct DbRow {
     consumer_kind: String,

--- a/server/crates/djinn-k8s/src/config.rs
+++ b/server/crates/djinn-k8s/src/config.rs
@@ -37,9 +37,12 @@ pub struct KubernetesConfig {
     pub cpu_request: String,
     /// CPU **request** for a *light* task-run Pod (Planner / Reviewer / Lead /
     /// every Refinement sub-role / grooming). These pods orchestrate an agent
-    /// session and never run the project's compile/test toolchain, so they get
-    /// a fractional-core request. v1 leases default: `"300m"`. Overridable via
-    /// `DJINN_K8S_LIGHT_CPU_REQUEST`.
+    /// session and are *unlikely* to run the project's compile/test toolchain
+    /// (measured at 5.5% of light sessions), so they get a fractional-core
+    /// request. They are not incapable of compiling — the minority that do are
+    /// governed by the measured, role-agnostic invocation lease, which is why
+    /// the CPU **limit** below is deliberately not role-classed. v1 leases
+    /// default: `"300m"`. Overridable via `DJINN_K8S_LIGHT_CPU_REQUEST`.
     ///
     /// Only the CPU REQUEST is role-classed: the CPU **limit**
     /// ([`Self::cpu_limit`]) and both memory bounds are identical for light and


### PR DESCRIPTION
Two small, independent correctness fixes.

## 1. Echoed lease deadlines always read `0`

`BuildLeaseRepository`'s shared column list selected `queue_deadline::text`, which renders PostgreSQL's own output format (`2026-07-25 20:30:00+00`), while `djinn-coordinator`'s `build_lease::ms` parses **RFC3339** and maps a parse failure to `0`. Every deadline echoed back in `LeaseStatus` and `LeaseGrant` was therefore `0` — and because `0` is itself meaningful in this contract (`deadline(ms)` returns `None` for `ms <= 0`, leaving the column NULL, i.e. "no deadline"), nothing failed loudly.

Expiry was never affected: it is evaluated in SQL against the stored column.

The trap was live rather than hypothetical. `BuildLeaseGraphWarmAdapter::recoverable` already reads the durable `launch_deadline` with the same RFC3339 parser, so every warm lease recovered across a coordinator restart came back unbounded.

Fixed at the single canonical representation rather than by adding a second parser: the column list now renders every `timestamptz` with

```sql
to_char(<col> AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
```

which is the same RFC3339 form callers already bind on the way in (`$n::timestamptz`). Millisecond precision is preserved so epoch-ms values round-trip exactly, and NULL still renders NULL so a genuine no-deadline row keeps echoing `0`. `process_lease_degrade_tests::durable_deadline_ms` carried the second, Postgres-format parser this defect forced on it; it is now the well-known one.

### Round-trip coverage

New `build_lease_deadline_echo_tests` runs the real `BuildLeaseRepository` against a fresh database — no hand-built rows:

| test | asserts |
| --- | --- |
| `queued_and_status_echo_the_stored_deadlines_rather_than_zero` | queue response and a later status read both echo the stored epoch ms; the durable strings parse back losslessly |
| `a_grant_echoes_the_stored_deadlines_rather_than_zero` | the grant a caller launches on carries the same values |
| `an_absent_deadline_still_echoes_zero_and_stays_null` | `0` in still means `0` out, column NULL |
| `warm_recovery_reports_the_stored_launch_deadline` | the live warm-recovery consumer no longer reports `0` |

Deadlines are chosen to cover both a sub-second value (`+30_123 ms`) and an exact second, where PostgreSQL omits the fraction.

Reverting only the column list turns three of the four red (`left: (0, 0)` / `right: (1785312030123, 1785312060000)`); `an_absent_deadline_still_echoes_zero_and_stays_null` stays green, which is the half that must not regress.

This does not touch #2599's producer-side work: invocation deadlines remain absolute epoch milliseconds, typed as `Duration` at the producer, converted once at queue time.

## 2. The "light roles never compile" falsehood, in its three remaining copies

`LIGHT_ROLE_AUDIT_REASON` asserted that light roles "never run the project toolchain". Measured against production transcripts on 2026-07-25: **5.5%** of light sessions ran a real compile, **8.1%** for reviewers alone, and light roles are **56%** of all task-runs. Commit `1719ef8c3` (2026-06-20) had already recorded a reviewer running a ~12-minute cold `cargo check` *"despite task-reviewer.md already instructing it not to"*.

#2600 corrected the same claim in `RoleResourceClass` and two propagated copies. A grep for the claim found **three** more still standing, and all three are corrected here:

- `build_admission.rs` — `LIGHT_ROLE_AUDIT_REASON`, the string quoted into the audit trail (the one #2600 deliberately left alone because the file was held elsewhere)
- `build_admission_light_role_tests.rs` — module doc
- `djinn-k8s/src/config.rs` — the `light_cpu_request` doc

All three now state the corrected framing: a **dispatch-admission prior, not a capability boundary**. Light roles are not pre-charged a slot because they are unlikely to compile, and anything that does compile is governed by the measured, role-agnostic invocation lease. Comments and one audit string; no behaviour changes. The `build_admission.rs` diff is confined to that constant and its doc comment.

## Verification

- `cargo check -p djinn-coordinator -p djinn-db -p djinn-k8s --tests`, `cargo clippy -p djinn-db -p djinn-coordinator --all-targets` (no new warnings on touched files), `cargo fmt --check` clean on touched files
- `cargo test -p djinn-coordinator --lib build_lease` — 27 passed
- `cargo test -p djinn-coordinator --lib build_admission` — 105 passed
- `cargo test -p djinn-coordinator --lib run_dir_observe` — 23 passed
- `cargo test -p djinn-db --lib build_lease` — 5 passed
- `cargo test -p djinn-agent --lib lease_degrade_tests` — 9 passed (includes #2599's `timeouts_render_as_absolute_epoch_deadlines` and `rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift`)
- `cargo test -p djinn-agent --test build_lease_shared_consumers` — 3 passed
- `./scripts/check-raw-sql-boundary.sh`, `python3 scripts/check_boundaries.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
