### PR TITLE
fix(goxi): make the brokered cgroup lift agree on one fence, and degrade instead of failing the shell

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -577,6 +577,15 @@ jobs:
       # rather than by reading `cpu.max` back — so a run that executes zero of
       # its proofs must fail rather than look green (task 7deu).
       LEASE_LIFECYCLE_EXPECTED_PROOFS: "1"
+      # Number of `#[ignore]`d proofs `brokered_lease_lift_boundary.rs` declares.
+      # `delegated_cpu_lease_lifecycle` calls `Launcher::fenced_lift` directly;
+      # production does not — it sends a `LIFT` control frame that the privileged
+      # broker validates first. That gap is exactly how goxi blocker 14 shipped:
+      # #2627's test proved `fenced_lift` was CALLED, the broker then REFUSED the
+      # control on a fence mismatch, and every armed invocation ran its whole life
+      # pinned at `cpu.max=[25000 100000]`. This suite drives the real broker
+      # protocol end to end and asserts the kernel transition.
+      BROKERED_LIFT_EXPECTED_PROOFS: "1"
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install
@@ -622,6 +631,7 @@ jobs:
           cargo test -p djinn-cgroup-launcher \
             --test kernel_boundary_under_rendered_context \
             --test delegated_cpu_lease_lifecycle \
+            --test brokered_lease_lift_boundary \
             --test brokered_git_trust \
             --no-run --message-format=json > "$RUNNER_TEMP/build.json"
           binary=$(jq -r 'select(.executable != null and .target.name == "kernel_boundary_under_rendered_context") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
@@ -636,6 +646,12 @@ jobs:
             exit 1
           fi
           echo "lease=$lease" >> "$GITHUB_OUTPUT"
+          brokered_lift=$(jq -r 'select(.executable != null and .target.name == "brokered_lease_lift_boundary") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
+          if [ -z "$brokered_lift" ] || [ ! -x "$brokered_lift" ]; then
+            echo "::error::could not locate the built brokered lift-boundary proof binary"
+            exit 1
+          fi
+          echo "brokered_lift=$brokered_lift" >> "$GITHUB_OUTPUT"
           git_trust=$(jq -r 'select(.executable != null and .target.name == "brokered_git_trust") | .executable' "$RUNNER_TEMP/build.json" | tail -1)
           if [ -z "$git_trust" ] || [ ! -x "$git_trust" ]; then
             echo "::error::could not locate the built brokered git-trust proof binary"
@@ -693,6 +709,33 @@ jobs:
             exit 1
           fi
           echo "::notice::per-invocation CPU lease proven: $passed/$LEASE_LIFECYCLE_EXPECTED_PROOFS privileged proofs executed"
+      - name: Prove the BROKER accepts the lift and the kernel honours it
+        run: |
+          set -euo pipefail
+          # goxi launcher blocker 14. The step above calls
+          # `Launcher::fenced_lift` directly; a task-run Pod never can — the
+          # worker holds a `UnixBrokerClient` and the lift is a `LIFT` control
+          # frame the privileged broker validates before it touches cgroupfs.
+          # This suite drives the real `UnixBrokerServer`/`UnixBrokerClient`
+          # protocol over a real socket against a real delegated cgroup2 root,
+          # refuses a wrong fence (so the accepted one proves something), and
+          # then reads `cpu.max` back FROM THE KERNEL either side of the
+          # accepted lift, asserting `25000 100000` -> `400000 100000` plus the
+          # measured throughput multiple on `cpu.stat`.
+          #
+          # --test-threads 1 because the proof's capability drop is irreversible
+          # and process-wide.
+          docker run --rm --privileged --cgroupns=private \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            ubuntu:24.04 \
+            bash -c 'mkdir -p /workspace && exec "$0" --ignored --test-threads 1 --nocapture' \
+            "${{ steps.build.outputs.brokered_lift }}" 2>&1 | tee "$RUNNER_TEMP/brokered-lift.log"
+          passed=$(sed -n 's/^test result: ok\. \([0-9]*\) passed.*/\1/p' "$RUNNER_TEMP/brokered-lift.log" | tail -1)
+          if [ "${passed:-0}" != "$BROKERED_LIFT_EXPECTED_PROOFS" ]; then
+            echo "::error::the brokered lift lane executed ${passed:-0} proofs but $BROKERED_LIFT_EXPECTED_PROOFS are declared; the broker is NOT proven to accept the lift control by this run"
+            exit 1
+          fi
+          echo "::notice::brokered cgroup lift proven: $passed/$BROKERED_LIFT_EXPECTED_PROOFS privileged proofs executed"
       - name: Prove a brokered child can run git in a worker-owned worktree
         run: |
           set -euo pipefail

--- a/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
+++ b/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
@@ -41,6 +41,8 @@ djinn-server epoch seed                  # create the row when it is ABSENT (ide
 djinn-server epoch advance --cap N       # perform the next safe FORWARD step
 djinn-server epoch set-cap --cap N        # change the reference cap (epoch-fenced)
 djinn-server epoch rollback --cap N        # perform the next safe ROLLBACK step
+                                           #   (defined from EVERY phase; see
+                                           #    "Aborting a forward overlap")
 djinn-server epoch kill-switch --cap N      # rollback from invocation-primary, urgent
 ```
 
@@ -239,12 +241,86 @@ task-run Pod**. Verify the pod, not the row.
 
 ## Aborting a forward overlap
 
-The phase machine is a strict forward cycle, so you cannot advance
-`forward_overlap` backward. If you must abort a cutover **before**
-`invocation_primary`, use `epoch set-cap`/mode change to set `v1 = off` while
-`v0` stays `enforce`: v0 remains the sole enforcing authority (safe, fail-closed)
-and no v1 quota is lifted. Re-arm shadow/overlap later to resume. A full reverse
-rollback (`rollback_overlap`) is only defined from `invocation_primary`.
+`djinn-server epoch rollback` handles this. It used to answer
+
+```
+no rollback step is defined from phase ForwardOverlap
+```
+
+which left an armed rollout with **no reverse gear**: the operator's only
+mitigation was setting `cgroupLauncher.mode: disabled` in Helm and redeploying
+while the durable row stayed at `forward_overlap` / `v1 enforce` (goxi launcher
+blocker 14, second defect). The workaround this section used to prescribe —
+"use `epoch set-cap`/mode change to set `v1 = off`" — named a command that does
+not exist: `set-cap` deliberately **preserves** the current modes, and there is
+no mode-setting subcommand.
+
+`rollback` now takes the correct step from every phase:
+
+| phase | `epoch rollback` does |
+| --- | --- |
+| `emergency_primary`, `v1 = off` | nothing — already at baseline |
+| `emergency_primary`, `v1 = shadow`/`enforce` | `abort_v1_arming`: set `v1 = off` |
+| `forward_overlap` | `abort_v1_arming`: set `v1 = off` |
+| `invocation_primary` | `arm_rollback`, then `enter_rollback_overlap` |
+| `rollback_overlap` | `complete_rollback` |
+
+### Why aborting the overlap is a mode change, not a phase move
+
+`AdmissionHandoffPhase` is a strict forward **ring** (`legal_next`:
+`emergency_primary → forward_overlap → invocation_primary → rollback_overlap →
+emergency_primary`) with no backward edge at the storage layer, so there is no
+"advance backward" to take.
+
+There does not need to be. Entering `forward_overlap` changes nothing but the
+phase, the epoch and the acks — `arm_overlap` already committed
+`v0 = enforce, v1 = enforce` while still in `emergency_primary`. The overlap's
+only semantic delta is that **v1 begins lifting quota**; v0 never stops
+enforcing. So the exact reverse of that delta is `v1 → off`, committed in place
+at the same phase. After it, `evaluate_invocation_lift` refuses to lift and the
+ring is left free to be driven forward again later (re-arm shadow/overlap to
+resume).
+
+Safety: `abort_v1_arming` requires `v0 = enforce` durably before it will touch
+v1, so the "at least one enforcing authority" invariant holds at every committed
+point. The write is the same epoch-fenced CAS as every other change and clears
+both acks, so the row is `IncompleteEpoch` — v0 `RequiredFailClosed`, v1
+`Unleased` — until the leader re-acknowledges. Fail-closed on both sides
+throughout. Re-running it is a no-op, so a retried rollback step converges.
+
+Unlike `complete_rollback` it does **not** wait for a v0 acknowledgement: it
+never releases an authority, only removes the one that is not primary, and an
+operator reaching for it is by definition aborting a cutover — blocking on an ack
+would withhold the reverse gear in exactly the incident it exists for.
+
+It is deliberately **refused** from `invocation_primary` and `rollback_overlap`
+(`InvalidTransition`): v0 may already be `observe` there, so disabling v1 in
+place could leave zero enforcing authorities. Those phases keep the three-step
+reverse ordering that re-confirms v0 first.
+
+## Alarm: refused cgroup lifts
+
+`djinn_build_admission_lift_rejected_total` counts authorized lifts the
+privileged launcher broker **refused**. Any non-zero value means armed
+invocations are running permanently clamped at the 250m unleased quota (a ~16x
+slowdown): the epoch authorized the escalation, the invocation held a matching
+durable grant, and the kernel-boundary control still came back refused.
+
+The runner **degrades** rather than failing the command — the child keeps running
+clamped — so this counter and its accompanying `tracing::error!`
+(`lease invocation lift REFUSED by the launcher broker`) are the only signal that
+the escalation path is broken. `djinn-agent-worker` exposes no `/metrics`
+endpoint, so in a task-run Pod the log line is what escapes; grep for it.
+
+The error carries a `ControlRejection` category naming *why* the broker refused
+(`Fence`, `Unarmed`, `AlreadyLifted`, `Terminal`, `Nonce`, …). Before goxi
+blocker 14 every refusal was reported as `InvalidControl` — which is a real and
+*different* broker error — and the misattribution cost the whole investigation.
+
+If the category is `Fence`, the worker's `BEGIN` and `LIFT` controls disagree
+about the invocation fence; see `djinn-agent/src/process_broker.rs`. If it is
+`Unarmed`, the leaf was born under an `Unleased` decision and no lift was ever
+possible for it, which points back at the epoch, not the launcher.
 
 ## Reading the shadow window
 

--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -183,7 +183,7 @@ impl ShellLaunchContext {
                         admission_db,
                         "in-pod worker",
                     )),
-                    Arc::new(UnixBrokerLauncher::new(client, 0)),
+                    Arc::new(UnixBrokerLauncher::new(client)),
                     Arc::new(SystemClock::new()),
                 )
                 .with_journal(journal),

--- a/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/brokered_shell_program_tests.rs
@@ -61,7 +61,7 @@ use super::{agent_context_from_db, create_test_db};
 use crate::process::{CgroupLauncherClient, LeaseInvocationRunner, ProcessHandle, command_spec};
 use djinn_cgroup_launcher::{CommandSpec, CpuStat};
 use djinn_core::clock::SystemClock;
-use djinn_supervisor::services::{LeaseFencingToken, TaskInvocationLeaseIdentity};
+use djinn_supervisor::services::TaskInvocationLeaseIdentity;
 use std::io;
 use std::path::Path;
 use std::process::{Command, ExitStatus, Stdio};
@@ -229,7 +229,7 @@ impl ProcessHandle for ProofChild {
     fn sample_cpu(&mut self) -> io::Result<CpuStat> {
         Ok(CpuStat::default())
     }
-    fn fenced_lift(&mut self, _: &LeaseFencingToken) -> io::Result<()> {
+    fn fenced_lift(&mut self) -> io::Result<()> {
         Ok(())
     }
     fn kill(&mut self) -> io::Result<()> {

--- a/server/crates/djinn-agent/src/extension/tests/shell_dispatch_tests.rs
+++ b/server/crates/djinn-agent/src/extension/tests/shell_dispatch_tests.rs
@@ -12,9 +12,7 @@ use crate::file_time::destructive_class::WORKTREE_LOCAL_FILE_MUTATION;
 use crate::process::{CgroupLauncherClient, LeaseInvocationRunner, ProcessHandle};
 use djinn_cgroup_launcher::CpuStat;
 use djinn_core::clock::SystemClock;
-use djinn_supervisor::services::{
-    DurableInvocationLiftAuthority, LeaseFencingToken, TaskInvocationLeaseIdentity,
-};
+use djinn_supervisor::services::{DurableInvocationLiftAuthority, TaskInvocationLeaseIdentity};
 use std::io;
 use std::process::{Command, ExitStatus};
 use std::sync::{Arc, Mutex};
@@ -153,7 +151,7 @@ impl ProcessHandle for BrokerShellHandle {
         })
     }
 
-    fn fenced_lift(&mut self, _: &LeaseFencingToken) -> io::Result<()> {
+    fn fenced_lift(&mut self) -> io::Result<()> {
         self.state.lock().unwrap().lifts += 1;
         Ok(())
     }

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -87,6 +87,11 @@ mod broker;
 /// ignored the `Command` it was handed.
 #[cfg(test)]
 pub(crate) use broker::command_spec;
+/// The SINGLE source of an invocation's broker fence. Exported so a proof reads
+/// the same function the `BEGIN` control does instead of restating the rule —
+/// a second statement of it is exactly how blocker 14 shipped.
+#[cfg(test)]
+pub(crate) use broker::invocation_fence as broker_invocation_fence;
 #[allow(unused_imports)] // constructed by the pending workspace broker composition
 pub(crate) use broker::{CgroupLauncherClient, ProcessHandle, UnixBrokerLauncher, birth_authority};
 
@@ -570,11 +575,16 @@ impl LeaseInvocationRunner {
         let mut deadline = self.clock.now_instant() + config.timeout;
         let (mut queued, mut fence, mut credit_used, mut lease_error) = (false, None, false, None);
         let mut unavailable_responses = 0_u8;
-        // Set once the durable queue ends without capacity for this invocation.
-        // From then on the child runs to its own terminal state at the
-        // launcher's unleased quota and the lease authority is never contacted
-        // again for a grant. See `lease_failure` for why the degrade is
-        // one-way.
+        // Set when this invocation can no longer be escalated: either the
+        // durable queue ended without capacity for it (`lease_failure`), or the
+        // privileged launcher broker REFUSED the one-way cgroup lift. From then
+        // on the child runs to its own terminal state at the launcher's unleased
+        // quota and the lease authority is never contacted again for a grant.
+        // See `lease_failure` for why the degrade is one-way.
+        //
+        // Both causes share one rule: contention or a lease-subsystem defect
+        // makes a command SLOW, never dead. Nothing here kills the child, and
+        // the durable record is still reconciled to terminal after the loop.
         let mut unleased_degrade = false;
         // This variable is assigned only by `terminal_now` or by a service
         // wait that observed terminal intent. Consequently no later response
@@ -765,14 +775,75 @@ impl LeaseInvocationRunner {
                                                 )
                                                 .map_err(LeaseInvocationError::Launcher)?;
                                         }
-                                        child
-                                            .fenced_lift(&token)
-                                            .map_err(LeaseInvocationError::Launcher)?;
-                                        tracing::info!(
-                                            invocation_id = %identity.invocation_id,
-                                            observed_usage_usec = cpu.usage_usec,
-                                            "lease invocation escalated: cgroup quota lifted"
-                                        );
+                                        // A REFUSED LIFT DEGRADES; IT DOES NOT
+                                        // FAIL THE COMMAND.
+                                        //
+                                        // This used to be `?`, so any refusal
+                                        // from the privileged broker became
+                                        // `LeaseInvocationError::Launcher` and
+                                        // failed the whole shell tool call:
+                                        //
+                                        //   ReplyLoop: tool call returned error
+                                        //   tool=shell error=failed to run shell
+                                        //   command: lease invocation failed: …
+                                        //
+                                        // measured in production at 5 failures
+                                        // per 10 launches. That is the worst
+                                        // available coupling: a defect in a
+                                        // *throttling optimisation* took out the
+                                        // agent's ability to run commands at
+                                        // all, and the fallback it denied itself
+                                        // — keep running clamped — is strictly
+                                        // better than dying.
+                                        //
+                                        // It also contradicted the precedent
+                                        // this very runner already sets one arm
+                                        // up: a lost lease QUEUE degrades to
+                                        // continued unleased execution
+                                        // (`lease_failure` → `unleased_degrade`)
+                                        // precisely because contention must make
+                                        // a command slow, never dead. A rejected
+                                        // lift is the same class of event and is
+                                        // now handled the same way.
+                                        //
+                                        // Nothing is swallowed. The child keeps
+                                        // running at the 250m unleased quota it
+                                        // was born at (containment is
+                                        // unaffected: the leaf, its kill path
+                                        // and its cpu.stat are all intact), the
+                                        // failure is logged at ERROR with the
+                                        // broker's refusal category, a telemetry
+                                        // counter records it, and the durable
+                                        // lease is still reconciled to terminal
+                                        // because `fence` is recorded below.
+                                        match child.fenced_lift() {
+                                            Ok(()) => tracing::info!(
+                                                invocation_id = %identity.invocation_id,
+                                                observed_usage_usec = cpu.usage_usec,
+                                                "lease invocation escalated: cgroup quota lifted"
+                                            ),
+                                            Err(error) => {
+                                                djinn_telemetry::build_admission::record_lift_rejected();
+                                                tracing::error!(
+                                                    invocation_id = %identity.invocation_id,
+                                                    task_run_id = %identity.task_run_id,
+                                                    observed_usage_usec = cpu.usage_usec,
+                                                    error = %error,
+                                                    "lease invocation lift REFUSED by the launcher \
+                                                     broker; the command keeps running CLAMPED at \
+                                                     the unleased quota instead of failing. This \
+                                                     is a lease-subsystem defect: the invocation \
+                                                     held a matching durable grant and the epoch \
+                                                     authorized a lift"
+                                                );
+                                                // One-way, exactly like the lost
+                                                // queue: do not re-enter the
+                                                // grant/lift path for an
+                                                // invocation whose one-way lift
+                                                // has already been refused.
+                                                unleased_degrade = true;
+                                            }
+                                        }
                                     }
                                     InvocationLiftDecision::Shadow => {
                                         // Reaching a valid bind means v1 would

--- a/server/crates/djinn-agent/src/process/tests/process_lease_admission_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_admission_tests.rs
@@ -81,7 +81,7 @@ fn lease_authority_without_an_admission_opinion() -> Arc<ScriptedServices> {
 /// Both assertions matter and neither is a status field:
 ///
 /// - `authorities == [Armed]` is the birth quota the broker committed (250m).
-/// - `lifts == [LeaseFencingToken(7)]` is the fenced `cpu.max` raise that the
+/// - `lifts == 1` is the fenced `cpu.max` raise that the
 ///   whole feature exists to perform.
 ///
 /// Asserting only the second would let a regression that never clamps pass;
@@ -114,7 +114,7 @@ async fn armed_epoch_is_born_clamped_and_then_lifted_through_the_in_pod_composit
     );
     assert_eq!(
         *launcher.lifts.lock().unwrap(),
-        vec![LeaseFencingToken(7)],
+        1,
         "the armed epoch reached a matching durable bind, so cpu.max MUST be \
          lifted under the granted fence. An empty vec here is goxi blocker 13: \
          `decision=Unleased authority=Unarmed` against `ForwardOverlap · epoch 3 \
@@ -154,7 +154,7 @@ async fn absent_row_still_fails_closed_through_the_in_pod_composition() {
         launcher.authorities(),
         vec![djinn_cgroup_launcher::LeaseAuthority::Unarmed]
     );
-    assert!(launcher.lifts.lock().unwrap().is_empty());
+    assert_eq!(*launcher.lifts.lock().unwrap(), 0);
 }
 
 /// The wrong-database hazard, end to end.
@@ -206,7 +206,7 @@ async fn a_non_platform_database_fails_closed_instead_of_lifting() {
         "a failed epoch read must never be treated as authorization"
     );
     assert!(
-        launcher.lifts.lock().unwrap().is_empty(),
+        *launcher.lifts.lock().unwrap() == 0,
         "a failed epoch read must never lift cpu.max"
     );
 }
