### PR TITLE
fix(agent-tests): wait on the lease counters and contain the fixture children

### DIFF
--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -87,6 +87,11 @@ mod broker;
 /// ignored the `Command` it was handed.
 #[cfg(test)]
 pub(crate) use broker::command_spec;
+/// Process-group containment for the launcher doubles' fixture children — the
+/// stand-in for the leaf cgroup a bare `std::process::Child` does not have. See
+/// [`broker::fixture_child`] for why a double that skips it leaks a process.
+#[cfg(test)]
+pub(crate) use broker::fixture_child;
 /// The SINGLE source of an invocation's broker fence. Exported so a proof reads
 /// the same function the `BEGIN` control does instead of restating the rule —
 /// a second statement of it is exactly how blocker 14 shipped.
@@ -1601,11 +1606,23 @@ mod tests {
         }
     }
 
+    /// A long-lived fixture child, contained the way the production handle
+    /// contains a leaf: its own process group, torn down as a group. Spawning it
+    /// through `sh -c` left the real command as a grandchild on any runner whose
+    /// `/bin/sh` forks rather than execs, and the direct-child kill orphaned it
+    /// holding this test process's stdout — a nextest `LEAK`.
+    fn fixture_sleep() -> std::process::Child {
+        let mut command = Command::new("sleep");
+        command.arg("1");
+        fixture_child::isolate_group(&mut command);
+        command.spawn().unwrap()
+    }
+
     /// A paused service future must lose to irreversible cancellation, so its
     /// grant cannot reach the lift path (terminal-before-grant ordering).
     #[tokio::test]
     async fn paused_grant_loses_to_terminal_intent() {
-        let mut child = Command::new("sh").arg("-c").arg("sleep 1").spawn().unwrap();
+        let mut child = fixture_sleep();
         let cancel = CancellationToken::new();
         cancel.cancel();
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, std::time::Instant::now());
@@ -1622,14 +1639,14 @@ mod tests {
             result,
             LeaseWait::Terminal((_, ProcessTermination::Cancelled))
         ));
-        let _ = child.kill();
-        let _ = child.wait();
+        fixture_child::kill_group(&mut child).unwrap();
+        fixture_child::wait_group_empty(&mut child).unwrap();
     }
 
     /// The injected fake clock controls timeout while a service response is paused.
     #[tokio::test]
     async fn fake_clock_times_out_paused_service() {
-        let mut child = Command::new("sh").arg("-c").arg("sleep 1").spawn().unwrap();
+        let mut child = fixture_sleep();
         let cancel = CancellationToken::new();
         let base = std::time::Instant::now();
         let clock = TestClock::new(std::time::SystemTime::UNIX_EPOCH, base);
@@ -1642,8 +1659,8 @@ mod tests {
             result,
             LeaseWait::Terminal((_, ProcessTermination::TimedOut))
         ));
-        let _ = child.kill();
-        let _ = child.wait();
+        fixture_child::kill_group(&mut child).unwrap();
+        fixture_child::wait_group_empty(&mut child).unwrap();
     }
 
     #[test]

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -87,17 +87,35 @@ impl ProcessHandle for ScriptedHandle {
         *self.lifts.lock().unwrap() += 1;
         Ok(())
     }
+    /// The production `kill` is `cgroup.kill`: it reaches the whole leaf, not
+    /// just the command's own process. Killing only the direct child is what
+    /// orphaned a fixture process on the runners whose `/bin/sh` forks.
     fn kill(&mut self) -> io::Result<()> {
         self.kills.fetch_add(1, Ordering::SeqCst);
-        let _ = self.child.kill();
+        let _ = fixture_child::kill_group(&mut self.child);
         Ok(())
     }
+    /// The production `wait_empty` returns only at `populated 0`. Counting the
+    /// call and returning is a claim this double cannot otherwise honour — and
+    /// the test process exiting while a fixture process is still alive is
+    /// exactly what nextest reports as `LEAK`.
     fn wait_empty(&mut self) -> io::Result<()> {
         self.empties.fetch_add(1, Ordering::SeqCst);
-        Ok(())
+        fixture_child::wait_group_empty(&mut self.child)
     }
     fn cleanup(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+/// The runner can also drop a handle without reaching the kill/`wait_empty`
+/// pair — every `?` in the invocation loop is such a path. In production the
+/// leaf still contains the child; here nothing would, so the group teardown is
+/// repeated on drop. It is idempotent: a reaped leader short-circuits it.
+impl Drop for ScriptedHandle {
+    fn drop(&mut self) {
+        let _ = fixture_child::kill_group(&mut self.child);
+        let _ = fixture_child::wait_group_empty(&mut self.child);
     }
 }
 
@@ -228,6 +246,30 @@ impl ProcessHandle for BrokerBackedHandle {
     }
 }
 
