### PR TITLE
fix(goxi): retain CAP_CHOWN so the launcher can hand the broker socket to the worker

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -561,7 +561,7 @@ jobs:
       # Number of `#[ignore]`d proofs the suite declares. The run below fails if
       # fewer than this many actually execute, so a lane that quietly runs zero
       # tests can never be mistaken for a proven kernel boundary.
-      ZF13_EXPECTED_PROOFS: "3"
+      ZF13_EXPECTED_PROOFS: "4"
       # Number of `#[ignore]`d proofs `delegated_cpu_lease_lifecycle.rs`
       # declares. That suite is the ONLY place the CPU lease is proven to
       # actually govern CPU — measured on `cpu.stat` over a wall-clock window

--- a/server/crates/djinn-cgroup-launcher/src/bootstrap.rs
+++ b/server/crates/djinn-cgroup-launcher/src/bootstrap.rs
@@ -54,19 +54,57 @@ use std::path::{Path, PathBuf};
 use crate::Error;
 
 /// Capability numbers (`include/uapi/linux/capability.h`).
+const CAP_CHOWN: u32 = 0;
 const CAP_SETGID: u32 = 6;
 const CAP_SETUID: u32 = 7;
 const CAP_SETPCAP: u32 = 8;
 const CAP_SYS_ADMIN: u32 = 21;
 const CAP_SYS_RESOURCE: u32 = 24;
 
-/// The only capabilities the launcher keeps once bootstrap is complete: exactly
-/// what `child::prepare_child` needs to move a child across the credential
-/// boundary before `execve`.
-const RETAINED_CAPABILITIES: &[u32] = &[CAP_SETGID, CAP_SETUID, CAP_SETPCAP];
+/// The only capabilities the launcher keeps once bootstrap is complete: what
+/// `child::prepare_child` needs to move a child across the credential boundary
+/// before `execve`, plus `CAP_CHOWN`.
+///
+/// # Why `CAP_CHOWN` is here (third v0.7.x rollback)
+///
+/// `transport::UnixBrokerServer::bind` hands the control socket to the worker
+/// with `chown(path, WORKER_UID, WORKER_GID)`, so that mode `0600` admits the
+/// worker (uid 1000) and excludes the launcher-spawned child (uid 1001) at the
+/// filesystem layer, ahead of credential authentication. `chown(2)` to change an
+/// owner requires `CAP_CHOWN` — being euid 0 is NOT sufficient inside a
+/// capability-bounded container, because the kernel checks the capability rather
+/// than the uid. Without it the bind fails `EPERM` and the launcher exits before
+/// serving, which is what failed the second armed production rollout.
+///
+/// It has to be in *this* list, not only in the rendered manifest: the `capset`
+/// below sets permitted and effective to exactly this mask, so a capability
+/// granted by the Pod spec but missing here is destroyed microseconds before the
+/// socket is bound — which is exactly what happened, and why granting `CHOWN` in
+/// the manifest alone did not fix it. `djinn-k8s` now renders the Pod grant FROM
+/// [`RETAINED_CAPABILITY_NAMES`], and the privileged proof
+/// `the_retained_capabilities_still_hand_the_broker_socket_to_the_worker`
+/// performs the real drop and then the real handoff, so neither the list nor the
+/// render can drift again without a red build.
+///
+/// Blast radius: the rootfs is read-only and the only writable mounts are the
+/// 1Mi memory-backed IPC emptyDir and the cgroup mountpoint, so this authorizes
+/// re-owning files on two small dedicated tmpfs volumes and nothing else.
+const RETAINED_CAPABILITIES: &[u32] = &[CAP_CHOWN, CAP_SETGID, CAP_SETUID, CAP_SETPCAP];
 
 /// The capabilities bootstrap needs and then destroys.
 const BOOTSTRAP_ONLY_CAPABILITIES: &[u32] = &[CAP_SYS_ADMIN, CAP_SYS_RESOURCE];
