### PR TITLE
feat(verify): add a recorded evidence tier so a warm build can be reused

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/adapter.rs
+++ b/server/crates/djinn-agent/src/actors/slot/adapter.rs
@@ -9,22 +9,24 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use djinn_core::canonical_verify::{
-    CanonicalCommandDescriptorV1, CanonicalFinalVerificationPlanV1, CanonicalHermeticityV1,
-    DeclaredExternalInputV1, ImmutableImageV1, ResolvedEnvironmentIdentityInputV1, ToolProbeStatus,
-    ToolProbeV1, VerificationInputManifestV1,
+    CanonicalCommandDescriptorV1, CanonicalEvidenceTierV1, CanonicalFinalVerificationPlanV1,
+    CanonicalHermeticityV1, DeclaredExternalInputV1, ImmutableImageV1,
+    ResolvedEnvironmentIdentityInputV1, ToolProbeStatus, ToolProbeV1, VerificationInputManifestV1,
 };
 use djinn_core::clock::SystemClock;
 use djinn_core::models::VerifySource;
 use djinn_db::advisory_lock;
 use djinn_db::{ImageRepository, TaskRunRepository};
 use djinn_git::verification_input::{
-    ResolvedExternalInputV1, VerificationInputFingerprintConfig, collect_verification_changed_paths,
+    OutputOnlyPolicy, ResolvedExternalInputV1, VerificationInputFingerprintConfig,
+    collect_verification_changed_paths,
 };
 use djinn_k8s::sidecar::resolve_image_services_strict;
 use djinn_sandbox::final_verification_execution::{
     EnvironmentIdentityResolver, FinalVerificationExecutionRequest,
 };
 use djinn_sandbox::service_provisioning::{ServiceProvisioners, UnixCatalogServiceProvisioner};
+use djinn_stack::environment::VerificationEvidenceTier as StackEvidenceTier;
 use djinn_supervisor::SupervisorServices;
 use globset::{Glob, GlobSetBuilder};
 
@@ -117,6 +119,40 @@ fn output_directories(globs: &[String]) -> Result<Vec<PathBuf>, String> {
         directories.insert(prefix);
     }
     Ok(directories.into_iter().collect())
+}
+
+/// Resolve declared environment names from the host process environment.
+///
+/// Production previously hardcoded an empty allowlist, so `command_environment`
+/// rejected every name a catalog service did not export — `PATH`, `HOME`,
+/// `CARGO_HOME`, and `CARGO_TARGET_DIR` could not be passed at all, and the
+/// config schema advertised an `environment_names` list that production could
+/// not satisfy.
+///
+/// Names exported by a catalog service are excluded: those values are minted
+/// per attempt by the lease and must not be frozen into identity. A declared
+/// name that is unset, or set to an empty value where a value is required, is
+/// omitted so the command fails closed with `UndeclaredCommandEnvironment`
+/// rather than silently running without it.
+///
+/// `require_value` distinguishes the two buckets: identity-bearing values are
+/// hashed and must be non-empty (canonicalization rejects an empty value),
+/// while volatile values are not hashed and may legitimately be empty — the
+/// production pod renders `RUSTC_WRAPPER=""` to clear a repo-level sccache
+/// setting, and dropping it would silently change how the build compiles.
+fn resolve_declared_environment(
+    names: &[String],
+    service_exported: &std::collections::BTreeSet<String>,
+    require_value: bool,
+) -> BTreeMap<String, String> {
+    names
+        .iter()
+        .filter(|name| !service_exported.contains(*name))
+        .filter_map(|name| {
+            let value = std::env::var(name).ok()?;
+            (!require_value || !value.is_empty()).then(|| (name.clone(), value))
+        })
+        .collect()
 }
 
 /// Canonical host runtime directories that the strict Landlock launcher must
