### PR TITLE
fix(goxi): give a brokered child a program execve can actually run

### DIFF
--- a/server/crates/djinn-agent/src/extension/tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests.rs
@@ -55,6 +55,7 @@ impl ToolCallOutcomeTestExt for djinn_core::tool_call::ToolCallOutcome {
     }
 }
 
+mod brokered_shell_program_tests;
 mod code_graph_tests;
 mod compatibility_fallback_tests;
 mod edit_dispatch_tests;

--- a/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
@@ -347,18 +347,18 @@ async fn a_brokered_shell_command_resolves_its_program_and_really_executes() {
         .expect("the resolved spec must satisfy the broker's own validator");
 }
 
-/// The child really is born with the environment the spec carries and nothing
-/// inherited. `env_clear` in [`execute`] is the launcher's contract: a
-/// `run_shell` that needs an unforwarded variable must fail here the way it
-/// fails in a pod.
+/// The child really is born with the environment the spec carries — the shell
+/// that runs is the one the launcher would have `execve`d, in the environment
+/// the launcher would have handed it, not the worker's.
+///
+/// The negative half is asserted on the SPEC rather than on the child's own
+/// view, deliberately: `env_clear` in [`execute`] is the harness's code, so a
+/// child that could not see a stray variable would prove the harness works.
+/// What has to hold in production is that the forwarded set is closed, and
+/// `CommandSpec::validate` is the thing that enforces it.
 #[tokio::test]
