### PR TITLE
fix(build-admission): reclaim leaked dispatch slots and make the durable cap live

### DIFF
--- a/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
+++ b/docs/BUILD_ADMISSION_EPOCH_RUNBOOK.md
@@ -130,6 +130,48 @@ UID leaves a candidate that must be cleaned before its slot frees.
   leases while occupied rows drain naturally. Light (coordinator-free) commands
   stay unaffected. Restore the cap with the same call once drained.
 
+### 3b. `set-cap` takes effect without a restart
+
+`epoch set-cap` changes what the RUNNING coordinator enforces. The durable
+reference cap is re-read and adopted by
+`BuildLeaseService::refresh_epoch_cap()` on the build-lease maintenance tick
+(30s) and again on the handoff tick (5 min), and a raised cap immediately drains
+the FIFO so work refused at the old cap is granted rather than waiting for the
+next dispatch attempt. Lowering the cap stops granting but never revokes an
+occupying row.
+
+This was not always true. Before this fix the resolved cap was only written to
+the enforcing atomic by `recover()`, so a `set-cap` reported success, `epoch
+show` read back the new value, and every denial kept quoting the old one until
+the pods restarted (production, 2026-07-25: `set-cap --cap 12`, denials still
+`occupancy=3 cap=3`). If you see that shape again, the denial's `cap` field —
+not `epoch show` — is the number actually in force.
+
+### 3c. Occupancy that no workload is using
+
+A build slot is a `build_leases` row, NOT an `admission_journal` row. The two
+ledgers have separate reconcilers and can disagree:
+
+- `BuildAdmissionReconciler` (startup + `initialize_build_admission_inventory`)
+  reconciles the v0 lifecycle journal and logs
+  `build_admission: reconciliation released stale durable occupancy`.
+- `BuildLeaseReclaimer`
+  (`server/crates/djinn-coordinator/src/build_lease_reclaim.rs`, every 30s)
+  reconciles the v1 capacity ledger and logs
+  `build_lease: reclamation pass over occupying leases`.
+
+**Only the second one frees a cap.** If admission denies with a non-zero
+`occupancy` while the namespace holds no matching Pods or Jobs, read the
+`build_lease` line: `occupying` is what the cap is compared against,
+`ownerless_dispatch` is the `task_dispatch` share retired on a durable
+ownership proof, and `blockers` means the pass could not be trusted at all
+(usually an unusable Kubernetes LIST). A journal line reporting
+`reclaimed=N` says nothing about whether capacity was freed.
+
+Leases are only retired on proof — a provably absent Kubernetes object, a
+terminal admission generation, or an unclaimed grant — so a degraded API server
+or an unreadable ledger leaves every slot occupied by design.
+
 ### 4. Stale epochs
 
 A stale epoch is any durable row whose current-phase acknowledgements are not at