@@ -337,7 +373,7 @@ impl AgentHostCallbacks {
     /// traversed exactly once and no consultation/lease/execution/persistence
     /// boundary is reached. Production code never calls this.
     #[cfg(test)]
-    fn dispatch_with_final_verification_probe(
+    pub(super) fn dispatch_with_final_verification_probe(
         agent: &AgentContext,
     ) -> (Self, Arc<FinalVerificationProbe>) {
         let probe = Arc::new(FinalVerificationProbe::default());
@@ -411,6 +447,10 @@ pub async fn resolve_final_verification_for_task_run(
         .await
         .map_err(|e| format!("strict catalog resolution failed: {e}"))?;
     let catalog_loopback_endpoints = catalog_loopback_endpoints(&services)?;
+    let service_exported_environment: std::collections::BTreeSet<String> = services
+        .iter()
+        .flat_map(|service| service.exported_environment_names.iter().cloned())
+        .collect();
     let service_provisioners: ServiceProvisioners = services
         .iter()
         .map(|service| {
@@ -438,7 +478,9 @@ pub async fn resolve_final_verification_for_task_run(
             })
             .collect(),
         output_only_globs: plan.output_only_globs.clone(),
+        volatile_environment_names: plan.input_manifest.volatile_environment_names.clone(),
     };
+    let recorded = plan.evidence_tier == StackEvidenceTier::Recorded;
     let external_inputs: Vec<_> = plan
         .read_only_external_inputs
         .iter()
@@ -453,6 +495,13 @@ pub async fn resolve_final_verification_for_task_run(
         base_ref: "main".into(),
         manifest: manifest.clone(),
         external_inputs: external_inputs.clone(),
+        // A recorded run excludes its warm build outputs from the fingerprint
+        // but must never delete them — they are the cache it exists to reuse.
+        output_policy: if recorded {
+            OutputOnlyPolicy::ExcludeOnly
+        } else {
+            OutputOnlyPolicy::PurgeBeforeFingerprint
+        },
     };
     let changed_paths = collect_verification_changed_paths(&worktree, &fingerprint_config)
         .await
@@ -475,6 +524,11 @@ pub async fn resolve_final_verification_for_task_run(
                 hermetic: plan.hermeticity.hermetic,
                 reusable: plan.hermeticity.reusable,
                 network_access: plan.hermeticity.network_access,
+            },
+            evidence_tier: if recorded {
+                CanonicalEvidenceTierV1::Recorded
+            } else {
+                CanonicalEvidenceTierV1::Attested
             },
         },
         selection: if plan.command_groups.is_empty() {
@@ -518,7 +572,11 @@ pub async fn resolve_final_verification_for_task_run(
         lockfile_digests: Vec::new(),
         target: std::env::consts::ARCH.into(),
         features: Vec::new(),
-        allowlisted_environment: BTreeMap::new(),
+        allowlisted_environment: resolve_declared_environment(
+            &plan.input_manifest.environment_names,
+            &service_exported_environment,
+            true,
+        ),
         services: services
             .into_iter()
             .map(
@@ -536,7 +594,14 @@ pub async fn resolve_final_verification_for_task_run(
             .collect(),
     };
     let resolver: EnvironmentIdentityResolver = Arc::new(move || Ok(identity.clone()));
-    let output_directories = output_directories(&manifest.output_only_globs)?;
+    // A recorded run applies no sandbox, so it holds no write grant and its
+    // globs are pure exclusions. Deriving directories would also reject globs
+    // that are perfectly valid as exclusions but lack a literal prefix.
+    let output_directories = if recorded {
+        Vec::new()
+    } else {
+        output_directories(&manifest.output_only_globs)?
+    };
     Ok(Some(
         djinn_slot::final_verification::FinalVerificationResolvedMaterial {
             execution_request: FinalVerificationExecutionRequest {
@@ -548,10 +613,17 @@ pub async fn resolve_final_verification_for_task_run(
                 output_directories,
                 catalog_loopback_endpoints,
                 service_provisioners,
+                volatile_environment: resolve_declared_environment(
+                    &plan.input_manifest.volatile_environment_names,
+                    &service_exported_environment,
+                    false,
+                ),
             },
             verify_source: VerifySource::Worker,
             required_checks,
             diff_fingerprint: String::new(),
+            reusable: plan.hermeticity.reusable,
+            evidence_tier: if recorded { "recorded" } else { "attested" },
         },
     ))
 }

--- a/server/crates/djinn-agent/src/actors/slot/mod.rs
+++ b/server/crates/djinn-agent/src/actors/slot/mod.rs
@@ -24,6 +24,8 @@ pub mod helpers; // HOST-ONLY: provider resolution, feedback, code-context
 pub(crate) mod host_callbacks; // HOST-ONLY: dispatch callback adapter
 pub(crate) mod lifecycle; // HOST-ONLY: per-stage lifecycle helpers
 mod pool; // HOST-ONLY: slot pool, handle, factory
+#[cfg(test)]
+mod recorded_verification_tests; // Recorded evidence tier, end to end
 pub(crate) mod reply_loop; // THIN SHIM: reply-loop facade adapter
 pub(crate) mod session_extraction; // THIN SHIM: extraction backfill adapter
 mod supervisor_runner; // HOST-ONLY: host-side dispatch logic

--- a/server/crates/djinn-agent/src/actors/slot/recorded_verification_tests.rs
+++ b/server/crates/djinn-agent/src/actors/slot/recorded_verification_tests.rs
@@ -1,0 +1,603 @@
+//! End-to-end coverage for the `recorded` final-verification evidence tier.
+//!
+//! These tests deliberately drive the real production path: the real project
+//! config, the real `resolve_final_verification_for_task_run` resolver, the real
+//! `coordinate_final_verification` coordinator, a real Postgres row, a real git
+//! worktree, and a real spawned command. Nothing here injects a
+//! `FinalVerificationExecutionEvidence` or hand-builds a `VerifyRun`.
+//!
+//! That is the point. The predecessor work shipped fourteen green acceptance
+//! criteria against fixtures that supplied what production does not, and did
+//! nothing in production. A test that hands the coordinator its answer proves
+//! only that the coordinator can read.
+//!
+//! "The command did not run" is proven with a marker file OUTSIDE the worktree,
+//! so observing it cannot itself perturb the fingerprint under test.
+
+use std::path::{Path, PathBuf};
+
+use djinn_core::events::EventBus;
+use djinn_db::repositories::task_run::CreateTaskRunParams;
+use djinn_db::{ImageRepository, ProjectRepository, TaskRunRepository};
+use djinn_slot::final_verification::{
+    FinalVerificationCoordinatorRequest, FinalVerificationRecordingOutcome,
+    coordinate_final_verification,
+};
+use djinn_stack::environment::{
+    EnvironmentConfig, FinalVerificationCommand, HermeticityDeclaration, VerificationEvidenceTier,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::context::AgentContext;
+use crate::test_helpers::{
+    create_test_db, create_test_epic, create_test_project, create_test_task, test_tempdir,
+};
+
+const IMAGE_ID: &str = "recorded-verification-image";
+
+async fn run_git(worktree: &Path, args: &[&str]) {
+    djinn_git::run_git_command_in(worktree, args.iter().map(|arg| (*arg).to_owned()).collect())
+        .await
+        .unwrap_or_else(|error| panic!("git {args:?} failed: {error}"));
+}
+
+async fn identify(worktree: &Path) {
+    run_git(worktree, &["config", "user.email", "test@example.com"]).await;
+    run_git(worktree, &["config", "user.name", "Recorded Test"]).await;
+}
+
+/// A shared origin the way production has one: worker and reviewer runs are
+/// separate Pods that only ever meet through the mirror.
+async fn origin_repo() -> tempfile::TempDir {
+    let origin = test_tempdir("recorded-origin-");
+    run_git(origin.path(), &["init", "-b", "main"]).await;
+    identify(origin.path()).await;
+    std::fs::create_dir_all(origin.path().join("server/src")).expect("create tree");
+    std::fs::write(origin.path().join("server/src/lib.rs"), "// base\n").expect("write source");
+    std::fs::write(
+        origin.path().join(".gitignore"),
+        "server/target/\nui/node_modules/\n",
+    )
+    .expect("write gitignore");
+    run_git(origin.path(), &["add", "."]).await;
+    run_git(origin.path(), &["commit", "-m", "base"]).await;
+    // The production mirror is a bare repository that accepts worker pushes to
+    // the checked-out branch; a non-bare test origin refuses by default.
+    run_git(
+        origin.path(),
+        &["config", "receive.denyCurrentBranch", "ignore"],
+    )
+    .await;
+    origin
+}
+
+async fn clone_from(origin: &Path, prefix: &str) -> tempfile::TempDir {
+    let clone = test_tempdir(prefix);
+    run_git(
+        clone.path(),
+        &[
+            "clone",
+            origin.to_str().expect("origin path is UTF-8"),
+            clone.path().to_str().expect("clone path is UTF-8"),
+        ],
+    )
+    .await;
+    identify(clone.path()).await;
+    clone
+}
+
+/// Build the residue a worked-in Pod worktree accumulates and a fresh reviewer
+/// clone never has: an ignored build directory and an ignored dependency tree.
+fn add_build_residue(worktree: &Path) {
+    let target = worktree.join("server/target/debug/deps");
+    std::fs::create_dir_all(&target).expect("create target");
+    std::fs::write(target.join("libdjinn.rlib"), b"warm artifact bytes").expect("write artifact");
+    let modules = worktree.join("ui/node_modules/left-pad");
+    std::fs::create_dir_all(&modules).expect("create node_modules");
+    std::fs::write(modules.join("index.js"), b"module.exports = 1;").expect("write module");
+}
+
+struct Fixture {
+    agent: AgentContext,
+    project_id: String,
+    task_id: String,
+}
+
+async fn fixture() -> Fixture {
+    let db = create_test_db();
+    let project = create_test_project(&db).await;
+    let epic = create_test_epic(&db, &project.id).await;
+    let task = create_test_task(&db, &project.id, &epic.id).await;
+    let images = ImageRepository::new(db.clone());
+    images
+        .create(IMAGE_ID, "recorded-verification", None, "{}")
+        .await
+        .expect("create catalog image");
+    // The production resolver requires a ready, digest-pinned catalog image and
+    // refuses to resolve without one; a test that skipped this would not be
+    // exercising the production resolution boundary at all.
+    images
+        .mark_ready(
+            IMAGE_ID,
+            "ghcr.io/djinn/recorded-verification:test",
+            Some(&format!("sha256:{}", "a".repeat(64))),
+        )
+        .await
+        .expect("mark catalog image ready");
+    images
+        .set_project_image(&project.id, Some(IMAGE_ID))
+        .await
+        .expect("bind project image");
+    Fixture {
+        agent: agent_context_from_db_for_test(db),
+        project_id: project.id,
+        task_id: task.id,
+    }
+}
+
+fn agent_context_from_db_for_test(db: djinn_db::Database) -> AgentContext {
+    crate::test_helpers::agent_context_from_db(db, CancellationToken::new())
+}
+
+/// Insert a task_run the way a dispatch does: a fresh uuidv7 per run, its own
+/// workspace path. Worker and reviewer runs of one task are separate rows.
+async fn task_run(fx: &Fixture, worktree: &Path) -> String {
+    let id = uuid::Uuid::now_v7().to_string();
+    let runs = TaskRunRepository::new(fx.agent.db.clone());
+    runs.create(CreateTaskRunParams {
+        id: &id,
+        project_id: &fx.project_id,
+        task_id: &fx.task_id,
+        trigger_type: "dispatch",
+        status: Some("running"),
+        workspace_path: Some(worktree.to_str().expect("worktree path is UTF-8")),
+        mirror_ref: None,
+        dispatch_group_id: None,
+    })
+    .await
+    .expect("create task run");
+    runs.set_catalog_image_id(&id, IMAGE_ID)
+        .await
+        .expect("bind run image");
+    id
+}
+
+/// The recorded plan under test. `marker` is appended to on every execution and
+/// lives outside the worktree, so a run that was suppressed leaves it unchanged
+/// without ever influencing the fingerprint.
+fn recorded_plan(marker: &Path) -> EnvironmentConfig {
+    let mut config = EnvironmentConfig::empty();
+    let plan = &mut config.lifecycle.final_verification;
+    plan.profile_id = "recorded-test".into();
+    plan.profile_revision = 1;
+    plan.evidence_tier = VerificationEvidenceTier::Recorded;
+    plan.hermeticity = HermeticityDeclaration {
+        hermetic: false,
+        reusable: true,
+        network_access: true,
+    };
+    plan.commands = vec![FinalVerificationCommand {
+        check_id: "build".into(),
+        executable: "/bin/sh".into(),
+        argv: vec!["-c".into(), format!("echo ran >> {}", marker.display())],
+        working_directory: String::new(),
+        environment_names: vec!["PATH".into()],
+        timeout_seconds: 60,
+        descriptor_revision: 1,
+    }];
+    plan.required_checks = vec!["build".into()];
+    plan.input_manifest.environment_names = vec!["PATH".into()];
+    plan.output_only_globs = vec!["server/target/**".into(), "ui/node_modules/**".into()];
+    config
+}
+
+async fn apply_config(fx: &Fixture, config: &EnvironmentConfig) {
+    config
+        .validate()
+        .expect("recorded plan must satisfy environment validation");
+    ProjectRepository::new(fx.agent.db.clone(), EventBus::noop())
+        .set_environment_config(
+            &fx.project_id,
+            &serde_json::to_string(config).expect("serialize config"),
+        )
+        .await
+        .expect("persist environment config");
+}
+
+async fn enable_reuse(fx: &Fixture) {
+    djinn_db::repositories::settings::SettingsRepository::new(
+        fx.agent.db.clone(),
+        EventBus::noop(),
+    )
+    .set(
+        &format!("project.{}.verify_run_reuse_enabled", fx.project_id),
+        "true",
+    )
+    .await
+    .expect("enable reuse");
+}
+
+/// Drive the coordinator through production callbacks with the observation
+/// probe attached.
+///
+/// The probe is what DECLINES the `final_verification_outcome_for_test`
+/// short-circuit. Without it, `AgentHostCallbacks` hands the coordinator a
+/// synthetic `Stored` outcome carrying `"test-fingerprint"`, and every
+/// assertion about outcomes passes while nothing at all executes. The marker
+/// assertions below are what caught that; keep them.
+async fn coordinate(fx: &Fixture, task_run_id: &str) -> FinalVerificationRecordingOutcome {
+    let (callbacks, probe) =
+        super::adapter::AgentHostCallbacks::dispatch_with_final_verification_probe(&fx.agent);
+    let ctx = super::adapter::build_slot_context(&fx.agent, std::sync::Arc::new(callbacks), None);
+    let outcome = coordinate_final_verification(
+        FinalVerificationCoordinatorRequest {
+            task_id: fx.task_id.clone(),
+            task_run_id: task_run_id.to_owned(),
+            cancellation: CancellationToken::new(),
+        },
+        &ctx,
+    )
+    .await;
+    assert_eq!(
+        probe
+            .terminal_outcome_shortcuts
+            .load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "the synthetic test outcome must never decide these tests"
+    );
+    outcome
+}
+
+fn marker_runs(marker: &Path) -> usize {
+    std::fs::read_to_string(marker).map_or(0, |text| text.lines().count())
+}
+
+fn marker_path(dir: &Path) -> PathBuf {
+    dir.join("executions.log")
+}
+
+async fn fingerprint_of(fx: &Fixture, task_run_id: &str) -> String {
+    let material =
+        super::adapter::resolve_final_verification_for_task_run(&fx.agent.db, task_run_id)
+            .await
+            .expect("resolve material")
+            .expect("configured plan");
+    match djinn_git::compute_verification_input_fingerprint_with_config(
+        &material.execution_request.worktree,
+        &material.execution_request.fingerprint_config,
+    )
+    .await
+    .expect("fingerprint computation")
+    {
+        djinn_git::VerificationInputFingerprint::Available(digest) => digest.fingerprint,
+        djinn_git::VerificationInputFingerprint::Unavailable(reason) => {
+            panic!("fingerprint unavailable: {reason}")
+        }
+    }
+}
+
+/// THE test the whole feature rests on.
+///
+/// A worker run works in a Pod worktree that accumulates ignored build output;
+/// the reviewer run is a *separate* task_run in a *fresh clone* with none of it.
+/// If those two fingerprint differently, reuse can never hit and the feature is
+/// an elaborate no-op that still reports success. Nothing else here matters if
+/// this fails.
+#[tokio::test]
+async fn worker_and_reviewer_clones_of_one_task_fingerprint_identically() {
+    let origin = origin_repo().await;
+    let fx = fixture().await;
+    let scratch = test_tempdir("recorded-marker-");
+    apply_config(&fx, &recorded_plan(&marker_path(scratch.path()))).await;
+
+    // Worker: clone, author a change, commit it, and accumulate build residue.
+    let worker_tree = clone_from(origin.path(), "recorded-worker-").await;
+    std::fs::write(
+        worker_tree.path().join("server/src/lib.rs"),
+        "// authored\n",
+    )
+    .expect("author change");
+    run_git(worker_tree.path(), &["add", "-A"]).await;
+    run_git(worker_tree.path(), &["commit", "-m", "authored work"]).await;
+    add_build_residue(worker_tree.path());
+    let worker_run = task_run(&fx, worker_tree.path()).await;
+
+    // Publish the branch the way a worker push does, so the reviewer can clone
+    // exactly the same commit rather than a re-created one.
+    run_git(worker_tree.path(), &["push", "origin", "main"]).await;
+
+    // Reviewer: a brand new clone. No build residue whatsoever.
+    let reviewer_tree = clone_from(origin.path(), "recorded-reviewer-").await;
+    let reviewer_run = task_run(&fx, reviewer_tree.path()).await;
+    assert!(
+        !reviewer_tree.path().join("server/target").exists(),
+        "the reviewer clone must genuinely lack the worker's build residue"
+    );
+
+    assert_eq!(
+        fingerprint_of(&fx, &worker_run).await,
+        fingerprint_of(&fx, &reviewer_run).await,
+        "a worked-in worktree and a fresh clone of the same commit must agree, \
+         or a reviewer can never reuse a worker's pass"
+    );
+}
+
+/// Excluding build output must not delete it. The attested tier purges; a
+/// recorded run reuses the very directory it excludes, so purging would convert
+/// every run into a cold build — the exact failure this tier exists to remove.
+#[tokio::test]
+async fn recorded_fingerprint_excludes_build_output_without_deleting_it() {
+    let origin = origin_repo().await;
+    let fx = fixture().await;
+    let scratch = test_tempdir("recorded-marker-");
+    apply_config(&fx, &recorded_plan(&marker_path(scratch.path()))).await;
+
+    let tree = clone_from(origin.path(), "recorded-preserve-").await;
+    add_build_residue(tree.path());
+    let run = task_run(&fx, tree.path()).await;
+    let artifact = tree.path().join("server/target/debug/deps/libdjinn.rlib");
+
+    let before = fingerprint_of(&fx, &run).await;
+    assert!(artifact.exists(), "fingerprinting deleted the warm cache");
+
+    // Changing excluded content must not move the fingerprint...
+    std::fs::write(&artifact, b"recompiled artifact bytes").expect("rewrite artifact");
+    assert_eq!(
+        before,
+        fingerprint_of(&fx, &run).await,
+        "excluded build output must not participate in the fingerprint"
+    );
+    // ...and must still be on disk afterwards.
+    assert_eq!(
+        std::fs::read(&artifact).expect("artifact survives"),
+        b"recompiled artifact bytes"
+    );
+}
+
+/// The owner's requirement, end to end: the worker runs it, the reviewer skips
+/// it. Proven by the command's own side effect, not by an outcome label alone.
+#[tokio::test]
+async fn worker_records_a_pass_that_a_reviewer_reuses_without_running_commands() {
+    let origin = origin_repo().await;
+    let fx = fixture().await;
+    let scratch = test_tempdir("recorded-marker-");
+    let marker = marker_path(scratch.path());
+    apply_config(&fx, &recorded_plan(&marker)).await;
+    enable_reuse(&fx).await;
+
+    let worker_tree = clone_from(origin.path(), "recorded-worker-").await;
+    add_build_residue(worker_tree.path());
+    let worker_run = task_run(&fx, worker_tree.path()).await;
+
+    let stored = coordinate(&fx, &worker_run).await;
+    assert!(
+        matches!(stored, FinalVerificationRecordingOutcome::Stored { .. }),
+        "warm worker run must record a pass, got {stored:?}"
+    );
+    assert_eq!(marker_runs(&marker), 1, "the worker must actually compile");
+
+    let reviewer_tree = clone_from(origin.path(), "recorded-reviewer-").await;
+    let reviewer_run = task_run(&fx, reviewer_tree.path()).await;
+
+    let reused = coordinate(&fx, &reviewer_run).await;
+    assert!(
+        matches!(reused, FinalVerificationRecordingOutcome::Reused { .. }),
+        "an unchanged tree must reuse the worker's pass, got {reused:?}"
+    );
+    assert_eq!(
+        marker_runs(&marker),
+        1,
+        "reuse must SKIP the command, not re-run it"
+    );
+}
+
+/// Any real input change must invalidate — tracked, untracked, and ignored are
+/// each checked independently, because they reach the fingerprint by three
+/// different code paths (`ls-files -s`, `--others`, and `--others -i`).
+#[tokio::test]
+async fn any_input_change_invalidates_the_recorded_pass() {
+    for (label, mutate) in [
+        (
+            "tracked",
+            Box::new(|tree: &Path| {
+                std::fs::write(tree.join("server/src/lib.rs"), "// edited\n").unwrap()
+            }) as Box<dyn Fn(&Path)>,
+        ),
+        (
+            "untracked",
+            Box::new(|tree: &Path| std::fs::write(tree.join("scratch.txt"), "note\n").unwrap()),
+        ),
+        (
+            "ignored-but-undeclared",
+            Box::new(|tree: &Path| {
+                // Ignored, yet NOT covered by an output-only glob, so it is a
+                // real input. This is the case an over-broad glob would silently
+                // erase — turning a no-op into a wrong answer.
+                std::fs::write(tree.join(".gitignore"), "server/target/\nlocal.env\n").unwrap();
+                std::fs::write(tree.join("local.env"), "SECRET=1\n").unwrap()
+            }),
+        ),
+    ] {
+        let origin = origin_repo().await;
+        let fx = fixture().await;
+        let scratch = test_tempdir("recorded-marker-");
+        let marker = marker_path(scratch.path());
+        apply_config(&fx, &recorded_plan(&marker)).await;
+        enable_reuse(&fx).await;
+
+        let first_tree = clone_from(origin.path(), "recorded-first-").await;
+        let first_run = task_run(&fx, first_tree.path()).await;
+        assert!(matches!(
+            coordinate(&fx, &first_run).await,
+            FinalVerificationRecordingOutcome::Stored { .. }
+        ));
+        assert_eq!(marker_runs(&marker), 1);
+
+        let second_tree = clone_from(origin.path(), "recorded-second-").await;
+        mutate(second_tree.path());
+        let second_run = task_run(&fx, second_tree.path()).await;
+
+        let outcome = coordinate(&fx, &second_run).await;
+        assert!(
+            matches!(outcome, FinalVerificationRecordingOutcome::Stored { .. }),
+            "a {label} change must force a fresh run, got {outcome:?}"
+        );
+        assert_eq!(
+            marker_runs(&marker),
+            2,
+            "a {label} change must re-execute the commands"
+        );
+    }
+}
+
+/// The rollout switch must be a genuine record-only mode: still runs, still
+/// records, never suppresses. That property is what makes step 4 of the rollout
+/// reversible, so it is asserted rather than assumed.
+#[tokio::test]
+async fn record_only_mode_records_every_run_and_reuses_none() {
+    let origin = origin_repo().await;
+    let fx = fixture().await;
+    let scratch = test_tempdir("recorded-marker-");
+    let marker = marker_path(scratch.path());
+    apply_config(&fx, &recorded_plan(&marker)).await;
+    // Deliberately do NOT enable the project switch.
+
+    let first_tree = clone_from(origin.path(), "recorded-first-").await;
+    let first_run = task_run(&fx, first_tree.path()).await;
+    assert!(matches!(
+        coordinate(&fx, &first_run).await,
+        FinalVerificationRecordingOutcome::Stored { .. }
+    ));
+
+    let second_tree = clone_from(origin.path(), "recorded-second-").await;
+    let second_run = task_run(&fx, second_tree.path()).await;
+    let outcome = coordinate(&fx, &second_run).await;
+
+    assert!(
+        matches!(outcome, FinalVerificationRecordingOutcome::Stored { .. }),
+        "record-only must re-run rather than reuse, got {outcome:?}"
+    );
+    assert_eq!(
+        marker_runs(&marker),
+        2,
+        "record-only must still execute every run"
+    );
+}
+
+/// `reusable: false` was not a kill-switch before this change: it influenced
+/// only the identity digest, so a cache hit was still permitted. With the
+/// project switch ON, an identical tree must still re-run.
+#[tokio::test]
+async fn a_plan_that_declares_itself_non_reusable_is_never_reused() {
+    let origin = origin_repo().await;
+    let fx = fixture().await;
+    let scratch = test_tempdir("recorded-marker-");
+    let marker = marker_path(scratch.path());
+    let mut config = recorded_plan(&marker);
+    config.lifecycle.final_verification.hermeticity.reusable = false;
+    apply_config(&fx, &config).await;
+    enable_reuse(&fx).await;
+
+    let first_tree = clone_from(origin.path(), "recorded-first-").await;
+    let first_run = task_run(&fx, first_tree.path()).await;
+    assert!(matches!(
+        coordinate(&fx, &first_run).await,
+        FinalVerificationRecordingOutcome::Stored { .. }
+    ));
+
+    let second_tree = clone_from(origin.path(), "recorded-second-").await;
+    let second_run = task_run(&fx, second_tree.path()).await;
+    assert!(matches!(
+        coordinate(&fx, &second_run).await,
+        FinalVerificationRecordingOutcome::Stored { .. }
+    ));
+    assert_eq!(
+        marker_runs(&marker),
+        2,
+        "a non-reusable plan must re-execute even on an identical tree"
+    );
+}
+
+/// Defect regression: production hardcoded an empty allowlist, so any declared
+/// name a catalog service did not export was rejected outright. A command that
+/// reads a declared variable is the smallest honest proof it now arrives.
+#[tokio::test]
+async fn declared_environment_reaches_the_command() {
+    let origin = origin_repo().await;
+    let fx = fixture().await;
+    let scratch = test_tempdir("recorded-marker-");
+    let marker = marker_path(scratch.path());
+    let mut config = recorded_plan(&marker);
+    let plan = &mut config.lifecycle.final_verification;
+    // HOME is set for every Pod process and for the test process alike.
+    plan.input_manifest.environment_names = vec!["PATH".into(), "HOME".into()];
+    plan.commands[0].environment_names = vec!["PATH".into(), "HOME".into()];
+    plan.commands[0].argv = vec![
+        "-c".into(),
+        format!("test -n \"$HOME\" && echo ran >> {}", marker.display()),
+    ];
+    apply_config(&fx, &config).await;
+
+    let tree = clone_from(origin.path(), "recorded-env-").await;
+    let run = task_run(&fx, tree.path()).await;
+    let outcome = coordinate(&fx, &run).await;
+
+    assert!(
+        matches!(outcome, FinalVerificationRecordingOutcome::Stored { .. }),
+        "a declared environment name must reach the command, got {outcome:?}"
+    );
+    assert_eq!(marker_runs(&marker), 1, "outcome was {outcome:?}");
+}
+
+/// A volatile value differing between runs must NOT change the identity digest.
+/// This is precisely what lets a reviewer (fresh `CARGO_TARGET_DIR`) reuse a
+/// worker's pass; if it regressed, reuse would silently stop hitting.
+#[tokio::test]
+async fn volatile_environment_values_do_not_fracture_identity_across_runs() {
+    let origin = origin_repo().await;
+    let fx = fixture().await;
+    let scratch = test_tempdir("recorded-marker-");
+    let mut config = recorded_plan(&marker_path(scratch.path()));
+    config
+        .lifecycle
+        .final_verification
+        .input_manifest
+        .volatile_environment_names = vec!["DJINN_RECORDED_VOLATILE".into()];
+    apply_config(&fx, &config).await;
+
+    let tree = clone_from(origin.path(), "recorded-volatile-").await;
+    let run = task_run(&fx, tree.path()).await;
+
+    let digest_for = |value: &str| {
+        // SAFETY: nextest runs each test in its own process, and this mutation
+        // happens before any resolver call in that process.
+        unsafe { std::env::set_var("DJINN_RECORDED_VOLATILE", value) };
+        async {
+            let material =
+                super::adapter::resolve_final_verification_for_task_run(&fx.agent.db, &run)
+                    .await
+                    .expect("resolve")
+                    .expect("configured");
+            let input = (material.execution_request.resolve_environment_identity)()
+                .expect("identity input");
+            let resolved = material.execution_request.volatile_environment.clone();
+            let digest = djinn_core::canonical_verify::EnvironmentIdentityV1::derive(input)
+                .expect("derive identity")
+                .digest;
+            (digest, resolved)
+        }
+    };
+
+    let (first_digest, first_values) = digest_for("/cache/cargo-target-runs/run-one").await;
+    let (second_digest, second_values) = digest_for("/cache/cargo-target-runs/run-two").await;
+
+    assert_ne!(
+        first_values, second_values,
+        "the test must actually vary the volatile value"
+    );
+    assert_eq!(
+        first_digest, second_digest,
+        "a volatile value must not reach the identity digest"
+    );
+    unsafe { std::env::remove_var("DJINN_RECORDED_VOLATILE") };
+}

--- a/server/crates/djinn-core/src/canonical_verify_identity.rs
+++ b/server/crates/djinn-core/src/canonical_verify_identity.rs
@@ -42,6 +42,21 @@ pub struct CanonicalHermeticityV1 {
     pub network_access: bool,
 }
 
+/// Resolved guarantee carried by a pass of this plan. This is identity material
+/// precisely so a warm recorded pass and an isolated attested pass can never
+/// satisfy each other's reuse lookup: the tier changes the digest.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CanonicalEvidenceTierV1 {
+    /// Isolated by the strict launcher; the identity digest describes the whole
+    /// execution environment.
+    #[default]
+    Attested,
+    /// Ordinary warm, incremental execution in the task-run Pod. Pre-existing
+    /// build outputs are visible and are not described by the digest.
+    Recorded,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CanonicalFinalVerificationPlanV1 {
@@ -54,6 +69,11 @@ pub struct CanonicalFinalVerificationPlanV1 {
     pub required_checks: Vec<String>,
     /// Resolved isolation and reuse guarantees for this plan.
     pub hermeticity: CanonicalHermeticityV1,
+    /// What a pass of this plan is worth. Defaulted so persisted V1/V2 rows
+    /// that predate the tier deserialize as `attested`, which is the guarantee
+    /// they were actually produced under.
+    #[serde(default)]
+    pub evidence_tier: CanonicalEvidenceTierV1,
 }
 
 /// One configured selection rule after configuration parsing has completed.
@@ -101,8 +121,15 @@ pub struct VerificationInputManifestV1 {
     pub version: u32,
     /// Set-like declarations of paths included by the resolved input producer.
     pub repo_paths: Vec<String>,
-    /// Set-like declaration of environment names permitted as inputs.
+    /// Set-like declaration of environment names permitted as inputs whose
+    /// resolved values are hashed into this identity.
     pub environment_names: Vec<String>,
+    /// Set-like declaration of environment names permitted as inputs whose
+    /// resolved values are deliberately NOT hashed. Only the names participate
+    /// in identity; the values are attempt-scoped, like catalog service
+    /// exports. Defaulted so persisted rows predating the field still parse.
+    #[serde(default)]
+    pub volatile_environment_names: Vec<String>,
     pub read_only_external_inputs: Vec<DeclaredExternalInputV1>,
     /// Set-like; output-only paths must not ambiguously overlap inputs.
     pub output_only_globs: Vec<String>,
@@ -206,8 +233,14 @@ pub enum EnvironmentIdentityError {
     MalformedDigest { kind: &'static str, value: String },
     #[error("ambiguous declaration: {detail}")]
     AmbiguousDeclaration { detail: String },
-    #[error("reusable final verification must be hermetic and deny network access")]
+    #[error("reusable attested final verification must be hermetic and deny network access")]
     InvalidReusableHermeticity,
+    #[error("recorded final verification must declare hermetic=false and network_access=true")]
+    InvalidRecordedHermeticity,
+    #[error("volatile environment names require the recorded evidence tier")]
+    VolatileEnvironmentNotRecorded,
+    #[error("environment name {name} is both identity-bearing and volatile")]
+    AmbiguousEnvironmentName { name: String },
     #[error("selected command group {group} is not referenced by a selection rule")]
     UnknownSelectedCommandGroup { group: String },
 }
@@ -285,10 +318,24 @@ impl ResolvedEnvironmentIdentityInputV1 {
             self.input_manifest.version,
             VERIFICATION_INPUT_MANIFEST_VERSION_V1,
         )?;
-        if self.plan.hermeticity.reusable
-            && (!self.plan.hermeticity.hermetic || self.plan.hermeticity.network_access)
-        {
-            return Err(EnvironmentIdentityError::InvalidReusableHermeticity);
+        match self.plan.evidence_tier {
+            CanonicalEvidenceTierV1::Attested => {
+                if self.plan.hermeticity.reusable
+                    && (!self.plan.hermeticity.hermetic || self.plan.hermeticity.network_access)
+                {
+                    return Err(EnvironmentIdentityError::InvalidReusableHermeticity);
+                }
+                // Attestation means every input is described by this digest.
+                // An unhashed environment value is by construction not.
+                if !self.input_manifest.volatile_environment_names.is_empty() {
+                    return Err(EnvironmentIdentityError::VolatileEnvironmentNotRecorded);
+                }
+            }
+            CanonicalEvidenceTierV1::Recorded => {
+                if self.plan.hermeticity.hermetic || !self.plan.hermeticity.network_access {
+                    return Err(EnvironmentIdentityError::InvalidRecordedHermeticity);
+                }
+            }
         }
         nonempty("profile_id", &self.plan.profile_id)?;
         if self.plan.profile_revision == 0 {
@@ -336,6 +383,20 @@ impl ResolvedEnvironmentIdentityInputV1 {
             &mut self.input_manifest.environment_names,
             "manifest environment name",
         )?;
+        normalize_strings(
+            &mut self.input_manifest.volatile_environment_names,
+            "manifest volatile environment name",
+        )?;
+        // A name in both buckets would mean "hashed" and "not hashed" at once;
+        // resolution would have to pick one silently.
+        let identity_bearing: BTreeSet<_> = self.input_manifest.environment_names.iter().collect();
+        for name in &self.input_manifest.volatile_environment_names {
+            if identity_bearing.contains(name) {
+                return Err(EnvironmentIdentityError::AmbiguousEnvironmentName {
+                    name: name.clone(),
+                });
+            }
+        }
         normalize_strings(
             &mut self.input_manifest.output_only_globs,
             "output-only glob",
@@ -602,6 +663,7 @@ mod tests {
                     reusable: true,
                     network_access: false,
                 },
+                evidence_tier: Default::default(),
             },
             selection: ResolvedVerificationSelectionV1::legacy_flat_plan(),
             input_manifest: VerificationInputManifestV1 {
@@ -613,6 +675,7 @@ mod tests {
                     locator: "https://registry.example".into(),
                 }],
                 output_only_globs: vec!["target/**".into()],
+                volatile_environment_names: Vec::new(),
             },
             image: ImmutableImageV1 {
                 reference: "rust:1.85".into(),
@@ -978,6 +1041,89 @@ mod tests {
 
     fn alternate_digest(hex: char) -> String {
         format!("sha256:{}", hex.to_string().repeat(64))
+    }
+
+    /// A recorded pass and an attested pass promise different things, so they
+    /// must never satisfy each other's reuse lookup. Making the tier identity
+    /// material is what enforces that in the type system rather than by
+    /// convention — the digest itself separates the two cache spaces.
+    #[test]
+    fn evidence_tier_separates_recorded_and_attested_cache_entries() {
+        let attested = EnvironmentIdentityV1::derive(input()).expect("attested identity");
+
+        let mut recorded_input = input();
+        recorded_input.plan.evidence_tier = CanonicalEvidenceTierV1::Recorded;
+        recorded_input.plan.hermeticity.hermetic = false;
+        recorded_input.plan.hermeticity.network_access = true;
+        let recorded = EnvironmentIdentityV1::derive(recorded_input).expect("recorded identity");
+
+        assert_ne!(
+            attested.digest, recorded.digest,
+            "a recorded pass must not be reusable as an attested one"
+        );
+    }
+
+    /// The reason the volatile bucket exists: production renders
+    /// `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`, a fresh path
+    /// per run. If its value reached the digest, a worker run and the reviewer
+    /// run of the same task could never share a pass and reuse would silently
+    /// never hit. Only the declared NAME is identity material.
+    #[test]
+    fn volatile_environment_names_are_identity_material_but_their_values_are_not() {
+        let recorded = || {
+            let mut input = input();
+            input.plan.evidence_tier = CanonicalEvidenceTierV1::Recorded;
+            input.plan.hermeticity.hermetic = false;
+            input.plan.hermeticity.network_access = true;
+            input
+        };
+        let baseline = EnvironmentIdentityV1::derive(recorded()).expect("baseline");
+
+        let mut declared = recorded();
+        declared
+            .input_manifest
+            .volatile_environment_names
+            .push("CARGO_TARGET_DIR".into());
+        let with_name = EnvironmentIdentityV1::derive(declared).expect("declared name");
+        assert_ne!(
+            baseline.digest, with_name.digest,
+            "declaring a volatile name changes what the plan may read, so it is identity material"
+        );
+
+        // No path exists for a volatile VALUE to enter this input at all — it
+        // rides on the execution request instead. Asserting the shape here
+        // keeps a future refactor from quietly adding one.
+        assert!(
+            !with_name.canonical_json.contains("cargo-target-runs"),
+            "a volatile value must never reach the canonical identity JSON"
+        );
+    }
+
+    /// Attestation means every input is described by the digest, and an
+    /// unhashed environment value is by construction not one.
+    #[test]
+    fn attested_plans_reject_volatile_environment_names() {
+        let mut bad = input();
+        bad.input_manifest
+            .volatile_environment_names
+            .push("CARGO_TARGET_DIR".into());
+        assert_eq!(
+            EnvironmentIdentityV1::derive(bad),
+            Err(EnvironmentIdentityError::VolatileEnvironmentNotRecorded)
+        );
+    }
+
+    /// Each tier has exactly one legal isolation shape at the identity boundary
+    /// too, so a resolver cannot route a plan to a launcher it did not declare.
+    #[test]
+    fn recorded_plans_must_declare_their_lack_of_isolation() {
+        let mut bad = input();
+        bad.plan.evidence_tier = CanonicalEvidenceTierV1::Recorded;
+        // Still claiming hermeticity while asking for the warm launcher.
+        assert_eq!(
+            EnvironmentIdentityV1::derive(bad),
+            Err(EnvironmentIdentityError::InvalidRecordedHermeticity)
+        );
     }
 
     #[test]

--- a/server/crates/djinn-git/src/lib.rs
+++ b/server/crates/djinn-git/src/lib.rs
@@ -503,8 +503,9 @@ pub use submission_diff::{
 };
 
 pub mod verification_input;
+pub mod verification_input_outputs;
 pub use verification_input::{
-    DEFAULT_VERIFICATION_BASE_REF, ResolvedExternalInputV1,
+    DEFAULT_VERIFICATION_BASE_REF, OutputOnlyPolicy, ResolvedExternalInputV1,
     VERIFICATION_INPUT_FINGERPRINT_VERSION_V1, VerificationInputDigestV1, VerificationInputError,
     VerificationInputFingerprint, VerificationInputFingerprintConfig, VerificationInputUnavailable,
     collect_verification_changed_paths, compute_verification_input_fingerprint,

--- a/server/crates/djinn-git/src/verification_input.rs
+++ b/server/crates/djinn-git/src/verification_input.rs
@@ -1,3 +1,5 @@
+pub use crate::verification_input_outputs::OutputOnlyPolicy;
+use crate::verification_input_outputs::cleanup_output_only;
 use crate::{CommandOutput, GitError, run_git_command_allow_failure, run_git_command_binary_in};
 use djinn_core::canonical_verify::{
     VERIFICATION_INPUT_MANIFEST_VERSION_V1, VerificationInputManifestV1,
@@ -23,6 +25,9 @@ pub struct VerificationInputFingerprintConfig {
     pub base_ref: String,
     pub manifest: VerificationInputManifestV1,
     pub external_inputs: Vec<ResolvedExternalInputV1>,
+    /// Whether `output_only_globs` also purge what they exclude. See
+    /// [`OutputOnlyPolicy`].
+    pub output_policy: OutputOnlyPolicy,
 }
 #[cfg(unix)]
 fn path_bytes(path: &Path) -> Vec<u8> {
@@ -43,6 +48,7 @@ fn empty_manifest() -> VerificationInputManifestV1 {
         version: VERIFICATION_INPUT_MANIFEST_VERSION_V1,
         repo_paths: Vec::new(),
         environment_names: Vec::new(),
+        volatile_environment_names: Vec::new(),
         read_only_external_inputs: Vec::new(),
         output_only_globs: Vec::new(),
     }
@@ -53,6 +59,7 @@ impl Default for VerificationInputFingerprintConfig {
             base_ref: DEFAULT_VERIFICATION_BASE_REF.to_string(),
             manifest: empty_manifest(),
             external_inputs: Vec::new(),
+            output_policy: OutputOnlyPolicy::default(),
         }
     }
 }
@@ -291,7 +298,10 @@ pub async fn compute_verification_input_fingerprint_with_config(
         Ok(globs) => globs,
         Err(reason) => return Ok(VerificationInputFingerprint::Unavailable(reason)),
     };
-    if let Err(reason) = cleanup_output_only(worktree, &output_only) {
+    // Exclusion below is unconditional; only the destructive half is gated.
+    if config.output_policy == OutputOnlyPolicy::PurgeBeforeFingerprint
+        && let Err(reason) = cleanup_output_only(worktree, &output_only)
+    {
         return Ok(VerificationInputFingerprint::Unavailable(reason));
     }
     let worktree_anchor = match PermittedRootAnchor::capture(worktree, b".") {
@@ -409,7 +419,7 @@ pub async fn compute_verification_input_fingerprint_with_config(
         },
     ))
 }
-fn unavailable_manifest(detail: impl Into<String>) -> VerificationInputUnavailable {
+pub(crate) fn unavailable_manifest(detail: impl Into<String>) -> VerificationInputUnavailable {
     VerificationInputUnavailable::MalformedManifest {
         detail: detail.into(),
     }
@@ -532,61 +542,6 @@ fn safe_relative(value: &str) -> bool {
         && !value
             .split('/')
             .any(|part| part.is_empty() || part == "." || part == "..")
-}
-fn cleanup_output_only(
-    worktree: &Path,
-    globs: &GlobSet,
-) -> Result<(), VerificationInputUnavailable> {
-    if globs.is_empty() {
-        return Ok(());
-    }
-    let root = std::fs::canonicalize(worktree).map_err(|e| {
-        VerificationInputUnavailable::UnreadableFile {
-            path: ".".into(),
-            error: e.to_string(),
-        }
-    })?;
-    cleanup_output_dir(&root, &root, globs)
-}
-fn cleanup_output_dir(
-    root: &Path,
-    dir: &Path,
-    globs: &GlobSet,
-) -> Result<(), VerificationInputUnavailable> {
-    for entry in
-        std::fs::read_dir(dir).map_err(|e| VerificationInputUnavailable::UnreadableFile {
-            path: dir.display().to_string(),
-            error: e.to_string(),
-        })?
-    {
-        let entry = entry.map_err(|e| VerificationInputUnavailable::UnreadableFile {
-            path: dir.display().to_string(),
-            error: e.to_string(),
-        })?;
-        if entry.file_name() == ".git" {
-            continue;
-        }
-        let path = entry.path();
-        let rel = path
-            .strip_prefix(root)
-            .map_err(|_| unavailable_manifest("output-only path escaped worktree"))?;
-        let meta = std::fs::symlink_metadata(&path)
-            .map_err(|_| unavailable_manifest("output-only traversal changed"))?;
-        if globs.is_match(rel) {
-            if meta.file_type().is_dir() {
-                std::fs::remove_dir_all(&path)
-            } else {
-                std::fs::remove_file(&path)
-            }
-            .map_err(|e| VerificationInputUnavailable::UnreadableFile {
-                path: rel.display().to_string(),
-                error: e.to_string(),
-            })?;
-        } else if meta.file_type().is_dir() {
-            cleanup_output_dir(root, &path, globs)?;
-        }
-    }
-    Ok(())
 }
 struct ExternalState {
     id: Vec<u8>,

--- a/server/crates/djinn-git/src/verification_input_outputs.rs
+++ b/server/crates/djinn-git/src/verification_input_outputs.rs
@@ -1,0 +1,104 @@
+//! Output-only glob handling for the verification input fingerprint.
+//!
+//! `output_only_globs` do two separable jobs, and conflating them is what made
+//! a warm, reusable final-verification plan impossible:
+//!
+//! 1. **Exclusion** — matching paths are left out of the fingerprint. This is
+//!    unconditional and lives in `verification_input.rs`; without it, a warm
+//!    worktree makes the fingerprint hash every byte of every ignored build
+//!    artifact (`git ls-files --others -i` enumerates ignored files
+//!    individually, and each one is then read in full).
+//! 2. **Purge** — matching paths are deleted from disk before hashing. The
+//!    attested tier requires it, because its strict launcher demands that
+//!    output directories be absent at launch. The recorded tier must not do it,
+//!    because the directory being excluded is the warm build cache the run
+//!    depends on.
+//!
+//! [`OutputOnlyPolicy`] is the switch between the two. Note that the purge runs
+//! on *every* fingerprint computation — including the C0/C1/C2 reuse
+//! checkpoints, not only immediately before execution.
+
+use std::path::Path;
+
+use globset::GlobSet;
+
+use crate::verification_input::{VerificationInputUnavailable, unavailable_manifest};
+
+/// Whether output-only globs also purge the paths they exclude.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum OutputOnlyPolicy {
+    /// Delete every matching entry before hashing. Required by the attested
+    /// tier, whose strict launcher rejects a pre-existing output directory.
+    #[default]
+    PurgeBeforeFingerprint,
+    /// Exclude matching entries from the hash and leave them on disk. Required
+    /// by the recorded tier, which reuses the warm outputs it excludes.
+    ExcludeOnly,
+}
+
+pub(crate) fn cleanup_output_only(
+    worktree: &Path,
+    globs: &GlobSet,
+) -> Result<(), VerificationInputUnavailable> {
+    if globs.is_empty() {
+        return Ok(());
+    }
+    let root = std::fs::canonicalize(worktree).map_err(|e| {
+        VerificationInputUnavailable::UnreadableFile {
+            path: ".".into(),
+            error: e.to_string(),
+        }
+    })?;
+    cleanup_output_dir(&root, &root, globs)
+}
+
+/// KNOWN LIMITATION (attested tier only). This deletes entries that MATCH the
+/// globs. `server/target/**` compiles to `^server/target/.*$`, which matches the
+/// children but not `server/target` itself, so an empty directory survives and
+/// the strict launcher then rejects with `OutputOnlyPreexisting` — an attested
+/// plan with output globs works at most once per worktree. No glob spelling
+/// escapes it: a directory-matching glob has no literal prefix and so fails
+/// `output_directories()`, while the pair `target` + `target/**` is rejected as
+/// overlapping. Fixing it means changing what "absent at launch" means, which is
+/// the attestation guarantee itself, so it is deliberately retained here rather
+/// than papered over. The recorded tier never reaches this function.
+fn cleanup_output_dir(
+    root: &Path,
+    dir: &Path,
+    globs: &GlobSet,
+) -> Result<(), VerificationInputUnavailable> {
+    for entry in
+        std::fs::read_dir(dir).map_err(|e| VerificationInputUnavailable::UnreadableFile {
+            path: dir.display().to_string(),
+            error: e.to_string(),
+        })?
+    {
+        let entry = entry.map_err(|e| VerificationInputUnavailable::UnreadableFile {
+            path: dir.display().to_string(),
+            error: e.to_string(),
+        })?;
+        if entry.file_name() == ".git" {
+            continue;
+        }
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(root)
+            .map_err(|_| unavailable_manifest("output-only path escaped worktree"))?;
+        let meta = std::fs::symlink_metadata(&path)
+            .map_err(|_| unavailable_manifest("output-only traversal changed"))?;
+        if globs.is_match(rel) {
+            if meta.file_type().is_dir() {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            }
+            .map_err(|e| VerificationInputUnavailable::UnreadableFile {
+                path: rel.display().to_string(),
+                error: e.to_string(),
+            })?;
+        } else if meta.file_type().is_dir() {
+            cleanup_output_dir(root, &path, globs)?;
+        }
+    }
+    Ok(())
+}

--- a/server/crates/djinn-git/src/verification_input_tests.rs
+++ b/server/crates/djinn-git/src/verification_input_tests.rs
@@ -309,6 +309,51 @@ async fn configured_output_only_files_are_removed_and_excluded_from_digest() {
     );
     assert_eq!(first.fingerprint, second.fingerprint);
 }
+/// `ExcludeOnly` must do the exclusion half and NOT the purge half.
+///
+/// The recorded evidence tier depends on this exactly: the directory it excludes
+/// from the fingerprint is the warm build cache it exists to reuse, so purging
+/// would turn every recorded run into a cold build — the failure the tier was
+/// introduced to remove. Note the purge runs on every fingerprint computation,
+/// including the C0/C1/C2 reuse checkpoints, so this is not only about the
+/// moment before execution.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exclude_only_policy_excludes_output_without_deleting_it() {
+    let fixture = init_repo_with_main_commit();
+    let mut config = VerificationInputFingerprintConfig::default();
+    config.manifest.output_only_globs.push("out/**".to_string());
+    config.output_policy = crate::verification_input::OutputOnlyPolicy::ExcludeOnly;
+    write_str(fixture.path(), "out/result.txt", "warm artifact\n");
+
+    let first = digest(configured_fingerprint(fixture.path(), &config).await);
+    assert!(
+        fixture.path().join("out/result.txt").exists(),
+        "ExcludeOnly must never delete the warm output it excludes"
+    );
+
+    write_str(fixture.path(), "out/result.txt", "recompiled artifact\n");
+    let second = digest(configured_fingerprint(fixture.path(), &config).await);
+    assert_eq!(
+        first.fingerprint, second.fingerprint,
+        "excluded output must not participate in the fingerprint"
+    );
+    assert_eq!(
+        std::fs::read_to_string(fixture.path().join("out/result.txt")).unwrap(),
+        "recompiled artifact\n",
+        "the excluded output must survive verbatim"
+    );
+
+    // The same globs under the default policy still purge, so the two policies
+    // are genuinely distinct rather than one silently winning.
+    config.output_policy = crate::verification_input::OutputOnlyPolicy::PurgeBeforeFingerprint;
+    let purged = digest(configured_fingerprint(fixture.path(), &config).await);
+    assert!(!fixture.path().join("out/result.txt").exists());
+    assert_eq!(
+        purged.fingerprint, first.fingerprint,
+        "both policies must agree on the digest; they differ only on disk"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn configured_overlapping_output_only_globs_fail_before_cleanup() {
     let fixture = init_repo_with_main_commit();

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -4960,7 +4960,8 @@
                   "input_manifest": {
                     "version": 1,
                     "repo_paths": [],
-                    "environment_names": []
+                    "environment_names": [],
+                    "volatile_environment_names": []
                   },
                   "read_only_external_inputs": [],
                   "output_only_globs": [],
@@ -4968,7 +4969,8 @@
                     "hermetic": false,
                     "reusable": false,
                     "network_access": false
-                  }
+                  },
+                  "evidence_tier": "attested"
                 }
               }
             },
@@ -5320,7 +5322,8 @@
                 "input_manifest": {
                   "version": 1,
                   "repo_paths": [],
-                  "environment_names": []
+                  "environment_names": [],
+                  "volatile_environment_names": []
                 },
                 "read_only_external_inputs": [],
                 "output_only_globs": [],
@@ -5328,7 +5331,8 @@
                   "hermetic": false,
                   "reusable": false,
                   "network_access": false
-                }
+                },
+                "evidence_tier": "attested"
               }
             }
           }
@@ -5442,7 +5446,8 @@
               "default": {
                 "version": 1,
                 "repo_paths": [],
-                "environment_names": []
+                "environment_names": [],
+                "volatile_environment_names": []
               }
             },
             "read_only_external_inputs": {
@@ -5466,6 +5471,11 @@
                 "reusable": false,
                 "network_access": false
               }
+            },
+            "evidence_tier": {
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry.",
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested"
             }
           },
           "additionalProperties": false
@@ -5573,6 +5583,15 @@
               "default": []
             },
             "environment_names": {
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "volatile_environment_names": {
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -5615,6 +5634,21 @@
             }
           },
           "additionalProperties": false
+        },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string",
+              "const": "attested"
+            },
+            {
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string",
+              "const": "recorded"
+            }
+          ]
         },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
