### PR TITLE
fix(goxi): never clamp an invocation the lease authority can never lift

### DIFF
--- a/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
@@ -134,6 +134,7 @@ impl CgroupLauncherClient for ProofLauncher {
         &self,
         mut command: Command,
         _: &TaskInvocationLeaseIdentity,
+        _authority: djinn_cgroup_launcher::LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>> {
         let named = command
             .get_program()

--- a/server/crates/djinn-agent/src/extension/tests/shell_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/shell_dispatch_tests.rs
@@ -39,6 +39,7 @@ struct BrokerShellState {
     /// is build-shaped and reaches the lease authority.
     cpu_usage_usec: u64,
     identities: Vec<TaskInvocationLeaseIdentity>,
+    authorities: Vec<djinn_cgroup_launcher::LeaseAuthority>,
     lifts: usize,
     killed_while_running: usize,
     empties: usize,
@@ -59,6 +60,7 @@ impl BrokerShellLauncher {
                 samples: 0,
                 cpu_usage_usec: 0,
                 identities: Vec::new(),
+                authorities: Vec::new(),
                 lifts: 0,
                 killed_while_running: 0,
                 empties: 0,
@@ -80,6 +82,7 @@ impl BrokerShellLauncher {
                 samples: 0,
                 cpu_usage_usec: 1_000_000,
                 identities: Vec::new(),
+                authorities: Vec::new(),
                 lifts: 0,
                 killed_while_running: 0,
                 empties: 0,
@@ -94,8 +97,12 @@ impl CgroupLauncherClient for BrokerShellLauncher {
         &self,
         _: Command,
         identity: &TaskInvocationLeaseIdentity,
+        authority: djinn_cgroup_launcher::LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>> {
-        self.state.lock().unwrap().identities.push(identity.clone());
+        let mut state = self.state.lock().unwrap();
+        state.identities.push(identity.clone());
+        state.authorities.push(authority);
+        drop(state);
         Ok(Box::new(BrokerShellHandle {
             state: self.state.clone(),
         }))
@@ -514,9 +521,22 @@ async fn shell_dispatch_lease_queue_timeout_returns_the_command_result_not_an_er
         broker.killed_while_running, 0,
         "the queued command must keep running, not be killed"
     );
+    assert_eq!(broker.lifts, 0, "a degraded command is never lifted");
+    // …and because this composition runs against the real durable authority in
+    // the state a normal deployment is actually in — no `admission_handoff` row,
+    // which `evaluate_invocation_lift` maps to `Unleased` — the leaf must have
+    // been born WITHOUT a quota of its own.
+    //
+    // This is the assertion the production path was missing (goxi launcher
+    // blocker 11). `lifts == 0` alone was satisfied by the defect: the leaf was
+    // pinned to the broker's 250m unleased quota for the whole command, so an
+    // armed launcher made every build ~16x slower than a disabled one.
+    // `djinn-server epoch show` on the production node reported
+    // `admission handoff row: <absent>` during the armed window.
     assert_eq!(
-        broker.lifts, 0,
-        "a degraded command stays at the unleased quota"
+        broker.authorities,
+        vec![djinn_cgroup_launcher::LeaseAuthority::Unarmed],
+        "an authority that can never grant a lift must not clamp the leaf either"
     );
     assert_eq!((broker.empties, broker.cleanups), (1, 1));
 }

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -718,9 +718,12 @@ impl LeaseInvocationRunner {
                                 // invocation-primary epoch (v1 enforcing) lifts;
                                 // shadow observes without lifting; every other
                                 // epoch (baseline, missing, unreadable, stale)
-                                // keeps the quota unleased. The durable lease is
-                                // still held and reconciled to terminal below in
-                                // all three cases, so `fence` is always recorded.
+                                // never lifts — and, because it can never lift,
+                                // the leaf it governs was already born WITHOUT a
+                                // quota, so there is nothing here to raise. The
+                                // durable lease is still held and reconciled to
+                                // terminal below in all three cases, so `fence` is
+                                // always recorded.
                                 // The decision resolved before launch, NOT a
                                 // fresh read: the birth quota was already
                                 // committed from it, so a re-read could ask for a

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -88,7 +88,7 @@ mod broker;
 #[cfg(test)]
 pub(crate) use broker::command_spec;
 #[allow(unused_imports)] // constructed by the pending workspace broker composition
-pub(crate) use broker::{CgroupLauncherClient, ProcessHandle, UnixBrokerLauncher};
+pub(crate) use broker::{CgroupLauncherClient, ProcessHandle, UnixBrokerLauncher, birth_authority};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct UnresolvedInvocation {
@@ -511,10 +511,42 @@ impl LeaseInvocationRunner {
                 .record_at(&identity, None, false, self.clock.now())
                 .map_err(LeaseInvocationError::Launcher)?;
         }
+        // Resolve the durable admission decision ONCE, before the leaf exists.
+        //
+        // This read used to happen only after a successful bind, which made it
+        // unable to influence the one thing it actually governs: the quota the
+        // leaf is born at. `Unleased` was then implemented as `{}` — and because
+        // the leaf had already been pinned to the 250m unleased quota, that
+        // "no-op" clamped every command for its whole life. Production ran with
+        // the `admission_handoff` row ABSENT, so `Unleased` was the decision for
+        // EVERY invocation: a measured leaf reached 21.1 CPU-seconds (84x the
+        // 0.25 CPU-s escalation threshold) while `cpu.max` never left
+        // `25000 100000`. Reading it here, and deriving the birth authority from
+        // it, is what makes an unarmed authority mean "do not clamp" instead of
+        // "clamp forever".
+        //
+        // One read per invocation is also the coherent choice: the birth quota is
+        // committed from this value and cannot be revised, so a mid-invocation
+        // epoch change must not be acted on by the bind arm below.
+        let lift_decision = self.services.invocation_lift_decision().await;
+        let authority = birth_authority(lift_decision);
         let mut child = self
             .launcher
-            .launch(cmd, &identity)
+            .launch(cmd, &identity, authority)
             .map_err(LeaseInvocationError::Launcher)?;
+        // The path reported nothing at all across four armed production
+        // rollouts: the entire diagnosis had to be done by reading cgroupfs by
+        // hand on the node. One line per invocation, naming the decision and the
+        // quota actually committed, is the difference between "the escalation
+        // never fired" and knowing why.
+        tracing::info!(
+            invocation_id = %identity.invocation_id,
+            task_run_id = %identity.task_run_id,
+            decision = ?lift_decision,
+            authority = ?authority,
+            threshold_usec = config.cpu_usage_threshold_usec,
+            "lease invocation launched into a cgroup leaf"
+        );
         let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
         let mut deadline = self.clock.now_instant() + config.timeout;
         let (mut queued, mut fence, mut credit_used, mut lease_error) = (false, None, false, None);
@@ -689,7 +721,13 @@ impl LeaseInvocationRunner {
                                 // keeps the quota unleased. The durable lease is
                                 // still held and reconciled to terminal below in
                                 // all three cases, so `fence` is always recorded.
-                                match self.services.invocation_lift_decision().await {
+                                // The decision resolved before launch, NOT a
+                                // fresh read: the birth quota was already
+                                // committed from it, so a re-read could ask for a
+                                // lift on a leaf the broker created unarmed (the
+                                // launcher rejects that with
+                                // `LiftWithoutAuthority`).
+                                match lift_decision {
                                     InvocationLiftDecision::Lift => {
                                         // The validated fence must survive before
                                         // the irreversible cgroup lift. A failed
@@ -708,6 +746,11 @@ impl LeaseInvocationRunner {
                                         child
                                             .fenced_lift(&token)
                                             .map_err(LeaseInvocationError::Launcher)?;
+                                        tracing::info!(
+                                            invocation_id = %identity.invocation_id,
+                                            observed_usage_usec = cpu.usage_usec,
+                                            "lease invocation escalated: cgroup quota lifted"
+                                        );
                                     }
                                     InvocationLiftDecision::Shadow => {
                                         // Reaching a valid bind means v1 would
@@ -814,12 +857,11 @@ impl LeaseInvocationRunner {
         // and the durable lease is reconciled, and a read failure projects to
         // `Unleased` — nothing here can lift cpu.max, mint a fence, or move
         // lease state.
-        if !queued
-            && matches!(
-                self.services.invocation_lift_decision().await,
-                InvocationLiftDecision::Shadow
-            )
-        {
+        // The epoch is the one resolved before launch, for the same reason the
+        // bind arm above uses it: this invocation's whole life was governed by
+        // that decision, so the shadow denominator must describe the same epoch
+        // the numerator does.
+        if !queued && matches!(lift_decision, InvocationLiftDecision::Shadow) {
             djinn_telemetry::build_admission::record_shadow_invocation(false);
         }
         if let Some(error) = lease_error {
@@ -1432,6 +1474,7 @@ mod tests {
             &self,
             mut command: Command,
             _: &TaskInvocationLeaseIdentity,
+            _authority: djinn_cgroup_launcher::LeaseAuthority,
         ) -> io::Result<Box<dyn ProcessHandle>> {
             let child = command.spawn()?;
             *self.child_pid.lock().unwrap() = Some(child.id());

--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -80,6 +80,7 @@ impl CgroupLauncherClient for DegradeLauncher {
         &self,
         _: Command,
         _: &TaskInvocationLeaseIdentity,
+        _: djinn_cgroup_launcher::LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>> {
         Ok(Box::new(DegradeHandle {
             state: self.state.clone(),

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -24,6 +24,14 @@ struct ScriptedLauncher {
     lifts: Arc<Mutex<Vec<LeaseFencingToken>>>,
     kills: Arc<AtomicUsize>,
     empties: Arc<AtomicUsize>,
+    /// The birth authority the runner handed each `launch`.
+    ///
+    /// This is the observation the suite was missing. Asserting only "no lift
+    /// happened" cannot distinguish "the leaf ran unclamped because nothing
+    /// could grant it" from "the leaf was pinned to 250m forever" — and it was
+    /// the second one in production for four rollouts. The quota is committed at
+    /// launch, so the launch argument is where it has to be checked.
+    authorities: Arc<Mutex<Vec<djinn_cgroup_launcher::LeaseAuthority>>>,
 }
 
 impl CgroupLauncherClient for ScriptedLauncher {
@@ -31,7 +39,9 @@ impl CgroupLauncherClient for ScriptedLauncher {
         &self,
         mut command: Command,
         _: &TaskInvocationLeaseIdentity,
+        authority: djinn_cgroup_launcher::LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>> {
+        self.authorities.lock().unwrap().push(authority);
         let child = command.spawn()?;
         *self.pid.lock().unwrap() = Some(child.id());
         Ok(Box::new(ScriptedHandle {
@@ -40,6 +50,12 @@ impl CgroupLauncherClient for ScriptedLauncher {
             kills: self.kills.clone(),
             empties: self.empties.clone(),
         }))
+    }
+}
+
+impl ScriptedLauncher {
+    fn authorities(&self) -> Vec<djinn_cgroup_launcher::LeaseAuthority> {
+        self.authorities.lock().unwrap().clone()
     }
 }
 struct ScriptedHandle {
@@ -95,6 +111,7 @@ struct BrokerBackedLauncher {
 
 struct BrokerBackedState {
     identities: Vec<TaskInvocationLeaseIdentity>,
+    authorities: Vec<djinn_cgroup_launcher::LeaseAuthority>,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
     status: Option<std::process::ExitStatus>,
@@ -110,6 +127,7 @@ impl BrokerBackedLauncher {
         Self {
             state: Arc::new(Mutex::new(BrokerBackedState {
                 identities: Vec::new(),
+                authorities: Vec::new(),
                 stdout: stdout.to_vec(),
                 stderr: stderr.to_vec(),
                 status: Some(std::process::ExitStatus::from_raw(code << 8)),
@@ -126,6 +144,7 @@ impl BrokerBackedLauncher {
         Self {
             state: Arc::new(Mutex::new(BrokerBackedState {
                 identities: Vec::new(),
+                authorities: Vec::new(),
                 stdout: Vec::new(),
                 stderr: Vec::new(),
                 status: None,
@@ -144,8 +163,12 @@ impl CgroupLauncherClient for BrokerBackedLauncher {
         &self,
         _: Command,
         identity: &TaskInvocationLeaseIdentity,
+        authority: djinn_cgroup_launcher::LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>> {
-        self.state.lock().unwrap().identities.push(identity.clone());
+        let mut state = self.state.lock().unwrap();
+        state.identities.push(identity.clone());
+        state.authorities.push(authority);
+        drop(state);
         Ok(Box::new(BrokerBackedHandle {
             state: self.state.clone(),
             cpu_usage_usec: self.cpu_usage_usec,
@@ -573,15 +596,38 @@ async fn shadow_epoch_binds_but_never_lifts() {
         launcher.lifts.lock().unwrap().is_empty(),
         "shadow epoch must never lift cpu.max"
     );
+    // Shadow is the one decision that clamps ON PURPOSE: it is an observation
+    // mode, so the leaf must still be born at the unleased quota.
+    assert_eq!(
+        launcher.authorities(),
+        vec![djinn_cgroup_launcher::LeaseAuthority::Armed],
+        "shadow observation is only meaningful against a clamped leaf"
+    );
     // The durable lease is still reconciled to terminal (fence recorded).
     assert!(services.release_calls.load(Ordering::SeqCst) <= 1);
     assert_eq!(launcher.kills.load(Ordering::SeqCst), 1);
 }
 
-/// AC3 (agent side): an unknown/stale/baseline epoch keeps the quota unleased —
-/// a matching bind does not lift.
+/// AC3 (agent side): an unknown/stale/baseline/ABSENT epoch cannot lift, so the
+/// leaf must be born WITHOUT a quota of its own — not pinned to the unleased
+/// quota for the whole command.
+///
+/// # The production symptom this now names (goxi launcher blocker 11)
+///
+/// The previous version of this test asserted only `lifts.is_empty()` and
+/// passed, because a no-op lift is exactly what the code did. What it could not
+/// see is that the leaf had *already* been born at 250m, so "never lifts" meant
+/// "clamped at 250m forever". Production ran with the durable
+/// `admission_handoff` row absent — `Unleased` for every invocation — and a
+/// measured leaf reached 21.1 CPU-seconds, 84x the 0.25 CPU-s escalation
+/// threshold, with `cpu.max` still reading `25000 100000`. Builds ran ~16x
+/// slower armed than disabled.
+///
+/// Reverting `birth_authority`'s `Unleased` arm to `Armed` reproduces that:
+/// this assertion fails with `Armed`, i.e. "the leaf was clamped by an authority
+/// that can never lift it".
 #[tokio::test]
-async fn unleased_epoch_binds_but_never_lifts() {
+async fn unleased_epoch_is_born_unclamped_because_no_grant_can_ever_lift_it() {
     let services = Arc::new(ScriptedServices::new(
         vec![granted(7)],
         vec![status(LeaseState::Active, Some(7))],
@@ -608,7 +654,62 @@ async fn unleased_epoch_binds_but_never_lifts() {
         launcher.lifts.lock().unwrap().is_empty(),
         "unleased epoch must never lift cpu.max"
     );
+    assert_eq!(
+        launcher.authorities(),
+        vec![djinn_cgroup_launcher::LeaseAuthority::Unarmed],
+        "an epoch that can never grant a lift must not clamp the leaf either; \
+         `Armed` here IS the production defect (cpu.max pinned at 25000 100000 \
+         while the leaf burned 21.1 CPU-seconds)"
+    );
     assert!(services.release_calls.load(Ordering::SeqCst) <= 1);
+}
+
+/// The mapping itself, enumerated: every decision the durable authority can
+/// produce, and the birth quota it commits.
+///
+/// `Unleased` is what `evaluate_invocation_lift` returns for an ABSENT handoff
+/// row, which is the state production is actually in — see
+/// `absent_handoff_row_is_unleased_and_therefore_unarmed` below for the
+/// composition that ties the two together.
+#[test]
+fn birth_authority_is_armed_only_when_a_lift_is_reachable() {
+    use djinn_cgroup_launcher::LeaseAuthority;
+    use djinn_supervisor::services::InvocationLiftDecision;
+    assert_eq!(
+        crate::process::birth_authority(InvocationLiftDecision::Lift),
+        LeaseAuthority::Armed
+    );
+    assert_eq!(
+        crate::process::birth_authority(InvocationLiftDecision::Shadow),
+        LeaseAuthority::Armed
+    );
+    assert_eq!(
+        crate::process::birth_authority(InvocationLiftDecision::Unleased),
+        LeaseAuthority::Unarmed
+    );
+}
+
+/// The composition that failed in production: the DURABLE row state that
+/// production actually has, projected through the real `evaluate_invocation_lift`
+/// and the real `birth_authority`, must reach the launcher as `Unarmed`.
+///
+/// `djinn-server epoch show` on the production node reported
+/// `admission handoff row: <absent>` while the launcher was armed. That is not a
+/// hypothetical: it is the exact input below.
+#[test]
+fn absent_handoff_row_is_unleased_and_therefore_unarmed() {
+    use djinn_cgroup_launcher::LeaseAuthority;
+    use djinn_supervisor::services::evaluate_invocation_lift;
+    // Absent row (production), and unreadable row (a DB blip) — both fail closed
+    // on the lift, so neither may clamp.
+    for row in [Ok(None), Err(())] {
+        let decision = evaluate_invocation_lift(row);
+        assert_eq!(
+            crate::process::birth_authority(decision),
+            LeaseAuthority::Unarmed,
+            "decision {decision:?} cannot lift, so it must not clamp"
+        );
+    }
 }
 
 #[tokio::test]
@@ -853,6 +954,7 @@ impl CgroupLauncherClient for FixtureLauncher {
         &self,
         _: Command,
         _: &TaskInvocationLeaseIdentity,
+        _: djinn_cgroup_launcher::LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>> {
         Ok(Box::new(FixtureHandle {
             state: self.state.clone(),

--- a/server/crates/djinn-agent/src/process_broker.rs
+++ b/server/crates/djinn-agent/src/process_broker.rs
@@ -6,9 +6,29 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use djinn_cgroup_launcher::{
-    CommandSpec, CpuStat, Invocation, broker::ChildStatus, transport::UnixBrokerClient,
+    CommandSpec, CpuStat, Invocation, LeaseAuthority, broker::ChildStatus,
+    transport::UnixBrokerClient,
 };
-use djinn_supervisor::services::{LeaseFencingToken, TaskInvocationLeaseIdentity};
+use djinn_supervisor::services::{
+    InvocationLiftDecision, LeaseFencingToken, TaskInvocationLeaseIdentity,
+};
+
+/// Project the durable admission decision onto the authority the leaf is BORN
+/// under.
+///
+/// The two `Armed` arms are deliberately different intents that share one birth
+/// quota: `Lift` will raise it on a matching fenced grant, and `Shadow` observes
+/// without lifting (documented to clamp on purpose). `Unleased` is the arm that
+/// cost four production rollouts — the durable `admission_handoff` row is
+/// absent/baseline/stale, no grant can ever authorize a lift, and clamping such
+/// an invocation to 250m is pure loss. It maps to `Unarmed` so the leaf is born
+/// with no quota of its own.
+pub(crate) fn birth_authority(decision: InvocationLiftDecision) -> LeaseAuthority {
+    match decision {
+        InvocationLiftDecision::Lift | InvocationLiftDecision::Shadow => LeaseAuthority::Armed,
+        InvocationLiftDecision::Unleased => LeaseAuthority::Unarmed,
+    }
+}
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
@@ -28,10 +48,17 @@ pub(crate) trait ProcessHandle: Send {
 
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) trait CgroupLauncherClient: Send + Sync + 'static {
+    /// Create the invocation leaf and spawn the child into it.
+    ///
+    /// `authority` is not advisory: it selects the leaf's birth `cpu.max`, which
+    /// is written before the child may `execve` and cannot be revised
+    /// afterwards. Callers must therefore resolve the durable admission decision
+    /// BEFORE calling this, not after the queue.
     fn launch(
         &self,
         command: Command,
         identity: &TaskInvocationLeaseIdentity,
+        authority: LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>>;
 }
 
@@ -56,6 +83,7 @@ impl CgroupLauncherClient for UnixBrokerLauncher {
         &self,
         command: Command,
         identity: &TaskInvocationLeaseIdentity,
+        authority: LeaseAuthority,
     ) -> io::Result<Box<dyn ProcessHandle>> {
         let spec = command_spec(command)?;
         let id = identity.invocation_id.clone();
@@ -66,7 +94,7 @@ impl CgroupLauncherClient for UnixBrokerLauncher {
                 fence: self.invocation_fence,
             })
             .map_err(broker_error)?;
-        if let Err(error) = client.create(&id, &id, &spec) {
+        if let Err(error) = client.create(&id, &id, authority, &spec) {
             let _ = client.cleanup(&id);
             return Err(broker_error(error));
         }

--- a/server/crates/djinn-cgroup-launcher/src/broker.rs
+++ b/server/crates/djinn-cgroup-launcher/src/broker.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, fs::File, io::Read, os::fd::RawFd};
 
 use crate::{
     CgroupFs, ChildProcess, CommandSpec, CpuStat, Error, Invocation, Launcher, Leaf,
-    SpawnIntoCgroup, child::WorkerReadinessAssertion,
+    LeaseAuthority, SpawnIntoCgroup, child::WorkerReadinessAssertion,
 };
 
 pub const WORKER_UID: u32 = 1000;
@@ -234,6 +234,7 @@ impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> Broker<F, S, N> {
         id: &str,
         nonce: ControlNonce,
         leaf_name: &str,
+        authority: LeaseAuthority,
         command: &CommandSpec,
     ) -> Result<ControlNonce, Error> {
         self.validate(connection, id, nonce)?;
@@ -257,7 +258,7 @@ impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> Broker<F, S, N> {
         command.validate()?;
         let (leaf, child) = self
             .launcher
-            .create_command(leaf_name, invocation, command)?;
+            .create_command(leaf_name, invocation, authority, command)?;
         let active = self
             .active
             .get_mut(id)
@@ -634,12 +635,26 @@ mod tests {
             )
             .unwrap();
         assert!(matches!(
-            broker.create(connection, "other", nonce, "leaf", &command()),
+            broker.create(
+                connection,
+                "other",
+                nonce,
+                "leaf",
+                LeaseAuthority::Armed,
+                &command()
+            ),
             Err(Error::InvalidInvocationBinding)
         ));
         let stale = nonce;
         let nonce = broker
-            .create(connection, "one", nonce, "leaf", &command())
+            .create(
+                connection,
+                "one",
+                nonce,
+                "leaf",
+                LeaseAuthority::Armed,
+                &command(),
+            )
             .unwrap();
         // The old create nonce is now irreversibly stale and cannot replay a control.
         assert!(matches!(
@@ -724,11 +739,25 @@ mod tests {
             )
             .unwrap();
         let nonce = broker
-            .create(connection, "one", nonce, "first", &command())
+            .create(
+                connection,
+                "one",
+                nonce,
+                "first",
+                LeaseAuthority::Armed,
+                &command(),
+            )
             .unwrap();
         assert_eq!(creates.get(), 1);
         assert!(matches!(
-            broker.create(connection, "one", nonce, "second", &command()),
+            broker.create(
+                connection,
+                "one",
+                nonce,
+                "second",
+                LeaseAuthority::Armed,
+                &command()
+            ),
             Err(Error::InvalidControl)
         ));
         assert_eq!(creates.get(), 1);
@@ -772,7 +801,14 @@ mod tests {
             )
             .unwrap();
         let nonce = broker
-            .create(connection, "one", nonce, "leaf", &command())
+            .create(
+                connection,
+                "one",
+                nonce,
+                "leaf",
+                LeaseAuthority::Armed,
+                &command(),
+            )
             .unwrap();
         assert!(matches!(
             broker.cleanup(connection, "one", nonce),

--- a/server/crates/djinn-cgroup-launcher/src/lease_authority.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lease_authority.rs
@@ -1,0 +1,82 @@
+//! The lease authority an invocation leaf is BORN under, and the `cpu.max`
+//! line that expresses "no quota at this level".
+//!
+//! Split out of `lib.rs` (goxi launcher blocker 11), which was within a few
+//! hundred bytes of the 51200-byte size guard. The contract is self-contained:
+//! it names no leaf, no child and no filesystem, only the projection from
+//! "can the durable authority ever lift this?" onto a birth quota.
+
+use crate::{DEFAULT_PERIOD_US, Error};
+
+/// `cpu.max` line for a leaf with NO quota of its own.
+///
+/// `max` is cgroup-v2's "no limit at this level"; the enclosing Pod cgroup still
+/// caps the child, so an unrestricted leaf runs at exactly the throughput the
+/// same command would get with no launcher at all.
+pub fn unrestricted_cpu_max() -> String {
+    format!("max {DEFAULT_PERIOD_US}")
+}
+
+/// Whether the durable lease authority is in a state that can ever lift THIS
+/// invocation.
+///
+/// # Why the birth quota needs this, and why it cannot be decided later
+///
+/// A leaf's `cpu.max` is written once, before the child is allowed to `execve`,
+/// and the lift is deliberately one-way and fenced. So the question "will a
+/// lease ever be able to raise this quota?" has to be answered *before the leaf
+/// exists* — there is no safe unfenced path back down from a clamp.
+///
+/// Getting that wrong cost four production rollouts. The launcher was armed
+/// while the durable `admission_handoff` row was ABSENT, which
+/// `evaluate_invocation_lift` maps to `Unleased` — a branch the runner
+/// implemented as a literal no-op. But the leaf had already been born at
+/// [`UnleasedQuota::DEFAULT_MILLICORES`], so "no-op" actually meant *every*
+/// build ran clamped to 250m for its whole life while the pod held 4 CPUs. A
+/// measured leaf reached 21.1 CPU-seconds — 84x the escalation threshold — and
+/// `cpu.max` never moved off `25000 100000`. Arming was a ~16x slowdown, i.e.
+/// strictly worse than leaving the feature off, which is why production sat on
+/// `mode: disabled`.
+///
+/// [`Self::Unarmed`] exists so that state is expressible at leaf creation:
+/// containment without a reachable lift is pure loss, so an invocation that
+/// provably cannot be lifted is not clamped in the first place.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LeaseAuthority {
+    /// v1 can act on this invocation: the leaf is born at the unleased quota
+    /// and a matching fenced grant lifts it to the leased quota. Shadow
+    /// observation also arms — it deliberately clamps without lifting.
+    Armed,
+    /// v1 cannot lift this invocation at all (the handoff row is absent,
+    /// unreadable, at the `emergency_primary` baseline, at a stale epoch, or
+    /// `v1_mode` is off).
+    ///
+    /// The leaf is still created, still named by invocation id, still killable
+    /// via `cgroup.kill` and still measurable on `cpu.stat` — every containment
+    /// property is retained. Only the quota is omitted, so the child inherits
+    /// the Pod's own budget instead of being pinned to a quota nothing can ever
+    /// raise.
+    Unarmed,
+}
+
+impl LeaseAuthority {
+    /// Can a fenced lift be applied to a leaf born under this authority?
+    pub fn can_lift(self) -> bool {
+        matches!(self, Self::Armed)
+    }
+
+    pub(crate) fn wire(self) -> u8 {
+        match self {
+            Self::Armed => 1,
+            Self::Unarmed => 0,
+        }
+    }
+
+    pub(crate) fn from_wire(value: u8) -> Result<Self, Error> {
+        match value {
+            0 => Ok(Self::Unarmed),
+            1 => Ok(Self::Armed),
+            _ => Err(Error::InvalidTransportFrame),
+        }
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -15,14 +15,16 @@ pub mod child;
 pub mod command_path;
 pub mod env;
 pub mod git_trust;
+pub mod lease_authority;
 pub mod spawn;
 pub mod transport;
 
 pub use command_path::safe_command_path;
 pub use env::{is_allowed_environment_entry, is_allowed_environment_key};
+pub use lease_authority::{LeaseAuthority, unrestricted_cpu_max};
 pub use spawn::{DenySpawn, NativeCgroupSpawn};
 
-const DEFAULT_PERIOD_US: u64 = 100_000;
+pub(crate) const DEFAULT_PERIOD_US: u64 = 100_000;
 
 /// CPU quota an invocation leaf runs at before a lease lifts it.
 ///
@@ -261,6 +263,7 @@ pub struct Leaf {
     name: String,
     fd: RawFd,
     invocation: Invocation,
+    authority: LeaseAuthority,
     lifted: bool,
     terminal: bool,
 }
@@ -271,6 +274,11 @@ impl Leaf {
     }
     pub fn cgroup_fd(&self) -> RawFd {
         self.fd
+    }
+    /// The authority this leaf was BORN under. It is immutable for the leaf's
+    /// life: the birth quota was already committed from it.
+    pub fn authority(&self) -> LeaseAuthority {
+        self.authority
     }
 }
 
@@ -330,10 +338,22 @@ impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
         self.config.leased_quota
     }
 
+    /// The `cpu.max` line a leaf is born at under `authority`.
+    ///
+    /// Exposed so the behavioural proof asserts against the same function the
+    /// production path writes, rather than a literal it maintains by hand.
+    pub fn birth_cpu_max(&self, authority: LeaseAuthority) -> String {
+        match authority {
+            LeaseAuthority::Armed => self.config.unleased_quota.cpu_max(),
+            LeaseAuthority::Unarmed => unrestricted_cpu_max(),
+        }
+    }
+
     pub fn create_command(
         &mut self,
         name: &str,
         invocation: Invocation,
+        authority: LeaseAuthority,
         command: &CommandSpec,
     ) -> Result<(Leaf, ChildProcess), Error> {
         validate_leaf_name(name)?;
@@ -359,8 +379,15 @@ impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
         command.validate()?;
 
         let fd = self.fs.create_direct_child(name)?;
+        // The birth quota is the ONLY observable effect of the lease authority
+        // for an invocation that is never granted, and it cannot be revised
+        // later: `fenced_lift` is one-way and there is deliberately no unfenced
+        // path back down. An `Unarmed` authority therefore means "no quota at
+        // this level" rather than "the unleased quota forever" — see
+        // [`LeaseAuthority`] for the production incident that distinction
+        // encodes.
         self.fs
-            .write_leaf(fd, "cpu.max", &self.config.unleased_quota.cpu_max())?;
+            .write_leaf(fd, "cpu.max", &self.birth_cpu_max(authority))?;
         // Spawn is deliberately last: all readiness and leaf setup failures
         // occur before the child can execute.
         let child = match self.syscall.spawn_into_cgroup(fd, &invocation, &command) {
@@ -378,6 +405,7 @@ impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
                 name: name.to_owned(),
                 fd,
                 invocation,
+                authority,
                 lifted: false,
                 terminal: false,
             },
@@ -392,6 +420,12 @@ impl<F: CgroupFs, S: SpawnIntoCgroup> Launcher<F, S> {
     pub fn fenced_lift(&mut self, leaf: &mut Leaf, fence: u64) -> Result<(), Error> {
         if leaf.terminal {
             return Err(Error::TerminalIntent);
+        }
+        // A leaf born unarmed has no quota to lift, and a caller asking to lift
+        // one has contradicted the authority it created the leaf under. Refuse
+        // rather than write a quota that would LOWER the ceiling from `max`.
+        if !leaf.authority.can_lift() {
+            return Err(Error::LiftWithoutAuthority);
         }
         if leaf.lifted {
             return Err(Error::LiftAlreadyApplied);
@@ -543,6 +577,8 @@ pub enum Error {
     FenceMismatch,
     #[error("lift was already applied")]
     LiftAlreadyApplied,
+    #[error("leaf was created under an unarmed lease authority and has no quota to lift")]
+    LiftWithoutAuthority,
     #[error("terminal intent forbids lift")]
     TerminalIntent,
     #[error("cgroup still has descendants")]
@@ -926,7 +962,9 @@ mod tests {
         }
     }
     fn create(l: &mut Launcher<FakeFs, FakeSpawn>, name: &str) -> Leaf {
-        l.create_command(name, invocation(), &command()).unwrap().0
+        l.create_command(name, invocation(), LeaseAuthority::Armed, &command())
+            .unwrap()
+            .0
     }
 
     #[test]
@@ -1022,7 +1060,8 @@ mod tests {
         let mut l = launcher();
         let mut spec = command();
         spec.environment = vec![("CARGO_BUILD_JOBS".into(), "12".into())];
-        l.create_command("override", invocation(), &spec).unwrap();
+        l.create_command("override", invocation(), LeaseAuthority::Armed, &spec)
+            .unwrap();
         let (_, spawn) = l.into_parts();
         assert_eq!(
             spawn.environments[0]
@@ -1074,7 +1113,7 @@ mod tests {
             spec.environment = vec![(key.to_owned(), value.to_owned())];
             assert!(
                 matches!(
-                    l.create_command("hostile", invocation(), &spec),
+                    l.create_command("hostile", invocation(), LeaseAuthority::Armed, &spec),
                     Err(Error::InvalidCommand)
                 ),
                 "{key}={value} must be refused"
@@ -1213,7 +1252,7 @@ mod tests {
         let mut malformed = command();
         malformed.program = "/bin/../sh".into();
         assert!(matches!(
-            l.create_command("one", invocation(), &malformed),
+            l.create_command("one", invocation(), LeaseAuthority::Armed, &malformed),
             Err(Error::InvalidCommand)
         ));
         let (fs, spawn) = l.into_parts();
@@ -1260,7 +1299,7 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(
-            l.create_command("one", invocation(), &command())
+            l.create_command("one", invocation(), LeaseAuthority::Armed, &command())
                 .map(|v| v.0),
             Err(Error::SpawnDenied)
         ));

--- a/server/crates/djinn-cgroup-launcher/src/transport.rs
+++ b/server/crates/djinn-cgroup-launcher/src/transport.rs
@@ -1,6 +1,6 @@
 //! Bounded Unix socket transport for authenticated broker controls.
 use crate::{
-    CgroupFs, CommandSpec, CpuStat, Error, Invocation, SpawnIntoCgroup,
+    CgroupFs, CommandSpec, CpuStat, Error, Invocation, LeaseAuthority, SpawnIntoCgroup,
     broker::{Broker, ConnectionId, ControlNonce, NonceSource, SocketPeer, WORKER_GID, WORKER_UID},
     child::WorkerReadinessAssertion,
 };
@@ -124,10 +124,10 @@ impl<F: CgroupFs, S: SpawnIntoCgroup, N: NonceSource> UnixBrokerServer<F, S, N> 
             }
             CREATE => {
                 let (i, n, x) = control(b)?;
-                let (leaf, command) = command_in(x)?;
+                let (leaf, authority, command) = command_in(x)?;
                 Ok(self
                     .broker
-                    .create(c, &i, n, &leaf, &command)?
+                    .create(c, &i, n, &leaf, authority, &command)?
                     .as_bytes()
                     .to_vec())
             }
@@ -273,9 +273,15 @@ impl UnixBrokerClient {
         self.nonces.insert(i.id, n);
         Ok(())
     }
-    pub fn create(&mut self, i: &str, leaf: &str, command: &CommandSpec) -> Result<(), Error> {
+    pub fn create(
+        &mut self,
+        i: &str,
+        leaf: &str,
+        authority: LeaseAuthority,
+        command: &CommandSpec,
+    ) -> Result<(), Error> {
         let mut x = self.control(i)?;
-        x.extend(command_out(leaf, command)?);
+        x.extend(command_out(leaf, authority, command)?);
         let r = self.call(CREATE, &x)?;
         self.rotate(i, &r)
     }
@@ -381,9 +387,17 @@ fn bytes_in(input: &[u8]) -> Result<Vec<u8>, Error> {
     }
     Ok(input[2..].to_vec())
 }
-fn command_out(leaf: &str, command: &CommandSpec) -> Result<Vec<u8>, Error> {
+fn command_out(
+    leaf: &str,
+    authority: LeaseAuthority,
+    command: &CommandSpec,
+) -> Result<Vec<u8>, Error> {
     command.validate()?;
     let mut out = enc(leaf)?;
+    // The authority travels WITH the create, not as a separate control: the
+    // birth quota is chosen inside the same broker call that makes the leaf, so
+    // there is no window in which a leaf exists without a decided ceiling.
+    out.push(authority.wire());
     for item in [&command.program, &command.cwd] {
         out.extend(enc(item)?);
     }
@@ -398,8 +412,10 @@ fn command_out(leaf: &str, command: &CommandSpec) -> Result<Vec<u8>, Error> {
     }
     Ok(out)
 }
-fn command_in(input: &[u8]) -> Result<(String, CommandSpec), Error> {
-    let (leaf, mut rest) = take_string(input)?;
+fn command_in(input: &[u8]) -> Result<(String, LeaseAuthority, CommandSpec), Error> {
+    let (leaf, rest) = take_string(input)?;
+    let (&authority, mut rest) = rest.split_first().ok_or(Error::InvalidTransportFrame)?;
+    let authority = LeaseAuthority::from_wire(authority)?;
     let (program, next) = take_string(rest)?;
     rest = next;
     let (cwd, next) = take_string(rest)?;
@@ -429,7 +445,7 @@ fn command_in(input: &[u8]) -> Result<(String, CommandSpec), Error> {
         environment,
     };
     command.validate()?;
-    Ok((leaf, command))
+    Ok((leaf, authority, command))
 }
 fn take_string(input: &[u8]) -> Result<(String, &[u8]), Error> {
     if input.len() < 2 {
@@ -954,7 +970,9 @@ mod tests {
                         fence: 1,
                     })
                     .unwrap();
-                client.create("child", "leaf", &command()).unwrap();
+                client
+                    .create("child", "leaf", LeaseAuthority::Armed, &command())
+                    .unwrap();
                 let mut stdout = Vec::new();
                 let mut stdout_eof = false;
                 while !stdout_eof {

--- a/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/brokered_git_trust.rs
@@ -46,7 +46,7 @@ use std::process::Command;
 use djinn_cgroup_launcher::child::{ARTIFACT_GID, CHILD_UID};
 use djinn_cgroup_launcher::{
     CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
-    Readiness, SpawnIntoCgroup, git_trust, is_allowed_environment_entry,
+    LeaseAuthority, Readiness, SpawnIntoCgroup, git_trust, is_allowed_environment_entry,
     is_allowed_environment_key,
 };
 
@@ -142,7 +142,7 @@ fn brokered_environment(workspace: &Path, caller: &[(&str, &str)]) -> Vec<(Strin
             .collect(),
     };
     launcher
-        .create_command("git-trust", invocation(), &spec)
+        .create_command("git-trust", invocation(), LeaseAuthority::Armed, &spec)
         .expect("the launcher must accept a conforming spec");
     let (_, spawn) = launcher.into_parts();
     let mut environment = spawn.environments.into_iter().next().expect("one spawn");
@@ -613,7 +613,7 @@ fn brokered_spec_error(caller: &[(&str, &str)]) -> Error {
             .collect(),
     };
     launcher
-        .create_command("hostile", invocation(), &spec)
+        .create_command("hostile", invocation(), LeaseAuthority::Armed, &spec)
         .expect_err("a hostile spec must be refused")
 }
 

--- a/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/containment_and_escalation.rs
@@ -24,7 +24,7 @@ use std::rc::Rc;
 
 use djinn_cgroup_launcher::{
     CgroupFs, CgroupMode, ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig,
-    Readiness, SpawnIntoCgroup,
+    LeaseAuthority, Readiness, SpawnIntoCgroup,
     broker::{
         Broker, BrokerConfig, OsNonceSource, PeerCredentials, UnixPeer, WORKER_GID, WORKER_UID,
     },
@@ -270,6 +270,7 @@ fn authenticated_broker_gives_each_command_a_fresh_250m_leaf_and_one_explicit_li
             "first-command",
             first_nonce,
             "first-leaf",
+            LeaseAuthority::Armed,
             &command(),
         )
         .expect("create first command");
@@ -298,6 +299,7 @@ fn authenticated_broker_gives_each_command_a_fresh_250m_leaf_and_one_explicit_li
             "second-command",
             second_nonce,
             "second-leaf",
+            LeaseAuthority::Armed,
             &command(),
         )
         .expect("create second command");
@@ -335,7 +337,7 @@ fn ac2_daemon_and_double_fork_stay_in_one_cgroup_and_release_gates_on_populated_
         fence: 5,
     };
     let (mut leaf, child) = launcher
-        .create_command("daemon-tree", invocation, &command())
+        .create_command("daemon-tree", invocation, LeaseAuthority::Armed, &command())
         .expect("create invocation");
     assert_eq!(child.pid, 4242);
 
@@ -408,6 +410,7 @@ fn ac2_cleanup_after_kill_still_requires_empty_before_unlink() {
                 id: "cancelled".to_owned(),
                 fence: 1,
             },
+            LeaseAuthority::Armed,
             &command(),
         )
         .expect("create");
@@ -492,13 +495,27 @@ fn ac3_forged_own_or_sibling_controls_and_nonce_replay_are_rejected() {
     // drive an invocation bound to another connection.
     let connection_b = authenticated_ready(&mut broker);
     assert!(matches!(
-        broker.create(connection_b, "one", nonce0, "leaf", &command()),
+        broker.create(
+            connection_b,
+            "one",
+            nonce0,
+            "leaf",
+            LeaseAuthority::Armed,
+            &command()
+        ),
         Err(Error::InvalidInvocationBinding)
     ));
 
     // The owning connection with the live nonce succeeds and rotates the nonce.
     let nonce1 = broker
-        .create(connection_a, "one", nonce0, "leaf", &command())
+        .create(
+            connection_a,
+            "one",
+            nonce0,
+            "leaf",
+            LeaseAuthority::Armed,
+            &command(),
+        )
         .expect("owning create");
 
     // Replaying the now-consumed nonce is a forged own-control: rejected.

--- a/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
@@ -25,7 +25,25 @@
 //! 5. after a fenced lift it burns *multiples more* in the same window and stops
 //!    being throttled;
 //! 6. a sibling leaf with no child accounts for nothing, so the measurement is
-//!    attributing CPU to the right cgroup.
+//!    attributing CPU to the right cgroup;
+//! 7. a leaf created under an UNARMED lease authority is never clamped at all —
+//!    `cpu.max` reads `max 100000` and it measures multiples of the clamped
+//!    leaf, while still containing its child.
+//!
+//! # What step 7 adds (goxi launcher blocker 11)
+//!
+//! Steps 4-5 prove the lease *can* govern CPU. They cannot see whether the lease
+//! is ever *reachable*. Production armed the launcher while the durable
+//! `admission_handoff` row was ABSENT — `djinn-server epoch show` reported
+//! `admission handoff row: <absent>` during the armed window — which
+//! `evaluate_invocation_lift` maps to `Unleased`, and the runner implemented that
+//! as a no-op. The leaf had already been born at 250m, so the "no-op" pinned
+//! every build there: a measured leaf reached 21,130,868 usec of CPU, 84x the
+//! 250,000 usec escalation threshold, with `cpu.max` never leaving
+//! `25000 100000`. Arming was a ~16x slowdown and rolled back four times.
+//!
+//! Step 7 makes that state measurable: containment without a reachable lift must
+//! cost nothing.
 //!
 //! Nothing here can pass vacuously. There is no `FakeCgroup`, no fake clone, no
 //! environment probe that returns "not applicable", and no assertion on a value
@@ -53,8 +71,8 @@ use std::time::{Duration, Instant};
 
 use djinn_cgroup_launcher::bootstrap::{Bootstrap, INIT_LEAF, holds_any_bootstrap_capability};
 use djinn_cgroup_launcher::{
-    CommandSpec, CpuStat, Invocation, Launcher, LauncherConfig, LeasedQuota, NativeCgroupFs,
-    NativeCgroupSpawn, UnleasedQuota,
+    CommandSpec, CpuStat, Invocation, Launcher, LauncherConfig, LeaseAuthority, LeasedQuota,
+    NativeCgroupFs, NativeCgroupSpawn, UnleasedQuota,
 };
 
 /// The workflow job that must execute the `#[ignore]`d proof below.
@@ -180,6 +198,31 @@ fn assert_rendered_required_job_contract() {
     );
 }
 
+/// The exact `cpu.max` lines the privileged proof reads back, pinned here so a
+/// change to a quota default or to the period cannot silently make the kernel
+/// assertions describe different numbers than production writes.
+#[test]
+fn the_asserted_cpu_max_lines_are_the_ones_the_launcher_writes() {
+    assert_eq!(
+        djinn_cgroup_launcher::unrestricted_cpu_max(),
+        "max 100000",
+        "an unarmed leaf's line is what step 7 asserts against the kernel"
+    );
+    // `25000 100000` is the line production measured on a leaf that burned 21.1
+    // CPU-seconds and never escalated; `4000000 100000` is what the lift must
+    // replace it with.
+    assert_eq!(
+        u64::from(UNLEASED_MILLICORES) * 100_000 / 1000,
+        25_000,
+        "the unleased line must be `25000 100000`"
+    );
+    assert_eq!(
+        u64::from(LEASED_MILLICORES) * 100_000 / 1000,
+        400_000,
+        "the leased line must be `400000 100000`"
+    );
+}
+
 /// The quotas this proof measures are the ones the launcher crate ships, so a
 /// change to either default cannot leave the measurement asserting a number
 /// nobody uses.
@@ -270,7 +313,12 @@ fn the_delegated_lease_throttles_and_lifts_measured_on_cpu_stat() {
         fence: 0x7de_u64,
     };
     let (mut leaf, child) = launcher
-        .create_command("leased", invocation, &spinner_command())
+        .create_command(
+            "leased",
+            invocation,
+            LeaseAuthority::Armed,
+            &spinner_command(),
+        )
         .expect("spawn the probe command into an invocation leaf");
 
     // A sibling that never gets a child. It is the control for step 6.
@@ -279,7 +327,12 @@ fn the_delegated_lease_throttles_and_lifts_measured_on_cpu_stat() {
         fence: 1,
     };
     let (idle_leaf, idle_child) = launcher
-        .create_command("idle", idle_invocation, &sleep_command())
+        .create_command(
+            "idle",
+            idle_invocation,
+            LeaseAuthority::Armed,
+            &sleep_command(),
+        )
         .expect("spawn the idle control");
 
     // ── 4. Membership, then the unleased measurement ────────────────────────
@@ -322,9 +375,32 @@ fn the_delegated_lease_throttles_and_lifts_measured_on_cpu_stat() {
     );
 
     // ── 5. The fenced lift, measured the same way ───────────────────────────
+    //
+    // `cpu.max` is read from the KERNEL either side of the lift, not inferred
+    // from the measurement. The production symptom of blocker 11 was precisely a
+    // quota that never changed: an armed launcher whose leaf sat at
+    // `25000 100000` while the child burned 21.1 CPU-seconds, 84x the escalation
+    // threshold. So the transition itself is an assertion.
+    let cpu_max_path = root.join("leased").join("cpu.max");
+    assert_eq!(
+        read_trimmed(&cpu_max_path),
+        launcher.birth_cpu_max(LeaseAuthority::Armed),
+        "an armed leaf must be born at the unleased quota"
+    );
+    assert_eq!(
+        read_trimmed(&cpu_max_path),
+        "25000 100000",
+        "the birth quota must be the 250m line production measured"
+    );
     launcher
         .fenced_lift(&mut leaf, 0x7de_u64)
         .expect("a matching fence must lift the quota");
+    assert_eq!(
+        read_trimmed(&cpu_max_path),
+        "400000 100000",
+        "the fenced lift must move cpu.max off the unleased quota; a lift that \
+         leaves it at `25000 100000` is the production defect (blocker 11)"
+    );
 
     let leased = measure(&mut launcher, &leaf, WINDOW);
     assert!(
@@ -379,7 +455,11 @@ fn the_delegated_lease_throttles_and_lifts_measured_on_cpu_stat() {
         idle.usage_usec
     );
 
-    // ── Teardown: cgroup-wide kill, drain, unlink ───────────────────────────
+    // ── Teardown of the armed leaves, BEFORE the unarmed measurement ────────
+    //
+    // The unarmed leaf has no quota of its own, so it takes whatever the runner
+    // will give it. Leaving the lifted 4-core leaf spinning alongside would make
+    // step 7 measure contention rather than the absence of a clamp.
     for (leaf, pid) in [(&mut leaf, child.pid), (&mut { idle_leaf }, idle_child.pid)] {
         launcher.kill(leaf).expect("cgroup.kill");
         let drained = (0..200).any(|_| {
@@ -393,6 +473,107 @@ fn the_delegated_lease_throttles_and_lifts_measured_on_cpu_stat() {
         launcher.remove(leaf).expect("remove the drained leaf");
         reap(pid);
     }
+
+    // ── 7. An UNARMED authority never clamps (goxi launcher blocker 11) ─────
+    //
+    // Production ran the launcher armed while the durable `admission_handoff`
+    // row was ABSENT. `evaluate_invocation_lift` maps that to `Unleased`, the
+    // runner treated it as a no-op, and because the leaf had already been born
+    // at 250m the "no-op" pinned every build there for its whole life: a
+    // measured leaf reached 21,130,868 usec of CPU — 84x the 250,000 usec
+    // escalation threshold — with `cpu.max` never leaving `25000 100000`.
+    // Arming was a ~16x slowdown, strictly worse than leaving it off.
+    //
+    // Both halves are asserted, because either alone can pass vacuously:
+    //   * the CONFIGURATION, read back from the kernel: no quota at this level;
+    //   * the BEHAVIOUR, measured over a wall-clock window: it actually runs
+    //     multiples faster than the clamped leaf did.
+    let (unarmed_leaf, unarmed_child) = launcher
+        .create_command(
+            "unarmed",
+            Invocation {
+                id: "unarmed".to_owned(),
+                fence: 2,
+            },
+            LeaseAuthority::Unarmed,
+            &spinner_command(),
+        )
+        .expect("spawn a probe under an unarmed lease authority");
+    let unarmed_members = read_trimmed(&root.join("unarmed").join("cgroup.procs"));
+    assert!(
+        unarmed_members
+            .split_ascii_whitespace()
+            .any(|entry| entry.parse::<i32>() == Ok(unarmed_child.pid)),
+        "an unarmed authority must still CONTAIN the child: it is only the quota that is \
+         omitted. Members were {unarmed_members:?}, expected pid {}",
+        unarmed_child.pid
+    );
+    let unarmed_cpu_max = root.join("unarmed").join("cpu.max");
+    assert_eq!(
+        read_trimmed(&unarmed_cpu_max),
+        launcher.birth_cpu_max(LeaseAuthority::Unarmed),
+        "an unarmed leaf must be born at the launcher's own unrestricted line"
+    );
+    assert_eq!(
+        read_trimmed(&unarmed_cpu_max),
+        "max 100000",
+        "an authority that can never grant a lift must leave the leaf with no \
+         quota of its own; `25000 100000` here IS the production defect"
+    );
+    let unarmed = measure(&mut launcher, &unarmed_leaf, WINDOW);
+    assert!(
+        unarmed.usage_usec > unleased.usage_usec * 3,
+        "the unarmed leaf burned {} usec against {} for the clamped leaf over comparable \
+         windows. An unarmed authority must cost nothing: if these are equal, arming the \
+         launcher without an armed epoch is still the ~16x regression that rolled back four \
+         times.",
+        unarmed.usage_usec,
+        unleased.usage_usec
+    );
+    assert_eq!(
+        unarmed.nr_throttled, 0,
+        "a leaf with no quota of its own cannot be throttled at its own level; {} throttled \
+         periods means it was clamped after all",
+        unarmed.nr_throttled
+    );
+    {
+        use std::io::Write;
+        let _ = writeln!(
+            std::io::stdout(),
+            "goxi-11 measured: unarmed {} usec / nr_throttled {} over {:?}; \
+             vs clamped {} usec; ratio {:.2}x (arming without an armed epoch must cost nothing)",
+            unarmed.usage_usec,
+            unarmed.nr_throttled,
+            unarmed.wall,
+            unleased.usage_usec,
+            unarmed.usage_usec as f64 / unleased.usage_usec.max(1) as f64,
+        );
+    }
+    // And the one-way lift contract holds in the other direction: nothing may
+    // lower an unrestricted leaf's ceiling by "lifting" it.
+    let mut unarmed_leaf = unarmed_leaf;
+    assert!(
+        matches!(
+            launcher.fenced_lift(&mut unarmed_leaf, 2),
+            Err(djinn_cgroup_launcher::Error::LiftWithoutAuthority)
+        ),
+        "lifting a leaf born unarmed would WRITE a quota where there was none"
+    );
+
+    // ── Teardown: cgroup-wide kill, drain, unlink ───────────────────────────
+    launcher.kill(&mut unarmed_leaf).expect("cgroup.kill");
+    let drained = (0..200).any(|_| {
+        if launcher.wait_empty(&unarmed_leaf).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+        false
+    });
+    assert!(drained, "the unarmed leaf never reached populated 0");
+    launcher
+        .remove(&unarmed_leaf)
+        .expect("remove the drained leaf");
+    reap(unarmed_child.pid);
 }
 
 // ─────────────────────────────── measurement ────────────────────────────────

--- a/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/rendered_boundary/mod.rs
@@ -30,8 +30,8 @@ use djinn_cgroup_launcher::child::{
 };
 use djinn_cgroup_launcher::transport::{UnixBrokerClient, UnixBrokerServer};
 use djinn_cgroup_launcher::{
-    ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig, NativeCgroupFs,
-    NativeCgroupSpawn, SpawnIntoCgroup,
+    ChildProcess, CommandSpec, Error, Invocation, Launcher, LauncherConfig, LeaseAuthority,
+    NativeCgroupFs, NativeCgroupSpawn, SpawnIntoCgroup,
 };
 
 /// Invocation whose child is the in-cgroup adversary rather than an exec.
@@ -452,7 +452,7 @@ fn worker_main(
             say!("fail:begin {id}: {error}");
             unsafe { libc::_exit(17) };
         }
-        if let Err(error) = client.create(id, leaf, &command) {
+        if let Err(error) = client.create(id, leaf, LeaseAuthority::Armed, &command) {
             say!("fail:create {id}: {error}");
             unsafe { libc::_exit(18) };
         }

--- a/server/crates/djinn-supervisor/src/services/invocation_admission.rs
+++ b/server/crates/djinn-supervisor/src/services/invocation_admission.rs
@@ -38,14 +38,38 @@ use crate::services::lease::InvocationLiftDecision;
 /// invocation and records telemetry (the "would throttle" arms) and then leaves
 /// the leaf pinned at the broker's unleased quota —
 /// `UnleasedQuota::DEFAULT_MILLICORES`, i.e. **250m** — for the whole command.
-/// `Unleased` is a literal no-op with the same effect. So a rollout that seeds
-/// the epoch and arms shadow makes every leased build slower, not faster: it is
-/// an observation mode whose entire purpose is to measure what enforcement
-/// *would* do. This is correct by design and asserted by
-/// `shadow_epoch_binds_but_never_lifts` and `unleased_epoch_binds_but_never_lifts`
-/// in `djinn-agent`'s `process/tests/process_lease_tests.rs` — do not "fix" it.
-/// Only `v1 = enforce` with a fully acknowledged
+/// So a rollout that seeds the epoch and arms shadow makes every leased build
+/// slower, not faster: it is an observation mode whose entire purpose is to
+/// measure what enforcement *would* do. This is correct by design and asserted by
+/// `shadow_epoch_binds_but_never_lifts` in `djinn-agent`'s
+/// `process/tests/process_lease_tests.rs` — do not "fix" it. Only `v1 = enforce`
+/// with a fully acknowledged
 /// `ForwardOverlap`/`InvocationPrimary`/`RollbackOverlap` phase lifts the quota.
+///
+/// # `Unleased` does NOT clamp (goxi launcher blocker 11)
+///
+/// This used to read "`Unleased` is a literal no-op with the same effect [as
+/// shadow]". Both halves of that were wrong in the same way. It was not a no-op:
+/// the leaf had already been born at the 250m unleased quota before this decision
+/// was ever read, so `Unleased` pinned every command there for its whole life.
+/// And it was not "the same effect as shadow" in intent — shadow clamps
+/// deliberately to observe, whereas `Unleased` means *no admission authority
+/// exists for this invocation at all*.
+///
+/// Production ran the launcher armed with the `admission_handoff` row ABSENT
+/// (`djinn-server epoch show` → `admission handoff row: <absent>`), which is this
+/// function's `Ok(None)` arm. A measured leaf reached 21,130,868 usec of CPU —
+/// 84x the 250,000 usec escalation threshold — with `cpu.max` never leaving
+/// `25000 100000`, making an armed launcher ~16x slower than a disabled one.
+///
+/// `Unleased` now selects `LeaseAuthority::Unarmed` at leaf creation (see
+/// `djinn-agent`'s `process_broker::birth_authority`), so the leaf is born with no
+/// quota of its own and inherits the Pod's budget. It is still contained, still
+/// killable, still measurable — it just costs nothing. Asserted behaviourally on
+/// a real cgroup2 hierarchy by step 7 of
+/// `djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs`, and on the
+/// production composition by
+/// `unleased_epoch_is_born_unclamped_because_no_grant_can_ever_lift_it`.
 #[must_use]
 pub fn evaluate_invocation_lift(
     row: Result<Option<AdmissionHandoffRow>, ()>,


### PR DESCRIPTION
## Which of the three suspects it is

**Suspect 3** — the lease is requested, but the lift never happens. The sampling loop and the threshold comparison were both working.

Evidence, from the armed v0.7.9 window on the production node:

- Only one pod in `/root/armed-v0.7.9-evidence/` had the launcher armed (`019f9df2-3f12`); the other six logged `cgroup launcher explicitly disabled`.
- Decoding the leaf UUIDv7 timestamps ties leaf `019f9df4-6f9d` to `10:24:30.109`, and the worker logged `cargo invocation observed … duration_seconds=41.866` at `10:25:11.976` → start `10:24:30.11`. **Exact match**: that leaf is that cargo test. 8,544,778 usec over 41.87 s wall is 204 millicores average — throttled at 250m for the entire command, i.e. the sample was rising and the threshold (250,000 usec) was crossed within ~1 s.
- `kubectl exec … djinn-server epoch show` on the production node returns:

```
admission handoff row: <absent>
```

`evaluate_invocation_lift(Ok(None))` → `InvocationLiftDecision::Unleased` → `process.rs` arm `InvocationLiftDecision::Unleased => {}`. So `fenced_lift` was **never called**, for every invocation, unconditionally.

## The actual defect

`Unleased` is documented as "a literal no-op". It was not one. The leaf had already been born at `UnleasedQuota::DEFAULT_MILLICORES` (250m) *before* the decision was ever read — the decision was read only after a successful bind — so "no-op" meant **clamped at 250m for the whole command** while the pod held 4 CPUs. Hence the measured 21.1 CPU-s at `cpu.max = 25000 100000`, and hence arming being a ~16× regression rather than a speed-up.

## The fix

The birth quota is the only observable effect of the decision for an invocation that is never granted, and it cannot be revised afterwards — `fenced_lift` is one-way and fenced, with deliberately no unfenced path back down. So the decision is now resolved **before the leaf exists** and selects the quota it is born at:

| decision | birth `cpu.max` | on grant |
|---|---|---|
| `Lift` | `25000 100000` | lifted to `400000 100000` |
| `Shadow` | `25000 100000` | never lifted (clamps on purpose) |
| `Unleased` | `max 100000` | n/a — no grant can authorize a lift |

An unarmed leaf keeps every containment property that was hard-won across blockers 1-10 — named by invocation id, killable via `cgroup.kill`, measurable on `cpu.stat`, capabilities dropped, Landlock/seccomp applied — and simply inherits the Pod's own budget. Arming without an armed epoch now costs nothing instead of 16×.

`fenced_lift` refuses a leaf born unarmed (`Error::LiftWithoutAuthority`) rather than writing a quota where there was none, and the bind arm reuses the pre-launch decision rather than re-reading it, so a mid-invocation epoch change can never ask for a lift on a leaf the broker created unarmed.

There is deliberately **no** second execution path: one runner, one launcher, one broker protocol, with the quota as the only variable. The `authority` travels on the same `create` control that makes the leaf, so no leaf can exist with an undecided ceiling.

## Instrumentation

This path reported nothing across four armed rollouts — the entire diagnosis had to be done by reading cgroupfs by hand on the node. It now emits one line per invocation naming the decision, the committed authority and the threshold, plus a line at the lift carrying the observed usage.

## Proof the quota transitions in a real leaf

Extended the privileged `launcher-kernel-boundary` suite (`delegated_cpu_lease_lifecycle.rs`) — real `mount(2)`, real cgroup2 delegation, real forks, no `FakeCgroup`. Executed locally under `docker run --privileged --cgroupns=private` exactly as the lane does:

```
7deu measured:    unleased 525318 usec / nr_throttled 19 over 2.000083772s;
                  leased  3994445 usec / nr_throttled 0  over 2.000061837s; ratio 7.60x
goxi-11 measured: unarmed 3992080 usec / nr_throttled 0  over 2.000100278s;
                  vs clamped 525318 usec; ratio 7.60x
```

`cpu.max` is read back **from the kernel** either side of the lift and asserted to move `25000 100000` → `400000 100000`; an unarmed leaf is asserted to read `max 100000` while its child pid is still asserted present in `cgroup.procs`. The armed leaves are torn down before the unarmed window so step 7 measures the absence of a clamp rather than contention.

### The control fails, and both halves fail independently

Reverting the fix at the launch boundary (`Unarmed` → `Armed`) reproduces the production symptom **by name**:

```
assertion `left == right` failed: an unarmed leaf must be born at the launcher's own unrestricted line
  left: "25000 100000"
 right: "max 100000"
```

Neutralising only the config read-back so the *measured* assertion has to catch it:

```
the unarmed leaf burned 526949 usec against 526378 for the clamped leaf over comparable windows.
```

I also caught my own arithmetic error this way: the first version asserted `4000000 100000` for the leased line and the always-on guard failed it — 4000m over a 100 ms period is `400000`, not `4000000`.

### Agent-side composition

Reverting `birth_authority`'s `Unleased` arm reds four tests:

- `birth_authority_is_armed_only_when_a_lift_is_reachable` — the mapping, enumerated over all three decisions.
- `absent_handoff_row_is_unleased_and_therefore_unarmed` — the real `evaluate_invocation_lift` fed `Ok(None)` (production) and `Err(())`.
- `unleased_epoch_is_born_unclamped_because_no_grant_can_ever_lift_it` — the runner. This **replaces** `unleased_epoch_binds_but_never_lifts`, which asserted only `lifts.is_empty()`; the defect satisfied that assertion, which is why it shipped.
- `shell_dispatch_lease_queue_timeout_returns_the_command_result_not_an_error` — `call_shell` → `ShellLaunchContext` → `LeaseInvocationRunner` → the real `DirectServices` authority over a real durable repository **with no handoff row**, i.e. the production configuration end to end.

None of the proof depends on the privileged lane's full root capability set: the kernel half asserts quotas and measured throughput, and the composition half runs unprivileged.

## Implicated prior work

**#2593** is incomplete. It armed the v1 lease cap in code, but there is no production-reachable armed epoch: the only writer of `phase`/`v1_mode` is the one-shot `djinn-server epoch …` admin CLI, and the durable row is absent in production. The lift was unreachable by construction, so the cap was armed against a gate that always denied. #2599, #2596 and #2608 are not implicated.

## Twelfth blocker

**The launcher arming switch and the lift authority are independent switches with no reachable combination that helps.** `cgroupLauncher.mode: required` is a Helm/env value; the lift needs `admission_handoff.v1_mode = enforce` plus a committed overlap phase plus current-epoch acks, writable only by a one-shot admin CLI whose `advance` also requires a leader-written emergency ack. Nothing validates the pair. After this PR arming is *safe* (no-cost) rather than *useful*: the leaf is unclamped, but no build is leased either, and there is still no production sequence that reaches `Lift`. Making the lease actually govern CPU in production needs the epoch cutover driven and verified — and note the row is currently absent because deleting it is the documented workaround for a separate seed wedge, so re-seeding it re-arms that hazard. Worth filing before anyone tries a fifth arming.

## Test evidence

- `djinn-cgroup-launcher`: 69 + 9 + 8 + 4 + 1 + 4 pass; privileged proof passes under `--privileged`.
- `djinn-agent --lib`: 1431 passed, 0 failed.
- `djinn-supervisor`, `djinn-k8s`: pass (the 11 `djinn-supervisor --lib` failures under `cargo test`'s shared-process parallelism are pre-existing global-telemetry interference in files this PR does not touch; they pass with `--test-threads=1`, and CI's nextest gives each test its own process).
- `djinn-agent-worker --test cancel_path --test in_pod_drive`: pass.
- `cargo clippy --all-targets --features qdrant -- -D warnings`: clean.
- `scripts/check-file-size.sh`: 0 oversized. `LeaseAuthority` split into `lease_authority.rs` because `lib.rs` was left with 353 bytes of headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
