### PR TITLE
fix(cargo-target-seed): stop hardlinking build-script OUT_DIR into the warm base

### DIFF
--- a/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
@@ -6,14 +6,44 @@
 //! dir. Mutable Cargo metadata is copied, and incremental state is skipped so it
 //! is never shared by inode with the warm base.
 //!
+//! # Only immutable payloads may be hardlinked
+//!
+//! The rule that governs [`classify_cargo_target_path`] is: **anything the run
+//! may rewrite must be copied, not linked.** A hardlink shares the inode with the
+//! warm base, so a rewrite in the private run dir lands THROUGH the link into the
+//! shared base that every other task-run pod seeds from. Cargo's fingerprints
+//! still consider the damaged units fresh, so nothing regenerates them and the
+//! base stops re-converging.
+//!
+//! Four classes are known to be rewritten in place and are carved out for that
+//! reason: cargo's per-profile lock files, `.rustc_info.json`, build-script
+//! `OUT_DIR` payloads, and the build-script stamp files. Adding a fifth means
+//! adding it here — the default arm is `Hardlink`, so an omission is silent.
+//!
+//! # Identities involved
+//!
+//! Four distinct uids touch this tree, and conflating any two of them produces a
+//! wrong conclusion about who can write what:
+//!
+//! | role                          | uid     | source                              |
+//! |-------------------------------|---------|-------------------------------------|
+//! | on-disk warm base owner       | `10001` | legacy; predates the warm pod move  |
+//! | warm Job pod                   | `1000`  | `warm_job.rs` (`WORKER_UID`)        |
+//! | task-run worker (this seeder) | `1000`  | `WORKER_UID`                        |
+//! | cargo and its build scripts   | `1001`  | `CHILD_UID`, gid `ARTIFACT_GID` 1000|
+//!
+//! The base's *bytes* were written by a warm pod that today runs as 1000, but the
+//! *inodes* on disk are still owned by the legacy 10001 from before that move.
+//! Cargo never runs as the seeder: the launcher `setresuid`s to `CHILD_UID` 1001,
+//! and the two share only gid 1000. So a seeded entry is writable by cargo when
+//! its GROUP bits allow it, never because the seeder created it.
+//!
 //! # Why a single entry must never discard the base
 //!
-//! The warm base is written by the warm Job (uid 10001) and read by the task-run
-//! worker (uid 1000, gid 1000). With `fs.protected_hardlinks=1` the kernel's
-//! `safe_hardlink_source()` refuses `linkat()` with **EPERM** for any source the
-//! calling process does not own unless it is a *group-writable regular file*.
-//! Measured against a 6.x kernel with a base owned by `10001:1000` and a process
-//! running `1000:1000`:
+//! With `fs.protected_hardlinks=1` the kernel's `safe_hardlink_source()` refuses
+//! `linkat()` with **EPERM** for any source the calling process does not own
+//! unless it is a *group-writable regular file*. Measured against a 6.x kernel
+//! with a base owned by `10001:1000` and a process running `1000:1000`:
 //!
 //! | source            | `linkat` | `copy` |
 //! |-------------------|----------|--------|
@@ -526,7 +556,85 @@ pub fn classify_cargo_target_path(relative_path: &Path) -> CloneAction {
         return CloneAction::Copy;
     }
 
+    // Build-script state under `build/<pkg>-<hash>/` is rewritten IN PLACE when
+    // cargo re-runs a build script, and it is the third instance of the same
+    // shared-inode hazard as `.rustc_info.json` and the cargo locks above.
+    //
+    // A `-sys` crate's build script populates `OUT_DIR` with `fs::copy`, and
+    // `std::fs::copy` on Unix opens the destination `O_CREAT|O_TRUNC` and only
+    // THEN `fchmod`s it to the source's mode, propagating the error
+    // (`open_to_and_set_permissions` in `std::sys::fs::unix`). Applied to a
+    // hardlinked destination, that single sequence produces both halves of the
+    // incident:
+    //
+    // 1. **The truncation writes THROUGH into the shared warm base.** The link
+    //    shares the inode, so `O_TRUNC` empties the base's copy — for every other
+    //    task-run pod that seeds from it, not just this run. Cargo's fingerprints
+    //    still consider those units fresh, so nothing ever regenerates them and
+    //    the base silently stops re-converging. Verified on the production node:
+    //    9 zero-byte files in the shared base, every one under `debug/build/*/out/`
+    //    and every one `nlink=2`, including
+    //    `build/libssh2-sys-*/out/include/libssh2.h`.
+    // 2. **The `fchmod` then fails EPERM and the build script panics.** Inode
+    //    metadata ops are owner-gated, and a hardlinked entry keeps the base's
+    //    owner. `libssh2-sys/build.rs:54` does `fs::copy(...).unwrap()`, so the
+    //    compile dies. Note EPERM, not EACCES: an OWNERSHIP failure, not a mode
+    //    one, which is why `ensure_owner_writable` cannot rescue it.
+    //
+    // Copying is what stops (1): the truncation lands on a private inode and the
+    // shared base is untouchable by construction. It does NOT by itself stop (2)
+    // — the seeder is uid 1000 and cargo runs as uid 1001, so `fchmod` on a
+    // seeded destination is still EPERM for the build script. Aligning those uids
+    // is separately planned work, and it is only safe AFTER this change: with a
+    // single identity the `fchmod` succeeds, and on a hardlinked entry that turns
+    // a loud panic into a silent overwrite of the shared base. Ownership is not
+    // the fix for the corruption; not sharing rewritable state by inode is.
+    //
+    // The `build-script-build` executables stay hardlinked: they are the heavy
+    // part of `build/` and cargo replaces them by rename, never in place.
+    if is_build_script_output(relative_path) || is_build_script_stamp(relative_path) {
+        return CloneAction::Copy;
+    }
+
     CloneAction::Hardlink
