### PR TITLE
fix(cargo-cache): align every cargo-cache content creator on uid 1001 (warm pod + brokered seed)

### DIFF
--- a/docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md
+++ b/docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md
@@ -1,0 +1,318 @@
+# Cargo cache ownership migration — one-time operator runbook
+
+**Do not run any of this until BOTH of the following have merged and are running
+in the cluster:**
+
+| PR | What it changes |
+|----|-----------------|
+| #2658 | `cargo_target_seed` stops hardlinking build-script `OUT_DIR` into the warm base |
+| this PR | the warm Job runs as uid `1001`; the task-run seed is performed through the broker at uid `1001` |
+
+Running the `chown` before those land moves the base to an ownership no running
+pod has, which is strictly worse than the mixed state it is in today. Running it
+after is what makes both changes take effect on the *existing* 27 GiB base
+instead of only on newly created files.
+
+This is a **one-time** migration. Nothing in the codebase performs it, and
+nothing should: a recursive `chown` over a multi-tens-of-GiB PVC is a
+multi-minute stall, which is exactly why the Pod render pins
+`fsGroupChangePolicy: OnRootMismatch` and why
+`djinn_agent_worker::volume_contract` never repairs.
+
+---
+
+## Why
+
+Two operation classes behave differently on a shared POSIX tree, and conflating
+them is what produced the current state:
+
+| Operation class | Examples | Governed by |
+|-----------------|----------|-------------|
+| directory-entry | `creat`, `unlink`, `rename`, `linkat` | the **directory's** mode |
+| content | `open(O_TRUNC)`, `write`, `truncate` | the **file's** mode |
+| **inode metadata** | **`chmod`, `chown`, `utimensat` with explicit times** | **ownership, and nothing else** |
+
+The first two work cross-identity through gid `1000` + setgid + `g+w`, which is
+what the existing volume-ownership contract establishes and what
+`docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md` documents.
+
+The third does not, and cannot be made to. The kernel refuses `chmod` to a
+non-owner with `EPERM` **even when the requested mode is byte-identical to the
+current one**. No mode bit, no setgid bit, no POSIX ACL and no group membership
+delegates it.
+
+`std::fs::copy` always ends in `set_permissions`. So:
+
+* a **build script** (uid `1001`, always — cargo runs as the launcher-spawned
+  child) that copies its output over a seeded destination owned by uid `1000`
+  writes the bytes and then fails at the final `chmod`;
+* the **warm pod's** post-cycle `g+w` normalization pass
+  (`volume_contract::normalize_warm_base_regular_files`) can only chmod files it
+  owns.
+
+The target state is therefore **two identities**, not one:
+
+> Every actor that **creates content** in `/cache/cargo-target*` is uid `1001`.
+> Actors that only manage **lifecycle** (create / delete / rename / readdir)
+> stay where they are and work through gid `1000` + setgid + `g+w`.
+
+| Actor | uid | Role after this migration |
+|-------|-----|---------------------------|
+| warm Job pod | `1001` | content creator |
+| task-run cargo + build scripts | `1001` | content creator |
+| task-run cargo-target **seed** | `1001` | content creator (brokered) |
+| task-run worker process | `1000` | lifecycle only (creates/removes run dirs) |
+| djinn-server / coordinator | `10001` | lifecycle only (`.warm-locks`, `.djinn-gc.lock`, prune, `read_dir`, `statvfs`) |
+
+`djinn-server` deliberately does **not** move. It has no `chown` call site
+anywhere in the Rust tree, and the only two `chmod` sites are in the worker.
+
+---
+
+## Measured starting state
+
+Taken from the production k3s cluster (`kubectl -n djinn exec djinn-server-… -c
+djinn-server`), project `019ea3bd-a305-73e3-806c-4edcc96ebfe2`, variant
+`mold-jobs-4`:
+
+```
+base size                              27 GiB
+total files                            16,138
+debug/build                            2,993 files / 522 MiB
+debug/.fingerprint                     7,270 files
+uid histogram (maxdepth 3)             6,794 × 10001,  2,422 × 1000
+zero-byte files under debug/build/*/out with nlink > 1        9
+roots                                  drwxrwsr-x 10001:1000   (setgid + g+w already correct)
+```
+
+Two things to read off that:
+
+* the group contract is **already satisfied** — this migration changes owners,
+  not modes;
+* the base is **mixed** `10001`/`1000`, not uniformly legacy. Neither identity
+  can chmod the other's inodes, so the normalization pass has been partial for
+  as long as both have existed.
+
+The 9 zero-byte `nlink>1` files under `debug/build/*/out/` are the corrupted
+units: a build-script `OUT_DIR` payload that was hardlinked into a private run
+dir and then truncated *through the link* into the shared base. Cargo's
+fingerprints still consider those units fresh, so nothing regenerates them.
+#2658 stops new ones being created; it does not repair the existing nine.
+
+---
+
+## Procedure
+
+### 0. Pre-flight
+
+```bash
+NS=djinn
+kubectl -n "$NS" get pvc                       # confirm the real cache claim name
+kubectl -n "$NS" get pods -l app.kubernetes.io/component=task-run
+kubectl -n "$NS" get jobs -l app.kubernetes.io/component=graph-warm
+```
+
+Confirm the deployed worker image already contains both PRs. If the running warm
+Job still renders `runAsUser: 1000`, stop — the image predates this change:
+
+```bash
+kubectl -n "$NS" get job -l app.kubernetes.io/component=graph-warm \
+  -o jsonpath='{.items[*].spec.template.spec.securityContext.runAsUser}'
+# expect: 1001
+```
+
+### 1. Quiesce
+
+Nothing may be writing the base while it is chowned. A warm Job mid-compile
+during the `chown` will emit `EPERM`s and can leave a half-written unit.
+
+```bash
+NS=djinn
+# Stop the coordinator so it dispatches no new task-runs or warm Jobs.
+kubectl -n "$NS" scale deploy/djinn --replicas=0
+
+# Drain what is already running. Task-runs seed and compile into
+# /cache/cargo-target-runs and read /cache/cargo-target.
+kubectl -n "$NS" delete jobs -l app.kubernetes.io/component=graph-warm --ignore-not-found
+kubectl -n "$NS" delete jobs -l app.kubernetes.io/component=task-run  --ignore-not-found
+
+# Wait for the pods to actually go away, not just for the Jobs to be marked.
+kubectl -n "$NS" wait --for=delete pod \
+  -l app.kubernetes.io/component=task-run --timeout=300s || true
+kubectl -n "$NS" get pods -l app.kubernetes.io/component=graph-warm
+```
+
+### 2. Delete the corrupted units
+
+The nine zero-byte `OUT_DIR` payloads are unrecoverable, and their fingerprints
+must go with them or cargo will keep treating the units as fresh.
+
+**Recommended (simpler, and defensible):** wipe all of `debug/build` plus every
+matching `debug/.fingerprint` entry. That is 2,993 files / 522 MiB out of a
+27 GiB base — about 2% — and it costs only the build-script re-runs, not a
+recompile of the workspace.
+
+**Targeted alternative:** delete only the nine and their fingerprints. It saves
+~500 MiB of rebuild and buys a much more delicate command; take it only if
+build-script re-runs are known to be expensive for this project.
+
+Both variants are inside the root pod below, which is the only context with
+enough privilege. Pick one and delete the other before running.
+
+### 3. The one-time chown, from a root pod
+
+`kubectl run --overrides` is the shape this cluster already uses for volume
+work (see `docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md`). Substitute the real
+claim name from step 0.
+
+```bash
+NS=djinn
+CACHE_PVC=djinn-cache        # <-- from `kubectl -n $NS get pvc`
+
+kubectl -n "$NS" run cargo-cache-ownership-fix --rm -i --restart=Never \
+  --image=busybox:1.36 \
+  --overrides='{
+    "spec": {
+      "securityContext": {"runAsUser": 0},
+      "containers": [{
+        "name": "fix",
+        "image": "busybox:1.36",
+        "command": ["sh", "-c", "set -eu\nB=/mnt/cache/cargo-target\n[ -d \"$B\" ] || { echo \"no cargo-target under $B\"; exit 1; }\n\necho \"== before ==\"\nfind \"$B\" -maxdepth 3 -printf \"%u\\n\" | sort | uniq -c\n\n# --- step 2: drop the corrupted build-script units -------------------\n# SIMPLE VARIANT (recommended): wipe debug/build + matching fingerprints.\nfor V in \"$B\"/*/mold-jobs-*; do\n  [ -d \"$V/debug/build\" ] || continue\n  echo \"pruning $V/debug/build\"\n  rm -rf \"$V/debug/build\"\n  rm -rf \"$V/debug/.fingerprint\"\ndone\n# TARGETED VARIANT (delete the block above and uncomment this instead):\n#for V in \"$B\"/*/mold-jobs-*; do\n#  find \"$V/debug/build\" -path \"*/out/*\" -type f -size 0 -links +1 2>/dev/null |\n#  while read -r F; do\n#    U=$(basename \"$(dirname \"$(dirname \"$F\")\")\")   # <pkg>-<hash>\n#    echo \"dropping unit $U (corrupt: $F)\"\n#    rm -rf \"$V/debug/build/$U\"\n#    rm -rf \"$V/debug/.fingerprint/${U%%-*}\"-*\n#  done\n#done\n\n# --- step 3: the one-time ownership move ----------------------------\necho \"chown -R 1001:1000 $B\"\nchown -R 1001:1000 \"$B\"\n\n# --- step 4: re-assert setgid on directories ------------------------\n# chown clears setuid/setgid on some filesystems; setgid is what makes new\n# files inherit gid 1000, so re-assert it unconditionally.\nchmod -R g+w \"$B\"\nfind \"$B\" -type d -exec chmod g+s {} +\n\necho \"== after ==\"\nfind \"$B\" -maxdepth 3 -printf \"%u %g %m\\n\" | sort | uniq -c\nls -land \"$B\"\necho done"],
+        "volumeMounts": [{"name": "cache", "mountPath": "/mnt/cache"}]
+      }],
+      "volumes": [{"name": "cache", "persistentVolumeClaim": {"claimName": "djinn-cache"}}]
+    }
+  }'
+```
+
+Notes:
+
+* `/cache/cargo-target-runs` is **not** touched. Run dirs are private,
+  short-lived, and recreated per task-run; the quiesce in step 1 already
+  removed the pods that owned them. If stale run dirs are present, delete them
+  outright rather than chowning them.
+* `chmod -R g+w` is safe here and is *not* the same as making files executable:
+  it only adds the group-write bit the contract already requires.
+* On a 27 GiB / 16k-file base this completes in well under a minute. It is the
+  `chown` walk that costs, and 16k inodes is small.
+
+### 4. Bring the cluster back
+
+```bash
+kubectl -n "$NS" scale deploy/djinn --replicas=1
+kubectl -n "$NS" rollout status deploy/djinn --timeout=300s
+```
+
+---
+
+## Do NOT do a cold re-warm instead
+
+Deleting `/cache/cargo-target` entirely and letting the next warm Job rebuild it
+is the cheap-looking option and it is a trap for this workspace.
+
+`warm_job.rs` documents a cold first warm at **~20–25 minutes for a ~12-crate
+workspace**, against `active_deadline_seconds` = `warm_job_timeout_seconds`
+(default **3600 s**) with **`backoffLimit: 0`**. The djinn `server/` workspace is
+~30 crates and its base measures 27 GiB. A cold warm that overruns the deadline
+is SIGKILLed mid-compile, the Job is not retried, and the next warm tick starts
+again from zero — an unbounded loop that never produces a base, while every
+task-run compiles cold in the meantime.
+
+The `chown` preserves the 27 GiB of already-compiled artifacts and costs under a
+minute. Take it.
+
+If a cold re-warm genuinely becomes unavoidable, raise
+`DJINN_K8S_WARM_JOB_TIMEOUT_SECONDS` **first** — the `warm_job_timeout_seconds`
+field doc in `djinn-k8s/src/config.rs` carries the full timing breakdown — and
+never trim the compile set to fit the deadline, which silently reduces what the
+base can seed.
+
+---
+
+## Verification
+
+### Immediately after step 4
+
+Ownership is uniform and the group contract is intact:
+
+```bash
+kubectl -n djinn exec deploy/djinn -c djinn-server -- sh -c '
+  B=/var/lib/djinn/cache/cargo-target
+  find "$B" -maxdepth 3 -printf "%u %g\n" | sort | uniq -c
+  ls -land "$B"'
+```
+
+Expect a single `1001 1000` row (plus the roots) and `drwxrwsr-x` — the `s` is
+the setgid bit; if it is missing, re-run the `find -type d -exec chmod g+s` from
+step 3.
+
+The worker's startup contract check must pass on the next pod. It fails closed,
+so a violation is loud:
+
+```bash
+kubectl -n djinn logs -l app.kubernetes.io/component=task-run -c worker --tail=200 \
+  | grep -E 'volume permission contract'
+# expect: "volume permission contract satisfied"
+# a violation logs "volume permission contract VIOLATED" with kind= and path=
+```
+
+### After the first warm Job completes
+
+The normalization pass now owns everything it walks, so `files_unchangeable`
+must be `0`:
+
+```bash
+kubectl -n djinn logs -l app.kubernetes.io/component=graph-warm --tail=-1 \
+  | grep 'normalized group-write mode'
+# expect: files_unchangeable=0
+# a non-zero value means some inode is still owned by another uid — re-run step 3
+```
+
+### After the first task-run
+
+The seed must report that it ran as the child, not the worker:
+
+```bash
+kubectl -n djinn logs -l app.kubernetes.io/component=task-run -c worker --tail=-1 \
+  | grep -E 'cargo target seed'
+# expect: "seeded at the cargo/build-script uid through the broker"  (seed_identity=child)
+# a line carrying brokered_seed_degradation=<reason> means it fell back to the
+# in-worker path — the run still succeeds, but the ownership fix is not in force
+# for that run. The reason names which of no_broker / disabled_by_env /
+# executable_unresolved / launch_failed / non_zero_exit / unparseable_summary.
+```
+
+### Within 24 h — the staleness alarm must clear
+
+`djinn-coordinator`'s cargo cache health sweep warns once a base has gone
+`WARM_BASE_STALE_AFTER_SECONDS` (24 h) without a rewrite. That is the only
+signal for "warming stopped happening": seeding still reports `hit`, disk usage
+is unchanged, and no warm Job fails.
+
+```bash
+kubectl -n djinn logs deploy/djinn --tail=-1 | grep 'cargo cache health'
+# the INFO line carries warm_base_age_seconds — it must DROP after each warm Job
+# the WARN "warm base has stopped re-converging" must stop appearing
+```
+
+If `warm_base_age_seconds` keeps climbing past 86,400 after the migration,
+warming is not running at all and the problem is upstream of this runbook —
+check that warm Jobs are being created and are not being 422'd at admission.
+
+---
+
+## Rollback
+
+There is no partial rollback of the `chown` itself; it is idempotent and can be
+re-run with a different target if needed. What can be rolled back independently:
+
+* **the brokered seed** — set `DJINN_CARGO_TARGET_SEED_BROKERED=0` in the
+  task-run worker environment. The seed reverts to the in-process uid-1000 path
+  with no redeploy. Build scripts that copy over seeded entries can then fail at
+  their final `chmod` again, which is the pre-change behaviour;
+* **the warm pod uid** — reverting this PR's `warm_job.rs` change puts warm back
+  at uid 1000. If the `chown` has already run, the warm pod can no longer chmod
+  the base it inherits, so do this only together with a `chown -R 1000:1000`.
+
+Reverting only #2658 while leaving this PR in place is **not** safe: the
+hardlink-into-base behaviour it removes is what creates new corrupted units.

--- a/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
+++ b/docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md
@@ -6,8 +6,21 @@ identities**:
 | Identity | Who | Where |
 |----------|-----|-------|
 | uid `10001` | `djinn-server` | `/var/lib/djinn/{mirrors,cache,projects}` |
