### PR TITLE
fix(repo-graph): remove the two real races behind the generation stream pin flakes

### DIFF
--- a/server/crates/djinn-db/src/repositories/repo_graph_generation_tests.rs
+++ b/server/crates/djinn-db/src/repositories/repo_graph_generation_tests.rs
@@ -21,6 +21,41 @@ async fn insert_project(db: &Database, project_id: &str) {
     .expect("insert project");
 }
 
+/// Prove that dropping a [`PinnedGalaxyArtifact`] discarded its pinned session
+/// instead of handing it back to the pool while it still holds the shared pin.
+///
+/// `Drop` cannot await `pg_advisory_unlock`, so it marks the session
+/// close-on-drop and SQLx disposes of it in a task spawned from the drop
+/// handler. The *server-side* release therefore is not ordered before the next
+/// statement any other connection issues — probing the advisory lock straight
+/// after `drop()` is a race, and that race is exactly what made this test flaky
+/// under `cargo nextest` parallelism. What the drop contract actually
+/// guarantees is that the pinned session never returns to the pool, and that is
+/// observable exactly: SQLx releases a dropped connection's pool permit only
+/// after its disposal task has finished, so holding every permit the pool can
+/// issue is a sleep-free, retry-free barrier. Once all of them are in hand no
+/// other connection from this pool exists, and each one can be asked directly
+/// whether it is carrying the leaked pin.
+async fn assert_no_pooled_connection_holds_pin(
+    db: &Database,
+    contender: sqlx::pool::PoolConnection<sqlx::Postgres>,
+    key: GenerationStreamPinKey,
+    context: &str,
+) {
+    let pool = db.pool();
+    let max_connections = pool.options().get_max_connections() as usize;
+    let mut pooled = vec![contender];
+    while pooled.len() < max_connections {
+        pooled.push(pool.acquire().await.expect("drain pool connection"));
+    }
+    for connection in pooled.iter_mut() {
+        let holds_pin = release_generation_stream_pin_shared(connection, key)
+            .await
+            .expect("probe pooled connection for a leaked shared pin");
+        assert!(!holds_pin, "{context}");
+    }
+}
+
 /// Publish via the legacy unmarked cache upsert.  The migration triggers
 /// mint a fresh generation (artifact_required = false) and advance
 /// `repo_graph_current`.
@@ -348,17 +383,14 @@ async fn pinned_reader_shared_pin_survives_commit_and_releases() {
         other => panic!("expected pinned artifact, got {other:?}"),
     };
     drop(reader);
