### PR TITLE
fix(board-health): stop asserting a dispatch verdict board_health cannot justify

### DIFF
--- a/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
+++ b/server/crates/djinn-control-plane/src/tools/task_tools/types.rs
@@ -1027,9 +1027,75 @@ pub struct BoardHealthStrandedThreshold {
 }
 
 /// Dispatch-gate evaluation attached to a single stranded-ready finding.
+/// The task's own `task_dispatch` build-lease row: the dispatcher's durable
+/// record of a layer-1 build-admission attempt. Absent when the task has no
+/// lease row, or when the ledger could not be read (see
+/// `BoardHealthDispatchGateCoverage::unevaluated_gates`).
+#[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct BoardHealthBuildLease {
+    /// `{task_id}:{generation}` — the lease key the dispatcher asked for.
+    pub consumer_id: String,
+    /// `queued`, `granted`, `launching`, `bound`, `active`, `suspect`, or
+    /// `terminal`.
+    pub state: String,
+    /// Set only on a `terminal` row.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_reason: Option<String>,
+    /// Weighted capacity this row buys (0 for a non-double-charged escalation).
+    pub weight: i64,
+    pub enqueue_sequence: i64,
+    /// Queued rows ahead of this one in the FIFO. Meaningful only while
+    /// `state == "queued"`.
+    pub queued_ahead: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+/// Pool-wide build capacity as the dispatcher's own authority reads it.
+/// Absent when the lease ledger could not be read.
+#[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct BoardHealthBuildCapacity {
+    /// Weighted `SUM` over the occupying lease states, across every consumer
+    /// kind (dispatch, invocation and warm all contend for one cap).
+    pub occupancy: i64,
+    /// `build_lease_caps.cap`.
+    pub cap: i64,
+    /// True only when `admission_handoff.v1_mode = 'enforce'`. While the v1
+    /// authority is off or shadowing it writes no dispatch rows and cannot be
+    /// denying anything, so a full pool is not attributed to it.
+    pub enforcing: bool,
+    /// `occupancy >= cap` with a positive cap.
+    pub at_capacity: bool,
+}
+
+/// What the dispatch-gate verdict actually covers.
+///
+/// This block exists because an empty `reasons` used to be indistinguishable
+/// from "no gate was consulted". The stranded-ready section evaluates the gates
+/// in `evaluated_gates`; the dispatcher applies many more, listed in
+/// `unevaluated_gates`. `reasons` speaks for the former only.
+#[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
+pub struct BoardHealthDispatchGateCoverage {
+    /// Always `partial` — this section can never see the whole dispatch path.
+    pub scope: String,
+    /// Gates whose durable state this section read.
+    #[serde(default)]
+    pub evaluated_gates: Vec<String>,
+    /// Gates the dispatcher applies that this section did not consult. Every
+    /// entry is a way a task can be left queued while `gate_verdict` is
+    /// `unexplained`.
+    #[serde(default)]
+    pub unevaluated_gates: Vec<String>,
+    /// Human-readable restatement of the bound, carried in the payload so an
+    /// operator reading raw JSON cannot miss it.
+    pub note: String,
+}
+
 /// Mirrors the DB-built JSON so callers can render the gate verdict and
 /// surface machine-readable `reasons` (e.g. `no_eligible_model`,
-/// `image_not_ready`).
+/// `image_not_ready`, `build_lease_queued`, `build_pool_at_capacity`).
 #[derive(Serialize, Deserialize, schemars::JsonSchema, Default)]
 pub struct BoardHealthDispatchGate {
     /// Role the coordinator would dispatch this task to, derived from
@@ -1057,15 +1123,34 @@ pub struct BoardHealthDispatchGate {
     /// True when a usable credential exists for the creator or as an
     /// org-shared fallback.
     pub credential_available: bool,
-    /// Final gate verdict — `stranded` when no blocker fired, `blocked`
-    /// otherwise.
+    /// The task's own `task_dispatch` build-lease row, when it has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_lease: Option<BoardHealthBuildLease>,
+    /// Pool-wide build capacity, when the lease ledger was readable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_capacity: Option<BoardHealthBuildCapacity>,
+    /// Final gate verdict — `blocked` when an evaluated gate fired,
+    /// `unexplained` when none did.
+    ///
+    /// **There is no `stranded` verdict.** It used to be emitted whenever
+    /// `reasons` was empty, which for a task with no chosen model was
+    /// structurally guaranteed — the payload asserted "nothing is wrong"
+    /// about tasks the dispatcher was refusing for reasons it never
+    /// consulted. `unexplained` says what an empty `reasons` actually means,
+    /// and `coverage` says what it was allowed to look at.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gate_verdict: Option<String>,
     /// Machine-readable gate reasons (`no_eligible_model`,
-    /// `image_not_ready`). Always present in the serialized output
-    /// (may be an empty array) so clients can rely on the key existing.
+    /// `image_not_ready`, `build_lease_queued`, `build_lease_terminal`,
+    /// `build_lease_occupied_without_session`, `build_pool_at_capacity`).
+    /// Always present in the serialized output (may be an empty array) so
+    /// clients can rely on the key existing. Read it together with
+    /// `coverage`: empty means "no EVALUATED gate fired".
     #[serde(default)]
     pub reasons: Vec<String>,
+    /// The bound on `reasons` and `gate_verdict`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<BoardHealthDispatchGateCoverage>,
     /// Last role the dispatcher actually attempted for this task, when
     /// known. Retained for backward compatibility with the initial
     /// board_health contract.
@@ -1092,9 +1177,17 @@ pub struct BoardHealthStrandedReadyFinding {
     pub epic_short_id: Option<String>,
     /// ISO-8601 UTC timestamp the task became unclaimed.
     pub unclaimed_since: String,
-    /// `high` when derived from an activity_log open transition or
-    /// session release; `low` when falling back to `tasks.updated_at`.
+    /// `high` when derived from a recorded event (open transition, session
+    /// release, or a blocker's close event); `low` for an `updated_at`-shaped
+    /// fallback.
     pub unclaimed_since_confidence: String,
+    /// Which signal produced `unclaimed_since`: `open_transition`,
+    /// `session_release`, `blocker_cleared`, `blocker_task_updated_at`, or
+    /// `task_updated_at`. The latest signal wins, so a task whose blocker
+    /// merged at 04:24 reports strand time from 04:24 rather than from
+    /// creation.
+    #[serde(default)]
+    pub unclaimed_since_basis: String,
     /// Elapsed minutes between `unclaimed_since` and the DB clock at
     /// query time.
     pub elapsed_minutes: i64,

--- a/server/crates/djinn-control-plane/tests/board_tools.rs
+++ b/server/crates/djinn-control-plane/tests/board_tools.rs
@@ -548,10 +548,28 @@ async fn board_health_stranded_ready_matches_seeded_task() {
     let gate = finding
         .get("dispatch_gate")
         .expect("dispatch_gate must be present");
+    // No gate board_health can evaluate fired, and the verdict must say
+    // exactly that rather than assert the task is merely `stranded` — that
+    // label was emitted whenever `reasons` was empty, which for a task with no
+    // chosen model was structurally guaranteed.
     assert_eq!(
         gate.get("gate_verdict").and_then(|v| v.as_str()),
-        Some("stranded"),
-        "gate_verdict must be stranded for an unblocked task"
+        Some("unexplained"),
+        "gate_verdict must be `unexplained` when no evaluated gate fired"
+    );
+    let coverage = gate
+        .get("coverage")
+        .expect("an unexplained verdict must ship its coverage");
+    assert_eq!(
+        coverage.get("scope").and_then(|v| v.as_str()),
+        Some("partial")
+    );
+    assert!(
+        coverage
+            .get("unevaluated_gates")
+            .and_then(|v| v.as_array())
+            .is_some_and(|gates| !gates.is_empty()),
+        "coverage must name the dispatcher gates this section did not consult"
     );
     assert_eq!(
         gate.get("credential_available").and_then(|v| v.as_bool()),

--- a/server/crates/djinn-coordinator/src/doctor/mod.rs
+++ b/server/crates/djinn-coordinator/src/doctor/mod.rs
@@ -214,8 +214,14 @@ mod smoke {
                     "manually_paused": false,
                     "rate_limited": false,
                     "credential_available": true,
-                    "gate_verdict": "stranded",
-                    "reasons": []
+                    "gate_verdict": "unexplained",
+                    "reasons": [],
+                    "coverage": {
+                        "scope": "partial",
+                        "evaluated_gates": ["model_health"],
+                        "unevaluated_gates": ["slot_pool_capacity"],
+                        "note": "reasons covers only evaluated_gates"
+                    }
                 }
             }],
         })))

--- a/server/crates/djinn-coordinator/src/doctor/stranded_ready.rs
+++ b/server/crates/djinn-coordinator/src/doctor/stranded_ready.rs
@@ -2,8 +2,14 @@
 //!
 //! Reuses the DB stranded-ready contract from `djinn_db::TaskRepository::board_health`
 //! (delivered by task `lke3`). The check is read-only: it snapshots the `stranded_ready`