-| uid/gid `1000` | task-run + warm Job worker | `/workspace`, `/cache`, `/mirror` |
-| uid `1001`, primary group `1000` | the launcher-spawned child (compiles, tests) | `/workspace`, `/cache` |
+| uid/gid `1000` | the task-run **worker process** | `/workspace`, `/cache`, `/mirror` |
+| uid `1001`, primary group `1000` | the launcher-spawned child (compiles, tests, **and the cargo-target seed**) and the **warm Job pod** | `/workspace`, `/cache` |
+
+> **The group carries directory-entry and content operations. It does not carry
+> inode metadata.** `chmod`, `chown` and `utimensat` with explicit times are
+> governed by **ownership alone** — `EPERM` to a non-owner even for a
+> byte-identical mode, with no mode bit, setgid bit, ACL or group membership able
+> to delegate them. Since `std::fs::copy` ends in `set_permissions`, every actor
+> that **creates content** in `/cache/cargo-target*` must be the same uid, and
+> that uid is `1001` because cargo and its build scripts are always the
+> launcher-spawned child. That is why the warm Job runs as `1001` and why the
+> task-run seed goes through the broker. Actors that only manage **lifecycle**
+> (create / delete / rename / readdir) stay where they are. Moving an existing
+> base to that state is a one-time operator action:
+> `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md`.
 
 They can only share those volumes under one contract:
 
@@ -103,7 +116,8 @@ base*. This happened while preparing the v0.7.0 deploy — 13,512 files owned by
 |-------|-----------|
 | Fresh install | The chart's `fix-volume-perms` initContainer normalizes the three volume **roots** to `ownerUid:artifactGid` with `chmod 2775` (setgid + `g+w`). O(1), idempotent, **never recursive**. |
 | Server access | The server pod gets `securityContext.supplementalGroups: [1000]` — membership in the artifact group with zero filesystem work. |