-    assert!(
-        try_acquire_generation_stream_pin_exclusive(&mut contender, key)
-            .await
-            .expect("try exclusive after drop"),
-        "drop must discard the pinned connection rather than leak its lock"
-    );
-    assert!(
-        release_generation_stream_pin_exclusive(&mut contender, key)
-            .await
-            .expect("release after drop")
-    );
+    assert_no_pooled_connection_holds_pin(
+        &db,
+        contender,
+        key,
+        "drop must discard the pinned connection rather than return it to the \
+         pool still holding its lock",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -401,18 +433,14 @@ async fn pinned_reader_read_error_discards_its_pinned_connection() {
     );
     drop(reader);
 
-    let mut contender = db.pool().acquire().await.expect("contender connection");
-    assert!(
-        try_acquire_generation_stream_pin_exclusive(&mut contender, key)
-            .await
-            .expect("try exclusive after read error"),
-        "a read error must not return a session holding the shared pin"
-    );
-    assert!(
-        release_generation_stream_pin_exclusive(&mut contender, key)
-            .await
-            .expect("release exclusive")
-    );
+    let contender = db.pool().acquire().await.expect("contender connection");
+    assert_no_pooled_connection_holds_pin(
+        &db,
+        contender,
+        key,
+        "a read error must not return a session holding the shared pin",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/server/crates/djinn-db/src/repositories/repo_graph_retention_tests.rs
+++ b/server/crates/djinn-db/src/repositories/repo_graph_retention_tests.rs
@@ -600,11 +600,19 @@ async fn normal_lock_order_completes_without_deadlock() {
     assert_eq!(generation_count(&db, "p-order").await, 2);
 
     // Verify no session advisory locks leaked for this project's generations.
-    // Other parallel tests intentionally hold locks in the same global class,
-    // so a class-only count is not isolated and flakes under nextest.
+    //
+    // `pg_locks` is cluster-wide: it lists advisory locks held in *every*
+    // database of the Postgres instance, and every test in this suite runs
+    // against its own `djinn_test_<uuid>` database on one shared server. A
+    // count filtered only by `classid` therefore also counts the pins that
+    // sibling tests legitimately hold at that instant, and reads non-zero for
+    // reasons that have nothing to do with this sweep. Scope the count to this
+    // database *and* to this project's own generation keys.
     let leaked_locks: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM pg_locks \
-         WHERE locktype = 'advisory' AND classid = $1 \
+         WHERE locktype = 'advisory' \
+           AND database = (SELECT oid FROM pg_database WHERE datname = current_database()) \
+           AND classid = $1 \
            AND objid::bigint = ANY(SELECT ((object_id + 4294967296) % 4294967296) \
                                    FROM unnest($2::bigint[]) AS object_id)",
     )
@@ -820,8 +828,9 @@ async fn dry_run_releases_all_session_pins() {
     assert_eq!(generation_count(&db, "p-dryrun-pins").await, 6);
 
     // Verify that no session advisory locks remain for this project's exact
-    // generation keys. Parallel tests may legitimately hold keys in the same
-    // lock class while this assertion runs.
+    // generation keys. `pg_locks` spans every database on the shared test
+    // server, so parallel tests in their own `djinn_test_<uuid>` databases may
+    // legitimately hold keys in the same lock class while this assertion runs.
     let generation_ids: Vec<String> = sqlx::query_scalar(
         "SELECT generation_id::text FROM repo_graph_generation WHERE project_id = 'p-dryrun-pins'",
     )
@@ -841,7 +850,9 @@ async fn dry_run_releases_all_session_pins() {
     let pin_class = crate::repositories::repo_graph_generation::GENERATION_STREAM_PIN_LOCK_CLASS;
     let leaked: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM pg_locks \
-         WHERE locktype = 'advisory' AND classid = $1 \
+         WHERE locktype = 'advisory' \
+           AND database = (SELECT oid FROM pg_database WHERE datname = current_database()) \
+           AND classid = $1 \
            AND objid::bigint = ANY(SELECT ((object_id + 4294967296) % 4294967296) \
                                    FROM unnest($2::bigint[]) AS object_id)",
     )


### PR DESCRIPTION
Two `djinn-db` tests flaked under nextest shard parallelism in [run 30228010437](https://github.com/djinnos/djinn/actions/runs/30228010437) (merge_group, PR #2637). Both sit on the `GENERATION_STREAM_PIN_LOCK_CLASS` advisory locks, but they had **different** root causes.

## 1. Asynchronous release on drop — a real race

`pinned_reader_shared_pin_survives_commit_and_releases` probed the advisory lock from a second connection immediately after `drop(reader)`:

```
panicked at repo_graph_generation_tests.rs:351:5:
drop must discard the pinned connection rather than leak its lock
```

`PinnedGalaxyArtifact::drop` cannot await `pg_advisory_unlock`. It marks the session close-on-drop, and SQLx 0.8.6's `impl Drop for PoolConnection` *spawns* the disposal (`crate::rt::spawn(self.take_and_close())`). The server-side release is therefore **not ordered before the contender's next statement** — the probe asserted an ordering the drop path never promised.

What the contract does guarantee is that the pinned session never returns to the pool, and that is exactly observable: SQLx releases a dropped connection's pool permit only after its disposal task finishes. So holding every permit the pool can issue is a sleep-free, retry-free barrier. Both tests now drain the pool and ask every connection it can hand out whether it carries the leaked shared pin.

The sibling test `pinned_reader_read_error_discards_its_pinned_connection` had the same latent race (observed failing 1/5 locally) and is fixed the same way. CI had not tripped it yet.

## 2. `pg_locks` is cluster-wide — scoping hardened

`normal_lock_order_completes_without_deadlock` and `dry_run_releases_all_session_pins` count leaked pins in `pg_locks`, which lists advisory locks held in **every database of the instance**, while each test runs in its own `djinn_test_<uuid>` database on one shared server.

Sampling the live cluster during a 32-thread run: **5 of 150 samples had 2–3 distinct databases simultaneously holding pins of this class**, with up to 512 locks visible to a class-only count — including one instant with ~450 pin-class locks held in a database other than the observing session's.

The keys were already scoped to the project's own generations by #2638 (which landed after the failing run, so it already fixes the observed CI failure). This adds `database = current_database()` on top, so no sibling database can be counted at all.

## Verification

`cargo nextest run -p djinn-db --lib -E 'test(repo_graph)' --test-threads 32` in a loop:

| | iterations | failures |
|---|---|---|
| baseline | 30 | 5 (16.7%) — identical panic to CI |
| class-only predicate restored (repro of #2) | 12 | 8 (67%) — `left: 1`, exact CI message |
| **after fix** | **40** | **0** |

Full `djinn-db` lib suite: 1166/1166 passed.

**Verified by neutralization** (each assertion still fails when the behavior it guards is genuinely broken):

- Removing `close_on_drop()` from `PinnedGalaxyArtifact::drop` → test 1 fails **deterministically** (0.41s, not flaky). The new assertion is strictly stronger than the one it replaces.
- Making retention's delete-mode skip its pre-commit pin release → `normal_lock_order_completes_without_deadlock` fails `left: 4, right: 0`. The database-scoped count still catches a real leak in the current database.
- Making dry-run skip its inline release → `dry_run_releases_all_session_pins` fails `left: 4, right: 0`.

Repo-wide grep for the same unscoped-catalog pattern: clean. `pg_locks` appears only in these two files; all ~20 `pg_stat_activity` reads are already `datname`-scoped.

## Notes

- **No production code changed** — test-only.
- No sleeps, retries, raised timeouts, or `#[ignore]`.
- Not yet run locally: `cargo clippy -p djinn-db -- -D warnings` was still compiling when this PR was opened, and the `repo_graph_retention_compatibility` integration binary was not exercised (it is unmodified and queries no `pg_locks`). CI covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
