### PR TITLE
fix(cache): make the cargo-target-runs root a required per-pod mount

### DIFF
--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -3447,7 +3447,13 @@ fn build_worker_agent_context(
         graph_warmer: None,
         repo_graph_ops: None,
         runtime_ops: None,
-        cargo_target_runs_root: None,
+        // In-Pod view of the shared cache PVC. The Job pod mounts it at
+        // `/cache`, NOT at the server pod's `$DJINN_HOME/cache`, and Job specs
+        // never set `DJINN_HOME` — so `djinn_core::paths::cargo_target_runs_root()`
+        // would resolve here to `~/.djinn/cache/cargo-target-runs`, an empty
+        // container-layer path. Name this pod's own mount explicitly; the same
+        // constant `CARGO_TARGET_DIR` is rendered from.
+        cargo_target_runs_root: PathBuf::from(cargo_target_seed::RUN_TARGET_ROOT),
         mirror: None,
         rpc_registry: None,
         // The K8s worker only ever serves one project per Pod, so default
@@ -4004,6 +4010,61 @@ mod tests {
             assert_ne!(
                 authorization.owner_project_id.as_deref(),
                 Some("other-owner")
+            );
+        }
+    }
+
+    /// The in-Pod `AgentContext` must name the *Job pod's* mount of the shared
+    /// cache PVC, never the server pod's.
+    ///
+    /// The same PVC is mounted at `/cache` here and at `$DJINN_HOME/cache` in the
+    /// server/coordinator pod, and Job specs never set `DJINN_HOME` — so any
+    /// host-convention resolution (`djinn_core::paths::cargo_target_runs_root()`,
+    /// directly or as an `unwrap_or_else` fallback) lands on
+    /// `~/.djinn/cache/cargo-target-runs`, an empty container-layer path. Anything
+    /// reaping through it would be a permanent silent no-op that leaks disk,
+    /// which is exactly the bug class #2660 fixed in the other direction.
+    ///
+    /// Asserted against the real production constructor, not a re-derivation.
+    #[tokio::test]
+    async fn worker_context_cargo_target_runs_root_is_the_job_pod_mount() {
+        let (stream, _peer) = tokio::io::duplex(64);
+        let (read, write) = tokio::io::split(stream);
+        let cancel = CancellationToken::new();
+        let (rpc, _tasks) = RpcServices::from_split(read, write, cancel.clone());
+        let context = build_worker_agent_context(
+            Database::open_in_memory().expect("in-memory worker database"),
+            rpc,
+            "proj".to_string(),
+            Vec::new(),
+            KnowledgeInjectionConfig::default(),
+            None,
+        );
+        let root = context.cargo_target_runs_root.clone();
+        cancel.cancel();
+
+        // It is the Job-pod constant, and the exact parent of the directory this
+        // pod actually builds into (the one `CARGO_TARGET_DIR` is rendered from).
+        assert_eq!(root, Path::new(cargo_target_seed::RUN_TARGET_ROOT));
+        assert_eq!(
+            cargo_target_seed::run_target_dir("run-abc").parent(),
+            Some(root.as_path()),
+            "context root must be the parent of this pod's private run dir"
+        );
+        // Same path the in-pod supervisor validates deletions against.
+        assert_eq!(root, Path::new(djinn_supervisor::CARGO_TARGET_RUNS_ROOT));
+
+        // Neutralization guard: every server-pod-convention resolution is
+        // rejected by shape, so reintroducing the fallback fails here.
+        let rendered = root.display().to_string();
+        assert!(
+            rendered.starts_with("/cache/"),
+            "Job-pod cache mount is /cache; got {rendered}"
+        );
+        for host_convention in [".djinn", "/var/lib/djinn", "/tmp/", "/home/"] {
+            assert!(
+                !rendered.contains(host_convention),
+                "worker resolved a server-pod cache convention ({host_convention}): {rendered}"
             );
         }
     }