-async fn the_executed_child_sees_the_forwarded_environment_and_not_the_workers() {
-    // SAFETY: single-threaded setup before the dispatch, test-local key, and
-    // the name is deliberately one the broker's allow-list does not carry.
-    unsafe { std::env::set_var("GOXI_NOT_FORWARDABLE", "leaked") };
-    let (response, conversion) =
-        brokered_shell("echo \"home=$HOME leak=${GOXI_NOT_FORWARDABLE:-absent}\"").await;
-    unsafe { std::env::remove_var("GOXI_NOT_FORWARDABLE") };
+async fn the_executed_child_sees_the_forwarded_environment() {
+    let (response, conversion) = brokered_shell("echo \"home=$HOME\"").await;
 
     let home = conversion
         .spec
@@ -369,9 +369,17 @@ async fn the_executed_child_sees_the_forwarded_environment_and_not_the_workers()
         .expect("HOME must survive the broker hop");
     let stdout = response["stdout"].as_str().expect("stdout is a string");
     assert!(
-        stdout.contains(&format!("home={home} leak=absent")),
-        "the child must see the spec's HOME and nothing outside the allow-list, got {stdout:?}"
+        stdout.contains(&format!("home={home}")),
+        "the child must see the spec's HOME, got {stdout:?}"
     );
+
+    for (key, _) in &conversion.spec.environment {
+        assert!(
+            djinn_cgroup_launcher::is_allowed_environment_key(key)
+                || key == djinn_cgroup_launcher::env::GIT_TRUST_ANCHOR_KEY,
+            "{key} reached a brokered child without being on the closed allow-list"
+        );
+    }
 }
 
 /// The harness substitutes exactly one field, and it is the one a CI runner

--- a/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
@@ -1,0 +1,560 @@
+//! The coverage whose absence hid goxi's seventh launcher blocker: a brokered
+//! `run_shell` could not start a process at all.
+//!
+//! # What went wrong, and why nothing caught it
+//!
+//! `extension::handlers::workspace` builds `Command::new("bash").arg("-lc")` —
+//! a **bare** program name, which is what [`std::process::Command`] documents a
+//! `PATH` search for. [`CommandSpec`] is not a `Command`; it is an `execve(2)`
+//! request, and `execve` performs no search. `CommandSpec::validate` therefore
+//! refused it outright:
+//!
+//! ```text
+//! program = "bash"        -> Err(InvalidCommand)
+//! program = "/bin/bash"   -> Ok(())
+//! ```
+//!
+//! Every brokered shell command failed `lease invocation failed:
+//! InvalidCommand`, and running a shell command is the first thing an armed
+//! task pod does. Even past validation the child would have `_exit`ed 127:
+//! `spawn.rs` hands `program` straight to `execve`.
+//!
+//! # Why the existing broker-backed tests were green
+//!
+//! `shell_dispatch_tests::BrokerShellLauncher` — the adapter behind every
+//! broker-backed dispatch test — "deliberately ignores `Command`", by its own
+//! doc comment. It never converts, so it never validates, so the one contract
+//! that mattered was untested from the side that has to satisfy it: the caller.
+//!
+//! So nothing below hand-assembles a [`CommandSpec`]. Every proof starts at the
+//! real [`call_shell`], and the spec under test comes out of the real
+//! [`crate::process::command_spec`] — the production conversion — applied to
+//! the real `Command` the handler built.
+//!
+//! # Non-vacuity
+//!
+//! [`ProofLauncher`] records, for the same `Command`, what the caller *named*
+//! and what the conversion *resolved*, and every proof asserts on both. The
+//! control is not a hypothetical: it is the caller's own program put through
+//! the same `CommandSpec::validate`, and it must come back
+//! `Err(Error::InvalidCommand)` **by name**. If a future change makes the
+//! handler name an absolute path itself, that control turns green and
+//! [`the_program_the_shell_handler_names_is_one_the_broker_refuses`] fails,
+//! loudly, saying so — which is the point. This chain of blockers is made of
+//! two sides of a contract drifting apart while each side's tests stayed green.
+//!
+//! # The one thing the harness supplies that a CI runner cannot
+//!
+//! `CommandSpec::validate` requires `cwd` to be `/workspace` or beneath it, and
+//! a CI runner has no writable `/workspace`. So [`ProofLauncher`] re-points the
+//! command's `current_dir` to a production-shaped `/workspace/...` **before**
+//! the real conversion — so validation runs against the real constraint — and
+//! then executes the validated spec against the equivalent real directory the
+//! test created. `program`, `argv` and `environment` are used verbatim; only
+//! `cwd` is rebased, and [`the_proof_substitutes_the_cwd_and_nothing_else`]
+//! pins that. This is the same materialized-root device
+//! `djinn-k8s`'s `launcher_child_filesystem_reachability` uses for the same
+//! reason.
+
+use super::handlers::call_shell;
+use super::{agent_context_from_db, create_test_db};
+use crate::process::{CgroupLauncherClient, LeaseInvocationRunner, ProcessHandle, command_spec};
+use djinn_cgroup_launcher::{CommandSpec, CpuStat};
+use djinn_core::clock::SystemClock;
+use djinn_supervisor::services::{LeaseFencingToken, TaskInvocationLeaseIdentity};
+use std::io;
+use std::path::Path;
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::{Arc, Mutex};
+use tokio_util::sync::CancellationToken;
+
+/// A production-shaped `cwd`. `CommandSpec::validate` accepts nothing else, and
+/// a task-run Pod always renders one (`WORKSPACE_MOUNT_DIR` + the worktree).
+const RENDERED_CWD: &str = "/workspace/goxi-brokered-shell-proof";
+
+/// The exact production failure, by name. Compared as the `Debug` spelling of
+/// the variant rather than by `PartialEq`, which `djinn_cgroup_launcher::Error`
+/// deliberately does not implement (it carries an `io::Error`).
+const PRODUCTION_FAILURE: &str = "InvalidCommand";
+
+/// `CommandSpec::validate`'s verdict, reduced to the variant name.
+fn verdict(spec: &CommandSpec) -> Result<(), String> {
+    spec.validate().map_err(|error| format!("{error:?}"))
+}
+
+// ───────────────────────── the real composition seam ─────────────────────────
+
+/// What the real conversion did to the real handler's `Command`.
+#[derive(Clone, Debug)]
+struct Conversion {
+    /// The program the CALLER named, verbatim from `Command::get_program`.
+    named: String,
+    /// That same program's verdict from the broker's own validator — the
+    /// control, derived from the caller rather than written down here.
+    named_verdict: Result<(), String>,
+    /// The spec the production conversion actually produced.
+    spec: CommandSpec,
+    /// `cwd` as the handler set it, before the harness rebased it.
+    handler_cwd: String,
+}
+
+/// A launcher client that runs the REAL conversion and then REALLY executes.
+///
+/// This is the opposite of `shell_dispatch_tests::BrokerShellLauncher`: that one
+/// exists to exercise the lease lifecycle and ignores the `Command`; this one
+/// exists to exercise the `Command` and keeps the lifecycle trivial.
+#[derive(Clone)]
+struct ProofLauncher {
+    /// Real directory standing in for [`RENDERED_CWD`].
+    workspace: Arc<std::path::PathBuf>,
+    conversions: Arc<Mutex<Vec<Conversion>>>,
+}
+
+impl ProofLauncher {
+    fn new(workspace: &Path) -> Self {
+        Self {
+            workspace: Arc::new(workspace.to_path_buf()),
+            conversions: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn conversion(&self) -> Conversion {
+        let recorded = self.conversions.lock().expect("conversions");
+        assert_eq!(
+            recorded.len(),
+            1,
+            "the handler must reach the broker exactly once"
+        );
+        recorded[0].clone()
+    }
+}
+
+impl CgroupLauncherClient for ProofLauncher {
+    fn launch(
+        &self,
+        mut command: Command,
+        _: &TaskInvocationLeaseIdentity,
+    ) -> io::Result<Box<dyn ProcessHandle>> {
+        let named = command
+            .get_program()
+            .to_str()
+            .expect("program is UTF-8")
+            .to_owned();
+        let handler_cwd = command
+            .get_current_dir()
+            .expect("the handler always sets a cwd")
+            .to_string_lossy()
+            .into_owned();
+
+        // Give the conversion the cwd production gives it. Everything else —
+        // program, argv, environment, including whatever the sandbox layered
+        // on — is exactly what the handler built.
+        command.current_dir(RENDERED_CWD);
+
+        // THE PRODUCTION CONVERSION. Not a copy of it, not a reimplementation.
+        let spec = command_spec(command)?;
+
+        // The control: the same validator, on the program the caller named,
+        // in an otherwise identical spec.
+        let named_verdict = verdict(&CommandSpec {
+            program: named.clone(),
+            ..spec.clone()
+        });
+
+        self.conversions
+            .lock()
+            .expect("conversions")
+            .push(Conversion {
+                named,
+                named_verdict,
+                spec: spec.clone(),
+                handler_cwd,
+            });
+
+        Ok(Box::new(execute(&spec, &self.workspace)?))
+    }
+}
+
+/// Run a validated spec the way the launcher runs it.
+///
+/// `spawn.rs` calls `execve(spec.program, argv, envp)` after `chdir(spec.cwd)`,
+/// with the child's environment replaced wholesale. This reproduces all four:
+/// `Command::new` performs a `PATH` search **only** for a program with no `/`
+/// in it, and `spec.program` is asserted absolute here, so no search can occur
+/// and the exec is `execve`-equivalent. `env_clear` gives the child exactly the
+/// spec's environment and nothing inherited, which is the launcher's contract.
+fn execute(spec: &CommandSpec, workspace: &Path) -> io::Result<ProofChild> {
+    assert!(
+        Path::new(&spec.program).is_absolute(),
+        "a validated spec must carry an absolute program, or this exec would PATH-search \
+         and stop modelling `execve`: {:?}",
+        spec.program
+    );
+    let output = Command::new(&spec.program)
+        .args(&spec.argv)
+        .env_clear()
+        .envs(spec.environment.iter().cloned())
+        // The one substitution: the validated `/workspace/...` rebased onto the
+        // real directory this test created. See the module docs.
+        .current_dir(workspace)
+        .stdin(Stdio::null())
+        .output()?;
+    Ok(ProofChild {
+        stdout: output.stdout,
+        stderr: output.stderr,
+        status: output.status,
+    })
+}
+
+struct ProofChild {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    status: ExitStatus,
+}
+
+impl ProcessHandle for ProofChild {
+    fn drain_stdout(&mut self) -> io::Result<Vec<u8>> {
+        Ok(std::mem::take(&mut self.stdout))
+    }
+    fn drain_stderr(&mut self) -> io::Result<Vec<u8>> {
+        Ok(std::mem::take(&mut self.stderr))
+    }
+    fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        Ok(Some(self.status))
+    }
+    fn wait(&mut self) -> io::Result<ExitStatus> {
+        Ok(self.status)
+    }
+    fn sample_cpu(&mut self) -> io::Result<CpuStat> {
+        Ok(CpuStat::default())
+    }
+    fn fenced_lift(&mut self, _: &LeaseFencingToken) -> io::Result<()> {
+        Ok(())
+    }
+    fn kill(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+    fn wait_empty(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+    fn cleanup(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn shell_args(command: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+    Some(
+        serde_json::json!({ "command": command })
+            .as_object()
+            .expect("shell arguments object")
+            .clone(),
+    )
+}
+
+/// Drive the real `call_shell` over the real broker conversion.
+async fn brokered_shell(command: &str) -> (serde_json::Value, Conversion) {
+    let worktree = crate::test_helpers::test_tempdir("goxi-brokered-shell-");
+    let mut state = agent_context_from_db(create_test_db(), CancellationToken::new());
+    let launcher = ProofLauncher::new(worktree.path());
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        Arc::new(djinn_supervisor::services::rpc::UnimplementedRpcServices::new()),
+        Arc::new(launcher.clone()),
+        Arc::new(SystemClock::new()),
+    ));
+    state.shell_launch = Some(crate::context::ShellLaunchContext::for_test(
+        runner,
+        "goxi-task".into(),
+        "goxi-task-run".into(),
+        "goxi-pod-uid".into(),
+    ));
+
+    let response = call_shell(
+        &state,
+        &shell_args(command),
+        worktree.path(),
+        None,
+        &crate::extension::ToolCancellation::never(),
+    )
+    .await
+    .expect("a brokered shell command must return its terminal output");
+
+    (response, launcher.conversion())
+}
+
+// ─────────────────────────────── the proofs ──────────────────────────────────
+
+/// The blocker itself: the program the handler names is one the broker refuses.
+///
+/// This is the control, and it is derived from the caller rather than asserted
+/// about a literal. If it ever passes, the handler has started naming an
+/// absolute path and every other proof here has quietly stopped covering the
+/// resolution — delete the resolution or keep a bare-name caller, but do not
+/// leave this file believing it proves something it no longer does.
+#[tokio::test]
+async fn the_program_the_shell_handler_names_is_one_the_broker_refuses() {
+    let (_, conversion) = brokered_shell("true").await;
+
+    assert!(
+        !conversion.named.contains('/'),
+        "the shell handler is expected to name a bare program (it builds \
+         `Command::new(\"bash\")`); it named {:?}",
+        conversion.named
+    );
+    assert_eq!(
+        conversion.named_verdict,
+        Err(PRODUCTION_FAILURE.to_owned()),
+        "the production failure is `InvalidCommand` on the program the handler names; \
+         without that this file's other proofs are vacuous"
+    );
+}
+
+/// The fix, end to end: a brokered `run_shell` actually runs a process and its
+/// output comes back through the tool response.
+#[tokio::test]
+async fn a_brokered_shell_command_resolves_its_program_and_really_executes() {
+    let (response, conversion) = brokered_shell("printf 'goxi-%s\\n' seventh-blocker").await;
+
+    assert_eq!(
+        response["ok"],
+        serde_json::json!(true),
+        "stderr: {}",
+        response["stderr"]
+    );
+    assert_eq!(response["exit_code"], serde_json::json!(0));
+    // `contains`, not equality: the handler builds a LOGIN shell (`bash -lc`),
+    // which sources `/etc/profile` and `/etc/profile.d/*` — production included.
+    // The marker can only appear if a process really ran the agent's command.
+    let stdout = response["stdout"].as_str().expect("stdout is a string");
+    assert!(
+        stdout.contains("goxi-seventh-blocker"),
+        "the brokered child's own output must reach the tool response, got {stdout:?}"
+    );
+
+    // The resolution is what made that possible.
+    let program = &conversion.spec.program;
+    assert!(
+        Path::new(program).is_absolute(),
+        "{program:?} must be absolute: `execve` performs no PATH search"
+    );
+    assert!(
+        program.ends_with(&format!("/{}", conversion.named)),
+        "{program:?} must be the caller's own program {:?} resolved, not a substitute",
+        conversion.named
+    );
+    conversion
+        .spec
+        .validate()
+        .expect("the resolved spec must satisfy the broker's own validator");
+}
+
+/// The child really is born with the environment the spec carries and nothing
+/// inherited. `env_clear` in [`execute`] is the launcher's contract: a
+/// `run_shell` that needs an unforwarded variable must fail here the way it
+/// fails in a pod.
+#[tokio::test]
+async fn the_executed_child_sees_the_forwarded_environment_and_not_the_workers() {
+    // SAFETY: single-threaded setup before the dispatch, test-local key, and
+    // the name is deliberately one the broker's allow-list does not carry.
+    unsafe { std::env::set_var("GOXI_NOT_FORWARDABLE", "leaked") };
+    let (response, conversion) =
+        brokered_shell("echo \"home=$HOME leak=${GOXI_NOT_FORWARDABLE:-absent}\"").await;
+    unsafe { std::env::remove_var("GOXI_NOT_FORWARDABLE") };
+
+    let home = conversion
+        .spec
+        .environment
+        .iter()
+        .find(|(key, _)| key == "HOME")
+        .map(|(_, value)| value.clone())
+        .expect("HOME must survive the broker hop");
+    let stdout = response["stdout"].as_str().expect("stdout is a string");
+    assert!(
+        stdout.contains(&format!("home={home} leak=absent")),
+        "the child must see the spec's HOME and nothing outside the allow-list, got {stdout:?}"
+    );
+}
+
+/// The harness substitutes exactly one field, and it is the one a CI runner
+/// cannot provide. Everything the blocker is about is used verbatim.
+#[tokio::test]
+async fn the_proof_substitutes_the_cwd_and_nothing_else() {
+    let (_, conversion) = brokered_shell("true").await;
+
+    assert_eq!(
+        conversion.spec.cwd, RENDERED_CWD,
+        "the conversion must be validated against a production-shaped cwd"
+    );
+    assert_ne!(
+        conversion.handler_cwd, RENDERED_CWD,
+        "the handler's own cwd is the test worktree; if these are equal the \
+         substitution is not happening and this guard proves nothing"
+    );
+    assert!(
+        CommandSpec {
+            cwd: conversion.handler_cwd.clone(),
+            ..conversion.spec.clone()
+        }
+        .validate()
+        .is_err(),
+        "the substitution is necessary: {:?} is not a cwd the broker accepts",
+        conversion.handler_cwd
+    );
+}
+
+// ────────────────────── the conversion contract, directly ────────────────────
+
+/// `-lc` and the command text must reach the child unchanged. A resolution that
+/// rewrote argv would silently change what the agent asked to run.
+#[tokio::test]
+async fn resolution_changes_the_program_and_leaves_argv_alone() {
+    let (_, conversion) = brokered_shell("echo untouched").await;
+
+    assert_eq!(
+        conversion.spec.argv,
+        vec!["-lc".to_owned(), "echo untouched".to_owned()],
+        "only the program is resolved"
+    );
+}
+
+/// `Command` resolves a bare name against the CHILD's `PATH` when one is set.
+/// The conversion must too, or a caller that pins `PATH` would get a different
+/// binary through the broker than it would get unbrokered.
+///
+/// The planted program is necessarily outside the broker's program allow-list
+/// (a test cannot write `/bin`), so the resolution is read off the refusal —
+/// which names the resolved path precisely because the coarse `InvalidCommand`
+/// on its own is what made this blocker expensive to find.
+#[test]
+fn resolution_uses_the_childs_path_not_the_workers() {
+    let planted = crate::test_helpers::test_tempdir("goxi-path-");
+    let program = planted.path().join("goxi-only-here");
+    std::fs::write(&program, "#!/bin/sh\nexit 0\n").expect("plant program");
+    make_executable(&program);
+
+    let mut command = Command::new("goxi-only-here");
+    command.current_dir(RENDERED_CWD);
+    // `PATH` is on the broker's forward allow-list, so an explicit one wins
+    // over the worker's inherited value — exactly as `Command::get_envs` does.
+    command.env("PATH", planted.path());
+
+    let message = command_spec(command)
+        .expect_err("a planted program is outside the program allow-list")
+        .to_string();
+    assert!(
+        message.contains(&format!("{}", program.display())),
+        "the bare name must have been resolved against the CHILD PATH: {message}"
+    );
+    assert!(
+        message.contains(PRODUCTION_FAILURE),
+        "and then refused by the allow-list, not by the resolution: {message}"
+    );
+}
+
+/// A program on no `PATH` entry fails here, named, instead of becoming an
+/// `execve` `ENOENT` and a child that `_exit`s 127 with no explanation.
+#[test]
+fn a_program_that_is_on_no_path_entry_is_refused_by_name() {
+    let empty = crate::test_helpers::test_tempdir("goxi-empty-path-");
+    let mut command = Command::new("goxi-no-such-program");
+    command.current_dir(RENDERED_CWD);
+    command.env("PATH", empty.path());
+
+    let error = command_spec(command).expect_err("an unresolvable program must not be sent");
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    let message = error.to_string();
+    assert!(
+        message.contains("goxi-no-such-program") && message.contains("PATH"),
+        "the refusal must name the program and the path it searched: {message}"
+    );
+}
+
+/// A caller that already names an absolute path keeps it byte for byte — the
+/// resolution is a repair for the `Command` contract, not a rewrite policy.
+#[test]
+fn an_absolute_program_is_passed_through_unchanged() {
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg("true").current_dir(RENDERED_CWD);
+    let spec = command_spec(command).expect("an absolute program needs no resolution");
+    assert_eq!(spec.program, "/bin/sh");
+}
+
+/// A **relative** path is not silently made absolute. `execvp` treats anything
+/// containing a `/` as a path, and resolving it against the worker's cwd would
+/// invent an authority the caller never asked for; the broker's own validator
+/// refuses it a moment later.
+#[test]
+fn a_relative_program_is_not_silently_promoted() {
+    let mut command = Command::new("./bash");
+    command.current_dir(RENDERED_CWD);
+    let error = command_spec(command).expect_err("a relative program must not be accepted");
+    let message = error.to_string();
+    assert!(
+        message.contains(PRODUCTION_FAILURE),
+        "a relative program must be refused as the production failure: {message}"
+    );
+    assert!(
+        message.contains("./bash"),
+        "the refusal must name what was rejected: {message}"
+    );
+}
+
+// ─────────────────────── the allow-list decision, pinned ─────────────────────
+
+/// The program allow-list is left exactly as narrow as it was, and this records
+/// the decision so widening it has to be deliberate.
+///
+/// It is **not** a code-provenance control and must not be sold as one:
+/// `/workspace/` is on it and the agent writes `/workspace`, and — decisively —
+/// the only program a brokered command ever names is a shell, which then
+/// resolves the agent's actual command against a `PATH` that is mostly outside
+/// the list. Measured in the rendered task image on the production node,
+/// `cargo` is `/usr/local/cargo/bin/cargo` and `node` is `/opt/node/bin/node`,
+/// so a brokered `cargo build` already runs a binary from a directory the list
+/// does not name.
+///
+/// Widening it to the two directories the seventh blocker's investigation found
+/// it rejects would therefore buy no safety and serve no caller: measured in the
+/// same image, `/usr/local/bin` is empty and `/opt/djinn/bin` holds only
+/// `djinn-agent-worker` and `djinn-cgroup-launcher`, neither of which is ever a
+/// brokered child. The hazard a narrow list really carries — a caller tripping
+/// it and failing closed — is fixed in the conversion instead.
+#[test]
+fn the_program_allow_list_stays_narrow_and_admits_the_shell_the_handler_uses() {
+    let spec = |program: &str| CommandSpec {
+        program: program.to_owned(),
+        argv: vec!["-lc".to_owned(), "true".to_owned()],
+        cwd: RENDERED_CWD.to_owned(),
+        environment: vec![("PATH".to_owned(), "/usr/bin:/bin".to_owned())],
+    };
+
+    // Both spellings of the shell exist in the rendered image (`/bin` is a
+    // symlink to `usr/bin`), so resolution may legitimately produce either.
+    for admitted in ["/bin/bash", "/usr/bin/bash", "/workspace/tool"] {
+        spec(admitted)
+            .validate()
+            .unwrap_or_else(|error| panic!("{admitted} must be admitted: {error}"));
+    }
+    for refused in [
+        "bash",
+        "./bash",
+        "/usr/bin/../etc/passwd",
+        "/usr//bin/bash",
+        // Deliberately still refused; see the doc comment above.
+        "/usr/local/bin/anything",
+        "/opt/djinn/bin/djinn-agent-worker",
+    ] {
+        assert!(
+            verdict(&spec(refused)) == Err(PRODUCTION_FAILURE.to_owned()),
+            "{refused} must stay outside the program allow-list"
+        );
+    }
+}
+
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(path)
+        .expect("plant metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("plant mode");
+}

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -80,6 +80,13 @@ pub fn isolate_process_group(cmd: &mut Command) {
 
 #[path = "process_broker.rs"]
 mod broker;
+/// The `Command` -> `CommandSpec` conversion the production broker adapter
+/// uses. Exported so a proof can drive the REAL conversion from the REAL
+/// caller instead of hand-assembling a spec — the seventh launcher blocker was
+/// invisible precisely because every broker-backed test used a launcher that
+/// ignored the `Command` it was handed.
+#[cfg(test)]
+pub(crate) use broker::command_spec;
 #[allow(unused_imports)] // constructed by the pending workspace broker composition
 pub(crate) use broker::{CgroupLauncherClient, ProcessHandle, UnixBrokerLauncher};
 

--- a/server/crates/djinn-agent/src/process_broker.rs
+++ b/server/crates/djinn-agent/src/process_broker.rs
@@ -202,13 +202,13 @@ fn remote_exit_status(_: ChildStatus) -> io::Result<ExitStatus> {
     ))
 }
 
-fn command_spec(command: Command) -> io::Result<CommandSpec> {
+pub(crate) fn command_spec(command: Command) -> io::Result<CommandSpec> {
     let text = |value: &std::ffi::OsStr, what| {
         value.to_str().map(str::to_owned).ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidInput, format!("{what} must be UTF-8"))
         })
     };
-    let program = text(command.get_program(), "program")?;
+    let named = text(command.get_program(), "program")?;
     let argv = command
         .get_args()
         .map(|argument| text(argument, "argument"))
@@ -217,14 +217,133 @@ fn command_spec(command: Command) -> io::Result<CommandSpec> {
         .get_current_dir()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "command cwd is required"))?;
     let cwd = text(cwd.as_os_str(), "cwd")?;
+    let environment = child_environment(&command)?;
+    let program = resolve_program(&named, &environment)?;
     let spec = CommandSpec {
         program,
         argv,
         cwd,
-        environment: child_environment(&command)?,
+        environment,
     };
-    spec.validate().map_err(broker_error)?;
+    spec.validate().map_err(|error| {
+        // Name what was rejected. The seventh launcher blocker cost a full
+        // investigation because the only thing production could say was
+        // "lease invocation failed: InvalidCommand", which does not
+        // distinguish the program from the cwd from a single environment
+        // entry — and `InvalidCommand` is deliberately coarse on the wire
+        // (the privileged broker does not describe its refusals to callers).
+        // This is the worker's own copy of the same check, so it can.
+        io::Error::other(format!(
+            "{error:?} ({error}): program {:?} (named {named:?}), cwd {:?}, \
+             {} environment entries",
+            spec.program,
+            spec.cwd,
+            spec.environment.len()
+        ))
+    })?;
     Ok(spec)
+}
+
+/// Resolve what the caller *named* into the absolute path `execve` requires.
+///
+/// # Why the conversion has to do this (task goxi, seventh launcher blocker)
+///
+/// [`std::process::Command`] documents a `PATH` search for a program with no
+/// `/` in it, and every caller in this repo relies on that:
+/// `extension::handlers::workspace` builds `Command::new("bash").arg("-lc")`,
+/// which is the **first thing an armed task pod runs**. [`CommandSpec`] is not a
+/// `Command`; it is an `execve(2)` request, and `execve` performs no search at
+/// all. So this conversion silently dropped a documented promise, twice over:
+///
+/// * `CommandSpec::validate` requires an absolute path from a known directory,
+///   so a bare name was refused before a leaf or a child existed — measured, on
+///   the real launcher, every brokered `run_shell` failed
+///   `lease invocation failed: InvalidCommand`;
+/// * and had it passed, `spawn.rs`'s `execve(prepared.program, …)` would have
+///   returned `ENOENT` and the child would have `_exit`ed 127 without running.
+///
+/// Resolving here rather than at one call site is the point. Fixing
+/// `workspace.rs` to say `/bin/bash` would leave the conversion just as lossy
+/// for the next `Command::new("git")` anyone writes, and that next caller would
+/// be blocker number nine.
+///
+/// # Which `PATH`
+///
+/// The child's, taken from `environment` — which is exactly what `Command` does
+/// on Unix (a `PATH` set on the command wins over the parent's for the search).
+/// The fallback when the child has no `PATH` is `execvp(3)`'s own
+/// `confstr(_CS_PATH)` default, for the same reason.
+///
+/// # Which filesystem
+///
+/// The worker's. A brokered child executes in the *launcher* container's mount
+/// namespace, not the worker's, so in principle the two could disagree — but
+/// both containers run the same image (`/opt/djinn/bin/djinn-agent-worker` and
+/// `/opt/djinn/bin/djinn-cgroup-launcher` are siblings in it), and a
+/// disagreement fails loudly at `execve` with exit 127 rather than silently.
+/// Doing the search inside the privileged broker instead would put a filesystem
+/// walk in the process whose entire design is to accept a bounded data-only
+/// request, and would buy nothing: the control is
+/// `CommandSpec::validate`'s allow-list applied to the resolved path, and that
+/// runs broker-side either way.
+fn resolve_program(named: &str, environment: &[(String, String)]) -> io::Result<String> {
+    // `execvp(3)`: a program containing a slash is a path and is used verbatim.
+    // A *relative* path stays relative here on purpose — resolving it against
+    // the worker's cwd would invent an authority the caller never asked for,
+    // and `CommandSpec::validate` refuses it a moment later.
+    if named.contains('/') {
+        return Ok(named.to_owned());
+    }
+    if named.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "brokered command names no program",
+        ));
+    }
+
+    let path = environment
+        .iter()
+        .find(|(key, _)| key == "PATH")
+        .map(|(_, value)| value.as_str())
+        .unwrap_or(DEFAULT_EXEC_PATH);
+
+    for directory in path.split(':') {
+        // `execvp` treats an empty PATH element as the current directory.
+        let directory = if directory.is_empty() { "." } else { directory };
+        let candidate = format!("{}/{named}", directory.trim_end_matches('/'));
+        if is_executable_file(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!(
+            "brokered command names program {named:?}, which is on no directory of the child \
+             PATH {path:?}; `execve` performs no PATH search, so this would have exec'd nothing"
+        ),
+    ))
+}
+
+/// `execvp(3)`'s search path when the environment carries none.
+const DEFAULT_EXEC_PATH: &str = "/usr/local/bin:/bin:/usr/bin";
+
+#[cfg(unix)]
+fn is_executable_file(candidate: &str) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(candidate).is_ok_and(|metadata| {
+        // `metadata` follows symlinks, which is required rather than incidental:
+        // the production `bash` is reached through one (`/bin` -> `usr/bin`).
+        // `!is_dir()` rather than `is_file()` so a device or fifo is judged by
+        // its mode, exactly as `execvp` would.
+        !metadata.is_dir() && metadata.permissions().mode() & 0o111 != 0
+    })
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(candidate: &str) -> bool {
+    std::fs::metadata(candidate).is_ok_and(|metadata| !metadata.is_dir())
 }
 
 /// The environment a brokered child is given.

