### PR TITLE
fix(dispatch): bound the arbiter ladder cumulatively and stop advertising a human hold

### DIFF
--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -53,6 +53,24 @@ use djinn_provider::message::{ContentBlock, Conversation};
 use djinn_provider::provider::{LlmProvider, LlmResponse, StreamEvent, TokenUsage, ToolChoice};
 use futures::StreamExt;
 
+/// Activity `actor_id` for a decision reached by a Lead arbiter session.
+///
+/// Matches the attribution the Lead's own board transitions already use (see
+/// `extension::handlers::task_admin`), so an arbiter decision and the board
+/// transition it causes agree on who acted.
+const ARBITER_ACTOR_ID: &str = "lead-agent";
+
+/// Activity `actor_role` for a decision reached by a Lead arbiter session.
+///
+/// `arbiter_decision` / `arbiter_parked` entries written from this module are
+/// the outcome of a `lead`-role agent session calling `submit_decision` — they
+/// are NOT coordinator actions. They were previously stamped
+/// `actor_id="system", actor_role="coordinator"`, which made a single arbiter
+/// ladder read as two subsystems fighting each other: in incident gy53 five
+/// consecutive Lead dispatches all surfaced on the task timeline as coordinator
+/// activity, hiding the fact that one role was reopening its own work.
+const ARBITER_ACTOR_ROLE: &str = "lead";
+
 /// Apply one provider event to the terminal response aggregate used by direct
 /// services. Returns `true` when the event terminates the stream.
 ///
