### PR TITLE
feat(cache): report unrecognised cache roots and orphaned tenant namespaces

### DIFF
--- a/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_target_seed.rs
@@ -94,13 +94,18 @@ const DEFAULT_LINK_FALLBACK_COPY_BUDGET_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const LINK_FALLBACK_COPY_BUDGET_ENV: &str = "DJINN_CARGO_TARGET_SEED_LINK_FALLBACK_COPY_BYTES";
 
 /// Filesystem convention for the warm, per-project Cargo target base.
-pub const WARM_BASE_ROOT: &str = "/cache/cargo-target";
+///
+/// Resolved from the cache-root manifest rather than written out, so this root
+/// cannot exist without a manifest entry describing it.
+pub const WARM_BASE_ROOT: &str = djinn_core::paths::CacheRootId::CargoTarget.job_pod_path();
 
 /// Existing pod environment selector for the Cargo/mold parallelism variant.
 pub const CARGO_BUILD_JOBS_ENV: &str = "CARGO_BUILD_JOBS";
 
 /// Filesystem convention for private, per-task-run Cargo target directories.
-pub const RUN_TARGET_ROOT: &str = "/cache/cargo-target-runs";
+///
+/// Resolved from the cache-root manifest, like [`WARM_BASE_ROOT`].
+pub const RUN_TARGET_ROOT: &str = djinn_core::paths::CacheRootId::CargoTargetRuns.job_pod_path();
 
 /// Implementation used to hardlink one base artifact into the run dir.
 ///

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -564,6 +564,15 @@ impl CoordinatorActor {
             Arc::clone(&closed_parent_open_children_source)
                 as Arc<dyn crate::doctor::ClosedParentOpenChildrenRepairSource>,
         );
