### PR TITLE
fix(warm-cache): restore the warm feature declaration removed by #2663

### DIFF
--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -1,4 +1,22 @@
 [build]
+# Feature set djinn's warm-cache pre-build compiles with, so the warm base
+# matches what CI and task-run pods actually build.
+#
+# `djinn-agent-worker::cargo_cache_policy` reads this key to derive the warm
+# job's `--features` args; without it the warm base is built with NO features
+# while CI (`.github/workflows/quality-gate.yml`) and worker commands use
+# `--features qdrant`. Feature resolution differs, so every unit whose
+# resolution depends on it misses the warm base and recompiles.
+#
+# This is djinn's own convention, NOT a cargo key: cargo emits
+# `warning: unused config key build.features` and ignores it. That warning is
+# expected — do not "fix" it by deleting this, and do not move the feature list
+# into the platform, which is deliberately repo-agnostic and reads it from here.
+#
+# Keep in sync with the `--features` used by the Server Clippy / Server Test
+# jobs in `.github/workflows/quality-gate.yml`.
+features = ["qdrant"]
+
 # NOTE: `rustc-wrapper = "sccache"` is intentionally NOT set here. The djinn
 # platform (warm/worker pods) reuses a warm, main-based per-project
 # cargo target base with INCREMENTAL compilation (CI-style, like


### PR DESCRIPTION
## What happened

PR #2657 (merged `90e02e9d2`, 12:23) declared `build.features = ["qdrant"]` in `server/.cargo/config.toml`. **PR #2663 (`mhb2`, merged `f3e8d5dc0`, 15:58) deleted the entire 18-line block — comment and all.**

```
 server/.cargo/config.toml | 18 ------------------
 1 file changed, 18 deletions(-)
```

`mhb2`'s stated scope was *"outsider-runnable cgroup-writable render and fail-closed lifecycle fixtures"* — Helm test fixtures under `deploy/helm/djinn/tests/`. This file has nothing to do with that.

## Why it matters

`djinn-agent-worker::cargo_cache_policy` (`:68`, parsed at `:144-152`) reads that key to derive the warm job's `--features` args. Without it the warm base is pre-built with **no features**, while CI (`quality-gate.yml`) and task-run worker commands both build `--features qdrant`. Feature resolution differs, so every unit whose resolution depends on `qdrant` misses the warm base and recompiles — which is exactly the waste #2657 existed to remove.

## Root cause is not a bad edit

`mhb2`'s branch predated #2657, so normalising `.cargo/config.toml` against its base silently reverted the newer change. Note that a sibling task's acceptance criteria currently read *"Keep `server/.cargo/config.toml` byte-identical to origin/main"* — that instruction is safe only when a branch is actually current with main, and dangerous when it is not.

The block already carries a comment saying **"do not 'fix' it by deleting this"**. That was not enough, because the deletion did not come from someone reading the comment — it came from a stale-base normalisation.

## Worth considering separately

This file is load-bearing for warm-cache correctness and is repeatedly targeted by "restore to base" instructions. A CI guard asserting `build.features` is present would prevent silent recurrence; a comment cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)