### PR TITLE
fix(refinement): inject real DoR findings on the durable dispatch path

### DIFF
--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -101,6 +101,34 @@ fn durable_role_name(role: RefinementRole) -> &'static str {
     }
 }
 
+/// Project a durable intent phase onto the in-process loop phase. Sole
+/// conversion point, so a new durable phase variant fails to compile here
+/// rather than silently mis-projecting at one of two call sites.
+fn refinement_phase_for_intent(
+    phase: djinn_core::refinement_liveness::RefinementPhase,
+) -> RefinementPhase {
+    match phase {
+        djinn_core::refinement_liveness::RefinementPhase::AdversaryAttack => {
+            RefinementPhase::AdversaryAttack
+        }
+        djinn_core::refinement_liveness::RefinementPhase::AdvocateRevision => {
+            RefinementPhase::AdvocateRevision
+        }
+        djinn_core::refinement_liveness::RefinementPhase::JudgeAdjudication => {
+            RefinementPhase::JudgeAdjudication
+        }
+    }
+}
+
+/// Shared readiness/feedback context injected into every tribunal role task.
+pub(super) struct RefinementRoleContext {
+    /// Rendered current-head DoR failures and `SpecLintResultV1` summary, plus
+    /// any advocate spec-lint correction owed for this same round.
+    pub readiness_context: String,
+    /// Latest human reviewer feedback recorded against the current revision.
+    pub reviewer_feedback: Option<String>,
+}
+
 impl CoordinatorActor {
     /// Drive all active refinement loops. Called from `run_tick()`.
     pub(super) async fn drive_active_refinements(&mut self) {
@@ -316,14 +344,30 @@ impl CoordinatorActor {
                             }
                         };
                         let role = durable_role_name(lease.role);
+                        // The durable ledger is the ONLY dispatch path for a
+                        // run with a `run_id`, so this context is what every
+                        // live tribunal role actually reads. It must carry the
+                        // real DoR/lint findings and reviewer feedback — a
+                        // placeholder here leaves the Advocate unable to fix
+                        // readiness and forces a mandatory Judge reject.
+                        let RefinementRoleContext {
+                            readiness_context,
+                            reviewer_feedback,
+                        } = self
+                            .build_refinement_role_context(
+                                &run.proposal_id,
+                                &run.run_id,
+                                refinement_phase_for_intent(lease.phase),
+                            )
+                            .await;
                         let Some(task_id) = self
                             .create_refinement_task_with_context_and_correlation(
                                 &run.proposal_id,
                                 role,
                                 lease.round,
                                 proposal.latest_revision_seq,
-                                "Durable refinement intent dispatch.",
-                                None,
+                                &readiness_context,
+                                reviewer_feedback.as_deref(),
                                 Some(&attributed_user),
                                 Some(&correlation),
                             )
@@ -397,17 +441,7 @@ impl CoordinatorActor {
             return None;
         }
 
-        let phase = match phase {
-            djinn_core::refinement_liveness::RefinementPhase::AdversaryAttack => {
-                RefinementPhase::AdversaryAttack
-            }
-            djinn_core::refinement_liveness::RefinementPhase::AdvocateRevision => {
-                RefinementPhase::AdvocateRevision
-            }
-            djinn_core::refinement_liveness::RefinementPhase::JudgeAdjudication => {
-                RefinementPhase::JudgeAdjudication
-            }
-        };
+        let phase = refinement_phase_for_intent(phase);
         let diverse_refinement = self.read_diverse_refinement_setting(proposal_id).await;
         let (agent_type, model_id) = self
             .resolve_refinement_dispatch_params(phase, diverse_refinement, Some(owner.as_str()))
@@ -707,6 +741,80 @@ impl CoordinatorActor {
                 phase = ?session.phase,
                 "Refinement role session never started; will re-dispatch (not counted as dry)"
             );
+        }
+    }
+
+    /// Build the shared per-role dispatch context every tribunal task needs:
+    /// the rendered current-head DoR/lint readiness report (plus any advocate
+    /// spec-lint correction for this same round) and the current-revision human
+    /// reviewer feedback.
+    ///
+    /// Both dispatch paths MUST go through this. The durable intent ledger
+    /// previously injected the fixed literal `"Durable refinement intent
+    /// dispatch."` as the readiness context and passed `None` for reviewer
+    /// feedback, so every durable-run role was dispatched blind:
+    ///
+    /// * the Advocate never learned which DoR checks were failing and so could
+    ///   not fix them, and
+    /// * the Judge — whose prompt treats any injected `Current DoR status`
+    ///   other than the exact clean message as a mandatory blocking reject —
+    ///   could never approve, no matter how good the spec was.
+    ///
+    /// Since `drive_one_refinement` returns early for any run with a non-empty
+    /// `run_id` ("durable runs are dispatched exclusively by the leased intent
+    /// ledger"), that placeholder was what every live refinement actually got.
+    async fn build_refinement_role_context(
+        &self,
+        proposal_id: &str,
+        run_id: &str,
+        phase: RefinementPhase,
+    ) -> RefinementRoleContext {
+        let readiness = self.evaluate_proposal_readiness(proposal_id).await;
+        let mut readiness_context = readiness
+            .as_ref()
+            .map(CoordinatorActor::format_readiness_context)
+            .unwrap_or_else(|| {
+                "Current proposal head could not be resolved for shared DoR/lint readiness."
+                    .to_string()
+            });
+
+        if phase == RefinementPhase::AdvocateRevision
+            && let Some(correction_context) =
+                self.active_refinements.get(run_id).and_then(|state| {
+                    super::refinement_outcome::format_advocate_lint_correction_context(
+                        &state.pending_advocate_lint_violations,
+                    )
+                })
+        {
+            readiness_context.push_str("\n\nSpec-lint correction required for this same round:\n");
+            readiness_context.push_str(&correction_context);
+        }
+
+        // Retrieve the latest current-revision human reviewer feedback recorded
+        // by a demand round. The helper filters to the proposal's current
+        // `latest_revision_seq` so stale feedback from a prior revision is
+        // never injected into the next tribunal task.
+        let event_bus = crate::events::event_bus_for(&self.events_tx);
+        let proposal_repo = djinn_db::ProposalRepository::new(self.db.clone(), event_bus);
+        let reviewer_feedback = match proposal_repo
+            .latest_current_revision_reviewer_feedback(proposal_id)
+            .await
+        {
+            Ok(fb) => fb,
+            Err(e) => {
+                tracing::warn!(
+                    proposal_id = %proposal_id,
+                    error = %e,
+                    "Failed to retrieve reviewer feedback for refinement dispatch; \
+                     proceeding without feedback injection"
+                );
+                None
+            }
+        };
+
+        RefinementRoleContext {
+            readiness_context,
+            reviewer_feedback,
         }
     }
 