+}
+
+/// True for build-script `OUT_DIR` payloads: `[<triple>/]<profile>/build/<pkg>-<hash>/out/**`.
+///
+/// Matched positionally (`build/*/out`) rather than by "has a component named
+/// `out`" so an unrelated path that merely contains `out` is not swept in.
+fn is_build_script_output(path: &Path) -> bool {
+    normal_components(path)
+        .windows(3)
+        .any(|window| window[0] == "build" && window[2] == "out")
+}
+
+/// True for the per-package stamp files cargo rewrites in place after re-running
+/// a build script (`build/<pkg>-<hash>/{output,stderr,root-output,invoked.timestamp}`).
+///
+/// These are tiny, so copying them is free, and hardlinking them writes through
+/// to the shared warm base exactly like `.rustc_info.json` does.
+fn is_build_script_stamp(path: &Path) -> bool {
+    const STAMP_NAMES: &[&str] = &["output", "stderr", "root-output", "invoked.timestamp"];
+
+    let parts = normal_components(path);
+    let Some((name, parents)) = parts.split_last() else {
+        return false;
+    };
+    // `build/<pkg>-<hash>/<stamp>`: the stamp sits exactly one level below the
+    // package dir, which itself sits directly under `build/`.
+    let under_build_package = matches!(parents.split_last(), Some((_, rest)) if rest.last().is_some_and(|component| *component == "build"));
+
+    under_build_package && STAMP_NAMES.iter().any(|stamp| *name == *stamp)
+}
+
+fn normal_components(path: &Path) -> Vec<&std::ffi::OsStr> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part),
+            _ => None,
+        })
+        .collect()
 }
 
 fn fallback_result(start: Instant, reason: CargoTargetSeedFallback) -> CargoTargetSeedResult {
@@ -772,6 +880,9 @@ fn apply_entry(
                     // its owner. The run dir is disposable, so restore owner
                     // write unconditionally.
                     ensure_owner_writable(&destination);
+                    // A link would have carried the base's mtime; this copy is
+                    // standing in for a link, so it must too.
+                    preserve_source_times(&source, &destination);
                     metrics
                         .degraded_link_file_count
                         .fetch_add(1, Ordering::Relaxed);
@@ -799,6 +910,9 @@ fn apply_entry(
                     // the source mode, so a read-only base entry (a symlinked
                     // vendored payload, say) would arrive unwritable.
                     ensure_owner_writable(&destination);
+                    // Cargo compares raw mtimes for staleness, so a copied entry
+                    // must present the same age as the links around it.
+                    preserve_source_times(&source, &destination);
                     metrics.copied_file_count.fetch_add(1, Ordering::Relaxed);
                     metrics.copied_bytes.fetch_add(copied, Ordering::Relaxed);
                     Ok(())
@@ -824,6 +938,50 @@ fn link_file(backend: LinkBackend, source: &Path, destination: &Path) -> io::Res
             }
         }
     }
+}
+
+/// Copy the source's access/modification times onto a seeded destination.
+///
+/// A hardlink shares the inode, so it carries the base's mtime for free. A byte
+/// copy does not: `fs::copy` reproduces mode but *not* timestamps, so a copied
+/// entry lands with a SEED-time mtime while its hardlinked neighbours keep their
+/// WARM-time mtime. Cargo's `StaleDependency` check is a raw mtime comparison
+/// against the unit's dependencies, so mixing the two epochs inside one target
+/// dir makes cargo see freshly-seeded metadata as newer than the artifacts it
+/// describes and rebuild units that were perfectly good — broadly, and dependent
+/// on which side of the classification each path happened to fall. Restoring the
+/// source times keeps a copy indistinguishable from a link to the freshness
+/// checker, which is the entire point of seeding.
+///
+/// Must run AFTER [`ensure_owner_writable`]: `chmod` bumps ctime and the open
+/// below needs the write bit, so setting times has to be the last touch.
+///
+/// The seeder owns every destination it creates, and an owner may always set
+/// explicit times (`utimensat` with explicit values is owner-gated, not
+/// root-gated), so this is permitted without any privilege.
+///
+/// Best-effort, like [`ensure_owner_writable`]: a stale timestamp costs a
+/// needless rebuild, which is not a reason to drop an otherwise correctly seeded
+/// artifact.
+fn preserve_source_times(source: &Path, destination: &Path) {
+    let Ok(source_meta) = fs::metadata(source) else {
+        return;
+    };
+    let Ok(modified) = source_meta.modified() else {
+        return;
+    };
+
+    let mut times = fs::FileTimes::new().set_modified(modified);
+    if let Ok(accessed) = source_meta.accessed() {
+        times = times.set_accessed(accessed);
+    }
+
+    // `File::set_times` requires a handle opened for writing on some targets;
+    // open for write WITHOUT truncating, so this never touches the bytes.
+    let Ok(file) = fs::OpenOptions::new().write(true).open(destination) else {
+        return;
+    };
+    let _ = file.set_times(times);
 }
 
 /// Restore owner write on a seeded artifact in the private run dir.

