### PR TITLE
fix(cache): the output-stash GC swept a tree the data never lands in (4.4 GiB un-GC'd)

### DIFF
--- a/server/crates/djinn-agent/src/output_stash/mod.rs
+++ b/server/crates/djinn-agent/src/output_stash/mod.rs
@@ -339,20 +339,32 @@ fn durable_root() -> Option<PathBuf> {
 
 #[cfg(not(any(test, feature = "test-support")))]
 fn durable_root() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME")
-        && !xdg.is_empty()
-    {
-        return Some(PathBuf::from(xdg).join("djinn").join("output_stash"));
+    Some(durable_root_from(
+        std::env::var("XDG_CACHE_HOME").ok(),
+        djinn_core::paths::output_stash_root(),
+    ))
+}
+
+/// Pure derivation behind [`durable_root`].
+///
+/// * `xdg_cache_home` — Job pods only. `djinn_k8s::job` renders
+///   `XDG_CACHE_HOME=/cache/xdg/{project_id}`, putting the stash on the shared
+///   cache PVC. Correct there and only there.
+/// * `host_root` — [`djinn_core::paths::output_stash_root`], the caller's own
+///   mount of that same PVC.
+///
+/// There is deliberately **no `$HOME` parameter**. The leg this replaced was
+/// `$HOME/.cache/djinn/output_stash`, which in the server pod is
+/// `/home/djinn/.cache/...`: an ephemeral container-layer path that dies with
+/// the Pod (and does not exist there at all), so a stash meant to be read back
+/// after a restart never survived one, and the coordinator's retention sweep
+/// could never see it.
+#[cfg_attr(any(test, feature = "test-support"), allow(dead_code))]
+fn durable_root_from(xdg_cache_home: Option<String>, host_root: PathBuf) -> PathBuf {
+    match xdg_cache_home {
+        Some(xdg) if !xdg.is_empty() => PathBuf::from(xdg).join("djinn").join("output_stash"),
+        _ => host_root,
     }
-    std::env::var("HOME")
-        .ok()
-        .filter(|h| !h.is_empty())
-        .map(|h| {
-            PathBuf::from(h)
-                .join(".cache")
-                .join("djinn")
-                .join("output_stash")
-        })
 }
 
 /// Content-addressed blob path: `<root>/blobs/<sha256(content)>`.

--- a/server/crates/djinn-agent/src/output_stash/tests.rs
+++ b/server/crates/djinn-agent/src/output_stash/tests.rs
@@ -1569,3 +1569,31 @@ fn routed_view_reads_v1_and_legacy_remains_compatible_but_unlisted() {
         .clone();
     assert!(handle_stash_tool(&stash, "output_view", Some(&legacy_args)).is_err());
 }
+
+/// The durable stash writer must resolve the caller's own mount when
+/// `XDG_CACHE_HOME` is absent — which is exactly the server pod, where
+/// `XDG_CACHE_HOME` is never rendered and `/home/djinn/.cache` does not exist.
+///
+/// Neutralization: `durable_root_from` takes no `$HOME` input at all, so a
+/// reintroduced `$HOME/.cache` fallback cannot satisfy this signature; the host
+/// root must come back verbatim.
+#[test]
+fn durable_root_falls_back_to_the_host_mount_not_home_cache() {
+    let host_root = std::path::PathBuf::from("/var/lib/djinn/cache/djinn/output_stash");
+
+    for absent in [None, Some(String::new())] {
+        let resolved = durable_root_from(absent, host_root.clone());
+        assert_eq!(resolved, host_root);
+        assert!(
+            !resolved.starts_with("/home/djinn/.cache"),
+            "{} must not resolve into the ephemeral $HOME/.cache tree",
+            resolved.display()
+        );
+    }
+
+    // Job pods keep the PVC-backed XDG answer.
+    assert_eq!(
+        durable_root_from(Some("/cache/xdg/proj".into()), host_root),
+        std::path::PathBuf::from("/cache/xdg/proj/djinn/output_stash")
+    );
+}

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -1317,6 +1317,9 @@ impl CoordinatorActor {
             // sweep's `unwrap_or_else` fallback meant the sweep silently no-op'd
             // on `ErrorKind::NotFound` and `cargo-target-runs` grew unbounded.
             cargo_target_runs_root: Some(djinn_core::paths::cargo_target_runs_root()),
+            // `None` = resolve `djinn_core::paths::cache_root()`, i.e. this
+            // pod's own mount of the shared cache PVC. Only tests override it.
+            host_cache_root: None,
             mirror: self.mirror.clone(),
             rpc_registry: self.rpc_registry.clone(),
             default_project_id: None,

--- a/server/crates/djinn-coordinator/src/context.rs
+++ b/server/crates/djinn-coordinator/src/context.rs
@@ -190,6 +190,23 @@ pub struct CacheCleanupConfig {
     /// corrected path and then set this flag.
     pub sccache_delete_armed: bool,
 
+    /// Arming switch for the destructive branch of the durable output-stash GC.
+    /// Env: `DJINN_CACHE_CLEANUP_OUTPUT_STASH_DELETE_ARMED` (default `false`).
+    ///
+    /// Same structural hazard as [`Self::sccache_delete_armed`], one layer
+    /// deeper. The stash GC resolved its root through the
+    /// `$XDG_CACHE_HOME → $HOME/.cache` chain, but `XDG_CACHE_HOME` is rendered
+    /// only into Job specs — so in the server pod the GC walked
+    /// `/home/djinn/.cache/djinn/output_stash`, which does not exist there.
+    /// Every tick logged `pointers_scanned=0 blobs_scanned=0 error_count=0`,
+    /// so the 30-day retention window has never once been applied to a real
+    /// blob; the stash on the cache PVC has only ever grown. Repointing the
+    /// sweep at the real tree arms a `remove_file` loop over production data
+    /// for the first time, and it must not inherit an authorization that could
+    /// only ever have been vacuous. Operators observe candidate counts against
+    /// the corrected roots first, then set this flag.
+    pub output_stash_delete_armed: bool,
+
     /// Whether cargo-target-runs debris cleanup is enabled.
     /// Env: `DJINN_CACHE_CLEANUP_CARGO_DEBRIS_ENABLED` (default `true`).
     pub cargo_debris_enabled: bool,
@@ -235,6 +252,7 @@ impl Default for CacheCleanupConfig {
             sccache_enabled: true,
             sccache_max_age_hours: 24,
             sccache_delete_armed: false,
+            output_stash_delete_armed: false,
             cargo_debris_enabled: true,
             cargo_debris_max_age_days: 7,
             warm_base_idle_retention_days: 14,
@@ -265,6 +283,11 @@ impl CacheCleanupConfig {
         let sccache_delete_armed = std::env::var("DJINN_CACHE_CLEANUP_SCCACHE_DELETE_ARMED")
             .map(|v| parse_bool_env(&v))
             .unwrap_or(false);
+
+        let output_stash_delete_armed =
+            std::env::var("DJINN_CACHE_CLEANUP_OUTPUT_STASH_DELETE_ARMED")
+                .map(|v| parse_bool_env(&v))
+                .unwrap_or(false);
 
         let cargo_debris_enabled = std::env::var("DJINN_CACHE_CLEANUP_CARGO_DEBRIS_ENABLED")
             .map(|v| parse_bool_env(&v))
@@ -315,6 +338,7 @@ impl CacheCleanupConfig {
             sccache_enabled,
             sccache_max_age_hours,
             sccache_delete_armed,
+            output_stash_delete_armed,
             cargo_debris_enabled,
             cargo_debris_max_age_days,
             warm_base_idle_retention_days,
@@ -384,6 +408,14 @@ pub struct CoordinatorContext {
     pub repo_graph_ops: Option<Arc<dyn bridge::RepoGraphOps>>,
     pub runtime_ops: Option<Arc<dyn bridge::RuntimeOps>>,
     pub cargo_target_runs_root: Option<PathBuf>,
+    /// Override for the host's cache mount root, used by every cache sweep in
+    /// [`crate::health::sweep_stale_resources`].
+    ///
+    /// `None` means "resolve `djinn_core::paths::cache_root()`", which is what
+    /// production wants. Tests MUST set it: the sub-sweeps run whole-tree
+    /// `remove_dir_all` / `remove_file` passes, and with `None` they resolve a
+    /// developer's real `~/.djinn/cache` on the machine running the suite.
+    pub host_cache_root: Option<PathBuf>,
     pub mirror: Option<Arc<MirrorManager>>,
     pub rpc_registry: Option<Arc<ConnectionRegistry>>,
     pub default_project_id: Option<String>,
@@ -392,6 +424,26 @@ pub struct CoordinatorContext {
 }
 
 impl CoordinatorContext {
+    /// The host cache mount a context with no override resolves.
+    ///
+    /// The cache PVC is mounted at `/cache` in Job pods and at
+    /// `$DJINN_HOME/cache` in the server pod, which has no `/cache` at all, so
+    /// every host-side sweep must derive from here.
+    pub fn default_host_cache_root() -> PathBuf {
+        djinn_core::paths::cache_root()
+    }
+
+    /// The host cache mount every cache sweep must operate under.
+    ///
+    /// Honours [`Self::host_cache_root`] so a test context can confine the
+    /// destructive sweeps to a tempdir instead of the developer's real
+    /// `~/.djinn/cache`.
+    pub fn resolved_host_cache_root(&self) -> PathBuf {
+        self.host_cache_root
+            .clone()
+            .unwrap_or_else(Self::default_host_cache_root)
+    }
+
     /// Get or spawn a `GitActorHandle` for the given project path.
     pub async fn git_actor(&self, path: &Path) -> Result<GitActorHandle, GitError> {
         let mut map = self.git_actors.lock().await;

--- a/server/crates/djinn-coordinator/src/dispatch/wave_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/wave_dispatch.rs
@@ -91,6 +91,7 @@ impl CoordinatorActor {
             repo_graph_ops: None,
             runtime_ops: None,
             cargo_target_runs_root: Some(djinn_core::paths::cargo_target_runs_root()),
+            host_cache_root: None,
             mirror: self.mirror.clone(),
             rpc_registry: None,
             default_project_id: None,

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -776,7 +776,7 @@ fn parse_iso_elapsed_with(ts: &str, now: time::OffsetDateTime) -> Option<u64> {
 /// the server pod — while every blob was written by Job pods to the cache PVC.
 pub(crate) fn durable_output_stash_gc_roots(host_cache_root: &Path) -> Vec<PathBuf> {
     crate::output_stash::durable_gc_roots_under(
-        &host_cache_root.join("xdg"),
+        &djinn_core::paths::xdg_cache_root_under(host_cache_root),
         crate::output_stash::durable_root_for_gc(),
     )
 }
@@ -987,6 +987,19 @@ mod output_stash_gc_tests {
                 "the sweep must not resolve the Job-pod literal"
             );
         }
+
+        // And the `xdg` component must come from `djinn_core::paths`, not a
+        // literal re-spelled here — otherwise the two can drift apart and the
+        // sweep silently walks a directory nothing writes to.
+        assert_eq!(
+            djinn_core::paths::xdg_cache_root_under(&host),
+            host.join("xdg")
+        );
+        assert!(
+            roots
+                .iter()
+                .any(|r| r.starts_with(djinn_core::paths::xdg_cache_root_under(&host)))
+        );
     }
 
     /// Deletion stays disarmed unless BOTH gates are set. Correcting the GC

--- a/server/crates/djinn-coordinator/src/health.rs
+++ b/server/crates/djinn-coordinator/src/health.rs
@@ -2,7 +2,7 @@
 use super::*;
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use djinn_core::clock::{Clock, SystemClock};
 use djinn_provider::github_api::GitHubApiClient;
@@ -136,19 +136,36 @@ pub(super) async fn sweep_stale_resources(
     reap_orphaned_pending_attempts(db).await;
     reap_orphaned_taskrun_jobs(db, app_state, "periodic").await;
     sweep_orphan_worker_sessions(db).await;
+    // Every cache sweep below runs `remove_file` / `remove_dir_all` under the
+    // host's cache mount. They resolve it through the context (which defaults
+    // to `djinn_core::paths::cache_root()`) rather than calling `paths::` at
+    // each site, so a test context can confine them to a tempdir. With the old
+    // direct `paths::` calls, `health::sweep_stale_resources` under test
+    // resolved — and deleted from — the developer's real `~/.djinn/cache`.
+    let host_cache_root = app_state.resolved_host_cache_root();
+    let cargo_target_runs_root = app_state
+        .cargo_target_runs_root
+        .clone()
+        .unwrap_or_else(|| host_cache_root.join("cargo-target-runs"));
     sweep_orphaned_cargo_target_run_dirs(
         db,
-        app_state.cargo_target_runs_root.as_deref(),
+        Some(cargo_target_runs_root.as_path()),
         &app_state.cache_cleanup,
     )
     .await;
-    sweep_durable_output_stash(db).await;
-    sweep_cargo_health().await;
-    sweep_sccache_guard(&app_state.cache_cleanup).await;
-    sweep_cargo_warm_base_guard(
+    sweep_durable_output_stash_under(
+        db,
+        &durable_output_stash_gc_roots(&host_cache_root),
+        &app_state.cache_cleanup,
+    )
+    .await;
+    sweep_cargo_health_under(&host_cache_root.join("cargo-target")).await;
+    sweep_sccache_guard_under(&app_state.cache_cleanup, &host_cache_root.join("sccache")).await;
+    sweep_cargo_warm_base_guard_under(
         db,
         &app_state.cache_cleanup,
         app_state.warm_job_guard.clone(),
+        &host_cache_root.join("cargo-target"),
     )
     .await;
 
@@ -749,12 +766,46 @@ fn parse_iso_elapsed_with(ts: &str, now: time::OffsetDateTime) -> Option<u64> {
 
 // ─── Durable output-stash GC ────────────────────────────────────────────────
 
-async fn sweep_durable_output_stash(db: &djinn_db::Database) {
-    let Some(root) = crate::output_stash::durable_root_for_gc() else {
-        tracing::debug!("CoordinatorActor: output-stash GC skipped; durable root unavailable");
-        return;
-    };
+/// Every durable output-stash root the sweep must visit, given the host's cache
+/// mount.
+///
+/// This is where the leak was: the sweep used to visit exactly one root, the
+/// `$XDG_CACHE_HOME → $HOME/.cache` chain evaluated in the *server* pod. Since
+/// `XDG_CACHE_HOME` is rendered only into Job specs, that resolved to
+/// `/home/djinn/.cache/djinn/output_stash` — a directory that does not exist in
+/// the server pod — while every blob was written by Job pods to the cache PVC.
+pub(crate) fn durable_output_stash_gc_roots(host_cache_root: &Path) -> Vec<PathBuf> {
+    crate::output_stash::durable_gc_roots_under(
+        &host_cache_root.join("xdg"),
+        crate::output_stash::durable_root_for_gc(),
+    )
+}
 
+/// Deletion is armed only when the global cleanup mode is `delete` AND the
+/// stash-specific arming switch is set. See
+/// `CacheCleanupConfig::output_stash_delete_armed` for why the second gate is
+/// not redundant.
+fn output_stash_gc_mode(
+    config: &crate::context::CacheCleanupConfig,
+) -> crate::output_stash::OutputStashGcMode {
+    if config.mode.is_delete() && config.output_stash_delete_armed {
+        crate::output_stash::OutputStashGcMode::Delete
+    } else {
+        crate::output_stash::OutputStashGcMode::ReportOnly
+    }
+}
+
+async fn sweep_durable_output_stash_under(
+    db: &djinn_db::Database,
+    roots: &[PathBuf],
+    config: &crate::context::CacheCleanupConfig,
+) {
+    if roots.is_empty() {
+        tracing::debug!("CoordinatorActor: output-stash GC skipped; no durable roots reachable");
+        return;
+    }
+
+    let mode = output_stash_gc_mode(config);
     let retention_days = output_stash_gc_retention_days();
     let retention_cutoff_unix_secs = output_stash_retention_cutoff_unix_secs(
         time::OffsetDateTime::now_utc().unix_timestamp(),
@@ -765,7 +816,7 @@ async fn sweep_durable_output_stash(db: &djinn_db::Database) {
         Err(e) => {
             tracing::warn!(
                 error = %e,
-                root = %root.display(),
+                root_count = roots.len(),
                 retention_days,
                 "CoordinatorActor: output-stash GC failed to load sessions; will retry on next sweep"
             );
@@ -773,59 +824,65 @@ async fn sweep_durable_output_stash(db: &djinn_db::Database) {
         }
     };
 
-    let gc_root = root.clone();
-    let report = match tokio::task::spawn_blocking(move || {
-        crate::output_stash::gc_durable_output_stash(
-            &gc_root,
-            retention_cutoff_unix_secs,
-            |session_id| Ok(sessions.get(session_id).cloned()),
-        )
-    })
-    .await
-    {
-        Ok(report) => report,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                root = %root.display(),
-                retention_days,
-                "CoordinatorActor: output-stash GC worker failed; will retry on next sweep"
-            );
-            return;
-        }
-    };
+    for root in roots {
+        let gc_root = root.clone();
+        let sessions = sessions.clone();
+        let report = match tokio::task::spawn_blocking(move || {
+            crate::output_stash::gc_durable_output_stash_with_mode(
+                &gc_root,
+                retention_cutoff_unix_secs,
+                |session_id| Ok(sessions.get(session_id).cloned()),
+                mode,
+            )
+        })
+        .await
+        {
+            Ok(report) => report,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    root = %root.display(),
+                    retention_days,
+                    "CoordinatorActor: output-stash GC worker failed; will retry on next sweep"
+                );
+                continue;
+            }
+        };
 
-    if report.is_success() {
-        tracing::info!(
-            root = %root.display(),
-            retention_days,
-            retention_cutoff_unix_secs,
-            pointers_scanned = report.pointers_scanned,
-            pointers_deleted = report.pointers_deleted,
-            pointers_retained = report.pointers_retained,
-            blobs_scanned = report.blobs_scanned,
-            blobs_deleted = report.blobs_deleted,
-            blobs_retained = report.blobs_retained,
-            error_count = 0_u64,
-            cleanup_outcome = "completed",
-            "CoordinatorActor: output-stash GC completed"
-        );
-    } else {
-        tracing::warn!(
-            root = %root.display(),
-            retention_days,
-            retention_cutoff_unix_secs,
-            pointers_scanned = report.pointers_scanned,
-            pointers_deleted = report.pointers_deleted,
-            pointers_retained = report.pointers_retained,
-            blobs_scanned = report.blobs_scanned,
-            blobs_deleted = report.blobs_deleted,
-            blobs_retained = report.blobs_retained,
-            error_count = report.errors.len(),
-            errors = ?report.errors,
-            cleanup_outcome = "completed_with_errors",
-            "CoordinatorActor: output-stash GC completed with errors; will retry failed work on next sweep"
-        );
+        if report.is_success() {
+            tracing::info!(
+                root = %root.display(),
+                mode = mode.as_metric_label(),
+                retention_days,
+                retention_cutoff_unix_secs,
+                pointers_scanned = report.pointers_scanned,
+                pointers_deleted = report.pointers_deleted,
+                pointers_retained = report.pointers_retained,
+                blobs_scanned = report.blobs_scanned,
+                blobs_deleted = report.blobs_deleted,
+                blobs_retained = report.blobs_retained,
+                error_count = 0_u64,
+                cleanup_outcome = "completed",
+                "CoordinatorActor: output-stash GC completed"
+            );
+        } else {
+            tracing::warn!(
+                root = %root.display(),
+                mode = mode.as_metric_label(),
+                retention_days,
+                retention_cutoff_unix_secs,
+                pointers_scanned = report.pointers_scanned,
+                pointers_deleted = report.pointers_deleted,
+                pointers_retained = report.pointers_retained,
+                blobs_scanned = report.blobs_scanned,
+                blobs_deleted = report.blobs_deleted,
+                blobs_retained = report.blobs_retained,
+                error_count = report.errors.len(),
+                errors = ?report.errors,
+                cleanup_outcome = "completed_with_errors",
+                "CoordinatorActor: output-stash GC completed with errors; will retry failed work on next sweep"
+            );
+        }
     }
 }
 
@@ -905,6 +962,127 @@ mod output_stash_gc_tests {
         assert_eq!(output_stash_retention_cutoff_unix_secs(-1, 30), 0);
         assert_eq!(output_stash_retention_cutoff_unix_secs(10, 30), 0);
     }
+
+    /// The sweep's roots must be derived from the host's own cache mount, so
+    /// they follow whatever the calling pod has mounted rather than the Job-pod
+    /// `/cache` convention or the server pod's ephemeral `$HOME/.cache`.
+    #[test]
+    fn gc_roots_are_derived_from_the_host_cache_mount() {
+        let host = crate::test_helpers::test_persistent_dir("djinn-stash-gc-roots-");
+        let project = "019ea3bd-a305-73e3-806c-4edcc96ebfe2";
+        let expected = host.join("xdg").join(project).join("djinn/output_stash");
+        std::fs::create_dir_all(&expected).unwrap();
+
+        let roots = durable_output_stash_gc_roots(&host);
+
+        assert!(
+            roots.contains(&expected),
+            "expected {} in {roots:?}",
+            expected.display()
+        );
+        for root in &roots {
+            assert_ne!(
+                root,
+                &PathBuf::from(format!("/cache/xdg/{project}/djinn/output_stash")),
+                "the sweep must not resolve the Job-pod literal"
+            );
+        }
+    }
+
+    /// Deletion stays disarmed unless BOTH gates are set. Correcting the GC
+    /// path re-points a real `remove_file` loop at production blobs for the
+    /// first time; `mode=delete` alone was authorised against a path that could
+    /// never produce a candidate.
+    #[test]
+    fn output_stash_deletion_requires_both_the_mode_and_the_arming_flag() {
+        use crate::context::{CacheCleanupConfig, CacheCleanupMode};
+        use crate::output_stash::OutputStashGcMode;
+
+        let base = CacheCleanupConfig::default();
+        assert!(
+            !base.output_stash_delete_armed,
+            "the arming flag must default to off"
+        );
+        assert_eq!(output_stash_gc_mode(&base), OutputStashGcMode::ReportOnly);
+
+        let mode_only = CacheCleanupConfig {
+            mode: CacheCleanupMode::Delete,
+            ..CacheCleanupConfig::default()
+        };
+        assert_eq!(
+            output_stash_gc_mode(&mode_only),
+            OutputStashGcMode::ReportOnly,
+            "global delete mode alone must not arm the stash sweep"
+        );
+
+        let armed_only = CacheCleanupConfig {
+            output_stash_delete_armed: true,
+            ..CacheCleanupConfig::default()
+        };
+        assert_eq!(
+            output_stash_gc_mode(&armed_only),
+            OutputStashGcMode::ReportOnly,
+            "the arming flag alone must not bypass the global dry-run mode"
+        );
+
+        let both = CacheCleanupConfig {
+            mode: CacheCleanupMode::Delete,
+            output_stash_delete_armed: true,
+            ..CacheCleanupConfig::default()
+        };
+        assert_eq!(output_stash_gc_mode(&both), OutputStashGcMode::Delete);
+    }
+
+    /// `sweep_stale_resources` runs five cache sweeps, two of which call
+    /// `remove_dir_all`. A test context that leaves their roots unset resolves
+    /// `djinn_core::paths::cache_root()` — on a developer machine, the real
+    /// `~/.djinn/cache`. Running the coordinator suite must never be able to
+    /// delete a developer's build cache.
+    #[tokio::test]
+    async fn test_coordinator_context_confines_every_cache_sweep_to_a_tempdir() {
+        let db = crate::test_helpers::create_test_db();
+        let ctx = crate::test_helpers::coordinator_context_from_db(
+            db,
+            tokio_util::sync::CancellationToken::new(),
+        );
+
+        let real_cache_root = djinn_core::paths::cache_root();
+        let resolved = ctx.resolved_host_cache_root();
+        assert!(
+            ctx.host_cache_root.is_some(),
+            "a test context must pin the host cache root"
+        );
+        assert_ne!(
+            resolved,
+            real_cache_root,
+            "test sweeps must not resolve the real cache root {}",
+            real_cache_root.display()
+        );
+
+        // Every derived root the sweep uses must sit inside the tempdir.
+        let cargo_target_runs = ctx
+            .cargo_target_runs_root
+            .clone()
+            .expect("test context must pin the cargo-target-runs root");
+        for root in [
+            cargo_target_runs,
+            resolved.join("cargo-target"),
+            resolved.join("sccache"),
+            resolved.join("xdg"),
+        ] {
+            assert!(
+                root.starts_with(&resolved),
+                "{} escapes the test cache root {}",
+                root.display(),
+                resolved.display()
+            );
+            assert!(
+                !root.starts_with(&real_cache_root),
+                "{} points into the developer's real cache",
+                root.display()
+            );
+        }
+    }
 }
 
 // ─── Cargo cache health sweep ──────────────────────────────────────────────
@@ -926,14 +1104,6 @@ struct CargoCacheProjectHealth {
     seed_hit_count: u64,
     cold_fallback_count: u64,
     warm_base_age_seconds: Option<u64>,
-}
-
-async fn sweep_cargo_health() {
-    // Resolve the host's own mount, never the Job-pod convention. The cache PVC
-    // is mounted at `/cache` in Job pods and at `$DJINN_HOME/cache` here, so a
-    // hardcoded `/cache/cargo-target` made this sweep return `NotFound` on its
-    // first statement and emit nothing — for the entire life of the deployment.
-    sweep_cargo_health_under(&djinn_core::paths::cargo_target_root()).await;
 }
 
 async fn sweep_cargo_health_under(warm_base_root: &Path) {
@@ -1360,18 +1530,17 @@ mod cargo_cache_health_tests {
 
 // ─── /cache/sccache guard ──────────────────────────────────────────────────
 
-/// Host-side path of the sccache directory on the shared PVC.
-///
-/// Job pods know this directory as `/cache/sccache` (the `SCCACHE_DIR`
-/// compatibility fallback, namespaced per project); the guard sweeps the parent
-/// directory as a whole. It MUST resolve through the host's own mount: the
-/// server pod has no `/cache` at all, so the former hardcoded
-/// `SCCACHE_ROOT = "/cache/sccache"` made this guard log
-/// `sccache guard skipped; path does not exist` on every tick for the entire
-/// life of the deployment.
-fn sccache_root() -> std::path::PathBuf {
-    djinn_core::paths::sccache_root()
-}
+// The sccache root is supplied by the caller, derived from
+// `CoordinatorContext::resolved_host_cache_root()`, so a test context can
+// confine this guard's destructive branch to a tempdir.
+//
+// Job pods know this directory as `/cache/sccache` (the `SCCACHE_DIR`
+// compatibility fallback, namespaced per project); the guard sweeps the parent
+// directory as a whole. It MUST resolve through the host's own mount: the
+// server pod has no `/cache` at all, so the former hardcoded
+// `SCCACHE_ROOT = "/cache/sccache"` made this guard log
+// `sccache guard skipped; path does not exist` on every tick for the entire
+// life of the deployment.
 
 /// Distinct structured outcomes for the sccache sweep guard.
 ///
@@ -1413,10 +1582,6 @@ pub(super) enum SccacheSweepOutcome {
 /// coordinator's cleanup config.
 ///
 /// Called from [`sweep_stale_resources`] on every periodic tick.
-async fn sweep_sccache_guard(config: &crate::context::CacheCleanupConfig) {
-    sweep_sccache_guard_under(config, &sccache_root()).await;
-}
-
 /// Testable implementation that accepts an explicit sccache root path.
 ///
 /// Returns the outcome so tests can assert it.
@@ -1693,7 +1858,12 @@ mod sccache_guard_tests {
     /// canonical accessor are the load-bearing assertions.
     #[test]
     fn sccache_guard_resolves_the_host_cache_mount_not_the_job_pod_path() {
-        let root = sccache_root();
+        // Reproduce the production derivation: a context with no
+        // `host_cache_root` override resolves `djinn_core::paths::cache_root()`,
+        // and the sweep hangs `sccache` off it.
+        let production_cache_root = crate::context::CoordinatorContext::default_host_cache_root();
+        assert_eq!(production_cache_root, djinn_core::paths::cache_root());
+        let root = production_cache_root.join("sccache");
         assert_ne!(
             root,
             std::path::PathBuf::from("/cache/sccache"),
@@ -4004,19 +4174,22 @@ mod cache_cleanup_cross_path_tests {
 /// rechecking safety while the lock is held.  Both dry-run and delete modes
 /// select the same candidates; dry-run reports projected bytes, delete reports
 /// reclaimed bytes.
-async fn sweep_cargo_warm_base_guard(
+async fn sweep_cargo_warm_base_guard_under(
     db: &djinn_db::Database,
     config: &crate::context::CacheCleanupConfig,
     warm_job_guard: Option<Arc<dyn crate::cargo_warm_base_gc::WarmJobGuard>>,
+    warm_base_root: &Path,
 ) {
     use crate::cargo_warm_base_gc as gc;
     use djinn_core::clock::SystemClock;
     use djinn_telemetry::cache_cleanup as metrics;
     let guard: Arc<dyn gc::WarmJobGuard> =
         warm_job_guard.unwrap_or_else(|| Arc::new(gc::UnavailableWarmJobGuard));
-    // Resolve the server pod's own cache mount, never the Job-pod `/cache`
-    // convention — the same defect `sweep_cargo_health` already documents.
-    let warm_base_root = gc::cargo_warm_base_root();
+    // The root is supplied by the caller, derived from the host's own cache
+    // mount (never the Job-pod `/cache` convention — the server pod has no
+    // `/cache` at all), so a test context can confine this destructive sweep to
+    // a tempdir instead of the developer's real `~/.djinn/cache`.
+    let warm_base_root = warm_base_root.to_path_buf();
     let inventory = match gc::inventory_under(&warm_base_root) {
         Ok(inventory) => inventory,
         Err(error) => {

--- a/server/crates/djinn-coordinator/src/output_stash.rs
+++ b/server/crates/djinn-coordinator/src/output_stash.rs
@@ -108,6 +108,49 @@ pub(crate) fn durable_root_for_gc() -> Option<PathBuf> {
     durable_root()
 }
 
+/// Every durable output-stash root this process can actually reach on disk.
+///
+/// The coordinator's GC used to sweep exactly one root — `durable_root()`,
+/// i.e. the `$XDG_CACHE_HOME → $HOME/.cache` chain evaluated **in the server
+/// pod**. `XDG_CACHE_HOME` is rendered only into Job specs, so in the server
+/// pod that chain lands on `/home/djinn/.cache/djinn/output_stash`: a path that
+/// does not exist there at all. `scan_pointers` maps `NotFound` to "nothing to
+/// do", so the sweep logged `pointers_scanned=0 blobs_scanned=0 error_count=0`
+/// on every tick — a success line indistinguishable from an empty stash —
+/// while every real blob accumulated on the cache PVC under
+/// `<pvc>/xdg/<project_id>/djinn/output_stash`, written by Job pods and never
+/// once considered for the 30-day retention window.
+///
+/// The server pod mounts that same claim at `$DJINN_HOME/cache`, so the
+/// per-project Job-pod roots are enumerable from here with no new volume
+/// plumbing (`djinn_k8s::job` already says as much in-tree).
+///
+/// The coordinator's entry point is
+/// `crate::health::durable_output_stash_gc_roots`, which supplies the host cache
+/// mount from the coordinator context.
+///
+/// `own_root` is this process's own stash root (kept so a server-hosted session
+/// that wrote locally is still collected); `xdg_cache_root` is the host's view
+/// of the per-project Job-pod `$XDG_CACHE_HOME` directories.
+pub(crate) fn durable_gc_roots_under(
+    xdg_cache_root: &Path,
+    own_root: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = own_root.into_iter().collect();
+
+    if let Ok(entries) = std::fs::read_dir(xdg_cache_root) {
+        for entry in entries.flatten() {
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                roots.push(djinn_core::paths::output_stash_dir_under(&entry.path()));
+            }
+        }
+    }
+
+    roots.sort();
+    roots.dedup();
+    roots
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DurablePointerKind {
     Version2,
@@ -335,20 +378,31 @@ fn durable_root() -> Option<PathBuf> {
 
 #[cfg(not(test))]
 fn durable_root() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME")
-        && !xdg.is_empty()
-    {
-        return Some(PathBuf::from(xdg).join("djinn").join("output_stash"));
+    Some(durable_root_from(
+        std::env::var("XDG_CACHE_HOME").ok(),
+        djinn_core::paths::output_stash_root(),
+    ))
+}
+
+/// Pure derivation behind [`durable_root`].
+///
+/// * `xdg_cache_home` — Job pods only. `djinn_k8s::job` renders
+///   `XDG_CACHE_HOME=/cache/xdg/{project_id}`, putting the stash on the shared
+///   cache PVC. Correct there and only there.
+/// * `host_root` — [`djinn_core::paths::output_stash_root`], the caller's own
+///   mount of that same PVC.
+///
+/// There is deliberately **no `$HOME` parameter**. The leg this replaced was
+/// `$HOME/.cache/djinn/output_stash`, which in the server pod is
+/// `/home/djinn/.cache/...`: an ephemeral container-layer path that does not
+/// exist there at all, so a stash meant to survive a restart never did and the
+/// retention sweep could never see it. See [`durable_gc_roots_under`].
+#[cfg_attr(test, allow(dead_code))]
+fn durable_root_from(xdg_cache_home: Option<String>, host_root: PathBuf) -> PathBuf {
+    match xdg_cache_home {
+        Some(xdg) if !xdg.is_empty() => PathBuf::from(xdg).join("djinn").join("output_stash"),
+        _ => host_root,
     }
-    std::env::var("HOME")
-        .ok()
-        .filter(|h| !h.is_empty())
-        .map(|h| {
-            PathBuf::from(h)
-                .join(".cache")
-                .join("djinn")
-                .join("output_stash")
-        })
 }
 
 /// Content-addressed blob path: `<root>/blobs/<sha256(content)>`.
@@ -398,6 +452,36 @@ impl OutputStashGcReport {
     }
 }
 
+/// Whether a GC pass may actually unlink files.
+///
+/// This exists because correcting the GC root **arms a sweep that has never
+/// run**. Every prior tick scanned a nonexistent directory, so the operational
+/// evidence authorising deletion ("30-day retention has been running fine for
+/// months") was collected against an empty set and is structurally worthless —
+/// the same trap `CacheCleanupConfig::sccache_delete_armed` documents. The
+/// corrected path points a real `remove_file` loop at ~4 GiB of production
+/// blobs, so it must be explicitly armed rather than inherit that authorization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputStashGcMode {
+    /// Scan and count deletion candidates; unlink nothing.
+    ReportOnly,
+    /// Scan and unlink expired pointers and unreferenced blobs.
+    Delete,
+}
+
+impl OutputStashGcMode {
+    fn deletes(self) -> bool {
+        matches!(self, Self::Delete)
+    }
+
+    pub fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::ReportOnly => "report_only",
+            Self::Delete => "delete",
+        }
+    }
+}
+
 fn is_terminal_session_status(status: SessionStatus) -> bool {
     matches!(
         status,
@@ -426,7 +510,30 @@ fn file_modified_unix_secs(path: &Path) -> Result<u64, String> {
 pub fn gc_durable_output_stash<F>(
     root: &Path,
     retention_cutoff_unix_secs: u64,
+    lookup_session: F,
+) -> OutputStashGcReport
+where
+    F: FnMut(&str) -> Result<Option<OutputStashGcSession>, String>,
+{
+    gc_durable_output_stash_with_mode(
+        root,
+        retention_cutoff_unix_secs,
+        lookup_session,
+        OutputStashGcMode::Delete,
+    )
+}
+
+/// [`gc_durable_output_stash`] with an explicit deletion mode.
+///
+/// In [`OutputStashGcMode::ReportOnly`] the scan is byte-identical but no file
+/// is unlinked: `pointers_deleted` / `blobs_deleted` report what *would* have
+/// been removed. This is the default the coordinator ships with — see
+/// [`OutputStashGcMode`] for why.
+pub fn gc_durable_output_stash_with_mode<F>(
+    root: &Path,
+    retention_cutoff_unix_secs: u64,
     mut lookup_session: F,
+    mode: OutputStashGcMode,
 ) -> OutputStashGcReport
 where
     F: FnMut(&str) -> Result<Option<OutputStashGcSession>, String>,
@@ -444,17 +551,32 @@ where
         &mut retained_hashes,
         &mut lookup_session,
         retention_cutoff_unix_secs,
+        mode,
     );
     scan_blobs(
         &blobs_dir,
         &mut report,
         &retained_hashes,
         retention_cutoff_unix_secs,
+        mode,
     );
 
     report
 }
 
+/// Unlink `path` unless the pass is report-only.
+///
+/// Report-only returns `Ok(())` without touching the filesystem, so callers
+/// account for the entry exactly as they would for a real deletion.
+fn remove_unless_report_only(path: &Path, mode: OutputStashGcMode) -> std::io::Result<()> {
+    if mode.deletes() {
+        std::fs::remove_file(path)
+    } else {
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn scan_pointers<F>(
     root: &Path,
     ids_dir: &Path,
@@ -462,6 +584,7 @@ fn scan_pointers<F>(
     retained_hashes: &mut HashSet<String>,
     lookup_session: &mut F,
     retention_cutoff_unix_secs: u64,
+    mode: OutputStashGcMode,
 ) where
     F: FnMut(&str) -> Result<Option<OutputStashGcSession>, String>,
 {
@@ -482,6 +605,7 @@ fn scan_pointers<F>(
                     retained_hashes,
                     lookup_session,
                     retention_cutoff_unix_secs,
+                    mode,
                 );
             }
         }
@@ -492,6 +616,7 @@ fn scan_pointers<F>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn process_pointer_entry<F>(
     root: &Path,
     entry: std::fs::DirEntry,
@@ -499,6 +624,7 @@ fn process_pointer_entry<F>(
     retained_hashes: &mut HashSet<String>,
     lookup_session: &mut F,
     retention_cutoff_unix_secs: u64,
+    mode: OutputStashGcMode,
 ) where
     F: FnMut(&str) -> Result<Option<OutputStashGcSession>, String>,
 {
@@ -530,7 +656,7 @@ fn process_pointer_entry<F>(
     };
 
     if !blob_path(root, &record.content_hash).is_file() {
-        match std::fs::remove_file(&pointer_path) {
+        match remove_unless_report_only(&pointer_path, mode) {
             Ok(()) => report.pointers_deleted += 1,
             Err(e) => {
                 report.errors.push(format!(
@@ -547,7 +673,7 @@ fn process_pointer_entry<F>(
         should_delete_pointer(&record, retention_cutoff_unix_secs, lookup_session, report);
 
     if should_delete {
-        match std::fs::remove_file(&pointer_path) {
+        match remove_unless_report_only(&pointer_path, mode) {
             Ok(()) => report.pointers_deleted += 1,
             Err(e) => {
                 report.errors.push(format!(
@@ -599,6 +725,7 @@ fn scan_blobs(
     report: &mut OutputStashGcReport,
     retained_hashes: &HashSet<String>,
     retention_cutoff_unix_secs: u64,
+    mode: OutputStashGcMode,
 ) {
     match std::fs::read_dir(blobs_dir) {
         Ok(entries) => {
@@ -610,7 +737,13 @@ fn scan_blobs(
                         continue;
                     }
                 };
-                process_blob_entry(entry, report, retained_hashes, retention_cutoff_unix_secs);
+                process_blob_entry(
+                    entry,
+                    report,
+                    retained_hashes,
+                    retention_cutoff_unix_secs,
+                    mode,
+                );
             }
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -625,6 +758,7 @@ fn process_blob_entry(
     report: &mut OutputStashGcReport,
     retained_hashes: &HashSet<String>,
     retention_cutoff_unix_secs: u64,
+    mode: OutputStashGcMode,
 ) {
     let blob = entry.path();
     if !blob.is_file() {
@@ -641,7 +775,7 @@ fn process_blob_entry(
     }
     match file_modified_unix_secs(&blob) {
         Ok(modified_at) if modified_at <= retention_cutoff_unix_secs => {
-            match std::fs::remove_file(&blob) {
+            match remove_unless_report_only(&blob, mode) {
                 Ok(()) => report.blobs_deleted += 1,
                 Err(e) => {
                     report
@@ -2625,5 +2759,181 @@ mod tests {
         // A stash with no session_id must NOT resolve a v2 record.
         let unowned = OutputStash::with_session_id_and_durable_root("nobody", root.clone());
         assert!(unowned.view("call-secret", 0, 10).is_err());
+    }
+
+    // ─── Durable root resolution (the cross-pod cache-path leak) ─────────────
+
+    /// The writer must resolve the caller's own mount when `XDG_CACHE_HOME` is
+    /// absent — which is exactly the server pod. Neutralization: there is no
+    /// `$HOME` input at all, so a reintroduced `$HOME/.cache` fallback cannot
+    /// satisfy this signature, and the host root is returned verbatim.
+    #[test]
+    fn durable_root_falls_back_to_the_host_mount_not_home_cache() {
+        let host_root = PathBuf::from("/var/lib/djinn/cache/djinn/output_stash");
+
+        for absent in [None, Some(String::new())] {
+            let resolved = durable_root_from(absent, host_root.clone());
+            assert_eq!(resolved, host_root);
+            assert!(
+                !resolved.starts_with("/home/djinn/.cache"),
+                "{} must not resolve into the ephemeral $HOME/.cache tree",
+                resolved.display()
+            );
+        }
+
+        // Job pods keep the PVC-backed XDG answer.
+        assert_eq!(
+            durable_root_from(Some("/cache/xdg/proj".into()), host_root),
+            PathBuf::from("/cache/xdg/proj/djinn/output_stash")
+        );
+    }
+
+    // ─── GC root discovery (the cross-pod cache-path leak) ────────────────────
+
+    /// Build a fake host-side view of the cache PVC: `<cache>/xdg/<project>/…`,
+    /// exactly the layout `djinn_k8s::job` produces via
+    /// `XDG_CACHE_HOME=/cache/xdg/{project_id}`.
+    fn host_cache_with_projects(name: &str, projects: &[&str]) -> PathBuf {
+        let cache = crate::test_helpers::test_persistent_dir("djinn-host-cache-").join(name);
+        let _ = std::fs::remove_dir_all(&cache);
+        for project in projects {
+            let stash = cache.join("xdg").join(project).join("djinn/output_stash");
+            std::fs::create_dir_all(stash.join("ids")).unwrap();
+            std::fs::create_dir_all(stash.join("blobs")).unwrap();
+        }
+        cache
+    }
+
+    /// The GC must discover the per-project stash roots Job pods actually wrote
+    /// on the shared cache PVC, seen through the *server pod's* mount.
+    #[test]
+    fn gc_roots_enumerate_the_per_project_job_pod_stashes() {
+        let cache = host_cache_with_projects("enumerate", &["project-a", "project-b"]);
+        // A non-project file at the xdg level must be ignored, not turned into
+        // a bogus root.
+        std::fs::write(cache.join("xdg").join("stray-file"), b"x").unwrap();
+
+        let roots = durable_gc_roots_under(&cache.join("xdg"), None);
+
+        assert_eq!(
+            roots,
+            vec![
+                cache.join("xdg/project-a/djinn/output_stash"),
+                cache.join("xdg/project-b/djinn/output_stash"),
+            ]
+        );
+    }
+
+    /// Neutralization: this is the exact production shape. `XDG_CACHE_HOME` is
+    /// unset in the server pod, so the old chain resolved
+    /// `$HOME/.cache/djinn/output_stash`. Point the discovery at that tree and
+    /// it finds NOTHING — while the real blobs sit under the cache mount.
+    /// A regression that reintroduces the `$HOME`-relative root fails here.
+    #[test]
+    fn home_relative_root_discovers_none_of_the_real_stashes() {
+        let cache = host_cache_with_projects("neutralize", &["project-a"]);
+        let ephemeral_home_cache = cache.join("fake-home/.cache");
+
+        let via_home = durable_gc_roots_under(&ephemeral_home_cache, None);
+        assert!(
+            via_home.is_empty(),
+            "the $HOME/.cache tree holds no Job-pod stash, yet discovery returned {via_home:?}"
+        );
+
+        let via_cache_mount = durable_gc_roots_under(&cache.join("xdg"), None);
+        assert_eq!(via_cache_mount.len(), 1);
+        assert!(via_cache_mount[0].starts_with(&cache));
+    }
+
+    /// The process's own root is still swept, and duplicates collapse.
+    #[test]
+    fn gc_roots_include_the_processes_own_root_without_duplicating_it() {
+        let cache = host_cache_with_projects("own-root", &["project-a"]);
+        let own = cache.join("xdg/project-a/djinn/output_stash");
+
+        let roots = durable_gc_roots_under(&cache.join("xdg"), Some(own.clone()));
+        assert_eq!(roots, vec![own.clone()]);
+
+        let elsewhere = cache.join("djinn/output_stash");
+        let roots = durable_gc_roots_under(&cache.join("xdg"), Some(elsewhere.clone()));
+        assert!(roots.contains(&elsewhere));
+        assert!(roots.contains(&own));
+        assert_eq!(roots.len(), 2);
+    }
+
+    // ─── Report-only arming gate ──────────────────────────────────────────────
+
+    /// Seed a root with one expired pointer + blob pair that a `Delete` pass
+    /// would remove. Returns `(root, pointer_path, blob_path)`.
+    fn seed_expired_entry(name: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let root = gc_root(name);
+        let mut stash =
+            OutputStash::with_session_id_and_durable_root("expired-session", root.clone());
+        stash
+            .insert("call-expired".into(), "shell".into(), "content\n".into())
+            .unwrap();
+        let pointer = owner_id_pointer_path(&root, "expired-session", "call-expired");
+        let record = parse_durable_pointer(&std::fs::read_to_string(&pointer).unwrap()).unwrap();
+        let blob = blob_path(&root, &record.content_hash);
+        assert!(pointer.is_file() && blob.is_file());
+        (root, pointer, blob)
+    }
+
+    fn expired_session_lookup(_id: &str) -> Result<Option<OutputStashGcSession>, String> {
+        Ok(Some(OutputStashGcSession {
+            status: SessionStatus::Completed,
+            ended_at_unix_secs: Some(0),
+        }))
+    }
+
+    /// Correcting the GC path arms a `remove_file` loop that has never once run
+    /// against real data. Report-only mode must count candidates and delete
+    /// nothing — asserted on the side effect (the files still exist), not on the
+    /// report's labels.
+    #[test]
+    fn report_only_mode_counts_candidates_but_unlinks_nothing() {
+        let (root, pointer, blob) = seed_expired_entry("report-only");
+
+        let report = gc_durable_output_stash_with_mode(
+            &root,
+            unix_time_secs() + 1_000,
+            expired_session_lookup,
+            OutputStashGcMode::ReportOnly,
+        );
+
+        assert_eq!(report.pointers_scanned, 1);
+        assert_eq!(report.pointers_deleted, 1, "candidate must be reported");
+        assert_eq!(report.blobs_deleted, 1, "candidate must be reported");
+        assert!(report.is_success());
+
+        assert!(
+            pointer.is_file(),
+            "report-only must not unlink {}",
+            pointer.display()
+        );
+        assert!(
+            blob.is_file(),
+            "report-only must not unlink {}",
+            blob.display()
+        );
+    }
+
+    /// The armed path still deletes — proving the report-only assertion above is
+    /// about the mode and not about an inert GC.
+    #[test]
+    fn delete_mode_actually_unlinks_the_same_candidates() {
+        let (root, pointer, blob) = seed_expired_entry("delete-mode");
+
+        let report = gc_durable_output_stash_with_mode(
+            &root,
+            unix_time_secs() + 1_000,
+            expired_session_lookup,
+            OutputStashGcMode::Delete,
+        );
+
+        assert_eq!(report.pointers_deleted, 1);
+        assert_eq!(report.blobs_deleted, 1);
+        assert!(!pointer.exists(), "delete mode must unlink the pointer");
+        assert!(!blob.exists(), "delete mode must unlink the blob");
     }
 }

--- a/server/crates/djinn-coordinator/src/test_helpers.rs
+++ b/server/crates/djinn-coordinator/src/test_helpers.rs
@@ -26,6 +26,18 @@ pub fn test_persistent_dir(prefix: &str) -> PathBuf {
     test_tempdir(prefix).keep()
 }
 
+/// Isolated stand-in for `djinn_core::paths::cache_root()` in tests.
+///
+/// One directory per test binary, so the cache sweeps in
+/// `health::sweep_stale_resources` operate on a tempdir instead of the
+/// developer's real `~/.djinn/cache`.
+pub fn test_cache_root() -> PathBuf {
+    static TEST_CACHE_ROOT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    TEST_CACHE_ROOT
+        .get_or_init(|| test_persistent_dir("djinn-test-cache-root-"))
+        .clone()
+}
+
 pub fn create_test_db() -> Database {
     Database::open_in_memory().expect("open in-memory test database")
 }
@@ -281,7 +293,17 @@ pub fn coordinator_context_from_db(
         warm_job_guard: None,
         repo_graph_ops: None,
         runtime_ops: None,
-        cargo_target_runs_root: None,
+        // A test context MUST NOT leave the cache sweeps unrooted.
+        //
+        // `health::sweep_stale_resources` runs five cache sweeps, and the
+        // destructive branches of the sccache and warm-base guards call
+        // `remove_dir_all`. With `None` here they resolved
+        // `djinn_core::paths::cache_root()`, which on a developer machine is the
+        // real `~/.djinn/cache` — so running the coordinator test suite could
+        // delete the developer's own build cache. Pin every root under one
+        // per-process tempdir instead.
+        cargo_target_runs_root: Some(test_cache_root().join("cargo-target-runs")),
+        host_cache_root: Some(test_cache_root()),
         mirror: None,
         rpc_registry: None,
         default_project_id: None,

--- a/server/crates/djinn-core/src/paths.rs
+++ b/server/crates/djinn-core/src/paths.rs
@@ -130,12 +130,27 @@ const SCIP_INDEXER_SUFFIX: [&str; 2] = ["djinn", "scip-indexer"];
 /// MUST enumerate from here, exactly as [`cargo_target_runs_root`] does for the
 /// non-XDG half of the same PVC.
 pub fn xdg_cache_root() -> PathBuf {
-    cache_root().join("xdg")
+    xdg_cache_root_under(&cache_root())
+}
+
+/// [`xdg_cache_root`] relative to an explicit cache mount.
+///
+/// Callers that already hold a resolved cache root (a coordinator context, a
+/// test tempdir) use this so the `xdg` path component lives in exactly one
+/// place.
+pub fn xdg_cache_root_under(cache_root: &Path) -> PathBuf {
+    cache_root.join("xdg")
 }
 
 /// Host-side view of one project's Job-pod `$XDG_CACHE_HOME`.
 pub fn project_xdg_cache_dir(project_id: &str) -> PathBuf {
     xdg_cache_root().join(project_id)
+}
+
+/// Host-side view of one project's Job-pod `$XDG_CACHE_HOME`, relative to an
+/// explicit cache mount.
+pub fn project_xdg_cache_dir_under(cache_root: &Path, project_id: &str) -> PathBuf {
+    xdg_cache_root_under(cache_root).join(project_id)
 }
 
 /// Durable output-stash root beneath an arbitrary XDG cache directory.

--- a/server/crates/djinn-core/src/paths.rs
+++ b/server/crates/djinn-core/src/paths.rs
@@ -6,7 +6,7 @@
 //! local location from `$DJINN_HOME/projects/{owner}/{repo}`, using
 //! this module as the single source of truth.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Root directory containing all project clones.
 ///
@@ -50,12 +50,26 @@ fn projects_root_from(djinn_home: Option<PathBuf>, home_dir: Option<PathBuf>) ->
 /// 2. `~/.djinn/cache` — docker-compose / local-dev fallback.
 /// 3. `/tmp/.djinn/cache` — last-ditch fallback when `$HOME` isn't set.
 pub fn cache_root() -> PathBuf {
-    if let Ok(djinn_home) = std::env::var("DJINN_HOME")
-        && !djinn_home.is_empty()
+    cache_root_from(
+        std::env::var_os("DJINN_HOME").map(PathBuf::from),
+        dirs::home_dir(),
+    )
+}
+
+/// Pure derivation behind [`cache_root`].
+///
+/// Deliberately takes **only** `$DJINN_HOME` and the home directory: there is
+/// no `XDG_CACHE_HOME` parameter, because `XDG_CACHE_HOME` is a Job-pod-only
+/// variable and consulting it on the host is precisely the bug this module
+/// exists to prevent. A regression that reintroduces an XDG leg has to change
+/// this signature.
+fn cache_root_from(djinn_home: Option<PathBuf>, home_dir: Option<PathBuf>) -> PathBuf {
+    if let Some(djinn_home) = djinn_home
+        && !djinn_home.as_os_str().is_empty()
     {
-        return PathBuf::from(djinn_home).join("cache");
+        return djinn_home.join("cache");
     }
-    dirs::home_dir()
+    home_dir
         .unwrap_or_else(|| PathBuf::from("/tmp"))
         .join(".djinn")
         .join("cache")
@@ -92,6 +106,71 @@ pub fn cargo_target_root() -> PathBuf {
 /// `path does not exist` no-op.
 pub fn sccache_root() -> PathBuf {
     cache_root().join("sccache")
+}
+
+/// Relative location of the durable output stash inside *any* XDG cache tree.
+///
+/// Kept as a shared constant so the writer (`$XDG_CACHE_HOME/djinn/output_stash`
+/// in Job pods) and the host-side GC cannot drift apart.
+const OUTPUT_STASH_SUFFIX: [&str; 2] = ["djinn", "output_stash"];
+
+/// Relative location of the SCIP indexer cache inside *any* XDG cache tree.
+const SCIP_INDEXER_SUFFIX: [&str; 2] = ["djinn", "scip-indexer"];
+
+/// Host-side root of the per-project XDG cache trees that Job pods write into.
+///
+/// `XDG_CACHE_HOME` is rendered **only** into Job pods, as
+/// `/cache/xdg/{project_id}` (`djinn_k8s::job`). It is set nowhere in the
+/// server/coordinator pod's Helm templates. So every `$XDG_CACHE_HOME`-relative
+/// store — the durable output stash, the SCIP indexer cache — lands on the
+/// shared cache PVC under `<pvc>/xdg/{project_id}/…` when a Job writes it, but
+/// the *same* XDG→`$HOME/.cache` chain evaluated in the server pod resolves to
+/// `/home/djinn/.cache`, a path that does not even exist there (verified in
+/// production). Host-side sweeps that want the bytes Job pods actually wrote
+/// MUST enumerate from here, exactly as [`cargo_target_runs_root`] does for the
+/// non-XDG half of the same PVC.
+pub fn xdg_cache_root() -> PathBuf {
+    cache_root().join("xdg")
+}
+
+/// Host-side view of one project's Job-pod `$XDG_CACHE_HOME`.
+pub fn project_xdg_cache_dir(project_id: &str) -> PathBuf {
+    xdg_cache_root().join(project_id)
+}
+
+/// Durable output-stash root beneath an arbitrary XDG cache directory.
+///
+/// Pass a [`project_xdg_cache_dir`] to get the host's view of a Job pod's stash.
+pub fn output_stash_dir_under(xdg_cache_dir: &Path) -> PathBuf {
+    let mut path = xdg_cache_dir.to_path_buf();
+    path.extend(OUTPUT_STASH_SUFFIX);
+    path
+}
+
+/// SCIP indexer cache root beneath an arbitrary XDG cache directory.
+pub fn scip_indexer_cache_dir_under(xdg_cache_dir: &Path) -> PathBuf {
+    let mut path = xdg_cache_dir.to_path_buf();
+    path.extend(SCIP_INDEXER_SUFFIX);
+    path
+}
+
+/// Host-side durable output-stash root for a process with no `$XDG_CACHE_HOME`.
+///
+/// This is where a server-pod-hosted session's durable stash *should* live: on
+/// the cache PVC, not on the pod's ephemeral container layer.
+pub fn output_stash_root() -> PathBuf {
+    output_stash_dir_under(&cache_root())
+}
+
+/// Host-side SCIP indexer cache root for a process with no `$XDG_CACHE_HOME`.
+///
+/// The last-resort fallback for `djinn_graph`'s cache-root resolution. The
+/// alternative it replaced was `$HOME/.cache/djinn/scip-indexer` (ephemeral,
+/// wrong tree) and — when `$HOME` was unset too — a **cwd-relative**
+/// `.cache/djinn/scip-indexer`, which silently scatters cache state into
+/// whatever directory the process happened to start in.
+pub fn scip_indexer_cache_root() -> PathBuf {
+    scip_indexer_cache_dir_under(&cache_root())
 }
 
 /// Per-project clone directory: `{projects_root}/{owner}/{repo}`.
@@ -165,5 +244,87 @@ mod tests {
             cache_root().join("cargo-target-runs")
         );
         assert_eq!(sccache_root(), cache_root().join("sccache"));
+    }
+
+    /// The XDG accessors exist precisely because `XDG_CACHE_HOME` is a Job-pod
+    /// -only variable. If any of them ever resolved through the ambient
+    /// `XDG_CACHE_HOME`/`$HOME` chain, the host sweep would walk the server
+    /// pod's ephemeral container layer instead of the PVC — the leak these
+    /// accessors were added to close.
+    ///
+    /// Neutralization check: `cache_root_from` is the *only* input path, and it
+    /// takes no `XDG_CACHE_HOME`. Every XDG accessor must hang off it, so a
+    /// server pod (`DJINN_HOME=/var/lib/djinn`, `HOME=/home/djinn`,
+    /// `XDG_CACHE_HOME` unset) resolves the PVC mount and never
+    /// `/home/djinn/.cache`, whatever the ambient environment says.
+    #[test]
+    fn xdg_host_accessors_ignore_the_ambient_xdg_and_home_chain() {
+        let server_pod_cache = cache_root_from(
+            Some(PathBuf::from("/var/lib/djinn")),
+            Some(PathBuf::from("/home/djinn")),
+        );
+        assert_eq!(server_pod_cache, PathBuf::from("/var/lib/djinn/cache"));
+        assert!(
+            !server_pod_cache.starts_with("/home/djinn/.cache"),
+            "the server pod's cache root must never be the ephemeral $HOME/.cache tree"
+        );
+
+        for path in [
+            xdg_cache_root(),
+            output_stash_root(),
+            scip_indexer_cache_root(),
+        ] {
+            assert!(
+                path.starts_with(cache_root()),
+                "{} must live under the host cache root {}",
+                path.display(),
+                cache_root().display()
+            );
+            if let Some(xdg) = std::env::var_os("XDG_CACHE_HOME") {
+                assert!(
+                    !path.starts_with(PathBuf::from(xdg)),
+                    "{} must not resolve through the ambient XDG_CACHE_HOME",
+                    path.display()
+                );
+            }
+        }
+        assert_eq!(xdg_cache_root(), cache_root().join("xdg"));
+    }
+
+    /// The Job pod writes `$XDG_CACHE_HOME/djinn/{output_stash,scip-indexer}`
+    /// where `$XDG_CACHE_HOME = /cache/xdg/<project_id>`. The host's view of
+    /// that exact tree must be `cache_root()/xdg/<project_id>/djinn/…` — and
+    /// must never collapse onto the Job-pod `/cache` literal.
+    #[test]
+    fn project_xdg_accessors_mirror_the_job_pod_layout_under_the_host_mount() {
+        let project = "019ea3bd-a305-73e3-806c-4edcc96ebfe2";
+        let project_xdg = project_xdg_cache_dir(project);
+        assert_eq!(project_xdg, cache_root().join("xdg").join(project));
+
+        assert_eq!(
+            output_stash_dir_under(&project_xdg),
+            project_xdg.join("djinn").join("output_stash")
+        );
+        assert_eq!(
+            scip_indexer_cache_dir_under(&project_xdg),
+            project_xdg.join("djinn").join("scip-indexer")
+        );
+
+        for (host, job_pod_literal) in [
+            (
+                output_stash_dir_under(&project_xdg),
+                format!("/cache/xdg/{project}/djinn/output_stash"),
+            ),
+            (
+                scip_indexer_cache_dir_under(&project_xdg),
+                format!("/cache/xdg/{project}/djinn/scip-indexer"),
+            ),
+        ] {
+            assert_ne!(
+                host,
+                PathBuf::from(&job_pod_literal),
+                "host accessor must not resolve to the Job-pod path {job_pod_literal}"
+            );
+        }
     }
 }

--- a/server/crates/djinn-graph/src/scip_indexer/cache.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/cache.rs
@@ -415,19 +415,36 @@ impl ScipCacheStore {
     }
 }
 
-fn resolve_cache_root_from_env(mut get_env: impl FnMut(&str) -> Option<String>) -> PathBuf {
+fn resolve_cache_root_from_env(get_env: impl FnMut(&str) -> Option<String>) -> PathBuf {
+    resolve_cache_root_with(get_env, djinn_core::paths::scip_indexer_cache_root)
+}
+
+/// Resolution order for the SCIP indexer cache root:
+///
+/// 1. `$DJINN_SCIP_CACHE_DIR` — explicit override (tests, ad-hoc runs).
+/// 2. `$XDG_CACHE_HOME/djinn/scip-indexer` — the **Job-pod** answer. `djinn_k8s`
+///    renders `XDG_CACHE_HOME=/cache/xdg/{project_id}`, putting the cache on the
+///    shared cache PVC. This leg is correct there and only there.
+/// 3. `host_root()` — [`djinn_core::paths::scip_indexer_cache_root`], the
+///    caller's own mount of that same PVC (`$DJINN_HOME/cache/djinn/scip-indexer`
+///    in the server pod).
+///
+/// The legs this replaced were `$HOME/.cache/djinn/scip-indexer` — which in the
+/// server pod is `/home/djinn/.cache`, an ephemeral container-layer path that
+/// does not exist there at all — and, with `$HOME` unset, a **cwd-relative**
+/// `.cache/djinn/scip-indexer`, which scatters cache state into whatever
+/// directory the process was started in.
+fn resolve_cache_root_with(
+    mut get_env: impl FnMut(&str) -> Option<String>,
+    host_root: impl FnOnce() -> PathBuf,
+) -> PathBuf {
     if let Some(path) = get_env(CACHE_DIR_ENV).filter(|value| !value.is_empty()) {
         return PathBuf::from(path);
     }
     if let Some(path) = get_env("XDG_CACHE_HOME").filter(|value| !value.is_empty()) {
         return PathBuf::from(path).join(DEFAULT_CACHE_SUFFIX);
     }
-    if let Some(path) = get_env("HOME").filter(|value| !value.is_empty()) {
-        return PathBuf::from(path)
-            .join(".cache")
-            .join(DEFAULT_CACHE_SUFFIX);
-    }
-    PathBuf::from(".cache").join(DEFAULT_CACHE_SUFFIX)
+    host_root()
 }
 
 fn version_override_env_name(indexer: SupportedIndexer) -> String {
@@ -629,29 +646,81 @@ mod tests {
     }
 
     #[test]
-    fn cache_root_prefers_explicit_env_then_xdg_then_home() {
+    fn cache_root_prefers_explicit_env_then_xdg_then_host_mount() {
+        let host_root = || PathBuf::from("/var/lib/djinn/cache").join(DEFAULT_CACHE_SUFFIX);
+
         assert_eq!(
-            resolve_cache_root_from_env(|name| match name {
-                CACHE_DIR_ENV => Some("/cache/scip".to_string()),
-                _ => None,
-            }),
+            resolve_cache_root_with(
+                |name| match name {
+                    CACHE_DIR_ENV => Some("/cache/scip".to_string()),
+                    _ => None,
+                },
+                host_root
+            ),
             PathBuf::from("/cache/scip")
         );
+        // Job pods: `XDG_CACHE_HOME=/cache/xdg/{project_id}` is the PVC.
         assert_eq!(
-            resolve_cache_root_from_env(|name| match name {
-                "XDG_CACHE_HOME" => Some("/xdg".to_string()),
-                "HOME" => Some("/home/me".to_string()),
-                _ => None,
-            }),
-            PathBuf::from("/xdg").join(DEFAULT_CACHE_SUFFIX)
+            resolve_cache_root_with(
+                |name| match name {
+                    "XDG_CACHE_HOME" => Some("/cache/xdg/proj".to_string()),
+                    "HOME" => Some("/home/djinn".to_string()),
+                    _ => None,
+                },
+                host_root
+            ),
+            PathBuf::from("/cache/xdg/proj").join(DEFAULT_CACHE_SUFFIX)
         );
-        assert_eq!(
-            resolve_cache_root_from_env(|name| match name {
-                "HOME" => Some("/home/me".to_string()),
-                _ => None,
-            }),
-            PathBuf::from("/home/me/.cache").join(DEFAULT_CACHE_SUFFIX)
-        );
+    }
+
+    /// Regression for the `$HOME`-relative leak: with `XDG_CACHE_HOME` unset —
+    /// which is exactly the server/coordinator pod, since `XDG_CACHE_HOME` is
+    /// rendered only into Job specs — the root must come from the host's own
+    /// cache mount, NOT from `$HOME/.cache` and NOT from a cwd-relative
+    /// `.cache`. Both of those resolve to a tree the SCIP artifacts are not in.
+    #[test]
+    fn cache_root_never_falls_back_to_home_or_the_current_directory() {
+        let host_root = PathBuf::from("/var/lib/djinn/cache").join(DEFAULT_CACHE_SUFFIX);
+
+        for env in [
+            // Server pod: HOME set, XDG unset.
+            Some("/home/djinn".to_string()),
+            // Nothing set at all: the old code returned a relative `.cache/…`.
+            None,
+        ] {
+            let resolved = resolve_cache_root_with(
+                |name| match name {
+                    "HOME" => env.clone(),
+                    _ => None,
+                },
+                || host_root.clone(),
+            );
+            assert_eq!(resolved, host_root);
+            assert!(
+                resolved.is_absolute(),
+                "{} must be absolute; a cwd-relative cache root scatters state",
+                resolved.display()
+            );
+            assert!(
+                !resolved.starts_with("/home/djinn/.cache"),
+                "{} must not resolve into the ephemeral $HOME/.cache tree",
+                resolved.display()
+            );
+        }
+    }
+
+    /// The production accessor must resolve through `djinn_core::paths`, so it
+    /// tracks whichever mount the calling pod actually has.
+    #[test]
+    fn production_cache_root_resolves_through_djinn_core_paths() {
+        let prior = std::env::var("XDG_CACHE_HOME").ok();
+        let prior_override = std::env::var(CACHE_DIR_ENV).ok();
+        if prior.is_none() && prior_override.is_none() {
+            assert_eq!(
+                resolve_cache_root_from_env(|name| std::env::var(name).ok()),
+                djinn_core::paths::scip_indexer_cache_root()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The bug: an `XDG_CACHE_HOME` asymmetry

`XDG_CACHE_HOME` is rendered **only into Job pods** — `djinn-k8s/src/job.rs` sets it to `/cache/xdg/<project_id>`. It is set **nowhere** for the server/coordinator pod (`grep -rn XDG_CACHE_HOME deploy/helm/djinn/templates/` is empty).

Verified in production (2026-07-27, `djinn-server-6fffb6ccf4-7j5s7`):

```
HOME=/home/djinn   DJINN_HOME=/var/lib/djinn   XDG_CACHE_HOME=<unset>
$ ls /home/djinn/.cache
ls: cannot access '/home/djinn/.cache': No such file or directory
```

So any `$XDG_CACHE_HOME → $HOME/.cache` chain resolves the cache PVC in a Job pod and a **nonexistent path** in the server pod. Same class as the four hardcoded-`/cache` bugs in #2660.

## Leak 1 — the durable output-stash GC swept a tree the data never lands in — CONFIRMED

Production log, every coordinator tick:

```json
{"message":"CoordinatorActor: output-stash GC completed",
 "root":"/home/djinn/.cache/djinn/output_stash","retention_days":30,
 "pointers_scanned":0,"pointers_deleted":0,"blobs_scanned":0,"blobs_deleted":0,
 "error_count":0,"cleanup_outcome":"completed"}
```

`scan_pointers` maps `NotFound` to "nothing to do", so this success line is indistinguishable from an empty stash. **The 30-day retention has never once been applied to a real blob.**

Meanwhile, on the cache PVC (host `/var/lib/rancher/k3s/storage/pvc-…_djinn_djinn-cache`):

| tree | size |
|---|---|
| `xdg/<project>/djinn/output_stash` (un-GC'd) | **4.4 GiB** (1274 blobs, 1582 id-pointers) |
| `xdg/<project>/djinn/scip-indexer` (no GC at all) | **4.1 GiB** |
| `xdg/` total | 9.1 GiB |
| whole cache PVC | 83 GiB (host disk 66% full) |

Oldest blob is dated 2026-07-25 — the `XDG_CACHE_HOME` rendering itself is recent — so **4.4 GiB accumulated in ~2 days** with a 30-day retention window that cannot fire.

**Fix:** the sweep now enumerates the per-project Job-pod roots through `djinn_core::paths` — `cache_root()/xdg/*/djinn/output_stash` — which is the server pod's view of the same claim. `job.rs` already documented that this needs no new volume plumbing; nothing implemented it.

## Leak 2 — SCIP indexer cache root — PARTIALLY CONFIRMED, one premise contradicted

`resolve_cache_root_from_env` fell back to `$HOME/.cache/djinn/scip-indexer` and then to a **cwd-relative** `.cache/djinn/scip-indexer`. Both are wrong for any host-side caller. Fixed: the non-XDG legs now resolve `djinn_core::paths::scip_indexer_cache_root()`.

**Contradiction, stated plainly:** the "permanent cross-pod cache miss" is *not* happening in production today. The deployed warmer is `K8sGraphWarmer` (348 log hits; zero `ensure_canonical_graph` lines in the server), and `/home/djinn/.cache` does not exist in the server pod — proof that no server-pod process has ever written a SCIP cache entry or a warm sentinel. SCIP indexing runs only in warm Job pods, where the XDG leg is correct. What remains real: (a) the fallback was wrong-by-construction for any host-side caller, now latent-fixed; (b) the cwd-relative last resort; (c) **there is still no GC of any kind on the 4.1 GiB scip-indexer tree** — deliberately out of scope here, since adding one means shipping a second untested destructive sweep. Filed as follow-up work below.

## Dormant deletion: report-only, not armed

Correcting Leak 1's path arms a `remove_file` loop that has **never run**. The operational evidence authorising it ("30-day retention has been fine for months") was collected against a nonexistent directory and is structurally empty — the exact trap `sccache_delete_armed` documents from #2660.

This PR ships **report-only**. Deletion requires *both* `DJINN_CACHE_CLEANUP_MODE=delete` **and** the new `DJINN_CACHE_CLEANUP_OUTPUT_STASH_DELETE_ARMED=true` (default `false`, no Helm change). Until armed, the sweep scans the corrected roots and logs `mode=report_only` with real candidate counts, so operators can size the sweep against live data before authorising it. `report_only_mode_counts_candidates_but_unlinks_nothing` asserts the **side effect** — the files still exist — not the report label, and `delete_mode_actually_unlinks_the_same_candidates` proves the assertion is about the mode and not an inert GC.

## Test-suite footgun: `remove_dir_all` on a developer's real `~/.djinn/cache`

`test_helpers.rs` left `cargo_target_runs_root: None`, and four sub-sweeps of `sweep_stale_resources` took no root at all — they called `djinn_core::paths::*()` directly, which on a developer machine is the real `~/.djinn/cache`. Two of those sweeps call `remove_dir_all` in delete mode. `tests/session_reaping.rs` invokes `sweep_stale_resources` for real.

Fixed structurally: `CoordinatorContext` gained `host_cache_root`, every cache sweep derives its root from it, and the test context pins all of them under one per-binary tempdir. `test_coordinator_context_confines_every_cache_sweep_to_a_tempdir` fails if anyone unsets it.

## Also fixed

Both `durable_root()` copies (`djinn-coordinator` and `djinn-agent`) now fall back to `paths::output_stash_root()` instead of `$HOME/.cache`. In Job pods nothing changes (XDG wins); in the server pod, stash writes move from an ephemeral container layer to the PVC — which is what the doc-comment claimed and what makes them GC-able.

## Neutralization results

Each regression was verified by reintroducing the bug and confirming the test goes red:

| neutralization | test |
|---|---|
| `xdg_cache_root()` → `~/.cache/xdg` | `paths::xdg_host_accessors_ignore_the_ambient_xdg_and_home_chain` FAILED, `paths::project_xdg_accessors_mirror_the_job_pod_layout_under_the_host_mount` FAILED |
| SCIP `$HOME/.cache` + cwd legs restored | `cache_root_never_falls_back_to_home_or_the_current_directory` FAILED |
| `durable_root_from` → `$HOME/.cache` | `durable_root_falls_back_to_the_host_mount_not_home_cache` FAILED |
| `remove_unless_report_only` always unlinks | `report_only_mode_counts_candidates_but_unlinks_nothing` FAILED |
| `host_cache_root: None` in the test context | `test_coordinator_context_confines_every_cache_sweep_to_a_tempdir` FAILED |

All restored and green afterwards. The pure-derivation helpers (`cache_root_from`, `durable_root_from`, `resolve_cache_root_with`) deliberately take **no `$HOME` parameter**, so a reintroduced `$HOME`-relative fallback cannot even satisfy the signature.

## Siblings found (reported, not fixed)

Same bug class, still open — all resolve `$HOME`/cwd in server-pod code:

- `server/src/server/state/mod.rs` — sessions dir via `dirs::home_dir()` with a **cwd-relative `"."` fallback**; a mkdir failure `return`s early and silently skips `initialize_agents` entirely. Highest severity of the set.
- `server/src/logging.rs` — `logs_dir()` = `$HOME/.djinn/logs` (ephemeral layer, not the PVC) behind a hard `.expect()`.
- `djinn-sandbox/src/lib.rs` — `djinn_cache_dir()` XDG→`$HOME/.cache/djinn`; `prepare_cache_dir` creates and Landlock-allows the wrong tree in the server pod. Its `writable_roots` list also hardcodes `/cache`, which never matches in the server pod.
- `djinn-provider/src/oauth/{codex,copilot}.rs` — token caches at `$HOME/.djinn/oauth`, cwd-relative fallback.
- `djinn-lsp/src/server_config.rs` — `djinn_bin_dir()` via `dirs::data_dir()`; with `$HOME` unset it becomes the rooted `/.local/share/djinn/bin`.
- `djinn-agent/src/task_merge.rs:224` — `paths::project_dir()` called from Job-pod code (`supervisor_impl/stage.rs` → `worker_execute_stage`), where `DJINN_HOME` is unset. It even prefers the derived path over the real `worktree_path`. Currently latent: the consumer parameter is `_project_path`, unused.
- `djinn-agent/src/task_confidence.rs` (tests) — `create_dir_all(paths::project_dir(..))` writes into a developer's real `~/.djinn/projects/`. Creates only, never deletes.
- **No SCIP-cache GC** on the 4.1 GiB tree, plus a warm-sentinel cleanup that has only ever run against Job-pod-local state.

The `llm_extraction.rs:1738` lead does **not** hold: its only caller chain runs through `supervisor_runner`, which is annotated `HOST-ONLY`, so it executes in the server pod where `DJINN_HOME` is set and the path is correct.

## Verification

`cargo fmt`, `cargo clippy --all-targets` (no new diagnostics in touched files), `scripts/check-file-size.sh` clean. No SQL changed, so no `sqlx prepare`.

- `djinn-graph --lib`: 639 passed.
- `djinn-agent --lib`: 1443 passed.
- `djinn-coordinator --lib`: 2055 passed, 2 failed — `tests::session_reaping::{expired_owner_group_reap_redispatches_after_reaping_each_eligible_group, spawn_failed_dispatch_orphan_reaches_no_pr_terminal_cap_live}`. Both pass in isolation; they assert over the **process-wide** Prometheus render and are polluted by `deploy_interruptions_environmental.rs` emitting `source="environmental_restart_orphan"`. Neither file is touched by this PR — the known shared-metrics-registry whole-crate failure mode.
- `djinn-core --lib`: 395 passed, 1 failed — `cargo_target_runs::tests::joint_trim_reports_over_budget_error_when_removal_fails`, deterministic. **Pre-existing on `main`**: `git diff origin/main -- crates/djinn-core` touches only `paths.rs`, and the failing path (`trim_cargo_target_runs_with_fs` + a hermetic mock `Filesystem`) contains zero `paths::` references.
- `rules::tests::*` stack-overflows under plain debug `cargo test`; clears with `RUST_MIN_STACK=33554432` (known).

## Rollout

1. Merge. The sweep starts reporting real candidate counts against the corrected roots on the next tick, deleting nothing.
2. Observe `mode=report_only` counts for a retention window's worth of ticks.
3. Only then set `DJINN_CACHE_CLEANUP_OUTPUT_STASH_DELETE_ARMED=true` (with `DJINN_CACHE_CLEANUP_MODE=delete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
