### PR TITLE
fix(cargo-target-seed): copy build-script output instead of hardlinking it

### DIFF
--- a/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
@@ -6,6 +6,21 @@
 //! dir. Mutable Cargo metadata is copied, and incremental state is skipped so it
 //! is never shared by inode with the warm base.
 //!
+//! # Only immutable payloads may be hardlinked
+//!
+//! The rule that governs [`classify_cargo_target_path`] is: **anything the run
+//! may rewrite must be copied, not linked.** A hardlink shares the inode with the
+//! warm base, which breaks such a path two ways — the rewrite either fails
+//! outright (`fchmod` on a file the caller does not own is EPERM regardless of
+//! mode, so `fs::copy` into a linked destination reports "Operation not
+//! permitted") or succeeds and writes THROUGH into the base that every other
+//! task-run pod seeds from.
+//!
+//! Four classes are known to be rewritten in place and are carved out for that
+//! reason: cargo's per-profile lock files, `.rustc_info.json`, build-script
+//! `OUT_DIR` payloads, and the build-script stamp files. Adding a fifth means
+//! adding it here — the default arm is `Hardlink`, so an omission is silent.
+//!
 //! # Why a single entry must never discard the base
 //!
 //! The warm base is written by the warm Job (uid 10001) and read by the task-run
@@ -526,7 +541,74 @@ pub fn classify_cargo_target_path(relative_path: &Path) -> CloneAction {
         return CloneAction::Copy;
     }
 
+    // Build-script state under `build/<pkg>-<hash>/` is rewritten IN PLACE when
+    // cargo re-runs a build script, and it is the third instance of the same
+    // shared-inode hazard as `.rustc_info.json` and the cargo locks above.
+    //
+    // Two distinct failures, both from hardlinking it:
+    //
+    // 1. **The build script cannot write at all.** A `-sys` crate's build script
+    //    populates `OUT_DIR` with `fs::copy`, and `fs::copy` finishes by applying
+    //    the SOURCE's mode to the destination — an `fchmod` on the destination
+    //    fd. `fchmod` is EPERM for a file the caller does not own, *regardless of
+    //    mode*, and a hardlinked entry keeps the warm base's owner. So the copy
+    //    fails "Operation not permitted" even though the bytes were writable
+    //    through the shared gid. `libssh2-sys/build.rs` does exactly this
+    //    (`fs::copy(...).unwrap()`), so the panic killed the whole compile before
+    //    it reached any workspace crate — the worker could never build locally.
+    //    Note EPERM, not EACCES: this is an OWNERSHIP failure, not a mode one,
+    //    which is why `ensure_owner_writable` cannot rescue it.
+    // 2. **A successful write corrupts the shared base.** Where the rewrite does
+    //    land, the shared inode means it writes THROUGH into the per-project warm
+    //    base that every other task-run pod seeds from.
+    //
+    // A byte copy makes the destination owned by the seeding process — which is
+    // also the process that later runs cargo — so both failures go away. The
+    // `build-script-build` executables stay hardlinked: they are the heavy part
+    // of `build/` and cargo replaces them by rename, never in place.
+    if is_build_script_output(relative_path) || is_build_script_stamp(relative_path) {
+        return CloneAction::Copy;
+    }
+
     CloneAction::Hardlink