--- a/server/crates/djinn-agent-worker/src/cargo_target_seed/foreign_owner_tests.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed/foreign_owner_tests.rs
@@ -44,9 +44,15 @@ struct BaseFile {
 ///
 /// The bulk is `0664` regular files and `0775` executables written by cargo and
 /// rustc under `umask 002`, which the kernel WILL let a foreign owner hardlink.
-/// The anomalies are the real-world minority that it will NOT: build-script
-/// `OUT_DIR` payloads and registry sources keep their SOURCE mode when a build
-/// script copies them, and the cargo registry ships `0644`/`0640`/`0600` files.
+/// The anomalies are the real-world minority that it will NOT: files that keep a
+/// SOURCE mode regardless of umask, plus anything a base built under `umask 022`
+/// leaves at `0644`/`0755`.
+///
+/// Build-script `OUT_DIR` payloads appear here too, but they never reach `linkat`
+/// at all — they are copied by classification because the run must be able to
+/// rewrite them. Keeping both groups distinct matters: if the only unlinkable
+/// entries were build-script output, the link-fallback path would silently stop
+/// being tested the moment that classification changed.
 const BASE_FILES: &[BaseFile] = &[
     // Linkable majority.
     BaseFile {
@@ -80,7 +86,12 @@ const BASE_FILES: &[BaseFile] = &[
         mode: 0o664,
         contents: b"dep info",
     },
-    // Anomalies the kernel refuses to hardlink for a foreign owner.
+    // Build-script OUT_DIR payloads. These are copied by CLASSIFICATION, not by
+    // link degradation: a re-running build script rewrites them in place, and a
+    // hardlinked destination both refuses the rewrite (`fs::copy` ends in an
+    // `fchmod` the non-owner cannot perform) and writes through into the shared
+    // base. Their odd modes are incidental here — they would be copied at 0664
+    // too. See `classify_cargo_target_path`.
     BaseFile {
         relative: "debug/build/ring-abc/out/aes_nohw.o",
         mode: 0o644,
@@ -95,6 +106,27 @@ const BASE_FILES: &[BaseFile] = &[
         relative: "debug/build/protobuf-ghi/out/protoc",
         mode: 0o755,
         contents: b"vendored tool not group writable",
+    },
+    // Anomalies the kernel refuses to hardlink for a foreign owner. These are
+    // ordinary compiled artifacts, not build-script output, so they still reach
+    // `linkat` and still exercise the bounded copy fallback. A warm base built
+    // under `umask 022` rather than `002` produces exactly this shape across
+    // `deps/`, which is why the fallback path must survive on its own merits and
+    // not merely because build-script payloads happened to populate it.
+    BaseFile {
+        relative: "debug/deps/libring-abc.rlib",
+        mode: 0o644,
+        contents: b"rlib written under umask 022",
+    },
+    BaseFile {
+        relative: "debug/libdjinn_core.a",
+        mode: 0o444,
+        contents: b"read-only static archive",
+    },
+    BaseFile {
+        relative: "debug/deps/djinn_probe-5678",
+        mode: 0o755,
+        contents: b"harness binary not group writable",
     },
 ];
 
@@ -198,9 +230,9 @@ fn foreign_owned_base_with_production_modes_seeds_completely() {
     // refuses are byte-copied instead of discarded.
     assert_eq!(result.linked_file_count, 4);
     assert_eq!(result.degraded_link_file_count, 3);
-    // `.fingerprint` and `.d` metadata are copied by classification, not by
-    // degradation.
-    assert_eq!(result.copied_file_count, 2);
+    // `.fingerprint`, `.d` metadata and the three build-script OUT_DIR payloads
+    // are copied by classification, not by degradation.
+    assert_eq!(result.copied_file_count, 5);
     assert!(!result.link_fallback_budget_exhausted);
     assert!(result.degraded());
     assert_every_expected_file_seeded(&run);
@@ -223,7 +255,10 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
 
     seed_cargo_target_dir_with_options(&base, &run, &emulating_options(2)).expect("seed");
 
-    let read_only_source = base.join("debug/build/zstd-sys-def/out/libzstd.a");
+    // Deliberately a NON-build-script artifact, so this exercises the degraded
+    // link-fallback copy. The classification-copy equivalent is covered by
+    // `copied_entries_are_writable_even_when_the_base_entry_is_read_only`.
+    let read_only_source = base.join("debug/libdjinn_core.a");
     assert_eq!(
         fs::metadata(&read_only_source)
             .expect("base metadata")
@@ -231,10 +266,10 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
             .mode()
             & 0o200,
         0,
-        "the fixture's vendored archive must be read-only in the base"
+        "the fixture's static archive must be read-only in the base"
     );
 
-    let seeded = run.join("debug/build/zstd-sys-def/out/libzstd.a");
+    let seeded = run.join("debug/libdjinn_core.a");
     let mode = fs::metadata(&seeded)
         .expect("seeded metadata")
         .permissions()
@@ -246,6 +281,77 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
     );
     // Proof rather than inference: the run can actually rewrite it.
     fs::write(&seeded, b"rebuilt by cargo").expect("rewrite seeded artifact");
+}
+
+/// The link-fallback copy is a *substitute for a hardlink*, so it has to be
+/// indistinguishable from one to cargo — including its age.
+///
+/// This arm is the easy one to forget: the classification-copy arm is the one
+/// everybody looks at, but an entry that lands here does so because the kernel
+/// refused the link, and it sits in `deps/` next to thousands of entries that DID
+/// link and kept their warm mtime. A seed-time mtime on one `.rlib` in that set
+/// is exactly the input cargo's raw-mtime `StaleDependency` check turns into a
+/// spurious rebuild of everything downstream of it.
+#[test]
+fn degraded_copies_present_the_same_age_as_the_links_they_substitute_for() {
+    let _guard = metric_test_guard();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("mold-jobs-4");
+    let run = tmp.path().join("run-target");
+    build_production_shaped_base(&base);
+
+    // `0644`: the kernel refuses this hardlink for a foreign owner, so it reaches
+    // the bounded copy fallback rather than the classification-copy arm.
+    let degraded = Path::new("debug/deps/libring-abc.rlib");
+    // A linkable `0664` neighbour, whose mtime comes free with the shared inode.
+    let linked = Path::new("debug/deps/libserde-abc.rlib");
+
+    let warm_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_600_000_000);
+    for path in [degraded, linked] {
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(base.join(path))
+            .expect("open base file to age it");
+        file.set_times(fs::FileTimes::new().set_modified(warm_time))
+            .expect("age base file");
+    }
+
+    let result = seed_cargo_target_dir_with_options(&base, &run, &emulating_options(2))
+        .expect("seed target dir");
+
+    // NON-VACUITY: the entry really did degrade to a copy. If a future change
+    // made it linkable, this test would otherwise pass while proving nothing.
+    assert!(
+        result.degraded_link_file_count > 0,
+        "the fixture must still produce link-fallback copies"
+    );
+    assert_ne!(
+        classify_cargo_target_path(degraded),
+        CloneAction::Copy,
+        "{} must reach the fallback via a REFUSED LINK, not via classification",
+        degraded.display()
+    );
+    let base_meta = fs::metadata(base.join(degraded)).expect("base metadata");
+    let run_meta = fs::metadata(run.join(degraded)).expect("seeded metadata");
+    assert_ne!(
+        (base_meta.dev(), base_meta.ino()),
+        (run_meta.dev(), run_meta.ino()),
+        "the degraded entry must be a private copy, not a link"
+    );
+
+    assert_eq!(
+        run_meta.modified().expect("seeded mtime"),
+        warm_time,
+        "a fallback copy must carry the mtime the hardlink it replaced would have"
+    );
+    assert_eq!(
+        fs::metadata(run.join(linked))
+            .expect("linked metadata")
+            .modified()
+            .expect("linked mtime"),
+        warm_time,
+        "the linked neighbour it must stay consistent with"
+    );
 }
 
 /// The pre-fix behaviour, stated as a property: a single entry the kernel
@@ -268,7 +374,7 @@ fn one_unseedable_entry_never_discards_the_base() {
         "unseedable entries must degrade the seed, not abandon the base"
     );
     assert_eq!(result.linked_file_count, 4);
-    assert_eq!(result.copied_file_count, 2);
+    assert_eq!(result.copied_file_count, 5);
     assert_eq!(result.degraded_link_file_count, 0);
     assert_eq!(result.unseeded_file_count, 3);
     assert!(result.link_fallback_budget_exhausted);
@@ -280,7 +386,10 @@ fn one_unseedable_entry_never_discards_the_base() {
         fs::read(run.join("debug/deps/libserde-abc.rlib")).expect("linked artifact"),
         b"serde rlib"
     );
-    assert!(!run.join("debug/build/protobuf-ghi/out/protoc").exists());
+    assert!(!run.join("debug/deps/djinn_probe-5678").exists());
+    // The budget bounds only the link fallback. Classification copies are not
+    // substitutes for a refused link, so build-script output still seeds.
+    assert!(run.join("debug/build/protobuf-ghi/out/protoc").exists());
 }
 
 /// The diagnostic that would have ended this investigation in one log line.