@@ -528,8 +546,8 @@ impl DirectServices {
         if let Err(e) = task_repo
             .log_activity(
                 Some(task_id),
-                "system",
-                "coordinator",
+                ARBITER_ACTOR_ID,
+                ARBITER_ACTOR_ROLE,
                 "arbiter_decision",
                 &decision_payload.to_string(),
             )
@@ -554,8 +572,8 @@ impl DirectServices {
         if let Err(e) = task_repo
             .log_activity(
                 Some(task_id),
-                "system",
-                "coordinator",
+                ARBITER_ACTOR_ID,
+                ARBITER_ACTOR_ROLE,
                 "arbiter_parked",
                 &parked_payload.to_string(),
             )
@@ -921,8 +939,8 @@ impl DirectServices {
         if let Err(e) = task_repo
             .log_activity(
                 Some(task_id),
-                "system",
-                "coordinator",
+                ARBITER_ACTOR_ID,
+                ARBITER_ACTOR_ROLE,
                 "arbiter_decision",
                 &decision_payload.to_string(),
             )
@@ -1841,8 +1859,8 @@ impl SupervisorServices for DirectServices {
         if let Err(e) = task_repo
             .log_activity(
                 Some(&task_id),
-                "system",
-                "coordinator",
+                ARBITER_ACTOR_ID,
+                ARBITER_ACTOR_ROLE,
                 "arbiter_decision",
                 &activity_payload.to_string(),
             )
@@ -2002,8 +2020,8 @@ impl SupervisorServices for DirectServices {
         if let Err(e) = task_repo
             .log_activity(
                 Some(&task_id),
-                "system",
-                "coordinator",
+                ARBITER_ACTOR_ID,
+                ARBITER_ACTOR_ROLE,
                 "arbiter_decision",
                 &activity_payload.to_string(),
             )

--- a/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
+++ b/server/crates/djinn-agent/src/extension/tests/snapshots/djinn_agent__extension__tests__schema_snapshot_tests__lead_tool_schemas.snap
@@ -1019,7 +1019,7 @@ expression: tool_schemas_lead()
             "park",
             "supersede"
           ],
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hand the task to an AUTONOMOUS Planner escalation with a structured dossier — this does NOT reach a human: a Planner session reads your dossier and owns terminal resolution by decomposing + superseding, closing won't-fix, or re-scoping + reopening), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
         },
         "rationale": {
           "type": "string",
@@ -1064,7 +1064,7 @@ expression: tool_schemas_lead()
         },
         "park_dossier": {
           "type": "object",
-          "description": "Required for park. Structured dossier for the human-review hold.",
+          "description": "Required for park. Structured dossier handed to the autonomous Planner escalation. No human reads it — write it for the Planner session that must resolve the task.",
           "required": [
             "hold_description",
             "failure_analysis"
@@ -1072,11 +1072,11 @@ expression: tool_schemas_lead()
           "properties": {
             "hold_description": {
               "type": "string",
-              "description": "Description of the hold for human reviewers"
+              "description": "Description of the hold for the Planner that will resolve it"
             },
             "failure_analysis": {
               "type": "string",
-              "description": "Analysis of why the task failed and needs human review"
+              "description": "Analysis of why the task failed and why no arbiter decision can unstick it"
             },
             "attempted_decisions": {
               "type": "array",
@@ -1087,7 +1087,7 @@ expression: tool_schemas_lead()
             },
             "recommended_action": {
               "type": "string",
-              "description": "Optional recommended action for the human reviewer"
+              "description": "Optional recommended action for the Planner (decompose + supersede, close won't-fix, or re-scope + reopen)"
             }
           }
         },

--- a/server/crates/djinn-coordinator/src/dispatch/park_reason_tests.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/park_reason_tests.rs
@@ -259,8 +259,16 @@ fn in_flight_submitted_attempt_does_not_park() {
     // submission_pending_review guard prevents the park from firing.
     let reason = CoordinatorActor::compute_park_reason(&task, &history);
     assert!(
-        reason.contains("Auto-parked for human review"),
+        reason.contains("Auto-parked to autonomous arbitration"),
         "park reason template should render; got: {reason}"
+    );
+    // The park rung has had no human in it since the arbiter replaced the
+    // human hold; the narration must not claim otherwise (gy53 audit — three
+    // artifacts still advertised a human hold the code cannot produce).
+    assert!(
+        !reason.contains("human review") && !reason.contains("A human must resolve"),
+        "park reason must not advertise a human hold the autonomous path never creates; got: \
+         {reason}"
     );
 }
 

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -1019,11 +1019,14 @@ impl CoordinatorActor {
     ) -> String {
         let detail = Self::park_reason_detail(task, history);
         format!(
-            "Auto-parked for human review after {} planner intervention(s) \
+            "Auto-parked to autonomous arbitration after {} planner intervention(s) \
              (intervention_count={}, total_reopen_count={}). {detail} The task is held (open + \
-             blocked on a human-review remediation task) so it frees the dispatch slot for other \
-             ready tasks while its branch and prior work are preserved. A human must resolve the \
-             remediation task to release it, or close this task if the work is no longer wanted.",
+             blocked on an autonomous planner-park escalation) so it frees the dispatch slot for \
+             other ready tasks while its branch and prior work are preserved. NO human hold is \
+             produced and no human is required to release it: the Lead arbiter adjudicates the \
+             hold cycle, and the Planner owns terminal resolution of the escalation (decompose + \
+             supersede, close as won't-fix, or re-scope + reopen). Closing the escalation releases \
+             this source.",
             MAX_PLANNER_INTERVENTIONS, task.intervention_count, task.total_reopen_count,
         )
     }
@@ -1243,10 +1246,32 @@ impl CoordinatorActor {
         quality_strikes: i64,
     ) -> bool {
         tracing::Span::current().record("attempt", quality_strikes);
-        // Second strike: hold on human-review remediation instead of
-        // re-escalating (which just resets and loops). Parked to `open`
-        // so the dispatch slot is freed; human resolves the remediation.
+        // Second strike: hand the task to the autonomous arbiter ladder instead
+        // of re-escalating the Planner (which just resets the counters and
+        // loops). Parked to `open` so the dispatch slot is freed.
         if task.intervention_count >= MAX_PLANNER_INTERVENTIONS {
+            // ── Cumulative cross-cycle bound (gy53) ─────────────────────────
+            //
+            // FIRST, before any per-cycle or per-fingerprint sub-guard below.
+            // Every other guard on this rung declines by RETURNING FALSE (which
+            // redispatches) and resets by incrementing, so a task that declines
+            // via a DIFFERENT sub-guard each round never terminates. gy53
+            // produced a novel CI fingerprint every round and rode the
+            // first-occurrence guard to `hold_cycle` 9 / 65 sessions / 12h of
+            // full dispatch monopoly. Evaluating the ceiling ahead of the
+            // sub-guards is what makes it guard-independent: cycle N terminates
+            // regardless of which guard WOULD have declined.
+            //
+            // Only applied when the ladder is about to open a FRESH cycle (no
+            // unconsumed row). A genuinely in-flight arbiter is left to finish
+            // — it may still approve or supersede — and is separately bounded
+            // by the 24h arbitration deadline and the decision-failure cap.
+            if self.arbiter_hold_cycle_ceiling_reached(task).await {
+                return self
+                    .terminally_fail_on_hold_cycle_ceiling(task, role, quality_strikes)
+                    .await;
+            }
+
             // uv3p Part B: attempted-remediation requirement on the park rung.
             // A park declares the current intervention's remediation a failure —
             // but the audits (cgcl/7fj3/nlus) show parks landing 272ms–36s after
@@ -1638,9 +1663,18 @@ impl CoordinatorActor {
 
             let failing_ci_job_ids = self.parse_failing_ci_job_ids(ci_failure_sections);
             let excluded_models = serde_json::json!(history.rotation_excluded_models());
+            // Give the arbiter its own history. Without these two fields every
+            // Lead session decided in ignorance of the identical reopens before
+            // it — gy53 ran five arbiter dispatches that could not see each
+            // other, so each one re-derived the same reopen from scratch.
+            let prior_arbiter_decisions =
+                Self::summarize_prior_arbitrations(&arbiter_repo, &task.id, hold_cycle).await;
             let dossier = serde_json::json!({
                 "reason": reason,
                 "role": role,
+                "hold_cycle": hold_cycle,
+                "hold_cycle_ceiling": MAX_ARBITER_HOLD_CYCLES,
+                "prior_arbiter_decisions": prior_arbiter_decisions,
                 "intervention_count": task.intervention_count,
                 "total_reopen_count": task.total_reopen_count,
                 "reopen_count": task.reopen_count,
@@ -2423,6 +2457,226 @@ impl CoordinatorActor {
         true
     }
 
+    /// Summarize every arbitration cycle already closed on this task, newest
+    /// last, for inclusion in the dossier handed to the next Lead arbiter.
+    ///
+    /// Each entry carries the cycle index, its terminal state, the decision the
+    /// arbiter reached (from the persisted `directive.decision`), the directive
+    /// text it injected, the verification command it demanded, and the failure
+    /// counters — i.e. exactly what a fresh arbiter needs in order to NOT
+    /// repeat the previous cycle's decision verbatim. Cycles at/after
+    /// `current_cycle` are excluded (the row being opened right now is not
+    /// prior history). Fail-open: an unreadable ledger yields an empty array
+    /// rather than blocking the dispatch.
+    async fn summarize_prior_arbitrations(
+        arbiter_repo: &TaskArbitrationRepository,
+        task_id: &str,
+        current_cycle: i32,
+    ) -> serde_json::Value {
+        let records = match arbiter_repo.list_for_task(task_id).await {
+            Ok(records) => records,
+            Err(e) => {
+                tracing::warn!(
+                    task_id,
+                    error = %e,
+                    "CoordinatorActor: failed to read prior arbitrations for the arbiter dossier; \
+                     proceeding with no decision history"
+                );
+                return serde_json::json!([]);
+            }
+        };
+        let entries: Vec<serde_json::Value> = records
+            .iter()
+            .filter(|record| record.hold_cycle < current_cycle)
+            .map(|record| {
+                let decision = record
+                    .directive
+                    .as_ref()
+                    .and_then(|directive| directive.get("decision"))
+                    .and_then(serde_json::Value::as_str);
+                let directive_text = record
+                    .directive
+                    .as_ref()
+                    .and_then(|directive| directive.get("directive"))
+                    .and_then(serde_json::Value::as_str);
+                let dossier_summary = record
+                    .dossier
+                    .as_ref()
+                    .and_then(|dossier| dossier.get("summary").or_else(|| dossier.get("reason")))
+                    .and_then(serde_json::Value::as_str)
+                    .map(|summary| summary.chars().take(400).collect::<String>());
+                serde_json::json!({
+                    "hold_cycle": record.hold_cycle,
+                    "state": record.state,
+                    "decision": decision,
+                    "directive": directive_text,
+                    "verification_command": record.verification_command,
+                    "excluded_models": record.excluded_models,
+                    "monitored_reopen_count": record.monitored_reopen_count,
+                    "decision_failure_count": record.decision_failure_count,
+                    "infra_retry_count": record.infra_retry_count,
+                    "summary": dossier_summary,
+                    "created_at": record.created_at,
+                    "consumed_at": record.consumed_at,
+                })
+            })
+            .collect();
+        serde_json::json!(entries)
+    }
+
+    /// Has this task spent its cumulative arbitration budget
+    /// ([`MAX_ARBITER_HOLD_CYCLES`])?
+    ///
+    /// The cumulative key is the task's max `hold_cycle` across its
+    /// `task_arbitrations` rows — i.e. how many arbiter hold cycles the board
+    /// has ever opened for this source. `resolve_current_hold_cycle` returns
+    /// the PROSPECTIVE cycle: the unconsumed row's own cycle when an arbiter is
+    /// in flight, otherwise `latest + 1` (the cycle a fresh `try_create` would
+    /// open).
+    ///
+    /// Returns `true` only when a FRESH cycle is about to be opened and that
+    /// cycle index is at/above the ceiling. An unconsumed row means an arbiter
+    /// is genuinely in flight; it is left alone (it may still approve or
+    /// supersede) and is bounded independently by the 24h arbitration deadline
+    /// and the decision-failure cap.
+    ///
+    /// Fail-open on any arbitration read error: an unreadable ledger must not
+    /// terminally fail live work. The pre-existing fail-CLOSED park handling
+    /// further down the rung still catches that case.
+    async fn arbiter_hold_cycle_ceiling_reached(&self, task: &djinn_core::models::Task) -> bool {
+        let arbiter_repo = TaskArbitrationRepository::new(self.db.clone());
+        match arbiter_repo.resolve_current_hold_cycle(&task.id).await {
+            Ok((_, Some(_unconsumed))) => false,
+            Ok((prospective_cycle, None)) => prospective_cycle >= MAX_ARBITER_HOLD_CYCLES,
+            Err(e) => {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    error = %e,
+                    "CoordinatorActor: cumulative hold-cycle ceiling check failed to read the \
+                     arbitration ledger; failing open to the existing rung guards"
+                );
+                false
+            }
+        }
+    }
+
+    /// Terminal exit for the cumulative hold-cycle ceiling.
+    ///
+    /// Clears in-memory + durable dispatch backoff, records a durable
+    /// `arbiter_hold_cycle_ceiling` activity entry naming the budget and the
+    /// counters that got the task here, then routes through the single
+    /// dispatch-exhaustion gateway
+    /// ([`terminally_fail_task`](Self::terminally_fail_task)) so the task
+    /// reaches a genuinely terminal, non-redispatching state (ForceClose, or —
+    /// for a PR-bearing task — a poller handoff that likewise stops coordinator
+    /// dispatch). Always returns `true`: the caller must skip its dispatch this
+    /// pass either way, because a task at the ceiling must never be
+    /// redispatched.
+    async fn terminally_fail_on_hold_cycle_ceiling(
+        &mut self,
+        task: &djinn_core::models::Task,
+        role: &'static str,
+        quality_strikes: i64,
+    ) -> bool {
+        let reason = format!(
+            "Cumulative arbitration ceiling reached: {MAX_ARBITER_HOLD_CYCLES} arbiter hold \
+             cycle(s) already spent on this task without convergence \
+             (intervention_count={}, total_reopen_count={}, quality_strikes={quality_strikes}, \
+             role={role}). Every per-cycle guard on the remediation ladder resets by \
+             incrementing, so a task that declines via a different guard each round would loop \
+             forever and monopolize the dispatch queue (incident gy53). Terminally failing this \
+             task instead of opening hold cycle {MAX_ARBITER_HOLD_CYCLES}; a planner may \
+             resurrect the work from the epic, and the branch plus its PR are preserved.",
+            task.intervention_count, task.total_reopen_count,
+        );
+        tracing::warn!(
+            task_id = %task.short_id,
+            role,
+            intervention_count = task.intervention_count,
+            total_reopen_count = task.total_reopen_count,
+            quality_strikes,
+            ceiling = MAX_ARBITER_HOLD_CYCLES,
+            "CoordinatorActor: cumulative arbiter hold-cycle ceiling reached — terminally failing \
+             the task instead of opening another hold cycle"
+        );
+
+        // Clear streak/cooldown so nothing re-arms dispatch behind the terminal
+        // transition.
+        self.dispatch_failure_streak.remove(&task.id);
+        self.dispatch_cooldowns.remove(&task.id);
+        self.last_dispatched.remove(&task.id);
+        self.inflight_dispatches.remove(&task.id);
+        self.clear_durable_dispatch_backoff_state(
+            &task.id,
+            Some(&task.short_id),
+            "arbiter_hold_cycle_ceiling",
+        )
+        .await;
+
+        // Durable "why" record, independent of the transition reason text.
+        // Recorded once per task: a PR-bearing task terminalizes via an
+        // idempotent poller handoff, so this rung can legitimately be re-entered
+        // by the PR poller on a later tick and must not spam the activity log or
+        // double-count the park metric.
+        if !self.hold_cycle_ceiling_already_recorded(&task.id).await {
+            let payload = serde_json::json!({
+                "event": "arbiter_hold_cycle_ceiling",
+                "task_id": task.short_id,
+                "ceiling": MAX_ARBITER_HOLD_CYCLES,
+                "intervention_count": task.intervention_count,
+                "total_reopen_count": task.total_reopen_count,
+                "reopen_count": task.reopen_count,
+                "quality_strikes": quality_strikes,
+                "role": role,
+                "ci_failure_fingerprint": task.ci_failure_fingerprint,
+                "reason": reason,
+            });
+            if let Err(e) = self
+                .task_repo()
+                .log_activity(
+                    Some(&task.id),
+                    "coordinator",
+                    "system",
+                    HOLD_CYCLE_CEILING_MARKER,
+                    &payload.to_string(),
+                )
+                .await
+            {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    error = %e,
+                    "CoordinatorActor: failed to log arbiter_hold_cycle_ceiling activity"
+                );
+            }
+
+            djinn_telemetry::arbiter::record_park(
+                djinn_telemetry::arbiter::PARK_REASON_HOLD_CYCLE_CEILING,
+                djinn_telemetry::arbiter::PARK_OUTCOME_SUCCESS,
+            );
+            self.record_task_parked_metric(task, quality_strikes).await;
+        }
+
+        self.terminally_fail_task(task, "coordinator", &reason)
+            .await;
+        true
+    }
+
+    /// Has the hold-cycle ceiling already been recorded for this task?
+    /// Fail-open (returns `false`) on a query error: a duplicate audit entry is
+    /// far cheaper than losing the record entirely.
+    async fn hold_cycle_ceiling_already_recorded(&self, task_id: &str) -> bool {
+        self.task_repo()
+            .query_activity(ActivityQuery {
+                task_id: Some(task_id.to_owned()),
+                event_type: Some(HOLD_CYCLE_CEILING_MARKER.to_string()),
+                limit: 1,
+                ..ActivityQuery::default()
+            })
+            .await
+            .map(|entries| !entries.is_empty())
+            .unwrap_or(false)
+    }
+
     /// Fail-closed loop-breaker park path for the second-strike rung.
     ///
     /// Clears in-memory and durable backoff, interrupts running sessions, then
@@ -2521,9 +2775,14 @@ impl CoordinatorActor {
     /// — it owns the board and decides whether to reshape, dedupe, or (if the issue
     /// requires deeper code-structural reasoning) dispatch an Architect spike.
     ///
-    /// For [`RemediationKind::HumanReview`] no agent is dispatched (a human must
-    /// resolve it) and creation is skipped when the source is already held by an
-    /// unresolved blocker.
+    /// Neither held-remediation kind dispatches an agent inline, and creation is
+    /// skipped when the source is already held by an unresolved blocker. Note
+    /// that the autonomous rungs never construct
+    /// [`RemediationKind::HumanReview`] — every loop-breaker path routes to
+    /// [`RemediationKind::PlannerEscalation`], which the coordinator's normal
+    /// dispatch pass claims for the Planner. `HumanReview` is reachable ONLY
+    /// through the tripwire org-policy escape hatch (a rule an operator
+    /// explicitly set to `adjudication = human`).
     pub(crate) async fn create_remediation_task(
         &mut self,
         source_task_id: &str,

--- a/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
+++ b/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
@@ -1,0 +1,425 @@
+//! Regression tests for the cumulative, cross-cycle arbitration ceiling
+//! ([`MAX_ARBITER_HOLD_CYCLES`]) on the second-strike park rung.
+//!
+//! Incident gy53 (2026-07-27): every guard on that rung is per-cycle or
+//! per-fingerprint and each RESETS by incrementing, so a task that declines via
+//! a DIFFERENT guard each round never terminates. gy53 was a large multi-crate
+//! retirement where each repair pushed the compile error down a layer, minting a
+//! NEW CI failure fingerprint every round — so the first-occurrence-fingerprint
+//! guard handed out an unlimited supply of "free" remediations. Result: 65
+//! sessions, `intervention_count` 9, `hold_cycle` 9, five Lead arbiter
+//! dispatches, ~100% of dispatch capacity for 12+ hours, zero merges board-wide
+//! for six hours. The control task fux8 had a comparable `intervention_count`
+//! of 5 but only two arbiter dispatches — because its CI happened to go green.
+//! The ladder terminated only when the work succeeded.
+//!
+//! The load-bearing property under test is NOT "some guard eventually parks".
+//! It is that the cumulative bound is evaluated BEFORE every sub-guard, so
+//! cycle N terminates **regardless of which sub-guard would have declined**. A
+//! test that repeats one guard would not prove that, so
+//! [`hold_cycle_ceiling_terminates_when_a_different_guard_declines_each_cycle`]
+//! deliberately rotates the declining guard between cycles and then presents,
+//! at the bound, the very guard that granted a free pass twice before.
+
+use super::*;
+use djinn_db::repositories::task_arbitration::{
+    CreateArbitrationParams, TaskArbitrationRepository,
+};
+
+/// Spend one arbiter hold cycle exactly as the production ladder does: open the
+/// arbitration row for `cycle`, then mark it consumed (what an arbiter decision
+/// does). `resolve_current_hold_cycle` then reports `cycle + 1` as the next
+/// cycle a fresh `try_create` would open.
+async fn spend_hold_cycle(db: &Database, task_id: &str, cycle: i32) {
+    let arb = TaskArbitrationRepository::new(db.clone());
+    let empty = serde_json::json!([]);
+    arb.try_create(CreateArbitrationParams {
+        task_id,
+        hold_cycle: cycle,
+        deadline_at: None,
+        mirror_head_sha: None,
+        github_head_sha: None,
+        pr_url: None,
+        failing_ci_job_ids: &empty,
+        dossier: None,
+        directive: Some(&serde_json::json!({ "decision": "reopen" })),
+        verification_command: None,
+        excluded_models: &empty,
+    })
+    .await
+    .expect("seed arbitration row");
+    assert!(
+        arb.mark_consumed(task_id, cycle)
+            .await
+            .expect("consume arbitration row"),
+        "seeded arbitration row at cycle {cycle} must transition to consumed"
+    );
+}
+
+/// Open an arbitration row and leave it UNCONSUMED — a Lead arbiter genuinely
+/// in flight for that cycle.
+async fn open_in_flight_hold_cycle(db: &Database, task_id: &str, cycle: i32) {
+    let arb = TaskArbitrationRepository::new(db.clone());
+    let empty = serde_json::json!([]);
+    arb.try_create(CreateArbitrationParams {
+        task_id,
+        hold_cycle: cycle,
+        deadline_at: None,
+        mirror_head_sha: None,
+        github_head_sha: None,
+        pr_url: None,
+        failing_ci_job_ids: &empty,
+        dossier: None,
+        directive: None,
+        verification_command: None,
+        excluded_models: &empty,
+    })
+    .await
+    .expect("seed in-flight arbitration row");
+}
+
+/// The `arbiter_hold_cycle_ceiling` audit entries recorded when the cumulative
+/// bound terminated a task.
+async fn hold_cycle_ceiling_markers(
+    repo: &TaskRepository,
+    task_id: &str,
+) -> Vec<serde_json::Value> {
+    repo.query_activity(ActivityQuery {
+        task_id: Some(task_id.to_owned()),
+        event_type: Some(HOLD_CYCLE_CEILING_MARKER.to_string()),
+        limit: 100,
+        ..ActivityQuery::default()
+    })
+    .await
+    .unwrap()
+    .into_iter()
+    .map(|e| serde_json::from_str::<serde_json::Value>(&e.payload).unwrap())
+    .collect()
+}
+
+/// Build a task sitting exactly on the second-strike rung
+/// (`intervention_count == MAX_PLANNER_INTERVENTIONS`).
+async fn task_on_the_park_rung(
+    db: &Database,
+    tx: &broadcast::Sender<DjinnEventEnvelope>,
+) -> djinn_core::models::Task {
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(tx));
+    let task = make_task_with_reopen_count(db, tx, REOPEN_INTERVENTION_THRESHOLD).await;
+    repo.reset_intervention_counters(&task.id).await.unwrap();
+    let task = repo.get(&task.id).await.unwrap().unwrap();
+    assert_eq!(
+        task.intervention_count, MAX_PLANNER_INTERVENTIONS,
+        "fixture must sit exactly on the second-strike rung"
+    );
+    task
+}
+
+/// **The gy53 regression.**
+///
+/// Each cycle declines through a DIFFERENT sub-guard, so no single guard's
+/// counter ever accumulates — exactly the shape that let gy53 ride to
+/// `hold_cycle` 9. The task must still terminate at the cumulative bound, and
+/// it must terminate through the ceiling rather than through the guard that
+/// would otherwise have granted yet another free remediation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hold_cycle_ceiling_terminates_when_a_different_guard_declines_each_cycle() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let base = task_on_the_park_rung(&db, &tx).await;
+
+    // ── Cycle 0: declines via `first_occurrence_fingerprint` ─────────────────
+    let mut round = base.clone();
+    round.ci_failure_fingerprint = Some("fp-round-0".to_string());
+    assert!(
+        !actor
+            .route_planner_intervention(&round, "worker", "strike", None, 5)
+            .await,
+        "a novel CI fingerprint must buy one remediation while under the ceiling"
+    );
+    spend_hold_cycle(&db, &base.id, 0).await;
+
+    // ── Cycle 1: declines via `no_attempted_remediation` ─────────────────────
+    // No fingerprint at all, and no post-intervention session ever submitted —
+    // a different guard, on a different counter, from cycle 0's.
+    let mut round = base.clone();
+    round.ci_failure_fingerprint = None;
+    assert!(
+        !actor
+            .route_planner_intervention(&round, "worker", "strike", None, 5)
+            .await,
+        "an unattempted remediation must redispatch while under the ceiling"
+    );
+    spend_hold_cycle(&db, &base.id, 1).await;
+
+    // ── Cycle 2: back to `first_occurrence_fingerprint`, new signature ───────
+    let mut round = base.clone();
+    round.ci_failure_fingerprint = Some("fp-round-2".to_string());
+    assert!(
+        !actor
+            .route_planner_intervention(&round, "worker", "strike", None, 5)
+            .await,
+        "a second novel fingerprint must also buy a remediation while under the ceiling"
+    );
+    spend_hold_cycle(&db, &base.id, 2).await;
+
+    // Three cycles are spent. Every sub-guard's own counter is still low: two
+    // distinct fingerprints each seen once, zero submitted remediations.
+    let markers_before = park_redispatch_markers(&repo, &base.id).await;
+    assert_eq!(
+        markers_before.len(),
+        3,
+        "each of the three declines recorded its own park-redispatch marker: {markers_before:?}"
+    );
+    let kinds: Vec<&str> = markers_before
+        .iter()
+        .map(|m| m["kind"].as_str().unwrap())
+        .collect();
+    assert!(
+        kinds.contains(&"first_occurrence_fingerprint")
+            && kinds.contains(&"no_attempted_remediation"),
+        "the declines must come from DIFFERENT sub-guards, else this test proves nothing: {kinds:?}"
+    );
+
+    // ── At the bound: present the guard that granted a free pass twice ───────
+    // A brand-new fingerprint again. Pre-fix this returned false and the worker
+    // redispatched; the cumulative ceiling must win instead.
+    let mut final_round = base.clone();
+    final_round.ci_failure_fingerprint = Some("fp-round-3".to_string());
+    let handled = actor
+        .route_planner_intervention(&final_round, "worker", "strike", None, 5)
+        .await;
+    assert!(
+        handled,
+        "at the cumulative ceiling the rung must handle (terminate) the task, NOT decline to a \
+         redispatch — a novel fingerprint no longer buys a remediation"
+    );
+
+    // The ceiling ran BEFORE the sub-guards: no fourth redispatch marker.
+    let markers_after = park_redispatch_markers(&repo, &base.id).await;
+    assert_eq!(
+        markers_after.len(),
+        markers_before.len(),
+        "the ceiling must short-circuit ahead of every sub-guard, so no new park-redispatch \
+         marker is written: {markers_after:?}"
+    );
+
+    // Terminal, non-redispatching state, with the reason recorded durably.
+    let closed = repo.get(&base.id).await.unwrap().unwrap();
+    assert_eq!(
+        closed.status, "closed",
+        "a PR-less task at the ceiling must be terminally closed, not parked or redispatched"
+    );
+    let ceiling_markers = hold_cycle_ceiling_markers(&repo, &base.id).await;
+    assert_eq!(
+        ceiling_markers.len(),
+        1,
+        "the ceiling records exactly one durable audit entry: {ceiling_markers:?}"
+    );
+    assert_eq!(ceiling_markers[0]["ceiling"], MAX_ARBITER_HOLD_CYCLES);
+    assert_eq!(
+        ceiling_markers[0]["ci_failure_fingerprint"], "fp-round-3",
+        "the audit entry names the fingerprint that would otherwise have won another free round"
+    );
+
+    // No fourth hold cycle was ever opened.
+    let arb = TaskArbitrationRepository::new(db.clone());
+    assert!(
+        arb.get_by_task_and_cycle(&base.id, MAX_ARBITER_HOLD_CYCLES)
+            .await
+            .unwrap()
+            .is_none(),
+        "the ceiling must refuse to open hold cycle {MAX_ARBITER_HOLD_CYCLES}"
+    );
+}
+
+/// Boundary: one cycle below the bound the ladder still behaves exactly as
+/// before. Without this the ceiling could be trivially satisfied by terminating
+/// everything, and the regression above would prove nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hold_cycle_ceiling_does_not_fire_below_the_bound() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let base = task_on_the_park_rung(&db, &tx).await;
+    for cycle in 0..(MAX_ARBITER_HOLD_CYCLES - 1) {
+        spend_hold_cycle(&db, &base.id, cycle).await;
+    }
+
+    let mut round = base.clone();
+    round.ci_failure_fingerprint = Some("fp-below-bound".to_string());
+    assert!(
+        !actor
+            .route_planner_intervention(&round, "worker", "strike", None, 5)
+            .await,
+        "with {} of {MAX_ARBITER_HOLD_CYCLES} cycles spent the rung must still decline to a \
+         redispatch",
+        MAX_ARBITER_HOLD_CYCLES - 1
+    );
+    let task = repo.get(&base.id).await.unwrap().unwrap();
+    assert_eq!(task.status, "open", "below the bound the task stays live");
+    assert!(
+        hold_cycle_ceiling_markers(&repo, &base.id).await.is_empty(),
+        "no ceiling audit entry may be written below the bound"
+    );
+    let markers = park_redispatch_markers(&repo, &base.id).await;
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0]["kind"], "first_occurrence_fingerprint");
+}
+
+/// A Lead arbiter genuinely in flight is left alone even at/above the bound: it
+/// may still approve or supersede, and it is independently bounded by the 24h
+/// arbitration deadline and the decision-failure cap. The ceiling only refuses
+/// to open a FRESH cycle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hold_cycle_ceiling_yields_to_an_in_flight_arbiter() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let base = task_on_the_park_rung(&db, &tx).await;
+    for cycle in 0..MAX_ARBITER_HOLD_CYCLES {
+        spend_hold_cycle(&db, &base.id, cycle).await;
+    }
+    open_in_flight_hold_cycle(&db, &base.id, MAX_ARBITER_HOLD_CYCLES).await;
+
+    let mut round = base.clone();
+    round.ci_failure_fingerprint = Some("fp-in-flight".to_string());
+    assert!(
+        !actor
+            .route_planner_intervention(&round, "worker", "strike", None, 5)
+            .await,
+        "an unconsumed arbitration row means an arbiter is live; the ceiling must not pre-empt it"
+    );
+    let task = repo.get(&base.id).await.unwrap().unwrap();
+    assert_eq!(
+        task.status, "open",
+        "the in-flight arbiter's task must not be terminally failed by the ceiling"
+    );
+    assert!(
+        hold_cycle_ceiling_markers(&repo, &base.id).await.is_empty(),
+        "no ceiling audit entry may be written while an arbiter is in flight"
+    );
+}
+
+/// gy53 itself carried an open PR. `terminally_fail_task` deliberately hands a
+/// PR-bearing task to the PR poller rather than force-closing it (the PR and
+/// branch are preserved), so the terminal state differs — but the rung must
+/// still HANDLE the task (the caller skips its dispatch), must record the
+/// reason, and must not open another hold cycle. Re-entry from a later poller
+/// tick must stay idempotent instead of spamming the audit log.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn hold_cycle_ceiling_hands_a_pr_bearing_task_to_the_poller_idempotently() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+    let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
+
+    let base = task_on_the_park_rung(&db, &tx).await;
+    repo.set_pr_url(&base.id, "https://github.com/djinnos/djinn/pull/2655")
+        .await
+        .unwrap();
+    let base = repo.get(&base.id).await.unwrap().unwrap();
+    for cycle in 0..MAX_ARBITER_HOLD_CYCLES {
+        spend_hold_cycle(&db, &base.id, cycle).await;
+    }
+
+    let mut round = base.clone();
+    round.ci_failure_fingerprint = Some("fp-pr-bearing".to_string());
+    assert!(
+        actor
+            .route_planner_intervention(&round, "worker", "strike", None, 5)
+            .await,
+        "a PR-bearing task at the ceiling must still be handled, never redispatched"
+    );
+    let handed_off = repo.get(&base.id).await.unwrap().unwrap();
+    assert_eq!(
+        handed_off.status, "pr_review",
+        "the terminal gate hands a PR-bearing task to the poller instead of force-closing it"
+    );
+
+    // A later poller tick re-enters the rung; the audit entry must not double.
+    let reloaded = repo.get(&base.id).await.unwrap().unwrap();
+    assert!(
+        actor
+            .route_planner_intervention(&reloaded, "worker", "strike", None, 5)
+            .await,
+        "re-entry at the ceiling must keep handling the task"
+    );
+    let ceiling_markers = hold_cycle_ceiling_markers(&repo, &base.id).await;
+    assert_eq!(
+        ceiling_markers.len(),
+        1,
+        "the ceiling audit entry is written once per task, not once per tick: {ceiling_markers:?}"
+    );
+    assert!(
+        park_redispatch_markers(&repo, &base.id).await.is_empty(),
+        "no sub-guard may run after the ceiling trips"
+    );
+    let arb = TaskArbitrationRepository::new(db.clone());
+    assert!(
+        arb.get_by_task_and_cycle(&base.id, MAX_ARBITER_HOLD_CYCLES)
+            .await
+            .unwrap()
+            .is_none(),
+        "no fresh hold cycle may be opened once the ceiling has tripped"
+    );
+}
+
+/// The arbiter dossier must carry the task's own arbitration history. Without
+/// it every Lead session decides in ignorance of the identical reopens before
+/// it — gy53 ran five arbiter dispatches that could not see each other.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn arbiter_dossier_carries_hold_cycle_and_prior_decisions() {
+    let db = test_helpers::create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let mut actor = coordinator_actor_for_tests(&db, &tx);
+
+    let base = task_on_the_park_rung(&db, &tx).await;
+    // One prior cycle, consumed with a `reopen` decision (what `spend_hold_cycle`
+    // records) — the history a fresh arbiter must be handed.
+    spend_hold_cycle(&db, &base.id, 0).await;
+
+    // Clear the fingerprint guard and the attempted-remediation gate so the
+    // rung actually reaches the arbiter-dispatch path and builds a dossier.
+    let mut round = base.clone();
+    round.ci_failure_fingerprint = None;
+    seed_terminated_post_intervention_sessions(&db, &tx, &base.id, &["m-a", "m-b"]).await;
+
+    assert!(
+        actor
+            .route_planner_intervention(&round, "worker", "strike", None, 5)
+            .await,
+        "with the sub-guards cleared and budget remaining, the rung dispatches the Lead arbiter"
+    );
+
+    let arb = TaskArbitrationRepository::new(db.clone());
+    let record = arb
+        .get_by_task_and_cycle(&base.id, 1)
+        .await
+        .unwrap()
+        .expect("hold cycle 1 must have been opened");
+    let dossier = record.dossier.expect("arbiter dossier must be persisted");
+    assert_eq!(
+        dossier["hold_cycle"], 1,
+        "the dossier must tell the arbiter which cycle it is on: {dossier}"
+    );
+    let prior = dossier["prior_arbiter_decisions"]
+        .as_array()
+        .expect("prior_arbiter_decisions must be an array");
+    assert_eq!(
+        prior.len(),
+        1,
+        "the dossier must summarize the one prior cycle: {dossier}"
+    );
+    assert_eq!(prior[0]["hold_cycle"], 0);
+    assert_eq!(
+        prior[0]["decision"], "reopen",
+        "the prior cycle's actual decision must be visible to the next arbiter: {dossier}"
+    );
+}

--- a/server/crates/djinn-coordinator/src/tests/mod.rs
+++ b/server/crates/djinn-coordinator/src/tests/mod.rs
@@ -1439,4 +1439,7 @@ mod tripwire_planner_escalation;
 mod escalation_ceiling;
 
 #[cfg(test)]
+mod hold_cycle_ceiling;
+
+#[cfg(test)]
 mod incarnation_lease_liveness;

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -352,9 +352,18 @@ pub(super) const PLANNER_INTERVENTION_MARKER: &str = "planner_intervention";
 /// park and redispatched instead (no post-intervention remediation was ever
 /// attempted, or a brand-new CI fingerprint deserved one shot). Payload carries
 /// the decision (`kind`), the fingerprint when relevant, and the non-attempt
-/// model count — an audit trail proving the fleet actually tried before a human
-/// is ever paged.
+/// model count — an audit trail proving the fleet actually tried before the
+/// ladder gives up.
 pub(super) const PARK_REDISPATCH_MARKER: &str = "park_attempted_remediation_redispatch";
+
+/// Activity marker recording that the cumulative arbitration ceiling
+/// ([`MAX_ARBITER_HOLD_CYCLES`]) terminated a task at the second-strike rung.
+/// Payload carries the ceiling, the intervention/reopen counters, the CI
+/// fingerprint in play, and the terminal reason text — the durable "why" behind
+/// a terminal close whose transition reason may later be truncated or rewritten.
+/// Written at most once per task (a PR-bearing task terminalizes via an
+/// idempotent poller handoff, so the rung can be re-entered).
+pub(super) const HOLD_CYCLE_CEILING_MARKER: &str = "arbiter_hold_cycle_ceiling";
 
 /// uv3p Part B: number of CONSECUTIVE post-intervention sessions that terminated
 /// pre-submission (across DIFFERENT models) after which the human-park rung
@@ -420,6 +429,48 @@ pub(super) const MAX_PLANNER_INTERVENTIONS: i64 = 1;
 /// documenting the exhausted ladder rather than creating another escalation. A
 /// planner can always resurrect the work from the epic level.
 pub(super) const MAX_AUTONOMOUS_ESCALATIONS: i64 = 3;
+
+/// Cumulative, cross-cycle arbitration ceiling: the maximum number of arbiter
+/// hold cycles a single source task may ever open before the second-strike
+/// rung stops re-entering the ladder and terminally fails the task.
+///
+/// **This is the only bound on the rung that is cumulative.** Every other guard
+/// on the second-strike ladder is per-cycle or per-fingerprint, and each one
+/// RESETS by incrementing:
+///
+/// - `hold_cycle` itself is otherwise unbounded — [`resolve_current_hold_cycle`]
+///   (`task_arbitration.rs`) does `hold_cycle.saturating_add(1)` whenever the
+///   prior row is consumed or failed, forever.
+/// - [`MAX_AUTONOMOUS_ESCALATIONS`] is reachable ONLY through
+///   `park_source_human_review`, which the ladder enters only on fail-closed
+///   error branches (arbitration DB error, consumed/failed row, expired 24h
+///   deadline, decision-failure cap). A task whose `try_create` keeps returning
+///   `Created` never touches it — the ceiling sits on the error path, not the
+///   happy path.
+/// - The first-occurrence CI fingerprint guard grants one free remediation per
+///   NOVEL fingerprint, so a task that never repeats a failure signature gets
+///   unlimited free remediations.
+///
+/// Incident gy53 (2026-07-27) is exactly that shape: a large multi-crate
+/// retirement where each repair pushed the compile error down a layer,
+/// producing a new CI fingerprint every round (5 distinct ones). No guard ever
+/// tripped: 65 sessions, `intervention_count` 9, `hold_cycle` 9, five Lead
+/// arbiter dispatches, ~100% of dispatch capacity for 12+ hours, zero merges
+/// board-wide for six hours. The control task fux8 had a comparable
+/// `intervention_count` of 5 but only two arbiter dispatches — because its CI
+/// happened to go green. Without a cumulative bound the ladder terminates only
+/// when the work succeeds.
+///
+/// Rationale for `3`: hold cycles 0, 1 and 2 give the Lead arbiter three full
+/// forensic rounds (each of which may reopen with a directive, rotate models,
+/// or supersede). A task that has burned three complete arbitration cycles
+/// without converging is not going to converge on the fourth; board-wide over
+/// nine days only 18 of 55 arbitrated tasks ever reached `hold_cycle > 0` at
+/// all, so this ceiling is far above normal operation while still an order of
+/// magnitude below gy53's observed 9.
+///
+/// [`resolve_current_hold_cycle`]: djinn_db::repositories::task_arbitration::TaskArbitrationRepository::resolve_current_hold_cycle
+pub(super) const MAX_ARBITER_HOLD_CYCLES: i32 = 3;
 
 /// Same-signature CI dead-end threshold: the number of consecutive identical
 /// required-CI failures (same failure fingerprint) on a PR whose head has NOT

--- a/server/crates/djinn-mcp-extension/src/finalize_tools.rs
+++ b/server/crates/djinn-mcp-extension/src/finalize_tools.rs
@@ -83,7 +83,7 @@ pub fn tool_submit_decision() -> RmcpTool {
                 "decision": {
                     "type": "string",
                     "enum": ["approve", "approve_conflict", "reopen", "park", "supersede"],
-                    "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
+                    "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hand the task to an AUTONOMOUS Planner escalation with a structured dossier — this does NOT reach a human: a Planner session reads your dossier and owns terminal resolution by decomposing + superseding, closing won't-fix, or re-scoping + reopening), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
                 },
                 "rationale": {"type": "string", "description": "Explanation for the decision"},
                 "evidence": {
@@ -111,17 +111,17 @@ pub fn tool_submit_decision() -> RmcpTool {
                 },
                 "park_dossier": {
                     "type": "object",
-                    "description": "Required for park. Structured dossier for the human-review hold.",
+                    "description": "Required for park. Structured dossier handed to the autonomous Planner escalation. No human reads it — write it for the Planner session that must resolve the task.",
                     "required": ["hold_description", "failure_analysis"],
                     "properties": {
-                        "hold_description": {"type": "string", "description": "Description of the hold for human reviewers"},
-                        "failure_analysis": {"type": "string", "description": "Analysis of why the task failed and needs human review"},
+                        "hold_description": {"type": "string", "description": "Description of the hold for the Planner that will resolve it"},
+                        "failure_analysis": {"type": "string", "description": "Analysis of why the task failed and why no arbiter decision can unstick it"},
                         "attempted_decisions": {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "Optional list of decisions attempted before parking"
                         },
-                        "recommended_action": {"type": "string", "description": "Optional recommended action for the human reviewer"}
+                        "recommended_action": {"type": "string", "description": "Optional recommended action for the Planner (decompose + supersede, close won't-fix, or re-scope + reopen)"}
                     }
                 },
                 "created_tasks": {

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__judge_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__judge_tool_schemas.snap
@@ -851,7 +851,7 @@ expression: tool_schemas_judge()
             "park",
             "supersede"
           ],
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hand the task to an AUTONOMOUS Planner escalation with a structured dossier — this does NOT reach a human: a Planner session reads your dossier and owns terminal resolution by decomposing + superseding, closing won't-fix, or re-scoping + reopening), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
         },
         "rationale": {
           "type": "string",
@@ -896,7 +896,7 @@ expression: tool_schemas_judge()
         },
         "park_dossier": {
           "type": "object",
-          "description": "Required for park. Structured dossier for the human-review hold.",
+          "description": "Required for park. Structured dossier handed to the autonomous Planner escalation. No human reads it — write it for the Planner session that must resolve the task.",
           "required": [
             "hold_description",
             "failure_analysis"
@@ -904,11 +904,11 @@ expression: tool_schemas_judge()
           "properties": {
             "hold_description": {
               "type": "string",
-              "description": "Description of the hold for human reviewers"
+              "description": "Description of the hold for the Planner that will resolve it"
             },
             "failure_analysis": {
               "type": "string",
-              "description": "Analysis of why the task failed and needs human review"
+              "description": "Analysis of why the task failed and why no arbiter decision can unstick it"
             },
             "attempted_decisions": {
               "type": "array",
@@ -919,7 +919,7 @@ expression: tool_schemas_judge()
             },
             "recommended_action": {
               "type": "string",
-              "description": "Optional recommended action for the human reviewer"
+              "description": "Optional recommended action for the Planner (decompose + supersede, close won't-fix, or re-scope + reopen)"
             }
           }
         },

--- a/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__lead_tool_schemas.snap
+++ b/server/crates/djinn-mcp-extension/src/tests/snapshots/djinn_mcp_extension__tests__schema_tests__lead_tool_schemas.snap
@@ -1018,7 +1018,7 @@ expression: tool_schemas_lead()
             "park",
             "supersede"
           ],
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hand the task to an AUTONOMOUS Planner escalation with a structured dossier — this does NOT reach a human: a Planner session reads your dossier and owns terminal resolution by decomposing + superseding, closing won't-fix, or re-scoping + reopening), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
         },
         "rationale": {
           "type": "string",
@@ -1063,7 +1063,7 @@ expression: tool_schemas_lead()
         },
         "park_dossier": {
           "type": "object",
-          "description": "Required for park. Structured dossier for the human-review hold.",
+          "description": "Required for park. Structured dossier handed to the autonomous Planner escalation. No human reads it — write it for the Planner session that must resolve the task.",
           "required": [
             "hold_description",
             "failure_analysis"
@@ -1071,11 +1071,11 @@ expression: tool_schemas_lead()
           "properties": {
             "hold_description": {
               "type": "string",
-              "description": "Description of the hold for human reviewers"
+              "description": "Description of the hold for the Planner that will resolve it"
             },
             "failure_analysis": {
               "type": "string",
-              "description": "Analysis of why the task failed and needs human review"
+              "description": "Analysis of why the task failed and why no arbiter decision can unstick it"
             },
             "attempted_decisions": {
               "type": "array",
@@ -1086,7 +1086,7 @@ expression: tool_schemas_lead()
             },
             "recommended_action": {
               "type": "string",
-              "description": "Optional recommended action for the human reviewer"
+              "description": "Optional recommended action for the Planner (decompose + supersede, close won't-fix, or re-scope + reopen)"
             }
           }
         },

--- a/server/crates/djinn-mcp-extension/tests/fixtures/tool_surface_baseline.json
+++ b/server/crates/djinn-mcp-extension/tests/fixtures/tool_surface_baseline.json
@@ -2268,7 +2268,7 @@
           "type": "array"
         },
         "decision": {
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)",
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hand the task to an AUTONOMOUS Planner escalation with a structured dossier — this does NOT reach a human: a Planner session reads your dossier and owns terminal resolution by decomposing + superseding, closing won't-fix, or re-scoping + reopening), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)",
           "enum": [
             "approve",
             "approve_conflict",
@@ -2312,7 +2312,7 @@
           "type": "array"
         },
         "park_dossier": {
-          "description": "Required for park. Structured dossier for the human-review hold.",
+          "description": "Required for park. Structured dossier handed to the autonomous Planner escalation. No human reads it — write it for the Planner session that must resolve the task.",
           "properties": {
             "attempted_decisions": {
               "description": "Optional list of decisions attempted before parking",
@@ -2322,15 +2322,15 @@
               "type": "array"
             },
             "failure_analysis": {
-              "description": "Analysis of why the task failed and needs human review",
+              "description": "Analysis of why the task failed and why no arbiter decision can unstick it",
               "type": "string"
             },
             "hold_description": {
-              "description": "Description of the hold for human reviewers",
+              "description": "Description of the hold for the Planner that will resolve it",
               "type": "string"
             },
             "recommended_action": {
-              "description": "Optional recommended action for the human reviewer",
+              "description": "Optional recommended action for the Planner (decompose + supersede, close won't-fix, or re-scope + reopen)",
               "type": "string"
             }
           },

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/lead.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/lead.json
@@ -397,6 +397,74 @@
     "concurrent_safe": true
   },
   {
+    "name": "ci_artifact",
+    "description": "Read a bounded GitHub Actions artifact. `list` lists artifacts and `fetch` renders one exact artifact. Select optional positive `run_id` or `pr_number`, never both; fetch requires non-empty `artifact`.",
+    "inputSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": [
+            "list",
+            "fetch"
+          ]
+        },
+        "run_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "pr_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "artifact": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": [
+              "run_id",
+              "pr_number"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "const": "fetch"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "artifact"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "artifact"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "readOnly": true,
+    "destructive": false,
+    "idempotent": true,
+    "openWorld": false,
+    "concurrent_safe": true
+  },
+  {
     "name": "github_search",
     "description": "Search GitHub code across public repositories using the GitHub Code Search API. Returns compact, navigable matches with snippets, file paths, URLs, and metadata. Each result has a result_id for reference. Use github_fetch_file to inspect the full file of a promising result.",
     "inputSchema": {
@@ -492,6 +560,20 @@
     "concurrent_safe": true
   },
   {
+    "name": "output_list",
+    "description": "List durable metadata for truncated outputs owned by the current trusted session.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "required": []
+    },
+    "readOnly": true,
+    "destructive": false,
+    "idempotent": true,
+    "openWorld": false,
+    "concurrent_safe": true
+  },
+  {
     "name": "task_create",
     "description": "Create a new task under an epic. Agents should use this only when explicitly allowed by their role and task design.",
     "inputSchema": {
@@ -549,6 +631,30 @@
             "type": "string"
           },
           "description": "Task IDs (UUID or short_id) that must complete before this task can be dispatched."
+        },
+        "execution_context": {
+          "type": "object",
+          "description": "Optional explicit execution eligibility metadata. Only the complete readiness_guardrail_analysis context is accepted; it is never inferred from task text, labels, roles, or issue type.",
+          "required": [
+            "kind",
+            "skill_name",
+            "skill_version"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "readiness_guardrail_analysis"
+            },
+            "skill_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "skill_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -622,6 +728,30 @@
             "type": "string"
           },
           "description": "Task IDs (UUID or short_id) to remove as blockers."
