### PR TITLE
fix(goxi): re-establish the startup gates a live promotion resets

### DIFF
--- a/server/src/server/state/admission_epoch_arming_tests.rs
+++ b/server/src/server/state/admission_epoch_arming_tests.rs
@@ -500,3 +500,161 @@ async fn absent_row_keeps_configured_mode_and_seed_restores_a_complete_baseline(
         BuildAdmissionDecision::Permitted { .. }
     ));
 }
+
+/// Re-seeding the row into an ALREADY-RUNNING deployment must not re-arm the
+/// 2026-07-19 outage.
+///
+/// Production is configured `mode: observe` with `maxBuildTaskRuns: 3` (the Helm
+/// chart's `buildAdmission`), and its row is currently absent, so its controller
+/// is a benign standalone Observe that never denies. The moment an operator
+/// restores the row, the durable state reads `RequiredFailClosed`, and the
+/// periodic handoff loop promotes the Observe controller through
+/// `require_enforcement()` — which resets EVERY startup gate.
+///
+/// Those gates are otherwise walked only by `initialize()` and by
+/// `become_leader()`, neither of which runs again inside a live process. So
+/// without the re-establishment this test pins, the promoted controller parks
+/// fail-closed forever and denies every admission with the incident's exact
+/// self-contradictory signature, recoverable only by restarting the pod.
+///
+/// This is why the incident happened even though #2264 had already wired
+/// `mark_topology_ready` to leadership the day before: the missing piece was
+/// never the call site, it was that the LIVE promotion path resets the gates with
+/// nothing left to reopen them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(clippy::await_holding_lock)]
+async fn seeding_a_live_observe_deployment_does_not_wedge_admission() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, observe_config());
+    // Production's current state: the row was deleted by the 2026-07-19
+    // remediation, so the deployment booted and won leadership as Observe.
+    handoff_repository(&state)
+        .delete_for_test()
+        .await
+        .expect("delete the row");
+    boot_through_leadership(&state).await;
+    let controller = admission(&state).clone();
+    assert_eq!(controller.mode(), BuildAdmissionMode::Observe);
+    assert!(matches!(
+        admit(&state, "pre-seed-task").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+
+    // The operator restores the row against the LIVE deployment.
+    let rendered = epoch_cli(&state, EpochAction::Seed).await;
+    assert!(rendered.starts_with("seed: applied"), "{rendered}");
+
+    // The next periodic handoff tick promotes Observe → Enforce. This is the
+    // exact moment the outage began.
+    leader_handoff_tick(&state).await;
+    assert_eq!(
+        controller.mode(),
+        BuildAdmissionMode::Enforce,
+        "a durable emergency-primary row must promote the configured Observe mode"
+    );
+
+    // The promotion must NOT leave the controller parked behind its own reset
+    // gates. Nothing restarts this process, so readiness restored here or never.
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::Healthy,
+        "promoting a live leader must re-establish the startup gates it reset"
+    );
+    assert_ne!(
+        admit(&state, "post-seed-task").await,
+        BuildAdmissionDecision::Denied {
+            occupancy: 0,
+            cap: 3
+        },
+        "re-seeding must not reproduce the incident's self-contradictory denial"
+    );
+    assert!(
+        matches!(
+            admit(&state, "post-seed-task-2").await,
+            BuildAdmissionDecision::Permitted { .. }
+        ),
+        "the restored deployment must keep admitting work"
+    );
+
+    // A further tick is stable — the promotion is not a flapping loop.
+    leader_handoff_tick(&state).await;
+    assert_eq!(controller.mode(), BuildAdmissionMode::Enforce);
+    assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+}
+
+/// A STANDBY must not re-open its own topology gate.
+///
+/// This is the load-bearing half of re-establishing the gates after a live
+/// promotion. The journal and Kubernetes gates are re-derived from real checks,
+/// but the topology gate encodes "this process holds the coordinator advisory
+/// lock" — which cannot be re-checked, only remembered. If re-establishment
+/// asserted it unconditionally, every standby pod would promote itself into a
+/// healthy Enforce writer and the single-active invariant would be gone, which is
+/// precisely the corruption the gate exists to prevent.
+///
+/// So a pod that never won leadership must stay fail-closed at `TopologyPending`
+/// even though it ran the same promotion path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(clippy::await_holding_lock)]
+async fn a_standby_promotion_never_re_asserts_the_topology_gate() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, observe_config());
+    handoff_repository(&state)
+        .delete_for_test()
+        .await
+        .expect("delete the row");
+
+    // A standby: every startup gate EXCEPT coordinator leadership.
+    boot_to_topology_gate(&state).await;
+    let controller = admission(&state).clone();
+    assert_eq!(controller.mode(), BuildAdmissionMode::Observe);
+
+    // Restore the row, then run the same promotion path the leader ran.
+    epoch_cli(&state, EpochAction::Seed).await;
+    leader_handoff_tick(&state).await;
+    assert_eq!(
+        controller.mode(),
+        BuildAdmissionMode::Enforce,
+        "the durable row promotes a standby's controller too"
+    );
+
+    // The journal and inventory gates were legitimately re-derived, so the
+    // remaining closed gate must be exactly topology — not an earlier one.
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::TopologyPending,
+        "a standby must NOT re-assert a topology gate it never held"
+    );
+    assert_eq!(
+        admit(&state, "standby-task").await,
+        BuildAdmissionDecision::Denied {
+            occupancy: 0,
+            cap: 3
+        },
+        "a promoted standby must fail closed"
+    );
+    assert_eq!(
+        handoff_repository(&state)
+            .read()
+            .await
+            .expect("read")
+            .expect("row")
+            .invocation_ack_epoch,
+        None,
+        "a standby writes no authority acknowledgement"
+    );
+
+    // Winning the lock is the only thing that opens it.
+    state.confirm_build_admission_topology().await;
+    assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+    assert!(matches!(
+        admit(&state, "promoted-leader-task").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+}

--- a/server/src/server/state/admission_epoch_arming_tests.rs
+++ b/server/src/server/state/admission_epoch_arming_tests.rs
@@ -1,0 +1,502 @@
+//! End-to-end reachability of the v1 invocation-lift authority.
+//!
+//! Every other test around the admission epoch drives a *stand-in* for one of
+//! the two production seams:
+//!
+//! * `djinn-coordinator`'s `EpochWorld::leader_tick` **re-implements**
+//!   `finalize_build_admission_handoff` rather than calling it, so it cannot
+//!   catch a divergence between the policy and the seam that applies it.
+//! * `djinn-agent`'s `process_lease_tests` hold the lift decision in a
+//!   `Mutex<InvocationLiftDecision>`, so they prove what the launcher does
+//!   *given* a decision, never that the decision is reachable.
+//! * `admin.rs`'s own tests drive the operator CLI against a bare repository
+//!   with a hand-written `acknowledge` standing in for the coordinator.
+//!
+//! Nothing joined them, so "a fresh deployment can reach a lift-granting phase"
+//! was asserted nowhere. These tests close that gap by composing only real
+//! seams against a real Postgres database:
+//!
+//! * the real migration-seeded row (no hand-built fixture),
+//! * the real ordered startup gates `AppState::initialize` runs,
+//! * the real `confirm_build_admission_topology` that `become_leader` calls,
+//! * the real `finalize_build_admission_handoff` the periodic leader loop ticks,
+//! * the real `crate::admin::run_admin_command` operator CLI, and
+//! * the real `evaluate_invocation_lift` the launcher reads.
+//!
+//! # The trap these tests are shaped to avoid
+//!
+//! Blocker eleven shipped because its test asserted only `lifts.is_empty()` — a
+//! property the defect satisfied. Asserting `Unleased` everywhere would repeat
+//! exactly that mistake, because `Unleased` is also what a permanently broken
+//! rollout returns. So every stage here asserts the *positive* reachable
+//! outcome, and the intermediate `Unleased`/`Shadow` stages each assert a
+//! **distinct, separately identified reason** for not lifting, so they fail
+//! independently rather than all passing for one wrong reason.
+
+use super::build_admission_config_tests::{
+    BUILD_ADMISSION_TELEMETRY_LOCK, admission, handoff_repository,
+    state_for_admission_config_with_db,
+};
+use super::*;
+use crate::admin::{AdminCommand, EpochAction, run_admin_command};
+use djinn_agent::actors::coordinator::BuildAdmissionReadiness;
+use djinn_coordinator::build_admission::BuildAdmissionDecision;
+use djinn_db::{AdmissionDomain, AdmissionHandoffPhase, V0Mode, V1Mode};
+use djinn_supervisor::services::{InvocationLiftDecision, evaluate_invocation_lift};
+
+/// Run one real operator CLI step and return its rendered output.
+async fn epoch_cli(state: &AppState, action: EpochAction) -> String {
+    run_admin_command(state.db(), AdminCommand::Epoch { action })
+        .await
+        .expect("operator epoch command")
+}
+
+/// The launcher-side decision, read from the durable row exactly as
+/// `DirectServices::invocation_lift_decision` and
+/// `WorkerSupervisorServices::invocation_lift_decision` read it.
+async fn launcher_lift(state: &AppState) -> InvocationLiftDecision {
+    evaluate_invocation_lift(handoff_repository(state).read().await.map_err(|_| ()))
+}
+
+/// One tick of the periodic leader handoff loop
+/// (`start_handoff_warning_loop` → `finalize_build_admission_handoff`). This is
+/// the production writer of the v0 acknowledgement, and the only thing that
+/// re-completes an epoch after an operator step bumps it.
+async fn leader_handoff_tick(state: &AppState) {
+    let controller = admission(state).clone();
+    state.finalize_build_admission_handoff(&controller).await;
+}
+
+/// Drive the ordered startup gates in the exact sequence `AppState::initialize`
+/// runs them (handoff → recovery → deferred recovery → inventory), then the
+/// topology confirmation that `become_leader` performs on winning the
+/// coordinator advisory lock.
+async fn boot_through_leadership(state: &AppState) {
+    boot_to_topology_gate(state).await;
+    state.confirm_build_admission_topology().await;
+}
+
+/// The same ordered startup gates, stopping *before* leadership is acquired —
+/// i.e. what a standby pod (or a leader that never won the lock) reaches.
+async fn boot_to_topology_gate(state: &AppState) {
+    state.initialize_build_admission_handoff().await;
+    state.initialize_build_admission_recovery().await;
+    state.initialize_build_admission_deferred_recovery().await;
+    *state.inner.graph_warmer.write().await =
+        Some(Arc::new(build_in_process_graph_warmer(state.clone())));
+    state.initialize_build_admission_inventory().await;
+}
+
+/// Ask the real emergency controller to admit a real task run.
+async fn admit(state: &AppState, work_id: &str) -> BuildAdmissionDecision {
+    admission(state)
+        .admit_task_run(
+            Some("worker"),
+            AdmissionDomain::TaskObservation,
+            work_id.to_owned(),
+            0,
+            format!("{work_id}-job"),
+        )
+        .await
+        .expect("admission decision")
+}
+
+fn observe_config() -> BuildAdmissionConfig {
+    BuildAdmissionConfig {
+        mode: BuildAdmissionMode::Observe,
+        cap: 3,
+    }
+}
+
+/// A fresh deployment reaches a lift-granting phase through nothing but the real
+/// startup seams and the real operator CLI, and admits work at every step.
+///
+/// This is the property the eleven previous blockers left unproven: `Lift` is
+/// *reachable*. It also pins the exact operator sequence the production runbook
+/// uses, so a change that silently lengthens or breaks that sequence fails here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(clippy::await_holding_lock)]
+async fn fresh_deployment_reaches_lift_through_real_startup_and_operator_cli() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db.clone(), observe_config());
+
+    // ── Stage 0: the migration-seeded baseline opens by itself. ───────────
+    boot_through_leadership(&state).await;
+    let controller = admission(&state).clone();
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::Healthy,
+        "coordinator leadership must complete the startup gates"
+    );
+    assert_eq!(
+        controller.mode(),
+        BuildAdmissionMode::Enforce,
+        "a durable emergency-primary row promotes the configured Observe mode"
+    );
+    let baseline = handoff_repository(&state)
+        .read()
+        .await
+        .expect("read")
+        .expect("row");
+    assert_eq!(baseline.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert_eq!(
+        baseline.emergency_ack_epoch,
+        Some(baseline.epoch),
+        "leadership acknowledged the seeded epoch with no operator action"
+    );
+    assert!(
+        matches!(
+            admit(&state, "baseline-task").await,
+            BuildAdmissionDecision::Permitted { .. }
+        ),
+        "the v0 baseline admits work"
+    );
+    // Reason #1 for not lifting: v1 is off. Distinct from every stage below.
+    assert_eq!(baseline.v1_mode, V1Mode::Off);
+    assert_eq!(
+        launcher_lift(&state).await,
+        InvocationLiftDecision::Unleased,
+        "v1 is off at the baseline, so the launcher must not lift"
+    );
+
+    // `epoch seed` is idempotent and must never disturb a live rollout.
+    let rendered = epoch_cli(&state, EpochAction::Seed).await;
+    assert!(
+        rendered.starts_with("seed: already present"),
+        "seed must not touch an existing row: {rendered}"
+    );
+
+    // ── Stage 1: arm shadow. v1 observes; it must NOT lift. ───────────────
+    epoch_cli(
+        &state,
+        EpochAction::Advance {
+            cap: Some(3),
+            generations: vec![],
+        },
+    )
+    .await;
+    let shadow = handoff_repository(&state)
+        .read()
+        .await
+        .expect("read")
+        .expect("row");
+    assert_eq!(shadow.v1_mode, V1Mode::Shadow);
+    assert_eq!(shadow.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert!(
+        shadow.epoch > baseline.epoch,
+        "arming bumps the epoch and clears both acknowledgements"
+    );
+    // Reason #2: shadow observes. A DISTINCT decision from Unleased, so a
+    // regression collapsing shadow into either neighbour fails right here.
+    leader_handoff_tick(&state).await;
+    assert_eq!(
+        launcher_lift(&state).await,
+        InvocationLiftDecision::Shadow,
+        "shadow must bind-and-observe, never lift"
+    );
+
+    // ── Stage 2: arm the overlap modes. v1 enforces but the phase has not ──
+    // ── advanced, so it still must not lift. ──────────────────────────────
+    epoch_cli(
+        &state,
+        EpochAction::Advance {
+            cap: Some(3),
+            generations: vec![],
+        },
+    )
+    .await;
+    let armed = handoff_repository(&state)
+        .read()
+        .await
+        .expect("read")
+        .expect("row");
+    assert_eq!(armed.v1_mode, V1Mode::Enforce);
+    assert_eq!(
+        armed.phase,
+        AdmissionHandoffPhase::EmergencyPrimary,
+        "arming modes never advances the phase on its own"
+    );
+    // Reason #3: v1 enforcing but the overlap is not armed. Independent of the
+    // acknowledgement state, which stage 3 covers.
+    assert_eq!(
+        launcher_lift(&state).await,
+        InvocationLiftDecision::Unleased,
+        "v1=enforce parked in emergency-primary must not lift"
+    );
+
+    // ── Stage 3: the overlap edge waits for the leader's v0 ack. ──────────
+    let rendered = epoch_cli(
+        &state,
+        EpochAction::Advance {
+            cap: None,
+            generations: vec![],
+        },
+    )
+    .await;
+    assert!(
+        rendered.contains("awaiting v0 emergency acknowledgement"),
+        "arming cleared the v0 ack, so the overlap edge must wait: {rendered}"
+    );
+    assert_eq!(
+        handoff_repository(&state)
+            .read()
+            .await
+            .expect("read")
+            .expect("row")
+            .phase,
+        AdmissionHandoffPhase::EmergencyPrimary,
+        "a waiting step mutates nothing"
+    );
+
+    // The periodic leader loop is what unblocks it — no restart involved.
+    leader_handoff_tick(&state).await;
+    assert_eq!(
+        handoff_repository(&state)
+            .read()
+            .await
+            .expect("read")
+            .expect("row")
+            .emergency_ack_epoch,
+        Some(armed.epoch),
+        "the leader handoff tick re-acknowledges the bumped epoch"
+    );
+
+    // ── Stage 4: enter the forward overlap. ───────────────────────────────
+    epoch_cli(
+        &state,
+        EpochAction::Advance {
+            cap: None,
+            generations: vec![],
+        },
+    )
+    .await;
+    let overlap = handoff_repository(&state)
+        .read()
+        .await
+        .expect("read")
+        .expect("row");
+    assert_eq!(overlap.phase, AdmissionHandoffPhase::ForwardOverlap);
+    assert_eq!(
+        overlap.invocation_ack_epoch,
+        Some(overlap.epoch),
+        "the executor records the v1 authority ack on the new epoch"
+    );
+    // Reason #4: the advance cleared v0's ack, and an overlap needs BOTH. This
+    // is the ordering guarantee that v0 is confirmed before v1 ever lifts.
+    assert_ne!(overlap.emergency_ack_epoch, Some(overlap.epoch));
+    assert_eq!(
+        launcher_lift(&state).await,
+        InvocationLiftDecision::Unleased,
+        "an overlap with no v0 acknowledgement must not lift"
+    );
+
+    // ── Stage 5: the leader completes the overlap epoch → LIFT. ───────────
+    leader_handoff_tick(&state).await;
+    let lifting = handoff_repository(&state)
+        .read()
+        .await
+        .expect("read")
+        .expect("row");
+    assert_eq!(lifting.emergency_ack_epoch, Some(lifting.epoch));
+    assert_eq!(lifting.invocation_ack_epoch, Some(lifting.epoch));
+    assert_eq!(
+        launcher_lift(&state).await,
+        InvocationLiftDecision::Lift,
+        "a fresh deployment MUST be able to reach a lift-granting phase"
+    );
+    // Both authorities enforce across the overlap, and work is still admitted:
+    // reaching Lift is not paid for with a fail-closed admission gate.
+    assert_eq!(lifting.v0_mode, V0Mode::Enforce);
+    assert_eq!(lifting.v1_mode, V1Mode::Enforce);
+    assert_eq!(controller.mode(), BuildAdmissionMode::Enforce);
+    assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+    assert!(
+        matches!(
+            admit(&state, "overlap-task").await,
+            BuildAdmissionDecision::Permitted { .. }
+        ),
+        "the lifting overlap admits work rather than denying it"
+    );
+
+    // ── Stage 6: a restart keeps lifting. ────────────────────────────────
+    let restarted = state_for_admission_config_with_db(db, observe_config());
+    boot_through_leadership(&restarted).await;
+    assert_eq!(
+        admission(&restarted).readiness(),
+        BuildAdmissionReadiness::Healthy
+    );
+    assert_eq!(
+        launcher_lift(&restarted).await,
+        InvocationLiftDecision::Lift,
+        "a restart must re-open on the committed overlap, not fall back to unleased"
+    );
+    assert!(matches!(
+        admit(&restarted, "restarted-task").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+}
+
+/// The 2026-07-19 wedge shape still fails closed.
+///
+/// This protection is load-bearing — it is what stops a second active admission
+/// writer — so it must keep denying. The test pins the *exact* self-contradictory
+/// denial from the incident (`occupancy 0 reached cap 3`) and then proves the
+/// denial is attributable specifically to the missing topology gate by opening
+/// only that gate and watching the same request be admitted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(clippy::await_holding_lock)]
+async fn unconfirmed_topology_still_fails_closed_and_never_lifts() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, observe_config());
+
+    // Every startup gate except coordinator leadership.
+    boot_to_topology_gate(&state).await;
+    let controller = admission(&state).clone();
+    assert_eq!(
+        controller.mode(),
+        BuildAdmissionMode::Enforce,
+        "the durable row promotes the configured Observe mode"
+    );
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::TopologyPending,
+        "leadership was never acquired"
+    );
+
+    // The incident signature: a denial whose occupancy is nowhere near the cap.
+    assert_eq!(
+        admit(&state, "wedged-task").await,
+        BuildAdmissionDecision::Denied {
+            occupancy: 0,
+            cap: 3
+        },
+        "an unconfirmed topology MUST fail closed"
+    );
+
+    // No gate short of topology may complete the epoch, and nothing lifts.
+    assert_eq!(
+        handoff_repository(&state)
+            .read()
+            .await
+            .expect("read")
+            .expect("row")
+            .emergency_ack_epoch,
+        None,
+        "only a healthy controller may acknowledge the durable epoch"
+    );
+    assert_eq!(
+        launcher_lift(&state).await,
+        InvocationLiftDecision::Unleased,
+        "an incomplete epoch never lifts"
+    );
+
+    // Ticking the leader loop must not launder the missing gate into an ack.
+    leader_handoff_tick(&state).await;
+    assert_eq!(
+        handoff_repository(&state)
+            .read()
+            .await
+            .expect("read")
+            .expect("row")
+            .emergency_ack_epoch,
+        None,
+        "the handoff loop must not acknowledge from an unready controller"
+    );
+    assert_eq!(
+        controller.readiness(),
+        BuildAdmissionReadiness::TopologyPending
+    );
+
+    // The control: opening ONLY the topology gate admits the same request, so
+    // the denial above is attributable to that gate and nothing else.
+    state.confirm_build_admission_topology().await;
+    assert_eq!(controller.readiness(), BuildAdmissionReadiness::Healthy);
+    assert!(
+        matches!(
+            admit(&state, "unwedged-task").await,
+            BuildAdmissionDecision::Permitted { .. }
+        ),
+        "confirming topology is what opens admission"
+    );
+}
+
+/// The documented 2026-07-19 remediation (deleting the row) stays safe, and
+/// `epoch seed` restores the rollout without re-arming the wedge.
+///
+/// Production is in exactly this state right now: the row is absent because an
+/// operator deleted it. This pins both halves of getting back — that the absent
+/// state is not itself a wedge, and that the restore lands on a *complete*
+/// baseline rather than the unacknowledged epoch the incident was about.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(clippy::await_holding_lock)]
+async fn absent_row_keeps_configured_mode_and_seed_restores_a_complete_baseline() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, observe_config());
+    handoff_repository(&state)
+        .delete_for_test()
+        .await
+        .expect("delete the row exactly as the 2026-07-19 remediation did");
+
+    boot_through_leadership(&state).await;
+    let controller = admission(&state).clone();
+    // Absence is mapped to the CONFIGURED standalone mode — it does not invent
+    // rollout state and does not promote to a fail-closed Enforce.
+    assert_eq!(
+        controller.mode(),
+        BuildAdmissionMode::Observe,
+        "an absent row preserves the configured standalone mode"
+    );
+    assert!(
+        matches!(
+            admit(&state, "absent-row-task").await,
+            BuildAdmissionDecision::Permitted { .. }
+        ),
+        "the remediated deployment admits work"
+    );
+    assert_eq!(
+        launcher_lift(&state).await,
+        InvocationLiftDecision::Unleased,
+        "an absent row never lifts, so arming is useless until it is restored"
+    );
+
+    // Restore. The seed is born acknowledged, so it lands directly on a
+    // COMPLETE emergency-primary baseline: the deployment never has to climb
+    // out of the unacknowledged epoch that started the incident.
+    let rendered = epoch_cli(&state, EpochAction::Seed).await;
+    assert!(rendered.starts_with("seed: applied"), "{rendered}");
+    let seeded = handoff_repository(&state)
+        .read()
+        .await
+        .expect("read")
+        .expect("row");
+    assert_eq!(seeded.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    assert_eq!(seeded.v0_mode, V0Mode::Enforce);
+    assert_eq!(seeded.v1_mode, V1Mode::Off);
+    assert_eq!(
+        seeded.emergency_ack_epoch,
+        Some(seeded.epoch),
+        "the restored row must be complete, NOT the unacknowledged incident shape"
+    );
+
+    // A restart on the restored row opens without operator intervention.
+    let restarted = state_for_admission_config_with_db(state.db().clone(), observe_config());
+    boot_through_leadership(&restarted).await;
+    assert_eq!(
+        admission(&restarted).readiness(),
+        BuildAdmissionReadiness::Healthy,
+        "the restored baseline self-opens"
+    );
+    assert!(matches!(
+        admit(&restarted, "restored-task").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+}

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -52,6 +52,8 @@ use djinn_runtime::GraphWarmerService;
 use djinn_supervisor::{AllowAllValidator, ConnectionRegistry, ServeHandle, serve_on_tcp};
 use djinn_workspace::{MirrorManager, WorkspaceStore, mirrors_root, workspaces_root};
 
+#[cfg(test)]
+mod admission_epoch_arming_tests;
 mod canonical_graph_refresh_planner;
 mod provider_catalog_refresh;
 mod settings;
@@ -980,9 +982,22 @@ impl AppState {
                         // without a restart: RequiredFailClosed re-closes a
                         // controller that is no longer Enforce, and MayDisable
                         // releases emergency once invocation-primary is
-                        // committed. This runs only on the leader (the loop is
-                        // started inside `become_leader`, after topology is
-                        // confirmed), so it mirrors `finalize` semantics.
+                        // committed. This is what re-acknowledges the emergency
+                        // authority after an operator `epoch advance` bumps the
+                        // epoch and clears both acks, so the rollout progresses
+                        // without a restart.
+                        //
+                        // This loop is started from
+                        // `initialize_build_admission_handoff`, i.e. on EVERY
+                        // pod, not only the leader. That is safe because
+                        // acknowledgement is gated on
+                        // `emergency_acknowledgement_allowed`, which requires
+                        // `readiness().is_healthy()`, and `topology_ready` is set
+                        // only by `confirm_build_admission_topology` inside
+                        // `become_leader`. A standby therefore ticks, observes,
+                        // and publishes telemetry but can never write an
+                        // acknowledgement: the readiness gate — not the spawn
+                        // site — is what keeps a single active admission writer.
                         if let Some(admission) = state.inner.build_admission.clone() {
                             state.finalize_build_admission_handoff(&admission).await;
                         }
@@ -3978,7 +3993,8 @@ mod build_admission_config_tests {
     };
 
     static BUILD_ADMISSION_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    static BUILD_ADMISSION_TELEMETRY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    pub(super) static BUILD_ADMISSION_TELEMETRY_LOCK: std::sync::Mutex<()> =
+        std::sync::Mutex::new(());
 
     fn state_for_admission_config(config: BuildAdmissionConfig) -> AppState {
         let db = Database::open_in_memory().expect("test database");
@@ -4046,7 +4062,10 @@ mod build_admission_config_tests {
             .expect("the composed lease must authorize a graph-warm Job POST");
     }
 
-    fn state_for_admission_config_with_db(db: Database, config: BuildAdmissionConfig) -> AppState {
+    pub(super) fn state_for_admission_config_with_db(
+        db: Database,
+        config: BuildAdmissionConfig,
+    ) -> AppState {
         let runtime = DatabaseRuntimeManager::new(
             crate::db::runtime::DatabaseRuntimeConfig::postgres(db.bootstrap_info().target.clone()),
         );
@@ -4091,7 +4110,7 @@ mod build_admission_config_tests {
         assert_eq!(state.agent_context().knowledge_injection, resolved);
     }
 
-    fn admission(state: &AppState) -> &Arc<BuildAdmissionController> {
+    pub(super) fn admission(state: &AppState) -> &Arc<BuildAdmissionController> {
         state
             .inner
             .build_admission
@@ -4099,7 +4118,7 @@ mod build_admission_config_tests {
             .expect("handoff controller")
     }
 
-    fn handoff_repository(state: &AppState) -> AdmissionHandoffRepository {
+    pub(super) fn handoff_repository(state: &AppState) -> AdmissionHandoffRepository {
         AdmissionHandoffRepository::new(state.db().clone())
     }
 

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -374,6 +374,14 @@ struct Inner {
     pub provider_catalog_refresh_started: AtomicBool,
     /// Ensures startup creates at most one persistent handoff-warning loop.
     pub handoff_warning_loop_started: AtomicBool,
+    /// Whether THIS process won the coordinator advisory lock and confirmed the
+    /// single-active build-admission topology.
+    ///
+    /// Needed because a live promotion to emergency `Enforce` resets every
+    /// startup gate (see `require_enforcement`), and the topology gate may only
+    /// be re-asserted by a process that actually holds the lock. A standby never
+    /// sets this, so it can never re-open its own topology gate.
+    pub build_admission_topology_confirmed: AtomicBool,
     /// Per-model circuit-breaker health tracker.
     pub health_tracker: HealthTracker,
     /// Immutable retrieval-health config parsed once at startup.
@@ -646,6 +654,7 @@ impl AppState {
                     provider_catalog_refresh::refresh_interval_from_env(),
                 provider_catalog_refresh_started: AtomicBool::new(false),
                 handoff_warning_loop_started: AtomicBool::new(false),
+                build_admission_topology_confirmed: AtomicBool::new(false),
                 health_tracker: HealthTracker::new(),
                 retrieval_config,
                 retrieval_metrics,
@@ -1229,10 +1238,49 @@ impl AppState {
         }
     }
 
+    /// Re-walk the build-admission startup gates after a live promotion reset
+    /// them.
+    ///
+    /// [`BuildAdmissionController::require_enforcement`] clears the journal,
+    /// inventory, and topology gates so a configured Off/Observe process cannot
+    /// weaken a durable emergency epoch on the strength of checks it never ran.
+    /// That is right at startup, where the gates are walked immediately
+    /// afterwards — but the same promotion also happens on the periodic handoff
+    /// tick of an already-running process, and there nothing else reopens them.
+    ///
+    /// The journal and Kubernetes gates are genuinely re-run here, never
+    /// asserted. The topology gate is different: it cannot be re-derived from a
+    /// check, only from the fact that this process holds the coordinator advisory
+    /// lock, so it is re-asserted only when this process already confirmed it. A
+    /// standby leaves `build_admission_topology_confirmed` false and therefore
+    /// stays fail-closed at `TopologyPending`, preserving the single-active
+    /// writer invariant.
+    async fn reestablish_build_admission_gates(&self, admission: &BuildAdmissionController) {
+        self.initialize_build_admission_recovery().await;
+        self.initialize_build_admission_inventory().await;
+        if self
+            .inner
+            .build_admission_topology_confirmed
+            .load(Ordering::Acquire)
+        {
+            admission.mark_topology_ready();
+        }
+        admission.publish_metrics().await;
+        tracing::info!(
+            mode = ?admission.mode(),
+            readiness = ?admission.readiness(),
+            topology_confirmed = self
+                .inner
+                .build_admission_topology_confirmed
+                .load(Ordering::Acquire),
+            "build_admission: startup gates re-established after a live promotion"
+        );
+    }
+
     /// Re-read the durable row after topology has made the emergency controller
     /// healthy Enforce, then acknowledge its exact emergency epoch.
     async fn finalize_build_admission_handoff(&self, admission: &BuildAdmissionController) {
-        let snapshot = evaluate_handoff(
+        let mut snapshot = evaluate_handoff(
             AdmissionHandoffRepository::new(self.db().clone())
                 .read()
                 .await
@@ -1251,10 +1299,37 @@ impl AppState {
             EmergencyAuthorityDecision::RequiredFailClosed
                 if admission.mode() != BuildAdmissionMode::Enforce =>
             {
-                // The durable row changed while this process was completing its
-                // startup gates. Re-close and require a fresh healthy pass.
+                // The durable row requires v0 but this controller is not yet
+                // enforcing. Promote it — which resets every startup gate — and
+                // then re-establish those gates, because this may be a LIVE
+                // process rather than one still walking startup.
+                //
+                // Re-establishing is not optional. `initialize()` and
+                // `become_leader()` are the only other places the gates are
+                // walked, and neither runs again in a live process. On
+                // 2026-07-19 an operator restored the durable row against a
+                // running `mode: observe` deployment; this promotion reset the
+                // gates, nothing reopened them, and the controller denied every
+                // admission with a self-contradictory `occupancy 0 reached cap 3`
+                // until the pods were restarted. Nineteen tasks stalled.
                 admission.require_enforcement();
-                return;
+                self.reestablish_build_admission_gates(admission).await;
+                // The gates moved, so the earlier projection is stale: re-read so
+                // a now-healthy controller can acknowledge in this same pass
+                // instead of waiting for the next tick.
+                snapshot = evaluate_handoff(
+                    AdmissionHandoffRepository::new(self.db().clone())
+                        .read()
+                        .await
+                        .map_err(|_| ()),
+                    admission.mode(),
+                    admission.mode() == BuildAdmissionMode::Enforce,
+                    admission.readiness(),
+                    InvocationAuthorityObservation::default(),
+                );
+                if snapshot.emergency != EmergencyAuthorityDecision::RequiredFailClosed {
+                    return;
+                }
             }
             EmergencyAuthorityDecision::RequiredFailClosed
             | EmergencyAuthorityDecision::ConfiguredStandalone => {}
@@ -1286,6 +1361,11 @@ impl AppState {
     /// its Enforce admission stays fail-closed with `TopologyPending`.
     async fn confirm_build_admission_topology(&self) {
         if let Some(admission) = self.inner.build_admission.clone() {
+            // Record leadership BEFORE marking the gate, so a later live
+            // promotion (which resets the gate) can legitimately re-assert it.
+            self.inner
+                .build_admission_topology_confirmed
+                .store(true, Ordering::Release);
             admission.mark_topology_ready();
             self.finalize_build_admission_handoff(&admission).await;
             admission.publish_metrics().await;


### PR DESCRIPTION
## The twelfth goxi blocker is a live wedge on the exact step the runbook needs

`#2622` made arming safe but useless: nothing reaches `Lift` because the durable
`admission_handoff` row is absent, deleted on 2026-07-19 to fix a fail-closed
wedge. The task was to make the row restorable without re-arming that outage.

**Restoring it re-arms the outage today.** That is the blocker, and it is a live
code defect — not the two stale notes it was recorded as.

### Both recorded defects are stale

**`mark_topology_ready` has a production call site.** The note said every caller
is a test. It is not:

```
main.rs:419  leader_state.become_leader()
  → become_leader → confirm_build_admission_topology → admission.mark_topology_ready()
```

Wired by **#2264 on 2026-07-18** — the day *before* the incident. So
`freshly_seeded_handoff_epoch_self_opens_without_operator_intervention` is not
testing a path production does not take: production's ordering in `initialize()`
(handoff → recovery → deferred recovery → inventory) followed by `become_leader`'s
topology confirmation is *exactly* what that test walks.

**The fresh-seed phase is handled.** `seed_baseline` creates the row **born
acknowledged**, so `epoch seed` lands on a *complete* baseline, never the
unacknowledged epoch the incident was about. Migration 129 still seeds NULL acks
for a genuinely fresh install, but that self-heals through the startup gates and
is covered by the existing regression test — changing it would delete that
coverage for a cosmetic gain, so this PR leaves it alone.

### The actual defect: a live promotion resets gates nothing reopens

Production is configured **`mode: observe`, `maxBuildTaskRuns: 3`** with the row
absent, so its controller is a benign standalone Observe that never denies. Then:

1. Operator runs `epoch seed` → durable state reads `RequiredFailClosed`.
2. The periodic handoff tick sees `mode() != Enforce` and calls
   **`require_enforcement()`**, which resets the journal, inventory, **and
   topology** gates.
3. Those gates are walked only by `initialize()` and `become_leader()` — neither
   runs again in a live process.
4. The controller parks fail-closed **forever**, denying everything with
   `occupancy 0 reached cap 3`. Only a pod restart recovers it.

This is why the incident happened *despite* #2264 landing the day before. The call
site was never missing. **The live promotion path resets the gates with nothing
left to reopen them.**

### Fix

After a live promotion, re-walk the gates. The journal and Kubernetes gates are
**genuinely re-run**, never asserted. The topology gate cannot be re-derived from
a check — it encodes "this process holds the coordinator advisory lock" — so it is
re-asserted **only if this process already confirmed it**, via a new
`build_admission_topology_confirmed` flag. A standby leaves it false and stays
fail-closed at `TopologyPending`, preserving the single-active writer invariant.
The projection is re-read afterwards so a now-healthy controller acknowledges in
the same pass instead of waiting up to 5 minutes.

### Proof: real seams, and every control mutation-verified

No existing test joined the two seams — each covered one side with a stand-in:

| Test | Stand-in |
|---|---|
| `EpochWorld::leader_tick` (djinn-coordinator) | **re-implements** `finalize_build_admission_handoff` |
| `process_lease_tests` (djinn-agent) | holds the decision in a `Mutex<InvocationLiftDecision>` |
| `admin.rs` tests | bare repo with a hand-written `acknowledge` |

The 5 new tests compose **only real seams** against a real Postgres database: the
migration-seeded row, the ordered startup gates, the real
`confirm_build_admission_topology`, the real `finalize_build_admission_handoff`,
the real `run_admin_command` CLI, and the real `evaluate_invocation_lift`.

Blocker eleven shipped because its test asserted only `lifts.is_empty()` — which
the defect satisfied. Asserting `Unleased` everywhere repeats that mistake, since
`Unleased` is also what a broken rollout returns. So each stage asserts the
**positive** outcome and each non-lifting stage a **distinct** reason: v1 `Off` →
`Shadow` → enforce-parked-in-baseline → overlap-without-the-v0-ack → **`Lift`**.

Every control fails independently:

| Reintroduced defect | Result |
|---|---|
| drop `mark_topology_ready()` from the production call site | 3 tests fail (`TopologyPending != Healthy`) |
| `seed_baseline` seeds a NULL ack | only the seed test fails |
| `ForwardOverlap` no longer lifts | only stage 5 fails (`Unleased != Lift`) |
| collapse `Shadow` into `Unleased` | only stage 2 — **the trap: "assert Unleased everywhere" passes this** |
| **the wedge fix removed** | only the live-reseed test fails (`JournalRecoveryIncomplete`) |
| **topology re-asserted unconditionally** | only the standby test fails — the single-writer invariant |

The wedge test pins the incident's exact `Denied { occupancy: 0, cap: 3 }`, proves
no gate short of topology may acknowledge, and proves a leader tick cannot launder
a missing gate into an ack.

### Also fixed

A materially wrong comment claiming the handoff loop "runs only on the leader
(started inside `become_leader`)". It is started from
`initialize_build_admission_handoff`, i.e. on **every pod**. Single-writer safety
comes from the readiness gate, not the spawn site — the invariant holds, the
stated reason for it did not.

## Verification

- **Full `djinn-server` lib suite: 609/609 pass** (real Postgres), including the
  25 admission tests; 107 coordinator `build_admission` tests green
- `cargo clippy -p djinn-server --lib --all-features --tests` clean; `cargo fmt` clean
- `scripts/check-file-size.sh`: 0 oversized (new file 660 lines / 26,448 bytes,
  inside 1500 / 51200; nothing of substance added to the oversize `state/mod.rs`)

Note for anyone reproducing locally: `server::tests::debug::test_debug_dispatch_state_does_not_mutate`
aborts with a tokio-worker stack overflow under the default 2 MB stack. It is not
a defect and not related to this PR — `quality-gate.yml` sets
`RUST_MIN_STACK: 8388608`, and with that set the whole suite passes. Use
`RUST_MIN_STACK=8388608 cargo nextest run -p djinn-server --lib` locally.

## No production change here

Operator steps are in the task report for the owner to run. Two follow-ups are
recommended and **not** done here: the unretried single-shot inventory gate, and
the unconditional broker round trip for a lift that cannot happen.
