### PR TITLE
fix(dispatch): retire spent task_dispatch lease attempts instead of replaying them forever

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission.rs
+++ b/server/crates/djinn-coordinator/src/build_admission.rs
@@ -258,8 +258,15 @@ pub enum DispatchSlotOutcome {
     /// The authority is not enforcing yet. Nothing was acquired and nothing is
     /// denied; `would_defer` records what enforcement WOULD have done.
     Observed { would_defer: bool },
-    /// The authority could not be reached. Fails closed for Enforce.
-    Unavailable,
+    /// The authority did not return a capacity answer. Fails closed for
+    /// Enforce.
+    ///
+    /// `detail` is the authority's own words -- typically the lease outcome or
+    /// `terminal_reason` that produced this. It exists because the previous
+    /// unit-variant form was indistinguishable, at the operator's log, from a
+    /// pool that was genuinely full: a lease tombstone arrived here and was
+    /// printed as `occupancy=0 cap=3`, a denial no capacity rule can justify.
+    Unavailable { detail: String },
 }
 
 /// The single capacity authority, as the admission controller sees it.
@@ -304,11 +311,49 @@ pub enum BuildAdmissionDecision {
         idempotent: bool,
     },
     Denied {
-        occupancy: i64,
+        /// Occupancy as READ from the capacity authority, or `None` when this
+        /// denial never consulted occupancy at all.
+        ///
+        /// `Option` rather than `i64` on purpose. The old shape forced every
+        /// non-capacity denial to invent a number, and the invented number was
+        /// `0` -- which the only operator-facing log then printed verbatim,
+        /// asserting a capacity figure arithmetically incapable of justifying
+        /// the denial it accompanied. A denial that did not measure occupancy
+        /// must now say so.
+        occupancy: Option<i64>,
         cap: i64,
+        /// Why. Printed alongside the numbers so a tombstoned lease can never
+        /// again be mistaken for a full pool.
+        cause: DenialCause,
     },
     /// Classification was absent or unrecognized. The observation counter is bounded.
     Unclassified,
+}
+
+/// Why one build-admission request was denied.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DenialCause {
+    /// The genuine one: weighted occupancy plus this request's weight exceeds
+    /// the cap. Only this variant carries a measured occupancy.
+    AtCapacity,
+    /// The controller itself is not admitting -- not yet recovered, or
+    /// draining. Nothing was measured and nothing was acquired.
+    ControllerNotAdmitting,
+    /// The build-slot authority answered with something that is not a capacity
+    /// answer. `detail` is its own words.
+    AuthorityUnavailable { detail: String },
+}
+
+impl std::fmt::Display for DenialCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AtCapacity => f.write_str("at_capacity"),
+            Self::ControllerNotAdmitting => f.write_str("controller_not_admitting"),
+            Self::AuthorityUnavailable { detail } => {
+                write!(f, "authority_unavailable: {detail}")
+            }
+        }
+    }
 }
 
 /// Observe-only disk-capacity adapter for build admission (proposal nquz,
@@ -1002,8 +1047,9 @@ impl BuildAdmissionController {
             // the constructor's configured value here made v0 and v1 disagree
             // in the operator's log about which number was in force.
             return Ok(BuildAdmissionDecision::Denied {
-                occupancy: 0,
+                occupancy: None,
                 cap: self.effective_cap(),
+                cause: DenialCause::ControllerNotAdmitting,
             });
         }
         // Capture an observe-only copy before any field of `request` is moved.
@@ -1156,18 +1202,29 @@ impl BuildAdmissionController {
                         }
                     }
                     self.publish_metrics().await;
-                    return Ok(BuildAdmissionDecision::Denied { occupancy, cap });
+                    return Ok(BuildAdmissionDecision::Denied {
+                        occupancy: Some(occupancy),
+                        cap,
+                        cause: DenialCause::AtCapacity,
+                    });
                 }
