### PR TITLE
fix(goxi): give a brokered child the filesystem it is told to use

### DIFF
--- a/server/crates/djinn-k8s/src/bin_packing_fixture_tests.rs
+++ b/server/crates/djinn-k8s/src/bin_packing_fixture_tests.rs
@@ -165,7 +165,7 @@ impl Rendered {
         let light = worker_resources(&cfg, RoleResourceClass::Light);
         let build = worker_resources(&cfg, RoleResourceClass::BuildCapable);
 
-        let launcher = launcher_sidecar_container(&cfg, IMAGE);
+        let launcher = launcher_sidecar_container(&cfg, IMAGE, false, false);
         let launcher_res = launcher.resources.as_ref().expect("launcher resources");
 
         let sidecar = sidecar_container(&cfg, &default_backing_sidecar_spec());

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -478,6 +478,13 @@ pub fn build_task_run_job(
         //     without this volume every armed pod dies `EROFS` with zero
         //     sessions. See `crate::invocation_journal`.
         volumes.push(invocation_journal_volume());
+        //   * `launcher-tmp` / `launcher-home` — writable `/tmp` and `$HOME`
+        //     for a brokered child. `readOnlyRootFilesystem: true` takes the
+        //     image's copies away, and the worker container (which has neither
+        //     flag) keeps them, so arming would otherwise REGRESS the
+        //     unbrokered path. Measured: `git config --global` fails
+        //     `Read-only file system` without these. See `launcher_child_fs`.
+        volumes.extend(crate::launcher_child_fs::launcher_scratch_volumes());
     }
     // Backing-service sidecars share a Memory /dev/shm (Postgres needs more than
     // the 64Mi default). Added only when services are injected so the manifest
@@ -509,7 +516,12 @@ pub fn build_task_run_job(
     // empty so no product databases start.
     let mut init_container_vec = Vec::new();
     if renders_launcher {
-        init_container_vec.push(launcher_sidecar_container(config, project_image_tag));
+        init_container_vec.push(launcher_sidecar_container(
+            config,
+            project_image_tag,
+            mirror_read_only,
+            cache_read_only,
+        ));
     }
     init_container_vec.extend(
         effective_services
@@ -1647,8 +1659,9 @@ mod tests {
         let volumes = pod.volumes.as_ref().expect("volumes set");
         assert_eq!(
             volumes.len(),
-            9,
-            "expected 9 volumes including launcher surfaces and the invocation journal"
+            11,
+            "expected 11 volumes: launcher surfaces, the invocation journal and \
+             the launcher's own /tmp + $HOME"
         );
         let expected_volume_names = [
             VOLUME_SPEC,
@@ -1660,6 +1673,10 @@ mod tests {
             crate::launcher::VOLUME_LAUNCHER_IPC,
             crate::launcher::VOLUME_LAUNCHER_CGROUP,
             crate::invocation_journal::VOLUME_INVOCATION_JOURNAL,
+            // The launcher's writable /tmp and $HOME: `readOnlyRootFilesystem`
+            // takes the image's copies away from a brokered child.
+            crate::launcher_child_fs::VOLUME_LAUNCHER_TMP,
+            crate::launcher_child_fs::VOLUME_LAUNCHER_HOME,
         ];
         for (volume, expected_name) in volumes.iter().zip(expected_volume_names.iter()) {
             assert_eq!(&volume.name, expected_name);

--- a/server/crates/djinn-k8s/src/launcher.rs
+++ b/server/crates/djinn-k8s/src/launcher.rs
@@ -626,7 +626,17 @@ pub fn worker_launcher_env() -> Vec<EnvVar> {
 /// launcher binary as its entrypoint — no fabricated image ref. It is a native
 /// sidecar (`restartPolicy: Always` init container) so it is up before the
 /// worker and torn down when the worker exits.
-pub fn launcher_sidecar_container(config: &KubernetesConfig, project_image_tag: &str) -> Container {
+///
+/// `mirror_read_only`/`cache_read_only` mirror the worker's own flags for the
+/// same run: a brokered command runs in THIS container's mount namespace, so
+/// the two must agree or the isolation contract holds only for commands that
+/// happen not to be brokered.
+pub fn launcher_sidecar_container(
+    config: &KubernetesConfig,
+    project_image_tag: &str,
+    mirror_read_only: bool,
+    cache_read_only: bool,
+) -> Container {
     Container {
         name: LAUNCHER_CONTAINER_NAME.to_string(),
         image: Some(project_image_tag.to_string()),
@@ -654,11 +664,12 @@ pub fn launcher_sidecar_container(config: &KubernetesConfig, project_image_tag: 
                 &launcher_leased_millicores(config).to_string(),
             ),
         ]),
-        // The IPC surface, plus the writable mountpoint the launcher mounts its
-        // delegated cgroup2 root onto. The volume supplies the mountpoint only;
-        // see [`launcher_cgroup_mountpoint_volume`] for why that distinction is
-        // the entire difference between this working and CrashLoopBackOff.
-        volume_mounts: Some(vec![worker_launcher_ipc_mount(), launcher_cgroup_mount()]),
+        // The launcher's own IPC + cgroup-mountpoint surfaces AND the data
+        // mounts a brokered child needs; see [`crate::launcher_child_fs`].
+        volume_mounts: Some(crate::launcher_child_fs::launcher_volume_mounts(
+            mirror_read_only,
+            cache_read_only,
+        )),
         security_context: Some(launcher_security_context()),
         resources: Some(ResourceRequirements {
             requests: Some(BTreeMap::from([
@@ -832,7 +843,7 @@ pub fn validate_enforcement_render(config: &KubernetesConfig) -> Result<(), Rend
     //    enforces the runtime half (`bootstrap::Bootstrap::run`, the capability
     //    drop, and `NativeCgroupFs::open`) before it binds its control socket.
     if config.cgroup_launcher_mode.renders_sidecar() {
-        let container = launcher_sidecar_container(config, "render-validation");
+        let container = launcher_sidecar_container(config, "render-validation", false, false);
         let security = container.security_context.as_ref().ok_or(
             RenderValidationError::ArmedRenderCannotDelegate {
                 reason: "the launcher container has no securityContext at all",

--- a/server/crates/djinn-k8s/src/launcher_child_fs.rs
+++ b/server/crates/djinn-k8s/src/launcher_child_fs.rs
@@ -1,0 +1,259 @@
+//! The filesystem surface a launcher-spawned child needs, and why the launcher
+//! container has to carry it.
+//!
+//! # The blocker (goxi, fifth in the chain)
+//!
+//! A brokered command does not run in the worker container. `clone3` /
+//! `CLONE_INTO_CGROUP` puts it in the **launcher container's** mount namespace,
+//! so the only paths it can reach are the ones the *launcher* mounts. Before
+//! this module the launcher mounted exactly two volumes — `launcher-ipc` and
+//! `launcher-cgroup` — and nothing else. Measured inside a rendered launcher
+//! container on the production node:
+//!
+//! ```text
+//! $ ls /workspace /cache /mirror
+//! ls: cannot access '/workspace': No such file or directory
+//! ls: cannot access '/mirror': No such file or directory
+//! /cache:   <- the IMAGE's /cache, not the PVC
+//! ```
+//!
+//! Every brokered command carries `cwd` under the workspace, so `spawn.rs`'s
+//! post-fork `chdir` failed `ENOENT` and the child `_exit`ed before `execve`.
+//! `env.rs` already documents that the child is expected to see
+//! `CARGO_TARGET_DIR` under `/cache` and `TMPDIR` under the workspace — the pod
+//! *names* those paths to the worker and the broker *forwards* them — so this
+//! was a render omission, not a design choice.
+//!
+//! # The invariant
+//!
+//! > Every filesystem path the rendered Pod names to the worker through an
+//! > environment variable the broker forwards to a child must be reachable and
+//! > writable in the launcher container's mount namespace; every path the child
+//! > is forbidden to see must NOT be.
+//!
+//! Both halves matter. The first is this blocker. The second is the isolation
+//! property `djinn_cgroup_launcher::child::ChildMounts::validate` enforces at
+//! runtime: the task spec, the per-task-run credentials bundle and the
+//! projected service-account token are worker-private, and mirroring *those*
+//! onto the launcher would hand a child the credentials the broker exists to
+//! keep away from it.
+//!
+//! The guard in `tests/launcher_child_filesystem_reachability.rs` derives both
+//! directions from the rendered manifest rather than naming `/workspace`: the
+//! required set comes from the rendered worker env filtered through
+//! `is_allowed_environment_key`, and "worker-private" means "the worker's own
+//! covering mount is Secret- or projected-backed" — which is why the launcher
+//! IPC volume at `/var/run/djinn/launcher`, nested *inside* the `spec` Secret
+//! mount, is correctly classified as shared rather than private. It proves
+//! itself non-vacuous by stripping the mount and reproducing the production
+//! `chdir` `ENOENT` by name against a materialized mount tree.
+//!
+//! # `readOnlyRootFilesystem: true` and the image-layer scratch surfaces
+//!
+//! Mirroring the worker's volumes is necessary but not sufficient. The launcher
+//! runs with `readOnlyRootFilesystem: true`, which the worker container does
+//! not, so **every writable surface that lives in the image layer disappears**.
+//! Measured in the rendered launcher container on the production node, with the
+//! data mounts already added:
+//!
+//! ```text
+//! # uid 0, inside cgroup-launcher
+//! /tmp:         touch: Read-only file system
+//! /home/djinn:  touch: Read-only file system
+//!
+//! # setpriv --reuid=1001 --regid=1000 --clear-groups  (the real child creds)
+//! git config --global user.name probe
+//!   error: could not lock config file /home/djinn/.gitconfig: Read-only file system
+//! ```
+//!
+//! The same two paths are writable in the worker container (measured on the
+//! same pod), so arming the launcher without this would be a *regression*
+//! against the unbrokered path rather than a new constraint.
+//!
+//! * **`/tmp`** — `TMPDIR` is rendered to the workspace and is honoured
+//!   (`mktemp -d` returned `/workspace/tmp.5EPDKA83CI` in the launcher's
+//!   namespace once the workspace was mounted), but a build is a tree of
+//!   third-party tools and the ones that hardcode `/tmp` do not consult it.
+//! * **`$HOME`** — `git config --global`, `rustup`, `npm`, `fnm` and `gopls`
+//!   all write there; `djinn_agent_worker::volume_contract` fails worker
+//!   readiness when `$HOME` is not writable *for exactly this reason*, and its
+//!   docs already assert "the launcher-spawned child (uid 1001, group 1000)
+//!   write[s] through the group". The image satisfies that with `2775`
+//!   ownership; `readOnlyRootFilesystem` defeats it regardless of ownership.
+//!
+//! Both are supplied as ordinary (disk-backed) `emptyDir`s: a build's scratch
+//! and a toolchain's home state are real data, not a socket, so they should not
+//! consume the pod's memory limit. Masking the image's own copies costs
+//! nothing — measured, the image's `/home/djinn` holds one empty `.local/state`
+//! and `/tmp` holds only build-time detritus.
+//!
+//! # Ownership: no chown is needed, and that was measured, not assumed
+//!
+//! This repo has twice been bitten by assuming a mount is enough (the
+//! `protected_hardlinks` EPERM on foreign-owned sources, and the `/mirror`
+//! chown see-saw where no single owner satisfied both uid 10001 and uid 1000),
+//! so the child's ability to write was measured on the real PVCs rather than
+//! derived from the manifest. On the production node:
+//!
+//! | path         | owner:group  | mode         | uid 1001 / gid 1000 |
+//! |--------------|--------------|--------------|---------------------|
+//! | `/cache`     | `10001:1000` | `drwxrwsr-x` | write OK            |
+//! | `/mirror`    | `10001:1000` | `drwxrwsr-x` | write OK            |
+//! | `/workspace` | `0:1000`     | `drwxrwsrwx` | write OK            |
+//!
+//! The child is *not* the owner of any of them — it writes through the group,
+//! which is precisely what `fsGroup: ARTIFACT_GID` + the setgid bit exist to
+//! provide, and what `child::prepare_child`'s `setgid(ARTIFACT_GID)` +
+//! `umask 0002` are for. Note `prepare_child` also calls `setgroups(0, NULL)`,
+//! so gid 1000 must be the child's PRIMARY group, not a supplementary one — it
+//! is. `fsGroupChangePolicy: OnRootMismatch` is a no-op here because both PVC
+//! roots already carry gid 1000, so no recursive re-own is triggered.
+
+use k8s_openapi::api::core::v1::{EmptyDirVolumeSource, Volume, VolumeMount};
+
+use crate::job::{
+    CACHE_MOUNT_DIR, MIRROR_MOUNT_DIR, VOLUME_CACHE, VOLUME_MIRROR, VOLUME_WORKSPACE,
+    WORKSPACE_MOUNT_DIR,
+};
+use crate::launcher::{launcher_cgroup_mount, worker_launcher_ipc_mount};
+
+/// Volume supplying the launcher container a writable `/tmp`.
+pub const VOLUME_LAUNCHER_TMP: &str = "launcher-tmp";
+/// Volume supplying the launcher container a writable `$HOME`.
+pub const VOLUME_LAUNCHER_HOME: &str = "launcher-home";
+
+/// Scratch directory a brokered child gets even when it ignores `TMPDIR`.
+pub const LAUNCHER_TMP_DIR: &str = "/tmp";
+
+/// `$HOME` inside every djinn devcontainer image, set by
+/// `djinn_image_builder::dockerfile` (`ENV HOME=/home/djinn`). Duplicated as a
+/// literal rather than imported because `djinn-k8s` does not depend on the
+/// image builder; the guard asserts the rendered value round-trips.
+pub const LAUNCHER_HOME_DIR: &str = "/home/djinn";
+
+/// Every volumeMount on the cgroup-launcher sidecar.
+///
+/// Two groups, and the distinction is the whole point of this module:
+///
+/// * the launcher's OWN surfaces — the IPC volume carrying the broker socket
+///   and the worker-private credential, and the writable *mountpoint* the
+///   launcher mounts its delegated cgroup2 root onto (a mountpoint, not a
+///   delegated root; see [`crate::launcher::launcher_cgroup_mountpoint_volume`]
+///   for why that distinction is the difference between working and
+///   CrashLoopBackOff);
+/// * the CHILD's surfaces — [`launcher_data_mounts`], which exist purely
+///   because a brokered command executes in this container's mount namespace
+///   and not the worker's.
+pub fn launcher_volume_mounts(mirror_read_only: bool, cache_read_only: bool) -> Vec<VolumeMount> {
+    let mut mounts = vec![worker_launcher_ipc_mount(), launcher_cgroup_mount()];
+    mounts.extend(launcher_data_mounts(mirror_read_only, cache_read_only));
+    mounts
+}
+
+/// The worker's data mounts, re-rendered for the launcher container.
+///
+/// `read_only` mirrors the worker's own flags for the same run so the two
+/// containers cannot disagree about whether a volume is writable — an
+/// evidence-spike run that denies the worker write access to `/mirror` and
+/// `/cache` must deny its brokered children the same, or the isolation
+/// contract holds only for commands that happen not to be brokered.
+pub fn launcher_data_mounts(mirror_read_only: bool, cache_read_only: bool) -> Vec<VolumeMount> {
+    vec![
+        data_mount(VOLUME_MIRROR, MIRROR_MOUNT_DIR, Some(mirror_read_only)),
+        data_mount(
+            VOLUME_CACHE,
+            CACHE_MOUNT_DIR,
+            cache_read_only.then_some(true),
+        ),
+        data_mount(VOLUME_WORKSPACE, WORKSPACE_MOUNT_DIR, None),
+        data_mount(VOLUME_LAUNCHER_TMP, LAUNCHER_TMP_DIR, None),
+        data_mount(VOLUME_LAUNCHER_HOME, LAUNCHER_HOME_DIR, None),
+    ]
+}
+
+/// The launcher-private scratch volumes. The shared data volumes are declared
+/// by `job.rs` for the worker already; only these two are new to the pod.
+pub fn launcher_scratch_volumes() -> Vec<Volume> {
+    [VOLUME_LAUNCHER_TMP, VOLUME_LAUNCHER_HOME]
+        .into_iter()
+        .map(|name| Volume {
+            name: name.to_string(),
+            // Disk-backed on purpose: a Memory emptyDir is charged to the pod's
+            // memory limit, and the launcher container's limit is the *build's*
+            // memory ceiling. A cargo build's scratch would eat it.
+            empty_dir: Some(EmptyDirVolumeSource::default()),
+            ..Volume::default()
+        })
+        .collect()
+}
+
+fn data_mount(name: &str, mount_path: &str, read_only: Option<bool>) -> VolumeMount {
+    VolumeMount {
+        name: name.to_string(),
+        mount_path: mount_path.to_string(),
+        read_only,
+        ..VolumeMount::default()
+    }
+}
+
+/// Is `path` inside `root` (or equal to it)?
+///
+/// Component-wise so `/cachexyz` is not treated as living under `/cache`.
+pub fn is_under(path: &str, root: &str) -> bool {
+    path == root
+        || (path.starts_with(root)
+            && (root.ends_with('/') || path.as_bytes().get(root.len()) == Some(&b'/')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn containment_is_component_wise_not_textual() {
+        assert!(is_under("/cache", "/cache"));
+        assert!(is_under("/cache/cargo", "/cache"));
+        assert!(!is_under("/cachexyz", "/cache"));
+        assert!(!is_under("/cach", "/cache"));
+        assert!(is_under("/var/run/djinn/spec.bin", "/var/run/djinn"));
+        assert!(!is_under("/var/run/djinn-other/x", "/var/run/djinn"));
+    }
+
+    /// The evidence-spike isolation contract may not be weaker for a brokered
+    /// command than for an unbrokered one.
+    #[test]
+    fn launcher_data_mounts_track_the_workers_read_only_flags() {
+        let normal = launcher_data_mounts(false, false);
+        let spike = launcher_data_mounts(true, true);
+        let flag = |mounts: &[VolumeMount], name: &str| {
+            mounts
+                .iter()
+                .find(|mount| mount.name == name)
+                .unwrap_or_else(|| panic!("{name} rendered"))
+                .read_only
+        };
+        assert_eq!(flag(&normal, VOLUME_MIRROR), Some(false));
+        assert_eq!(flag(&normal, VOLUME_CACHE), None);
+        assert_eq!(flag(&spike, VOLUME_MIRROR), Some(true));
+        assert_eq!(flag(&spike, VOLUME_CACHE), Some(true));
+        // The scratch surfaces are never read-only: they exist because
+        // `readOnlyRootFilesystem` already took the image's copies away.
+        assert_eq!(flag(&spike, VOLUME_LAUNCHER_TMP), None);
+        assert_eq!(flag(&spike, VOLUME_LAUNCHER_HOME), None);
+        // Workspace is an ephemeral per-Pod emptyDir; it is writable even for
+        // an evidence-spike run, exactly as it is for the worker.
+        assert_eq!(flag(&spike, VOLUME_WORKSPACE), None);
+    }
+
+    #[test]
+    fn the_scratch_volumes_are_disk_backed_not_charged_to_the_memory_limit() {
+        for volume in launcher_scratch_volumes() {
+            let source = volume.empty_dir.expect("scratch volume is an emptyDir");
+            assert_eq!(
+                source.medium, None,
+                "{} must not be Memory-backed: the launcher's memory limit is the build's ceiling",
+                volume.name
+            );
+        }
+    }
+}

--- a/server/crates/djinn-k8s/src/launcher_tests.rs
+++ b/server/crates/djinn-k8s/src/launcher_tests.rs
@@ -189,7 +189,7 @@ fn every_bootstrap_only_capability_is_one_the_launcher_drops_at_runtime() {
 #[test]
 fn the_rendered_grant_is_exactly_what_the_runtime_retains_plus_bootstrap_only() {
     let cfg = KubernetesConfig::for_testing();
-    let container = launcher_sidecar_container(&cfg, "registry.example/proj:tag");
+    let container = launcher_sidecar_container(&cfg, "registry.example/proj:tag", false, false);
     let add = container
         .security_context
         .unwrap()
@@ -223,7 +223,7 @@ fn the_rendered_grant_is_exactly_what_the_runtime_retains_plus_bootstrap_only() 
 #[test]
 fn the_launcher_container_declares_no_cpu_limit() {
     let cfg = KubernetesConfig::for_testing();
-    let c = launcher_sidecar_container(&cfg, "registry.example/proj:tag");
+    let c = launcher_sidecar_container(&cfg, "registry.example/proj:tag", false, false);
     let limits = c.resources.unwrap().limits.unwrap();
     assert!(
         !limits.contains_key("cpu"),
@@ -277,7 +277,7 @@ fn user_namespaces_are_never_requested_because_they_break_the_delegation() {
 #[test]
 fn the_launcher_mounts_a_writable_mountpoint_at_the_cgroup_root() {
     let cfg = KubernetesConfig::for_testing();
-    let c = launcher_sidecar_container(&cfg, "registry.example/proj:tag");
+    let c = launcher_sidecar_container(&cfg, "registry.example/proj:tag", false, false);
     let mount = c
         .volume_mounts
         .unwrap()
@@ -311,7 +311,7 @@ fn pod_security_context_ties_fsgroup_to_artifact_gid_on_root_mismatch() {
 fn launcher_sidecar_reuses_worker_image_with_launcher_entrypoint() {
     let cfg = KubernetesConfig::for_testing();
     let image = "registry.example/proj:tag";
-    let c = launcher_sidecar_container(&cfg, image);
+    let c = launcher_sidecar_container(&cfg, image, false, false);
     assert_eq!(c.name, LAUNCHER_CONTAINER_NAME);
     // Same image as the worker, different entrypoint (real packaged binary).
     assert_eq!(c.image.as_deref(), Some(image));
@@ -660,6 +660,8 @@ fn a_resolved_cpu_limit_override_retunes_the_lease() {
         init_containers: Some(vec![launcher_sidecar_container(
             &cfg,
             "registry.example/proj:tag",
+            false,
+            false,
         )]),
         ..PodSpec::default()
     };

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -16,6 +16,7 @@ pub mod invocation_journal;
 pub mod job;
 pub mod label_value;
 pub mod launcher;
+pub mod launcher_child_fs;
 mod launcher_cpu;
 pub mod runtime;
 pub mod secret;

--- a/server/crates/djinn-k8s/tests/launcher_child_filesystem_reachability.rs
+++ b/server/crates/djinn-k8s/tests/launcher_child_filesystem_reachability.rs
@@ -1,0 +1,522 @@
+//! The coverage whose absence hid goxi's fifth launcher blocker.
+//!
+//! # What went wrong, and why nothing caught it
+//!
+//! A brokered command does not execute in the worker container. It is born by
+//! `clone3(CLONE_INTO_CGROUP)` in the **cgroup-launcher's** mount namespace, so
+//! the only paths it can reach are the ones the launcher container mounts. The
+//! launcher mounted `launcher-ipc` and `launcher-cgroup` and nothing else, while
+//! the pod went on telling the worker that its build lives under `/cache`, its
+//! mirror under `/mirror` and its scratch under `/workspace`. Measured in a
+//! rendered launcher container on the production node:
+//!
+//! ```text
+//! $ ls /workspace /cache /mirror
+//! ls: cannot access '/workspace': No such file or directory
+//! ls: cannot access '/mirror': No such file or directory
+//! /cache:   <- the IMAGE's /cache, not the PVC
+//! ```
+//!
+//! Every brokered `CommandSpec` carries a `cwd` under the workspace, so the
+//! post-fork `chdir` in `spawn.rs` failed `ENOENT` and the child `_exit`ed
+//! before it ever reached `execve`.
+//!
+//! Four blockers preceded this one and **every single one was invisible to a
+//! rendered-manifest assertion**: an AppArmor profile denying `mount(2)` with a
+//! silent EACCES, `hostUsers: false` breaking cgroup delegation to the mapped
+//! uid, `chown(2)` on the broker socket needing CAP_CHOWN rather than merely
+//! `runAsUser: 0`, and `EROFS` under a `readOnly` Secret mount. A test that
+//! asserts "the workspace volumeMount is present" would have been green through
+//! all five.
+//!
+//! # So this file does not assert a mount list
+//!
+//! It derives the invariant from the manifest instead:
+//!
+//! > Every filesystem path the rendered Pod names to the worker through an
+//! > environment variable that the broker forwards to a child must be reachable
+//! > and **writable** in the launcher container's mount namespace; every path
+//! > the child is forbidden to see must NOT be.
+//!
+//! Nothing below names `/workspace`, `/cache` or `/mirror`. The required set is
+//! computed by running the production env renderer, filtering it through
+//! `djinn_cgroup_launcher::is_allowed_environment_key` — the same predicate the
+//! privileged broker re-applies in `CommandSpec::validate` — and keeping the
+//! values that are absolute paths. Add a new path-valued env var to `job.rs`
+//! and this guard starts requiring it without being edited.
+//!
+//! And it does not stop at the manifest. [`the_rendered_launcher_mount_set_lets_a_real_chdir_and_write_succeed`]
+//! materializes the rendered mount set as a real directory tree, then runs a
+//! real `chdir(2)` and a real `File::create` through it — the same two syscalls
+//! that failed in production. [`removing_the_workspace_mount_reproduces_the_production_enoent`]
+//! deletes the mount from the rendered spec and requires that same harness to
+//! reproduce `NotFound` **by name**, so the suite cannot pass vacuously.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::{Container, PodSpec, Volume, VolumeMount};
+use uuid::Uuid;
+
+use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
+use djinn_cgroup_launcher::is_allowed_environment_key;
+use djinn_k8s::config::KubernetesConfig;
+use djinn_k8s::job::build_task_run_job;
+use djinn_k8s::launcher::LAUNCHER_CONTAINER_NAME;
+use djinn_k8s::launcher_child_fs::{LAUNCHER_HOME_DIR, LAUNCHER_TMP_DIR, is_under};
+
+// ─────────────────────────── rendering helpers ───────────────────────────────
+
+fn render(is_evidence_spike: bool) -> Job {
+    build_task_run_job(
+        &KubernetesConfig::for_testing(),
+        &Uuid::now_v7(),
+        "proj-goxi",
+        "djinn-taskrun-goxi",
+        "registry.example/djinn-project:goxi",
+        &[],
+        None,
+        is_evidence_spike,
+        None,
+    )
+}
+
+fn pod_of(job: &Job) -> &PodSpec {
+    job.spec
+        .as_ref()
+        .and_then(|spec| spec.template.spec.as_ref())
+        .expect("rendered Job has a pod spec")
+}
+
+fn container<'a>(pod: &'a PodSpec, name: &str) -> &'a Container {
+    pod.containers
+        .iter()
+        .chain(pod.init_containers.iter().flatten())
+        .find(|container| container.name == name)
+        .unwrap_or_else(|| panic!("rendered pod has a {name} container"))
+}
+
+/// Every path-valued env var the pod declares to the worker **that the broker
+/// forwards to a brokered child**.
+///
+/// The filter is the load-bearing part: `is_allowed_environment_key` is the
+/// single predicate `process_broker::child_environment` applies on the way out
+/// and `CommandSpec::validate` re-applies inside the privileged broker, so a key
+/// it rejects genuinely never reaches a child and genuinely does not need a
+/// mount.
+fn child_visible_declared_paths(pod: &PodSpec) -> BTreeMap<String, String> {
+    container(pod, "worker")
+        .env
+        .iter()
+        .flatten()
+        .filter(|env| is_allowed_environment_key(&env.name))
+        .filter_map(|env| {
+            let value = env.value.as_deref()?;
+            value
+                .starts_with('/')
+                .then(|| (env.name.clone(), value.to_owned()))
+        })
+        .collect()
+}
+
+/// The volumeMount covering `path`, if any: the longest `mount_path` that
+/// contains it, which is how the kernel resolves overlapping mounts.
+///
+/// The longest-match rule is not a detail. The worker mounts the `spec` Secret
+/// at `/var/run/djinn` AND the launcher-IPC emptyDir at
+/// `/var/run/djinn/launcher`; a shortest- or first-match would classify the
+/// broker credential as a secret and the guard would demand the *opposite* of
+/// the truth.
+fn covering_mount<'a>(mounts: &'a [VolumeMount], path: &str) -> Option<&'a VolumeMount> {
+    mounts
+        .iter()
+        .filter(|mount| is_under(path, &mount.mount_path))
+        .max_by_key(|mount| mount.mount_path.len())
+}
+
+/// Paths the pod names to the worker that the WORKER PROCESS ITSELF consumes,
+/// which no brokered child ever opens.
+///
+/// The broker's allow-list forwards the whole `DJINN_` namespace, so the worker's
+/// own private configuration rides along to the child as dead strings. That is
+/// harmless — but it means "the pod declared it" is not by itself proof that the
+/// child needs it, and mounting these into the launcher would widen the child's
+/// reach for no reason.
+///
+/// Each entry must name a path the worker resolves before or outside the broker
+/// hop. `no_child_irrelevant_path_has_gone_stale` fails if one stops being
+/// rendered, so this cannot quietly become a licence to ignore a real blocker.
+const CHILD_IRRELEVANT_ENV_KEYS: &[(&str, &str)] = &[(
+    // Opened by `ShellLaunchContext::broker_backed` in the worker, before the
+    // supervisor starts. It records invocations ACROSS the broker hop, so by
+    // construction it is written on the worker side of it.
+    "DJINN_INVOCATION_JOURNAL_DIR",
+    "the worker's own durable invocation journal, opened worker-side",
+)];
+
+/// Why `path` is unreachable from the child by design, or `None` if the child
+/// is genuinely expected to use it.
+///
+/// The first arm is derived rather than listed: a path is a credential surface
+/// exactly when the worker's own covering mount is Secret- or projected-backed
+/// — the task spec, the per-task-run credentials bundle, the projected SA token.
+/// `ChildMounts::validate` refuses to spawn a child holding any of them, so
+/// mounting them into the launcher would reintroduce through the filesystem what
+/// the broker exists to close off. Adding a new Secret mount to the worker
+/// extends this classification with no edit here.
+fn unreachable_by_design(pod: &PodSpec, key: &str, path: &str) -> Option<&'static str> {
+    let mounts = container(pod, "worker")
+        .volume_mounts
+        .as_deref()
+        .unwrap_or_default();
+    let secret_backed = covering_mount(mounts, path).is_some_and(|mount| {
+        pod.volumes
+            .iter()
+            .flatten()
+            .find(|volume: &&Volume| volume.name == mount.name)
+            .is_some_and(|volume| volume.secret.is_some() || volume.projected.is_some())
+    });
+    if secret_backed {
+        return Some("worker credential surface (Secret/projected volume)");
+    }
+    CHILD_IRRELEVANT_ENV_KEYS
+        .iter()
+        .find(|(name, _)| *name == key)
+        .map(|(_, reason)| *reason)
+}
+
+/// An exemption that no longer corresponds to a rendered env var is a stale
+/// exemption, and a stale exemption is how a real blocker gets waved through.
+#[test]
+fn no_child_irrelevant_path_has_gone_stale() {
+    let job = render(false);
+    let declared = child_visible_declared_paths(pod_of(&job));
+    for (key, reason) in CHILD_IRRELEVANT_ENV_KEYS {
+        assert!(
+            declared.contains_key(*key),
+            "{key} is exempted as {reason:?}, but the pod no longer declares it as a \
+             child-visible path — delete the exemption instead of carrying it"
+        );
+    }
+}
+
+// ──────────────────────── the derived invariant ──────────────────────────────
+
+/// The blocker itself, expressed as a property rather than a mount list.
+#[test]
+fn every_child_visible_declared_path_is_writable_in_the_launcher_mount_namespace() {
+    for is_evidence_spike in [false, true] {
+        let job = render(is_evidence_spike);
+        let pod = pod_of(&job);
+        let launcher = container(pod, LAUNCHER_CONTAINER_NAME);
+        let mounts = launcher.volume_mounts.as_deref().unwrap_or_default();
+
+        let declared = child_visible_declared_paths(pod);
+        assert!(
+            declared.len() >= 4,
+            "the derivation found only {} child-visible declared paths, which is too few to be \
+             exercising anything — the filter or the renderer changed shape: {declared:?}",
+            declared.len()
+        );
+
+        let mut required = 0usize;
+        let mut denied = 0usize;
+        for (key, path) in &declared {
+            // The isolation half of the invariant: a path the child does not
+            // need must not be reachable from the launcher either.
+            if let Some(reason) = unreachable_by_design(pod, key, path) {
+                assert!(
+                    covering_mount(mounts, path).is_none(),
+                    "{key}={path} is {reason} and must NOT be reachable from the launcher's \
+                     mount namespace, but a volumeMount covers it"
+                );
+                denied += 1;
+                continue;
+            }
+
+            let mount = covering_mount(mounts, path).unwrap_or_else(|| {
+                panic!(
+                    "the pod tells the worker {key}={path}, the broker forwards {key} to a \
+                     brokered child, and the child runs in the LAUNCHER's mount namespace — \
+                     but no launcher volumeMount covers {path}. This is the production \
+                     failure: `chdir`/open under {path} returns ENOENT and the child _exits \
+                     before execve. Launcher mounts: {:?}",
+                    mounts
+                        .iter()
+                        .map(|mount| mount.mount_path.as_str())
+                        .collect::<Vec<_>>()
+                )
+            });
+            // Reachable is not enough: the child must have the same access the
+            // worker was promised. Parity is asserted against the WORKER's own
+            // mount rather than against `false`, because an evidence-spike run
+            // legitimately denies both of them write access to /cache and
+            // /mirror — and if that isolation held only for commands that
+            // happen not to be brokered it would not be isolation at all.
+            let worker_mounts = container(pod, "worker")
+                .volume_mounts
+                .as_deref()
+                .unwrap_or_default();
+            let worker_read_only = covering_mount(worker_mounts, path)
+                .map(|mount| mount.read_only == Some(true))
+                .unwrap_or(false);
+            assert_eq!(
+                mount.read_only == Some(true),
+                worker_read_only,
+                "{key}={path}: the launcher mounts it read_only={:?} but the worker sees \
+                 read_only={worker_read_only}. A brokered command must get exactly the access \
+                 the pod promised the worker — more would break the evidence-spike contract, \
+                 less turns the production ENOENT into an EROFS and nothing else.",
+                mount.read_only
+            );
+            if !worker_read_only {
+                required += 1;
+            }
+        }
+        // Both halves must have fired. A classifier that silently sorted every
+        // path into one bucket would make one of the two assertions vacuous.
+        assert!(
+            required > 0,
+            "no writable path was required, so the reachability half proved nothing"
+        );
+        assert!(
+            denied > 0,
+            "no worker-private path was denied, so the isolation half proved nothing"
+        );
+    }
+}
+
+/// `readOnlyRootFilesystem: true` takes away every writable surface that lives
+/// in the image layer. The worker container carries no such flag, so a scratch
+/// path that works unbrokered must not stop working when brokered.
+///
+/// Measured on the production node inside the rendered launcher container:
+/// `touch /tmp/x` and `touch /home/djinn/x` both returned `Read-only file
+/// system` for uid 0, and `git config --global user.name` failed with
+/// `could not lock config file /home/djinn/.gitconfig: Read-only file system`
+/// for the real child credentials (uid 1001 / gid 1000). Both paths were
+/// writable in the worker container on the same pod.
+#[test]
+fn a_read_only_root_filesystem_does_not_take_away_scratch_the_worker_still_has() {
+    let job = render(false);
+    let pod = pod_of(&job);
+    let launcher = container(pod, LAUNCHER_CONTAINER_NAME);
+    assert_eq!(
+        launcher
+            .security_context
+            .as_ref()
+            .and_then(|context| context.read_only_root_filesystem),
+        Some(true),
+        "this guard exists because the launcher's rootfs is read-only; if that changed, \
+         re-derive it rather than deleting it"
+    );
+
+    let worker = container(pod, "worker");
+    assert_ne!(
+        worker
+            .security_context
+            .as_ref()
+            .and_then(|context| context.read_only_root_filesystem),
+        Some(true),
+        "the worker's rootfs is writable, which is why moving a command into the launcher \
+         is what removes these surfaces"
+    );
+
+    let mounts = launcher.volume_mounts.as_deref().unwrap_or_default();
+    for path in [LAUNCHER_TMP_DIR, LAUNCHER_HOME_DIR] {
+        let mount = covering_mount(mounts, path).unwrap_or_else(|| {
+            panic!(
+                "{path} is writable in the worker container and read-only in the launcher's \
+                 image layer, so the launcher must supply it from a volume"
+            )
+        });
+        assert_eq!(mount.mount_path, path, "{path} must be mounted directly");
+        assert_ne!(mount.read_only, Some(true), "{path} must be writable");
+        let volume = pod
+            .volumes
+            .iter()
+            .flatten()
+            .find(|volume| volume.name == mount.name)
+            .unwrap_or_else(|| panic!("{path} mounts {}, which the pod must declare", mount.name));
+        assert!(
+            volume.empty_dir.is_some(),
+            "{path} must come from an emptyDir; a PVC would share a build's scratch across pods"
+        );
+    }
+}
+
+/// The child writes through the ARTIFACT group, never as an owner — so the
+/// render must keep `fsGroup` tied to the gid the launcher actually `setgid`s
+/// to. Measured on the production PVCs: `/cache` and `/mirror` are
+/// `10001:1000 drwxrwsr-x` and `/workspace` is `0:1000 drwxrwsrwx`; uid 1001 in
+/// gid 1000 wrote all three, and owns none of them.
+///
+/// `child::prepare_child` calls `setgroups(0, NULL)` before `setgid`, so gid
+/// 1000 has to be the child's PRIMARY group — a supplementary group would be
+/// dropped and every write would EACCES.
+#[test]
+fn the_child_writes_through_the_fs_group_because_it_owns_none_of_the_volumes() {
+    let pod_group = pod_of(&render(false))
+        .security_context
+        .as_ref()
+        .and_then(|context| context.fs_group)
+        .expect("the pod must set fsGroup");
+    assert_eq!(
+        pod_group,
+        i64::from(ARTIFACT_GID),
+        "the launcher setgid()s its child to ARTIFACT_GID and clears supplementary groups, so \
+         the volumes must be group-owned by exactly that gid or the child cannot write"
+    );
+    assert_ne!(
+        u32::try_from(pod_group).ok(),
+        Some(CHILD_UID),
+        "the child is not the owner of the shared volumes; it writes through the group"
+    );
+}
+
+// ───────────────────── real syscalls through the mount set ───────────────────
+
+/// A private scratch directory. Deliberately not `tempfile`: this crate does not
+/// carry it as a dev-dependency, matching `rendered_launcher_delegation.rs`.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(label: &str) -> Self {
+        let base = std::env::var_os("CARGO_TARGET_TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("goxi-{label}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("create scratch dir");
+        Self(base)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Materialize `mounts` as a real directory tree under `root`, the way a kubelet
+/// materializes a container's mount namespace: a path exists if and only if some
+/// mount covers it.
+fn materialize(root: &Path, mounts: &[VolumeMount]) {
+    for mount in mounts {
+        let relative = mount.mount_path.trim_start_matches('/');
+        std::fs::create_dir_all(root.join(relative)).expect("materialize mount");
+    }
+}
+
+/// Run the two syscalls the production child ran — `chdir(cwd)` then create a
+/// file under each required path — against a materialized mount set.
+///
+/// Returns the first failure, so a caller can assert on the ERROR KIND rather
+/// than on a boolean. This is what makes the negative case a reproduction
+/// instead of a tautology.
+fn exercise(root: &Path, cwd: &str, writes: &[&str]) -> std::io::Result<()> {
+    // `chdir` is process-global, so resolve rather than mutate: the failure mode
+    // under test is "the directory is not there", which `metadata` reports with
+    // the same `NotFound`/ENOENT the child's `chdir` returned.
+    let target = root.join(cwd.trim_start_matches('/'));
+    let metadata = std::fs::metadata(&target)?;
+    assert!(metadata.is_dir(), "{cwd} must resolve to a directory");
+    for path in writes {
+        let file = root
+            .join(path.trim_start_matches('/'))
+            .join(".goxi-write-probe");
+        std::fs::File::create(&file)?;
+        std::fs::remove_file(&file)?;
+    }
+    Ok(())
+}
+
+/// The brokered `cwd`. Derived from the pod's own `TMPDIR`, which `job.rs`
+/// renders to the workspace root the agent's worktree is created under — not
+/// spelled out here, so a renderer change moves this with it.
+fn brokered_cwd(pod: &PodSpec) -> String {
+    child_visible_declared_paths(pod)
+        .remove("TMPDIR")
+        .expect("the pod declares TMPDIR, which roots the brokered cwd")
+}
+
+#[test]
+fn the_rendered_launcher_mount_set_lets_a_real_chdir_and_write_succeed() {
+    let job = render(false);
+    let pod = pod_of(&job);
+    let mounts = container(pod, LAUNCHER_CONTAINER_NAME)
+        .volume_mounts
+        .clone()
+        .expect("launcher has volume mounts");
+
+    let scratch = Scratch::new("mounted");
+    materialize(&scratch.0, &mounts);
+
+    let declared = child_visible_declared_paths(pod);
+    let writes: Vec<&str> = declared
+        .iter()
+        .filter(|(key, path)| unreachable_by_design(pod, key, path).is_none())
+        // Only the mount roots exist in a freshly materialized namespace; the
+        // per-project leaves below them are created by the build itself.
+        .filter_map(|(_, path)| covering_mount(&mounts, path).map(|m| m.mount_path.as_str()))
+        .collect();
+    assert!(!writes.is_empty(), "nothing to exercise");
+
+    exercise(&scratch.0, &brokered_cwd(pod), &writes)
+        .expect("the rendered launcher mount set must let a brokered child chdir and write");
+}
+
+/// Non-vacuity: with the workspace mount removed, the SAME harness must
+/// reproduce the production failure, by name.
+#[test]
+fn removing_the_workspace_mount_reproduces_the_production_enoent() {
+    let job = render(false);
+    let pod = pod_of(&job);
+    let cwd = brokered_cwd(pod);
+    let mut mounts = container(pod, LAUNCHER_CONTAINER_NAME)
+        .volume_mounts
+        .clone()
+        .expect("launcher has volume mounts");
+
+    let before = mounts.len();
+    mounts.retain(|mount| !is_under(&cwd, &mount.mount_path));
+    assert_eq!(
+        before - 1,
+        mounts.len(),
+        "exactly the mount covering the brokered cwd must be removed; if this is not 1 the \
+         test is no longer removing what it thinks it is"
+    );
+
+    let scratch = Scratch::new("unmounted");
+    materialize(&scratch.0, &mounts);
+
+    let error = exercise(&scratch.0, &cwd, &[])
+        .expect_err("without the workspace mount the brokered cwd must not resolve");
+    assert_eq!(
+        error.kind(),
+        std::io::ErrorKind::NotFound,
+        "the production failure is ENOENT from the post-fork chdir in spawn.rs, which _exits \
+         the child before execve; got {error:?}"
+    );
+
+    // And the manifest-level guard must reject the same spec, so the two halves
+    // agree about what is broken.
+    let mut broken = pod.clone();
+    for container in broken
+        .init_containers
+        .iter_mut()
+        .flatten()
+        .filter(|container| container.name == LAUNCHER_CONTAINER_NAME)
+    {
+        if let Some(mounts) = container.volume_mounts.as_mut() {
+            mounts.retain(|mount| !is_under(&cwd, &mount.mount_path));
+        }
+    }
+    let launcher = container(&broken, LAUNCHER_CONTAINER_NAME);
+    let remaining = launcher.volume_mounts.as_deref().unwrap_or_default();
+    assert!(
+        covering_mount(remaining, &cwd).is_none(),
+        "the stripped spec must be the one the derived invariant rejects"
+    );
+}


### PR DESCRIPTION
## The blocker (goxi, fifth in the arm chain)

A launcher-spawned command runs in the **cgroup-launcher's** mount namespace, not the worker's. The sidecar mounted `launcher-ipc` and `launcher-cgroup` and nothing else, while the pod went on telling the worker its build lives under `/cache`, its mirror under `/mirror` and its scratch under `/workspace`. Measured inside a rendered launcher container on the production node:

```
$ ls /workspace /cache /mirror
ls: cannot access '/workspace': No such file or directory
ls: cannot access '/mirror': No such file or directory
/cache:   <- the IMAGE's /cache, not the PVC
```

Every brokered `CommandSpec` carries a `cwd` under the workspace, so the post-fork `chdir` in `spawn.rs` returned `ENOENT` and the child `_exit`ed before `execve`. `env.rs` already documents that the child is expected to see `CARGO_TARGET_DIR` under `/cache` and `TMPDIR` under `/workspace`, so this was a render omission, not a design choice.

## The fix

`launcher_child_fs.rs` (new module — `launcher.rs` was at 50 650 / 51 200 bytes) renders the launcher's full mount set:

| mount | source | why |
|---|---|---|
| `/mirror`, `/cache`, `/workspace` | the worker's own volumes, **with the worker's `readOnly` flags** | the blocker |
| `/tmp`, `/home/djinn` | disk-backed `emptyDir` | `readOnlyRootFilesystem: true` (see below) |

`readOnly` parity is asserted against the worker rather than against `false`: an evidence-spike run legitimately denies both of them write access, and if that isolation held only for commands that happen not to be brokered it would not be isolation.

## The two open questions, measured not assumed

### 1. Can `CHILD_UID` 1001 / `ARTIFACT_GID` 1000 write those volumes? — **Yes, and no chown is needed.**

Measured on the production PVCs and confirmed by writing as the real child credentials (`setpriv --reuid=1001 --regid=1000 --clear-groups`):

| path | owner:group | mode | uid 1001 / gid 1000 |
|---|---|---|---|
| `/cache` | `10001:1000` | `2775` | chdir OK, write OK |
| `/mirror` | `10001:1000` | `2775` | chdir OK, write OK |
| `/workspace` | `0:1000` | `2777` | chdir OK, write OK |

The child owns none of them — it writes **through the group**, which is exactly what `fsGroup: ARTIFACT_GID` plus the setgid bit exist to provide. Files land `1001:1000` mode `664`, so the worker (uid 1000) can read and rewrite them.

Two hazards checked explicitly, given this repo's history with `protected_hardlinks` and the `/mirror` chown see-saw:

* `prepare_child` calls `setgroups(0, NULL)` before `setgid`, so gid 1000 must be the child's **primary** group — it is. A supplementary group would have been dropped and every write would have `EACCES`d.
* `fsGroupChangePolicy: OnRootMismatch` is a no-op here because both PVC roots already carry gid 1000, so no recursive re-own of the large caches is triggered.

### 2. Does `readOnlyRootFilesystem: true` starve build tools of `/tmp`? — **Yes, and `$HOME` too.**

`TMPDIR` is rendered to `/workspace` and *is* honoured once the workspace is mounted (`mktemp -d` → `/workspace/tmp.N2mPeRb6vW`). But `readOnlyRootFilesystem` removes every writable surface in the **image layer**, which the worker container — carrying no such flag — keeps. Measured in the rendered launcher container:

```
# uid 0
touch /tmp/x          -> Read-only file system
touch /home/djinn/x   -> Read-only file system

# uid 1001 / gid 1000, the real child credentials
git config --global user.name probe
  error: could not lock config file /home/djinn/.gitconfig: Read-only file system
```

Both are writable in the worker container on the same pod, so arming without this would be a **regression against the unbrokered path**, not a new constraint. `volume_contract.rs` already fails worker readiness on a non-writable `$HOME` for precisely this reason, and its docs already assert "the launcher-spawned child (uid 1001, group 1000) write[s] through the group". Ownership was never the problem; `readOnlyRootFilesystem` defeats it regardless of ownership.

Supplied as **disk-backed** `emptyDir`s: a Memory medium is charged to the pod's memory limit, and the launcher container's limit is the *build's* ceiling. Masking the image copies costs nothing — measured, the image's `/home/djinn` holds one empty `.local/state`.

## The guard

`tests/launcher_child_filesystem_reachability.rs`. A test asserting the volumeMounts appear in the rendered spec is necessary but not sufficient — all four prior blockers would have been green through one. So this derives the invariant instead:

> Every filesystem path the rendered Pod names to the worker through an environment variable **the broker forwards to a child** must be reachable and writable in the launcher's mount namespace; every path the child is forbidden to see must not be.

Nothing in it names `/workspace`, `/cache` or `/mirror`. The required set is the rendered worker env filtered through `djinn_cgroup_launcher::is_allowed_environment_key` — the same predicate the privileged broker re-applies in `CommandSpec::validate`. The isolation half is derived too: "worker-private" means *the worker's own covering mount is Secret- or projected-backed*, using longest-prefix matching, which is why the launcher IPC volume nested **inside** the `spec` Secret mount at `/var/run/djinn/launcher` is correctly classified as shared rather than private. Both halves must fire or the test fails as vacuous.

It then leaves the manifest entirely: `materialize()` builds the rendered mount set as a real directory tree and the test runs the real syscalls through it.

### Proof it fails without the fix

Reverting `launcher_volume_mounts` to the pre-fix two-mount set:

```
test the_child_writes_through_the_fs_group_because_it_owns_none_of_the_volumes ... ok
test a_read_only_root_filesystem_does_not_take_away_scratch_the_worker_still_has ... FAILED
test removing_the_workspace_mount_reproduces_the_production_enoent ... FAILED
test every_child_visible_declared_path_is_writable_in_the_launcher_mount_namespace ... FAILED
test the_rendered_launcher_mount_set_lets_a_real_chdir_and_write_succeed ... FAILED

the rendered launcher mount set must let a brokered child chdir and write:
  Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

That last line is the production failure reproduced by name — `ENOENT`, the same errno `spawn.rs`'s `chdir` returned before `_exit`.

The guard also caught two real defects in its own first drafts, which is the best evidence it is not decorative: it rejected a naive `/var/run/djinn` prefix rule (which would have demanded the *opposite* of the truth for the broker credential), and after the #2614 rebase it flagged `DJINN_INVOCATION_JOURNAL_DIR` — a true positive for the derivation, a false positive for the invariant, since the journal is opened worker-side. That is now an explicit exemption with a stated reason plus a companion test that fails if the exemption goes stale.

## Verified on a production probe pod

Rendered directly from this code (`build_task_run_job` → JSON → probe pod on the production node, real PVCs attached; **production itself not armed**):

* `cgroup-launcher: ready=true, restarts=0` — the real launcher still bootstraps its delegated cgroup root with the extra mounts.
* As uid 1001 / gid 1000: `/workspace`, `/cache`, `/mirror`, `/tmp`, `/home/djinn` all chdir **and** write; files land `1001:1000:664`.
* `/var/run/djinn/spec.bin`, `/var/run/djinn/credentials.bin`, `/var/run/secrets/tokens/djinn` — all **absent**. The isolation half holds in the real namespace, not just in the manifest.
* `git config --global user.name` now succeeds; `mktemp -d` honours `TMPDIR` and falls back to a writable `/tmp`.

## I believe a sixth blocker exists

**Every brokered `git` command will fail `detected dubious ownership`.** Measured, with the worker's real `umask 0002`:

```
# worker (uid 1000) creates the worktree
/workspace/wt owner=1000:1000 mode=2775

# brokered child (uid 1001, gid 1000)
write into worktree  -> WRITE_OK      (permissions are fine)
git status           -> fatal: detected dubious ownership in repository at '/workspace/wt'
GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0=* git status  -> exit=0
```

Root cause: `job.rs` renders `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_0` / `GIT_CONFIG_VALUE_0` = `safe.directory=*` precisely so a direct git invocation in the pod works. The child is uid 1001 and never owns the uid-1000 worktree, so it needs them — but `is_allowed_environment_key` has no `GIT_` prefix and no `GIT_CONFIG_*` entry (`grep -c GIT_CONFIG env.rs` = 0), so `child_environment` strips exactly the three variables that fix it. Until this PR the documented remedy was doubly blocked, because `git config --global` could not write the read-only `$HOME` either; that half is fixed here.

Deliberately **not** fixed in this PR: `GIT_CONFIG_KEY_n`/`VALUE_n` is an arbitrary-git-config injection primitive (`core.sshCommand`, `core.pager` → arbitrary exec), so widening the broker's security allow-list deserves its own review rather than riding on a mounts change. The narrow fix is to forward the three exact keys, not a `GIT_` prefix.

Note also that the worktree *write* permission is fine only because the worker applies `apply_artifact_umask()` (0002). A worker at umask 022 would render the worktree `2755` and the child could not write it at all — worth keeping in view given the recent umask-022 regression in the warm path.

## CI note

The first run failed on `Server Test (shard-3, 2)` with `Docker pull failed with exit code 1` after backoff retries — the Docker Hub anonymous rate limit — which fail-fast cascaded the rest of the run into `cancelled`. Re-run clean; not related to this change.

A local `cargo clippy -p djinn-k8s --all-targets` also reports `disallowed_methods: Instant::now` in `graph_warmer_ledger_tests.rs`, a file this PR does not touch. It reproduces against a pristine `origin/main` checkout of the crate (introduced by #2608) and CI's own `Server Clippy` lane is green, so it is a local-invocation difference rather than a regression here.