+        },
+        "execution_context": {
+          "type": "object",
+          "description": "Complete replacement for explicit execution eligibility metadata. Partial JSON updates are not supported.",
+          "required": [
+            "kind",
+            "skill_name",
+            "skill_version"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "readiness_guardrail_analysis"
+            },
+            "skill_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "skill_version": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -884,7 +1014,7 @@
             "park",
             "supersede"
           ],
-          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hold the task for human review with a structured dossier), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
+          "description": "The decision: approve (work is complete + correct — the worker just couldn't self-certify; requires evidence citation), approve_conflict (correct but a merge conflict exists — approve then send for conflict retry; requires evidence citation), reopen (send back to a fresh worker with a directive and verification command), park (hand the task to an AUTONOMOUS Planner escalation with a structured dossier — this does NOT reach a human: a Planner session reads your dossier and owns terminal resolution by decomposing + superseding, closing won't-fix, or re-scoping + reopening), supersede (you decomposed the work into replacement subtasks that carry it forward — the source task and its PR are force-closed as superseded automatically; requires a non-empty created_tasks array)"
         },
         "rationale": {
           "type": "string",
@@ -929,7 +1059,7 @@
         },
         "park_dossier": {
           "type": "object",
-          "description": "Required for park. Structured dossier for the human-review hold.",
+          "description": "Required for park. Structured dossier handed to the autonomous Planner escalation. No human reads it — write it for the Planner session that must resolve the task.",
           "required": [
             "hold_description",
             "failure_analysis"
@@ -937,11 +1067,11 @@
           "properties": {
             "hold_description": {
               "type": "string",
-              "description": "Description of the hold for human reviewers"
+              "description": "Description of the hold for the Planner that will resolve it"
             },
             "failure_analysis": {
               "type": "string",
-              "description": "Analysis of why the task failed and needs human review"
+              "description": "Analysis of why the task failed and why no arbiter decision can unstick it"
             },
             "attempted_decisions": {
               "type": "array",
@@ -952,7 +1082,7 @@
             },
             "recommended_action": {
               "type": "string",
-              "description": "Optional recommended action for the human reviewer"
+              "description": "Optional recommended action for the Planner (decompose + supersede, close won't-fix, or re-scope + reopen)"
             }
           }
         },

--- a/server/crates/djinn-roles/src/prompts/lead.md
+++ b/server/crates/djinn-roles/src/prompts/lead.md
@@ -2,7 +2,7 @@
 
 You are the park-rung forensic arbiter. A task has been routed to you because the coordinator's arbiter state machine determined it needs Lead-level inspection before proceeding. Your job is to examine the evidence and render a single decision that the supervisor will execute as a board transition.
 
-**`submit_decision` owns the board transition — you do NOT.** Make any prerequisite edits first (`task_update`, `task_create`, `blocked_by_add`, `task_delete_branch`), then end the session with the single `submit_decision(decision=...)` that matches your finding. The supervisor applies the corresponding status change for you (`approve` → approved+merge, `reopen` → back to a fresh worker with directive + verification command, `park` → human-review hold with dossier, `supersede` → force-close the source + its PR as superseded by your replacement subtasks). **Do not call any separate transition tool** to approve, close, reopen, or complete — that double-transitions and fights the supervisor.
+**`submit_decision` owns the board transition — you do NOT.** Make any prerequisite edits first (`task_update`, `task_create`, `blocked_by_add`, `task_delete_branch`), then end the session with the single `submit_decision(decision=...)` that matches your finding. The supervisor applies the corresponding status change for you (`approve` → approved+merge, `reopen` → back to a fresh worker with directive + verification command, `park` → autonomous Planner escalation carrying your dossier (NOT a human hold), `supersede` → force-close the source + its PR as superseded by your replacement subtasks). **Do not call any separate transition tool** to approve, close, reopen, or complete — that double-transitions and fights the supervisor.
 
 **Shell is read-only for arbiter:** `git diff`, `git log`, `git show`, `cat`, `ls`. Do not write or modify files.
 
@@ -81,10 +81,10 @@ Supersede is NOT appropriate when:
 - No autonomous resolution exists even in principle (use Park).
 
 ### Park (`decision="park"`)
-The task cannot proceed as-is and needs human oversight. Use park ONLY when no autonomous resolution exists even in principle — the task needs credentials you cannot obtain, a product decision, a destructive/irreversible action, or has genuinely ambiguous intent. If you have already decomposed the work into replacement subtasks, use `supersede`, not park. You MUST provide a structured dossier:
+**Park does NOT reach a human.** It hands the task to an autonomous **Planner** escalation carrying your dossier; that Planner session owns terminal resolution (decompose + supersede, close won't-fix, or re-scope + reopen). Nobody will be paged, and no person has to close anything to release the source. Use park ONLY when no autonomous resolution exists even in principle *at your level* — the decision belongs one level up on the board because the task needs credentials you cannot obtain, a product decision, a destructive/irreversible action, or has genuinely ambiguous intent. If you have already decomposed the work into replacement subtasks, use `supersede`, not park. You MUST provide a structured dossier, written FOR THE PLANNER:
 - `hold_description`: What is blocking progress (one sentence)
 - `failure_analysis`: Your forensic finding — what went wrong, what evidence you found, why the current state is stuck
-- `recommended_action`: What a human should do (close as redundant, decompose, rescope, merge into another task, etc.)
+- `recommended_action`: What the Planner should do (close as redundant, decompose + supersede, rescope, merge into another task, etc.)
 
 Park is appropriate when:
 - The task is redundant (predecessor or sibling already merged the work — cite the `merge_commit_sha` or commit)

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -2898,13 +2898,18 @@ pub mod arbiter {
     pub const PARK_REASON_ARBITER_DECIDED: &str = "arbiter_decided";
     pub const PARK_REASON_CONSUMED_REENTRY: &str = "consumed_reentry";
     pub const PARK_REASON_ARBITRATION_ERROR: &str = "arbitration_error";
+    /// Cumulative cross-cycle arbitration ceiling: the task spent its whole
+    /// hold-cycle budget without converging and was terminally failed instead
+    /// of opening another cycle (incident gy53).
+    pub const PARK_REASON_HOLD_CYCLE_CEILING: &str = "hold_cycle_ceiling";
 
-    pub const ALL_PARK_REASONS: [&str; 5] = [
+    pub const ALL_PARK_REASONS: [&str; 6] = [
         PARK_REASON_DEADLINE_EXPIRED,
         PARK_REASON_DECISION_FAILURE_CAP,
         PARK_REASON_ARBITER_DECIDED,
         PARK_REASON_CONSUMED_REENTRY,
         PARK_REASON_ARBITRATION_ERROR,
+        PARK_REASON_HOLD_CYCLE_CEILING,
     ];
 
     // ── Monitored reopen outcome ───────────────────────────────────────


### PR DESCRIPTION
## Why: the ladder terminates only when the work happens to succeed

Task `gy53` consumed ~100% of dispatch capacity for 12+ hours — 65 sessions,
`intervention_count` 9, `hold_cycle` 9, five Lead arbiter dispatches, zero merges
board-wide for six hours — and nobody was notified.

**No guard on the second-strike park rung is cumulative.** Every one is
per-fingerprint or per-cycle, and each resets by incrementing:

| guard | why it never fired for gy53 |
|---|---|
| `hold_cycle` | unbounded — `resolve_current_hold_cycle` does `saturating_add(1)` forever. There was no `MAX_HOLD_CYCLE` anywhere in the workspace. |
| `MAX_AUTONOMOUS_ESCALATIONS = 3` | reachable only via `park_source_human_review`, i.e. on fail-closed error branches (DB error, consumed/failed row, expired 24h deadline, decision-failure cap). gy53's `try_create` returned `Created` every time. **The ceiling sat on the error path, not the happy path.** |
| `first_occurrence_fingerprint` | grants one free remediation per *novel* CI fingerprint. gy53 was a large multi-crate retirement where each repair pushed the compile error down a layer, minting a new fingerprint every round. A task that never repeats a failure gets unlimited free remediations. |

The contrast that makes this concrete: **`fux8`** had a comparable
`intervention_count` of 5 but only **two** arbiter dispatches — because its CI
went green. Board-wide over nine days: 100 `arbiter_dispatched` events across 55
tasks, 18 of which reached `hold_cycle > 0`. The ladder terminates only when the
work happens to succeed.

## 1. The cumulative bound (the core fix)

`MAX_ARBITER_HOLD_CYCLES = 3`, keyed on the task's max `hold_cycle` across its
`task_arbitrations` rows, evaluated **at the top of the rung, before every
sub-guard**. Placement is the load-bearing part: each sub-guard declines by
`return false` (which redispatches), so a bound placed after them is unreachable
for a task that declines via a different guard each round — gy53's exact shape.
Cycle N now terminates regardless of which guard *would* have declined.

At the bound the task routes through `terminally_fail_task` (the single
dispatch-exhaustion gateway enforced by `terminal_gate_boundary.rs`) and records
an `arbiter_hold_cycle_ceiling` activity entry carrying the ceiling, the counters,
the fingerprint in play, and the terminal reason. A PR-bearing task terminalizes
via the existing idempotent poller handoff rather than a force-close, so the audit
entry is written once per task, not once per tick.

An arbiter genuinely **in flight** (unconsumed row) is left alone — it may still
approve or supersede, and it is independently bounded by the 24h arbitration
deadline and the decision-failure cap. The ceiling only refuses to open a *fresh*
cycle. Arbitration-ledger read errors fail **open**, into the pre-existing
fail-closed park handling; an unreadable ledger must not terminally fail live work.

Sizing: with this in place gy53's cycle-3 dispatch (09:35 UTC) would never have
happened — the task would have terminated around 08:47, before the monopoly
matured. Only 18 of 55 arbitrated tasks in nine days ever reached `hold_cycle > 0`
at all, so 3 sits far above normal operation.

### Regression (`tests/hold_cycle_ceiling.rs`)

`hold_cycle_ceiling_terminates_when_a_different_guard_declines_each_cycle`
deliberately rotates the declining guard between cycles
(`first_occurrence_fingerprint` → `no_attempted_remediation` →
`first_occurrence_fingerprint`) and then, at the bound, presents the very guard
that granted a free pass twice before. It asserts the task terminates, that **no
fourth park-redispatch marker is written** (proving the ceiling short-circuits
ahead of the sub-guards), and that no fourth hold cycle is opened. Plus a
below-the-bound boundary test, an in-flight-arbiter test, and a PR-bearing
idempotency test.

Verified by neutralization, two ways:

- `if false && ...` on the gate → both ceiling tests fail with exactly the gy53
  symptom ("must handle (terminate) the task, NOT decline to a redispatch").
- gate **moved after** the sub-guards, left fully functional → the same two tests
  still fail. The test asserts the ordering, not merely the existence of a check.
  The three non-ceiling tests correctly stay green under both.

## 2. The narration was left behind by the arbiter cutover

Three artifacts advertised a human hold the code cannot produce. `retry.rs`'s own
doc already admitted *"NO human-review hold is ever produced on the autonomous
path"*, and `arbiter_park` stamps `"autonomous_escalation": true`. Live proof —
every gy53 `arbiter_dispatched` payload reads:

> *"The task is held (open + blocked on a human-review remediation task) … **A human must resolve the remediation task to release it**"*

The most consequential of the three: `submit_decision`'s `park` / `park_dossier`
descriptions are **what the arbiter model reads when choosing a decision**. The
model may have been selecting `park` believing it escalates to a person. All three
are replaced with what actually happens (an autonomous Planner escalation that owns
terminal resolution), plus the same correction in the Lead role prompt. Only one
narration ships.

Goldens regenerated together: djinn-agent lead schema snapshot, djinn-mcp-extension
lead + judge schema snapshots, `tool_surface_baseline.json`, and the djinn-provider
`builtin/lead.json` projection corpus (refreshed via the documented `tail -n +6`
path — note this also picks up a pre-existing drift, the `ci_artifact` tool a prior
PR added without refreshing the fixture). The server MCP snapshot and the UI
generated MCP types are unaffected: `submit_decision` is agent-side only and appears
in neither. `djinn_mcp_server_corpus_fixture_is_current` passes unchanged.

## 3. The tripwire path is NOT dead — left alone

`RemediationKind::HumanReview`'s single production construction site
(`pr_poller/tripwire_hold.rs:226`) is **not** stale pre-arbiter code. It is a
documented, tested **org-policy escape hatch**:

- `create_tripwire_hold_with_policy` is reached from a live path
  (`pr_watcher.rs:433`) and branches on `policy.adjudication_for(rule).is_human()`.
- Every rule in `TripwirePolicy::default()` is `Adjudication::Arbiter`, and
  production always passes the default (org-policy loading is an explicit
  `TODO(per-project-policy)`), so the branch is currently **unreachable in
  production** — but by configuration, not by decay.
- The `policy` seam exists specifically so tests exercise the hatch end-to-end
  (`tripwire_planner_escalation.rs:199` asserts a `Human`-adjudicated rule takes
  the legacy path).
- `tripwire_hold_release.rs` and `actor.rs:1770` still implement close-release
  semantics for `human-review-hold`.

Live board (via djinn MCP, no raw SQL): **zero** tasks carry `human-review-hold` in
any status, and **zero** `tripwire.hold.created` events exist. So it has never
fired — consistent with "dormant by default", not with "dead". Per the instruction
not to delete a working escalation path on assumption, both it and the
`human-review-hold` label handling at `retry.rs:2768` are untouched. Its doc comment
is corrected to say the autonomous rungs never construct it.

## 4. Actor mislabel

Every `arbiter_decision` / `arbiter_parked` entry written from `direct_services.rs`
is the outcome of a `lead`-role agent session calling `submit_decision`, but was
stamped `actor_id: "system", actor_role: "coordinator"` — confirmed in live data for
all four gy53 reopens. That is what made one role reopening its own work read as two
subsystems fighting. Now `("lead-agent", "lead")`, matching the attribution the
Lead's own board transitions already use. The supervisor-driven session-termination
paths keep system attribution, which is accurate for them.

## 5. Arbiter history in the dossier

Confirmed by reading the construction site: the dossier at `retry.rs:1641` carried
no `hold_cycle` and no prior decisions, so each of gy53's five Lead sessions decided
in ignorance of the identical reopens before it. It now carries `hold_cycle`,
`hold_cycle_ceiling`, and `prior_arbiter_decisions` — per closed cycle: state,
decision, directive text, verification command, excluded models, and failure counters.

## Verification

- `djinn-coordinator --lib`: **2036/2036** (nextest, `--test-threads=1`).
- `djinn-agent --lib`: **1442 passed, 1 skipped**. Arbiter integration binaries: 14/14.
- `djinn-mcp-extension` + `djinn-provider` + `djinn-roles`: **1162/1162**.
- `djinn-control-plane` corpus-fixture currency: pass.
- `cargo fmt --all`; `cargo clippy --all-targets` on all five touched crates — zero
  warnings attributable to this change (the remaining ones are pre-existing, in
  `djinn-db/readiness` and `djinn-mcp-extension/{compatibility,helpers}.rs`).
- `scripts/check-file-size.sh`: 0 oversized.

Two things worth flagging for the reviewer:

- `rules::tests::amend_while_building_dispatches_one_reconcile_task_from_event`
  stack-overflows under plain `cargo test` locally. It reproduces **identically on
  unmodified `main`** and does not occur under nextest (per-test processes), so it is
  a pre-existing local debug-build issue, not a regression here.
- One full-suite run showed a single flake in
  `tests::intervention::loop_guard_second_strike_parks_task`; it passed in isolation,
  passed 3x as a module, and the full suite passed 2036/2036 on rerun.

Out of scope as instructed: the doctor dispatch-monopoly check, and everything in the
build-lease / dispatch-admission path (`build_lease.rs`, `build_slot_authority.rs`,
`build_admission.rs`, `admission_journal.rs` — untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
