### PR TITLE
chore(warm-cache): declare the workspace feature set for the warm base

### DIFF
--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -1,4 +1,22 @@
 [build]
+# Feature set djinn's warm-cache pre-build compiles with, so the warm base
+# matches what CI and task-run pods actually build.
+#
+# `djinn-agent-worker::cargo_cache_policy` reads this key to derive the warm
+# job's `--features` args; without it the warm base is built with NO features
+# while CI (`.github/workflows/quality-gate.yml`) and worker commands use
+# `--features qdrant`. Feature resolution differs, so every unit whose
+# resolution depends on it misses the warm base and recompiles.
+#
+# This is djinn's own convention, NOT a cargo key: cargo emits
+# `warning: unused config key build.features` and ignores it. That warning is
+# expected — do not "fix" it by deleting this, and do not move the feature list
+# into the platform, which is deliberately repo-agnostic and reads it from here.
+#
+# Keep in sync with the `--features` used by the Server Clippy / Server Test
+# jobs in `.github/workflows/quality-gate.yml`.
+features = ["qdrant"]
+
 # NOTE: `rustc-wrapper = "sccache"` is intentionally NOT set here. The djinn
 # platform (warm/worker pods) reuses a warm, main-based per-project
 # cargo target base with INCREMENTAL compilation (CI-style, like


### PR DESCRIPTION
## Why

`djinn-agent-worker::cargo_cache_policy` derives the warm job's `--features` args from this workspace's `.cargo/config.toml` `build.features` (`cargo_cache_policy.rs:68`, parsed at `:144-152`). **This workspace never declared the key**, so the warm base was pre-built with **no features**, while CI (`.github/workflows/quality-gate.yml`) and task-run worker commands both build `--features qdrant`.

Feature resolution is part of a unit's fingerprint, so every unit whose resolution depends on `qdrant` missed the warm base and recompiled in the pod.

## Deliberately repo-side

The platform is already repo-agnostic here — it reads whatever the project declares and hardcodes nothing. So this needs **no platform change**, and the feature list stays out of the platform where it belongs.

## Note on the cargo warning

`build.features` is djinn's own convention, not a cargo key. Cargo emits:

```
warning: unused config key `build.features` in .../server/.cargo/config.toml
```

and ignores it (exit 0, verified). The comment in the file records this so it isn't later deleted as dead config.

## Verification

- `cargo metadata` exits 0 with only the expected unused-key warning
- The array form is parsed by the branch at `cargo_cache_policy.rs:147-152` → `--features qdrant`
- `cargo test -p djinn-agent-worker --lib` — 46 passed

## Not covered here

This closes the *feature* half of the warm-base mismatch. The larger half is `RUSTFLAGS`: agent commands that set `RUSTFLAGS='-D warnings'` inline replace the pod's `CARGO_BUILD_RUSTFLAGS` (mold) entirely, which changes `-C metadata` for every unit and discards 100% of the warm base. That is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)