+        // Read-only cache-root manifest detector. On-demand cadence: it stats
+        // the cache PVC and walks candidates, which is too expensive for the
+        // cheap periodic subset. It has no fix path.
+        crate::doctor::register_stale_cache_roots_check(
+            djinn_core::doctor::registry(),
+            Arc::new(crate::doctor::ProjectRepositoryStaleCacheRootsSource::new(
+                db.clone(),
+            )),
+        );
         crate::doctor::register_refinement_phantom_active_check(
             djinn_core::doctor::registry(),
             Arc::new(

--- a/server/crates/djinn-coordinator/src/doctor/mod.rs
+++ b/server/crates/djinn-coordinator/src/doctor/mod.rs
@@ -21,6 +21,7 @@ pub mod live_mover;
 pub mod mismatch_scan;
 pub mod refinement_phantom_active;
 pub mod retrieval_health;
+pub mod stale_cache_roots;
 pub mod stranded_ready;
 
 use std::sync::Arc;
@@ -37,6 +38,12 @@ pub use refinement_phantom_active::{
     MemoryRefinementPhantomActiveSource, ProposalRepositoryRefinementPhantomActiveSource,
     REFINEMENT_PHANTOM_ACTIVE_CHECK_NAME, RefinementPhantomActiveCheck,
     RefinementPhantomActiveSource,
+};
+pub use stale_cache_roots::{
+    CacheObservation, CacheObservationClass, CacheScanConfig, CacheScanReport, LiveProjectSet,
+    MemoryStaleCacheRootsSource, ProjectRepositoryStaleCacheRootsSource,
+    STALE_CACHE_ROOTS_CHECK_NAME, StaleCacheRootsCheck, StaleCacheRootsSource,
+    scan_cache_roots_under, scan_production_cache_root,
 };
 pub use stranded_ready::{
     MemoryStrandedReadySource, STRANDED_READY_CHECK_NAME, StrandedReadyCandidate,
@@ -114,6 +121,17 @@ pub fn register_closed_parent_open_children_check_with_repair(
     registry.register(Arc::new(
         ClosedParentOpenChildrenCheck::new(source).with_repair_source(repair_source),
     ))
+}
+
+/// Register the read-only cache-root manifest detector.
+///
+/// The check reports; it has no fix path at all, so registering it can never
+/// arm a deletion.
+pub fn register_stale_cache_roots_check(
+    registry: &DoctorRegistry,
+    source: Arc<dyn StaleCacheRootsSource>,
+) -> Option<String> {
+    registry.register(Arc::new(StaleCacheRootsCheck::new(source)))
 }
 
 /// Register the read-only exact-run phantom refinement detector.

--- a/server/crates/djinn-coordinator/src/doctor/stale_cache_roots.rs
+++ b/server/crates/djinn-coordinator/src/doctor/stale_cache_roots.rs
@@ -1,0 +1,948 @@
+//! Report-only detector for cache directories nothing points at any more.
+//!
+//! # Why an allowlist
+//!
+//! Every other cache cleanup in this crate is a *denylist*: one hardcoded guard
+//! per remembered path (the sccache guard, the warm-base idle GC, the
+//! cargo-debris sweep, the pressure sweep). A denylist can only clean paths
+//! somebody enumerated, so a retired cache root is invisible to it *by
+//! construction* — which is how `/cache/sccache` sat at 6.1 GB for forty days
+//! with nothing writing it.
+//!
+//! This check inverts that. [`djinn_core::paths::CacheRootId`] is a closed,
+//! macro-generated manifest of every cache root djinn actually uses; anything
+//! under the cache root that is not in the manifest is reported. New junk is
+//! caught without anyone having predicted it.
+//!
+//! # Two kinds of stale
+//!
+//! - **An unrecognised root** — a whole subsystem that was retired, or a
+//!   directory an ad-hoc command dropped on the PVC.
+//! - **An orphaned tenant namespace** — a *recognised* root containing a
+//!   per-project namespace for a project that no longer exists in the database.
+//!   On a shared, multi-tenant deployment this is the recurring case: removing
+//!   a project leaves its warm base, sccache and XDG namespaces behind forever.
+//!
+//! # Report-only, by construction
+//!
+//! There is no deletion path here at all — not a disabled one, not an
+//! arming flag. `fix` is the trait default (`FixNotSupported`). PR #2660 found
+//! that sccache deletion had already been "authorised" by a dry-run watching a
+//! path that does not exist in the server pod, so the authorising evidence was
+//! structurally guaranteed to be empty. A detector that cannot delete cannot be
+//! armed on vacuous evidence.
+//!
+//! # Fail-closed reconciliation
+//!
+//! Claiming a namespace is orphaned means claiming its owner is *gone*. A false
+//! positive here, if anyone ever acted on it, deletes every warm base on the
+//! deployment. So the reconciliation only ever narrows:
+//!
+//! - a transient enumeration failure yields **no** orphan claims;
+//! - an **empty** project enumeration also yields no orphan claims, because an
+//!   empty result is indistinguishable from a mis-scoped query — the price is
+//!   that a genuinely projectless deployment never reports orphans;
+//! - names the manifest reserves for djinn's own machinery (`.warm-locks`) are
+//!   never treated as tenant namespaces;
+//! - only *directories* directly under a `PerProject` root are considered.
+//!
+//! Whenever reconciliation is skipped the check says so with an explicit
+//! finding, so a skipped run never reads as a clean run.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use djinn_core::doctor::{
+    DoctorCheck, DoctorCheckCadence, DoctorResult, Finding, FindingSeverity, ResolverSnapshot,
+};
+use djinn_core::paths::{CacheRootId, CacheRootNamespacing};
+use serde::Serialize;
+use serde_json::json;
+use std::sync::Arc;
+
+pub const STALE_CACHE_ROOTS_CHECK_NAME: &str = "cache.stale_roots";
+
+/// Age past which an unrecognised entry, or a declared-but-untouched root, is
+/// worth an operator's attention.
+pub const DEFAULT_IDLE_THRESHOLD_DAYS: u64 = 30;
+
+/// Directory entries a single measurement may visit before it gives up and
+/// reports a lower bound. Bounds the cost of walking a multi-gigabyte tree.
+pub const DEFAULT_ENTRY_BUDGET: usize = 200_000;
+
+const SECONDS_PER_DAY: u64 = 86_400;
+
+/// Tunables for one scan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheScanConfig {
+    pub idle_threshold_days: u64,
+    pub entry_budget: usize,
+}
+
+impl Default for CacheScanConfig {
+    fn default() -> Self {
+        Self {
+            idle_threshold_days: DEFAULT_IDLE_THRESHOLD_DAYS,
+            entry_budget: DEFAULT_ENTRY_BUDGET,
+        }
+    }
+}
+
+impl CacheScanConfig {
+    fn idle_threshold_seconds(self) -> u64 {
+        self.idle_threshold_days.saturating_mul(SECONDS_PER_DAY)
+    }
+}
+
+/// The live tenant set, or a positive statement that it could not be
+/// established. There is deliberately no third "empty but fine" state: see the
+/// module docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LiveProjectSet {
+    /// Positively enumerated and non-empty.
+    Known(BTreeSet<String>),
+    /// Not established. No namespace may be called orphaned.
+    Unavailable { reason: String },
+}
+
+impl LiveProjectSet {
+    /// Build from a completed enumeration. An empty enumeration is treated as
+    /// *unavailable*, not as "every namespace is orphaned".
+    pub fn from_enumeration(ids: impl IntoIterator<Item = String>) -> Self {
+        let ids: BTreeSet<String> = ids.into_iter().collect();
+        if ids.is_empty() {
+            Self::unavailable("empty_project_enumeration")
+        } else {
+            Self::Known(ids)
+        }
+    }
+
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self::Unavailable {
+            reason: reason.into(),
+        }
+    }
+
+    fn known(&self) -> Option<&BTreeSet<String>> {
+        match self {
+            Self::Known(ids) => Some(ids),
+            Self::Unavailable { .. } => None,
+        }
+    }
+}
+
+/// What the scan found at a path, in filesystem terms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheEntryKind {
+    Dir,
+    File,
+    Symlink,
+    Other,
+}
+
+/// Size / recency / ownership facts for one path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Measurement {
+    /// Total bytes of regular files at or under the path. A lower bound when
+    /// `size_truncated` is set.
+    pub size_bytes: u64,
+    /// The walk hit [`CacheScanConfig::entry_budget`] and stopped early.
+    pub size_truncated: bool,
+    /// Newest mtime at or under the path, as a Unix timestamp.
+    pub newest_mtime_unix: Option<u64>,
+    /// Owning uid of the path itself.
+    pub uid: Option<u32>,
+}
+
+/// Why a path was reported.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "class", rename_all = "snake_case")]
+pub enum CacheObservationClass {
+    /// A directory directly under the cache root with no manifest entry.
+    UnrecognisedRoot,
+    /// A non-directory directly under the cache root. The manifest describes
+    /// directories, so any loose file here is by definition undeclared.
+    UnrecognisedEntry,
+    /// A per-project namespace under a declared root whose project is absent
+    /// from a positively-enumerated, non-empty live project set.
+    OrphanedProjectNamespace {
+        root: &'static str,
+        project_id: String,
+    },
+    /// A manifest root that exists but has not been written for longer than the
+    /// idle threshold. Not junk by itself — but if the subsystem was retired,
+    /// this is the signal to delete its manifest entry.
+    DeclaredRootIdle { root: &'static str },
+}
+
+/// One reported path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CacheObservation {
+    /// Path relative to the cache root (`"sccache"`, `"cargo-target/<id>"`).
+    pub relative_path: String,
+    pub kind: CacheEntryKind,
+    #[serde(flatten)]
+    pub class: CacheObservationClass,
+    #[serde(flatten)]
+    pub measurement: Measurement,
+    /// Seconds since `newest_mtime_unix`, at scan time.
+    pub age_seconds: Option<u64>,
+}
+
+impl CacheObservation {
+    fn age_days(&self) -> Option<u64> {
+        self.age_seconds.map(|secs| secs / SECONDS_PER_DAY)
+    }
+}
+
+/// Outcome of the tenant enumeration, carried into the report so a skipped
+/// reconciliation is visible rather than silent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ProjectSetStatus {
+    Known { project_count: usize },
+    Unavailable { reason: String },
+}
+
+/// Everything one scan observed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CacheScanReport {
+    pub cache_root: PathBuf,
+    pub cache_root_exists: bool,
+    pub project_set: ProjectSetStatus,
+    pub idle_threshold_days: u64,
+    pub scanned_at_unix: u64,
+    /// Roots that were reconciled against the live project set. Empty when the
+    /// set was unavailable.
+    pub reconciled_roots: Vec<&'static str>,
+    pub observations: Vec<CacheObservation>,
+}
+
+// ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+/// Scan `cache_root` and classify everything directly under it.
+///
+/// `cache_root` is passed explicitly so the scan is testable against a tempdir;
+/// production callers resolve it through [`djinn_core::paths::cache_root`] and
+/// never hardcode a path (the server pod mounts the cache PVC at
+/// `$DJINN_HOME/cache`, not at the Job-pod `/cache`).
+///
+/// # Granularity
+///
+/// The manifest is about cache *roots*, so the scan classifies the immediate
+/// children of `cache_root` and stops there — except for `PerProject` roots,
+/// where it descends exactly one level to reach tenant namespaces. It never
+/// descends into a `PerRun` root: `cargo-target-runs/<id>` directories are
+/// created and destroyed by every task run, so their contents carry no
+/// staleness signal and a dedicated sweep already owns them.
+pub fn scan_cache_roots_under(
+    cache_root: &Path,
+    live_projects: &LiveProjectSet,
+    now_unix: u64,
+    config: CacheScanConfig,
+) -> CacheScanReport {
+    let project_set = match live_projects {
+        LiveProjectSet::Known(ids) => ProjectSetStatus::Known {
+            project_count: ids.len(),
+        },
+        LiveProjectSet::Unavailable { reason } => ProjectSetStatus::Unavailable {
+            reason: reason.clone(),
+        },
+    };
+    let mut report = CacheScanReport {
+        cache_root: cache_root.to_path_buf(),
+        cache_root_exists: false,
+        project_set,
+        idle_threshold_days: config.idle_threshold_days,
+        scanned_at_unix: now_unix,
+        reconciled_roots: Vec::new(),
+        observations: Vec::new(),
+    };
+
+    let entries = match std::fs::read_dir(cache_root) {
+        Ok(entries) => entries,
+        Err(error) => {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    path = %cache_root.display(),
+                    %error,
+                    "stale_cache_roots: cache root unreadable; reporting nothing"
+                );
+            }
+            return report;
+        }
+    };
+    report.cache_root_exists = true;
+
+    let mut named: Vec<(String, CacheEntryKind)> = Vec::new();
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        named.push((name, entry_kind(&entry)));
+    }
+    named.sort_by(|left, right| left.0.cmp(&right.0));
+
+    for (name, kind) in named {
+        let path = cache_root.join(&name);
+        match (kind, CacheRootId::from_dir_name(&name)) {
+            (CacheEntryKind::Dir, Some(root)) => {
+                classify_declared_root(&mut report, root, &path, live_projects, now_unix, config);
+            }
+            (CacheEntryKind::Dir, None) => {
+                let measurement = measure(&path, config.entry_budget);
+                report.observations.push(observation(
+                    name,
+                    CacheEntryKind::Dir,
+                    CacheObservationClass::UnrecognisedRoot,
+                    measurement,
+                    now_unix,
+                ));
+            }
+            (kind, _) => {
+                // A non-directory directly under the cache root: not a cache
+                // root under any reading of the manifest.
+                let measurement = measure(&path, config.entry_budget);
+                report.observations.push(observation(
+                    name,
+                    kind,
+                    CacheObservationClass::UnrecognisedEntry,
+                    measurement,
+                    now_unix,
+                ));
+            }
+        }
+    }
+
+    report
+}
+
+fn classify_declared_root(
+    report: &mut CacheScanReport,
+    root: CacheRootId,
+    path: &Path,
+    live_projects: &LiveProjectSet,
+    now_unix: u64,
+    config: CacheScanConfig,
+) {
+    // Idleness gate first, and cheaply: only the root's own mtime and its
+    // immediate children's. A live root (cargo-target is tens of gigabytes) is
+    // therefore never deep-walked.
+    if let Some(newest) = shallow_newest_mtime(path) {
+        let age = now_unix.saturating_sub(newest);
+        if age >= config.idle_threshold_seconds() {
+            let measurement = measure(path, config.entry_budget);
+            report.observations.push(observation(
+                root.dir_name().to_owned(),
+                CacheEntryKind::Dir,
+                CacheObservationClass::DeclaredRootIdle {
+                    root: root.dir_name(),
+                },
+                measurement,
+                now_unix,
+            ));
+        }
+    }
+
+    // Exhaustive on purpose: a new namespacing kind (a per-user cache root, say
+    // — none exists today, the only tenant key rendered into a cache path is
+    // `project_id`) must not silently inherit "descend and reconcile against
+    // projects".
+    match root.namespacing() {
+        CacheRootNamespacing::PerProject => {
+            reconcile_project_namespaces(report, root, path, live_projects, now_unix, config);
+        }
+        // Content-addressed across every tenant: nothing under it is
+        // attributable to a project, so nothing under it is reclaimable when a
+        // project goes away.
+        CacheRootNamespacing::Shared => {}
+        // Churn by design; owned by the run-dir sweep.
+        CacheRootNamespacing::PerRun => {}
+    }
+}
+
+fn reconcile_project_namespaces(
+    report: &mut CacheScanReport,
+    root: CacheRootId,
+    path: &Path,
+    live_projects: &LiveProjectSet,
+    now_unix: u64,
+    config: CacheScanConfig,
+) {
+    let Some(live) = live_projects.known() else {
+        // Fail closed: without a positively-established owner set there is no
+        // basis for calling anything orphaned.
+        return;
+    };
+    let entries = match std::fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "stale_cache_roots: namespace root unreadable; skipping reconciliation"
+            );
+            return;
+        }
+    };
+    report.reconciled_roots.push(root.dir_name());
+
+    let mut names: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        // Only directories are namespaces. Anything else under a namespace root
+        // is left alone rather than guessed at.
+        if entry_kind(&entry) != CacheEntryKind::Dir {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        names.push(name);
+    }
+    names.sort();
+
+    for name in names {
+        if root.spec().reserved_children.contains(&name.as_str()) {
+            continue;
+        }
+        if live.contains(&name) {
+            continue;
+        }
+        let child = path.join(&name);
+        let measurement = measure(&child, config.entry_budget);
+        report.observations.push(observation(
+            format!("{}/{name}", root.dir_name()),
+            CacheEntryKind::Dir,
+            CacheObservationClass::OrphanedProjectNamespace {
+                root: root.dir_name(),
+                project_id: name,
+            },
+            measurement,
+            now_unix,
+        ));
+    }
+}
+
+fn observation(
+    relative_path: String,
+    kind: CacheEntryKind,
+    class: CacheObservationClass,
+    measurement: Measurement,
+    now_unix: u64,
+) -> CacheObservation {
+    let age_seconds = measurement
+        .newest_mtime_unix
+        .map(|mtime| now_unix.saturating_sub(mtime));
+    CacheObservation {
+        relative_path,
+        kind,
+        class,
+        measurement,
+        age_seconds,
+    }
+}
+
+fn entry_kind(entry: &std::fs::DirEntry) -> CacheEntryKind {
+    match entry.file_type() {
+        Ok(file_type) if file_type.is_dir() => CacheEntryKind::Dir,
+        Ok(file_type) if file_type.is_file() => CacheEntryKind::File,
+        Ok(file_type) if file_type.is_symlink() => CacheEntryKind::Symlink,
+        Ok(_) => CacheEntryKind::Other,
+        Err(_) => CacheEntryKind::Other,
+    }
+}
+
+fn mtime_unix(metadata: &std::fs::Metadata) -> Option<u64> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|delta| delta.as_secs())
+}
+
+fn uid_of(metadata: &std::fs::Metadata) -> Option<u32> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Some(metadata.uid())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        None
+    }
+}
+
+/// Newest mtime of `path` and its immediate children. Cheap enough to run
+/// against a live multi-gigabyte root on every scan.
+fn shallow_newest_mtime(path: &Path) -> Option<u64> {
+    let mut newest = std::fs::symlink_metadata(path)
+        .ok()
+        .as_ref()
+        .and_then(mtime_unix);
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            if let Some(child) = entry.metadata().ok().as_ref().and_then(mtime_unix) {
+                newest = Some(newest.map_or(child, |current: u64| current.max(child)));
+            }
+        }
+    }
+    newest
+}
+
+/// Total size, newest mtime and owning uid at or under `path`, visiting at most
+/// `entry_budget` directory entries.
+fn measure(path: &Path, entry_budget: usize) -> Measurement {
+    let top = std::fs::symlink_metadata(path).ok();
+    let mut measurement = Measurement {
+        size_bytes: 0,
+        size_truncated: false,
+        newest_mtime_unix: top.as_ref().and_then(mtime_unix),
+        uid: top.as_ref().and_then(uid_of),
+    };
+    let Some(top) = top else {
+        return measurement;
+    };
+    if !top.is_dir() {
+        measurement.size_bytes = top.len();
+        return measurement;
+    }
+
+    let mut visited = 0usize;
+    let mut stack: Vec<PathBuf> = vec![path.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&current) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if visited >= entry_budget {
+                measurement.size_truncated = true;
+                return measurement;
+            }
+            visited += 1;
+            // symlink_metadata: never follow a link out of the cache tree, and
+            // never double-count its target.
+            let Ok(metadata) = entry.path().symlink_metadata() else {
+                continue;
+            };
+            if let Some(mtime) = mtime_unix(&metadata) {
+                measurement.newest_mtime_unix = Some(
+                    measurement
+                        .newest_mtime_unix
+                        .map_or(mtime, |current| current.max(mtime)),
+                );
+            }
+            if metadata.is_dir() {
+                stack.push(entry.path());
+            } else if metadata.is_file() {
+                measurement.size_bytes = measurement.size_bytes.saturating_add(metadata.len());
+            }
+        }
+    }
+    measurement
+}
+
+/// Production entry point: scan the host's own view of the cache PVC.
+///
+/// Resolves through [`djinn_core::paths::cache_root`] and nothing else. The
+/// server pod mounts the claim at `$DJINN_HOME/cache` while Job pods mount it
+/// at `/cache`; a Job-pod literal in server-pod code is a silent no-op, which
+/// is precisely how four cache bugs shipped.
+pub fn scan_production_cache_root(
+    live_projects: &LiveProjectSet,
+    now_unix: u64,
+    config: CacheScanConfig,
+) -> CacheScanReport {
+    scan_cache_roots_under(
+        &djinn_core::paths::cache_root(),
+        live_projects,
+        now_unix,
+        config,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Doctor check
+// ---------------------------------------------------------------------------
+
+/// Read-only source of the latest scan.
+pub trait StaleCacheRootsSource: Send + Sync {
+    /// The most recent report, or `None` when no scan has completed.
+    fn report(&self) -> Option<CacheScanReport>;
+    /// Hook for a source that refreshes at check time.
+    fn refresh_for_run(&self) {}
+}
+
+/// In-memory source for tests.
+pub struct MemoryStaleCacheRootsSource {
+    report: Option<CacheScanReport>,
+}
+
+impl MemoryStaleCacheRootsSource {
+    pub fn new(report: CacheScanReport) -> Self {
+        Self {
+            report: Some(report),
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self { report: None }
+    }
+}
+
+impl StaleCacheRootsSource for MemoryStaleCacheRootsSource {
+    fn report(&self) -> Option<CacheScanReport> {
+        self.report.clone()
+    }
+}
+
+/// Reports cache roots and tenant namespaces nothing points at. Never deletes.
+pub struct StaleCacheRootsCheck {
+    source: Arc<dyn StaleCacheRootsSource>,
+}
+
+impl StaleCacheRootsCheck {
+    pub fn new(source: Arc<dyn StaleCacheRootsSource>) -> Self {
+        Self { source }
+    }
+
+    /// Turn a report into findings. Pure, so the mapping is testable without
+    /// touching a filesystem.
+    pub fn findings_for(report: &CacheScanReport) -> Vec<Finding> {
+        let mut findings = Vec::new();
+        let idle_threshold_seconds = report.idle_threshold_days.saturating_mul(SECONDS_PER_DAY);
+
+        if let ProjectSetStatus::Unavailable { reason } = &report.project_set {
+            // Say so loudly: a skipped reconciliation must never read as a
+            // clean deployment.
+            findings.push(
+                Finding::new(
+                    FindingSeverity::Info,
+                    STALE_CACHE_ROOTS_CHECK_NAME,
+                    ResolverSnapshot::new(
+                        "resolve_stale_cache_roots",
+                        json!({
+                            "cache_root": report.cache_root,
+                            "project_set": report.project_set,
+                        }),
+                        json!({
+                            "namespace_reconciliation": "skipped",
+                            "reason": reason,
+                        }),
+                    ),
+                    format!(
+                        "per-project cache namespace reconciliation was skipped ({reason}); \
+                         no namespace under {} is claimed orphaned",
+                        report.cache_root.display()
+                    ),
+                )
+                .with_entity_id("cache_root", report.cache_root.display().to_string())
+                .with_evidence(json!({
+                    "cache_root": report.cache_root,
+                    "reason": reason,
+                    "reconciled_roots": report.reconciled_roots,
+                })),
+            );
+        }
+
+        for observation in &report.observations {
+            findings.push(Self::finding_for(
+                report,
+                observation,
+                idle_threshold_seconds,
+            ));
+        }
+        findings
+    }
+
+    fn finding_for(
+        report: &CacheScanReport,
+        observation: &CacheObservation,
+        idle_threshold_seconds: u64,
+    ) -> Finding {
+        let stale = observation
+            .age_seconds
+            .is_some_and(|age| age >= idle_threshold_seconds);
+        let age_days = observation.age_days();
+        let size = observation.measurement.size_bytes;
+        let at_least = if observation.measurement.size_truncated {
+            "at least "
+        } else {
+            ""
+        };
+        let uid = observation.measurement.uid;
+
+        let (severity, detail) = match &observation.class {
+            CacheObservationClass::UnrecognisedRoot => (
+                if stale {
+                    FindingSeverity::Warn
+                } else {
+                    FindingSeverity::Info
+                },
+                format!(
+                    "{} is not a cache root djinn declares ({at_least}{size} bytes, \
+                     last modified {} days ago, uid {})",
+                    observation.relative_path,
+                    render_days(age_days),
+                    render_uid(uid),
+                ),
+            ),
+            CacheObservationClass::UnrecognisedEntry => (
+                if stale {
+                    FindingSeverity::Warn
+                } else {
+                    FindingSeverity::Info
+                },
+                format!(
+                    "{} is a loose {:?} at the cache root, not a declared cache root \
+                     ({at_least}{size} bytes, last modified {} days ago, uid {})",
+                    observation.relative_path,
+                    observation.kind,
+                    render_days(age_days),
+                    render_uid(uid),
+                ),
+            ),
+            CacheObservationClass::OrphanedProjectNamespace { root, project_id } => (
+                FindingSeverity::Warn,
+                format!(
+                    // Deliberately does not assert that `project_id` IS a
+                    // project — only that it is not one of the live ones. A
+                    // stray directory placed under a namespace root reads
+                    // correctly under this wording; "project X was deleted"
+                    // would not.
+                    "{root} holds the namespace {project_id}, which is not in the live project \
+                     set ({at_least}{size} bytes, last modified {} days ago, uid {})",
+                    render_days(age_days),
+                    render_uid(uid),
+                ),
+            ),
+            CacheObservationClass::DeclaredRootIdle { root } => (
+                FindingSeverity::Info,
+                format!(
+                    "{root} is declared in the cache-root manifest but has not been written for \
+                     {} days ({at_least}{size} bytes, uid {}); if the subsystem was retired, \
+                     remove its manifest entry",
+                    render_days(age_days),
+                    render_uid(uid),
+                ),
+            ),
+        };
+
+        let inputs = json!({
+            "cache_root": report.cache_root,
+            "relative_path": observation.relative_path,
+            "manifest": CacheRootId::ALL
+                .iter()
+                .map(|root| root.dir_name())
+                .collect::<Vec<_>>(),
+            "project_set": report.project_set,
+            "idle_threshold_days": report.idle_threshold_days,
+        });
+        let outputs = serde_json::to_value(observation).unwrap_or(serde_json::Value::Null);
+        let mut finding = Finding::new(
+            severity,
+            STALE_CACHE_ROOTS_CHECK_NAME,
+            ResolverSnapshot::new("resolve_stale_cache_roots", inputs, outputs.clone()),
+            detail,
+        )
+        .with_entity_id("cache_root", report.cache_root.display().to_string())
+        .with_entity_id("relative_path", observation.relative_path.clone())
+        .with_evidence(json!({
+            "cache_root": report.cache_root,
+            "observation": outputs,
+            "scanned_at_unix": report.scanned_at_unix,
+            "reconciled_roots": report.reconciled_roots,
+        }));
+        if let CacheObservationClass::OrphanedProjectNamespace { project_id, .. } =
+            &observation.class
+        {
+            finding = finding.with_entity_id("project_id", project_id.clone());
+        }
+        finding
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Production source
+// ---------------------------------------------------------------------------
+
+/// Page size for the project enumeration. `list_ids_page_after` is the bounded
+/// keyset API background jobs are required to use.
+const PROJECT_PAGE_SIZE: i64 = 500;
+
+/// Production source: enumerates the live project set through the repository
+/// layer, then scans the host cache root.
+pub struct ProjectRepositoryStaleCacheRootsSource {
+    db: djinn_db::Database,
+    config: CacheScanConfig,
+    cache: std::sync::RwLock<Option<CacheScanReport>>,
+}
+
+impl ProjectRepositoryStaleCacheRootsSource {
+    pub fn new(db: djinn_db::Database) -> Self {
+        Self {
+            db,
+            config: CacheScanConfig::default(),
+            cache: std::sync::RwLock::new(None),
+        }
+    }
+
+    /// Enumerate every project id, or fail closed.
+    ///
+    /// "Every" is load-bearing: this is a shared, multi-tenant board, so the
+    /// enumeration must not be scoped to a user, a project, or an activity
+    /// window. A namespace is only orphaned relative to a *complete* owner set,
+    /// so a partial page walk aborts the whole reconciliation rather than
+    /// shrinking the set it compares against.
+    async fn enumerate_live_projects(&self) -> LiveProjectSet {
+        // Read-only enumeration: a noop bus, so this detector can never emit a
+        // domain event as a side effect of looking.
+        let repo =
+            djinn_db::ProjectRepository::new(self.db.clone(), djinn_core::events::EventBus::noop());
+        let mut ids: Vec<String> = Vec::new();
+        let mut cursor: Option<String> = None;
+        loop {
+            match repo
+                .list_ids_page_after(cursor.as_deref(), PROJECT_PAGE_SIZE)
+                .await
+            {
+                Ok(page) => {
+                    let Some(last) = page.last().cloned() else {
+                        break;
+                    };
+                    ids.extend(page);
+                    cursor = Some(last);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "stale_cache_roots: project enumeration failed; \
+                         no cache namespace will be claimed orphaned"
+                    );
+                    return LiveProjectSet::unavailable(format!(
+                        "project_enumeration_failed: {error}"
+                    ));
+                }
+            }
+        }
+        // An empty result is indistinguishable from a mis-scoped query, so
+        // `from_enumeration` downgrades it to Unavailable.
+        LiveProjectSet::from_enumeration(ids)
+    }
+
+    /// Refresh the cached report. Errors are absorbed into the report's own
+    /// fail-closed state rather than surfaced, so a check run always has an
+    /// interpretable answer.
+    pub async fn refresh(&self) {
+        let live = self.enumerate_live_projects().await;
+        let config = self.config;
+        let now: u64 = time::OffsetDateTime::now_utc()
+            .unix_timestamp()
+            .try_into()
+            .unwrap_or(0);
+        let report = match tokio::task::spawn_blocking(move || {
+            scan_production_cache_root(&live, now, config)
+        })
+        .await
+        {
+            Ok(report) => report,
+            Err(error) => {
+                tracing::warn!(%error, "stale_cache_roots: cache scan task failed");
+                return;
+            }
+        };
+        if let Ok(mut guard) = self.cache.write() {
+            *guard = Some(report);
+        }
+    }
+
+    /// Bridge the async refresh into the synchronous `DoctorCheck::run` path.
+    /// Mirrors `refinement_phantom_active`'s established shape.
+    fn refresh_blocking(&self) {
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| handle.block_on(self.refresh()));
+            }
+            Ok(_) => {
+                std::thread::scope(|scope| {
+                    scope.spawn(|| match tokio::runtime::Runtime::new() {
+                        Ok(runtime) => runtime.block_on(self.refresh()),
+                        Err(error) => tracing::warn!(
+                            %error,
+                            "stale_cache_roots: failed to create refresh runtime"
+                        ),
+                    });
+                });
+            }
+            Err(_) => match tokio::runtime::Runtime::new() {
+                Ok(runtime) => runtime.block_on(self.refresh()),
+                Err(error) => {
+                    tracing::warn!(%error, "stale_cache_roots: failed to create refresh runtime")
+                }
+            },
+        }
+    }
+}
+
+impl StaleCacheRootsSource for ProjectRepositoryStaleCacheRootsSource {
+    fn report(&self) -> Option<CacheScanReport> {
+        self.cache.read().ok().and_then(|guard| guard.clone())
+    }
+
+    fn refresh_for_run(&self) {
+        self.refresh_blocking();
+    }
+}
+
+fn render_days(age_days: Option<u64>) -> String {
+    age_days.map_or_else(|| "unknown".to_owned(), |days| days.to_string())
+}
+
+fn render_uid(uid: Option<u32>) -> String {
+    uid.map_or_else(|| "unknown".to_owned(), |uid| uid.to_string())
+}
+
+impl DoctorCheck for StaleCacheRootsCheck {
+    fn name(&self) -> &'static str {
+        STALE_CACHE_ROOTS_CHECK_NAME
+    }
+
+    fn description(&self) -> &'static str {
+        "Reports cache roots absent from the djinn_core::paths manifest and per-project cache \
+         namespaces whose project no longer exists; read-only, never deletes"
+    }
+
+    /// On demand only. The scan stats the filesystem and, for candidates,
+    /// walks them — too expensive for the coordinator's cheap periodic subset.
+    fn cadence(&self) -> DoctorCheckCadence {
+        DoctorCheckCadence::OnDemand
+    }
+
+    fn run(&self) -> DoctorResult<Vec<Finding>> {
+        self.source.refresh_for_run();
+        let Some(report) = self.source.report() else {
+            // No completed scan is not the same as nothing to report.
+            return Ok(vec![
+                Finding::new(
+                    FindingSeverity::Info,
+                    STALE_CACHE_ROOTS_CHECK_NAME,
+                    ResolverSnapshot::new(
+                        "resolve_stale_cache_roots",
+                        json!({ "scan": "unavailable" }),
+                        json!({ "reported": false }),
+                    ),
+                    "cache-root scan has not completed; no cache-root claim is made",
+                )
+                .with_evidence(json!({ "scan": "unavailable" })),
+            ]);
+        };
+        Ok(Self::findings_for(&report))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/crates/djinn-coordinator/src/doctor/stale_cache_roots/tests.rs
+++ b/server/crates/djinn-coordinator/src/doctor/stale_cache_roots/tests.rs
@@ -1,0 +1,512 @@
+//! Tests for the cache-root manifest check.
+//!
+//! Every test drives a real temporary directory tree: the check's whole value
+//! is that it notices things nobody enumerated, so a fake filesystem would
+//! attest the classifier against exactly the cases the author remembered.
+
+use super::*;
+use djinn_core::doctor::{DoctorRegistry, doctor_run};
+use std::fs;
+use std::time::{Duration, SystemTime};
+
+const DAY: u64 = 86_400;
+const NOW: u64 = 1_800_000_000;
+
+fn live(ids: &[&str]) -> LiveProjectSet {
+    LiveProjectSet::from_enumeration(ids.iter().map(|id| (*id).to_owned()))
+}
+
+/// Create `path` with `bytes` of content and an mtime `age_days` in the past.
+fn write_aged_file(path: &Path, bytes: usize, age_days: u64) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, vec![b'x'; bytes]).expect("write file");
+    set_age(path, age_days);
+}
+
+fn set_age(path: &Path, age_days: u64) {
+    let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(NOW - age_days * DAY);
+    let times = fs::FileTimes::new().set_accessed(mtime).set_modified(mtime);
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .or_else(|_| fs::File::open(path))
+        .expect("open for utime");
+    file.set_times(times).expect("set times");
+}
+
+/// Age a directory *after* its contents are in place (writing a child bumps the
+/// directory mtime).
+fn set_dir_age(path: &Path, age_days: u64) {
+    set_age(path, age_days);
+}
+
+fn scan(root: &Path, live: &LiveProjectSet) -> CacheScanReport {
+    scan_cache_roots_under(root, live, NOW, CacheScanConfig::default())
+}
+
+fn classes(report: &CacheScanReport) -> Vec<(String, CacheObservationClass)> {
+    report
+        .observations
+        .iter()
+        .map(|obs| (obs.relative_path.clone(), obs.class.clone()))
+        .collect()
+}
+
+fn find<'a>(report: &'a CacheScanReport, relative_path: &str) -> Option<&'a CacheObservation> {
+    report
+        .observations
+        .iter()
+        .find(|obs| obs.relative_path == relative_path)
+}
+
+// ---------------------------------------------------------------------------
+// (a) unrecognised roots
+// ---------------------------------------------------------------------------
+
+/// The headline case: a directory nobody declared is reported, with the size,
+/// age and uid an operator needs to judge it.
+#[test]
+fn unrecognised_root_is_reported_with_size_age_and_uid() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let retired = root.join("retired-subsystem");
+    write_aged_file(&retired.join("blob-a"), 4_096, 40);
+    write_aged_file(&retired.join("nested/blob-b"), 2_048, 45);
+    set_dir_age(&retired.join("nested"), 40);
+    set_dir_age(&retired, 40);
+
+    let report = scan(root, &live(&["project-live"]));
+
+    let observed = find(&report, "retired-subsystem").expect("unrecognised root reported");
+    assert_eq!(observed.class, CacheObservationClass::UnrecognisedRoot);
+    assert_eq!(observed.kind, CacheEntryKind::Dir);
+    assert_eq!(
+        observed.measurement.size_bytes, 6_144,
+        "size must be the recursive byte total"
+    );
+    assert!(!observed.measurement.size_truncated);
+    assert_eq!(
+        observed.age_seconds,
+        Some(40 * DAY),
+        "age must come from the newest mtime in the tree"
+    );
+    assert!(
+        observed.measurement.uid.is_some(),
+        "owning uid must be reported so an operator can attribute the directory"
+    );
+
+    let findings = StaleCacheRootsCheck::findings_for(&report);
+    let finding = findings
+        .iter()
+        .find(|f| {
+            f.entity_ids.get("relative_path").map(String::as_str) == Some("retired-subsystem")
+        })
+        .expect("finding for the unrecognised root");
+    assert_eq!(finding.severity, FindingSeverity::Warn);
+    assert!(
+        finding.detail.contains("6144") && finding.detail.contains("40 days"),
+        "detail must carry size and age: {}",
+        finding.detail
+    );
+}
+
+/// The inverse assertion, and the one that proves the check is a manifest and
+/// not a match-anything reporter: every declared root is silent.
+#[test]
+fn manifest_roots_are_not_reported() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    for declared in CacheRootId::ALL.iter().copied() {
+        let path = root.join(declared.dir_name());
+        write_aged_file(&path.join("recent-content"), 128, 0);
+        set_dir_age(&path, 0);
+    }
+
+    let report = scan(root, &live(&["project-live"]));
+
+    assert!(
+        report.observations.is_empty(),
+        "a cache root holding only declared, freshly-written roots must be silent, got {:?}",
+        classes(&report)
+    );
+    assert!(StaleCacheRootsCheck::findings_for(&report).is_empty());
+}
+
+/// A loose file at the cache root is not a cache root under any reading of the
+/// manifest. The live PVC has 281 of these.
+#[test]
+fn loose_file_at_the_cache_root_is_reported() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    write_aged_file(&root.join("clippy.log"), 512, 60);
+
+    let report = scan(root, &live(&["project-live"]));
+
+    let observed = find(&report, "clippy.log").expect("loose file reported");
+    assert_eq!(observed.class, CacheObservationClass::UnrecognisedEntry);
+    assert_eq!(observed.kind, CacheEntryKind::File);
+    assert_eq!(observed.measurement.size_bytes, 512);
+    assert_eq!(observed.age_seconds, Some(60 * DAY));
+}
+
+/// A declared root that nothing writes any more is the sccache shape: still in
+/// the manifest, still rendered, but idle. Reported as Info so retiring the
+/// manifest entry becomes a visible decision.
+#[test]
+fn declared_but_idle_root_is_reported_as_info() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let sccache = root.join(CacheRootId::Sccache.dir_name());
+    write_aged_file(&sccache.join("project-live/objects"), 1_024, 40);
+    set_dir_age(&sccache.join("project-live"), 40);
+    set_dir_age(&sccache, 40);
+
+    let cargo = root.join(CacheRootId::Cargo.dir_name());
+    write_aged_file(&cargo.join("registry/index"), 64, 0);
+    set_dir_age(&cargo, 0);
+
+    let report = scan(root, &live(&["project-live"]));
+
+    let observed = find(&report, "sccache").expect("idle declared root reported");
+    assert_eq!(
+        observed.class,
+        CacheObservationClass::DeclaredRootIdle { root: "sccache" }
+    );
+    assert_eq!(observed.measurement.size_bytes, 1_024);
+    assert_eq!(observed.age_seconds, Some(40 * DAY));
+    assert!(
+        find(&report, "cargo").is_none(),
+        "a freshly-written declared root must not be called idle"
+    );
+
+    let findings = StaleCacheRootsCheck::findings_for(&report);
+    let finding = findings
+        .iter()
+        .find(|f| f.entity_ids.get("relative_path").map(String::as_str) == Some("sccache"))
+        .expect("finding for the idle root");
+    assert_eq!(finding.severity, FindingSeverity::Info);
+    assert!(
+        finding.detail.contains("remove its manifest entry"),
+        "detail must point at the retirement action: {}",
+        finding.detail
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (3) per-run churn is not staleness
+// ---------------------------------------------------------------------------
+
+/// `cargo-target-runs/<uuid>` directories are created and destroyed by every
+/// task run. Old ones are normal, not evidence of a retired subsystem, and a
+/// dedicated sweep owns them — the manifest is about roots, not their contents.
+#[test]
+fn per_run_churn_under_a_known_root_is_not_reported() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let runs = root.join(CacheRootId::CargoTargetRuns.dir_name());
+    for (id, age) in [
+        ("019ea3bd-a305-73e3-806c-4edcc96ebfe2", 0),
+        ("019eb111-1111-7111-8111-111111111111", 90),
+    ] {
+        write_aged_file(&runs.join(id).join("debug/build"), 256, age);
+        set_dir_age(&runs.join(id), age);
+    }
+    set_dir_age(&runs, 0);
+
+    let report = scan(root, &live(&["project-live"]));
+
+    assert!(
+        report.observations.is_empty(),
+        "per-run directories must never be reported, got {:?}",
+        classes(&report)
+    );
+    assert!(
+        !report
+            .reconciled_roots
+            .contains(&CacheRootId::CargoTargetRuns.dir_name()),
+        "a PerRun root must never be reconciled against the project set"
+    );
+}
+
+/// Contents of a Shared root are content-addressed across every tenant, so no
+/// child of one is attributable to a project.
+#[test]
+fn shared_root_children_are_never_reconciled() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let cargo = root.join(CacheRootId::Cargo.dir_name());
+    write_aged_file(&cargo.join("registry/serde-1.0.0/lib.rs"), 32, 0);
+    set_dir_age(&cargo, 0);
+
+    let report = scan(root, &live(&["project-live"]));
+
+    assert!(
+        report.observations.is_empty(),
+        "shared cache contents are not tenant namespaces, got {:?}",
+        classes(&report)
+    );
+    assert!(!report.reconciled_roots.contains(&"cargo"));
+}
+
+// ---------------------------------------------------------------------------
+// (b) orphaned per-project namespaces
+// ---------------------------------------------------------------------------
+
+#[test]
+fn orphaned_project_namespace_is_reported_and_live_one_is_not() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let warm = root.join(CacheRootId::CargoTarget.dir_name());
+    write_aged_file(
+        &warm.join("live-project/mold-jobs-4/debug/deps/a.rlib"),
+        900,
+        1,
+    );
+    write_aged_file(
+        &warm.join("gone-project/mold-jobs-4/debug/deps/b.rlib"),
+        700,
+        70,
+    );
+    set_dir_age(&warm.join("gone-project"), 70);
+    // djinn's own flock directory, keyed by project id but reserved.
+    fs::create_dir_all(warm.join(".warm-locks/live-project")).expect("lock dir");
+    set_dir_age(&warm, 1);
+
+    let report = scan(root, &live(&["live-project"]));
+
+    assert_eq!(
+        classes(&report),
+        vec![(
+            "cargo-target/gone-project".to_owned(),
+            CacheObservationClass::OrphanedProjectNamespace {
+                root: "cargo-target",
+                project_id: "gone-project".to_owned(),
+            }
+        )],
+        "only the namespace whose project is absent may be reported"
+    );
+    let observed = find(&report, "cargo-target/gone-project").expect("orphan reported");
+    assert_eq!(observed.measurement.size_bytes, 700);
+    assert_eq!(observed.age_seconds, Some(70 * DAY));
+
+    let findings = StaleCacheRootsCheck::findings_for(&report);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, FindingSeverity::Warn);
+    assert_eq!(
+        findings[0].entity_ids.get("project_id").map(String::as_str),
+        Some("gone-project"),
+        "the owning project id must be on the finding so an operator can check the claim"
+    );
+}
+
+/// Fail-closed #1: a transient enumeration failure must produce no orphan
+/// claim, and must say that it produced none.
+#[test]
+fn unavailable_project_set_claims_no_orphans_and_says_so() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let warm = root.join(CacheRootId::CargoTarget.dir_name());
+    write_aged_file(&warm.join("some-project/mold-jobs-4/x"), 10, 5);
+    set_dir_age(&warm, 5);
+
+    let report = scan(
+        root,
+        &LiveProjectSet::unavailable("project_enumeration_failed: connection reset"),
+    );
+
+    assert!(
+        report.observations.is_empty(),
+        "no namespace may be called orphaned without a live owner set, got {:?}",
+        classes(&report)
+    );
+    assert!(report.reconciled_roots.is_empty());
+
+    let findings = StaleCacheRootsCheck::findings_for(&report);
+    assert_eq!(findings.len(), 1, "the skip must be visible");
+    assert_eq!(findings[0].severity, FindingSeverity::Info);
+    assert!(
+        findings[0].detail.contains("skipped") && findings[0].detail.contains("connection reset"),
+        "the skip finding must name the reason: {}",
+        findings[0].detail
+    );
+}
+
+/// Fail-closed #2: an *empty* enumeration is indistinguishable from a
+/// mis-scoped query. Reporting orphans here would flag every live project's
+/// warm base on the deployment.
+#[test]
+fn empty_project_enumeration_is_treated_as_unavailable() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let warm = root.join(CacheRootId::CargoTarget.dir_name());
+    write_aged_file(&warm.join("project-a/mold-jobs-4/x"), 10, 5);
+    write_aged_file(&warm.join("project-b/mold-jobs-4/x"), 10, 5);
+    set_dir_age(&warm, 5);
+
+    let empty: [&str; 0] = [];
+    let set = live(&empty);
+    assert!(
+        matches!(set, LiveProjectSet::Unavailable { .. }),
+        "an empty enumeration must not become an empty Known set"
+    );
+
+    let report = scan(root, &set);
+    assert!(
+        report.observations.is_empty(),
+        "an empty project set must not orphan every namespace, got {:?}",
+        classes(&report)
+    );
+}
+
+/// Every per-project root is reconciled, not just the one somebody remembered.
+#[test]
+fn every_per_project_root_is_reconciled() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let per_project: Vec<CacheRootId> = CacheRootId::ALL
+        .iter()
+        .copied()
+        .filter(|id| id.namespacing() == CacheRootNamespacing::PerProject)
+        .collect();
+    assert!(
+        per_project.len() >= 2,
+        "manifest must have per-project roots"
+    );
+    for id in &per_project {
+        let path = root.join(id.dir_name()).join("gone-project");
+        write_aged_file(&path.join("content"), 16, 3);
+        set_dir_age(&root.join(id.dir_name()), 3);
+    }
+
+    let report = scan(root, &live(&["live-project"]));
+
+    let mut reported: Vec<String> = report
+        .observations
+        .iter()
+        .map(|obs| obs.relative_path.clone())
+        .collect();
+    reported.sort();
+    let mut expected: Vec<String> = per_project
+        .iter()
+        .map(|id| format!("{}/gone-project", id.dir_name()))
+        .collect();
+    expected.sort();
+    assert_eq!(reported, expected);
+}
+
+// ---------------------------------------------------------------------------
+// path resolution + wiring
+// ---------------------------------------------------------------------------
+
+/// The production entry point must resolve through `djinn_core::paths`, which
+/// mounts the cache PVC at `$DJINN_HOME/cache` in the server pod. A hardcoded
+/// Job-pod `/cache` here would make the whole check a permanent no-op — the
+/// exact bug PR #2660 fixed three times over.
+#[test]
+fn production_scan_resolves_the_cache_root_through_paths() {
+    let report = scan_production_cache_root(
+        &LiveProjectSet::unavailable("test"),
+        NOW,
+        CacheScanConfig::default(),
+    );
+    assert_eq!(report.cache_root, djinn_core::paths::cache_root());
+    assert_ne!(
+        report.cache_root,
+        PathBuf::from(djinn_core::paths::JOB_POD_CACHE_MOUNT),
+        "the server pod has no /cache; the scan must use the host mount"
+    );
+    for root in CacheRootId::ALL.iter().copied() {
+        assert!(
+            root.host_path().starts_with(&report.cache_root),
+            "{} must live under the scanned root",
+            root.dir_name()
+        );
+    }
+}
+
+#[test]
+fn check_reports_findings_through_the_doctor_registry() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    write_aged_file(&root.join("retired-subsystem/blob"), 100, 50);
+    set_dir_age(&root.join("retired-subsystem"), 50);
+
+    let report = scan(root, &live(&["live-project"]));
+    let registry = DoctorRegistry::new();
+    let replaced = crate::doctor::register_stale_cache_roots_check(
+        &registry,
+        Arc::new(MemoryStaleCacheRootsSource::new(report)),
+    );
+    assert!(replaced.is_none());
+
+    let results = doctor_run(&registry, Some(&[STALE_CACHE_ROOTS_CHECK_NAME])).expect("run");
+    assert_eq!(results.len(), 1);
+    let (name, findings) = &results[0];
+    assert_eq!(name, STALE_CACHE_ROOTS_CHECK_NAME);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, FindingSeverity::Warn);
+}
+
+/// No deletion path exists, so no arming can be granted on vacuous evidence.
+#[test]
+fn check_never_offers_a_fix() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let report = scan(temp.path(), &live(&["live-project"]));
+    let check = StaleCacheRootsCheck::new(Arc::new(MemoryStaleCacheRootsSource::new(report)));
+    let finding = Finding::new(
+        FindingSeverity::Warn,
+        STALE_CACHE_ROOTS_CHECK_NAME,
+        ResolverSnapshot::new("resolve_stale_cache_roots", json!({}), json!({})),
+        "detail",
+    );
+    assert!(matches!(
+        check.fix(&finding),
+        Err(djinn_core::doctor::DoctorError::FixNotSupported { .. })
+    ));
+}
+
+/// A source that has never produced a scan must not read as "all clean".
+#[test]
+fn missing_scan_reports_its_own_absence() {
+    let check = StaleCacheRootsCheck::new(Arc::new(MemoryStaleCacheRootsSource::empty()));
+    let findings = check.run().expect("run");
+    assert_eq!(findings.len(), 1);
+    assert!(findings[0].detail.contains("has not completed"));
+}
+
+/// A missing cache root (fresh deployment, local dev) is a non-event.
+#[test]
+fn absent_cache_root_reports_nothing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let report = scan(&temp.path().join("no-such-cache"), &live(&["p"]));
+    assert!(!report.cache_root_exists);
+    assert!(report.observations.is_empty());
+}
+
+/// The measurement is bounded, and says when it stopped short, so a huge tree
+/// cannot turn an on-demand check into an unbounded walk.
+#[test]
+fn measurement_is_budgeted_and_reports_truncation() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    let big = root.join("big-unrecognised");
+    for index in 0..12 {
+        write_aged_file(&big.join(format!("file-{index}")), 100, 5);
+    }
+    set_dir_age(&big, 5);
+
+    let report = scan_cache_roots_under(
+        root,
+        &live(&["p"]),
+        NOW,
+        CacheScanConfig {
+            idle_threshold_days: DEFAULT_IDLE_THRESHOLD_DAYS,
+            entry_budget: 5,
+        },
+    );
+    let observed = find(&report, "big-unrecognised").expect("reported");
+    assert!(observed.measurement.size_truncated);
+    assert!(observed.measurement.size_bytes < 1_200);
+}