@@ -303,7 +412,7 @@ fn entry_error_names_the_operation_the_path_and_why_the_kernel_refused() {
         "the failing OPERATION must lead the message: {error}"
     );
     assert!(
-        ["out/aes_nohw.o", "out/libzstd.a", "out/protoc"]
+        ["libring-abc.rlib", "libdjinn_core.a", "djinn_probe-5678"]
             .iter()
             .any(|path| error.contains(path)),
         "the failing PATH must be named: {error}"
@@ -383,24 +492,24 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let base = tmp.path().join("mold-jobs-4");
     let run = tmp.path().join("run-target");
-    fs::create_dir_all(base.join("debug/build/foo-abc/out")).expect("create base");
-    let target = base.join("debug/build/foo-abc/out/libnative.so.1.2.3");
+    // Deliberately under `deps/`, NOT a build-script `out/` dir: there the Copy
+    // classification would make the assertion below pass even if symlink
+    // handling were removed entirely.
+    fs::create_dir_all(base.join("debug/deps")).expect("create base");
+    let target = base.join("debug/deps/libnative.so.1.2.3");
     fs::write(&target, b"native library").expect("write link target");
     fs::set_permissions(&target, fs::Permissions::from_mode(0o664)).expect("mode");
-    std::os::unix::fs::symlink(&target, base.join("debug/build/foo-abc/out/libnative.so"))
+    std::os::unix::fs::symlink(&target, base.join("debug/deps/libnative.so"))
         .expect("symlink to a regular file");
     std::os::unix::fs::symlink(
-        base.join("debug/build/foo-abc/out/missing"),
-        base.join("debug/build/foo-abc/out/dangling.so"),
+        base.join("debug/deps/missing"),
+        base.join("debug/deps/dangling.so"),
     )
     .expect("dangling symlink");
     // A symlinked directory that points at its own ancestor: descending would
     // never terminate.
-    std::os::unix::fs::symlink(
-        base.join("debug"),
-        base.join("debug/build/foo-abc/out/loop"),
-    )
-    .expect("symlinked directory");
+    std::os::unix::fs::symlink(base.join("debug"), base.join("debug/deps/loop"))
+        .expect("symlinked directory");
 
     let entries = scan_entries(&base).expect("scan must survive symlinks");
     let symlink_entry = entries
@@ -418,7 +527,7 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
 
     assert!(!result.cold_started(), "{:?}", result.first_entry_error);
     assert_eq!(result.unseeded_file_count, 0);
-    let seeded_link = run.join("debug/build/foo-abc/out/libnative.so");
+    let seeded_link = run.join("debug/deps/libnative.so");
     assert_eq!(
         fs::read(&seeded_link).expect("seeded symlink payload"),
         b"native library"
@@ -430,8 +539,8 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
             .is_file(),
         "the run dir must own a private regular file, not a link into the base"
     );
-    assert!(!run.join("debug/build/foo-abc/out/dangling.so").exists());
-    assert!(!run.join("debug/build/foo-abc/out/loop").exists());
+    assert!(!run.join("debug/deps/dangling.so").exists());
+    assert!(!run.join("debug/deps/loop").exists());
 }
 
 /// Everything classified `Copy` is copied precisely so the run can rewrite it,