+}
+
+/// True for build-script `OUT_DIR` payloads: `[<triple>/]<profile>/build/<pkg>-<hash>/out/**`.
+///
+/// Matched positionally (`build/*/out`) rather than by "has a component named
+/// `out`" so an unrelated path that merely contains `out` is not swept in.
+fn is_build_script_output(path: &Path) -> bool {
+    normal_components(path)
+        .windows(3)
+        .any(|window| window[0] == "build" && window[2] == "out")
+}
+
+/// True for the per-package stamp files cargo rewrites in place after re-running
+/// a build script (`build/<pkg>-<hash>/{output,stderr,root-output,invoked.timestamp}`).
+///
+/// These are tiny, so copying them is free, and hardlinking them writes through
+/// to the shared warm base exactly like `.rustc_info.json` does.
+fn is_build_script_stamp(path: &Path) -> bool {
+    const STAMP_NAMES: &[&str] = &["output", "stderr", "root-output", "invoked.timestamp"];
+
+    let parts = normal_components(path);
+    let Some((name, parents)) = parts.split_last() else {
+        return false;
+    };
+    // `build/<pkg>-<hash>/<stamp>`: the stamp sits exactly one level below the
+    // package dir, which itself sits directly under `build/`.
+    let under_build_package = matches!(parents.split_last(), Some((_, rest)) if rest.last().is_some_and(|component| *component == "build"));
+
+    under_build_package && STAMP_NAMES.iter().any(|stamp| *name == *stamp)
+}
+
+fn normal_components(path: &Path) -> Vec<&std::ffi::OsStr> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part),
+            _ => None,
+        })
+        .collect()
 }
 
 fn fallback_result(start: Instant, reason: CargoTargetSeedFallback) -> CargoTargetSeedResult {

--- a/server/crates/djinn-agent-worker/src/cargo_target_seed/foreign_owner_tests.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed/foreign_owner_tests.rs
@@ -44,9 +44,15 @@ struct BaseFile {
 ///
 /// The bulk is `0664` regular files and `0775` executables written by cargo and
 /// rustc under `umask 002`, which the kernel WILL let a foreign owner hardlink.
-/// The anomalies are the real-world minority that it will NOT: build-script
-/// `OUT_DIR` payloads and registry sources keep their SOURCE mode when a build
-/// script copies them, and the cargo registry ships `0644`/`0640`/`0600` files.
+/// The anomalies are the real-world minority that it will NOT: files that keep a
+/// SOURCE mode regardless of umask, plus anything a base built under `umask 022`
+/// leaves at `0644`/`0755`.
+///
+/// Build-script `OUT_DIR` payloads appear here too, but they never reach `linkat`
+/// at all — they are copied by classification because the run must be able to
+/// rewrite them. Keeping both groups distinct matters: if the only unlinkable
+/// entries were build-script output, the link-fallback path would silently stop
+/// being tested the moment that classification changed.
 const BASE_FILES: &[BaseFile] = &[
     // Linkable majority.
     BaseFile {
@@ -80,7 +86,12 @@ const BASE_FILES: &[BaseFile] = &[
         mode: 0o664,
         contents: b"dep info",
     },
-    // Anomalies the kernel refuses to hardlink for a foreign owner.
+    // Build-script OUT_DIR payloads. These are copied by CLASSIFICATION, not by
+    // link degradation: a re-running build script rewrites them in place, and a
+    // hardlinked destination both refuses the rewrite (`fs::copy` ends in an
+    // `fchmod` the non-owner cannot perform) and writes through into the shared
+    // base. Their odd modes are incidental here — they would be copied at 0664
+    // too. See `classify_cargo_target_path`.
     BaseFile {
         relative: "debug/build/ring-abc/out/aes_nohw.o",
         mode: 0o644,
@@ -95,6 +106,27 @@ const BASE_FILES: &[BaseFile] = &[
         relative: "debug/build/protobuf-ghi/out/protoc",
         mode: 0o755,
         contents: b"vendored tool not group writable",
+    },
+    // Anomalies the kernel refuses to hardlink for a foreign owner. These are
+    // ordinary compiled artifacts, not build-script output, so they still reach
+    // `linkat` and still exercise the bounded copy fallback. A warm base built
+    // under `umask 022` rather than `002` produces exactly this shape across
+    // `deps/`, which is why the fallback path must survive on its own merits and
+    // not merely because build-script payloads happened to populate it.
+    BaseFile {
+        relative: "debug/deps/libring-abc.rlib",
+        mode: 0o644,
+        contents: b"rlib written under umask 022",
+    },
+    BaseFile {
+        relative: "debug/libdjinn_core.a",
+        mode: 0o444,
+        contents: b"read-only static archive",
+    },
+    BaseFile {
+        relative: "debug/deps/djinn_probe-5678",
+        mode: 0o755,
+        contents: b"harness binary not group writable",
     },
 ];
 
@@ -198,9 +230,9 @@ fn foreign_owned_base_with_production_modes_seeds_completely() {
     // refuses are byte-copied instead of discarded.
     assert_eq!(result.linked_file_count, 4);
     assert_eq!(result.degraded_link_file_count, 3);
-    // `.fingerprint` and `.d` metadata are copied by classification, not by
-    // degradation.
-    assert_eq!(result.copied_file_count, 2);
+    // `.fingerprint`, `.d` metadata and the three build-script OUT_DIR payloads
+    // are copied by classification, not by degradation.
+    assert_eq!(result.copied_file_count, 5);
     assert!(!result.link_fallback_budget_exhausted);
     assert!(result.degraded());
     assert_every_expected_file_seeded(&run);
@@ -223,7 +255,10 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
 
     seed_cargo_target_dir_with_options(&base, &run, &emulating_options(2)).expect("seed");
 
-    let read_only_source = base.join("debug/build/zstd-sys-def/out/libzstd.a");
+    // Deliberately a NON-build-script artifact, so this exercises the degraded
+    // link-fallback copy. The classification-copy equivalent is covered by
+    // `copied_entries_are_writable_even_when_the_base_entry_is_read_only`.
+    let read_only_source = base.join("debug/libdjinn_core.a");
     assert_eq!(
         fs::metadata(&read_only_source)
             .expect("base metadata")
@@ -231,10 +266,10 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
             .mode()
             & 0o200,
         0,
-        "the fixture's vendored archive must be read-only in the base"
+        "the fixture's static archive must be read-only in the base"
     );
 
-    let seeded = run.join("debug/build/zstd-sys-def/out/libzstd.a");
+    let seeded = run.join("debug/libdjinn_core.a");
     let mode = fs::metadata(&seeded)
         .expect("seeded metadata")
         .permissions()
@@ -268,7 +303,7 @@ fn one_unseedable_entry_never_discards_the_base() {
         "unseedable entries must degrade the seed, not abandon the base"
     );
     assert_eq!(result.linked_file_count, 4);
-    assert_eq!(result.copied_file_count, 2);
+    assert_eq!(result.copied_file_count, 5);
     assert_eq!(result.degraded_link_file_count, 0);
     assert_eq!(result.unseeded_file_count, 3);
     assert!(result.link_fallback_budget_exhausted);
@@ -280,7 +315,10 @@ fn one_unseedable_entry_never_discards_the_base() {
         fs::read(run.join("debug/deps/libserde-abc.rlib")).expect("linked artifact"),
         b"serde rlib"
     );
-    assert!(!run.join("debug/build/protobuf-ghi/out/protoc").exists());
+    assert!(!run.join("debug/deps/djinn_probe-5678").exists());
+    // The budget bounds only the link fallback. Classification copies are not
+    // substitutes for a refused link, so build-script output still seeds.
+    assert!(run.join("debug/build/protobuf-ghi/out/protoc").exists());
 }
 
 /// The diagnostic that would have ended this investigation in one log line.
@@ -303,7 +341,7 @@ fn entry_error_names_the_operation_the_path_and_why_the_kernel_refused() {
         "the failing OPERATION must lead the message: {error}"
     );
     assert!(
-        ["out/aes_nohw.o", "out/libzstd.a", "out/protoc"]
+        ["libring-abc.rlib", "libdjinn_core.a", "djinn_probe-5678"]
             .iter()
             .any(|path| error.contains(path)),
         "the failing PATH must be named: {error}"
@@ -383,24 +421,24 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let base = tmp.path().join("mold-jobs-4");
     let run = tmp.path().join("run-target");
-    fs::create_dir_all(base.join("debug/build/foo-abc/out")).expect("create base");
-    let target = base.join("debug/build/foo-abc/out/libnative.so.1.2.3");
+    // Deliberately under `deps/`, NOT a build-script `out/` dir: there the Copy
+    // classification would make the assertion below pass even if symlink
+    // handling were removed entirely.
+    fs::create_dir_all(base.join("debug/deps")).expect("create base");
+    let target = base.join("debug/deps/libnative.so.1.2.3");
     fs::write(&target, b"native library").expect("write link target");
     fs::set_permissions(&target, fs::Permissions::from_mode(0o664)).expect("mode");
-    std::os::unix::fs::symlink(&target, base.join("debug/build/foo-abc/out/libnative.so"))
+    std::os::unix::fs::symlink(&target, base.join("debug/deps/libnative.so"))
         .expect("symlink to a regular file");
     std::os::unix::fs::symlink(
-        base.join("debug/build/foo-abc/out/missing"),
-        base.join("debug/build/foo-abc/out/dangling.so"),
+        base.join("debug/deps/missing"),
+        base.join("debug/deps/dangling.so"),
     )
     .expect("dangling symlink");
     // A symlinked directory that points at its own ancestor: descending would
     // never terminate.
-    std::os::unix::fs::symlink(
-        base.join("debug"),
-        base.join("debug/build/foo-abc/out/loop"),
-    )
-    .expect("symlinked directory");
+    std::os::unix::fs::symlink(base.join("debug"), base.join("debug/deps/loop"))
+        .expect("symlinked directory");
 
     let entries = scan_entries(&base).expect("scan must survive symlinks");
     let symlink_entry = entries
@@ -418,7 +456,7 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
 
     assert!(!result.cold_started(), "{:?}", result.first_entry_error);
     assert_eq!(result.unseeded_file_count, 0);
-    let seeded_link = run.join("debug/build/foo-abc/out/libnative.so");
+    let seeded_link = run.join("debug/deps/libnative.so");
     assert_eq!(
         fs::read(&seeded_link).expect("seeded symlink payload"),
         b"native library"
@@ -430,8 +468,8 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
             .is_file(),
         "the run dir must own a private regular file, not a link into the base"
     );
-    assert!(!run.join("debug/build/foo-abc/out/dangling.so").exists());
-    assert!(!run.join("debug/build/foo-abc/out/loop").exists());
+    assert!(!run.join("debug/deps/dangling.so").exists());
+    assert!(!run.join("debug/deps/loop").exists());
 }
 
 /// Everything classified `Copy` is copied precisely so the run can rewrite it,

--- a/server/crates/djinn-agent-worker/src/cargo_target_seed/tests.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed/tests.rs
@@ -45,10 +45,69 @@ fn classifies_heavy_artifacts_for_hardlink() {
         classify_cargo_target_path(Path::new("debug/deps/libserde-abc.rlib")),
         CloneAction::Hardlink
     );
+    // The compiled build script itself IS immutable — cargo replaces it by
+    // rename, never in place — so it stays hardlinked. It is also the heavy part
+    // of `build/`, which is why the carve-out below is scoped to `out/` and the
+    // stamps rather than to all of `build/`.
     assert_eq!(
-        classify_cargo_target_path(Path::new("release/build/foo/out/generated.rs")),
+        classify_cargo_target_path(Path::new("release/build/ring-abc/build-script-build")),
         CloneAction::Hardlink
     );
+}
+
+#[test]
+fn classifies_build_script_output_for_copy() {
+    // A hardlinked OUT_DIR payload cannot be rewritten by a re-running build
+    // script: `fs::copy` applies the source mode to the destination, and that
+    // `fchmod` is EPERM on a file owned by the warm base's uid. `libssh2-sys`
+    // does exactly this and `.unwrap()`s, so the panic killed every local
+    // compile in the pod. Copying makes the destination owned by the seeding
+    // process, which is the same process that later runs cargo.
+    for path in [
+        "release/build/foo-abc/out/generated.rs",
+        "debug/build/libssh2-sys-abc/out/libssh2.h",
+        "debug/build/openssl-sys-def/out/openssl/include/opensslconf.h",
+        "x86_64-unknown-linux-gnu/debug/build/foo-abc/out/generated.rs",
+    ] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(path)),
+            CloneAction::Copy,
+            "{path} is build-script output and must be copied, not linked"
+        );
+    }
+}
+
+#[test]
+fn classifies_build_script_stamps_for_copy() {
+    // Cargo rewrites these in place after re-running a build script; a shared
+    // inode writes through into the warm base every other pod seeds from.
+    for name in ["output", "stderr", "root-output", "invoked.timestamp"] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(&format!("debug/build/foo-abc/{name}"))),
+            CloneAction::Copy,
+            "debug/build/foo-abc/{name} must be copied"
+        );
+    }
+}
+
+#[test]
+fn build_script_matchers_do_not_oversweep() {
+    // `out`/`output` only carry meaning at their cargo-defined position. A
+    // dependency artifact that merely contains the word must keep its normal
+    // classification, or the carve-out silently converts the heavy majority of
+    // the base from hardlinks into byte copies.
+    for path in [
+        "debug/deps/out.rlib",
+        "debug/deps/libout-abc.rlib",
+        "debug/out/stray.bin",
+        "debug/build/foo-abc/out.rs",
+    ] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(path)),
+            CloneAction::Hardlink,
+            "{path} must not be swept into the build-script carve-out"
+        );
+    }
 }
 
 #[test]