--- a/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
+++ b/server/crates/djinn-agent/src/actors/slot/supervisor_runner.rs
@@ -1716,10 +1716,10 @@ async fn reap_orphan_task_run(
 }
 
 async fn teardown_cargo_target_run_dir(app_state: &AgentContext, task_run_id: &str) {
-    let root = app_state
-        .cargo_target_runs_root
-        .clone()
-        .unwrap_or_else(djinn_core::paths::cargo_target_runs_root);
+    // No fallback by design: `cargo_target_runs_root` is the *calling process's*
+    // mount of the shared cache PVC, and the server pod and the Job pods mount it
+    // at different paths. See the field doc on `AgentContext`.
+    let root = app_state.cargo_target_runs_root.clone();
     let id = task_run_id.to_string();
     let log_root = root.clone();
     let log_id = id.clone();
@@ -3011,5 +3011,49 @@ mod tests {
             !failover_comment_already_logged(&task_repo, &task.id, "zai/glm-5.2").await,
             "a different model has no prior comment ⇒ must not be suppressed"
         );
+    }
+
+    /// The host teardown backstop must reap under the root the *calling process*
+    /// was configured with, and nothing else.
+    ///
+    /// This asserts the side effect, not the log line: the run dir is really gone
+    /// and its sibling really survives. The field carries this process's own mount
+    /// of the shared cache PVC — the server pod sees it at `$DJINN_HOME/cache`,
+    /// Job pods at `/cache` — so if this function ever resolved a path itself
+    /// (e.g. reinstating an `unwrap_or_else(djinn_core::paths::cargo_target_runs_root)`
+    /// fallback) it would sweep a directory that does not exist in the other pod
+    /// and leak silently. That would leave the run dir below intact and fail here.
+    #[tokio::test]
+    async fn host_teardown_reaps_only_the_exact_run_dir_under_the_configured_root() {
+        let root = tempfile::tempdir().expect("teardown root tempdir");
+        let mut app_state = crate::test_helpers::agent_context_from_db(
+            djinn_db::Database::open_in_memory().expect("in-memory db"),
+            CancellationToken::new(),
+        );
+        app_state.cargo_target_runs_root = root.path().to_path_buf();
+
+        let target = root.path().join("run-under-test");
+        let sibling = root.path().join("run-untouched");
+        std::fs::create_dir_all(target.join("debug")).expect("create run dir");
+        std::fs::write(target.join("debug/artifact.rlib"), b"bytes").expect("write artifact");
+        std::fs::create_dir_all(&sibling).expect("create sibling run dir");
+
+        teardown_cargo_target_run_dir(&app_state, "run-under-test").await;
+
+        assert!(
+            !target.exists(),
+            "teardown must remove the run dir under the configured root: {}",
+            target.display()
+        );
+        assert!(
+            sibling.exists(),
+            "teardown must not touch other runs under the same root"
+        );
+        assert!(root.path().exists(), "teardown must not remove the root");
+
+        // Idempotent: a second pass over an already-absent dir is a no-op, not a
+        // failure, and still leaves the sibling alone.
+        teardown_cargo_target_run_dir(&app_state, "run-under-test").await;
+        assert!(sibling.exists());
     }
 }

