### PR TITLE
fix(goxi): Mount a writable invocation journal so the armed worker survives startup

### DIFF
--- a/server/crates/djinn-agent-worker/src/launcher_handshake.rs
+++ b/server/crates/djinn-agent-worker/src/launcher_handshake.rs
@@ -98,14 +98,42 @@ pub enum LauncherHandshake {
 
 /// Bounded failure reasons for the post-detection handshake. All fold into
 /// [`LauncherHandshake::FailedClosed`].
+///
+/// # Every variant names the failing operation, its path and its errno
+///
+/// This is the worker half of a fail-closed boundary: in `required` mode any
+/// variant here aborts the Pod outright. A message that says only "write worker
+/// launcher handshake: Permission denied" costs a deploy cycle to attribute, so
+/// each filesystem failure carries the syscall-level operation, the exact path
+/// and the raw errno — the same treatment `Error::SocketSetupFailed` already
+/// gives the launcher's own socket setup.
 #[derive(Debug, thiserror::Error)]
 pub enum HandshakeError {
-    #[error("write worker launcher handshake: {0}")]
-    Io(#[source] std::io::Error),
-    #[error("launcher control socket never bound within the handshake window")]
-    ConnectTimeout,
-    #[error("connect launcher control socket: {0}")]
-    Connect(#[source] std::io::Error),
+    #[error("worker handshake {operation} on {path} failed (errno {errno}): {source}")]
+    Io {
+        operation: &'static str,
+        path: String,
+        errno: i32,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error(
+        "launcher control socket {path} never bound within the handshake window \
+         ({attempts} attempts x {poll_ms}ms); the sidecar is running but never reached \
+         UnixBrokerServer::bind, so check its own stderr for a named readiness failure"
+    )]
+    ConnectTimeout {
+        path: String,
+        attempts: u32,
+        poll_ms: u64,
+    },
+    #[error("connect(2) launcher control socket {path} failed (errno {errno}): {source}")]
+    Connect {
+        path: String,
+        errno: i32,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("launcher rejected the worker handshake (credential or peer mismatch): {0}")]
     AuthRejected(#[source] LauncherError),
     #[error("prepare non-dumpable worker readiness: {0}")]
@@ -180,9 +208,22 @@ fn ensure_credential(credential_path: &Path) -> Result<Vec<u8>, HandshakeError> 
     let mut credential = vec![0_u8; CREDENTIAL_BYTES];
     File::open("/dev/urandom")
         .and_then(|mut file| file.read_exact(&mut credential))
-        .map_err(HandshakeError::Io)?;
+        .map_err(|source| {
+            io_failure("read credential entropy", Path::new("/dev/urandom"), source)
+        })?;
     atomic_publish(credential_path, &credential)?;
     Ok(credential)
+}
+
+/// Build a [`HandshakeError::Io`] that names the operation, the path and the
+/// raw errno. Nothing on this path may surface a bare `io::Error`.
+fn io_failure(operation: &'static str, path: &Path, source: std::io::Error) -> HandshakeError {
+    HandshakeError::Io {
+        operation,
+        path: path.display().to_string(),
+        errno: source.raw_os_error().unwrap_or_default(),
+        source,
+    }
 }
 
 /// Publish the worker PID as a trimmed decimal string, mirroring the launcher's
@@ -196,8 +237,10 @@ fn write_worker_pid(mount_dir: &Path) -> Result<(), HandshakeError> {
 /// launcher poll never observes a half-written file at `path`.
 fn atomic_publish(path: &Path, bytes: &[u8]) -> Result<(), HandshakeError> {
     let temp = path.with_extension("tmp");
-    std::fs::write(&temp, bytes).map_err(HandshakeError::Io)?;
-    std::fs::rename(&temp, path).map_err(HandshakeError::Io)?;
+    std::fs::write(&temp, bytes)
+        .map_err(|source| io_failure("write handshake temp", &temp, source))?;
+    std::fs::rename(&temp, path)
+        .map_err(|source| io_failure("rename handshake temp into place", path, source))?;
     Ok(())
 }
 
@@ -220,10 +263,20 @@ fn connect_with_retry(
                     .map_err(HandshakeError::AuthRejected);
             }
             Err(error) if is_pre_bind_race(&error) => std::thread::sleep(CONNECT_POLL),
-            Err(error) => return Err(HandshakeError::Connect(error)),
+            Err(source) => {
+                return Err(HandshakeError::Connect {
+                    path: socket_path.display().to_string(),
+                    errno: source.raw_os_error().unwrap_or_default(),
+                    source,
+                });
+            }
         }
     }
-    Err(HandshakeError::ConnectTimeout)
+    Err(HandshakeError::ConnectTimeout {
+        path: socket_path.display().to_string(),
+        attempts: CONNECT_ATTEMPTS,
+        poll_ms: CONNECT_POLL.as_millis() as u64,
+    })
 }
 
 /// A not-yet-bound control socket surfaces as `ENOENT` (the launcher has not

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -3457,7 +3457,11 @@ mod tests {
         for handshake in [
             Some(LauncherHandshake::AbsentMount),
             Some(LauncherHandshake::FailedClosed(
-                HandshakeError::ConnectTimeout,
+                HandshakeError::ConnectTimeout {
+                    path: "/var/run/djinn/launcher/broker.sock".to_string(),
+                    attempts: 300,
+                    poll_ms: 100,
+                },
             )),
             None,
         ] {
@@ -3475,6 +3479,54 @@ mod tests {
                 "required-mode error must preserve enforcement context: {error}"
             );
         }
+    }
+
+    /// Four production deploy cycles were spent attributing armed-launcher
+    /// failures whose only log line named neither the operation nor the path.
+    /// Every fail-closed handshake variant must carry both, plus an errno where
+    /// one exists, so the next failure is readable from a single line.
+    #[test]
+    fn required_launcher_failures_name_the_failing_operation_and_path() {
+        use launcher_handshake::HandshakeError;
+
+        let cases = [
+            HandshakeError::Io {
+                operation: "write handshake temp",
+                path: "/var/run/djinn/launcher/credential.tmp".to_string(),
+                errno: 30,
+                source: std::io::Error::from_raw_os_error(30),
+            },
+            HandshakeError::Connect {
+                path: "/var/run/djinn/launcher/broker.sock".to_string(),
+                errno: 13,
+                source: std::io::Error::from_raw_os_error(13),
+            },
+            HandshakeError::ConnectTimeout {
+                path: "/var/run/djinn/launcher/broker.sock".to_string(),
+                attempts: 300,
+                poll_ms: 100,
+            },
+        ];
+        for case in cases {
+            let rendered = case.to_string();
+            assert!(
+                rendered.contains("/var/run/djinn/launcher/"),
+                "handshake failure must name the path it touched: {rendered}"
+            );
+            assert!(
+                rendered.len() > 40,
+                "handshake failure must be more than a bare errno string: {rendered}"
+            );
+        }
+        let io = HandshakeError::Io {
+            operation: "rename handshake temp into place",
+            path: "/var/run/djinn/launcher/worker.pid".to_string(),
+            errno: 13,
+            source: std::io::Error::from_raw_os_error(13),
+        }
+        .to_string();
+        assert!(io.contains("rename handshake temp into place"), "{io}");
+        assert!(io.contains("errno 13"), "{io}");
     }
 
     #[tokio::test]

--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -86,6 +86,16 @@ impl ShellLaunchContext {
         services: Arc<dyn SupervisorServices>,
         client: UnixBrokerClient,
     ) -> std::io::Result<Self> {
+        // The journal directory must be a WRITABLE mount. `/var/run/djinn` in a
+        // rendered task-run Pod is the `spec` Secret volume mounted
+        // `readOnly: true`, so this directory only works because
+        // `djinn_k8s::invocation_journal` renders a dedicated emptyDir over it
+        // and passes the path back in `DJINN_INVOCATION_JOURNAL_DIR`. Without
+        // that volume `create_dir_all` returns EROFS and the armed worker aborts
+        // before any session exists — measured in production, launcher blocker
+        // 4. The fallback below is kept identical to the rendered path so an
+        // older worker image paired with a newer render still lands on the
+        // mount; do not change one without the other.
         let journal_dir = std::env::var_os("DJINN_INVOCATION_JOURNAL_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("/var/run/djinn/invocation-journal"));

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -13,7 +13,7 @@
 use std::fs::{self, File, OpenOptions};
 use std::future::Future;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -93,6 +93,22 @@ struct UnresolvedInvocation {
     recorded_at_ms: u128,
 }
 
+/// Re-wrap an `io::Error` from journal setup so the message carries the failing
+/// operation, the exact directory and the OS errno. The kind is preserved so
+/// callers that match on `ErrorKind` are unaffected.
+fn named_journal_error(operation: &str, directory: &Path, error: io::Error) -> io::Error {
+    let errno = error
+        .raw_os_error()
+        .map_or_else(|| "none".to_string(), |code| code.to_string());
+    io::Error::new(
+        error.kind(),
+        format!(
+            "invocation journal {operation} on {} failed (errno {errno}): {error}",
+            directory.display()
+        ),
+    )
+}
+
 /// Pod-local write-ahead journal. Replacements fsync the file and parent.
 pub struct InvocationJournal {
     directory: PathBuf,
@@ -100,6 +116,19 @@ pub struct InvocationJournal {
     update_lock: Mutex<()>,
 }
 impl InvocationJournal {
+    /// Open (creating if needed) the pod-local journal directory.
+    ///
+    /// # Every failure here names its operation, path and errno
+    ///
+    /// This constructor runs on the worker's REQUIRED startup path, before a
+    /// session exists, and a failure aborts the whole task-run Pod. It used to
+    /// propagate the bare `io::Error`, so an armed production rollout died with
+    /// nothing but `Read-only file system (os error 30)` in the log — no
+    /// operation, no directory — and cost a deploy cycle to attribute. (The
+    /// cause: the compiled-in default directory sits inside the read-only
+    /// `spec` Secret mount; the render now supplies a writable volume, see
+    /// `djinn_k8s::invocation_journal`.) Naming the operation and the path is
+    /// what makes the next such failure readable from one log line.
     pub fn new(directory: PathBuf, pod_uid: String) -> io::Result<Self> {
         if pod_uid.is_empty() || pod_uid.contains('/') || pod_uid.contains('\0') {
             return Err(io::Error::new(
@@ -107,8 +136,11 @@ impl InvocationJournal {
                 "invalid pod UID",
             ));
         }
-        fs::create_dir_all(&directory)?;
-        File::open(&directory)?.sync_all()?;
+        fs::create_dir_all(&directory)
+            .map_err(|error| named_journal_error("create_dir_all", &directory, error))?;
+        File::open(&directory)
+            .and_then(|handle| handle.sync_all())
+            .map_err(|error| named_journal_error("open+fsync", &directory, error))?;
         Ok(Self {
             directory,
             pod_uid,

--- a/server/crates/djinn-k8s/src/invocation_journal.rs
+++ b/server/crates/djinn-k8s/src/invocation_journal.rs
@@ -1,0 +1,181 @@
+//! Writable render surface for the worker's durable invocation journal.
+//!
+//! # Why this module exists (launcher blocker 4, v0.7.8 rollback)
+//!
+//! In `required` mode the worker composes its shell path from an authenticated
+//! broker connection, and that composition opens a pod-local write-ahead
+//! journal before the supervisor ever runs:
+//!
+//! ```text
+//! djinn-agent::context::ShellLaunchContext::broker_backed
+//!   -> InvocationJournal::new(DJINN_INVOCATION_JOURNAL_DIR)
+//!        -> std::fs::create_dir_all(directory)
+//! ```
+//!
+//! The binary's compiled-in default for that directory is
+//! `/var/run/djinn/invocation-journal`. `/var/run/djinn` in a task-run Pod is
+//! the **`spec` Secret volume, mounted `readOnly: true`**, so `create_dir_all`
+//! returns `EROFS` and the worker aborts before it creates a session. Measured
+//! on the production node inside a real task-run worker container:
+//!
+//! ```text
+//! $ mkdir -p /var/run/djinn/invocation-journal
+//! mkdir: cannot create directory '/var/run/djinn/invocation-journal':
+//!        Read-only file system
+//! ```
+//!
+//! That is the whole of launcher blocker 4: the cgroup-launcher sidecar reached
+//! `Ready` with zero restarts, the worker↔broker handshake completed (AUTH +
+//! READY were both accepted on the node in a probe carrying the exact rendered
+//! security context), and the worker then died one call later on a directory the
+//! manifest never made writable. Every Job exhausted its retries with zero
+//! sessions, and nothing lease-related was ever reached — which is exactly why
+//! no lease error appeared anywhere.
+//!
+//! This is the same defect class as the renderer/binary contract gap that has
+//! now produced several of these: **the binary requires something the manifest
+//! renderer never supplies, and the tests pass because the test harness supplies
+//! it** (`InvocationJournal` tests all pass a `tempfile::tempdir()`).
+//!
+//! # The fix
+//!
+//! Render a dedicated writable volume at [`INVOCATION_JOURNAL_DIR`] and pass
+//! the path explicitly as `DJINN_INVOCATION_JOURNAL_DIR` rather than leaving the
+//! worker to fall back to a compiled-in default the render does not know about.
+//! Nesting a writable `emptyDir` under the read-only `spec` mount is sound and
+//! is measured, not assumed — the launcher IPC volume already nests the same way
+//! at `/var/run/djinn/launcher`, and a node probe confirmed a nested `emptyDir`
+//! is writable while its read-only parent is not:
+//!
+//! ```text
+//! touch /var/run/djinn/launcher/probe-write            -> OK
+//! mkdir -p /var/run/djinn/invocation-journal           -> EROFS
+//! mkdir -p /var/run/djinn/invocation-journal-mounted/x -> OK   (emptyDir)
+//! ```
+//!
+//! The journal is rendered ONLY when the launcher is armed. In the explicit
+//! `disabled` profile `shell_launch` is `None`, `broker_backed` is never called,
+//! and no journal is opened — so the disabled manifest keeps its exact shape.
+
+use k8s_openapi::api::core::v1::{EmptyDirVolumeSource, EnvVar, Volume, VolumeMount};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+
+/// Volume name for the worker-private invocation journal.
+pub const VOLUME_INVOCATION_JOURNAL: &str = "invocation-journal";
+
+/// Directory the worker opens its durable invocation journal in.
+///
+/// MUST equal the `djinn-agent` default in
+/// `ShellLaunchContext::broker_backed`, because that default is what a worker
+/// falls back to when `DJINN_INVOCATION_JOURNAL_DIR` is absent. Keeping the two
+/// equal means an older worker image paired with a newer render still lands on
+/// the mount rather than on the read-only Secret volume.
+pub const INVOCATION_JOURNAL_DIR: &str = "/var/run/djinn/invocation-journal";
+
+/// Env var the worker reads the journal directory from.
+pub const INVOCATION_JOURNAL_DIR_ENV: &str = "DJINN_INVOCATION_JOURNAL_DIR";
+
+/// Upper bound on the journal volume.
+///
+/// The journal holds one small text record per *unresolved* invocation and
+/// removes it on resolution, so the steady-state content is a handful of
+/// records at most. 4Mi is generous for that and still bounds a runaway.
+const INVOCATION_JOURNAL_SIZE_LIMIT: &str = "4Mi";
+
+/// The worker-private journal volume.
+///
+/// Memory-backed: the records carry task/task-run/pod identity plus a lease
+/// fencing token, they are only meaningful for the lifetime of THIS Pod (the
+/// recorded pod UID is what recovery matches on), and an `emptyDir` — memory or
+/// disk — dies with the Pod either way. Memory-backed keeps them off the node
+/// filesystem and makes the `sync_all` the journal performs a no-op rather than
+/// a disk barrier on a path that is written on every shell command.
+pub fn invocation_journal_volume() -> Volume {
+    Volume {
+        name: VOLUME_INVOCATION_JOURNAL.to_string(),
+        empty_dir: Some(EmptyDirVolumeSource {
+            medium: Some("Memory".to_string()),
+            size_limit: Some(Quantity(INVOCATION_JOURNAL_SIZE_LIMIT.to_string())),
+        }),
+        ..Volume::default()
+    }
+}
+
+/// Worker-side mount of [`invocation_journal_volume`]. Writable, and mounted
+/// into the worker ONLY — the journal is the worker's private record of which
+/// invocations it still owes a resolution for, and neither the launcher nor a
+/// backing-service sidecar has any business reading or writing it.
+pub fn worker_invocation_journal_mount() -> VolumeMount {
+    VolumeMount {
+        name: VOLUME_INVOCATION_JOURNAL.to_string(),
+        mount_path: INVOCATION_JOURNAL_DIR.to_string(),
+        ..VolumeMount::default()
+    }
+}
+
+/// The explicit journal-directory env the worker receives with the sidecar.
+pub fn worker_invocation_journal_env() -> EnvVar {
+    EnvVar {
+        name: INVOCATION_JOURNAL_DIR_ENV.to_string(),
+        value: Some(INVOCATION_JOURNAL_DIR.to_string()),
+        ..EnvVar::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The env the worker reads and the mount the kubelet creates must name the
+    /// SAME directory. If they drift, the worker opens a path no volume backs
+    /// and falls straight back onto the read-only Secret mount — the exact
+    /// blocker this module exists to close.
+    #[test]
+    fn journal_env_mount_and_default_all_name_one_directory() {
+        assert_eq!(
+            worker_invocation_journal_env().value.as_deref(),
+            Some(INVOCATION_JOURNAL_DIR)
+        );
+        assert_eq!(
+            worker_invocation_journal_mount().mount_path,
+            INVOCATION_JOURNAL_DIR
+        );
+        assert_eq!(
+            worker_invocation_journal_mount().name,
+            invocation_journal_volume().name
+        );
+    }
+
+    /// The journal mount must be WRITABLE. A `readOnly: true` mount here fails
+    /// exactly the way the unmounted path did, and would be an easy thing to
+    /// copy from the neighbouring read-only spec/token mounts.
+    #[test]
+    fn journal_mount_is_writable() {
+        assert_ne!(
+            worker_invocation_journal_mount().read_only,
+            Some(true),
+            "the worker creates and fsyncs this directory; a read-only mount is EROFS"
+        );
+    }
+
+    /// The directory must sit under a real volume, not inside the read-only
+    /// `spec` Secret mount root itself. `/var/run/djinn` IS that Secret mount,
+    /// so the journal path has to be a strict descendant that a nested volume
+    /// can cover.
+    #[test]
+    fn journal_directory_is_a_strict_descendant_of_the_spec_mount_root() {
+        assert!(INVOCATION_JOURNAL_DIR.starts_with("/var/run/djinn/"));
+        assert_ne!(INVOCATION_JOURNAL_DIR, "/var/run/djinn");
+    }
+
+    #[test]
+    fn journal_volume_is_a_bounded_memory_empty_dir() {
+        let volume = invocation_journal_volume();
+        let empty_dir = volume.empty_dir.expect("journal is an emptyDir");
+        assert_eq!(empty_dir.medium.as_deref(), Some("Memory"));
+        assert_eq!(
+            empty_dir.size_limit.map(|quantity| quantity.0).as_deref(),
+            Some(INVOCATION_JOURNAL_SIZE_LIMIT)
+        );
+    }
+}

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -22,6 +22,9 @@ use djinn_runtime::RoleKind;
 use djinn_supervisor::cargo_target_run_dir;
 
 use crate::config::KubernetesConfig;
+use crate::invocation_journal::{
+    invocation_journal_volume, worker_invocation_journal_env, worker_invocation_journal_mount,
+};
 use crate::launcher::{
     RoleResourceClass, launcher_cgroup_mountpoint_volume, launcher_ipc_volume,
     launcher_sidecar_container, pod_host_users, pod_security_context, worker_launcher_env,
@@ -276,6 +279,12 @@ pub fn build_task_run_job(
     let renders_launcher = config.cgroup_launcher_mode.renders_sidecar();
     if renders_launcher {
         worker_env.extend(worker_launcher_env());
+        // The broker-backed shell path opens a durable invocation journal
+        // BEFORE any session exists, and the worker's compiled-in default for
+        // it lands inside the read-only `spec` Secret mount (EROFS). Name the
+        // directory explicitly and mount it below; see
+        // `crate::invocation_journal` for the measured failure.
+        worker_env.push(worker_invocation_journal_env());
     }
 
     // The private control emptyDir is added only when a wrapper sidecar is
@@ -310,6 +319,10 @@ pub fn build_task_run_job(
         // with the cgroup-launcher sidecar only; never mounted into a backing
         // sidecar, and closed off from the launcher-spawned child.
         worker_volume_mounts.push(worker_launcher_ipc_mount());
+        // Writable home for the durable invocation journal. Worker-only, and
+        // nested under the read-only `spec` mount exactly the way the launcher
+        // IPC volume already is.
+        worker_volume_mounts.push(worker_invocation_journal_mount());
     }
     if any_wrapper {
         worker_volume_mounts.push(control_volume_mount());
@@ -458,6 +471,13 @@ pub fn build_task_run_job(
         //     mountpoint has to come from a volume at all.
         volumes.push(launcher_ipc_volume());
         volumes.push(launcher_cgroup_mountpoint_volume());
+        //   * `invocation-journal` — Memory emptyDir the worker opens its
+        //     durable invocation journal in. `ShellLaunchContext::broker_backed`
+        //     runs `create_dir_all` on it before the supervisor starts, and its
+        //     default path is inside the READ-ONLY `spec` Secret mount, so
+        //     without this volume every armed pod dies `EROFS` with zero
+        //     sessions. See `crate::invocation_journal`.
+        volumes.push(invocation_journal_volume());
     }
     // Backing-service sidecars share a Memory /dev/shm (Postgres needs more than
     // the 64Mi default). Added only when services are injected so the manifest
@@ -1581,15 +1601,16 @@ mod tests {
             "DJINN_DATABASE_URL must be absent when database_url is None"
         );
 
-        // Production/default rendering adds the worker-private launcher IPC mount
-        // to the six baseline mounts.
+        // Production/default rendering adds the worker-private launcher IPC
+        // mount and the writable invocation-journal mount to the six baseline
+        // mounts.
         let mounts = container.volume_mounts.as_ref().expect("volume_mounts set");
         assert_eq!(
             mounts.len(),
-            7,
-            "expected 7 volume mounts including launcher IPC"
+            8,
+            "expected 8 volume mounts including launcher IPC and the invocation journal"
         );
-        let expected_mounts: [(&str, &str, Option<bool>); 7] = [
+        let expected_mounts: [(&str, &str, Option<bool>); 8] = [
             (VOLUME_SPEC, SPEC_MOUNT_DIR, Some(true)),
             (VOLUME_AUTH_TOKEN, TOKEN_MOUNT_DIR, Some(true)),
             (VOLUME_MIRROR, MIRROR_MOUNT_DIR, Some(false)),
@@ -1605,6 +1626,15 @@ mod tests {
                 crate::launcher::LAUNCHER_IPC_DIR,
                 None,
             ),
+            // Writable, and nested under the READ-ONLY spec mount at
+            // /var/run/djinn. Without it the worker's `create_dir_all` on the
+            // journal returns EROFS and the armed pod dies before any session
+            // exists — see `crate::invocation_journal`.
+            (
+                crate::invocation_journal::VOLUME_INVOCATION_JOURNAL,
+                crate::invocation_journal::INVOCATION_JOURNAL_DIR,
+                None,
+            ),
         ];
         for (mount, (exp_name, exp_path, exp_ro)) in mounts.iter().zip(expected_mounts.iter()) {
             assert_eq!(&mount.name, exp_name);
@@ -1617,8 +1647,8 @@ mod tests {
         let volumes = pod.volumes.as_ref().expect("volumes set");
         assert_eq!(
             volumes.len(),
-            8,
-            "expected 8 volumes including launcher surfaces"
+            9,
+            "expected 9 volumes including launcher surfaces and the invocation journal"
         );
         let expected_volume_names = [
             VOLUME_SPEC,
@@ -1629,6 +1659,7 @@ mod tests {
             crate::env_config::VOLUME_ENV_CONFIG,
             crate::launcher::VOLUME_LAUNCHER_IPC,
             crate::launcher::VOLUME_LAUNCHER_CGROUP,
+            crate::invocation_journal::VOLUME_INVOCATION_JOURNAL,
         ];
         for (volume, expected_name) in volumes.iter().zip(expected_volume_names.iter()) {
             assert_eq!(&volume.name, expected_name);

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -12,6 +12,7 @@ pub mod graph_warmer;
 pub mod graph_warmer_candidates;
 pub mod graph_warmer_identity;
 pub mod infra_death_log_tail;
+pub mod invocation_journal;
 pub mod job;
 pub mod label_value;
 pub mod launcher;

--- a/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
+++ b/server/crates/djinn-k8s/tests/rendered_launcher_delegation.rs
@@ -52,6 +52,7 @@ use uuid::Uuid;
 
 use djinn_cgroup_launcher::{CGROUP2_SUPER_MAGIC, Error as LauncherError, NativeCgroupFs};
 use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::invocation_journal::VOLUME_INVOCATION_JOURNAL;
 use djinn_k8s::job::build_task_run_job;
 use djinn_k8s::launcher::{
     CgroupLauncherMode, LAUNCHER_CGROUP_ROOT, LAUNCHER_CONTAINER_NAME, LAUNCHER_UID,
@@ -518,4 +519,133 @@ fn launcher_mode_parses_exactly_its_two_documented_values() {
             "{typo:?} must not parse"
         );
     }
+}
+
+/// **Launcher blocker 4.** Every directory the armed worker is *told* to write
+/// must be backed by a mount it can actually write.
+///
+/// # The failure this exists for
+///
+/// `ShellLaunchContext::broker_backed` — reached only in `required` mode, and
+/// reached BEFORE any session exists — opens a durable invocation journal with
+/// `fs::create_dir_all`. Its compiled-in default directory is
+/// `/var/run/djinn/invocation-journal`, and `/var/run/djinn` in this very
+/// manifest is the `spec` Secret volume mounted `readOnly: true`. Measured in a
+/// production task-run worker container:
+///
+/// ```text
+/// mkdir: cannot create directory '/var/run/djinn/invocation-journal':
+///        Read-only file system
+/// ```
+///
+/// So the sidecar came up healthy, the worker↔broker handshake completed, and
+/// every armed Job then died `EROFS` with zero sessions and no lease error
+/// anywhere — because the lease path was never reached. Nothing caught it: the
+/// journal's own tests hand it a `tempfile::tempdir()`, which is always
+/// writable, and the manifest tests assert struct shape, and an absent volume is
+/// a perfectly well-formed absence.
+///
+/// The invariant asserted here is the general one, not the single instance: a
+/// directory named to the worker through the environment may not sit under a
+/// `readOnly` mount unless a writable mount covers it directly.
+#[test]
+fn every_writable_directory_named_to_the_armed_worker_is_backed_by_a_writable_mount() {
+    let job = render();
+    let pod = pod_of(&job);
+    let worker = pod
+        .containers
+        .iter()
+        .find(|container| container.name == "worker")
+        .expect("rendered pod has a worker container");
+    let env = worker.env.as_deref().unwrap_or_default();
+    let mounts = worker.volume_mounts.as_deref().unwrap_or_default();
+
+    let journal = env
+        .iter()
+        .find(|var| var.name == "DJINN_INVOCATION_JOURNAL_DIR")
+        .and_then(|var| var.value.as_deref())
+        .expect(
+            "the armed render must name the invocation journal directory explicitly rather than \
+             leaving the worker to fall back on a compiled-in default the render cannot see",
+        );
+
+    // Directories the worker is handed and then writes into. Add to this list
+    // whenever the render starts naming another writable path.
+    let writable_directories: &[&str] = &[journal];
+    for &directory in writable_directories {
+        let covering_writable = mounts
+            .iter()
+            .any(|mount| mount.mount_path == directory && mount.read_only != Some(true));
+        let read_only_parent = mounts.iter().find(|mount| {
+            mount.read_only == Some(true)
+                && directory.starts_with(&format!("{}/", mount.mount_path))
+        });
+        assert!(
+            covering_writable,
+            "the worker is told to write {directory}, but no writable volumeMount covers it{}",
+            read_only_parent.map_or(String::new(), |mount| format!(
+                " — and the readOnly mount at {} does, so create_dir_all returns EROFS",
+                mount.mount_path
+            ))
+        );
+        let volumes = pod.volumes.as_deref().unwrap_or_default();
+        let name = &mounts
+            .iter()
+            .find(|mount| mount.mount_path == directory)
+            .expect("checked above")
+            .name;
+        assert!(
+            volumes.iter().any(|volume| &volume.name == name),
+            "worker mounts volume {name} at {directory}, which the pod does not declare"
+        );
+    }
+}
+
+/// The journal surface is armed-mode only: the explicit `disabled` profile never
+/// constructs a broker-backed shell path, so it must keep its exact manifest
+/// shape — no env, no mount, no volume.
+#[test]
+fn the_disabled_profile_renders_no_invocation_journal_surface() {
+    let mut config = KubernetesConfig::for_testing();
+    config.cgroup_launcher_mode = CgroupLauncherMode::Disabled;
+    let job = build_task_run_job(
+        &config,
+        &Uuid::now_v7(),
+        "proj-grkq",
+        "djinn-taskrun-grkq",
+        "registry.example/djinn-project:grkq",
+        &[],
+        None,
+        false,
+        None,
+    );
+    let pod = pod_of(&job);
+    let worker = pod
+        .containers
+        .iter()
+        .find(|container| container.name == "worker")
+        .expect("rendered pod has a worker container");
+    assert!(
+        !worker
+            .env
+            .iter()
+            .flatten()
+            .any(|var| var.name == "DJINN_INVOCATION_JOURNAL_DIR"),
+        "disabled mode never opens a journal, so it must not name one"
+    );
+    assert!(
+        !worker
+            .volume_mounts
+            .iter()
+            .flatten()
+            .any(|mount| mount.name == VOLUME_INVOCATION_JOURNAL),
+        "disabled mode must keep the pre-enforcement mount shape"
+    );
+    assert!(
+        !pod.volumes
+            .iter()
+            .flatten()
+            .any(|volume| volume.name == VOLUME_INVOCATION_JOURNAL),
+        "disabled mode must keep the pre-enforcement volume shape"
+    );
 }


### PR DESCRIPTION
## Launcher blocker 4: the armed worker dies `EROFS` opening its invocation journal

The cgroup-launcher sidecar now starts correctly in production (`ready=true`,
`restarts=0` on v0.7.8 — the first time). Every task-run Job still went
`BackoffLimitExceeded` with **zero** sessions and **no** lease- or
launcher-related error in the server log.

### The failing operation

```
djinn-agent::context::ShellLaunchContext::broker_backed
  -> InvocationJournal::new(DJINN_INVOCATION_JOURNAL_DIR)
       -> std::fs::create_dir_all("/var/run/djinn/invocation-journal")   <- EROFS
```

`/var/run/djinn` in a task-run Pod is the **`spec` Secret volume, mounted
`readOnly: true`**. Measured inside a real production worker container:

```
$ mkdir -p /var/run/djinn/invocation-journal
mkdir: cannot create directory '/var/run/djinn/invocation-journal': Read-only file system
```

`broker_backed` is reached only in `required` mode, and it runs **before the
supervisor starts**. So the worker aborted before any session existed, which is
exactly why the lease path was never reached and nothing lease-shaped was ever
logged.

### The handshake was cleared, not assumed

The leading hypothesis was the worker↔broker handshake. It is fine. A probe pod
on the production node carrying the **exact rendered securityContext** — root
launcher with `CHOWN/SETGID/SETUID/SETPCAP` + `SYS_ADMIN/SYS_RESOURCE`,
`RuntimeDefault` seccomp, `appArmorProfile: Unconfined`,
`readOnlyRootFilesystem: true`, `shareProcessNamespace: true`, `fsGroup: 1000` —
ran the real `djinn-cgroup-launcher` binary against a hand-driven worker end:

```
PROBE: ipcdir mode 0o43777 uid 0 gid 1000
PROBE: published credential + worker.pid = 13
PROBE: socket mode 0o140600 uid 1000 gid 1000     <- #2609's chown landed
PROBE: connect(2) OK
PROBE: AUTH reply b'\x00'                          <- SO_PEERCRED pid/uid/gid + credential accepted
PROBE: READY reply b'\x00'
PROBE: HANDSHAKE OK
```

So `#2604a`, `#2604b` and `#2609` are all genuinely fixed, and the chown target
uid/gid match the worker exactly.

### The fix

Render a dedicated writable `emptyDir` at the journal directory and pass the
path explicitly as `DJINN_INVOCATION_JOURNAL_DIR` rather than leaving the worker
on a compiled-in default the renderer cannot see. Armed-mode only — the
`disabled` profile never constructs a broker-backed shell path, so its manifest
keeps its exact shape (asserted).

Nesting a writable `emptyDir` under the read-only parent is sound and is
**measured**, not assumed — the launcher IPC volume already nests the same way
at `/var/run/djinn/launcher`. Node probe, all three cases in one container:

```
touch  /var/run/djinn/launcher/probe-write   -> OK       (existing nested emptyDir)
mkdir -p /var/run/djinn/invocation-journal   -> EROFS    (today)
mkdir -p /var/run/djinn/invocation-journal   -> CREATED  (with this PR's volume)
```

### Why nothing caught it

Same class as the renderer/binary contract gap that produced the previous three:
**the binary requires something the manifest renderer never supplies, and the
tests pass because the harness supplies it.** Every `InvocationJournal` test
hands it a `tempfile::tempdir()`, which is always writable; the manifest tests
assert struct shape, and an absent volume is a perfectly well-formed absence.

The new guard in `tests/rendered_launcher_delegation.rs` derives the invariant
from the rendered manifest instead of naming the instance: *a directory named to
the worker through the environment may not sit under a `readOnly` mount unless a
writable mount covers it directly.* It was verified non-vacuous — removing the
mount makes it fail with the production message:

```
the worker is told to write /var/run/djinn/invocation-journal, but no writable
volumeMount covers it — and the readOnly mount at /var/run/djinn does, so
create_dir_all returns EROFS
```

### Diagnostics

Four deploy cycles were spent on failures that named neither the operation nor
the path. Both fail-closed worker boundaries now do:

* `InvocationJournal::new` — was a bare `io::Error`, so the entire diagnostic
  available for a failed production rollout was `Read-only file system (os error
  30)`. Now: `invocation journal create_dir_all on /var/run/djinn/invocation-journal
  failed (errno 30): Read-only file system (os error 30)`. `ErrorKind` is
  preserved for callers that match on it.
* `HandshakeError::Io` / `Connect` / `ConnectTimeout` — now carry operation, path
  and errno, matching what `Error::SocketSetupFailed` already gives the
  launcher's own socket setup. `ConnectTimeout` additionally names the window and
  points at the sidecar's own stderr, which is where a readiness failure would be.

### Known next blocker (NOT fixed here — evidence attached)

The launcher-spawned child runs in the **launcher container's** mount namespace,
and `launcher_sidecar_container` mounts only `launcher-ipc` and
`launcher-cgroup`. Inside a rendered launcher container on the node:

```
$ ls /workspace /cache /mirror
ls: cannot access '/workspace': No such file or directory
ls: cannot access '/mirror': No such file or directory
/cache:   <- the IMAGE's /cache, not the PVC
```

Every brokered command is issued with `cwd: /workspace`, so `spawn.rs`'s
post-fork `chdir` will fail `ENOENT` and the child will `_exit`. `env.rs` already
documents that the child is expected to see `CARGO_TARGET_DIR` under `/cache`
and `TMPDIR` under `/workspace`, so this is a render omission, not a design
choice. The minimal fix is to mirror the worker's `workspace`/`cache`/`mirror`
`volumeMounts` (with the same `readOnly` flags) onto the launcher sidecar; the
open question that needs its own measurement is whether the child uid
(`CHILD_UID` 1001, primary group `ARTIFACT_GID` 1000) can write those volumes
under the current `fsGroup` ownership, and whether `readOnlyRootFilesystem: true`
starves build tools of `/tmp`. Left out of this PR deliberately so the startup
fix is not entangled with an untested pod-shape change.