@@ -348,6 +407,69 @@ fn seeds_target_tree_with_required_clone_semantics() {
         // cargo rewrite cannot corrupt the shared warm base.
         assert_different_inode(&base.join(rustc_info), &run.join(rustc_info));
     }
+}
+
+#[test]
+fn build_script_output_is_privately_owned_and_rewritable_without_touching_the_base() {
+    // The gy53 production failure: a hardlinked OUT_DIR payload made every local
+    // compile in the task-run pod die in `libssh2-sys`'s build script with
+    // "Operation not permitted", because `fs::copy` ends by `fchmod`-ing the
+    // destination and the destination was still owned by the warm base's uid.
+    //
+    // The inode assertions below are the load-bearing ones: they fail
+    // deterministically under the old `Hardlink` classification on any uid,
+    // whereas the EPERM itself only reproduces when the base is genuinely
+    // foreign-owned (see `foreign_owner_tests`).
+    let _guard = metric_test_guard();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("warm-base");
+    let run = tmp.path().join("run-target");
+
+    let out_header = Path::new("debug/build/libssh2-sys-abc/out/libssh2.h");
+    let out_nested = Path::new("debug/build/openssl-sys-def/out/openssl/include/opensslconf.h");
+    let stamp = Path::new("debug/build/libssh2-sys-abc/output");
+    let build_script = Path::new("debug/build/libssh2-sys-abc/build-script-build");
+
+    write_base_file(&base, out_header, b"original vendored header");
+    write_base_file(&base, out_nested, b"original vendored conf");
+    write_base_file(&base, stamp, b"cargo:rustc-link-lib=ssh2");
+    write_base_file(&base, build_script, b"build script binary");
+
+    seed_cargo_target_dir_with_options(&base, &run, &CargoTargetSeedOptions::new(4))
+        .expect("seed target dir");
+
+    // Every rewritable build-script path must own a private inode...
+    for path in [out_header, out_nested, stamp] {
+        assert_different_inode(&base.join(path), &run.join(path));
+    }
+    // ...while the immutable build script itself stays hardlinked, so the
+    // carve-out did not quietly convert the heavy part of `build/` into copies.
+    let base_script = fs::metadata(base.join(build_script)).expect("base build script");
+    let run_script = fs::metadata(run.join(build_script)).expect("run build script");
+    assert_eq!(
+        (base_script.dev(), base_script.ino()),
+        (run_script.dev(), run_script.ino()),
+        "the compiled build script is immutable and must still be hardlinked"
+    );
+
+    // Reproduce what a re-running `-sys` build script actually does: `fs::copy`
+    // a vendored source over the seeded OUT_DIR path.
+    let vendored = tmp.path().join("vendored-libssh2.h");
+    fs::write(&vendored, b"regenerated vendored header").expect("write vendored source");
+    fs::copy(&vendored, run.join(out_header)).expect(
+        "a re-running build script must be able to fs::copy over its own seeded OUT_DIR payload",
+    );
+
+    assert_eq!(
+        fs::read(run.join(out_header)).expect("read rewritten run payload"),
+        b"regenerated vendored header"
+    );
+    // The shared warm base that every other task-run pod seeds from is untouched.
+    assert_eq!(
+        fs::read(base.join(out_header)).expect("read base payload"),
+        b"original vendored header",
+        "rewriting the run dir must not write through into the shared warm base"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

A hardlinked build-script `OUT_DIR` payload cannot be rewritten when cargo re-runs the build script.

`fs::copy` finishes by applying the source's mode to the destination — an `fchmod` on the destination fd — and `fchmod` is **EPERM for a file the caller does not own, regardless of mode**. A hardlinked entry keeps the warm base's owner, so the copy fails `Operation not permitted` even though the bytes were writable through the shared gid. Note EPERM, not EACCES: this is an *ownership* failure, which is why `ensure_owner_writable` cannot rescue it.

`libssh2-sys/build.rs` does exactly this and `.unwrap()`s it:

```rust
54: fs::copy("libssh2/include/libssh2.h", include.join("libssh2.h")).unwrap();
```

So the panic killed the compile before it reached any workspace crate. Task-run pods whose build-script fingerprint went stale could never build locally and fell back to guessing against CI at ~20 min per attempt — task `gy53` burned **51 sessions over 10 hours** this way, with both work submissions reporting the same blocker.

The sharing is a corruption hazard in the other direction too: where a rewrite *does* land, the shared inode writes **through** into the per-project warm base that every other task-run pod seeds from.

This is the identical failure already carved out for `.rustc_info.json` and the cargo lock files. Build-script state is the third instance, and it was in the default `Hardlink` arm only by omission.

## What

- Classify `build/<pkg>-<hash>/out/**` and the in-place stamp files (`output`, `stderr`, `root-output`, `invoked.timestamp`) as `Copy`. The destination is then owned by the seeding process — which is also the process that later runs cargo.
- `build-script-build` executables **stay hardlinked**: cargo replaces them by rename, never in place, and they are the heavy part of `build/`.
- Matching is positional (`build/*/out`), not "has a component named `out`", so unrelated artifacts are not swept in and silently converted from hardlinks into byte copies.

## Test fallout worth reviewing

The foreign-owner fixture used build-script `OUT_DIR` payloads as its **only** unlinkable entries, so this reclassification would have silently retired the link-fallback coverage entirely. It gains ordinary compiled artifacts at `0644`/`0444`/`0755` — the shape a base built under `umask 022` produces — so that path is still exercised on its own merits.

The symlink fixture moves out of a build-script dir for the same reason: under the new classification its `CloneAction::Copy` assertion would have passed even with symlink handling removed.

## Verification

`cargo test -p djinn-agent-worker --lib` — 46 passed.

Verified by **neutralization**: reverting the classification arm alone fails the new tests, including the load-bearing side-effect test that rewrites a seeded payload and asserts the warm base is byte-for-byte unchanged.

## Tradeoff

Build-script outputs are now byte-copied per run rather than shared by inode, which costs private disk in `/cache/cargo-target-runs` (a path with a history of node DiskPressure). Copying is the cheaper of the two correct options — the alternative, `Skip`, would force every vendored `-sys` crate to recompile from scratch on every task run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)