--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -919,7 +919,7 @@ impl BuildAdmissionController {
         if over_cap {
             tracing::error!(
                 ledger_rows = occupancy,
-                cap = self.cap,
+                cap = self.effective_cap(),
                 mode = ?self.mode(),
                 "build_admission: occupied build slots exceed the cap; every enforced \
                  admission will be denied until the excess is released. Run the \
@@ -928,7 +928,7 @@ impl BuildAdmissionController {
         } else {
             tracing::info!(
                 ledger_rows = occupancy,
-                cap = self.cap,
+                cap = self.effective_cap(),
                 "build_admission: occupied build slots are back within the cap"
             );
         }
@@ -941,16 +941,20 @@ impl BuildAdmissionController {
     /// size of the problem rather than the size of the fix.
     pub fn publish_reconciliation(&self, stale_rows: usize, reclaimed: usize, fenced: usize) {
         if stale_rows > 0 || reclaimed > 0 {
-            let level_is_alarm = i64::try_from(stale_rows).unwrap_or(i64::MAX) > self.cap;
+            // Compared against the cap actually in force, not the configured
+            // fallback: an epoch `set-cap` changes what "more stale rows than
+            // the cap" means the moment it is adopted.
+            let effective_cap = self.effective_cap();
+            let level_is_alarm = i64::try_from(stale_rows).unwrap_or(i64::MAX) > effective_cap;
             if level_is_alarm {
                 tracing::error!(
                     stale_rows,
                     reclaimed,
                     fenced,
-                    cap = self.cap,
+                    cap = effective_cap,
                     mode = ?self.mode(),
                     "build_admission: reconciliation found more occupying rows with absent \
-                     Kubernetes objects than the configured cap; this is the population that \
+                     Kubernetes objects than the cap in force; this is the population that \
                      wedges the board when the cap is armed"
                 );
             } else {
@@ -958,7 +962,7 @@ impl BuildAdmissionController {
                     stale_rows,
                     reclaimed,
                     fenced,
-                    cap = self.cap,
+                    cap = effective_cap,
                     "build_admission: reconciliation released stale durable occupancy"
                 );
             }
@@ -993,9 +997,13 @@ impl BuildAdmissionController {
         request: BuildAdmissionRequest,
     ) -> Result<BuildAdmissionDecision, WarmAdmissionError> {
         if self.mode() == BuildAdmissionMode::Enforce && (!self.is_ready() || self.is_draining()) {
+            // The cap reported with a denial is the one that WOULD have been
+            // enforced, resolved from the single capacity authority. Reporting
+            // the constructor's configured value here made v0 and v1 disagree
+            // in the operator's log about which number was in force.
             return Ok(BuildAdmissionDecision::Denied {
                 occupancy: 0,
-                cap: self.cap,
+                cap: self.effective_cap(),
             });
         }
         // Capture an observe-only copy before any field of `request` is moved.
@@ -1156,7 +1164,7 @@ impl BuildAdmissionController {
                     if self.mode() != BuildAdmissionMode::Observe {
                         return Ok(BuildAdmissionDecision::Denied {
                             occupancy: 0,
-                            cap: self.cap,
+                            cap: self.effective_cap(),
                         });
                     }
                     tracing::warn!(

--- a/server/crates/djinn-coordinator/src/build_lease.rs
+++ b/server/crates/djinn-coordinator/src/build_lease.rs
@@ -402,73 +402,6 @@ impl BuildLeaseService {
         self.dispatch_enforcing.store(enforcing, Ordering::Release);
     }
 
-    /// The reference cap this service is currently enforcing.
-    ///
-    /// Meaningful only after [`Self::recover`]; before that it is the
-    /// constructor's configured value. A zero cap denies every consumer
-    /// unconditionally, so composition uses this to refuse to wire a consumer
-    /// behind a gate that can never open.
-    #[must_use]
-    pub fn cap(&self) -> i64 {
-        self.cap.load(Ordering::Acquire)
-    }
-
-    /// Resolve the durable lease-table cap against the process configuration.
-    ///
-    /// A positive durable cap has been armed by a real writer (`set_cap`, or a
-    /// previous `grant_next` converging the table on this process's cap) and is
-    /// kept verbatim. A durable `0` is the migration-seeded, never-armed state
-    /// and yields to [`Self::configured_cap`]; see that field for why `0` can
-    /// never be a deliberate durable policy on the production path.
-    fn armed_fallback(&self, durable: i64) -> i64 {
-        if durable > 0 {
-            return durable;
-        }
-        if self.configured_cap > 0 {
-            tracing::info!(
-                configured_cap = self.configured_cap,
-                "build lease: durable cap is unarmed (0); adopting the configured build-slot cap"
-            );
-        }
-        self.configured_cap
-    }
-
-    /// Read the durable admission-handoff epoch and apply its reference cap.
-    ///
-    /// Returns the reference cap to enforce, defaulting to `fallback` (the
-    /// lease-table cap) when no handoff reader is installed or the row carries
-    /// no cap. An unreadable epoch clears the observed epoch (fail closed) and
-    /// retains the fallback cap. The handoff reference cap is authoritative for
-    /// the v1 authority when set, so a restart converges on the epoch's cap
-    /// rather than a stale lease-table value.
-    async fn read_handoff_epoch(&self, fallback: i64) -> i64 {
-        let fallback = self.armed_fallback(fallback);
-        let Some(handoff) = self.handoff.as_ref() else {
-            return fallback;
-        };
-        match handoff.read().await {
-            Ok(Some(row)) => {
-                self.observed_epoch.store(row.epoch, Ordering::Release);
-                self.dispatch_enforcing
-                    .store(row.v1_mode.is_enforcing(), Ordering::Release);
-                row.cap.unwrap_or(fallback)
-            }
-            Ok(None) => {
-                // No durable epoch row: nothing to observe, keep the fallback.
-                self.observed_epoch.store(-1, Ordering::Release);
-                self.dispatch_enforcing.store(false, Ordering::Release);
-                fallback
-            }
-            Err(_) => {
-                // Unreadable epoch: fail closed on the observed epoch, and do
-                // NOT enforce a cap we could not confirm was armed.
-                self.observed_epoch.store(-1, Ordering::Release);
-                self.dispatch_enforcing.store(false, Ordering::Release);
-                fallback
-            }
-        }
-    }
-
     /// Recover queued and all occupied rows before opening the service.
     pub async fn recover(&self) -> LeaseResult {
         let _guard = self.operation.lock().await;
@@ -1081,6 +1014,11 @@ fn status(row: &BuildLeaseRow) -> LeaseStatus {
         candidate_cleanup: row.candidate_cleanup.is_some(),
     }
 }
+
+/// Cap resolution. A child module so it still reaches this service's private
+/// state, split into its own file only for the source-size guard.
+#[path = "build_lease_cap.rs"]
+mod cap;
 
 #[cfg(test)]
 mod tests {

--- a/server/crates/djinn-coordinator/src/build_lease_cap.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_cap.rs
@@ -1,0 +1,150 @@
+//! Cap resolution for the one v1 build-slot FIFO.
+//!
+//! Split out of `build_lease.rs` for the file-size guard; this is the same
+//! `BuildLeaseService` and the same private state, in a child module.
+//!
+//! Everything here answers one question: what cap is enforced RIGHT NOW. The
+//! answer has a strict precedence — the durable admission-epoch reference cap,
+//! then a positive `build_lease_caps` row, then the process configuration —
+//! and exactly one place that writes the enforced value
+//! ([`BuildLeaseService::read_handoff_epoch`]).
+//!
+//! That single writer is the fix for a real production defect. `set-cap` used
+//! to be inert against a running process because the resolved cap was only
+//! STORED by `recover()`; see `read_handoff_epoch` for the full account.
+
+use std::sync::atomic::Ordering;
+
+use super::BuildLeaseService;
+
+impl BuildLeaseService {
+    /// The reference cap this service is currently enforcing.
+    ///
+    /// Meaningful only after [`Self::recover`]; before that it is the
+    /// constructor's configured value. A zero cap denies every consumer
+    /// unconditionally, so composition uses this to refuse to wire a consumer
+    /// behind a gate that can never open.
+    #[must_use]
+    pub fn cap(&self) -> i64 {
+        self.cap.load(Ordering::Acquire)
+    }
+
+    /// Resolve the durable lease-table cap against the process configuration.
+    ///
+    /// A positive durable cap has been armed by a real writer (`set_cap`, or a
+    /// previous `grant_next` converging the table on this process's cap) and is
+    /// kept verbatim. A durable `0` is the migration-seeded, never-armed state
+    /// and yields to [`Self::configured_cap`]; see that field for why `0` can
+    /// never be a deliberate durable policy on the production path.
+    fn armed_fallback(&self, durable: i64) -> i64 {
+        if durable > 0 {
+            return durable;
+        }
+        if self.configured_cap > 0 {
+            tracing::info!(
+                configured_cap = self.configured_cap,
+                "build lease: durable cap is unarmed (0); adopting the configured build-slot cap"
+            );
+        }
+        self.configured_cap
+    }
+
+    /// Read the durable admission-handoff epoch and apply its reference cap.
+    ///
+    /// Returns the reference cap to enforce, defaulting to `fallback` (the
+    /// lease-table cap) when no handoff reader is installed or the row carries
+    /// no cap. An unreadable epoch clears the observed epoch (fail closed) and
+    /// retains the fallback cap. The handoff reference cap is authoritative for
+    /// the v1 authority when set, so a restart converges on the epoch's cap
+    /// rather than a stale lease-table value.
+    ///
+    /// The resolved cap is STORED, not merely returned. It used to be returned
+    /// only, and `recover()` was the sole caller that wrote it to `self.cap` —
+    /// which is what made `djinn-server epoch set-cap` inert against a running
+    /// process. Production on 2026-07-25: `set-cap --cap 12` reported success
+    /// and `epoch show` read back `cap 12`, while every subsequent denial still
+    /// said `occupancy=3 cap=3` because the live `grant_next` read a cached
+    /// atomic that only a restart could refresh. An operator's only cap knob
+    /// silently doing nothing during an incident is worse than refusing the
+    /// write, so the durable cap is now authoritative at runtime: every read of
+    /// the epoch converges the enforced value, and
+    /// [`Self::refresh_epoch_cap`] performs that read on the coordinator's
+    /// handoff tick.
+    ///
+    /// Storing here is deliberately the ONLY write path besides `set_cap`, so
+    /// there is one rule for what the enforced cap is: whatever the last
+    /// successful epoch read resolved. An unreadable or capless epoch stores
+    /// the fallback rather than widening the cap.
+    pub(super) async fn read_handoff_epoch(&self, fallback: i64) -> i64 {
+        let cap = self.resolve_handoff_epoch(fallback).await;
+        self.cap.store(cap, Ordering::Release);
+        cap
+    }
+
+    async fn resolve_handoff_epoch(&self, fallback: i64) -> i64 {
+        let fallback = self.armed_fallback(fallback);
+        let Some(handoff) = self.handoff.as_ref() else {
+            return fallback;
+        };
+        match handoff.read().await {
+            Ok(Some(row)) => {
+                self.observed_epoch.store(row.epoch, Ordering::Release);
+                self.dispatch_enforcing
+                    .store(row.v1_mode.is_enforcing(), Ordering::Release);
+                row.cap.unwrap_or(fallback)
+            }
+            Ok(None) => {
+                // No durable epoch row: nothing to observe, keep the fallback.
+                self.observed_epoch.store(-1, Ordering::Release);
+                self.dispatch_enforcing.store(false, Ordering::Release);
+                fallback
+            }
+            Err(_) => {
+                // Unreadable epoch: fail closed on the observed epoch, and do
+                // NOT enforce a cap we could not confirm was armed.
+                self.observed_epoch.store(-1, Ordering::Release);
+                self.dispatch_enforcing.store(false, Ordering::Release);
+                fallback
+            }
+        }
+    }
+
+    /// Re-read the durable admission epoch and adopt its reference cap, without
+    /// a restart.
+    ///
+    /// This is what makes `djinn-server epoch set-cap` a live control rather
+    /// than a value that takes effect at the next rollout. It is called on the
+    /// coordinator's periodic handoff tick — the same tick that already
+    /// re-evaluates the epoch's v0/v1 modes — so the cap and the modes it is
+    /// paired with can never be observed from different epochs for long.
+    ///
+    /// A RAISED cap must also drain: `grant_next` runs only when someone
+    /// queues, so without this an operator who raises the cap to unwedge a
+    /// stalled board still waits for the next dispatch attempt before anything
+    /// moves. Lowering never revokes an occupying row; it simply stops granting.
+    ///
+    /// Returns the cap now in force, or `None` before recovery has opened the
+    /// service (occupancy is unknown then, and unknown is never a reason to
+    /// change what is enforced).
+    pub async fn refresh_epoch_cap(&self) -> Option<i64> {
+        if !self.is_ready() {
+            return None;
+        }
+        let _guard = self.operation.lock().await;
+        let previous = self.cap.load(Ordering::Acquire);
+        let durable = self.repository.snapshot().await.map(|s| s.cap).ok()?;
+        let cap = self.read_handoff_epoch(durable).await;
+        if cap == previous {
+            return Some(cap);
+        }
+        tracing::info!(
+            previous_cap = previous,
+            cap,
+            "build lease: adopted the durable admission-epoch cap without a restart"
+        );
+        if cap > previous {
+            let _ = self.drain().await;
+        }
+        Some(cap)
+    }
+}

--- a/server/crates/djinn-coordinator/src/build_lease_cap_refresh_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_cap_refresh_tests.rs
@@ -1,0 +1,207 @@
+//! `epoch set-cap` against a RUNNING process.
+//!
+//! Production, 2026-07-25, mid-incident: `djinn-server epoch set-cap --cap 12`
+//! reported `set-cap: applied`, `djinn-server epoch show` read back
+//! `phase ForwardOverlap · epoch 4 · v0_mode Enforce · v1_mode Enforce · cap 12`,
+//! and the very next denial still said `occupancy=3 cap=3`. The durable write
+//! landed; the live `grant_next` read a cached atomic that only `recover()`
+//! ever wrote, so the operator's one cap knob was inert until a restart.
+//!
+//! Every assertion below is on an ENFORCED DECISION — a lease that was queued
+//! behind the old cap becoming granted, or a request refused at the new one —
+//! never on reading the durable column back. Reading the column back is exactly
+//! what made the defect look fixed in the first place.
+
+use std::sync::Arc;
+
+use djinn_db::{
+    AdmissionHandoffRepository, BuildLeaseKey, BuildLeaseRepository, BuildLeaseState, Database,
+    V0Mode, V1Mode,
+};
+use djinn_supervisor::services::{
+    GraphWarmLeaseIdentity, LeaseDeadlines, LeaseIdentity, LeaseQueueRequest, LeaseResult,
+};
+
+use crate::build_admission_transition::AdmissionTransitionExecutor;
+use crate::build_lease::BuildLeaseService;
+
+const PROJECT: &str = "019ea3bd-a305-73e3-806c-4edcc96ebfe2";
+
+struct Fixture {
+    service: Arc<BuildLeaseService>,
+    leases: Arc<BuildLeaseRepository>,
+    operator: AdmissionTransitionExecutor,
+    epoch: i64,
+}
+
+impl Fixture {
+    /// Run the operator command the runbook runs: `djinn-server epoch set-cap`.
+    /// This is the same executor `server/src/admin.rs` drives, so nothing here
+    /// simulates the write path.
+    async fn operator_set_cap(&self, cap: i64) {
+        self.operator
+            .set_cap(self.epoch, cap)
+            .await
+            .expect("the durable cap write must succeed");
+    }
+
+    async fn queue_warm(&self, request: &str) -> LeaseResult {
+        self.service
+            .queue(LeaseQueueRequest {
+                identity: LeaseIdentity::GraphWarm(GraphWarmLeaseIdentity {
+                    project_id: PROJECT.into(),
+                    warm_request_id: request.into(),
+                    graph_revision: format!("rev-{request}"),
+                }),
+                deadlines: LeaseDeadlines {
+                    queue_deadline_ms: 0,
+                    launch_deadline_ms: 0,
+                },
+            })
+            .await
+    }
+
+    async fn state(&self, request: &str) -> BuildLeaseState {
+        self.leases
+            .get(&BuildLeaseKey {
+                consumer_kind: djinn_db::BuildLeaseConsumerKind::GraphWarm,
+                consumer_id: request.into(),
+            })
+            .await
+            .unwrap()
+            .expect("the lease row must exist")
+            .state
+    }
+
+    async fn occupied(&self) -> i64 {
+        self.leases.snapshot().await.unwrap().occupied
+    }
+}
+
+/// A running process that has already recovered against an armed epoch cap,
+/// exactly as `AppState` composes it.
+async fn running_process(epoch_cap: i64) -> Fixture {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let handoff = Arc::new(AdmissionHandoffRepository::new(db.clone()));
+    let row = handoff
+        .set_modes_and_cap(0, V0Mode::Enforce, V1Mode::Enforce, Some(epoch_cap))
+        .await
+        .expect("arm the epoch");
+    let leases = Arc::new(BuildLeaseRepository::new(db.clone()));
+    let service = Arc::new(
+        // The configured `DJINN_MAX_BUILD_TASKRUNS` fallback is deliberately
+        // different from the epoch cap, so any assertion below that passes by
+        // reading the environment instead of the epoch is visible.
+        BuildLeaseService::new(Arc::clone(&leases), 9).with_handoff_epoch(Arc::clone(&handoff)),
+    );
+    assert!(matches!(service.recover().await, LeaseResult::Status(_)));
+    assert_eq!(
+        service.cap(),
+        epoch_cap,
+        "the armed epoch cap outranks the configured fallback at startup"
+    );
+    Fixture {
+        service,
+        leases,
+        operator: AdmissionTransitionExecutor::new(handoff),
+        epoch: row.epoch,
+    }
+}
+
+/// The defect, and the fix, in one: a durable `set-cap` must change what the
+/// live process ENFORCES, and must unblock work that was refused at the old cap
+/// without waiting for the next request.
+#[tokio::test]
+async fn a_durable_set_cap_changes_what_the_running_process_enforces() {
+    let fixture = running_process(1).await;
+
+    assert!(matches!(
+        fixture.queue_warm("holder").await,
+        LeaseResult::Granted(_)
+    ));
+    assert!(
+        matches!(fixture.queue_warm("waiter").await, LeaseResult::Queued(_)),
+        "cap 1 is genuinely enforced before the operator touches anything"
+    );
+    assert_eq!(fixture.occupied().await, 1);
+
+    // The incident action. It reports success and the durable row now reads 2.
+    fixture.operator_set_cap(2).await;
+    assert_eq!(
+        fixture.service.cap(),
+        1,
+        "precondition: a durable write alone does not reach the cached cap — \
+         this is precisely what made the production knob inert"
+    );
+
+    assert_eq!(
+        fixture.service.refresh_epoch_cap().await,
+        Some(2),
+        "the live process must adopt the durable cap without a restart"
+    );
+    assert_eq!(fixture.service.cap(), 2);
+    assert_eq!(
+        fixture.state("waiter").await,
+        BuildLeaseState::Granted,
+        "raising the cap must DRAIN: the lease refused at cap 1 is granted now, \
+         not at whatever time something else happens to queue"
+    );
+    assert_eq!(fixture.occupied().await, 2);
+    assert!(
+        matches!(fixture.queue_warm("third").await, LeaseResult::Queued(_)),
+        "and the new cap is then enforced as the real ceiling"
+    );
+}
+
+/// Lowering the cap stops granting but never revokes capacity an occupant is
+/// already using: an in-flight build is not killed by an operator typo.
+#[tokio::test]
+async fn lowering_the_cap_stops_granting_without_revoking_occupied_slots() {
+    let fixture = running_process(2).await;
+    for request in ["first", "second"] {
+        assert!(matches!(
+            fixture.queue_warm(request).await,
+            LeaseResult::Granted(_)
+        ));
+    }
+    assert_eq!(fixture.occupied().await, 2);
+
+    fixture.operator_set_cap(1).await;
+    assert_eq!(fixture.service.refresh_epoch_cap().await, Some(1));
+    assert_eq!(
+        fixture.occupied().await,
+        2,
+        "occupied slots are never revoked by a cap change"
+    );
+    for request in ["first", "second"] {
+        assert_eq!(fixture.state(request).await, BuildLeaseState::Granted);
+    }
+    assert!(
+        matches!(fixture.queue_warm("third").await, LeaseResult::Queued(_)),
+        "the lowered cap is enforced against NEW requests"
+    );
+}
+
+/// A refresh before recovery has opened the service changes nothing. Occupancy
+/// is unknown then, and unknown is never a reason to move what is enforced.
+#[tokio::test]
+async fn a_refresh_before_recovery_never_moves_the_enforced_cap() {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    let handoff = Arc::new(AdmissionHandoffRepository::new(db.clone()));
+    handoff
+        .set_modes_and_cap(0, V0Mode::Enforce, V1Mode::Enforce, Some(7))
+        .await
+        .expect("arm the epoch");
+    let service = BuildLeaseService::new(Arc::new(BuildLeaseRepository::new(db.clone())), 3)
+        .with_handoff_epoch(handoff);
+
+    assert_eq!(service.refresh_epoch_cap().await, None);
+    assert_eq!(
+        service.cap(),
+        3,
+        "an unrecovered service keeps its configured cap rather than adopting an \
+         epoch it has not yet reconciled occupancy against"
+    );
+}

--- a/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
@@ -1,0 +1,504 @@
+//! The production dispatch outage of 2026-07-25, end to end.
+//!
+//! Symptom: `build admission denied; leaving task queued  occupancy=3 cap=3`
+//! for EVERY task for ~40 minutes, with zero task-run Pods and zero Jobs in the
+//! namespace. Three occupying `task_dispatch` rows in `build_leases` survived a
+//! full `djinn-server` rollout restart, that restart's journal recovery, the
+//! startup Kubernetes inventory reconciliation (which reported
+//! `stale_rows=2 reclaimed=2` — a *different* ledger), and the deletion of every
+//! `Complete` task-run Job.
+//!
+//! Nothing here writes a lease or journal row by hand. The leak is produced by
+//! the production composition: a real admission through
+//! [`BuildAdmissionController`] over the real [`BuildLeaseService`], a real
+//! predecessor-epoch recovery, and a real
+//! [`BuildAdmissionReconciler`] pass — after which the v0 lifecycle ledger is
+//! empty and the v1 capacity ledger is still full. Producing that shape is as
+//! much the behaviour under test as the reclamation is.
+//!
+//! # What stays green if reclamation does nothing
+//!
+//! Nothing that matters. Every assertion below is on a side effect:
+//! [`CapacityHarness::occupancy`] (the weighted `build_leases` sum the cap is
+//! actually compared against) and an `admit_task_run` that returns
+//! `Permitted`. Neutralizing `BuildLeaseReclaimer::ownerless_proof` for the
+//! dispatch branch fails `dispatch_leak_wedges_every_task_until_it_is_reclaimed`
+//! on the occupancy assertion and again on the admit.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use djinn_db::{
+    AdmissionDomain, AdmissionJournalRepository, AdmissionState, BuildLeaseConsumerKind,
+    BuildLeaseKey, BuildLeaseState, Database,
+};
+use djinn_k8s::{
+    ObjectPresence, UidGetResult, WarmAdmission, WarmAdmissionPermit, WarmAdmissionTransition,
+    WorkloadInventory, WorkloadObjectKind, WorkloadRecord,
+};
+
+use crate::build_admission::{
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode,
+};
+use crate::build_admission_capacity_support::{CapacityHarness, controller_with_capacity_over};
+use crate::build_admission_inventory::BuildAdmissionReconciler;
+use crate::build_lease_reclaim::{BuildLeaseReclaimer, dispatch_identity};
+use crate::build_slot_authority::BuildLeaseDispatchAuthority;
+
+const PREDECESSOR: &str = "coordinator-a:predecessor-epoch";
+const SUCCESSOR: &str = "coordinator-b:successor-epoch";
+
+/// A namespace with no Jobs at all: exactly what `kubectl get jobs -n djinn`
+/// answered while occupancy read 3.
+struct EmptyNamespace;
+
+#[async_trait]
+impl WorkloadInventory for EmptyNamespace {
+    async fn list(&self) -> Result<Vec<WorkloadRecord>, String> {
+        Ok(Vec::new())
+    }
+    async fn get_uid(&self, _: WorkloadObjectKind, _: &str, _: &str) -> UidGetResult {
+        UidGetResult::NotFound
+    }
+    async fn presence(&self, _: WorkloadObjectKind, _: &str) -> ObjectPresence {
+        ObjectPresence::Absent
+    }
+}
+
+fn lease_key(task_id: &str, generation: i64) -> BuildLeaseKey {
+    BuildLeaseKey {
+        consumer_kind: BuildLeaseConsumerKind::TaskDispatch,
+        consumer_id: format!("{task_id}:{generation}"),
+    }
+}
+
+async fn admit(controller: &BuildAdmissionController, task_id: &str) -> BuildAdmissionDecision {
+    controller
+        .admit_task_run(
+            Some("worker"),
+            AdmissionDomain::TaskObservation,
+            task_id.to_owned(),
+            0,
+            format!("task-run-{task_id}-0"),
+        )
+        .await
+        .expect("admission must be reachable")
+}
+
+async fn permitted(controller: &BuildAdmissionController, task_id: &str) -> WarmAdmissionPermit {
+    match admit(controller, task_id).await {
+        BuildAdmissionDecision::Permitted { permit, .. } => permit,
+        other => panic!("{task_id} must be permitted, got {other:?}"),
+    }
+}
+
+/// Dispatch one task-run exactly as `begin_task_run_build_admission` /
+/// `finish_task_run_build_admission` do: acquire the layer-1 slot, record the
+/// create, and leave the generation in `create_unknown` because the slot pool
+/// returns no Kubernetes UID.
+async fn dispatch_task_run(harness: &CapacityHarness, task_id: &str) {
+    let permit = permitted(&harness.controller, task_id).await;
+    harness
+        .controller
+        .transition(&permit, WarmAdmissionTransition::CreateStarted)
+        .await
+        .expect("record the create");
+    harness
+        .controller
+        .transition(
+            &permit,
+            WarmAdmissionTransition::CreateUnknown {
+                diagnostic: "slot-pool accepted create without object UID".to_owned(),
+            },
+        )
+        .await
+        .expect("record the ambiguous create outcome");
+}
+
+/// The replacement process: a fresh server epoch over the same durable ledgers
+/// AND the same surviving capacity authority, running the two startup
+/// reconciliations in production order.
+///
+/// Sharing the authority is the point. A successor wired to a fresh pool would
+/// not inherit the predecessor's occupancy, and the outage this file reproduces
+/// is precisely that the occupancy DOES survive the restart.
+async fn restart_and_reconcile(
+    harness: &CapacityHarness,
+    cap: i64,
+) -> Arc<BuildAdmissionController> {
+    let successor = Arc::new(
+        BuildAdmissionController::new(
+            Arc::clone(&harness.journal),
+            BuildAdmissionMode::Enforce,
+            cap,
+            SUCCESSOR,
+        )
+        .with_slot_authority(Arc::new(BuildLeaseDispatchAuthority::new(Arc::clone(
+            &harness.lease,
+        )))),
+    );
+    successor
+        .recover_all_predecessors_and_seed()
+        .await
+        .expect("durable journal recovery");
+    let report = BuildAdmissionReconciler::with_settle_window(
+        Arc::clone(&successor),
+        Arc::new(EmptyNamespace),
+        Duration::ZERO,
+    )
+    .reconcile()
+    .await;
+    assert!(
+        report.blockers.is_empty(),
+        "blockers: {:?}",
+        report.blockers
+    );
+    successor
+}
+
+fn reclaimer(harness: &CapacityHarness) -> BuildLeaseReclaimer {
+    BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(&harness.leases),
+        Arc::clone(&harness.journal),
+        Arc::new(EmptyNamespace),
+        Duration::ZERO,
+    )
+}
+
+async fn harness(cap: i64) -> CapacityHarness {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    controller_with_capacity_over(&db, BuildAdmissionMode::Enforce, cap, PREDECESSOR).await
+}
+
+/// The whole outage: a dispatch slot outlives its task-run, every later task is
+/// denied at a cap nothing is really using, and reclamation is what gives the
+/// board back.
+#[tokio::test]
+async fn dispatch_leak_wedges_every_task_until_it_is_reclaimed() {
+    let harness = harness(1).await;
+    dispatch_task_run(&harness, "wedging-task").await;
+    assert_eq!(
+        harness.occupancy().await,
+        1,
+        "the dispatch attempt must occupy a real build slot"
+    );
+
+    // The pod dies during a failed rollout; the replacement recovers. This is
+    // the pass that logged `stale_rows=2 reclaimed=2` in production.
+    let successor = restart_and_reconcile(&harness, 1).await;
+    assert_eq!(
+        harness
+            .journal
+            .generation_state(AdmissionDomain::TaskObservation, "wedging-task", 0)
+            .await
+            .unwrap(),
+        Some(AdmissionState::Terminal),
+        "the v0 lifecycle ledger released the generation on a Kubernetes absence proof"
+    );
+    assert_eq!(
+        harness.ledger_rows().await,
+        0,
+        "no lifecycle row occupies anything any more"
+    );
+
+    // ...and the capacity ledger did not move at all. This is the defect.
+    assert_eq!(
+        harness.occupancy().await,
+        1,
+        "the v1 capacity ledger still holds the slot: no reclaimer could see it"
+    );
+    assert_eq!(
+        harness
+            .leases
+            .get(&lease_key("wedging-task", 0))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Launching,
+        "a properly acknowledged dispatch slot, orphaned: only its holder could \
+         release it, and its holder is gone"
+    );
+    assert!(
+        matches!(
+            admit(&successor, "next-task").await,
+            BuildAdmissionDecision::Denied {
+                occupancy: 1,
+                cap: 1
+            }
+        ),
+        "the production symptom: every task denied against occupancy it cannot use"
+    );
+
+    // Reclamation, on the proof that the generation this slot was bought for is
+    // over.
+    let report = reclaimer(&harness).reclaim().await;
+    assert!(
+        report.blockers.is_empty(),
+        "blockers: {:?}",
+        report.blockers
+    );
+    assert!(
+        report.failures.is_empty(),
+        "failures: {:?}",
+        report.failures
+    );
+
+    // The side effects come FIRST, deliberately. A reclaimer that returns a
+    // convincing report and frees nothing is the exact failure mode this suite
+    // exists to catch, so neutralizing reclamation must fail here — on the
+    // capacity the cap is compared against and on a real admission — rather
+    // than on a counter.
+    assert_eq!(
+        harness.occupancy().await,
+        0,
+        "occupancy must return to zero: this is the side effect, not the report"
+    );
+    assert!(
+        matches!(
+            admit(&successor, "next-task").await,
+            BuildAdmissionDecision::Permitted { .. }
+        ),
+        "and the next task must actually be PERMITTED, not merely counted"
+    );
+    assert_eq!(harness.occupancy().await, 1, "by taking the freed slot");
+
+    // Corroboration only.
+    assert_eq!(report.occupying, 1);
+    assert_eq!(report.ownerless_dispatch, 1);
+    assert_eq!(report.reclaimed, 1);
+    assert_eq!(report.fenced, 0);
+}
+
+/// The negative that matters most: a dispatch slot whose generation is still
+/// running is live work, and no amount of age or Kubernetes emptiness makes it
+/// reclaimable.
+///
+/// The empty namespace here is deliberate. A task-run Job's name is derived
+/// from a `task_run_id` that does not exist when the slot is bought, so an
+/// empty listing says nothing at all about a dispatch lease. If reclamation
+/// ever starts reading the namespace for this population, this test fails.
+#[tokio::test]
+async fn a_dispatch_slot_whose_generation_still_occupies_is_never_retired() {
+    let harness = harness(2).await;
+    dispatch_task_run(&harness, "running-task").await;
+    assert_eq!(
+        harness
+            .journal
+            .generation_state(AdmissionDomain::TaskObservation, "running-task", 0)
+            .await
+            .unwrap(),
+        Some(AdmissionState::CreateUnknown)
+    );
+
+    let report = reclaimer(&harness).reclaim().await;
+    assert_eq!(report.occupying, 1);
+    assert_eq!(
+        report.absent, 0,
+        "an occupying generation is not a proof of anything"
+    );
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(harness.occupancy().await, 1);
+}
+
+/// The second dispatch leak: the FIFO grants a slot to a requester that already
+/// gave up on a `Queued` answer, and nobody is left to hand it back.
+///
+/// Produced entirely through the production composition — a denial at a full
+/// cap leaves a queued position, the holder's release plus a later request
+/// drains the FIFO onto that position, and nothing ever acknowledges it. The
+/// resulting row is `granted` (never `launching`, because `granted` is exactly
+/// the state a live dispatch has already left) with no ledger row behind it.
+#[tokio::test]
+async fn a_grant_the_fifo_handed_to_nobody_is_retired_and_gives_the_cap_back() {
+    let harness = harness(1).await;
+
+    // The holder takes the only slot, then fails before the pool creates
+    // anything, which is the production `DefinitiveFailure` release.
+    let holder = permitted(&harness.controller, "holder").await;
+    harness
+        .controller
+        .transition(&holder, WarmAdmissionTransition::CreateStarted)
+        .await
+        .expect("record the create");
+    assert!(
+        matches!(
+            admit(&harness.controller, "abandoned").await,
+            BuildAdmissionDecision::Denied { .. }
+        ),
+        "the second task must be refused behind the full cap, leaving a queue position"
+    );
+    harness
+        .controller
+        .transition(
+            &holder,
+            WarmAdmissionTransition::DefinitiveFailure {
+                diagnostic: "slot-pool rejected before task-run creation".to_owned(),
+            },
+        )
+        .await
+        .expect("release the holder");
+
+    // A later task's own queue drains the FIFO — onto the abandoned position,
+    // not onto itself. This is the wedge.
+    assert!(matches!(
+        admit(&harness.controller, "live").await,
+        BuildAdmissionDecision::Denied { .. }
+    ));
+    let abandoned = harness
+        .leases
+        .get(&lease_key("abandoned", 0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        abandoned.state,
+        BuildLeaseState::Granted,
+        "granted and never acknowledged: no dispatch is holding it"
+    );
+    assert_eq!(harness.occupancy().await, 1);
+    assert_eq!(
+        harness
+            .journal
+            .generation_state(AdmissionDomain::TaskObservation, "abandoned", 0)
+            .await
+            .unwrap(),
+        None,
+        "no admission ever proceeded on this grant"
+    );
+
+    let report = reclaimer(&harness).reclaim().await;
+    assert_eq!(harness.occupancy().await, 0);
+    assert!(
+        matches!(
+            admit(&harness.controller, "live").await,
+            BuildAdmissionDecision::Permitted { .. }
+        ),
+        "the waiting task must be permitted once the phantom grant is retired"
+    );
+    assert_eq!(report.ownerless_dispatch, 1);
+    assert_eq!(report.reclaimed, 1);
+}
+
+/// A dispatch lease that IS held — acknowledged into `launching` — but whose
+/// ledger row cannot be found is UNKNOWN state, not proven ownerless.
+///
+/// `BuildAdmissionController::admit` writes no journal row while v0 is `off`,
+/// so an absent row can never by itself mean "nobody owns this". Fail-closed
+/// here is a deliberate trade; the grant-never-claimed case above is the only
+/// shape where an absent row IS conclusive, because a live dispatch has always
+/// left `granted` behind.
+#[tokio::test]
+async fn a_held_dispatch_lease_with_no_ledger_row_stays_occupying() {
+    let harness = harness(1).await;
+    let permit = permitted(&harness.controller, "unledgered").await;
+    harness
+        .controller
+        .transition(&permit, WarmAdmissionTransition::CreateStarted)
+        .await
+        .expect("record the create");
+    assert_eq!(
+        harness
+            .leases
+            .get(&lease_key("unledgered", 0))
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        BuildLeaseState::Launching,
+        "an acknowledged dispatch slot is past `granted`"
+    );
+
+    // A journal that holds no row for this generation, as v0 `off` would leave.
+    let empty_ledger = Arc::new(AdmissionJournalRepository::new(
+        Database::open_in_memory().unwrap(),
+    ));
+    let report = BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(&harness.leases),
+        empty_ledger,
+        Arc::new(EmptyNamespace),
+        Duration::ZERO,
+    )
+    .reclaim()
+    .await;
+    assert_eq!(report.occupying, 1);
+    assert_eq!(report.absent, 0);
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(harness.occupancy().await, 1);
+}
+
+/// A lease that has not settled is not judged at all: a dispatch still mid-flight
+/// must be allowed to write its ledger row first.
+#[tokio::test]
+async fn an_unsettled_dispatch_lease_is_not_judged() {
+    let harness = harness(1).await;
+    dispatch_task_run(&harness, "fresh-task").await;
+    restart_and_reconcile(&harness, 1).await;
+
+    let report = BuildLeaseReclaimer::with_settle_window(
+        Arc::clone(&harness.leases),
+        Arc::clone(&harness.journal),
+        Arc::new(EmptyNamespace),
+        Duration::from_secs(3600),
+    )
+    .reclaim()
+    .await;
+    assert_eq!(report.occupying, 1);
+    assert_eq!(report.reclaimed, 0);
+    assert_eq!(harness.occupancy().await, 1);
+}
+
+/// The generation a dispatch lease owns is read from its durable identity, and
+/// an identity that does not parse yields nothing rather than a guess.
+#[test]
+fn dispatch_identities_come_from_the_durable_row_or_nowhere() {
+    let row = |kind, identity: &str| djinn_db::BuildLeaseRow {
+        key: BuildLeaseKey {
+            consumer_kind: kind,
+            consumer_id: "consumer".into(),
+        },
+        immutable_identity: identity.into(),
+        enqueue_sequence: 1,
+        fencing_token: Some(1),
+        state: BuildLeaseState::Granted,
+        queue_deadline: None,
+        launch_deadline: None,
+        bound_pod_uid: None,
+        candidate_cleanup: None,
+        terminal_reason: None,
+        weight: 1,
+        timeout_credit_consumed: false,
+        created_at: "now".into(),
+        updated_at: "now".into(),
+        granted_at: None,
+        terminal_at: None,
+    };
+    assert_eq!(
+        dispatch_identity(&row(
+            BuildLeaseConsumerKind::TaskDispatch,
+            "dispatch:019ea3bd-a305-73e3-806c-4edcc96ebfe2:4"
+        )),
+        Some(("019ea3bd-a305-73e3-806c-4edcc96ebfe2".to_owned(), 4))
+    );
+    // A warm or invocation lease is never read as a dispatch identity, even if
+    // its identity string happened to look like one.
+    assert_eq!(
+        dispatch_identity(&row(BuildLeaseConsumerKind::GraphWarm, "dispatch:task:0")),
+        None
+    );
+    for malformed in [
+        "dispatch:task-1",
+        "dispatch::0",
+        "dispatch:task-1:not-a-number",
+        "dispatch:task-1:-1",
+        "warm:project:request:revision",
+    ] {
+        assert_eq!(
+            dispatch_identity(&row(BuildLeaseConsumerKind::TaskDispatch, malformed)),
+            None,
+            "{malformed} must not resolve to a generation"
+        );
+    }
+}

--- a/server/crates/djinn-coordinator/src/build_lease_reclaim.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_reclaim.rs
@@ -41,13 +41,56 @@
 //! * the durable write is a compare-and-set on the full observed identity, so a
 //!   holder that acknowledges between the proof and the write fences the
 //!   reclamation instead of losing its lease.
+//!
+//! # The `task_dispatch` population had no proof at all
+//!
+//! Migration 153 joined layer-1 dispatch admission to this ledger as the
+//! `task_dispatch` consumer kind, and #2608 made it the ONLY authority that
+//! decides whether a task-run may spawn. [`lease_object_name`] was never taught
+//! about it, so every `task_dispatch` row fell into the unrecognised arm,
+//! returned `None`, and was skipped by this sweep — permanently unreclaimable.
+//!
+//! That is a total dispatch outage rather than a slow warm base. Production on
+//! 2026-07-25: three occupying `task_dispatch` rows against `cap 3`, ZERO
+//! task-run Pods and ZERO Jobs in the namespace, `build admission denied;
+//! leaving task queued  occupancy=3 cap=3` for every task for ~40 minutes. The
+//! rows survived a full `djinn-server` rollout restart, that restart's own
+//! journal recovery, the startup Kubernetes inventory reconciliation (which
+//! reported `stale_rows=2 reclaimed=2` — a DIFFERENT ledger, the v0 lifecycle
+//! journal), and the deletion of every `Complete` task-run Job.
+//!
+//! A dispatch lease cannot be probed the way a warm lease is: its identity is
+//! `dispatch:{task_id}:{generation}`, and the Kubernetes Job it leads to is
+//! named from a `task_run_id` that does not exist yet at acquisition time.
+//! There is no object name to ask about, and guessing one would make the
+//! absence proof vacuous. Its owner is instead a durable fact:
+//!
+//! * a dispatch slot is acquired for exactly one admission generation, and
+//! * `BuildAdmissionController::transition_permit` hands that slot back on the
+//!   same edge that marks the generation terminal.
+//!
+//! So a settled dispatch lease whose journal generation is already `terminal`
+//! is holding capacity for a lifecycle that provably ended, and the ways that
+//! generation reaches `terminal` are exactly the ways the slot should already
+//! have been released: the ordinary lifecycle callback, restart recovery
+//! (`recover_all_predecessors`, which retires every predecessor-epoch row and
+//! releases no lease), and the inventory reconciler's own Kubernetes absence
+//! proof. Reclamation therefore INHERITS the journal's evidence instead of
+//! inventing a weaker one of its own.
+//!
+//! What is deliberately NOT proof: a dispatch lease with no journal row at all.
+//! `BuildAdmissionController::admit` writes no ledger row while v0 is `off`, so
+//! an absent row is genuinely unknown state and stays occupying. The
+//! grant-without-a-row window is closed on the other side instead — `admit`
+//! hands the slot back when the ledger append fails.
 
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
 use djinn_db::{
-    BuildLeaseConsumerKind, BuildLeaseRepository, BuildLeaseRow, ReclaimAbsentBuildLeaseInput,
+    AdmissionDomain, AdmissionJournalRepository, AdmissionState, BuildLeaseConsumerKind,
+    BuildLeaseRepository, BuildLeaseRow, BuildLeaseState, ReclaimAbsentBuildLeaseInput,
     ReclaimAbsentBuildLeaseOutcome,
 };
 use djinn_k8s::{
@@ -71,8 +114,16 @@ const MAX_NAMED_FAILURES: usize = 5;
 pub struct BuildLeaseReclaimReport {
     /// Occupying leases the pass examined.
     pub occupying: usize,
-    /// Leases whose object was proven absent.
+    /// Leases whose object was proven absent, plus the `task_dispatch` leases
+    /// whose owning admission generation is proven terminal. Both are the
+    /// "this lease has no owner" population; see `ownerless_dispatch` for the
+    /// dispatch share on its own.
     pub absent: usize,
+    /// `task_dispatch` leases retired because their owning admission
+    /// generation is terminal. Reported separately because this is the
+    /// population that produced a total dispatch outage while every
+    /// Kubernetes-shaped reconciler reported success.
+    pub ownerless_dispatch: usize,
     /// Leases retired by this pass.
     pub reclaimed: usize,
     /// Leases that changed after their absence proof and were left alone.
@@ -101,8 +152,14 @@ impl BuildLeaseReclaimReport {
 /// Derived from the durable identity, never from a process-local attempt id, so
 /// the absence probe asks about exactly the object this lease would have
 /// created. An identity this function does not recognise yields `None` and the
-/// lease is never reclaimed: guessing a name is how an absence proof becomes
-/// vacuous.
+/// lease is never reclaimed on a Kubernetes proof: guessing a name is how an
+/// absence proof becomes vacuous.
+///
+/// `task_dispatch` deliberately yields `None`. It is not an oversight and not a
+/// name this function could learn: the slot is acquired BEFORE the task-run
+/// exists, so the Job name it leads to (`taskrun_job_name(task_run_id)`) is not
+/// yet determined. That population is proven ownerless through its admission
+/// generation instead — see [`dispatch_identity`] and the module docs.
 pub fn lease_object_name(row: &BuildLeaseRow) -> Option<String> {
     let mut fields = row.immutable_identity.split(':');
     match (row.key.consumer_kind, fields.next()?) {
@@ -121,9 +178,56 @@ pub fn lease_object_name(row: &BuildLeaseRow) -> Option<String> {
     }
 }
 
-/// Periodic sweep that retires occupying build leases with no Kubernetes object.
+/// The admission generation a `task_dispatch` lease bought capacity for.
+///
+/// Read from the durable `dispatch:{task_id}:{generation}` identity written by
+/// `BuildLeaseService::identity`, never from a process-local counter: the
+/// generation a dispatch attempt reserves is resolved by the journal
+/// (`resolve_dispatch_generation`) before the slot is acquired, so this is the
+/// exact journal key that owns the lease. An identity that does not parse
+/// yields `None` and the lease is left occupying.
+pub fn dispatch_identity(row: &BuildLeaseRow) -> Option<(String, i64)> {
+    if row.key.consumer_kind != BuildLeaseConsumerKind::TaskDispatch {
+        return None;
+    }
+    let rest = row.immutable_identity.strip_prefix("dispatch:")?;
+    let (task_id, generation) = rest.rsplit_once(':')?;
+    let generation: i64 = generation.parse().ok()?;
+    (!task_id.is_empty() && generation >= 0).then(|| (task_id.to_owned(), generation))
+}
+
+/// Why one settled occupying lease may be retired.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OwnerlessProof {
+    /// The authoritative LIST and an independent GET both say the object this
+    /// lease committed to does not exist.
+    ObjectAbsent,
+    /// The lease is a `task_dispatch` row whose admission generation is
+    /// terminal: the lifecycle it bought capacity for has ended.
+    GenerationTerminal,
+    /// The lease is a `task_dispatch` row the FIFO granted to a requester that
+    /// had already given up: still `granted`, never acknowledged, and no
+    /// admission ever proceeded on it.
+    GrantNeverClaimed,
+}
+
+impl OwnerlessProof {
+    /// Whether this proof is about the `task_dispatch` population, which no
+    /// Kubernetes-shaped reclaimer could see at all before #2608's capacity
+    /// cut-over was given a sweep of its own.
+    fn is_dispatch(self) -> bool {
+        matches!(self, Self::GenerationTerminal | Self::GrantNeverClaimed)
+    }
+}
+
+/// Periodic sweep that retires occupying build leases with no owner.
 pub struct BuildLeaseReclaimer {
     repository: Arc<BuildLeaseRepository>,
+    /// The v0 lifecycle ledger. Required, not optional: it is the only thing
+    /// that can answer who owns a `task_dispatch` lease, and an optional
+    /// dependency here would let composition silently reinstate the
+    /// unreclaimable population this module exists to retire.
+    journal: Arc<AdmissionJournalRepository>,
     inventory: Arc<dyn WorkloadInventory>,
     settle_window: Duration,
     serial: Mutex<()>,
@@ -133,9 +237,15 @@ impl BuildLeaseReclaimer {
     #[must_use]
     pub fn new(
         repository: Arc<BuildLeaseRepository>,
+        journal: Arc<AdmissionJournalRepository>,
         inventory: Arc<dyn WorkloadInventory>,
     ) -> Self {
-        Self::with_settle_window(repository, inventory, DEFAULT_LEASE_RECLAIM_SETTLE_WINDOW)
+        Self::with_settle_window(
+            repository,
+            journal,
+            inventory,
+            DEFAULT_LEASE_RECLAIM_SETTLE_WINDOW,
+        )
     }
 
     /// Reclaim with an explicit settle window. Tests use a zero window to
@@ -143,15 +253,78 @@ impl BuildLeaseReclaimer {
     #[must_use]
     pub fn with_settle_window(
         repository: Arc<BuildLeaseRepository>,
+        journal: Arc<AdmissionJournalRepository>,
         inventory: Arc<dyn WorkloadInventory>,
         settle_window: Duration,
     ) -> Self {
         Self {
             repository,
+            journal,
             inventory,
             settle_window,
             serial: Mutex::new(()),
         }
+    }
+
+    /// Whether one settled occupying lease is provably ownerless, and why.
+    ///
+    /// Every branch is a proof, never an age heuristic. `None` means the
+    /// question could not be answered — an unrecognised identity, a lease whose
+    /// object is still listed, an `Uncertain` probe against a degraded API
+    /// server, an unreadable journal, or a dispatch generation that is still
+    /// occupying — and an unanswered question always leaves the lease holding
+    /// its slot.
+    async fn ownerless_proof(
+        &self,
+        row: &BuildLeaseRow,
+        listed_names: &HashSet<String>,
+    ) -> Option<OwnerlessProof> {
+        if let Some((task_id, generation)) = dispatch_identity(row) {
+            return match self
+                .journal
+                .generation_state(AdmissionDomain::TaskObservation, &task_id, generation)
+                .await
+            {
+                Ok(Some(AdmissionState::Terminal)) => Some(OwnerlessProof::GenerationTerminal),
+                // Still occupying the lifecycle ledger: the task-run may be
+                // live, and this lease is its capacity.
+                Ok(Some(_)) => None,
+                // No ledger row at all. That is unknown state, not proof — v0
+                // `off` writes no rows — EXCEPT in the one durable state that
+                // says the grant was never claimed.
+                //
+                // `acquire_dispatch_slot` acknowledges every grant it takes
+                // (`queue` then `grant`), so a lease a live dispatch holds is
+                // always `launching` or later. A settled `granted` row is
+                // therefore always a FIFO grant handed to a requester that had
+                // already walked away on a `Queued` answer — the same trap the
+                // warm path hit — and with no ledger row behind it, no
+                // admission ever proceeded on it either. Three independent
+                // durable facts, none of them "the row looks old".
+                Ok(None) if row.state == BuildLeaseState::Granted => {
+                    Some(OwnerlessProof::GrantNeverClaimed)
+                }
+                Ok(None) => None,
+                Err(error) => {
+                    tracing::warn!(
+                        consumer_id = %row.key.consumer_id,
+                        %error,
+                        "build_lease: admission ledger unreadable; dispatch lease left occupying"
+                    );
+                    None
+                }
+            };
+        }
+        let object_name = lease_object_name(row)?;
+        if listed_names.contains(&object_name) {
+            return None;
+        }
+        (self
+            .inventory
+            .presence(WorkloadObjectKind::Job, &object_name)
+            .await
+            == ObjectPresence::Absent)
+            .then_some(OwnerlessProof::ObjectAbsent)
     }
 
     /// One reclamation pass.
@@ -192,21 +365,13 @@ impl BuildLeaseReclaimer {
             if !settled {
                 continue;
             }
-            let Some(object_name) = lease_object_name(&row) else {
+            let Some(proof) = self.ownerless_proof(&row, &listed_names).await else {
                 continue;
             };
-            if listed_names.contains(&object_name) {
-                continue;
-            }
-            if self
-                .inventory
-                .presence(WorkloadObjectKind::Job, &object_name)
-                .await
-                != ObjectPresence::Absent
-            {
-                continue;
-            }
             report.absent += 1;
+            if proof.is_dispatch() {
+                report.ownerless_dispatch += 1;
+            }
             let input = ReclaimAbsentBuildLeaseInput {
                 key: row.key.clone(),
                 observed_state: row.state,
@@ -222,9 +387,9 @@ impl BuildLeaseReclaimer {
                         consumer_kind = ?row.key.consumer_kind,
                         consumer_id = %row.key.consumer_id,
                         state = ?row.state,
-                        object = %object_name,
-                        "build_lease: retired an occupying lease whose Kubernetes object is \
-                         provably absent"
+                        identity = %row.immutable_identity,
+                        proof = ?proof,
+                        "build_lease: retired an occupying lease that provably has no owner"
                     );
                 }
                 Ok(ReclaimAbsentBuildLeaseOutcome::AlreadyTerminal(_)) => {}
@@ -233,9 +398,9 @@ impl BuildLeaseReclaimer {
                     tracing::warn!(
                         consumer_kind = ?row.key.consumer_kind,
                         consumer_id = %row.key.consumer_id,
-                        object = %object_name,
+                        identity = %row.immutable_identity,
                         %reason,
-                        "build_lease: refused to retire a lease that changed after its absence \
+                        "build_lease: refused to retire a lease that changed after its ownerless \
                          proof"
                     );
                 }

--- a/server/crates/djinn-coordinator/src/build_lease_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_reclaim_tests.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use djinn_db::{
-    BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseState, Database,
-    ReclaimAbsentBuildLeaseInput, ReclaimAbsentBuildLeaseOutcome,
+    AdmissionJournalRepository, BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository,
+    BuildLeaseState, Database, ReclaimAbsentBuildLeaseInput, ReclaimAbsentBuildLeaseOutcome,
 };
 use djinn_k8s::{
     LeasedWarmJobIdentity, ObjectPresence, UidGetResult, WorkloadInventory, WorkloadObjectKind,
@@ -233,6 +233,13 @@ fn reclaimer(
 ) -> BuildLeaseReclaimer {
     BuildLeaseReclaimer::with_settle_window(
         Arc::clone(repository),
+        // Warm and invocation reclamation prove absence from Kubernetes and
+        // ask the admission ledger nothing at all, so an empty ledger is the
+        // honest fixture: if either path ever starts consulting it, these
+        // tests change behaviour rather than passing quietly.
+        Arc::new(AdmissionJournalRepository::new(
+            Database::open_in_memory().unwrap(),
+        )),
         Arc::new(inventory),
         Duration::ZERO,
     )
@@ -437,6 +444,9 @@ async fn an_unusable_listing_blocks_the_pass_and_retires_nothing() {
     wedge(&service).await;
     let report = BuildLeaseReclaimer::with_settle_window(
         Arc::clone(&repository),
+        Arc::new(AdmissionJournalRepository::new(
+            Database::open_in_memory().unwrap(),
+        )),
         Arc::new(Unlistable),
         Duration::ZERO,
     )
@@ -464,6 +474,9 @@ async fn an_unsettled_lease_is_not_judged_by_a_listing_it_could_predate() {
 
     let report = BuildLeaseReclaimer::with_settle_window(
         Arc::clone(&repository),
+        Arc::new(AdmissionJournalRepository::new(
+            Database::open_in_memory().unwrap(),
+        )),
         Arc::new(NamespaceInventory::empty()),
         Duration::from_secs(3600),
     )

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -211,7 +211,11 @@ mod build_admission_stale_reclaim_tests;
 #[cfg(test)]
 mod build_lease_cap_arming_tests;
 #[cfg(test)]
+mod build_lease_cap_refresh_tests;
+#[cfg(test)]
 mod build_lease_deadline_echo_tests;
+#[cfg(test)]
+mod build_lease_dispatch_reclaim_tests;
 #[cfg(test)]
 mod build_lease_integration_tests;
 #[cfg(test)]

--- a/server/crates/djinn-db/src/repositories/admission_journal.rs
+++ b/server/crates/djinn-db/src/repositories/admission_journal.rs
@@ -630,6 +630,37 @@ impl AdmissionJournalRepository {
         Ok(ReclaimAbsentOutcome::Reclaimed(reclaimed))
     }
 
+    /// The durable state of one exact generation, or `None` when the ledger
+    /// holds no row for that key.
+    ///
+    /// This is the ownership question the v1 capacity ledger cannot answer for
+    /// itself. A `task_dispatch` build lease is bought for one task-run
+    /// generation and handed back when that generation's LIFECYCLE ends, but
+    /// the lease row carries no Kubernetes object name to probe: a task-run
+    /// Job's name is derived from a `task_run_id` that does not exist yet when
+    /// the slot is acquired. The journal generation IS that lease's owner, so
+    /// `Terminal` here is proof that the lease is holding capacity for a
+    /// lifecycle which already ended. See
+    /// `djinn_coordinator::build_lease_reclaim`.
+    pub async fn generation_state(
+        &self,
+        domain: AdmissionDomain,
+        work_id: &str,
+        generation: i64,
+    ) -> DbResult<Option<AdmissionState>> {
+        self.db.ensure_initialized().await?;
+        let state: Option<String> = sqlx::query_scalar(
+            "SELECT state FROM admission_journal \
+             WHERE domain = $1 AND work_id = $2 AND generation = $3",
+        )
+        .bind(domain.as_str())
+        .bind(work_id)
+        .bind(generation)
+        .fetch_optional(self.db.pool())
+        .await?;
+        state.map(|state| AdmissionState::parse(&state)).transpose()
+    }
+
     /// Count rows that currently occupy task-or-warm capacity.
     pub async fn count_task_or_warm_occupancy(&self) -> DbResult<i64> {
         self.db.ensure_initialized().await?;

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -1010,6 +1010,18 @@ impl AppState {
                         if let Some(admission) = state.inner.build_admission.clone() {
                             state.finalize_build_admission_handoff(&admission).await;
                         }
+                        // The epoch's REFERENCE CAP is part of the same durable
+                        // row this tick already re-reads for v0/v1 modes, and
+                        // it must be adopted on the same schedule. Without
+                        // this, `djinn-server epoch set-cap` wrote a value the
+                        // running process never read: production 2026-07-25
+                        // reported `set-cap --cap 12` applied, `epoch show`
+                        // confirmed `cap 12`, and every denial that followed
+                        // still said `cap=3` until the pods were restarted.
+                        // This loop runs on every pod including standbys,
+                        // which is safe: adopting a cap is a read of the
+                        // durable row, never a write to it.
+                        state.inner.build_lease.refresh_epoch_cap().await;
                         if let Some(event) = log_state.observe_persistent(
                             SystemClockTrait::new().now_instant(),
                             state.publish_handoff_warning().await,
@@ -1467,14 +1479,29 @@ impl AppState {
                     let lease_reclaimer = warmer.workload_inventory().map(|inventory| {
                         Arc::new(BuildLeaseReclaimer::new(
                             Arc::new(djinn_db::BuildLeaseRepository::new(self.db().clone())),
+                            // The v0 lifecycle ledger. It is the only thing
+                            // that can prove a `task_dispatch` lease has no
+                            // owner: that population commits to no Kubernetes
+                            // object name, so before it was wired here every
+                            // leaked dispatch slot was permanently
+                            // unreclaimable and a leak was a total dispatch
+                            // outage.
+                            Arc::new(djinn_db::AdmissionJournalRepository::new(self.db().clone())),
                             inventory,
                         ))
                     });
+                    let cap_refresh_lease = self.inner.build_lease.clone();
                     tokio::spawn(async move {
                         let mut tick = tokio::time::interval(Duration::from_secs(30));
                         tick.tick().await;
                         loop {
                             tick.tick().await;
+                            // Adopt an operator `epoch set-cap` on the build
+                            // lease's own maintenance cadence rather than
+                            // waiting out the five-minute handoff tick: a cap
+                            // change is an incident control, and the whole
+                            // point of it is that the board unwedges now.
+                            cap_refresh_lease.refresh_epoch_cap().await;
                             recovery_warmer.reconcile_durable_warm_leases().await;
                             let Some(reclaimer) = lease_reclaimer.as_ref() else {
                                 continue;
@@ -1488,6 +1515,7 @@ impl AppState {
                                 tracing::warn!(
                                     occupying = report.occupying,
                                     absent = report.absent,
+                                    ownerless_dispatch = report.ownerless_dispatch,
                                     reclaimed = report.reclaimed,
                                     fenced = report.fenced,
                                     failures = report.failure_count,


### PR DESCRIPTION
Two defects, both measured in production on 2026-07-25, both on the layer-1
build-admission path. They are filed together because they were the same
incident: the first wedged the board, the second made the operator's only
mitigation do nothing.

## Defect A — build-admission occupancy leaked, and a leak was a total dispatch outage

**Symptom.** With v0/v1 enforcing at `cap 3`, production denied **every** task
for ~40 minutes:

```
{"message":"build admission denied; leaving task queued","occupancy":3,"cap":3}
```

At that moment there were zero task-run Pods and zero Jobs in the namespace.
The three occupying entries survived a full `djinn-server` rollout restart, that
restart's own journal recovery, its Kubernetes inventory reconciliation
(`stale_rows=2 reclaimed=2`), and the deletion of every `Complete` task-run Job.
There is prior history of 318 stale occupying rows needing a manual clear before
enforce could be armed.

**Root cause.** The three occupying entries were not `admission_journal` rows.
Since #2608 the single capacity authority is `build_leases`, and layer-1
dispatch admission occupies it as the `task_dispatch` consumer kind added by
migration 153. `BuildLeaseReclaimer` — the only sweep over that ledger —
resolves what to probe through `lease_object_name`, which handles `graph_warm`
and `task_invocation` and returns `None` for everything else. Every
`task_dispatch` row therefore fell into the unrecognised arm and was skipped,
permanently. Nothing else can retire one either: `release`/`cancel` need the
holder's fencing token, `abandon_queued` refuses anything past `queued`, and
`recover_all_predecessors` only touches the *journal*.

That is why the two counts disagreed. The reconciler that logged
`stale_rows=2 reclaimed=2` was reconciling the v0 **lifecycle** ledger; the
three rows holding the cap were in the v1 **capacity** ledger, which had no
reclaimer for that population at all. The startup log looked like success while
the outage continued.

`lease_object_name` was not merely missing a case. A dispatch slot is acquired
*before* the task-run exists, so the Job name it leads to
(`taskrun_job_name(task_run_id)`) is not yet determined. There is no object name
to probe, and guessing one makes the absence proof vacuous.

**Fix.** A dispatch lease's owner is a durable fact rather than a Kubernetes
object: it is bought for exactly one admission generation, and
`transition_permit` hands it back on the same edge that marks that generation
terminal. `BuildLeaseReclaimer` now takes the `AdmissionJournalRepository` as a
**required** dependency and retires a settled occupying `task_dispatch` lease on
one of two proofs:

* `GenerationTerminal` — the `(task_observation, task_id, generation)` row is
  `terminal`. Every way it gets there is a way the slot should already have been
  released: the ordinary lifecycle callback, restart recovery, or the inventory
  reconciler's own Kubernetes absence proof. Reclamation *inherits* that
  evidence instead of inventing a weaker one.
* `GrantNeverClaimed` — no ledger row **and** the lease is still `granted`.
  `acquire_dispatch_slot` acknowledges every grant it takes (`queue` then
  `grant`), so a live dispatch is always `launching` or later; a settled
  `granted` row is always a FIFO grant handed to a requester that walked away on
  a `Queued` answer, with no admission behind it. This closes the second leak
  path: a task denied at a full cap leaves a queue position, and if it closes
  before retrying, a later drain grants that position to nobody.

Fail-closed is preserved everywhere else, deliberately: an occupying generation,
an unreadable journal, an unparseable identity, or a *held* (`launching`+) lease
with no ledger row all leave the slot occupied. The last one is genuinely
unknown — v0 `off` writes no ledger rows — so it is not treated as proof.

The write remains a compare-and-set on the full observed lease identity, so a
holder that acts between the proof and the write fences the reclamation.
Reclamation already runs every 30s in production, so a leak now self-heals
instead of requiring an operator.

## Defect B — `epoch set-cap` wrote a value the running process never read

**Symptom.** `djinn-server epoch set-cap --cap 12` reported `set-cap: applied`
and `epoch show` confirmed `... v1_mode Enforce · cap 12`. The very next denial
still said `"occupancy":3,"cap":3`, until the pods were restarted.

**Root cause.** `BuildLeaseService::read_handoff_epoch` already resolved the
durable epoch's reference cap correctly — and *returned* it. Only `recover()`
ever stored the result into the `cap` atomic that `drain()`/`grant_next`
actually enforce; `recovery_snapshot()` recomputed the fresh value on every call
and threw it away. So the enforced cap could only change at process start, where
it happened to coincide with `DJINN_MAX_BUILD_TASKRUNS=3`.

**Fix — make the durable cap authoritative at runtime**, rather than making
`set-cap` refuse.

The refusal option was rejected. The durable cap is *already* the designed
authority: `read_handoff_epoch` documents that the handoff reference cap is
authoritative for the v1 authority when set, `recover()` applies it over both
the lease table and the environment, and the whole `epoch advance`/`rollback`
protocol carries a cap through every arming step. Making `set-cap` refuse would
demote that row to advisory and leave the operator with no cap control at all
except a redeploy — during exactly the incident where a redeploy is what you are
trying to avoid.

So the resolved cap is now **stored**, not just returned, in the one place that
resolves it, and a new `BuildLeaseService::refresh_epoch_cap()` performs that
read on two existing cadences: the coordinator's handoff tick (which already
re-reads the same row for v0/v1 modes) and the build-lease maintenance tick
(30s, so an incident mitigation takes effect in seconds). A *raised* cap also
drains the FIFO, since `grant_next` otherwise only runs when someone queues — an
operator raising the cap to unwedge a stalled board would still have to wait for
the next dispatch attempt.

Precedence is unchanged (epoch cap → positive `build_lease_caps` row →
configured fallback); an unreadable or capless epoch stores the fallback rather
than widening the cap; lowering never revokes an occupying row.

**Interaction with #2608's unified authority.** `BuildAdmissionController` reads
capacity only through `BuildSlotAuthority`, so `effective_cap()` follows the
refreshed value automatically and v0/v1 cannot disagree about the number in
force. Three sites still reported the *constructor's* configured cap in
operator-facing output — the `Denied { cap }` returned on the not-ready and
authority-unavailable paths, the over-cap alarm, and the reconciliation
alarm/threshold — and now use `effective_cap()`. Telemetry *labels* keep the
configured value on purpose: a label that moved with a live cap change would
split every metric series.

`build_lease.rs` crossed the 51 200-byte source guard, so cap resolution moved
to `build_lease_cap.rs` as a child module of the same type (same private state,
no API change).

## Tests — asserting the side effect, not the report

Every new test drives the production composition (`BuildAdmissionController`
over a real `BuildLeaseService` over a real Postgres database). Nothing writes a
lease or journal row by hand.

`build_lease_dispatch_reclaim_tests.rs`

* `dispatch_leak_wedges_every_task_until_it_is_reclaimed` — the whole incident.
  A real dispatch takes a slot; a real predecessor-epoch recovery plus a real
  `BuildAdmissionReconciler` pass empty the v0 ledger (reproducing the
  `stale_rows`/`reclaimed` line); the v1 ledger still reads occupancy 1, at
  which point `admit_task_run` returns `Denied { occupancy: 1, cap: 1 }`. After
  one reclaim pass it asserts **occupancy back to 0** and that the next
  `admit_task_run` is actually **`Permitted`** and takes the freed slot.
* `a_grant_the_fifo_handed_to_nobody_is_retired_and_gives_the_cap_back` — the
  second leak path, likewise ending in a permitted admit.
* Negatives: an occupying generation is never retired; a *held* lease with no
  ledger row is never retired; an unsettled lease is not judged at all; identity
  parsing rejects malformed rows rather than guessing.

`build_lease_cap_refresh_tests.rs` asserts an **enforced decision**, never a
column read-back: a lease refused at `cap 1` becomes `Granted` after
`refresh_epoch_cap()` adopts a durable `set-cap 2` written through the same
`AdmissionTransitionExecutor` that `server/src/admin.rs` drives; the new cap is
then enforced as the real ceiling; lowering stops granting without revoking; and
a refresh before recovery moves nothing. The fixture's configured fallback (9)
is deliberately different from every epoch cap, so an assertion that passed by
reading the environment instead of the epoch would be visible.

**Neutralization.** Making `ownerless_proof` return `None` for the dispatch
branch fails `dispatch_leak_wedges_every_task_until_it_is_reclaimed` on the
occupancy assertion and again on the admit; removing the `self.cap.store(...)`
in `read_handoff_epoch` fails
`a_durable_set_cap_changes_what_the_running_process_enforces` on the granted
state, not merely on a number.

## Not verifiable outside production

The 30s and 5-minute wiring in `AppState` is composition, exercised only by the
running server; the tests drive `refresh_epoch_cap()` and `reclaim()` directly.
Whether the rows currently wedging production are `GenerationTerminal` or
`GrantNeverClaimed` cannot be determined from here — both are covered, and the
`ownerless_dispatch` field on the reclaim log line reports which fired.