+
+/// Linux capability names, without the `CAP_` prefix, for the capabilities the
+/// launcher keeps for the pod's lifetime. The Pod `securityContext` must grant
+/// every one of these; the API server rejects the `CAP_` spelling alongside
+/// `allowPrivilegeEscalation: false`, hence the bare names.
+///
+/// Exported so `djinn-k8s` renders from this list instead of a second hand-kept
+/// copy — the duplication that let the manifest and the runtime disagree.
+pub const RETAINED_CAPABILITY_NAMES: &[&str] = &["CHOWN", "SETGID", "SETUID", "SETPCAP"];
+
+/// Capability names the launcher holds only during bootstrap and then drops.
+pub const BOOTSTRAP_ONLY_CAPABILITY_NAMES: &[&str] = &["SYS_ADMIN", "SYS_RESOURCE"];
 
 /// `_LINUX_CAPABILITY_VERSION_3`.
 const CAPABILITY_VERSION_3: u32 = 0x2008_0522;
@@ -329,12 +367,61 @@ mod tests {
     fn the_retained_set_is_exactly_what_the_credential_boundary_needs() {
         assert_eq!(
             RETAINED_CAPABILITIES,
-            &[CAP_SETGID, CAP_SETUID, CAP_SETPCAP]
+            &[CAP_CHOWN, CAP_SETGID, CAP_SETUID, CAP_SETPCAP]
         );
         assert_eq!(
             capability_mask(RETAINED_CAPABILITIES),
-            (1 << 6) | (1 << 7) | (1 << 8)
+            1 | (1 << 6) | (1 << 7) | (1 << 8)
         );
+    }
+
+    /// `CAP_CHOWN` is retained because the broker socket is handed to the worker
+    /// with `chown(2)`, which needs the capability even at euid 0. Losing it
+    /// fails the bind with `EPERM` after bootstrap has already succeeded — the
+    /// third distinct blocker found by arming this on a real kernel.
+    #[test]
+    fn chown_is_retained_so_the_broker_socket_can_be_handed_to_the_worker() {
+        assert!(RETAINED_CAPABILITIES.contains(&CAP_CHOWN));
+        assert_eq!(CAP_CHOWN, 0, "CAP_CHOWN is capability number 0");
+        assert_ne!(
+            capability_mask(RETAINED_CAPABILITIES) & 1,
+            0,
+            "bit 0 must survive the post-bootstrap capset"
+        );
+    }
+
+    /// The numeric list the `capset` uses and the name list the Pod render
+    /// consumes must describe the same capabilities. They are separate constants
+    /// in separate crates, and a capability present in one but not the other is
+    /// invisible until a real kernel refuses the syscall: granted-but-not-retained
+    /// is destroyed by the capset, retained-but-not-granted never arrives.
+    #[test]
+    fn the_retained_numbers_and_names_describe_the_same_capabilities() {
+        let expected: Vec<&str> = RETAINED_CAPABILITIES
+            .iter()
+            .map(|capability| match *capability {
+                CAP_CHOWN => "CHOWN",
+                CAP_SETGID => "SETGID",
+                CAP_SETUID => "SETUID",
+                CAP_SETPCAP => "SETPCAP",
+                other => panic!("capability {other} has no name mapping"),
+            })
+            .collect();
+        assert_eq!(expected, RETAINED_CAPABILITY_NAMES);
+        assert_eq!(
+            BOOTSTRAP_ONLY_CAPABILITY_NAMES,
+            &["SYS_ADMIN", "SYS_RESOURCE"]
+        );
+        for name in RETAINED_CAPABILITY_NAMES
+            .iter()
+            .chain(BOOTSTRAP_ONLY_CAPABILITY_NAMES)
+        {
+            assert!(
+                !name.starts_with("CAP_"),
+                "{name} uses the spelling the API server rejects alongside \
+                 allowPrivilegeEscalation: false"
+            );
+        }
     }
 
     /// `CAP_SYS_ADMIN` is the escape primitive; it must never be retained, and

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -563,6 +563,21 @@ pub enum Error {
     ChildPreparation(&'static str),
     #[error("restricted seccomp is unavailable")]
     SeccompUnavailable,
+    /// A named filesystem/ownership step that failed, carrying the operation,
+    /// the path it acted on, and the errno.
+    ///
+    /// The bare [`Io`](Error::Io) below renders as "filesystem operation failed:
+    /// Operation not permitted (os error 1)", which names neither the syscall
+    /// nor the path. That message cost a production rollout: it was the only
+    /// evidence that `chown(2)` on the broker socket was failing for want of
+    /// `CAP_CHOWN`, and it was not enough to act on. Any step whose failure is a
+    /// readiness/permission question should use this instead.
+    #[error("{operation} failed on {path} (errno {errno})")]
+    SocketSetupFailed {
+        operation: &'static str,
+        path: String,
+        errno: i32,
+    },
     #[error("filesystem operation failed: {0}")]
     Io(#[from] io::Error),
 }

--- a/server/crates/djinn-cgroup-launcher/src/transport.rs
+++ b/server/crates/djinn-cgroup-launcher/src/transport.rs
@@ -56,8 +56,18 @@ impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> UnixBrokerServer<F, S, N> 
             }
             fs::remove_file(&path)?;
         }
-        let listener = UnixListener::bind(&path)?;
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        let listener = UnixListener::bind(&path).map_err(|error| Error::SocketSetupFailed {
+            operation: "bind(broker control socket)",
+            path: path.display().to_string(),
+            errno: error.raw_os_error().unwrap_or_default(),
+        })?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).map_err(|error| {
+            Error::SocketSetupFailed {
+                operation: "chmod(broker socket to 0600)",
+                path: path.display().to_string(),
+                errno: error.raw_os_error().unwrap_or_default(),
+            }
+        })?;
         restrict_socket_to_worker(&path)?;
         Ok(Self {
             broker,
@@ -204,6 +214,18 @@ impl<F, S, N> Drop for UnixBrokerServer<F, S, N> {
 ///
 /// Unprivileged embeddings (tests, local runs) already own the socket they just
 /// created, so there is nothing to hand over and this is a no-op.
+/// Hand the bound control socket to the worker.
+///
+/// Mode `0600` plus `WORKER_UID` ownership is what excludes the
+/// launcher-spawned child (uid 1001) from the broker at the filesystem layer,
+/// ahead of credential authentication.
+///
+/// `chown(2)` needs `CAP_CHOWN` even at euid 0 — the kernel checks the
+/// capability, not the uid — so the launcher retains it past bootstrap
+/// (`bootstrap::RETAINED_CAPABILITIES`). When that capability was missing this
+/// returned a bare `EPERM` with no operation or path attached, and the resulting
+/// "filesystem operation failed: Operation not permitted" was the entire
+/// diagnostic available for a failed production rollout. It is named now.
 fn restrict_socket_to_worker(path: &Path) -> Result<(), Error> {
     if unsafe { libc::geteuid() } != 0 {
         return Ok(());
@@ -211,7 +233,13 @@ fn restrict_socket_to_worker(path: &Path) -> Result<(), Error> {
     let raw = std::ffi::CString::new(path.as_os_str().as_encoded_bytes())
         .map_err(|_| Error::UnsafeSocketPath)?;
     if unsafe { libc::chown(raw.as_ptr(), WORKER_UID, WORKER_GID) } != 0 {
-        return Err(Error::Io(std::io::Error::last_os_error()));
+        return Err(Error::SocketSetupFailed {
+            operation: "chown(broker socket to the worker uid/gid)",
+            path: path.display().to_string(),
+            errno: std::io::Error::last_os_error()
+                .raw_os_error()
+                .unwrap_or_default(),
+        });
     }
     Ok(())
 }

--- a/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
@@ -150,7 +150,7 @@ fn assert_rendered_required_job_contract() {
         ("launcher_capabilities_drop", "ALL"),
         (
             "launcher_capabilities_add",
-            "SETUID,SETGID,SETPCAP,SYS_ADMIN,SYS_RESOURCE",
+            "CHOWN,SETGID,SETUID,SETPCAP,SYS_ADMIN,SYS_RESOURCE",
         ),
         ("launcher_cpu_limit", "none"),
         ("launcher_cpu_request", "50m"),

--- a/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
+++ b/server/crates/djinn-cgroup-launcher/tests/fixtures/rendered-security-context.env
@@ -39,7 +39,15 @@ launcher_run_as_group=0
 launcher_allow_privilege_escalation=false
 launcher_read_only_root_filesystem=true
 launcher_capabilities_drop=ALL
-launcher_capabilities_add=SETUID,SETGID,SETPCAP,SYS_ADMIN,SYS_RESOURCE
+#
+# CHOWN is RETAINED past bootstrap: `UnixBrokerServer::bind` hands the control
+# socket to the worker with chown(2), and chown needs CAP_CHOWN even at euid 0
+# because the kernel checks the capability rather than the uid. Its absence
+# failed the second armed production rollout with a bare EPERM after a fully
+# successful bootstrap. The render derives this list from
+# `bootstrap::RETAINED_CAPABILITY_NAMES` + `BOOTSTRAP_ONLY_CAPABILITY_NAMES`, so
+# the manifest grant and the runtime capset cannot drift apart.
+launcher_capabilities_add=CHOWN,SETGID,SETUID,SETPCAP,SYS_ADMIN,SYS_RESOURCE
 launcher_bootstrap_only_capabilities=SYS_ADMIN,SYS_RESOURCE
 
 # The runtime's default AppArmor profile carries a flat `deny mount,` and denies

--- a/server/crates/djinn-cgroup-launcher/tests/kernel_boundary_under_rendered_context.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/kernel_boundary_under_rendered_context.rs
@@ -462,6 +462,130 @@ fn an_incompatible_volume_ownership_mode_rejects_the_spawn_before_exec() {
     chown(&environment.root, expected_uid, 0);
 }
 
+// ═══ privileged proof 4: the retained caps still hand the socket to the worker ═══
+
+/// After the launcher drops its bootstrap capabilities, it must STILL be able to
+/// hand the broker control socket to the worker.
+///
+/// # Why this proof exists (third v0.7.x production rollback)
+///
+/// `UnixBrokerServer::bind` finishes by `chown`ing the socket to the worker
+/// uid/gid, which is what excludes the uid-1001 child at the filesystem layer
+/// ahead of credential authentication. `chown(2)` requires `CAP_CHOWN` even at
+/// euid 0 — the kernel checks the capability, not the uid — and the retained set
+/// did not include it. The launcher therefore completed its whole bootstrap and
+/// then died `EPERM` on the very last step of startup, on a real node, twice.
+///
+/// Every existing proof in this lane runs with the FULL root capability set, so
+/// all of them passed while production could not start. This one is different:
+/// it performs the real [`drop_bootstrap_capabilities`] first and only then
+/// exercises the handoff, so it fails if the retained set is ever narrowed below
+/// what the shipped startup path needs. It runs in a forked child because the
+/// drop is irreversible.
+#[ignore = "privileged: needs uid 0 holding the rendered bootstrap capabilities \
+            (CI job launcher-kernel-boundary)"]
+#[test]
+fn the_retained_capabilities_still_hand_the_broker_socket_to_the_worker() {
+    let context = RenderedContext::load();
+    // Establishes the same privileged preconditions as the sibling proofs (uid 0
+    // and a real delegated cgroup root), even though the socket itself must live
+    // on an ordinary filesystem: cgroup2 cannot hold a Unix socket inode, which
+    // is why this deliberately does NOT reuse the delegated root as a directory.
+    let _environment = require_privileged_environment(&context);
+    let worker_uid = context.u32("worker_run_as_user");
+    let worker_gid = context.u32("worker_run_as_group");
+
+    let scratch = std::env::var_os("CARGO_TARGET_TMPDIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
+        .join(format!("djinn-socket-handoff-{}", std::process::id()));
+    std::fs::create_dir_all(&scratch).expect("create the scratch dir for the control socket");
+    let socket = scratch.join("handoff.sock");
+    let _ = std::fs::remove_file(&socket);
+    let (read_fd, write_fd) = pipe();
+
+    let pid = unsafe { libc::fork() };
+    assert!(pid >= 0, "fork the capability-dropping child");
+    if pid == 0 {
+        // Child: drop exactly as the shipped launcher does, then perform the
+        // shipped handoff. Anything unexpected is reported, never panicked.
+        unsafe { libc::close(read_fd) };
+        let mut report = String::new();
+        match djinn_cgroup_launcher::bootstrap::drop_bootstrap_capabilities() {
+            Ok(()) => report.push_str("dropped=0\n"),
+            Err(error) => report.push_str(&format!("dropped=1 ({error})\n")),
+        }
+        let listener = std::os::unix::net::UnixListener::bind(&socket);
+        match listener {
+            Ok(_) => report.push_str("bind_errno=0\n"),
+            Err(error) => {
+                report.push_str(&format!(
+                    "bind_errno={}\n",
+                    error.raw_os_error().unwrap_or(-1)
+                ));
+            }
+        }
+        let raw = std::ffi::CString::new(socket.to_string_lossy().as_bytes())
+            .expect("socket path has no interior NUL");
+        let rc = unsafe { libc::chown(raw.as_ptr(), worker_uid, worker_gid) };
+        let errno = if rc == 0 {
+            0
+        } else {
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(-1)
+        };
+        report.push_str(&format!("chown_errno={errno}\n"));
+
+        use std::io::Write as _;
+        let mut sink = unsafe { <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(write_fd) };
+        let _ = sink.write_all(report.as_bytes());
+        let _ = sink.flush();
+        unsafe { libc::_exit(0) };
+    }
+
+    unsafe { libc::close(write_fd) };
+    let mut status = 0;
+    unsafe { libc::waitpid(pid, &raw mut status, 0) };
+    let report = {
+        use std::io::Read as _;
+        let mut source = unsafe { <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(read_fd) };
+        let mut text = String::new();
+        source.read_to_string(&mut text).expect("read the report");
+        text
+    };
+
+    assert!(
+        report.contains("dropped=0\n"),
+        "the bootstrap capability drop itself must succeed: {report}"
+    );
+    assert!(
+        report.contains("bind_errno=0\n"),
+        "binding the control socket must succeed after the drop: {report}"
+    );
+    assert!(
+        report.contains("chown_errno=0\n"),
+        "handing the control socket to the worker must succeed after the bootstrap drop. \
+         errno 1 (EPERM) means CAP_CHOWN is missing from \
+         `bootstrap::RETAINED_CAPABILITIES` or from the rendered Pod grant — the launcher \
+         would complete bootstrap and then die on the last step of startup: {report}"
+    );
+
+    // The handoff really happened: mode 0600 + worker ownership is what excludes
+    // the uid-1001 child from the broker before authentication is consulted.
+    let metadata = std::fs::metadata(&socket).expect("the bound socket must exist");
+    use std::os::unix::fs::MetadataExt as _;
+    assert_eq!(
+        metadata.uid(),
+        worker_uid,
+        "socket must be owned by the worker"
+    );
+    assert_eq!(
+        metadata.gid(),
+        worker_gid,
+        "socket must be grouped to the worker"
+    );
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
 /// The privileged lane's own YAML block, isolated from sibling jobs so this
 /// guard asserts the lane's wiring and never trips over unrelated CI edits.
 fn privileged_lane_block() -> String {

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -3827,9 +3827,18 @@ mod tests {
         // bootstrap phase ONLY — it `capset`s them away before the broker binds
         // its socket, so no user-controlled code ever runs while they are held.
         // See `launcher::launcher_capabilities`.
+        // CHOWN is retained past bootstrap so the broker socket can be handed to
+        // the worker uid; chown(2) needs the capability even at euid 0.
         assert_eq!(
             add,
-            &["SETUID", "SETGID", "SETPCAP", "SYS_ADMIN", "SYS_RESOURCE"]
+            &[
+                "CHOWN",
+                "SETGID",
+                "SETUID",
+                "SETPCAP",
+                "SYS_ADMIN",
+                "SYS_RESOURCE"
+            ]
         );
         // The `CAP_`-prefixed spelling is what the API server rejects alongside
         // `allowPrivilegeEscalation: false`.

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -44,6 +44,12 @@ pub use djinn_cgroup_launcher::broker::{WORKER_GID, WORKER_UID};
 // `CHILD_UID` is applied by the launcher when it spawns the child, not in the
 // pod manifest, so it is only referenced by tests/docs on the render side.
 pub use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
+// The capability lists the runtime actually `capset`s to. The render derives the
+// container's `capabilities.add` from these so the manifest cannot grant a
+// capability the runtime discards, nor omit one the runtime needs.
+use djinn_cgroup_launcher::bootstrap::{
+    BOOTSTRAP_ONLY_CAPABILITY_NAMES, RETAINED_CAPABILITY_NAMES,
+};
 use djinn_cgroup_launcher::{
     CgroupMode, Error as LauncherError, LeasedQuota, Readiness, UnleasedQuota,
 };
@@ -355,22 +361,32 @@ pub fn worker_security_context() -> SecurityContext {
 /// written is API-invalid. Keeping `allowPrivilegeEscalation: false` is the
 /// stronger posture and it is what the launcher actually needs — it drops
 /// privilege, it never gains any across `execve`.
+/// Every capability the launcher container is granted: the set it keeps for the
+/// pod's lifetime, plus the two it destroys once the delegated root exists.
+///
+/// Both lists come from `djinn_cgroup_launcher::bootstrap`, which is the crate
+/// that actually performs the post-bootstrap `capset`. They used to be a second
+/// hand-kept copy here, and the copies disagreed: the runtime retained
+/// `CAP_CHOWN` nowhere while `UnixBrokerServer::bind` needed it to hand the
+/// control socket to the worker, so the launcher died `EPERM` after a fully
+/// successful bootstrap. Rendering from the runtime's own lists makes that
+/// class of drift unrepresentable rather than merely tested.
 fn launcher_capabilities() -> Capabilities {
+    let add = RETAINED_CAPABILITY_NAMES
+        .iter()
+        .chain(BOOTSTRAP_ONLY_CAPABILITY_NAMES)
+        .map(|capability| (*capability).to_string())
+        .collect();
     Capabilities {
         drop: Some(vec!["ALL".to_string()]),
-        add: Some(vec![
-            "SETUID".to_string(),
-            "SETGID".to_string(),
-            "SETPCAP".to_string(),
-            "SYS_ADMIN".to_string(),
-            "SYS_RESOURCE".to_string(),
-        ]),
+        add: Some(add),
     }
 }
 
 /// Capabilities the launcher holds only during bootstrap and then `capset`s
-/// away. Named here so the render and the runtime drop assert one list.
-pub const LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES: &[&str] = &["SYS_ADMIN", "SYS_RESOURCE"];
+/// away. Re-exported from the launcher crate so the render and the runtime drop
+/// really are one list rather than two that agree by inspection.
+pub const LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES: &[&str] = BOOTSTRAP_ONLY_CAPABILITY_NAMES;
 
 /// Container-level security context for the launcher sidecar. Root, minimal
 /// caps, restricted seccomp, read-only rootfs (it only writes the delegated

--- a/server/crates/djinn-k8s/src/launcher_tests.rs
+++ b/server/crates/djinn-k8s/src/launcher_tests.rs
@@ -9,6 +9,9 @@
 
 use super::*;
 
+use djinn_cgroup_launcher::bootstrap::{
+    BOOTSTRAP_ONLY_CAPABILITY_NAMES, RETAINED_CAPABILITY_NAMES,
+};
 use djinn_runtime::RoleKind;
 
 /// The classifier itself is proven exhaustively in `djinn-runtime` (one
@@ -107,8 +110,11 @@ fn worker_security_context_is_restricted() {
     assert_eq!(sc.seccomp_profile.as_ref().unwrap().type_, "RuntimeDefault");
 }
 
-/// The launcher is granted exactly the five capabilities it needs, spelled
+/// The launcher is granted exactly the six capabilities it needs, spelled
 /// the way the API server accepts, and is never `privileged`.
+///
+/// `CHOWN` is retained past bootstrap because the broker socket is handed to the
+/// worker with `chown(2)`, which requires the capability even at euid 0.
 #[test]
 fn launcher_capabilities_are_exactly_the_designed_set() {
     let caps = launcher_capabilities();
@@ -116,7 +122,14 @@ fn launcher_capabilities_are_exactly_the_designed_set() {
     let add = caps.add.expect("launcher adds capabilities");
     assert_eq!(
         add,
-        vec!["SETUID", "SETGID", "SETPCAP", "SYS_ADMIN", "SYS_RESOURCE"]
+        vec![
+            "CHOWN",
+            "SETGID",
+            "SETUID",
+            "SETPCAP",
+            "SYS_ADMIN",
+            "SYS_RESOURCE"
+        ]
     );
     // `privileged: true` would grant everything and defeat the bootstrap
     // drop entirely; it must never appear.
@@ -162,7 +175,45 @@ fn every_bootstrap_only_capability_is_one_the_launcher_drops_at_runtime() {
         .iter()
         .filter(|granted| !LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES.contains(&granted.as_str()))
         .collect();
-    assert_eq!(permanent, vec!["SETUID", "SETGID", "SETPCAP"]);
+    assert_eq!(permanent, vec!["CHOWN", "SETGID", "SETUID", "SETPCAP"]);
+}
+
+/// The rendered grant and the runtime `capset` must be the same set.
+///
+/// This is the guard for the third v0.7.x rollback. The launcher retains exactly
+/// `bootstrap::RETAINED_CAPABILITIES` and destroys the rest, so a capability the
+/// manifest grants but the runtime does not retain is gone microseconds later,
+/// and one the runtime retains but the manifest never grants never existed. Both
+/// directions are silent until a real kernel refuses a syscall — which is how
+/// `CAP_CHOWN` came to be missing while `UnixBrokerServer::bind` needed it.
+#[test]
+fn the_rendered_grant_is_exactly_what_the_runtime_retains_plus_bootstrap_only() {
+    let cfg = KubernetesConfig::for_testing();
+    let container = launcher_sidecar_container(&cfg, "registry.example/proj:tag");
+    let add = container
+        .security_context
+        .unwrap()
+        .capabilities
+        .unwrap()
+        .add
+        .unwrap();
+
+    let expected: Vec<String> = RETAINED_CAPABILITY_NAMES
+        .iter()
+        .chain(BOOTSTRAP_ONLY_CAPABILITY_NAMES)
+        .map(|capability| (*capability).to_string())
+        .collect();
+    assert_eq!(
+        add, expected,
+        "the Pod grant must be the runtime's retained set plus its bootstrap-only set"
+    );
+
+    for retained in RETAINED_CAPABILITY_NAMES {
+        assert!(
+            !LAUNCHER_BOOTSTRAP_ONLY_CAPABILITIES.contains(retained),
+            "{retained} cannot be both retained and dropped"
+        );
+    }
 }
 
 /// Defect 1, asserted on the manifest: a CPU limit on the launcher container


### PR DESCRIPTION
Third distinct blocker in the goxi launcher path, found the same way as the first two — by arming it on a real kernel.

## What failed

After #2604 fixed the AppArmor mount denial and the `hostUsers` delegation break, the launcher completed its **entire** bootstrap and then died on the last step of startup:

```
before #2604:  could not mount a private cgroup2 filesystem (errno 13)   <- EACCES, AppArmor
after  #2604:  filesystem operation failed: Operation not permitted      <- EPERM
```

## It is not seccomp

EPERM looked like seccomp, and goxi's proposal asked for a "clone3 seccomp allowlist", so seccomp was the obvious suspect. Measured on the production node, one variable at a time, everything else held fixed:

| post-bootstrap `CapEff` | seccomp | `chown(socket, 1000, 1000)` |
|---|---|---|
| `0x1c0` (as shipped) | RuntimeDefault | **EPERM** |
| `0x1c1` (**+CAP_CHOWN**) | RuntimeDefault | **succeeds** |
| `0x1c0` (as shipped) | **Unconfined** | **still EPERM** |

The third row is the control: relaxing seccomp changes nothing. `clone3` is not implicated and is not even used any more — `spawn.rs` replaced it with `fork(2)`.

## Root cause

`transport::restrict_socket_to_worker` hands the control socket to the worker with `chown(path, WORKER_UID, WORKER_GID)` so that mode `0600` admits the worker (uid 1000) and excludes the launcher-spawned child (uid 1001) at the filesystem layer, ahead of credential authentication.

`chown(2)` requires **CAP_CHOWN**. Being euid 0 is not sufficient in a capability-bounded container — the kernel checks the capability, not the uid. The launcher held `SETUID`/`SETGID`/`SETPCAP` and nothing else.

## The trap: it must be added in two places

Granting `CHOWN` in the Pod spec alone does **not** fix it. `drop_bootstrap_capabilities` sets permitted and effective to *exactly* `RETAINED_CAPABILITIES`, destroying the capability microseconds before the socket is bound.

Proven on the node with the real launcher binary and a real worker handshake — with `CHOWN` granted only in the manifest, the socket is created but still owned by `root` and the launcher still exits EPERM:

```
srw------- 1 root 1000 broker.sock     <- bind + chmod succeeded, chown did not
```

So the render now derives `capabilities.add` **from** the runtime's own `RETAINED_CAPABILITY_NAMES` + `BOOTSTRAP_ONLY_CAPABILITY_NAMES` instead of a second hand-kept copy that could disagree with it. That class of drift is now unrepresentable rather than merely tested.

## Why every existing test passed while production could not start

- The privileged `launcher-kernel-boundary` lane runs as **full root with the complete capability set**, so no proof in it can observe a capability-restriction bug.
- The rendered-manifest tests assert *fields*, not that anything starts.

This adds a fourth privileged proof that performs the **real** `drop_bootstrap_capabilities` first and only then exercises the real socket handoff. Verified both directions on a real kernel:

- with the fix → passes
- without the fix → fails with `dropped=0, bind_errno=0, chown_errno=1`

`ZF13_EXPECTED_PROOFS` is bumped 3 → 4 so the lane's own count guard stays honest.

## Error reporting

`"filesystem operation failed: Operation not permitted"` naming neither syscall nor path was the entire diagnostic available for a failed production rollout. The socket-setup steps now report operation, path and errno by name:

```
chown(broker socket to the worker uid/gid) failed on /var/run/djinn/launcher/broker.sock (errno 1)
```

## What this gives up

Nothing structural. `CAP_CHOWN` is retained for the pod's lifetime, but the rootfs is read-only and the only writable mounts are the 1Mi memory-backed IPC emptyDir and the cgroup mountpoint, so it authorizes re-owning files on two small dedicated tmpfs volumes and nothing else. It preserves the uid-1001-child exclusion that the privileged suite already asserts; dropping the chown instead (mode `0660` on the setgid-inherited group) would have widened socket access to the child, which is strictly worse.

## The systemic point

Three blockers in one path — AppArmor `deny mount`, `hostUsers` breaking cgroup delegation, and a missing `CAP_CHOWN` — each invisible to manifest-level assertions, each found only by starting the container on a real kernel, and each hidden behind the previous one because layered denials only reveal themselves one at a time. The launcher needs a smoke test that starts it and serves the broker socket. More rendered-manifest acceptance criteria would not have caught any of the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