@@ -1010,51 +1118,12 @@ impl CoordinatorActor {
 
         // Build a readiness-enriched task description so the agent sees
         // current DoR findings.
-        let lint_correction_context = if phase == RefinementPhase::AdvocateRevision {
-            self.active_refinements.get(run_id).and_then(|state| {
-                super::refinement_outcome::format_advocate_lint_correction_context(
-                    &state.pending_advocate_lint_violations,
-                )
-            })
-        } else {
-            None
-        };
-
-        let mut readiness_context = readiness
-            .as_ref()
-            .map(CoordinatorActor::format_readiness_context)
-            .unwrap_or_else(|| {
-                "Current proposal head could not be resolved for shared DoR/lint readiness."
-                    .to_string()
-            });
-        if let Some(correction_context) = lint_correction_context {
-            readiness_context.push_str("\n\nSpec-lint correction required for this same round:\n");
-            readiness_context.push_str(&correction_context);
-        }
-
-        // Retrieve the latest current-revision human reviewer feedback recorded
-        // by a demand round. The helper filters to the proposal's current
-        // `latest_revision_seq` so stale feedback from a prior revision is
-        // never injected into the next tribunal task.
-        let reviewer_feedback = {
-            let event_bus = crate::events::event_bus_for(&self.events_tx);
-            let proposal_repo = djinn_db::ProposalRepository::new(self.db.clone(), event_bus);
-            match proposal_repo
-                .latest_current_revision_reviewer_feedback(&proposal_id)
-                .await
-            {
-                Ok(fb) => fb,
-                Err(e) => {
-                    tracing::warn!(
-                        proposal_id = %proposal_id,
-                        error = %e,
-                        "Failed to retrieve reviewer feedback for refinement dispatch; \
-                         proceeding without feedback injection"
-                    );
-                    None
-                }
-            }
-        };
+        let RefinementRoleContext {
+            readiness_context,
+            reviewer_feedback,
+        } = self
+            .build_refinement_role_context(&proposal_id, run_id, phase)
+            .await;
 
         // ── Step 3: Create the refinement task (first DB side effect) ────────
         //

--- a/server/crates/djinn-coordinator/src/refinement_dor_status_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dor_status_tests.rs
@@ -753,6 +753,20 @@ fn tribunal_readiness_uses_only_shared_lint_constructor() {
         !dispatch.contains("lint_for_revision"),
         "dispatch must consume the coordinator's shared readiness result rather than lint directly"
     );
+
+    // Regression (bzpt): no dispatch path may substitute a constant for the
+    // head-derived DoR status. The durable intent ledger shipped the literal
+    // "Durable refinement intent dispatch." into the injected
+    // `Current DoR status`, which left the Advocate unable to see its blockers
+    // and made an approving Judge verdict impossible.
+    assert!(
+        !dispatch.contains("Durable refinement intent dispatch"),
+        "durable dispatch must not inject a placeholder in place of real DoR findings"
+    );
+    assert!(
+        dispatch.contains("build_refinement_role_context"),
+        "both dispatch paths must build the injected role context through the shared helper"
+    );
 }
 
 /// Regression (criterion 4): `resolve_refinement_review` (human acceptance)