--- a/server/crates/djinn-agent-worker/src/cargo_target_seed/tests.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed/tests.rs
@@ -45,10 +45,71 @@ fn classifies_heavy_artifacts_for_hardlink() {
         classify_cargo_target_path(Path::new("debug/deps/libserde-abc.rlib")),
         CloneAction::Hardlink
     );
+    // The compiled build script itself IS immutable — cargo replaces it by
+    // rename, never in place — so it stays hardlinked. It is also the heavy part
+    // of `build/`, which is why the carve-out below is scoped to `out/` and the
+    // stamps rather than to all of `build/`.
     assert_eq!(
-        classify_cargo_target_path(Path::new("release/build/foo/out/generated.rs")),
+        classify_cargo_target_path(Path::new("release/build/ring-abc/build-script-build")),
         CloneAction::Hardlink
     );
+}
+
+#[test]
+fn classifies_build_script_output_for_copy() {
+    // A hardlinked OUT_DIR payload shares its inode with the shared warm base.
+    // When a re-running build script rewrites it, `fs::copy` opens the
+    // destination `O_CREAT|O_TRUNC` and only then `fchmod`s it, so the
+    // truncation lands THROUGH the link into the base (9 zero-byte `nlink=2`
+    // files were found there in production, all under `debug/build/*/out/`)
+    // before the `fchmod` fails EPERM and `libssh2-sys` panics on its
+    // `.unwrap()`. Copying gives the run a private inode, so the truncation can
+    // no longer reach the base.
+    for path in [
+        "release/build/foo-abc/out/generated.rs",
+        "debug/build/libssh2-sys-abc/out/libssh2.h",
+        "debug/build/openssl-sys-def/out/openssl/include/opensslconf.h",
+        "x86_64-unknown-linux-gnu/debug/build/foo-abc/out/generated.rs",
+    ] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(path)),
+            CloneAction::Copy,
+            "{path} is build-script output and must be copied, not linked"
+        );
+    }
+}
+
+#[test]
+fn classifies_build_script_stamps_for_copy() {
+    // Cargo rewrites these in place after re-running a build script; a shared
+    // inode writes through into the warm base every other pod seeds from.
+    for name in ["output", "stderr", "root-output", "invoked.timestamp"] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(&format!("debug/build/foo-abc/{name}"))),
+            CloneAction::Copy,
+            "debug/build/foo-abc/{name} must be copied"
+        );
+    }
+}
+
+#[test]
+fn build_script_matchers_do_not_oversweep() {
+    // `out`/`output` only carry meaning at their cargo-defined position. A
+    // dependency artifact that merely contains the word must keep its normal
+    // classification, or the carve-out silently converts the heavy majority of
+    // the base from hardlinks into byte copies.
+    for path in [
+        "debug/deps/out.rlib",
+        "debug/deps/libout-abc.rlib",
+        "debug/out/stray.bin",
+        "debug/build/foo-abc/out.rs",
+    ] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(path)),
+            CloneAction::Hardlink,
+            "{path} must not be swept into the build-script carve-out"
+        );
+    }
 }
 
 #[test]