--- a/server/crates/djinn-cgroup-launcher/src/command_path.rs
+++ b/server/crates/djinn-cgroup-launcher/src/command_path.rs
@@ -1,0 +1,137 @@
+//! What a [`CommandSpec`](crate::CommandSpec) path may be, and what that
+//! guarantee is worth.
+//!
+//! Split out of `lib.rs` so the decision recorded below — the one the seventh
+//! goxi launcher blocker forced — has a place to live next to its tests rather
+//! than a comment wedged between two unrelated types.
+
+/// Path hygiene for the two paths a [`CommandSpec`] carries.
+///
+/// # What this is, and what it is deliberately NOT (task goxi, seventh blocker)
+///
+/// The load-bearing half is **shape**: absolute, normalized, NUL-free. That is
+/// not tidiness. `spawn.rs` hands `program` straight to `execve(2)`, which
+/// performs no `PATH` search, so a bare name can only ever `ENOENT`; and a
+/// *relative* program or cwd would be resolved against a directory the caller
+/// influences. Both are refused here, before a leaf or a child exists.
+///
+/// The directory prefix list is the weaker half, and it must not be mistaken
+/// for a code-provenance control, because it is not one and cannot be made into
+/// one:
+///
+/// * `/workspace/` is on it, and `/workspace` is the tree the agent writes. A
+///   caller can put a binary there and name it. That alone settles it.
+/// * Decisively, the *only* program a brokered command ever names is a shell.
+///   `extension::handlers::workspace` builds `bash -lc <command>`, and `bash`
+///   then resolves `<command>` itself against a `PATH` that is mostly outside
+///   this list. Measured in the rendered task image on the production node:
+///
+///   ```text
+///   PATH=/opt/djinn/bin:/usr/local/cargo/bin:/opt/node/bin:/usr/local/go/bin:
+///        /go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+///   cargo -> /usr/local/cargo/bin/cargo      node -> /opt/node/bin/node
+///   ```
+///
+///   So a brokered `cargo build` already executes a binary from a directory
+///   this list does not name, and always did. What actually confines a brokered
+///   child is `child::prepare_child` (uid 1001, no capabilities, `no_new_privs`,
+///   seccomp), its cgroup leaf, its mount namespace, and the closed environment
+///   allow-list — none of which this function participates in.
+///
+/// # Why it is nevertheless left exactly as it is
+///
+/// Widening it to `/usr/local/bin/` or `/opt/djinn/bin/` — the two directories
+/// the seventh blocker's investigation found it rejects — would buy nothing and
+/// would advertise a guarantee that does not exist. Measured in the same image:
+/// `/usr/local/bin` is **empty**, and `/opt/djinn/bin` holds exactly
+/// `djinn-agent-worker` and `djinn-cgroup-launcher`, neither of which is ever a
+/// brokered child. There is no caller for either entry.
+///
+/// The real hazard of a narrow list is the one that produced this blocker: a
+/// caller trips it and fails closed with a coarse error. That is fixed where it
+/// belongs, in `djinn_agent::process_broker::resolve_program`, by making the
+/// `Command` -> `CommandSpec` conversion honour the `PATH` search `Command`
+/// documents — so a caller who names a program the ordinary way now gets the
+/// absolute path this function asks for, instead of a refusal. Guessing at
+/// directories would have papered over that and left the conversion lossy.
+pub fn safe_command_path(path: &str, cwd: bool) -> bool {
+    !path.contains('\0')
+        && !path.contains("//")
+        && !path.split('/').any(|part| part == "..")
+        && if cwd {
+            path == "/workspace" || path.starts_with("/workspace/")
+        } else {
+            path.starts_with("/bin/")
+                || path.starts_with("/usr/bin/")
+                || path.starts_with("/workspace/")
+        }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shape half — the half that is load-bearing. `execve(2)` performs no
+    /// `PATH` search and resolves nothing, so a bare or relative program can
+    /// only ever name the wrong thing or nothing at all.
+    #[test]
+    fn only_absolute_normalized_paths_are_accepted() {
+        for malformed in [
+            // The seventh blocker: what `Command::new("bash")` converts to.
+            "bash",
+            "./bash",
+            "../bin/bash",
+            "usr/bin/bash",
+            "/usr/bin/../etc/passwd",
+            "/usr//bin/bash",
+            "/bin/ba\0sh",
+            "",
+        ] {
+            assert!(
+                !safe_command_path(malformed, false),
+                "{malformed:?} is not a shape `execve` can use"
+            );
+        }
+        for path in ["/bin/bash", "/usr/bin/git", "/workspace/tool"] {
+            assert!(safe_command_path(path, false), "{path:?} must be accepted");
+        }
+    }
+
+    /// The cwd half is stricter on purpose: a brokered command runs in the task
+    /// workspace and nowhere else, and `spawn.rs` `chdir`s there before `execve`.
+    #[test]
+    fn a_cwd_must_be_the_workspace_or_beneath_it() {
+        for path in ["/workspace", "/workspace/project/worktree"] {
+            assert!(safe_command_path(path, true), "{path} must be a valid cwd");
+        }
+        for path in ["/", "/tmp", "/workspacex", "/bin/bash", "workspace"] {
+            assert!(!safe_command_path(path, true), "{path} must not be a cwd");
+        }
+    }
+
+    /// The decision, pinned. Widening the program prefix list is a change of
+    /// posture, not a typo fix — read the module docs before touching this.
+    ///
+    /// Measured in the rendered task image on the production node:
+    /// `/usr/local/bin` is empty, and `/opt/djinn/bin` holds only
+    /// `djinn-agent-worker` and `djinn-cgroup-launcher`, neither of which is
+    /// ever a brokered child. There is no caller for either entry, and the list
+    /// confines nothing anyway — the one program a brokered command names is a
+    /// shell, which resolves everything else itself.
+    #[test]
+    fn the_program_prefix_list_stays_at_bin_usr_bin_and_workspace() {
+        for outside in [
+            "/usr/local/bin/anything",
+            "/opt/djinn/bin/djinn-agent-worker",
+            "/usr/local/cargo/bin/cargo",
+            "/opt/node/bin/node",
+            "/sbin/ip",
+            "/cache/go/bin/tool",
+        ] {
+            assert!(
+                !safe_command_path(outside, false),
+                "{outside} is deliberately outside the program allow-list"
+            );
+        }
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -12,11 +12,13 @@ use thiserror::Error;
 pub mod bootstrap;
 pub mod broker;
 pub mod child;
+pub mod command_path;
 pub mod env;
 pub mod git_trust;
 pub mod spawn;
 pub mod transport;
 
+pub use command_path::safe_command_path;
 pub use env::{is_allowed_environment_entry, is_allowed_environment_key};
 pub use spawn::{DenySpawn, NativeCgroupSpawn};
 
@@ -245,19 +247,6 @@ impl CommandSpec {
             .then_some(())
             .ok_or(Error::InvalidCommand)
     }
-}
-
-fn safe_command_path(path: &str, cwd: bool) -> bool {
-    !path.contains('\0')
-        && !path.contains("//")
-        && !path.split('/').any(|part| part == "..")
-        && if cwd {
-            path == "/workspace" || path.starts_with("/workspace/")
-        } else {
-            path.starts_with("/bin/")
-                || path.starts_with("/usr/bin/")
-                || path.starts_with("/workspace/")
-        }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
`extension::handlers::workspace` builds `Command::new("bash").arg("-lc")` — a **bare** name, which is what `std::process::Command` documents a `PATH` search for. `CommandSpec` is not a `Command`; it is an `execve(2)` request, and `execve` performs no search. The conversion between them dropped that promise, so `CommandSpec::validate` refused the program outright:

```
program = "bash"              -> Err(InvalidCommand)
program = "/bin/bash"         -> Ok(())
program = "/usr/local/bin/x"  -> Err(InvalidCommand)
```

Every brokered `run_shell` failed `lease invocation failed: InvalidCommand`, and running a shell command is the first thing an armed task pod does. Had it passed validation, `spawn.rs`'s `execve(prepared.program, …)` would have returned `ENOENT` and the child would have `_exit`ed 127 without running. **Seventh blocker in the goxi chain.**

## The fix is in the conversion, not the one call site

`process_broker::resolve_program` performs the `execvp(3)` search `Command` documents, against the **child's** `PATH` (which is what `Command` uses on Unix when one is set), falling back to `execvp`'s own default. Fixing `workspace.rs` to say `/bin/bash` would leave the conversion just as lossy for the next `Command::new("git")` anyone writes — and that caller would be blocker nine. A program containing a slash is passed through verbatim, including a relative one: resolving that against the worker's cwd would invent an authority the caller never asked for, and `validate` refuses it a moment later.

## The allow-list is deliberately NOT widened

`/usr/local/bin` and `/opt/djinn/bin` stay outside it. The reasoning now lives in its own module (`djinn-cgroup-launcher::command_path`) with tests that pin the decision.

**It is not a code-provenance control and cannot be made into one.** `/workspace/` is already on the list and `/workspace` is the tree the agent writes. Decisively, the only program a brokered command ever names is a shell, and `bash -lc` then resolves the agent's actual command against a `PATH` that is mostly outside the list. Measured in the rendered task image on the production node:

```
PATH=/opt/djinn/bin:/usr/local/cargo/bin:/opt/node/bin:/usr/local/go/bin:/go/bin:
     /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/cache/go/bin
cargo -> /usr/local/cargo/bin/cargo        node -> /opt/node/bin/node
```

So a brokered `cargo build` already runs a binary from a directory the list does not name, and always did. What actually confines a brokered child is `child::prepare_child` (uid 1001, no capabilities, `no_new_privs`, seccomp), its cgroup leaf, its mount namespace, and the closed environment allow-list.

**And there is no caller for either entry.** Measured in the same image, `/usr/local/bin` is **empty** and `/opt/djinn/bin` holds exactly `djinn-agent-worker` and `djinn-cgroup-launcher`, neither of which is ever a brokered child. Widening would advertise a guarantee that does not exist and serve nobody.

What the list *does* buy is **shape** — absolute, normalized, NUL-free — and that half is load-bearing, because `execve` resolves nothing and a relative path would be resolved against a directory the caller influences. The real hazard of a narrow list, a caller tripping it and failing closed, is fixed by making the conversion honour its contract rather than by guessing at directories.

The refusal is also no longer mute. `InvalidCommand` is deliberately coarse on the wire, but the worker runs its own copy of the same check, so it now names the program, what the caller originally named, the cwd and the environment size.

## Proof, and its non-vacuity

Every broker-backed test to date used `BrokerShellLauncher`, which "deliberately ignores `Command`" by its own doc comment — it never converts, so it never validates, so the one contract that mattered was untested from the side that has to satisfy it.

The new suite starts at the real `call_shell`, hands the real `Command` to the real `process_broker::command_spec`, and **really executes** the validated spec: `bash -lc "printf …"` runs and its stdout comes back through the tool response. The control is derived from the caller rather than written down — the same validator, on the program the handler itself named, must return `InvalidCommand`. If the handler ever starts naming an absolute path, that control turns green and the suite fails saying so.

Reverting `resolve_program` reproduces the production failure exactly, by name, in **7 of the 10** proofs:

```
failed to run shell command: lease invocation failed: ...
  InvalidCommand (...): program "bash" (named "bash"),
  cwd "/workspace/goxi-brokered-shell-proof", 30 environment entries
```

The three that stay green are contract pins that do not depend on the resolution — that is the honest split, not a gap.

One thing the harness supplies that a CI runner cannot: `validate` requires a cwd under `/workspace` and a runner has none, so the spec is validated against the production-shaped path and executed against the equivalent real directory — the same materialized-root device `launcher_child_filesystem_reachability` uses. Only `cwd` is substituted; `program`, `argv` and `environment` are verbatim, and a guard test pins exactly that **and** proves the substitution is necessary.

## The shared `$HOME`: acceptable, do not isolate per invocation

`#2616` gave the launcher a writable `$HOME` emptyDir shared by every brokered child. That is fine, and per-invocation isolation would be the wrong move:

* **It is not a behaviour change.** On the unbrokered path every shell command runs in the *worker* container and writes the same `/home/djinn`, so `git config --global` from one command has always been visible to the next. Per-invocation `$HOME` isolation was never a property of `run_shell`.
* **It is not a boundary.** All brokered children are uid 1001, so a child that wanted cross-invocation state could keep it in `/workspace` or `/cache` regardless. Isolating `$HOME` would cost real behaviour (`rustup`, `npm`, `fnm`, `gopls` all keep state there) and buy nothing enforceable.
* **The load-bearing difference runs the other way,** and it is a defect — see below.

## An eighth blocker, and a ninth — both found by reading, then measured

Neither is fixed here; both are separable and each deserves its own proof.

### 8. `TMPDIR=/var/tmp` is on the read-only root filesystem

`djinn-sandbox`'s Linux backend sets `cmd.env("TMPDIR", "/var/tmp")` on **every** shell command, and `TMPDIR` is on the broker's forward allow-list, so it survives the hop. But `/var/tmp` is in the image layer, and the launcher runs `readOnlyRootFilesystem: true`; `#2616` supplied emptyDirs for `/tmp` and `$HOME` and not for `/var/tmp`. Measured in a launcher-shaped probe pod on the production node, against the same image, with the real child credentials:

```
# launcher-shaped container (readOnlyRootFilesystem, uid 1001 / gid 1000)
TMPDIR=/var/tmp mktemp -d  ->  failed ... '/var/tmp/tmp.XXXXXXXXXX': Read-only file system   (rc 1)

# worker container, same pod, same command
TMPDIR=/var/tmp mktemp -d  ->  /var/tmp/tmp.dQoTl2xVLm                                       (rc 0)
```

And the variable really does reach the child: dumped out of the real `command_spec` in the new suite, the spec a brokered `run_shell` produces carries `("TMPDIR", "/var/tmp")`. So every brokered child is born pointing its temp directory at a read-only path, and any tool that honours `TMPDIR` — cargo, cc, the Go toolchain, git — fails where the unbrokered path succeeds. Note *why* `#2616`'s guard cannot see this: it derives its required set from *paths the pod renders into the worker env*, and `TMPDIR=/var/tmp` is injected by the sandbox at spawn time, after the render. The fix is either a `/var/tmp` emptyDir on the launcher or making the sandbox's redirect agree with the launcher's writable set — but the guard's derivation needs widening either way, or blocker ten is the same shape.

### 9. `$HOME/.gitconfig` divergence silently disables private-dependency auth

`djinn_agent_worker::configure_private_dep_access` writes the GitHub installation token as a `url.…insteadOf` rewrite with `git config --global`, into the **worker** container's `$HOME/.gitconfig`; cargo/go/pnpm read it back with djinn nowhere in the loop. `#2617` chose `GIT_CONFIG_SYSTEM` over `GIT_CONFIG_GLOBAL` specifically to preserve that, reasoning "system scope is purely additive: `$HOME/.gitconfig` … keeps being read exactly as before". True inside one container; false across the boundary. Measured on the same probe:

```
worker container:    /home/djinn/.gitconfig  present, owned 1000:1000
launcher container:  /home/djinn             empty (fresh emptyDir)
```

So a brokered private-dependency fetch has no token and falls back to unauthenticated — which fails closed on private repos and, worse, may just rate-limit on public ones. This is the *other* half of the shared-`$HOME` question: the problem is not that brokered children share a `$HOME`, it is that they share one the worker never wrote to.

### Also worth a look (not measured to a failure)

The brokered path drops the Landlock policy: `sandbox::SANDBOX.apply` installs it via `Command::pre_exec`, and `command_spec` reads only program/argv/cwd/env, so the closure is discarded. Confidentiality still holds by a different mechanism (the credential Secret is not mounted in the launcher container at all, which is stronger), but *write* confinement does not — `/mirror` is mounted read-write on the launcher and Landlock denied it. That is a policy question rather than a blocker: it will not stop an armed run, it will only make one less confined than the path it replaces.