@@ -5986,7 +6020,8 @@
                   "input_manifest": {
                     "version": 1,
                     "repo_paths": [],
-                    "environment_names": []
+                    "environment_names": [],
+                    "volatile_environment_names": []
                   },
                   "read_only_external_inputs": [],
                   "output_only_globs": [],
@@ -5994,7 +6029,8 @@
                     "hermetic": false,
                     "reusable": false,
                     "network_access": false
-                  }
+                  },
+                  "evidence_tier": "attested"
                 }
               }
             },
@@ -6346,7 +6382,8 @@
                 "input_manifest": {
                   "version": 1,
                   "repo_paths": [],
-                  "environment_names": []
+                  "environment_names": [],
+                  "volatile_environment_names": []
                 },
                 "read_only_external_inputs": [],
                 "output_only_globs": [],
@@ -6354,7 +6391,8 @@
                   "hermetic": false,
                   "reusable": false,
                   "network_access": false
-                }
+                },
+                "evidence_tier": "attested"
               }
             }
           }
@@ -6468,7 +6506,8 @@
               "default": {
                 "version": 1,
                 "repo_paths": [],
-                "environment_names": []
+                "environment_names": [],
+                "volatile_environment_names": []
               }
             },
             "read_only_external_inputs": {
@@ -6492,6 +6531,11 @@
                 "reusable": false,
                 "network_access": false
               }
+            },
+            "evidence_tier": {
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry.",
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested"
             }
           },
           "additionalProperties": false
@@ -6599,6 +6643,15 @@
               "default": []
             },
             "environment_names": {
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "volatile_environment_names": {
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -6641,6 +6694,21 @@
             }
           },
           "additionalProperties": false
+        },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string",
+              "const": "attested"
+            },
+            {
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string",
+              "const": "recorded"
+            }
+          ]
         },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
@@ -6954,7 +7022,8 @@
                   "input_manifest": {
                     "version": 1,
                     "repo_paths": [],
-                    "environment_names": []
+                    "environment_names": [],
+                    "volatile_environment_names": []
                   },
                   "read_only_external_inputs": [],
                   "output_only_globs": [],
@@ -6962,7 +7031,8 @@
                     "hermetic": false,
                     "reusable": false,
                     "network_access": false
-                  }
+                  },
+                  "evidence_tier": "attested"
                 }
               }
             },
@@ -7314,7 +7384,8 @@
                 "input_manifest": {
                   "version": 1,
                   "repo_paths": [],
-                  "environment_names": []
+                  "environment_names": [],
+                  "volatile_environment_names": []
                 },
                 "read_only_external_inputs": [],
                 "output_only_globs": [],
@@ -7322,7 +7393,8 @@
                   "hermetic": false,
                   "reusable": false,
                   "network_access": false
-                }
+                },
+                "evidence_tier": "attested"
               }
             }
           }
@@ -7436,7 +7508,8 @@
               "default": {
                 "version": 1,
                 "repo_paths": [],
-                "environment_names": []
+                "environment_names": [],
+                "volatile_environment_names": []
               }
             },
             "read_only_external_inputs": {
@@ -7460,6 +7533,11 @@
                 "reusable": false,
                 "network_access": false
               }
+            },
+            "evidence_tier": {
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry.",
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested"
             }
           },
           "additionalProperties": false
@@ -7567,6 +7645,15 @@
               "default": []
             },
             "environment_names": {
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "volatile_environment_names": {
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -7609,6 +7696,21 @@
             }
           },
           "additionalProperties": false
+        },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string",
+              "const": "attested"
+            },
+            {
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string",
+              "const": "recorded"
+            }
+          ]
         },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
@@ -13451,7 +13553,8 @@
                   "input_manifest": {
                     "version": 1,
                     "repo_paths": [],
-                    "environment_names": []
+                    "environment_names": [],
+                    "volatile_environment_names": []
                   },
                   "read_only_external_inputs": [],
                   "output_only_globs": [],
@@ -13459,7 +13562,8 @@
                     "hermetic": false,
                     "reusable": false,
                     "network_access": false
-                  }
+                  },
+                  "evidence_tier": "attested"
                 }
               }
             },
@@ -13811,7 +13915,8 @@
                 "input_manifest": {
                   "version": 1,
                   "repo_paths": [],
-                  "environment_names": []
+                  "environment_names": [],
+                  "volatile_environment_names": []
                 },
                 "read_only_external_inputs": [],
                 "output_only_globs": [],
@@ -13819,7 +13924,8 @@
                   "hermetic": false,
                   "reusable": false,
                   "network_access": false
-                }
+                },
+                "evidence_tier": "attested"
               }
             }
           }
@@ -13933,7 +14039,8 @@
               "default": {
                 "version": 1,
                 "repo_paths": [],
-                "environment_names": []
+                "environment_names": [],
+                "volatile_environment_names": []
               }
             },
             "read_only_external_inputs": {
@@ -13957,6 +14064,11 @@
                 "reusable": false,
                 "network_access": false
               }
+            },
+            "evidence_tier": {
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry.",
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested"
             }
           },
           "additionalProperties": false
@@ -14064,6 +14176,15 @@
               "default": []
             },
             "environment_names": {
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "volatile_environment_names": {
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -14106,6 +14227,21 @@
             }
           },
           "additionalProperties": false
+        },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string",
+              "const": "attested"
+            },
+            {
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string",
+              "const": "recorded"
+            }
+          ]
         },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
@@ -14395,7 +14531,8 @@
                   "input_manifest": {
                     "version": 1,
                     "repo_paths": [],
-                    "environment_names": []
+                    "environment_names": [],
+                    "volatile_environment_names": []
                   },
                   "read_only_external_inputs": [],
                   "output_only_globs": [],
@@ -14403,7 +14540,8 @@
                     "hermetic": false,
                     "reusable": false,
                     "network_access": false
-                  }
+                  },
+                  "evidence_tier": "attested"
                 }
               }
             },
@@ -14755,7 +14893,8 @@
                 "input_manifest": {
                   "version": 1,
                   "repo_paths": [],
-                  "environment_names": []
+                  "environment_names": [],
+                  "volatile_environment_names": []
                 },
                 "read_only_external_inputs": [],
                 "output_only_globs": [],
@@ -14763,7 +14902,8 @@
                   "hermetic": false,
                   "reusable": false,
                   "network_access": false
-                }
+                },
+                "evidence_tier": "attested"
               }
             }
           }
@@ -14877,7 +15017,8 @@
               "default": {
                 "version": 1,
                 "repo_paths": [],
-                "environment_names": []
+                "environment_names": [],
+                "volatile_environment_names": []
               }
             },
             "read_only_external_inputs": {
@@ -14901,6 +15042,11 @@
                 "reusable": false,
                 "network_access": false
               }
+            },
+            "evidence_tier": {
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry.",
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested"
             }
           },
           "additionalProperties": false
@@ -15008,6 +15154,15 @@
               "default": []
             },
             "environment_names": {
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "volatile_environment_names": {
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -15050,6 +15205,21 @@
             }
           },
           "additionalProperties": false
+        },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string",
+              "const": "attested"
+            },
+            {
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string",
+              "const": "recorded"
+            }
+          ]
         },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",
@@ -15313,7 +15483,8 @@
                   "input_manifest": {
                     "version": 1,
                     "repo_paths": [],
-                    "environment_names": []
+                    "environment_names": [],
+                    "volatile_environment_names": []
                   },
                   "read_only_external_inputs": [],
                   "output_only_globs": [],
@@ -15321,7 +15492,8 @@
                     "hermetic": false,
                     "reusable": false,
                     "network_access": false
-                  }
+                  },
+                  "evidence_tier": "attested"
                 }
               }
             },
@@ -15673,7 +15845,8 @@
                 "input_manifest": {
                   "version": 1,
                   "repo_paths": [],
-                  "environment_names": []
+                  "environment_names": [],
+                  "volatile_environment_names": []
                 },
                 "read_only_external_inputs": [],
                 "output_only_globs": [],
@@ -15681,7 +15854,8 @@
                   "hermetic": false,
                   "reusable": false,
                   "network_access": false
-                }
+                },
+                "evidence_tier": "attested"
               }
             }
           }
@@ -15795,7 +15969,8 @@
               "default": {
                 "version": 1,
                 "repo_paths": [],
-                "environment_names": []
+                "environment_names": [],
+                "volatile_environment_names": []
               }
             },
             "read_only_external_inputs": {
@@ -15819,6 +15994,11 @@
                 "reusable": false,
                 "network_access": false
               }
+            },
+            "evidence_tier": {
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry.",
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested"
             }
           },
           "additionalProperties": false
@@ -15926,6 +16106,15 @@
               "default": []
             },
             "environment_names": {
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "volatile_environment_names": {
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
               "type": "array",
               "items": {
                 "type": "string"
@@ -15968,6 +16157,21 @@
             }
           },
           "additionalProperties": false
+        },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string",
+              "const": "attested"
+            },
+            {
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string",
+              "const": "recorded"
+            }
+          ]
         },
         "CargoCachePolicy": {
           "description": "Per-project Cargo target-cache strategy override.\n\nThe default [`AutoDetected`](Self::AutoDetected) mode is detection-driven:\nconsumers resolve the policy by reading the project shape (Cargo workspace\nlayout, `.cargo/config.toml`, and configured setup command\npatterns) instead of hardcoding one universal compile set. That resolver is\nintentionally non-mutating. It may observe a project's `.cargo/config.toml`,\nincluding `rustc-wrapper = \"sccache\"` and feature-related settings, but it\nmust never create or modify `.cargo/config.toml`.",

--- a/server/crates/djinn-sandbox/src/final_verification.rs
+++ b/server/crates/djinn-sandbox/src/final_verification.rs
@@ -340,7 +340,7 @@ fn launch_with_backend_and_setup(
         });
     }
 