+/// A scripted-call counter a test can AWAIT instead of spinning on.
+///
+/// The counter and the wakeup have to be one object: a test that polls the count
+/// on a fixed budget of yields is timing the machine, not the runner. See
+/// [`wait_for`].
+#[derive(Default)]
+struct CallCounter {
+    count: AtomicUsize,
+    progress: Notify,
+}
+
+impl CallCounter {
+    /// Record a call and wake every waiter. The order matters: waiters register
+    /// before they read the count, so a bump that happens after their read still
+    /// wakes them.
+    fn record(&self) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        self.progress.notify_waiters();
+    }
+    fn load(&self, ordering: Ordering) -> usize {
+        self.count.load(ordering)
+    }
+}
+
 struct ScriptedServices {
     cancel: CancellationToken,
     queue: Mutex<VecDeque<LeaseResult>>,
@@ -235,11 +277,11 @@ struct ScriptedServices {
     status: Mutex<VecDeque<LeaseResult>>,
     abandon: Mutex<VecDeque<LeaseResult>>,
     release: Mutex<VecDeque<LeaseResult>>,
-    queue_calls: AtomicUsize,
-    grant_calls: AtomicUsize,
-    status_calls: AtomicUsize,
-    abandon_calls: AtomicUsize,
-    release_calls: AtomicUsize,
+    queue_calls: CallCounter,
+    grant_calls: CallCounter,
+    status_calls: CallCounter,
+    abandon_calls: CallCounter,
+    release_calls: CallCounter,
     release_fences: Mutex<Vec<LeaseFencingToken>>,
     pause_queue: AtomicBool,
     pause_grant: AtomicBool,
@@ -263,11 +305,11 @@ impl ScriptedServices {
             status: Mutex::new(status.into()),
             abandon: Mutex::new(VecDeque::new()),
             release: Mutex::new(VecDeque::new()),
-            queue_calls: AtomicUsize::new(0),
-            grant_calls: AtomicUsize::new(0),
-            status_calls: AtomicUsize::new(0),
-            abandon_calls: AtomicUsize::new(0),
-            release_calls: AtomicUsize::new(0),
+            queue_calls: CallCounter::default(),
+            grant_calls: CallCounter::default(),
+            status_calls: CallCounter::default(),
+            abandon_calls: CallCounter::default(),
+            release_calls: CallCounter::default(),
             release_fences: Mutex::new(Vec::new()),
             pause_queue: AtomicBool::new(false),
             pause_grant: AtomicBool::new(false),
@@ -297,7 +339,7 @@ impl SupervisorServices for ScriptedServices {
         &self.cancel
     }
     async fn queue_lease(&self, _: LeaseQueueRequest) -> LeaseResult {
-        self.queue_calls.fetch_add(1, Ordering::SeqCst);
+        self.queue_calls.record();
         self.queue_entered.notify_waiters();
         if self.pause_queue.load(Ordering::SeqCst) {
             std::future::pending().await
@@ -306,7 +348,7 @@ impl SupervisorServices for ScriptedServices {
         }
     }
     async fn grant_lease(&self, _: LeaseGrantRequest) -> LeaseResult {
-        self.grant_calls.fetch_add(1, Ordering::SeqCst);
+        self.grant_calls.record();
         self.grant_entered.notify_waiters();
         if self.pause_grant.load(Ordering::SeqCst) {
             std::future::pending().await
@@ -315,7 +357,7 @@ impl SupervisorServices for ScriptedServices {
         }
     }
     async fn lease_status(&self, _: LeaseStatusRequest) -> LeaseResult {
-        self.status_calls.fetch_add(1, Ordering::SeqCst);
+        self.status_calls.record();
         self.status_entered.notify_one();
         if self.pause_status.load(Ordering::SeqCst) {
             self.status_resume.notified().await;
@@ -323,7 +365,7 @@ impl SupervisorServices for ScriptedServices {
         Self::pop(&self.status)
     }
     async fn abandon_lease(&self, _: LeaseAbandonRequest) -> LeaseResult {
-        self.abandon_calls.fetch_add(1, Ordering::SeqCst);
+        self.abandon_calls.record();
         Self::pop(&self.abandon)
     }
     async fn bind_lease_pod(
@@ -339,7 +381,7 @@ impl SupervisorServices for ScriptedServices {
         })
     }
     async fn release_lease(&self, request: LeaseReleaseRequest) -> LeaseResult {
-        self.release_calls.fetch_add(1, Ordering::SeqCst);
+        self.release_calls.record();
         self.release_fences
             .lock()
             .unwrap()
@@ -517,9 +559,17 @@ fn granted(token: u64) -> LeaseResult {
         deadlines: deadlines(),
     })
 }
+/// A child that outlives the test unless the runner terminates it.
+///
+/// Deliberately NOT `sh -c "sleep 30"`: where `/bin/sh` forks its `-c` command
+/// (dash, i.e. the CI runners) that fixture is two processes, and the `sleep`
+/// survived a kill aimed at the shell — orphaned, still holding the test
+/// process's stdout, which is the `LEAK` nextest reported. One process, in its
+/// own group, is what the launcher double can actually contain.
 fn command() -> Command {
-    let mut c = Command::new("sh");
-    c.arg("-c").arg("sleep 30");
+    let mut c = Command::new("sleep");
+    c.arg("30");
+    fixture_child::isolate_group(&mut c);
     c
 }
 fn config() -> LeaseInvocationConfig {
@@ -536,14 +586,46 @@ fn config() -> LeaseInvocationConfig {
 fn clock() -> Arc<TestClock> {
     Arc::new(TestClock::new(SystemTime::UNIX_EPOCH, Instant::now()))
 }
-async fn wait_for(counter: &AtomicUsize, n: usize) {
-    for _ in 0..10_000 {
-        if counter.load(Ordering::SeqCst) >= n {
-            return;
+/// Wait until the runner has issued `n` calls of this kind.
+///
+/// # Why this is not a yield budget any more
+///
+/// It used to be `for _ in 0..10_000 { yield_now().await }`, which counts
+/// nothing the runner does: 10_000 yields is a wall-clock deadline of a few tens
+/// of milliseconds on whatever machine happens to run the test. Every call the
+/// runner makes here is downstream of one real await — the durable
+/// `invocation_lift_decision()` read, issued BEFORE the leaf is launched — so on
+/// a loaded runner opening a cold Postgres connection the budget expired first
+/// and `a_non_platform_database_fails_closed_instead_of_lifting` failed all
+/// three retries in 21ms, 44ms and 53ms with "counter did not reach 3". The
+/// production behaviour it asserts was never involved.
+///
+/// Waiting on the counter's own notification removes the deadline race
+/// entirely; the outer timeout exists only so a runner that never issues the
+/// call fails with this message instead of hanging.
+async fn wait_for(counter: &CallCounter, n: usize) {
+    let reached = async {
+        loop {
+            // Registered BEFORE the load, so a bump racing this check wakes us
+            // rather than being missed.
+            let progressed = counter.progress.notified();
+            tokio::pin!(progressed);
+            progressed.as_mut().enable();
+            if counter.load(Ordering::SeqCst) >= n {
+                return;
+            }
+            progressed.await;
         }
-        tokio::task::yield_now().await;
+    };
+    if tokio::time::timeout(Duration::from_secs(30), reached)
+        .await
+        .is_err()
+    {
+        panic!(
+            "counter did not reach {n} (observed {})",
+            counter.load(Ordering::SeqCst)
+        );
     }
-    panic!("counter did not reach {n}");
 }
 
 #[tokio::test]

--- a/server/crates/djinn-agent/src/process_broker.rs
+++ b/server/crates/djinn-agent/src/process_broker.rs
@@ -505,6 +505,106 @@ fn child_environment(command: &Command) -> io::Result<Vec<(String, String)>> {
     Ok(environment.into_iter().collect())
 }
 
+/// The containment a launcher double owes the fixture children it spawns.
+///
+/// # Why a bare `std::process::Child` is not a leaf cgroup
+///
+/// [`ProcessHandle::kill`] is `cgroup.kill` in production: it reaches EVERY
+/// process in the invocation's leaf, children of the command included. And
+/// [`ProcessHandle::wait_empty`] returns only once the leaf reports
+/// `populated 0`, i.e. once nothing from that invocation is running any more.
+/// The doubles stand a bare [`std::process::Child`] in for that leaf, and a bare
+/// child has neither property: `Child::kill` signals ONLY the direct child, and
+/// there is nothing that waits for its descendants.
+///
+/// That gap is invisible wherever `/bin/sh` execs its `-c` command (bash does),
+/// and it leaks a process wherever `/bin/sh` FORKS it (dash does — which is
+/// `/bin/sh` on the CI runners). There, `sh -c "sleep 30"` is two processes; the
+/// double killed the shell, the `sleep` was orphaned still holding the test
+/// process's inherited stdout, and nextest — which waits for that pipe to close
+/// after the test process exits — reported the test as `LEAK`.
+///
+/// So the fixtures spawn into their own process group and tear the whole group
+/// down: `kill_group` is the stand-in for `cgroup.kill`, and `wait_group_empty`
+/// is the stand-in for `populated 0`. A double that returned from `wait_empty`
+/// while a fixture process was still alive would be asserting a containment
+/// property the production handle has and the double does not.
+#[cfg(test)]
+pub(crate) mod fixture_child {
+    use std::io;
+    use std::process::{Child, Command};
+    use std::time::Duration;
+
+    /// Spawn this command as the leader of its own process group, so the whole
+    /// subtree it may create stays addressable by one signal.
+    pub(crate) fn isolate_group(command: &mut Command) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        #[cfg(not(unix))]
+        let _ = command;
+    }
+
+    /// SIGKILL the child's whole process group — the double's `cgroup.kill`.
+    pub(crate) fn kill_group(child: &mut Child) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            // A reaped pid can be recycled, so signalling by pid is only sound
+            // while the leader is still un-reaped. `try_wait` reaps an exited
+            // leader, and once it has, the group can no longer be named here.
+            if child.try_wait()?.is_some() {
+                return Ok(());
+            }
+            let pid = i32::try_from(child.id())
+                .map_err(|_| io::Error::other("fixture child pid does not fit in pid_t"))?;
+            // SAFETY: `kill(2)` with a negated pid signals the process group led
+            // by that pid. The fixture children are group leaders
+            // (`isolate_group`), so the group is exactly this child's subtree.
+            if unsafe { libc::kill(-pid, libc::SIGKILL) } != 0 {
+                // No such group (the child was spawned without isolation, or the
+                // group is already gone): fall back to the direct child.
+                let error = io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(error);
+                }
+                return child.kill();
+            }
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        child.kill()
+    }
+
+    /// Return only once nothing from this fixture is running — the double's
+    /// `populated 0`. Reaps the leader, then waits out its group.
+    pub(crate) fn wait_group_empty(child: &mut Child) -> io::Result<()> {
+        #[cfg(unix)]
+        let pid = i32::try_from(child.id()).ok();
+        child.wait()?;
+        #[cfg(unix)]
+        {
+            let Some(pid) = pid else { return Ok(()) };
+            // The group was just SIGKILLed, so this settles in microseconds. The
+            // bound is a safety valve only: a double must not be able to hang a
+            // test run forever.
+            for _ in 0..10_000 {
+                // SAFETY: signal 0 performs the existence check only.
+                if unsafe { libc::kill(-pid, 0) } != 0 {
+                    return Ok(());
+                }
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err(io::Error::other(
+                "fixture process group never emptied after SIGKILL",
+            ))
+        }
+        #[cfg(not(unix))]
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 impl ProcessHandle for std::process::Child {
     fn drain_stdout(&mut self) -> io::Result<Vec<u8>> {
@@ -535,11 +635,11 @@ impl ProcessHandle for std::process::Child {
     }
 
     fn kill(&mut self) -> io::Result<()> {
-        std::process::Child::kill(self)
+        fixture_child::kill_group(self)
     }
 
     fn wait_empty(&mut self) -> io::Result<()> {
-        Ok(())
+        fixture_child::wait_group_empty(self)
     }
 
     fn cleanup(&mut self) -> io::Result<()> {


### PR DESCRIPTION
Fixes the hard failure and the leak markers from [run 30228010437](https://github.com/djinnos/djinn/actions/runs/30228010437) (merge_group, PR #2637). Both turned out to be defects in the **test doubles**, not in the runner they exercise. **No production behavior changed** — every hunk is `#[cfg(test)]` or inside `mod tests`.

## 1. The hard failure — a yield budget masquerading as a call count

`process::tests::lease_runner_tests::admission_composition_tests::a_non_platform_database_fails_closed_instead_of_lifting` failed all 3 nextest retries on shard-4:

```
panicked at process_lease_tests.rs:546:5: counter did not reach 3
```

The helper was `for _ in 0..10_000 { yield_now().await }`. A yield budget is not a count of anything the runner does — it is a wall-clock deadline of a few tens of milliseconds, on whatever machine happens to run it.

Every call it waits for is downstream of the one real await the runner performs *before* launching the leaf (`self.lift.invocation_lift_decision().await`, `process.rs:555`). This test is the **only** one in the file whose read opens a *cold* Postgres connection — `{server_prefix}/postgres`, deliberately not the platform DB, which is the whole point of the test. On a loaded runner the budget expired before the connect-and-fail round trip returned.

Instrumented locally: this test burned **2151 of the 10 000 yields (37.8 ms)** waiting on that read, versus **4–64 yields** for every other test in the file. The production fail-closed path was never reached, let alone wrong.

Fixed by giving the counter its own `Notify` (`CallCounter`) and awaiting it, with a 30s timeout that preserves the original failure message only if the call genuinely never happens.

## 2. The LEAK markers — the doubles skipped the containment production has

Five tests were flagged `LEAK` across shards 2, 3 and 4 (all ~0.21s).

The fixture spawned `sh -c "sleep 30"`, and the launcher doubles stood a bare `std::process::Child` in for a leaf cgroup. Two gaps versus production:

| | double | production |
|---|---|---|
| `kill` | signals only the direct child | `cgroup.kill` over the whole leaf (`djinn-cgroup-launcher/src/lib.rs:446`) |
| `wait_empty` | increments a counter, returns `Ok(())` | succeeds only at `populated 0` (`:451`) |

That gap is **invisible where `/bin/sh` execs its `-c` command** (bash — my box) and **leaks where it forks it** (dash — the CI runners). Verified directly in a Debian container: `sh` at pid 8 with a `sleep` child at pid 10. The double killed the shell; the `sleep` was orphaned still holding the test process's inherited stdout — precisely nextest's leak signal. The runner already reaps the direct child (`child.wait()` after `wait_empty`), so only a grandchild could leak.

Fixed at the fixture layer: a new `#[cfg(test)] fixture_child` module providing `isolate_group` / `kill_group` (SIGKILL to `-pgid`, ESRCH fallback) / `wait_group_empty`, wired into `ScriptedHandle::kill`/`wait_empty` plus a `Drop` guard for the `?` paths, and into the `cfg(test)` `impl ProcessHandle for std::process::Child`. The lease fixture is now a single `sleep` in its own group rather than a shell.

## Verification

**Reproduced the hard failure**: restored the old `wait_for` and wrapped the real `DurableInvocationLiftAuthority` in a 300 ms delay (standing in for CI's slow cold connect) → `TRY 1/2/3 FAIL … counter did not reach 3` at 0.030s each, the exact CI signature. With the new `wait_for` and the same 300 ms read: `PASS [0.352s]`.

**Neutralized the production behavior it guards**: made `log_and_project` return `Lift` for `AdmissionEpochRead::Failed` → red on all 3 tries with `a failed epoch read must never be treated as authorization / left: [Armed] right: [Unarmed]`. Reverted.

**Reproduced the LEAK**: built a `/bin/sh` shim that forks its `-c` command (dash semantics) and ran the crate under it → `LEAK [0.219s]`, the same 0.21s signature as CI.

**Neutralized the leak fix**: with `sh -c "sleep 30"` restored and `kill`→direct-child, `wait_empty`→no-op, empty `Drop` → LEAK returns. Restoring only the group kill+wait (still under the forking shell) → 0 leaks across 3 runs. Final fixture → 0 leaks.

Full crate: `cargo nextest run -p djinn-agent --lib --profile ci` → **1442 passed, 0 leaky** (3 runs). `cargo clippy -p djinn-agent --lib --all-targets --all-features` clean. `cargo fmt --check` clean. `scripts/check-file-size.sh --all` → 0 oversized.

## Notes

- **Non-lib test targets were not run locally** — the machine's disk was 100% full during this work, so linking the ~20 integration binaries failed with `No space left on device`. All `process::tests` live in `--lib`, which did run in full. CI covers the rest.
- The LEAK was never reproduced on this machine's real `/bin/sh` (bash execs, so the grandchild never exists); the reproduction used a shim emulating dash, and the dash fork behavior itself was verified in a container.
- `poll_until` in the same file has the same yield-budget shape but is only used with the non-IO `FixtureLauncher`, so it cannot hit this race. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
