### PR TITLE
fix(dispatch): bind the catalog image on the per-attempt task-run insert

### DIFF
--- a/server/crates/djinn-agent/src/actors/slot/adapter.rs
+++ b/server/crates/djinn-agent/src/actors/slot/adapter.rs
@@ -682,6 +682,55 @@ mod resolve_final_verification_tests {
         }
     }
 
+    /// Seed the same shape, but insert the `task_run` row through
+    /// `TaskRunOutcomeRepository::create_run_for_attempt` — the per-attempt
+    /// insert every real dispatch takes (worker → `create_task_run` RPC →
+    /// `DirectServices`). `fixture` above uses `TaskRunRepository::create`,
+    /// which binds `catalog_image_id`; that divergence between the two insert
+    /// paths is exactly why the production NULL-binding defect shipped green.
+    async fn fixture_via_attempt_dispatch(workspace_path: Option<&str>) -> Fixture {
+        let db = create_test_db();
+        let project = create_test_project(&db).await;
+        let epic = create_test_epic(&db, &project.id).await;
+        let task = create_test_task(&db, &project.id, &epic.id).await;
+        let attempt = djinn_db::TaskAttemptRepository::new(db.clone())
+            .create_or_get_pending(djinn_db::CreateTaskAttemptParams {
+                id: &uuid::Uuid::now_v7().to_string(),
+                task_id: &task.id,
+                role: "worker",
+                dispatch_key: "final-verification-attempt-dispatch",
+                session_id: None,
+                attempt_seq: None,
+                dispatch_owner_incarnation_id: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .expect("allocate the exact attempt dispatch allocates");
+        let task_run_id = uuid::Uuid::now_v7().to_string();
+        djinn_db::repositories::task_run_outcome::TaskRunOutcomeRepository::new(db.clone())
+            .create_run_for_attempt(
+                CreateTaskRunParams {
+                    id: &task_run_id,
+                    project_id: &project.id,
+                    task_id: &task.id,
+                    trigger_type: "dispatch",
+                    status: Some("starting"),
+                    workspace_path,
+                    mirror_ref: None,
+                    dispatch_group_id: None,
+                },
+                &attempt.id,
+            )
+            .await
+            .expect("per-attempt dispatch insert");
+        Fixture {
+            agent: agent_context_from_db(db, CancellationToken::new()),
+            project_id: project.id,
+            task_id: task.id,
+            task_run_id,
+        }
+    }
+
     async fn run_git(worktree: &std::path::Path, args: &[&str]) {
         djinn_git::run_git_command_in(worktree, args.iter().map(|arg| (*arg).to_owned()).collect())
             .await
@@ -931,6 +980,55 @@ mod resolve_final_verification_tests {
                 panic!("verification must never substitute a project image selected after dispatch")
             }
         }
+    }
+
+    /// Production-incident regression: every real dispatch inserts its
+    /// `task_runs` row through the per-attempt path, which omitted
+    /// `catalog_image_id`. With a non-empty `final_verification` plan applied,
+    /// that NULL binding made this gate unsatisfiable — it returned
+    /// `task run has no bound catalog image`, `submit_work` was hard-blocked by
+    /// the same error, and djinn escalated instead of submitting finished work.
+    /// A run created the way dispatch creates it must reach the gate and
+    /// resolve material against the image bound at dispatch.
+    #[tokio::test]
+    async fn attempt_dispatched_run_reaches_verification_with_its_bound_catalog_image() {
+        let worktree = initialized_worktree().await;
+        let fx = fixture_via_attempt_dispatch(Some(
+            worktree.path().to_str().expect("worktree path is UTF-8"),
+        ))
+        .await;
+        configure_final_verification_plan(&fx).await;
+
+        // Assert the consequence first: an unbound run reproduces the exact
+        // production failure here, so a regression names the observed symptom
+        // rather than only the missing column.
+        let material = match resolve(&fx).await {
+            Ok(material) => material,
+            Err(detail) => panic!(
+                "a dispatched run with a configured plan must reach verification, got {detail}"
+            ),
+        }
+        .expect("a configured plan must not be a typed skip");
+        assert_eq!(material.execution_request.worktree, worktree.path());
+        assert_eq!(material.required_checks, vec!["lint"]);
+
+        // The bound value is the project's selection snapshotted at dispatch —
+        // not a read-time substitution, which is why the mismatch check inside
+        // the resolver stays satisfiable rather than bypassed.
+        let bound = TaskRunRepository::new(fx.agent.db.clone())
+            .catalog_image_id(&fx.task_run_id)
+            .await
+            .expect("read dispatch-bound catalog image");
+        let selected = ImageRepository::new(fx.agent.db.clone())
+            .resolve_for_project(&fx.project_id)
+            .await
+            .expect("resolve the project catalog selection")
+            .expect("the fixture project selects a catalog image");
+        assert_eq!(
+            bound.as_deref(),
+            Some(selected.id.as_str()),
+            "the per-attempt dispatch insert must bind the project's selected catalog image"
+        );
     }
 
     /// A configured plan reads the path persisted onto a pod-shaped NULL row.

--- a/server/crates/djinn-db/src/repositories/task_run_outcome.rs
+++ b/server/crates/djinn-db/src/repositories/task_run_outcome.rs
@@ -118,7 +118,24 @@ impl TaskRunOutcomeRepository {
                 .map_err(|_| DbError::InvalidData("dispatch_group_id must be a UUID".to_owned()))?;
         }
         let mut tx = self.db.pool().begin().await?;
-        sqlx::query("INSERT INTO task_runs (id, project_id, task_id, trigger_type, status, workspace_path, mirror_ref, dispatch_group_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)")
+        // Catalog authorization is bound at dispatch, never re-selected from a
+        // mutable project at read time. This per-attempt insert must therefore
+        // bind `catalog_image_id` with exactly the same semantics as
+        // [`crate::repositories::task_run::TaskRunRepository::create`]: the
+        // project's currently selected image, snapshotted inside this
+        // transaction so a rolled-back run leaves no partial binding. Omitting
+        // it left every real dispatch with a NULL binding, which fails the
+        // final-verification completion boundary closed.
+        //
+        // Runtime query (not the macro): `catalog_image_id` evolves with the
+        // task-run schema and must not require regenerating sqlx offline
+        // metadata.
+        sqlx::query(
+            "INSERT INTO task_runs
+                (id, project_id, task_id, trigger_type, status, workspace_path, mirror_ref, dispatch_group_id, catalog_image_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
+                (SELECT selected_image_id FROM projects WHERE id = $2))",
+        )
             .bind(params.id).bind(params.project_id).bind(params.task_id).bind(params.trigger_type)
             .bind(status).bind(params.workspace_path).bind(params.mirror_ref).bind(params.dispatch_group_id).execute(&mut *tx).await?;
         let attempt: Option<(String, Option<String>, i32)> = sqlx::query_as(
@@ -637,6 +654,193 @@ mod tests {
             Some("not_applicable")
         );
         assert_eq!(no_review_fact.merge_queue_result.as_deref(), Some("passed"));
+    }
+
+    /// Production-incident regression: `create_run_for_attempt` is the insert
+    /// every real dispatch takes, and it omitted `catalog_image_id`. Every
+    /// dispatched run therefore reached the final-verification completion
+    /// boundary with a NULL binding and hard-failed with `task run has no
+    /// bound catalog image`, so no work could be submitted while a project had
+    /// a non-empty `final_verification` plan. The binding must match
+    /// [`crate::repositories::task_run::TaskRunRepository::create`] exactly:
+    /// the project's currently selected catalog image, snapshotted at insert.
+    #[tokio::test]
+    async fn per_attempt_run_creation_binds_the_projects_selected_catalog_image() {
+        let db = Database::open_in_memory().unwrap();
+        let (project_id, task_id) = create_task(&db).await;
+
+        let images = crate::repositories::image::ImageRepository::new(db.clone());
+        let image_id = format!(
+            "catalog-{}",
+            &uuid::Uuid::now_v7().simple().to_string()[..16]
+        );
+        images
+            .create(&image_id, "rust-node", None, "{}")
+            .await
+            .expect("register catalog image");
+        images
+            .set_project_image(&project_id, Some(&image_id))
+            .await
+            .expect("select catalog image for project");
+
+        let attempt = TaskAttemptRepository::new(db.clone())
+            .create_or_get_pending(CreateTaskAttemptParams {
+                id: &uuid::Uuid::now_v7().to_string(),
+                task_id: &task_id,
+                role: "worker",
+                dispatch_key: "catalog-binding-at-dispatch",
+                session_id: None,
+                attempt_seq: None,
+                dispatch_owner_incarnation_id: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .expect("allocate exact attempt");
+
+        let run_id = uuid::Uuid::now_v7().to_string();
+        TaskRunOutcomeRepository::new(db.clone())
+            .create_run_for_attempt(
+                CreateTaskRunParams {
+                    id: &run_id,
+                    project_id: &project_id,
+                    task_id: &task_id,
+                    trigger_type: TaskRunTrigger::NewTask.as_str(),
+                    status: None,
+                    workspace_path: None,
+                    mirror_ref: None,
+                    dispatch_group_id: None,
+                },
+                &attempt.id,
+            )
+            .await
+            .expect("per-attempt dispatch insert");
+
+        let runs = crate::repositories::task_run::TaskRunRepository::new(db.clone());
+        assert_eq!(
+            runs.catalog_image_id(&run_id)
+                .await
+                .expect("read dispatch-bound catalog image")
+                .as_deref(),
+            Some(image_id.as_str()),
+            "the per-attempt dispatch insert must bind the project's selected catalog image"
+        );
+
+        // Negative control: the value is read from `projects.selected_image_id`
+        // at insert time, not inherited from a sibling run. With the selection
+        // cleared there is nothing to bind and the insert must not invent one —
+        // NULL stays the honest legacy/non-catalog marker the completion
+        // boundary fails closed on.
+        images
+            .set_project_image(&project_id, None)
+            .await
+            .expect("clear catalog selection");
+        let unselected_run_id = {
+            let attempt = TaskAttemptRepository::new(db.clone())
+                .create_or_get_pending(CreateTaskAttemptParams {
+                    id: &uuid::Uuid::now_v7().to_string(),
+                    task_id: &task_id,
+                    role: "worker",
+                    dispatch_key: "catalog-binding-unselected",
+                    session_id: None,
+                    attempt_seq: None,
+                    dispatch_owner_incarnation_id: None,
+                    dispatch_group_id: None,
+                })
+                .await
+                .expect("allocate exact attempt");
+            let run_id = uuid::Uuid::now_v7().to_string();
+            TaskRunOutcomeRepository::new(db.clone())
+                .create_run_for_attempt(
+                    CreateTaskRunParams {
+                        id: &run_id,
+                        project_id: &project_id,
+                        task_id: &task_id,
+                        trigger_type: TaskRunTrigger::NewTask.as_str(),
+                        status: None,
+                        workspace_path: None,
+                        mirror_ref: None,
+                        dispatch_group_id: None,
+                    },
+                    &attempt.id,
+                )
+                .await
+                .expect("per-attempt dispatch insert without a project selection");
+            run_id
+        };
+        assert_eq!(
+            runs.catalog_image_id(&unselected_run_id)
+                .await
+                .expect("read dispatch-bound catalog image"),
+            None,
+            "a project with no catalog selection must bind nothing"
+        );
+    }
+
+    /// The binding is snapshotted inside the same transaction as the attempt
+    /// association, so a rejected association leaves no partially bound run
+    /// behind for a later retry to inherit.
+    #[tokio::test]
+    async fn a_rejected_attempt_association_leaves_no_bound_run_behind() {
+        let db = Database::open_in_memory().unwrap();
+        let (project_id, task_id) = create_task(&db).await;
+        let (_other_project_id, other_task_id) = create_task(&db).await;
+
+        let images = crate::repositories::image::ImageRepository::new(db.clone());
+        let image_id = format!(
+            "catalog-{}",
+            &uuid::Uuid::now_v7().simple().to_string()[..16]
+        );
+        images
+            .create(&image_id, "rollback", None, "{}")
+            .await
+            .unwrap();
+        images
+            .set_project_image(&project_id, Some(&image_id))
+            .await
+            .unwrap();
+
+        // An attempt belonging to a different task contradicts the run's task,
+        // which is rejected after the run row was inserted in this transaction.
+        let foreign_attempt = TaskAttemptRepository::new(db.clone())
+            .create_or_get_pending(CreateTaskAttemptParams {
+                id: &uuid::Uuid::now_v7().to_string(),
+                task_id: &other_task_id,
+                role: "worker",
+                dispatch_key: "catalog-binding-rollback",
+                session_id: None,
+                attempt_seq: None,
+                dispatch_owner_incarnation_id: None,
+                dispatch_group_id: None,
+            })
+            .await
+            .unwrap();
+
+        let run_id = uuid::Uuid::now_v7().to_string();
+        TaskRunOutcomeRepository::new(db.clone())
+            .create_run_for_attempt(
+                CreateTaskRunParams {
+                    id: &run_id,
+                    project_id: &project_id,
+                    task_id: &task_id,
+                    trigger_type: TaskRunTrigger::NewTask.as_str(),
+                    status: None,
+                    workspace_path: None,
+                    mirror_ref: None,
+                    dispatch_group_id: None,
+                },
+                &foreign_attempt.id,
+            )
+            .await
+            .expect_err("a contradictory attempt association must be rejected");
+
+        assert!(
+            crate::repositories::task_run::TaskRunRepository::new(db)
+                .get(&run_id)
+                .await
+                .expect("read rolled-back run")
+                .is_none(),
+            "the rejected transaction must leave no task-run row, bound or otherwise"
+        );
     }
 }
 


### PR DESCRIPTION
## The defect

Every task run dispatched in production had `task_runs.catalog_image_id = NULL`. With a non-empty `final_verification` plan applied, that made **every submission hard-fail** and djinn escalated instead of submitting completed work:

> "the mandatory canonical verification gate twice returned infrastructure error `task run has no bound catalog image`, and submit_work is hard-blocked by that same verification error."

There are two insert paths into `task_runs`:

| Path | Binds `catalog_image_id`? | Live? |
|---|---|---|
| `TaskRunRepository::create` | yes | yes (non-attempt callers) |
| `TaskRunOutcomeRepository::create_run_for_attempt` | **no** | yes — the per-attempt dispatch path |

The per-attempt path is what real dispatches take: in-pod supervisor → `SupervisorServices::create_task_run` RPC → `DirectServices::create_task_run` (`direct_services.rs:1098`) → `create_run_for_attempt`. Migration `148_task_run_catalog_image.sql` declares the column `VARCHAR(36) NULL` with no `DEFAULT`, so the omitted column defaulted to NULL on every dispatch.

The consumer that fails closed is `resolve_final_verification_for_task_run` (`slot/adapter.rs`), which reads the dispatch-bound image, `.ok_or("task run has no bound catalog image")`, then cross-checks it against `ImageRepository::resolve_for_project`.

## The fix

`create_run_for_attempt` now binds `catalog_image_id` from `projects.selected_image_id` inside the existing transaction, with exactly the semantics of `TaskRunRepository::create`.

The immutability contract is **unchanged**. The value is snapshotted at dispatch; the read-time mismatch check stays; no read-time fallback to mutable project state is introduced. Binding inside the transaction means a rolled-back run cannot leave a partial binding.

The insert stays a runtime `sqlx::query` (not the macro), so `catalog_image_id` still requires no sqlx offline metadata — no generated artifact changes in this PR.

## Why this shipped green

Both existing fixtures that assert the binding — `slot::adapter::resolve_final_verification_tests::fixture` and `agent-worker/tests/in_pod_drive.rs` — insert the run via `TaskRunRepository::create`, the path that was already correct. No test exercised the binding through the path production actually uses.

## Tests (both fail against unpatched code)

1. `djinn-db … per_attempt_run_creation_binds_the_projects_selected_catalog_image` — asserts the side effect: `catalog_image_id(run_id)` returns the project's selected image. Includes a negative control (selection cleared → binds nothing, so the value is genuinely read from `projects.selected_image_id` at insert rather than inherited).
2. `djinn-agent … attempt_dispatched_run_reaches_verification_with_its_bound_catalog_image` — end-to-end consequence: a run created through the attempt path, with a non-empty `final_verification` plan, reaches the gate and resolves material. Neutralizing the fix reproduces the exact production string `task run has no bound catalog image`.
3. `a_rejected_attempt_association_leaves_no_bound_run_behind` — the transactional property.

Neutralization output is in the task report.

## Audit of the other insert paths

| Site | Verdict |
|---|---|
| `task_run_outcome.rs:121` | **production — fixed here** |
| `warm_base_activity.rs:142` | test-only (`#[cfg(test)]` at line 97) — no change |
| `llm_call_attempt.rs:323` | test-only (`#[cfg(test)]` at line 288) — no change |
| `attempt_lifecycle.rs:626` | test-only (`#[cfg(test)]` at line 466), not a production caller |

## Backfill

No data migration. Historical NULL is the honest "legacy or non-catalog dispatch" marker the code already documents; retroactively filling it from today's project selection would assert an authorization that never happened and defeat the drift check. Runs in flight across the deploy stay NULL and must be re-dispatched. Re-enable the `final_verification` plan only after this is deployed and pre-fix runs have drained.