@@ -348,6 +409,145 @@ fn seeds_target_tree_with_required_clone_semantics() {
         // cargo rewrite cannot corrupt the shared warm base.
         assert_different_inode(&base.join(rustc_info), &run.join(rustc_info));
     }
+}
+
+#[test]
+fn build_script_output_is_privately_owned_and_rewritable_without_touching_the_base() {
+    // The verified production failure: a hardlinked OUT_DIR payload let a
+    // re-running build script truncate the SHARED warm base through the link.
+    // Nine zero-byte files were found in the base, every one under
+    // `debug/build/*/out/` and every one `nlink=2` — cargo's fingerprints still
+    // called those units fresh, so nothing regenerated them and the base stopped
+    // re-converging.
+    //
+    // The inode assertions and the final base-contents assertion below are the
+    // load-bearing ones: they fail deterministically under the old `Hardlink`
+    // classification on any uid, whereas the EPERM half of the same syscall
+    // sequence only reproduces when the base is genuinely foreign-owned (see
+    // `foreign_owner_tests`).
+    let _guard = metric_test_guard();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("warm-base");
+    let run = tmp.path().join("run-target");
+
+    let out_header = Path::new("debug/build/libssh2-sys-abc/out/libssh2.h");
+    let out_nested = Path::new("debug/build/openssl-sys-def/out/openssl/include/opensslconf.h");
+    let stamp = Path::new("debug/build/libssh2-sys-abc/output");
+    let build_script = Path::new("debug/build/libssh2-sys-abc/build-script-build");
+
+    write_base_file(&base, out_header, b"original vendored header");
+    write_base_file(&base, out_nested, b"original vendored conf");
+    write_base_file(&base, stamp, b"cargo:rustc-link-lib=ssh2");
+    write_base_file(&base, build_script, b"build script binary");
+
+    seed_cargo_target_dir_with_options(&base, &run, &CargoTargetSeedOptions::new(4))
+        .expect("seed target dir");
+
+    // Every rewritable build-script path must own a private inode...
+    for path in [out_header, out_nested, stamp] {
+        assert_different_inode(&base.join(path), &run.join(path));
+    }
+    // ...while the immutable build script itself stays hardlinked, so the
+    // carve-out did not quietly convert the heavy part of `build/` into copies.
+    let base_script = fs::metadata(base.join(build_script)).expect("base build script");
+    let run_script = fs::metadata(run.join(build_script)).expect("run build script");
+    assert_eq!(
+        (base_script.dev(), base_script.ino()),
+        (run_script.dev(), run_script.ino()),
+        "the compiled build script is immutable and must still be hardlinked"
+    );
+
+    // Reproduce what a re-running `-sys` build script actually does: `fs::copy`
+    // a vendored source over the seeded OUT_DIR path.
+    let vendored = tmp.path().join("vendored-libssh2.h");
+    fs::write(&vendored, b"regenerated vendored header").expect("write vendored source");
+    fs::copy(&vendored, run.join(out_header)).expect(
+        "a re-running build script must be able to fs::copy over its own seeded OUT_DIR payload",
+    );
+
+    assert_eq!(
+        fs::read(run.join(out_header)).expect("read rewritten run payload"),
+        b"regenerated vendored header"
+    );
+    // The shared warm base that every other task-run pod seeds from is untouched.
+    assert_eq!(
+        fs::read(base.join(out_header)).expect("read base payload"),
+        b"original vendored header",
+        "rewriting the run dir must not write through into the shared warm base"
+    );
+}
+
+#[test]
+fn copied_entries_present_the_same_age_as_hardlinked_ones() {
+    // A hardlink carries the base's mtime for free because it IS the same inode.
+    // `fs::copy` does not copy timestamps, so without an explicit restore every
+    // `Copy`-classified entry would land with a SEED-time mtime while its
+    // `Hardlink`-classified neighbours kept their WARM-time mtime. Cargo's
+    // `StaleDependency` check is a raw mtime comparison, so that split makes
+    // freshly-seeded metadata look newer than the artifacts it describes and
+    // triggers broad, ordering-dependent spurious rebuilds — trading one failure
+    // for another. Every seeded path must present the base's age, whichever arm
+    // produced it.
+    let _guard = metric_test_guard();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("warm-base");
+    let run = tmp.path().join("run-target");
+
+    let copied = Path::new("debug/build/libssh2-sys-abc/out/libssh2.h");
+    let stamp = Path::new("debug/build/libssh2-sys-abc/output");
+    let fingerprint = Path::new("debug/.fingerprint/foo-abc/lib-foo.json");
+    let dep_info = Path::new("debug/deps/foo.d");
+    let rustc_info = Path::new(".rustc_info.json");
+    let linked = Path::new("debug/deps/libserde-abc.rlib");
+
+    for path in [copied, stamp, fingerprint, dep_info, rustc_info, linked] {
+        write_base_file(&base, path, b"warm artifact");
+    }
+
+    // Age the whole base well past any clock granularity the seed could
+    // accidentally reproduce, so an unpreserved mtime cannot coincidentally pass.
+    let warm_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_600_000_000);
+    for path in [copied, stamp, fingerprint, dep_info, rustc_info, linked] {
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(base.join(path))
+            .expect("open base file to age it");
+        file.set_times(fs::FileTimes::new().set_modified(warm_time))
+            .expect("age base file");
+    }
+
+    seed_cargo_target_dir_with_options(&base, &run, &CargoTargetSeedOptions::new(4))
+        .expect("seed target dir");
+
+    for path in [copied, stamp, fingerprint, dep_info, rustc_info] {
+        assert_eq!(
+            classify_cargo_target_path(path),
+            CloneAction::Copy,
+            "{} must be a copy for this test to prove anything",
+            path.display()
+        );
+        // NON-VACUITY: a copy really did produce a private inode, so the mtime
+        // below is preserved rather than merely inherited from a shared one.
+        assert_different_inode(&base.join(path), &run.join(path));
+        assert_eq!(
+            fs::metadata(run.join(path))
+                .expect("seeded metadata")
+                .modified()
+                .expect("seeded mtime"),
+            warm_time,
+            "copied entry {} must present the base's mtime, not the seed's",
+            path.display()
+        );
+    }
+
+    // The hardlinked majority it has to stay consistent with.
+    assert_eq!(
+        fs::metadata(run.join(linked))
+            .expect("linked metadata")
+            .modified()
+            .expect("linked mtime"),
+        warm_time
+    );
 }
 
 #[test]