--- a/server/crates/djinn-coordinator/src/refinement_durable_dispatch_tests.rs
+++ b/server/crates/djinn-coordinator/src/refinement_durable_dispatch_tests.rs
@@ -508,3 +508,110 @@ async fn materialized_enqueue_failure_is_retried_with_the_same_task() {
         task_id
     );
 }
+
+/// Regression (proposal bzpt, 2026-07-26): the durable intent ledger is the
+/// ONLY dispatch path for a run with a `run_id` — `drive_one_refinement`
+/// returns early before the legacy `dispatch_next_refinement_phase` for any
+/// durable run. That ledger path used to inject the fixed literal
+/// `"Durable refinement intent dispatch."` as the readiness context and pass
+/// `None` for reviewer feedback, so every live tribunal role was dispatched
+/// blind:
+///
+/// * the Advocate never learned which DoR checks were failing, and
+/// * the Judge — whose prompt makes any injected `Current DoR status` other
+///   than the exact clean message a mandatory blocking reject — could never
+///   approve, regardless of spec quality.
+///
+/// On bzpt this produced advocate task pw4v whose entire description was
+/// "Current DoR status: Durable refinement intent dispatch." and a judge
+/// verdict that rejected a spec it had otherwise found complete.
+///
+/// This drives the real durable driver and asserts the materialized task
+/// carries the head-derived DoR failures, the lint summary, and the current
+/// reviewer feedback.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn durable_dispatch_injects_real_dor_findings_not_a_placeholder() {
+    let db = crate::test_helpers::create_test_db();
+    let fixture = refinement_cap_tests::seed_refinement_fixture(&db).await;
+    let (events_tx, _events_rx) = tokio::sync::broadcast::channel::<DjinnEventEnvelope>(256);
+    let pool = refinement_cap_tests::spawn_test_pool(&db, 4);
+    let mut actor = refinement_cap_tests::build_refinement_actor(&db, &events_tx, pool);
+
+    let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+
+    // Human demand-round feedback recorded against the current revision. The
+    // durable path used to drop this on the floor.
+    let reviewer_feedback = "REVIEWER-FEEDBACK-durable-path-bzpt";
+    repo.record_refinement_lifecycle(
+        &fixture.proposal_id,
+        "refinement_start",
+        Some(&serde_json::json!({
+            "source": "human_demand_round",
+            "reviewer_feedback": reviewer_feedback,
+            "reason": reviewer_feedback,
+        })),
+    )
+    .await
+    .expect("record demand-round reviewer feedback");
+
+    let (run_id, generation) = admit_run(&repo, &fixture.proposal_id, "durable-dor-injection").await;
+    let intent_id = only_intent(&repo, &run_id, generation).await;
+    actor.active_refinements.insert(
+        run_id.clone(),
+        super::super::refinement::RefinementLoopState::new(fixture.proposal_id.clone(), 0)
+            .with_run_identity(run_id.clone(), generation)
+            .with_attributed_user(Some(fixture.user_id.clone())),
+    );
+
+    // Independently establish what the shared evaluator says about this head,
+    // so the assertions below are pinned to real findings rather than to any
+    // string the dispatcher happens to emit.
+    let readiness = actor
+        .evaluate_proposal_readiness(&fixture.proposal_id)
+        .await
+        .expect("fixture readiness resolves");
+    assert!(
+        !readiness.ready,
+        "fixture head (one-line body, empty ACs) must fail DoR for this test to be non-vacuous"
+    );
+    let expected_failures = readiness
+        .to_error_string()
+        .expect("failing head must render failure text");
+
+    actor.drive_active_refinements().await;
+
+    let task = TaskRepository::new(db.clone(), EventBus::noop())
+        .find_by_refinement_intent_id(&intent_id)
+        .await
+        .expect("read materialized task")
+        .expect("durable driver materialized a task");
+
+    assert!(
+        !task.description.contains("Durable refinement intent dispatch"),
+        "durable dispatch must not inject a placeholder readiness context:\n{}",
+        task.description
+    );
+    assert!(
+        task.description.contains(&expected_failures),
+        "durable dispatch must inject the head-derived DoR failures ({expected_failures}):\n{}",
+        task.description
+    );
+    assert!(
+        task.description
+            .contains("Latest SpecLintResultV1 summary (errors and warnings):"),
+        "durable dispatch must inject the shared lint summary:\n{}",
+        task.description
+    );
+    assert!(
+        !task
+            .description
+            .contains("Proposal currently meets all DoR checks."),
+        "a failing head must never render the clean DoR message the Judge treats as pass:\n{}",
+        task.description
+    );
+    assert!(
+        task.description.contains(reviewer_feedback),
+        "durable dispatch must inject current-revision reviewer feedback:\n{}",
+        task.description
+    );
+}


