### PR TITLE
fix(build-admission): Reclaim build leases and admission rows whose Kubernetes object is gone

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission_inventory.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_inventory.rs
@@ -45,7 +45,40 @@ pub struct InventoryReport {
     pub stale: usize,
     /// Reclamations refused because the row changed after its absence proof.
     pub fenced: usize,
+    /// Named per-row reclamation failures, bounded by
+    /// [`MAX_NAMED_RECLAIM_FAILURES`]. See `reclaim_failure_count` for the
+    /// exact total.
+    ///
+    /// Deliberately not `blockers`: failing to retire one row leaves that row
+    /// occupying, which over-counts capacity. Over-counting is the conservative
+    /// direction — it can only deny admissions, never over-admit — so it must
+    /// not fail the whole pass and must not gate Enforce on the namespace's
+    /// history instead of its current state.
+    pub reclaim_failures: Vec<String>,
+    /// Exact number of per-row reclamation failures, named or not.
+    pub reclaim_failure_count: usize,
+    /// Pass-level failures. A non-empty `blockers` means the pass could not be
+    /// trusted at all (unusable listing, unreadable journal, failed seeding)
+    /// and Enforce stays fail-closed.
     pub blockers: Vec<String>,
+}
+
+/// Bound on how many individual reclaim failures one pass names. The count is
+/// always exact; the samples exist so an operator can see *which* row without a
+/// log line that grows with the stale population.
+pub const MAX_NAMED_RECLAIM_FAILURES: usize = 5;
+
+impl InventoryReport {
+    /// Record one per-row reclamation failure without failing the pass.
+    fn reclaim_failure(&mut self, row: &AdmissionJournalRow, error: &str) {
+        self.reclaim_failure_count += 1;
+        if self.reclaim_failures.len() < MAX_NAMED_RECLAIM_FAILURES {
+            self.reclaim_failures.push(format!(
+                "{}:{}:{}: {error}",
+                row.key.work_id, row.key.generation, row.object_name
+            ));
+        }
+    }
 }
 fn identity(key: &AdmissionJournalKey) -> String {
     format!("{:?}:{}:{}", key.domain, key.work_id, key.generation)
@@ -215,6 +248,36 @@ impl BuildAdmissionReconciler {
             == ObjectPresence::Absent
     }
 
+    /// Classify one failed retirement of a single occupying row.
+    ///
+    /// A rejected transition is a decision about that one row: its own identity
+    /// no longer permits the write. Costing all 58 rows for one of them is what
+    /// made arming Enforce depend on the namespace's *history* rather than its
+    /// current state, so it is counted, named within a bound, and the sweep
+    /// continues. Anything else — a connection loss, a serialization failure —
+    /// says nothing about the row and everything about the journal, so it stays
+    /// a pass-level blocker and marks the journal unhealthy.
+    fn record_reclaim_failure(
+        &self,
+        out: &mut InventoryReport,
+        row: &AdmissionJournalRow,
+        error: &djinn_db::Error,
+    ) {
+        if matches!(error, djinn_db::Error::InvalidTransition(_)) {
+            out.reclaim_failure(row, &error.to_string());
+            tracing::warn!(
+                work_id = %row.key.work_id,
+                generation = row.key.generation,
+                object = %row.object_name,
+                %error,
+                "build_admission: one occupying row could not be retired; reclamation continues"
+            );
+            return;
+        }
+        self.controller.mark_journal_unhealthy();
+        out.blockers.push(error.to_string());
+    }
+
     pub async fn reconcile(&self) -> InventoryReport {
         let _g = self.serial.lock().await;
         if self.controller.mode() == BuildAdmissionMode::Off {
@@ -302,36 +365,91 @@ impl BuildAdmissionReconciler {
         for row in &active {
             let id = identity(&row.key);
             if row.state == AdmissionState::Live {
-                let proof = if let Some(c) = by.get(&id) {
+                // Two different proofs, and they need two different writes.
+                //
+                // A *completed* object still exists, so its lifecycle callback
+                // is the ordinary one and `mark_terminal`'s latest-generation
+                // fence is meaningful. A *vanished* object has no lifecycle
+                // left to run, and requiring the row to be the latest
+                // generation there is precisely backwards: a Live row that a
+                // later generation has already superseded is the population
+                // most in need of retiring, and `mark_terminal` rejects exactly
+                // it with `stale admission generation`. That rejection is what
+                // left 58 superseded Live rows occupying the cap while every
+                // reconciliation pass reported them as blockers.
+                let completed = by.get(&id).is_some_and(|c| {
                     c.object.terminal && c.object.uid.as_deref() == row.object_uid.as_deref()
-                } else if let Some(uid) = row.object_uid.as_deref() {
-                    self.inventory
-                        .get_uid(WorkloadObjectKind::Job, &row.object_name, uid)
-                        .await
-                        == UidGetResult::NotFound
-                } else {
-                    false
-                };
-                if proof {
-                    out.stale += 1;
+                });
+                // Absence is proven the same way it always was, plus the LIST
+                // fence a pre-Live row already gets: the authoritative listing
+                // holds no object under this name, and a direct GET — which
+                // answers `NotFound` only on an authoritative `Ok(None)`, never
+                // on a transport failure — agrees. A Live row recorded a UID, so
+                // that GET is the same probe `presence` would make; asking twice
+                // would only add a second chance for a transient `Uncertain` to
+                // discard a valid proof.
+                let absent = !completed
+                    && !listed_names.contains(&row.object_name)
+                    && match row.object_uid.as_deref() {
+                        Some(uid) => {
+                            self.inventory
+                                .get_uid(WorkloadObjectKind::Job, &row.object_name, uid)
+                                .await
+                                == UidGetResult::NotFound
+                        }
+                        None => false,
+                    };
+                if !completed && !absent {
+                    continue;
+                }
+                out.stale += 1;
+                let outcome = if absent {
+                    // Generation-agnostic, fenced on the full observed identity.
                     match self
                         .controller
+                        .journal()
+                        .reclaim_absent_object(&ReclaimAbsentInput {
+                            key: row.key.clone(),
+                            observed_state: row.state,
+                            observed_creator_server_epoch: row.creator_server_epoch.clone(),
+                            observed_object_name: row.object_name.clone(),
+                            observed_object_uid: row.object_uid.clone(),
+                        })
+                        .await
+                    {
+                        Ok(ReclaimAbsentOutcome::Reclaimed(_)) => Ok(true),
+                        Ok(ReclaimAbsentOutcome::AlreadyTerminal(_)) => Ok(false),
+                        Ok(ReclaimAbsentOutcome::Fenced { reason }) => {
+                            out.fenced += 1;
+                            tracing::warn!(
+                                work_id = %row.key.work_id,
+                                generation = row.key.generation,
+                                object = %row.object_name,
+                                %reason,
+                                "build_admission: refused to retire a Live admission row that \
+                                 changed after its absence proof"
+                            );
+                            Ok(false)
+                        }
+                        Err(error) => Err(error),
+                    }
+                } else {
+                    self.controller
                         .journal()
                         .mark_terminal(&TerminalAdmissionInput {
                             key: row.key.clone(),
                             object_uid: row.object_uid.clone(),
                         })
                         .await
-                    {
-                        Ok(_) => {
-                            out.released += 1;
-                            self.controller.release_notifier().notify_one();
-                        }
-                        Err(error) => {
-                            self.controller.mark_journal_unhealthy();
-                            out.blockers.push(error.to_string());
-                        }
+                        .map(|_| true)
+                };
+                match outcome {
+                    Ok(true) => {
+                        out.released += 1;
+                        self.controller.release_notifier().notify_one();
                     }
+                    Ok(false) => {}
+                    Err(error) => self.record_reclaim_failure(&mut out, row, &error),
                 }
                 continue;
             }
@@ -378,10 +496,7 @@ impl BuildAdmissionReconciler {
                          after its absence proof"
                     );
                 }
-                Err(error) => {
-                    self.controller.mark_journal_unhealthy();
-                    out.blockers.push(error.to_string());
-                }
+                Err(error) => self.record_reclaim_failure(&mut out, row, &error),
             }
         }
         if out.blockers.is_empty() {

--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -17,8 +17,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use djinn_core::events::EventBus;
 use djinn_db::{
-    AdmissionDomain, AdmissionJournalRepository, AdmissionState, Database, ImageRepository,
-    ProjectRepository,
+    AdmissionDomain, AdmissionJournalKey, AdmissionJournalRepository, AdmissionState,
+    AdmissionWorkloadKind, CreateStartedInput, Database, ImageRepository, ProjectRepository,
+    ReserveAdmissionInput, ReserveAdmissionResult, TerminalAdmissionInput, UidFencedAdmissionInput,
 };
 use djinn_k8s::{
     K8sGraphWarmer, KubernetesConfig, ObjectPresence, UidGetResult, WarmAdmission,
@@ -497,4 +498,229 @@ async fn current_epoch_and_unsettled_rows_are_never_reclaimed() {
         "an unsettled row is not yet safe to judge by a listing"
     );
     assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 1);
+}
+
+/// One task's durable generation history, written through the journal
+/// primitives a pre-`ymx9` server called.
+///
+/// Before `ymx9` the caller supplied the generation (a task's `reopen_count`)
+/// and the journal trusted it, so a dispatch could open generation N+1 while
+/// generation N was still `live`. Post-`ymx9` resolution cannot produce that
+/// shape any more, but production is full of rows that predate it: at the time
+/// of writing, 58 `live` `task_observation` rows, every one of them superseded
+/// by a later generation. `reserve` with an explicit generation IS the
+/// pre-`ymx9` call, so this is the production writer, not a fixture.
+async fn pre_ymx9_generation_history(
+    journal: &AdmissionJournalRepository,
+    work_id: &str,
+    generations: &[(i64, bool)],
+) {
+    for (generation, terminal) in generations {
+        let key = AdmissionJournalKey {
+            domain: AdmissionDomain::TaskObservation,
+            work_id: work_id.into(),
+            generation: *generation,
+        };
+        let object_name = format!("task-run-{work_id}-{generation}");
+        let object_uid = format!("uid-{work_id}-{generation}");
+        let reserved = journal
+            .reserve(
+                &ReserveAdmissionInput {
+                    key: key.clone(),
+                    workload_kind: AdmissionWorkloadKind::Task,
+                    creator_server_epoch: PREDECESSOR_EPOCH.into(),
+                    object_name: object_name.clone(),
+                },
+                64,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(reserved, ReserveAdmissionResult::Reserved { .. }));
+        journal
+            .mark_create_started(&CreateStartedInput {
+                key: key.clone(),
+                creator_server_epoch: PREDECESSOR_EPOCH.into(),
+                object_name,
+            })
+            .await
+            .unwrap();
+        journal
+            .mark_live(&UidFencedAdmissionInput {
+                key: key.clone(),
+                object_uid: object_uid.clone(),
+            })
+            .await
+            .unwrap();
+        if *terminal {
+            journal
+                .mark_terminal(&TerminalAdmissionInput {
+                    key,
+                    object_uid: Some(object_uid),
+                })
+                .await
+                .unwrap();
+        }
+    }
+}
+
+/// The exact production shape behind
+/// `invalid transition: stale admission generation 1 for 019f6f04-…`.
+///
+/// A `live` generation that a later generation superseded is the population
+/// most in need of reclaiming, and requiring it to be the latest generation
+/// vetoes precisely its own reclamation. Absence still has to be proven — the
+/// namespace listing and the direct GET both answer that the object is gone —
+/// but a stale generation is not a reason to occupy the cap forever.
+#[tokio::test]
+async fn superseded_live_generations_are_reclaimed_once_their_object_is_proven_absent() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    // The three work ids blocking production reconciliation, generation for
+    // generation: a terminal predecessor, an orphaned `live` middle, and a
+    // terminal successor that makes the middle row stale.
+    for work_id in [
+        "019f6f04-b477-7851-8be9-ce2e41453d46",
+        "019f6fed-d0c9-7441-bf25-502e6d9e6e2e",
+    ] {
+        pre_ymx9_generation_history(&journal, work_id, &[(0, true), (1, false), (2, true)]).await;
+    }
+    // The remaining production row: generation 0 orphaned, 1 and 2 terminal.
+    pre_ymx9_generation_history(
+        &journal,
+        "019f6fec-f41c-7da0-9e14-34cea42b7dd5",
+        &[(0, false), (1, true), (2, true)],
+    )
+    .await;
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        3,
+        "three superseded live generations occupy the cap"
+    );
+
+    let controller = replacement(&journal, 3);
+    controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    controller.mark_topology_ready();
+
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+
+    assert!(
+        report.blockers.is_empty(),
+        "a stale generation must not veto its own reclamation: {:?}",
+        report.blockers
+    );
+    assert_eq!(report.reclaim_failure_count, 0);
+    assert_eq!(report.stale, 3);
+    assert_eq!(report.released, 3);
+    assert_eq!(report.fenced, 0);
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        0,
+        "the whole superseded population must be retired"
+    );
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::Healthy,
+        "Enforce must arm on the namespace's current state, not its history"
+    );
+}
+
+/// One unreclaimable row must cost one row, not the whole pass.
+///
+/// The unreclaimable row here is a superseded `live` generation whose Job still
+/// exists and has completed: the object is present, so the ordinary
+/// `mark_terminal` callback applies and its latest-generation fence rejects the
+/// write. That rejection is a fact about one row. While it failed the pass, a
+/// namespace holding one such object denied every other row's reclamation and
+/// left Enforce fail-closed on history rather than current state.
+#[tokio::test]
+async fn one_unreclaimable_row_costs_one_row_and_the_sweep_continues() {
+    let db = Database::open_in_memory().unwrap();
+    let journal = Arc::new(AdmissionJournalRepository::new(db.clone()));
+    pre_ymx9_generation_history(&journal, "completed-object", &[(0, false), (1, true)]).await;
+    for index in 0..3 {
+        pre_ymx9_generation_history(
+            &journal,
+            &format!("absent-object-{index}"),
+            &[(0, false), (1, true)],
+        )
+        .await;
+    }
+    assert_eq!(journal.count_task_or_warm_occupancy().await.unwrap(), 4);
+
+    // The superseded row's Job is still in the namespace, carries the admission
+    // identity the dispatch path stamps on it, and has completed. The object is
+    // present, so its ordinary lifecycle callback applies — and that callback
+    // is the one whose latest-generation fence rejects a superseded row.
+    let completed = WorkloadRecord {
+        kind: WorkloadObjectKind::Job,
+        name: "task-run-completed-object-0".into(),
+        uid: Some("uid-completed-object-0".into()),
+        labels: [
+            (
+                djinn_k8s::LABEL_ADMISSION_DOMAIN.to_string(),
+                "task_observation".to_string(),
+            ),
+            (
+                djinn_k8s::LABEL_ADMISSION_WORK_ID.to_string(),
+                "completed-object".to_string(),
+            ),
+            (
+                djinn_k8s::LABEL_ADMISSION_GENERATION.to_string(),
+                "0".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        terminal: true,
+        images: vec!["djinn:test".into()],
+        commands: vec!["djinn-agent-worker".into()],
+    };
+
+    let controller = replacement(&journal, 3);
+    controller
+        .recover_all_predecessors_and_seed()
+        .await
+        .unwrap();
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&controller),
+        Arc::new(NamespaceInventory::holding(vec![completed])),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+
+    assert!(
+        report.blockers.is_empty(),
+        "a per-row reclaim failure is not a pass-level blocker: {:?}",
+        report.blockers
+    );
+    assert_eq!(
+        report.reclaim_failure_count, 1,
+        "exactly one row could not be retired"
+    );
+    assert_eq!(report.reclaim_failures.len(), 1);
+    assert!(
+        report.reclaim_failures[0].contains("completed-object")
+            && report.reclaim_failures[0].contains("stale admission generation"),
+        "the failure must name the row and its cause: {:?}",
+        report.reclaim_failures
+    );
+    assert_eq!(
+        report.released, 3,
+        "the three rows whose objects are absent must still be retired"
+    );
+    assert_eq!(
+        journal.count_task_or_warm_occupancy().await.unwrap(),
+        1,
+        "only the unreclaimable row keeps occupying"
+    );
 }

--- a/server/crates/djinn-coordinator/src/build_lease_reclaim.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_reclaim.rs
@@ -1,0 +1,251 @@
+//! Reclamation of v1 build leases whose Kubernetes object is provably gone.
+//!
+//! The v1 lease ledger has no reclaimer of its own. Every exit from an
+//! occupying state needs the holder: `release`/`cancel` carry the fencing
+//! token, and `abandon_queued` refuses anything past `queued`. Two further
+//! gaps close the trap on a grant whose requester gave up on a `Queued` answer
+//! before ever acknowledging it — which is how the FIFO ends up granting a slot
+//! to nobody, since a later `queue`'s drain always grants the FIFO head:
+//!
+//! * `BuildLeaseGraphWarmAdapter::recoverable` maps only
+//!   `Launching`/`Bound`/`Active`/`Suspect` and returns `None` for everything
+//!   else, so a `granted` row is invisible to `reconcile_durable_warm_leases`;
+//! * `BuildLeaseService::expire_deadlines` — the one thing that would move
+//!   `granted` to the recoverable `suspect` — has no production caller at all,
+//!   and even when called it only exchanges one occupying state for another.
+//!
+//! Neither gap is a deadline problem, which is why this module reads no
+//! deadline. (#2605 fixed a real defect one layer over: the shared column list
+//! rendered PostgreSQL's timestamp format while `build_lease::ms` parsed
+//! RFC3339 and mapped failure to `0` — already the encoding for "no deadline" —
+//! so every *recovered* lease came back unbounded. That governs the
+//! `launching`-and-later rows `recoverable` can see; it cannot reach a
+//! `granted` row, and it cannot make an uncalled `expire_deadlines` run.)
+//!
+//! That is the production wedge this module closes: three `granted` graph-warm
+//! rows against a cap of three, no Kubernetes object behind any of them, every
+//! later warm answered `graph warm lease is queued`, and a warm base that had
+//! not re-converged for four days while still seeding perfectly.
+//!
+//! The discipline is the admission journal's (`reclaim_absent_object`), and
+//! deliberately not "the row looks old":
+//!
+//! * the lease has settled — untouched for the whole settle window, so no
+//!   in-flight create can still be mid-POST for it;
+//! * the authoritative LIST that just succeeded contains no object under this
+//!   lease's deterministic name;
+//! * a direct GET, taken now and independently of that LIST, answers
+//!   [`ObjectPresence::Absent`]. `Uncertain` — a transport or permission
+//!   failure — is never proof, so a degraded API server leaves every lease
+//!   occupying;
+//! * the durable write is a compare-and-set on the full observed identity, so a
+//!   holder that acknowledges between the proof and the write fences the
+//!   reclamation instead of losing its lease.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use djinn_db::{
+    BuildLeaseConsumerKind, BuildLeaseRepository, BuildLeaseRow, ReclaimAbsentBuildLeaseInput,
+    ReclaimAbsentBuildLeaseOutcome,
+};
+use djinn_k8s::{
+    ObjectPresence, WorkloadInventory, WorkloadObjectKind, deterministic_warm_job_name,
+    taskrun_job_name,
+};
+use tokio::sync::Mutex;
+
+/// How long an occupying lease must stay untouched before its absence proof is
+/// allowed to retire it. Matches the admission journal's reclaim settle window:
+/// both windows exist to outlast an in-flight create whose object the API
+/// server has not yet made visible.
+pub const DEFAULT_LEASE_RECLAIM_SETTLE_WINDOW: Duration = Duration::from_secs(300);
+
+/// Bound on how many individual reclaim failures one pass names. The count is
+/// always exact; the samples exist so an operator can see *which* lease without
+/// a log line that grows with the stale population.
+const MAX_NAMED_FAILURES: usize = 5;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BuildLeaseReclaimReport {
+    /// Occupying leases the pass examined.
+    pub occupying: usize,
+    /// Leases whose object was proven absent.
+    pub absent: usize,
+    /// Leases retired by this pass.
+    pub reclaimed: usize,
+    /// Leases that changed after their absence proof and were left alone.
+    pub fenced: usize,
+    /// Per-lease failures. Bounded by [`MAX_NAMED_FAILURES`]; see
+    /// `failure_count` for the exact total.
+    pub failures: Vec<String>,
+    /// Exact number of per-lease failures, named or not.
+    pub failure_count: usize,
+    /// Pass-level failures: an unusable Kubernetes listing or an unreadable
+    /// ledger. These mean the pass could not be trusted at all.
+    pub blockers: Vec<String>,
+}
+
+impl BuildLeaseReclaimReport {
+    fn fail(&mut self, lease: &str, error: &str) {
+        self.failure_count += 1;
+        if self.failures.len() < MAX_NAMED_FAILURES {
+            self.failures.push(format!("{lease}: {error}"));
+        }
+    }
+}
+
+/// The Kubernetes object name a lease's immutable identity commits to.
+///
+/// Derived from the durable identity, never from a process-local attempt id, so
+/// the absence probe asks about exactly the object this lease would have
+/// created. An identity this function does not recognise yields `None` and the
+/// lease is never reclaimed: guessing a name is how an absence proof becomes
+/// vacuous.
+pub fn lease_object_name(row: &BuildLeaseRow) -> Option<String> {
+    let mut fields = row.immutable_identity.split(':');
+    match (row.key.consumer_kind, fields.next()?) {
+        (BuildLeaseConsumerKind::GraphWarm, "warm") => {
+            let project_id = fields.next()?;
+            let warm_request_id = fields.next()?;
+            (!project_id.is_empty() && !warm_request_id.is_empty())
+                .then(|| deterministic_warm_job_name(project_id, warm_request_id))
+        }
+        (BuildLeaseConsumerKind::TaskInvocation, "task") => {
+            let _task_id = fields.next()?;
+            let task_run_id = fields.next()?;
+            (!task_run_id.is_empty()).then(|| taskrun_job_name(task_run_id))
+        }
+        _ => None,
+    }
+}
+
+/// Periodic sweep that retires occupying build leases with no Kubernetes object.
+pub struct BuildLeaseReclaimer {
+    repository: Arc<BuildLeaseRepository>,
+    inventory: Arc<dyn WorkloadInventory>,
+    settle_window: Duration,
+    serial: Mutex<()>,
+}
+
+impl BuildLeaseReclaimer {
+    #[must_use]
+    pub fn new(
+        repository: Arc<BuildLeaseRepository>,
+        inventory: Arc<dyn WorkloadInventory>,
+    ) -> Self {
+        Self::with_settle_window(repository, inventory, DEFAULT_LEASE_RECLAIM_SETTLE_WINDOW)
+    }
+
+    /// Reclaim with an explicit settle window. Tests use a zero window to
+    /// exercise reclamation without sleeping; production uses the default.
+    #[must_use]
+    pub fn with_settle_window(
+        repository: Arc<BuildLeaseRepository>,
+        inventory: Arc<dyn WorkloadInventory>,
+        settle_window: Duration,
+    ) -> Self {
+        Self {
+            repository,
+            inventory,
+            settle_window,
+            serial: Mutex::new(()),
+        }
+    }
+
+    /// One reclamation pass.
+    ///
+    /// Freed capacity is not granted here: granting is the lease service's
+    /// FIFO decision and every `queue` drains it, so the next build request
+    /// takes the slot this pass released. Reclamation deliberately owns no
+    /// capacity arithmetic.
+    pub async fn reclaim(&self) -> BuildLeaseReclaimReport {
+        let _serial = self.serial.lock().await;
+        let mut report = BuildLeaseReclaimReport::default();
+
+        // An unusable listing is a pass-level blocker: without an authoritative
+        // namespace view nothing below is evidence of anything.
+        let listed_names: HashSet<String> = match self.inventory.list().await {
+            Ok(records) => records.into_iter().map(|record| record.name).collect(),
+            Err(error) => {
+                report.blockers.push(error);
+                return report;
+            }
+        };
+
+        let rows = match self
+            .repository
+            .list_occupying_with_settlement(self.settle_window.as_secs() as i64)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(error) => {
+                report.blockers.push(error.to_string());
+                return report;
+            }
+        };
+        report.occupying = rows.len();
+
+        for (row, settled) in rows {
+            let lease = format!("{:?}/{}", row.key.consumer_kind, row.key.consumer_id);
+            if !settled {
+                continue;
+            }
+            let Some(object_name) = lease_object_name(&row) else {
+                continue;
+            };
+            if listed_names.contains(&object_name) {
+                continue;
+            }
+            if self
+                .inventory
+                .presence(WorkloadObjectKind::Job, &object_name)
+                .await
+                != ObjectPresence::Absent
+            {
+                continue;
+            }
+            report.absent += 1;
+            let input = ReclaimAbsentBuildLeaseInput {
+                key: row.key.clone(),
+                observed_state: row.state,
+                observed_immutable_identity: row.immutable_identity.clone(),
+                observed_fencing_token: row.fencing_token,
+                observed_bound_pod_uid: row.bound_pod_uid.clone(),
+                observed_updated_at: row.updated_at.clone(),
+            };
+            match self.repository.reclaim_absent_object(&input).await {
+                Ok(ReclaimAbsentBuildLeaseOutcome::Reclaimed(_)) => {
+                    report.reclaimed += 1;
+                    tracing::warn!(
+                        consumer_kind = ?row.key.consumer_kind,
+                        consumer_id = %row.key.consumer_id,
+                        state = ?row.state,
+                        object = %object_name,
+                        "build_lease: retired an occupying lease whose Kubernetes object is \
+                         provably absent"
+                    );
+                }
+                Ok(ReclaimAbsentBuildLeaseOutcome::AlreadyTerminal(_)) => {}
+                Ok(ReclaimAbsentBuildLeaseOutcome::Fenced { reason }) => {
+                    report.fenced += 1;
+                    tracing::warn!(
+                        consumer_kind = ?row.key.consumer_kind,
+                        consumer_id = %row.key.consumer_id,
+                        object = %object_name,
+                        %reason,
+                        "build_lease: refused to retire a lease that changed after its absence \
+                         proof"
+                    );
+                }
+                Err(error) => report.fail(&lease, &error.to_string()),
+            }
+        }
+        report
+    }
+}
+
+#[cfg(test)]
+#[path = "build_lease_reclaim_tests.rs"]
+mod tests;