### PR DESCRIPTION
## The shared warm base is being corrupted right now

Verified on the production node: **9 zero-byte files in the shared per-project warm base. Every one of them is under `debug/build/*/out/`. Every one of them is `nlink=2`** — including `build/libssh2-sys-*/out/include/libssh2.h`.

`nlink=2` is the whole story: those inodes are shared with a per-task-run target dir, and something in a run dir emptied them. Cargo's fingerprints still consider the affected units fresh, so nothing ever regenerates them. This is the mechanism behind the coordinator reporting that the warm base has stopped re-converging.

## How zero bytes get there

`server/crates/djinn-agent-worker/src/cargo_target_seed.rs` seeds a private per-task-run target dir from the shared warm base. `classify_cargo_target_path` carves out three known "rewritten in place" hazards — `incremental/**`, the cargo lock files, `.rustc_info.json` — each with a comment describing a past incident. It misses a fourth: build-script `OUT_DIR` payloads (`debug/build/<pkg>-<hash>/out/**`) fall through to the default `Hardlink` arm.

`-sys` crates populate `OUT_DIR` with `std::fs::copy`. On Unix that opens the destination `O_CREAT|O_TRUNC` and only **then** `fchmod`s it to the source's mode, propagating the error (`open_to_and_set_permissions` in `std::sys::fs::unix` — the `writer.set_permissions(perm)?` after the truncating open). Through a hardlink, that one sequence fails twice:

1. **The truncation lands through the link, into the shared base.** This is the 9 zero-byte files. It is silent and permanent.
2. **The `fchmod` then fails EPERM**, because inode-metadata ops are owner-gated and a hardlinked entry keeps the base's owner. `libssh2-sys/build.rs:54` does `fs::copy(...).unwrap()`, so the compile dies.

The build failure and the base corruption are the same syscall sequence, in that order. The loud half is the second one; the damaging half already happened.

## This is NOT fixed by aligning uids — that would make it silent

Worth being explicit, because the EPERM in (2) looks like an ownership bug and invites exactly the wrong patch.

Four distinct uids touch this tree: the base inodes are owned by uid 10001 (legacy), the warm pod now runs as 1000 (`warm_job.rs`), the seeder is 1000 (`WORKER_UID`), and cargo and its build scripts run as **1001** (`CHILD_UID`, gid 1000). Aligning them makes the `fchmod` succeed — and on a hardlinked entry that converts a loud panic into a **silent, complete overwrite of the shared base**. Strictly worse than what we have.

Ownership alignment is separately planned work, and it is only safe *after* this change. Not sharing rewritable state by inode is the fix for the corruption; ownership is not.

Corollary, stated plainly: **this PR does not on its own fix the `libssh2-sys` build-script panic.** A copied destination is owned by uid 1000 and the build script still runs as 1001, so the `fchmod` is still EPERM. What this PR does is make the truncation land on a private inode, so the failure can no longer damage anything outside the run that caused it. The panic goes away when the uid work lands on top.

## The change

- Classify `build/<pkg>-<hash>/out/**` and the in-place stamps (`output`, `stderr`, `root-output`, `invoked.timestamp`) as `Copy`.
- Matching is **positional** (`build/*/out`), not "has a component named `out`", so an unrelated artifact is not swept in and silently converted from a hardlink into a byte copy. There is a test for the over-sweep specifically.
- `build-script-build` executables stay hardlinked: cargo replaces them by rename, never in place, and they are the heavy part of `build/`.
- **Preserve source atime/mtime on every copied entry, in both copy arms.** A hardlink carries the base's mtime for free because it *is* the same inode; `fs::copy` does not copy timestamps. Without this, copied entries land with seed-time mtimes while their hardlinked neighbours keep warm-time mtimes — and cargo's `StaleDependency` check is a raw mtime comparison, so the fix would trade base corruption for broad, ordering-dependent spurious rebuilds. Times are applied last, after `ensure_owner_writable`, because chmod bumps ctime and the handle needs the write bit. Best-effort like the surrounding metadata fix-ups: a stale timestamp costs a rebuild, not an artifact.
- Correct the module doc's identity claims, which were stale in both directions (it said the base is written by uid 10001 and read by 1000, and did not mention 1001 at all).

**Measured cost:** 2374 files, **0.16 GiB per run**, against an existing 2 GiB fallback-copy budget. Effectively free.

## Look hardest at the `foreign_owner_tests` fixture change

This is the part of the diff that could quietly remove coverage, so it deserves the most review attention.

That fixture previously used build-script `OUT_DIR` payloads as its **only** unlinkable entries. Reclassifying them to `Copy` means they never reach `linkat` at all — so this change would have silently retired the entire link-fallback code path from testing while every test stayed green. The fixture gains ordinary compiled artifacts at `0644`/`0444`/`0755` (the shape a base built under `umask 022` produces across `deps/`) so the fallback path is still exercised on its own merits.

The symlink fixture moves out of a build-script dir for the same class of reason: under the new classification, its `CloneAction::Copy` assertion would have passed even with symlink handling deleted entirely.

## Verification

`SQLX_OFFLINE=true cargo test -p djinn-agent-worker --lib -- --test-threads=1` — 48 passed, 0 failed. `cargo fmt --check` clean; `cargo clippy --all-targets` clean for this crate (the 2 remaining warnings are pre-existing in `djinn-db`).

Verified by neutralization, not just by green:

- **Disabling the classification arm alone** fails `classifies_build_script_output_for_copy`, `classifies_build_script_stamps_for_copy`, `build_script_output_is_privately_owned_and_rewritable_without_touching_the_base` (on the inode assertion, before it even reaches the base-contents assertion), and the new mtime test (on its non-vacuity guard).
- **Disabling `preserve_source_times` alone** fails both new mtime tests — one per copy arm: `copied_entries_present_the_same_age_as_hardlinked_ones` (classification copy) and `degraded_copies_present_the_same_age_as_the_links_they_substitute_for` (link-fallback copy). Both report a seed-time mtime against the expected warm-time one.

Every other failure in those two runs was the shared telemetry mutex poisoning after the first panic; each passes when run individually. Triage the first failure.

The load-bearing test is the side-effect one: it seeds a payload, rewrites it the way a re-running build script does, and asserts the warm base is byte-for-byte unchanged. It fails deterministically under the old classification on any uid — unlike the EPERM half, which only reproduces against a genuinely foreign-owned base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