@@ -253,7 +253,7 @@ async fn shadow_epoch_binds_but_never_lifts() {
     assert_eq!(services.queue_calls.load(Ordering::SeqCst), 1);
     assert_eq!(services.grant_calls.load(Ordering::SeqCst), 1);
     assert!(
-        launcher.lifts.lock().unwrap().is_empty(),
+        *launcher.lifts.lock().unwrap() == 0,
         "shadow epoch must never lift cpu.max"
     );
     // Shadow is the one decision that clamps ON PURPOSE: it is an observation
@@ -316,7 +316,7 @@ async fn unleased_epoch_is_born_unclamped_because_no_grant_can_ever_lift_it() {
     run.await.unwrap().unwrap();
     assert_eq!(services.grant_calls.load(Ordering::SeqCst), 1);
     assert!(
-        launcher.lifts.lock().unwrap().is_empty(),
+        *launcher.lifts.lock().unwrap() == 0,
         "unleased epoch must never lift cpu.max"
     );
     assert_eq!(

--- a/server/crates/djinn-agent/src/process/tests/process_lease_broker_lift_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_broker_lift_tests.rs
@@ -1,0 +1,360 @@
+//! The production broker composition, driven against a REAL broker.
+//!
+//! # The coverage gap this closes (goxi launcher blocker 14)
+//!
+//! Every other test in this tree drives a `CgroupLauncherClient` **double**. A
+//! double's `fenced_lift` returns `Ok(())`, so the only thing those tests can
+//! observe is that the runner *called* it. #2627 shipped on exactly that
+//! assertion — plus "the birth authority was `Armed`" — and both were true in
+//! production while the privileged broker refused every single lift:
+//!
+//! ```text
+//! error=failed to run shell command: lease invocation failed:
+//!       Launcher(Custom { kind: Other, error: InvalidControl })
+//! ```
+//!
+//! The cause was a fence the composition could never satisfy.
+//! [`UnixBrokerLauncher`] sent a launcher-wide constant `0` in the `BEGIN`
+//! control that BORE the leaf, and the coordinator's durable
+//! `build_lease_fencing_token_seq` value in the `LIFT` control. That sequence
+//! starts at 1, so the two were never equal and `Launcher::fenced_lift` returned
+//! `FenceMismatch` — 100% of the time, deterministically, for every armed
+//! invocation.
+//!
+//! So these tests take the real [`UnixBrokerLauncher`] and the real
+//! [`UnixBrokerClient`], connect them to a real [`UnixBrokerServer`] over a real
+//! Unix socket, and assert on the `cpu.max` values the broker's launcher
+//! actually wrote through its filesystem seam. Nothing here can pass while the
+//! broker refuses the control.
+//!
+//! The kernel half — that the written line is one cgroup2 really honours, and
+//! that the leaf's throughput multiplies — is
+//! `djinn-cgroup-launcher/tests/brokered_lease_lift_boundary.rs`, run by the
+//! `launcher-kernel-boundary` CI lane.
+
+use super::*;
+use djinn_cgroup_launcher::broker::{Broker, BrokerConfig, OsNonceSource};
+use djinn_cgroup_launcher::child::{WorkerDumpability, prepare_worker_readiness};
+use djinn_cgroup_launcher::transport::{UnixBrokerClient, UnixBrokerServer};
+use djinn_cgroup_launcher::{
+    CgroupFs, CgroupMode, ChildProcess, ControlRejection, Error as LauncherError, Invocation,
+    Launcher, LauncherConfig, LeaseAuthority, Readiness, SpawnIntoCgroup,
+};
+use std::collections::BTreeSet;
+use std::os::fd::RawFd;
+use std::os::unix::net::UnixStream;
+
+/// The two `cpu.max` lines the transition runs between, as the shipped defaults
+/// render them.
+const UNLEASED_CPU_MAX: &str = "25000 100000";
+const LEASED_CPU_MAX: &str = "400000 100000";
+
+/// Every `write_leaf` the broker's launcher performed, in order.
+type Writes = Arc<Mutex<Vec<(String, String)>>>;
+
+/// Filesystem seam that records what the PRIVILEGED side wrote.
+///
+/// It is not a stand-in for the broker: the broker, its authentication, its
+/// nonce rotation, its invocation binding and `Launcher::fenced_lift`'s fence
+/// check are all real here. Only the cgroupfs underneath is recorded rather
+/// than mounted, because a task-run Pod's kernel boundary is proven in the
+/// privileged lane and cannot be mounted from a unit-test shard.
+struct RecordingFs {
+    writes: Writes,
+    next_fd: RawFd,
+    /// Latest value per (fd, file), so `read_leaf` answers what was written.
+    files: std::collections::HashMap<(RawFd, String), String>,
+}
+
+impl RecordingFs {
+    fn new(writes: Writes) -> Self {
+        Self {
+            writes,
+            next_fd: 100,
+            files: std::collections::HashMap::new(),
+        }
+    }
+}
+
+impl CgroupFs for RecordingFs {
+    fn readiness(&self) -> Result<Readiness, LauncherError> {
+        Ok(Readiness {
+            mode: CgroupMode::V2,
+            root_writable: true,
+            owner_uid: unsafe { libc::geteuid() },
+            delegated_controllers: BTreeSet::from(["cpu".to_owned()]),
+        })
+    }
+    fn create_direct_child(&mut self, _: &str) -> Result<RawFd, LauncherError> {
+        self.next_fd += 1;
+        Ok(self.next_fd)
+    }
+    fn write_leaf(&mut self, fd: RawFd, file: &str, value: &str) -> Result<(), LauncherError> {
+        self.writes
+            .lock()
+            .unwrap()
+            .push((file.to_owned(), value.to_owned()));
+        self.files.insert((fd, file.to_owned()), value.to_owned());
+        Ok(())
+    }
+    fn read_leaf(&mut self, fd: RawFd, file: &str) -> Result<String, LauncherError> {
+        if file == "cgroup.events" {
+            return Ok("populated 0".to_owned());
+        }
+        Ok(self
+            .files
+            .get(&(fd, file.to_owned()))
+            .cloned()
+            .unwrap_or_else(|| "usage_usec 0".to_owned()))
+    }
+    fn remove_leaf(&mut self, _: RawFd, _: &str) -> Result<(), LauncherError> {
+        Ok(())
+    }
+}
+
+/// Spawn seam that records the [`Invocation`] the leaf was BORN with, so the
+/// birth fence is observable independently of what the lift later presents.
+struct RecordingSpawn {
+    born: Arc<Mutex<Vec<Invocation>>>,
+}
+
+impl SpawnIntoCgroup for RecordingSpawn {
+    fn spawn_into_cgroup(
+        &mut self,
+        _: RawFd,
+        invocation: &Invocation,
+        _: &djinn_cgroup_launcher::CommandSpec,
+    ) -> Result<ChildProcess, LauncherError> {
+        self.born.lock().unwrap().push(invocation.clone());
+        Ok(ChildProcess {
+            pid: 1,
+            stdout: -1,
+            stderr: -1,
+        })
+    }
+}
+
+/// Dumpability double. The real `prctl(PR_SET_DUMPABLE, 0)` is process-wide and
+/// this binary runs many unrelated tests in the same process; the privileged
+/// lane exercises the real seam.
+struct TestDumpability;
+impl WorkerDumpability for TestDumpability {
+    fn set_non_dumpable(&mut self) -> Result<(), LauncherError> {
+        Ok(())
+    }
+    fn get_dumpable(&mut self) -> Result<i32, LauncherError> {
+        Ok(0)
+    }
+}
+
+const CREDENTIAL: &[u8] = b"broker-lift-test-credential";
+
+fn broker(
+    writes: Writes,
+    born: Arc<Mutex<Vec<Invocation>>>,
+) -> Broker<RecordingFs, RecordingSpawn> {
+    let launcher = Launcher::new(
+        RecordingFs::new(writes),
+        RecordingSpawn { born },
+        LauncherConfig::new(None, None, unsafe { libc::geteuid() }).expect("launcher config"),
+    )
+    .expect("launcher");
+    Broker::new(
+        launcher,
+        BrokerConfig {
+            worker_pid: std::process::id(),
+            worker_uid: unsafe { libc::geteuid() },
+            worker_gid: unsafe { libc::getegid() },
+            pod_credential: CREDENTIAL.to_vec(),
+        },
+        OsNonceSource,
+    )
+    .expect("broker")
+}
+
+fn connected_client(stream: UnixStream) -> UnixBrokerClient {
+    let mut client =
+        UnixBrokerClient::connect(stream, CREDENTIAL).expect("the broker must authenticate us");
+    client
+        .ready(prepare_worker_readiness(&mut TestDumpability).expect("readiness"))
+        .expect("READY");
+    client
+}
+
+fn identity() -> TaskInvocationLeaseIdentity {
+    TaskInvocationLeaseIdentity {
+        task_id: "task".to_owned(),
+        task_run_id: "run".to_owned(),
+        invocation_id: uuid::Uuid::now_v7().to_string(),
+    }
+}
+
+fn shell_command() -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg("true").current_dir("/workspace");
+    command
+}
+
+/// THE regression test.
+///
+/// The real production composition — `UnixBrokerLauncher` -> `UnixBrokerClient`
+/// -> Unix socket -> `UnixBrokerServer` -> `Broker` -> `Launcher` — must be able
+/// to lift the leaf it just created. Before the fix this fails at
+/// `handle.fenced_lift()` with the broker's refusal, because the `BEGIN` that
+/// bore the leaf named a different fence than the `LIFT`.
+#[test]
+fn the_production_composition_can_actually_lift_the_leaf_it_created() {
+    let writes: Writes = Arc::new(Mutex::new(Vec::new()));
+    let born = Arc::new(Mutex::new(Vec::new()));
+    let (client_stream, server_stream) = UnixStream::pair().expect("socketpair");
+
+    std::thread::scope(|scope| {
+        let mut server = UnixBrokerServer::new(broker(writes.clone(), born.clone()));
+        let served = scope.spawn(move || server.serve_connection(server_stream));
+
+        let launcher = UnixBrokerLauncher::new(connected_client(client_stream));
+        let identity = identity();
+        let mut handle = launcher
+            .launch(shell_command(), &identity, LeaseAuthority::Armed)
+            .expect("the brokered launch must succeed");
+
+        let birth = writes.lock().unwrap().clone();
+        assert_eq!(
+            birth,
+            vec![("cpu.max".to_owned(), UNLEASED_CPU_MAX.to_owned())],
+            "an armed leaf must be born clamped at the unleased quota"
+        );
+
+        // The whole blocker, in one call. It returned
+        // `Launcher(… InvalidControl)` in production and failed the shell tool.
+        handle
+            .fenced_lift()
+            .expect("the broker must ACCEPT the lift for the invocation it just began");
+
+        assert_eq!(
+            writes.lock().unwrap().clone(),
+            vec![
+                ("cpu.max".to_owned(), UNLEASED_CPU_MAX.to_owned()),
+                ("cpu.max".to_owned(), LEASED_CPU_MAX.to_owned()),
+            ],
+            "the accepted lift must have written the leased quota. Production observed ZERO \
+             cpu.max transitions across the entire life of every armed invocation"
+        );
+
+        // And the birth fence really is the one the composition derives from the
+        // invocation identity — the single source that makes the two controls
+        // unable to disagree.
+        let born = born.lock().unwrap().clone();
+        assert_eq!(born.len(), 1);
+        assert_eq!(
+            born[0].fence,
+            crate::process::broker_invocation_fence(&identity.invocation_id),
+            "the leaf must be born with the fence derived from its invocation id"
+        );
+        assert_ne!(
+            born[0].fence, 0,
+            "a constant zero birth fence is what the composition shipped with; it can never \
+             equal a coordinator fencing token, which starts at 1"
+        );
+
+        handle.cleanup().expect("cleanup");
+        drop(handle);
+        drop(launcher);
+        served.join().expect("server thread").expect("served");
+    });
+}
+
+/// The fence check is LIVE, so the test above is not passing vacuously.
+///
+/// A `LIFT` presenting anything other than the fence the invocation was begun
+/// with must be refused — and refused *legibly*. Production's only diagnostic
+/// was `InvalidControl`, which is a real and different broker error, so the
+/// message pointed away from the fence for the whole investigation.
+#[test]
+fn a_lift_whose_fence_disagrees_with_the_birth_is_refused_and_says_so() {
+    let writes: Writes = Arc::new(Mutex::new(Vec::new()));
+    let born = Arc::new(Mutex::new(Vec::new()));
+    let (client_stream, server_stream) = UnixStream::pair().expect("socketpair");
+
+    std::thread::scope(|scope| {
+        let mut server = UnixBrokerServer::new(broker(writes.clone(), born.clone()));
+        let served = scope.spawn(move || server.serve_connection(server_stream));
+
+        let mut client = connected_client(client_stream);
+        let id = uuid::Uuid::now_v7().to_string();
+        let fence = crate::process::broker_invocation_fence(&id);
+        client
+            .begin(Invocation {
+                id: id.clone(),
+                fence,
+            })
+            .expect("BEGIN");
+        client
+            .create(
+                &id,
+                &id,
+                LeaseAuthority::Armed,
+                &crate::process::command_spec(shell_command()).expect("spec"),
+            )
+            .expect("CREATE");
+
+        // This is precisely what production sent: the coordinator's durable
+        // fencing token (sequence values start at 1) against a leaf born under a
+        // different fence.
+        let refused = client
+            .lift(&id, 1)
+            .expect_err("a mismatched fence must be refused");
+        assert!(
+            matches!(
+                refused,
+                LauncherError::ControlRejected(ControlRejection::Fence)
+            ),
+            "the refusal must NAME the fence; production reported this as `InvalidControl`, a \
+             different real broker error, and the misattribution cost the investigation. Got \
+             {refused:?}"
+        );
+        assert_eq!(
+            writes.lock().unwrap().clone(),
+            vec![("cpu.max".to_owned(), UNLEASED_CPU_MAX.to_owned())],
+            "a refused lift must not have written a quota"
+        );
+
+        // A rejected fence leaves the binding usable, so the correct fence still
+        // lifts. That is what makes the failure above about the FENCE and not
+        // about the connection having been poisoned.
+        client.lift(&id, fence).expect("the matching fence lifts");
+        assert_eq!(
+            writes.lock().unwrap().last().cloned(),
+            Some(("cpu.max".to_owned(), LEASED_CPU_MAX.to_owned()))
+        );
+
+        drop(client);
+        served.join().expect("server thread").expect("served");
+    });
+}
+
+/// Two invocations in one pod must not share a fence, or a lift could be applied
+/// to the wrong leaf while still "matching".
+#[test]
+fn distinct_invocations_get_distinct_fences() {
+    let fences: std::collections::BTreeSet<u64> = (0..64)
+        .map(|_| crate::process::broker_invocation_fence(&uuid::Uuid::now_v7().to_string()))
+        .collect();
+    assert_eq!(
+        fences.len(),
+        64,
+        "distinct invocation ids must yield distinct fences"
+    );
+    // Deterministic: the same identity must derive the same fence at BEGIN and
+    // at LIFT even if the two are computed independently.
+    let id = uuid::Uuid::now_v7().to_string();
+    assert_eq!(
+        crate::process::broker_invocation_fence(&id),
+        crate::process::broker_invocation_fence(&id)
+    );
+    // Non-uuid ids still separate rather than collapsing to a constant.
+    assert_ne!(
+        crate::process::broker_invocation_fence("a"),
+        crate::process::broker_invocation_fence("b")
+    );
+}

--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -33,7 +33,11 @@ struct DegradeState {
     samples: usize,
     stdout: Vec<u8>,
     status: Option<std::process::ExitStatus>,
-    lifts: Vec<LeaseFencingToken>,
+    lifts: usize,
+    /// When set, `fenced_lift` fails the way the privileged broker failed in
+    /// production. It still counts the attempt, so a test can tell "the runner
+    /// tried and the broker refused" from "the runner never tried".
+    lift_error: Option<&'static str>,
     kills: usize,
     killed_while_running: usize,
     empties: usize,
@@ -48,7 +52,8 @@ impl DegradeLauncher {
                 samples: 0,
                 stdout: b"degraded command output\n".to_vec(),
                 status: None,
-                lifts: Vec::new(),
+                lifts: 0,
+                lift_error: None,
                 kills: 0,
                 killed_while_running: 0,
                 empties: 0,
@@ -64,8 +69,16 @@ impl DegradeLauncher {
     fn running() -> Self {
         Self::new(None)
     }
-    fn lifts(&self) -> Vec<LeaseFencingToken> {
-        self.state.lock().unwrap().lifts.clone()
+    /// A child whose lift the privileged broker REFUSES — goxi blocker 14. The
+    /// message is the one production actually produced.
+    fn lift_refused() -> Self {
+        let launcher = Self::new(Some(3));
+        launcher.state.lock().unwrap().lift_error =
+            Some("lease invocation failed: Launcher(ControlRejected(Fence))");
+        launcher
+    }
+    fn lifts(&self) -> usize {
+        self.state.lock().unwrap().lifts
     }
     fn killed_while_running(&self) -> usize {
         self.state.lock().unwrap().killed_while_running
@@ -128,9 +141,13 @@ impl ProcessHandle for DegradeHandle {
             ..CpuStat::default()
         })
     }
-    fn fenced_lift(&mut self, token: &LeaseFencingToken) -> io::Result<()> {
-        self.state.lock().unwrap().lifts.push(token.clone());
-        Ok(())
+    fn fenced_lift(&mut self) -> io::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        state.lifts += 1;
+        match state.lift_error {
+            Some(message) => Err(io::Error::other(message)),
+            None => Ok(()),
+        }
     }
     fn kill(&mut self) -> io::Result<()> {
         use std::os::unix::process::ExitStatusExt;
@@ -197,7 +214,7 @@ async fn lease_wait_timeout_degrades_to_unleased_not_error() {
     // Slow, not unconstrained: nothing lifted the leaf off the broker's
     // unleased quota, and the runner never tried to escalate again.
     assert!(
-        launcher.lifts().is_empty(),
+        launcher.lifts() == 0,
         "a degraded invocation must keep the unleased quota"
     );
     assert_eq!(services.queue_calls.load(Ordering::SeqCst), 1);
@@ -247,7 +264,7 @@ async fn credited_timeout_retries_once_then_degrades() {
     assert_eq!(output.process.termination, ProcessTermination::Exited);
     assert_eq!(output.process.output.status.code(), Some(0));
     assert_eq!(launcher.killed_while_running(), 0);
-    assert!(launcher.lifts().is_empty());
+    assert!(launcher.lifts() == 0);
     assert!(services.status_calls.load(Ordering::SeqCst) >= 1);
 }
 
@@ -286,7 +303,7 @@ async fn terminal_record_before_any_grant_degrades_and_stops_polling() {
     assert_eq!(output.process.termination, ProcessTermination::Exited);
     assert_eq!(output.process.output.status.code(), Some(0));
     assert_eq!(launcher.killed_while_running(), 0);
-    assert!(launcher.lifts().is_empty());
+    assert!(launcher.lifts() == 0);
     assert_eq!(services.grant_calls.load(Ordering::SeqCst), 0);
 }
 
@@ -330,7 +347,7 @@ async fn cancellation_after_degrade_still_terminates_the_child() {
         1,
         "cancellation must still kill the degraded child"
     );
-    assert!(launcher.lifts().is_empty());
+    assert!(launcher.lifts() == 0);
 }
 
 /// The degrade is scoped to a lost queue. An identity conflict means the lease
@@ -362,7 +379,7 @@ async fn lease_identity_conflict_still_fails() {
         .expect_err("an identity conflict is not contention");
 
     assert!(matches!(error, LeaseInvocationError::LeaseIdentityConflict));
-    assert!(launcher.lifts().is_empty());
+    assert!(launcher.lifts() == 0);
 }
 
 /// Repeated unavailability is a broken authority, not a queue: it must still
@@ -388,7 +405,7 @@ async fn repeated_unavailability_still_fails() {
         .expect_err("an unusable lease authority is not contention");
 
     assert!(matches!(error, LeaseInvocationError::LeaseUnavailable));
-    assert!(launcher.lifts().is_empty());
+    assert!(launcher.lifts() == 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -561,7 +578,7 @@ async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
     // The whole point: the lease was actually granted, bound, and lifted off the
     // unleased 250m quota. Under the defect this list was always empty.
     assert_eq!(
-        launcher.lifts().len(),
+        launcher.lifts(),
         1,
         "a lease queued with the rendered deadlines must reach the fenced lift"
     );
@@ -664,7 +681,7 @@ async fn real_lease_authority_queue_timeout_degrades_to_a_successful_command() {
         "the real timeout path must never kill a running child"
     );
     assert!(
-        launcher.lifts().is_empty(),
+        launcher.lifts() == 0,
         "a degraded invocation never lifts the unleased quota"
     );
 
@@ -700,5 +717,99 @@ fn timeouts_render_as_absolute_epoch_deadlines() {
     assert_eq!(
         epoch_ms(std::time::UNIX_EPOCH + Duration::from_millis(1_234)),
         1_234
+    );
+}
+
+/// A REFUSED LIFT MUST DEGRADE, NOT FAIL THE COMMAND (goxi blocker 14).
+///
+/// The lift used to propagate with `?`, so any refusal from the privileged
+/// broker became `LeaseInvocationError::Launcher` and failed the whole shell
+/// tool call. Production measured 5 such failures against 10 launches in one
+/// pod and the agent's `shell` tool errored repeatedly:
+///
+/// ```text
+/// ReplyLoop: tool call returned error tool=shell
+///   error=failed to run shell command: lease invocation failed: …
+/// ```
+///
+/// That converts a defect in a *throttling optimisation* into total loss of the
+/// agent's ability to run commands, when the fallback it denied itself — keep
+/// running at the unleased quota — is strictly better than dying. It also
+/// contradicted the precedent every test above pins: a lost lease QUEUE degrades
+/// to continued unleased execution because contention must make a command slow,
+/// never dead. A rejected lift is the same class of event.
+///
+/// This drives the REAL runner over the REAL durable lease services against an
+/// armed epoch, so the invocation genuinely reaches the `Lift` arm — the lift is
+/// attempted and refused, not skipped.
+#[tokio::test]
+async fn a_refused_lift_degrades_the_command_instead_of_failing_it() {
+    let db = crate::test_helpers::create_test_db();
+    arm_invocation_lift(&db).await;
+    let services = real_lease_services(
+        &db,
+        Arc::new(djinn_coordinator::build_lease::SystemLeaseClock),
+    )
+    .await;
+    let launcher = Arc::new(DegradeLauncher::lift_refused());
+    let now_ms = wall_clock_ms();
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        services.clone(),
+        Arc::new(
+            djinn_supervisor::services::DurableInvocationLiftAuthority::new(
+                db.clone(),
+                "degrade-test",
+            ),
+        ),
+        launcher.clone(),
+        clock_pinned_at(now_ms),
+    ));
+    let context = crate::context::ShellLaunchContext::for_test(
+        Arc::clone(&runner),
+        "task".into(),
+        "run".into(),
+        "pod".into(),
+    );
+
+    let output = runner
+        .output(
+            command(),
+            context.invocation(Duration::from_secs(60)),
+            CancellationToken::new(),
+        )
+        .await
+        .expect(
+            "a refused cgroup lift must NOT fail the command. This is the assertion that would \
+             have caught goxi blocker 14 turning a lease-subsystem defect into a dead `shell` \
+             tool",
+        );
+
+    // The command completed normally, output intact, child never killed.
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+    assert_eq!(output.process.output.status.code(), Some(0));
+    assert_eq!(output.process.output.stdout, b"degraded command output\n");
+    assert_eq!(
+        launcher.killed_while_running(),
+        0,
+        "a refused lift must never kill a running child"
+    );
+
+    // The lift was genuinely ATTEMPTED and refused — not skipped. Without this
+    // the test would also pass on a runner that never reached the `Lift` arm at
+    // all, which is a different (and equally shipped) defect. It is also the
+    // one-way assertion: the runner must not retry a refused one-way lift.
+    assert_eq!(
+        launcher.lifts(),
+        1,
+        "the invocation must have reached the lift exactly once and had it refused"
+    );
+
+    // And the durable lease is still reconciled to terminal, so a refused lift
+    // never leaks a counted build slot.
+    let row = durable_row(&db, &output.identity.invocation_id).await;
+    assert_eq!(
+        row.state,
+        djinn_db::BuildLeaseState::Terminal,
+        "a degraded invocation must still reconcile its durable lease to terminal"
     );
 }

--- a/server/crates/djinn-agent/src/process/tests/process_lease_shadow_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_shadow_tests.rs
@@ -60,7 +60,7 @@ fn shadow_epoch_emits_both_would_throttle_arms_from_production_paths() {
             run.await.unwrap().unwrap();
             assert_eq!(services.grant_calls.load(Ordering::SeqCst), 1);
             assert!(
-                launcher.lifts.lock().unwrap().is_empty(),
+                *launcher.lifts.lock().unwrap() == 0,
                 "the escalating shadow arm must still never lift cpu.max"
             );
 

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 #[derive(Default)]
 struct ScriptedLauncher {
     pid: Arc<Mutex<Option<u32>>>,
-    lifts: Arc<Mutex<Vec<LeaseFencingToken>>>,
+    lifts: Arc<Mutex<usize>>,
     kills: Arc<AtomicUsize>,
     empties: Arc<AtomicUsize>,
     /// The birth authority the runner handed each `launch`.
@@ -60,7 +60,7 @@ impl ScriptedLauncher {
 }
 struct ScriptedHandle {
     child: std::process::Child,
-    lifts: Arc<Mutex<Vec<LeaseFencingToken>>>,
+    lifts: Arc<Mutex<usize>>,
     kills: Arc<AtomicUsize>,
     empties: Arc<AtomicUsize>,
 }
@@ -83,8 +83,8 @@ impl ProcessHandle for ScriptedHandle {
             ..CpuStat::default()
         })
     }
-    fn fenced_lift(&mut self, token: &LeaseFencingToken) -> io::Result<()> {
-        self.lifts.lock().unwrap().push(token.clone());
+    fn fenced_lift(&mut self) -> io::Result<()> {
+        *self.lifts.lock().unwrap() += 1;
         Ok(())
     }
     fn kill(&mut self) -> io::Result<()> {
@@ -205,7 +205,7 @@ impl ProcessHandle for BrokerBackedHandle {
             ..CpuStat::default()
         })
     }
-    fn fenced_lift(&mut self, _: &LeaseFencingToken) -> io::Result<()> {
+    fn fenced_lift(&mut self) -> io::Result<()> {
         Ok(())
     }
     fn kill(&mut self) -> io::Result<()> {
@@ -576,7 +576,7 @@ async fn repeated_active_statuses_queue_and_lift_exactly_once() {
     assert_eq!(output.process.termination, ProcessTermination::Cancelled);
     assert_eq!(services.queue_calls.load(Ordering::SeqCst), 1);
     assert_eq!(services.grant_calls.load(Ordering::SeqCst), 1);
-    assert_eq!(*launcher.lifts.lock().unwrap(), vec![LeaseFencingToken(7)]);
+    assert_eq!(*launcher.lifts.lock().unwrap(), 1);
     assert_eq!(launcher.kills.load(Ordering::SeqCst), 1);
     assert_eq!(launcher.empties.load(Ordering::SeqCst), 1);
     assert!(services.release_calls.load(Ordering::SeqCst) <= 1);
@@ -611,7 +611,7 @@ async fn terminal_intent_while_grant_paused_permanently_prevents_lift() {
     cancel.cancel();
     let output = run.await.unwrap().unwrap();
     assert_eq!(output.process.termination, ProcessTermination::Cancelled);
-    assert!(launcher.lifts.lock().unwrap().is_empty());
+    assert_eq!(*launcher.lifts.lock().unwrap(), 0);
     assert_eq!(launcher.kills.load(Ordering::SeqCst), 1);
     assert_eq!(launcher.empties.load(Ordering::SeqCst), 1);
     assert!(services.release_calls.load(Ordering::SeqCst) <= 1);
@@ -653,7 +653,7 @@ async fn transient_queue_grant_status_and_release_are_reconciled() {
     wait_for(&services.status_calls, 4).await;
     cancel.cancel();
     run.await.unwrap().unwrap();
-    assert_eq!(*launcher.lifts.lock().unwrap(), vec![LeaseFencingToken(11)]);
+    assert_eq!(*launcher.lifts.lock().unwrap(), 1);
     assert_eq!(services.queue_calls.load(Ordering::SeqCst), 1);
     assert_eq!(services.grant_calls.load(Ordering::SeqCst), 2);
     assert_eq!(services.release_calls.load(Ordering::SeqCst), 2);
@@ -692,7 +692,7 @@ async fn transient_status_and_abandon_are_reconciled_without_capacity_double_ret
     wait_for(&services.queue_calls, 1).await;
     cancel.cancel();
     run.await.unwrap().unwrap();
-    assert!(launcher.lifts.lock().unwrap().is_empty());
+    assert_eq!(*launcher.lifts.lock().unwrap(), 0);
     assert_eq!(services.abandon_calls.load(Ordering::SeqCst), 2);
     assert_eq!(services.release_calls.load(Ordering::SeqCst), 0);
     assert_eq!(launcher.kills.load(Ordering::SeqCst), 1);
@@ -811,7 +811,7 @@ struct FixtureState {
     wait_polls: usize,
     killed: bool,
     samples: usize,
-    lifts: Vec<LeaseFencingToken>,
+    lifts: usize,
     kills: usize,
     empties: usize,
     cleanups: usize,
@@ -827,7 +827,7 @@ impl FixtureLauncher {
                 wait_polls: 0,
                 killed: false,
                 samples: 0,
-                lifts: Vec::new(),
+                lifts: 0,
                 kills: 0,
                 empties: 0,
                 cleanups: 0,
@@ -840,8 +840,8 @@ impl FixtureLauncher {
     fn samples(&self) -> usize {
         self.state.lock().unwrap().samples
     }
-    fn lifts(&self) -> Vec<LeaseFencingToken> {
-        self.state.lock().unwrap().lifts.clone()
+    fn lifts(&self) -> usize {
+        self.state.lock().unwrap().lifts
     }
 }
 
@@ -901,8 +901,8 @@ impl ProcessHandle for FixtureHandle {
             ..CpuStat::default()
         })
     }
-    fn fenced_lift(&mut self, token: &LeaseFencingToken) -> io::Result<()> {
-        self.state.lock().unwrap().lifts.push(token.clone());
+    fn fenced_lift(&mut self) -> io::Result<()> {
+        self.state.lock().unwrap().lifts += 1;
         Ok(())
     }
     fn kill(&mut self) -> io::Result<()> {
@@ -995,7 +995,7 @@ async fn ac1_light_fixtures_finish_unleased_with_zero_lease_calls() {
             "light fixture {fixture:?} is measured at the unleased quota"
         );
         assert!(
-            launcher.lifts().is_empty(),
+            launcher.lifts() == 0,
             "light fixture {fixture:?} never lifts its quota"
         );
         assert_eq!(
@@ -1154,7 +1154,7 @@ async fn ac4_natural_exit_while_grant_paused_prevents_lift() {
         "the grant stage is reached before the child's natural exit wins"
     );
     assert!(
-        launcher.lifts().is_empty(),
+        launcher.lifts() == 0,
         "a natural exit before grant resolution can never lift the quota"
     );
 }
@@ -1190,7 +1190,7 @@ async fn ac4_fallback_timeout_on_paused_response_terminates_without_lift() {
 
     assert_eq!(output.process.termination, ProcessTermination::TimedOut);
     assert_eq!(services.queue_calls.load(Ordering::SeqCst), 1);
-    assert!(launcher.lifts().is_empty(), "a timed-out queue never lifts");
+    assert!(launcher.lifts() == 0, "a timed-out queue never lifts");
 }
 
 /// Cancellation before a grant is issued: the queue response is paused, cancel
@@ -1223,7 +1223,7 @@ async fn ac4_cancellation_before_grant_prevents_lift() {
     let output = run.await.expect("join").expect("cancelled cleanly");
 
     assert_eq!(output.process.termination, ProcessTermination::Cancelled);
-    assert!(launcher.lifts().is_empty());
+    assert!(launcher.lifts() == 0);
     let state = launcher.state.lock().unwrap();
     assert_eq!((state.kills, state.empties, state.cleanups), (1, 1, 1));
 }
@@ -1258,7 +1258,7 @@ async fn ac4_unresolved_state_releases_with_exact_fence_at_most_once() {
     cancel.cancel();
     run.await.unwrap().unwrap();
 
-    assert_eq!(*launcher.lifts.lock().unwrap(), vec![LeaseFencingToken(11)]);
+    assert_eq!(*launcher.lifts.lock().unwrap(), 1);
     assert_eq!(
         *services.release_fences.lock().unwrap(),
         vec![LeaseFencingToken(11)],
@@ -1302,7 +1302,7 @@ async fn ac4_unresolved_state_without_fence_abandons_at_most_once() {
     cancel.cancel();
     run.await.unwrap().unwrap();
 
-    assert!(launcher.lifts.lock().unwrap().is_empty());
+    assert_eq!(*launcher.lifts.lock().unwrap(), 0);
     assert_eq!(
         services.abandon_calls.load(Ordering::SeqCst),
         1,
@@ -1317,6 +1317,8 @@ mod shadow_tests;
 
 #[path = "process_lease_admission_tests.rs"]
 mod admission_composition_tests;
+#[path = "process_lease_broker_lift_tests.rs"]
+mod broker_lift_tests;
 #[path = "process_lease_degrade_tests.rs"]
 mod lease_degrade_tests;
 #[path = "process_lease_recovery_tests.rs"]

--- a/server/crates/djinn-agent/src/process_broker.rs
+++ b/server/crates/djinn-agent/src/process_broker.rs
@@ -9,9 +9,7 @@ use djinn_cgroup_launcher::{
     CommandSpec, CpuStat, Invocation, LeaseAuthority, broker::ChildStatus,
     transport::UnixBrokerClient,
 };
-use djinn_supervisor::services::{
-    InvocationLiftDecision, LeaseFencingToken, TaskInvocationLeaseIdentity,
-};
+use djinn_supervisor::services::{InvocationLiftDecision, TaskInvocationLeaseIdentity};
 
 /// Project the durable admission decision onto the authority the leaf is BORN
 /// under.
@@ -40,7 +38,35 @@ pub(crate) trait ProcessHandle: Send {
     fn try_wait(&mut self) -> io::Result<Option<ExitStatus>>;
     fn wait(&mut self) -> io::Result<ExitStatus>;
     fn sample_cpu(&mut self) -> io::Result<CpuStat>;
-    fn fenced_lift(&mut self, fence: &LeaseFencingToken) -> io::Result<()>;
+    /// Apply the one-way cgroup lift to the leaf THIS handle owns.
+    ///
+    /// # Why this takes no fencing token (goxi launcher blocker 14)
+    ///
+    /// There are two different fences in this system and they were conflated
+    /// here, which broke every escalation in production:
+    ///
+    /// * the **broker invocation fence** — declared by the worker in the
+    ///   `BEGIN` control, stored on the leaf at birth, and the only value
+    ///   `Launcher::fenced_lift` will accept on a `LIFT`; and
+    /// * the **durable lease fencing token** — minted by the coordinator from
+    ///   `build_lease_fencing_token_seq` at grant time, i.e. long after the leaf
+    ///   exists, and therefore something the birth control cannot possibly have
+    ///   named.
+    ///
+    /// The composition passed a launcher-wide constant `0` to `BEGIN` and the
+    /// coordinator's token to `LIFT`. The sequence starts at 1, so the two could
+    /// never be equal: every lift was refused with `FenceMismatch`, reported to
+    /// the worker as the indistinguishable `InvalidControl`, and (because the
+    /// error failed the command) took the agent's `shell` tool down with it.
+    ///
+    /// The durable token still governs **whether** a lift may happen — the
+    /// runner only reaches this call inside a `LeaseResult::Bound` arm whose
+    /// `fencing_token` matches the grant it validated, and it writes that token
+    /// to the invocation journal first. It just is not the value the cgroup
+    /// boundary is fenced by, so it is not accepted here: an implementation that
+    /// silently ignored an argument would be the same defect wearing a
+    /// signature.
+    fn fenced_lift(&mut self) -> io::Result<()>;
     fn kill(&mut self) -> io::Result<()>;
     fn wait_empty(&mut self) -> io::Result<()>;
     fn cleanup(&mut self) -> io::Result<()>;
@@ -62,18 +88,55 @@ pub(crate) trait CgroupLauncherClient: Send + Sync + 'static {
     ) -> io::Result<Box<dyn ProcessHandle>>;
 }
 
+/// The broker invocation fence for one invocation identity.
+///
+/// # Why it is derived rather than configured (goxi launcher blocker 14)
+///
+/// `Launcher::fenced_lift` accepts exactly the fence the leaf was born with, and
+/// the leaf is born inside `BEGIN`/`CREATE` — before any lease exists. So the
+/// fence has to be a value the *worker* can name at birth and name again,
+/// identically, at lift time. It used to be a launcher-wide constant supplied at
+/// construction (`UnixBrokerLauncher::new(client, 0)`), while the lift presented
+/// the coordinator's durable token; see [`ProcessHandle::fenced_lift`] for the
+/// full account of why those two can never agree.
+///
+/// Deriving it from the invocation identity gives the property the contract
+/// actually needs: **the birth quota and the lift name the same invocation**.
+/// The id is the `uuid::Uuid::now_v7()` the runner mints per invocation and is
+/// also the leaf name the broker binds every control to, so two concurrent
+/// invocations in one pod get two different fences and a lift carrying the wrong
+/// one is refused rather than silently applied to the wrong leaf.
+///
+/// # Why a digest of the whole id
+///
+/// A UUIDv7's high 64 bits are a 48-bit millisecond timestamp plus a short
+/// counter, so invocations minted inside the same millisecond share them —
+/// measured, 64 ids collapsed to 2 values. Folding the ENTIRE id keeps the
+/// distinctness the contract needs. This is a collision-avoidance aid over the
+/// handful of invocations live in one pod at once, not a security primitive:
+/// the broker's actual authority is the authenticated peer, the per-invocation
+/// binding and the rotating control nonce.
+pub(crate) fn invocation_fence(invocation_id: &str) -> u64 {
+    // FNV-1a, 64-bit. Deterministic and dependency-free, so `BEGIN` and `LIFT`
+    // derive the same value from the same identity with no shared state.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in invocation_id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
 /// Production-only Unix broker adapter; it has no local `Command::spawn` fallback.
 pub(crate) struct UnixBrokerLauncher {
     client: Arc<Mutex<UnixBrokerClient>>,
-    invocation_fence: u64,
 }
 
 impl UnixBrokerLauncher {
     #[allow(dead_code)] // constructed by workspace broker composition
-    pub(crate) fn new(client: UnixBrokerClient, invocation_fence: u64) -> Self {
+    pub(crate) fn new(client: UnixBrokerClient) -> Self {
         Self {
             client: Arc::new(Mutex::new(client)),
-            invocation_fence,
         }
     }
 }
@@ -87,11 +150,16 @@ impl CgroupLauncherClient for UnixBrokerLauncher {
     ) -> io::Result<Box<dyn ProcessHandle>> {
         let spec = command_spec(command)?;
         let id = identity.invocation_id.clone();
+        // ONE source for the fence, read once and carried into the handle. The
+        // `BEGIN` below and the `LIFT` in `fenced_lift` must present the same
+        // value or the privileged broker refuses the lift, so there must be no
+        // second place that decides it.
+        let fence = invocation_fence(&id);
         let mut client = lock_client(&self.client)?;
         client
             .begin(Invocation {
                 id: id.clone(),
-                fence: self.invocation_fence,
+                fence,
             })
             .map_err(broker_error)?;
         if let Err(error) = client.create(&id, &id, authority, &spec) {
@@ -101,6 +169,7 @@ impl CgroupLauncherClient for UnixBrokerLauncher {
         Ok(Box::new(UnixBrokerProcessHandle {
             client: self.client.clone(),
             id,
+            fence,
             status: None,
             stdout: Vec::new(),
         }))
@@ -110,6 +179,9 @@ impl CgroupLauncherClient for UnixBrokerLauncher {
 struct UnixBrokerProcessHandle {
     client: Arc<Mutex<UnixBrokerClient>>,
     id: String,
+    /// The fence this invocation was BEGUN with. Copied from the same value the
+    /// `BEGIN` control carried so the lift cannot disagree with the birth.
+    fence: u64,
     status: Option<ExitStatus>,
     // Status polling uses the broker's stdout operation, which drains its
     // accumulated stream buffer. Preserve those bytes for the next drain.
@@ -176,9 +248,10 @@ impl ProcessHandle for UnixBrokerProcessHandle {
             .map_err(broker_error)
     }
 
-    fn fenced_lift(&mut self, fence: &LeaseFencingToken) -> io::Result<()> {
+    fn fenced_lift(&mut self) -> io::Result<()> {
+        let fence = self.fence;
         lock_client(&self.client)?
-            .lift(&self.id, fence.0)
+            .lift(&self.id, fence)
             .map_err(broker_error)
     }
 
@@ -457,7 +530,7 @@ impl ProcessHandle for std::process::Child {
         })
     }
 
-    fn fenced_lift(&mut self, _: &LeaseFencingToken) -> io::Result<()> {
+    fn fenced_lift(&mut self) -> io::Result<()> {
         Ok(())
     }
 

--- a/server/crates/djinn-cgroup-launcher/src/control_rejection.rs
+++ b/server/crates/djinn-cgroup-launcher/src/control_rejection.rs
@@ -1,0 +1,237 @@
+//! Why the privileged broker refused a control, as a bounded wire category.
+//!
+//! # Why this exists (goxi launcher blocker 14)
+//!
+//! [`crate::transport::reply`] used to answer every server-side failure with a
+//! single byte, `1`, and the client turned that byte into
+//! [`crate::Error::InvalidControl`] regardless of what had actually happened.
+//! So a production worker whose `LIFT` was rejected for a **fence mismatch**
+//! reported:
+//!
+//! ```text
+//! lease invocation failed: Launcher(Custom { kind: Other, error: InvalidControl })
+//! ```
+//!
+//! `InvalidControl` is a real broker error in its own right (see
+//! [`crate::Error::InvalidControl`]), so the message named a cause that had not
+//! occurred, and it named it identically for a stale nonce, an unarmed leaf, an
+//! already-applied lift and a terminal invocation. The whole diagnosis had to be
+//! done by reading `cpu.max`/`cpu.stat` off the node by hand — for the second
+//! time in this feature.
+//!
+//! # What is and is not disclosed
+//!
+//! The peer is already authenticated at this point: the broker checked
+//! `SO_PEERCRED` pid/uid/gid against the configured worker and compared the
+//! worker-private pod credential, both before any control is dispatched. Telling
+//! *that* peer which category its own control fell into leaks nothing it could
+//! not learn by probing, and it is deliberately a CATEGORY: no path, no errno,
+//! no leaf name, no command text, no length. The coarse-on-purpose refusals
+//! (`InvalidCommand` above all) stay coarse — [`ControlRejection::Command`]
+//! still does not say whether the program, the cwd or one environment entry was
+//! at fault, which is why the worker keeps its own copy of that check.
+
+/// The category of a refused broker control, as carried on the wire.
+///
+/// Codes are stable: they are a protocol surface between the worker and a
+/// privileged process that may be a different build during a rolling update, so
+/// an unknown code decodes to [`Self::Unspecified`] rather than failing the
+/// frame.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ControlRejection {
+    /// The presented fencing value is not the one this invocation was begun
+    /// with. This is what a `LIFT` returns when the birth fence and the lift
+    /// fence disagree.
+    Fence,
+    /// The one-way lift has already been applied to this leaf.
+    AlreadyLifted,
+    /// The leaf was born under an unarmed lease authority, so it has no quota to
+    /// lift and writing one would LOWER its ceiling.
+    Unarmed,
+    /// Terminal intent has been recorded for this invocation; no lift may follow.
+    Terminal,
+    /// The control does not name the invocation bound to this connection.
+    Binding,
+    /// The control nonce was stale, forged, or replayed.
+    Nonce,
+    /// The connection has not presented a valid worker readiness assertion.
+    Worker,
+    /// Peer credentials or the worker-private pod credential did not match.
+    Credential,
+    /// The command request is malformed, over-budget, or outside the allow-list.
+    /// Deliberately says no more than that.
+    Command,
+    /// The control is legal but does not match the invocation's current state
+    /// (no leaf yet, a duplicate create, a still-populated cgroup, …).
+    State,
+    /// The frame itself did not parse: wrong length, an unknown opcode, a
+    /// trailing descriptor, an oversized payload. Distinct from
+    /// [`Self::Command`] on purpose — a malformed frame is rejected before the
+    /// allow-list ever sees a command, so reporting the two alike would let a
+    /// wire-format mistake masquerade as a policy refusal (which is exactly what
+    /// the launcher's own allow-list tests were doing).
+    Malformed,
+    /// A privileged-side filesystem, cgroup or child-process operation failed.
+    Kernel,
+    /// A category this build does not know. Never produced locally; only decoded
+    /// from a peer that is a newer build.
+    Unspecified,
+}
+
+impl ControlRejection {
+    /// Classify a broker-side error into its wire category.
+    pub fn of(error: &crate::Error) -> Self {
+        use crate::Error as E;
+        match error {
+            E::FenceMismatch => Self::Fence,
+            E::LiftAlreadyApplied => Self::AlreadyLifted,
+            E::LiftWithoutAuthority => Self::Unarmed,
+            E::TerminalIntent => Self::Terminal,
+            E::InvalidInvocationBinding => Self::Binding,
+            E::InvalidNonce => Self::Nonce,
+            E::InvalidWorker => Self::Worker,
+            E::UnauthenticatedPeer | E::InvalidCredential => Self::Credential,
+            E::InvalidCommand => Self::Command,
+            E::InvalidControl | E::StillPopulated | E::UnsafeLeafName => Self::State,
+            E::InvalidTransportFrame => Self::Malformed,
+            _ => Self::Kernel,
+        }
+    }
+
+    pub fn code(self) -> u8 {
+        match self {
+            Self::Fence => 1,
+            Self::AlreadyLifted => 2,
+            Self::Unarmed => 3,
+            Self::Terminal => 4,
+            Self::Binding => 5,
+            Self::Nonce => 6,
+            Self::Worker => 7,
+            Self::Credential => 8,
+            Self::Command => 9,
+            Self::State => 10,
+            Self::Kernel => 11,
+            Self::Malformed => 12,
+            Self::Unspecified => 0,
+        }
+    }
+
+    /// Decode a wire code. An unrecognised code is [`Self::Unspecified`]: a
+    /// worker paired with a newer launcher must still see "the broker refused
+    /// this", never a transport-frame error that hides it.
+    pub fn from_code(code: u8) -> Self {
+        match code {
+            1 => Self::Fence,
+            2 => Self::AlreadyLifted,
+            3 => Self::Unarmed,
+            4 => Self::Terminal,
+            5 => Self::Binding,
+            6 => Self::Nonce,
+            7 => Self::Worker,
+            8 => Self::Credential,
+            9 => Self::Command,
+            10 => Self::State,
+            11 => Self::Kernel,
+            12 => Self::Malformed,
+            _ => Self::Unspecified,
+        }
+    }
+
+    /// One-line operator-facing explanation. This is what reaches a task-run
+    /// Pod's logs, so it names the contract that was violated rather than the
+    /// enum variant.
+    pub fn explain(self) -> &'static str {
+        match self {
+            Self::Fence => {
+                "the fencing value presented with this control is not the one the invocation was \
+                 begun with; the birth quota and the lift must name one fence"
+            }
+            Self::AlreadyLifted => "the one-way lift has already been applied to this leaf",
+            Self::Unarmed => {
+                "the leaf was born under an unarmed lease authority and has no quota to lift"
+            }
+            Self::Terminal => "terminal intent forbids a lift on this invocation",
+            Self::Binding => "the control is not bound to the active launcher invocation",
+            Self::Nonce => "the control nonce was stale, forged, or replayed",
+            Self::Worker => "the connection has not presented a valid worker readiness assertion",
+            Self::Credential => "peer or worker-private credential authentication failed",
+            Self::Command => {
+                "the command request is malformed, over-budget, or outside the broker allow-list"
+            }
+            Self::State => "the control does not match the invocation's current state",
+            Self::Malformed => "the control frame did not parse: bad length, opcode, or payload",
+            Self::Kernel => "a privileged cgroup, filesystem, or child-process operation failed",
+            Self::Unspecified => "the broker refused the control for an unrecognised reason",
+        }
+    }
+}
+
+impl std::fmt::Display for ControlRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}: {}", self.explain())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Error;
+
+    /// Every category must survive the wire, and an unknown code must decode to
+    /// a refusal rather than corrupting the frame.
+    #[test]
+    fn every_category_round_trips_and_unknown_codes_stay_refusals() {
+        for category in [
+            ControlRejection::Fence,
+            ControlRejection::AlreadyLifted,
+            ControlRejection::Unarmed,
+            ControlRejection::Terminal,
+            ControlRejection::Binding,
+            ControlRejection::Nonce,
+            ControlRejection::Worker,
+            ControlRejection::Credential,
+            ControlRejection::Command,
+            ControlRejection::State,
+            ControlRejection::Kernel,
+            ControlRejection::Malformed,
+            ControlRejection::Unspecified,
+        ] {
+            assert_eq!(ControlRejection::from_code(category.code()), category);
+        }
+        assert_eq!(
+            ControlRejection::from_code(200),
+            ControlRejection::Unspecified
+        );
+    }
+
+    /// The classification that matters: a fence mismatch must NOT be reported as
+    /// `InvalidControl`. Those two were the same byte on the wire, which is why
+    /// production said "InvalidControl" for a fence the runner had chosen wrong.
+    #[test]
+    fn a_fence_mismatch_is_distinguishable_from_an_invalid_control() {
+        assert_eq!(
+            ControlRejection::of(&Error::FenceMismatch),
+            ControlRejection::Fence
+        );
+        assert_eq!(
+            ControlRejection::of(&Error::InvalidControl),
+            ControlRejection::State
+        );
+        assert_ne!(
+            ControlRejection::of(&Error::FenceMismatch),
+            ControlRejection::of(&Error::InvalidControl),
+            "the two errors production could not tell apart must not share a wire code"
+        );
+        // And the lift-specific refusals stay distinct from each other, because
+        // the operator action differs: a fence mismatch is a runner defect, an
+        // unarmed leaf is a durable-epoch state.
+        assert_ne!(
+            ControlRejection::of(&Error::LiftWithoutAuthority),
+            ControlRejection::of(&Error::FenceMismatch)
+        );
+        assert_ne!(
+            ControlRejection::of(&Error::LiftAlreadyApplied),
+            ControlRejection::of(&Error::FenceMismatch)
+        );
+    }
+}

--- a/server/crates/djinn-cgroup-launcher/src/lib.rs
+++ b/server/crates/djinn-cgroup-launcher/src/lib.rs
@@ -13,6 +13,7 @@ pub mod bootstrap;
 pub mod broker;
 pub mod child;
 pub mod command_path;
+pub mod control_rejection;
 pub mod env;
 pub mod git_trust;
 pub mod lease_authority;
@@ -20,6 +21,7 @@ pub mod spawn;
 pub mod transport;
 
 pub use command_path::safe_command_path;
+pub use control_rejection::ControlRejection;
 pub use env::{is_allowed_environment_entry, is_allowed_environment_key};
 pub use lease_authority::{LeaseAuthority, unrestricted_cpu_max};
 pub use spawn::{DenySpawn, NativeCgroupSpawn};
@@ -599,6 +601,16 @@ pub enum Error {
     InvalidNonce,
     #[error("control does not match the active invocation state")]
     InvalidControl,
+    /// The privileged broker refused a control, as observed by the CLIENT.
+    ///
+    /// This is the only error a transport client can synthesise from a refusal
+    /// reply, and it is deliberately distinct from [`Self::InvalidControl`]:
+    /// before goxi blocker 14 the client reported every server-side refusal —
+    /// fence mismatch, stale nonce, unarmed leaf, terminal intent — as
+    /// `InvalidControl`, which is also a real and *different* broker error. See
+    /// [`crate::control_rejection`].
+    #[error("the privileged broker refused the control ({0})")]
+    ControlRejected(ControlRejection),
     #[error("invalid or oversized launcher transport frame")]
     InvalidTransportFrame,
     #[error("broker socket path is unsafe or already owned by another process")]

--- a/server/crates/djinn-cgroup-launcher/src/transport.rs
+++ b/server/crates/djinn-cgroup-launcher/src/transport.rs
@@ -1,6 +1,7 @@
 //! Bounded Unix socket transport for authenticated broker controls.
 use crate::{
-    CgroupFs, CommandSpec, CpuStat, Error, Invocation, LeaseAuthority, SpawnIntoCgroup,
+    CgroupFs, CommandSpec, ControlRejection, CpuStat, Error, Invocation, LeaseAuthority,
+    SpawnIntoCgroup,
     broker::{Broker, ConnectionId, ControlNonce, NonceSource, SocketPeer, WORKER_GID, WORKER_UID},
     child::WorkerReadinessAssertion,
 };
@@ -480,6 +481,9 @@ fn write(s: &mut UnixStream, x: &[u8]) -> Result<(), Error> {
     s.write_all(x)?;
     Ok(())
 }
+/// Answer one control. A refusal carries its bounded [`ControlRejection`]
+/// category and nothing else — never the error's message, path, errno or the
+/// rejected bytes.
 fn reply(s: &mut UnixStream, r: Result<Vec<u8>, Error>) -> Result<(), Error> {
     match r {
         Ok(x) => {
@@ -487,14 +491,19 @@ fn reply(s: &mut UnixStream, r: Result<Vec<u8>, Error>) -> Result<(), Error> {
             y.extend(x);
             write(s, &y)
         }
-        Err(_) => write(s, &[1]),
+        Err(error) => write(s, &[1, ControlRejection::of(&error).code()]),
     }
 }
 fn response(s: &mut UnixStream) -> Result<Vec<u8>, Error> {
     let x = read(s)?;
     match x.split_first() {
         Some((0, x)) => Ok(x.to_vec()),
-        Some((1, _)) => Err(Error::InvalidControl),
+        // A refusal from a peer that predates the reason byte still decodes, as
+        // `Unspecified`: a rolling update must not turn a legible refusal into
+        // an illegible frame error.
+        Some((1, reason)) => Err(Error::ControlRejected(ControlRejection::from_code(
+            reason.first().copied().unwrap_or_default(),
+        ))),
         _ => Err(Error::InvalidTransportFrame),
     }
 }
@@ -835,19 +844,28 @@ mod tests {
 
     #[test]
     fn unix_rejections_never_create_a_leaf_or_call_the_clone_seam() {
-        let cases: Vec<(&str, Vec<u8>)> = vec![
-            ("malformed", vec![0]),
+        // Each case pins WHY it was refused, not merely that it was. Until goxi
+        // blocker 14 gave refusals a category these all asserted the same
+        // indistinct error — and `create_wire` was omitting the authority byte,
+        // so every "policy" case here was actually being refused as a malformed
+        // frame before `CommandSpec::validate` ever saw the command. The
+        // allow-list assertions were vacuous and nothing could tell.
+        let cases: Vec<(&str, Vec<u8>, ControlRejection)> = vec![
+            ("malformed", vec![0], ControlRejection::Malformed),
             (
                 "unsafe-program",
                 create_wire("/bin/../sh", "/workspace", &[]),
+                ControlRejection::Command,
             ),
             (
                 "unsafe-cwd",
                 create_wire("/bin/true", "/workspace/../escape", &[]),
+                ControlRejection::Command,
             ),
             (
                 "forbidden-env",
                 create_wire("/bin/true", "/workspace", &[("LD_PRELOAD", "x")]),
+                ControlRejection::Command,
             ),
             (
                 "over-budget",
@@ -856,14 +874,19 @@ mod tests {
                     "/workspace",
                     &[("DJINN_VALUE", &"x".repeat(CommandSpec::MAX_BYTES))],
                 ),
+                ControlRejection::Command,
             ),
-            ("descriptor-shape", {
-                let mut x = create_wire("/bin/true", "/workspace", &[]);
-                x.extend([0, 1, 2]);
-                x
-            }),
+            (
+                "descriptor-shape",
+                {
+                    let mut x = create_wire("/bin/true", "/workspace", &[]);
+                    x.extend([0, 1, 2]);
+                    x
+                },
+                ControlRejection::Malformed,
+            ),
         ];
-        for (name, wire) in cases {
+        for (name, wire, expected) in cases {
             let counts = Counts::new();
             let (client_stream, server_stream) = UnixStream::pair().unwrap();
             thread::scope(|scope| {
@@ -881,10 +904,13 @@ mod tests {
                     .unwrap();
                 let mut payload = client.control(name).unwrap();
                 payload.extend(wire);
-                assert!(matches!(
-                    client.call(CREATE, &payload),
-                    Err(Error::InvalidControl)
-                ));
+                let refused = client
+                    .call(CREATE, &payload)
+                    .expect_err("a rejected CREATE must not succeed");
+                assert!(
+                    matches!(refused, Error::ControlRejected(actual) if actual == expected),
+                    "{name} must be refused as {expected:?}, got {refused:?}"
+                );
                 drop(client);
                 task.join().unwrap().unwrap();
             });
@@ -901,16 +927,20 @@ mod tests {
             let mut server = UnixBrokerServer::new(broker(counts.clone(), NoClone(counts.clone())));
             let task = scope.spawn(move || server.serve_connection(server_stream));
             let mut client = UnixBrokerClient::connect(client_stream, b"test-credential").unwrap();
+            // The categories are pinned, not just "some refusal": before goxi
+            // blocker 14 every one of these arrived as the single indistinct
+            // , and a fence mismatch wearing that name is what
+            // sent the investigation in the wrong direction.
             assert!(matches!(
                 client.call(READY, &[0; 16]),
-                Err(Error::InvalidControl)
+                Err(Error::ControlRejected(ControlRejection::Worker))
             ));
             assert!(matches!(
                 client.begin(Invocation {
                     id: "unready".into(),
                     fence: 1
                 }),
-                Err(Error::InvalidControl)
+                Err(Error::ControlRejected(ControlRejection::Worker))
             ));
             ready(&mut client);
             client
@@ -925,20 +955,20 @@ mod tests {
             wrong_id.extend(create_wire("/bin/true", "/workspace", &[]));
             assert!(matches!(
                 client.call(CREATE, &wrong_id),
-                Err(Error::InvalidControl)
+                Err(Error::ControlRejected(ControlRejection::Binding))
             ));
             let mut stale = client.control("bound").unwrap();
             stale[2 + "bound".len()] ^= 1;
             stale.extend(create_wire("/bin/true", "/workspace", &[]));
             assert!(matches!(
                 client.call(CREATE, &stale),
-                Err(Error::InvalidControl)
+                Err(Error::ControlRejected(ControlRejection::Nonce))
             ));
             let mut descriptor = client.control("bound").unwrap();
             descriptor.push(9);
             assert!(matches!(
                 client.call(STDOUT, &descriptor),
-                Err(Error::InvalidControl)
+                Err(Error::ControlRejected(_))
             ));
             drop(client);
             task.join().unwrap().unwrap();
@@ -1066,8 +1096,15 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    /// A well-formed `CREATE` payload, in the exact field order `command_in`
+    /// parses: leaf, **authority byte**, program, cwd, argc, argv, envc, env.
+    ///
+    /// The authority byte used to be missing here, which made every case above
+    /// fail at `take_string` on a shifted frame rather than at the check it
+    /// claimed to exercise.
     fn create_wire(program: &str, cwd: &str, environment: &[(&str, &str)]) -> Vec<u8> {
         let mut wire = enc("leaf").unwrap();
+        wire.push(LeaseAuthority::Armed.wire());
         wire.extend(enc(program).unwrap());
         wire.extend(enc(cwd).unwrap());
         wire.push(0);

--- a/server/crates/djinn-cgroup-launcher/tests/brokered_lease_lift_boundary.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/brokered_lease_lift_boundary.rs
@@ -1,0 +1,431 @@
+//! The escalation proof taken through the REAL broker protocol.
+//!
+//! # Why this file exists (goxi launcher blocker 14)
+//!
+//! `delegated_cpu_lease_lifecycle.rs` proves the lease governs CPU by calling
+//! `Launcher::fenced_lift` **directly**. That is one layer above where the
+//! production lift actually happens: in a task-run Pod the worker never holds a
+//! `Launcher`, it holds a `UnixBrokerClient`, and the lift is a `LIFT` control
+//! frame carrying an invocation id, a rotating nonce and a fence — which the
+//! privileged broker validates before it touches cgroupfs.
+//!
+//! That gap is not theoretical. #2627 fixed the in-pod lift *decision* and
+//! shipped with a test asserting that `fenced_lift` was called and that the
+//! birth authority was `Armed`. Both were true in production. The broker then
+//! **refused the control**, every armed invocation ran its whole life pinned at
+//! `cpu.max=[25000 100000]` while burning 670,199 and 749,566 usec (2.7x and 3.0x
+//! the escalation threshold) with `nr_throttled` climbing to 30, and — because a
+//! rejected lift failed the command — the agent's `shell` tool started returning
+//! `lease invocation failed: Launcher(… InvalidControl)`.
+//!
+//! Nothing in the lane could see it, because nothing in the lane spoke the
+//! protocol. This file does:
+//!
+//! 1. the launcher establishes its own delegated cgroup2 root and drops
+//!    `CAP_SYS_ADMIN`, exactly as the sidecar does;
+//! 2. a **real** [`UnixBrokerServer`] serves a **real** [`UnixBrokerClient`]
+//!    over a Unix socket, through `authenticate` / `READY` / `BEGIN` / `CREATE`;
+//! 3. the leaf is born at the unleased quota — read back **from the kernel**,
+//!    not from a value this test wrote;
+//! 4. a `LIFT` carrying the WRONG fence is refused, and the refusal is legible
+//!    (`ControlRejection::Fence`, not the indistinguishable `InvalidControl`),
+//!    and `cpu.max` has not moved;
+//! 5. a `LIFT` carrying the fence the invocation was BEGUN with is accepted, and
+//!    `cpu.max` transitions `25000 100000` -> `400000 100000` in the kernel;
+//! 6. and the transition is real throughput, not a file write: `cpu.stat` usage
+//!    over a wall-clock window multiplies and `nr_throttled` stops advancing.
+//!
+//! Step 4 is what makes step 5 non-vacuous. A `LIFT` that the broker accepts
+//! regardless of the fence would pass step 5 while proving nothing about the
+//! contract that broke.
+//!
+//! # Where it runs
+//!
+//! uid 0 plus a cgroup-v2 hierarchy it may mount and delegate, so the proof is
+//! `#[ignore]`d and executed by the `launcher-kernel-boundary` CI lane.
+//! [`the_brokered_lift_lane_is_wired`] is NOT ignored and fails the ordinary
+//! shard if that lane stops running this binary.
+//!
+//! # Why it is its own binary
+//!
+//! `Bootstrap::run` is irreversible and process-wide: once `CAP_SYS_ADMIN` is
+//! gone nothing later in the same process can mount. Sharing a process with
+//! `delegated_cpu_lease_lifecycle` would make whichever proof ran second fail
+//! for a reason that has nothing to do with what it asserts.
+
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use djinn_cgroup_launcher::bootstrap::{Bootstrap, INIT_LEAF};
+use djinn_cgroup_launcher::broker::{Broker, BrokerConfig, OsNonceSource};
+use djinn_cgroup_launcher::child::{NativeWorkerDumpability, prepare_worker_readiness};
+use djinn_cgroup_launcher::transport::{UnixBrokerClient, UnixBrokerServer};
+use djinn_cgroup_launcher::{
+    CommandSpec, ControlRejection, CpuStat, Error, Invocation, Launcher, LauncherConfig,
+    LeaseAuthority, LeasedQuota, NativeCgroupFs, NativeCgroupSpawn, UnleasedQuota,
+};
+
+/// The workflow job that must execute the `#[ignore]`d proof below.
+const PRIVILEGED_LANE_JOB: &str = "launcher-kernel-boundary";
+/// Marker the lane uses to declare how many brokered-lift proofs it expects.
+const EXPECTED_PROOFS_KEY: &str = "BROKERED_LIFT_EXPECTED_PROOFS";
+
+const UNLEASED_MILLICORES: u16 = UnleasedQuota::DEFAULT_MILLICORES;
+const LEASED_MILLICORES: u32 = LeasedQuota::DEFAULT_MILLICORES;
+/// The two `cpu.max` lines the transition runs between. Read back from the
+/// kernel either side of the `LIFT`; production measured the first one pinned
+/// for the whole life of every armed invocation.
+const UNLEASED_CPU_MAX: &str = "25000 100000";
+const LEASED_CPU_MAX: &str = "400000 100000";
+/// Wall-clock window each throughput measurement is taken over.
+const WINDOW: Duration = Duration::from_secs(2);
+/// Busy loops the probe runs; two, so a lifted leaf can exceed one core.
+const SPINNERS: u64 = 2;
+/// The fence this invocation is BEGUN with, and the only value its `LIFT` may
+/// carry. Deliberately not zero and not one: production sent a hard-coded `0` at
+/// `BEGIN` and the coordinator's `build_lease_fencing_token_seq` value (which
+/// starts at 1) at `LIFT`, so a proof using either would pass by coincidence.
+const INVOCATION_FENCE: u64 = 0x005e_ed0f_1ce5_u64;
+/// A fence the invocation was never begun with.
+const WRONG_FENCE: u64 = INVOCATION_FENCE ^ 1;
+
+// ═══════════════════ always-on: the lane cannot silently skip ════════════════
+
+/// The privileged lane must run THIS binary, with `--ignored`, without
+/// swallowing its failure, and must declare how many proofs it expects.
+#[test]
+fn the_brokered_lift_lane_is_wired() {
+    let source = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/brokered_lease_lift_boundary.rs"),
+    )
+    .expect("read this test file to count its privileged proofs");
+    // Only attributes at the start of a line; prose mentions are backticked.
+    let declared = source.matches("\n#[ignore").count();
+    assert!(
+        declared > 0,
+        "this file must declare a privileged proof; an empty suite proves nothing"
+    );
+
+    let lane = privileged_lane_block();
+    assert!(
+        lane.contains("--test brokered_lease_lift_boundary"),
+        "the privileged lane must run THIS test binary. It is the only proof that the broker \
+         ACCEPTS the lift control — #2627 shipped a green test that asserted only that \
+         `fenced_lift` was called, and the broker refused it in production"
+    );
+    assert!(
+        !lane.contains("continue-on-error"),
+        "the privileged lane may not swallow its own failure"
+    );
+    assert!(
+        lane.contains(&format!("{EXPECTED_PROOFS_KEY}: \"{declared}\"")),
+        "the lane must declare `{EXPECTED_PROOFS_KEY}: \"{declared}\"` so a run that executes \
+         fewer than the {declared} declared proofs fails instead of passing"
+    );
+}
+
+/// The `cpu.max` lines asserted against the kernel below are the ones the
+/// launcher actually writes, so a quota default change cannot leave this proof
+/// measuring numbers nobody uses.
+#[test]
+fn the_asserted_cpu_max_lines_are_the_ones_the_launcher_writes() {
+    assert_eq!(UNLEASED_MILLICORES, 250);
+    assert_eq!(LEASED_MILLICORES, 4_000);
+    assert_eq!(
+        format!("{} 100000", u64::from(UNLEASED_MILLICORES) * 100_000 / 1000),
+        UNLEASED_CPU_MAX
+    );
+    assert_eq!(
+        format!("{} 100000", u64::from(LEASED_MILLICORES) * 100_000 / 1000),
+        LEASED_CPU_MAX
+    );
+    LauncherConfig::new(Some(UNLEASED_MILLICORES), Some(LEASED_MILLICORES), 0)
+        .expect("the measured configuration must be one the launcher accepts");
+}
+
+/// The refusal the worker sees must name the fence, not the catch-all.
+///
+/// Production's entire diagnostic was
+/// `Launcher(Custom { kind: Other, error: InvalidControl })` for what was really
+/// a fence mismatch — and `InvalidControl` is a real, different broker error, so
+/// the message actively pointed away from the defect.
+#[test]
+fn a_refused_lift_is_distinguishable_from_every_other_refusal() {
+    assert_eq!(
+        ControlRejection::of(&Error::FenceMismatch),
+        ControlRejection::Fence
+    );
+    assert_ne!(
+        ControlRejection::of(&Error::FenceMismatch),
+        ControlRejection::of(&Error::InvalidControl),
+    );
+    assert_ne!(
+        ControlRejection::of(&Error::FenceMismatch),
+        ControlRejection::of(&Error::LiftWithoutAuthority),
+    );
+}
+
+// ═════════ privileged proof: the BROKER accepts the lift, kernel-measured ════
+
+/// Bootstrap, serve the real protocol, and watch `cpu.max` move in the kernel.
+#[ignore = "privileged: needs uid 0 and a cgroup-v2 hierarchy it may mount and delegate \
+            (CI job launcher-kernel-boundary)"]
+#[test]
+fn the_brokered_lift_control_moves_cpu_max_from_unleased_to_leased() {
+    require_root();
+    let root = scratch_dir("brokered-lift");
+
+    // ── 1. The launcher establishes its own delegated root ──────────────────
+    Bootstrap::new(&root).run().unwrap_or_else(|error| {
+        panic!(
+            "the launcher could not establish its delegated cgroup root at {}: {error}",
+            root.display()
+        )
+    });
+    assert!(
+        root.join(INIT_LEAF).is_dir(),
+        "bootstrap must vacate the delegated root into an init leaf"
+    );
+
+    // ── 2. The real broker, over the real filesystem and spawn seams ────────
+    let launcher = Launcher::new(
+        NativeCgroupFs::open(&root, 0).expect("the established root must satisfy readiness"),
+        NativeCgroupSpawn,
+        LauncherConfig::new(Some(UNLEASED_MILLICORES), Some(LEASED_MILLICORES), 0)
+            .expect("launcher config"),
+    )
+    .expect("launcher");
+    let broker = Broker::new(
+        launcher,
+        BrokerConfig {
+            // The socketpair's peer is this very process, so the broker's
+            // `SO_PEERCRED` check is exercised for real against real
+            // credentials rather than stubbed out.
+            worker_pid: std::process::id(),
+            worker_uid: unsafe { libc::geteuid() },
+            worker_gid: unsafe { libc::getegid() },
+            pod_credential: b"brokered-lift-proof-credential".to_vec(),
+        },
+        OsNonceSource,
+    )
+    .expect("broker");
+
+    let (client_stream, server_stream) = UnixStream::pair().expect("control socketpair");
+    let leaf = "brokered-lift";
+    thread::scope(|scope| {
+        let mut server = UnixBrokerServer::new(broker);
+        let served = scope.spawn(move || server.serve_connection(server_stream));
+
+        let mut client =
+            UnixBrokerClient::connect(client_stream, b"brokered-lift-proof-credential")
+                .expect("the broker must authenticate this peer and credential");
+        client
+            // The real `prctl` seam, not a double: the broker's readiness gate
+            // is satisfied exactly the way the worker satisfies it.
+            .ready(
+                prepare_worker_readiness(&mut NativeWorkerDumpability).expect("worker readiness"),
+            )
+            .expect("READY");
+        client
+            .begin(Invocation {
+                id: leaf.to_owned(),
+                fence: INVOCATION_FENCE,
+            })
+            .expect("BEGIN");
+        client
+            .create(leaf, leaf, LeaseAuthority::Armed, &spinner_command())
+            .expect("CREATE must make the leaf and spawn the probe into it");
+
+        // ── 3. Born clamped — read from the KERNEL ──────────────────────────
+        let cpu_max = root.join(leaf).join("cpu.max");
+        assert_eq!(
+            read_trimmed(&cpu_max),
+            UNLEASED_CPU_MAX,
+            "an armed leaf must be born at the unleased quota"
+        );
+        let unleased = measure(&mut client, leaf, WINDOW);
+
+        // ── 4. A wrong fence is REFUSED, legibly, and moves nothing ─────────
+        let refused = client.lift(leaf, WRONG_FENCE).expect_err(
+            "a LIFT carrying a fence this invocation was never begun with must be refused; if it \
+             is accepted, step 5 below proves nothing about the fencing contract",
+        );
+        assert!(
+            matches!(refused, Error::ControlRejected(ControlRejection::Fence)),
+            "the refusal must name the FENCE. Production reported this exact rejection as \
+             `InvalidControl` — a different, real broker error — and the misattribution is why \
+             the defect survived a release. Got: {refused:?}"
+        );
+        assert_eq!(
+            read_trimmed(&cpu_max),
+            UNLEASED_CPU_MAX,
+            "a refused lift must not have written a quota"
+        );
+
+        // ── 5. The matching fence lifts, measured on the kernel's cpu.max ───
+        client
+            .lift(leaf, INVOCATION_FENCE)
+            .expect("the LIFT carrying the fence the invocation was BEGUN with must be accepted");
+        assert_eq!(
+            read_trimmed(&cpu_max),
+            LEASED_CPU_MAX,
+            "the brokered lift must move cpu.max off the unleased quota. This is the assertion \
+             production failed: cpu.max stayed `{UNLEASED_CPU_MAX}` for the whole life of every \
+             armed invocation, with zero transitions observed over a 2s sampling loop"
+        );
+
+        // ── 6. …and it is throughput, not a file write ──────────────────────
+        let lifted = measure(&mut client, leaf, WINDOW);
+        let unleased_ceiling = quota_usec(u32::from(UNLEASED_MILLICORES), lifted.wall);
+        assert!(
+            lifted.usage_usec > unleased_ceiling * 2,
+            "after the brokered lift the leaf burned {} usec against {} unleased over comparable \
+             windows ({:?} / {:?}). A lift the kernel does not honour is a lift in name only",
+            lifted.usage_usec,
+            unleased.usage_usec,
+            lifted.wall,
+            unleased.wall
+        );
+        assert_eq!(
+            lifted.nr_throttled, 0,
+            "the lifted leaf was throttled {} more times; {SPINNERS} busy loops cannot saturate \
+             a {LEASED_MILLICORES}m lease, so any throttling means the quota did not move",
+            lifted.nr_throttled
+        );
+        assert!(
+            unleased.nr_throttled > 0,
+            "the unleased leaf was never throttled, so the 250m quota was not biting and the \
+             comparison above describes nothing"
+        );
+
+        // ── 7. The one-way contract holds through the broker too ────────────
+        let again = client
+            .lift(leaf, INVOCATION_FENCE)
+            .expect_err("the lift is one-way; a second one must be refused");
+        assert!(
+            matches!(
+                again,
+                Error::ControlRejected(ControlRejection::AlreadyLifted)
+            ),
+            "a repeated lift must be refused as already-applied, got {again:?}"
+        );
+
+        // ── Teardown through the broker's own controls ──────────────────────
+        client.kill(leaf).expect("cgroup.kill");
+        let drained = (0..200).any(|_| {
+            if client.wait_empty(leaf).is_ok() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+            false
+        });
+        assert!(drained, "the leaf never reached populated 0");
+        client.cleanup(leaf).expect("remove the drained leaf");
+        drop(client);
+        served.join().expect("server thread").expect("served");
+    });
+}
+
+// ─────────────────────────────── measurement ────────────────────────────────
+
+struct Measured {
+    usage_usec: u64,
+    nr_throttled: u64,
+    wall: Duration,
+}
+
+/// Sample `cpu.stat` **through the broker's `SAMPLE` control**, sleep, sample
+/// again, and return the delta. Going through the protocol rather than reading
+/// the file directly keeps the measurement describing what a worker can
+/// actually observe.
+fn measure(client: &mut UnixBrokerClient, leaf: &str, window: Duration) -> Measured {
+    let before: CpuStat = client.sample(leaf).expect("SAMPLE");
+    #[allow(clippy::disallowed_methods)]
+    let started = Instant::now();
+    std::thread::sleep(window);
+    let elapsed = started.elapsed();
+    let after: CpuStat = client.sample(leaf).expect("SAMPLE");
+    Measured {
+        usage_usec: after.usage_usec.saturating_sub(before.usage_usec),
+        nr_throttled: after.nr_throttled.saturating_sub(before.nr_throttled),
+        wall: elapsed,
+    }
+}
+
+/// CPU microseconds a `millicores` quota permits over `wall`, capped by how much
+/// the probe could possibly consume ([`SPINNERS`] cores).
+fn quota_usec(millicores: u32, wall: Duration) -> u64 {
+    let wall_usec = wall.as_micros() as u64;
+    (wall_usec * u64::from(millicores) / 1000).min(wall_usec * SPINNERS)
+}
+
+// ──────────────────────────────── helpers ───────────────────────────────────
+
+fn spinner_command() -> CommandSpec {
+    CommandSpec {
+        program: "/bin/sh".to_owned(),
+        argv: vec![
+            "-c".to_owned(),
+            "while : ; do : ; done & while : ; do : ; done".to_owned(),
+        ],
+        cwd: "/workspace".to_owned(),
+        environment: vec![],
+    }
+}
+
+fn require_root() {
+    let euid = unsafe { libc::geteuid() };
+    assert_eq!(
+        euid, 0,
+        "the brokered lift proof must run as uid 0 (uid {euid} cannot mount cgroup2). It runs in \
+         the `{PRIVILEGED_LANE_JOB}` CI lane; reproduce it locally with: \
+         `cargo test -p djinn-cgroup-launcher --test brokered_lease_lift_boundary --no-run` then \
+         `docker run --rm --privileged --cgroupns=private -v \"$PWD:$PWD\" ubuntu:24.04 \
+         bash -c 'mkdir -p /workspace && exec \"$0\" --ignored --test-threads 1' <the binary>`"
+    );
+    assert!(
+        Path::new("/workspace").is_dir(),
+        "/workspace is missing: the rendered CommandSpec cwd must exist before a child can exec"
+    );
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let base = PathBuf::from(format!("/tmp/djinn-goxi-{label}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).expect("create scratch dir");
+    base
+}
+
+fn read_trimmed(path: &Path) -> String {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+        .trim()
+        .to_owned()
+}
+
+/// The privileged lane's own YAML block, isolated from sibling jobs.
+fn privileged_lane_block() -> String {
+    let workflow = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../..")
+            .join(".github/workflows/quality-gate.yml"),
+    )
+    .expect("read the CI workflow that must host the privileged lane");
+    let header = format!("\n  {PRIVILEGED_LANE_JOB}:\n");
+    let start = workflow.find(&header).unwrap_or_else(|| {
+        panic!("no `{PRIVILEGED_LANE_JOB}` job: the brokered lift proof would never execute")
+    }) + 1;
+    let mut block = String::new();
+    for (index, line) in workflow[start..].lines().enumerate() {
+        let sibling_job =
+            line.starts_with("  ") && !line.starts_with("   ") && line.trim_end().ends_with(':');
+        if index > 0 && sibling_job {
+            break;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+    block
+}

--- a/server/crates/djinn-coordinator/src/build_admission_transition.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_transition.rs
@@ -38,6 +38,14 @@
 //! replica ack, leaving both authorities enforcing and v1 un-disabled) →
 //! `complete_rollback` (disable v1 only after the overlap confirms v0 again).
 //! No transaction lifts or disables v1 quota before v0 is confirmed.
+//!
+//! That ordering starts at [`AdmissionHandoffPhase::InvocationPrimary`], because
+//! it exists to re-confirm v0 *before* releasing it. A cutover that has not got
+//! that far — `emergency_primary` with v1 armed, or `forward_overlap` — has
+//! nothing to re-confirm: v0 is still enforcing, and the only committed delta is
+//! that v1 lifts quota. [`AdmissionTransitionExecutor::abort_v1_arming`] reverses
+//! exactly that delta in place. The phase ring has no backward edge and does not
+//! need one.
 
 use std::sync::Arc;
 
@@ -374,6 +382,77 @@ impl AdmissionTransitionExecutor {
             .map_err(map_db)
     }
 
+    /// Abort a v1 arming that has not yet released v0, by setting v1 `Off`
+    /// **without a phase transition**.
+    ///
+    /// # Why this exists (goxi launcher blocker 14, second defect)
+    ///
+    /// `AdmissionHandoffPhase` is a strict forward ring
+    /// ([`AdmissionHandoffPhase::legal_next`]), so there is no backward edge to
+    /// take out of [`AdmissionHandoffPhase::ForwardOverlap`]. `epoch rollback`
+    /// only knew the three-step reverse ordering that starts at
+    /// `InvocationPrimary`, so an operator who had advanced into the forward
+    /// overlap got:
+    ///
+    /// ```text
+    /// no rollback step is defined from phase ForwardOverlap
+    /// ```
+    ///
+    /// An armed rollout with no reverse gear. The only mitigation left was to
+    /// disable the launcher in Helm and redeploy — which is exactly what
+    /// happened, while the durable row stayed at `ForwardOverlap`/`v1 Enforce`.
+    ///
+    /// # Why it is safe, and why it is not a phase transition
+    ///
+    /// Reaching `ForwardOverlap` changes nothing but the phase, the epoch and
+    /// the acks: `arm_overlap` already committed `v0 Enforce, v1 Enforce` while
+    /// still in `EmergencyPrimary`. The overlap's ONLY semantic delta is that v1
+    /// begins lifting quota; v0 never stops enforcing. So the reverse of that
+    /// delta is not a phase move at all — it is `v1 -> Off`, after which
+    /// `evaluate_invocation_lift` refuses to lift and the ring is left free to
+    /// be re-driven forward later. `v0` is required to be durably `Enforce`
+    /// first, so the "at least one enforcing authority" invariant holds at every
+    /// committed point; the write itself bumps the epoch and clears both acks,
+    /// so the row is `IncompleteEpoch` (v0 fail-closed, v1 unleased) until the
+    /// leader re-acknowledges — fail-closed on both sides throughout.
+    ///
+    /// Unlike [`Self::complete_rollback`] this does **not** wait for a v0
+    /// acknowledgement. It never releases an authority — it only removes the
+    /// one that is not primary — and the operator reaching for it is by
+    /// definition aborting a cutover, so blocking on an ack would withhold the
+    /// reverse gear in exactly the incident it exists for.
+    ///
+    /// Refused from `InvocationPrimary` and `RollbackOverlap`: v0 may already be
+    /// `Observe` there, so disabling v1 could leave zero enforcing authorities.
+    /// Those phases keep the three-step reverse ordering below.
+    pub async fn abort_v1_arming(
+        &self,
+        expected_epoch: i64,
+    ) -> Result<AdmissionHandoffRow, TransitionError> {
+        let row = self.current(expected_epoch).await?;
+        if !matches!(
+            row.phase,
+            AdmissionHandoffPhase::EmergencyPrimary | AdmissionHandoffPhase::ForwardOverlap
+        ) {
+            return Err(TransitionError::InvalidTransition(format!(
+                "v1 arming can only be aborted while v0 is still primary (emergency_primary or \
+                 forward_overlap); phase is {:?}, which requires the reverse rollback ordering",
+                row.phase
+            )));
+        }
+        if row.v0_mode != V0Mode::Enforce {
+            return Err(TransitionError::HaltedV0Unconfirmed { epoch: row.epoch });
+        }
+        if row.v1_mode == V1Mode::Off {
+            return Ok(row);
+        }
+        validate_config(V0Mode::Enforce, V1Mode::Off, row.cap)?;
+        self.repo
+            .set_modes_and_cap(expected_epoch, V0Mode::Enforce, V1Mode::Off, row.cap)
+            .await
+            .map_err(map_db)
+    }
+
     /// Advance `InvocationPrimary` → `RollbackOverlap` **only** after confirming
     /// v0 is enforcing with a controller-replica acknowledgement at the current
     /// epoch. If v0 is not confirmed this returns
@@ -659,6 +738,97 @@ mod tests {
             V1Mode::Off,
             "v1 disabled only after v0 confirmed"
         );
+    }
+
+    /// goxi blocker 14, second defect: a cutover that has reached
+    /// `ForwardOverlap` must have a reverse gear.
+    ///
+    /// `epoch rollback` answered `no rollback step is defined from phase
+    /// ForwardOverlap`, so an operator who had advanced into the overlap had no
+    /// epoch-level way back and had to disable the launcher in Helm and
+    /// redeploy while the durable row stayed armed. The reverse of the overlap
+    /// is not a phase move — the ring has no backward edge — it is `v1 -> Off`
+    /// in place.
+    #[tokio::test]
+    async fn a_forward_overlap_can_be_aborted_by_disabling_v1_in_place() {
+        let exec = executor().await;
+        let shadow = exec.arm_shadow(0, 3).await.unwrap();
+        let overlap_modes = exec.arm_overlap(shadow.epoch, 3).await.unwrap();
+        leader_acks_emergency(&exec).await;
+        let overlap = exec
+            .enter_forward_overlap(overlap_modes.epoch)
+            .await
+            .unwrap();
+        assert_eq!(overlap.phase, AdmissionHandoffPhase::ForwardOverlap);
+        assert_eq!(overlap.v1_mode, V1Mode::Enforce);
+
+        let aborted = exec.abort_v1_arming(overlap.epoch).await.unwrap();
+        assert_eq!(
+            aborted.v1_mode,
+            V1Mode::Off,
+            "the abort must stop v1 from lifting quota"
+        );
+        assert_eq!(
+            aborted.v0_mode,
+            V0Mode::Enforce,
+            "v0 never stops enforcing, so an enforcing authority survives the abort"
+        );
+        assert_eq!(
+            aborted.phase,
+            AdmissionHandoffPhase::ForwardOverlap,
+            "the phase ring is forward-only; the abort is a mode change, not a backward edge"
+        );
+        assert_eq!(aborted.cap, Some(3), "an abort must not change the cap");
+        assert!(
+            aborted.epoch > overlap.epoch,
+            "the abort is epoch-fenced like every other committed change"
+        );
+        // Re-running it is a no-op rather than an error, so a retried rollback
+        // step converges instead of failing an operator mid-incident.
+        let again = exec.abort_v1_arming(aborted.epoch).await.unwrap();
+        assert_eq!(again.epoch, aborted.epoch);
+        assert_eq!(again.v1_mode, V1Mode::Off);
+    }
+
+    /// The same abort covers an `emergency_primary` row still carrying an armed
+    /// shadow or overlap v1 — the other phase that fell into the
+    /// `no rollback step is defined` catch-all.
+    #[tokio::test]
+    async fn an_armed_shadow_can_be_aborted_before_the_overlap() {
+        let exec = executor().await;
+        let shadow = exec.arm_shadow(0, 3).await.unwrap();
+        assert_eq!(shadow.v1_mode, V1Mode::Shadow);
+        let aborted = exec.abort_v1_arming(shadow.epoch).await.unwrap();
+        assert_eq!(aborted.v1_mode, V1Mode::Off);
+        assert_eq!(aborted.v0_mode, V0Mode::Enforce);
+        assert_eq!(aborted.phase, AdmissionHandoffPhase::EmergencyPrimary);
+    }
+
+    /// The abort must NOT be reachable once v0 has been released: from
+    /// `InvocationPrimary`/`RollbackOverlap` v0 may already be observing, so
+    /// disabling v1 in place could leave zero enforcing authorities. Those
+    /// phases keep the three-step reverse ordering that re-confirms v0 first.
+    #[tokio::test]
+    async fn the_abort_is_refused_once_v0_has_been_released() {
+        let exec = executor().await;
+        let primary = cutover(&exec, 3, &[]).await;
+        assert!(matches!(
+            exec.abort_v1_arming(primary.epoch).await,
+            Err(TransitionError::InvalidTransition(_))
+        ));
+        let observed = exec.observe_v0(primary.epoch).await.unwrap();
+        assert_eq!(observed.v0_mode, V0Mode::Observe);
+        assert!(
+            matches!(
+                exec.abort_v1_arming(observed.epoch).await,
+                Err(TransitionError::InvalidTransition(_))
+            ),
+            "disabling v1 while v0 observes would leave no enforcing authority"
+        );
+        // And the row is untouched by the refusal.
+        let after = exec.show().await.unwrap().unwrap();
+        assert_eq!(after.epoch, observed.epoch);
+        assert_eq!(after.v1_mode, V1Mode::Enforce);
     }
 
     /// AC2 cap guard: a rollback must not raise the cap.

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -247,6 +247,7 @@ const BUILD_ADMISSION_JOURNAL_DEGRADED: &str = "djinn_build_admission_journal_de
 const BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH: &str = "djinn_build_admission_create_unknown_health";
 const BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL: &str =
     "djinn_build_admission_shadow_invocation_total";
+const BUILD_ADMISSION_LIFT_REJECTED_TOTAL: &str = "djinn_build_admission_lift_rejected_total";
 const BUILD_ADMISSION_TRANSITION_TOTAL: &str = "djinn_build_admission_transition_total";
 // One closed enumeration for every durable journal write attempt: the two
 // lifecycle outcomes plus the two startup-reconciliation outcomes. Extending
@@ -2262,6 +2263,13 @@ fn register_metrics() {
         "Shadow-mode v1 invocation decisions the launcher observed but did not act on."
     );
     metrics::describe_counter!(
+        BUILD_ADMISSION_LIFT_REJECTED_TOTAL,
+        "Authorized cgroup lifts the privileged launcher broker refused. Any \
+         non-zero value means armed invocations are running permanently clamped \
+         at the unleased quota: the epoch authorized an escalation, a matching \
+         durable grant was held, and the kernel boundary still refused it."
+    );
+    metrics::describe_counter!(
         BUILD_ADMISSION_TRANSITION_TOTAL,
         "Durable admission-journal lifecycle transitions by outcome. A rejected \
          share near one means the journal is refusing every observation and \
@@ -3625,6 +3633,24 @@ pub mod build_admission {
         );
         metrics::counter!(super::BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL, "decision" => decision, "class" => class)
             .increment(1);
+    }
+
+    /// Record one authorized cgroup lift that the privileged broker REFUSED.
+    ///
+    /// This is the alarm for goxi launcher blocker 14. The invocation reached a
+    /// matching durable bind under a `Lift` epoch — every control-plane
+    /// precondition held — and the kernel-boundary control still came back
+    /// refused, so the command runs its whole life clamped at the 250m unleased
+    /// quota (a ~16x slowdown). The runner now degrades instead of failing the
+    /// command, which means this counter is the ONLY control-plane signal that
+    /// the escalation path is broken: a silent degrade with no counter is how a
+    /// throttling regression hides for four rollouts.
+    ///
+    /// Emitted with a structured `tracing::error!` at the call site for the same
+    /// reason [`record_shadow_invocation`] logs: `djinn-agent-worker` exposes no
+    /// `/metrics` endpoint, so in a task-run Pod the log line is what escapes.
+    pub fn record_lift_rejected() {
+        metrics::counter!(super::BUILD_ADMISSION_LIFT_REJECTED_TOTAL).increment(1);
     }
 }
 

--- a/server/src/admin.rs
+++ b/server/src/admin.rs
@@ -23,6 +23,8 @@ use std::fmt::Write as _;
 use std::sync::Arc;
 
 use djinn_coordinator::build_admission_transition::{AdmissionTransitionExecutor, TransitionError};
+#[cfg(test)]
+use djinn_db::AdmissionHandoffAuthority;
 use djinn_db::{
     AdmissionHandoffPhase, AdmissionHandoffRepository, AdmissionHandoffRow, Database, V0Mode,
     V1Mode,
@@ -61,14 +63,18 @@ pub enum EpochAction {
         #[arg(long)]
         cap: i64,
     },
-    /// Perform the next safe ROLLBACK step from invocation-primary.
+    /// Perform the next safe ROLLBACK step. Defined from EVERY phase: from
+    /// invocation-primary/rollback-overlap it drives the three-step reverse
+    /// ordering that re-confirms v0 before releasing it; from an armed
+    /// emergency-primary or a forward-overlap — where v0 never stopped
+    /// enforcing — it aborts the cutover by setting v1 off in place.
     Rollback {
         /// Same-or-lower cap for the rollback arm; defaults to the current cap.
         #[arg(long)]
         cap: Option<i64>,
     },
-    /// Urgent rollback from invocation-primary — the same safe ordering as
-    /// `rollback`, initiated while v0 is still enforcing from the overlap.
+    /// Urgent rollback — the same safe ordering as `rollback`, initiated while
+    /// v0 is still enforcing from the overlap.
     KillSwitch {
         /// Same-or-lower cap for the rollback arm; defaults to the current cap.
         #[arg(long)]
@@ -188,7 +194,23 @@ async fn advance_rollback(
         AdmissionHandoffPhase::EmergencyPrimary if row.v1_mode == V1Mode::Off => {
             Ok("rollback complete: emergency-primary baseline (v0 enforce, v1 off)".to_string())
         }
-        phase => Err(format!("no rollback step is defined from phase {phase:?}")),
+        // A cutover that has NOT yet released v0 is aborted by disabling v1 in
+        // place, not by a phase move — the phase machine is a strict forward
+        // ring with no backward edge. This covers `forward_overlap` (where the
+        // only committed delta is "v1 lifts quota") and an `emergency_primary`
+        // row still carrying an armed shadow/overlap v1.
+        //
+        // Before this arm existed both fell through to
+        // `no rollback step is defined from phase ForwardOverlap`, so an
+        // operator who had advanced into the overlap had no epoch-level reverse
+        // gear at all: the documented workaround ("set v1 = off") named a
+        // command that did not exist, `set-cap` deliberately preserves modes,
+        // and the only remaining mitigation was disabling the launcher in Helm
+        // and redeploying while the durable row stayed armed. See
+        // `AdmissionTransitionExecutor::abort_v1_arming` for why this is safe.
+        AdmissionHandoffPhase::EmergencyPrimary | AdmissionHandoffPhase::ForwardOverlap => {
+            fold(exec.abort_v1_arming(epoch).await, "abort-v1-arming")
+        }
     }
 }
 
@@ -290,6 +312,90 @@ mod tests {
         .await
         .expect("arm shadow");
         assert!(rendered.starts_with("arm-shadow: applied"), "{rendered}");
+    }
+
+    /// goxi launcher blocker 14, second defect: `epoch rollback` must have a
+    /// step from **every** phase.
+    ///
+    /// It used to answer `no rollback step is defined from phase ForwardOverlap`,
+    /// so an operator who had advanced into the overlap had no epoch-level
+    /// reverse gear and had to disable the launcher in Helm and redeploy while
+    /// the durable row stayed armed. This drives the whole thing through the
+    /// **CLI dispatch** — `advance_rollback`'s phase table — which had no test at
+    /// all.
+    #[tokio::test]
+    async fn rollback_has_a_step_from_every_phase_including_the_forward_overlap() {
+        let db = Database::open_in_memory().expect("test database");
+        let repo = Arc::new(AdmissionHandoffRepository::new(db));
+        repo.read().await.expect("initialize fixture");
+
+        let advance = || EpochAction::Advance {
+            cap: Some(3),
+            generations: Vec::new(),
+        };
+        let rollback = || EpochAction::Rollback { cap: Some(3) };
+
+        // A rollback from an armed shadow (still emergency_primary) disables v1
+        // rather than erroring.
+        run_admin_command_with(&repo, advance())
+            .await
+            .expect("arm shadow");
+        let rendered = run_admin_command_with(&repo, rollback())
+            .await
+            .expect("an armed shadow must be abortable");
+        assert!(
+            rendered.starts_with("abort-v1-arming: applied"),
+            "{rendered}"
+        );
+        assert_eq!(
+            repo.read().await.expect("read").expect("row").v1_mode,
+            V1Mode::Off
+        );
+
+        // Drive forward into the overlap: shadow -> overlap modes -> the phase
+        // advance (which needs the leader's v0 ack).
+        for _ in 0..2 {
+            run_admin_command_with(&repo, advance())
+                .await
+                .expect("arm forward");
+        }
+        let epoch = repo.read().await.expect("read").expect("row").epoch;
+        repo.acknowledge(AdmissionHandoffAuthority::Emergency, epoch)
+            .await
+            .expect("leader acks v0");
+        let rendered = run_admin_command_with(&repo, advance())
+            .await
+            .expect("enter the forward overlap");
+        assert!(
+            rendered.starts_with("enter-forward-overlap: applied"),
+            "{rendered}"
+        );
+        let overlap = repo.read().await.expect("read").expect("row");
+        assert_eq!(overlap.phase, AdmissionHandoffPhase::ForwardOverlap);
+        assert_eq!(overlap.v1_mode, V1Mode::Enforce);
+
+        // THE regression: this returned
+        // `no rollback step is defined from phase ForwardOverlap`.
+        let rendered = run_admin_command_with(&repo, rollback())
+            .await
+            .expect("a forward overlap must be abortable; an armed rollout needs a reverse gear");
+        assert!(
+            rendered.starts_with("abort-v1-arming: applied"),
+            "{rendered}"
+        );
+        let aborted = repo.read().await.expect("read").expect("row");
+        assert_eq!(aborted.v1_mode, V1Mode::Off, "v1 must stop lifting");
+        assert_eq!(
+            aborted.v0_mode,
+            V0Mode::Enforce,
+            "v0 must still be enforcing, so an authority survives the abort"
+        );
+
+        // And the terminal answer is still reported rather than looping.
+        let rendered = run_admin_command_with(&repo, rollback())
+            .await
+            .expect("the baseline reports completion");
+        assert!(rendered.starts_with("abort-v1-arming"), "{rendered}");
     }
 
     async fn run_admin_command_with(


### PR DESCRIPTION
## goxi launcher blocker 14

`#2627` fixed the in-pod lift *decision* and it worked — production measured
`decision=Lift authority=Armed threshold_usec=250000` and leaves born correctly
clamped at `cpu.max=[25000 100000]`. But the escalation was **refused by the
broker** on every invocation, and because the refusal propagated with `?` it
took the agent's `shell` tool down with it:

```
tool=shell error=failed to run shell command: lease invocation failed:
      Launcher(Custom { kind: Other, error: InvalidControl })
```

Measured on the delegated cgroup: leaves reached 670,199 and 749,566 usec (2.7x
and 3.0x the escalation threshold), pinned at `cpu.max=[25000 100000]` with
**zero** transitions and `nr_throttled` climbing to 30. 5 `lease invocation
failed` against 10 launches in one pod.

## 1. Why the broker returned `InvalidControl`

**Two different fences, conflated.**

| | value | when it exists |
| --- | --- | --- |
| broker invocation fence | worker-declared in `BEGIN`, stored on the leaf at birth, the only value `Launcher::fenced_lift` accepts | before the child `execve`s |
| durable lease fencing token | `nextval('build_lease_fencing_token_seq')` | at grant time, long after the leaf |

`UnixBrokerLauncher::new(client, 0)` (`context.rs:186`) sent a launcher-wide
constant `0` in `BEGIN`; `fenced_lift(&token)` sent the coordinator's token in
`LIFT`. The sequence starts at 1, so `leaf.invocation.fence != fence` was
**deterministically true for every armed invocation** and
`Launcher::fenced_lift` returned `FenceMismatch`.

It surfaced as `InvalidControl` because `transport::reply` collapsed *every*
server-side error into a single byte `1` and the client rendered that as
`Error::InvalidControl` — which is also a real, different broker error, so the
message named a cause that had not occurred and pointed the investigation away
from the fence.

The token cannot be the birth fence: it does not exist when the leaf is born.

## 2. The fix

- **One source for the fence.** `process_broker::invocation_fence(id)` derives
  it from the invocation identity; `launch` reads it once, uses it for `BEGIN`,
  and stores it on the handle for `LIFT`. There is no second place that decides
  it, so the two controls cannot disagree.
- **`ProcessHandle::fenced_lift` takes no token.** An implementation that
  silently ignored the argument would be the same defect wearing a signature.
  The durable token still governs *whether* a lift may happen — the runner only
  reaches the call inside a matching `LeaseResult::Bound` arm and journals the
  token first — it is just not the value the cgroup boundary is fenced by.
- **Refusals are legible.** A bounded `ControlRejection` category now travels on
  the wire (`Fence`, `Unarmed`, `AlreadyLifted`, `Terminal`, `Nonce`, `Binding`,
  `Command`, `State`, `Malformed`, `Kernel`). Category only — no path, no errno,
  no command text — to an already-authenticated peer. An unknown code decodes to
  `Unspecified` so a rolling update never turns a legible refusal into an
  illegible frame error.

Containment, the fencing contract and `evaluate_invocation_lift` are unchanged.

## 3. Should a failed lift fail the command? No — it degrades.

Right now it did, which converted a defect in a *throttling optimisation* into
total loss of the agent's ability to run commands. That is the worst available
coupling, and the fallback it denied itself — keep running clamped at 250m — is
strictly better than dying.

It also contradicted the precedent this very runner sets one arm up: a lost
lease **queue** degrades to continued unleased execution (`lease_failure` ->
`unleased_degrade`) precisely because contention must make a command *slow,
never dead*. A rejected lift is the same class of event.

Nothing is swallowed:

- the child keeps running at the unleased quota it was born at (leaf, kill path
  and `cpu.stat` all intact);
- `tracing::error!` at the call site names the refusal category;
- `djinn_build_admission_lift_rejected_total` counts it — documented in the
  runbook as an alarm, since `djinn-agent-worker` exposes no `/metrics` and any
  non-zero value means armed invocations are running permanently clamped;
- `unleased_degrade` is set (one-way, like the lost queue) so the refused
  one-way lift is never retried;
- `fence` is still recorded, so the durable lease still reconciles to terminal
  and no counted build slot leaks.

## 4. Regression tests that exercise the real broker

The specific gap: #2627's test asserted `fenced_lift` was *called* and the birth
authority was `Armed`. Both were true in production.

**`djinn-cgroup-launcher/tests/brokered_lease_lift_boundary.rs`** — new
privileged proof, wired into the `launcher-kernel-boundary` lane with its own
`BROKERED_LIFT_EXPECTED_PROOFS` declaration and an always-on guard that fails the
ordinary shard if the lane stops running it. It bootstraps a real delegated
cgroup2 root, drops `CAP_SYS_ADMIN`, serves a real `UnixBrokerServer` to a real
`UnixBrokerClient` over a real socket, then:

1. reads `cpu.max` **from the kernel** at birth -> `25000 100000`;
2. sends a `LIFT` with the **wrong** fence -> refused as
   `ControlRejected(Fence)`, `cpu.max` unmoved *(this is what makes step 3
   non-vacuous)*;
3. sends the matching fence -> accepted, `cpu.max` **from the kernel** ->
   `400000 100000`;
4. measures `cpu.stat` through the broker's own `SAMPLE` control over a 2s
   window either side: throughput multiplies, `nr_throttled` stops advancing;
5. a second `LIFT` is refused as `AlreadyLifted` — the one-way contract holds
   through the broker too.

Executed locally in the lane's exact container:

```
$ docker run --rm --privileged --cgroupns=private ... --ignored --test-threads 1
running 1 test
test the_brokered_lift_control_moves_cpu_max_from_unleased_to_leased ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 4.04s
```

**`process_lease_broker_lift_tests.rs`** — the production composition
(`UnixBrokerLauncher` -> `UnixBrokerClient` -> socket -> `UnixBrokerServer` ->
`Broker` -> `Launcher`) proving the launch can lift the leaf it just created,
plus that a mismatched fence is refused *and says so*.

**`a_refused_lift_degrades_the_command_instead_of_failing_it`** — the real runner
over the real durable lease services against an armed epoch, so the lift is
genuinely attempted and refused rather than skipped.

### Verified by neutralization

Reintroduce the shipped constant `0` at `BEGIN`:

```
panicked at process_lease_broker_lift_tests.rs:230:14:
the broker must ACCEPT the lift for the invocation it just began:
  Custom { kind: Other, error: ControlRejected(Fence) }
test result: FAILED. 2 passed; 1 failed;
```

Stop writing `cpu.max` in `Launcher::fenced_lift` — the **kernel** proof:

```
panicked at brokered_lease_lift_boundary.rs:270:9:
assertion `left == right` failed: the brokered lift must move cpu.max off the
unleased quota. This is the assertion production failed: cpu.max stayed
`25000 100000` for the whole life of every armed invocation, with zero
transitions observed over a 2s sampling loop
  left: "25000 100000"
 right: "400000 100000"
```

Remove the fence check — the non-vacuity step catches it:

```
panicked at brokered_lease_lift_boundary.rs:250:54:
a LIFT carrying a fence this invocation was never begun with must be refused;
if it is accepted, step 5 below proves nothing about the fencing contract: ()
```

Restore `?` on the lift — the degrade test catches it:

```
panicked at process_lease_degrade_tests.rs:781:10:
a refused cgroup lift must NOT fail the command...:
  Launcher(Custom { kind: Other, error: "lease invocation failed: Launcher(ControlRejected(Fence))" })
```

### Bonus: a vacuity found on the way

`transport.rs`'s `create_wire` test helper omitted the `LeaseAuthority` byte, so
every "policy" rejection case (`unsafe-program`, `unsafe-cwd`, `forbidden-env`,
`over-budget`) was actually being refused as a *shifted frame* before
`CommandSpec::validate` ever saw the command — the launcher's own allow-list
assertions were vacuous. The new categories made it visible; the helper is fixed
and each case now pins the category it is refused with.

## 5. Second defect: no reverse gear from `ForwardOverlap`

`djinn-server epoch rollback` answered `no rollback step is defined from phase
ForwardOverlap`. An armed rollout with no epoch-level way back; the only
mitigation was `cgroupLauncher.mode: disabled` + redeploy while the durable row
stayed at `ForwardOverlap`/`v1 Enforce`. The workaround the runbook prescribed
("use `epoch set-cap`/mode change to set `v1 = off`") named a command that does
not exist — `set-cap` deliberately *preserves* modes and there is no
mode-setting subcommand.

**It is well-defined, so it is implemented.** The phase ring genuinely has no
backward edge, and does not need one: entering `forward_overlap` changes nothing
but the phase, epoch and acks — `arm_overlap` already committed
`v0 Enforce, v1 Enforce` while still in `emergency_primary`. The overlap's only
semantic delta is that **v1 begins lifting quota**; v0 never stops enforcing. So
the reverse of that delta is `v1 -> off` **in place**, not a phase move.

`AdmissionTransitionExecutor::abort_v1_arming`:

- requires `v0 = Enforce` durably first, so the "at least one enforcing
  authority" invariant holds at every committed point;
- is the same epoch-fenced CAS as every other change and clears both acks, so
  the row is `IncompleteEpoch` (v0 fail-closed, v1 unleased) until the leader
  re-acknowledges — fail-closed on both sides throughout;
- does **not** wait for a v0 ack, unlike `complete_rollback`: it never releases
  an authority, and blocking would withhold the reverse gear in exactly the
  incident it exists for;
- is **refused** from `invocation_primary`/`rollback_overlap`, where v0 may
  already be observing — those keep the three-step ordering that re-confirms v0
  first;
- is idempotent, so a retried rollback step converges.

`epoch rollback` now has a step from every phase. The runbook section is
rewritten with the phase table and the safety argument, the CLI help no longer
claims rollback only works from invocation-primary, and `advance_rollback`'s
phase table has tests for the first time (it had none).

## Test status

- `djinn-cgroup-launcher`: 100 passed (+ the privileged proof executed in Docker)
- `djinn-agent --lib`: 1442 passed
- `djinn-coordinator build_admission`: 110 passed
- `djinn-server admin::tests`: 2 passed
- `cargo check --workspace --all-targets`, `cargo clippy` on every touched
  crate, `cargo fmt`, `scripts/check-file-size.sh --all`: clean

`server::tests::metrics_debug_dispatch::debug_dispatch_state_returns_wedge_to_admin_and_403_to_non_admin`
failed once under the parallel `-p djinn-server --lib` run and passes in
isolation — the known shared-test-DB collision flake, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
