### PR TITLE
fix(refinement): observe ledger-dispatched role exits and make every stop durable

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/refinement_helpers.rs
+++ b/server/crates/djinn-control-plane/src/tools/refinement_helpers.rs
@@ -338,6 +338,7 @@ pub(crate) fn liveness_fields(result: &RefinementLivenessResult) -> (&'static st
                     RefinementLivenessEvidence::AwaitingEvidencePark => "awaiting_evidence_park",
                     RefinementLivenessEvidence::PendingIntent { .. } => "pending_intent",
                     RefinementLivenessEvidence::ClaimedIntent { .. } => "claimed_intent",
+                    RefinementLivenessEvidence::MaterializedIntent { .. } => "materialized_intent",
                     RefinementLivenessEvidence::OpenTask { .. } => "open_task",
                     RefinementLivenessEvidence::QueuedTask { .. } => "queued_task",
                     RefinementLivenessEvidence::RunningTask { .. } => "running_task",

--- a/server/crates/djinn-coordinator/src/dispatch/liveness.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/liveness.rs
@@ -114,6 +114,37 @@ impl DbTaskStatus {
     pub fn is_terminal(&self) -> bool {
         matches!(self, Self::Closed)
     }
+
+    /// Whether this status is a **recorded handoff**: the task has moved to a
+    /// boundary that some other actor now owns (review, PR, lead intervention)
+    /// or has finished outright.
+    ///
+    /// This is deliberately wider than [`Self::is_terminal`] and exists only for
+    /// protocol-violation detection. A session that exits with its task parked
+    /// at a handoff boundary did its job and handed the task on — that is the
+    /// normal shape of a worker or reviewer turn, not a structural
+    /// inconsistency. Treating every non-`closed` status as "nonterminal" made
+    /// the violation branch fire on 74.8% of ALL session exits in production
+    /// (2133/2852 over seven days), including 741 clean reviewer exits at
+    /// `in_task_review` and 950 handoff exits in total, which drowned the signal
+    /// the check exists to raise.
+    ///
+    /// `Open` and `InProgress` are NOT settled: a pod that exits while the task
+    /// is still queued or still claimed left nothing behind, which is the
+    /// genuine inconsistency this detector is for.
+    pub fn is_settled(&self) -> bool {
+        matches!(
+            self,
+            Self::NeedsTaskReview
+                | Self::InTaskReview
+                | Self::Approved
+                | Self::PrDraft
+                | Self::PrReview
+                | Self::NeedsLeadIntervention
+                | Self::InLeadIntervention
+                | Self::Closed
+        )
+    }
 }
 
 // ─── Classification evidence ────────────────────────────────────────────────
@@ -307,8 +338,9 @@ pub struct ClassificationResult {
 /// 1. **Terminal task state** → noop/idempotent outcome
 /// 2. **Hard runtime cap exceeded** → `Dead` with `Timeout` outcome (forbids
 ///    extension)
-/// 3. **Protocol violation** → inconsistent clean/nonzero exit on non-terminal
-///    task
+/// 3. **Protocol violation** → inconsistent clean/nonzero exit on a task that
+///    is positively known to be unsettled (still `open`/`in_progress`) with a
+///    session row positively known to still be running
 /// 4. **Dead** → absent/failed pod with no recent activity
 /// 5. **Slow** → activity signal absent/idle, pod running, below hard cap
 /// 6. **Live** → default when other conditions don't match
@@ -340,9 +372,22 @@ pub fn classify(evidence: &LivenessEvidence) -> ClassificationResult {
     }
 
     // ── 3. Protocol violation detection ─────────────────────────────────
-    // A protocol violation occurs when we see structurally inconsistent
-    // signals: a pod that exited (succeeded/failed) while the task is still
-    // non-terminal and the session is not in a terminal DB state.
+    // A protocol violation is a STRUCTURAL INCONSISTENCY, so every term must be
+    // POSITIVE evidence. Absence is not guilt.
+    //
+    // The previous rule mixed one positive guard with one fail-open one:
+    // precedence 1 needed `db_task_status.is_some_and(is_terminal)` to hold to
+    // exonerate, while this branch used `db_session_status.is_none_or(...)` to
+    // convict. Missing evidence therefore fell through precedence 1 AND
+    // satisfied this branch — an absent task row or session row convicted
+    // deterministically. Both terms are now `is_some_and`, so an unknown state
+    // is fail-safe: it produces no violation, and no destructive action either
+    // (the reaping paths are precedence 2/4, which are untouched).
+    //
+    // The task term is also tightened from "not closed" to "not settled": see
+    // [`DbTaskStatus::is_settled`]. A session that exits with its task at a
+    // review/PR/intervention boundary handed off; only a task still `open` or
+    // `in_progress` was genuinely left stranded.
     let pod_exited = matches!(
         evidence.pod_phase,
         Some(PodPhase::Succeeded) | Some(PodPhase::Failed)
@@ -350,9 +395,13 @@ pub fn classify(evidence: &LivenessEvidence) -> ClassificationResult {
     let session_nonterminal = evidence
         .db_session_status
         .as_ref()
-        .is_none_or(|s| !s.is_terminal());
+        .is_some_and(|s| !s.is_terminal());
+    let task_unsettled = evidence
+        .db_task_status
+        .as_ref()
+        .is_some_and(|s| !s.is_settled());
 
-    if pod_exited && session_nonterminal {
+    if pod_exited && session_nonterminal && task_unsettled {
         // Classify the type of protocol violation based on exit code
         let reason = match evidence.exit_code {
             Some(0) => LivenessReason::CleanExitNonterminal,
@@ -760,16 +809,90 @@ mod tests {
         assert_ne!(result.outcome, Some(LivenessOutcome::KillNoop));
     }
 
+    /// Absence is not guilt. A violation needs POSITIVE evidence on both axes,
+    /// so a missing session row can no longer convict an exited pod — the
+    /// asymmetry that made unknown evidence land in `ProtocolViolation`
+    /// deterministically.
     #[test]
-    fn no_session_status_with_exited_pod_is_protocol_violation() {
-        // No session row + pod exited = structural inconsistency
+    fn no_session_status_with_exited_pod_is_not_a_protocol_violation() {
         let mut ev = live_evidence();
         ev.pod_phase = Some(PodPhase::Succeeded);
         ev.exit_code = Some(0);
         ev.db_session_status = None; // no session row
 
         let result = classify(&ev);
-        assert_eq!(result.verdict, Verdict::ProtocolViolation);
+        assert_ne!(result.verdict, Verdict::ProtocolViolation);
+        assert_ne!(result.outcome, Some(LivenessOutcome::ProtocolViolation));
+    }
+
+    /// The mirror image: a missing task row must not convict either. Before
+    /// this, `db_task_status = None` failed precedence 1's `is_some_and` guard
+    /// AND satisfied this branch, so it was a guaranteed violation.
+    #[test]
+    fn no_task_status_with_exited_pod_is_not_a_protocol_violation() {
+        let mut ev = live_evidence();
+        ev.pod_phase = Some(PodPhase::Succeeded);
+        ev.exit_code = Some(0);
+        ev.db_session_status = Some(DbSessionStatus::Running);
+        ev.db_task_status = None; // no task row
+
+        let result = classify(&ev);
+        assert_ne!(result.verdict, Verdict::ProtocolViolation);
+    }
+
+    /// A session that exits with its task parked at a recorded handoff did its
+    /// job. Every `is_settled` status must be exonerated, on both a clean and a
+    /// crashing exit.
+    #[test]
+    fn exit_at_a_recorded_handoff_is_not_a_protocol_violation() {
+        for status in [
+            DbTaskStatus::NeedsTaskReview,
+            DbTaskStatus::InTaskReview,
+            DbTaskStatus::Approved,
+            DbTaskStatus::PrDraft,
+            DbTaskStatus::PrReview,
+            DbTaskStatus::NeedsLeadIntervention,
+            DbTaskStatus::InLeadIntervention,
+        ] {
+            for (phase, code) in [(PodPhase::Succeeded, 0), (PodPhase::Failed, 1)] {
+                let mut ev = live_evidence();
+                ev.pod_phase = Some(phase);
+                ev.exit_code = Some(code);
+                ev.db_session_status = Some(DbSessionStatus::Running);
+                ev.db_task_status = Some(status);
+
+                let result = classify(&ev);
+                assert_ne!(
+                    result.verdict,
+                    Verdict::ProtocolViolation,
+                    "{status:?} is a recorded handoff, not a structural inconsistency"
+                );
+            }
+        }
+    }
+
+    /// The detector must keep firing on the shape it exists for: a pod that
+    /// exited leaving its task still claimed or still queued, with the session
+    /// row never settled.
+    #[test]
+    fn exit_leaving_the_task_unsettled_is_still_a_protocol_violation() {
+        for status in [DbTaskStatus::Open, DbTaskStatus::InProgress] {
+            let mut clean = live_evidence();
+            clean.pod_phase = Some(PodPhase::Succeeded);
+            clean.exit_code = Some(0);
+            clean.db_session_status = Some(DbSessionStatus::Running);
+            clean.db_task_status = Some(status);
+            let result = classify(&clean);
+            assert_eq!(result.verdict, Verdict::ProtocolViolation, "{status:?}");
+            assert_eq!(result.reason, Some(LivenessReason::CleanExitNonterminal));
+
+            let mut crashed = clean.clone();
+            crashed.pod_phase = Some(PodPhase::Failed);
+            crashed.exit_code = Some(1);
+            let result = classify(&crashed);
+            assert_eq!(result.verdict, Verdict::ProtocolViolation, "{status:?}");
+            assert_eq!(result.outcome, Some(LivenessOutcome::Crash));
+        }
     }
 
     #[test]

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -2751,15 +2751,27 @@ impl CoordinatorActor {
         }
 
         // ── 5. Log protocol violation prominently ──────────────────────
+        //
+        // The message states the ACTUAL accounting, per exit kind. Only
+        // `failed`/`interrupted` exits terminalize an attempt (step 6 below); a
+        // `completed` exit records evidence and nothing else. The previous text
+        // claimed "counts as failed attempt" for every violation including clean
+        // ones, which read as retry inflation that never happened.
         if result.verdict == Verdict::ProtocolViolation {
+            let attempt_accounting = if matches!(session_status, "failed" | "interrupted") {
+                "terminalizes the live attempt"
+            } else {
+                "evidence only — no attempt accounting"
+            };
             tracing::warn!(
                 task_id = %task_id,
                 session_id = %session_id,
                 session_status = %session_status,
                 reason = ?result.reason,
                 outcome = ?result.outcome,
+                attempt_accounting,
                 "classify_session_exit_liveness: protocol violation detected — \
-                 session exited while task is nonterminal; counts as failed attempt"
+                 session exited while its task was still unsettled"
             );
         }
 

--- a/server/crates/djinn-coordinator/src/doctor/refinement_phantom_active.rs
+++ b/server/crates/djinn-coordinator/src/doctor/refinement_phantom_active.rs
@@ -19,9 +19,10 @@ use tracing::warn;
 
 pub const REFINEMENT_PHANTOM_ACTIVE_CHECK_NAME: &str = "refinement_phantom_active";
 const HEARTBEAT_GRACE_MILLIS: i64 = 60_000;
-const MISSING_EVIDENCE_CLASSES: [&str; 6] = [
+const MISSING_EVIDENCE_CLASSES: [&str; 7] = [
     "explicit_park",
     "pending_or_claimed_intent",
+    "materialized_intent",
     "active_task",
     "live_session",
     "between_phase_handoff",

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -153,6 +153,7 @@ pub(crate) mod refinement;
 pub(crate) mod refinement_dispatch;
 #[cfg(test)]
 mod refinement_e2e_evidence_regression_tests;
+mod refinement_inflight;
 mod refinement_lint_evidence;
 mod refinement_objections;
 mod refinement_outcome;

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -30,6 +30,7 @@ use super::evidence_lifecycle_state::EvidenceLifecycleState;
 use super::refinement::{RefinementPhase, StopReason, role_for_phase};
 
 use super::actor::CoordinatorActor;
+use super::refinement_inflight::DurableInflightRegistration;
 use super::refinement_outcome::RefinementOutcomeApplication;
 use super::types::InflightDispatch;
 use djinn_core::clock::{Clock, SystemClock};
@@ -196,6 +197,31 @@ impl CoordinatorActor {
                                 Ok(Some(proposal)) => proposal,
                                 Ok(None) | Err(_) => continue,
                             };
+                            // Register the in-flight projection BEFORE any gate
+                            // that can `continue`. The outcome path is the only
+                            // writer of the successor intent, and it is only
+                            // reachable through this projection — a materialized
+                            // intent whose role already ran must be observable
+                            // even when attribution or admission would deny a
+                            // fresh enqueue. Skipping this is what left every
+                            // durable run stuck at `materialized` forever.
+                            let role_ran = self
+                                .register_durable_refinement_inflight(DurableInflightRegistration {
+                                    run_id: &run.run_id,
+                                    generation: run.generation,
+                                    proposal: &proposal,
+                                    phase: intent.phase,
+                                    round: intent.round,
+                                    task_id: &task.id,
+                                })
+                                .await;
+                            if role_ran {
+                                // The role already produced a session. What the
+                                // run is owed now is its OUTCOME, not another
+                                // dispatch; re-enqueueing a finished (and by now
+                                // closed) role task would loop forever.
+                                continue;
+                            }
                             let Some(owner) = proposal.refinement_owner_user_id.as_deref() else {
                                 tracing::debug!(intent_id = %intent.intent_id, "awaiting durable refinement attribution");
                                 continue;
@@ -327,6 +353,19 @@ impl CoordinatorActor {
                 {
                     continue;
                 }
+                // Track the freshly materialized role as in-flight in the same
+                // pass that enqueues it, so its very first exit is observed and
+                // its outcome applied. Registering only on a later poll would
+                // leave a one-tick hole with no watcher.
+                self.register_durable_refinement_inflight(DurableInflightRegistration {
+                    run_id: &lease.run_id,
+                    generation: lease.generation,
+                    proposal: &proposal,
+                    phase: lease.phase,
+                    round: lease.round,
+                    task_id: &task_id,
+                })
+                .await;
                 let project_path = self.resolve_refinement_project_path(&run.proposal_id).await;
                 if let Err(error) = self.pool.dispatch(&task_id, &project_path, &model_id).await {
                     tracing::warn!(task_id = %task_id, %error, "durable refinement enqueue failed; task remains retryable");
@@ -1239,3 +1278,7 @@ mod refinement_wake_tests;
 #[cfg(test)]
 #[path = "refinement_durable_dispatch_tests.rs"]
 mod refinement_durable_dispatch_tests;
+
+#[cfg(test)]
+#[path = "refinement_durable_handoff_tests.rs"]
+mod refinement_durable_handoff_tests;

--- a/server/crates/djinn-coordinator/src/refinement_durable_handoff_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_durable_handoff_tests.rs
@@ -1,0 +1,354 @@
+//! Durable phase-handoff regressions.
+//!
+//! The durable intent ledger is the only dispatch authority for a run that has
+//! a run identity. These tests drive a real adversary turn to completion
+//! through `drive_active_refinements` — with NO hand-injected in-memory
+//! projection — and assert the side effect that matters: the successor Advocate
+//! intent is durably written, an Advocate role task is materialized, and no
+//! ledger-dispatched role can leave its run running with a NULL stop tag.
+
+use djinn_core::{
+    events::{DjinnEventEnvelope, EventBus},
+    models::Task,
+    refinement_liveness::{
+        RefinementIntentState, RefinementPhase as DurablePhase, RefinementRole, RefinementRunState,
+    },
+};
+use djinn_db::{
+    AdmitRefinementRunRequest, CreateSessionParams, LoadRefinementRunSnapshotRequest,
+    ProposalDebateTrailCreateInput, ProposalRepository, RefinementAdmissionOutcome,
+    RefinementAdmissionSource, SessionRepository, TaskRepository,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+use super::refinement_cap_tests;
+
+/// A pool whose runner holds its slot until the session is killed, so a
+/// dispatched role task stays observably running for as long as the test needs.
+/// The role's durable output is seeded directly by the test, exactly as a real
+/// agent would have written it.
+fn spawn_holding_pool(db: &djinn_db::Database) -> djinn_slot::SlotPoolHandle {
+    let cancel = CancellationToken::new();
+    djinn_slot::SlotPoolHandle::spawn_with_factory(
+        crate::test_helpers::agent_context_from_db(db.clone(), cancel.clone()),
+        cancel,
+        djinn_slot::SlotPoolConfig {
+            models: vec![djinn_slot::ModelSlotConfig {
+                model_id: refinement_cap_tests::TEST_MODEL.to_owned(),
+                max_slots: 2,
+                roles: ["advocate", "adversary", "judge", "worker"]
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect(),
+            }],
+            role_priorities: HashMap::new(),
+        },
+        Arc::new(|slot_id, model_id, event_tx, app_state, cancel| {
+            let runner: djinn_slot::TestLifecycleRunner =
+                Arc::new(move |_task_id, _, _, _, kill, _, _| {
+                    Box::pin(async move {
+                        kill.cancelled().await;
+                        Ok(())
+                    })
+                });
+            djinn_slot::SlotHandle::spawn_with_test_runner(
+                slot_id, model_id, event_tx, app_state, cancel, runner,
+            )
+        }),
+    )
+}
+
+async fn wait_until_pool_holds(pool: &djinn_slot::SlotPoolHandle, task_id: &str) {
+    for _ in 0..200 {
+        if pool
+            .has_session(task_id)
+            .await
+            .expect("query holding pool session")
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("holding pool never reported {task_id} running");
+}
+
+async fn release_pool_session(pool: &djinn_slot::SlotPoolHandle, task_id: &str) {
+    let _ = pool.kill_session(task_id).await;
+    for _ in 0..200 {
+        if !pool
+            .has_session(task_id)
+            .await
+            .expect("query holding pool session")
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("holding pool did not free {task_id}");
+}
+
+struct HandoffFixture {
+    db: djinn_db::Database,
+    actor: crate::actor::CoordinatorActor,
+    proposal_id: String,
+    project_id: String,
+    run_id: String,
+    generation: i32,
+}
+
+async fn handoff_fixture() -> HandoffFixture {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = refinement_cap_tests::seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = spawn_holding_pool(&db);
+    let actor = refinement_cap_tests::build_refinement_actor(&db, &events_tx, pool);
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+    let (run_id, generation) = match repo
+        .admit_refinement_run(AdmitRefinementRunRequest {
+            proposal_id: fixture.proposal_id.clone(),
+            idempotency_key: uuid::Uuid::now_v7().to_string(),
+            source: RefinementAdmissionSource::Demand {
+                demand_id: uuid::Uuid::now_v7().to_string(),
+            },
+            heartbeat_grace_millis: 60_000,
+        })
+        .await
+        .expect("admit durable handoff run")
+    {
+        RefinementAdmissionOutcome::Admitted {
+            run_id, generation, ..
+        }
+        | RefinementAdmissionOutcome::Existing {
+            run_id, generation, ..
+        } => (run_id, generation),
+    };
+    HandoffFixture {
+        db,
+        actor,
+        proposal_id: fixture.proposal_id,
+        project_id: fixture.project_id,
+        run_id,
+        generation,
+    }
+}
+
+async fn snapshot(f: &HandoffFixture) -> djinn_db::RefinementRunSnapshotResult {
+    ProposalRepository::new(f.db.clone(), EventBus::noop())
+        .load_refinement_run_snapshot(LoadRefinementRunSnapshotRequest {
+            run_id: f.run_id.clone(),
+            heartbeat_grace_millis: 60_000,
+        })
+        .await
+        .expect("load exact run snapshot")
+        .expect("run exists")
+}
+
+/// The role task this run has materialized for `role`, if any.
+async fn role_task(f: &HandoffFixture, role: &str) -> Option<Task> {
+    TaskRepository::new(f.db.clone(), EventBus::noop())
+        .list_by_project(&f.project_id)
+        .await
+        .expect("list project tasks")
+        .into_iter()
+        .find(|task| {
+            task.issue_type == "refinement"
+                && task.refinement_role.as_deref() == Some(role)
+                && task.refinement_run_id.as_deref() == Some(f.run_id.as_str())
+        })
+}
+
+/// Write the durable artifacts a real role agent leaves behind: a session row
+/// for its task and, for the adversary, a blocking objection on this round.
+async fn record_agent_turn(
+    f: &HandoffFixture,
+    task_id: &str,
+    agent_type: &str,
+    objection: Option<(&str, i32)>,
+) {
+    SessionRepository::new(f.db.clone(), EventBus::noop())
+        .create(CreateSessionParams {
+            project_id: &f.project_id,
+            task_id: Some(task_id),
+            model: refinement_cap_tests::TEST_MODEL,
+            agent_type,
+            metadata_json: None,
+            task_run_id: None,
+            pricing: None,
+            cost_basis: None,
+        })
+        .await
+        .expect("record role agent session");
+    if let Some((body, round)) = objection {
+        ProposalRepository::new(f.db.clone(), EventBus::noop())
+            .add_debate_trail_entry(ProposalDebateTrailCreateInput {
+                proposal_id: &f.proposal_id,
+                kind: "objection",
+                body,
+                blocking: true,
+                agent_role: agent_type,
+                author_kind: "agent",
+                author_model: Some(refinement_cap_tests::TEST_MODEL),
+                source_task_id: Some(task_id),
+                against_revision_seq: 0,
+                round,
+                body_metadata: None,
+            })
+            .await
+            .expect("record adversary objection");
+    }
+}
+
+/// Drive the opening Adversary intent to a real, finished agent turn: the
+/// ledger materializes and enqueues the role task, the agent runs, files a
+/// blocking objection, and exits cleanly with its slot freed.
+async fn run_adversary_turn(f: &mut HandoffFixture) -> Task {
+    f.actor.drive_active_refinements().await;
+    let adversary = role_task(f, "adversary")
+        .await
+        .expect("the ledger must materialize the opening adversary task");
+    wait_until_pool_holds(&f.actor.pool, &adversary.id).await;
+    record_agent_turn(
+        f,
+        &adversary.id,
+        "adversary",
+        Some(("missing rollback plan", 1)),
+    )
+    .await;
+    release_pool_session(&f.actor.pool, &adversary.id).await;
+    adversary
+}
+
+/// The load-bearing regression.
+///
+/// Before this fix the coordinator never registered an in-flight projection for
+/// a ledger-dispatched intent, so `process_refinement_outcome` was unreachable
+/// on the durable path, `complete_refinement_intent` was never called, and the
+/// run sat `running` with no successor intent and a NULL stop tag forever —
+/// exactly the state proposals `bzpt`, `op33` and `8ixk` were found in, with
+/// adversary debate entries and no advocate or judge turn.
+///
+/// The assertion is the side effect that matters: an **Advocate turn actually
+/// happens**. Not "the classifier returned X", not "a projection exists" — a
+/// durable Advocate intent, a completed Adversary intent, a closed Adversary
+/// task, and a materialized Advocate role task.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn durable_adversary_exit_hands_off_to_a_real_advocate_turn() {
+    let mut f = handoff_fixture().await;
+    let adversary = run_adversary_turn(&mut f).await;
+
+    // The coordinator must observe that clean exit and hand off.
+    f.actor.drive_active_refinements().await;
+
+    let after = snapshot(&f).await;
+    let advocate_intent = after
+        .snapshot
+        .intents
+        .iter()
+        .find(|intent| {
+            intent.run_id == f.run_id
+                && intent.phase == DurablePhase::AdvocateRevision
+                && intent.role == RefinementRole::Advocate
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "the adversary exit must durably enqueue the Advocate successor; \
+                 intents were {:?}",
+                after.snapshot.intents
+            )
+        });
+    assert_ne!(
+        advocate_intent.state,
+        RefinementIntentState::Completed,
+        "the successor advocate intent must still be dispatchable"
+    );
+    assert!(
+        after.snapshot.intents.iter().any(|intent| {
+            intent.phase == DurablePhase::AdversaryAttack
+                && intent.state == RefinementIntentState::Completed
+        }),
+        "the adversary intent must be durably completed, not left materialized"
+    );
+    assert_eq!(
+        TaskRepository::new(f.db.clone(), EventBus::noop())
+            .get(&adversary.id)
+            .await
+            .expect("reload adversary task")
+            .expect("adversary task exists")
+            .status,
+        "closed",
+        "a finished role task must not linger open and keep the run artificially live"
+    );
+
+    // The successor intent must produce a real Advocate role task — the
+    // advocate TURN, not merely a ledger row.
+    f.actor.drive_active_refinements().await;
+    let advocate = role_task(&f, "advocate")
+        .await
+        .expect("the advocate successor intent must materialize an advocate role task");
+    assert_eq!(
+        advocate.refinement_run_id.as_deref(),
+        Some(f.run_id.as_str())
+    );
+    assert_eq!(
+        advocate.refinement_generation,
+        Some(i64::from(f.generation))
+    );
+    wait_until_pool_holds(&f.actor.pool, &advocate.id).await;
+}
+
+/// No ledger-dispatched role may leave its run `running` with a NULL stop tag.
+///
+/// A role that is dispatched and then never settles must still hit the
+/// coordinator's execution watchdog and terminalize the run with a durable stop
+/// reason. That watchdog only ever fired for legacy map-driven dispatches,
+/// because a ledger-dispatched intent had no in-flight projection to watch, so
+/// a durable run that lost its role simply stayed active forever.
+///
+/// Time is aged rather than slept: the projection the coordinator registered on
+/// its own is back-dated past the execution budget.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_ledger_dispatched_role_that_never_settles_terminalizes_the_run() {
+    let mut f = handoff_fixture().await;
+
+    f.actor.drive_active_refinements().await;
+    let adversary = role_task(&f, "adversary")
+        .await
+        .expect("the ledger must materialize the opening adversary task");
+    wait_until_pool_holds(&f.actor.pool, &adversary.id).await;
+    // The agent session started but never produced an outcome.
+    record_agent_turn(&f, &adversary.id, "adversary", None).await;
+
+    let aged = std::time::Instant::now()
+        .checked_sub(Duration::from_secs(4_000))
+        .expect("monotonic clock supports back-dating");
+    let watched = match f.actor.refinement_sessions.get_mut(&f.run_id) {
+        Some(session) => {
+            session.dispatched_at = aged;
+            session.session_started_at = Some(aged);
+            true
+        }
+        None => false,
+    };
+    assert!(
+        watched,
+        "a ledger-dispatched role must be registered as in-flight so the \
+         execution watchdog can see it"
+    );
+
+    f.actor.drive_active_refinements().await;
+
+    let after = snapshot(&f).await;
+    assert_eq!(
+        after.snapshot.run.state,
+        RefinementRunState::Terminal,
+        "a ledger-dispatched role that never settles must terminalize its run, \
+         never leave it abandoned and active"
+    );
+    assert!(
+        after.snapshot.run.terminal_reason.is_some(),
+        "a terminal run must carry a durable stop reason, not a NULL stop tag"
+    );
+}

--- a/server/crates/djinn-coordinator/src/refinement_inflight.rs
+++ b/server/crates/djinn-coordinator/src/refinement_inflight.rs
@@ -1,0 +1,161 @@
+//! In-flight projection for ledger-dispatched refinement intents.
+//!
+//! The durable intent ledger is the dispatch authority for a run that has a run
+//! identity, but the *outcome* path — the only writer of the successor intent —
+//! is reached through the coordinator's disposable `refinement_sessions` /
+//! `active_refinements` projections. Only the legacy map-driven dispatcher ever
+//! populated those, so a ledger-dispatched role was never observed finishing:
+//! `process_refinement_outcome` was unreachable, `complete_refinement_intent`
+//! was never called, and every durable run stalled at `materialized` with a
+//! NULL stop tag (0 intents advanced past `materialized` fleet-wide in a week).
+//!
+//! This module rebuilds that projection from the durable ledger on every tick,
+//! so the phase in flight is always named by the ledger and the coordinator's
+//! existing monitoring — outcome application, task close, dispatch-retry cap,
+//! and the execution watchdog — applies to durable runs exactly as it did to
+//! legacy ones.
+
+use djinn_core::models::Proposal;
+use djinn_core::refinement_liveness::RefinementPhase as DurablePhase;
+use djinn_db::SessionRepository;
+
+use super::actor::CoordinatorActor;
+use super::refinement::{RefinementLoopState, RefinementPhase};
+use super::refinement_dispatch::RefinementSession;
+use djinn_core::clock::{Clock, SystemClock};
+
+/// The exact ledger work whose in-flight projection is being (re)registered.
+pub(super) struct DurableInflightRegistration<'a> {
+    pub run_id: &'a str,
+    pub generation: i32,
+    pub proposal: &'a Proposal,
+    pub phase: DurablePhase,
+    pub round: i32,
+    pub task_id: &'a str,
+}
+
+fn local_phase(phase: DurablePhase) -> RefinementPhase {
+    match phase {
+        DurablePhase::AdversaryAttack => RefinementPhase::AdversaryAttack,
+        DurablePhase::AdvocateRevision => RefinementPhase::AdvocateRevision,
+        DurablePhase::JudgeAdjudication => RefinementPhase::JudgeAdjudication,
+    }
+}
+
+impl CoordinatorActor {
+    /// Ensure the disposable projections name this materialized intent as the
+    /// run's in-flight work, and report whether its role agent already started.
+    ///
+    /// Idempotent and monotonic: an existing projection that already tracks this
+    /// exact (run, generation, task, phase) is left untouched, so per-tick
+    /// replay never resets the dispatch clock, the cached session-start instant,
+    /// or a phase the outcome path has already advanced.
+    ///
+    /// Returns `true` when an agent session row exists for `task_id` — i.e. the
+    /// role ran and what the run is owed is its outcome, not another dispatch.
+    /// A DB read failure reports `true` (fail-safe): a transient blip must not
+    /// re-enqueue a role that may be mid-flight.
+    pub(super) async fn register_durable_refinement_inflight(
+        &mut self,
+        registration: DurableInflightRegistration<'_>,
+    ) -> bool {
+        let DurableInflightRegistration {
+            run_id,
+            generation,
+            proposal,
+            phase,
+            round,
+            task_id,
+        } = registration;
+        let phase = local_phase(phase);
+
+        let tracked = self.refinement_sessions.get(run_id).is_some_and(|session| {
+            session.run_id == run_id
+                && session.generation == generation
+                && session.task_id == task_id
+                && session.phase == phase
+        });
+
+        let (role_ran, model_id) = self.observe_refinement_role_session(task_id).await;
+
+        if tracked {
+            // Cache the first observed session start so the execution budget is
+            // measured from when the agent actually began, not from dispatch.
+            if role_ran
+                && let Some(session) = self.refinement_sessions.get_mut(run_id)
+                && session.session_started_at.is_none()
+            {
+                session.session_started_at = Some(SystemClock::new().now_instant());
+            }
+            return role_ran;
+        }
+
+        // The ledger is the authority for which phase/round is in flight; a
+        // projection rebuilt alongside a fresh in-flight session must agree with
+        // it, or the outcome correlation fence rejects every observation and the
+        // run stalls exactly as it did before.
+        let mut state = RefinementLoopState::new(&proposal.id, proposal.latest_revision_seq)
+            .with_run_identity(run_id.to_owned(), generation)
+            .with_attributed_user(proposal.refinement_owner_user_id.clone());
+        state.phase = phase;
+        state.current_round = round;
+        if let Some(existing) = self.active_refinements.get(run_id)
+            && existing.generation == generation
+            && existing.phase == phase
+            && existing.current_round == round
+        {
+            // Preserve the live projection's accumulated loop state (dry-round
+            // counters, objection signatures, spawn budget) rather than
+            // resetting it from the ledger.
+            state = existing.clone();
+        }
+        self.active_refinements.insert(run_id.to_owned(), state);
+
+        let now = SystemClock::new().now_instant();
+        self.refinement_sessions.insert(
+            run_id.to_owned(),
+            RefinementSession {
+                run_id: run_id.to_owned(),
+                generation,
+                task_id: task_id.to_owned(),
+                phase,
+                dispatched_at: now,
+                session_started_at: role_ran.then_some(now),
+                model_id: model_id.unwrap_or_default(),
+            },
+        );
+        tracing::debug!(
+            run_id = %run_id,
+            task_id = %task_id,
+            ?phase,
+            round,
+            role_ran,
+            "registered ledger-dispatched refinement role as in-flight"
+        );
+        role_ran
+    }
+
+    /// Whether an agent session row exists for a refinement role task, and the
+    /// model the latest one ran on. Fails safe toward "started" so a DB blip
+    /// never re-enqueues a possibly-running role.
+    async fn observe_refinement_role_session(&self, task_id: &str) -> (bool, Option<String>) {
+        let session_repo = SessionRepository::new(
+            self.db.clone(),
+            crate::events::event_bus_for(&self.events_tx),
+        );
+        match session_repo.list_for_task(task_id).await {
+            Ok(sessions) => {
+                let model = sessions.last().map(|session| session.model_id.clone());
+                (!sessions.is_empty(), model)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    task_id = %task_id,
+                    %error,
+                    "failed to read refinement role sessions; assuming the role started"
+                );
+                (true, None)
+            }
+        }
+    }
+}

--- a/server/crates/djinn-coordinator/src/refinement_outcome.rs
+++ b/server/crates/djinn-coordinator/src/refinement_outcome.rs
@@ -709,17 +709,64 @@ impl CoordinatorActor {
     /// Terminate a refinement loop keyed by its exact durable run. Lifecycle
     /// persistence retains the proposal ID carried in the projection.
     pub(super) async fn terminate_refinement(&mut self, run_id: &str, reason: StopReason) {
-        let Some(proposal_id) = self
-            .active_refinements
-            .get(run_id)
-            .map(|state| state.proposal_id.clone())
+        let Some((proposal_id, durable_run_id, generation)) =
+            self.active_refinements.get(run_id).map(|state| {
+                (
+                    state.proposal_id.clone(),
+                    state.run_id.clone(),
+                    state.generation,
+                )
+            })
         else {
             return;
         };
         if let Some(state) = self.active_refinements.get_mut(run_id) {
             state.terminate(reason.clone());
         }
-        self.persist_refinement_stop(&proposal_id, &reason).await;
+        // Terminalize the exact durable run under its `(run_id, generation)`
+        // CAS fence. Without this the coordinator's own stop decisions —
+        // execution watchdog, dispatch-retry cap, spawn cap — moved only the
+        // disposable projection: the row stayed `running` with a NULL stop tag
+        // and the loop was silently abandoned. Only the outcome-commit and reap
+        // paths ever wrote a stop tag, so a run that died any other way was
+        // unreapable and invisible.
+        if !durable_run_id.is_empty() && generation > 0 {
+            let repo = ProposalRepository::new(
+                self.db.clone(),
+                crate::events::event_bus_for(&self.events_tx),
+            );
+            match repo
+                .terminal_refinement_run(djinn_db::TerminalRefinementRunRequest {
+                    run_id: durable_run_id.clone(),
+                    generation,
+                    reason: durable_stop_reason(Some(&reason)),
+                })
+                .await
+            {
+                Ok(true) => tracing::info!(
+                    proposal_id,
+                    run_id = %durable_run_id,
+                    generation,
+                    reason = reason.tag(),
+                    "terminalized durable refinement run"
+                ),
+                Ok(false) => tracing::warn!(
+                    proposal_id,
+                    run_id = %durable_run_id,
+                    generation,
+                    "durable refinement run was already terminal at stop"
+                ),
+                Err(error) => tracing::warn!(
+                    proposal_id,
+                    run_id = %durable_run_id,
+                    generation,
+                    %error,
+                    "failed to terminalize durable refinement run; retrying on a later stop"
+                ),
+            }
+        } else {
+            self.persist_refinement_stop(&proposal_id, &reason).await;
+        }
         self.refinement_sessions.remove(run_id);
     }
 

--- a/server/crates/djinn-core/src/refinement_liveness.rs
+++ b/server/crates/djinn-core/src/refinement_liveness.rs
@@ -229,6 +229,7 @@ pub enum RefinementLivenessEvidence {
     AwaitingEvidencePark,
     PendingIntent { intent_id: String },
     ClaimedIntent { intent_id: String },
+    MaterializedIntent { intent_id: String },
     OpenTask { task_id: String },
     QueuedTask { task_id: String },
     RunningTask { task_id: String },
@@ -306,6 +307,31 @@ pub fn evaluate_refinement_liveness(
     }) {
         return RefinementLivenessResult::Live {
             evidence: RefinementLivenessEvidence::ClaimedIntent {
+                intent_id: intent.intent_id.clone(),
+            },
+        };
+    }
+
+    // A materialized intent has already produced its correlated role task, so
+    // the run holds durable in-flight work whose outcome the coordinator still
+    // owes it. That stays true after the role agent exits and its task closes:
+    // the successor intent is written by the outcome path, not by the agent.
+    // Without this class the window between "role finished" and "outcome
+    // applied" reads as a phantom, and the admission reaper terminalizes a run
+    // whose adversary genuinely ran — destroying the round and minting a fresh
+    // generation that repeats the loop (21 `reaped_phantom` runs in one week).
+    // The window is bounded on the other side by the coordinator's execution
+    // watchdog, which terminalizes an unsettled role with a durable stop tag.
+    if let Some(intent) = snapshot.intents.iter().find(|intent| {
+        &intent.run_id == run_id
+            && intent.state == RefinementIntentState::Materialized
+            && snapshot.tasks.iter().any(|task| {
+                &task.run_id == run_id
+                    && task.intent_id.as_deref() == Some(intent.intent_id.as_str())
+            })
+    }) {
+        return RefinementLivenessResult::Live {
+            evidence: RefinementLivenessEvidence::MaterializedIntent {
                 intent_id: intent.intent_id.clone(),
             },
         };
@@ -457,6 +483,67 @@ mod tests {
         current.sessions[0].run_id = "run-prior".into();
         assert!(matches!(
             evaluate_refinement_liveness(&current, NOW),
+            RefinementLivenessResult::Stale { .. }
+        ));
+    }
+
+    /// A materialized intent whose correlated role task exists is durable
+    /// in-flight work: the coordinator still owes it an outcome. That must
+    /// remain true after the role agent exits and its task closes, which is the
+    /// exact window in which the admission reaper used to terminalize a run
+    /// whose adversary had genuinely run (`stop_tag = reaped_phantom`) and mint
+    /// a fresh generation that repeated the loop.
+    #[test]
+    fn materialized_intent_with_its_role_task_is_live_even_after_the_task_closes() {
+        for task_state in [
+            RefinementTaskState::Running,
+            RefinementTaskState::Closed,
+            RefinementTaskState::Cancelled,
+        ] {
+            let mut value = snapshot();
+            value
+                .intents
+                .push(intent(RefinementIntentState::Materialized));
+            value.tasks.push(task(task_state));
+            assert_eq!(
+                evaluate_refinement_liveness(&value, NOW),
+                RefinementLivenessResult::Live {
+                    evidence: RefinementLivenessEvidence::MaterializedIntent {
+                        intent_id: "intent-1".into(),
+                    },
+                },
+                "{task_state:?}"
+            );
+        }
+    }
+
+    /// The class stays narrow: a materialized intent with NO correlated task is
+    /// not evidence of anything, and neither is one whose task belongs to a
+    /// different run.
+    #[test]
+    fn materialized_intent_without_its_own_role_task_is_not_live() {
+        let mut value = snapshot();
+        value
+            .intents
+            .push(intent(RefinementIntentState::Materialized));
+        assert!(matches!(
+            evaluate_refinement_liveness(&value, NOW),
+            RefinementLivenessResult::Stale { .. }
+        ));
+
+        let mut foreign = task(RefinementTaskState::Closed);
+        foreign.run_id = "run-prior".into();
+        value.tasks.push(foreign);
+        assert!(matches!(
+            evaluate_refinement_liveness(&value, NOW),
+            RefinementLivenessResult::Stale { .. }
+        ));
+
+        let mut unlinked = task(RefinementTaskState::Closed);
+        unlinked.intent_id = None;
+        value.tasks.push(unlinked);
+        assert!(matches!(
+            evaluate_refinement_liveness(&value, NOW),
             RefinementLivenessResult::Stale { .. }
         ));
     }


### PR DESCRIPTION
## Root cause

A durable refinement run is dispatched **only** by the intent ledger, but the outcome path — the only writer of the successor intent — is reached through the coordinator's in-memory `refinement_sessions` projection, which **only the legacy map-driven dispatcher ever populated**. `drive_one_refinement` returns early for any run with a run identity when that map has no entry, so a ledger-dispatched role was never observed finishing: `process_refinement_outcome` was unreachable, `complete_refinement_intent` was never called, and the run sat `running` with no successor intent and a NULL `stop_tag`.

Production confirms it: **zero** `refinement_dispatch_intents` rows advanced past `materialized` in seven days (4 `materialized`, 3 `claimed`, none completed, all `next_intent_id` NULL). `bzpt`, `op33` and `8ixk` each had adversary debate entries and no advocate or judge turn.

Two more defects compound it:

- `terminate_refinement` moved only the disposable projection and delegated to `persist_refinement_stop`, **which just logs a warning**. Every coordinator-side stop (execution watchdog, dispatch-retry cap) left the row `running` with `stop_tag` NULL. Only outcome-commit and the reapers ever wrote a stop tag.
- `evaluate_refinement_liveness` had no evidence class for a `materialized` intent. Once the role's task closed, all six evidence classes were missing, so the admission reaper terminalized runs whose adversary had genuinely run (`stop_tag = reaped_phantom`, 21 in one week) and immediately minted generation N+1, repeating the loop — `bzpt` reached gen 3 and `8ixk` gen 4 within an hour. `refinement_projection_is_current` also requires `Live`, so it discarded the projection before an outcome could be applied.

## Hypothesis chain, adjudicated against production

- **A (classifier fails open on missing evidence) — disproven as stated.** `db_task_status` is populated in **2133/2133** protocol-violation rows; zero NULLs. The real classifier defect is different and larger: `db_session_status` is force-set to `"running"` on the exit path and only `closed` counted as a terminal task, so the branch fired on **74.8% of all session exits** (2133/2852 over 7d), including 741 clean reviewer exits at `in_task_review`.
- **B (misfiled violation is charged as a failed attempt and consumes the refinement dispatch) — disproven for this incident.** All four stuck adversary sessions ended `completed`; a `completed` exit persists evidence and takes no attempt accounting. B is true only for `failed`/`interrupted` exits, which is a separate (and largely correct) path.
- **C (handoff is in-memory only) — confirmed, and sharper than stated.** It is not that losing the loop strands a run; the durable dispatch path never creates the projection the outcome path requires, so the handoff never happens at all, even with the loop alive.

## Changes

1. **`refinement_inflight` (new)** — rebuilds the in-flight projection from the durable ledger every tick, so the ledger names the phase in flight and the existing monitoring (outcome application, task close, retry cap, execution watchdog) applies to durable runs. A role that already produced a session is not re-enqueued: what the run is owed is its outcome.
2. **`terminate_refinement`** — terminalizes the exact durable run under its `(run_id, generation)` CAS fence with a mapped stop reason.
3. **`evaluate_refinement_liveness`** — new `MaterializedIntent` evidence class, scoped to intents whose correlated role task exists. Bounded on the other side by the watchdog from (2).
4. **Liveness classifier** — the protocol-violation branch now requires **positive** evidence on both axes (`is_some_and` on each) instead of one positive guard and one `is_none_or` fail-open, so absent evidence no longer convicts. The task term is tightened from "not closed" to "not settled": a session exiting with its task at a recorded handoff (review, PR, lead intervention) did its job. Genuinely stranded exits (`open`/`in_progress`) still fire, and the reaping paths (precedence 2/4) are untouched.
5. **Violation log** — states the actual per-exit-kind attempt accounting instead of claiming "counts as failed attempt" for clean exits, which never had one. That line is what suggested hypothesis B.

## Regression coverage

`durable_adversary_exit_hands_off_to_a_real_advocate_turn` drives a real adversary turn to completion through `drive_active_refinements` with **no hand-injected projection** — the ledger materializes and enqueues the role task, the agent runs, files a blocking objection and exits with its slot freed — then asserts the side effect that matters: a durable Advocate intent, a completed Adversary intent, a closed Adversary task, and a materialized Advocate role task.

Neutralized (registration disabled), it fails with the exact production shape:

```
the adversary exit must durably enqueue the Advocate successor; intents were
[RefinementIntentSnapshot { intent_id: "...", run_id: "...", round: 1,
 state: Materialized, phase: AdversaryAttack, role: Adversary,
 lease_expires_at: None }]
```

`a_ledger_dispatched_role_that_never_settles_terminalizes_the_run` ages the coordinator's own projection past the execution budget and asserts the run reaches `Terminal` with a non-NULL stop reason. Before change (2) it failed `left: Active, right: Terminal`.

Plus liveness-classifier cases for both absent-evidence axes, every settled status on clean and crashing exits, and both unsettled statuses still convicting; and evaluator cases for `MaterializedIntent` including its negatives.

## Verification

`cargo test -p djinn-coordinator --lib refinement` — 138 passed. Full `djinn-coordinator`, `djinn-core`, `djinn-db`, `djinn-control-plane` suites introduce **no new failures**; the residual failures reproduce identically on a clean `main` tree (order-dependent shared-metric-registry contamination).

## Recovery of the three stuck runs

They self-heal on deploy; no operator surgery is needed (and none was performed — production access was read-only). On the first tick the ledger's `materialized` intents are registered, their outcomes applied, and the Advocate successors written. `op33` (`019f9ff7-088b`) and `bzpt` gen 3 (`019fa025-8c15`) hold materialized intents with closed adversary tasks and complete debate trails; `8ixk` gen 4 (`019fa006-220f`) holds an expired `claimed` intent that the ordinary claim CAS re-acquires. Change (3) is load-bearing here: without the `MaterializedIntent` class, `refinement_projection_is_current` would discard the projection before the outcome could be applied.

## Known residual

The remaining `in_progress`/`open` protocol violations are a **settlement race**, not a classifier logic error: the task's post-run transition commits after the session-exit event is handled. `cvlm` was classified at `19:49:15.730` with `db_task_status = in_progress` and closed at `19:49:18.745` — 3.0s later. Fixing that needs settlement ordering and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)