### PR TITLE
fix(coordinator): classify dispatch cooldown failures

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/task_dispatch.rs
@@ -2325,10 +2325,7 @@ impl CoordinatorActor {
                     // Fall through to dispatch (deliberately no `continue`).
                 } else {
                     match reappearing {
-                        Some(ReappearingDispatch::SameRoleFailure {
-                            next_streak,
-                            cooldown,
-                        }) => {
+                        Some(ReappearingDispatch::SameRoleFailure { next_streak }) => {
                             // A3: a throttle/rate-limit reappearance is a transient
                             // provider fault, NOT evidence the task is structurally
                             // undispatchable — so it must not advance the terminal
@@ -2448,16 +2445,25 @@ impl CoordinatorActor {
                                 self.dispatch_failure_streak.remove(&task.id);
                             }
 
+                            // Deterministic run/CI failures cannot heal while waiting:
+                            // retain a fixed one-minute anti-spin floor so a prompt
+                            // compile/test/snapshot fix can be retried promptly.
+                            // Typed provider failures can heal with time and therefore
+                            // retain the escalating provider-protection ladder.
+                            let cooldown = dispatch_cooldown_for_failure(
+                                next_streak,
+                                provider_failure.is_some(),
+                            );
+
                             // A6: honor a provider-stated reset as a redispatch floor.
-                            // `cooldown` is the escalating ladder value for this
-                            // reappearance; when the provider stated a Retry-After /
-                            // rate-limit-reset that exceeds it, redispatch no earlier
-                            // than that reset (otherwise a 5-hour quota window would be
-                            // probed every ~30 min, burning failover). The provider
-                            // reset is deliberately allowed to EXCEED the ladder's
-                            // 30-min ceiling — that's the whole point — but is clamped
-                            // to a hard safety max so a malformed value can't wedge the
-                            // task forever.
+                            // When the provider stated a Retry-After /
+                            // rate-limit-reset that exceeds the selected cooldown,
+                            // redispatch no earlier than that reset (otherwise a
+                            // 5-hour quota window would be probed every ~30 min,
+                            // burning failover). The provider reset is deliberately
+                            // allowed to EXCEED the ladder's 30-min ceiling — that's
+                            // the whole point — but is clamped to a hard safety max so
+                            // a malformed value can't wedge the task forever.
                             let retry_after_ms = provider_failure.and_then(|f| f.retry_after_ms);
                             let effective_cooldown =
                                 apply_provider_retry_floor(cooldown, retry_after_ms);
@@ -2476,8 +2482,9 @@ impl CoordinatorActor {
                                 role,
                                 streak = stored_streak,
                                 throttle,
+                                provider_backoff = provider_failure.is_some(),
                                 cooldown_secs = effective_cooldown.as_secs(),
-                                "CoordinatorActor: repeated task failure — backing off dispatch (escalating cooldown)"
+                                "CoordinatorActor: repeated task failure — backing off dispatch"
                             );
                             self.dispatch_cooldowns.insert(
                                 task.id.clone(),

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -567,17 +567,16 @@ pub(super) struct DispatchMarker {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ReappearingDispatch {
-    SameRoleFailure {
-        next_streak: u32,
-        cooldown: Duration,
-    },
+    SameRoleFailure { next_streak: u32 },
     RoleTransition,
 }
 
-/// Base cooldown before re-dispatching a task that failed (lifecycle setup, a
-/// crashed run, or a provider that returned empty/throttled turns). Escalates
-/// per consecutive failure via [`escalating_dispatch_cooldown`] to prevent hot
-/// re-dispatch loops that hammer a degraded provider.
+/// Fixed floor before re-dispatching a task after a deterministic run/CI
+/// failure. One minute prevents a coordinator-tick spin while keeping compile,
+/// test, golden, snapshot, and other code failures responsive to a prompt fix.
+///
+/// Provider/environmental failures use this as the base of
+/// [`escalating_dispatch_cooldown`].
 pub(super) const DISPATCH_COOLDOWN: Duration = Duration::from_secs(60);
 
 /// Upper bound on the escalating per-task dispatch cooldown.
@@ -594,10 +593,11 @@ pub(super) const PROVIDER_RETRY_AFTER_MAX: Duration = Duration::from_secs(6 * 60
 
 /// Consecutive failed dispatch attempts (same role) — whether the run failed or
 /// the task's owner has no model that resolves a credential — after which the
-/// task is failed **terminally** instead of looping forever. Combined with the
-/// escalating cooldown this spans hours, so transient provider/credential blips
-/// never reach it; only structurally-undispatchable tasks do. Terminal close
-/// also keeps review-type tasks from wedging open forever.
+/// task is failed **terminally** instead of looping forever. Provider and
+/// credential failures reach it through the escalating cooldown; deterministic
+/// run/CI failures keep a fixed anti-spin floor and are ordinarily routed into
+/// the cumulatively bounded Planner/arbiter ladder first. Terminal close remains
+/// the final backstop for roles or paths that cannot enter that ladder.
 pub(super) const MAX_DISPATCH_FAILURES: u32 = 10;
 
 /// Consecutive failover-chain exhaustions for a task whose role lane has a
@@ -682,6 +682,22 @@ pub(super) fn escalating_dispatch_cooldown(streak: u32) -> Duration {
     Duration::from_secs(secs)
 }
 
+/// Select the redispatch cooldown for a same-role failed reappearance.
+///
+/// Typed provider failures are conditions that can heal with time (provider
+/// errors, empty/throttled turns, model-health trips), so they ride the
+/// escalating ladder. Untyped failures are the deterministic run/CI class and
+/// retain only [`DISPATCH_COOLDOWN`]'s fixed anti-spin floor; their cumulative
+/// safety bounds remain the Planner/arbiter ladder and
+/// [`MAX_DISPATCH_FAILURES`].
+pub(super) fn dispatch_cooldown_for_failure(streak: u32, had_provider_failure: bool) -> Duration {
+    if had_provider_failure {
+        escalating_dispatch_cooldown(streak)
+    } else {
+        DISPATCH_COOLDOWN
+    }
+}
+
 /// A3: the terminal `dispatch_failure_streak` value to STORE after a same-role
 /// failed reappearance.
 ///
@@ -737,10 +753,7 @@ pub(super) fn classify_reappearing_dispatch(
     }
 
     let next_streak = current_streak.saturating_add(1);
-    Some(ReappearingDispatch::SameRoleFailure {
-        next_streak,
-        cooldown: escalating_dispatch_cooldown(next_streak),
-    })
+    Some(ReappearingDispatch::SameRoleFailure { next_streak })
 }
 
 #[cfg(test)]
@@ -761,7 +774,7 @@ mod cooldown_tests {
     }
 
     #[test]
-    fn reappearing_same_role_is_failure_and_escalates_from_existing_streak() {
+    fn reappearing_same_role_is_failure_and_advances_existing_streak() {
         let marker = DispatchMarker {
             instant: StdInstant::now(),
             role: "worker".to_owned(),
@@ -769,10 +782,32 @@ mod cooldown_tests {
 
         assert_eq!(
             classify_reappearing_dispatch(marker, "worker", 1),
-            Some(ReappearingDispatch::SameRoleFailure {
-                next_streak: 2,
-                cooldown: Duration::from_secs(120),
-            })
+            Some(ReappearingDispatch::SameRoleFailure { next_streak: 2 })
+        );
+    }
+
+    #[test]
+    fn deterministic_ci_failure_keeps_fixed_floor_instead_of_provider_backoff() {
+        assert_eq!(
+            dispatch_cooldown_for_failure(5, false),
+            DISPATCH_COOLDOWN,
+            "compile/test/snapshot failures must remain prompt at later streaks"
+        );
+        assert!(
+            dispatch_cooldown_for_failure(5, false) < escalating_dispatch_cooldown(5),
+            "the deterministic class must not accrue the provider ladder"
+        );
+    }
+
+    #[test]
+    fn provider_failure_still_accrues_escalating_backoff() {
+        assert_eq!(
+            dispatch_cooldown_for_failure(5, true),
+            escalating_dispatch_cooldown(5)
+        );
+        assert_eq!(
+            dispatch_cooldown_for_failure(5, true),
+            Duration::from_secs(16 * 60)
         );
     }
 


### PR DESCRIPTION
## Summary

- keep escalating dispatch cooldowns for typed provider/environmental failures
- use a fixed 60-second anti-spin floor for deterministic run and CI failures
- preserve Retry-After flooring/clamping, terminal failure accounting, arbiter bounds, and the single-candidate operator signal

## Verification

- `cargo fmt --check`
- `SQLX_OFFLINE=true cargo clippy` (passes; two pre-existing `djinn-db/src/repositories/readiness/mod.rs` warnings)
- `scripts/check-file-size.sh`
- targeted cooldown, A6, single-candidate signal, and arbiter ceiling regressions
- neutralization: restoring the old always-escalating classification made the deterministic regression fail with 960s vs 60s; the provider-preservation regression remained green
- `SQLX_OFFLINE=true RUST_MIN_STACK=33554432 cargo test -p djinn-coordinator --lib -- --test-threads=1`: 2023 passed; two shared metrics-registry contamination failures passed individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)