--- a/server/crates/djinn-coordinator/src/build_lease_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_reclaim_tests.rs
@@ -1,0 +1,580 @@
+//! Regression coverage for the production wedge where the v1 build-lease FIFO
+//! fills with occupying leases that have no Kubernetes object.
+//!
+//! Production symptom: three `granted` graph-warm rows against a cap of three,
+//! `kubectl get jobs -n djinn` holding no warm Job at all, every later warm
+//! answered `K8sGraphWarmer: v1 lease did not authorize Job POST /
+//! graph warm lease is queued` roughly nine times per forty minutes, and a warm
+//! base that had not re-converged for four days while still seeding every task
+//! pod perfectly.
+//!
+//! Nothing here writes a lease row by hand. Every stale row is produced by the
+//! production [`BuildLeaseService`] against a real
+//! [`BuildLeaseRepository`] on a fresh database: a lease is queued behind a
+//! full cap, its requester gives up on the `Queued` answer exactly as
+//! `BuildLeaseGraphWarmAdapter::acquire` does, and the FIFO later grants it to
+//! nobody. Producing that shape is as much the behaviour under test as the
+//! reclamation is.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_db::{
+    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseState, Database,
+    ReclaimAbsentBuildLeaseInput, ReclaimAbsentBuildLeaseOutcome,
+};
+use djinn_k8s::{
+    LeasedWarmJobIdentity, ObjectPresence, UidGetResult, WorkloadInventory, WorkloadObjectKind,
+    WorkloadRecord,
+};
+use djinn_supervisor::services::{
+    GraphWarmLeaseIdentity, LeaseDeadlines, LeaseFencingToken, LeaseGrantRequest, LeaseIdentity,
+    LeaseQueueRequest, LeaseReleaseRequest, LeaseResult,
+};
+use tokio::sync::RwLock;
+
+use crate::build_lease::{BuildLeaseService, ManualLeaseClock};
+use crate::build_lease_reclaim::{BuildLeaseReclaimer, lease_object_name};
+
+const PROJECT: &str = "019ea3bd-a305-73e3-806c-4edcc96ebfe2";
+
+/// An inventory whose namespace holds exactly the Jobs it was given, answering
+/// `presence` from that same set the way a live API server does.
+struct NamespaceInventory {
+    records: RwLock<Vec<WorkloadRecord>>,
+    /// When set, every probe is a transport failure: the API server could not
+    /// answer, which is never proof of anything.
+    degraded: bool,
+}
+
+impl NamespaceInventory {
+    fn empty() -> Self {
+        Self {
+            records: RwLock::new(Vec::new()),
+            degraded: false,
+        }
+    }
+    fn holding(names: &[&str]) -> Self {
+        Self {
+            records: RwLock::new(
+                names
+                    .iter()
+                    .map(|name| WorkloadRecord {
+                        kind: WorkloadObjectKind::Job,
+                        name: (*name).to_string(),
+                        uid: Some(format!("uid-{name}")),
+                        labels: Default::default(),
+                        terminal: false,
+                        images: Vec::new(),
+                        commands: Vec::new(),
+                    })
+                    .collect(),
+            ),
+            degraded: false,
+        }
+    }
+    /// A namespace that lists cleanly but cannot answer a direct GET.
+    fn uncertain() -> Self {
+        Self {
+            records: RwLock::new(Vec::new()),
+            degraded: true,
+        }
+    }
+}
+
+#[async_trait]
+impl WorkloadInventory for NamespaceInventory {
+    async fn list(&self) -> Result<Vec<WorkloadRecord>, String> {
+        Ok(self.records.read().await.clone())
+    }
+    async fn get_uid(&self, _kind: WorkloadObjectKind, name: &str, uid: &str) -> UidGetResult {
+        if self.degraded {
+            return UidGetResult::Uncertain;
+        }
+        match self
+            .records
+            .read()
+            .await
+            .iter()
+            .find(|record| record.name == name)
+        {
+            Some(record) if record.uid.as_deref() == Some(uid) => UidGetResult::Present,
+            Some(_) => UidGetResult::Uncertain,
+            None => UidGetResult::NotFound,
+        }
+    }
+    async fn presence(&self, _kind: WorkloadObjectKind, name: &str) -> ObjectPresence {
+        if self.degraded {
+            return ObjectPresence::Uncertain;
+        }
+        match self
+            .records
+            .read()
+            .await
+            .iter()
+            .find(|record| record.name == name)
+        {
+            Some(record) => ObjectPresence::Present {
+                uid: record.uid.clone(),
+            },
+            None => ObjectPresence::Absent,
+        }
+    }
+}
+
+fn warm(request_id: &str) -> LeaseIdentity {
+    LeaseIdentity::GraphWarm(GraphWarmLeaseIdentity {
+        project_id: PROJECT.into(),
+        warm_request_id: request_id.into(),
+        graph_revision: format!("rev-{request_id}"),
+    })
+}
+
+fn queue_request(request_id: &str) -> LeaseQueueRequest {
+    LeaseQueueRequest {
+        identity: warm(request_id),
+        // Production carries a two-hour deadline on both edges, and the clock
+        // starts at 100ms, so every lease in these tests is comfortably INSIDE
+        // its launch deadline. That is deliberate: reclamation is driven by a
+        // proven-absent Kubernetes object, never by a deadline, so an
+        // unexpired lease must still be reclaimable.
+        deadlines: LeaseDeadlines {
+            queue_deadline_ms: 100 + 7_200_000,
+            launch_deadline_ms: 100 + 7_200_000,
+        },
+    }
+}
+
+fn undeadlined_request(request_id: &str) -> LeaseQueueRequest {
+    LeaseQueueRequest {
+        identity: warm(request_id),
+        // A non-positive value means "no deadline": the durable column stays
+        // NULL and the lease never expires on that edge.
+        deadlines: LeaseDeadlines {
+            queue_deadline_ms: 0,
+            launch_deadline_ms: 0,
+        },
+    }
+}
+
+fn key(request_id: &str) -> BuildLeaseKey {
+    BuildLeaseKey {
+        consumer_kind: BuildLeaseConsumerKind::GraphWarm,
+        consumer_id: request_id.into(),
+    }
+}
+
+/// The Kubernetes name the production warm dispatch path commits to for a
+/// request id, derived through the production identity type.
+fn warm_job_name(request_id: &str) -> String {
+    LeasedWarmJobIdentity::new(PROJECT, request_id, "rev", 1).object_name
+}
+
+async fn service(cap: i64) -> (Arc<BuildLeaseService>, Arc<BuildLeaseRepository>) {
+    let repository = Arc::new(BuildLeaseRepository::new(
+        Database::open_in_memory().unwrap(),
+    ));
+    let service = Arc::new(BuildLeaseService::with_seams(
+        Arc::clone(&repository),
+        cap,
+        Arc::new(ManualLeaseClock::new(100)),
+        Arc::new(crate::build_lease::NoopLeaseTransactionPause),
+        Arc::new(crate::build_lease::NoopLeaseTelemetry),
+    ));
+    assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+    assert!(matches!(service.set_cap(cap).await, LeaseResult::Status(_)));
+    (service, repository)
+}
+
+/// Reproduce the production wedge: a `granted` lease nobody holds.
+///
+/// `holder` takes the only slot and acknowledges it. `abandoned` is queued
+/// behind the full cap and its requester gives up on the `Queued` answer, which
+/// is exactly what `BuildLeaseGraphWarmAdapter::acquire` returns to the warmer.
+/// Releasing `holder` lets the FIFO grant `abandoned` to a requester that is
+/// already gone, and nothing in the ledger can ever retire it.
+async fn wedge(service: &Arc<BuildLeaseService>) {
+    let granted = service.queue(queue_request("holder")).await;
+    let LeaseResult::Granted(grant) = granted else {
+        panic!("the first queue against a free cap must grant: {granted:?}");
+    };
+    assert!(matches!(
+        service
+            .grant(LeaseGrantRequest {
+                identity: warm("holder"),
+                fencing_token: grant.fencing_token.clone(),
+            })
+            .await,
+        LeaseResult::Status(_)
+    ));
+    assert!(
+        matches!(
+            service.queue(queue_request("abandoned")).await,
+            LeaseResult::Queued(_)
+        ),
+        "the second warm must be queued behind the full cap"
+    );
+    assert!(matches!(
+        service
+            .release(LeaseReleaseRequest {
+                identity: warm("holder"),
+                fencing_token: grant.fencing_token,
+                candidate_cleanup: false,
+            })
+            .await,
+        LeaseResult::Released { .. }
+    ));
+}
+
+fn reclaimer(
+    repository: &Arc<BuildLeaseRepository>,
+    inventory: NamespaceInventory,
+) -> BuildLeaseReclaimer {
+    BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(repository),
+        Arc::new(inventory),
+        Duration::ZERO,
+    )
+}
+
+/// The wedge end to end: an abandoned grant holds the whole cap, every later
+/// warm is answered `Queued`, and reclamation against an authoritative empty
+/// namespace frees the slot so warming runs again.
+#[tokio::test]
+async fn abandoned_grant_wedges_the_cap_until_its_absent_object_is_proven() {
+    let (service, repository) = service(1).await;
+    wedge(&service).await;
+
+    // The live warm request. Its own queue drains the FIFO, which grants the
+    // abandoned lease rather than this one: the production symptom.
+    assert!(
+        matches!(
+            service.queue(queue_request("live")).await,
+            LeaseResult::Queued(_)
+        ),
+        "this is the wedge: the live warm cannot be granted"
+    );
+    let abandoned = repository.get(&key("abandoned")).await.unwrap().unwrap();
+    assert_eq!(
+        abandoned.state,
+        BuildLeaseState::Granted,
+        "the abandoned lease occupies the cap in `granted`, which no existing sweep can see"
+    );
+    assert_eq!(
+        lease_object_name(&abandoned).as_deref(),
+        Some(warm_job_name("abandoned").as_str()),
+        "the absence probe must ask about the exact object the warm dispatch path would create"
+    );
+
+    let report = reclaimer(&repository, NamespaceInventory::empty())
+        .reclaim()
+        .await;
+    assert!(
+        report.blockers.is_empty(),
+        "blockers: {:?}",
+        report.blockers
+    );
+    assert!(
+        report.failures.is_empty(),
+        "failures: {:?}",
+        report.failures
+    );
+    assert_eq!(report.occupying, 1);
+    assert_eq!(report.absent, 1);
+    assert_eq!(report.reclaimed, 1);
+    assert_eq!(report.fenced, 0);
+
+    assert_eq!(
+        repository
+            .get(&key("abandoned"))
+            .await
+            .unwrap()
+            .unwrap()
+            .terminal_reason
+            .as_deref(),
+        Some("reclaimed_absent")
+    );
+    assert!(
+        matches!(
+            service.queue(queue_request("live")).await,
+            LeaseResult::Granted(_)
+        ),
+        "the live warm must be granted once the phantom occupant is retired"
+    );
+}
+
+/// Reclamation reads no deadline at all, so nothing it does can depend on how
+/// a deadline round-trips.
+///
+/// This matters because the deadline round-trip was itself broken until #2605:
+/// the shared column list rendered PostgreSQL's own timestamp format while
+/// `build_lease::ms` parsed RFC3339 and mapped failure to `0` — which already
+/// means "no deadline" — so every echoed deadline read as unbounded. A
+/// reclaimer keyed on `launch_deadline` would have behaved one way against that
+/// defect and another way after it was fixed. This one is keyed on the settle
+/// window (a SQL predicate on `updated_at`) and a proven-absent object, so both
+/// a lease with no durable deadline at all and a lease well inside a real
+/// two-hour deadline are reclaimed identically.
+#[tokio::test]
+async fn reclamation_reads_no_deadline_and_retires_bounded_and_unbounded_leases_alike() {
+    let (service, repository) = service(2).await;
+
+    // One lease with a real, unexpired two-hour launch deadline; one with no
+    // durable deadline at all. Both are granted, both are abandoned.
+    for request in [queue_request("bounded"), undeadlined_request("unbounded")] {
+        assert!(matches!(
+            service.queue(request).await,
+            LeaseResult::Granted(_)
+        ));
+    }
+    let bounded = repository.get(&key("bounded")).await.unwrap().unwrap();
+    let unbounded = repository.get(&key("unbounded")).await.unwrap().unwrap();
+    assert!(
+        bounded.launch_deadline.is_some(),
+        "the bounded lease must carry a durable deadline: {bounded:?}"
+    );
+    assert!(
+        unbounded.launch_deadline.is_none(),
+        "the unbounded lease must carry no durable deadline: {unbounded:?}"
+    );
+    assert_eq!(bounded.state, BuildLeaseState::Granted);
+    assert_eq!(unbounded.state, BuildLeaseState::Granted);
+
+    let report = reclaimer(&repository, NamespaceInventory::empty())
+        .reclaim()
+        .await;
+    assert!(
+        report.blockers.is_empty(),
+        "blockers: {:?}",
+        report.blockers
+    );
+    assert_eq!(report.occupying, 2);
+    assert_eq!(
+        report.reclaimed, 2,
+        "an unexpired deadline is not a reason to keep a phantom lease, and an \
+         absent deadline is not a reason to keep one either"
+    );
+    for id in ["bounded", "unbounded"] {
+        assert_eq!(
+            repository.get(&key(id)).await.unwrap().unwrap().state,
+            BuildLeaseState::Terminal,
+            "{id} must be retired on the absence proof alone"
+        );
+    }
+}
+
+/// The negative that matters most: a lease whose Job is still in the namespace
+/// is live work, and no amount of age makes it reclaimable.
+#[tokio::test]
+async fn a_lease_whose_object_still_exists_is_never_retired() {
+    let (service, repository) = service(1).await;
+    wedge(&service).await;
+
+    let report = reclaimer(
+        &repository,
+        NamespaceInventory::holding(&[&warm_job_name("abandoned")]),
+    )
+    .reclaim()
+    .await;
+    assert_eq!(report.occupying, 1);
+    assert_eq!(report.absent, 0, "the object was listed; nothing is absent");
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(
+        repository
+            .get(&key("abandoned"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Granted
+    );
+}
+
+/// A namespace that lists cleanly but cannot answer a direct GET proves
+/// nothing. A degraded API server must leave every lease occupying.
+#[tokio::test]
+async fn an_uncertain_probe_is_never_proof_of_absence() {
+    let (service, repository) = service(1).await;
+    wedge(&service).await;
+
+    let report = reclaimer(&repository, NamespaceInventory::uncertain())
+        .reclaim()
+        .await;
+    assert_eq!(report.occupying, 1);
+    assert_eq!(report.absent, 0, "`Uncertain` is never proof");
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(
+        repository
+            .get(&key("abandoned"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Granted
+    );
+}
+
+/// An unusable listing is a pass-level blocker, and it must stop the pass
+/// before any lease is judged.
+#[tokio::test]
+async fn an_unusable_listing_blocks_the_pass_and_retires_nothing() {
+    struct Unlistable;
+    #[async_trait]
+    impl WorkloadInventory for Unlistable {
+        async fn list(&self) -> Result<Vec<WorkloadRecord>, String> {
+            Err("connection refused".into())
+        }
+        async fn get_uid(&self, _: WorkloadObjectKind, _: &str, _: &str) -> UidGetResult {
+            panic!("no lease may be judged without an authoritative listing")
+        }
+        async fn presence(&self, _: WorkloadObjectKind, _: &str) -> ObjectPresence {
+            panic!("no lease may be judged without an authoritative listing")
+        }
+    }
+
+    let (service, repository) = service(1).await;
+    wedge(&service).await;
+    let report = BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(&repository),
+        Arc::new(Unlistable),
+        Duration::ZERO,
+    )
+    .reclaim()
+    .await;
+    assert_eq!(report.blockers.len(), 1);
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(
+        repository
+            .get(&key("abandoned"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Granted
+    );
+}
+
+/// A lease that has not settled is not yet judged at all: a create the API
+/// server has not made visible must be allowed to appear first.
+#[tokio::test]
+async fn an_unsettled_lease_is_not_judged_by_a_listing_it_could_predate() {
+    let (service, repository) = service(1).await;
+    wedge(&service).await;
+
+    let report = BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(&repository),
+        Arc::new(NamespaceInventory::empty()),
+        Duration::from_secs(3600),
+    )
+    .reclaim()
+    .await;
+    assert_eq!(report.occupying, 1);
+    assert_eq!(report.absent, 0);
+    assert_eq!(report.reclaimed, 0);
+}
+
+/// The durable fence itself: evidence gathered before the holder acted must not
+/// retire the lease the holder just moved.
+#[tokio::test]
+async fn evidence_that_predates_a_holder_acknowledgement_is_fenced() {
+    let (service, repository) = service(1).await;
+    wedge(&service).await;
+    let observed = repository.get(&key("abandoned")).await.unwrap().unwrap();
+
+    // The holder wakes up and acknowledges its grant after the proof was taken.
+    assert!(matches!(
+        service
+            .grant(LeaseGrantRequest {
+                identity: warm("abandoned"),
+                fencing_token: LeaseFencingToken(observed.fencing_token.unwrap() as u64),
+            })
+            .await,
+        LeaseResult::Status(_)
+    ));
+
+    let outcome = repository
+        .reclaim_absent_object(&ReclaimAbsentBuildLeaseInput {
+            key: observed.key.clone(),
+            observed_state: observed.state,
+            observed_immutable_identity: observed.immutable_identity.clone(),
+            observed_fencing_token: observed.fencing_token,
+            observed_bound_pod_uid: observed.bound_pod_uid.clone(),
+            observed_updated_at: observed.updated_at.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, ReclaimAbsentBuildLeaseOutcome::Fenced { .. }),
+        "a lease that moved after its absence proof must not be retired: {outcome:?}"
+    );
+    assert_eq!(
+        repository
+            .get(&key("abandoned"))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Launching
+    );
+}
+
+/// Task-invocation leases share the same cap and the same reclaimer; their
+/// object name is derived from the durable identity, never guessed.
+#[test]
+fn lease_object_names_come_from_the_durable_identity_or_nowhere() {
+    let row = |kind, identity: &str| djinn_db::BuildLeaseRow {
+        key: BuildLeaseKey {
+            consumer_kind: kind,
+            consumer_id: "consumer".into(),
+        },
+        immutable_identity: identity.into(),
+        enqueue_sequence: 1,
+        fencing_token: Some(1),
+        state: BuildLeaseState::Granted,
+        queue_deadline: None,
+        launch_deadline: None,
+        bound_pod_uid: None,
+        candidate_cleanup: None,
+        terminal_reason: None,
+        timeout_credit_consumed: false,
+        created_at: "now".into(),
+        updated_at: "now".into(),
+        granted_at: None,
+        terminal_at: None,
+    };
+    assert_eq!(
+        lease_object_name(&row(
+            BuildLeaseConsumerKind::TaskInvocation,
+            "task:task-1:run-9:invocation-3"
+        ))
+        .as_deref(),
+        Some(djinn_k8s::taskrun_job_name("run-9").as_str())
+    );
+    assert_eq!(
+        lease_object_name(&row(BuildLeaseConsumerKind::GraphWarm, "warm:proj:req:rev")).as_deref(),
+        Some(
+            LeasedWarmJobIdentity::new("proj", "req", "rev", 1)
+                .object_name
+                .as_str()
+        )
+    );
+    // An identity this reclaimer does not recognise is never reclaimed: a
+    // guessed name turns an absence proof into a vacuous one.
+    assert_eq!(
+        lease_object_name(&row(BuildLeaseConsumerKind::GraphWarm, "something-else")),
+        None
+    );
+    assert_eq!(
+        lease_object_name(&row(
+            BuildLeaseConsumerKind::TaskInvocation,
+            "task::run:inv"
+        ))
+        .as_deref(),
+        Some(djinn_k8s::taskrun_job_name("run").as_str())
+    );
+    assert_eq!(
+        lease_object_name(&row(BuildLeaseConsumerKind::TaskInvocation, "task:t::inv")),
+        None
+    );
+}

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -55,6 +55,8 @@ pub mod build_admission_inventory;
 pub mod build_admission_transition;
 /// Durable v1 lease service; v0 admission remains rollout authority.
 pub mod build_lease;
+/// Retirement of occupying build leases whose Kubernetes object is provably gone.
+pub mod build_lease_reclaim;
 pub mod cargo_warm_base_gc;
 pub(crate) mod ci_preflight_gate;
 pub mod ci_reproduction;

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -82,7 +82,7 @@ pub use repositories::{
     build_lease::{
         BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseRow,
         BuildLeaseSnapshot, BuildLeaseState, GrantNextBuildLeaseResult, QueueBuildLeaseInput,
-        QueueBuildLeaseResult,
+        QueueBuildLeaseResult, ReclaimAbsentBuildLeaseInput, ReclaimAbsentBuildLeaseOutcome,
     },
     chat_interruption_notice::{
         ChatInterruptionNotice, ChatInterruptionNoticeRepository, CreateChatInterruptionNotice,

--- a/server/crates/djinn-db/src/repositories/build_lease.rs
+++ b/server/crates/djinn-db/src/repositories/build_lease.rs
@@ -123,6 +123,31 @@ pub struct BuildLeaseSnapshot {
     pub rows: Vec<BuildLeaseRow>,
 }
 
+/// The full observed identity of one occupying lease, gathered *before* its
+/// Kubernetes object was proven absent.
+///
+/// Every field participates in the compare-and-set performed by
+/// [`BuildLeaseRepository::reclaim_absent_object`]. `observed_updated_at` is
+/// what closes the race against the lease's own holder: any acknowledgement,
+/// bind, or status report between the absence proof and the write bumps
+/// `updated_at`, and the reclamation is fenced instead of retiring live work.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReclaimAbsentBuildLeaseInput {
+    pub key: BuildLeaseKey,
+    pub observed_state: BuildLeaseState,
+    pub observed_immutable_identity: String,
+    pub observed_fencing_token: Option<i64>,
+    pub observed_bound_pod_uid: Option<String>,
+    pub observed_updated_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReclaimAbsentBuildLeaseOutcome {
+    Reclaimed(BuildLeaseRow),
+    AlreadyTerminal(BuildLeaseRow),
+    Fenced { reason: String },
+}
+
 /// Atomic repository for queueing and fencing build units.
 pub struct BuildLeaseRepository {
     db: Database,
@@ -464,6 +489,105 @@ impl BuildLeaseRepository {
             .collect()
     }
 
+    /// Every currently occupying lease, each paired with whether it has been
+    /// untouched for at least `settle_seconds`.
+    ///
+    /// Read-only and lock-free: reclamation gathers evidence from this listing
+    /// and then fences its write on the row's `updated_at`, so a lease that
+    /// moves between the listing and the write is rejected rather than raced.
+    pub async fn list_occupying_with_settlement(
+        &self,
+        settle_seconds: i64,
+    ) -> DbResult<Vec<(BuildLeaseRow, bool)>> {
+        if settle_seconds < 0 {
+            return Err(DbError::InvalidData(
+                "settle window must be non-negative".into(),
+            ));
+        }
+        self.db.ensure_initialized().await?;
+        let rows = sqlx::query_as::<_, SettlementDbRow>(&format!(
+            "SELECT {COLS}, (updated_at <= now() - make_interval(secs => $2)) AS settled \
+             FROM build_leases WHERE state = ANY($1) ORDER BY enqueue_sequence"
+        ))
+        .bind(OCCUPYING.as_slice())
+        .bind(settle_seconds as f64)
+        .fetch_all(self.db.pool())
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                let settled = row.settled.unwrap_or(false);
+                BuildLeaseRow::try_from(row.row).map(|row| (row, settled))
+            })
+            .collect()
+    }
+
+    /// Retire one occupying lease whose Kubernetes object is provably gone.
+    ///
+    /// Nothing else in this ledger can leave an occupying state without a call
+    /// from the process that holds the lease: `release`/`cancel` need the
+    /// fencing token, `abandon_queued` refuses anything past `queued`, and
+    /// `expire_deadlines` only downgrades `granted`/`launching` to the equally
+    /// occupying `suspect`. A lease whose holder died — or, the production
+    /// shape this fixes, a `granted` row whose requester gave up before it was
+    /// ever acknowledged — therefore occupies the shared cap forever and
+    /// starves every later build. This is the durable half of the reconciler
+    /// that retires it; the caller owns the Kubernetes absence evidence.
+    ///
+    /// The write is a compare-and-set on the full observed identity (state,
+    /// immutable identity, fencing token, bound pod UID, and `updated_at`).
+    /// Anything that changed after the proof was gathered yields
+    /// [`ReclaimAbsentBuildLeaseOutcome::Fenced`] and writes nothing, so this
+    /// can never retire a lease that might still correspond to live work.
+    pub async fn reclaim_absent_object(
+        &self,
+        input: &ReclaimAbsentBuildLeaseInput,
+    ) -> DbResult<ReclaimAbsentBuildLeaseOutcome> {
+        if !OCCUPYING.contains(&state_str(input.observed_state)) {
+            return Err(DbError::InvalidData(
+                "reclamation evidence must describe an occupying build lease state".into(),
+            ));
+        }
+        self.db.ensure_initialized().await?;
+        let mut tx = self.db.pool().begin().await?;
+        lock(&mut tx).await?;
+        let Some(row) = fetch(&mut tx, &input.key, true).await? else {
+            tx.commit().await?;
+            return Ok(ReclaimAbsentBuildLeaseOutcome::Fenced {
+                reason: "build lease no longer exists".into(),
+            });
+        };
+        if row.state == BuildLeaseState::Terminal {
+            tx.commit().await?;
+            return Ok(ReclaimAbsentBuildLeaseOutcome::AlreadyTerminal(row));
+        }
+        if row.state != input.observed_state
+            || row.immutable_identity != input.observed_immutable_identity
+            || row.fencing_token != input.observed_fencing_token
+            || row.bound_pod_uid != input.observed_bound_pod_uid
+            || row.updated_at != input.observed_updated_at
+        {
+            let reason = format!(
+                "build lease changed after the absence proof (observed {:?}@{}, found {:?}@{})",
+                input.observed_state, input.observed_updated_at, row.state, row.updated_at
+            );
+            tx.commit().await?;
+            return Ok(ReclaimAbsentBuildLeaseOutcome::Fenced { reason });
+        }
+        let reclaimed = sqlx::query_as::<_, DbRow>(&format!(
+            "UPDATE build_leases SET state='terminal',terminal_reason='reclaimed_absent',\
+             terminal_at=now(),updated_at=now() WHERE consumer_kind=$1 AND consumer_id=$2 \
+             RETURNING {COLS}"
+        ))
+        .bind(input.key.consumer_kind.as_str())
+        .bind(&input.key.consumer_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(ReclaimAbsentBuildLeaseOutcome::Reclaimed(
+            reclaimed.try_into()?,
+        ))
+    }
+
     async fn terminal(
         &self,
         key: &BuildLeaseKey,
@@ -583,6 +707,12 @@ const COLS: &str = "consumer_kind,consumer_id,immutable_identity,enqueue_sequenc
     to_char(granted_at AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS granted_at,\
     to_char(terminal_at AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS terminal_at";
 #[derive(sqlx::FromRow)]
+struct SettlementDbRow {
+    #[sqlx(flatten)]
+    row: DbRow,
+    settled: Option<bool>,
+}
+#[derive(sqlx::FromRow)]
 struct DbRow {
     consumer_kind: String,
     consumer_id: String,
@@ -624,6 +754,19 @@ impl TryFrom<DbRow> for BuildLeaseRow {
             granted_at: v.granted_at,
             terminal_at: v.terminal_at,
         })
+    }
+}
+/// Durable column spelling of a lifecycle state, so occupancy membership is
+/// decided against the same [`OCCUPYING`] list the SQL uses.
+fn state_str(state: BuildLeaseState) -> &'static str {
+    match state {
+        BuildLeaseState::Queued => "queued",
+        BuildLeaseState::Granted => "granted",
+        BuildLeaseState::Launching => "launching",
+        BuildLeaseState::Bound => "bound",
+        BuildLeaseState::Active => "active",
+        BuildLeaseState::Suspect => "suspect",
+        BuildLeaseState::Terminal => "terminal",
     }
 }
 async fn lock(tx: &mut Transaction<'_, Postgres>) -> DbResult<()> {

--- a/server/crates/djinn-k8s/src/graph_warmer_identity.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_identity.rs
@@ -89,7 +89,7 @@ pub fn warm_work_id(project_id: &str, revision: &str) -> String {
 /// Kept within [`LABEL_VALUE_MAX_BYTES`] rather than the 253-byte object-name
 /// budget, for the `job-name` projection described in the module docs.
 /// Determinism is what makes the create idempotent across dispatch retries.
-pub(crate) fn deterministic_warm_job_name(project_id: &str, work_id: &str) -> String {
+pub fn deterministic_warm_job_name(project_id: &str, work_id: &str) -> String {
     let project = warm_id_segment(project_id, WARM_NAME_PROJECT_BUDGET);
     let mut hash = 0xcbf29ce484222325_u64;
     for byte in work_id.bytes() {

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -45,8 +45,8 @@ pub use graph_warmer_candidates::{
     WarmCandidateKind, WarmCandidateObject, WarmCandidateSet, WarmCandidateSetState,
     WarmInventoryObservation,
 };
-pub use graph_warmer_identity::{LeasedWarmJobIdentity, warm_work_id};
-pub use runtime::KubernetesRuntime;
+pub use graph_warmer_identity::{LeasedWarmJobIdentity, deterministic_warm_job_name, warm_work_id};
+pub use runtime::{KubernetesRuntime, taskrun_job_name};
 pub use token_review::TokenReviewer;
 pub use warm_job::{build_leased_warm_job, build_warm_job};
 pub use workload_inventory::{

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -25,6 +25,7 @@ use djinn_agent::lsp::LspManager;
 use djinn_agent::roles::RoleRegistry;
 use djinn_agent::runtime_bridge::{K8sTokenReviewValidator, RuntimeKind, runtime_kind};
 use djinn_coordinator::build_lease::BuildLeaseService;
+use djinn_coordinator::build_lease_reclaim::BuildLeaseReclaimer;
 use djinn_coordinator::graph_warm_lease::BuildLeaseGraphWarmAdapter;
 use djinn_coordinator::run_dir_observe::{RunDirObserveSeams, arm_disk_observation};
 use djinn_core::clock::{Clock, SystemClock as SystemClockTrait};
@@ -1130,12 +1131,20 @@ impl AppState {
                     reclaimed = report.reclaimed,
                     stale = report.stale,
                     fenced = report.fenced,
+                    // A per-row reclaim failure leaves that row occupying,
+                    // which only ever over-counts capacity, so it does not
+                    // fail the pass. It still has to be visible: this is the
+                    // count of rows the next pass will have to try again.
+                    reclaim_failures = report.reclaim_failure_count,
+                    named_reclaim_failures = ?report.reclaim_failures,
                     readiness = ?admission.readiness(),
                     "build_admission: Kubernetes inventory reconciliation complete"
                 );
             } else {
                 tracing::error!(
                     mode = ?admission.mode(),
+                    reclaim_failures = report.reclaim_failure_count,
+                    named_reclaim_failures = ?report.reclaim_failures,
                     blockers = ?report.blockers,
                     "build_admission: Kubernetes inventory reconciliation blocked; Enforce remains fail-closed"
                 );
@@ -1313,12 +1322,45 @@ impl AppState {
                     // UID-preconditioned deletion acknowledgements are not
                     // terminal evidence and must be revisited after startup.
                     let recovery_warmer = warmer.clone();
+                    // Warm-lease reconciliation inventories retained *identities*
+                    // and its recovery view drops `granted` rows outright, so
+                    // nothing there can retire a lease whose Kubernetes object
+                    // never existed or is already gone. That is what let three
+                    // phantom `granted` rows hold a cap of three and freeze the
+                    // warm base for four days. The reclaimer rides the same
+                    // period against the same authoritative inventory.
+                    let lease_reclaimer = warmer.workload_inventory().map(|inventory| {
+                        Arc::new(BuildLeaseReclaimer::new(
+                            Arc::new(djinn_db::BuildLeaseRepository::new(self.db().clone())),
+                            inventory,
+                        ))
+                    });
                     tokio::spawn(async move {
                         let mut tick = tokio::time::interval(Duration::from_secs(30));
                         tick.tick().await;
                         loop {
                             tick.tick().await;
                             recovery_warmer.reconcile_durable_warm_leases().await;
+                            let Some(reclaimer) = lease_reclaimer.as_ref() else {
+                                continue;
+                            };
+                            let report = reclaimer.reclaim().await;
+                            if report.reclaimed > 0
+                                || report.fenced > 0
+                                || report.failure_count > 0
+                                || !report.blockers.is_empty()
+                            {
+                                tracing::warn!(
+                                    occupying = report.occupying,
+                                    absent = report.absent,
+                                    reclaimed = report.reclaimed,
+                                    fenced = report.fenced,
+                                    failures = report.failure_count,
+                                    named_failures = ?report.failures,
+                                    blockers = ?report.blockers,
+                                    "build_lease: reclamation pass over occupying leases"
+                                );
+                            }
                         }
                     });
                     warmer as Arc<dyn GraphWarmerService>


### PR DESCRIPTION
Two durable ledgers could accumulate occupancy that nothing could ever retire. Both wedged production tonight.

## Wedge A — the v1 build-lease ledger has no reclaimer

Every exit from an occupying lease state needs the holder: `release`/`cancel` carry the fencing token, and `abandon_queued` refuses anything past `queued`. Two further gaps close the trap on a grant whose requester gave up on a `Queued` answer before ever acknowledging it — which is how the FIFO grants a slot to nobody, since a later `queue`'s drain always grants the FIFO head:

- `BuildLeaseGraphWarmAdapter::recoverable` maps only `Launching`/`Bound`/`Active`/`Suspect` and returns `None` for everything else, so a `granted` row is invisible to `reconcile_durable_warm_leases`;
- `BuildLeaseService::expire_deadlines` — the one thing that would move `granted` to the recoverable `suspect` — **has no production caller at all** (grep: only its own definition and `djinn-agent` tests), and even when called it only exchanges one occupying state for another.

Production, verified directly:

```
 consumer_kind |          consumer_id           |  state  | bound_pod_uid | granted_at
 graph_warm    | gw.019ea3bd-….fd5e40f100d0     | granted |               | 2026-07-25 23:41:53.522+00
 graph_warm    | gw.019ea3bd-….40fe81126266     | granted |               | 2026-07-25 23:41:53.553+00
 graph_warm    | gw.019ea3bd-….88d73e159ae6     | granted |               | 2026-07-25 23:41:53.574+00
 graph_warm    | gw.019ea3bd-….eaff0af39428     | queued  |               |
```

Cap 3, occupancy 3, all three granted within 50ms of each other (a drain, long after they were created), `kubectl get jobs -n djinn` holding no warm Job at all, `K8sGraphWarmer: v1 lease did not authorize Job POST / graph warm lease is queued` ~9 times per 40 minutes, and a warm base dated 2026-07-22 02:01 that still seeded every task pod perfectly while decaying.

### Relationship to #2605

#2605 fixed a real defect one layer over: the shared column list rendered PostgreSQL's timestamp format while `build_lease::ms` parsed RFC3339 and mapped failure to `0` — already the encoding for "no deadline" — so every *recovered* lease came back unbounded. That is a genuine contributing defect for the `launching`-and-later population `recoverable` can see. It is **not** the cause of the rows above: it cannot reach a `granted` row, which `recoverable` discards before any deadline is read, and it cannot make an uncalled `expire_deadlines` run. The two bullets above are therefore independent defects, and they are why the reclaimer is still needed.

This module reads **no deadline at all**, so nothing it does depends on how a deadline round-trips. `reclamation_reads_no_deadline_and_retires_bounded_and_unbounded_leases_alike` pins that: a lease well inside a real two-hour deadline and a lease with a NULL deadline are retired identically, on the absence proof alone.

### The fix

`BuildLeaseRepository::reclaim_absent_object` retires one occupying lease under a compare-and-set on its **full observed identity** — state, immutable identity, fencing token, bound pod UID and `updated_at`. A holder that acknowledges, binds, or reports between the absence proof and the write bumps `updated_at` (or the state) and fences the reclamation instead of losing its lease.

`BuildLeaseReclaimer` gathers evidence with #2597's discipline, never with "the row looks old":

- the lease has **settled** — a SQL predicate on `updated_at`, so no create can still be mid-POST;
- the authoritative **LIST** holds no object under its deterministic name;
- a direct **GET** answers `Absent`. `Uncertain` is never proof, so a degraded API server leaves every lease occupying.

Object names come from the durable identity through the same functions the dispatch path uses (`deterministic_warm_job_name`, `taskrun_job_name`); an identity the reclaimer does not recognise yields `None` and is never reclaimed, because a guessed name is how an absence proof becomes vacuous. It rides the existing 30s warm-reconciliation loop and owns **no capacity arithmetic** — freed slots are granted by the next `queue`'s own drain.

## Wedge B — reconciliation blocked by its own reclaim failures

`mark_terminal` goes through `current_row_for_update`, which rejects any generation that is not the latest with `stale admission generation N for <work_id>`. Pre-`ymx9` rows are precisely that shape. Production right now:

```
WITH latest AS (SELECT domain,work_id,max(generation) g FROM admission_journal GROUP BY 1,2)
SELECT a.state, (a.generation = l.g) AS is_latest, count(*) …
 live  | f | 58
```

All 58 occupying rows are superseded generations. Every one failed `mark_terminal`, every failure became a pass-level blocker, `reclaimed: 0`, `Enforce remains fail-closed`.

1. A **vanished** object has no lifecycle left to run, so an absence proof now routes to `reclaim_absent_object`, which is generation-agnostic and CASes on the observed identity. A **completed** object still exists, so it keeps its ordinary `mark_terminal` callback where the latest-generation fence is meaningful. Absence is still proven, never assumed from age: not in the LIST, and a direct GET answering `NotFound` (only ever an authoritative `Ok(None)`).
2. A rejected transition is a fact about **one row**. Those failures are counted exactly (`reclaim_failure_count`), named within a bound of five (`reclaim_failures`), logged per row, and the sweep continues. Leaving a row occupying over-counts capacity, which can only deny admissions and never over-admit, so it must not gate Enforce. Only unusable inventory, an unreadable journal, or failed seeding remain pass-level `blockers`.

## Testing

Every regression runs against a **fresh real Postgres database**, and every stale row is produced by a production writer:

- Wedge A: the production `BuildLeaseService` and `BuildLeaseRepository` reproduce the wedge — a lease queued behind a full cap whose requester gives up on `Queued` exactly as `BuildLeaseGraphWarmAdapter::acquire` does, then granted by the FIFO to nobody. The test asserts the live warm is denied *before* reclamation and granted *after*.
- Wedge B: `reserve` with a caller-supplied generation **is** the pre-`ymx9` call, replaying the exact generation histories of the three work ids production named (`019f6f04-…` gen 0 terminal / 1 live / 2 terminal, and so on).

Negatives, none of which may retire anything: an object still in the namespace, a probe answering `Uncertain`, a lease inside its settle window, an unusable LIST, and evidence that predates a holder acknowledgement (fenced by the CAS).

Both fixes were verified to fail against `main` by neutralizing them:

- `build_lease_reclaim::…::abandoned_grant_wedges_the_cap_…` → `reclaimed: left: 0, right: 1`
- `…::superseded_live_generations_are_reclaimed_…` → blockers non-empty
- `…::one_unreclaimable_row_costs_one_row_…` → `reclaim_failure_count: left: 0, right: 1`

Rebased onto `0b5a41ec8` (#2605). `cargo nextest -p djinn-coordinator -E 'test(build_lease) + test(build_admission)'`: 142 passed. `-p djinn-db -p djinn-k8s -E 'test(lease) + test(warm) + test(admission)'`: 125 passed. Clippy clean on every changed crate.

## Coordination

Diff is confined to reclamation and error handling. No capacity accounting is touched, so this is orthogonal to #25's `over_cap` / `SeededOccupancyAboveCap` / `count_task_or_warm_occupancy` unification. Nothing in the launcher/cgroup (#33) or verification/identity (#31) paths is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)