### PR DESCRIPTION
## The bug

`drive_one_refinement` returns early for any run with a non-empty `run_id` — *"durable runs are dispatched exclusively by the leased intent ledger"* — so `drive_durable_refinement_intents` is the **only** dispatch path for every live refinement. That path hard-coded a placeholder:

```rust
create_refinement_task_with_context_and_correlation(
    …,
    "Durable refinement intent dispatch.",  // readiness_context
    None,                                    // reviewer_feedback
    …)
```

It never called `evaluate_proposal_readiness`. The readiness plumbing in `dispatch_next_refinement_phase` (and its tests) was real, correct, and unreachable — it only runs on the legacy non-durable compatibility path.

## What it cost, on proposal `bzpt`

**The Advocate was dispatched blind.** Advocate task `pw4v`'s stored description, in full:

```
Proposal refinement session: advocate role for proposal 019f9ff4-…, round 3, against revision 7.

Current DoR status: Durable refinement intent dispatch.
```

`bzpt`'s real `gate_status.dor_failures` were `objective_coverage`, `dependencies_coverage`, and `open_questions_risks_coverage` — and `advocate.md` already instructs the advocate to add *"explicit Problem / Scope / Objectives / Dependencies / Risks sections"*. It was told to fix DoR and never told what was failing.

**The Judge could never approve.** `judge.md` makes any injected `Current DoR status` other than the exact string `Proposal currently meets all DoR checks.` a mandatory blocking reject. The placeholder is never that string, so *every* durable-path round ends in reject regardless of spec quality. `bzpt`'s verdict says so explicitly — it found the spec substantively complete with every objection resolved, then:

> However, the injected DoR status is exactly "Durable refinement intent dispatch," not the mandatory clean message… Verdict: reject / needs-work.

**Reviewer feedback was also dropped**, since the same call site passed `None`.

## The fix

Extract `build_refinement_role_context` as the single builder for the injected context — head-derived DoR failures, `SpecLintResultV1` summary, advocate spec-lint correction, current-revision reviewer feedback — and route **both** the durable ledger and the legacy path through it, so they cannot diverge again.

Also folds the duplicated durable→loop phase projection into `refinement_phase_for_intent`, leaving one exhaustive match instead of two.

**The DoR gate is unchanged and the judge is not made more permissive.** Only what the roles are told about the gate changes.

## Verification

`durable_dispatch_injects_real_dor_findings_not_a_placeholder` drives the real durable driver (`drive_active_refinements`) and asserts the materialized task carries the head-derived failure text, the lint summary, and the reviewer feedback — pinned to what the shared evaluator independently reports, not to a fixed string.

Verified **non-vacuous by neutralization**: restoring the placeholder makes it fail, reproducing `pw4v`'s description verbatim:

```
durable dispatch must not inject a placeholder readiness context:
Proposal refinement session: adversary role for proposal …, round 1, against revision 1.

Current DoR status: Durable refinement intent dispatch.
```

A source-level guard in `tribunal_readiness_uses_only_shared_lint_constructor` keeps the placeholder from returning.

`cargo clippy -p djinn-coordinator --all-targets` clean; 139/139 refinement tests pass; file-size guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