--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -440,11 +440,25 @@ pub struct AgentContext {
     /// control-plane seam without depending on Kubernetes directly. `None` in
     /// off-server/test contexts falls back to the agent-internal no-op runtime.
     pub runtime_ops: Option<Arc<dyn bridge::RuntimeOps>>,
-    /// Root under which coordinator stale-resource GC enumerates per-task-run
-    /// Cargo target directories. `None` uses the production PVC path
-    /// (`/cache/cargo-target-runs`); tests may inject a temp dir so sweeps never
-    /// touch the shared build cache used by the test process itself.
-    pub cargo_target_runs_root: Option<PathBuf>,
+    /// **This process's own view** of the per-task-run Cargo target root.
+    ///
+    /// Required, deliberately: the shared cache PVC is mounted at *different*
+    /// paths by different pods — the server/coordinator pod mounts it at
+    /// `$DJINN_HOME/cache` (so this is
+    /// [`djinn_core::paths::cargo_target_runs_root`]) while Job pods mount it at
+    /// `/cache` (so this is `djinn_supervisor::CARGO_TARGET_RUNS_ROOT`). There is
+    /// no correct default across both, so there is no default at all: every
+    /// constructor MUST name its own mount and the compiler enforces it.
+    ///
+    /// An `Option` with an `unwrap_or_else` fallback used to sit here. That shape
+    /// is the hazard, not a convenience: whichever convention the fallback picks
+    /// is silently wrong in the other pod, and "silently wrong" means reaping a
+    /// nonexistent directory — a permanent no-op that leaks disk instead of
+    /// failing visibly. That is precisely the bug class fixed in #2660.
+    ///
+    /// Tests inject a temp dir so sweeps never touch the shared build cache used
+    /// by the test process itself.
+    pub cargo_target_runs_root: PathBuf,
     /// Shared bare-mirror manager. Used by the mirror-native merge path in
     /// `task_merge` to run squash-merges against an ephemeral hardlinked
     /// clone instead of a worktree under `.task-runtime/worktrees/.merge-*`.

--- a/server/crates/djinn-agent/src/test_helpers.rs
+++ b/server/crates/djinn-agent/src/test_helpers.rs
@@ -119,7 +119,7 @@ pub fn agent_context_from_db(db: Database, _cancel: CancellationToken) -> AgentC
         graph_warmer: None,
         repo_graph_ops: None,
         runtime_ops: None,
-        cargo_target_runs_root: Some(test_path("cargo-target-runs-")),
+        cargo_target_runs_root: test_path("cargo-target-runs-"),
         mirror: None,
         rpc_registry: None,
         default_project_id: None,

--- a/server/crates/djinn-agent/tests/arbiter_park_transaction.rs
+++ b/server/crates/djinn-agent/tests/arbiter_park_transaction.rs
@@ -51,7 +51,7 @@ fn test_agent_context(db: Database) -> AgentContext {
         graph_warmer: None,
         repo_graph_ops: None,
         runtime_ops: None,
-        cargo_target_runs_root: Some({
+        cargo_target_runs_root: {
             let path = std::env::current_dir()
                 .unwrap()
                 .join("target")
@@ -59,7 +59,7 @@ fn test_agent_context(db: Database) -> AgentContext {
                 .join(format!("cargo-target-runs-{}", uuid::Uuid::now_v7()));
             std::fs::create_dir_all(&path).unwrap();
             path
-        }),
+        },
         mirror: None,
         rpc_registry: None,
         default_project_id: None,

--- a/server/crates/djinn-agent/tests/arbiter_supersede_transaction.rs
+++ b/server/crates/djinn-agent/tests/arbiter_supersede_transaction.rs
@@ -52,7 +52,7 @@ fn test_agent_context(db: Database) -> AgentContext {
         graph_warmer: None,
         repo_graph_ops: None,
         runtime_ops: None,
-        cargo_target_runs_root: Some({
+        cargo_target_runs_root: {
             let path = std::env::current_dir()
                 .unwrap()
                 .join("target")
@@ -60,7 +60,7 @@ fn test_agent_context(db: Database) -> AgentContext {
                 .join(format!("cargo-target-runs-{}", uuid::Uuid::now_v7()));
             std::fs::create_dir_all(&path).unwrap();
             path
-        }),
+        },
         mirror: None,
         rpc_registry: None,
         default_project_id: None,

--- a/server/crates/djinn-agent/tests/phase1_supervisor.rs
+++ b/server/crates/djinn-agent/tests/phase1_supervisor.rs
@@ -90,7 +90,7 @@ fn test_agent_context(db: Database) -> AgentContext {
         graph_warmer: None,
         repo_graph_ops: None,
         runtime_ops: None,
-        cargo_target_runs_root: Some({
+        cargo_target_runs_root: {
             let path = std::env::current_dir()
                 .unwrap()
                 .join("target")
@@ -98,7 +98,7 @@ fn test_agent_context(db: Database) -> AgentContext {
                 .join(format!("cargo-target-runs-{}", uuid::Uuid::now_v7()));
             std::fs::create_dir_all(&path).unwrap();
             path
-        }),
+        },
         mirror: None,
         rpc_registry: None,
         default_project_id: None,

--- a/server/crates/djinn-control-plane/tests/execution_tools.rs
+++ b/server/crates/djinn-control-plane/tests/execution_tools.rs
@@ -453,7 +453,7 @@ impl RealPoolKillHarness {
             graph_warmer: None,
             repo_graph_ops: None,
             runtime_ops: Some(Arc::new(runtime.clone())),
-            cargo_target_runs_root: Some(tempfile::tempdir().expect("cargo tempdir").keep()),
+            cargo_target_runs_root: tempfile::tempdir().expect("cargo tempdir").keep(),
             mirror: None,
             rpc_registry: None,
             default_project_id: None,

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -2217,7 +2217,7 @@ impl AppState {
             // Host-side runs root for the coordinator sweep + teardown backstop.
             // Resolves to `$DJINN_HOME/cache/cargo-target-runs` (the server pod's
             // mount of the shared cache PVC), not the Job-pod `/cache` path.
-            cargo_target_runs_root: Some(djinn_core::paths::cargo_target_runs_root()),
+            cargo_target_runs_root: djinn_core::paths::cargo_target_runs_root(),
             mirror: Some(self.inner.mirror.clone()),
             rpc_registry: Some(self.inner.rpc_registry.clone()),
             // Host-side AgentContext serves multiple projects (chat surface


### PR DESCRIPTION
## What

`AgentContext.cargo_target_runs_root` was `Option<PathBuf>`, and its only production consumer — `teardown_cargo_target_run_dir` in `actors/slot/supervisor_runner.rs` — resolved the `None` arm with `unwrap_or_else(djinn_core::paths::cargo_target_runs_root)`, i.e. the **server-pod** convention (`$DJINN_HOME/cache`, falling back to `~/.djinn/cache`). The in-Pod worker context (`djinn-agent-worker/src/main.rs`) set the field to `None`.

The shared cache PVC is mounted at **different paths per pod type**: Job pods (task-run / warm / verify) mount it at `/cache` (`djinn-k8s/src/job.rs`, `CACHE_MOUNT_DIR`), the server/coordinator pod at `$DJINN_HOME/cache` (`deploy/helm/djinn/templates/configmap.yaml:12`). Job specs never set `DJINN_HOME` — `rg DJINN_HOME server/crates/djinn-k8s/src/` is empty — so inside a Job pod that fallback resolves to `~/.djinn/cache/cargo-target-runs` = `/home/djinn/.djinn/cache/cargo-target-runs`, an empty container-layer path while the pod's real run dir is `/cache/cargo-target-runs/<id>`.

This is the mirror image of the three sites fixed in #2660 (`cargo_warm_base_gc.rs`, the `health.rs` sccache guard, the health run-dir sweep): those resolved the *Job-pod* convention inside the *server* pod; this resolved the *server* convention inside a *Job* pod.

## Reachability: not currently a live leak

Traced the real call path. `teardown_cargo_target_run_dir` is **not reachable from the worker binary**:

- called only from `execute_runtime_report_phase` ← `dispatch_task_runtime` ← `AgentHostCallbacks::run_task_dispatch`, which returns `Ok(())` unless `dispatch_mode == true`;
- `dispatch_mode == true` only via `AgentHostCallbacks::dispatch(..)`, built only in `actors/slot/actor.rs` and `actors/slot/pool/handle.rs` — the host slot pool, which the worker never constructs;
- the worker only enters `djinn_agent::supervisor::worker_execute_stage` → `supervisor_impl::execute_stage`, whose reply-loop callbacks are `dispatch_mode: false` (`adapter.rs:362`);
- the runtime being torn down there is a `SessionRuntime` that creates/deletes K8s Jobs — inherently host-side;
- `rg djinn_core::paths crates/djinn-agent-worker/` has zero hits.

In-pod cleanup of the run dir is handled correctly and separately by `djinn_supervisor::cleanup_cargo_target_run_dir`, which derives from `CARGO_TARGET_DIR` and validates it against `CARGO_TARGET_RUNS_ROOT = "/cache/cargo-target-runs"`.

So this is a **latent inconsistency**, not an active contributor to the node's disk use. Scoped accordingly: no behaviour change in production, but the hazard is removed structurally.

## The fix

The `Option` + `unwrap_or_else` shape *is* the hazard — whichever convention the fallback picks is silently wrong in the other pod, and "silently wrong" here means reaping a nonexistent directory: a permanent no-op that leaks disk instead of failing visibly. Both this defect and #2660's three came out of that shape.

`cargo_target_runs_root` is now a required `PathBuf`. There is no default across pod types, so there is no default at all — every constructor names **its own** mount and the compiler enforces it:

- worker → `cargo_target_seed::RUN_TARGET_ROOT` (`/cache/cargo-target-runs`), the same constant `CARGO_TARGET_DIR` is rendered from;
- server → `djinn_core::paths::cargo_target_runs_root()`;
- tests → their temp dirs (unchanged behaviour, `Some(..)` unwrapped).

Blast radius is 9 sites; `CoordinatorContext`'s separate same-named field is left alone (see below).

Also corrects the field's doc comment, which claimed `None` resolved to `/cache/cargo-target-runs`. That has been false since #2660 — and it is exactly the sort of stale comment a future edit "corrects the code" to match, reintroducing the bug.

## Tests, verified by neutralization

Both assert side effects, not labels.

`djinn-agent-worker`: `worker_context_cargo_target_runs_root_is_the_job_pod_mount` runs the real `build_worker_agent_context` and asserts the root is the Job-pod constant, is the exact parent of `run_target_dir(..)`, equals `djinn_supervisor::CARGO_TARGET_RUNS_ROOT`, starts with `/cache/`, and contains none of `.djinn` / `/var/lib/djinn` / `/tmp/` / `/home/`.

> Neutralized by restoring `djinn_core::paths::cargo_target_runs_root()` at the worker construction site → **FAILED**, `left: "/home/fernando/.djinn/cache/cargo-target-runs"`, `right: "/cache/cargo-target-runs"` — the exact `~/.djinn/cache` shape the bug produces in a Job pod.

`djinn-agent`: `host_teardown_reaps_only_the_exact_run_dir_under_the_configured_root` populates a temp root with a run dir and a sibling, calls `teardown_cargo_target_run_dir`, and asserts the run dir is really gone, the sibling really survives, the root survives, and a second pass is idempotent.

> Neutralized by making the teardown resolve the host path itself instead of reading the context field → **FAILED**, "teardown must remove the run dir under the configured root".

## Siblings found (reported, not fixed)

Swept every cache-path resolution for the same class. Two look like real, currently-live leaks and want their own tasks:

1. **Durable output-stash GC sweeps a tree the data never lands in.** `djinn-coordinator/src/output_stash.rs:337-351` resolves `$XDG_CACHE_HOME/djinn/output_stash` else `$HOME/.cache/...`. `XDG_CACHE_HOME` is set for Job pods (`job.rs:934-937`, `/cache/xdg/<project_id>`) but **never for the server pod**, so the coordinator's GC root (`health.rs:753`, every tick) is `/home/djinn/.cache/djinn/output_stash` — an ephemeral container layer — while every real stash blob is on the PVC. The 30-day retention never fires against the data it was written for. This is acknowledged in-tree as an open gap at `job.rs:925-933`; nothing implements the extension.
2. **SCIP indexer cache splits per pod.** `djinn-graph/src/scip_indexer/cache.rs:418-430`, same `XDG_CACHE_HOME` asymmetry: the warm Job writes to `/cache/xdg/<project>/djinn/scip-indexer` (persistent, no GC of any kind) while the server pod reads `/home/djinn/.cache/djinn/scip-indexer`. Permanent 100% cross-pod cache miss that presents as "cache works, just cold", and the warm-sentinel cleanup (`warm_sentinel.rs:140-200`) runs against a tree that never holds warm-Job artifacts. Its last fallback (`cache.rs:430`) is cwd-relative, which is its own hazard.

Lower severity / judgement calls:

3. `CoordinatorContext.cargo_target_runs_root` keeps the `Option` + `unwrap_or_else` shape (`health.rs:1986`). Left as-is deliberately: that fallback is host-correct, and the comment above it documents exactly why. But it means `djinn-coordinator/src/test_helpers.rs:284` (`None`) leaves `sweep_stale_resources` resolving a developer's real `~/.djinn/cache`; four sub-sweeps there take no root parameter at all, one of which `remove_dir_all`s in delete mode. Worth a look.
4. `djinn_core::paths::project_dir()` — the projects analogue — is called from code that also runs *inside* the Job pod, where `projects_root()` is the nonexistent `/home/djinn/.djinn/projects`: `djinn-agent/src/task_merge.rs:224` (named as a known Phase-7 followup in `worker_services.rs:29-35`) and `djinn-slot/src/llm_extraction.rs:1738` (not covered by that note; silently yields an empty scope set).

## Verification

- `cargo test -p djinn-agent --lib -- --test-threads=1` → 1443 passed, 0 failed.
- `cargo test -p djinn-agent-worker --lib --bins -- --test-threads=1` → 48 + 316 passed, plus 1 **pre-existing** intermittent failure, `warm_shutdown_drains_two_registered_groups_and_setsid_adoptee`. Confirmed against clean `main` at `c9138d46`: passed once, then failed 3/3 consecutive full serial runs with the identical `surviving_pids` assertion. It is a process-group drain/timing flake, unrelated to this diff (which touches no process handling), and passes in isolation on both branches.
- `cargo fmt --check` clean; `cargo clippy --all-targets` on all four touched crates introduces no warnings in any touched file (the `djinn-db` and memory-tools warnings are pre-existing).
- `scripts/check-file-size.sh --all` → 0 oversized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