-| Worker/warm pods | The Pod render pins `fsGroup: 1000` + `fsGroupChangePolicy: OnRootMismatch` and runs as uid/gid `1000` (task-run **and** warm — they share `/cache`). |
+| Task-run pods | The Pod render pins `fsGroup: 1000` + `fsGroupChangePolicy: OnRootMismatch` and runs the worker container as uid/gid `1000`. The worker only manages lifecycle in the cargo trees; cargo, its build scripts and the cargo-target seed all run as the launcher-spawned child at uid `1001`. |
+| Warm pods | Same `fsGroup` + `fsGroupChangePolicy`, but `runAsUser: 1001` (`CHILD_UID`) — the warm pod **creates content** in the shared cargo base, so it must be the same uid as the build scripts that later copy over it. A warm Job renders no launcher sidecar and no broker socket, so this does not touch the worker/child security boundary (asserted by `warm_pod_never_renders_a_launcher_sidecar`). |
 | Runtime | `djinn-agent-worker` validates the **actually mounted** roots at startup (`volume_contract`) and fails readiness with a typed error naming the path and observed-versus-required ownership/mode. |
 
 The startup check stats the workspace, the git metadata (`<workspace>/.git` and
@@ -118,10 +132,22 @@ checks a *sample of the subtree*, not just the root, because the exact
 production near-miss had a hand-fixed root over a broken subtree. A passing
 sample (production has reported `entries_sampled=512, budget_exhausted=true`)
 is not proof that every warm-base file conforms. The warm worker therefore does
-the authoritative full regular-file mode normalization after each Cargo cycle;
-the startup check **never repairs** — a recursive `chown` over a 300G cache is a
-multi-minute stall on pod start, which is the whole reason
-`fsGroupChangePolicy` is `OnRootMismatch`.
+a full regular-file mode normalization after each Cargo cycle; the startup check
+**never repairs** — a recursive `chown` over a 300G cache is a multi-minute
+stall on pod start, which is the whole reason `fsGroupChangePolicy` is
+`OnRootMismatch`.
+
+That normalization is **authoritative only over the files the warm pod owns**,
+and saying otherwise was wrong for as long as the sentence existed. `chmod` is
+granted by ownership, not by mode: a warm pod cannot add `g+w` to a file another
+uid created, however conforming the directory is. A live production base
+measured **6,794 files owned by uid `10001` against 2,422 owned by `1000`** —
+neither identity could chmod the other's inodes, so the pass had always been
+partial. It reports that honestly: `files_unchangeable` counts the refusals and
+`first_chmod_error` names the first path, and a refusal does not abort the walk
+(it used to, via `?`, which meant one foreign-owned file left every later file
+unnormalized). `files_unchangeable > 0` after a warm cycle means
+`docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md` has not been run yet.
 
 ## `$HOME` is part of the startup check too (9jrg)
 
@@ -232,10 +258,20 @@ Substitute the real claim names (`kubectl -n "$NS" get pvc`) — they differ whe
 `storage.*.existingClaim` is set. On a large cache this takes minutes; that is
 exactly why it is an operator action and not something a pod does at startup.
 
-Cheaper alternative when only the cache is broken: delete the Cargo warm base
-(`/cache/cargo-target`, `/cache/cargo-target-runs`) and let the next warm Job
-rebuild it under the correct ownership. It costs one cold warm cycle and no
+Cheaper-looking alternative when only the cache is broken: delete the Cargo warm
+base (`/cache/cargo-target`, `/cache/cargo-target-runs`) and let the next warm
+Job rebuild it under the correct ownership. It costs one cold warm cycle and no
 `chown` walk.
+
+**Do not take that option for a large Rust workspace.** `warm_job.rs` documents
+a cold first warm at ~20–25 min for a ~12-crate workspace against a 3600 s
+`active_deadline_seconds` with `backoffLimit: 0`; djinn's own `server/`
+workspace is ~30 crates and its base measures 27 GiB. A cold warm that overruns
+the deadline is SIGKILLed mid-compile, is not retried, and the next warm tick
+starts from zero — an unbounded loop that never produces a base while every
+task-run compiles cold. Prefer the targeted `chown` in
+`docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md`, which preserves the compiled
+artifacts and completes in under a minute on 16k inodes.
 
 ### Break-glass
 

--- a/docs/deploy/configuration.md
+++ b/docs/deploy/configuration.md
@@ -162,11 +162,14 @@ recreating/migrating the claim.
 
 ### Ownership contract
 
-All three volumes are written by the server (uid `10001`) *and* by task-run /
-warm Job Pods (uid/gid `1000`, plus the launcher-spawned child at uid `1001`
-with primary group `1000`). Sharing them requires group ownership by the
-artifact GID, group-write, and setgid on directories so new files inherit the
-group:
+All three volumes are written by the server (uid `10001`), by the task-run
+worker process (uid/gid `1000`), and by the launcher-spawned child — cargo, its
+build scripts and the cargo-target seed — at uid `1001` with primary group
+`1000`. The warm Job Pod also runs as uid `1001`, because it *creates content*
+in the shared cargo base and `chmod` is granted by ownership alone, not by mode
+(see `docs/VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md`). Sharing these volumes
+requires group ownership by the artifact GID, group-write, and setgid on
+directories so new files inherit the group:
 
 ```yaml
 storage:

--- a/server/crates/djinn-agent-worker/src/brokered_cargo_target_seed.rs
+++ b/server/crates/djinn-agent-worker/src/brokered_cargo_target_seed.rs
@@ -1,0 +1,469 @@
+//! Perform the task-run Cargo target seed **as the launcher-spawned child**
+//! (uid 1001) instead of in the worker process (uid 1000).
+//!
+//! # The defect this closes
+//!
+//! Directory-entry operations (`create` / `unlink` / `rename` / `linkat`) are
+//! governed by the DIRECTORY's permissions, and content operations
+//! (`open(O_TRUNC)` / `write` / `truncate`) by the FILE's. So gid 1000 plus
+//! setgid plus `g+w` genuinely lets the worker (1000) and cargo (1001) share the
+//! cargo trees for those.
+//!
+//! Inode-METADATA operations — `chmod`, `chown`, `utimensat` with explicit
+//! times — are governed by **ownership only**. The kernel returns `EPERM` to a
+//! non-owner even when the requested mode is byte-identical to the current one,
+//! and no mode bit, setgid bit, ACL or group membership can delegate them.
+//!
+//! `std::fs::copy` always ends in `set_permissions`. So when the uid-1000
+//! worker seeds a `Copy`-classified entry into the private run dir, the
+//! resulting inode is owned by 1000 — and the build script that later
+//! `fs::copy`s its output over that same path runs as 1001 and fails at the
+//! final `chmod`, with the bytes already written. Build-script `OUT_DIR`
+//! payloads are exactly the class the seeder copies rather than hardlinks
+//! (see `cargo_target_seed`'s module docs), so this is not an edge case.
+//!
+//! Performing the seed at 1001 makes the seeded inodes born owned by the
+//! identity that will later overwrite them, and the `chmod` succeeds because
+//! the copier is the owner.
+//!
+//! # Why `bash -lc`, and not a widened program prefix list
+//!
+//! `djinn_cgroup_launcher::command_path::safe_command_path` admits `/bin/`,
+//! `/usr/bin/` and `/workspace/` programs; `/opt/djinn/bin` is deliberately not
+//! on the list, and its module docs record that decision as a posture rather
+//! than an oversight (widening it would advertise a provenance guarantee that
+//! does not exist, since the one program a brokered command names is a shell
+//! which then resolves everything else itself). Every brokered command in this
+//! repo already goes through `bash -lc`. This one does too — no posture change,
+//! no new pinned-decision test to rewrite.
+//!
+//! # Degradation is mandatory, not optional
+//!
+//! Brokering the seed puts it behind the build-lease admission path. A LOST
+//! QUEUE is already safe: `LeaseInvocationRunner` degrades that to unleased
+//! execution and the child still runs to completion. What is not safe is
+//! treating a broker-level failure (socket gone, launch refused, reap failed)
+//! as fatal — that would convert a launcher problem into a failed dispatch for
+//! every task-run in the fleet. So every failure here, including a non-zero
+//! exit and an unparseable summary, falls back to the in-worker seed that
+//! shipped before this change. [`BROKERED_SEED_ENV`] turns the whole path off
+//! without a redeploy.
+//!
+//! # Why `djinn_sandbox::SANDBOX.apply` is deliberately not called
+//!
+//! The tool-facing shell path applies it; this one does not, and adding it
+//! would be cargo-culting. `LandlockSandbox::apply` installs its ruleset through
+//! `Command::pre_exec`, and `pre_exec` is a closure in THIS process — it cannot
+//! cross the broker, which reconstructs the child from a `CommandSpec`
+//! (program, argv, cwd, environment) inside the launcher. So on the brokered
+//! path the Landlock policy is not applied whether it is requested or not
+//! (`prepare_child` installs no Landlock either; its confinement is uid 1001,
+//! no capabilities, `no_new_privs`, a seccomp deny-list, the cgroup leaf, the
+//! mount namespace and the closed environment allow-list).
+//!
+//! The only part of `apply` that would survive is its `TMPDIR` override, and the
+//! seed writes no temporary files — it links and copies straight into the
+//! destination. Calling it would therefore change nothing except to imply a
+//! confinement that is not in force. The seed is also not agent-authored code:
+//! it is this binary, invoked with two paths the worker computed.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::cargo_target_seed::{CargoTargetSeedFallback, CargoTargetSeedResult};
+
+/// Env switch: set to `0`/`false`/`off` to skip the brokered seed and use the
+/// in-worker path. Operator break-glass; the default is on.
+pub const BROKERED_SEED_ENV: &str = "DJINN_CARGO_TARGET_SEED_BROKERED";
+
+/// Env override for the brokered seed's wall-clock budget, in seconds.
+pub const BROKERED_SEED_TIMEOUT_ENV: &str = "DJINN_CARGO_TARGET_SEED_TIMEOUT_SECONDS";
+
+/// Default wall-clock budget for the brokered seed.
+///
+/// The measured production base is ~27 GiB / ~16k files and the seed is
+/// overwhelmingly `linkat`, not byte copies, so this is generous by an order of
+/// magnitude. It exists so a wedged broker cannot hold a task-run open
+/// indefinitely — on expiry the invocation is terminated and the in-worker path
+/// takes over.
+pub const DEFAULT_BROKERED_SEED_TIMEOUT: Duration = Duration::from_secs(900);
+
+/// Line prefix the seed subcommand writes its machine-readable summary under.
+///
+/// A prefix rather than "parse the whole of stdout" because the child runs
+/// under `bash -lc`, and a login shell's profile scripts are free to print
+/// whatever they like before the program starts.
+pub const SEED_RESULT_PREFIX: &str = "DJINN_CARGO_TARGET_SEED_RESULT ";
+
+/// Why the brokered seed did not produce the result, so the caller can name the
+/// degradation in one structured field instead of a free-text blob.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BrokeredSeedDegradation {
+    /// No broker: the launcher is disabled or the handshake did not happen.
+    NoBroker,
+    /// [`BROKERED_SEED_ENV`] disabled the path.
+    DisabledByEnv,
+    /// `current_exe()` could not be resolved, so no program could be named.
+    ExecutableUnresolved,
+    /// The broker could not launch or reap the child at all.
+    LaunchFailed,
+    /// The child ran and exited non-zero.
+    NonZeroExit,
+    /// The child exited 0 but emitted no parseable summary line.
+    UnparseableSummary,
+}
+
+impl BrokeredSeedDegradation {
+    /// Stable low-cardinality label for logs and metrics.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoBroker => "no_broker",
+            Self::DisabledByEnv => "disabled_by_env",
+            Self::ExecutableUnresolved => "executable_unresolved",
+            Self::LaunchFailed => "launch_failed",
+            Self::NonZeroExit => "non_zero_exit",
+            Self::UnparseableSummary => "unparseable_summary",
+        }
+    }
+}
+
+/// Whether the brokered seed path is enabled by the environment.
+pub fn brokered_seed_enabled() -> bool {
+    match std::env::var(BROKERED_SEED_ENV) {
+        Ok(raw) => !matches!(
+            raw.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        Err(_) => true,
+    }
+}
+
+/// Wall-clock budget for the brokered seed.
+pub fn brokered_seed_timeout() -> Duration {
+    std::env::var(BROKERED_SEED_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|seconds| *seconds > 0)
+        .map_or(DEFAULT_BROKERED_SEED_TIMEOUT, Duration::from_secs)
+}
+
+/// Single-quote `value` for a POSIX shell.
+///
+/// The paths involved are uuid-derived today, but a project id is
+/// operator-supplied and this string is handed to `bash -lc`; quoting it is the
+/// difference between a path and a command.
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r"'\''"))
+}
+
+/// Build the `bash -lc` command that runs the seed subcommand in the child.
+///
+/// `cwd` must be `/workspace` or beneath — `safe_command_path(_, cwd: true)`
+/// refuses anything else, and `spawn.rs` `chdir`s there before `execve`.
+pub fn build_seed_command(exe: &Path, base: &Path, run_dir: &Path, cwd: &Path) -> Command {
+    let script = format!(
+        "exec {exe} seed-cargo-target --base {base} --run-dir {run_dir}",
+        exe = shell_quote(&exe.display().to_string()),
+        base = shell_quote(&base.display().to_string()),
+        run_dir = shell_quote(&run_dir.display().to_string()),
+    );
+    let mut command = Command::new("bash");
+    command.arg("-lc").arg(script).current_dir(cwd);
+    command
+}
+
+/// The seed result as it crosses the process boundary.
+///
+/// A dedicated DTO rather than `serde` on [`CargoTargetSeedResult`]: the wire
+/// shape is this module's concern, and the seed module's type is consumed by
+/// telemetry and log call sites that must stay free to change independently.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SeedWireResult {
+    pub elapsed_ms: u64,
+    pub linked_file_count: u64,
+    pub copied_file_count: u64,
+    pub skipped_file_count: u64,
+    pub linked_bytes: u64,
+    pub copied_bytes: u64,
+    pub degraded_link_file_count: u64,
+    pub unseeded_file_count: u64,
+    pub base_seedable_file_count: u64,
+    pub link_fallback_budget_exhausted: bool,
+    pub first_entry_error: Option<String>,
+    pub fallback: Option<WireFallback>,
+}
+
+/// Wire form of [`CargoTargetSeedFallback`]: a stable tag plus its detail
+/// string, so a new variant on either side degrades to a named unknown instead
+/// of a parse failure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WireFallback {
+    pub kind: String,
+    pub detail: String,
+}
+
+impl From<&CargoTargetSeedResult> for SeedWireResult {
+    fn from(result: &CargoTargetSeedResult) -> Self {
+        Self {
+            elapsed_ms: u64::try_from(result.elapsed.as_millis()).unwrap_or(u64::MAX),
+            linked_file_count: result.linked_file_count,
+            copied_file_count: result.copied_file_count,
+            skipped_file_count: result.skipped_file_count,
+            linked_bytes: result.linked_bytes,
+            copied_bytes: result.copied_bytes,
+            degraded_link_file_count: result.degraded_link_file_count,
+            unseeded_file_count: result.unseeded_file_count,
+            base_seedable_file_count: result.base_seedable_file_count,
+            link_fallback_budget_exhausted: result.link_fallback_budget_exhausted,
+            first_entry_error: result.first_entry_error.clone(),
+            fallback: result.fallback_reason.as_ref().map(|reason| match reason {
+                CargoTargetSeedFallback::BaseMissing => WireFallback {
+                    kind: "base_missing".into(),
+                    detail: String::new(),
+                },
+                CargoTargetSeedFallback::BaseNotDirectory => WireFallback {
+                    kind: "base_not_directory".into(),
+                    detail: String::new(),
+                },
+                CargoTargetSeedFallback::BaseUnusable(detail) => WireFallback {
+                    kind: "base_unusable".into(),
+                    detail: detail.clone(),
+                },
+                CargoTargetSeedFallback::ScanFailed(detail) => WireFallback {
+                    kind: "scan_failed".into(),
+                    detail: detail.clone(),
+                },
+                CargoTargetSeedFallback::CloneFailed(detail) => WireFallback {
+                    kind: "clone_failed".into(),
+                    detail: detail.clone(),
+                },
+            }),
+        }
+    }
+}
+
+impl From<SeedWireResult> for CargoTargetSeedResult {
+    fn from(wire: SeedWireResult) -> Self {
+        Self {
+            elapsed: Duration::from_millis(wire.elapsed_ms),
+            linked_file_count: wire.linked_file_count,
+            copied_file_count: wire.copied_file_count,
+            skipped_file_count: wire.skipped_file_count,
+            linked_bytes: wire.linked_bytes,
+            copied_bytes: wire.copied_bytes,
+            degraded_link_file_count: wire.degraded_link_file_count,
+            unseeded_file_count: wire.unseeded_file_count,
+            base_seedable_file_count: wire.base_seedable_file_count,
+            link_fallback_budget_exhausted: wire.link_fallback_budget_exhausted,
+            first_entry_error: wire.first_entry_error,
+            fallback_reason: wire.fallback.map(|fallback| match fallback.kind.as_str() {
+                "base_missing" => CargoTargetSeedFallback::BaseMissing,
+                "base_not_directory" => CargoTargetSeedFallback::BaseNotDirectory,
+                "base_unusable" => CargoTargetSeedFallback::BaseUnusable(fallback.detail),
+                "scan_failed" => CargoTargetSeedFallback::ScanFailed(fallback.detail),
+                "clone_failed" => CargoTargetSeedFallback::CloneFailed(fallback.detail),
+                unknown => CargoTargetSeedFallback::BaseUnusable(format!(
+                    "unrecognized fallback {unknown}: {}",
+                    fallback.detail
+                )),
+            }),
+        }
+    }
+}
+
+/// Render the summary line the seed subcommand prints on stdout.
+pub fn encode_seed_result(result: &CargoTargetSeedResult) -> String {
+    let wire = SeedWireResult::from(result);
+    format!(
+        "{SEED_RESULT_PREFIX}{}",
+        serde_json::to_string(&wire).unwrap_or_default()
+    )
+}
+
+/// Recover the seed result from the child's stdout, or `None` when no line
+/// carries a parseable summary.
+///
+/// Scans from the END: a login shell may print before the program runs, and if
+/// the payload itself ever contained an embedded newline the last complete
+/// line is the authoritative one.
+pub fn decode_seed_result(stdout: &str) -> Option<CargoTargetSeedResult> {
+    stdout
+        .lines()
+        .rev()
+        .filter_map(|line| line.strip_prefix(SEED_RESULT_PREFIX))
+        .find_map(|payload| serde_json::from_str::<SeedWireResult>(payload.trim()).ok())
+        .map(CargoTargetSeedResult::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn sample() -> CargoTargetSeedResult {
+        CargoTargetSeedResult {
+            elapsed: Duration::from_millis(4_321),
+            linked_file_count: 11,
+            copied_file_count: 5,
+            skipped_file_count: 3,
+            linked_bytes: 900,
+            copied_bytes: 40,
+            degraded_link_file_count: 2,
+            unseeded_file_count: 1,
+            base_seedable_file_count: 16,
+            link_fallback_budget_exhausted: true,
+            first_entry_error: Some("copy /a/b: EPERM".into()),
+            fallback_reason: Some(CargoTargetSeedFallback::ScanFailed("boom".into())),
+        }
+    }
+
+    /// The wire hop must be lossless: the parent records telemetry and emits
+    /// the coordinator-facing structured event from this value, so a field that
+    /// silently zeroes across the boundary is a silent metrics regression.
+    #[test]
+    fn the_seed_result_round_trips_through_the_child_stdout_line() {
+        let original = sample();
+        let line = encode_seed_result(&original);
+        let recovered =
+            decode_seed_result(&format!("some login-shell noise\n{line}\ntrailing noise\n"))
+                .expect("summary line is recoverable");
+        assert_eq!(recovered, original);
+    }
+
+    /// Neutralization guard: if the subcommand stops printing the summary, the
+    /// parent must NOT silently accept a zeroed result — it must see `None` and
+    /// degrade to the in-worker seed.
+    #[test]
+    fn stdout_without_a_summary_line_yields_no_result() {
+        assert!(decode_seed_result("").is_none());
+        assert!(decode_seed_result("cargo target seed: done\n").is_none());
+        assert!(
+            decode_seed_result(&format!("{SEED_RESULT_PREFIX}{{not json\n")).is_none(),
+            "a corrupt payload must not be mistaken for a successful seed"
+        );
+    }
+
+    /// The one program a brokered command may name is a shell, and the cwd must
+    /// be the workspace: `safe_command_path` refuses anything else, and the
+    /// launcher's refusal is a coarse `InvalidCommand` on the wire.
+    #[test]
+    fn the_brokered_command_names_a_shell_and_runs_in_the_workspace() {
+        let command = build_seed_command(
+            Path::new("/opt/djinn/bin/djinn-agent-worker"),
+            Path::new("/cache/cargo-target/p/mold-jobs-4"),
+            Path::new("/cache/cargo-target-runs/run-1"),
+            Path::new("/workspace"),
+        );
+        assert_eq!(command.get_program(), "bash");
+        assert_eq!(command.get_current_dir(), Some(Path::new("/workspace")));
+        let args: Vec<String> = command
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args[0], "-lc");
+        assert!(
+            args[1].contains("seed-cargo-target"),
+            "script must invoke the seed subcommand: {}",
+            args[1]
+        );
+        assert!(
+            args[1].contains("'/cache/cargo-target/p/mold-jobs-4'"),
+            "base must be quoted: {}",
+            args[1]
+        );
+        assert!(
+            args[1].contains("'/cache/cargo-target-runs/run-1'"),
+            "run dir must be quoted: {}",
+            args[1]
+        );
+        // `safe_command_path` admits `/bin/`, `/usr/bin/` and `/workspace/`
+        // programs only. Naming the worker binary directly would be refused,
+        // and widening that list is a posture change the launcher's own docs
+        // argue against.
+        assert!(
+            !djinn_cgroup_launcher::command_path::safe_command_path(
+                "/opt/djinn/bin/djinn-agent-worker",
+                false
+            ),
+            "if this ever becomes admissible, the bash -lc hop can be dropped — \
+             but that is a deliberate posture change, not a cleanup"
+        );
+        assert!(djinn_cgroup_launcher::command_path::safe_command_path(
+            "/workspace",
+            true
+        ));
+    }
+
+    /// A path with a quote in it must not become a second shell word.
+    #[test]
+    fn shell_metacharacters_in_a_path_stay_inside_one_argument() {
+        let command = build_seed_command(
+            Path::new("/opt/djinn/bin/djinn-agent-worker"),
+            Path::new("/cache/cargo-target/p'; touch /tmp/pwned; '"),
+            Path::new("/cache/cargo-target-runs/run-1"),
+            Path::new("/workspace"),
+        );
+        let script = command
+            .get_args()
+            .nth(1)
+            .expect("script")
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            !script.contains("; touch /tmp/pwned; '\n") && script.contains(r"'\''"),
+            "the quote must be escaped, not closed: {script}"
+        );
+    }
+
+    #[test]
+    fn the_env_switch_defaults_on_and_is_explicit_to_turn_off() {
+        // Read through the same predicate production uses; the env is not
+        // mutated here (tests share a process) so this pins the default only.
+        if std::env::var(BROKERED_SEED_ENV).is_err() {
+            assert!(brokered_seed_enabled(), "the default must be ON");
+        }
+        assert_eq!(brokered_seed_timeout(), brokered_seed_timeout());
+    }
+
+    #[test]
+    fn every_degradation_reason_has_a_distinct_label() {
+        let all = [
+            BrokeredSeedDegradation::NoBroker,
+            BrokeredSeedDegradation::DisabledByEnv,
+            BrokeredSeedDegradation::ExecutableUnresolved,
+            BrokeredSeedDegradation::LaunchFailed,
+            BrokeredSeedDegradation::NonZeroExit,
+            BrokeredSeedDegradation::UnparseableSummary,
+        ];
+        let labels: std::collections::BTreeSet<&str> =
+            all.iter().map(|reason| reason.as_str()).collect();
+        assert_eq!(labels.len(), all.len(), "labels must be distinguishable");
+    }
+
+    #[test]
+    fn an_unknown_wire_fallback_degrades_to_a_named_reason_not_a_parse_error() {
+        let wire = SeedWireResult {
+            fallback: Some(WireFallback {
+                kind: "invented_by_a_newer_worker".into(),
+                detail: "why".into(),
+            }),
+            ..SeedWireResult::from(&sample())
+        };
+        let result = CargoTargetSeedResult::from(wire);
+        match result.fallback_reason {
+            Some(CargoTargetSeedFallback::BaseUnusable(detail)) => {
+                assert!(detail.contains("invented_by_a_newer_worker"), "{detail}");
+            }
+            other => panic!("expected a named unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_default_timeout_is_a_bound_not_an_expectation() {
+        assert!(DEFAULT_BROKERED_SEED_TIMEOUT >= Duration::from_secs(600));
+        let _ = PathBuf::new();
+    }
+}

--- a/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
@@ -6,14 +6,44 @@
 //! dir. Mutable Cargo metadata is copied, and incremental state is skipped so it
 //! is never shared by inode with the warm base.
 //!
+//! # Only immutable payloads may be hardlinked
+//!
+//! The rule that governs [`classify_cargo_target_path`] is: **anything the run
+//! may rewrite must be copied, not linked.** A hardlink shares the inode with the
+//! warm base, so a rewrite in the private run dir lands THROUGH the link into the
+//! shared base that every other task-run pod seeds from. Cargo's fingerprints
+//! still consider the damaged units fresh, so nothing regenerates them and the
+//! base stops re-converging.
+//!
+//! Four classes are known to be rewritten in place and are carved out for that
+//! reason: cargo's per-profile lock files, `.rustc_info.json`, build-script
+//! `OUT_DIR` payloads, and the build-script stamp files. Adding a fifth means
+//! adding it here — the default arm is `Hardlink`, so an omission is silent.
+//!
+//! # Identities involved
+//!
+//! Four distinct uids touch this tree, and conflating any two of them produces a
+//! wrong conclusion about who can write what:
+//!
+//! | role                          | uid     | source                              |
+//! |-------------------------------|---------|-------------------------------------|
+//! | on-disk warm base owner       | `10001` | legacy; predates the warm pod move  |
+//! | warm Job pod                   | `1000`  | `warm_job.rs` (`WORKER_UID`)        |
+//! | task-run worker (this seeder) | `1000`  | `WORKER_UID`                        |
+//! | cargo and its build scripts   | `1001`  | `CHILD_UID`, gid `ARTIFACT_GID` 1000|
+//!
+//! The base's *bytes* were written by a warm pod that today runs as 1000, but the
+//! *inodes* on disk are still owned by the legacy 10001 from before that move.
+//! Cargo never runs as the seeder: the launcher `setresuid`s to `CHILD_UID` 1001,
+//! and the two share only gid 1000. So a seeded entry is writable by cargo when
+//! its GROUP bits allow it, never because the seeder created it.
+//!
 //! # Why a single entry must never discard the base
 //!
-//! The warm base is written by the warm Job (uid 10001) and read by the task-run
-//! worker (uid 1000, gid 1000). With `fs.protected_hardlinks=1` the kernel's
-//! `safe_hardlink_source()` refuses `linkat()` with **EPERM** for any source the
-//! calling process does not own unless it is a *group-writable regular file*.
-//! Measured against a 6.x kernel with a base owned by `10001:1000` and a process
-//! running `1000:1000`:
+//! With `fs.protected_hardlinks=1` the kernel's `safe_hardlink_source()` refuses
+//! `linkat()` with **EPERM** for any source the calling process does not own
+//! unless it is a *group-writable regular file*. Measured against a 6.x kernel
+//! with a base owned by `10001:1000` and a process running `1000:1000`:
 //!
 //! | source            | `linkat` | `copy` |
 //! |-------------------|----------|--------|
@@ -526,7 +556,85 @@ pub fn classify_cargo_target_path(relative_path: &Path) -> CloneAction {
         return CloneAction::Copy;
     }
 
+    // Build-script state under `build/<pkg>-<hash>/` is rewritten IN PLACE when
+    // cargo re-runs a build script, and it is the third instance of the same
+    // shared-inode hazard as `.rustc_info.json` and the cargo locks above.
+    //
+    // A `-sys` crate's build script populates `OUT_DIR` with `fs::copy`, and
+    // `std::fs::copy` on Unix opens the destination `O_CREAT|O_TRUNC` and only
+    // THEN `fchmod`s it to the source's mode, propagating the error
+    // (`open_to_and_set_permissions` in `std::sys::fs::unix`). Applied to a
+    // hardlinked destination, that single sequence produces both halves of the
+    // incident:
+    //
+    // 1. **The truncation writes THROUGH into the shared warm base.** The link
+    //    shares the inode, so `O_TRUNC` empties the base's copy — for every other
+    //    task-run pod that seeds from it, not just this run. Cargo's fingerprints
+    //    still consider those units fresh, so nothing ever regenerates them and
+    //    the base silently stops re-converging. Verified on the production node:
+    //    9 zero-byte files in the shared base, every one under `debug/build/*/out/`
+    //    and every one `nlink=2`, including
+    //    `build/libssh2-sys-*/out/include/libssh2.h`.
+    // 2. **The `fchmod` then fails EPERM and the build script panics.** Inode
+    //    metadata ops are owner-gated, and a hardlinked entry keeps the base's
+    //    owner. `libssh2-sys/build.rs:54` does `fs::copy(...).unwrap()`, so the
+    //    compile dies. Note EPERM, not EACCES: an OWNERSHIP failure, not a mode
+    //    one, which is why `ensure_owner_writable` cannot rescue it.
+    //
+    // Copying is what stops (1): the truncation lands on a private inode and the
+    // shared base is untouchable by construction. It does NOT by itself stop (2)
+    // — the seeder is uid 1000 and cargo runs as uid 1001, so `fchmod` on a
+    // seeded destination is still EPERM for the build script. Aligning those uids
+    // is separately planned work, and it is only safe AFTER this change: with a
+    // single identity the `fchmod` succeeds, and on a hardlinked entry that turns
+    // a loud panic into a silent overwrite of the shared base. Ownership is not
+    // the fix for the corruption; not sharing rewritable state by inode is.
+    //
+    // The `build-script-build` executables stay hardlinked: they are the heavy
+    // part of `build/` and cargo replaces them by rename, never in place.
+    if is_build_script_output(relative_path) || is_build_script_stamp(relative_path) {
+        return CloneAction::Copy;
+    }
+
     CloneAction::Hardlink
+}
+
+/// True for build-script `OUT_DIR` payloads: `[<triple>/]<profile>/build/<pkg>-<hash>/out/**`.
+///
+/// Matched positionally (`build/*/out`) rather than by "has a component named
+/// `out`" so an unrelated path that merely contains `out` is not swept in.
+fn is_build_script_output(path: &Path) -> bool {
+    normal_components(path)
+        .windows(3)
+        .any(|window| window[0] == "build" && window[2] == "out")
+}
+
+/// True for the per-package stamp files cargo rewrites in place after re-running
+/// a build script (`build/<pkg>-<hash>/{output,stderr,root-output,invoked.timestamp}`).
+///
+/// These are tiny, so copying them is free, and hardlinking them writes through
+/// to the shared warm base exactly like `.rustc_info.json` does.
+fn is_build_script_stamp(path: &Path) -> bool {
+    const STAMP_NAMES: &[&str] = &["output", "stderr", "root-output", "invoked.timestamp"];
+
+    let parts = normal_components(path);
+    let Some((name, parents)) = parts.split_last() else {
+        return false;
+    };
+    // `build/<pkg>-<hash>/<stamp>`: the stamp sits exactly one level below the
+    // package dir, which itself sits directly under `build/`.
+    let under_build_package = matches!(parents.split_last(), Some((_, rest)) if rest.last().is_some_and(|component| *component == "build"));
+
+    under_build_package && STAMP_NAMES.iter().any(|stamp| *name == *stamp)
+}
+
+fn normal_components(path: &Path) -> Vec<&std::ffi::OsStr> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(part) => Some(part),
+            _ => None,
+        })
+        .collect()
 }
 
 fn fallback_result(start: Instant, reason: CargoTargetSeedFallback) -> CargoTargetSeedResult {
@@ -772,6 +880,9 @@ fn apply_entry(
                     // its owner. The run dir is disposable, so restore owner
                     // write unconditionally.
                     ensure_owner_writable(&destination);
+                    // A link would have carried the base's mtime; this copy is
+                    // standing in for a link, so it must too.
+                    preserve_source_times(&source, &destination);
                     metrics
                         .degraded_link_file_count
                         .fetch_add(1, Ordering::Relaxed);
@@ -799,6 +910,9 @@ fn apply_entry(
                     // the source mode, so a read-only base entry (a symlinked
                     // vendored payload, say) would arrive unwritable.
                     ensure_owner_writable(&destination);
+                    // Cargo compares raw mtimes for staleness, so a copied entry
+                    // must present the same age as the links around it.
+                    preserve_source_times(&source, &destination);
                     metrics.copied_file_count.fetch_add(1, Ordering::Relaxed);
                     metrics.copied_bytes.fetch_add(copied, Ordering::Relaxed);
                     Ok(())
@@ -824,6 +938,50 @@ fn link_file(backend: LinkBackend, source: &Path, destination: &Path) -> io::Res
             }
         }
     }
+}
+
+/// Copy the source's access/modification times onto a seeded destination.
+///
+/// A hardlink shares the inode, so it carries the base's mtime for free. A byte
+/// copy does not: `fs::copy` reproduces mode but *not* timestamps, so a copied
+/// entry lands with a SEED-time mtime while its hardlinked neighbours keep their
+/// WARM-time mtime. Cargo's `StaleDependency` check is a raw mtime comparison
+/// against the unit's dependencies, so mixing the two epochs inside one target
+/// dir makes cargo see freshly-seeded metadata as newer than the artifacts it
+/// describes and rebuild units that were perfectly good — broadly, and dependent
+/// on which side of the classification each path happened to fall. Restoring the
+/// source times keeps a copy indistinguishable from a link to the freshness
+/// checker, which is the entire point of seeding.
+///
+/// Must run AFTER [`ensure_owner_writable`]: `chmod` bumps ctime and the open
+/// below needs the write bit, so setting times has to be the last touch.
+///
+/// The seeder owns every destination it creates, and an owner may always set
+/// explicit times (`utimensat` with explicit values is owner-gated, not
+/// root-gated), so this is permitted without any privilege.
+///
+/// Best-effort, like [`ensure_owner_writable`]: a stale timestamp costs a
+/// needless rebuild, which is not a reason to drop an otherwise correctly seeded
+/// artifact.
+fn preserve_source_times(source: &Path, destination: &Path) {
+    let Ok(source_meta) = fs::metadata(source) else {
+        return;
+    };
+    let Ok(modified) = source_meta.modified() else {
+        return;
+    };
+
+    let mut times = fs::FileTimes::new().set_modified(modified);
+    if let Ok(accessed) = source_meta.accessed() {
+        times = times.set_accessed(accessed);
+    }
+
+    // `File::set_times` requires a handle opened for writing on some targets;
+    // open for write WITHOUT truncating, so this never touches the bytes.
+    let Ok(file) = fs::OpenOptions::new().write(true).open(destination) else {
+        return;
+    };
+    let _ = file.set_times(times);
 }
 
 /// Restore owner write on a seeded artifact in the private run dir.

--- a/server/crates/djinn-agent-worker/src/cargo_target_seed/foreign_owner_tests.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed/foreign_owner_tests.rs
@@ -44,9 +44,15 @@ struct BaseFile {
 ///
 /// The bulk is `0664` regular files and `0775` executables written by cargo and
 /// rustc under `umask 002`, which the kernel WILL let a foreign owner hardlink.
-/// The anomalies are the real-world minority that it will NOT: build-script
-/// `OUT_DIR` payloads and registry sources keep their SOURCE mode when a build
-/// script copies them, and the cargo registry ships `0644`/`0640`/`0600` files.
+/// The anomalies are the real-world minority that it will NOT: files that keep a
+/// SOURCE mode regardless of umask, plus anything a base built under `umask 022`
+/// leaves at `0644`/`0755`.
+///
+/// Build-script `OUT_DIR` payloads appear here too, but they never reach `linkat`
+/// at all — they are copied by classification because the run must be able to
+/// rewrite them. Keeping both groups distinct matters: if the only unlinkable
+/// entries were build-script output, the link-fallback path would silently stop
+/// being tested the moment that classification changed.
 const BASE_FILES: &[BaseFile] = &[
     // Linkable majority.
     BaseFile {
@@ -80,7 +86,12 @@ const BASE_FILES: &[BaseFile] = &[
         mode: 0o664,
         contents: b"dep info",
     },
-    // Anomalies the kernel refuses to hardlink for a foreign owner.
+    // Build-script OUT_DIR payloads. These are copied by CLASSIFICATION, not by
+    // link degradation: a re-running build script rewrites them in place, and a
+    // hardlinked destination both refuses the rewrite (`fs::copy` ends in an
+    // `fchmod` the non-owner cannot perform) and writes through into the shared
+    // base. Their odd modes are incidental here — they would be copied at 0664
+    // too. See `classify_cargo_target_path`.
     BaseFile {
         relative: "debug/build/ring-abc/out/aes_nohw.o",
         mode: 0o644,
@@ -95,6 +106,27 @@ const BASE_FILES: &[BaseFile] = &[
         relative: "debug/build/protobuf-ghi/out/protoc",
         mode: 0o755,
         contents: b"vendored tool not group writable",
+    },
+    // Anomalies the kernel refuses to hardlink for a foreign owner. These are
+    // ordinary compiled artifacts, not build-script output, so they still reach
+    // `linkat` and still exercise the bounded copy fallback. A warm base built
+    // under `umask 022` rather than `002` produces exactly this shape across
+    // `deps/`, which is why the fallback path must survive on its own merits and
+    // not merely because build-script payloads happened to populate it.
+    BaseFile {
+        relative: "debug/deps/libring-abc.rlib",
+        mode: 0o644,
+        contents: b"rlib written under umask 022",
+    },
+    BaseFile {
+        relative: "debug/libdjinn_core.a",
+        mode: 0o444,
+        contents: b"read-only static archive",
+    },
+    BaseFile {
+        relative: "debug/deps/djinn_probe-5678",
+        mode: 0o755,
+        contents: b"harness binary not group writable",
     },
 ];
 
@@ -198,9 +230,9 @@ fn foreign_owned_base_with_production_modes_seeds_completely() {
     // refuses are byte-copied instead of discarded.
     assert_eq!(result.linked_file_count, 4);
     assert_eq!(result.degraded_link_file_count, 3);
-    // `.fingerprint` and `.d` metadata are copied by classification, not by
-    // degradation.
-    assert_eq!(result.copied_file_count, 2);
+    // `.fingerprint`, `.d` metadata and the three build-script OUT_DIR payloads
+    // are copied by classification, not by degradation.
+    assert_eq!(result.copied_file_count, 5);
     assert!(!result.link_fallback_budget_exhausted);
     assert!(result.degraded());
     assert_every_expected_file_seeded(&run);
@@ -223,7 +255,10 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
 
     seed_cargo_target_dir_with_options(&base, &run, &emulating_options(2)).expect("seed");
 
-    let read_only_source = base.join("debug/build/zstd-sys-def/out/libzstd.a");
+    // Deliberately a NON-build-script artifact, so this exercises the degraded
+    // link-fallback copy. The classification-copy equivalent is covered by
+    // `copied_entries_are_writable_even_when_the_base_entry_is_read_only`.
+    let read_only_source = base.join("debug/libdjinn_core.a");
     assert_eq!(
         fs::metadata(&read_only_source)
             .expect("base metadata")
@@ -231,10 +266,10 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
             .mode()
             & 0o200,
         0,
-        "the fixture's vendored archive must be read-only in the base"
+        "the fixture's static archive must be read-only in the base"
     );
 
-    let seeded = run.join("debug/build/zstd-sys-def/out/libzstd.a");
+    let seeded = run.join("debug/libdjinn_core.a");
     let mode = fs::metadata(&seeded)
         .expect("seeded metadata")
         .permissions()
@@ -246,6 +281,77 @@ fn degraded_copies_are_writable_by_the_run_that_owns_them() {
     );
     // Proof rather than inference: the run can actually rewrite it.
     fs::write(&seeded, b"rebuilt by cargo").expect("rewrite seeded artifact");
+}
+
+/// The link-fallback copy is a *substitute for a hardlink*, so it has to be
+/// indistinguishable from one to cargo — including its age.
+///
+/// This arm is the easy one to forget: the classification-copy arm is the one
+/// everybody looks at, but an entry that lands here does so because the kernel
+/// refused the link, and it sits in `deps/` next to thousands of entries that DID
+/// link and kept their warm mtime. A seed-time mtime on one `.rlib` in that set
+/// is exactly the input cargo's raw-mtime `StaleDependency` check turns into a
+/// spurious rebuild of everything downstream of it.
+#[test]
+fn degraded_copies_present_the_same_age_as_the_links_they_substitute_for() {
+    let _guard = metric_test_guard();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("mold-jobs-4");
+    let run = tmp.path().join("run-target");
+    build_production_shaped_base(&base);
+
+    // `0644`: the kernel refuses this hardlink for a foreign owner, so it reaches
+    // the bounded copy fallback rather than the classification-copy arm.
+    let degraded = Path::new("debug/deps/libring-abc.rlib");
+    // A linkable `0664` neighbour, whose mtime comes free with the shared inode.
+    let linked = Path::new("debug/deps/libserde-abc.rlib");
+
+    let warm_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_600_000_000);
+    for path in [degraded, linked] {
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(base.join(path))
+            .expect("open base file to age it");
+        file.set_times(fs::FileTimes::new().set_modified(warm_time))
+            .expect("age base file");
+    }
+
+    let result = seed_cargo_target_dir_with_options(&base, &run, &emulating_options(2))
+        .expect("seed target dir");
+
+    // NON-VACUITY: the entry really did degrade to a copy. If a future change
+    // made it linkable, this test would otherwise pass while proving nothing.
+    assert!(
+        result.degraded_link_file_count > 0,
+        "the fixture must still produce link-fallback copies"
+    );
+    assert_ne!(
+        classify_cargo_target_path(degraded),
+        CloneAction::Copy,
+        "{} must reach the fallback via a REFUSED LINK, not via classification",
+        degraded.display()
+    );
+    let base_meta = fs::metadata(base.join(degraded)).expect("base metadata");
+    let run_meta = fs::metadata(run.join(degraded)).expect("seeded metadata");
+    assert_ne!(
+        (base_meta.dev(), base_meta.ino()),
+        (run_meta.dev(), run_meta.ino()),
+        "the degraded entry must be a private copy, not a link"
+    );
+
+    assert_eq!(
+        run_meta.modified().expect("seeded mtime"),
+        warm_time,
+        "a fallback copy must carry the mtime the hardlink it replaced would have"
+    );
+    assert_eq!(
+        fs::metadata(run.join(linked))
+            .expect("linked metadata")
+            .modified()
+            .expect("linked mtime"),
+        warm_time,
+        "the linked neighbour it must stay consistent with"
+    );
 }
 
 /// The pre-fix behaviour, stated as a property: a single entry the kernel
@@ -268,7 +374,7 @@ fn one_unseedable_entry_never_discards_the_base() {
         "unseedable entries must degrade the seed, not abandon the base"
     );
     assert_eq!(result.linked_file_count, 4);
-    assert_eq!(result.copied_file_count, 2);
+    assert_eq!(result.copied_file_count, 5);
     assert_eq!(result.degraded_link_file_count, 0);
     assert_eq!(result.unseeded_file_count, 3);
     assert!(result.link_fallback_budget_exhausted);
@@ -280,7 +386,10 @@ fn one_unseedable_entry_never_discards_the_base() {
         fs::read(run.join("debug/deps/libserde-abc.rlib")).expect("linked artifact"),
         b"serde rlib"
     );
-    assert!(!run.join("debug/build/protobuf-ghi/out/protoc").exists());
+    assert!(!run.join("debug/deps/djinn_probe-5678").exists());
+    // The budget bounds only the link fallback. Classification copies are not
+    // substitutes for a refused link, so build-script output still seeds.
+    assert!(run.join("debug/build/protobuf-ghi/out/protoc").exists());
 }
 
 /// The diagnostic that would have ended this investigation in one log line.
@@ -303,7 +412,7 @@ fn entry_error_names_the_operation_the_path_and_why_the_kernel_refused() {
         "the failing OPERATION must lead the message: {error}"
     );
     assert!(
-        ["out/aes_nohw.o", "out/libzstd.a", "out/protoc"]
+        ["libring-abc.rlib", "libdjinn_core.a", "djinn_probe-5678"]
             .iter()
             .any(|path| error.contains(path)),
         "the failing PATH must be named: {error}"
@@ -383,24 +492,24 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let base = tmp.path().join("mold-jobs-4");
     let run = tmp.path().join("run-target");
-    fs::create_dir_all(base.join("debug/build/foo-abc/out")).expect("create base");
-    let target = base.join("debug/build/foo-abc/out/libnative.so.1.2.3");
+    // Deliberately under `deps/`, NOT a build-script `out/` dir: there the Copy
+    // classification would make the assertion below pass even if symlink
+    // handling were removed entirely.
+    fs::create_dir_all(base.join("debug/deps")).expect("create base");
+    let target = base.join("debug/deps/libnative.so.1.2.3");
     fs::write(&target, b"native library").expect("write link target");
     fs::set_permissions(&target, fs::Permissions::from_mode(0o664)).expect("mode");
-    std::os::unix::fs::symlink(&target, base.join("debug/build/foo-abc/out/libnative.so"))
+    std::os::unix::fs::symlink(&target, base.join("debug/deps/libnative.so"))
         .expect("symlink to a regular file");
     std::os::unix::fs::symlink(
-        base.join("debug/build/foo-abc/out/missing"),
-        base.join("debug/build/foo-abc/out/dangling.so"),
+        base.join("debug/deps/missing"),
+        base.join("debug/deps/dangling.so"),
     )
     .expect("dangling symlink");
     // A symlinked directory that points at its own ancestor: descending would
     // never terminate.
-    std::os::unix::fs::symlink(
-        base.join("debug"),
-        base.join("debug/build/foo-abc/out/loop"),
-    )
-    .expect("symlinked directory");
+    std::os::unix::fs::symlink(base.join("debug"), base.join("debug/deps/loop"))
+        .expect("symlinked directory");
 
     let entries = scan_entries(&base).expect("scan must survive symlinks");
     let symlink_entry = entries
@@ -418,7 +527,7 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
 
     assert!(!result.cold_started(), "{:?}", result.first_entry_error);
     assert_eq!(result.unseeded_file_count, 0);
-    let seeded_link = run.join("debug/build/foo-abc/out/libnative.so");
+    let seeded_link = run.join("debug/deps/libnative.so");
     assert_eq!(
         fs::read(&seeded_link).expect("seeded symlink payload"),
         b"native library"
@@ -430,8 +539,8 @@ fn symlinks_are_materialised_privately_and_never_hardlinked() {
             .is_file(),
         "the run dir must own a private regular file, not a link into the base"
     );
-    assert!(!run.join("debug/build/foo-abc/out/dangling.so").exists());
-    assert!(!run.join("debug/build/foo-abc/out/loop").exists());
+    assert!(!run.join("debug/deps/dangling.so").exists());
+    assert!(!run.join("debug/deps/loop").exists());
 }
 
 /// Everything classified `Copy` is copied precisely so the run can rewrite it,

--- a/server/crates/djinn-agent-worker/src/cargo_target_seed/tests.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed/tests.rs
@@ -45,10 +45,71 @@ fn classifies_heavy_artifacts_for_hardlink() {
         classify_cargo_target_path(Path::new("debug/deps/libserde-abc.rlib")),
         CloneAction::Hardlink
     );
+    // The compiled build script itself IS immutable — cargo replaces it by
+    // rename, never in place — so it stays hardlinked. It is also the heavy part
+    // of `build/`, which is why the carve-out below is scoped to `out/` and the
+    // stamps rather than to all of `build/`.
     assert_eq!(
-        classify_cargo_target_path(Path::new("release/build/foo/out/generated.rs")),
+        classify_cargo_target_path(Path::new("release/build/ring-abc/build-script-build")),
         CloneAction::Hardlink
     );
+}
+
+#[test]
+fn classifies_build_script_output_for_copy() {
+    // A hardlinked OUT_DIR payload shares its inode with the shared warm base.
+    // When a re-running build script rewrites it, `fs::copy` opens the
+    // destination `O_CREAT|O_TRUNC` and only then `fchmod`s it, so the
+    // truncation lands THROUGH the link into the base (9 zero-byte `nlink=2`
+    // files were found there in production, all under `debug/build/*/out/`)
+    // before the `fchmod` fails EPERM and `libssh2-sys` panics on its
+    // `.unwrap()`. Copying gives the run a private inode, so the truncation can
+    // no longer reach the base.
+    for path in [
+        "release/build/foo-abc/out/generated.rs",
+        "debug/build/libssh2-sys-abc/out/libssh2.h",
+        "debug/build/openssl-sys-def/out/openssl/include/opensslconf.h",
+        "x86_64-unknown-linux-gnu/debug/build/foo-abc/out/generated.rs",
+    ] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(path)),
+            CloneAction::Copy,
+            "{path} is build-script output and must be copied, not linked"
+        );
+    }
+}
+
+#[test]
+fn classifies_build_script_stamps_for_copy() {
+    // Cargo rewrites these in place after re-running a build script; a shared
+    // inode writes through into the warm base every other pod seeds from.
+    for name in ["output", "stderr", "root-output", "invoked.timestamp"] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(&format!("debug/build/foo-abc/{name}"))),
+            CloneAction::Copy,
+            "debug/build/foo-abc/{name} must be copied"
+        );
+    }
+}
+
+#[test]
+fn build_script_matchers_do_not_oversweep() {
+    // `out`/`output` only carry meaning at their cargo-defined position. A
+    // dependency artifact that merely contains the word must keep its normal
+    // classification, or the carve-out silently converts the heavy majority of
+    // the base from hardlinks into byte copies.
+    for path in [
+        "debug/deps/out.rlib",
+        "debug/deps/libout-abc.rlib",
+        "debug/out/stray.bin",
+        "debug/build/foo-abc/out.rs",
+    ] {
+        assert_eq!(
+            classify_cargo_target_path(Path::new(path)),
+            CloneAction::Hardlink,
+            "{path} must not be swept into the build-script carve-out"
+        );
+    }
 }
 
 #[test]
@@ -348,6 +409,145 @@ fn seeds_target_tree_with_required_clone_semantics() {
         // cargo rewrite cannot corrupt the shared warm base.
         assert_different_inode(&base.join(rustc_info), &run.join(rustc_info));
     }
+}
+
+#[test]
+fn build_script_output_is_privately_owned_and_rewritable_without_touching_the_base() {
+    // The verified production failure: a hardlinked OUT_DIR payload let a
+    // re-running build script truncate the SHARED warm base through the link.
+    // Nine zero-byte files were found in the base, every one under
+    // `debug/build/*/out/` and every one `nlink=2` — cargo's fingerprints still
+    // called those units fresh, so nothing regenerated them and the base stopped
+    // re-converging.
+    //
+    // The inode assertions and the final base-contents assertion below are the
+    // load-bearing ones: they fail deterministically under the old `Hardlink`
+    // classification on any uid, whereas the EPERM half of the same syscall
+    // sequence only reproduces when the base is genuinely foreign-owned (see
+    // `foreign_owner_tests`).
+    let _guard = metric_test_guard();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("warm-base");
+    let run = tmp.path().join("run-target");
+
+    let out_header = Path::new("debug/build/libssh2-sys-abc/out/libssh2.h");
+    let out_nested = Path::new("debug/build/openssl-sys-def/out/openssl/include/opensslconf.h");
+    let stamp = Path::new("debug/build/libssh2-sys-abc/output");
+    let build_script = Path::new("debug/build/libssh2-sys-abc/build-script-build");
+
+    write_base_file(&base, out_header, b"original vendored header");
+    write_base_file(&base, out_nested, b"original vendored conf");
+    write_base_file(&base, stamp, b"cargo:rustc-link-lib=ssh2");
+    write_base_file(&base, build_script, b"build script binary");
+
+    seed_cargo_target_dir_with_options(&base, &run, &CargoTargetSeedOptions::new(4))
+        .expect("seed target dir");
+
+    // Every rewritable build-script path must own a private inode...
+    for path in [out_header, out_nested, stamp] {
+        assert_different_inode(&base.join(path), &run.join(path));
+    }
+    // ...while the immutable build script itself stays hardlinked, so the
+    // carve-out did not quietly convert the heavy part of `build/` into copies.
+    let base_script = fs::metadata(base.join(build_script)).expect("base build script");
+    let run_script = fs::metadata(run.join(build_script)).expect("run build script");
+    assert_eq!(
+        (base_script.dev(), base_script.ino()),
+        (run_script.dev(), run_script.ino()),
+        "the compiled build script is immutable and must still be hardlinked"
+    );
+
+    // Reproduce what a re-running `-sys` build script actually does: `fs::copy`
+    // a vendored source over the seeded OUT_DIR path.
+    let vendored = tmp.path().join("vendored-libssh2.h");
+    fs::write(&vendored, b"regenerated vendored header").expect("write vendored source");
+    fs::copy(&vendored, run.join(out_header)).expect(
+        "a re-running build script must be able to fs::copy over its own seeded OUT_DIR payload",
+    );
+
+    assert_eq!(
+        fs::read(run.join(out_header)).expect("read rewritten run payload"),
+        b"regenerated vendored header"
+    );
+    // The shared warm base that every other task-run pod seeds from is untouched.
+    assert_eq!(
+        fs::read(base.join(out_header)).expect("read base payload"),
+        b"original vendored header",
+        "rewriting the run dir must not write through into the shared warm base"
+    );
+}
+
+#[test]
+fn copied_entries_present_the_same_age_as_hardlinked_ones() {
+    // A hardlink carries the base's mtime for free because it IS the same inode.
+    // `fs::copy` does not copy timestamps, so without an explicit restore every
+    // `Copy`-classified entry would land with a SEED-time mtime while its
+    // `Hardlink`-classified neighbours kept their WARM-time mtime. Cargo's
+    // `StaleDependency` check is a raw mtime comparison, so that split makes
+    // freshly-seeded metadata look newer than the artifacts it describes and
+    // triggers broad, ordering-dependent spurious rebuilds — trading one failure
+    // for another. Every seeded path must present the base's age, whichever arm
+    // produced it.
+    let _guard = metric_test_guard();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("warm-base");
+    let run = tmp.path().join("run-target");
+
+    let copied = Path::new("debug/build/libssh2-sys-abc/out/libssh2.h");
+    let stamp = Path::new("debug/build/libssh2-sys-abc/output");
+    let fingerprint = Path::new("debug/.fingerprint/foo-abc/lib-foo.json");
+    let dep_info = Path::new("debug/deps/foo.d");
+    let rustc_info = Path::new(".rustc_info.json");
+    let linked = Path::new("debug/deps/libserde-abc.rlib");
+
+    for path in [copied, stamp, fingerprint, dep_info, rustc_info, linked] {
+        write_base_file(&base, path, b"warm artifact");
+    }
+
+    // Age the whole base well past any clock granularity the seed could
+    // accidentally reproduce, so an unpreserved mtime cannot coincidentally pass.
+    let warm_time = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_600_000_000);
+    for path in [copied, stamp, fingerprint, dep_info, rustc_info, linked] {
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .open(base.join(path))
+            .expect("open base file to age it");
+        file.set_times(fs::FileTimes::new().set_modified(warm_time))
+            .expect("age base file");
+    }
+
+    seed_cargo_target_dir_with_options(&base, &run, &CargoTargetSeedOptions::new(4))
+        .expect("seed target dir");
+
+    for path in [copied, stamp, fingerprint, dep_info, rustc_info] {
+        assert_eq!(
+            classify_cargo_target_path(path),
+            CloneAction::Copy,
+            "{} must be a copy for this test to prove anything",
+            path.display()
+        );
+        // NON-VACUITY: a copy really did produce a private inode, so the mtime
+        // below is preserved rather than merely inherited from a shared one.
+        assert_different_inode(&base.join(path), &run.join(path));
+        assert_eq!(
+            fs::metadata(run.join(path))
+                .expect("seeded metadata")
+                .modified()
+                .expect("seeded mtime"),
+            warm_time,
+            "copied entry {} must present the base's mtime, not the seed's",
+            path.display()
+        );
+    }
+
+    // The hardlinked majority it has to stay consistent with.
+    assert_eq!(
+        fs::metadata(run.join(linked))
+            .expect("linked metadata")
+            .modified()
+            .expect("linked mtime"),
+        warm_time
+    );
 }
 
 #[test]

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -62,9 +62,11 @@
 
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+mod brokered_cargo_target_seed;
 pub mod cargo_cache_policy;
 pub mod cargo_incremental_prune;
 pub mod cargo_metrics;
@@ -210,6 +212,32 @@ enum Cmd {
     WarmGraph {
         /// Project id (matches `projects.id`). Positional.
         project_id: String,
+    },
+
+    /// Seed a private per-task-run Cargo target dir from the project's warm
+    /// base and exit, printing a machine-readable summary line on stdout.
+    ///
+    /// # This subcommand exists to be run as a DIFFERENT UID
+    ///
+    /// It is not an operator entry point and no renderer launches it. The
+    /// task-run worker (uid 1000) re-enters its own binary through the cgroup
+    /// broker, which spawns children as `CHILD_UID` (1001), so the seeded
+    /// inodes are born owned by the identity that later overwrites them.
+    /// `chmod` is granted by ownership alone, and `std::fs::copy` ends in
+    /// `set_permissions` — a build script at 1001 cannot finish a copy over a
+    /// file the worker created at 1000, whatever its mode says. See
+    /// `brokered_cargo_target_seed`.
+    ///
+    /// Both arguments are positional-free and explicit so the parent can quote
+    /// them into a `bash -lc` script without relying on any inherited state.
+    SeedCargoTarget {
+        /// Warm base to seed FROM. Read-only to this process.
+        #[arg(long)]
+        base: PathBuf,
+
+        /// Private per-task-run target dir to seed INTO.
+        #[arg(long)]
+        run_dir: PathBuf,
     },
 
     /// Compare two cached repo graph artifacts for a project and exit.
@@ -411,12 +439,52 @@ async fn run() -> Result<()> {
     match cli.cmd {
         Cmd::TaskRun(args) => run_task_run(args).await,
         Cmd::WarmGraph { project_id } => run_warm_graph(&project_id).await,
+        Cmd::SeedCargoTarget { base, run_dir } => run_seed_cargo_target(&base, &run_dir),
         Cmd::CompareGraphArtifacts {
             project_id,
             old_commit,
             new_commit,
         } => run_compare_graph_artifacts(&project_id, &old_commit, &new_commit).await,
     }
+}
+
+/// The `seed-cargo-target` subcommand body — the half that runs at uid 1001.
+///
+/// Synchronous on purpose: this process does exactly one thing and exits, and
+/// the seed is bounded parallel filesystem work driven by its own rayon pool
+/// (`seed_cargo_target_dir`), not async IO.
+///
+/// The summary goes to STDOUT on a prefixed line and everything else to stderr,
+/// because the parent recovers this value across the process boundary and
+/// records the task-run's seed telemetry from it. A seed that runs but cannot
+/// report is indistinguishable to the parent from one that never ran, and
+/// degrades to the in-worker path.
+fn run_seed_cargo_target(base: &Path, run_dir: &Path) -> Result<()> {
+    let result = seed_cargo_target_dir(base, run_dir)
+        .with_context(|| format!("seed {} from {}", run_dir.display(), base.display()))?;
+    info!(
+        uid = volume_contract::current_uid(),
+        gid = volume_contract::current_gid(),
+        base = %base.display(),
+        run_dir = %run_dir.display(),
+        linked_file_count = result.linked_file_count,
+        copied_file_count = result.copied_file_count,
+        skipped_file_count = result.skipped_file_count,
+        "cargo target seed: brokered child completed the seed"
+    );
+    // Written and FLUSHED explicitly rather than with `println!` (which the
+    // workspace lint bans, and which swallows the write error): this line is the
+    // whole return value of the process. A silently dropped or short write is
+    // indistinguishable to the parent from a seed that never ran, so it must be
+    // an error the exit status carries.
+    let line = brokered_cargo_target_seed::encode_seed_result(&result);
+    let mut stdout = std::io::stdout().lock();
+    stdout
+        .write_all(line.as_bytes())
+        .and_then(|()| stdout.write_all(b"\n"))
+        .and_then(|()| stdout.flush())
+        .context("write the cargo-target seed summary to stdout")?;
+    Ok(())
 }
 
 /// Configure git + Go in the worker Pod so the agent's build/test commands can
@@ -710,7 +778,31 @@ fn completed_seed_join(
     Ok(result)
 }
 
-async fn prepare_cargo_target_dir(spec: &TaskRunSpec, workspace_path: &Path) -> PathBuf {
+/// Everything the cargo-target seed needs, resolved **before** the launcher
+/// handshake and independently of it.
+///
+/// # Why the resolution and the seed are two steps now
+///
+/// The seed itself moved after the launcher handshake so it can run as the
+/// launcher-spawned child (uid 1001) — see `brokered_cargo_target_seed`. The
+/// *resolution* must not move with it: `set_cargo_target_dir_for_children`
+/// publishes `CARGO_TARGET_DIR` into this process's environment, which is what
+/// every later child (brokered or not) inherits, and [`CargoTargetRunDirGuard`]
+/// is armed from the destination path. Keeping resolution where it always was
+/// preserves both the env-publication ordering and the guard's drop order
+/// relative to every other resource `run_task_run` holds.
+struct CargoTargetPlan {
+    /// Shared per-project warm base to seed FROM.
+    source_base: PathBuf,
+    /// Private per-task-run target dir to seed INTO.
+    destination_run_dir: PathBuf,
+    /// Absolute workspace dir, for the coordinator health sweep's correlation.
+    workspace_dir_display: String,
+    /// Absolute destination, for the same correlation.
+    cargo_target_dir_display: String,
+}
+
+fn plan_cargo_target_dir(spec: &TaskRunSpec, workspace_path: &Path) -> CargoTargetPlan {
     // Canonicalize once so every structured event for this task-run shares the
     // same absolute workspace_dir. The cargo warm path uses the SAME canonical
     // form (see `warm_cargo_target_base`), so emitting both absolute paths
@@ -780,13 +872,203 @@ async fn prepare_cargo_target_dir(spec: &TaskRunSpec, workspace_path: &Path) -> 
         "cargo target seed: preparing private run target dir"
     );
 
-    let seed_source_base = source_base.clone();
-    let seed_destination_run_dir = destination_run_dir.clone();
-    let seed_start = djinn_core::clock::Clock::now_instant(&djinn_core::clock::SystemClock::new());
-    let seed_join_result = tokio::task::spawn_blocking(move || {
+    CargoTargetPlan {
+        source_base,
+        destination_run_dir,
+        workspace_dir_display,
+        cargo_target_dir_display,
+    }
+}
+
+/// Run the seed for `plan`, preferring the brokered (uid 1001) path.
+///
+/// Returns the pre-existing join-result shape verbatim so every downstream
+/// telemetry classification (`classify_seed_outcome`, `record_seed_terminal_seconds`)
+/// stays byte-identical: the brokered path is a different *executor*, not a
+/// different *outcome vocabulary*.
+///
+/// A brokered failure is never fatal. `shell_launch: None` (launcher disabled
+/// or absent) and every broker-level error degrade to the in-worker seed that
+/// shipped before this change — the same seed, at uid 1000, with the same
+/// per-entry copy/skip safety net. What the fallback costs is exactly what this
+/// change buys: the seeded `Copy` inodes are owned by 1000 again, so a build
+/// script at 1001 that copies over one of them fails at its final `chmod`. That
+/// is a degraded build, not a dead dispatch, and it is what the fleet already
+/// lived with.
+async fn seed_cargo_target_dir_for_run(
+    spec: &TaskRunSpec,
+    plan: &CargoTargetPlan,
+    shell_launch: Option<&ShellLaunchContext>,
+    cancel: &CancellationToken,
+) -> Result<std::io::Result<CargoTargetSeedResult>, tokio::task::JoinError> {
+    match brokered_seed_attempt(spec, plan, shell_launch, cancel).await {
+        Ok(result) => return Ok(Ok(result)),
+        // Cancellation is a SHUTDOWN, not a degradation. A brokered seed that
+        // ended because SIGTERM or the soft deadline fired must not be retried
+        // in-process: the fallback would run the whole seed again — minutes, on
+        // a 27 GiB base — inside a 60s `terminationGracePeriodSeconds`, turning
+        // a graceful wind-down into a SIGKILL that loses the checkpoint. The
+        // run dir is torn down by its guard either way, and a cancelled run
+        // never compiles.
+        Err(_) if cancel.is_cancelled() => {
+            warn!(
+                task_run_id = %spec.task_run_id,
+                "cargo target seed: cancelled during the brokered seed; not re-seeding \
+                 in-process — the run is shutting down"
+            );
+            return Ok(Ok(CargoTargetSeedResult {
+                elapsed: Duration::ZERO,
+                linked_file_count: 0,
+                copied_file_count: 0,
+                skipped_file_count: 0,
+                linked_bytes: 0,
+                copied_bytes: 0,
+                degraded_link_file_count: 0,
+                unseeded_file_count: 0,
+                base_seedable_file_count: 0,
+                link_fallback_budget_exhausted: false,
+                first_entry_error: None,
+                fallback_reason: Some(CargoTargetSeedFallback::CloneFailed(
+                    "cancelled during the brokered seed".to_string(),
+                )),
+            }));
+        }
+        Err(degradation) => {
+            warn!(
+                task_run_id = %spec.task_run_id,
+                project_id = %spec.project_id,
+                seed_identity = "worker",
+                brokered_seed_degradation = degradation.as_str(),
+                destination_run_dir = %plan.destination_run_dir.display(),
+                "cargo target seed: brokered seed unavailable; seeding in-process at the \
+                 worker uid. Copy-classified entries will be owned by the worker, so a \
+                 build script that copies over one of them can fail at its final chmod"
+            );
+            // The brokered child may have created part of the destination
+            // before failing, and the in-worker seed's `hard_link`/`copy` would
+            // then hit EEXIST on every such entry and count it as an error. The
+            // run dir is private to this task-run and was created moments ago,
+            // so discarding it is free and makes the fallback a clean seed
+            // rather than a merge. Never touch a destination that is not the
+            // run-target dir we own — an operator-configured CARGO_TARGET_DIR
+            // may point anywhere.
+            if plan
+                .destination_run_dir
+                .starts_with(cargo_target_seed::RUN_TARGET_ROOT)
+                && let Err(error) = teardown_run_dir(&plan.destination_run_dir)
+            {
+                warn!(
+                    task_run_id = %spec.task_run_id,
+                    destination_run_dir = %plan.destination_run_dir.display(),
+                    error = %error,
+                    "cargo target seed: could not clear a partial brokered seed before \
+                     falling back; the in-process seed will report EEXIST per stale entry"
+                );
+            }
+        }
+    }
+
+    let seed_source_base = plan.source_base.clone();
+    let seed_destination_run_dir = plan.destination_run_dir.clone();
+    tokio::task::spawn_blocking(move || {
         seed_cargo_target_dir(seed_source_base, seed_destination_run_dir)
     })
-    .await;
+    .await
+}
+
+/// One brokered seed attempt. `Err` names why it did not produce a result; the
+/// caller degrades on every one of them.
+async fn brokered_seed_attempt(
+    spec: &TaskRunSpec,
+    plan: &CargoTargetPlan,
+    shell_launch: Option<&ShellLaunchContext>,
+    cancel: &CancellationToken,
+) -> Result<CargoTargetSeedResult, brokered_cargo_target_seed::BrokeredSeedDegradation> {
+    use brokered_cargo_target_seed::BrokeredSeedDegradation as Degradation;
+
+    let Some(launch) = shell_launch else {
+        return Err(Degradation::NoBroker);
+    };
+    if !brokered_cargo_target_seed::brokered_seed_enabled() {
+        return Err(Degradation::DisabledByEnv);
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        return Err(Degradation::ExecutableUnresolved);
+    };
+
+    // The cwd must be `/workspace` or beneath: `safe_command_path(_, cwd: true)`
+    // refuses anything else and the broker's refusal is an opaque
+    // `InvalidCommand` on the wire.
+    let command = brokered_cargo_target_seed::build_seed_command(
+        &exe,
+        &plan.source_base,
+        &plan.destination_run_dir,
+        Path::new(volume_contract::WORKSPACE_MOUNT_ROOT),
+    );
+    let output = match launch
+        .brokered_output(
+            command,
+            brokered_cargo_target_seed::brokered_seed_timeout(),
+            cancel.clone(),
+        )
+        .await
+    {
+        Ok(output) => output,
+        Err(error) => {
+            warn!(
+                task_run_id = %spec.task_run_id,
+                error = %error,
+                "cargo target seed: broker could not run the seed child"
+            );
+            return Err(Degradation::LaunchFailed);
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.status.success() {
+        warn!(
+            task_run_id = %spec.task_run_id,
+            exit_code = output.status.code().unwrap_or(-1),
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "cargo target seed: brokered seed child exited non-zero"
+        );
+        return Err(Degradation::NonZeroExit);
+    }
+    let Some(result) = brokered_cargo_target_seed::decode_seed_result(&stdout) else {
+        warn!(
+            task_run_id = %spec.task_run_id,
+            "cargo target seed: brokered seed child exited 0 but emitted no parseable summary"
+        );
+        return Err(Degradation::UnparseableSummary);
+    };
+    info!(
+        task_run_id = %spec.task_run_id,
+        project_id = %spec.project_id,
+        seed_identity = "child",
+        linked_file_count = result.linked_file_count,
+        copied_file_count = result.copied_file_count,
+        "cargo target seed: seeded at the cargo/build-script uid through the broker"
+    );
+    Ok(result)
+}
+
+/// Record telemetry and emit the structured events for a completed seed
+/// attempt, and return the destination the run compiles into.
+async fn prepare_cargo_target_dir(
+    spec: &TaskRunSpec,
+    plan: &CargoTargetPlan,
+    shell_launch: Option<&ShellLaunchContext>,
+    cancel: &CancellationToken,
+) -> PathBuf {
+    let CargoTargetPlan {
+        source_base,
+        destination_run_dir,
+        workspace_dir_display,
+        cargo_target_dir_display,
+    } = plan;
+
+    let seed_start = djinn_core::clock::Clock::now_instant(&djinn_core::clock::SystemClock::new());
+    let seed_join_result = seed_cargo_target_dir_for_run(spec, plan, shell_launch, cancel).await;
     let seed_elapsed = seed_start.elapsed();
     // Record exactly one workspace_seed_seconds sample per started seed
     // attempt, regardless of outcome (ok / error / cancelled).
@@ -922,7 +1204,7 @@ async fn prepare_cargo_target_dir(spec: &TaskRunSpec, workspace_path: &Path) -> 
         }
     }
 
-    destination_run_dir
+    destination_run_dir.clone()
 }
 
 /// Resolve the cargo workspace directory under `project_root`.
@@ -1297,16 +1579,22 @@ async fn warm_cargo_target_base(
     // `755` build script in this base would make `linkat` fail under
     // fs.protected_hardlinks. Do a complete post-cycle pass, not merely over
     // files this cycle reports touching: Cargo can resurrect an older artifact.
-    // This runs while the warm-base lock is still held and on the uid that owns
-    // the base. Task-run seeding retains its per-entry copy/skip degradation
-    // path as the safety net if a future filesystem anomaly escapes this pass.
+    // This runs while the warm-base lock is still held. `chmod` is granted by
+    // OWNERSHIP alone, so the pass is authoritative only over files this pod
+    // owns — which is every file it created, and (after the one-time operator
+    // `chown -R 1001:1000` in `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md`)
+    // the whole base. `files_unchangeable > 0` means the migration has not run
+    // yet; it is a transitional signal, not a failure. Task-run seeding retains
+    // its per-entry copy/skip degradation path as the safety net.
     match volume_contract::normalize_warm_base_regular_files(&base_dir) {
         Ok(result) => info!(
             project_id,
             warm_base = %base_dir.display(),
             regular_files = result.regular_files,
             files_normalized = result.files_normalized,
-            "cargo warm: normalized group-write mode on every regular warm-base file"
+            files_unchangeable = result.files_unchangeable,
+            first_chmod_error = result.first_chmod_error.as_deref().unwrap_or(""),
+            "cargo warm: normalized group-write mode on the regular warm-base files this pod owns"
         ),
         Err(error) => warn!(
             project_id,
@@ -2192,11 +2480,17 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
         bincode::deserialize(&spec_bytes).context("bincode deserialize TaskRunSpec")?;
     info!(task_id = %spec.task_id, flow = ?spec.flow, "received spec");
 
-    let cargo_target_run_dir = prepare_cargo_target_dir(&spec, &args.workspace_path).await;
+    // Resolve the target dirs and publish `CARGO_TARGET_DIR` HERE — the seed
+    // itself runs later, after the launcher handshake, so it can be performed by
+    // the launcher-spawned child (uid 1001) rather than by this process (uid
+    // 1000). See `seed_cargo_target_dir_for_run`. Resolution stays here so the
+    // env var is published before anything could spawn a child, and so this
+    // guard keeps its original position in `run_task_run`'s drop order.
+    let cargo_target_plan = plan_cargo_target_dir(&spec, &args.workspace_path);
     let _cargo_target_guard = CargoTargetRunDirGuard::new(
         spec.task_run_id.clone(),
         spec.project_id.clone(),
-        cargo_target_run_dir,
+        cargo_target_plan.destination_run_dir.clone(),
     );
 
     // Configure git + Go so the agent's build/test commands can fetch the
@@ -2406,6 +2700,21 @@ async fn run_task_run(args: WorkerDefaultArgs) -> Result<()> {
             .context("recover durable invocation journal")?,
         ),
     };
+
+    // 3c. Seed the private Cargo target dir — HERE, not before the handshake.
+    //
+    // The seed must run as the launcher-spawned child (uid 1001), because
+    // `chmod` is granted by ownership alone and `std::fs::copy` ends in
+    // `set_permissions`: a build script at 1001 cannot finish a copy over a
+    // `Copy`-classified entry the uid-1000 worker seeded, whatever the mode
+    // bits say. The broker is the only thing that can spawn at 1001, and it
+    // does not exist until `shell_launch` above is composed.
+    //
+    // It stays AHEAD of the pre-task boundary and supervisor dispatch below —
+    // both can compile — and `plan_cargo_target_dir` already published
+    // `CARGO_TARGET_DIR` for every child, brokered or not, before this point.
+    // A brokered failure degrades to the in-worker seed; it never fails the run.
+    prepare_cargo_target_dir(&spec, &cargo_target_plan, shell_launch.as_ref(), &cancel).await;
 
     // 4. Attach to the host-materialised workspace.
     let workspace = Workspace::attach_existing(args.workspace_path.as_path(), &spec.task_branch)

--- a/server/crates/djinn-agent-worker/src/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/src/volume_contract.rs
@@ -18,6 +18,30 @@
 //!
 //! ## The contract
 //!
+//! The contract below is about the **group**, and it is deliberately silent on
+//! the owning uid — nothing in this module reads or enforces `st_uid`
+//! ([`check_metadata`] compares `st_gid` only). That is correct for everything
+//! the group mechanism can actually carry: directory-entry operations
+//! (create / unlink / rename / `linkat`) are governed by the DIRECTORY's
+//! permissions, and content operations (`open(O_TRUNC)` / `write` / `truncate`)
+//! by the FILE's, so gid 1000 + setgid + `g+w` genuinely lets any of the
+//! identities do those across uids.
+//!
+//! What the group cannot carry is **inode-metadata** operations — `chmod`,
+//! `chown`, `utimensat` with explicit times. Those are governed by OWNERSHIP
+//! alone: the kernel returns `EPERM` to a non-owner even when the requested
+//! mode is byte-identical to the current one, and no mode bit, setgid bit, ACL
+//! or group membership can delegate them. `std::fs::copy` always ends in
+//! `set_permissions`, so *any actor that copies over an existing file must own
+//! it*. That is the whole reason the warm Job now runs as `CHILD_UID` (1001)
+//! rather than `WORKER_UID` (1000): cargo and its build scripts run as 1001 and
+//! copy over seeded artifacts, and the task-run seed is performed through the
+//! broker so the seeded inodes are born owned by 1001 too. Lifecycle-only
+//! actors — djinn-server at uid 10001 (`.warm-locks`, `.djinn-gc.lock`,
+//! `remove_dir_all`, `read_dir`, `statvfs`) and the task-run worker at 1000
+//! (creating and removing run dirs) — never touch inode metadata here and stay
+//! where they are. See `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md`.
+//!
 //! For every mounted root the pod writes through:
 //!   * group ownership is [`ARTIFACT_GID`] — so the worker (gid 1000) and the
 //!     launcher-spawned child (primary group 1000) share every artifact;
@@ -142,23 +166,68 @@ pub enum ContractMode {
 /// a source executable's mode when it copies a build-script output and can
 /// resurrect an old artifact in a later warm cycle, so a touched-files list is
 /// not a sufficient proof that every seedable source is hardlinkable.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct WarmBaseModeNormalization {
     /// Regular files encountered during the full walk.
     pub regular_files: u64,
     /// Regular files to which the group-write bit was added.
     pub files_normalized: u64,
+    /// Regular files that needed `g+w` but whose `chmod` was refused — almost
+    /// always `EPERM` because the file is owned by another uid. Counted rather
+    /// than fatal: see the ownership note on
+    /// [`normalize_warm_base_regular_files`].
+    pub files_unchangeable: u64,
+    /// First `chmod` refusal, rendered with path and error, for the log line.
+    pub first_chmod_error: Option<String>,
 }
 
 /// Add group-write to every regular file below a completed Cargo warm base.
 ///
-/// The warm worker owns these files and holds the per-base lock while this
-/// runs. Symlinks are deliberately neither followed nor mutated: they are not
-/// eligible safe-hardlink sources and changing their target would escape the
-/// base invariant. Directories already have their distinct setgid/group-write
+/// # `chmod` needs OWNERSHIP, and this pass only owns what it created
+///
+/// `fs::set_permissions` is `chmod(2)`, which the kernel grants to the file's
+/// OWNER and to `CAP_FOWNER` — and to nobody else, whatever the mode, the
+/// setgid bit, the ACL or the group. So this pass is only authoritative over
+/// the files the warm pod itself created. It is written to be *partial by
+/// design*: a file it cannot chmod yields `EPERM`, the caller logs a warning,
+/// and the seed's per-entry copy/skip degradation remains the safety net.
+///
+/// Historically this comment claimed "the warm worker owns these files". That
+/// was FALSE on the live cache: the base was created by a pod that ran as uid
+/// 10001, later warm pods ran as 1000, and neither could chmod the other's
+/// inodes — a live production base measured 6,794 files owned by 10001 against
+/// 2,422 owned by 1000. It becomes true only once (a) the warm pod runs as
+/// `CHILD_UID` (1001), which is this change, AND (b) an operator performs the
+/// one-time `chown -R 1001:1000` in
+/// `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md`. Until (b) has run, expect
+/// this pass to report `files_normalized` well below the mismatch count and to
+/// warn; that is the accurate signal, not a regression.
+///
+/// The warm worker holds the per-base lock while this runs. Symlinks are
+/// deliberately neither followed nor mutated: they are not eligible
+/// safe-hardlink sources and changing their target would escape the base
+/// invariant. Directories already have their distinct setgid/group-write
 /// contract. This operation preserves every other permission bit, including
 /// execute, so build scripts remain executable (`755` becomes `775`).
 pub fn normalize_warm_base_regular_files(base: &Path) -> io::Result<WarmBaseModeNormalization> {
+    normalize_warm_base_regular_files_with(base, &|path, mode| {
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))
+    })
+}
+
+/// [`normalize_warm_base_regular_files`] with the `chmod` implementation
+/// injected.
+///
+/// This seam exists for the same reason `cargo_target_seed::LinkBackend` does:
+/// the behaviour under test is the kernel's refusal to let a NON-OWNER `chmod`,
+/// and a CI runner cannot create a foreign-owned file without root — so a test
+/// running as the owner never observes the refusal at all, and would attest the
+/// non-fatal path against a case that cannot occur. Production always passes
+/// the real `set_permissions` above.
+pub fn normalize_warm_base_regular_files_with(
+    base: &Path,
+    chmod: &dyn Fn(&Path, u32) -> io::Result<()>,
+) -> io::Result<WarmBaseModeNormalization> {
     let metadata = match fs::symlink_metadata(base) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
@@ -194,8 +263,23 @@ pub fn normalize_warm_base_regular_files(base: &Path) -> io::Result<WarmBaseMode
             result.regular_files += 1;
             let mode = metadata.mode();
             if mode & MODE_GROUP_WRITE == 0 {
-                fs::set_permissions(&path, fs::Permissions::from_mode(mode | MODE_GROUP_WRITE))?;
-                result.files_normalized += 1;
+                // A refusal here is NOT fatal, and must never be. `chmod` is
+                // granted by ownership alone, so one foreign-owned file used to
+                // abort the walk with `?` and leave every LATER file in the base
+                // unnormalized — the transitional state this change creates (a
+                // 1001 warm pod over a base still holding 10001- and 1000-owned
+                // inodes) would have hit that on the first entry. Count it,
+                // keep the first error for the log, and continue.
+                match chmod(&path, mode | MODE_GROUP_WRITE) {
+                    Ok(()) => result.files_normalized += 1,
+                    Err(error) => {
+                        result.files_unchangeable += 1;
+                        if result.first_chmod_error.is_none() {
+                            result.first_chmod_error =
+                                Some(format!("chmod {}: {error}", path.display()));
+                        }
+                    }
+                }
             }
         }
     }

--- a/server/crates/djinn-agent-worker/tests/volume_contract.rs
+++ b/server/crates/djinn-agent-worker/tests/volume_contract.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 use djinn_agent_worker::volume_contract::{
     ContractMode, VolumeContract, VolumeContractError, VolumeRoot, current_gid, enforce_with,
-    normalize_warm_base_regular_files, validate,
+    normalize_warm_base_regular_files, normalize_warm_base_regular_files_with, validate,
 };
 use tempfile::TempDir;
 
@@ -188,6 +188,79 @@ fn warm_base_normalization_makes_all_regular_files_group_writable() {
             .files_normalized,
         0,
         "successive warm cycles remain converged without a manual chmod"
+    );
+}
+
+/// A file this pod does not own must not abort the pass.
+///
+/// `chmod(2)` is granted by OWNERSHIP alone — no mode bit, setgid bit, ACL or
+/// group membership delegates it, and the kernel returns `EPERM` even when the
+/// requested mode is byte-identical to the current one. The live warm base is
+/// exactly that shape (measured: 6,794 files owned by uid 10001 against 2,422
+/// owned by 1000), so a `?` on the `chmod` meant the FIRST foreign-owned file
+/// ended the walk and left every later file unnormalized while the caller
+/// logged one warning.
+///
+/// A CI runner cannot create a foreign-owned file without root, and a test
+/// running as the owner never observes the refusal at all — so the refusal is
+/// injected, the same way `cargo_target_seed::LinkBackend` injects the kernel's
+/// `safe_hardlink_source()` refusal.
+#[test]
+fn a_chmod_refusal_is_counted_and_the_walk_continues() {
+    let dir = TempDir::new().expect("tempdir");
+    let base = dir.path().join("warm-base");
+    fs::create_dir_all(base.join("debug/deps")).expect("mkdir");
+    // Ten 644 files: the walk must reach all of them even though the first one
+    // it tries is refused.
+    for index in 0..10 {
+        let path = base.join(format!("debug/deps/lib{index}.rlib"));
+        fs::write(&path, b"x").expect("write");
+        chmod(&path, 0o644);
+    }
+    let refused = base.join("debug/deps/lib0.rlib");
+
+    let refused_for_closure = refused.clone();
+    let result = normalize_warm_base_regular_files_with(&base, &move |path, mode| {
+        if path == refused_for_closure {
+            return Err(std::io::Error::from_raw_os_error(libc::EPERM));
+        }
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))
+    })
+    .expect("a chmod refusal must never be a hard error");
+
+    assert_eq!(result.regular_files, 10);
+    assert_eq!(
+        result.files_normalized, 9,
+        "every file the pass owns must still be normalized"
+    );
+    assert_eq!(result.files_unchangeable, 1);
+    assert!(
+        result
+            .first_chmod_error
+            .as_deref()
+            .is_some_and(|error| error.contains("lib0.rlib")),
+        "the refusal must name the path: {:?}",
+        result.first_chmod_error
+    );
+
+    // The observable side effect, not the counter: the other nine really are
+    // group-writable on disk.
+    for index in 1..10 {
+        let mode = fs::symlink_metadata(base.join(format!("debug/deps/lib{index}.rlib")))
+            .expect("stat")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o664, "lib{index} was left unnormalized");
+    }
+    assert_eq!(
+        fs::symlink_metadata(&refused)
+            .expect("stat refused")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o644,
+        "the refused file is genuinely unchanged; the counter is not cosmetic"
     );
 }
 

--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -217,6 +217,41 @@ impl ShellLaunchContext {
         &self.runner
     }
 
+    /// Run one command **as the launcher-spawned child (uid 1001)** and collect
+    /// its output.
+    ///
+    /// # Why this exists as a public entry point
+    ///
+    /// The tool-facing shell path (`extension::handlers::workspace`) is not the
+    /// only thing that must run at `CHILD_UID`. Anything that CREATES CONTENT in
+    /// `/cache/cargo-target*` has to, because `chmod`/`chown`/`utimes` are
+    /// governed by ownership alone and `std::fs::copy` ends in
+    /// `set_permissions`: a build script at uid 1001 cannot copy over a file the
+    /// uid-1000 worker created, however conforming that file's mode is. The
+    /// task-run cargo-target seed is exactly such a producer, so the worker
+    /// re-enters through the broker rather than seeding in-process.
+    ///
+    /// # This never fails because of contention
+    ///
+    /// Losing the build-lease queue is contention, not a failure: the runner
+    /// degrades the invocation to the launcher's unleased quota and the child
+    /// still runs to completion (see `lease_failure` in `crate::process`). The
+    /// `Err` arm here means the broker could not launch or reap at all. Callers
+    /// that have a non-brokered fallback must take it on `Err` and must not
+    /// treat it as fatal.
+    pub async fn brokered_output(
+        &self,
+        cmd: std::process::Command,
+        timeout: Duration,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> std::io::Result<std::process::Output> {
+        self.runner
+            .output(cmd, self.invocation(timeout), cancel)
+            .await
+            .map(|output| output.process.output)
+            .map_err(|error| std::io::Error::other(format!("{error:?}")))
+    }
+
     /// Compose a shell context around a remote-child runner double in tests.
     /// Production construction remains restricted to [`Self::broker_backed`],
     /// which owns the authenticated Unix broker adapter.

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -303,52 +303,28 @@ exec {bin} warm-graph "{project_id}"
         volumes: Some(volumes),
         node_selector,
         tolerations,
-        // ── Why the warm pod runs as CHILD_UID (1001), not WORKER_UID (1000) ──
+        // Why CHILD_UID (1001), not WORKER_UID (1000). The rule for this field
+        // is not "match the task-run pod": it is that every actor which CREATES
+        // CONTENT in the shared `/cache/cargo-target` tree must be the same uid.
+        // That uid is 1001, because cargo and its build scripts always run as
+        // the launcher-spawned child, and a build script copying over a seeded
+        // artifact ends in `set_permissions`. `chmod`/`chown`/`utimes` are
+        // governed by OWNERSHIP alone — EPERM to a non-owner even for a
+        // byte-identical mode, and no mode bit, setgid, ACL or group grants
+        // them. (Directory-entry and content ops DO work cross-identity through
+        // gid 1000 + setgid + `g+w`; only inode metadata does not.)
         //
-        // The warm pod and every task-run write the SAME `/cache/cargo-target`
-        // tree, so the rule that governs this field is not "match the task-run
-        // pod" — it is **whoever CREATES content in the shared cargo cache must
-        // be the same uid**. That uid is 1001, and it is not negotiable:
-        // `cargo` and its build scripts always run as the launcher-spawned
-        // child (`CHILD_UID`), never as the worker, and a build script that
-        // `std::fs::copy`s over a seeded artifact ends in `set_permissions`.
+        // This does not touch the launcher's security boundary: that boundary is
+        // the 0600 worker-owned broker socket, which refuses uid 1001 at
+        // `connect(2)`, and a warm Job renders no launcher sidecar and no socket
+        // at all. Asserted by `warm_pod_never_renders_a_launcher_sidecar`.
         //
-        // `chmod`/`chown`/`utimes` are governed by **ownership only**. No mode
-        // bits, no setgid, no group membership and no ACL can grant them — the
-        // kernel returns EPERM even when the requested mode is byte-identical
-        // to the current one. So a build script at 1001 cannot finish a copy
-        // over a file the warm pod created at 1000, however conforming that
-        // file's mode is. Directory-entry ops (create/unlink/rename/link) and
-        // content ops (open/write/truncate) DO work cross-identity through gid
-        // 1000 + setgid + `g+w`; only inode-metadata ops do not. Aligning the
-        // *content creator* is therefore the only fix, and aligning it upward
-        // (1000 -> 1001) is the only direction available, since `CHILD_UID` is
-        // fixed by the launcher.
+        // `run_as_group`/`fsGroup` stay at ARTIFACT_GID: group remains the
+        // mechanism for the lifecycle-only actors (djinn-server at 10001,
+        // task-run worker at 1000). Only content creation moved.
         //
-        // This does NOT touch the launcher's security boundary. That boundary
-        // is the broker control socket, which is 0600 and worker-owned
-        // precisely so uid 1001 is refused at `connect(2)`
-        // (`djinn_cgroup_launcher::transport::restrict_socket_to_worker`).
-        // A warm Job renders exactly ONE container plus the optional warm-gate
-        // init container — no launcher sidecar, no broker socket, no
-        // handshake — so nothing in this pod is on the far side of that
-        // boundary. `WORKER_UID != CHILD_UID` stays true everywhere it means
-        // anything; see `warm_pod_never_renders_a_launcher_sidecar`.
-        //
-        // `run_as_group` / `fsGroup` stay at `ARTIFACT_GID` (1000): group is
-        // still the mechanism for the lifecycle-only actors (djinn-server at
-        // uid 10001 creating `.warm-locks` / `.djinn-gc.lock` and pruning, the
-        // task-run worker at 1000 creating and removing run dirs). Only content
-        // creation moved. `OnRootMismatch` keeps the kubelet from doing an
-        // unbounded recursive chown on every pod start; the worker binary
-        // re-validates the mounted result at startup
-        // (`djinn_agent_worker::volume_contract`) and fails closed.
-        //
-        // The existing on-disk base is a mix of 10001 (legacy) and 1000
-        // (post-pwrr warm pods); a ONE-TIME operator `chown -R 1001:1000` moves
-        // it to the target state. See
-        // `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md` — that migration
-        // must run AFTER this lands, and a full cold re-warm must be avoided.
+        // Moving the EXISTING base to this state is a one-time operator action:
+        // `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md`.
         security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
             run_as_user: Some(i64::from(crate::launcher::CHILD_UID)),
             run_as_group: Some(i64::from(crate::launcher::ARTIFACT_GID)),
@@ -577,13 +553,7 @@ mod tests {
 
         let pod = spec.template.spec.as_ref().expect("pod");
         assert_eq!(pod.restart_policy.as_deref(), Some("Never"));
-        // Every actor that CREATES CONTENT in the shared /cache/cargo-target
-        // tree must be uid 1001, because cargo and its build scripts always run
-        // as the launcher-spawned child and `fs::copy` ends in
-        // `set_permissions` — an ownership-only operation no mode bit can
-        // delegate. The warm pod is a content creator, so it is 1001. Actors
-        // that only manage lifecycle (djinn-server at 10001, the task-run
-        // worker at 1000) stay where they are and work through gid 1000.
+        // See the rationale on `security_context` in `build_warm_job`.
         let psc = pod.security_context.as_ref().expect("pod security context");
         assert_eq!(
             psc.run_as_user,
@@ -601,7 +571,7 @@ mod tests {
         assert_eq!(
             psc.run_as_group,
             Some(i64::from(crate::launcher::ARTIFACT_GID)),
-            "group stays 1000: it is still the mechanism for the lifecycle-only \
+            "group stays 1000: still the mechanism for the lifecycle-only \
              identities that share this tree"
         );
         assert_eq!(
@@ -894,16 +864,10 @@ mod tests {
     /// The precondition that makes running the warm pod as `CHILD_UID` free of
     /// security consequence — asserted, not assumed.
     ///
-    /// The 1000/1001 split is load-bearing: `transport::restrict_socket_to_worker`
-    /// hands the broker control socket to `WORKER_UID` at mode `0600` so that
-    /// uid 1001 is refused by the kernel at `connect(2)`, before a byte of the
-    /// control protocol is read. Moving the *warm* pod to 1001 would matter only
-    /// if a warm pod had a broker socket to connect to. It does not: a warm Job
-    /// renders one `warmer` container and, on the leased path, one `warm-lease-gate`
-    /// init container. No `cgroup-launcher` sidecar, no launcher IPC volume, no
-    /// handshake.
-    ///
-    /// If a launcher is ever added to the warm path, this test fails and the uid
+    /// `transport::restrict_socket_to_worker` hands the broker control socket to
+    /// `WORKER_UID` at mode `0600` so uid 1001 is refused at `connect(2)`. That
+    /// only matters if a warm pod has a socket to connect to; it does not. If a
+    /// launcher is ever added to the warm path this test fails, and the uid
     /// choice above must be revisited in the same change.
     #[test]
     fn warm_pod_never_renders_a_launcher_sidecar() {

--- a/server/crates/djinn-k8s/src/warm_job.rs
+++ b/server/crates/djinn-k8s/src/warm_job.rs
@@ -110,12 +110,13 @@ pub fn build_warm_job(
     let cmd = format!(
         r#"set -euo pipefail
 # Everything this Pod creates on the shared volumes must stay group-writable for
-# the other identity that reads/writes them (the launcher-spawned child, uid
-# 1001 primary group 1000). The container default 022 would give the clone 755
+# the other identities that read/write them (djinn-server at uid 10001, the
+# task-run worker at uid 1000 — both of which only manage lifecycle here and
+# work through gid 1000). The container default 022 would give the clone 755
 # dirs / 644 files, which the worker's startup contract check rejects. See
 # `djinn_agent_worker::volume_contract`.
 umask 0002
-# The mirror is server-owned (uid 10001) while this pod runs as uid 1000, so git
+# The mirror is server-owned (uid 10001) while this pod runs as uid 1001, so git
 # needs a `safe.directory` exception for it. It must be a config FILE in protected
 # scope: git honours safe.directory only from system/global files in the inner
 # `git-upload-pack` child of `git clone --local`, and strips command-scope config
@@ -302,19 +303,55 @@ exec {bin} warm-graph "{project_id}"
         volumes: Some(volumes),
         node_selector,
         tolerations,
-        // The warm pod shares the /cache cargo target PVC with task-runs, so it
-        // MUST carry the same identity and the same volume-ownership contract
-        // qut0 put on the task-run pod — otherwise the two halves of the shared
-        // cache write as different owners and neither can overwrite the other
-        // (task pwrr: the warm pod was still pinned to the legacy 10001 after
-        // task-runs moved to 1000). `fsGroup = ARTIFACT_GID` with
-        // `OnRootMismatch` gives the warm process membership in the artifact
-        // group without an unbounded recursive chown on every pod start; the
-        // worker binary re-validates the mounted result at startup
+        // ── Why the warm pod runs as CHILD_UID (1001), not WORKER_UID (1000) ──
+        //
+        // The warm pod and every task-run write the SAME `/cache/cargo-target`
+        // tree, so the rule that governs this field is not "match the task-run
+        // pod" — it is **whoever CREATES content in the shared cargo cache must
+        // be the same uid**. That uid is 1001, and it is not negotiable:
+        // `cargo` and its build scripts always run as the launcher-spawned
+        // child (`CHILD_UID`), never as the worker, and a build script that
+        // `std::fs::copy`s over a seeded artifact ends in `set_permissions`.
+        //
+        // `chmod`/`chown`/`utimes` are governed by **ownership only**. No mode
+        // bits, no setgid, no group membership and no ACL can grant them — the
+        // kernel returns EPERM even when the requested mode is byte-identical
+        // to the current one. So a build script at 1001 cannot finish a copy
+        // over a file the warm pod created at 1000, however conforming that
+        // file's mode is. Directory-entry ops (create/unlink/rename/link) and
+        // content ops (open/write/truncate) DO work cross-identity through gid
+        // 1000 + setgid + `g+w`; only inode-metadata ops do not. Aligning the
+        // *content creator* is therefore the only fix, and aligning it upward
+        // (1000 -> 1001) is the only direction available, since `CHILD_UID` is
+        // fixed by the launcher.
+        //
+        // This does NOT touch the launcher's security boundary. That boundary
+        // is the broker control socket, which is 0600 and worker-owned
+        // precisely so uid 1001 is refused at `connect(2)`
+        // (`djinn_cgroup_launcher::transport::restrict_socket_to_worker`).
+        // A warm Job renders exactly ONE container plus the optional warm-gate
+        // init container — no launcher sidecar, no broker socket, no
+        // handshake — so nothing in this pod is on the far side of that
+        // boundary. `WORKER_UID != CHILD_UID` stays true everywhere it means
+        // anything; see `warm_pod_never_renders_a_launcher_sidecar`.
+        //
+        // `run_as_group` / `fsGroup` stay at `ARTIFACT_GID` (1000): group is
+        // still the mechanism for the lifecycle-only actors (djinn-server at
+        // uid 10001 creating `.warm-locks` / `.djinn-gc.lock` and pruning, the
+        // task-run worker at 1000 creating and removing run dirs). Only content
+        // creation moved. `OnRootMismatch` keeps the kubelet from doing an
+        // unbounded recursive chown on every pod start; the worker binary
+        // re-validates the mounted result at startup
         // (`djinn_agent_worker::volume_contract`) and fails closed.
+        //
+        // The existing on-disk base is a mix of 10001 (legacy) and 1000
+        // (post-pwrr warm pods); a ONE-TIME operator `chown -R 1001:1000` moves
+        // it to the target state. See
+        // `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md` — that migration
+        // must run AFTER this lands, and a full cold re-warm must be avoided.
         security_context: Some(k8s_openapi::api::core::v1::PodSecurityContext {
-            run_as_user: Some(i64::from(crate::launcher::WORKER_UID)),
-            run_as_group: Some(i64::from(crate::launcher::WORKER_GID)),
+            run_as_user: Some(i64::from(crate::launcher::CHILD_UID)),
+            run_as_group: Some(i64::from(crate::launcher::ARTIFACT_GID)),
             ..crate::launcher::pod_security_context()
         }),
         ..PodSpec::default()
@@ -540,18 +577,32 @@ mod tests {
 
         let pod = spec.template.spec.as_ref().expect("pod");
         assert_eq!(pod.restart_policy.as_deref(), Some("Never"));
-        // Must carry the SAME identity and volume-ownership contract as a
-        // task-run pod: both write the shared /cache cargo target PVC, so a
-        // divergent uid/fsGroup leaves artifacts neither side can overwrite.
+        // Every actor that CREATES CONTENT in the shared /cache/cargo-target
+        // tree must be uid 1001, because cargo and its build scripts always run
+        // as the launcher-spawned child and `fs::copy` ends in
+        // `set_permissions` — an ownership-only operation no mode bit can
+        // delegate. The warm pod is a content creator, so it is 1001. Actors
+        // that only manage lifecycle (djinn-server at 10001, the task-run
+        // worker at 1000) stay where they are and work through gid 1000.
         let psc = pod.security_context.as_ref().expect("pod security context");
         assert_eq!(
             psc.run_as_user,
+            Some(i64::from(crate::launcher::CHILD_UID)),
+            "warm pod must run as the cargo/build-script uid (1001): it CREATES \
+             content in the shared cargo base, and chmod/chown/utimes are \
+             governed by ownership alone"
+        );
+        assert_ne!(
+            psc.run_as_user,
             Some(i64::from(crate::launcher::WORKER_UID)),
-            "warm pod must run as the worker uid to share the cargo cache safely"
+            "the 1000/1001 split is load-bearing: the broker control socket is \
+             worker-owned 0600 precisely to refuse uid 1001 at connect(2)"
         );
         assert_eq!(
             psc.run_as_group,
-            Some(i64::from(crate::launcher::WORKER_GID))
+            Some(i64::from(crate::launcher::ARTIFACT_GID)),
+            "group stays 1000: it is still the mechanism for the lifecycle-only \
+             identities that share this tree"
         );
         assert_eq!(
             psc.fs_group,
@@ -838,6 +889,63 @@ mod tests {
         );
         assert_eq!(cfg.warm_memory_request, "2Gi");
         assert_eq!(cfg.warm_memory_limit, "6Gi");
+    }
+
+    /// The precondition that makes running the warm pod as `CHILD_UID` free of
+    /// security consequence — asserted, not assumed.
+    ///
+    /// The 1000/1001 split is load-bearing: `transport::restrict_socket_to_worker`
+    /// hands the broker control socket to `WORKER_UID` at mode `0600` so that
+    /// uid 1001 is refused by the kernel at `connect(2)`, before a byte of the
+    /// control protocol is read. Moving the *warm* pod to 1001 would matter only
+    /// if a warm pod had a broker socket to connect to. It does not: a warm Job
+    /// renders one `warmer` container and, on the leased path, one `warm-lease-gate`
+    /// init container. No `cgroup-launcher` sidecar, no launcher IPC volume, no
+    /// handshake.
+    ///
+    /// If a launcher is ever added to the warm path, this test fails and the uid
+    /// choice above must be revisited in the same change.
+    #[test]
+    fn warm_pod_never_renders_a_launcher_sidecar() {
+        let cfg = KubernetesConfig::for_testing();
+        let plain = build_warm_job(&cfg, "proj-xyz", "example/warm:latest", None);
+        let leased = build_leased_warm_job(
+            &cfg,
+            "proj-xyz",
+            "example/warm:latest",
+            None,
+            &LeasedWarmJobIdentity::new("proj-xyz", "req-1", "rev-1", 7),
+        );
+
+        for (label, job) in [("plain", &plain), ("leased", &leased)] {
+            let pod = job
+                .spec
+                .as_ref()
+                .and_then(|spec| spec.template.spec.as_ref())
+                .expect("pod spec");
+            let names: Vec<&str> = pod
+                .containers
+                .iter()
+                .chain(pod.init_containers.iter().flatten())
+                .map(|c| c.name.as_str())
+                .collect();
+            assert!(
+                !names.contains(&crate::launcher::LAUNCHER_CONTAINER_NAME),
+                "{label} warm job renders a launcher sidecar ({names:?}); the warm \
+                 pod runs as CHILD_UID and would now be on the WRONG side of the \
+                 worker-owned 0600 broker socket"
+            );
+            let volume_names: Vec<&str> = pod
+                .volumes
+                .iter()
+                .flatten()
+                .map(|v| v.name.as_str())
+                .collect();
+            assert!(
+                !volume_names.contains(&crate::launcher::VOLUME_LAUNCHER_IPC),
+                "{label} warm job mounts the launcher IPC volume ({volume_names:?})"
+            );
+        }
     }
 
     /// The worker contract merged by l15u/t6g0 acquires its per-project


### PR DESCRIPTION
> **DEPENDS ON #2658 — DO NOT MERGE BEFORE IT.**
> This branch is cut from `fix/build-script-out-dir-seed-writethrough` and touches the same files. #2658 stops NEW corrupted units being created; this PR stops the ownership mismatch that makes the seeded artifacts unwritable by the identity that later overwrites them. Merging this first leaves the write-through defect in place while changing who owns the tree.

## The rule the shared cargo trees actually obey

Two permission classes behave differently, and conflating them is what froze the warm base:

| Class | Examples | Governed by |
|---|---|---|
| directory-entry | `creat`, `unlink`, `rename`, `linkat` | the **directory's** mode |
| content | `open(O_TRUNC)`, `write`, `truncate` | the **file's** mode |
| **inode metadata** | **`chmod`, `chown`, `utimensat` w/ explicit times** | **ownership, and nothing else** |

The first two work cross-identity through gid 1000 + setgid + `g+w` — that is what the existing volume-ownership contract establishes, and it is correct.

The third cannot be delegated. The kernel returns `EPERM` to a non-owner **even when the requested mode is byte-identical to the current one**; no mode bit, setgid bit, POSIX ACL or group membership grants it. And `std::fs::copy` always ends in `set_permissions`.

Therefore: **every actor that CREATES CONTENT in `/cache/cargo-target*` must be the same uid, and that uid is 1001**, because cargo and its build scripts are always the launcher-spawned child. Actors that only manage **lifecycle** stay where they are and keep working through the group.

| Actor | uid | Role |
|---|---|---|
| warm Job pod | `1000` → **`1001`** | content creator |
| task-run cargo + build scripts | `1001` | content creator (unchanged) |
| task-run cargo-target **seed** | `1000` → **`1001`** | content creator |
| task-run worker process | `1000` | lifecycle only |
| djinn-server / coordinator | `10001` | lifecycle only |

`djinn-server` deliberately does not move: there is no `chown` call site anywhere in the Rust tree, and the only two `chmod` sites are in the worker.

## B — warm pod runs as `CHILD_UID`

`warm_job.rs`: `run_as_user: WORKER_UID` → `CHILD_UID`. `run_as_group` / `fsGroup` stay at `ARTIFACT_GID` (1000). The rationale comment that argued *for* 1000 is rewritten.

**The 1000/1001 split stays load-bearing.** The broker control socket is 0600 and worker-owned precisely so uid 1001 is refused at `connect(2)` (`transport::restrict_socket_to_worker`). That only matters if a warm pod has a broker socket — it does not. A warm Job renders exactly one `warmer` container plus the optional `warm-lease-gate` init container: no launcher sidecar, no launcher IPC volume, no handshake. Asserted, not assumed, by the new `warm_pod_never_renders_a_launcher_sidecar` over both the plain and leased renders; if a launcher is ever added to the warm path that test fails and forces the uid choice to be revisited.

## C — the task-run seed runs as the launcher child

New `djinn-agent-worker seed-cargo-target --base <p> --run-dir <p>` subcommand is the uid-1001 half. The worker re-enters its own binary through the broker (which spawns at 1001), so `Copy`-classified inodes are born owned by the identity that later `fs::copy`s over them.

* **`bash -lc`, not a widened prefix list.** `safe_command_path` admits `/bin/`, `/usr/bin/`, `/workspace/`; `/opt/djinn/bin` is deliberately absent and `command_path.rs`'s own docs record that as a posture, with a test pinning it. Every brokered command in the repo already goes through `bash -lc`; this one does too. No posture change, no pinned-decision test rewritten. Paths are single-quoted (test covers an embedded quote).
* **Ordering.** The seed moved after the launcher handshake; *resolution* stayed at its original site, so `CARGO_TARGET_DIR` is still published before anything could spawn a child and `CargoTargetRunDirGuard` keeps its position in `run_task_run`'s drop order.
* **Degradation is mandatory.** A lost build-lease queue already degrades inside `LeaseInvocationRunner` (contention makes a command slow, never dead). On top of that: `no_broker`, `disabled_by_env`, `executable_unresolved`, `launch_failed`, `non_zero_exit`, `unparseable_summary` each fall back to the in-worker seed and are named in one structured field. `DJINN_CARGO_TARGET_SEED_BROKERED=0` disables the path without a redeploy. A partial brokered seed is cleared first (only when the destination is under `RUN_TARGET_ROOT`) so the fallback is a clean seed, not a merge.
* **Cancellation is shutdown, not degradation.** Re-seeding a 27 GiB base in-process inside a 60s `terminationGracePeriodSeconds` would turn a graceful wind-down into a SIGKILL that loses the checkpoint. It returns a named cold result instead.

## Lockstep

* `normalize_warm_base_regular_files` no longer aborts on the first `chmod` refusal. It used to `?`, so one foreign-owned file left every LATER file unnormalized — the exact transitional state this change creates. Refusals are counted (`files_unchangeable`) with the first path kept for the log. Behaviour verified by neutralization: restoring the `?` fails the new test.
* The doc claiming "the warm worker owns these files" was **false**. Measured on the live base: **6,794 files owned by uid 10001 against 2,422 owned by 1000** — neither could chmod the other's inodes, so the pass had always been partial. Corrected in `volume_contract.rs`, `VOLUME_OWNERSHIP_CONTRACT_RUNBOOK.md` and `docs/deploy/configuration.md`.
* `docs/CARGO_CACHE_OWNERSHIP_MIGRATION_RUNBOOK.md` — the one-time operator migration (quiesce → drop the corrupted units → `chown -R 1001:1000` from a root pod → re-assert `g+s` → verification). **Run only after this PR and #2658 land.**

### The migration explicitly rejects a cold re-warm

`warm_job.rs` documents ~20–25 min cold for a **~12-crate** workspace against a 3600 s `active_deadline_seconds` with `backoffLimit: 0`. This workspace is ~30 crates and its base measures **27 GiB**. A cold warm that overruns is SIGKILLed mid-compile, is not retried, and the next tick starts from zero — an unbounded loop that never produces a base while every task-run compiles cold. The `chown` preserves the compiled artifacts and completes in under a minute on 16k inodes.

## Measured on production k3s (read-only)

```
base                                   27 GiB, 16,138 files
debug/build                            2,993 files / 522 MiB
debug/.fingerprint                     7,270 files
uid histogram (maxdepth 3)             6,794 x 10001,  2,422 x 1000
zero-byte nlink>1 under build/*/out/   9
roots                                  drwxrwsr-x 10001:1000  (group contract already correct)
task-run pod                           worker uid/gid 1000, cgroup-launcher native sidecar present
warm jobs                              none running at inspection time
```

The base is **mixed**, not uniformly legacy — worth knowing before reading the runbook.

## Contradicting the brief

Two premises did not hold, and neither needed a change:

1. **`volume_contract.rs:789,800,852` / `main.rs:2182,3205` are not "expected-uid enforcement".** There is no uid enforcement in that module at all — `check_metadata` compares `st_gid` only, and `current_uid()` is read solely to *report* a `$HOME` violation. Those line numbers are the `task_run_roots` / `warm_roots` / `enforce_at_startup` call sites. Nothing there needed to move, and the module docs now say explicitly that the contract is deliberately silent on uid.
2. **`deploy/helm/djinn/tests/volume-ownership-render.sh` does not pin warm's uid.** It only inspects the server Deployment and the `fix-volume-perms` initContainer. Unchanged, and it still passes.

## Verification

* `cargo test -p djinn-agent-worker --lib --bin djinn-agent-worker --test volume_contract -- --test-threads=1` — green except `tests::warm_shutdown_drains_two_registered_groups_and_setsid_adoptee`, which **fails identically on the base branch** under full-suite ordering and passes in isolation on both. Not from this change.
* `cargo test -p djinn-k8s` — 256 + 29 green.
* `cargo test -p djinn-agent --lib` — 1441 green; `jit_pitfalls_trace_serialization_failure_is_fail_open` is an ordering flake in untouched code (passes in isolation).
* `bash deploy/helm/djinn/tests/volume-ownership-render.sh` — PASS.
* `cargo fmt --all -- --check` clean; `cargo clippy --all-targets` clean on the changed crates (pre-existing `djinn-db` boolean warnings and the `Instant::now` errors in `graph_warmer_ledger_tests.rs` are on the base branch too).
* **End-to-end smoke:** built the binary and ran `bash -lc "exec <bin> seed-cargo-target --base ... --run-dir ..."` against a fixture base — seeded 1 hardlink + 2 copies, printed the parseable summary line on stdout, exit 0.
* **Neutralization:** removing the non-fatal `chmod` handling fails `a_chmod_refusal_is_counted_and_the_walk_continues` (confirmed by actually reverting it and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)