-    let mut child = command.spawn().map_err(|source| {
+    let child = command.spawn().map_err(|source| {
         if source.raw_os_error() == Some(ISOLATION_SETUP_ERROR) {
             FinalVerificationError::BackendUnavailable {
                 reason: "final-verification isolation setup failed",
@@ -349,6 +349,18 @@ fn launch_with_backend_and_setup(
             FinalVerificationError::Launch(source)
         }
     })?;
+    wait_capturing_output(child, timeout)
+}
+
+/// Poll to completion or the deadline, then capture output.
+///
+/// Shared with the recorded launcher so both tiers report `timed_out`, exit
+/// codes, and captured streams identically — the tiers differ in the isolation
+/// they apply, and must not also differ in how a result is observed.
+pub(crate) fn wait_capturing_output(
+    mut child: std::process::Child,
+    timeout: Option<Duration>,
+) -> Result<FinalVerificationResult, FinalVerificationError> {
     let clock = SystemClock::new();
     let deadline = timeout.map(|duration| clock.now_instant() + duration);
     let timed_out = loop {

--- a/server/crates/djinn-sandbox/src/final_verification_execution.rs
+++ b/server/crates/djinn-sandbox/src/final_verification_execution.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
 
 use djinn_core::canonical_verify::{
-    CanonicalCommandDescriptorV1, EnvironmentIdentityError, EnvironmentIdentityV1,
-    ResolvedEnvironmentIdentityInputV1,
+    CanonicalCommandDescriptorV1, CanonicalEvidenceTierV1, EnvironmentIdentityError,
+    EnvironmentIdentityV1, ResolvedEnvironmentIdentityInputV1,
 };
 use djinn_core::clock::{Clock, SystemClock};
 use djinn_git::{
@@ -23,6 +23,7 @@ use crate::final_verification::{
     FinalVerificationError, FinalVerificationLoopbackEndpoint, FinalVerificationNetworkSession,
     FinalVerificationRequest, launch_final_verification_in_network_session_with_timeout,
 };
+use crate::recorded_verification::launch_recorded_verification_with_timeout;
 use crate::service_provisioning::{
     ServiceProvisioners, ServiceProvisioningCode, ServiceProvisioningPhase, create_ready_leases,
     delete_leases,
@@ -45,7 +46,16 @@ pub struct FinalVerificationExecutionRequest {
     pub tool_runtime: Vec<PathBuf>,
     pub read_only_external_mounts: Vec<PathBuf>,
     /// Concrete output-only directories resolved from the manifest globs.
+    /// Must be empty for the recorded tier, which grants no sandbox writes
+    /// because it applies no sandbox.
     pub output_directories: Vec<PathBuf>,
+    /// Values for `input_manifest.volatile_environment_names`, resolved from
+    /// the host. Deliberately carried here and NOT on the identity input:
+    /// everything in `ResolvedEnvironmentIdentityInputV1` is serialized into
+    /// the canonical JSON and hashed, and hashing a per-task-run value
+    /// (`CARGO_TARGET_DIR`) would make a worker run and the reviewer run of the
+    /// same task permanently incompatible for reuse.
+    pub volatile_environment: BTreeMap<String, String>,
     /// Strict-catalog ports that the attempt-owned session may expose. This is
     /// resolved before execution and never derived from command input.
     pub catalog_loopback_endpoints: Vec<FinalVerificationLoopbackEndpoint>,
@@ -83,6 +93,9 @@ pub struct FinalVerificationCommandEvidence {
 /// Stable reasons that make a run unsuitable for durable reusable evidence.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FinalVerificationIneligibilityReason {
+    /// The plan's declared tier and its hermeticity declaration disagree.
+    /// Configuration validation and identity derivation both reject this, so
+    /// reaching it means a resolver bypassed them; fail closed.
     NonHermeticPlan,
     ManifestBindingMismatch {
         detail: String,
@@ -161,29 +174,31 @@ pub async fn execute_final_verification(
         Ok(leases) => leases,
         Err(error) => return service_error_evidence(error.phase, error.code),
     };
-    // Proxy setup occurs after leases so it shares the same reverse teardown.
-    let session =
-        match FinalVerificationNetworkSession::create(request.catalog_loopback_endpoints.clone()) {
-            Ok(session) => session,
-            Err(_) => match delete_leases(&leases).await {
-                Ok(()) => {
-                    return service_error_evidence(
-                        ServiceProvisioningPhase::Proxy,
-                        ServiceProvisioningCode::Unavailable,
-                    );
-                }
-                Err(error) => return service_error_evidence(error.phase, error.code),
-            },
-        };
     let service_environment = leases
         .iter()
         .flat_map(|(_, lease)| lease.environment.clone())
         .collect();
+    let endpoints = request.catalog_loopback_endpoints.clone();
+    // The launcher is chosen from the plan's tier, which is only known after
+    // the identity resolver runs. Selecting lazily keeps the resolver call
+    // pattern at exactly two calls (pre and post), which the recompute
+    // discipline and the host-side resolver probe both depend on — and it
+    // means a recorded run never builds the namespace session it would not
+    // use, so a host without usable namespaces cannot block the warm tier.
+    // Proxy setup still happens after leases, sharing the same teardown.
     let mut evidence = execute_final_verification_with_launcher_and_services(
         request,
         service_environment,
-        |request, timeout| {
-            launch_final_verification_in_network_session_with_timeout(request, &session, timeout)
+        |tier| match tier {
+            CanonicalEvidenceTierV1::Attested => FinalVerificationNetworkSession::create(endpoints)
+                .map(AttemptLauncher::Attested)
+                .map_err(
+                    |_| FinalVerificationIneligibilityReason::ServiceProvisioning {
+                        phase: ServiceProvisioningPhase::Proxy,
+                        code: ServiceProvisioningCode::Unavailable,
+                    },
+                ),
+            CanonicalEvidenceTierV1::Recorded => Ok(AttemptLauncher::Recorded),
         },
     )
     .await;
@@ -197,6 +212,40 @@ pub async fn execute_final_verification(
     evidence
 }
 
+/// One attempt's launcher. Implemented by the production tier launchers and by
+/// the in-module test shim, so the command loop is identical for all of them.
+trait LaunchAttempt {
+    fn launch(
+        &self,
+        request: FinalVerificationRequest,
+        timeout: Duration,
+    ) -> Result<crate::final_verification::FinalVerificationResult, FinalVerificationError>;
+}
+
+/// The per-attempt launcher, selected by the plan's evidence tier.
+///
+/// The attested variant owns the attempt's namespace session for the whole
+/// run; the recorded variant owns nothing, because it isolates nothing.
+enum AttemptLauncher {
+    Attested(FinalVerificationNetworkSession),
+    Recorded,
+}
+
+impl LaunchAttempt for AttemptLauncher {
+    fn launch(
+        &self,
+        request: FinalVerificationRequest,
+        timeout: Duration,
+    ) -> Result<crate::final_verification::FinalVerificationResult, FinalVerificationError> {
+        match self {
+            Self::Attested(session) => {
+                launch_final_verification_in_network_session_with_timeout(request, session, timeout)
+            }
+            Self::Recorded => launch_recorded_verification_with_timeout(request, timeout),
+        }
+    }
+}
+
 #[cfg(test)]
 async fn execute_final_verification_with_launcher(
     request: FinalVerificationExecutionRequest,
@@ -208,19 +257,43 @@ async fn execute_final_verification_with_launcher(
         FinalVerificationError,
     >,
 ) -> FinalVerificationExecutionEvidence {
-    execute_final_verification_with_launcher_and_services(request, BTreeMap::new(), launch).await
+    execute_final_verification_with_launcher_and_services(request, BTreeMap::new(), |_| {
+        Ok(TestLauncher(launch))
+    })
+    .await
 }
 
-async fn execute_final_verification_with_launcher_and_services(
-    request: FinalVerificationExecutionRequest,
-    service_environment: BTreeMap<String, String>,
-    launch: impl Fn(
+/// Test shim so in-module tests can inject a launcher without constructing a
+/// namespace session or spawning real processes.
+#[cfg(test)]
+struct TestLauncher<F>(F);
+
+#[cfg(test)]
+impl<F> LaunchAttempt for TestLauncher<F>
+where
+    F: Fn(
         FinalVerificationRequest,
         Duration,
-    ) -> Result<
-        crate::final_verification::FinalVerificationResult,
-        FinalVerificationError,
-    >,
+    )
+        -> Result<crate::final_verification::FinalVerificationResult, FinalVerificationError>,
+{
+    fn launch(
+        &self,
+        request: FinalVerificationRequest,
+        timeout: Duration,
+    ) -> Result<crate::final_verification::FinalVerificationResult, FinalVerificationError> {
+        (self.0)(request, timeout)
+    }
+}
+
+/// `select_launcher` is invoked exactly once, immediately after the plan's tier
+/// is known and before the first command runs.
+async fn execute_final_verification_with_launcher_and_services<L: LaunchAttempt>(
+    request: FinalVerificationExecutionRequest,
+    service_environment: BTreeMap<String, String>,
+    select_launcher: impl FnOnce(
+        CanonicalEvidenceTierV1,
+    ) -> Result<L, FinalVerificationIneligibilityReason>,
 ) -> FinalVerificationExecutionEvidence {
     let initial_input = match (request.resolve_environment_identity)() {
         Ok(input) => input,
@@ -248,12 +321,30 @@ async fn execute_final_verification_with_launcher_and_services(
     };
 
     let plan = initial_input.plan.clone();
-    if !plan.hermeticity.hermetic || !plan.hermeticity.reusable || plan.hermeticity.network_access {
+    // Each tier has exactly one legal isolation shape. Configuration validation
+    // and `ResolvedEnvironmentIdentityInputV1::canonicalized` both enforce this
+    // already; re-checking here means no resolver can route a plan to a
+    // launcher that does not match what the plan claims.
+    let tier_is_coherent = match plan.evidence_tier {
+        CanonicalEvidenceTierV1::Attested => {
+            plan.hermeticity.hermetic
+                && plan.hermeticity.reusable
+                && !plan.hermeticity.network_access
+        }
+        CanonicalEvidenceTierV1::Recorded => {
+            !plan.hermeticity.hermetic && plan.hermeticity.network_access
+        }
+    };
+    if !tier_is_coherent {
         return ineligible(
             evidence,
             FinalVerificationIneligibilityReason::NonHermeticPlan,
         );
     }
+    let launcher = match select_launcher(plan.evidence_tier) {
+        Ok(launcher) => launcher,
+        Err(reason) => return ineligible(evidence, reason),
+    };
     let pre_identity = match EnvironmentIdentityV1::derive(initial_input.clone()) {
         Ok(identity) => identity,
         Err(error) => return ineligible(evidence, identity_reason(error)),
@@ -275,6 +366,7 @@ async fn execute_final_verification_with_launcher_and_services(
         .input_manifest
         .environment_names
         .iter()
+        .chain(&initial_input.input_manifest.volatile_environment_names)
         .cloned()
         .collect();
     for (position, descriptor) in plan.commands.iter().cloned().enumerate() {
@@ -282,20 +374,24 @@ async fn execute_final_verification_with_launcher_and_services(
             &descriptor,
             &declared_environment,
             &initial_input.allowlisted_environment,
+            &request.volatile_environment,
             &service_environment,
         ) {
             Ok(environment) => environment,
             Err(reason) => return ineligible(evidence, reason),
         };
         let started_at_unix_millis = now_millis();
-        // Outputs are created exactly once. Subsequent descriptors retain the
-        // strict read-only worktree and cannot obtain a broader host grant.
+        // Attested: outputs are created exactly once, so subsequent descriptors
+        // retain the strict read-only worktree and cannot obtain a broader host
+        // grant. This is why an attested multi-command plan where every step
+        // compiles is impossible — a known limitation retained deliberately.
+        // Recorded resolves to an empty list and applies no grant at all.
         let command_outputs = if position == 0 {
             output_directories.clone()
         } else {
             Vec::new()
         };
-        let launched = launch(
+        let launched = launcher.launch(
             FinalVerificationRequest {
                 argv: std::iter::once(descriptor.executable.clone())
                     .chain(descriptor.argv.iter().cloned())
@@ -439,6 +535,38 @@ fn bind_manifest(
             "launcher external mounts differ from fingerprint resolved mounts",
         ));
     }
+    // Volatile values never reach the identity digest, so the manifest's
+    // declared NAME SET is the only thing binding them. Check it exactly, in
+    // both directions: an extra resolved name is an undeclared input, and a
+    // missing one is a command that would fail closed later for the wrong
+    // reason.
+    let declared_volatile: BTreeSet<_> = input
+        .input_manifest
+        .volatile_environment_names
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let resolved_volatile: BTreeSet<_> = request
+        .volatile_environment
+        .keys()
+        .map(String::as_str)
+        .collect();
+    if declared_volatile != resolved_volatile {
+        return Err(manifest_binding(
+            "resolved volatile environment differs from manifest declarations",
+        ));
+    }
+    // A recorded run applies no sandbox, so it can hold no sandbox write grant.
+    // Deriving output directories would also reject globs that are perfectly
+    // valid as pure exclusions (anything without a literal directory prefix).
+    if input.plan.evidence_tier == CanonicalEvidenceTierV1::Recorded {
+        if !request.output_directories.is_empty() {
+            return Err(manifest_binding(
+                "recorded plans grant no output directories",
+            ));
+        }
+        return Ok((external_mounts, Vec::new()));
+    }
     let output_directories = output_directories(&input.input_manifest.output_only_globs)?;
     if request.output_directories != output_directories {
         return Err(manifest_binding(
@@ -489,29 +617,41 @@ fn manifest_binding(detail: impl Into<String>) -> FinalVerificationIneligibility
     }
 }
 
+/// Resolve one descriptor's environment from the three declared sources.
+///
+/// `manifest_names` is the union of both manifest buckets: every name a command
+/// references must be declared somewhere, in either tier. The value then comes
+/// from, in order, the attempt's catalog service exports, the identity-bearing
+/// allowlist, or the volatile bucket. Only the middle one is hashed into the
+/// identity digest; the other two are attempt-scoped by design.
 fn command_environment(
     descriptor: &CanonicalCommandDescriptorV1,
     manifest_names: &BTreeSet<String>,
     allowlisted: &BTreeMap<String, String>,
+    volatile: &BTreeMap<String, String>,
     service_environment: &BTreeMap<String, String>,
 ) -> Result<BTreeMap<String, String>, FinalVerificationIneligibilityReason> {
     descriptor
         .environment_names
         .iter()
         .map(|name| {
-            if let Some(value) = service_environment.get(name)
-                && manifest_names.contains(name)
-            {
-                return Ok((name.clone(), value.clone()));
-            }
-            if !manifest_names.contains(name) || !allowlisted.contains_key(name) {
+            if !manifest_names.contains(name) {
                 return Err(
                     FinalVerificationIneligibilityReason::UndeclaredCommandEnvironment {
                         name: name.clone(),
                     },
                 );
             }
-            Ok((name.clone(), allowlisted[name].clone()))
+            for source in [service_environment, allowlisted, volatile] {
+                if let Some(value) = source.get(name) {
+                    return Ok((name.clone(), value.clone()));
+                }
+            }
+            Err(
+                FinalVerificationIneligibilityReason::UndeclaredCommandEnvironment {
+                    name: name.clone(),
+                },
+            )
         })
         .collect()
 }
@@ -631,6 +771,7 @@ mod tests {
                     reusable: true,
                     network_access: false,
                 },
+                evidence_tier: CanonicalEvidenceTierV1::Attested,
             },
             selection:
                 djinn_core::canonical_verify::ResolvedVerificationSelectionV1::legacy_flat_plan(),
@@ -638,6 +779,7 @@ mod tests {
                 version: 1,
                 repo_paths: Vec::new(),
                 environment_names: Vec::new(),
+                volatile_environment_names: Vec::new(),
                 read_only_external_inputs: Vec::new(),
                 output_only_globs,
             },
@@ -696,10 +838,12 @@ mod tests {
                 base_ref: "main".into(),
                 manifest: input.input_manifest,
                 external_inputs: Vec::new(),
+                output_policy: djinn_git::OutputOnlyPolicy::default(),
             },
             tool_runtime: Vec::new(),
             read_only_external_mounts: Vec::new(),
             output_directories,
+            volatile_environment: BTreeMap::new(),
             catalog_loopback_endpoints: Vec::new(),
             service_provisioners: Vec::new(),
         }
@@ -769,7 +913,7 @@ mod tests {
         let evidence = execute_final_verification_with_launcher_and_services(
             request,
             service_environment,
-            launch,
+            |_| Ok(TestLauncher(launch)),
         )
         .await;
         delete_leases(&leases)

--- a/server/crates/djinn-sandbox/src/lib.rs
+++ b/server/crates/djinn-sandbox/src/lib.rs
@@ -23,6 +23,8 @@ pub mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "linux")]
+pub mod recorded_verification;
+#[cfg(target_os = "linux")]
 pub mod service_provisioning;
 
 #[cfg(target_os = "linux")]

--- a/server/crates/djinn-sandbox/src/recorded_verification.rs
+++ b/server/crates/djinn-sandbox/src/recorded_verification.rs
@@ -1,0 +1,242 @@
+//! Launcher for the `recorded` final-verification evidence tier.
+//!
+//! Deliberately the opposite of [`crate::final_verification`]: no user or
+//! network namespace, no Landlock ruleset, no read-only worktree, and no
+//! output-directory precondition. A recorded command runs as an ordinary
+//! task-run Pod process, exactly like the compiles the agent itself performs,
+//! so it sees — and reuses — the warm incremental build directory.
+//!
+//! That is the whole point. The attested tier's isolation is what forces a cold
+//! full build per submission; the recorded tier trades the isolation guarantee
+//! for the warm cache and says so in the plan's `evidence_tier`. What survives
+//! is the part that actually answers "did anything change": the caller still
+//! computes the whole-tree fingerprint and the environment identity before and
+//! after this launcher runs, and rejects the result if either moved.
+//!
+//! What a recorded launch does NOT protect against, stated plainly:
+//!
+//! * a poisoned or stale incremental build cache producing a false pass;
+//! * ambient state outside the declared environment influencing the command;
+//! * the command writing anywhere the Pod user can write.
+//!
+//! Every task compile in a djinn Pod already runs under exactly those
+//! conditions, so this is not a new exposure — but it is one the plan author
+//! opts into by name rather than by omitting a flag.
+//!
+//! Two guards are retained even here, because both catch configuration
+//! mistakes rather than adversarial behaviour: argv must be well-formed, and
+//! the working directory must resolve inside the worktree.
+
+#![cfg(target_os = "linux")]
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use crate::final_verification::{
+    FinalVerificationError, FinalVerificationRequest, FinalVerificationResult,
+    FinalVerificationViolation, wait_capturing_output,
+};
+
+/// Run one final-verification command warm, in the ambient Pod environment.
+///
+/// `tool_runtime`, `read_only_external_mounts`, and `output_directories` on the
+/// request are ignored: they exist to describe a sandbox policy, and there is
+/// no sandbox here. `output_directories` being ignored is what makes the
+/// attested tier's "output dirs must be absent at launch" limitation — and its
+/// "only the first command gets a writable directory" restriction — inapplicable
+/// to this tier: every command can write the whole worktree, as an ordinary
+/// build does.
+pub fn launch_recorded_verification_with_timeout(
+    request: FinalVerificationRequest,
+    timeout: Duration,
+) -> Result<FinalVerificationResult, FinalVerificationError> {
+    if request.argv.first().is_none_or(String::is_empty)
+        || request.argv.iter().any(|arg| arg.contains('\0'))
+    {
+        return Err(FinalVerificationViolation::InvalidArgv.into());
+    }
+    let worktree = canonical_directory("worktree", &request.worktree)?;
+    let working_directory = canonical_directory("working_directory", &request.working_directory)?;
+    // A configured `working_directory` that escapes the worktree is a plan
+    // authoring error, and one that would run the command somewhere the
+    // fingerprint does not describe. Fail closed on it in both tiers.
+    if !working_directory.starts_with(&worktree) {
+        return Err(
+            FinalVerificationViolation::WorkingDirectoryOutsideWorktree {
+                path: working_directory,
+            }
+            .into(),
+        );
+    }
+
+    let mut command = Command::new(&request.argv[0]);
+    command
+        .args(&request.argv[1..])
+        .current_dir(&working_directory)
+        // Still `env_clear`: the recorded tier relaxes isolation, not the
+        // requirement that every environment input be declared in the manifest.
+        // Values arrive already resolved, split into identity-bearing and
+        // volatile buckets by the caller.
+        .env_clear()
+        .envs(&request.environment)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let child = command.spawn().map_err(FinalVerificationError::Launch)?;
+    wait_capturing_output(child, Some(timeout))
+}
+
+fn canonical_directory(
+    field: &'static str,
+    path: &std::path::Path,
+) -> Result<std::path::PathBuf, FinalVerificationViolation> {
+    let canonical =
+        path.canonicalize()
+            .map_err(|_| FinalVerificationViolation::InvalidDirectory {
+                field,
+                path: path.to_path_buf(),
+            })?;
+    if !canonical.is_dir() {
+        return Err(FinalVerificationViolation::InvalidDirectory {
+            field,
+            path: canonical,
+        });
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn request(worktree: &Path, script: &str) -> FinalVerificationRequest {
+        FinalVerificationRequest {
+            argv: vec!["/bin/sh".into(), "-c".into(), script.into()],
+            worktree: worktree.to_path_buf(),
+            working_directory: worktree.to_path_buf(),
+            tool_runtime: Vec::new(),
+            read_only_external_mounts: Vec::new(),
+            output_directories: Vec::new(),
+            environment: BTreeMap::from([("PATH".to_string(), "/bin:/usr/bin".to_string())]),
+        }
+    }
+
+    /// The defining difference from the attested launcher: a pre-existing
+    /// build directory is an input, not a violation, and it survives the run.
+    #[test]
+    fn preexisting_output_directory_is_reused_not_rejected() {
+        let worktree = TempDir::new().unwrap();
+        let warm = worktree.path().join("target");
+        std::fs::create_dir(&warm).unwrap();
+        std::fs::write(warm.join("artifact"), b"warm").unwrap();
+
+        let result = launch_recorded_verification_with_timeout(
+            request(
+                worktree.path(),
+                "cat target/artifact && echo more > target/second",
+            ),
+            Duration::from_secs(30),
+        )
+        .unwrap();
+
+        assert!(
+            result.succeeded(),
+            "warm output must be readable: {}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+        assert_eq!(result.stdout, b"warm");
+        assert_eq!(std::fs::read(warm.join("artifact")).unwrap(), b"warm");
+        assert!(
+            warm.join("second").exists(),
+            "the run must be able to write"
+        );
+    }
+
+    /// Attested restricts writes to output directories, and only for the first
+    /// command. A recorded run is an ordinary build: every command writes.
+    #[test]
+    fn every_command_can_write_the_worktree() {
+        let worktree = TempDir::new().unwrap();
+        for index in 0..3 {
+            let result = launch_recorded_verification_with_timeout(
+                request(worktree.path(), &format!("echo x > step{index}")),
+                Duration::from_secs(30),
+            )
+            .unwrap();
+            assert!(result.succeeded(), "command {index} could not write");
+        }
+        for index in 0..3 {
+            assert!(worktree.path().join(format!("step{index}")).exists());
+        }
+    }
+
+    /// `env_clear` still applies: an undeclared name is absent, so the recorded
+    /// tier cannot silently depend on ambient environment it did not declare.
+    #[test]
+    fn undeclared_environment_is_not_inherited() {
+        let worktree = TempDir::new().unwrap();
+        let result = launch_recorded_verification_with_timeout(
+            request(worktree.path(), "test -z \"$DJINN_RECORDED_PROBE\""),
+            Duration::from_secs(30),
+        )
+        .unwrap();
+        assert!(
+            result.succeeded(),
+            "ambient environment leaked into the run"
+        );
+    }
+
+    #[test]
+    fn working_directory_outside_the_worktree_fails_closed() {
+        let worktree = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let mut invalid = request(worktree.path(), "true");
+        invalid.working_directory = outside.path().to_path_buf();
+        assert!(matches!(
+            launch_recorded_verification_with_timeout(invalid, Duration::from_secs(5)),
+            Err(FinalVerificationError::Violation(
+                FinalVerificationViolation::WorkingDirectoryOutsideWorktree { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn timeout_is_enforced_and_reported() {
+        let worktree = TempDir::new().unwrap();
+        let result = launch_recorded_verification_with_timeout(
+            request(worktree.path(), "sleep 5"),
+            Duration::from_millis(50),
+        )
+        .unwrap();
+        assert!(result.timed_out);
+        assert!(!result.succeeded());
+    }
+
+    #[test]
+    fn malformed_argv_fails_closed() {
+        let worktree = TempDir::new().unwrap();
+        let mut invalid = request(worktree.path(), "true");
+        invalid.argv = vec![String::new()];
+        assert!(matches!(
+            launch_recorded_verification_with_timeout(invalid, Duration::from_secs(5)),
+            Err(FinalVerificationError::Violation(
+                FinalVerificationViolation::InvalidArgv
+            ))
+        ));
+        let mut nul = request(worktree.path(), "true");
+        nul.argv = vec!["/bin/sh".into(), "-c".into(), "true\0".into()];
+        assert!(matches!(
+            launch_recorded_verification_with_timeout(nul, Duration::from_secs(5)),
+            Err(FinalVerificationError::Violation(
+                FinalVerificationViolation::InvalidArgv
+            ))
+        ));
+        let _ = PathBuf::new();
+    }
+}

--- a/server/crates/djinn-slot/src/final_verification.rs
+++ b/server/crates/djinn-slot/src/final_verification.rs
@@ -25,7 +25,12 @@ use djinn_sandbox::service_provisioning::{ServiceProvisioningCode, ServiceProvis
 use time::format_description::well_known::Rfc3339;
 use tokio_util::sync::CancellationToken;
 
+mod outcome_telemetry;
 mod provisioning_gate;
+use outcome_telemetry::{
+    emit_error, emit_ineligible, emit_lookup_outcome_with_test_observation, emit_outcome,
+    error_outcome, ineligible_outcome, lookup_none,
+};
 use provisioning_gate::{
     emit_service_provisioning_outcome, provisioning_outcome_label, provisioning_phase_label,
     service_provisioning_failure,
@@ -55,6 +60,14 @@ pub struct FinalVerificationResolvedMaterial {
     pub verify_source: VerifySource,
     /// Required check IDs from the same canonical plan used by the request.
     pub required_checks: Vec<String>,
+    /// The plan's `hermeticity.reusable`. Carried on the material (rather than
+    /// re-read from the identity resolver) so the completion-intent path adds
+    /// no resolver call. Before this existed, `reusable` influenced nothing but
+    /// the identity digest and was not a reuse kill-switch at all: setting it
+    /// false silently still permitted a cache hit.
+    pub reusable: bool,
+    /// The plan's declared evidence tier, as a bounded audit label.
+    pub evidence_tier: &'static str,
     /// Legacy audit fingerprint. It is not used for final-verification reuse.
     pub diff_fingerprint: String,
 }
@@ -409,6 +422,16 @@ pub(crate) async fn coordinate_final_verification_core(
             ));
         }
     };
+    // One bounded audit line naming what this project's plan actually promises.
+    // Deliberately not a metric label: the tier is a per-project constant, so a
+    // label would add cardinality without adding information.
+    tracing::info!(
+        evidence_tier = material.evidence_tier,
+        reusable = material.reusable,
+        task_id = %request.task_id, task_run_id = %request.task_run_id,
+        verification_attempt_id = %verification_attempt_id,
+        "final verification plan resolved"
+    );
     // Record the bounded full/subset selection surface for the agent tool
     // telemetry as soon as the configured material is resolved. Best-effort:
     // an identity-resolution error leaves the selection unset. Gated so the
@@ -576,6 +599,19 @@ async fn consult_reusable_final_verification(
             return lookup_none("error", request, attempt_id, "task_context", &error, ctx);
         }
     };
+    // A plan that declares itself non-reusable must not be reused. This is
+    // checked before the settings gate so the audit reason names the plan, not
+    // the rollout switch.
+    if !material.reusable {
+        return lookup_none(
+            "disabled",
+            request,
+            attempt_id,
+            "plan_not_reusable",
+            "",
+            ctx,
+        );
+    }
     let key = format!("project.{}.verify_run_reuse_enabled", task.project_id);
     if injected_consultation_failure(
         ctx,
@@ -800,51 +836,6 @@ fn coverage_equals_required(coverage: Option<&serde_json::Value>, required: &[St
     actual == expected
 }
 
-fn lookup_none<T>(
-    outcome: &'static str,
-    request: &FinalVerificationCoordinatorRequest,
-    attempt_id: &str,
-    reason: &'static str,
-    detail: &str,
-    ctx: &SlotContext,
-) -> Option<T> {
-    emit_lookup_outcome_with_test_observation(outcome, request, attempt_id, reason, detail, ctx);
-    None
-}
-
-fn emit_lookup_outcome(
-    outcome: &'static str,
-    request: &FinalVerificationCoordinatorRequest,
-    attempt_id: &str,
-    reason: &str,
-    detail: &str,
-) {
-    // The metric has only the bounded outcome label. Rich identifiers and
-    // diagnostics are emitted in the structured audit event below.
-    if djinn_telemetry::final_verification::increment_lookup(outcome).is_err() {
-        tracing::warn!(verify_run_lookup_outcome = outcome, task_id = %request.task_id,
-            task_run_id = %request.task_run_id, verification_attempt_id = %attempt_id,
-            audit_reason = reason, audit_detail = detail,
-            "final verification reuse telemetry emission failed");
-    }
-    tracing::info!(verify_run_lookup_outcome = outcome, task_id = %request.task_id,
-        task_run_id = %request.task_run_id, verification_attempt_id = %attempt_id,
-        audit_reason = reason, audit_detail = detail, "final verification reuse consultation");
-}
-
-fn emit_lookup_outcome_with_test_observation(
-    outcome: &'static str,
-    request: &FinalVerificationCoordinatorRequest,
-    attempt_id: &str,
-    reason: &'static str,
-    detail: &str,
-    ctx: &SlotContext,
-) {
-    emit_lookup_outcome(outcome, request, attempt_id, reason, detail);
-    ctx.callbacks
-        .record_final_verification_consultation_outcome_for_test(outcome, reason);
-}
-
 /// Release before any durable write. This is the commit protocol boundary: the
 /// repository insert is permitted only after the normal invocation lease has
 /// successfully released.
@@ -1019,129 +1010,6 @@ fn format_evidence_reason(evidence: &FinalVerificationExecutionEvidence) -> Stri
         || "malformed final-verification evidence".to_owned(),
         |reason| format!("{reason:?}"),
     )
-}
-
-fn ineligible_outcome(attempt_id: &str, reason: &str) -> FinalVerificationRecordingOutcome {
-    FinalVerificationRecordingOutcome::Ineligible {
-        verification_attempt_id: attempt_id.to_owned(),
-        reason: reason.to_owned(),
-    }
-}
-fn error_outcome(attempt_id: &str, detail: &str) -> FinalVerificationRecordingOutcome {
-    FinalVerificationRecordingOutcome::Error {
-        verification_attempt_id: attempt_id.to_owned(),
-        detail: detail.to_owned(),
-    }
-}
-fn emit_ineligible(
-    request: &FinalVerificationCoordinatorRequest,
-    attempt_id: &str,
-    reason: &str,
-) -> FinalVerificationRecordingOutcome {
-    emit_outcome(request, ineligible_outcome(attempt_id, reason))
-}
-fn emit_error(
-    request: &FinalVerificationCoordinatorRequest,
-    attempt_id: &str,
-    detail: &str,
-) -> FinalVerificationRecordingOutcome {
-    emit_outcome(request, error_outcome(attempt_id, detail))
-}
-fn emit_outcome(
-    request: &FinalVerificationCoordinatorRequest,
-    outcome: FinalVerificationRecordingOutcome,
-) -> FinalVerificationRecordingOutcome {
-    match &outcome {
-        FinalVerificationRecordingOutcome::Stored {
-            verification_attempt_id,
-            verify_run_id,
-            evidence,
-        } => {
-            let _ = djinn_telemetry::final_verification::increment_record(
-                djinn_telemetry::final_verification::RECORD_STORED,
-            );
-            tracing::info!(
-                recording_outcome = "stored", task_id = %request.task_id, task_run_id = %request.task_run_id,
-                verification_attempt_id = %verification_attempt_id, verify_run_id = %verify_run_id,
-                persisted_run_id = %evidence.persisted_run_id,
-                ordered_commands = %evidence.ordered_commands,
-                covered_checks = %evidence.covered_checks,
-                required_checks = ?evidence.required_checks,
-                verification_input_fingerprint = %evidence.verification_input_fingerprint,
-                manifest_version = %evidence.manifest_version,
-                environment_identity_digest = %evidence.environment_identity_digest,
-                "final verification recording completed"
-            )
-        }
-        FinalVerificationRecordingOutcome::Reused {
-            verification_attempt_id,
-            evidence,
-        } => tracing::info!(
-            recording_outcome = "reused", task_id = %request.task_id, task_run_id = %request.task_run_id,
-            verification_attempt_id = %verification_attempt_id, verify_run_id = %evidence.persisted_run_id,
-            ordered_commands = %evidence.ordered_commands,
-            covered_checks = %evidence.covered_checks,
-            required_checks = ?evidence.required_checks,
-            verification_input_fingerprint = %evidence.verification_input_fingerprint,
-            manifest_version = %evidence.manifest_version,
-            environment_identity_digest = %evidence.environment_identity_digest,
-            "final verification recording completed"
-        ),
-        FinalVerificationRecordingOutcome::Ineligible {
-            verification_attempt_id,
-            reason,
-        } => {
-            let _ = djinn_telemetry::final_verification::increment_record(
-                djinn_telemetry::final_verification::RECORD_INELIGIBLE,
-            );
-            tracing::info!(
-                recording_outcome = "ineligible", task_id = %request.task_id, task_run_id = %request.task_run_id,
-                verification_attempt_id = %verification_attempt_id, reason = %reason,
-                "final verification recording completed"
-            )
-        }
-        FinalVerificationRecordingOutcome::InfrastructureIneligible {
-            verification_attempt_id,
-            phase,
-            code,
-        } => {
-            // Infrastructure ineligibility records no passing row, so it counts
-            // as an ineligible writer outcome; the bounded provisioning phase/code
-            // ride the structured audit fields, never the record metric labels.
-            let _ = djinn_telemetry::final_verification::increment_record(
-                djinn_telemetry::final_verification::RECORD_INELIGIBLE,
-            );
-            tracing::info!(
-                recording_outcome = "infrastructure_ineligible",
-                task_id = %request.task_id, task_run_id = %request.task_run_id,
-                verification_attempt_id = %verification_attempt_id,
-                provisioning_phase = provisioning_phase_label(*phase),
-                provisioning_outcome = provisioning_outcome_label(*code),
-                "final verification recording completed"
-            )
-        }
-        FinalVerificationRecordingOutcome::Error {
-            verification_attempt_id,
-            detail,
-        } => {
-            let _ = djinn_telemetry::final_verification::increment_record(
-                djinn_telemetry::final_verification::RECORD_ERROR,
-            );
-            tracing::error!(
-                recording_outcome = "error", task_id = %request.task_id, task_run_id = %request.task_run_id,
-                verification_attempt_id = %verification_attempt_id, detail = %detail,
-                "final verification recording completed"
-            )
-        }
-        FinalVerificationRecordingOutcome::NotConfigured {
-            verification_attempt_id,
-        } => tracing::info!(
-            recording_outcome = "not_configured", task_id = %request.task_id, task_run_id = %request.task_run_id,
-            verification_attempt_id = %verification_attempt_id,
-            "final verification recording completed"
-        ),
-    }
-    outcome
 }
 
 #[cfg(test)]

--- a/server/crates/djinn-slot/src/final_verification/outcome_telemetry.rs
+++ b/server/crates/djinn-slot/src/final_verification/outcome_telemetry.rs
@@ -1,0 +1,179 @@
+//! Bounded telemetry and outcome construction for the final-verification
+//! coordinator.
+//!
+//! Split out of `final_verification.rs` so the coordinator keeps only the
+//! resolve/consult/lease/execute/persist protocol. Every metric here carries a
+//! single bounded label; rich identifiers, the evidence tier, and diagnostics
+//! ride the structured tracing events instead, so no per-project or per-task
+//! value can reach a metric's cardinality.
+
+use djinn_telemetry::final_verification as telemetry;
+
+use super::{
+    FinalVerificationCoordinatorRequest, FinalVerificationRecordingOutcome,
+    provisioning_outcome_label, provisioning_phase_label,
+};
+use crate::host::SlotContext;
+
+pub(super) fn lookup_none<T>(
+    outcome: &'static str,
+    request: &FinalVerificationCoordinatorRequest,
+    attempt_id: &str,
+    reason: &'static str,
+    detail: &str,
+    ctx: &SlotContext,
+) -> Option<T> {
+    emit_lookup_outcome_with_test_observation(outcome, request, attempt_id, reason, detail, ctx);
+    None
+}
+
+pub(super) fn emit_lookup_outcome(
+    outcome: &'static str,
+    request: &FinalVerificationCoordinatorRequest,
+    attempt_id: &str,
+    reason: &str,
+    detail: &str,
+) {
+    // The metric has only the bounded outcome label. Rich identifiers and
+    // diagnostics are emitted in the structured audit event below.
+    if telemetry::increment_lookup(outcome).is_err() {
+        tracing::warn!(verify_run_lookup_outcome = outcome, task_id = %request.task_id,
+            task_run_id = %request.task_run_id, verification_attempt_id = %attempt_id,
+            audit_reason = reason, audit_detail = detail,
+            "final verification reuse telemetry emission failed");
+    }
+    tracing::info!(verify_run_lookup_outcome = outcome, task_id = %request.task_id,
+        task_run_id = %request.task_run_id, verification_attempt_id = %attempt_id,
+        audit_reason = reason, audit_detail = detail, "final verification reuse consultation");
+}
+
+pub(super) fn emit_lookup_outcome_with_test_observation(
+    outcome: &'static str,
+    request: &FinalVerificationCoordinatorRequest,
+    attempt_id: &str,
+    reason: &'static str,
+    detail: &str,
+    ctx: &SlotContext,
+) {
+    emit_lookup_outcome(outcome, request, attempt_id, reason, detail);
+    ctx.callbacks
+        .record_final_verification_consultation_outcome_for_test(outcome, reason);
+}
+
+pub(super) fn ineligible_outcome(
+    attempt_id: &str,
+    reason: &str,
+) -> FinalVerificationRecordingOutcome {
+    FinalVerificationRecordingOutcome::Ineligible {
+        verification_attempt_id: attempt_id.to_owned(),
+        reason: reason.to_owned(),
+    }
+}
+pub(super) fn error_outcome(attempt_id: &str, detail: &str) -> FinalVerificationRecordingOutcome {
+    FinalVerificationRecordingOutcome::Error {
+        verification_attempt_id: attempt_id.to_owned(),
+        detail: detail.to_owned(),
+    }
+}
+pub(super) fn emit_ineligible(
+    request: &FinalVerificationCoordinatorRequest,
+    attempt_id: &str,
+    reason: &str,
+) -> FinalVerificationRecordingOutcome {
+    emit_outcome(request, ineligible_outcome(attempt_id, reason))
+}
+pub(super) fn emit_error(
+    request: &FinalVerificationCoordinatorRequest,
+    attempt_id: &str,
+    detail: &str,
+) -> FinalVerificationRecordingOutcome {
+    emit_outcome(request, error_outcome(attempt_id, detail))
+}
+pub(super) fn emit_outcome(
+    request: &FinalVerificationCoordinatorRequest,
+    outcome: FinalVerificationRecordingOutcome,
+) -> FinalVerificationRecordingOutcome {
+    match &outcome {
+        FinalVerificationRecordingOutcome::Stored {
+            verification_attempt_id,
+            verify_run_id,
+            evidence,
+        } => {
+            let _ = telemetry::increment_record(telemetry::RECORD_STORED);
+            tracing::info!(
+                recording_outcome = "stored", task_id = %request.task_id, task_run_id = %request.task_run_id,
+                verification_attempt_id = %verification_attempt_id, verify_run_id = %verify_run_id,
+                persisted_run_id = %evidence.persisted_run_id,
+                ordered_commands = %evidence.ordered_commands,
+                covered_checks = %evidence.covered_checks,
+                required_checks = ?evidence.required_checks,
+                verification_input_fingerprint = %evidence.verification_input_fingerprint,
+                manifest_version = %evidence.manifest_version,
+                environment_identity_digest = %evidence.environment_identity_digest,
+                "final verification recording completed"
+            )
+        }
+        FinalVerificationRecordingOutcome::Reused {
+            verification_attempt_id,
+            evidence,
+        } => tracing::info!(
+            recording_outcome = "reused", task_id = %request.task_id, task_run_id = %request.task_run_id,
+            verification_attempt_id = %verification_attempt_id, verify_run_id = %evidence.persisted_run_id,
+            ordered_commands = %evidence.ordered_commands,
+            covered_checks = %evidence.covered_checks,
+            required_checks = ?evidence.required_checks,
+            verification_input_fingerprint = %evidence.verification_input_fingerprint,
+            manifest_version = %evidence.manifest_version,
+            environment_identity_digest = %evidence.environment_identity_digest,
+            "final verification recording completed"
+        ),
+        FinalVerificationRecordingOutcome::Ineligible {
+            verification_attempt_id,
+            reason,
+        } => {
+            let _ = telemetry::increment_record(telemetry::RECORD_INELIGIBLE);
+            tracing::info!(
+                recording_outcome = "ineligible", task_id = %request.task_id, task_run_id = %request.task_run_id,
+                verification_attempt_id = %verification_attempt_id, reason = %reason,
+                "final verification recording completed"
+            )
+        }
+        FinalVerificationRecordingOutcome::InfrastructureIneligible {
+            verification_attempt_id,
+            phase,
+            code,
+        } => {
+            // Infrastructure ineligibility records no passing row, so it counts
+            // as an ineligible writer outcome; the bounded provisioning phase/code
+            // ride the structured audit fields, never the record metric labels.
+            let _ = telemetry::increment_record(telemetry::RECORD_INELIGIBLE);
+            tracing::info!(
+                recording_outcome = "infrastructure_ineligible",
+                task_id = %request.task_id, task_run_id = %request.task_run_id,
+                verification_attempt_id = %verification_attempt_id,
+                provisioning_phase = provisioning_phase_label(*phase),
+                provisioning_outcome = provisioning_outcome_label(*code),
+                "final verification recording completed"
+            )
+        }
+        FinalVerificationRecordingOutcome::Error {
+            verification_attempt_id,
+            detail,
+        } => {
+            let _ = telemetry::increment_record(telemetry::RECORD_ERROR);
+            tracing::error!(
+                recording_outcome = "error", task_id = %request.task_id, task_run_id = %request.task_run_id,
+                verification_attempt_id = %verification_attempt_id, detail = %detail,
+                "final verification recording completed"
+            )
+        }
+        FinalVerificationRecordingOutcome::NotConfigured {
+            verification_attempt_id,
+        } => tracing::info!(
+            recording_outcome = "not_configured", task_id = %request.task_id, task_run_id = %request.task_run_id,
+            verification_attempt_id = %verification_attempt_id,
+            "final verification recording completed"
+        ),
+    }
+    outcome
+}

--- a/server/crates/djinn-slot/src/final_verification/recording_tests.rs
+++ b/server/crates/djinn-slot/src/final_verification/recording_tests.rs
@@ -96,6 +96,8 @@ fn passing(value: &str) -> FinalVerificationExecutionEvidence {
 }
 fn material(checks: Vec<String>) -> FinalVerificationResolvedMaterial {
     FinalVerificationResolvedMaterial {
+        reusable: true,
+        evidence_tier: "attested",
         execution_request: FinalVerificationExecutionRequest {
             worktree: PathBuf::new(),
             resolve_environment_identity: Arc::new(|| panic!("injected evidence only")),
@@ -103,6 +105,7 @@ fn material(checks: Vec<String>) -> FinalVerificationResolvedMaterial {
             tool_runtime: vec![],
             read_only_external_mounts: vec![],
             output_directories: vec![],
+            volatile_environment: Default::default(),
             catalog_loopback_endpoints: vec![],
             service_provisioners: vec![],
         },

--- a/server/crates/djinn-slot/src/final_verification/service_provisioning_tests.rs
+++ b/server/crates/djinn-slot/src/final_verification/service_provisioning_tests.rs
@@ -107,6 +107,8 @@ fn tracking_material(
 /// service provisioners. Mirrors `recording_tests::material`.
 fn bare_material(checks: &[&str]) -> FinalVerificationResolvedMaterial {
     FinalVerificationResolvedMaterial {
+        reusable: true,
+        evidence_tier: "attested",
         execution_request: FinalVerificationExecutionRequest {
             worktree: std::path::PathBuf::new(),
             resolve_environment_identity: Arc::new(|| panic!("injected evidence only")),
@@ -114,6 +116,7 @@ fn bare_material(checks: &[&str]) -> FinalVerificationResolvedMaterial {
             tool_runtime: vec![],
             read_only_external_mounts: vec![],
             output_directories: vec![],
+            volatile_environment: Default::default(),
             catalog_loopback_endpoints: vec![],
             service_provisioners: vec![],
         },

--- a/server/crates/djinn-slot/src/final_verification/telemetry_contract_tests.rs
+++ b/server/crates/djinn-slot/src/final_verification/telemetry_contract_tests.rs
@@ -1,3 +1,4 @@
+use super::outcome_telemetry::emit_lookup_outcome;
 use super::*;
 use std::io::Write;
 use std::sync::{Arc, Mutex};

--- a/server/crates/djinn-slot/src/final_verification_agent_tool_tests.rs
+++ b/server/crates/djinn-slot/src/final_verification_agent_tool_tests.rs
@@ -58,6 +58,7 @@ fn agent_tool_material(worktree: std::path::PathBuf) -> FinalVerificationResolve
         environment_names: vec![],
         read_only_external_inputs: vec![],
         output_only_globs: vec![],
+        volatile_environment_names: Vec::new(),
     };
     let commands = required_checks
         .iter()
@@ -85,6 +86,7 @@ fn agent_tool_material(worktree: std::path::PathBuf) -> FinalVerificationResolve
                 reusable: true,
                 network_access: false,
             },
+            evidence_tier: Default::default(),
         },
         selection: ResolvedVerificationSelectionV1::legacy_flat_plan(),
         input_manifest: manifest.clone(),
@@ -120,16 +122,20 @@ fn agent_tool_material(worktree: std::path::PathBuf) -> FinalVerificationResolve
                 base_ref: "main".into(),
                 manifest,
                 external_inputs: vec![],
+                output_policy: Default::default(),
             },
             tool_runtime: vec![],
             read_only_external_mounts: vec![],
             output_directories: vec![],
             catalog_loopback_endpoints: vec![],
             service_provisioners: vec![],
+            volatile_environment: Default::default(),
         },
         verify_source: VerifySource::Worker,
         required_checks,
         diff_fingerprint: "agent-tool-audit-diff".into(),
+        reusable: true,
+        evidence_tier: "attested",
     }
 }
 

--- a/server/crates/djinn-slot/src/reply_loop_completion_intent_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop_completion_intent_tests.rs
@@ -474,6 +474,7 @@ pub(crate) fn reuse_material_with_fingerprint_config(
                 reusable: true,
                 network_access: false,
             },
+            evidence_tier: Default::default(),
         },
         selection: ResolvedVerificationSelectionV1::legacy_flat_plan(),
         input_manifest: manifest.clone(),
@@ -511,10 +512,13 @@ pub(crate) fn reuse_material_with_fingerprint_config(
             output_directories: vec![],
             catalog_loopback_endpoints: vec![],
             service_provisioners: vec![],
+            volatile_environment: Default::default(),
         },
         verify_source: VerifySource::Worker,
         required_checks,
         diff_fingerprint: "reply-loop-reuse-audit-diff".into(),
+        reusable: true,
+        evidence_tier: "attested",
     }
 }
 
@@ -1290,110 +1294,4 @@ async fn repeat_worker_reuses_compatible_persisted_pass_after_completion_intent(
     assert!(error_ids(&conversation).is_empty());
 }
 
-#[tokio::test]
-async fn ineligible_result_is_persisted_and_valid_resubmission_is_reverified() {
-    let fixture = make_fixture(vec![ineligible("command failed"), stored()]).await;
-    let provider = FakeProvider::script(vec![
-        submit_turn("submit-failed", &fixture.task_id, "first attempt"),
-        submit_turn("submit-stored", &fixture.task_id, "corrected attempt"),
-    ]);
-    let mut conversation = base_conversation();
-    let (result, output, _, _, _, _) = run_with_provider(
-        &provider,
-        &[dummy_tool_schema("submit_work")],
-        &mut conversation,
-        &fixture.slot_ctx,
-        &fixture.project_path,
-        &fixture.task_id,
-        &fixture.session_id,
-        &fixture.cancel,
-    )
-    .await;
-
-    assert!(result.is_ok());
-    assert_eq!(fixture.callbacks.coordinator_count(), 2);
-    assert_eq!(error_ids(&conversation), vec!["submit-failed"]);
-    assert_eq!(
-        output.finalize_payload.as_ref().unwrap()["summary"],
-        "corrected attempt"
-    );
-    let persisted = djinn_db::SessionMessageRepository::new(
-        fixture.slot_ctx.db.clone(),
-        fixture.slot_ctx.event_bus.clone(),
-    )
-    .load_conversation(&fixture.session_id)
-    .await
-    .expect("load persisted conversation");
-    assert_eq!(error_ids(&persisted), vec!["submit-failed"]);
-}
-
-#[tokio::test]
-async fn terminal_error_exhausts_conversation_without_success_or_submission() {
-    let fixture = make_fixture(vec![coordinator_error("persistence unavailable")]).await;
-    let provider = FakeProvider::script_with_terminal_error(
-        vec![submit_turn("submit-error", &fixture.task_id, "attempt")],
-        "terminal provider failure after submit-error",
-    );
-    let mut conversation = base_conversation();
-    let (result, output, _, _, _, _) = run_with_provider(
-        &provider,
-        &[dummy_tool_schema("submit_work")],
-        &mut conversation,
-        &fixture.slot_ctx,
-        &fixture.project_path,
-        &fixture.task_id,
-        &fixture.session_id,
-        &fixture.cancel,
-    )
-    .await;
-
-    assert!(
-        result.is_err(),
-        "explicit provider failure terminates the real reply loop"
-    );
-    assert_eq!(provider.remaining(), 0, "terminal provider turn consumed");
-    assert_eq!(fixture.callbacks.coordinator_count(), 1);
-    assert!(output.finalize_payload.is_none());
-    assert!(output.completion_intent.is_none());
-    assert_eq!(error_ids(&conversation), vec!["submit-error"]);
-}
-
-#[tokio::test]
-async fn three_non_stored_attempts_each_reach_verification_and_never_succeed() {
-    let fixture = make_fixture(vec![
-        ineligible("command one failed"),
-        coordinator_error("writer failed"),
-        ineligible("command three failed"),
-    ])
-    .await;
-    let provider = FakeProvider::script_with_terminal_error(
-        vec![
-            submit_turn("submit-1", &fixture.task_id, "attempt one"),
-            submit_turn("submit-2", &fixture.task_id, "attempt two"),
-            submit_turn("submit-3", &fixture.task_id, "attempt three"),
-        ],
-        "terminal provider failure after three non-stored attempts",
-    );
-    let mut conversation = base_conversation();
-    let (result, output, _, _, _, _) = run_with_provider(
-        &provider,
-        &[dummy_tool_schema("submit_work")],
-        &mut conversation,
-        &fixture.slot_ctx,
-        &fixture.project_path,
-        &fixture.task_id,
-        &fixture.session_id,
-        &fixture.cancel,
-    )
-    .await;
-
-    assert!(result.is_err());
-    assert_eq!(provider.remaining(), 0, "terminal provider turn consumed");
-    assert_eq!(fixture.callbacks.coordinator_count(), 3);
-    assert!(output.finalize_payload.is_none());
-    assert!(output.completion_intent.is_none());
-    assert_eq!(
-        error_ids(&conversation),
-        vec!["submit-1", "submit-2", "submit-3"]
-    );
-}
+mod resubmission_tests;

--- a/server/crates/djinn-slot/src/reply_loop_completion_intent_tests/resubmission_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop_completion_intent_tests/resubmission_tests.rs
@@ -1,0 +1,114 @@
+//! Resubmission and terminal-error behaviour after a non-stored completion
+//! verification. Split out of `reply_loop_completion_intent_tests.rs` purely to
+//! keep that file under the size guard; it shares the same harness via
+//! `use super::*`.
+
+use super::*;
+
+#[tokio::test]
+async fn ineligible_result_is_persisted_and_valid_resubmission_is_reverified() {
+    let fixture = make_fixture(vec![ineligible("command failed"), stored()]).await;
+    let provider = FakeProvider::script(vec![
+        submit_turn("submit-failed", &fixture.task_id, "first attempt"),
+        submit_turn("submit-stored", &fixture.task_id, "corrected attempt"),
+    ]);
+    let mut conversation = base_conversation();
+    let (result, output, _, _, _, _) = run_with_provider(
+        &provider,
+        &[dummy_tool_schema("submit_work")],
+        &mut conversation,
+        &fixture.slot_ctx,
+        &fixture.project_path,
+        &fixture.task_id,
+        &fixture.session_id,
+        &fixture.cancel,
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert_eq!(fixture.callbacks.coordinator_count(), 2);
+    assert_eq!(error_ids(&conversation), vec!["submit-failed"]);
+    assert_eq!(
+        output.finalize_payload.as_ref().unwrap()["summary"],
+        "corrected attempt"
+    );
+    let persisted = djinn_db::SessionMessageRepository::new(
+        fixture.slot_ctx.db.clone(),
+        fixture.slot_ctx.event_bus.clone(),
+    )
+    .load_conversation(&fixture.session_id)
+    .await
+    .expect("load persisted conversation");
+    assert_eq!(error_ids(&persisted), vec!["submit-failed"]);
+}
+
+#[tokio::test]
+async fn terminal_error_exhausts_conversation_without_success_or_submission() {
+    let fixture = make_fixture(vec![coordinator_error("persistence unavailable")]).await;
+    let provider = FakeProvider::script_with_terminal_error(
+        vec![submit_turn("submit-error", &fixture.task_id, "attempt")],
+        "terminal provider failure after submit-error",
+    );
+    let mut conversation = base_conversation();
+    let (result, output, _, _, _, _) = run_with_provider(
+        &provider,
+        &[dummy_tool_schema("submit_work")],
+        &mut conversation,
+        &fixture.slot_ctx,
+        &fixture.project_path,
+        &fixture.task_id,
+        &fixture.session_id,
+        &fixture.cancel,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "explicit provider failure terminates the real reply loop"
+    );
+    assert_eq!(provider.remaining(), 0, "terminal provider turn consumed");
+    assert_eq!(fixture.callbacks.coordinator_count(), 1);
+    assert!(output.finalize_payload.is_none());
+    assert!(output.completion_intent.is_none());
+    assert_eq!(error_ids(&conversation), vec!["submit-error"]);
+}
+
+#[tokio::test]
+async fn three_non_stored_attempts_each_reach_verification_and_never_succeed() {
+    let fixture = make_fixture(vec![
+        ineligible("command one failed"),
+        coordinator_error("writer failed"),
+        ineligible("command three failed"),
+    ])
+    .await;
+    let provider = FakeProvider::script_with_terminal_error(
+        vec![
+            submit_turn("submit-1", &fixture.task_id, "attempt one"),
+            submit_turn("submit-2", &fixture.task_id, "attempt two"),
+            submit_turn("submit-3", &fixture.task_id, "attempt three"),
+        ],
+        "terminal provider failure after three non-stored attempts",
+    );
+    let mut conversation = base_conversation();
+    let (result, output, _, _, _, _) = run_with_provider(
+        &provider,
+        &[dummy_tool_schema("submit_work")],
+        &mut conversation,
+        &fixture.slot_ctx,
+        &fixture.project_path,
+        &fixture.task_id,
+        &fixture.session_id,
+        &fixture.cancel,
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(provider.remaining(), 0, "terminal provider turn consumed");
+    assert_eq!(fixture.callbacks.coordinator_count(), 3);
+    assert!(output.finalize_payload.is_none());
+    assert!(output.completion_intent.is_none());
+    assert_eq!(
+        error_ids(&conversation),
+        vec!["submit-1", "submit-2", "submit-3"]
+    );
+}

--- a/server/crates/djinn-slot/src/reply_loop_reviewer_reuse_tests.rs
+++ b/server/crates/djinn-slot/src/reply_loop_reviewer_reuse_tests.rs
@@ -63,6 +63,7 @@ fn reviewer_reuse_material(worktree: std::path::PathBuf) -> FinalVerificationRes
         environment_names: vec![],
         read_only_external_inputs: vec![],
         output_only_globs: vec![],
+        volatile_environment_names: Vec::new(),
     };
     let commands = required_checks
         .iter()
@@ -90,6 +91,7 @@ fn reviewer_reuse_material(worktree: std::path::PathBuf) -> FinalVerificationRes
                 reusable: true,
                 network_access: false,
             },
+            evidence_tier: Default::default(),
         },
         selection: djinn_core::canonical_verify::ResolvedVerificationSelectionV1::legacy_flat_plan(
         ),
@@ -126,16 +128,20 @@ fn reviewer_reuse_material(worktree: std::path::PathBuf) -> FinalVerificationRes
                 base_ref: "main".into(),
                 manifest,
                 external_inputs: vec![],
+                output_policy: Default::default(),
             },
             tool_runtime: vec![],
             read_only_external_mounts: vec![],
             output_directories: vec![],
             catalog_loopback_endpoints: vec![],
             service_provisioners: vec![],
+            volatile_environment: Default::default(),
         },
         verify_source: VerifySource::Worker,
         required_checks,
         diff_fingerprint: "reviewer-reuse-audit-diff".into(),
+        reusable: true,
+        evidence_tier: "attested",
     }
 }
 

--- a/server/crates/djinn-stack/src/environment.rs
+++ b/server/crates/djinn-stack/src/environment.rs
@@ -1047,6 +1047,40 @@ pub struct FinalVerificationPlan {
     pub output_only_globs: Vec<String>,
     #[serde(default)]
     pub hermeticity: HermeticityDeclaration,
+    /// What a recorded pass of this plan is worth. See
+    /// [`VerificationEvidenceTier`]; the tier is identity material, so an
+    /// attested pass and a recorded pass can never share a cache entry.
+    #[serde(default)]
+    pub evidence_tier: VerificationEvidenceTier,
+}
+
+/// The guarantee a persisted final-verification pass carries.
+///
+/// This is deliberately an enum rather than the absence of a flag: the two
+/// tiers promise materially different things, and a reader of a plan must be
+/// able to see which one is in force without reconstructing it from three
+/// booleans.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationEvidenceTier {
+    /// Commands ran under the strict launcher: fresh network namespace,
+    /// Landlock ABI-V3, read-only worktree, and output-only directories that
+    /// were absent at launch. A pass certifies the commands succeeded in an
+    /// isolated environment fully described by the identity digest.
+    #[default]
+    Attested,
+    /// Commands ran as an ordinary warm, incremental build in the task-run Pod:
+    /// no namespace, no Landlock, no output-directory precondition, and the
+    /// pre-existing build outputs left by earlier compiles are visible.
+    ///
+    /// A pass certifies only that (a) the whole-tree fingerprint was identical
+    /// before and after, (b) the environment identity was identical before and
+    /// after, and (c) every configured command exited zero in that window. It
+    /// does NOT certify independence from leftover build state — a poisoned
+    /// incremental cache can produce a green recorded pass. That is the same
+    /// exposure every task compile already accepts; this tier makes accepting
+    /// it a deliberate, named choice rather than an implied one.
+    Recorded,
 }
 
 /// Manual `Default` so that `version` matches the serde default (1) rather
@@ -1066,6 +1100,7 @@ impl Default for FinalVerificationPlan {
             read_only_external_inputs: Vec::new(),
             output_only_globs: Vec::new(),
             hermeticity: HermeticityDeclaration::default(),
+            evidence_tier: VerificationEvidenceTier::Attested,
         }
     }
 }
@@ -1119,8 +1154,30 @@ pub struct VerificationInputManifest {
     pub version: u32,
     #[serde(default)]
     pub repo_paths: Vec<String>,
+    /// Environment names whose **values** are identity material: the resolved
+    /// value is hashed into the environment identity digest, so a change to it
+    /// invalidates every reusable pass. Use this for anything whose value
+    /// genuinely changes what the commands do (`PATH`, `CARGO_HOME`,
+    /// `CARGO_BUILD_RUSTFLAGS`).
     #[serde(default)]
     pub environment_names: Vec<String>,
+    /// Environment names that are declared and passed to commands, but whose
+    /// **values** are deliberately NOT identity material — only the name is
+    /// (via this manifest). The resolved value never reaches the identity
+    /// digest, so a per-run value does not fracture reuse across task runs.
+    ///
+    /// This is the same contract catalog services already have: a declared
+    /// name with an attempt-scoped value. It exists because the production
+    /// pod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`
+    /// (a fresh path per run) and `RUSTC_WRAPPER=""` (an empty value, which
+    /// identity material forbids). Hashing either would mean a worker run and
+    /// the reviewer run of the same task could never share a pass — which is
+    /// the entire point of the recorded tier.
+    ///
+    /// Rejected unless `evidence_tier` is `recorded`: an unhashed input would
+    /// void the attested tier's guarantee.
+    #[serde(default)]
+    pub volatile_environment_names: Vec<String>,
 }
 
 /// Manual `Default` so that `version` matches the serde default (1).
@@ -1130,6 +1187,7 @@ impl Default for VerificationInputManifest {
             version: FINAL_VERIFICATION_VERSION,
             repo_paths: Vec::new(),
             environment_names: Vec::new(),
+            volatile_environment_names: Vec::new(),
         }
     }
 }
@@ -1311,6 +1369,7 @@ impl FinalVerificationPlan {
                 env_name,
             )?;
         }
+        self.validate_volatile_environment_names()?;
         // Bounded external inputs list with uniqueness checks.
         if self.read_only_external_inputs.len() > MAX_FINAL_VERIFICATION_INPUTS {
             return Err(EnvironmentConfigError::ListTooLong {
@@ -1349,14 +1408,88 @@ impl FinalVerificationPlan {
         for glob in &self.output_only_globs {
             validate_glob("lifecycle.final_verification.output_only_globs", glob)?;
         }
-        if self.hermeticity.reusable
-            && (!self.hermeticity.hermetic || self.hermeticity.network_access)
-        {
+        self.validate_evidence_tier()
+    }
+
+    /// Bind the declared tier to the isolation it actually gets. Each tier has
+    /// exactly one legal hermeticity shape, so the plan JSON states the
+    /// guarantee rather than leaving it to be inferred from three booleans.
+    fn validate_evidence_tier(&self) -> EnvResult<()> {
+        match self.evidence_tier {
+            // Unchanged pre-existing rule: an attested pass is only reusable
+            // because the strict launcher isolated it.
+            VerificationEvidenceTier::Attested => {
+                if self.hermeticity.reusable
+                    && (!self.hermeticity.hermetic || self.hermeticity.network_access)
+                {
+                    return Err(EnvironmentConfigError::UnsafeIdentifier {
+                        field: "lifecycle.final_verification.hermeticity.reusable".into(),
+                        value: "reusable attested plans must be hermetic and deny network access"
+                            .into(),
+                    });
+                }
+            }
+            // A recorded plan runs as an ordinary Pod process. Requiring the
+            // truthful declaration (not isolated, has network) keeps the config
+            // from reading like a weaker attestation.
+            VerificationEvidenceTier::Recorded => {
+                if self.hermeticity.hermetic || !self.hermeticity.network_access {
+                    return Err(EnvironmentConfigError::UnsafeIdentifier {
+                        field: "lifecycle.final_verification.evidence_tier".into(),
+                        value: "recorded plans must declare hermetic=false and network_access=true"
+                            .into(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_volatile_environment_names(&self) -> EnvResult<()> {
+        let field = "lifecycle.final_verification.input_manifest.volatile_environment_names";
+        let volatile = &self.input_manifest.volatile_environment_names;
+        if volatile.is_empty() {
+            return Ok(());
+        }
+        // A value that never reaches the identity digest is an undeclared input
+        // to an attested result, which is exactly what attestation rules out.
+        if self.evidence_tier != VerificationEvidenceTier::Recorded {
             return Err(EnvironmentConfigError::UnsafeIdentifier {
-                field: "lifecycle.final_verification.hermeticity.reusable".into(),
-                value: "reusable plans must be hermetic and deny network access".into(),
+                field: field.into(),
+                value: "volatile environment names require evidence_tier=recorded".into(),
             });
-        };
+        }
+        if volatile.len() > MAX_ENV_ENTRIES {
+            return Err(EnvironmentConfigError::ListTooLong {
+                field: field.into(),
+                len: volatile.len(),
+                max: MAX_ENV_ENTRIES,
+            });
+        }
+        let identity_bearing: HashSet<&str> = self
+            .input_manifest
+            .environment_names
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let mut seen = HashSet::new();
+        for env_name in volatile {
+            validate_identifier(field, env_name)?;
+            if !seen.insert(env_name.as_str()) {
+                return Err(EnvironmentConfigError::DuplicateName {
+                    field: field.into(),
+                    name: env_name.clone(),
+                });
+            }
+            // One name cannot be both hashed and not hashed; the ambiguity
+            // would decide silently at resolution time.
+            if identity_bearing.contains(env_name.as_str()) {
+                return Err(EnvironmentConfigError::DuplicateName {
+                    field: field.into(),
+                    name: env_name.clone(),
+                });
+            }
+        }
         Ok(())
     }
 }
@@ -3219,11 +3352,13 @@ mod tests {
                 version: 1,
                 repo_paths: vec!["server".into()],
                 environment_names: vec!["CI".into()],
+                volatile_environment_names: vec![],
             },
             read_only_external_inputs: vec![ExternalInputDeclaration {
                 id: "base-image".into(),
                 locator: "docker://ghcr.io/djinn/base:latest".into(),
             }],
+            evidence_tier: VerificationEvidenceTier::Attested,
             output_only_globs: vec!["target/**/*.d".into()],
             hermeticity: HermeticityDeclaration {
                 hermetic: true,
@@ -3599,6 +3734,86 @@ mod tests {
         assert!(matches!(
             err,
             EnvironmentConfigError::UnsafeIdentifier { .. }
+        ));
+    }
+
+    /// Each tier has exactly one legal isolation shape. The point of the enum
+    /// is that a reader sees the guarantee instead of reconstructing it from
+    /// three booleans, so the boolean/tier pairing must be enforced, not
+    /// merely documented.
+    #[test]
+    fn evidence_tier_binds_to_exactly_one_hermeticity_shape() {
+        let recorded = |hermetic, reusable, network_access| {
+            let mut plan = valid_final_verification_plan();
+            plan.evidence_tier = VerificationEvidenceTier::Recorded;
+            plan.hermeticity = HermeticityDeclaration {
+                hermetic,
+                reusable,
+                network_access,
+            };
+            plan.validate()
+        };
+        // Recorded is honest about being unisolated and networked. `reusable`
+        // stays free: false is a legitimate "run and record, never reuse".
+        assert!(recorded(false, true, true).is_ok());
+        assert!(recorded(false, false, true).is_ok());
+        // Claiming isolation, or claiming the network is denied, is not.
+        assert!(recorded(true, true, true).is_err());
+        assert!(recorded(false, true, false).is_err());
+
+        let attested = |hermetic, reusable, network_access| {
+            let mut plan = valid_final_verification_plan();
+            plan.evidence_tier = VerificationEvidenceTier::Attested;
+            plan.hermeticity = HermeticityDeclaration {
+                hermetic,
+                reusable,
+                network_access,
+            };
+            plan.validate()
+        };
+        assert!(attested(true, true, false).is_ok());
+        // The pre-existing rule is unchanged: attested reuse requires isolation.
+        assert!(attested(false, true, false).is_err());
+        assert!(attested(true, true, true).is_err());
+    }
+
+    /// A volatile value is by definition not described by the identity digest,
+    /// which is exactly what an attested result promises it has none of.
+    #[test]
+    fn volatile_environment_names_require_the_recorded_tier() {
+        let mut plan = valid_final_verification_plan();
+        plan.input_manifest.volatile_environment_names = vec!["CARGO_TARGET_DIR".into()];
+        assert!(
+            plan.validate().is_err(),
+            "attested plans must reject unhashed environment inputs"
+        );
+
+        plan.evidence_tier = VerificationEvidenceTier::Recorded;
+        plan.hermeticity = HermeticityDeclaration {
+            hermetic: false,
+            reusable: true,
+            network_access: true,
+        };
+        plan.validate()
+            .expect("recorded plans may declare volatile names");
+    }
+
+    /// A name in both buckets would have to be hashed and not hashed at once;
+    /// resolution would silently pick one.
+    #[test]
+    fn a_name_cannot_be_both_identity_bearing_and_volatile() {
+        let mut plan = valid_final_verification_plan();
+        plan.evidence_tier = VerificationEvidenceTier::Recorded;
+        plan.hermeticity = HermeticityDeclaration {
+            hermetic: false,
+            reusable: true,
+            network_access: true,
+        };
+        plan.input_manifest.environment_names = vec!["CI".into(), "CARGO_HOME".into()];
+        plan.input_manifest.volatile_environment_names = vec!["CARGO_HOME".into()];
+        assert!(matches!(
+            plan.validate().unwrap_err(),
+            EnvironmentConfigError::DuplicateName { .. }
         ));
     }
 

--- a/server/crates/djinn-stack/src/environment.rs
+++ b/server/crates/djinn-stack/src/environment.rs
@@ -4003,6 +4003,97 @@ mod tests {
         );
     }
 
+    /// A complete, realistic recorded plan must survive JSON round-trip and
+    /// validation exactly as an operator would paste it.
+    ///
+    /// The unit tests above each poke one field; this asserts the whole shape
+    /// an operator actually writes is applicable. It is the cheap guard against
+    /// shipping a documented plan that cannot be applied — the failure mode
+    /// where a descriptor names an environment variable production cannot
+    /// supply, and the plan is accepted but every run fails closed with
+    /// `UndeclaredCommandEnvironment`.
+    #[test]
+    fn a_complete_recorded_plan_round_trips_and_validates() {
+        let json = serde_json::json!({
+            "version": 1,
+            "profile_id": "warm-recorded",
+            "profile_revision": 1,
+            "evidence_tier": "recorded",
+            "hermeticity": { "hermetic": false, "reusable": true, "network_access": true },
+            "command_groups": [{
+                "name": "server",
+                "commands": [{
+                    "check_id": "server-check",
+                    "executable": "/usr/local/cargo/bin/cargo",
+                    "argv": ["check", "--workspace", "--all-targets"],
+                    "working_directory": "server",
+                    "environment_names": [
+                        "PATH", "HOME", "CARGO_HOME", "RUSTUP_HOME", "CARGO_TARGET_DIR",
+                        "CARGO_BUILD_JOBS", "CARGO_BUILD_RUSTFLAGS", "CARGO_INCREMENTAL",
+                        "RUSTC_WRAPPER", "SQLX_OFFLINE", "TMPDIR"
+                    ],
+                    "timeout_seconds": 2700,
+                    "descriptor_revision": 1
+                }]
+            }],
+            "selection_rules": [
+                { "match": ["server/**"], "command_groups": ["server"] },
+                { "match": ["**"], "command_groups": ["server"] }
+            ],
+            "required_checks": ["server-check"],
+            "input_manifest": {
+                "version": 1,
+                "repo_paths": [],
+                "environment_names": [
+                    "PATH", "HOME", "CARGO_HOME", "RUSTUP_HOME", "CARGO_BUILD_JOBS",
+                    "CARGO_BUILD_RUSTFLAGS", "CARGO_INCREMENTAL", "SQLX_OFFLINE", "TMPDIR"
+                ],
+                // Per-task-run and empty-valued respectively: hashing either
+                // would stop a reviewer ever reusing a worker's pass.
+                "volatile_environment_names": ["CARGO_TARGET_DIR", "RUSTC_WRAPPER"]
+            },
+            // Exactly one `**`-leading glob is permitted, because
+            // `output_globs_may_overlap` treats any two of them as overlapping.
+            "output_only_globs": [
+                "server/target/**", "ui/node_modules/**", "node_modules/**", "ui/dist/**",
+                ".cache/**", ".task-runtime/**", ".claude/**", ".tmp/**", "tmp/**"
+            ],
+            "read_only_external_inputs": []
+        });
+
+        let plan: FinalVerificationPlan =
+            serde_json::from_value(json.clone()).expect("recorded plan must deserialize");
+        plan.validate().expect("recorded plan must validate");
+
+        // Every name the command reads must be declared in one bucket or the
+        // other, or production fails closed at `command_environment`.
+        let declared: HashSet<&str> = plan
+            .input_manifest
+            .environment_names
+            .iter()
+            .chain(&plan.input_manifest.volatile_environment_names)
+            .map(String::as_str)
+            .collect();
+        for command in plan.normalized_commands() {
+            for name in &command.environment_names {
+                assert!(
+                    declared.contains(name.as_str()),
+                    "{name} is read by a command but declared in neither manifest bucket"
+                );
+            }
+        }
+
+        // Re-serializing must not lose the tier or the volatile bucket.
+        let round_tripped: FinalVerificationPlan =
+            serde_json::from_str(&serde_json::to_string(&plan).expect("serialize"))
+                .expect("re-deserialize");
+        assert_eq!(round_tripped, plan);
+        assert_eq!(
+            round_tripped.evidence_tier,
+            VerificationEvidenceTier::Recorded
+        );
+    }
+
     #[test]
     fn final_verification_json_schema_exposes_all_types() {
         let schema = schemars::schema_for!(EnvironmentConfig);

--- a/server/crates/djinn-stack/src/lib.rs
+++ b/server/crates/djinn-stack/src/lib.rs
@@ -51,7 +51,8 @@ pub use environment::{
     FinalVerificationCommand, FinalVerificationCommandGroup, FinalVerificationPlan,
     FinalVerificationSelectionRule, GoLanguage, HermeticityDeclaration, HookCommand, JavaLanguage,
     Languages, LifecycleHooks, NodeLanguage, PreTaskCommand, PreTaskFailurePolicy, PythonLanguage,
-    RubyLanguage, RustLanguage, SCHEMA_VERSION, VerificationInputManifest, Workspace,
+    RubyLanguage, RustLanguage, SCHEMA_VERSION, VerificationEvidenceTier,
+    VerificationInputManifest, Workspace,
 };
 pub use schema::{LanguageStat, ManifestSignals, Runtimes, Stack};
 pub use slug::workspace_slug;

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -5113,6 +5113,7 @@ expression: signatures
               "$ref": "#/$defs/LifecycleHooks",
               "default": {
                 "final_verification": {
+                  "evidence_tier": "attested",
                   "hermeticity": {
                     "hermetic": false,
                     "network_access": false,
@@ -5121,7 +5122,8 @@ expression: signatures
                   "input_manifest": {
                     "environment_names": [],
                     "repo_paths": [],
-                    "version": 1
+                    "version": 1,
+                    "volatile_environment_names": []
                   },
                   "output_only_globs": [],
                   "profile_id": "",
@@ -5261,6 +5263,11 @@ expression: signatures
               },
               "type": "array"
             },
+            "evidence_tier": {
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested",
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry."
+            },
             "hermeticity": {
               "$ref": "#/$defs/HermeticityDeclaration",
               "default": {
@@ -5274,7 +5281,8 @@ expression: signatures
               "default": {
                 "environment_names": [],
                 "repo_paths": [],
-                "version": 1
+                "version": 1,
+                "volatile_environment_names": []
               }
             },
             "output_only_globs": {
@@ -5504,6 +5512,7 @@ expression: signatures
             "final_verification": {
               "$ref": "#/$defs/FinalVerificationPlan",
               "default": {
+                "evidence_tier": "attested",
                 "hermeticity": {
                   "hermetic": false,
                   "network_access": false,
@@ -5512,7 +5521,8 @@ expression: signatures
                 "input_manifest": {
                   "environment_names": [],
                   "repo_paths": [],
-                  "version": 1
+                  "version": 1,
+                  "volatile_environment_names": []
                 },
                 "output_only_globs": [],
                 "profile_id": "",
@@ -5648,11 +5658,27 @@ expression: signatures
           ],
           "type": "object"
         },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "const": "attested",
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string"
+            },
+            {
+              "const": "recorded",
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string"
+            }
+          ]
+        },
         "VerificationInputManifest": {
           "additionalProperties": false,
           "properties": {
             "environment_names": {
               "default": [],
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
               "items": {
                 "type": "string"
               },
@@ -5669,6 +5695,14 @@ expression: signatures
               "default": 1,
               "format": "int64",
               "type": "integer"
+            },
+            "volatile_environment_names": {
+              "default": [],
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -6098,6 +6132,7 @@ expression: signatures
               "$ref": "#/$defs/LifecycleHooks",
               "default": {
                 "final_verification": {
+                  "evidence_tier": "attested",
                   "hermeticity": {
                     "hermetic": false,
                     "network_access": false,
@@ -6106,7 +6141,8 @@ expression: signatures
                   "input_manifest": {
                     "environment_names": [],
                     "repo_paths": [],
-                    "version": 1
+                    "version": 1,
+                    "volatile_environment_names": []
                   },
                   "output_only_globs": [],
                   "profile_id": "",
@@ -6246,6 +6282,11 @@ expression: signatures
               },
               "type": "array"
             },
+            "evidence_tier": {
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested",
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry."
+            },
             "hermeticity": {
               "$ref": "#/$defs/HermeticityDeclaration",
               "default": {
@@ -6259,7 +6300,8 @@ expression: signatures
               "default": {
                 "environment_names": [],
                 "repo_paths": [],
-                "version": 1
+                "version": 1,
+                "volatile_environment_names": []
               }
             },
             "output_only_globs": {
@@ -6528,6 +6570,7 @@ expression: signatures
             "final_verification": {
               "$ref": "#/$defs/FinalVerificationPlan",
               "default": {
+                "evidence_tier": "attested",
                 "hermeticity": {
                   "hermetic": false,
                   "network_access": false,
@@ -6536,7 +6579,8 @@ expression: signatures
                 "input_manifest": {
                   "environment_names": [],
                   "repo_paths": [],
-                  "version": 1
+                  "version": 1,
+                  "volatile_environment_names": []
                 },
                 "output_only_globs": [],
                 "profile_id": "",
@@ -6672,11 +6716,27 @@ expression: signatures
           ],
           "type": "object"
         },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "const": "attested",
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string"
+            },
+            {
+              "const": "recorded",
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string"
+            }
+          ]
+        },
         "VerificationInputManifest": {
           "additionalProperties": false,
           "properties": {
             "environment_names": {
               "default": [],
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
               "items": {
                 "type": "string"
               },
@@ -6693,6 +6753,14 @@ expression: signatures
               "default": 1,
               "format": "int64",
               "type": "integer"
+            },
+            "volatile_environment_names": {
+              "default": [],
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -7103,6 +7171,7 @@ expression: signatures
               "$ref": "#/$defs/LifecycleHooks",
               "default": {
                 "final_verification": {
+                  "evidence_tier": "attested",
                   "hermeticity": {
                     "hermetic": false,
                     "network_access": false,
@@ -7111,7 +7180,8 @@ expression: signatures
                   "input_manifest": {
                     "environment_names": [],
                     "repo_paths": [],
-                    "version": 1
+                    "version": 1,
+                    "volatile_environment_names": []
                   },
                   "output_only_globs": [],
                   "profile_id": "",
@@ -7251,6 +7321,11 @@ expression: signatures
               },
               "type": "array"
             },
+            "evidence_tier": {
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested",
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry."
+            },
             "hermeticity": {
               "$ref": "#/$defs/HermeticityDeclaration",
               "default": {
@@ -7264,7 +7339,8 @@ expression: signatures
               "default": {
                 "environment_names": [],
                 "repo_paths": [],
-                "version": 1
+                "version": 1,
+                "volatile_environment_names": []
               }
             },
             "output_only_globs": {
@@ -7494,6 +7570,7 @@ expression: signatures
             "final_verification": {
               "$ref": "#/$defs/FinalVerificationPlan",
               "default": {
+                "evidence_tier": "attested",
                 "hermeticity": {
                   "hermetic": false,
                   "network_access": false,
@@ -7502,7 +7579,8 @@ expression: signatures
                 "input_manifest": {
                   "environment_names": [],
                   "repo_paths": [],
-                  "version": 1
+                  "version": 1,
+                  "volatile_environment_names": []
                 },
                 "output_only_globs": [],
                 "profile_id": "",
@@ -7638,11 +7716,27 @@ expression: signatures
           ],
           "type": "object"
         },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "const": "attested",
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string"
+            },
+            {
+              "const": "recorded",
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string"
+            }
+          ]
+        },
         "VerificationInputManifest": {
           "additionalProperties": false,
           "properties": {
             "environment_names": {
               "default": [],
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
               "items": {
                 "type": "string"
               },
@@ -7659,6 +7753,14 @@ expression: signatures
               "default": 1,
               "format": "int64",
               "type": "integer"
+            },
+            "volatile_environment_names": {
+              "default": [],
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -13560,6 +13662,7 @@ expression: signatures
               "$ref": "#/$defs/LifecycleHooks",
               "default": {
                 "final_verification": {
+                  "evidence_tier": "attested",
                   "hermeticity": {
                     "hermetic": false,
                     "network_access": false,
@@ -13568,7 +13671,8 @@ expression: signatures
                   "input_manifest": {
                     "environment_names": [],
                     "repo_paths": [],
-                    "version": 1
+                    "version": 1,
+                    "volatile_environment_names": []
                   },
                   "output_only_globs": [],
                   "profile_id": "",
@@ -13708,6 +13812,11 @@ expression: signatures
               },
               "type": "array"
             },
+            "evidence_tier": {
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested",
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry."
+            },
             "hermeticity": {
               "$ref": "#/$defs/HermeticityDeclaration",
               "default": {
@@ -13721,7 +13830,8 @@ expression: signatures
               "default": {
                 "environment_names": [],
                 "repo_paths": [],
-                "version": 1
+                "version": 1,
+                "volatile_environment_names": []
               }
             },
             "output_only_globs": {
@@ -13951,6 +14061,7 @@ expression: signatures
             "final_verification": {
               "$ref": "#/$defs/FinalVerificationPlan",
               "default": {
+                "evidence_tier": "attested",
                 "hermeticity": {
                   "hermetic": false,
                   "network_access": false,
@@ -13959,7 +14070,8 @@ expression: signatures
                 "input_manifest": {
                   "environment_names": [],
                   "repo_paths": [],
-                  "version": 1
+                  "version": 1,
+                  "volatile_environment_names": []
                 },
                 "output_only_globs": [],
                 "profile_id": "",
@@ -14095,11 +14207,27 @@ expression: signatures
           ],
           "type": "object"
         },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "const": "attested",
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string"
+            },
+            {
+              "const": "recorded",
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string"
+            }
+          ]
+        },
         "VerificationInputManifest": {
           "additionalProperties": false,
           "properties": {
             "environment_names": {
               "default": [],
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
               "items": {
                 "type": "string"
               },
@@ -14116,6 +14244,14 @@ expression: signatures
               "default": 1,
               "format": "int64",
               "type": "integer"
+            },
+            "volatile_environment_names": {
+              "default": [],
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -14503,6 +14639,7 @@ expression: signatures
               "$ref": "#/$defs/LifecycleHooks",
               "default": {
                 "final_verification": {
+                  "evidence_tier": "attested",
                   "hermeticity": {
                     "hermetic": false,
                     "network_access": false,
@@ -14511,7 +14648,8 @@ expression: signatures
                   "input_manifest": {
                     "environment_names": [],
                     "repo_paths": [],
-                    "version": 1
+                    "version": 1,
+                    "volatile_environment_names": []
                   },
                   "output_only_globs": [],
                   "profile_id": "",
@@ -14651,6 +14789,11 @@ expression: signatures
               },
               "type": "array"
             },
+            "evidence_tier": {
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested",
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry."
+            },
             "hermeticity": {
               "$ref": "#/$defs/HermeticityDeclaration",
               "default": {
@@ -14664,7 +14807,8 @@ expression: signatures
               "default": {
                 "environment_names": [],
                 "repo_paths": [],
-                "version": 1
+                "version": 1,
+                "volatile_environment_names": []
               }
             },
             "output_only_globs": {
@@ -14894,6 +15038,7 @@ expression: signatures
             "final_verification": {
               "$ref": "#/$defs/FinalVerificationPlan",
               "default": {
+                "evidence_tier": "attested",
                 "hermeticity": {
                   "hermetic": false,
                   "network_access": false,
@@ -14902,7 +15047,8 @@ expression: signatures
                 "input_manifest": {
                   "environment_names": [],
                   "repo_paths": [],
-                  "version": 1
+                  "version": 1,
+                  "volatile_environment_names": []
                 },
                 "output_only_globs": [],
                 "profile_id": "",
@@ -15038,11 +15184,27 @@ expression: signatures
           ],
           "type": "object"
         },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "const": "attested",
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string"
+            },
+            {
+              "const": "recorded",
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string"
+            }
+          ]
+        },
         "VerificationInputManifest": {
           "additionalProperties": false,
           "properties": {
             "environment_names": {
               "default": [],
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
               "items": {
                 "type": "string"
               },
@@ -15059,6 +15221,14 @@ expression: signatures
               "default": 1,
               "format": "int64",
               "type": "integer"
+            },
+            "volatile_environment_names": {
+              "default": [],
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"
@@ -15420,6 +15590,7 @@ expression: signatures
               "$ref": "#/$defs/LifecycleHooks",
               "default": {
                 "final_verification": {
+                  "evidence_tier": "attested",
                   "hermeticity": {
                     "hermetic": false,
                     "network_access": false,
@@ -15428,7 +15599,8 @@ expression: signatures
                   "input_manifest": {
                     "environment_names": [],
                     "repo_paths": [],
-                    "version": 1
+                    "version": 1,
+                    "volatile_environment_names": []
                   },
                   "output_only_globs": [],
                   "profile_id": "",
@@ -15568,6 +15740,11 @@ expression: signatures
               },
               "type": "array"
             },
+            "evidence_tier": {
+              "$ref": "#/$defs/VerificationEvidenceTier",
+              "default": "attested",
+              "description": "What a recorded pass of this plan is worth. See\n[`VerificationEvidenceTier`]; the tier is identity material, so an\nattested pass and a recorded pass can never share a cache entry."
+            },
             "hermeticity": {
               "$ref": "#/$defs/HermeticityDeclaration",
               "default": {
@@ -15581,7 +15758,8 @@ expression: signatures
               "default": {
                 "environment_names": [],
                 "repo_paths": [],
-                "version": 1
+                "version": 1,
+                "volatile_environment_names": []
               }
             },
             "output_only_globs": {
@@ -15811,6 +15989,7 @@ expression: signatures
             "final_verification": {
               "$ref": "#/$defs/FinalVerificationPlan",
               "default": {
+                "evidence_tier": "attested",
                 "hermeticity": {
                   "hermetic": false,
                   "network_access": false,
@@ -15819,7 +15998,8 @@ expression: signatures
                 "input_manifest": {
                   "environment_names": [],
                   "repo_paths": [],
-                  "version": 1
+                  "version": 1,
+                  "volatile_environment_names": []
                 },
                 "output_only_globs": [],
                 "profile_id": "",
@@ -15955,11 +16135,27 @@ expression: signatures
           ],
           "type": "object"
         },
+        "VerificationEvidenceTier": {
+          "description": "The guarantee a persisted final-verification pass carries.\n\nThis is deliberately an enum rather than the absence of a flag: the two\ntiers promise materially different things, and a reader of a plan must be\nable to see which one is in force without reconstructing it from three\nbooleans.",
+          "oneOf": [
+            {
+              "const": "attested",
+              "description": "Commands ran under the strict launcher: fresh network namespace,\nLandlock ABI-V3, read-only worktree, and output-only directories that\nwere absent at launch. A pass certifies the commands succeeded in an\nisolated environment fully described by the identity digest.",
+              "type": "string"
+            },
+            {
+              "const": "recorded",
+              "description": "Commands ran as an ordinary warm, incremental build in the task-run Pod:\nno namespace, no Landlock, no output-directory precondition, and the\npre-existing build outputs left by earlier compiles are visible.\n\nA pass certifies only that (a) the whole-tree fingerprint was identical\nbefore and after, (b) the environment identity was identical before and\nafter, and (c) every configured command exited zero in that window. It\ndoes NOT certify independence from leftover build state — a poisoned\nincremental cache can produce a green recorded pass. That is the same\nexposure every task compile already accepts; this tier makes accepting\nit a deliberate, named choice rather than an implied one.",
+              "type": "string"
+            }
+          ]
+        },
         "VerificationInputManifest": {
           "additionalProperties": false,
           "properties": {
             "environment_names": {
               "default": [],
+              "description": "Environment names whose **values** are identity material: the resolved\nvalue is hashed into the environment identity digest, so a change to it\ninvalidates every reusable pass. Use this for anything whose value\ngenuinely changes what the commands do (`PATH`, `CARGO_HOME`,\n`CARGO_BUILD_RUSTFLAGS`).",
               "items": {
                 "type": "string"
               },
@@ -15976,6 +16172,14 @@ expression: signatures
               "default": 1,
               "format": "int64",
               "type": "integer"
+            },
+            "volatile_environment_names": {
+              "default": [],
+              "description": "Environment names that are declared and passed to commands, but whose\n**values** are deliberately NOT identity material — only the name is\n(via this manifest). The resolved value never reaches the identity\ndigest, so a per-run value does not fracture reuse across task runs.\n\nThis is the same contract catalog services already have: a declared\nname with an attempt-scoped value. It exists because the production\npod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`\n(a fresh path per run) and `RUSTC_WRAPPER=\"\"` (an empty value, which\nidentity material forbids). Hashing either would mean a worker run and\nthe reviewer run of the same task could never share a pass — which is\nthe entire point of the recorded tier.\n\nRejected unless `evidence_tier` is `recorded`: an unhashed input would\nvoid the attested tier's guarantee.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object"

--- a/ui/src/api/environmentConfig.ts
+++ b/ui/src/api/environmentConfig.ts
@@ -148,6 +148,13 @@ export interface FinalVerificationPlan {
   read_only_external_inputs?: Array<Record<string, string>>;
   output_only_globs?: string[];
   hermeticity?: Record<string, boolean>;
+  /**
+   * `"attested"` (isolated, the default) or `"recorded"` (an ordinary warm,
+   * incremental build). Mirrors
+   * `djinn_stack::environment::VerificationEvidenceTier`; it states what a
+   * persisted pass of this plan is actually worth.
+   */
+  evidence_tier?: "attested" | "recorded";
 }
 
 export interface LifecycleHooks {

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -2814,6 +2814,12 @@ export namespace ImageCreateInputSchema {
    * migrated without a flag day.
    */
   commands?: FinalVerificationCommand[]
+  /**
+   * What a recorded pass of this plan is worth. See
+   * [`VerificationEvidenceTier`]; the tier is identity material, so an
+   * attested pass and a recorded pass can never share a cache entry.
+   */
+  evidence_tier?: ("attested" | "recorded")
   hermeticity?: HermeticityDeclaration
   input_manifest?: VerificationInputManifest
   output_only_globs?: string[]
@@ -2849,9 +2855,34 @@ export namespace ImageCreateInputSchema {
   reusable?: boolean
   }
   export interface VerificationInputManifest {
+  /**
+   * Environment names whose **values** are identity material: the resolved
+   * value is hashed into the environment identity digest, so a change to it
+   * invalidates every reusable pass. Use this for anything whose value
+   * genuinely changes what the commands do (`PATH`, `CARGO_HOME`,
+   * `CARGO_BUILD_RUSTFLAGS`).
+   */
   environment_names?: string[]
   repo_paths?: string[]
   version?: number
+  /**
+   * Environment names that are declared and passed to commands, but whose
+   * **values** are deliberately NOT identity material — only the name is
+   * (via this manifest). The resolved value never reaches the identity
+   * digest, so a per-run value does not fracture reuse across task runs.
+   * 
+   * This is the same contract catalog services already have: a declared
+   * name with an attempt-scoped value. It exists because the production
+   * pod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`
+   * (a fresh path per run) and `RUSTC_WRAPPER=""` (an empty value, which
+   * identity material forbids). Hashing either would mean a worker run and
+   * the reviewer run of the same task could never share a pass — which is
+   * the entire point of the recorded tier.
+   * 
+   * Rejected unless `evidence_tier` is `recorded`: an unhashed input would
+   * void the attested tier's guarantee.
+   */
+  volatile_environment_names?: string[]
   }
   export interface ExternalInputDeclaration {
   id: string
@@ -3241,6 +3272,12 @@ export namespace ImageListOutputSchema {
    * migrated without a flag day.
    */
   commands?: FinalVerificationCommand[]
+  /**
+   * What a recorded pass of this plan is worth. See
+   * [`VerificationEvidenceTier`]; the tier is identity material, so an
+   * attested pass and a recorded pass can never share a cache entry.
+   */
+  evidence_tier?: ("attested" | "recorded")
   hermeticity?: HermeticityDeclaration
   input_manifest?: VerificationInputManifest
   output_only_globs?: string[]
@@ -3276,9 +3313,34 @@ export namespace ImageListOutputSchema {
   reusable?: boolean
   }
   export interface VerificationInputManifest {
+  /**
+   * Environment names whose **values** are identity material: the resolved
+   * value is hashed into the environment identity digest, so a change to it
+   * invalidates every reusable pass. Use this for anything whose value
+   * genuinely changes what the commands do (`PATH`, `CARGO_HOME`,
+   * `CARGO_BUILD_RUSTFLAGS`).
+   */
   environment_names?: string[]
   repo_paths?: string[]
   version?: number
+  /**
+   * Environment names that are declared and passed to commands, but whose
+   * **values** are deliberately NOT identity material — only the name is
+   * (via this manifest). The resolved value never reaches the identity
+   * digest, so a per-run value does not fracture reuse across task runs.
+   * 
+   * This is the same contract catalog services already have: a declared
+   * name with an attempt-scoped value. It exists because the production
+   * pod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`
+   * (a fresh path per run) and `RUSTC_WRAPPER=""` (an empty value, which
+   * identity material forbids). Hashing either would mean a worker run and
+   * the reviewer run of the same task could never share a pass — which is
+   * the entire point of the recorded tier.
+   * 
+   * Rejected unless `evidence_tier` is `recorded`: an unhashed input would
+   * void the attested tier's guarantee.
+   */
+  volatile_environment_names?: string[]
   }
   export interface ExternalInputDeclaration {
   id: string
@@ -3644,6 +3706,12 @@ export namespace ImageUpdateInputSchema {
    * migrated without a flag day.
    */
   commands?: FinalVerificationCommand[]
+  /**
+   * What a recorded pass of this plan is worth. See
+   * [`VerificationEvidenceTier`]; the tier is identity material, so an
+   * attested pass and a recorded pass can never share a cache entry.
+   */
+  evidence_tier?: ("attested" | "recorded")
   hermeticity?: HermeticityDeclaration
   input_manifest?: VerificationInputManifest
   output_only_globs?: string[]
@@ -3679,9 +3747,34 @@ export namespace ImageUpdateInputSchema {
   reusable?: boolean
   }
   export interface VerificationInputManifest {
+  /**
+   * Environment names whose **values** are identity material: the resolved
+   * value is hashed into the environment identity digest, so a change to it
+   * invalidates every reusable pass. Use this for anything whose value
+   * genuinely changes what the commands do (`PATH`, `CARGO_HOME`,
+   * `CARGO_BUILD_RUSTFLAGS`).
+   */
   environment_names?: string[]
   repo_paths?: string[]
   version?: number
+  /**
+   * Environment names that are declared and passed to commands, but whose
+   * **values** are deliberately NOT identity material — only the name is
+   * (via this manifest). The resolved value never reaches the identity
+   * digest, so a per-run value does not fracture reuse across task runs.
+   * 
+   * This is the same contract catalog services already have: a declared
+   * name with an attempt-scoped value. It exists because the production
+   * pod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`
+   * (a fresh path per run) and `RUSTC_WRAPPER=""` (an empty value, which
+   * identity material forbids). Hashing either would mean a worker run and
+   * the reviewer run of the same task could never share a pass — which is
+   * the entire point of the recorded tier.
+   * 
+   * Rejected unless `evidence_tier` is `recorded`: an unhashed input would
+   * void the attested tier's guarantee.
+   */
+  volatile_environment_names?: string[]
   }
   export interface ExternalInputDeclaration {
   id: string
@@ -6303,6 +6396,12 @@ export namespace ProjectEnvironmentConfigGetOutputSchema {
    * migrated without a flag day.
    */
   commands?: FinalVerificationCommand[]
+  /**
+   * What a recorded pass of this plan is worth. See
+   * [`VerificationEvidenceTier`]; the tier is identity material, so an
+   * attested pass and a recorded pass can never share a cache entry.
+   */
+  evidence_tier?: ("attested" | "recorded")
   hermeticity?: HermeticityDeclaration
   input_manifest?: VerificationInputManifest
   output_only_globs?: string[]
@@ -6338,9 +6437,34 @@ export namespace ProjectEnvironmentConfigGetOutputSchema {
   reusable?: boolean
   }
   export interface VerificationInputManifest {
+  /**
+   * Environment names whose **values** are identity material: the resolved
+   * value is hashed into the environment identity digest, so a change to it
+   * invalidates every reusable pass. Use this for anything whose value
+   * genuinely changes what the commands do (`PATH`, `CARGO_HOME`,
+   * `CARGO_BUILD_RUSTFLAGS`).
+   */
   environment_names?: string[]
   repo_paths?: string[]
   version?: number
+  /**
+   * Environment names that are declared and passed to commands, but whose
+   * **values** are deliberately NOT identity material — only the name is
+   * (via this manifest). The resolved value never reaches the identity
+   * digest, so a per-run value does not fracture reuse across task runs.
+   * 
+   * This is the same contract catalog services already have: a declared
+   * name with an attempt-scoped value. It exists because the production
+   * pod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`
+   * (a fresh path per run) and `RUSTC_WRAPPER=""` (an empty value, which
+   * identity material forbids). Hashing either would mean a worker run and
+   * the reviewer run of the same task could never share a pass — which is
+   * the entire point of the recorded tier.
+   * 
+   * Rejected unless `evidence_tier` is `recorded`: an unhashed input would
+   * void the attested tier's guarantee.
+   */
+  volatile_environment_names?: string[]
   }
   export interface ExternalInputDeclaration {
   id: string
@@ -6690,6 +6814,12 @@ export namespace ProjectEnvironmentConfigResetOutputSchema {
    * migrated without a flag day.
    */
   commands?: FinalVerificationCommand[]
+  /**
+   * What a recorded pass of this plan is worth. See
+   * [`VerificationEvidenceTier`]; the tier is identity material, so an
+   * attested pass and a recorded pass can never share a cache entry.
+   */
+  evidence_tier?: ("attested" | "recorded")
   hermeticity?: HermeticityDeclaration
   input_manifest?: VerificationInputManifest
   output_only_globs?: string[]
@@ -6725,9 +6855,34 @@ export namespace ProjectEnvironmentConfigResetOutputSchema {
   reusable?: boolean
   }
   export interface VerificationInputManifest {
+  /**
+   * Environment names whose **values** are identity material: the resolved
+   * value is hashed into the environment identity digest, so a change to it
+   * invalidates every reusable pass. Use this for anything whose value
+   * genuinely changes what the commands do (`PATH`, `CARGO_HOME`,
+   * `CARGO_BUILD_RUSTFLAGS`).
+   */
   environment_names?: string[]
   repo_paths?: string[]
   version?: number
+  /**
+   * Environment names that are declared and passed to commands, but whose
+   * **values** are deliberately NOT identity material — only the name is
+   * (via this manifest). The resolved value never reaches the identity
+   * digest, so a per-run value does not fracture reuse across task runs.
+   * 
+   * This is the same contract catalog services already have: a declared
+   * name with an attempt-scoped value. It exists because the production
+   * pod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`
+   * (a fresh path per run) and `RUSTC_WRAPPER=""` (an empty value, which
+   * identity material forbids). Hashing either would mean a worker run and
+   * the reviewer run of the same task could never share a pass — which is
+   * the entire point of the recorded tier.
+   * 
+   * Rejected unless `evidence_tier` is `recorded`: an unhashed input would
+   * void the attested tier's guarantee.
+   */
+  volatile_environment_names?: string[]
   }
   export interface ExternalInputDeclaration {
   id: string
@@ -7070,6 +7225,12 @@ export namespace ProjectEnvironmentConfigSetInputSchema {
    * migrated without a flag day.
    */
   commands?: FinalVerificationCommand[]
+  /**
+   * What a recorded pass of this plan is worth. See
+   * [`VerificationEvidenceTier`]; the tier is identity material, so an
+   * attested pass and a recorded pass can never share a cache entry.
+   */
+  evidence_tier?: ("attested" | "recorded")
   hermeticity?: HermeticityDeclaration
   input_manifest?: VerificationInputManifest
   output_only_globs?: string[]
@@ -7105,9 +7266,34 @@ export namespace ProjectEnvironmentConfigSetInputSchema {
   reusable?: boolean
   }
   export interface VerificationInputManifest {
+  /**
+   * Environment names whose **values** are identity material: the resolved
+   * value is hashed into the environment identity digest, so a change to it
+   * invalidates every reusable pass. Use this for anything whose value
+   * genuinely changes what the commands do (`PATH`, `CARGO_HOME`,
+   * `CARGO_BUILD_RUSTFLAGS`).
+   */
   environment_names?: string[]
   repo_paths?: string[]
   version?: number
+  /**
+   * Environment names that are declared and passed to commands, but whose
+   * **values** are deliberately NOT identity material — only the name is
+   * (via this manifest). The resolved value never reaches the identity
+   * digest, so a per-run value does not fracture reuse across task runs.
+   * 
+   * This is the same contract catalog services already have: a declared
+   * name with an attempt-scoped value. It exists because the production
+   * pod renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`
+   * (a fresh path per run) and `RUSTC_WRAPPER=""` (an empty value, which
+   * identity material forbids). Hashing either would mean a worker run and
+   * the reviewer run of the same task could never share a pass — which is
+   * the entire point of the recorded tier.
+   * 
+   * Rejected unless `evidence_tier` is `recorded`: an unhashed input would
+   * void the attested tier's guarantee.
+   */
+  volatile_environment_names?: string[]
   }
   export interface ExternalInputDeclaration {
   id: string


### PR DESCRIPTION
## Why

Proposal `czd9` shipped `done` with 14/14 acceptance criteria and does **nothing** in production. Two things were true at once:

1. The djinn project's `final_verification` plan is empty, so `resolve_final_verification_for_task_run` short-circuits to `NotConfigured` and no verification is ever recorded or reused.
2. **Filling that plan was impossible.** `reusable: true` required `hermetic: true`, and hermetic means a fresh net namespace, Landlock ABI-V3, a read-only `/usr` (so a read-only `CARGO_HOME`, where cargo cannot even take its `.package-cache` lock), and output directories that must be *absent at launch* — i.e. a cold full build per submission, replacing today's two warm incremental ones.

Worse than "reuse was impossible": **no plan worked at all.** `final_verification_execution.rs` returned `NonHermeticPlan` for `reusable: false` too, so any configured plan was permanently `Ineligible` and would have blocked every submission.

The insight this builds on: hermeticity is about *trusting* a result; it is not what *computes* the fingerprint. The expensive half was already built and correct — `compute_verification_input_fingerprint_with_config` hashes the merge-base and HEAD, the whole git index, full content bytes of every tracked worktree entry, submodule gitlink state, and every untracked *and ignored* file. "Did anything change" was already answered properly.

## What this does

Adds an explicit `evidence_tier` to the final-verification plan so a pass from an **ordinary warm, incremental** build can be reused, keyed on the existing fingerprint.

```jsonc
"evidence_tier": "recorded",
"hermeticity": { "hermetic": false, "reusable": true, "network_access": true }
```

An enum rather than permitting `reusable: true, hermetic: false`, because the two tiers promise materially different things and a reader must see which is in force without reconstructing it from three booleans. The tier is identity material, so a recorded pass and an attested pass can never satisfy each other's reuse lookup — the digest itself separates the two cache spaces.

**What a recorded pass guarantees:** the whole-tree fingerprint was byte-identical at F0 and F1; the environment identity was identical before and after; every configured command exited 0 in that window; required checks were fully covered. C0/C1/F0/F1/C2 recompute discipline, the freshness evaluator, and the `project.<id>.verify_run_reuse_enabled` shadow switch are all unchanged.

**What it does not guarantee:** independence from the warm `CARGO_TARGET_DIR`, or from ambient state not named in the manifest. A poisoned incremental cache can produce a green recorded pass. Every task compile in a djinn Pod already runs under exactly those conditions, so this is not a new exposure — but it is now a named, deliberate choice rather than an implied one. The operator surface is the config field itself (you cannot get warm reuse without typing `"recorded"`), plus an `evidence_tier` field on the recording/lookup audit events. Deliberately **not** a metric label: the tier is a per-project constant, so a label would add cardinality without information.

### Three supporting changes, each required to make the above actually run

**Exclusion decoupled from purge.** `output_only_globs` did two jobs: excluding paths from the fingerprint *and* deleting them. Exclusion is not optional — `git ls-files --others -i` enumerates ignored files individually and each is then read in full, so without it a warm worktree hashes every byte of `ui/node_modules`. But the purge would delete the very warm cache a recorded run reuses, and it runs on *every* fingerprint including the C0/C1/C2 reuse checkpoints. New `OutputOnlyPolicy::{PurgeBeforeFingerprint, ExcludeOnly}` splits them; attested keeps today's behaviour.

**Environment resolution (landed defect).** `allowlisted_environment` was hardcoded `BTreeMap::new()` in production, so `command_environment` rejected any name a catalog service did not export — `PATH`, `HOME`, `CARGO_HOME`, `CARGO_TARGET_DIR` could not be passed at all, and the schema advertised an `environment_names` list production could not satisfy. Now resolved from the host process environment, in two declared buckets:

| bucket | value hashed into identity? | empty value |
|---|---|---|
| `environment_names` | yes | rejected |
| `volatile_environment_names` | **no** (only the name is) | allowed |

The second bucket is not a loophole — it is the contract catalog service exports already have (declared name, attempt-scoped value). It exists for exactly two names, and without it the feature cannot work: production renders `CARGO_TARGET_DIR=/cache/cargo-target-runs/<task_run_id>`, a fresh path per run, so hashing it would mean a worker run and the reviewer run of the same task could *never* share a pass; and `RUSTC_WRAPPER=""` is an empty value, which identity material forbids. `volatile_environment_names` is rejected unless the tier is `recorded` — an unhashed input would void attestation.

**`reusable` is now a real kill-switch.** It previously influenced nothing but the identity digest; setting it false still permitted a cache hit. It now gates consultation, giving a genuine per-project "run and record, never reuse" mode.

### Landed defects deliberately RETAINED — please read before assuming a regression

Both are properties of the hermetic path and reworking the strict launcher is out of scope for a change already touching the identity model and the config schema. **The attested tier remains unusable for a compiling plan until they are fixed.** That is the pre-existing state, not something this PR introduces.

1. **`output_only_globs` make an attested plan work at most once per worktree.** `cleanup_output_dir` deletes entries *matching* the globs; `server/target/**` compiles to `^server/target/.*$`, which matches children but not the directory itself, so an empty `server/target/` survives and the launcher rejects with `OutputOnlyPreexisting`. No glob spelling escapes it: a directory-matching glob has no literal prefix and fails `output_directories()`, while `target` + `target/**` is rejected as overlapping. Documented in place.
2. **Only the first attested command gets a writable directory**, so an attested multi-command plan where each step compiles is impossible. Documented in place.

Both are **moot for the recorded tier**: it purges nothing, requires no absent directory, holds no write grant, and every command can write the worktree as an ordinary build does.

## Payoff

A reviewer run gets a *different* `CARGO_TARGET_DIR` (`/cache/cargo-target-runs/<fresh uuid>`), created per run and deleted at teardown, re-seeded by hardlink from the shared warm base. So a reuse hit skips a full target-dir **re-seed plus** the incremental delta build — not merely a marginal rebuild. That is the argument for doing this at all.

## Testing

Tests drive the real execution and reuse paths: the real project config, the real resolver, the real coordinator, a real Postgres row, a real git worktree, and a real spawned command. No hand-built `PlatformCache`/`VerifyRun`, and no injected `FinalVerificationExecutionEvidence`.

This mattered concretely. The first green-looking run was a **false pass**: `AgentHostCallbacks` short-circuits the coordinator under `#[cfg(test)]` with a synthetic `Stored` outcome carrying `"test-fingerprint"`, and every outcome assertion passed while nothing executed. What caught it was asserting a *side effect* — a marker file appended to by the command itself, kept outside the worktree so observing it cannot perturb the fingerprint under test. The tests now attach the observation probe and assert `terminal_outcome_shortcuts == 0`.

The load-bearing test is `worker_and_reviewer_clones_of_one_task_fingerprint_identically`: two independent task_runs of one task, one a worked-in worktree with ignored build residue, the other a fresh clone with none, must record the **same** `verification_input_fingerprint`. If a fresh clone and a worked-in worktree fingerprinted differently, reuse could never hit and this would ship as an elaborate no-op that reports success.

Also covered: worker records → reviewer reuses without re-running (proven by the marker); tracked, untracked, and **ignored-but-undeclared** changes each independently force a fresh run (three different code paths into the fingerprint — and the ignored case is the one an over-broad glob would silently erase, converting a no-op into a *wrong* answer); excluded build output is excluded but **not deleted**; record-only mode records every run and reuses none; a non-reusable plan is never reused; declared environment reaches the command; a volatile value differing between runs does not move the identity digest.

## Follow-up (not in scope)

The recorded launcher spawns directly and so does not go through the cgroup CPU-lease broker: a recorded compile runs unleased *and* at un-pinned parallelism, since `CARGO_BUILD_JOBS`/`NEXTEST_TEST_THREADS` are normally overridden per-spawn by the launcher. The attested launcher has the identical gap today. Routing final verification through the lease path touches `build_admission.rs`/`build_lease.rs`, owned by another agent (#25).

## Rollout

This ships dark. `evidence_tier` defaults to `attested`, so merging changes nothing — the djinn plan is still empty.

1. Apply the plan JSON with `verify_run_reuse_enabled` absent (defaults off). Every submission runs and records; consultation emits `disabled`/`default_off` and never suppresses.
2. Confirm two runs of one task record the same `verification_input_fingerprint`. (Now also asserted by test, but confirm against the real repo's ignore set.)
3. Set `project.<id>.verify_run_reuse_enabled = true`. Watch `verify_run_lookup_outcome=hit`.
4. Roll back by clearing the setting.