--- a/server/crates/djinn-core/src/paths.rs
+++ b/server/crates/djinn-core/src/paths.rs
@@ -61,6 +61,238 @@ pub fn cache_root() -> PathBuf {
         .join("cache")
 }
 
+// ---------------------------------------------------------------------------
+// Cache-root manifest
+// ---------------------------------------------------------------------------
+
+/// Mount path of the shared cache PVC inside **Job** pods (warm / verify /
+/// task-run). The server/coordinator pod mounts the same claim at
+/// [`cache_root`] instead; see that function for why the two must never be
+/// conflated.
+pub const JOB_POD_CACHE_MOUNT: &str = "/cache";
+
+/// How the immediate children of a cache root are keyed.
+///
+/// This drives how far a host-side inspector may descend before it stops being
+/// able to say anything meaningful about what it sees.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CacheRootNamespacing {
+    /// Contents are keyed by content, not by tenant (a Cargo registry, a pnpm
+    /// store, a Go module cache). Shared deliberately across every project on
+    /// the deployment, so nothing under it can be attributed to a tenant and
+    /// nothing under it can be declared orphaned by a tenant reconciliation.
+    Shared,
+    /// Immediate children are project ids. These ARE reconcilable against the
+    /// live project set: a child whose name is not a live project id belongs to
+    /// a project that no longer exists.
+    PerProject,
+    /// Immediate children are per-task-run ids with a lifetime of one task run.
+    /// They are created and destroyed constantly by normal operation, so their
+    /// presence, absence, age and count carry no staleness signal at all — a
+    /// dedicated sweep (`djinn_coordinator::health::sweep_orphaned_cargo_target_run_dirs`)
+    /// owns them. A cache-root inspector must never descend into these.
+    PerRun,
+}
+
+/// Static description of one cache root djinn actually uses.
+#[derive(Debug, Clone, Copy)]
+pub struct CacheRootSpec {
+    /// Directory name directly under the cache mount. Never a nested path:
+    /// the manifest describes cache *roots*, not their contents.
+    pub dir_name: &'static str,
+    /// How the root's immediate children are keyed.
+    pub namespacing: CacheRootNamespacing,
+    /// Child names owned by djinn's own machinery rather than by a tenant.
+    /// A reconciler must not classify these as tenant namespaces.
+    pub reserved_children: &'static [&'static str],
+    /// Where the platform renders this root. Kept as prose so a reader can go
+    /// straight to the code that would have to change to retire the root.
+    pub declared_by: &'static str,
+    /// What the root holds, and why it is on the shared PVC.
+    pub purpose: &'static str,
+}
+
+/// Declare the cache-root manifest.
+///
+/// One list generates the [`CacheRootId`] enum, its `ALL` slice, and the
+/// per-variant [`CacheRootSpec`]. Because all three come from the same
+/// expansion it is *structurally impossible* to add a variant that is missing
+/// from `ALL` or from the spec table — the failure mode of a hand-synced
+/// manifest, which is the very bug this manifest exists to prevent.
+macro_rules! declare_cache_roots {
+    ($(
+        $(#[$meta:meta])*
+        $variant:ident {
+            dir: $dir:literal,
+            namespacing: $ns:expr,
+            reserved_children: [$($reserved:literal),* $(,)?],
+            declared_by: $declared:literal,
+            purpose: $purpose:literal,
+        }
+    )+) => {
+        /// Every cache root djinn is known to use, as a closed set.
+        ///
+        /// Adding a variant is a compile-time obligation to describe it: the
+        /// generated `spec()` match is exhaustive over this enum.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub enum CacheRootId {
+            $($(#[$meta])* $variant,)+
+        }
+
+        impl CacheRootId {
+            /// The manifest: every declared cache root, in declaration order.
+            pub const ALL: &'static [CacheRootId] = &[$(CacheRootId::$variant,)+];
+
+            /// Static description of this root.
+            pub const fn spec(self) -> &'static CacheRootSpec {
+                match self {
+                    $(CacheRootId::$variant => &CacheRootSpec {
+                        dir_name: $dir,
+                        namespacing: $ns,
+                        reserved_children: &[$($reserved,)*],
+                        declared_by: $declared,
+                        purpose: $purpose,
+                    },)+
+                }
+            }
+
+            /// Absolute path of this root **inside a Job pod**.
+            ///
+            /// Renderers that bake a cache path into a Pod spec or an image ENV
+            /// must resolve through here rather than interpolating `/cache/...`,
+            /// so a newly-introduced root cannot exist without a manifest entry.
+            pub const fn job_pod_path(self) -> &'static str {
+                match self {
+                    $(CacheRootId::$variant => concat!("/cache/", $dir),)+
+                }
+            }
+        }
+    };
+}
+
+declare_cache_roots! {
+    /// Warm, per-project Cargo target bases.
+    CargoTarget {
+        dir: "cargo-target",
+        namespacing: CacheRootNamespacing::PerProject,
+        // The shared warm-base flock directory, keyed by project id but owned
+        // by djinn's warm machinery rather than being a cache namespace.
+        reserved_children: [".warm-locks"],
+        declared_by: "djinn_k8s::job::cache_env_vars (CARGO_TARGET_DIR) / djinn_agent_worker::cargo_target_seed::WARM_BASE_ROOT",
+        purpose: "per-project warm Cargo target base seeded into task-run target dirs",
+    }
+    /// Private per-task-run Cargo target dirs seeded from the warm base.
+    CargoTargetRuns {
+        dir: "cargo-target-runs",
+        namespacing: CacheRootNamespacing::PerRun,
+        reserved_children: [],
+        declared_by: "djinn_supervisor::CARGO_TARGET_RUNS_ROOT (task-run CARGO_TARGET_DIR)",
+        purpose: "private per-task-run Cargo target dir; churns constantly by design",
+    }
+    /// Compatibility-only sccache store.
+    Sccache {
+        dir: "sccache",
+        namespacing: CacheRootNamespacing::PerProject,
+        reserved_children: [],
+        declared_by: "djinn_k8s::job::common_cache_env_vars (SCCACHE_DIR)",
+        purpose: "writable, Landlock-allowed fallback for a repo tool that invokes sccache itself; djinn build pods clear RUSTC_WRAPPER and never populate it",
+    }
+    /// Per-project XDG cache home (durable output stash, SCIP indexer cache).
+    Xdg {
+        dir: "xdg",
+        namespacing: CacheRootNamespacing::PerProject,
+        reserved_children: [],
+        declared_by: "djinn_k8s::job::common_cache_env_vars (XDG_CACHE_HOME)",
+        purpose: "per-project XDG cache home: durable output stash and SCIP indexer cache",
+    }
+    /// Shared Cargo registry index and crate sources.
+    Cargo {
+        dir: "cargo",
+        namespacing: CacheRootNamespacing::Shared,
+        reserved_children: [],
+        declared_by: "djinn_k8s::job::common_cache_env_vars (CARGO_HOME)",
+        purpose: "content-addressed Cargo registry index and crate sources, shared across projects",
+    }
+    /// Shared Go module and build caches.
+    Go {
+        dir: "go",
+        namespacing: CacheRootNamespacing::Shared,
+        reserved_children: [],
+        declared_by: "djinn_image_builder::dockerfile (GOMODCACHE / GOCACHE / GOBIN image ENV)",
+        purpose: "content-addressed Go module cache, build cache and GOBIN",
+    }
+    /// Shared pnpm home and store.
+    Pnpm {
+        dir: "pnpm",
+        namespacing: CacheRootNamespacing::Shared,
+        reserved_children: [],
+        declared_by: "djinn_image_builder::dockerfile (PNPM_HOME image ENV)",
+        purpose: "content-addressed pnpm global dir and store",
+    }
+    /// Shared npm cache.
+    Npm {
+        dir: "npm",
+        namespacing: CacheRootNamespacing::Shared,
+        reserved_children: [],
+        declared_by: "djinn_image_builder::dockerfile (npm_config_cache image ENV)",
+        purpose: "content-addressed npm package cache",
+    }
+    /// Shared yarn cache.
+    Yarn {
+        dir: "yarn",
+        namespacing: CacheRootNamespacing::Shared,
+        reserved_children: [],
+        declared_by: "djinn_image_builder::dockerfile (YARN_CACHE_FOLDER image ENV)",
+        purpose: "content-addressed yarn package cache",
+    }
+    /// Shared pip cache.
+    Pip {
+        dir: "pip",
+        namespacing: CacheRootNamespacing::Shared,
+        reserved_children: [],
+        declared_by: "djinn_image_builder::dockerfile (PIP_CACHE_DIR image ENV)",
+        purpose: "content-addressed pip wheel/http cache",
+    }
+    /// Shared uv cache.
+    Uv {
+        dir: "uv",
+        namespacing: CacheRootNamespacing::Shared,
+        reserved_children: [],
+        declared_by: "djinn_image_builder::dockerfile (UV_CACHE_DIR image ENV)",
+        purpose: "content-addressed uv package cache",
+    }
+}
+
+impl CacheRootId {
+    /// Directory name of this root under the cache mount.
+    pub const fn dir_name(self) -> &'static str {
+        self.spec().dir_name
+    }
+
+    /// How this root's immediate children are keyed.
+    pub const fn namespacing(self) -> CacheRootNamespacing {
+        self.spec().namespacing
+    }
+
+    /// Host-side (server/coordinator pod) absolute path of this root.
+    ///
+    /// Always derived from [`cache_root`], never from [`JOB_POD_CACHE_MOUNT`]:
+    /// the server pod has no `/cache`, so a Job-pod literal here silently
+    /// operates on a nonexistent directory.
+    pub fn host_path(self) -> PathBuf {
+        cache_root().join(self.dir_name())
+    }
+
+    /// Resolve a directory name observed directly under the cache root to its
+    /// manifest entry, if any. `None` means "not a cache root djinn declares".
+    pub fn from_dir_name(name: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|root| root.dir_name() == name)
+    }
+}
+
 /// Host-side directory holding per-task-run private Cargo target dirs.
 ///
 /// This is the server/coordinator pod's view of the same directory the Job
