### PR TITLE
fix(refinement): attribute every admission source so demanded rounds can dispatch

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools.rs
@@ -54,8 +54,36 @@ pub(crate) async fn admit_refinement_run(
     repo: &ProposalRepository,
     proposal_id: &str,
     source: RefinementAdmissionSource,
-    owner_user_id: Option<Option<&str>>,
+    explicit_owner_user_id: Option<&str>,
 ) -> Result<bool, String> {
+    // Every admission source — explicit start, demanded round, and
+    // committed-revision resume alike — must leave the run attributed.
+    // `proposals.refinement_owner_user_id` is the ONLY attribution
+    // `drive_durable_refinement_intents` accepts: with it absent the coordinator
+    // re-claims the run's dispatch intent on every tick and then `continue`s, so
+    // the run never creates a role task, never appends a debate entry, and
+    // reports `stale` in the gap between two claims — while `run_state` still
+    // reads `active`. Demand and revision admission previously passed no owner
+    // at all, which minted generation after generation of exactly that run.
+    //
+    // Resolution order is explicit override → already-persisted owner →
+    // proposal author. Falling back to the persisted owner (rather than
+    // unconditionally to the author) also stops a re-`start` from silently
+    // reassigning a run that someone else already owns.
+    let attributed_user = match explicit_owner_user_id {
+        Some(explicit) => Some(explicit.to_owned()),
+        None => repo
+            .get(proposal_id)
+            .await
+            .map_err(|_| "Persistence".to_owned())?
+            .and_then(|proposal| {
+                proposal
+                    .refinement_owner_user_id
+                    .or(proposal.author_user_id)
+            }),
+    }
+    .filter(|owner| !owner.trim().is_empty());
+
     let identity = match &source {
         RefinementAdmissionSource::ExplicitStart { actor } => format!("explicit:{actor}"),
         RefinementAdmissionSource::Demand { demand_id } => format!("demand:{demand_id}"),
@@ -85,8 +113,11 @@ pub(crate) async fn admit_refinement_run(
         RefinementAdmissionOutcome::Admitted { run_id, .. }
         | RefinementAdmissionOutcome::Existing { run_id, .. } => run_id,
     };
-    if let Some(owner_user_id) = owner_user_id {
-        repo.start_refinement_with_owner(proposal_id, owner_user_id)
+    // Only ever write a resolved owner. Writing `None` here would clear an
+    // attribution that the durable dispatcher depends on, turning a working run
+    // into a silently undispatchable one.
+    if let Some(attributed_user) = attributed_user.as_deref() {
+        repo.start_refinement_with_owner(proposal_id, Some(attributed_user))
             .await
             .map_err(|_| "Persistence".to_owned())?;
     }
@@ -248,7 +279,7 @@ impl DjinnMcpServer {
                         .unwrap_or_else(|| "proposal-author".to_owned())
                 ),
             },
-            Some(refinement_owner_user_id.as_deref()),
+            p.owner_user_id.as_deref(),
         )
         .await
         {

--- a/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part3.inc
+++ b/server/crates/djinn-control-plane/src/tools/refinement_tools/tests_part3.inc
@@ -1,4 +1,103 @@
 
+    // ── Durable attribution on every admission source ────────────────────
+
+    /// Every admission source must leave the run attributed, because
+    /// `proposals.refinement_owner_user_id` is the only attribution the durable
+    /// dispatcher accepts. Production run `019fa0bb-c31f` (proposal `8ixk`) sat
+    /// on generation 5 with `run_state = active` and zero debate entries for
+    /// twelve days: `proposal_refinement_demand_round` admitted generation after
+    /// generation without ever writing an owner, so
+    /// `drive_durable_refinement_intents` re-claimed its intent every tick and
+    /// then bailed with "awaiting durable refinement attribution".
+    ///
+    /// Neutralization: reverting `admit_refinement_run` to pass the owner
+    /// through only from `proposal_refinement_start` fails this on the demand
+    /// assertion with `Some("attribution-author-019f")` != `None`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn every_admission_source_leaves_the_run_durably_attributed() {
+        let (server, db) = test_server().await;
+        let repo = ProposalRepository::new(db.clone(), EventBus::noop());
+        let proposal = repo
+            .create(ProposalCreateInput {
+                title: "Attribution on demand",
+                body: "body",
+                acceptance_criteria: Some("[]"),
+                status: None,
+                body_format: None,
+            })
+            .await
+            .unwrap();
+        link_proposal_to_project(&db, &repo, &proposal.id).await;
+
+        // `refinement_owner_user_id` is FK-constrained to `users`, so the
+        // author fallback can only be observed against a real row.
+        sqlx::query("INSERT INTO users (id, github_id, github_login) VALUES ($1, $2, $3)")
+            .bind("attribution-author-019f")
+            .bind(919_067_201i64)
+            .bind("attribution-author-019f")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        sqlx::query("UPDATE proposals SET author_user_id = $2 WHERE id = $1")
+            .bind(&proposal.id)
+            .bind("attribution-author-019f")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        // A demanded round carries no explicit owner. It must still attribute
+        // the run from the proposal author.
+        let response = server
+            .dispatch_tool(
+                "proposal_refinement_demand_round",
+                serde_json::json!({
+                    "proposal_id": proposal.id,
+                    "reason": "attribution regression",
+                    "request_id": "demand-attribution-019f",
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response["accepted"], true, "{response}");
+        assert_eq!(
+            repo.get(&proposal.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .refinement_owner_user_id
+                .as_deref(),
+            Some("attribution-author-019f"),
+            "a demanded round must attribute the run it admits"
+        );
+
+        // A later start without an explicit owner must not clear or reassign
+        // the attribution the run already has.
+        let response = server
+            .dispatch_tool(
+                "proposal_refinement_start",
+                serde_json::json!({
+                    "proposal_id": proposal.id,
+                    "request_id": "start-attribution-019f",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(
+            response["error"].as_str() != Some("Persistence"),
+            "{response}"
+        );
+        assert_eq!(
+            repo.get(&proposal.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .refinement_owner_user_id
+                .as_deref(),
+            Some("attribution-author-019f"),
+            "an implicit start must never clear a run's durable owner"
+        );
+    }
+
     // ── Needs-evidence cap accounting tests ──────────────────────────────
 
     use djinn_db::{NeedsEvidenceCapStatus, NeedsEvidenceClaimLink, ProposalDebateTrailCreateInput};

--- a/server/crates/djinn-coordinator/src/refinement_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/refinement_dispatch.rs
@@ -251,7 +251,13 @@ impl CoordinatorActor {
                                 continue;
                             }
                             let Some(owner) = proposal.refinement_owner_user_id.as_deref() else {
-                                tracing::debug!(intent_id = %intent.intent_id, "awaiting durable refinement attribution");
+                                tracing::warn!(
+                                    intent_id = %intent.intent_id,
+                                    run_id = %run.run_id,
+                                    proposal_id = %run.proposal_id,
+                                    "refinement run has no durable owner; its intent cannot dispatch and will \
+                                     be retried on every tick until the proposal is attributed"
+                                );
                                 continue;
                             };
                             let Some((_agent_type, model_id)) = self
@@ -309,7 +315,13 @@ impl CoordinatorActor {
                     Ok(None) | Err(_) => continue,
                 };
                 let Some(attributed_user) = proposal.refinement_owner_user_id.clone() else {
-                    tracing::debug!(intent_id = %lease.intent_id, "awaiting durable refinement attribution");
+                    tracing::warn!(
+                        intent_id = %lease.intent_id,
+                        run_id = %run.run_id,
+                        proposal_id = %run.proposal_id,
+                        "refinement run has no durable owner; its intent cannot dispatch and will \
+                         be retried on every tick until the proposal is attributed"
+                    );
                     continue;
                 };
                 let Some((_agent_type, model_id)) = self


### PR DESCRIPTION
## Why

`proposals.refinement_owner_user_id` is the **only** attribution that `drive_durable_refinement_intents` accepts (`refinement_dispatch.rs`, both the materialized and the freshly-claimed branch). Only `proposal_refinement_start` ever wrote it — `proposal_refinement_demand_round` and committed-revision resume both called `admit_refinement_run(.., None)`.

A run admitted by either of those paths re-claims its dispatch intent on every coordinator tick and then `continue`s. It never creates a role task, never appends a debate entry, and reports `stale` with **no evidence class at all** in the gap between two claims (the claim lease is 60s; the observed durable-poll interval is 60–91s). A demanded round then reaps exactly that stale run and mints the next generation of the same undispatchable run.

This is distinct from #2634 (which made the durable path insert into `refinement_sessions`, made `terminate_refinement` durable, and added the `materialized_intent` evidence class) and from #2639 (the hard-coded DoR placeholder). Those fixed a run that dispatched; this fixes a run that could never dispatch at all.

## Production evidence

Run `019fa0bb-c31f-7be1-a81e-a8019afa9f3d` (proposal `8ixk`) sat on **generation 5**, `run_state = active`, `stop_reason = reaped_phantom`, with its last debate entry dated 2026-07-15 — twelve days of nothing — while the coordinator emitted this every tick:

```
DEBUG awaiting durable refinement attribution intent_id=019fa0bb-c325-7593-a983-cab86ea47517
      target=djinn_coordinator::refinement_dispatch
```

Attributing the proposal dispatched its adversary within one tick (cycle 76), and the run then completed a full adversary → advocate → judge cycle and opened round 2. A second proposal in the same state (`019f6862-…`, intent `019fa067-e79c`) kept looping untouched throughout — an in-production control for the same machinery differing only in attribution.

## What changed

`admit_refinement_run` now resolves attribution for **all three** sources, in the order **explicit override → already-persisted owner → proposal author**, and only ever persists a resolved owner. Writing `None` previously *cleared* an existing attribution, turning a working run into a silently undispatchable one.

The dispatcher's two bail-out sites move from `debug!` to `warn!` naming the run and proposal: after this change an unattributed run is an invariant violation, not an expected wait.

## Proof by neutralization

Reverting the resolution to explicit-owner-only fails the new test on the demand assertion:

```
thread '...every_admission_source_leaves_the_run_durably_attributed' panicked at
crates/djinn-control-plane/src/tools/refinement_tools/tests_part3.inc:62:9:
assertion `left == right` failed: a demanded round must attribute the run it admits
  left: None
 right: Some("attribution-author-019f")
```

## Tests

- `cargo test -p djinn-control-plane --lib refinement` — 107 passed
- `cargo test -p djinn-coordinator --lib refinement` — 141 passed
- `scripts/check-file-size.sh` — 0 oversized
- No MCP tool parameter surface changed, so no derived golden is affected.

## Not covered here

The claim lease (`lease_millis: 60_000`) is shorter than the observed durable-poll interval, so a run the coordinator is actively working on can still read `stale` with no evidence between two ticks. With attribution present the intent reaches `materialized` in one tick and `materialized_intent` is permanent evidence, so the window stops mattering in practice — but it is a real false-stale source and is left for a separate change rather than widened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)