-                DispatchSlotOutcome::Unavailable => {
+                DispatchSlotOutcome::Unavailable { detail } => {
                     // A capacity authority we cannot reach is not permission.
                     // Observe stays non-denying; anything else fails closed.
+                    //
+                    // No occupancy is reported here because none was read. The
+                    // previous `occupancy: 0` was fabricated at this exact
+                    // line, and it is what made a permanently tombstoned lease
+                    // indistinguishable in the log from a full pool.
                     if self.mode() != BuildAdmissionMode::Observe {
                         return Ok(BuildAdmissionDecision::Denied {
-                            occupancy: 0,
+                            occupancy: None,
                             cap: self.effective_cap(),
+                            cause: DenialCause::AuthorityUnavailable { detail },
                         });
                     }
                     tracing::warn!(
+                        %detail,
                         "build admission: build-slot authority unavailable; \
                          Observe continues without capacity accounting"
                     );
@@ -2143,8 +2200,17 @@ impl WarmAdmission for BuildAdmissionController {
             .await?;
         match decision {
             BuildAdmissionDecision::Permitted { permit, .. } => Ok(permit),
-            BuildAdmissionDecision::Denied { occupancy, cap } => Err(WarmAdmissionError::Denied {
-                diagnostic: format!("occupancy {occupancy} reached cap {cap}"),
+            BuildAdmissionDecision::Denied {
+                occupancy,
+                cap,
+                cause,
+            } => Err(WarmAdmissionError::Denied {
+                diagnostic: match occupancy {
+                    Some(occupancy) => format!("occupancy {occupancy} reached cap {cap} ({cause})"),
+                    None => {
+                        format!("denied without measuring occupancy against cap {cap} ({cause})")
+                    }
+                },
             }),
             BuildAdmissionDecision::Unclassified => Err(WarmAdmissionError::Denied {
                 diagnostic: "unclassified build workload".into(),

--- a/server/crates/djinn-coordinator/src/build_admission_light_role_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_light_role_tests.rs
@@ -22,7 +22,7 @@ use djinn_k8s::{WarmAdmission, WarmAdmissionTransition};
 use djinn_runtime::RoleResourceClass;
 
 use crate::build_admission::{
-    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, TaskRunRole,
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, DenialCause, TaskRunRole,
 };
 use crate::build_admission_capacity_support::{CapacityHarness, controller_with_capacity};
 
@@ -104,8 +104,9 @@ async fn light_roles_are_permitted_while_a_build_holds_the_only_slot() {
         matches!(
             admit(&h.controller, Some("worker"), "second-build").await,
             BuildAdmissionDecision::Denied {
-                occupancy: 1,
-                cap: 1
+                occupancy: Some(1),
+                cap: 1,
+                cause: DenialCause::AtCapacity
             }
         ),
         "a second build-capable task-run must be denied at cap 1"
@@ -358,8 +359,9 @@ async fn graph_warm_jobs_still_consume_a_slot() {
         matches!(
             admit(&h.controller, Some("worker"), "build-after-warm").await,
             BuildAdmissionDecision::Denied {
-                occupancy: 1,
-                cap: 1
+                occupancy: Some(1),
+                cap: 1,
+                cause: DenialCause::AtCapacity
             }
         ),
         "a warm Job's slot must deny a build-capable task-run at the same cap"

--- a/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_stale_reclaim_tests.rs
@@ -31,7 +31,7 @@ use tokio::sync::RwLock;
 
 use crate::build_admission::{
     BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, BuildAdmissionReadiness,
-    BuildAdmissionRequest, BuildWorkloadKind, CapacitySource,
+    BuildAdmissionRequest, BuildWorkloadKind, CapacitySource, DenialCause,
 };
 use crate::build_admission_capacity_support::{CapacityHarness, attach_capacity};
 use crate::build_admission_inventory::BuildAdmissionReconciler;
@@ -421,8 +421,9 @@ async fn production_shaped_stale_population_is_reclaimed_and_enforce_admits_at_c
         matches!(
             fourth,
             BuildAdmissionDecision::Denied {
-                occupancy: 3,
-                cap: 3
+                occupancy: Some(3),
+                cap: 3,
+                cause: DenialCause::AtCapacity
             }
         ),
         "the cap must still bind after reconciliation; reclamation is not a bypass: {fourth:?}"

--- a/server/crates/djinn-coordinator/src/build_lease.rs
+++ b/server/crates/djinn-coordinator/src/build_lease.rs
@@ -12,8 +12,8 @@ use std::sync::{
 use async_trait::async_trait;
 use djinn_db::{
     AdmissionHandoffRepository, BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository,
-    BuildLeaseRow, BuildLeaseState, GrantNextBuildLeaseResult, QueueBuildLeaseInput,
-    QueueBuildLeaseResult,
+    BuildLeaseRow, BuildLeaseState, BuildLeaseTerminalReason, GrantNextBuildLeaseResult,
+    QueueBuildLeaseInput, QueueBuildLeaseResult,
 };
 use djinn_runtime::BuildSlotWeight;
 use djinn_supervisor::services::{
@@ -974,21 +974,41 @@ fn queue_result(row: &BuildLeaseRow) -> Option<LeaseResult> {
         BuildLeaseState::Terminal => Some(terminal_result(row)),
     }
 }
+/// Map a retained terminal row onto the typed outcome its owner replays.
+///
+/// The match over [`BuildLeaseTerminalReason`] is EXHAUSTIVE and deliberately
+/// has no `_` arm. It used to, and that arm cost a production outage: when the
+/// dispatch reclaimer introduced `reclaimed_absent`, the new reason fell into
+/// `_ => LeaseUnavailable` and every task whose dispatch lease had been
+/// reclaimed was denied forever, with a log line that named capacity as the
+/// cause. Adding a reason must be a compile error here, not a silent denial.
+///
+/// The only remaining fall-through is a reason this binary cannot parse at all
+/// -- a row written by a NEWER schema than the one running. That is genuinely
+/// unknown, and unknown is not permission.
 fn terminal_result(row: &BuildLeaseRow) -> LeaseResult {
-    match row.terminal_reason.as_deref() {
-        Some("abandoned") => LeaseResult::Abandoned {
-            candidate_cleanup: row.candidate_cleanup.is_some(),
-        },
-        Some("cancelled") => LeaseResult::Cancelled {
-            candidate_cleanup: row.candidate_cleanup.is_some(),
-        },
-        Some("released") => LeaseResult::Released {
-            candidate_cleanup: row.candidate_cleanup.is_some(),
-        },
-        Some("deadline_expired") => LeaseResult::LeaseWaitTimeout {
+    let candidate_cleanup = row.candidate_cleanup.is_some();
+    let Some(reason) = row
+        .terminal_reason
+        .as_deref()
+        .and_then(BuildLeaseTerminalReason::parse)
+    else {
+        return LeaseResult::LeaseUnavailable;
+    };
+    match reason {
+        BuildLeaseTerminalReason::Abandoned => LeaseResult::Abandoned { candidate_cleanup },
+        BuildLeaseTerminalReason::Cancelled => LeaseResult::Cancelled { candidate_cleanup },
+        BuildLeaseTerminalReason::Released => LeaseResult::Released { candidate_cleanup },
+        BuildLeaseTerminalReason::DeadlineExpired => LeaseResult::LeaseWaitTimeout {
             timeout_credit: None,
         },
-        _ => LeaseResult::LeaseUnavailable,
+        // The object this lease was fenced onto was PROVEN absent, so the unit
+        // is dead and its holder is gone. There is no live work to replay and
+        // no outcome to report: the owner must mint a new attempt rather than
+        // adopt this one. `task_dispatch` does exactly that (the repository
+        // retires the spent row on the next `queue`); warm and invocation
+        // owners re-enter under a fresh identity.
+        BuildLeaseTerminalReason::ReclaimedAbsent => LeaseResult::LeaseUnavailable,
     }
 }
 fn status(row: &BuildLeaseRow) -> LeaseStatus {

--- a/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_dispatch_reclaim_tests.rs
@@ -39,7 +39,7 @@ use djinn_k8s::{
 };
 
 use crate::build_admission::{
-    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode,
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, DenialCause,
 };
 use crate::build_admission_capacity_support::{CapacityHarness, controller_with_capacity_over};
 use crate::build_admission_inventory::BuildAdmissionReconciler;
@@ -225,8 +225,9 @@ async fn dispatch_leak_wedges_every_task_until_it_is_reclaimed() {
         matches!(
             admit(&successor, "next-task").await,
             BuildAdmissionDecision::Denied {
-                occupancy: 1,
-                cap: 1
+                occupancy: Some(1),
+                cap: 1,
+                cause: DenialCause::AtCapacity
             }
         ),
         "the production symptom: every task denied against occupancy it cannot use"

--- a/server/crates/djinn-coordinator/src/build_lease_dispatch_tombstone_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_dispatch_tombstone_tests.rs
@@ -1,0 +1,331 @@
+//! The board-wide dispatch wedge of 2026-07-27, end to end.
+//!
+//! Symptom: zero active sessions, six dispatchable tasks, and 78
+//! `build admission denied; leaving task queued` lines in five minutes — every
+//! one of them at `cap=3` with `occupancy` 0 or 1 and a request weighing 1. No
+//! capacity rule can deny at that occupancy. The board never recovered on its
+//! own and would not have recovered from a restart either.
+//!
+//! # The mechanism, which is a closed loop
+//!
+//! A task's dispatch slot is keyed `task_dispatch/{task_id}:{generation}`.
+//!
+//! 1. The pool is full, so admission denies and leaves a QUEUED lease row under
+//!    that key. It returns `Denied` *before* the journal reservation.
+//! 2. Nothing claims the position before its queue deadline, so the row goes
+//!    `terminal/deadline_expired` — or the task is closed and reopened and the
+//!    row goes `terminal/abandoned`, or the reclaimer proves its object absent
+//!    and it goes `terminal/reclaimed_absent`.
+//! 3. `queue()` had no state filter, so it replayed that terminal row forever.
+//!    The replay became `LeaseWaitTimeout` / `LeaseUnavailable`, which the slot
+//!    authority converted into a denial.
+//! 4. Because the denial returns before the journal write, no journal row is
+//!    ever created, so `resolve_dispatch_generation` returns the SAME
+//!    generation next tick — so the key never changes, so the same tombstone is
+//!    read again. Nothing in the loop can advance.
+//!
+//! Emptying the pool does not help. That is what makes these tests falsifiable:
+//! each one drives the pool to occupancy ZERO and then demands the task
+//! actually dispatch.
+//!
+//! # What stays green if the fix does nothing
+//!
+//! Nothing. Every assertion below is on a side effect — the weighted
+//! `build_leases` occupancy the cap is really compared against, and an
+//! `admit_task_run` that must return `Permitted`. Reverting the
+//! `spent_dispatch_attempt` branch in `BuildLeaseRepository::queue` fails both
+//! tests on the `permitted(...)` call, which is the outage itself, not a
+//! counter.
+
+use djinn_db::{
+    AdmissionDomain, BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseState,
+    BuildLeaseTerminalReason, Database,
+};
+use djinn_k8s::{WarmAdmission, WarmAdmissionPermit, WarmAdmissionTransition};
+
+use crate::build_admission::{
+    BuildAdmissionController, BuildAdmissionDecision, BuildAdmissionMode, DenialCause,
+};
+use crate::build_admission_capacity_support::{CapacityHarness, controller_with_capacity_over};
+
+const EPOCH: &str = "coordinator:tombstone-epoch";
+
+/// Well past any dispatch queue deadline this composition can mint. Passed to
+/// the same `expire_deadlines` the coordinator tick calls, so the row is
+/// retired by the production sweep rather than by a hand-written UPDATE.
+const AFTER_THE_DEADLINE: &str = "2099-01-01T00:00:00Z";
+
+async fn harness(cap: i64) -> CapacityHarness {
+    let db = Database::open_in_memory().unwrap();
+    db.ensure_initialized().await.unwrap();
+    controller_with_capacity_over(&db, BuildAdmissionMode::Enforce, cap, EPOCH).await
+}
+
+fn lease_key(task_id: &str, generation: i64) -> BuildLeaseKey {
+    BuildLeaseKey {
+        consumer_kind: BuildLeaseConsumerKind::TaskDispatch,
+        consumer_id: format!("{task_id}:{generation}"),
+    }
+}
+
+async fn admit(controller: &BuildAdmissionController, task_id: &str) -> BuildAdmissionDecision {
+    controller
+        .admit_task_run(
+            Some("worker"),
+            AdmissionDomain::TaskObservation,
+            task_id.to_owned(),
+            0,
+            format!("task-run-{task_id}-0"),
+        )
+        .await
+        .expect("admission must be reachable")
+}
+
+async fn permitted(controller: &BuildAdmissionController, task_id: &str) -> WarmAdmissionPermit {
+    match admit(controller, task_id).await {
+        BuildAdmissionDecision::Permitted { permit, .. } => permit,
+        other => panic!("{task_id} must be permitted over an EMPTY pool, got {other:?}"),
+    }
+}
+
+/// Read the durable terminal reason on a dispatch key, asserting the row is
+/// terminal. This is the tombstone, produced by production code only.
+async fn tombstone(harness: &CapacityHarness, task_id: &str) -> String {
+    let row = harness
+        .leases
+        .get(&lease_key(task_id, 0))
+        .await
+        .unwrap()
+        .expect("the denied attempt must have left a durable dispatch row");
+    assert_eq!(
+        row.state,
+        BuildLeaseState::Terminal,
+        "the attempt must be spent for this to be the wedge under test"
+    );
+    row.terminal_reason
+        .expect("a terminal row names its reason")
+}
+
+/// The five-task branch: `deadline_expired`.
+///
+/// A task denied behind a full pool leaves a queue position; the position
+/// outlives its deadline and is swept; and from then on the task is refused
+/// forever — including, crucially, when the pool is completely empty.
+#[tokio::test]
+async fn a_deadline_expired_dispatch_attempt_does_not_wedge_its_task_forever() {
+    let harness = harness(1).await;
+
+    // Fill the single slot with real warm capacity, so the denial that follows
+    // is a genuine capacity denial and not an artefact of the fixture.
+    let held = harness
+        .hold_warm_lease("holder")
+        .await
+        .expect("the warm holder must take the only slot");
+    assert_eq!(harness.occupancy().await, 1);
+
+    assert_eq!(
+        admit(&harness.controller, "victim").await,
+        BuildAdmissionDecision::Denied {
+            occupancy: Some(1),
+            cap: 1,
+            cause: DenialCause::AtCapacity,
+        },
+        "a full pool denies, and says so with the occupancy it actually read"
+    );
+
+    // The coordinator's own deadline sweep, run at a time past the position's
+    // 30-minute queue deadline.
+    harness
+        .leases
+        .expire_deadlines(AFTER_THE_DEADLINE)
+        .await
+        .unwrap();
+    assert_eq!(
+        tombstone(&harness, "victim").await,
+        BuildLeaseTerminalReason::DeadlineExpired.as_str()
+    );
+
+    // The pool empties completely. Nothing is occupying anything.
+    harness.release_warm_lease(held).await;
+    assert_eq!(
+        harness.occupancy().await,
+        0,
+        "the precondition that makes any further denial indefensible"
+    );
+
+    // The side effect, first: the task must actually dispatch.
+    let _permit = permitted(&harness.controller, "victim").await;
+    assert_eq!(
+        harness.occupancy().await,
+        1,
+        "and it must dispatch by TAKING the free slot, not by being waved through"
+    );
+
+    // The generation must NOT have been consumed by the denials.
+    //
+    // A `Denied` outcome returns before the journal reservation, so no journal
+    // row is written and `resolve_dispatch_generation` keeps returning the same
+    // number. That is correct — a denied attempt reserved nothing and must not
+    // burn a generation — but it is exactly what made the wedge self-sustaining
+    // once the key under that generation was tombstoned. With the tombstone
+    // retired, the generation the denials preserved is the one the success
+    // takes.
+    assert!(
+        harness
+            .journal
+            .generation_state(AdmissionDomain::TaskObservation, "victim", 0)
+            .await
+            .unwrap()
+            .is_some(),
+        "the successful admission must land on generation 0 — the generation \
+         every preceding denial deliberately left unconsumed"
+    );
+
+    // Corroboration: the durable row is a live occupying attempt again, not the
+    // retired one replayed.
+    let row = harness
+        .leases
+        .get(&lease_key("victim", 0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.state, BuildLeaseState::Launching);
+    assert!(
+        row.fencing_token.is_some(),
+        "a fresh attempt carries a fresh fencing token, so the retired \
+         attempt's token is fenced out"
+    );
+}
+
+/// The `vjjb` branch: `abandoned`.
+///
+/// This one reached the slot authority's `_ =>` arm, so it was reported as
+/// `Unavailable` and printed with a FABRICATED `occupancy=0` — a denial
+/// asserting a capacity figure it never consulted. Both halves are asserted:
+/// the task dispatches, and no denial invents a number.
+#[tokio::test]
+async fn an_abandoned_dispatch_attempt_does_not_wedge_its_task_forever() {
+    let harness = harness(1).await;
+    let held = harness
+        .hold_warm_lease("holder")
+        .await
+        .expect("the warm holder must take the only slot");
+
+    assert!(matches!(
+        admit(&harness.controller, "victim").await,
+        BuildAdmissionDecision::Denied {
+            cause: DenialCause::AtCapacity,
+            ..
+        }
+    ));
+
+    // The production path a closed/reopened task takes: its queued dispatch
+    // position is surrendered rather than left to be granted to nobody.
+    assert_eq!(
+        harness
+            .leases
+            .abandon_queued_dispatch("victim")
+            .await
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        tombstone(&harness, "victim").await,
+        BuildLeaseTerminalReason::Abandoned.as_str()
+    );
+
+    harness.release_warm_lease(held).await;
+    assert_eq!(harness.occupancy().await, 0);
+
+    let _permit = permitted(&harness.controller, "victim").await;
+    assert_eq!(harness.occupancy().await, 1);
+}
+
+/// A denial must never again print an occupancy it did not read.
+///
+/// Enforced structurally rather than by scraping a log line: only
+/// [`DenialCause::AtCapacity`] may carry `Some(occupancy)`, and it is the only
+/// cause the cap can produce.
+#[tokio::test]
+async fn only_a_capacity_denial_reports_an_occupancy() {
+    let harness = harness(1).await;
+    let held = harness.hold_warm_lease("holder").await.unwrap();
+    let denial = admit(&harness.controller, "victim").await;
+    harness.release_warm_lease(held).await;
+
+    match denial {
+        BuildAdmissionDecision::Denied {
+            occupancy,
+            cap,
+            cause,
+        } => {
+            assert_eq!(cause, DenialCause::AtCapacity);
+            assert_eq!(occupancy, Some(1));
+            assert_eq!(cap, 1);
+            assert!(
+                occupancy.is_some_and(|occupancy| occupancy.saturating_add(1) > cap),
+                "a capacity denial must be arithmetically capable of justifying \
+                 itself: this is the assertion the outage's log line failed"
+            );
+        }
+        other => panic!("expected a capacity denial, got {other:?}"),
+    }
+}
+
+/// A retired dispatch attempt must not resurrect a slot it never handed back.
+///
+/// The retirement is a DELETE, so it is worth proving it cannot be aimed at an
+/// occupying row: the fresh attempt has to queue behind live capacity like any
+/// other newcomer.
+#[tokio::test]
+async fn retiring_a_spent_attempt_never_frees_capacity_it_did_not_own() {
+    let harness = harness(1).await;
+    let holder = permitted(&harness.controller, "holder").await;
+    assert_eq!(harness.occupancy().await, 1);
+
+    // A second admission for the SAME task replays the live attempt: it is this
+    // attempt's own capacity, held, not a second slot.
+    assert!(matches!(
+        admit(&harness.controller, "holder").await,
+        BuildAdmissionDecision::Permitted { .. }
+    ));
+    assert_eq!(
+        harness.occupancy().await,
+        1,
+        "an occupying attempt is replayed, never retired and re-bought"
+    );
+
+    // And a different task still contends normally.
+    assert!(matches!(
+        admit(&harness.controller, "contender").await,
+        BuildAdmissionDecision::Denied {
+            cause: DenialCause::AtCapacity,
+            ..
+        }
+    ));
+    assert_eq!(harness.occupancy().await, 1);
+
+    // The holder hands its slot back through the production release path, and
+    // only then does the contender get it.
+    harness
+        .controller
+        .transition(
+            &holder,
+            WarmAdmissionTransition::DefinitiveFailure {
+                diagnostic: "slot-pool rejected before task-run creation".to_owned(),
+            },
+        )
+        .await
+        .expect("release the holder");
+
+    // The contender's queue position -- taken during the denial above -- is
+    // drained onto the freed slot, and its next admission adopts that grant.
+    // One slot in, one slot out: retiring nothing, double-granting nothing.
+    let _permit = permitted(&harness.controller, "contender").await;
+    assert_eq!(
+        harness.occupancy().await,
+        1,
+        "the cap of 1 is still exactly one slot: the holder's capacity moved to \
+         the contender, it was not duplicated"
+    );
+}

--- a/server/crates/djinn-coordinator/src/build_slot_authority.rs
+++ b/server/crates/djinn-coordinator/src/build_slot_authority.rs
@@ -44,6 +44,27 @@ impl BuildLeaseDispatchAuthority {
             generation,
         })
     }
+
+    /// Report a genuine capacity refusal, with the occupancy actually read.
+    ///
+    /// If occupancy cannot be read, this is NOT reported as a capacity denial:
+    /// an unmeasured pool is unknown, and a fabricated number here is exactly
+    /// what made the wedge unreadable in the log.
+    async fn at_capacity(&self) -> DispatchSlotOutcome {
+        match self.occupancy().await {
+            Some(occupancy) => DispatchSlotOutcome::AtCapacity {
+                occupancy,
+                cap: self.cap(),
+            },
+            None => unavailable("occupancy could not be read"),
+        }
+    }
+}
+
+fn unavailable(detail: &str) -> DispatchSlotOutcome {
+    DispatchSlotOutcome::Unavailable {
+        detail: detail.to_owned(),
+    }
 }
 
 #[async_trait]
@@ -52,7 +73,7 @@ impl BuildSlotAuthority for BuildLeaseDispatchAuthority {
         if !self.service.is_ready() {
             // Recovery has not completed, so occupancy is unknown. Unknown is
             // never permission.
-            return DispatchSlotOutcome::Unavailable;
+            return unavailable("lease service has not finished recovery");
         }
 
         // ── Shadow ──────────────────────────────────────────────────────────
@@ -87,38 +108,48 @@ impl BuildSlotAuthority for BuildLeaseDispatchAuthority {
             // Queued means the pool is full and this attempt now holds a FIFO
             // position. The task stays queued and the dispatcher retries; the
             // row is reclaimed by its queue deadline if the task never returns.
-            LeaseResult::Queued(_) => {
-                return match self.occupancy().await {
-                    Some(occupancy) => DispatchSlotOutcome::AtCapacity {
-                        occupancy,
-                        cap: self.cap(),
-                    },
-                    None => DispatchSlotOutcome::Unavailable,
-                };
-            }
+            //
+            // This is the ONLY outcome that may be reported as a capacity
+            // denial, because it is the only one produced by the cap.
+            LeaseResult::Queued(_) => return self.at_capacity().await,
             // A grant that arrived earlier and is already launching/bound is
             // this same attempt's capacity, replayed. It is held, not lost.
-            LeaseResult::Status(status)
-                if matches!(
-                    status.state,
+            LeaseResult::Status(status) => {
+                return match status.state {
                     LeaseState::Granted
-                        | LeaseState::Launching
-                        | LeaseState::Bound
-                        | LeaseState::Active
-                ) =>
-            {
-                return DispatchSlotOutcome::Granted;
-            }
-            LeaseResult::LeaseWaitTimeout { .. } => {
-                return match self.occupancy().await {
-                    Some(occupancy) => DispatchSlotOutcome::AtCapacity {
-                        occupancy,
-                        cap: self.cap(),
-                    },
-                    None => DispatchSlotOutcome::Unavailable,
+                    | LeaseState::Launching
+                    | LeaseState::Bound
+                    | LeaseState::Active => DispatchSlotOutcome::Granted,
+                    // Still waiting behind the FIFO: the pool is full.
+                    LeaseState::Queued => self.at_capacity().await,
+                    // Counted but unproven. It is not ours to use and the cap
+                    // is not what refused us.
+                    LeaseState::Suspect => unavailable("lease is suspect"),
+                    // A terminal state reached the queue path. With the spent
+                    // dispatch attempt retired by the repository this should be
+                    // unreachable; if it is ever reached it is NOT capacity.
+                    LeaseState::Cancelled => unavailable("lease already cancelled"),
+                    LeaseState::Released => unavailable("lease already released"),
                 };
             }
-            _ => return DispatchSlotOutcome::Unavailable,
+            LeaseResult::Bound(_) => return DispatchSlotOutcome::Granted,
+            // ── Not capacity answers ────────────────────────────────────────
+            //
+            // Every arm below used to be a single `_ => Unavailable`, and one
+            // of them (`reclaimed_absent`, arriving here as `LeaseUnavailable`)
+            // wedged production permanently while the operator's log blamed
+            // capacity. They are enumerated so a new `LeaseResult` variant is a
+            // compile error, and each carries its own words to the log.
+            LeaseResult::LeaseWaitTimeout { .. } => {
+                return unavailable("queue deadline expired before capacity was granted");
+            }
+            LeaseResult::Abandoned { .. } => return unavailable("lease attempt was abandoned"),
+            LeaseResult::Cancelled { .. } => return unavailable("lease attempt was cancelled"),
+            LeaseResult::Released { .. } => return unavailable("lease attempt was released"),
+            LeaseResult::LeaseIdentityConflict { .. } => {
+                return unavailable("lease identity conflict for this dispatch generation");
+            }
+            LeaseResult::LeaseUnavailable => return unavailable("lease ledger unavailable"),
         };
 
         // Acknowledge the grant so a recovered coordinator can tell a granted
@@ -136,7 +167,9 @@ impl BuildSlotAuthority for BuildLeaseDispatchAuthority {
             {
                 DispatchSlotOutcome::Granted
             }
-            _ => DispatchSlotOutcome::Unavailable,
+            other => unavailable(&format!(
+                "grant acknowledgement did not reach launching: {other:?}"
+            )),
         }
     }
 

--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -738,12 +738,24 @@ impl CoordinatorActor {
                 }
                 Ok(Some(permit))
             }
-            Ok(BuildAdmissionDecision::Denied { occupancy, cap }) => {
+            Ok(BuildAdmissionDecision::Denied {
+                occupancy,
+                cap,
+                cause,
+            }) => {
+                // `occupancy` is what was MEASURED, or "unmeasured" when the
+                // denial never consulted it. This line used to print a
+                // hard-coded 0 for every non-capacity denial, which is how a
+                // permanently tombstoned dispatch lease spent 40 minutes
+                // looking like a full pool at `occupancy=0 cap=3`. The cause
+                // is what tells those two apart.
                 tracing::info!(
                     task_id,
                     role,
-                    occupancy,
+                    occupancy = occupancy
+                        .map_or_else(|| "unmeasured".to_owned(), |value| value.to_string()),
                     cap,
+                    cause = %cause,
                     "build admission denied; leaving task queued"
                 );
                 Err(())

--- a/server/crates/djinn-coordinator/src/lib.rs
+++ b/server/crates/djinn-coordinator/src/lib.rs
@@ -218,6 +218,8 @@ mod build_lease_deadline_echo_tests;
 #[cfg(test)]
 mod build_lease_dispatch_reclaim_tests;
 #[cfg(test)]
+mod build_lease_dispatch_tombstone_tests;
+#[cfg(test)]
 mod build_lease_integration_tests;
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/server/crates/djinn-db/src/lib.rs
+++ b/server/crates/djinn-db/src/lib.rs
@@ -81,8 +81,9 @@ pub use repositories::{
     },
     build_lease::{
         BuildLeaseConsumerKind, BuildLeaseKey, BuildLeaseRepository, BuildLeaseRow,
-        BuildLeaseSnapshot, BuildLeaseState, GrantNextBuildLeaseResult, QueueBuildLeaseInput,
-        QueueBuildLeaseResult, ReclaimAbsentBuildLeaseInput, ReclaimAbsentBuildLeaseOutcome,
+        BuildLeaseSnapshot, BuildLeaseState, BuildLeaseTerminalReason, GrantNextBuildLeaseResult,
+        QueueBuildLeaseInput, QueueBuildLeaseResult, ReclaimAbsentBuildLeaseInput,
+        ReclaimAbsentBuildLeaseOutcome,
     },
     chat_interruption_notice::{
         ChatInterruptionNotice, ChatInterruptionNoticeRepository, CreateChatInterruptionNotice,

--- a/server/crates/djinn-db/src/repositories/build_lease.rs
+++ b/server/crates/djinn-db/src/repositories/build_lease.rs
@@ -76,6 +76,52 @@ impl BuildLeaseState {
     }
 }
 
+/// The closed set of reasons a build lease can reach `terminal`.
+///
+/// This exists so the set is a Rust type rather than a scattering of SQL string
+/// literals. Every producer below writes [`Self::as_str`] and every consumer
+/// matches the enum EXHAUSTIVELY, so adding a reason is a compile error at the
+/// mapping sites instead of a silent fall-through.
+///
+/// That fall-through is not hypothetical: `reclaimed_absent` was added by the
+/// dispatch reclaimer with no mapping, landed in a `_ =>` arm that answered
+/// `LeaseUnavailable`, and permanently wedged every task whose dispatch lease
+/// had been reclaimed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildLeaseTerminalReason {
+    Abandoned,
+    Cancelled,
+    Released,
+    DeadlineExpired,
+    ReclaimedAbsent,
+}
+impl BuildLeaseTerminalReason {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Abandoned => "abandoned",
+            Self::Cancelled => "cancelled",
+            Self::Released => "released",
+            Self::DeadlineExpired => "deadline_expired",
+            Self::ReclaimedAbsent => "reclaimed_absent",
+        }
+    }
+    /// Parse a stored reason. `None` covers both a NULL column and a value
+    /// written by a future version of this schema.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "abandoned" => Some(Self::Abandoned),
+            "cancelled" => Some(Self::Cancelled),
+            "released" => Some(Self::Released),
+            "deadline_expired" => Some(Self::DeadlineExpired),
+            "reclaimed_absent" => Some(Self::ReclaimedAbsent),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BuildLeaseKey {
     pub consumer_kind: BuildLeaseConsumerKind,
@@ -133,6 +179,11 @@ pub enum QueueBuildLeaseResult {
     Queued {
         row: BuildLeaseRow,
         idempotent: bool,
+        /// `Some(terminal_reason)` when this call retired a spent
+        /// `task_dispatch` attempt to mint `row`. Purely diagnostic, but it is
+        /// the only place the tombstone that used to wedge dispatch is
+        /// observable, so it is carried out to the operator log.
+        superseded: Option<String>,
     },
     LeaseIdentityConflict {
         existing: BuildLeaseRow,
@@ -187,6 +238,46 @@ impl BuildLeaseRepository {
 
     /// Queue a stable identity. Exact replay returns the original row; any
     /// immutable mismatch is a typed result rather than a capacity side effect.
+    ///
+    /// # Terminal rows are replayed -- except for `task_dispatch`
+    ///
+    /// Retaining a terminal row and replaying it is the whole point of this
+    /// ledger for `graph_warm` and `task_invocation`: a lost response must be
+    /// answered with the outcome that actually happened (`Released`,
+    /// `Cancelled`, a timeout credit) and must never silently re-run finished
+    /// work. That behaviour is untouched here.
+    ///
+    /// `task_dispatch` is the one population where it is wrong, and it wedged
+    /// production. Its key is `{task_id}:{generation}` — a *coordinate*, not an
+    /// attempt: the dispatcher asks for that same coordinate on every tick for
+    /// as long as the task is dispatchable. A terminal row under it is a SPENT
+    /// ATTEMPT, occupying nothing, yet replaying it answered `LeaseWaitTimeout`
+    /// / `LeaseUnavailable` forever, which layer-1 admission converted into a
+    /// denial *before* the journal write that would have advanced the
+    /// generation. The key therefore never changed and the denial re-derived
+    /// itself every tick: a closed, self-sustaining wedge that survives every
+    /// restart. Six dispatchable tasks sat behind it at occupancy 0-1 of cap 3.
+    ///
+    /// So a terminal `task_dispatch` row is retired and a fresh attempt minted
+    /// under the same key. Deleting rather than resetting in place is
+    /// deliberate:
+    ///
+    /// * the row's identity, weight and `bound_pod_uid` are trigger-immutable,
+    ///   so a terminal→queued UPDATE would break against the schema the moment
+    ///   the configured dispatch weight changed or the row had ever been bound;
+    /// * a brand new `enqueue_sequence` sends the new attempt to the BACK of
+    ///   the FIFO, where a new arrival belongs — an in-place reset would keep
+    ///   the retired attempt's queue position and let it cut the line;
+    /// * a brand new `fencing_token` (nextval, never reissued) means any actor
+    ///   still holding the retired attempt's token is fenced out, exactly as it
+    ///   would be against any other new row.
+    ///
+    /// No capacity can be double-granted by this: terminal rows are excluded
+    /// from [`OCCUPYING`], so the retired row was buying nothing that the fresh
+    /// attempt could buy twice. The dispatch lifecycle/audit trail lives in
+    /// `admission_journal`, which migration 153 retains for exactly that
+    /// purpose; `build_leases` holds dispatch capacity, and spent capacity is
+    /// not evidence.
     pub async fn queue(&self, input: &QueueBuildLeaseInput) -> DbResult<QueueBuildLeaseResult> {
         if input.key.consumer_id.trim().is_empty() || input.immutable_identity.trim().is_empty() {
             return Err(DbError::InvalidData(
@@ -201,16 +292,37 @@ impl BuildLeaseRepository {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
         lock(&mut tx).await?;
-        if let Some(row) = fetch(&mut tx, &input.key, false).await? {
-            tx.commit().await?;
-            return Ok(if row.immutable_identity == input.immutable_identity {
-                QueueBuildLeaseResult::Queued {
-                    row,
-                    idempotent: true,
-                }
-            } else {
-                QueueBuildLeaseResult::LeaseIdentityConflict { existing: row }
-            });
+        let mut superseded: Option<String> = None;
+        if let Some(row) = fetch(&mut tx, &input.key, true).await? {
+            let spent_dispatch_attempt = row.state == BuildLeaseState::Terminal
+                && input.key.consumer_kind == BuildLeaseConsumerKind::TaskDispatch;
+            if !spent_dispatch_attempt {
+                tx.commit().await?;
+                return Ok(if row.immutable_identity == input.immutable_identity {
+                    QueueBuildLeaseResult::Queued {
+                        row,
+                        idempotent: true,
+                        superseded: None,
+                    }
+                } else {
+                    QueueBuildLeaseResult::LeaseIdentityConflict { existing: row }
+                });
+            }
+            sqlx::query("DELETE FROM build_leases WHERE consumer_kind=$1 AND consumer_id=$2 AND state='terminal'")
+                .bind(input.key.consumer_kind.as_str())
+                .bind(&input.key.consumer_id)
+                .execute(&mut *tx)
+                .await?;
+            let reason = row
+                .terminal_reason
+                .clone()
+                .unwrap_or_else(|| "unknown".to_owned());
+            tracing::info!(
+                consumer_id = %input.key.consumer_id,
+                terminal_reason = %reason,
+                "retired spent task_dispatch lease attempt; minting a fresh one"
+            );
+            superseded = Some(reason);
         }
         let row = sqlx::query_as::<_, DbRow>(&format!("INSERT INTO build_leases (consumer_kind,consumer_id,immutable_identity,queue_deadline,launch_deadline,weight,state) VALUES ($1,$2,$3,$4::timestamptz,$5::timestamptz,$6,'queued') RETURNING {COLS}"))
             .bind(input.key.consumer_kind.as_str()).bind(&input.key.consumer_id).bind(&input.immutable_identity).bind(&input.queue_deadline).bind(&input.launch_deadline).bind(input.weight).fetch_one(&mut *tx).await?;
@@ -218,6 +330,7 @@ impl BuildLeaseRepository {
         Ok(QueueBuildLeaseResult::Queued {
             row: row.try_into()?,
             idempotent: false,
+            superseded,
         })
     }
 
@@ -322,12 +435,13 @@ impl BuildLeaseRepository {
         lock(&mut tx).await?;
         let result = sqlx::query(
             "UPDATE build_leases \
-             SET state='terminal', terminal_reason='abandoned', terminal_at=now(), updated_at=now() \
+             SET state='terminal', terminal_reason=$2, terminal_at=now(), updated_at=now() \
              WHERE consumer_kind='task_dispatch' \
                AND split_part(consumer_id, ':', 1) = $1 \
                AND state='queued'",
         )
         .bind(task_id)
+        .bind(BuildLeaseTerminalReason::Abandoned.as_str())
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;
@@ -395,11 +509,12 @@ impl BuildLeaseRepository {
         let consumed = sqlx::query_scalar::<_, bool>(
             "UPDATE build_leases SET timeout_credit_consumed=TRUE, updated_at=now() \
              WHERE consumer_kind=$1 AND consumer_id=$2 AND state='terminal' \
-             AND terminal_reason='deadline_expired' AND timeout_credit_consumed=FALSE \
+             AND terminal_reason=$3 AND timeout_credit_consumed=FALSE \
              RETURNING TRUE",
         )
         .bind(key.consumer_kind.as_str())
         .bind(&key.consumer_id)
+        .bind(BuildLeaseTerminalReason::DeadlineExpired.as_str())
         .fetch_optional(&mut *tx)
         .await?
         .unwrap_or(false);
@@ -482,11 +597,12 @@ impl BuildLeaseRepository {
             ));
         }
         let result = sqlx::query_as::<_, DbRow>(&format!(
-            "UPDATE build_leases SET state='terminal',terminal_reason='abandoned',candidate_cleanup=COALESCE($1, candidate_cleanup),terminal_at=now(),updated_at=now() WHERE consumer_kind=$2 AND consumer_id=$3 RETURNING {COLS}"
+            "UPDATE build_leases SET state='terminal',terminal_reason=$4,candidate_cleanup=COALESCE($1, candidate_cleanup),terminal_at=now(),updated_at=now() WHERE consumer_kind=$2 AND consumer_id=$3 RETURNING {COLS}"
         ))
         .bind(cleanup.map(sqlx::types::Json))
         .bind(key.consumer_kind.as_str())
         .bind(&key.consumer_id)
+        .bind(BuildLeaseTerminalReason::Abandoned.as_str())
         .fetch_one(&mut *tx)
         .await?;
         tx.commit().await?;
@@ -497,7 +613,8 @@ impl BuildLeaseRepository {
         key: &BuildLeaseKey,
         cleanup: Option<serde_json::Value>,
     ) -> DbResult<BuildLeaseRow> {
-        self.terminal(key, None, "cancelled", cleanup).await
+        self.terminal(key, None, BuildLeaseTerminalReason::Cancelled, cleanup)
+            .await
     }
     /// Fenced counterpart for a cancel request that carries a grant token.
     pub async fn cancel_fenced(
@@ -506,7 +623,13 @@ impl BuildLeaseRepository {
         token: i64,
         cleanup: Option<serde_json::Value>,
     ) -> DbResult<BuildLeaseRow> {
-        self.terminal(key, Some(token), "cancelled", cleanup).await
+        self.terminal(
+            key,
+            Some(token),
+            BuildLeaseTerminalReason::Cancelled,
+            cleanup,
+        )
+        .await
     }
     pub async fn release(
         &self,
@@ -514,7 +637,13 @@ impl BuildLeaseRepository {
         token: i64,
         cleanup: Option<serde_json::Value>,
     ) -> DbResult<BuildLeaseRow> {
-        self.terminal(key, Some(token), "released", cleanup).await
+        self.terminal(
+            key,
+            Some(token),
+            BuildLeaseTerminalReason::Released,
+            cleanup,
+        )
+        .await
     }
 
     /// Bind is the sole operation which can set a pod UID; the database trigger
@@ -587,7 +716,7 @@ impl BuildLeaseRepository {
         self.db.ensure_initialized().await?;
         let mut tx = self.db.pool().begin().await?;
         lock(&mut tx).await?;
-        let rows=sqlx::query_as::<_,DbRow>(&format!("UPDATE build_leases SET state='terminal', terminal_reason='deadline_expired', terminal_at=$1::timestamptz, updated_at=now() WHERE state='queued' AND queue_deadline <= $1::timestamptz RETURNING {COLS}")).bind(now).fetch_all(&mut *tx).await?;
+        let rows=sqlx::query_as::<_,DbRow>(&format!("UPDATE build_leases SET state='terminal', terminal_reason=$2, terminal_at=$1::timestamptz, updated_at=now() WHERE state='queued' AND queue_deadline <= $1::timestamptz RETURNING {COLS}")).bind(now).bind(BuildLeaseTerminalReason::DeadlineExpired.as_str()).fetch_all(&mut *tx).await?;
         let launch=sqlx::query_as::<_,DbRow>(&format!("UPDATE build_leases SET state='suspect', updated_at=now() WHERE state IN ('granted','launching') AND launch_deadline <= $1::timestamptz RETURNING {COLS}")).bind(now).fetch_all(&mut *tx).await?;
         tx.commit().await?;
         rows.into_iter()
@@ -681,12 +810,13 @@ impl BuildLeaseRepository {
             return Ok(ReclaimAbsentBuildLeaseOutcome::Fenced { reason });
         }
         let reclaimed = sqlx::query_as::<_, DbRow>(&format!(
-            "UPDATE build_leases SET state='terminal',terminal_reason='reclaimed_absent',\
+            "UPDATE build_leases SET state='terminal',terminal_reason=$3,\
              terminal_at=now(),updated_at=now() WHERE consumer_kind=$1 AND consumer_id=$2 \
              RETURNING {COLS}"
         ))
         .bind(input.key.consumer_kind.as_str())
         .bind(&input.key.consumer_id)
+        .bind(BuildLeaseTerminalReason::ReclaimedAbsent.as_str())
         .fetch_one(&mut *tx)
         .await?;
         tx.commit().await?;
@@ -699,7 +829,7 @@ impl BuildLeaseRepository {
         &self,
         key: &BuildLeaseKey,
         token: Option<i64>,
-        reason: &str,
+        reason: BuildLeaseTerminalReason,
         cleanup: Option<serde_json::Value>,
     ) -> DbResult<BuildLeaseRow> {
         self.db.ensure_initialized().await?;
@@ -717,7 +847,7 @@ impl BuildLeaseRepository {
             tx.commit().await?;
             return Ok(row);
         }
-        let result=sqlx::query_as::<_,DbRow>(&format!("UPDATE build_leases SET state='terminal',terminal_reason=$1,candidate_cleanup=COALESCE($2, candidate_cleanup),terminal_at=now(),updated_at=now() WHERE consumer_kind=$3 AND consumer_id=$4 RETURNING {COLS}")).bind(reason).bind(cleanup.map(sqlx::types::Json)).bind(key.consumer_kind.as_str()).bind(&key.consumer_id).fetch_one(&mut *tx).await?;
+        let result=sqlx::query_as::<_,DbRow>(&format!("UPDATE build_leases SET state='terminal',terminal_reason=$1,candidate_cleanup=COALESCE($2, candidate_cleanup),terminal_at=now(),updated_at=now() WHERE consumer_kind=$3 AND consumer_id=$4 RETURNING {COLS}")).bind(reason.as_str()).bind(cleanup.map(sqlx::types::Json)).bind(key.consumer_kind.as_str()).bind(&key.consumer_id).fetch_one(&mut *tx).await?;
         tx.commit().await?;
         result.try_into()
     }
@@ -922,7 +1052,7 @@ async fn set_cap_tx(tx: &mut Transaction<'_, Postgres>, cap: i64) -> DbResult<()
     Ok(())
 }
 async fn expire_queued_tx(tx: &mut Transaction<'_, Postgres>, now: &str) -> DbResult<()> {
-    sqlx::query("UPDATE build_leases SET state='terminal',terminal_reason='deadline_expired',terminal_at=$1::timestamptz,updated_at=now() WHERE state='queued' AND queue_deadline <= $1::timestamptz").bind(now).execute(&mut **tx).await?;
+    sqlx::query("UPDATE build_leases SET state='terminal',terminal_reason=$2,terminal_at=$1::timestamptz,updated_at=now() WHERE state='queued' AND queue_deadline <= $1::timestamptz").bind(now).bind(BuildLeaseTerminalReason::DeadlineExpired.as_str()).execute(&mut **tx).await?;
     Ok(())
 }
 async fn snapshot_tx(tx: &mut Transaction<'_, Postgres>) -> DbResult<BuildLeaseSnapshot> {

--- a/server/crates/djinn-db/src/repositories/build_lease_tests.rs
+++ b/server/crates/djinn-db/src/repositories/build_lease_tests.rs
@@ -268,3 +268,192 @@ async fn concurrent_terminal_attempts_return_capacity_exactly_once() {
     assert_eq!(next.key, second.key);
     assert_eq!(repo.snapshot().await.unwrap().occupied, 1);
 }
+
+/// A spent `task_dispatch` attempt must be retired, not replayed forever.
+///
+/// This is the 2026-07-27 board wedge, at the ledger. The key
+/// `task_dispatch/{task_id}:{generation}` is a COORDINATE the dispatcher asks
+/// for on every tick, not an attempt. Once a terminal row sat under it,
+/// `queue()` — which had no state filter — returned that row unchanged forever,
+/// and layer-1 admission turned the replay into a denial *before* the journal
+/// write that would have advanced the generation. So the key never changed, the
+/// tombstone was read again next tick, and the loop closed on itself: six
+/// dispatchable tasks, zero sessions, 78 denials in five minutes at occupancy
+/// 0-1 of cap 3.
+///
+/// Every terminal signature a dispatch row can reach is covered, each produced
+/// by the production path that produces it. The load-bearing assertion in each
+/// round is the last one: the fresh attempt is actually GRANTED against a cap
+/// of 1, which the tombstone could never be.
+#[tokio::test]
+async fn a_spent_task_dispatch_attempt_is_retired_rather_than_replayed_forever() {
+    let repo = BuildLeaseRepository::new(Database::open_in_memory().unwrap());
+
+    for (task_id, reason) in [
+        ("expired-task", BuildLeaseTerminalReason::DeadlineExpired),
+        ("reclaimed-task", BuildLeaseTerminalReason::ReclaimedAbsent),
+        ("abandoned-task", BuildLeaseTerminalReason::Abandoned),
+        ("released-task", BuildLeaseTerminalReason::Released),
+        ("cancelled-task", BuildLeaseTerminalReason::Cancelled),
+    ] {
+        let consumer_id = format!("{task_id}:0");
+        let request = input(
+            BuildLeaseConsumerKind::TaskDispatch,
+            &consumer_id,
+            &format!("dispatch:{task_id}:0"),
+        );
+
+        // ── Produce the tombstone, only through production paths ────────────
+        match reason {
+            BuildLeaseTerminalReason::DeadlineExpired => {
+                // The coordinator stamps an absolute queue deadline on every
+                // dispatch attempt; the tick sweep retires it once passed.
+                let stamped = QueueBuildLeaseInput {
+                    queue_deadline: Some(NOW.to_owned()),
+                    ..request.clone()
+                };
+                repo.queue(&stamped).await.unwrap();
+                let expired = repo.expire_deadlines(LATER).await.unwrap();
+                assert_eq!(expired.len(), 1);
+            }
+            BuildLeaseTerminalReason::ReclaimedAbsent => {
+                repo.queue(&request).await.unwrap();
+                let granted = grant(&repo, 1).await;
+                assert!(matches!(
+                    repo.reclaim_absent_object(&ReclaimAbsentBuildLeaseInput {
+                        key: request.key.clone(),
+                        observed_state: granted.state,
+                        observed_immutable_identity: granted.immutable_identity.clone(),
+                        observed_fencing_token: granted.fencing_token,
+                        observed_bound_pod_uid: granted.bound_pod_uid.clone(),
+                        observed_updated_at: granted.updated_at.clone(),
+                    })
+                    .await
+                    .unwrap(),
+                    ReclaimAbsentBuildLeaseOutcome::Reclaimed(_)
+                ));
+            }
+            BuildLeaseTerminalReason::Abandoned => {
+                repo.queue(&request).await.unwrap();
+                assert_eq!(repo.abandon_queued_dispatch(task_id).await.unwrap(), 1);
+            }
+            BuildLeaseTerminalReason::Released => {
+                repo.queue(&request).await.unwrap();
+                let granted = grant(&repo, 1).await;
+                repo.release(&request.key, granted.fencing_token.unwrap(), None)
+                    .await
+                    .unwrap();
+            }
+            BuildLeaseTerminalReason::Cancelled => {
+                repo.queue(&request).await.unwrap();
+                repo.cancel(&request.key, None).await.unwrap();
+            }
+        }
+
+        let tombstone = repo.get(&request.key).await.unwrap().unwrap();
+        assert_eq!(tombstone.state, BuildLeaseState::Terminal, "{task_id}");
+        assert_eq!(
+            tombstone.terminal_reason.as_deref(),
+            Some(reason.as_str()),
+            "{task_id}"
+        );
+        assert_eq!(
+            repo.snapshot().await.unwrap().occupied,
+            0,
+            "a terminal row occupies nothing, so retiring it can free nothing"
+        );
+
+        // ── The tick that used to wedge: the same key, asked for again ──────
+        let fresh = match repo.queue(&request).await.unwrap() {
+            QueueBuildLeaseResult::Queued {
+                row,
+                idempotent,
+                superseded,
+            } => {
+                assert!(
+                    !idempotent,
+                    "{task_id}: a spent attempt must not replay as an idempotent hit"
+                );
+                assert_eq!(
+                    superseded.as_deref(),
+                    Some(reason.as_str()),
+                    "{task_id}: the retirement must be reported, so an operator \
+                     can see a tombstone was cleared"
+                );
+                row
+            }
+            other => panic!("{task_id}: the fresh attempt must queue, got {other:?}"),
+        };
+        assert_eq!(fresh.state, BuildLeaseState::Queued);
+        assert_eq!(fresh.terminal_reason, None);
+        assert_eq!(fresh.fencing_token, None);
+        assert!(
+            fresh.enqueue_sequence > tombstone.enqueue_sequence,
+            "{task_id}: a fresh attempt joins the BACK of the FIFO rather than \
+             inheriting the retired attempt's queue position"
+        );
+
+        // The side effect that is the whole point: capacity is obtainable.
+        let granted = grant(&repo, 1).await;
+        assert_eq!(granted.key, request.key, "{task_id}");
+        assert_ne!(
+            granted.fencing_token, tombstone.fencing_token,
+            "{task_id}: the retired attempt's token must be fenced out"
+        );
+        assert_eq!(repo.snapshot().await.unwrap().occupied, 1);
+
+        // Hand the slot back so the next round starts from an empty pool.
+        repo.release(&request.key, granted.fencing_token.unwrap(), None)
+            .await
+            .unwrap();
+        assert_eq!(repo.snapshot().await.unwrap().occupied, 0);
+    }
+}
+
+/// The retirement above is scoped to `task_dispatch` alone.
+///
+/// Retained terminal replay is load-bearing for the other two populations: a
+/// warm Job whose response was lost must be told it was `Released`, not handed
+/// a fresh grant that re-runs a finished compile. Widening the fix to every
+/// consumer kind would break exactly that, and would break it silently.
+#[tokio::test]
+async fn a_terminal_warm_or_invocation_lease_is_still_replayed_verbatim() {
+    let repo = BuildLeaseRepository::new(Database::open_in_memory().unwrap());
+    for (kind, id) in [
+        (BuildLeaseConsumerKind::GraphWarm, "warm-request"),
+        (BuildLeaseConsumerKind::TaskInvocation, "invocation-id"),
+    ] {
+        let request = input(kind, id, &format!("{id}-v1"));
+        repo.queue(&request).await.unwrap();
+        let granted = grant(&repo, 1).await;
+        repo.release(&request.key, granted.fencing_token.unwrap(), None)
+            .await
+            .unwrap();
+
+        match repo.queue(&request).await.unwrap() {
+            QueueBuildLeaseResult::Queued {
+                row,
+                idempotent,
+                superseded,
+            } => {
+                assert_eq!(
+                    row.state,
+                    BuildLeaseState::Terminal,
+                    "{kind:?} must replay its retained outcome"
+                );
+                assert_eq!(
+                    row.terminal_reason.as_deref(),
+                    Some(BuildLeaseTerminalReason::Released.as_str())
+                );
+                assert!(idempotent, "{kind:?}");
+                assert_eq!(superseded, None, "{kind:?}");
+            }
+            other => panic!("{kind:?} replay must return the retained row, got {other:?}"),
+        }
+        assert_eq!(
+            repo.snapshot().await.unwrap().occupied,
+            0,
+            "and the replay must not re-buy capacity"
+        );
+    }
+}

--- a/server/src/server/state/admission_epoch_arming_tests.rs
+++ b/server/src/server/state/admission_epoch_arming_tests.rs
@@ -40,7 +40,7 @@ use super::build_admission_config_tests::{
 use super::*;
 use crate::admin::{AdminCommand, EpochAction, run_admin_command};
 use djinn_agent::actors::coordinator::BuildAdmissionReadiness;
-use djinn_coordinator::build_admission::BuildAdmissionDecision;
+use djinn_coordinator::build_admission::{BuildAdmissionDecision, DenialCause};
 use djinn_db::{AdmissionDomain, AdmissionHandoffPhase, V0Mode, V1Mode};
 use djinn_supervisor::services::{InvocationLiftDecision, evaluate_invocation_lift};
 
@@ -373,8 +373,9 @@ async fn unconfirmed_topology_still_fails_closed_and_never_lifts() {
     assert_eq!(
         admit(&state, "wedged-task").await,
         BuildAdmissionDecision::Denied {
-            occupancy: 0,
-            cap: 3
+            occupancy: None,
+            cap: 3,
+            cause: DenialCause::ControllerNotAdmitting
         },
         "an unconfirmed topology MUST fail closed"
     );
@@ -566,8 +567,9 @@ async fn seeding_a_live_observe_deployment_does_not_wedge_admission() {
     assert_ne!(
         admit(&state, "post-seed-task").await,
         BuildAdmissionDecision::Denied {
-            occupancy: 0,
-            cap: 3
+            occupancy: None,
+            cap: 3,
+            cause: DenialCause::ControllerNotAdmitting
         },
         "re-seeding must not reproduce the incident's self-contradictory denial"
     );
@@ -634,8 +636,9 @@ async fn a_standby_promotion_never_re_asserts_the_topology_gate() {
     assert_eq!(
         admit(&state, "standby-task").await,
         BuildAdmissionDecision::Denied {
-            occupancy: 0,
-            cap: 3
+            occupancy: None,
+            cap: 3,
+            cause: DenialCause::ControllerNotAdmitting
         },
         "a promoted standby must fail closed"
     );


### PR DESCRIPTION
## Production impact: the board is fully wedged

Zero active sessions, six dispatchable tasks, nothing dispatching. 78
`build admission denied; leaving task queued` lines in five minutes, every one of
them at `cap=3` with `occupancy` 0 or 1 against a request weighing 1 — a denial
no capacity rule can produce. It did not clear on its own and would not have
cleared on a restart.

**Deploying this PR self-heals it. No manual step is required.** See
[Unwedging the six live tasks](#unwedging-the-six-live-tasks).

## The bug, which is a closed loop

A task's dispatch slot is keyed `build_leases(consumer_kind='task_dispatch',
consumer_id='{task_id}:{generation}')`.

1. The pool is full, so admission denies and leaves a **queued** lease row under
   that key. It returns `Denied` *before* the journal `reserve()`.
2. Nothing claims the position before its 30-minute queue deadline, so the row
   goes `terminal/deadline_expired`. (Or the task is closed and its position is
   swept → `abandoned`; or the reclaimer proves its object absent →
   `reclaimed_absent`.)
3. `BuildLeaseRepository::queue` had **no state filter**, so it returned that
   terminal row forever. There is no `DELETE FROM build_leases` and no
   terminal→queued transition anywhere in the repo, so the row was permanent.
4. The replay became `LeaseWaitTimeout` or `LeaseUnavailable`, which
   `build_slot_authority` converted into a denial.
5. Because the denial returns before the journal write, no journal row is ever
   created, so `resolve_dispatch_generation` returns the **same** generation next
   tick — so the key never changes, so the same tombstone is read again.

Nothing in the loop can advance. Emptying the pool does not help.

Two branches were live: five tasks on `deadline_expired` (reported as
`AtCapacity` with a real but far-below-cap occupancy) and `vjjb` on the
`_ => LeaseUnavailable` catch-all (reported with a **fabricated** `occupancy: 0`
that the denial never consulted). `gy53` escaped only because repeated operator
interventions bumped its `reopen_count`, minting a new generation and therefore a
new lease key each time.

## What changed

**1. The tombstone (the actual wedge).** `BuildLeaseRepository::queue` now treats
a `terminal` row as a spent attempt **for `task_dispatch` only**: it retires the
row and inserts a fresh one under the same key.

Scoped to `task_dispatch` deliberately. Retained terminal replay is load-bearing
for `graph_warm` and `task_invocation` — a warm Job whose response was lost must
be told it was `Released`, not handed a fresh grant that re-runs a finished
compile. Widening the fix to every consumer kind would break that silently, so
there is a test pinning the old behaviour for those two kinds.

Delete-and-reinsert rather than an in-place terminal→queued reset, because:

- identity, `weight` and `bound_pod_uid` are **trigger-immutable** (migration
  139/153), so an in-place UPDATE would fail against the schema the moment the
  configured dispatch weight changed or the row had ever been bound, and the
  `build_leases_bound_uid_check` constraint forbids a queued row carrying a pod
  UID it cannot clear;
- a fresh `enqueue_sequence` (BIGSERIAL) puts the new attempt at the **back** of
  the FIFO, where a new arrival belongs — an in-place reset would inherit the
  retired attempt's queue position and cut the line;
- a fresh `fencing_token` (`nextval`, never reissued) fences out any actor still
  holding the retired attempt's token, exactly as against any other new row.

No capacity can be double-granted: terminal rows are excluded from `OCCUPYING`,
so the retired row was buying nothing the fresh attempt could buy twice. The
dispatch lifecycle/audit trail lives in `admission_journal`, which migration 153
explicitly retains for that purpose.

**2. The generation deadlock.** Fixed by decoupling rather than by burning
generations. The lease attempt now advances **independently of the journal
generation** — retirement mints a new `enqueue_sequence` and a new fencing token
under the same key — so a stable generation is no longer a trap. Recording a
terminal journal row on every denial was the alternative and is worse: it would
burn a generation per denial tick for tasks that are legitimately queued behind a
full pool, and it would write lifecycle rows for reservations that never
happened. A denial reserved nothing and must not consume a generation; a test
asserts the successful admission lands on generation 0, the generation every
preceding denial deliberately left unconsumed.

**3. The catch-alls.** New `BuildLeaseTerminalReason` enum is now the single
registry of terminal reasons; every SQL producer writes `as_str()`. Both
`terminal_result` (djinn-coordinator/src/build_lease.rs) and the queue match in
`build_slot_authority` are exhaustive with **no `_` arm** — adding a reason or a
`LeaseResult` variant is a compile error at the mapping site. Verified by
temporarily adding a variant; it failed to compile in both places.

**4. No more fabricated occupancy.** `BuildAdmissionDecision::Denied` now carries
`occupancy: Option<i64>` and a `DenialCause` (`AtCapacity` /
`ControllerNotAdmitting` / `AuthorityUnavailable { detail }`). Only `AtCapacity`
— the one outcome the cap itself produces — may carry `Some(occupancy)`. The
operator log prints the cause and prints `unmeasured` where it used to print a
0 it never read.

Before / after for the `vjjb` line:

```
build admission denied; leaving task queued  occupancy=0 cap=3
build admission denied; leaving task queued  occupancy="unmeasured" cap=3 cause="authority_unavailable: lease attempt was abandoned"
```

## Unwedging the six live tasks

`bx1f` 019f9f40…, `vjjb` 019fa05f…, `h1mo` 019fa135…, `li5m` 019fa174…,
`0309` 019fa1a8…, `mhb2` 019fa0f9…

**The deploy alone unwedges all six. No manual step, no production mutation, no
SQL.** On the first dispatch tick after rollout, `acquire_dispatch_slot` calls
`queue()` for the same key, which now retires the tombstone, inserts a fresh
queued row, and drains it into a grant against an occupancy of 0-1 of cap 3.
Both live signatures are covered:

- five tasks at `terminal/deadline_expired` — retired, granted;
- `vjjb` at `terminal/abandoned` (or `reclaimed_absent`) — retired, granted.

This holds whichever generation `resolve_dispatch_generation` returns. If a
terminal journal row happens to exist at generation 0, it resolves to 1, whose
key has no tombstone and queues cleanly; if there is no journal row at all — the
production case, since every denial returned before `reserve()` — it stays at 0
and the tombstone is retired.

**If a stopgap is needed before this can be deployed**, the least-invasive one
uses existing tooling and no SQL: close and reopen the task through the djinn
MCP tools (`task_transition`). That bumps `reopen_count`, which mints a new
generation and therefore a new lease key with no tombstone under it. It is
exactly the accident that kept `gy53` alive. It is per-task, it leaves the
tombstones behind, and every one of those tasks will wedge again on its next
denial — so it is a stopgap, not a fix.

No production mutation was executed by this PR.

## Verification

- `cargo test -p djinn-db --lib -- --test-threads=1` — **1170 passed, 0 failed**.
- `cargo test -p djinn-coordinator --lib -- --test-threads=1` — **2032 passed,
  3 failed**; all three (`tests::intervention::arbiter_dossier_includes_attempt_ledger`,
  two in `tests::session_reaping`) pass in isolation and fail only from
  process-global metrics-registry contamination when the whole crate runs in one
  process. CI runs nextest (process per test). Unrelated to this change.
- `cargo fmt --all`, `cargo clippy -p djinn-db -p djinn-coordinator --all-targets`
  — no new warnings in any touched file.
- `scripts/check-file-size.sh` — 0 oversized files.
- No sqlx metadata regeneration needed: every query touched is a runtime
  `sqlx::query`/`query_as`, not a macro. `.sqlx` is unchanged.

### Regression tests, verified by neutralization

New `build_lease_dispatch_tombstone_tests.rs` (coordinator, through the real
`BuildAdmissionController` + `BuildLeaseService` composition) and two tests in
`build_lease_tests.rs` (repository). Every tombstone is produced by a production
path — the queue-deadline sweep, `abandon_queued_dispatch`,
`reclaim_absent_object`, `release`, `cancel` — never hand-written.

The load-bearing assertion in each coordinator test is that the pool is driven to
occupancy **zero** and the task must then actually be `Permitted` and take the
slot. Reverting the `spent_dispatch_attempt` branch in `queue()`:

```
a_deadline_expired_dispatch_attempt_does_not_wedge_its_task_forever ... FAILED
  victim must be permitted over an EMPTY pool, got Denied { occupancy: None, cap: 1,
    cause: AuthorityUnavailable { detail: "queue deadline expired before capacity was granted" } }

an_abandoned_dispatch_attempt_does_not_wedge_its_task_forever ... FAILED
  victim must be permitted over an EMPTY pool, got Denied { occupancy: None, cap: 1,
    cause: AuthorityUnavailable { detail: "lease attempt was abandoned" } }

a_spent_task_dispatch_attempt_is_retired_rather_than_replayed_forever ... FAILED
```

That is the outage itself, reproduced. Restored, all pass.

Also pinned: `a_terminal_warm_or_invocation_lease_is_still_replayed_verbatim`
(the fix does not widen to warm/invocation) and
`retiring_a_spent_attempt_never_frees_capacity_it_did_not_own` (an occupying
attempt is replayed, never retired and re-bought — the cap never widens).

## Notes

- The pre-existing `rules::tests::*` stack overflow under a debug build reproduces
  on a clean `main` in this environment and is unrelated; it clears with
  `RUST_MIN_STACK=33554432`.
- Proposal `xkm4` names this area but is `status: draft`, 0/6 ACs, never
  graduated — and it names `reclaimed_absent` only. The dominant signature here
  was `deadline_expired`, a *mapped* reason that wedged anyway, because the real
  defect was `queue()`'s unfiltered fetch. Fixing only the catch-all would have
  left five of the six stuck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