-//! board-health section and emits one [`Finding`] per stranded task, preserving the
-//! threshold, severity, age, and dispatch-gate evidence already computed by the DB.
+//! board-health section and emits one [`Finding`] per task the section could NOT
+//! explain, preserving the threshold, severity, age, and dispatch-gate evidence
+//! already computed by the DB.
+//!
+//! This check has no independent judgement — it is a pure mirror. Everything it
+//! can and cannot claim is decided in `djinn-db`'s
+//! `repositories::task::board_health_dispatch_gate`, so read that module before
+//! changing what a finding here asserts.
 
 use djinn_core::doctor::{
     DoctorCheck, DoctorCheckCadence, DoctorResult, Finding, FindingSeverity, ResolverSnapshot,
@@ -37,6 +43,10 @@ pub struct StrandedReadyCandidate {
     pub epic_short_id: Option<String>,
     pub unclaimed_since: String,
     pub unclaimed_since_confidence: String,
+    /// Which signal the strand clock started from. Optional so a payload from
+    /// before the blocker-clear reset still parses.
+    #[serde(default)]
+    pub unclaimed_since_basis: Option<String>,
     pub elapsed_minutes: i64,
     pub severity: String,
     pub threshold: serde_json::Value,
@@ -60,6 +70,10 @@ impl StrandedReadyCandidate {
                 .get("unclaimed_since_confidence")?
                 .as_str()?
                 .to_owned(),
+            unclaimed_since_basis: value
+                .get("unclaimed_since_basis")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
             elapsed_minutes: value.get("elapsed_minutes")?.as_i64()?,
             severity: value.get("severity")?.as_str()?.to_owned(),
             threshold: value.get("threshold")?.clone(),
@@ -123,18 +137,39 @@ impl StrandedReadyCheck {
         );
         let severity_label = severity.as_str();
 
-        // Defence in depth: the DB contract is expected to exclude tasks whose
-        // dispatch gate would allow a normal dispatch. If a non-stranded verdict
-        // leaks through, skip it so the doctor check stays read-only and does not
-        // flag tasks that are gated for legitimate reasons.
+        // This check is a pure mirror of the DB `stranded_ready` section, so
+        // whatever that section can justify is what a finding can claim.
+        //
+        // A `blocked` candidate carries a named, durable cause (an unhealthy
+        // model, a queued build lease, a full build pool) and is therefore
+        // EXPLAINED — it belongs in the board-health payload, not in the
+        // doctor's alarm list. Only `unexplained` — no gate the section can
+        // evaluate accounts for the non-dispatch — becomes a finding.
+        //
+        // The verdict used to be `stranded`, which was emitted whenever the
+        // section's reasons list was empty. For a task with no chosen model
+        // that was structurally guaranteed, which is how 30-40 identical
+        // reasons-free `critical` findings were emitted every 30 seconds
+        // during the 2026-07-27 lease-tombstone incident: every one about a
+        // victim, none about the cause. With the cause now named on the
+        // candidates that have one, those become `blocked` and stop firing.
         let gate_verdict = candidate
             .dispatch_gate
             .get("gate_verdict")
             .and_then(|v| v.as_str())
-            .unwrap_or("stranded");
-        if gate_verdict != "stranded" {
+            // A payload with no verdict at all told us nothing, which is
+            // exactly what `unexplained` means.
+            .unwrap_or("unexplained");
+        if gate_verdict != "unexplained" {
             return None;
         }
+
+        let unevaluated = candidate
+            .dispatch_gate
+            .get("coverage")
+            .and_then(|coverage| coverage.get("unevaluated_gates"))
+            .and_then(|gates| gates.as_array())
+            .map_or(0, Vec::len);
 
         let inputs = json!({
             "id": candidate.id,
@@ -148,11 +183,17 @@ impl StrandedReadyCheck {
             "is_stranded": true,
             "severity": severity_label,
             "reason": "stranded_ready",
+            "gate_verdict": gate_verdict,
+            "unevaluated_gate_count": unevaluated,
         });
         let snapshot =
             ResolverSnapshot::new("resolve_stranded_ready", inputs.clone(), outputs.clone());
+        // The detail states the bound rather than implying the board proved
+        // nothing was wrong.
         let detail = format!(
-            "task {} ({}) has been stranded-ready for {} minutes (severity: {})",
+            "task {} ({}) has been dispatchable and unclaimed for {} minutes (severity: {}); \
+             no gate board_health can evaluate explains it, and {unevaluated} dispatcher \
+             gates were not consulted",
             candidate.short_id, candidate.title, candidate.elapsed_minutes, severity_label
         );
         let evidence = json!({
@@ -164,6 +205,7 @@ impl StrandedReadyCheck {
             "epic_short_id": candidate.epic_short_id,
             "unclaimed_since": candidate.unclaimed_since,
             "unclaimed_since_confidence": candidate.unclaimed_since_confidence,
+            "unclaimed_since_basis": candidate.unclaimed_since_basis,
             "elapsed_minutes": candidate.elapsed_minutes,
             "severity": severity_label,
             "threshold": candidate.threshold,
@@ -386,6 +428,7 @@ mod tests {
             json!("2026-01-01T00:00:00.000Z"),
         );
         map.insert("unclaimed_since_confidence".to_owned(), json!("high"));
+        map.insert("unclaimed_since_basis".to_owned(), json!("blocker_cleared"));
         map.insert("elapsed_minutes".to_owned(), json!(45));
         map.insert("severity".to_owned(), json!("warn"));
         map.insert(
@@ -403,8 +446,14 @@ mod tests {
                 "manually_paused": false,
                 "rate_limited": false,
                 "credential_available": true,
-                "gate_verdict": "stranded",
+                "gate_verdict": "unexplained",
                 "reasons": [],
+                "coverage": {
+                    "scope": "partial",
+                    "evaluated_gates": ["build_lease_admission", "model_health"],
+                    "unevaluated_gates": ["provider_circuit_breaker", "slot_pool_capacity"],
+                    "note": "reasons covers only evaluated_gates",
+                },
             }),
         );
         for (k, v) in overrides {
@@ -457,11 +506,69 @@ mod tests {
         );
         assert_eq!(
             finding.evidence["dispatch_gate"]["gate_verdict"],
-            "stranded"
+            "unexplained"
         );
+        assert_eq!(finding.evidence["unclaimed_since_basis"], "blocker_cleared");
         assert_eq!(finding.resolver_snapshot.resolver, "resolve_stranded_ready");
         assert_eq!(finding.resolver_snapshot.outputs["severity"], "warn");
+        assert_eq!(
+            finding.resolver_snapshot.outputs["unevaluated_gate_count"],
+            2
+        );
         assert!(finding.detail.contains("task-1") && finding.detail.contains("45 minutes"));
+        // The detail must state the bound, not imply the board proved the task
+        // was fine.
+        assert!(
+            finding.detail.contains("were not consulted"),
+            "detail must disclose the gates it did not evaluate: {}",
+            finding.detail
+        );
+    }
+
+    /// A candidate the DB section could explain (a queued build lease, a full
+    /// build pool, an unhealthy model) is EXPLAINED and must not be re-reported
+    /// as an unexplained starvation alarm every 30 seconds.
+    #[test]
+    fn capacity_blocked_candidate_is_not_an_unexplained_finding() {
+        let mut overrides = serde_json::Map::new();
+        overrides.insert(
+            "dispatch_gate".to_owned(),
+            json!({
+                "evaluated_role": "worker",
+                "toolset": ["task_edit"],
+                "model_requirement": null,
+                "image_ready": true,
+                "breaker_open": false,
+                "manually_paused": false,
+                "rate_limited": false,
+                "credential_available": true,
+                "build_capacity": {"occupancy": 3, "cap": 3, "enforcing": true, "at_capacity": true},
+                "gate_verdict": "blocked",
+                "reasons": ["build_pool_at_capacity"],
+            }),
+        );
+        let source = Arc::new(MemoryStrandedReadySource::new(snapshot_with(vec![
+            candidate_json(overrides),
+        ])));
+        let findings = StrandedReadyCheck::new(source).run().expect("run");
+        assert!(
+            findings.is_empty(),
+            "a candidate with a named durable cause must not fire the starvation alarm"
+        );
+    }
+
+    /// A payload with no verdict at all told us nothing, which is what
+    /// `unexplained` means — it must still surface rather than be silently
+    /// dropped.
+    #[test]
+    fn missing_verdict_is_treated_as_unexplained() {
+        let mut overrides = serde_json::Map::new();
+        overrides.insert("dispatch_gate".to_owned(), json!({"reasons": []}));
+        let source = Arc::new(MemoryStrandedReadySource::new(snapshot_with(vec![
+            candidate_json(overrides),
+        ])));
+        let findings = StrandedReadyCheck::new(source).run().expect("run");
+        assert_eq!(findings.len(), 1);
     }
 
     #[test]
@@ -498,7 +605,7 @@ mod tests {
     }
 
     #[test]
-    fn non_stranded_gate_verdict_is_skipped() {
+    fn unrecognised_gate_verdict_is_skipped() {
         let mut overrides = serde_json::Map::new();
         overrides.insert(
             "dispatch_gate".to_owned(),
@@ -511,7 +618,7 @@ mod tests {
                 "manually_paused": false,
                 "rate_limited": false,
                 "credential_available": true,
-                "gate_verdict": "not_stranded",
+                "gate_verdict": "some_future_verdict",
                 "reasons": [],
             }),
         );
@@ -521,7 +628,7 @@ mod tests {
         let findings = StrandedReadyCheck::new(source).run().expect("run");
         assert!(
             findings.is_empty(),
-            "a candidate with a non-stranded gate verdict must be skipped"
+            "only the `unexplained` verdict may raise a starvation finding"
         );
     }
 

--- a/server/crates/djinn-coordinator/src/tests/doctor_stranded_ready_e2e.rs
+++ b/server/crates/djinn-coordinator/src/tests/doctor_stranded_ready_e2e.rs
@@ -109,8 +109,23 @@ async fn stranded_ready_consistency_across_doctor_and_board_health() {
         "90-minute backdate → error severity"
     );
     assert_eq!(
+        board_gate_verdict, "unexplained",
+        "no gate board_health can evaluate is open for a fresh test task, and the \
+         verdict must say so rather than assert the task is merely `stranded`"
+    );
+    assert_ne!(
         board_gate_verdict, "stranded",
-        "no gates should be open for a fresh test task"
+        "the `stranded` verdict is retired: it asserted a conclusion this section \
+         cannot reach"
+    );
+    let coverage = &board_gate["coverage"];
+    assert_eq!(coverage["scope"], "partial");
+    assert!(
+        !coverage["unevaluated_gates"]
+            .as_array()
+            .expect("unevaluated_gates is an array")
+            .is_empty(),
+        "an `unexplained` verdict must ship the gates it did not consult"
     );
 
     // ── 3. Doctor surface: run stranded_ready check ────────────────────

--- a/server/crates/djinn-db/src/repositories/task/board_health.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health.rs
@@ -443,10 +443,10 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
             }
 
             // ── Unclaimed-since / severity ─────────────────────────────────
-            // The LATEST signal wins: each one marks a moment the task became
-            // dispatchable, and only the most recent is still true. Including
-            // the blocker-clear signal is what stops a blocked task from
-            // reporting its whole blocked interval as strand time.
+            // The latest BECAME-DISPATCHABLE signal wins; `updated_at` is only
+            // a fallback, never part of that comparison. See `strand_clock` for
+            // why the distinction matters — folding `updated_at` into the max
+            // would let any edit reset a starved task's clock.
             let open_transition_at: Option<String> =
                 row.try_get("open_transition_at").ok().flatten();
             let session_release_at: Option<String> =

--- a/server/crates/djinn-db/src/repositories/task/board_health.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health.rs
@@ -18,6 +18,8 @@ use std::collections::HashMap;
 
 use sqlx::Row;
 
+use super::board_health_dispatch_gate::strand_clock;
+
 /// Bounded number of recent liveness-evidence rows surfaced in `liveness_outcomes`.
 const LIVENESS_OUTCOMES_LIMIT: i64 = 25;
 /// Bounded number of recent protocol-violation rows surfaced.
@@ -281,10 +283,10 @@ pub(super) async fn attribution_findings_section(pool: &sqlx::PgPool) -> serde_j
 ///   * owner-credential-blocked (the creator has credentials but they are all
 ///     revoked and no org-shared fallback credential is available).
 ///
-/// Surviving findings carry a `dispatch_gate` object documenting the evaluated
-/// role, its toolset, the model requirement, image readiness, each gate flag,
-/// credential availability, a final `gate_verdict`, and machine-readable
-/// `reasons` (e.g. `no_eligible_model`, `image_not_ready`).
+/// Surviving findings carry a `dispatch_gate` object built by
+/// [`super::board_health_dispatch_gate`]. **Its verdict is `blocked` or
+/// `unexplained`, never `stranded`** — read that module before changing what a
+/// finding here claims.
 pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::Value {
     let warning_threshold = STRANDED_THRESHOLD_MINUTES;
     let error_threshold = STRANDED_THRESHOLD_MINUTES * 2;
@@ -307,6 +309,11 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
 
     let now_iso = db_utc_now(pool).await;
 
+    // The dispatcher's OWN durable record of layer-1 build admission. Loaded
+    // once for the whole section (two queries, no N+1) so each finding can
+    // report a lease/capacity fact instead of an independent guess.
+    let lease_ledger = super::board_health_dispatch_gate::load_lease_ledger(pool).await;
+
     let stranded_sql = r#"SELECT t.id, t.short_id, t.title, t.status, t.updated_at, t.owner,
                   t.epic_id, t.issue_type, t.project_id, t.created_by_user_id,
                   e.short_id AS epic_short_id,
@@ -327,6 +334,22 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
                    WHERE s.task_id = t.id AND s.ended_at IS NOT NULL
                    ORDER BY s.ended_at DESC
                    LIMIT 1) AS session_release_at,
+                  -- When the LAST blocker cleared. This section excludes tasks
+                  -- with unresolved blockers but never reset the clock when one
+                  -- cleared, so a task blocked for ten hours reported eighteen
+                  -- hours of strand. `blockers` carries no timestamp, so the
+                  -- clearing moment is the blocking task's close event, with its
+                  -- `updated_at` as the low-confidence fallback.
+                  (SELECT MAX(bal.created_at)
+                   FROM blockers b
+                   JOIN activity_log bal ON bal.task_id = b.blocking_task_id
+                   WHERE b.task_id = t.id
+                     AND bal.event_type = 'status_changed'
+                     AND bal.payload->>'to_status' = 'closed') AS blocker_closed_event_at,
+                  (SELECT MAX(bt2.updated_at)
+                   FROM blockers b
+                   JOIN tasks bt2 ON bt2.id = b.blocking_task_id
+                   WHERE b.task_id = t.id) AS blocker_task_updated_at,
                   EXISTS (SELECT 1 FROM sessions s
                           WHERE s.task_id = t.id AND s.status = 'paused') AS has_paused_session,
                   EXISTS (SELECT 1 FROM dispatch_pauses dp
@@ -420,24 +443,27 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
             }
 
             // ── Unclaimed-since / severity ─────────────────────────────────
-            // Prefer the most recent high-confidence release signal (ready/open
-            // transition or session release); fall back to updated_at.
+            // The LATEST signal wins: each one marks a moment the task became
+            // dispatchable, and only the most recent is still true. Including
+            // the blocker-clear signal is what stops a blocked task from
+            // reporting its whole blocked interval as strand time.
             let open_transition_at: Option<String> =
                 row.try_get("open_transition_at").ok().flatten();
             let session_release_at: Option<String> =
                 row.try_get("session_release_at").ok().flatten();
+            let blocker_closed_event_at: Option<String> =
+                row.try_get("blocker_closed_event_at").ok().flatten();
+            let blocker_task_updated_at: Option<String> =
+                row.try_get("blocker_task_updated_at").ok().flatten();
             let updated_at: String = row.get("updated_at");
 
-            let high_signal = match (open_transition_at, session_release_at) {
-                (Some(a), Some(b)) => Some(if a >= b { a } else { b }),
-                (Some(a), None) => Some(a),
-                (None, Some(b)) => Some(b),
-                (None, None) => None,
-            };
-            let (unclaimed_since, confidence) = match high_signal {
-                Some(ts) => (ts, "high"),
-                None => (updated_at.clone(), "low"),
-            };
+            let (unclaimed_since, confidence, unclaimed_since_basis) = strand_clock(
+                &updated_at,
+                open_transition_at.as_deref(),
+                session_release_at.as_deref(),
+                blocker_closed_event_at.as_deref(),
+                blocker_task_updated_at.as_deref(),
+            );
 
             let elapsed = elapsed_minutes_iso(&unclaimed_since, &now_iso).unwrap_or(0);
             // Not yet stranded (below 1× threshold).
@@ -473,14 +499,26 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
 
             let evaluated_role = dispatched_role_for_status_type(&task_status, &issue_type);
             let toolset = super::queries::toolset_for_role(evaluated_role);
-            let gate_verdict = if reasons.is_empty() {
-                "stranded"
-            } else {
-                "blocked"
-            };
+            let task_id: String = row.get("id");
+            // The verdict and `reasons` are assembled together from the same
+            // list, alongside the coverage statement that bounds them.
+            let dispatch_gate = super::board_health_dispatch_gate::dispatch_gate_json(
+                evaluated_role,
+                toolset,
+                inflight_model_id,
+                image_ready,
+                breaker_open,
+                manually_paused,
+                rate_limited,
+                credential_available,
+                row.get::<Option<String>, _>("last_dispatched_role"),
+                cooldown_until,
+                super::board_health_dispatch_gate::lease_gate(&lease_ledger, &task_id),
+                reasons,
+            );
 
             Some(serde_json::json!({
-                "id":            row.get::<String, _>("id"),
+                "id":            task_id,
                 "short_id":      row.get::<String, _>("short_id"),
                 "title":         row.get::<String, _>("title"),
                 "status":        task_status,
@@ -489,6 +527,7 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
                 "epic_short_id": row.get::<Option<String>, _>("epic_short_id"),
                 "unclaimed_since": unclaimed_since,
                 "unclaimed_since_confidence": confidence,
+                "unclaimed_since_basis": unclaimed_since_basis,
                 "elapsed_minutes": elapsed,
                 "severity":      severity,
                 "threshold":     serde_json::json!({
@@ -496,22 +535,7 @@ pub(super) async fn stranded_ready_section(pool: &sqlx::PgPool) -> serde_json::V
                     "error_minutes":    error_threshold,
                     "critical_minutes": critical_threshold,
                 }),
-                "dispatch_gate": serde_json::json!({
-                    "evaluated_role":       evaluated_role,
-                    "toolset":              toolset,
-                    "model_requirement":    inflight_model_id,
-                    "image_ready":          image_ready,
-                    "breaker_open":         breaker_open,
-                    "manually_paused":      manually_paused,
-                    "rate_limited":         rate_limited,
-                    "credential_available": credential_available,
-                    "gate_verdict":         gate_verdict,
-                    "reasons":              reasons,
-                    // Retained for backward compatibility with the initial
-                    // board_health contract.
-                    "last_dispatched_role": row.get::<Option<String>, _>("last_dispatched_role"),
-                    "cooldown_until":       cooldown_until,
-                }),
+                "dispatch_gate": dispatch_gate,
             }))
         })
         .collect();

--- a/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_dispatch_gate.rs
@@ -1,0 +1,771 @@
+//! Dispatch-gate evidence for the stranded-ready board-health section.
+//!
+//! # Why this module exists
+//!
+//! The stranded-ready section used to emit, per stranded task:
+//!
+//! ```json
+//! "dispatch_gate": { "image_ready": true, "breaker_open": false, ...,
+//!                    "gate_verdict": "stranded", "reasons": [] }
+//! ```
+//!
+//! Every field in that payload was true. It was also irrelevant. `reasons`
+//! could only ever be populated from `dispatch_state.inflight_model_id` x
+//! `model_health`, so a task with no chosen model produced a **structurally
+//! guaranteed** empty `reasons` and a **structurally guaranteed** `stranded`
+//! verdict. The section performed an independent re-evaluation over six gates
+//! while the real dispatcher applies more than thirty, and it never read the
+//! dispatcher's own recorded decision. On 2026-07-27 six tasks sat undispatched
+//! for up to eighteen hours behind a build-lease tombstone, and this payload
+//! asserted, once every thirty seconds, that nothing was wrong with any of them.
+//!
+//! An empty `reasons` list that actually means *"I did not look"* is worse than
+//! no field at all. Two rules follow, and both are enforced here:
+//!
+//! 1. **No verdict this code cannot justify.** `stranded` is gone. An empty
+//!    `reasons` now yields `unexplained` — literally "none of the gates this
+//!    section can evaluate explains the non-dispatch" — and the payload names
+//!    which gates were and were not consulted so the claim is auditable.
+//! 2. **Read what the dispatcher actually recorded.** Layer-1 build admission
+//!    persists its unit of work in `build_leases` as a `task_dispatch` row. A
+//!    queued row means this task is behind the FIFO, a terminal row is the
+//!    #2661 tombstone shape, and ledger-wide `SUM(weight)` versus
+//!    `build_lease_caps.cap` is the pool occupancy the dispatcher itself
+//!    consults. That is durable, joinable evidence and it is now surfaced.
+//!
+//! # What is NOT available
+//!
+//! `BuildAdmissionDecision::Denied` carries a [`DenialCause`] as of #2661, but
+//! that value is only ever **logged** — `dispatch/task_dispatch.rs` emits it on
+//! a `tracing::info!` line and returns. Nothing writes it to any table, so
+//! `ControllerNotAdmitting` and `AuthorityUnavailable { detail }` cannot be
+//! joined against from here at all, and `AtCapacity` is only *inferable* from
+//! the ledger state this module reads. Persisting the cause on the denial path
+//! is tracked as follow-up; until then this module reports ledger facts and
+//! declines to invent the rest.
+//!
+//! [`DenialCause`]: https://github.com/djinnos/djinn/pull/2661
+
+use std::collections::HashMap;
+
+use sqlx::Row;
+
+/// Gates the stranded-ready section evaluates from durable state.
+///
+/// This list is the honest scope of `reasons`: an empty `reasons` means none of
+/// **these** fired, and says nothing whatsoever about the rest of the dispatch
+/// path.
+pub(super) const EVALUATED_GATES: &[&str] = &[
+    "breaker_cooldown",
+    "rate_limit_backoff",
+    "manual_dispatch_pause",
+    "owner_credential",
+    "model_health",
+    "build_lease_admission",
+];
+
+/// Gates the real dispatcher applies that this section cannot see.
+///
+/// Not exhaustive and deliberately not silent: every entry here is a way a task
+/// can be left queued while this section reports `unexplained`. Sourced from
+/// the per-task gate sequence in `djinn-coordinator`'s `dispatch/task_dispatch.rs`.
+pub(super) const UNEVALUATED_GATES: &[&str] = &[
+    "per_user_lane_concurrency_cap",
+    "per_user_model_concurrency_cap",
+    "slot_pool_capacity",
+    "provider_circuit_breaker",
+    "failover_chain_exhaustion",
+    "respawn_guard_attempt_defer",
+    "project_dispatch_image_readiness",
+    "arbiter_deadline_hold",
+    "human_review_hold_label",
+    "creator_attribution",
+    "github_app_credentials",
+    "legacy_settings_migration_hold",
+];
+
+/// Lease states that occupy build capacity. Mirrors the partial index in
+/// migration 153 (`build_leases_occupied_idx`).
+const OCCUPYING_LEASE_STATES: &[&str] = &["granted", "launching", "bound", "active", "suspect"];
+
+/// One `task_dispatch` build-lease row: the dispatcher's own record of a
+/// layer-1 admission attempt for a task.
+#[derive(Clone, Debug)]
+pub(super) struct DispatchLeaseRow {
+    pub consumer_id: String,
+    pub state: String,
+    pub terminal_reason: Option<String>,
+    pub weight: i64,
+    pub enqueue_sequence: i64,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+    /// Queued rows ahead of this one in the FIFO. Only meaningful while
+    /// `state == "queued"`.
+    pub queued_ahead: i64,
+}
+
+/// Ledger-wide capacity as the dispatcher's authority reads it.
+#[derive(Clone, Debug)]
+pub(super) struct LeaseCapacity {
+    pub occupancy: i64,
+    pub cap: i64,
+    /// True only when the durable admission epoch has armed the v1 authority
+    /// (`admission_handoff.v1_mode = 'enforce'`). While it is `off`/`shadow`
+    /// the lease FIFO writes no dispatch rows and cannot be denying anything.
+    pub enforcing: bool,
+}
+
+/// What this section managed to learn about the build-lease ledger.
+///
+/// `Unobservable` is a first-class outcome on purpose. Falling back to "no
+/// rows" on a failed read is exactly the mistake this module exists to undo: it
+/// would let an unread ledger masquerade as a clean one.
+#[derive(Clone, Debug)]
+pub(super) enum LeaseLedger {
+    Observed {
+        by_task: HashMap<String, DispatchLeaseRow>,
+        capacity: LeaseCapacity,
+    },
+    Unobservable {
+        detail: &'static str,
+    },
+}
+
+/// Result of applying the build-lease gate to one task.
+pub(super) struct LeaseGateOutcome {
+    /// The task's own lease row as JSON, or `null` when it has none.
+    pub build_lease: serde_json::Value,
+    /// Pool-wide capacity as JSON, or `null` when the ledger was unreadable.
+    pub build_capacity: serde_json::Value,
+    /// Machine-readable reasons contributed by this gate.
+    pub reasons: Vec<&'static str>,
+    /// False when the ledger could not be read, which moves
+    /// `build_lease_admission` from evaluated to unevaluated for this task.
+    pub evaluated: bool,
+    /// Why the gate could not be evaluated, surfaced in `coverage` so an
+    /// unreadable ledger is visible rather than merely absent.
+    pub unevaluated_detail: Option<&'static str>,
+}
+
+/// Load the `task_dispatch` lease ledger and the pool capacity in two queries.
+///
+/// Both are runtime `sqlx::query` calls (no offline-cache entries), matching
+/// the rest of the board-health sections. Either failing yields
+/// [`LeaseLedger::Unobservable`] — never a silently empty ledger.
+pub(super) async fn load_lease_ledger(pool: &sqlx::PgPool) -> LeaseLedger {
+    // Newest attempt per task. `consumer_id` is `{task_id}:{generation}` (see
+    // `djinn-coordinator`'s `build_lease::identity`), and task ids never
+    // contain a colon, so `split_part(..., ':', 1)` is an exact task id.
+    let lease_sql = r#"SELECT DISTINCT ON (split_part(b.consumer_id, ':', 1))
+                  split_part(b.consumer_id, ':', 1) AS task_id,
+                  b.consumer_id,
+                  b.state,
+                  b.terminal_reason,
+                  b.weight::BIGINT AS weight,
+                  b.enqueue_sequence::BIGINT AS enqueue_sequence,
+                  to_char(b.created_at AT TIME ZONE 'utc',
+                          'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at,
+                  to_char(b.updated_at AT TIME ZONE 'utc',
+                          'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at,
+                  (SELECT COUNT(*) FROM build_leases q
+                    WHERE q.state = 'queued'
+                      AND q.enqueue_sequence < b.enqueue_sequence)::BIGINT AS queued_ahead
+           FROM build_leases b
+           WHERE b.consumer_kind = 'task_dispatch'
+           ORDER BY split_part(b.consumer_id, ':', 1), b.enqueue_sequence DESC"#;
+
+    let Ok(rows) = sqlx::query(lease_sql).fetch_all(pool).await else {
+        return LeaseLedger::Unobservable {
+            detail: "build_leases could not be read",
+        };
+    };
+
+    // Occupancy is the weighted SUM over the occupying states across EVERY
+    // consumer kind — warm and invocation leases contend with dispatch for the
+    // same cap. `admission_handoff.v1_mode` says whether that cap is armed.
+    let capacity_sql = r#"SELECT
+             COALESCE((SELECT SUM(weight) FROM build_leases
+                        WHERE state IN ('granted','launching','bound','active','suspect')),
+                      0)::BIGINT AS occupancy,
+             COALESCE((SELECT cap FROM build_lease_caps WHERE singleton), 0)::BIGINT AS cap,
+             COALESCE((SELECT v1_mode FROM admission_handoff WHERE name = 'build'),
+                      'off') AS v1_mode"#;
+
+    let Ok(capacity_row) = sqlx::query(capacity_sql).fetch_one(pool).await else {
+        return LeaseLedger::Unobservable {
+            detail: "build-lease capacity could not be read",
+        };
+    };
+
+    let capacity = LeaseCapacity {
+        occupancy: capacity_row.try_get("occupancy").unwrap_or(0),
+        cap: capacity_row.try_get("cap").unwrap_or(0),
+        enforcing: capacity_row
+            .try_get::<String, _>("v1_mode")
+            .map(|mode| mode == "enforce")
+            .unwrap_or(false),
+    };
+
+    let by_task = rows
+        .into_iter()
+        .filter_map(|row| {
+            let task_id: String = row.try_get("task_id").ok()?;
+            Some((
+                task_id,
+                DispatchLeaseRow {
+                    consumer_id: row.try_get("consumer_id").ok()?,
+                    state: row.try_get("state").ok()?,
+                    terminal_reason: row.try_get("terminal_reason").ok().flatten(),
+                    weight: row.try_get("weight").unwrap_or(0),
+                    enqueue_sequence: row.try_get("enqueue_sequence").unwrap_or(0),
+                    created_at: row.try_get("created_at").ok().flatten(),
+                    updated_at: row.try_get("updated_at").ok().flatten(),
+                    queued_ahead: row.try_get("queued_ahead").unwrap_or(0),
+                },
+            ))
+        })
+        .collect();
+
+    LeaseLedger::Observed { by_task, capacity }
+}
+
+/// Apply the build-lease gate to one task.
+///
+/// Every reason produced here is a statement about a durable row, never an
+/// inference about what the dispatcher "probably" did.
+pub(super) fn lease_gate(ledger: &LeaseLedger, task_id: &str) -> LeaseGateOutcome {
+    let (by_task, capacity) = match ledger {
+        LeaseLedger::Unobservable { detail } => {
+            return LeaseGateOutcome {
+                build_lease: serde_json::Value::Null,
+                build_capacity: serde_json::Value::Null,
+                reasons: Vec::new(),
+                evaluated: false,
+                unevaluated_detail: Some(detail),
+            };
+        }
+        LeaseLedger::Observed { by_task, capacity } => (by_task, capacity),
+    };
+
+    let at_capacity = capacity.cap > 0 && capacity.occupancy >= capacity.cap;
+    let build_capacity = serde_json::json!({
+        "occupancy": capacity.occupancy,
+        "cap":       capacity.cap,
+        "enforcing": capacity.enforcing,
+        "at_capacity": at_capacity,
+    });
+
+    let lease = by_task.get(task_id);
+    let build_lease = lease.map_or(serde_json::Value::Null, |row| {
+        serde_json::json!({
+            "consumer_id":      row.consumer_id,
+            "state":            row.state,
+            "terminal_reason":  row.terminal_reason,
+            "weight":           row.weight,
+            "enqueue_sequence": row.enqueue_sequence,
+            "queued_ahead":     row.queued_ahead,
+            "created_at":       row.created_at,
+            "updated_at":       row.updated_at,
+        })
+    });
+
+    // While the v1 authority is off or in shadow the FIFO writes no dispatch
+    // rows and grants nothing, so it is structurally incapable of denying this
+    // task. Reporting a capacity reason here would be the same fabrication this
+    // module exists to remove — but the gate WAS evaluated, and the answer is
+    // "not this".
+    if !capacity.enforcing {
+        return LeaseGateOutcome {
+            build_lease,
+            build_capacity,
+            reasons: Vec::new(),
+            evaluated: true,
+            unevaluated_detail: None,
+        };
+    }
+
+    let mut reasons: Vec<&'static str> = Vec::new();
+    match lease {
+        // The task holds a FIFO position: layer-1 admission denied it and the
+        // ledger says why — the pool was full when it asked.
+        Some(row) if row.state == "queued" => reasons.push("build_lease_queued"),
+        // The newest attempt is terminal. This is the #2661 tombstone shape:
+        // before that fix a spent row was replayed forever and every denial
+        // re-derived itself.
+        Some(row) if row.state == "terminal" => reasons.push("build_lease_terminal"),
+        // The lease occupies capacity but this task has no running session (the
+        // section already excluded tasks that do). The slot is charged to work
+        // that is not happening.
+        Some(row) if OCCUPYING_LEASE_STATES.contains(&row.state.as_str()) => {
+            reasons.push("build_lease_occupied_without_session");
+        }
+        Some(_) => {}
+        // No row of its own, but the shared pool is full: the next admission
+        // attempt for this task cannot be granted. This is the signal that was
+        // missing while a monopolising task starved the board.
+        None if at_capacity => reasons.push("build_pool_at_capacity"),
+        None => {}
+    }
+
+    LeaseGateOutcome {
+        build_lease,
+        build_capacity,
+        reasons,
+        evaluated: true,
+        unevaluated_detail: None,
+    }
+}
+
+// ── Strand clock ────────────────────────────────────────────────────────────
+
+/// One candidate answer to "since when has this task been dispatchable".
+#[derive(Clone, Copy, Debug)]
+pub(super) struct StrandSignal<'a> {
+    pub at: &'a str,
+    /// `high` for a recorded event, `low` for a `updated_at`-shaped fallback.
+    pub confidence: &'static str,
+    /// Which signal this is, so the number can be argued with.
+    pub basis: &'static str,
+}
+
+/// Resolve the strand clock from *became-dispatchable* signals: the LATEST one
+/// wins.
+///
+/// Latest, not first-available, because every signal here marks a moment the
+/// task became dispatchable and only the most recent one is still true.
+///
+/// Timestamps are the fixed-width `YYYY-MM-DDTHH:MM:SS.MSZ` form Postgres
+/// `to_char` produces throughout this schema, so lexicographic ordering is
+/// chronological ordering. Ties prefer the higher-confidence basis.
+pub(super) fn resolve_unclaimed_since(
+    candidates: &[StrandSignal<'_>],
+) -> Option<(String, &'static str, &'static str)> {
+    candidates
+        .iter()
+        .max_by(|a, b| {
+            a.at.cmp(b.at)
+                .then_with(|| confidence_rank(a.confidence).cmp(&confidence_rank(b.confidence)))
+        })
+        .map(|winner| (winner.at.to_owned(), winner.confidence, winner.basis))
+}
+
+fn confidence_rank(confidence: &str) -> u8 {
+    match confidence {
+        "high" => 2,
+        _ => 1,
+    }
+}
+
+/// The strand clock for one stranded-ready row.
+///
+/// # Two kinds of timestamp, and why they are not interchangeable
+///
+/// `open_transition_at`, `session_release_at` and the blocker-clear pair each
+/// mark a moment the task **became dispatchable**. The latest of them is the
+/// answer, because it is the only one still true. Adding the blocker-clear
+/// signal is the fix for a task created at 10:00 and blocked until 04:24 the
+/// next day: it was not stranded for eighteen hours, it was blocked for ten of
+/// them, and the section excluded it the whole time without ever restarting its
+/// clock.
+///
+/// `task_updated_at` is **not** such a moment. It is bumped by any write to the
+/// task — a description edit, a label change — so folding it into the same
+/// `max` would silently reset the clock on a genuinely starved task and hide
+/// the starvation this section exists to find. It is used only when no
+/// became-dispatchable signal exists at all, and is reported as `low`
+/// confidence when it is.
+pub(super) fn strand_clock(
+    task_updated_at: &str,
+    open_transition_at: Option<&str>,
+    session_release_at: Option<&str>,
+    blocker_closed_event_at: Option<&str>,
+    blocker_task_updated_at: Option<&str>,
+) -> (String, &'static str, &'static str) {
+    let mut signals: Vec<StrandSignal<'_>> = Vec::new();
+    if let Some(at) = open_transition_at {
+        signals.push(StrandSignal {
+            at,
+            confidence: "high",
+            basis: "open_transition",
+        });
+    }
+    if let Some(at) = session_release_at {
+        signals.push(StrandSignal {
+            at,
+            confidence: "high",
+            basis: "session_release",
+        });
+    }
+    match (blocker_closed_event_at, blocker_task_updated_at) {
+        (Some(at), _) => signals.push(StrandSignal {
+            at,
+            confidence: "high",
+            basis: "blocker_cleared",
+        }),
+        // No recorded close event for the blocker; its `updated_at` is the best
+        // available proxy and is flagged as such.
+        (None, Some(at)) => signals.push(StrandSignal {
+            at,
+            confidence: "low",
+            basis: "blocker_task_updated_at",
+        }),
+        (None, None) => {}
+    }
+    resolve_unclaimed_since(&signals)
+        .unwrap_or_else(|| (task_updated_at.to_owned(), "low", "task_updated_at"))
+}
+
+// ── Verdict ─────────────────────────────────────────────────────────────────
+
+/// The verdict emitted when a gate this section CAN evaluate fired.
+pub(super) const VERDICT_BLOCKED: &str = "blocked";
+/// The verdict emitted when none did.
+///
+/// Deliberately not `stranded`. The section cannot see most of the dispatch
+/// path, so "no reason found" is a statement about this code's coverage, not
+/// about the task.
+pub(super) const VERDICT_UNEXPLAINED: &str = "unexplained";
+
+/// Assemble the `dispatch_gate` payload.
+///
+/// `reasons` and `gate_verdict` are derived together from the same list so they
+/// can never disagree, and `coverage` travels with them so an empty `reasons`
+/// can be read as the bounded claim it is.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn dispatch_gate_json(
+    evaluated_role: &str,
+    toolset: &'static [&'static str],
+    model_requirement: Option<String>,
+    image_ready: bool,
+    breaker_open: bool,
+    manually_paused: bool,
+    rate_limited: bool,
+    credential_available: bool,
+    last_dispatched_role: Option<String>,
+    cooldown_until: Option<String>,
+    lease: LeaseGateOutcome,
+    mut reasons: Vec<&'static str>,
+) -> serde_json::Value {
+    reasons.extend(lease.reasons);
+
+    let mut evaluated_gates: Vec<&'static str> = EVALUATED_GATES
+        .iter()
+        .copied()
+        .filter(|gate| lease.evaluated || *gate != "build_lease_admission")
+        .collect();
+    evaluated_gates.sort_unstable();
+
+    let mut unevaluated_gates: Vec<&'static str> = UNEVALUATED_GATES.to_vec();
+    if !lease.evaluated {
+        unevaluated_gates.push("build_lease_admission");
+    }
+    unevaluated_gates.sort_unstable();
+
+    let gate_verdict = if reasons.is_empty() {
+        VERDICT_UNEXPLAINED
+    } else {
+        VERDICT_BLOCKED
+    };
+
+    serde_json::json!({
+        "evaluated_role":       evaluated_role,
+        "toolset":              toolset,
+        "model_requirement":    model_requirement,
+        "image_ready":          image_ready,
+        "breaker_open":         breaker_open,
+        "manually_paused":      manually_paused,
+        "rate_limited":         rate_limited,
+        "credential_available": credential_available,
+        "build_lease":          lease.build_lease,
+        "build_capacity":       lease.build_capacity,
+        "gate_verdict":         gate_verdict,
+        "reasons":              reasons,
+        "coverage": serde_json::json!({
+            "scope":             "partial",
+            "evaluated_gates":   evaluated_gates,
+            "unevaluated_gates": unevaluated_gates,
+            "build_lease_unevaluated_detail": lease.unevaluated_detail,
+            "note": "`reasons` covers only `evaluated_gates`. An empty `reasons` \
+                     yields `unexplained`, which means no evaluated gate fired — \
+                     NOT that the dispatcher had no reason. The dispatcher's own \
+                     DenialCause (#2661) is logged, never persisted, so it cannot \
+                     be joined here.",
+        }),
+        // Retained for backward compatibility with the initial board_health
+        // contract.
+        "last_dispatched_role": last_dispatched_role,
+        "cooldown_until":       cooldown_until,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capacity(occupancy: i64, cap: i64, enforcing: bool) -> LeaseCapacity {
+        LeaseCapacity {
+            occupancy,
+            cap,
+            enforcing,
+        }
+    }
+
+    fn lease_row(state: &str) -> DispatchLeaseRow {
+        DispatchLeaseRow {
+            consumer_id: "task-1:7".to_owned(),
+            state: state.to_owned(),
+            terminal_reason: None,
+            weight: 1,
+            enqueue_sequence: 42,
+            created_at: Some("2026-07-27T00:00:00.000Z".to_owned()),
+            updated_at: Some("2026-07-27T00:10:00.000Z".to_owned()),
+            queued_ahead: 2,
+        }
+    }
+
+    fn observed(rows: Vec<(&str, DispatchLeaseRow)>, capacity: LeaseCapacity) -> LeaseLedger {
+        LeaseLedger::Observed {
+            by_task: rows
+                .into_iter()
+                .map(|(id, row)| (id.to_owned(), row))
+                .collect(),
+            capacity,
+        }
+    }
+
+    fn gate(ledger: &LeaseLedger, task_id: &str) -> serde_json::Value {
+        dispatch_gate_json(
+            "worker",
+            &["task_edit"],
+            None,
+            true,
+            false,
+            false,
+            false,
+            true,
+            None,
+            None,
+            lease_gate(ledger, task_id),
+            Vec::new(),
+        )
+    }
+
+    /// The regression this module exists for: a task denied for a capacity /
+    /// lease reason must never report an empty-`reasons` verdict again.
+    #[test]
+    fn queued_dispatch_lease_is_a_named_capacity_reason() {
+        let ledger = observed(vec![("task-1", lease_row("queued"))], capacity(3, 3, true));
+        let gate = gate(&ledger, "task-1");
+        assert_eq!(gate["gate_verdict"], VERDICT_BLOCKED);
+        assert_eq!(
+            gate["reasons"].as_array().unwrap(),
+            &vec![serde_json::json!("build_lease_queued")]
+        );
+        assert_eq!(gate["build_lease"]["state"], "queued");
+        assert_eq!(gate["build_lease"]["queued_ahead"], 2);
+        assert_eq!(gate["build_capacity"]["occupancy"], 3);
+        assert_eq!(gate["build_capacity"]["cap"], 3);
+        assert_eq!(gate["build_capacity"]["at_capacity"], true);
+    }
+
+    /// The #2661 tombstone shape: the newest attempt is terminal.
+    #[test]
+    fn terminal_dispatch_lease_is_reported_as_such() {
+        let mut row = lease_row("terminal");
+        row.terminal_reason = Some("reclaimed_absent".to_owned());
+        let ledger = observed(vec![("task-1", row)], capacity(0, 3, true));
+        let gate = gate(&ledger, "task-1");
+        assert_eq!(gate["gate_verdict"], VERDICT_BLOCKED);
+        assert!(
+            gate["reasons"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!("build_lease_terminal"))
+        );
+        assert_eq!(gate["build_lease"]["terminal_reason"], "reclaimed_absent");
+    }
+
+    /// A full pool is a real, checkable explanation for a task that never even
+    /// got a row. This is the signal that was missing while one task
+    /// monopolised the board.
+    #[test]
+    fn full_pool_explains_a_task_with_no_lease_row() {
+        let ledger = observed(Vec::new(), capacity(3, 3, true));
+        let gate = gate(&ledger, "task-1");
+        assert_eq!(gate["gate_verdict"], VERDICT_BLOCKED);
+        assert_eq!(
+            gate["reasons"].as_array().unwrap(),
+            &vec![serde_json::json!("build_pool_at_capacity")]
+        );
+        assert!(gate["build_lease"].is_null());
+    }
+
+    /// Neutralisation guard: with no lease evidence and a pool that is NOT
+    /// full, nothing is claimed. The verdict is `unexplained`, never
+    /// `stranded`, and `stranded` is not emitted anywhere.
+    #[test]
+    fn no_evidence_yields_unexplained_not_stranded() {
+        let ledger = observed(Vec::new(), capacity(0, 3, true));
+        let gate = gate(&ledger, "task-1");
+        assert_eq!(gate["gate_verdict"], VERDICT_UNEXPLAINED);
+        assert!(gate["reasons"].as_array().unwrap().is_empty());
+        assert_ne!(gate["gate_verdict"], "stranded");
+        let unevaluated = gate["coverage"]["unevaluated_gates"].as_array().unwrap();
+        assert!(
+            !unevaluated.is_empty(),
+            "an empty `reasons` must ship the list of gates it did not consult"
+        );
+        let evaluated = gate["coverage"]["evaluated_gates"].as_array().unwrap();
+        assert!(evaluated.contains(&serde_json::json!("build_lease_admission")));
+    }
+
+    /// An unreadable ledger must move the lease gate from evaluated to
+    /// unevaluated rather than pass as a clean one.
+    #[test]
+    fn unobservable_ledger_is_declared_unevaluated() {
+        let ledger = LeaseLedger::Unobservable { detail: "boom" };
+        let gate = gate(&ledger, "task-1");
+        assert_eq!(gate["gate_verdict"], VERDICT_UNEXPLAINED);
+        assert!(gate["build_lease"].is_null());
+        assert!(gate["build_capacity"].is_null());
+        let evaluated = gate["coverage"]["evaluated_gates"].as_array().unwrap();
+        assert!(!evaluated.contains(&serde_json::json!("build_lease_admission")));
+        let unevaluated = gate["coverage"]["unevaluated_gates"].as_array().unwrap();
+        assert!(unevaluated.contains(&serde_json::json!("build_lease_admission")));
+    }
+
+    /// A non-armed v1 authority grants and denies nothing, so it must not be
+    /// blamed for a full pool it is not enforcing.
+    #[test]
+    fn shadow_mode_pool_is_not_blamed() {
+        let ledger = observed(Vec::new(), capacity(9, 3, false));
+        let gate = gate(&ledger, "task-1");
+        assert_eq!(gate["gate_verdict"], VERDICT_UNEXPLAINED);
+        assert_eq!(gate["build_capacity"]["enforcing"], false);
+        assert_eq!(gate["build_capacity"]["at_capacity"], true);
+    }
+
+    /// A model-health reason still blocks, and the lease gate composes with it.
+    #[test]
+    fn model_reasons_and_lease_reasons_compose() {
+        let ledger = observed(vec![("task-1", lease_row("queued"))], capacity(3, 3, true));
+        let gate = dispatch_gate_json(
+            "worker",
+            &["task_edit"],
+            Some("prov/model".to_owned()),
+            false,
+            false,
+            false,
+            false,
+            true,
+            None,
+            None,
+            lease_gate(&ledger, "task-1"),
+            vec!["no_eligible_model"],
+        );
+        let reasons = gate["reasons"].as_array().unwrap();
+        assert!(reasons.contains(&serde_json::json!("no_eligible_model")));
+        assert!(reasons.contains(&serde_json::json!("build_lease_queued")));
+        assert_eq!(gate["gate_verdict"], VERDICT_BLOCKED);
+    }
+
+    // ── Strand clock ────────────────────────────────────────────────────────
+
+    /// The `bx1f` case: created long ago, never dispatched (so no open
+    /// transition and no session release), blocked until its blocker merged.
+    /// The clock must start when the blocker cleared, not at creation.
+    #[test]
+    fn blocker_clearing_resets_the_strand_clock() {
+        let (at, confidence, basis) = strand_clock(
+            "2026-07-26T10:00:00.000Z",
+            None,
+            None,
+            Some("2026-07-27T04:24:00.000Z"),
+            Some("2026-07-27T04:24:30.000Z"),
+        );
+        assert_eq!(at, "2026-07-27T04:24:00.000Z");
+        assert_eq!(confidence, "high");
+        assert_eq!(basis, "blocker_cleared");
+    }
+
+    /// With no recorded close event the blocking task's `updated_at` is the
+    /// proxy, and it is reported as the low-confidence signal it is.
+    #[test]
+    fn blocker_updated_at_is_the_low_confidence_proxy() {
+        let (at, confidence, basis) = strand_clock(
+            "2026-07-26T10:00:00.000Z",
+            None,
+            None,
+            None,
+            Some("2026-07-27T04:24:00.000Z"),
+        );
+        assert_eq!(at, "2026-07-27T04:24:00.000Z");
+        assert_eq!(confidence, "low");
+        assert_eq!(basis, "blocker_task_updated_at");
+    }
+
+    /// A blocker that cleared BEFORE the task became open must not drag the
+    /// clock backwards.
+    #[test]
+    fn an_older_blocker_clear_does_not_win() {
+        let (_, _, basis) = strand_clock(
+            "2026-07-26T10:00:00.000Z",
+            Some("2026-07-27T09:00:00.000Z"),
+            None,
+            Some("2026-07-27T04:24:00.000Z"),
+            None,
+        );
+        assert_eq!(basis, "open_transition");
+    }
+
+    /// **Neutralisation guard for the clock change.** `tasks.updated_at` is
+    /// bumped by any write — a description edit, a label change — so it must
+    /// never participate in the `max`. If it did, editing a starved task would
+    /// silently reset its strand clock and hide exactly the starvation this
+    /// section exists to find.
+    #[test]
+    fn a_recent_task_edit_cannot_reset_the_clock() {
+        let (at, confidence, basis) = strand_clock(
+            // Edited seconds ago...
+            "2026-07-27T12:00:00.000Z",
+            // ...but dispatchable since last year.
+            Some("2025-01-01T00:00:00.000Z"),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(at, "2025-01-01T00:00:00.000Z");
+        assert_eq!(confidence, "high");
+        assert_eq!(basis, "open_transition");
+    }
+
+    /// With no became-dispatchable signal at all the fallback is used, and the
+    /// basis says so, so the reported number can be discounted.
+    #[test]
+    fn fallback_reports_low_confidence_and_its_basis() {
+        let (at, confidence, basis) =
+            strand_clock("2026-07-27T09:00:00.000Z", None, None, None, None);
+        assert_eq!(at, "2026-07-27T09:00:00.000Z");
+        assert_eq!(confidence, "low");
+        assert_eq!(basis, "task_updated_at");
+    }
+
+    /// Identical timestamps: the recorded event wins over the fallback.
+    #[test]
+    fn ties_prefer_the_recorded_event() {
+        let resolved = resolve_unclaimed_since(&[
+            StrandSignal {
+                at: "2026-07-27T09:00:00.000Z",
+                confidence: "low",
+                basis: "task_updated_at",
+            },
+            StrandSignal {
+                at: "2026-07-27T09:00:00.000Z",
+                confidence: "high",
+                basis: "session_release",
+            },
+        ])
+        .expect("a signal is always available");
+        assert_eq!(resolved.2, "session_release");
+    }
+}

--- a/server/crates/djinn-db/src/repositories/task/mod.rs
+++ b/server/crates/djinn-db/src/repositories/task/mod.rs
@@ -12,6 +12,7 @@ use djinn_core::models::{
 mod activity;
 mod blockers;
 mod board_health;
+mod board_health_dispatch_gate;
 mod ci;
 mod parent_disposition;
 mod queries;

--- a/server/crates/djinn-db/tests/task_tests.rs
+++ b/server/crates/djinn-db/tests/task_tests.rs
@@ -16,6 +16,8 @@ pub(crate) use tokio::sync::broadcast;
 
 #[path = "task_tests/board_health.rs"]
 mod board_health;
+#[path = "task_tests/board_health_dispatch_gate.rs"]
+mod board_health_dispatch_gate;
 #[path = "task_tests/closed_task_sync.rs"]
 mod closed_task_sync;
 #[path = "task_tests/existing.rs"]

--- a/server/crates/djinn-db/tests/task_tests/board_health_dispatch_gate.rs
+++ b/server/crates/djinn-db/tests/task_tests/board_health_dispatch_gate.rs
@@ -1,0 +1,349 @@
+//! Integration coverage for the honest stranded-ready dispatch gate.
+//!
+//! These tests exist because the previous payload was structurally incapable of
+//! being wrong: `reasons` could only be populated from the model-health join,
+//! so a task with no chosen model always reported `gate_verdict: "stranded"`
+//! with `reasons: []`, and the doctor re-emitted that as a `critical` finding
+//! every thirty seconds. Each test below fails if that behaviour returns.
+
+use super::*;
+
+/// Seed a stranded open task in its own project, backdated past the threshold.
+async fn stranded_task(db: &Database, repo: &TaskRepository, title: &str) -> Task {
+    let project = create_test_project(db).await;
+    let epic = create_test_epic(db, &project.id).await;
+    let task = repo
+        .create_fixture_in_project(
+            &project.id,
+            Some(&epic.id),
+            title,
+            "desc",
+            "design",
+            "task",
+            1,
+            "worker",
+            Some("open"),
+            None,
+        )
+        .await
+        .unwrap();
+    backdate_task_updated_at(db, &task.id, "600 minutes").await;
+    task
+}
+
+/// Arm the v1 lease authority and set the pool cap.
+async fn arm_lease_authority(db: &Database, cap: i64) {
+    sqlx::query("UPDATE admission_handoff SET v1_mode = 'enforce' WHERE name = 'build'")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query("UPDATE build_lease_caps SET cap = $1 WHERE singleton")
+        .bind(cap)
+        .execute(db.pool())
+        .await
+        .unwrap();
+}
+
+/// Insert a `task_dispatch` build-lease row exactly as the dispatcher's
+/// layer-1 admission would.
+async fn insert_dispatch_lease(db: &Database, task_id: &str, generation: i64, state: &str) {
+    let consumer_id = format!("{task_id}:{generation}");
+    let identity = format!("dispatch:{task_id}:{generation}");
+    // The schema requires a fencing token for occupying states, forbids one on
+    // queued/terminal, and requires `terminal_at` on terminal rows.
+    let sql = match state {
+        "queued" => {
+            "INSERT INTO build_leases \
+             (consumer_kind, consumer_id, immutable_identity, state, weight) \
+             VALUES ('task_dispatch', $1, $2, 'queued', 1)"
+        }
+        "terminal" => {
+            "INSERT INTO build_leases \
+             (consumer_kind, consumer_id, immutable_identity, state, weight, \
+              terminal_reason, terminal_at) \
+             VALUES ('task_dispatch', $1, $2, 'terminal', 1, 'reclaimed_absent', now())"
+        }
+        _ => {
+            "INSERT INTO build_leases \
+             (consumer_kind, consumer_id, immutable_identity, state, weight, \
+              fencing_token, granted_at) \
+             VALUES ('task_dispatch', $1, $2, 'active', 1, \
+                     nextval('build_lease_fencing_token_seq'), now())"
+        }
+    };
+    sqlx::query(sql)
+        .bind(&consumer_id)
+        .bind(&identity)
+        .execute(db.pool())
+        .await
+        .unwrap();
+}
+
+async fn gate_for(repo: &TaskRepository, task_id: &str) -> serde_json::Value {
+    let report = repo.board_health(24).await.unwrap();
+    report["stranded_ready"]["findings"]
+        .as_array()
+        .expect("stranded_ready.findings is an array")
+        .iter()
+        .find(|f| f["id"] == task_id)
+        .unwrap_or_else(|| panic!("task {task_id} must appear as stranded"))["dispatch_gate"]
+        .clone()
+}
+
+/// **The regression.** A task the dispatcher denied for a capacity/lease reason
+/// must not report an empty-`reasons` `stranded` verdict. Before this change
+/// the lease ledger was never read at all
+/// (`grep -c "build_leases" board_health.rs` was 0), so this task produced
+/// `gate_verdict: "stranded", reasons: []`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn queued_dispatch_lease_is_reported_as_a_capacity_denial() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Capacity-denied task").await;
+
+    arm_lease_authority(&db, 1).await;
+    insert_dispatch_lease(&db, &task.id, 3, "queued").await;
+
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(
+        gate["gate_verdict"], "blocked",
+        "a task holding a FIFO position was denied by the cap and must say so"
+    );
+    assert_ne!(
+        gate["gate_verdict"], "stranded",
+        "the `stranded` verdict is retired"
+    );
+    let reasons = gate["reasons"].as_array().unwrap();
+    assert!(
+        reasons.contains(&serde_json::json!("build_lease_queued")),
+        "expected build_lease_queued, got {reasons:?}"
+    );
+    assert_eq!(gate["build_lease"]["state"], "queued");
+    assert_eq!(gate["build_lease"]["consumer_id"], format!("{}:3", task.id));
+    assert_eq!(gate["build_capacity"]["cap"], 1);
+    assert_eq!(gate["build_capacity"]["enforcing"], true);
+}
+
+/// The #2661 tombstone shape: the newest `task_dispatch` attempt is terminal.
+/// That is precisely what wedged dispatch for eighteen hours while this payload
+/// reported nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn terminal_dispatch_lease_is_reported() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Tombstoned task").await;
+
+    arm_lease_authority(&db, 3).await;
+    insert_dispatch_lease(&db, &task.id, 1, "terminal").await;
+
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(gate["gate_verdict"], "blocked");
+    assert!(
+        gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("build_lease_terminal"))
+    );
+    assert_eq!(gate["build_lease"]["terminal_reason"], "reclaimed_absent");
+}
+
+/// A full pool explains every task waiting behind it, even the ones that never
+/// got a lease row of their own. This is the signal that was missing while one
+/// monopolising task starved the board.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_full_pool_explains_a_task_with_no_lease_row() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let victim = stranded_task(&db, &repo, "Victim task").await;
+    let hog = stranded_task(&db, &repo, "Monopolising task").await;
+
+    arm_lease_authority(&db, 1).await;
+    // The hog occupies the only slot; the victim has no row at all.
+    insert_dispatch_lease(&db, &hog.id, 1, "active").await;
+
+    let gate = gate_for(&repo, &victim.id).await;
+    assert_eq!(gate["gate_verdict"], "blocked");
+    assert!(
+        gate["reasons"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("build_pool_at_capacity")),
+        "a victim of a full pool must be told the pool is full"
+    );
+    assert!(gate["build_lease"].is_null());
+    assert_eq!(gate["build_capacity"]["occupancy"], 1);
+    assert_eq!(gate["build_capacity"]["at_capacity"], true);
+}
+
+/// Neutralisation: with the lease ledger empty and the pool not full, nothing
+/// is claimed. The verdict must be `unexplained` — never `stranded` — and it
+/// must ship the list of gates it did not consult, so an empty `reasons` can be
+/// read as the bounded claim it is.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn no_evidence_yields_unexplained_with_declared_coverage() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Genuinely unexplained task").await;
+    arm_lease_authority(&db, 3).await;
+
+    let gate = gate_for(&repo, &task.id).await;
+    assert_eq!(gate["gate_verdict"], "unexplained");
+    assert!(gate["reasons"].as_array().unwrap().is_empty());
+    let coverage = &gate["coverage"];
+    assert_eq!(coverage["scope"], "partial");
+    let evaluated = coverage["evaluated_gates"].as_array().unwrap();
+    assert!(evaluated.contains(&serde_json::json!("build_lease_admission")));
+    let unevaluated = coverage["unevaluated_gates"].as_array().unwrap();
+    assert!(
+        unevaluated.len() >= 5,
+        "an empty `reasons` must disclose the gates it did not consult, got {unevaluated:?}"
+    );
+    assert!(unevaluated.contains(&serde_json::json!("slot_pool_capacity")));
+}
+
+/// A pool that is full while the v1 authority is NOT armed grants and denies
+/// nothing, so it must not be blamed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unarmed_authority_is_not_blamed_for_a_full_pool() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let victim = stranded_task(&db, &repo, "Shadow-mode victim").await;
+    let hog = stranded_task(&db, &repo, "Shadow-mode hog").await;
+
+    // Cap armed, but v1_mode left at its seeded 'off'.
+    sqlx::query("UPDATE build_lease_caps SET cap = 1 WHERE singleton")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    insert_dispatch_lease(&db, &hog.id, 1, "active").await;
+
+    let gate = gate_for(&repo, &victim.id).await;
+    assert_eq!(gate["gate_verdict"], "unexplained");
+    assert_eq!(gate["build_capacity"]["enforcing"], false);
+    assert_eq!(
+        gate["build_capacity"]["at_capacity"], true,
+        "the numbers are still reported; they are simply not blamed"
+    );
+}
+
+/// Defect 2. `bx1f` was reported stranded for 18.2 h although its blocker only
+/// merged eight hours earlier. It had never been dispatched (no open
+/// transition, no session), so the clock fell back to creation time and the
+/// section never reset it when the blocker cleared.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_strand_clock_restarts_when_the_last_blocker_clears() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let project = create_test_project(&db).await;
+    let epic = create_test_epic(&db, &project.id).await;
+
+    let blocked = repo
+        .create_fixture_in_project(
+            &project.id,
+            Some(&epic.id),
+            "Was blocked for most of its life",
+            "desc",
+            "design",
+            "task",
+            1,
+            "worker",
+            Some("open"),
+            None,
+        )
+        .await
+        .unwrap();
+    let blocker = repo
+        .create_fixture_in_project(
+            &project.id,
+            Some(&epic.id),
+            "The blocker",
+            "desc",
+            "design",
+            "task",
+            1,
+            "worker",
+            Some("open"),
+            None,
+        )
+        .await
+        .unwrap();
+    repo.add_blocker(&blocked.id, &blocker.id).await.unwrap();
+
+    // The blocked task was created 18 hours ago and never dispatched.
+    backdate_task_updated_at(&db, &blocked.id, "1080 minutes").await;
+    // Its blocker closed 8 hours ago.
+    sqlx::query("UPDATE tasks SET status = 'closed' WHERE id = $1")
+        .bind(&blocker.id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    backdate_task_updated_at(&db, &blocker.id, "480 minutes").await;
+    sqlx::query(
+        "INSERT INTO activity_log (id, task_id, event_type, payload, created_at) \
+         VALUES ($1, $2, 'status_changed', $3::jsonb, \
+                 to_char(now() AT TIME ZONE 'utc' - '480 minutes'::interval, \
+                         'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'))",
+    )
+    .bind(uuid::Uuid::now_v7().to_string())
+    .bind(&blocker.id)
+    .bind(r#"{"to_status":"closed"}"#)
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let report = repo.board_health(24).await.unwrap();
+    let finding = report["stranded_ready"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["id"] == blocked.id)
+        .expect("an unblocked stale task must appear as stranded")
+        .clone();
+
+    assert_eq!(
+        finding["unclaimed_since_basis"], "blocker_cleared",
+        "the clock must start when the last blocker cleared"
+    );
+    assert_eq!(finding["unclaimed_since_confidence"], "high");
+    let elapsed = finding["elapsed_minutes"].as_i64().unwrap();
+    assert!(
+        (470..=500).contains(&elapsed),
+        "expected ~480 minutes of real exposure, not the ~1080 since creation; got {elapsed}"
+    );
+    assert_eq!(
+        finding["severity"], "critical",
+        "8 hours is still critical — the fix corrects the number, it does not hide the task"
+    );
+}
+
+/// Neutralisation guard for the fix above: with no blocker at all the clock is
+/// unchanged, so the reset cannot be masking a shortened window for every task.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unblocked_task_keeps_its_original_clock() {
+    let db = create_test_db();
+    let (tx, _rx) = broadcast::channel(256);
+    let repo = TaskRepository::new(db.clone(), event_bus_for(&tx));
+    let task = stranded_task(&db, &repo, "Never blocked").await;
+
+    let report = repo.board_health(24).await.unwrap();
+    let finding = report["stranded_ready"]["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["id"] == task.id)
+        .expect("task must appear as stranded")
+        .clone();
+    assert_eq!(finding["unclaimed_since_basis"], "task_updated_at");
+    assert_eq!(finding["unclaimed_since_confidence"], "low");
+    let elapsed = finding["elapsed_minutes"].as_i64().unwrap();
+    assert!(
+        (590..=620).contains(&elapsed),
+        "an unblocked task keeps its full 600-minute window; got {elapsed}"
+    );
+}


### PR DESCRIPTION
## Why

Today six dispatchable tasks sat undispatched for up to 18 hours behind a lease
tombstone (fixed in #2661). Diagnosing it took hours because the board's own
diagnostics actively misled us. This PR fixes the diagnostics.

## Defect 1 — a verdict that had never seen the dispatcher

`stranded_ready_section` emitted, per stranded task:

```json
"dispatch_gate": { "image_ready": true, "breaker_open": false, ...,
                   "gate_verdict": "stranded", "reasons": [] }
```

Every field was true. It was also irrelevant:

- `reasons` was populated in exactly one block and could only ever contain
  `no_eligible_model` or `image_not_ready`, both derived from
  `dispatch_state.inflight_model_id` × `model_health`.
- `gate_verdict` was the trivial `if reasons.is_empty() { "stranded" }`.
- `grep -c "build_leases\|admission_journal\|LeaseResult" board_health.rs` = **0**.

So for any task with no chosen model (`inflight_model_id IS NULL` →
`image_ready: true` unconditionally), `reasons` was **structurally guaranteed**
empty and the verdict **structurally guaranteed** `stranded`. This was not a
catch-all swallowing a cause — the cause was never in scope. An empty `reasons`
that actually means *"I did not look"* is worse than no field at all.

### Fix

**1. No verdict this code cannot justify.** `stranded` is retired. The verdict
is now `blocked` (an evaluated gate fired) or `unexplained` (none did), and a
`coverage` block travels with `reasons`:

```json
"coverage": {
  "scope": "partial",
  "evaluated_gates": ["breaker_cooldown", "build_lease_admission", "model_health", ...],
  "unevaluated_gates": ["slot_pool_capacity", "per_user_lane_concurrency_cap",
                        "provider_circuit_breaker", "failover_chain_exhaustion", ...],
  "note": "`reasons` covers only `evaluated_gates` ..."
}
```

The section evaluates 6 gates; the dispatcher applies ~38. `unevaluated_gates`
is derived from the per-task gate sequence in `dispatch/task_dispatch.rs`.

**2. Read what the dispatcher actually recorded.** Layer-1 build admission
persists its unit of work as a `task_dispatch` row in `build_leases`. The gate
now joins against it (`consumer_id` is `{task_id}:{generation}`) plus the
weighted `SUM(weight)`/`build_lease_caps.cap` occupancy the admission authority
itself consults, and reports:

| reason | meaning |
|---|---|
| `build_lease_queued` | the task holds a FIFO position — the pool was full when it asked |
| `build_lease_terminal` | the newest attempt is terminal — **the #2661 tombstone shape** |
| `build_lease_occupied_without_session` | the lease occupies capacity but no session is running |
| `build_pool_at_capacity` | no row of its own, but the shared pool is full |

`admission_handoff.v1_mode` gates all of it: while the v1 authority is
`off`/`shadow` it writes no dispatch rows and grants nothing, so a full pool is
reported but **not blamed**. An unreadable ledger moves `build_lease_admission`
from `evaluated_gates` to `unevaluated_gates` rather than passing as a clean one.

### Is the real denial cause persisted?

**No — it is logged only.** `BuildAdmissionDecision::Denied` carries a
`DenialCause` as of #2661, but `dispatch/task_dispatch.rs:739` emits it on a
`tracing::info!` line and returns `Err(())`. Nothing writes it to any table.
`admission_journal` records lifecycle/fencing for admissions that *succeeded*;
`build_leases` records the lease state. So:

- `AtCapacity` — **inferable** from the ledger, which is what this PR surfaces.
- `ControllerNotAdmitting` / `AuthorityUnavailable { detail }` — **not
  recoverable at all** from durable state.

Persisting the cause on the denial path is worth a follow-up: a
`dispatch_denials` row (or a `dispatch_state.last_denial_cause` column) written
where the `tracing::info!` currently is would close the remaining gap. This PR
does not fabricate it.

## Defect 2 — `unclaimed_since` inflated strand time

The section excludes blocked tasks but never reset the clock when a blocker
cleared. `bx1f` was reported stranded **18.2 h**; its blocker `fux8` merged at
04:24, so real exposure was ~8 h. It had `reopen_count: 0, session_count: 0` —
never dispatched — so the clock fell back to creation time.

`blockers` carries no timestamp, so the clearing moment comes from the blocking
task's recorded `status_changed → closed` activity row, with its `updated_at` as
a low-confidence proxy. The latest *became-dispatchable* signal wins.

`tasks.updated_at` deliberately stays a pure fallback rather than joining the
`max`: it is bumped by any write, so folding it in would let a description edit
silently reset a starved task's clock and hide the starvation this section
exists to find. A new `unclaimed_since_basis` field names which signal won
(`open_transition` / `session_release` / `blocker_cleared` /
`blocker_task_updated_at` / `task_updated_at`).

## Doctor findings

Confirmed: `doctor/stranded_ready.rs` is a **pure mirror** — it parses the DB
section's JSON and filtered on `gate_verdict == "stranded"`. Fixing the section
fixes the finding. It now fires only for `unexplained`; a task with a named
durable cause is *explained* and belongs in the payload, not the alarm list. In
the incident all 30-40 victims would have become
`blocked: build_pool_at_capacity` and the alarm list would have been near-empty
instead of 40 identical reasons-free `critical`s. The finding detail now states
its own bound rather than implying the board proved nothing was wrong.

## Verification

- `cargo test -p djinn-db --lib -- --test-threads=1` → **1183 passed, 0 failed**
  (local Postgres on :5433, so the Postgres-backed tests did run).
- `cargo test -p djinn-db --test task_tests` → 141 passed.
- `cargo test -p djinn-coordinator --lib doctor::` → 66 passed.
- `cargo test -p djinn-control-plane --test board_tools` → 7 passed.
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets` clean on all
  touched files (remaining warnings are pre-existing in `readiness/mod.rs` and
  migration tests).
- `scripts/check-file-size.sh --all` → 0 oversized.
- No sqlx metadata regeneration needed: every new query is a runtime
  `sqlx::query`, matching the rest of `board_health.rs`, so the offline cache is
  untouched.

### Neutralization

| neutralized | result |
|---|---|
| `lease_gate` returns before deriving any reason | **4 unit + 3 integration tests fail** |
| blocker-clear signals dropped from `strand_clock` | **2 unit + 1 integration test fail** |
| `VERDICT_UNEXPLAINED` reverted to `"stranded"` | **1 unit + 2 integration + 1 control-plane test fail** |

Each was restored and the suites re-run green.

## Contradicting the brief

One correction to the task framing. The brief suggested resetting the clock by
taking the latest of all available signals. Implemented literally that broke
`board_health_stranded_ready_high_confidence_with_activity_log`, and correctly
so: `tasks.updated_at` is not a became-dispatchable marker, and letting it win
the `max` would reset the strand clock on any edit. The fallback/signal
distinction above is the version that landed, with
`a_recent_task_edit_cannot_reset_the_clock` guarding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