@@ -68,7 +300,7 @@ pub fn cache_root() -> PathBuf {
 /// teardown backstop both resolve their root here so they operate on the
 /// directory that is actually mounted in the server pod.
 pub fn cargo_target_runs_root() -> PathBuf {
-    cache_root().join("cargo-target-runs")
+    CacheRootId::CargoTargetRuns.host_path()
 }
 
 /// Host-side directory holding the warm, per-project Cargo target bases.
@@ -79,7 +311,7 @@ pub fn cargo_target_runs_root() -> PathBuf {
 /// [`cargo_target_runs_root`] does: the Job-pod path does not exist in the
 /// server pod, so a hardcoded `/cache/cargo-target` silently reports nothing.
 pub fn cargo_target_root() -> PathBuf {
-    cache_root().join("cargo-target")
+    CacheRootId::CargoTarget.host_path()
 }
 
 /// Host-side directory holding the shared sccache store.
@@ -91,7 +323,7 @@ pub fn cargo_target_root() -> PathBuf {
 /// server pod, so a hardcoded literal makes the guard a permanent
 /// `path does not exist` no-op.
 pub fn sccache_root() -> PathBuf {
-    cache_root().join("sccache")
+    CacheRootId::Sccache.host_path()
 }
 
 /// Per-project clone directory: `{projects_root}/{owner}/{repo}`.
@@ -165,5 +397,89 @@ mod tests {
             cache_root().join("cargo-target-runs")
         );
         assert_eq!(sccache_root(), cache_root().join("sccache"));
+    }
+
+    /// The named accessors must be views onto manifest entries, not a second,
+    /// parallel list. If a root gains an accessor without a manifest entry, the
+    /// cache-root inspector would report the live root as unrecognised.
+    #[test]
+    fn named_accessors_resolve_to_manifest_entries() {
+        for (path, id) in [
+            (cargo_target_root(), CacheRootId::CargoTarget),
+            (cargo_target_runs_root(), CacheRootId::CargoTargetRuns),
+            (sccache_root(), CacheRootId::Sccache),
+        ] {
+            assert_eq!(path, id.host_path());
+            assert_eq!(
+                CacheRootId::from_dir_name(id.dir_name()),
+                Some(id),
+                "{} must be resolvable from its directory name",
+                id.dir_name()
+            );
+        }
+    }
+
+    #[test]
+    fn manifest_entries_are_unique_single_segment_names() {
+        let mut seen = std::collections::BTreeSet::new();
+        for root in CacheRootId::ALL.iter().copied() {
+            let name = root.dir_name();
+            assert!(
+                seen.insert(name),
+                "duplicate cache root directory name {name}"
+            );
+            assert!(!name.is_empty(), "cache root name must not be empty");
+            assert!(
+                !name.contains('/'),
+                "{name} is a nested path; the manifest describes cache ROOTS only"
+            );
+            assert_eq!(
+                root.job_pod_path(),
+                format!("{JOB_POD_CACHE_MOUNT}/{name}"),
+                "job-pod path must be the cache mount joined with the root name"
+            );
+            assert_eq!(
+                root.host_path(),
+                cache_root().join(name),
+                "host path must hang off the host cache root"
+            );
+        }
+    }
+
+    /// Every manifest entry must be reachable from `ALL`. The macro makes this
+    /// structurally true; the assertion pins it so a future hand-written
+    /// `impl` cannot quietly reintroduce a hand-synced list.
+    #[test]
+    fn manifest_covers_every_declared_variant() {
+        for root in CacheRootId::ALL.iter().copied() {
+            let spec = root.spec();
+            assert!(
+                !spec.declared_by.is_empty(),
+                "{} must name where the platform renders it",
+                spec.dir_name
+            );
+            assert!(
+                !spec.purpose.is_empty(),
+                "{} must state what it holds",
+                spec.dir_name
+            );
+        }
+        // The set of roots that carry tenant namespaces is what the orphan
+        // reconciler descends into. Pinning it makes adding a per-project root
+        // a visible, reviewed change rather than an incidental one.
+        let per_project: Vec<&str> = CacheRootId::ALL
+            .iter()
+            .copied()
+            .filter(|root| root.namespacing() == CacheRootNamespacing::PerProject)
+            .map(CacheRootId::dir_name)
+            .collect();
+        assert_eq!(per_project, vec!["cargo-target", "sccache", "xdg"]);
+        let per_run: Vec<&str> = CacheRootId::ALL
+            .iter()
+            .copied()
+            .filter(|root| root.namespacing() == CacheRootNamespacing::PerRun)
+            .map(CacheRootId::dir_name)
+            .collect();
+        assert_eq!(per_run, vec!["cargo-target-runs"]);
     }
 }

--- a/server/crates/djinn-k8s/src/job.rs
+++ b/server/crates/djinn-k8s/src/job.rs
@@ -18,6 +18,7 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use uuid::Uuid;
 
+use djinn_core::paths::CacheRootId;
 use djinn_runtime::RoleKind;
 use djinn_supervisor::cargo_target_run_dir;
 
@@ -172,7 +173,7 @@ pub const TOKEN_MOUNT_FILE: &str = "/var/run/secrets/tokens/djinn";
 /// worker's commits.
 pub const MIRROR_MOUNT_DIR: &str = "/mirror";
 /// Mount path for the writeable shared cache PVC.
-pub const CACHE_MOUNT_DIR: &str = "/cache";
+pub const CACHE_MOUNT_DIR: &str = djinn_core::paths::JOB_POD_CACHE_MOUNT;
 /// Mount path of the ephemeral workspace emptyDir.
 pub const WORKSPACE_MOUNT_DIR: &str = "/workspace";
 /// Audience advertised on the projected ServiceAccount token.
@@ -933,9 +934,9 @@ fn common_cache_env_vars(project_id: &str, cpu_limit: &str) -> Vec<EnvVar> {
         // needs no new volume plumbing.
         env_var(
             "XDG_CACHE_HOME",
-            &format!("{CACHE_MOUNT_DIR}/xdg/{project_id}"),
+            &format!("{}/{project_id}", CacheRootId::Xdg.job_pod_path()),
         ),
-        env_var("CARGO_HOME", &format!("{CACHE_MOUNT_DIR}/cargo")),
+        env_var("CARGO_HOME", CacheRootId::Cargo.job_pod_path()),
         // NOTE: we deliberately do NOT force `RUSTC_WRAPPER=sccache` or
         // `CARGO_INCREMENTAL=0` here. The fast path is incremental compilation
         // over a warm, main-based per-project target base (CI-style, like
@@ -950,7 +951,7 @@ fn common_cache_env_vars(project_id: &str, cpu_limit: &str) -> Vec<EnvVar> {
         // stale contents, so Djinn's build path must not rely on it.
         env_var(
             "SCCACHE_DIR",
-            &format!("{CACHE_MOUNT_DIR}/sccache/{project_id}"),
+            &format!("{}/{project_id}", CacheRootId::Sccache.job_pod_path()),
         ),
         // Default is 10G, which evicts fast on a large workspace; give sccache
         // more headroom on the shared PVC.
@@ -1039,7 +1040,10 @@ pub(crate) fn cache_env_vars(project_id: &str, cpu_limit: &str) -> Vec<EnvVar> {
     let jobs = cpu_limit_to_jobs(cpu_limit);
     env.push(env_var(
         "CARGO_TARGET_DIR",
-        &format!("{CACHE_MOUNT_DIR}/cargo-target/{project_id}/mold-jobs-{jobs}"),
+        &format!(
+            "{}/{project_id}/mold-jobs-{jobs}",
+            CacheRootId::CargoTarget.job_pod_path()
+        ),
     ));
     env
 }

--- a/server/crates/djinn-k8s/tests/cache_root_manifest_guard.rs
+++ b/server/crates/djinn-k8s/tests/cache_root_manifest_guard.rs
@@ -1,0 +1,160 @@
+//! Drift guard: no renderer may bake a cache root the manifest does not know.
+//!
+//! `djinn_core::paths::CacheRootId` is a closed manifest, and the coordinator's
+//! `cache.stale_roots` doctor check reports anything under the cache PVC that
+//! is not in it. That check is only as good as the manifest's completeness, and
+//! the manifest is only complete if it cannot be bypassed.
+//!
+//! Two mechanisms keep it complete:
+//!
+//! 1. **Structural.** The manifest, the `CacheRootId` enum and its `ALL` slice
+//!    all come out of one macro expansion, so a variant cannot exist without a
+//!    description. Renderers call `CacheRootId::_::job_pod_path()`, so the
+//!    obvious way to add a root goes through the manifest.
+//! 2. **This test.** A renderer could still bypass (1) by interpolating a path
+//!    string. So every `/cache/<segment>` literal in the files that render
+//!    Pod specs and image ENV is extracted and checked against the manifest.
+//!
+//! Limits, stated plainly: this catches roots djinn *renders*. It cannot catch
+//! a root created by a tool defaulting into `/cache`, by an ad-hoc command run
+//! with the PVC mounted, or by a future renderer in a file not listed here —
+//! those are exactly what the runtime doctor check is for. Nor does it force
+//! *retirement*: removing a subsystem still requires deleting its manifest
+//! entry by hand. The `declared_root_idle` finding is the runtime nudge for
+//! that, and it is why the manifest carries a `declared_by` field naming the
+//! code that would have to change.
+
+use djinn_core::paths::{CacheRootId, JOB_POD_CACHE_MOUNT};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Files that bake a cache path into a Pod spec, a container ENV, or a
+/// filesystem convention shared with Job pods.
+const RENDERER_SOURCES: &[&str] = &[
+    "crates/djinn-k8s/src/job.rs",
+    "crates/djinn-k8s/src/warm_job.rs",
+    "crates/djinn-image-builder/src/dockerfile.rs",
+    "crates/djinn-agent-worker/src/cargo_target_seed.rs",
+    "crates/djinn-supervisor/src/lib.rs",
+];
+
+/// `server/` — `CARGO_MANIFEST_DIR` is `server/crates/djinn-k8s`.
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/<crate> has a workspace root")
+        .to_path_buf()
+}
+
+/// Pull the first path segment out of every `/cache/<segment>` occurrence.
+///
+/// Interpolated segments (`{project_id}`, `{}`) are skipped: they are values
+/// *inside* a root, not root names. A `/cache` preceded by a path or word
+/// character is skipped too — prose like "workspace/cache/mirror volumes" is
+/// not a rendered path.
+fn cache_segments(source: &str) -> BTreeSet<String> {
+    let needle = format!("{JOB_POD_CACHE_MOUNT}/");
+    let mut found = BTreeSet::new();
+    let mut rest = source;
+    let mut consumed = 0usize;
+    while let Some(index) = rest.find(&needle) {
+        let absolute = consumed + index;
+        let preceded_by_path_char = source[..absolute]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '/');
+        if preceded_by_path_char {
+            consumed = absolute + needle.len();
+            rest = &source[consumed..];
+            continue;
+        }
+        let after = &rest[index + needle.len()..];
+        let end = after
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'))
+            .unwrap_or(after.len());
+        let segment = &after[..end];
+        if !segment.is_empty() {
+            found.insert(segment.to_owned());
+        }
+        consumed = absolute + needle.len();
+        rest = &source[consumed..];
+    }
+    found
+}
+
+#[test]
+fn every_rendered_cache_root_is_in_the_manifest() {
+    let declared: BTreeSet<&str> = CacheRootId::ALL
+        .iter()
+        .copied()
+        .map(CacheRootId::dir_name)
+        .collect();
+    let root = workspace_root();
+    let mut checked_files = 0usize;
+    let mut undeclared: Vec<String> = Vec::new();
+
+    for relative in RENDERER_SOURCES {
+        let path = root.join(relative);
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+        checked_files += 1;
+        for segment in cache_segments(&source) {
+            if !declared.contains(segment.as_str()) {
+                undeclared.push(format!("{relative}: /cache/{segment}"));
+            }
+        }
+    }
+
+    assert_eq!(
+        checked_files,
+        RENDERER_SOURCES.len(),
+        "every renderer source must be readable; a moved file silently disables this guard"
+    );
+    assert!(
+        undeclared.is_empty(),
+        "these renderers bake cache roots that djinn_core::paths::CacheRootId does not declare, \
+         so the cache.stale_roots doctor check would report them as unrecognised (or, worse, \
+         never notice when they are retired). Add a manifest entry:\n{}",
+        undeclared.join("\n")
+    );
+}
+
+/// The guard is only meaningful if it actually looks at something.
+#[test]
+fn guard_extracts_the_roots_it_claims_to() {
+    let segments = cache_segments(
+        r#"format!("{CACHE_MOUNT_DIR}/xdg/{project_id}") "/cache/cargo-target-runs" "/cache/" "#,
+    );
+    assert!(segments.contains("cargo-target-runs"));
+    assert!(!segments.contains("{project_id}"));
+    assert!(
+        cache_segments("workspace/cache/mirror volumes are group-owned").is_empty(),
+        "prose containing a `/cache/` substring is not a rendered path"
+    );
+
+    // A hypothetical undeclared root must be detected, otherwise the guard
+    // above would pass vacuously.
+    let declared: BTreeSet<&str> = CacheRootId::ALL
+        .iter()
+        .copied()
+        .map(CacheRootId::dir_name)
+        .collect();
+    let invented = cache_segments(r#""/cache/some-retired-subsystem/x""#);
+    assert!(
+        invented
+            .iter()
+            .any(|segment| !declared.contains(segment.as_str())),
+        "the guard must flag a root that is not in the manifest"
+    );
+}
+
+/// The k8s crate's own mount constant must be the manifest's, not a second
+/// literal that could drift away from it.
+#[test]
+fn job_pod_cache_mount_is_single_sourced() {
+    assert_eq!(djinn_k8s::job::CACHE_MOUNT_DIR, JOB_POD_CACHE_MOUNT);
+    for root in CacheRootId::ALL.iter().copied() {
+        assert!(root.job_pod_path().starts_with(JOB_POD_CACHE_MOUNT));
+    }
+}

--- a/server/crates/djinn-supervisor/src/lib.rs
+++ b/server/crates/djinn-supervisor/src/lib.rs
@@ -66,7 +66,11 @@ pub use djinn_runtime::spec::{
 };
 
 /// Root under the shared cache PVC for per-task-run Cargo target directories.
-pub const CARGO_TARGET_RUNS_ROOT: &str = "/cache/cargo-target-runs";
+///
+/// Resolved from the cache-root manifest rather than written out, so this root
+/// cannot exist without a manifest entry describing it.
+pub const CARGO_TARGET_RUNS_ROOT: &str =
+    djinn_core::paths::CacheRootId::CargoTargetRuns.job_pod_path();
 
 /// Canonical private Cargo target directory for a task-run Pod.
 pub fn cargo_target_run_dir(task_run_id: &str) -> PathBuf {


### PR DESCRIPTION
## The problem

Cache cleanup is a **denylist**: one hardcoded guard per remembered path (the sccache guard, the warm-base idle GC, the cargo-debris sweep, the pressure sweep). It can only ever clean paths somebody enumerated, so a retired cache root is invisible to it *by construction*. Same failure mode as the `classify_cargo_target_path` bug fixed in #2658 — enumerate-the-hazards, miss the fourth one.

## The manifest

`djinn_core::paths` gains `CacheRootId`, a closed manifest of every cache root the platform renders. **A single macro expansion generates the enum, its `ALL` slice and the per-root spec**, so it is structurally impossible to add a variant that is missing from either — the failure mode of a hand-synced list.

Twelve roots, derived from where the platform actually renders them (not from this repo, this project, or this cluster):

| root | namespacing | declared by |
|---|---|---|
| `cargo-target` | per-project (reserves `.warm-locks`) | `job.rs` `CARGO_TARGET_DIR` |
| `cargo-target-runs` | **per-run** | task-run `CARGO_TARGET_DIR` |
| `sccache`, `xdg` | per-project | `job.rs` `SCCACHE_DIR` / `XDG_CACHE_HOME` |
| `cargo` | shared | `job.rs` `CARGO_HOME` |
| `djinn` | shared | `paths::{output_stash_root, scip_indexer_cache_root}` (#2670) |
| `go`, `pnpm`, `npm`, `yarn`, `pip`, `uv` | shared | image `ENV` in `dockerfile.rs` |

> **Merged with `main` after #2668 and #2670 landed**, which touched `paths.rs` in the same region (conflict resolved there). #2670 added `xdg_cache_root()` / `output_stash_root()` / `scip_indexer_cache_root()`; those now resolve through `CacheRootId` rather than through a second hardcoded literal, and `xdg_cache_root()` is pinned to its manifest entry by `named_accessors_resolve_to_manifest_entries` so it cannot drift back. #2670 also makes `<cache>/djinn` a genuinely in-use server-pod root, hence the new `Djinn` entry. All three test suites re-run green on the merged tree (12 + 3 + 16).

### How it resists drift

1. **Structural** — one list, three generated artifacts. No hand-syncing.
2. **Renderers resolve through it** — `job.rs`'s four cache env vars, `djinn_supervisor::CARGO_TARGET_RUNS_ROOT`, `cargo_target_seed::{WARM_BASE_ROOT, RUN_TARGET_ROOT}` all call `CacheRootId::_::job_pod_path()`. `djinn_k8s::job::CACHE_MOUNT_DIR` is now `djinn_core::paths::JOB_POD_CACHE_MOUNT`.
3. **A guard test closes the interpolation hole** — `crates/djinn-k8s/tests/cache_root_manifest_guard.rs` extracts every `/cache/<segment>` literal from the five renderer sources and fails if a segment is not in the manifest. It found a false positive of its own on first run (prose "workspace/cache/mirror volumes") and now requires the match not be preceded by a path character.

**Limits, stated plainly.** The guard catches roots djinn *renders*. It cannot catch a root created by a tool defaulting into `/cache`, by an ad-hoc command with the PVC mounted, or by a future renderer in a file not listed — those are what the runtime check is for. It also does not force *retirement*: deleting a subsystem still means deleting its manifest entry by hand. The `declared_root_idle` finding is the runtime nudge for that, and each spec carries a `declared_by` field naming the code that would have to change.

## The check: `cache.stale_roots`

Read-only doctor check, on-demand cadence (it stats the PVC and walks candidates — too expensive for the cheap periodic subset). Resolves the cache root through `djinn_core::paths::cache_root()` and nothing else: the server pod mounts the claim at `$DJINN_HOME/cache`, not the Job-pod `/cache`, and hardcoding that has now produced four bugs.

Reports, each with **size, last-modified age and owning uid**:

- **(a) unrecognised roots** — a directory or loose file under the cache root with no manifest entry;
- **(b) orphaned tenant namespaces** — a per-project namespace under a manifest root whose project is not in the live project set;
- **declared-but-idle roots** — a manifest root untouched for 30 days, i.e. "if you retired this, delete its manifest entry".

### Granularity

The manifest is about cache *roots*, so the scan classifies the immediate children of the cache root and stops — **except** for per-project roots, where it descends exactly one level to reach tenant namespaces. It never descends into a `PerRun` root: `cargo-target-runs/<uuid>` is created and destroyed by every task run, its age and count carry no staleness signal, and `sweep_orphaned_cargo_target_run_dirs` already owns it. Shared, content-addressed roots (`cargo`, `pnpm`, …) are never reconciled against tenants, because nothing under them is attributable to one. The `match` on `CacheRootNamespacing` is exhaustive, so a future per-user cache root cannot silently inherit "reconcile against projects".

Measurement is budgeted (200k entries) and reports truncation, so a 61 GB tree cannot turn the check into an unbounded walk. Idleness is gated on a cheap depth-1 mtime first, so a live root is never deep-walked.

## Report-only, and why there is no arming flag

There is **no deletion path here at all** — not a disabled one, not a flag that defaults off. `fix` is the trait default (`FixNotSupported`), asserted by a test. #2660 found that sccache deletion had already been "authorised" by a Stage-3 dry-run observing a path that does not exist in the server pod, so the authorising evidence was structurally guaranteed to be empty. A detector that cannot delete cannot be armed on vacuous evidence.

## How "the owner is gone" is decided

Claiming a namespace is orphaned is claiming its owner is gone; a false positive, if anyone ever acted on it, destroys every warm base on the deployment. The reconciliation only ever narrows:

- the live set is enumerated through `ProjectRepository::list_ids_page_after` (the bounded keyset API), **globally** — not scoped to a user, a project, or an activity window, because this is a shared board;
- **a failed page aborts the whole reconciliation.** No orphan claim is made against a partial set;
- **an empty enumeration is treated as unavailable**, not as "everything is orphaned". An empty result is indistinguishable from a mis-scoped query. Price: a genuinely projectless deployment never reports orphans. Worth it;
- names the manifest reserves for djinn's own machinery (`.warm-locks`) are never treated as tenant namespaces;
- only *directories* directly under a per-project root are considered;
- **a skipped reconciliation emits an explicit Info finding naming the reason**, so it never reads as a clean deployment.

The finding carries the owning project id as an entity id, and the detail says "holds the namespace X, which is not in the live project set" — deliberately *not* "project X was deleted", since a stray directory reads correctly under the first wording and not the second.

## What it reports today against the live layout

Inspected read-only on the production node (`/var/lib/rancher/k3s/storage/pvc-*_djinn_djinn-cache`). Live project set: **one** project, `019ea3bd-a305-73e3-806c-4edcc96ebfe2`.

**(a) Unrecognised — 25 directories (5.8 GB) + 281 loose files (37.5 MB):**

`npm-cache` 1.1G · `home` 905M · `planner-check` 862M · `djinn-home` 600M · `models` 523M · `cargo-new` 459M · `djinn-gi2d-integration` 357M · `cargo-target-tmp` 322M · `.npm` 302M · `node-v22.16.0-linux-x64` 193M · `.npm-global` 76M · `mirror-push.git` 48M · `node` 40M · `pnpm-install` 40M · `corepack` 39M · `node-corepack` 20M · `pnpm-bin` 20M · `pnpm-global` 20M · `.corepack` 20M · `djinn-gnu-make` 2.5M · plus `oafa-backup`, `djinn-strike-test`, `djinn-test-home`, `fnm`, `fnm_multishells`. All uid 10001. Loose files include 281 `.log`/`.txt`/`.rs` artifacts dated 2026-06-16 → 2026-07-25.

**Caveat from the merge:** before #2670, `<cache>/djinn` (124 KB) was a 26th unrecognised directory. #2670 made it a real server-pod root, so the check is now correctly silent on it — even though its *current* contents are pre-existing strays (`b7pe-agent-helpers.log`, `test.tmp`, `oafa-backup/`) rather than a stash. Contents of a `Shared` root are below the manifest's granularity by design, so that 124 KB is now invisible to this check. Small, and I'd rather under-claim on a declared root than guess at its insides.

Most would be `Warn` (older than 30 days); `models`, `home`, `djinn-gnu-make`, `djinn-strike-test`, `djinn-test-home` are `Info` (touched within 30 days). Note several are near-misses of declared roots — `npm-cache` vs `npm`, `pnpm-bin`/`pnpm-global`/`pnpm-install` vs `pnpm`, `.corepack`/`corepack`/`node-corepack` — exactly the shape a denylist never catches.

**(b) Orphaned namespaces — one, `xdg/pnpm` (501 MB).** Not a live project id. It is a stray directory rather than a deleted tenant, which is why the wording does not assert deletion. The live project's `cargo-target/019ea3bd-…` (55G), `xdg/019ea3bd-…` (9.4G) and `cargo-target/.warm-locks` are all correctly silent. Zero deleted-project namespaces because this deployment has never removed a project — (b) is the structurally larger case on a multi-tenant deployment, but it yields one finding *here*.

**Declared-but-idle — zero today, and this contradicts the brief.** `/cache/sccache` (6.1 GB, last modified 2026-06-18) **was deleted during this session.** It was present at 6.1 GB on first inspection and gone a few hours later. So the headline case is no longer observable. Had this shipped a day earlier it would have reported exactly one `declared_root_idle`: sccache, 6.1 GB, 39 days. Note also that sccache is *declared* — `job.rs` still renders `SCCACHE_DIR` — so a correct manifest includes it, and the right finding was always "declared but idle", not "unrecognised". Disk moved 65% → 71% over the session as `cargo-target-runs` grew to 48 GB.

## Verification

Re-run on the merged tree (post #2668/#2670):

- `cargo test -p djinn-coordinator --lib doctor::stale_cache_roots` — 16/16.
- `cargo test -p djinn-k8s --test cache_root_manifest_guard` — 3/3.
- `cargo test -p djinn-core --lib paths::` — 12/12 (includes #2670's four new XDG/stash tests).
- `cargo test -p djinn-core --lib` — 396 pass, 1 fail: `cargo_target_runs::tests::joint_trim_reports_over_budget_error_when_removal_fails`, **confirmed pre-existing** by reverting `paths.rs` to `main`'s version and re-running (still fails; that module has no `paths::` reference).
- `cargo test -p djinn-coordinator --lib` — 2060 pass, 2 fail (`tests::session_reaping::*`), both **pass in isolation**; the shared metrics-registry whole-crate artifact.
- `djinn-agent-worker --bin` — 6 failures with this change, **12 on unmodified `main` source** under the same load. Load-dependent, pre-existing, and the baseline is strictly worse.
- Pre-existing `clippy::disallowed_methods` errors in `djinn-k8s/src/graph_warmer_ledger_tests.rs` (`Instant::now`), untouched by this PR.
- `cargo fmt`, `scripts/check-file-size.sh` clean. No SQL changed, so no `cargo sqlx prepare`.

### Neutralization

Each mechanism was reverted and the tests confirmed to fail:

| neutralization | result |
|---|---|
| scan returns empty | **7 fail** |
| empty enumeration becomes `Known(∅)`; reconcile against unknown owner set | **2 fail** (both fail-closed tests) |
| descend into `PerRun` roots | **1 fail** — reports both churn dirs as orphans |
| hardcode `/cache` in the production entry point | **1 fail** — `left: "/cache"`, `right: "…/.djinn/cache"` |
| delete `pnpm` from the manifest | **guard fails**, naming `dockerfile.rs: /cache/pnpm` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
