### PR TITLE
fix: release epics at arbiter ceiling

### DIFF
--- a/server/crates/djinn-agent/src/direct_services.rs
+++ b/server/crates/djinn-agent/src/direct_services.rs
@@ -677,19 +677,42 @@ impl DirectServices {
             .as_ref()
             .map(|t| format!("{} ({})", t.title, t.short_id))
             .unwrap_or_else(|| source_task_id.to_string());
-        let description = format!(
-            "Escalated from task {source_label}. The arbiter decided to PARK and \
-             handed you (the Planner) terminal ownership of this task.\n\nYou OWN \
-             the resolution: decompose the source into replacement subtasks and \
-             supersede it, close it as won't-fix with a reason, or re-scope and \
-             reopen it. Do NOT create another escalation and do NOT wait for a \
-             human — closing THIS task releases the blocked source.\n\nReason: {}",
-            dossier_text
-        );
-        let instructions = "The arbiter parked this task and handed you terminal ownership. \
-             Resolve it autonomously (decompose + supersede, close as won't-fix, or re-scope + \
-             reopen the source); closing this task releases the blocked source. Do NOT escalate \
-             again and do NOT wait for a human.";
+        let final_disposition = dossier
+            .get("final_disposition")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let (description, instructions) = if final_disposition {
+            (
+                format!(
+                    "Escalated from exhausted task {source_label}. The one-shot final arbiter \
+                     decided to PARK and handed you (the Planner) terminal ownership of the \
+                     epic/proposal shape.\n\nReplan from the durable branch/PR context: create \
+                     replacement tasks (including spikes when uncertainty remains) and supersede \
+                     the source with those replacement IDs, or close the source as no longer \
+                     required. Do NOT reopen the exhausted source and do NOT create another \
+                     escalation. Closing THIS planner task alone is insufficient until the source \
+                     has a terminal disposition.\n\nReason: {dossier_text}"
+                ),
+                "This is terminal epic/proposal replanning after the arbitration ceiling. Create \
+                 replacements and supersede the exhausted source, or close the source as no \
+                 longer required. Do not reopen it and do not create another escalation.",
+            )
+        } else {
+            (
+                format!(
+                    "Escalated from task {source_label}. The arbiter decided to PARK and \
+                     handed you (the Planner) terminal ownership of this task.\n\nYou OWN \
+                     the resolution: decompose the source into replacement subtasks and \
+                     supersede it, close it as won't-fix with a reason, or re-scope and \
+                     reopen it. Do NOT create another escalation and do NOT wait for a \
+                     human — closing THIS task releases the blocked source.\n\nReason: {dossier_text}"
+                ),
+                "The arbiter parked this task and handed you terminal ownership. Resolve it \
+                 autonomously (decompose + supersede, close as won't-fix, or re-scope + reopen \
+                 the source); closing this task releases the blocked source. Do NOT escalate \
+                 again and do NOT wait for a human.",
+            )
+        };
 
         // Create the escalation review task.
         let review_task = match djinn_core::auth_context::SESSION_USER_ID
@@ -697,7 +720,9 @@ impl DirectServices {
                 source_creator.clone(),
                 task_repo.create_in_project_with_provenance(
                     project_id,
-                    None,
+                    source_task
+                        .as_ref()
+                        .and_then(|task| task.epic_id.as_deref()),
                     EffectiveCreatorProvenance {
                         explicit_user_id: source_creator.as_deref(),
                         source_task_id: source_task.as_ref().map(|task| task.id.as_str()),

--- a/server/crates/djinn-agent/src/supervisor_impl/stage.rs
+++ b/server/crates/djinn-agent/src/supervisor_impl/stage.rs
@@ -526,6 +526,7 @@ async fn advertise_read_sources(
 fn lead_stage_outcome(
     finalize_name: &str,
     finalize_payload: Option<&serde_json::Value>,
+    terminal_disposition_required: bool,
 ) -> StageOutcome {
     let payload_str = |key: &str| {
         finalize_payload
@@ -543,6 +544,21 @@ fn lead_stage_outcome(
     match finalize_name {
         "submit_decision" => {
             let decision = payload_str("decision").unwrap_or("");
+            if terminal_disposition_required && !matches!(decision, "park" | "supersede") {
+                let dossier = serde_json::json!({
+                    "final_disposition": true,
+                    "hold_description": format!(
+                        "Final arbiter returned non-terminal decision '{decision}'"
+                    ),
+                    "failure_analysis": "The cumulative arbitration budget is exhausted, so approve/reopen outcomes cannot start another PR-poller or worker cycle.",
+                    "submitted_decision": decision,
+                    "submitted_payload": finalize_payload,
+                    "recommended_action": "Replan the epic/proposal and either create replacement work that supersedes the exhausted task or close work that is no longer required.",
+                });
+                return StageOutcome::LeadParked {
+                    park_dossier_json: dossier.to_string(),
+                };
+            }
             match decision {
                 // approve: work is complete + correct.
                 // Requires evidence citation.
@@ -666,8 +682,17 @@ fn lead_stage_outcome(
                                     provider_failure: None,
                                 }
                             } else {
-                                let dossier_json =
-                                    serde_json::to_string(d).unwrap_or_else(|_| "{}".to_string());
+                                let mut dossier = d.clone();
+                                if terminal_disposition_required
+                                    && let Some(object) = dossier.as_object_mut()
+                                {
+                                    object.insert(
+                                        "final_disposition".to_string(),
+                                        serde_json::Value::Bool(true),
+                                    );
+                                }
+                                let dossier_json = serde_json::to_string(&dossier)
+                                    .unwrap_or_else(|_| "{}".to_string());
                                 StageOutcome::LeadParked {
                                     park_dossier_json: dossier_json,
                                 }
@@ -1444,7 +1469,26 @@ pub(crate) async fn execute_stage(
                         },
                     },
                     RoleKind::Lead => {
-                        lead_stage_outcome(finalize_name, final_output.finalize_payload.as_ref())
+                        let terminal_disposition_required = {
+                            use djinn_db::repositories::task_arbitration::TaskArbitrationRepository;
+                            TaskArbitrationRepository::new(agent_context.db.clone())
+                                .resolve_current_hold_cycle(&task.id)
+                                .await
+                                .ok()
+                                .and_then(|(_, record)| record)
+                                .and_then(|record| record.directive)
+                                .and_then(|directive| {
+                                    directive
+                                        .get("terminal_disposition_required")
+                                        .and_then(serde_json::Value::as_bool)
+                                })
+                                .unwrap_or(false)
+                        };
+                        lead_stage_outcome(
+                            finalize_name,
+                            final_output.finalize_payload.as_ref(),
+                            terminal_disposition_required,
+                        )
                     }
                     // Refinement tribunal roles each finalize via their own
                     // configured tool: the Advocate `submit_work`, the Adversary
@@ -2140,7 +2184,7 @@ mod tests {
         });
         assert!(
             matches!(
-                lead_stage_outcome("submit_decision", Some(&payload)),
+                lead_stage_outcome("submit_decision", Some(&payload), false),
                 StageOutcome::LeadApproved { ref evidence } if !evidence.is_empty()
             ),
             "approve with valid evidence must succeed",
@@ -2153,7 +2197,7 @@ mod tests {
             "decision": "approve",
             "rationale": "looks good to me"
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("evidence"),
@@ -2173,7 +2217,7 @@ mod tests {
                 "summary": ""
             }
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("evidence"),
@@ -2196,7 +2240,7 @@ mod tests {
         });
         assert!(
             matches!(
-                lead_stage_outcome("submit_decision", Some(&payload)),
+                lead_stage_outcome("submit_decision", Some(&payload), false),
                 StageOutcome::LeadApproveConflict { ref reason, ref evidence } if reason == "correct but conflicts" && !evidence.is_empty()
             ),
             "approve_conflict with evidence and reason must succeed",
@@ -2211,7 +2255,7 @@ mod tests {
             "verification_command": "cargo test --test pagination",
             "exclude_models": ["gpt-4o"]
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::LeadReopen {
                 directive,
                 verification_command,
@@ -2235,7 +2279,7 @@ mod tests {
             "decision": "reopen",
             "verification_command": "cargo test"
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("directive"),
@@ -2252,7 +2296,7 @@ mod tests {
             "decision": "reopen",
             "directive": "Fix the bug"
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("verification_command"),
@@ -2276,7 +2320,7 @@ mod tests {
                 "recommended_action": "Assign to auth-team lead"
             }
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::LeadParked { park_dossier_json } => {
                 let parsed: serde_json::Value =
                     serde_json::from_str(&park_dossier_json).expect("valid JSON");
@@ -2299,7 +2343,7 @@ mod tests {
             "decision": "park",
             "rationale": "stuck"
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("park_dossier"),
@@ -2319,7 +2363,7 @@ mod tests {
                 "failure_analysis": "some analysis"
             }
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("hold_description"),
@@ -2336,7 +2380,7 @@ mod tests {
             "decision": "escalate",
             "rationale": "cannot resolve"
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("unknown or removed"),
@@ -2353,7 +2397,7 @@ mod tests {
             "decision": "decompose",
             "created_tasks": ["task-1", "task-2"]
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("unknown or removed"),
@@ -2370,7 +2414,7 @@ mod tests {
             "decision": "force_close",
             "rationale": "redundant"
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("unknown or removed"),
@@ -2383,7 +2427,7 @@ mod tests {
 
     #[test]
     fn arbiter_no_finalize_tool_fails() {
-        match lead_stage_outcome("", None) {
+        match lead_stage_outcome("", None, false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("without calling submit_decision"),
@@ -2396,7 +2440,7 @@ mod tests {
 
     #[test]
     fn arbiter_unexpected_finalize_tool_fails() {
-        match lead_stage_outcome("submit_work", None) {
+        match lead_stage_outcome("submit_work", None, false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("unexpected tool"),
@@ -2420,7 +2464,7 @@ mod tests {
             "decision": "park",
             "park_dossier": dossier
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::LeadParked { park_dossier_json } => {
                 let parsed: serde_json::Value =
                     serde_json::from_str(&park_dossier_json).expect("valid JSON");
@@ -2440,7 +2484,7 @@ mod tests {
             "rationale": "decomposed into 3 replacement subtasks",
             "created_tasks": ["repl-1", "repl-2", "repl-3"]
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::LeadSuperseded {
                 replacement_task_ids,
                 ..
@@ -2465,7 +2509,7 @@ mod tests {
             "decision": "supersede",
             "rationale": "meant to decompose but created nothing"
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("created_tasks"),
@@ -2487,7 +2531,7 @@ mod tests {
             "decision": "supersede",
             "created_tasks": []
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("created_tasks") && reason.contains("park"),
@@ -2499,6 +2543,64 @@ mod tests {
     }
 
     #[test]
+    fn final_arbiter_non_terminal_decision_is_terminally_parked() {
+        for decision in ["approve", "approve_conflict", "reopen"] {
+            let payload = serde_json::json!({
+                "decision": decision,
+                "reason": "try another cycle",
+                "evidence": {"summary": "locally acceptable"},
+                "directive": "repair once more",
+                "verification_command": "cargo test"
+            });
+            match lead_stage_outcome("submit_decision", Some(&payload), true) {
+                StageOutcome::LeadParked { park_dossier_json } => {
+                    let dossier: serde_json::Value =
+                        serde_json::from_str(&park_dossier_json).unwrap();
+                    assert_eq!(dossier["submitted_decision"], decision);
+                    assert!(
+                        dossier["recommended_action"]
+                            .as_str()
+                            .unwrap()
+                            .contains("Replan")
+                    );
+                }
+                other => panic!("final {decision} must convert to terminal park, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn final_arbiter_still_accepts_supersede() {
+        let payload = serde_json::json!({
+            "decision": "supersede",
+            "reason": "replace exhausted source",
+            "created_tasks": ["replacement-1"]
+        });
+        assert!(matches!(
+            lead_stage_outcome("submit_decision", Some(&payload), true),
+            StageOutcome::LeadSuperseded { .. }
+        ));
+    }
+
+    #[test]
+    fn final_arbiter_park_marks_terminal_planner_replan() {
+        let payload = serde_json::json!({
+            "decision": "park",
+            "park_dossier": {
+                "hold_description": "architecture is genuinely ambiguous",
+                "failure_analysis": "prior decisions conflict"
+            }
+        });
+        match lead_stage_outcome("submit_decision", Some(&payload), true) {
+            StageOutcome::LeadParked { park_dossier_json } => {
+                let dossier: serde_json::Value = serde_json::from_str(&park_dossier_json).unwrap();
+                assert_eq!(dossier["final_disposition"], true);
+            }
+            other => panic!("final park must remain a terminal planner park, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn arbiter_supersede_blank_ids_are_dropped_and_fail_when_all_blank() {
         // Whitespace-only ids are not real replacements — after trimming they
         // leave an empty set, which must fail with park guidance.
@@ -2506,7 +2608,7 @@ mod tests {
             "decision": "supersede",
             "created_tasks": ["   ", ""]
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::Failed { reason, .. } => {
                 assert!(
                     reason.contains("created_tasks"),
@@ -2526,7 +2628,7 @@ mod tests {
             "evidence": {"source": "git diff + CI", "summary": "all AC met"}
         });
         assert!(matches!(
-            lead_stage_outcome("submit_decision", Some(&approve)),
+            lead_stage_outcome("submit_decision", Some(&approve), false),
             StageOutcome::LeadApproved { .. }
         ));
 
@@ -2536,7 +2638,7 @@ mod tests {
             "verification_command": "cargo test -p djinn-coordinator"
         });
         assert!(matches!(
-            lead_stage_outcome("submit_decision", Some(&reopen)),
+            lead_stage_outcome("submit_decision", Some(&reopen), false),
             StageOutcome::LeadReopen { .. }
         ));
 
@@ -2545,7 +2647,7 @@ mod tests {
             "park_dossier": {"hold_description": "stuck", "failure_analysis": "why"}
         });
         assert!(matches!(
-            lead_stage_outcome("submit_decision", Some(&park)),
+            lead_stage_outcome("submit_decision", Some(&park), false),
             StageOutcome::LeadParked { .. }
         ));
 
@@ -2554,7 +2656,7 @@ mod tests {
             "evidence": {"source": "git diff", "summary": "correct but conflict"}
         });
         assert!(matches!(
-            lead_stage_outcome("submit_decision", Some(&approve_conflict)),
+            lead_stage_outcome("submit_decision", Some(&approve_conflict), false),
             StageOutcome::LeadApproveConflict { .. }
         ));
     }
@@ -2567,7 +2669,7 @@ mod tests {
             "verification_command": "cargo clippy",
             "exclude_models": ["model-a", "model-b"]
         });
-        match lead_stage_outcome("submit_decision", Some(&payload)) {
+        match lead_stage_outcome("submit_decision", Some(&payload), false) {
             StageOutcome::LeadReopen { exclude_models, .. } => {
                 assert_eq!(exclude_models, vec!["model-a", "model-b"]);
             }

--- a/server/crates/djinn-agent/tests/arbiter_park_transaction.rs
+++ b/server/crates/djinn-agent/tests/arbiter_park_transaction.rs
@@ -284,6 +284,11 @@ async fn direct_services_arbiter_park_full_transaction() {
         "escalation must be a review task (planner-dispatchable)"
     );
     assert_eq!(hold_task.status, "open", "escalation must be open");
+    assert_eq!(
+        hold_task.epic_id.as_deref(),
+        Some(epic_id.as_str()),
+        "planner escalation must stay inside the source epic so the epic has dispatchable replanning work"
+    );
     assert!(
         hold_task.labels.contains("planner-park-escalation"),
         "escalation must carry the planner-park-escalation label, got: {}",

--- a/server/crates/djinn-coordinator/src/actor.rs
+++ b/server/crates/djinn-coordinator/src/actor.rs
@@ -582,6 +582,12 @@ impl CoordinatorActor {
                 ),
             ),
         );
+        crate::doctor::register_stalled_epic_check(
+            djinn_core::doctor::registry(),
+            Arc::new(crate::doctor::TaskRepositoryStalledEpicSource::new(
+                db.clone(),
+            )),
+        );
 
         Self {
             receiver,

--- a/server/crates/djinn-coordinator/src/dispatch/retry.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/retry.rs
@@ -1266,9 +1266,24 @@ impl CoordinatorActor {
             // unconsumed row). A genuinely in-flight arbiter is left to finish
             // — it may still approve or supersede — and is separately bounded
             // by the 24h arbitration deadline and the decision-failure cap.
-            if self.arbiter_hold_cycle_ceiling_reached(task).await {
+            let final_disposition = self.arbiter_hold_cycle_ceiling_reached(task).await;
+            if final_disposition && self.hold_cycle_ceiling_already_recorded(&task.id).await {
+                let dossier = serde_json::json!({
+                    "kind": "final_arbiter_reentry",
+                    "hold_description": "The one-shot final arbiter disposition already ran",
+                    "failure_analysis": "The exhausted task returned to the remediation rung after its final arbiter. A second final arbiter would violate the cumulative bound.",
+                    "recommended_action": "Replan the epic from this autonomous planner escalation; supersede the exhausted task with replacement work or close work that is no longer required.",
+                    "task_id": task.short_id,
+                    "hold_cycle_ceiling": MAX_ARBITER_HOLD_CYCLES,
+                });
                 return self
-                    .terminally_fail_on_hold_cycle_ceiling(task, role, quality_strikes)
+                    .park_source_human_review_with_dossier(
+                        task,
+                        "One-shot final arbiter disposition already consumed",
+                        quality_strikes,
+                        None,
+                        &dossier,
+                    )
                     .await;
             }
 
@@ -1304,7 +1319,8 @@ impl CoordinatorActor {
             // is unfounded against a novel failure (8y3q's fix was one token).
             // Skip the fingerprint check when CI evidence is stale (from a prior
             // head SHA) — it cannot serve as a park-triggering strike.
-            if !ci_stale
+            if !final_disposition
+                && !ci_stale
                 && let Some(fingerprint) = task
                     .ci_failure_fingerprint
                     .as_deref()
@@ -1345,7 +1361,8 @@ impl CoordinatorActor {
             // Below the bound, redispatch with forced model rotation instead of
             // consuming the final strike (dispatch-time exclusion in
             // task_dispatch.rs drops the models that just failed).
-            if !history.any_submitted
+            if !final_disposition
+                && !history.any_submitted
                 && history.non_attempt_models.len() < NON_ATTEMPT_PARK_THRESHOLD
             {
                 self.record_park_redispatch_marker(
@@ -1370,7 +1387,7 @@ impl CoordinatorActor {
             // (mirror-vs-GitHub staleness) must not serve as the park-triggering
             // strike. If the task is in needs_task_review/in_task_review with no
             // rejection newer than the submission, do not park.
-            if history.any_submitted && history.submission_pending_review {
+            if !final_disposition && history.any_submitted && history.submission_pending_review {
                 self.record_park_redispatch_marker(task, "submission_pending_review", None, 0)
                     .await;
                 tracing::warn!(
@@ -1674,6 +1691,12 @@ impl CoordinatorActor {
                 "role": role,
                 "hold_cycle": hold_cycle,
                 "hold_cycle_ceiling": MAX_ARBITER_HOLD_CYCLES,
+                "final_disposition": final_disposition,
+                "decision_mandate": if final_disposition {
+                    Some("This is the single final decision for this remediation rung. Choose exactly one terminal disposition: (1) supersede after creating replacement task(s), which transfers downstream blockers and closes the exhausted source; or (2) park with a complete dossier, which creates an autonomous planner escalation that can replan the epic/proposal. Do not approve, approve_conflict, or reopen: no further worker or arbiter cycle is permitted.")
+                } else {
+                    None
+                },
                 "prior_arbiter_decisions": prior_arbiter_decisions,
                 "intervention_count": task.intervention_count,
                 "total_reopen_count": task.total_reopen_count,
@@ -1689,8 +1712,13 @@ impl CoordinatorActor {
                 "attempt_ledger": attempt_ledger,
             });
             let directive = serde_json::json!({
-                "kind": "lead_arbiter",
-                "goal": "Forensic review of the current hold cycle after repeated planner interventions",
+                "kind": if final_disposition { "final_lead_arbiter" } else { "lead_arbiter" },
+                "goal": if final_disposition {
+                    "Make the one-shot terminal disposition: supersede with replacements or park into autonomous epic/proposal replanning"
+                } else {
+                    "Forensic review of the current hold cycle after repeated planner interventions"
+                },
+                "terminal_disposition_required": final_disposition,
                 "verification_command": None::<String>,
             });
             let deadline = {
@@ -1763,6 +1791,15 @@ impl CoordinatorActor {
 
             match create_result {
                 TryCreateResult::Created(_) => {
+                    if final_disposition {
+                        self.record_hold_cycle_ceiling_final_dispatch(
+                            task,
+                            role,
+                            quality_strikes,
+                            hold_cycle,
+                        )
+                        .await;
+                    }
                     // Arbiter dispatch path — fresh arbitration row created.
                     self.dispatch_arbiter_second_strike(
                         task,
@@ -2560,33 +2597,27 @@ impl CoordinatorActor {
         }
     }
 
-    /// Terminal exit for the cumulative hold-cycle ceiling.
+    /// Record the one-shot final arbiter opened at the cumulative ceiling.
     ///
-    /// Clears in-memory + durable dispatch backoff, records a durable
-    /// `arbiter_hold_cycle_ceiling` activity entry naming the budget and the
-    /// counters that got the task here, then routes through the single
-    /// dispatch-exhaustion gateway
-    /// ([`terminally_fail_task`](Self::terminally_fail_task)) so the task
-    /// reaches a genuinely terminal, non-redispatching state (ForceClose, or —
-    /// for a PR-bearing task — a poller handoff that likewise stops coordinator
-    /// dispatch). Always returns `true`: the caller must skip its dispatch this
-    /// pass either way, because a task at the ceiling must never be
-    /// redispatched.
-    async fn terminally_fail_on_hold_cycle_ceiling(
+    /// The ceiling is no longer a generic dispatch failure: a PR handoff from
+    /// `terminally_fail_task` can remain open forever and keep an epic's batch
+    /// completion rule from firing. The final arbiter instead owns one of two
+    /// release-producing dispositions: supersede with replacement tasks, or
+    /// park into the autonomous Planner escalation path.
+    async fn record_hold_cycle_ceiling_final_dispatch(
         &mut self,
         task: &djinn_core::models::Task,
         role: &'static str,
         quality_strikes: i64,
-    ) -> bool {
+        hold_cycle: i32,
+    ) {
         let reason = format!(
             "Cumulative arbitration ceiling reached: {MAX_ARBITER_HOLD_CYCLES} arbiter hold \
              cycle(s) already spent on this task without convergence \
              (intervention_count={}, total_reopen_count={}, quality_strikes={quality_strikes}, \
-             role={role}). Every per-cycle guard on the remediation ladder resets by \
-             incrementing, so a task that declines via a different guard each round would loop \
-             forever and monopolize the dispatch queue (incident gy53). Terminally failing this \
-             task instead of opening hold cycle {MAX_ARBITER_HOLD_CYCLES}; a planner may \
-             resurrect the work from the epic, and the branch plus its PR are preserved.",
+             role={role}). Opening the one-shot final arbiter at hold cycle {hold_cycle}; it must \
+             either supersede the source with replacement work or park into an autonomous \
+             Planner escalation that can replan the epic/proposal.",
             task.intervention_count, task.total_reopen_count,
         );
         tracing::warn!(
@@ -2596,28 +2627,13 @@ impl CoordinatorActor {
             total_reopen_count = task.total_reopen_count,
             quality_strikes,
             ceiling = MAX_ARBITER_HOLD_CYCLES,
-            "CoordinatorActor: cumulative arbiter hold-cycle ceiling reached — terminally failing \
-             the task instead of opening another hold cycle"
+            hold_cycle,
+            "CoordinatorActor: cumulative arbiter hold-cycle ceiling reached — dispatching the \
+             one-shot final arbiter"
         );
 
-        // Clear streak/cooldown so nothing re-arms dispatch behind the terminal
-        // transition.
-        self.dispatch_failure_streak.remove(&task.id);
-        self.dispatch_cooldowns.remove(&task.id);
-        self.last_dispatched.remove(&task.id);
-        self.inflight_dispatches.remove(&task.id);
-        self.clear_durable_dispatch_backoff_state(
-            &task.id,
-            Some(&task.short_id),
-            "arbiter_hold_cycle_ceiling",
-        )
-        .await;
-
-        // Durable "why" record, independent of the transition reason text.
-        // Recorded once per task: a PR-bearing task terminalizes via an
-        // idempotent poller handoff, so this rung can legitimately be re-entered
-        // by the PR poller on a later tick and must not spam the activity log or
-        // double-count the park metric.
+        // Durable one-shot marker. Re-entry sees this marker and routes directly
+        // to the Planner escalation instead of dispatching another final arbiter.
         if !self.hold_cycle_ceiling_already_recorded(&task.id).await {
             let payload = serde_json::json!({
                 "event": "arbiter_hold_cycle_ceiling",
@@ -2628,6 +2644,8 @@ impl CoordinatorActor {
                 "reopen_count": task.reopen_count,
                 "quality_strikes": quality_strikes,
                 "role": role,
+                "hold_cycle": hold_cycle,
+                "disposition": "final_arbiter",
                 "ci_failure_fingerprint": task.ci_failure_fingerprint,
                 "reason": reason,
             });
@@ -2655,10 +2673,6 @@ impl CoordinatorActor {
             );
             self.record_task_parked_metric(task, quality_strikes).await;
         }
-
-        self.terminally_fail_task(task, "coordinator", &reason)
-            .await;
-        true
     }
 
     /// Has the hold-cycle ceiling already been recorded for this task?

--- a/server/crates/djinn-coordinator/src/doctor/mod.rs
+++ b/server/crates/djinn-coordinator/src/doctor/mod.rs
@@ -22,6 +22,7 @@ pub mod mismatch_scan;
 pub mod refinement_phantom_active;
 pub mod retrieval_health;
 pub mod stale_cache_roots;
+pub mod stalled_epic;
 pub mod stranded_ready;
 
 use std::sync::Arc;
@@ -44,6 +45,10 @@ pub use stale_cache_roots::{
     MemoryStaleCacheRootsSource, ProjectRepositoryStaleCacheRootsSource,
     STALE_CACHE_ROOTS_CHECK_NAME, StaleCacheRootsCheck, StaleCacheRootsSource,
     scan_cache_roots_under, scan_production_cache_root,
+};
+pub use stalled_epic::{
+    MemoryStalledEpicSource, STALLED_EPIC_CHECK_NAME, StalledEpicCheck, StalledEpicSource,
+    TaskRepositoryStalledEpicSource,
 };
 pub use stranded_ready::{
     MemoryStrandedReadySource, STRANDED_READY_CHECK_NAME, StrandedReadyCandidate,
@@ -140,6 +145,14 @@ pub fn register_refinement_phantom_active_check(
     source: Arc<dyn RefinementPhantomActiveSource>,
 ) -> Option<String> {
     registry.register(Arc::new(RefinementPhantomActiveCheck::new(source)))
+}
+
+/// Register the read-only stalled-epic detector.
+pub fn register_stalled_epic_check(
+    registry: &DoctorRegistry,
+    source: Arc<dyn StalledEpicSource>,
+) -> Option<String> {
+    registry.register(Arc::new(StalledEpicCheck::new(source)))
 }
 
 // ---------------------------------------------------------------------------

--- a/server/crates/djinn-coordinator/src/doctor/stalled_epic.rs
+++ b/server/crates/djinn-coordinator/src/doctor/stalled_epic.rs
@@ -1,0 +1,189 @@
+//! Read-only doctor check for open epics with no dispatchable work.
+
+use std::sync::Arc;
+
+use djinn_core::doctor::{
+    DoctorCheck, DoctorCheckCadence, DoctorError, DoctorResult, Finding, FindingSeverity,
+    ResolverSnapshot,
+};
+use serde_json::json;
+use tracing::warn;
+
+pub const STALLED_EPIC_CHECK_NAME: &str = "stalled_epic";
+
+pub trait StalledEpicSource: Send + Sync {
+    fn snapshot(&self) -> serde_json::Value;
+    fn refresh_for_run(&self) {}
+}
+
+pub struct StalledEpicCheck {
+    source: Arc<dyn StalledEpicSource>,
+}
+
+impl StalledEpicCheck {
+    pub fn new(source: Arc<dyn StalledEpicSource>) -> Self {
+        Self { source }
+    }
+}
+
+impl DoctorCheck for StalledEpicCheck {
+    fn name(&self) -> &'static str {
+        STALLED_EPIC_CHECK_NAME
+    }
+
+    fn description(&self) -> &'static str {
+        "Reports open epics with no active planning task and no dispatchable worker work"
+    }
+
+    fn cadence(&self) -> DoctorCheckCadence {
+        DoctorCheckCadence::OnDemand
+    }
+
+    fn run(&self) -> DoctorResult<Vec<Finding>> {
+        self.source.refresh_for_run();
+        let snapshot = self.source.snapshot();
+        Ok(snapshot["findings"]
+            .as_array()
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+            .iter()
+            .filter_map(|raw| {
+                let epic_id = raw["id"].as_str()?.to_owned();
+                let short_id = raw["short_id"].as_str()?.to_owned();
+                let title = raw["title"].as_str()?.to_owned();
+                Some(
+                    Finding::new(
+                        FindingSeverity::Warn,
+                        STALLED_EPIC_CHECK_NAME,
+                        ResolverSnapshot::new(
+                            "report_stalled_epic",
+                            json!({"epic": raw}),
+                            json!({"would_mutate": false}),
+                        ),
+                        format!(
+                            "open epic {short_id} ({title}) has no active planning task and no dispatchable worker work"
+                        ),
+                    )
+                    .with_entity_id("epic_id", epic_id)
+                    .with_entity_id("short_id", short_id)
+                    .with_evidence(json!({"epic": raw})),
+                )
+            })
+            .collect())
+    }
+
+    fn fix(&self, _finding: &Finding) -> DoctorResult<()> {
+        Err(DoctorError::FixNotSupported {
+            check: self.name().to_string(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MemoryStalledEpicSource {
+    snapshot: serde_json::Value,
+}
+
+impl MemoryStalledEpicSource {
+    pub fn new(snapshot: serde_json::Value) -> Self {
+        Self { snapshot }
+    }
+}
+
+impl StalledEpicSource for MemoryStalledEpicSource {
+    fn snapshot(&self) -> serde_json::Value {
+        self.snapshot.clone()
+    }
+}
+
+#[derive(Clone)]
+pub struct TaskRepositoryStalledEpicSource {
+    db: djinn_db::Database,
+    cache: Arc<tokio::sync::RwLock<serde_json::Value>>,
+}
+
+impl TaskRepositoryStalledEpicSource {
+    pub fn new(db: djinn_db::Database) -> Self {
+        Self {
+            db,
+            cache: Arc::new(tokio::sync::RwLock::new(json!({}))),
+        }
+    }
+
+    pub async fn refresh(&self) {
+        let repo =
+            djinn_db::TaskRepository::new(self.db.clone(), djinn_core::events::EventBus::noop());
+        let snapshot = match repo.board_health(30).await {
+            Ok(report) => report
+                .get("stalled_epics")
+                .cloned()
+                .unwrap_or_else(|| json!({})),
+            Err(error) => {
+                warn!(%error, "stalled_epic doctor: failed to load snapshot");
+                json!({})
+            }
+        };
+        *self.cache.write().await = snapshot;
+    }
+}
+
+impl StalledEpicSource for TaskRepositoryStalledEpicSource {
+    fn snapshot(&self) -> serde_json::Value {
+        self.cache
+            .try_read()
+            .map(|guard| guard.clone())
+            .unwrap_or_else(|_| json!({}))
+    }
+
+    fn refresh_for_run(&self) {
+        let source = self.clone();
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| handle.block_on(source.refresh()));
+            }
+            Ok(_) => {
+                let _ = std::thread::spawn(move || {
+                    if let Ok(runtime) = tokio::runtime::Runtime::new() {
+                        runtime.block_on(source.refresh());
+                    }
+                })
+                .join();
+            }
+            Err(_) => {
+                if let Ok(runtime) = tokio::runtime::Runtime::new() {
+                    runtime.block_on(source.refresh());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use djinn_core::doctor::DoctorCheck;
+
+    #[test]
+    fn reports_exact_1woc_shape_without_offering_a_fix() {
+        let source = MemoryStalledEpicSource::new(json!({
+            "total": 1,
+            "findings": [{
+                "id": "epic-1woc", "short_id": "1woc", "title": "Retire verification",
+                "tasks": [
+                    {"short_id": "w3q8", "issue_type": "planning", "status": "closed"},
+                    {"short_id": "vulw", "issue_type": "planning", "status": "closed"},
+                    {"short_id": "gy53", "issue_type": "task", "status": "pr_review", "pr_url": "https://example.test/pr/2655"},
+                    {"short_id": "zb05", "issue_type": "task", "status": "open", "blocked_by": ["gy53"]}
+                ]
+            }]
+        }));
+        let check = StalledEpicCheck::new(Arc::new(source));
+        let finding = check.run().unwrap().pop().unwrap();
+        assert_eq!(finding.entity_ids["short_id"], "1woc");
+        assert_eq!(finding.evidence["epic"]["tasks"][2]["short_id"], "gy53");
+        assert!(matches!(
+            check.fix(&finding),
+            Err(DoctorError::FixNotSupported { .. })
+        ));
+    }
+}

--- a/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
+++ b/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
@@ -118,9 +118,9 @@ async fn task_on_the_park_rung(
 ///
 /// Each cycle declines through a DIFFERENT sub-guard, so no single guard's
 /// counter ever accumulates — exactly the shape that let gy53 ride to
-/// `hold_cycle` 9. The task must still terminate at the cumulative bound, and
-/// it must terminate through the ceiling rather than through the guard that
-/// would otherwise have granted yet another free remediation.
+/// `hold_cycle` 9. The task must still stop worker redispatch at the cumulative
+/// bound and enter the one-shot final arbiter rather than the guard that would
+/// otherwise grant another free remediation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hold_cycle_ceiling_terminates_when_a_different_guard_declines_each_cycle() {
     let db = test_helpers::create_test_db();
@@ -206,11 +206,12 @@ async fn hold_cycle_ceiling_terminates_when_a_different_guard_declines_each_cycl
          marker is written: {markers_after:?}"
     );
 
-    // Terminal, non-redispatching state, with the reason recorded durably.
-    let closed = repo.get(&base.id).await.unwrap().unwrap();
+    // Non-worker-dispatching final-arbiter state, with the reason recorded
+    // durably.
+    let held = repo.get(&base.id).await.unwrap().unwrap();
     assert_eq!(
-        closed.status, "closed",
-        "a PR-less task at the ceiling must be terminally closed, not parked or redispatched"
+        held.status, "needs_lead_intervention",
+        "the task must enter its one-shot final arbiter, not be worker-redispatched"
     );
     let ceiling_markers = hold_cycle_ceiling_markers(&repo, &base.id).await;
     assert_eq!(
@@ -224,14 +225,21 @@ async fn hold_cycle_ceiling_terminates_when_a_different_guard_declines_each_cycl
         "the audit entry names the fingerprint that would otherwise have won another free round"
     );
 
-    // No fourth hold cycle was ever opened.
+    // The prospective ceiling cycle is the single final arbitration row.
     let arb = TaskArbitrationRepository::new(db.clone());
-    assert!(
-        arb.get_by_task_and_cycle(&base.id, MAX_ARBITER_HOLD_CYCLES)
-            .await
-            .unwrap()
-            .is_none(),
-        "the ceiling must refuse to open hold cycle {MAX_ARBITER_HOLD_CYCLES}"
+    let final_row = arb
+        .get_by_task_and_cycle(&base.id, MAX_ARBITER_HOLD_CYCLES)
+        .await
+        .unwrap()
+        .expect("the ceiling opens one final arbitration row");
+    assert_eq!(
+        final_row.directive.unwrap()["terminal_disposition_required"],
+        true
+    );
+    assert_eq!(
+        final_row.dossier.unwrap()["final_disposition"],
+        true,
+        "the arbiter must receive the terminal mandate in its dossier"
     );
 }
 
@@ -307,14 +315,11 @@ async fn hold_cycle_ceiling_yields_to_an_in_flight_arbiter() {
     );
 }
 
-/// gy53 itself carried an open PR. `terminally_fail_task` deliberately hands a
-/// PR-bearing task to the PR poller rather than force-closing it (the PR and
-/// branch are preserved), so the terminal state differs — but the rung must
-/// still HANDLE the task (the caller skips its dispatch), must record the
-/// reason, and must not open another hold cycle. Re-entry from a later poller
-/// tick must stay idempotent instead of spamming the audit log.
+/// gy53 itself carried an open PR. The old generic terminal gate handed it to
+/// the PR poller and stranded the epic. A PR-bearing task must instead receive
+/// the same one-shot final arbiter, with no eager successor cycle.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn hold_cycle_ceiling_hands_a_pr_bearing_task_to_the_poller_idempotently() {
+async fn hold_cycle_ceiling_dispatches_one_final_arbiter_for_pr_task() {
     let db = test_helpers::create_test_db();
     let (tx, _rx) = broadcast::channel(256);
     let mut actor = coordinator_actor_for_tests(&db, &tx);
@@ -339,18 +344,10 @@ async fn hold_cycle_ceiling_hands_a_pr_bearing_task_to_the_poller_idempotently()
     );
     let handed_off = repo.get(&base.id).await.unwrap().unwrap();
     assert_eq!(
-        handed_off.status, "pr_review",
-        "the terminal gate hands a PR-bearing task to the poller instead of force-closing it"
+        handed_off.status, "needs_lead_intervention",
+        "the PR-bearing task must reach the final arbiter instead of being parked in pr_review"
     );
 
-    // A later poller tick re-enters the rung; the audit entry must not double.
-    let reloaded = repo.get(&base.id).await.unwrap().unwrap();
-    assert!(
-        actor
-            .route_planner_intervention(&reloaded, "worker", "strike", None, 5)
-            .await,
-        "re-entry at the ceiling must keep handling the task"
-    );
     let ceiling_markers = hold_cycle_ceiling_markers(&repo, &base.id).await;
     assert_eq!(
         ceiling_markers.len(),
@@ -362,12 +359,18 @@ async fn hold_cycle_ceiling_hands_a_pr_bearing_task_to_the_poller_idempotently()
         "no sub-guard may run after the ceiling trips"
     );
     let arb = TaskArbitrationRepository::new(db.clone());
+    let final_row = arb
+        .get_by_task_and_cycle(&base.id, MAX_ARBITER_HOLD_CYCLES)
+        .await
+        .unwrap()
+        .expect("one final row exists");
+    assert!(final_row.consumed_at.is_none());
     assert!(
-        arb.get_by_task_and_cycle(&base.id, MAX_ARBITER_HOLD_CYCLES)
+        arb.get_by_task_and_cycle(&base.id, MAX_ARBITER_HOLD_CYCLES + 1)
             .await
             .unwrap()
             .is_none(),
-        "no fresh hold cycle may be opened once the ceiling has tripped"
+        "dispatching the final arbiter must not eagerly open a successor cycle"
     );
 }
 

--- a/server/crates/djinn-coordinator/src/tests/terminal_gate_boundary.rs
+++ b/server/crates/djinn-coordinator/src/tests/terminal_gate_boundary.rs
@@ -43,22 +43,20 @@ fn coordinator_exhaustion_force_close_has_one_terminal_gate() {
         "terminally_fail_task must be the sole dispatch-exhaustion ForceClose gateway"
     );
 
-    // These are the two current exhaustion owners: model-chain/max-retry
-    // dispatch and the autonomous-remediation ceiling. They may call the gate,
-    // but never the ForceClose transition directly.
-    for (path, source) in [
-        ("dispatch/task_dispatch.rs", TASK_DISPATCH_SRC),
-        ("dispatch/retry.rs", RETRY_SRC),
-    ] {
-        assert!(
-            source.contains("terminally_fail_task"),
-            "{path} owns an exhaustion path and must route it through terminally_fail_task"
-        );
-        assert!(
-            !source.contains("TransitionAction::ForceClose"),
-            "{path} must not bypass terminally_fail_task with TransitionAction::ForceClose"
-        );
-    }
+    // Model-chain/max-retry dispatch remains generic exhaustion and must use
+    // the terminal gate.
+    assert!(
+        TASK_DISPATCH_SRC.contains("terminally_fail_task"),
+        "dispatch/task_dispatch.rs owns generic exhaustion and must route it through terminally_fail_task"
+    );
+    // The arbitration ceiling is a lifecycle disposition, not generic
+    // exhaustion: its one-shot final arbiter must release the epic through
+    // supersede or autonomous Planner escalation. It still must not introduce
+    // a second ForceClose gateway.
+    assert!(
+        !RETRY_SRC.contains("TransitionAction::ForceClose"),
+        "dispatch/retry.rs must not bypass terminally_fail_task with TransitionAction::ForceClose"
+    );
 
     // Catch new recovery/exhaustion modules as well. Test fixtures are excluded
     // because they only model transitions; production modules are all scanned.

--- a/server/crates/djinn-coordinator/src/types.rs
+++ b/server/crates/djinn-coordinator/src/types.rs
@@ -431,8 +431,8 @@ pub(super) const MAX_PLANNER_INTERVENTIONS: i64 = 1;
 pub(super) const MAX_AUTONOMOUS_ESCALATIONS: i64 = 3;
 
 /// Cumulative, cross-cycle arbitration ceiling: the maximum number of arbiter
-/// hold cycles a single source task may ever open before the second-strike
-/// rung stops re-entering the ladder and terminally fails the task.
+/// ordinary hold cycles a single source task may open before the second-strike
+/// rung bypasses every redispatch guard and opens one final-disposition arbiter.
 ///
 /// **This is the only bound on the rung that is cumulative.** Every other guard
 /// on the second-strike ladder is per-cycle or per-fingerprint, and each one
@@ -463,8 +463,10 @@ pub(super) const MAX_AUTONOMOUS_ESCALATIONS: i64 = 3;
 ///
 /// Rationale for `3`: hold cycles 0, 1 and 2 give the Lead arbiter three full
 /// forensic rounds (each of which may reopen with a directive, rotate models,
-/// or supersede). A task that has burned three complete arbitration cycles
-/// without converging is not going to converge on the fourth; board-wide over
+/// or supersede). At prospective cycle 3 the arbiter gets exactly one final
+/// decision surface: supersede with replacements, or park into autonomous
+/// Planner replanning. Any non-terminal response is converted to that park.
+/// Board-wide over
 /// nine days only 18 of 55 arbitrated tasks ever reached `hold_cycle > 0` at
 /// all, so this ceiling is far above normal operation while still an order of
 /// magnitude below gy53's observed 9.

--- a/server/crates/djinn-db/src/repositories/task/board_health_stalled_epics.rs
+++ b/server/crates/djinn-db/src/repositories/task/board_health_stalled_epics.rs
@@ -1,0 +1,150 @@
+//! Bounded board-health projection for open epics with no dispatchable work.
+
+use sqlx::Row;
+
+/// Open epics whose task graph has no coordinator-dispatchable work.
+pub(super) async fn stalled_epics_section(pool: &sqlx::PgPool) -> serde_json::Value {
+    let rows = sqlx::query(
+        r#"SELECT e.id, e.short_id, e.title,
+                  COALESCE(
+                    (SELECT jsonb_agg(jsonb_build_object(
+                        'id', t.id, 'short_id', t.short_id,
+                        'issue_type', t.issue_type, 'status', t.status,
+                        'pr_url', t.pr_url
+                    ) ORDER BY t.created_at)
+                       FROM tasks t WHERE t.epic_id = e.id),
+                    '[]'::jsonb
+                  ) AS tasks
+             FROM epics e
+            WHERE e.status = 'open'
+              AND NOT EXISTS (
+                SELECT 1 FROM tasks p
+                 WHERE p.epic_id = e.id
+                   AND p.issue_type IN ('planning', 'decomposition')
+                   AND p.status IN ('open', 'in_progress')
+              )
+              AND EXISTS (
+                SELECT 1 FROM tasks w
+                 WHERE w.epic_id = e.id
+                   AND w.issue_type NOT IN ('planning', 'decomposition')
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM tasks w
+                 WHERE w.epic_id = e.id
+                   AND w.issue_type NOT IN ('planning', 'decomposition')
+                   AND (
+                     w.status NOT IN ('closed', 'pr_review')
+                     AND NOT (
+                       w.status = 'open' AND EXISTS (
+                         SELECT 1
+                           FROM blockers b
+                           JOIN tasks blocker ON blocker.id = b.blocking_task_id
+                          WHERE b.task_id = w.id
+                            AND blocker.status <> 'closed'
+                       )
+                     )
+                   )
+              )
+            ORDER BY e.created_at"#,
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default();
+
+    serde_json::json!({
+        "total": rows.len(),
+        "findings": rows.into_iter().map(|row| serde_json::json!({
+            "id": row.get::<String, _>("id"),
+            "short_id": row.get::<String, _>("short_id"),
+            "title": row.get::<String, _>("title"),
+            "tasks": row.get::<serde_json::Value, _>("tasks"),
+        })).collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn insert_task(
+        db: &Database,
+        project_id: &str,
+        epic_id: &str,
+        issue_type: &str,
+        status: &str,
+    ) -> String {
+        let id = uuid::Uuid::now_v7().to_string();
+        let compact_id = id.replace('-', "");
+        let creator = crate::repositories::test_support::seed_test_user(db).await;
+        sqlx::query(
+            r#"INSERT INTO tasks (
+                 id, project_id, short_id, epic_id, title, description, design,
+                 issue_type, status, priority, owner, labels, acceptance_criteria,
+                 memory_refs, created_by_user_id
+               ) VALUES (
+                 $1, $2, $3, $4, 'Task', '', '', $5, $6, 1, '',
+                 '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, $7
+               )"#,
+        )
+        .bind(&id)
+        .bind(project_id)
+        .bind(format!("t{}", &compact_id[compact_id.len() - 8..]))
+        .bind(epic_id)
+        .bind(issue_type)
+        .bind(status)
+        .bind(creator)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn reports_closed_planners_terminal_pr_and_blocked_dependent() {
+        let db = Database::open_in_memory().unwrap();
+        let project_id = uuid::Uuid::now_v7().to_string();
+        crate::repositories::test_support::seed_project(&db, &project_id, "stalled").await;
+        let epic_id = uuid::Uuid::now_v7().to_string();
+        sqlx::query(
+            r#"INSERT INTO epics (
+                 id, project_id, short_id, title, description, emoji, color, owner,
+                 status
+               ) VALUES ($1, $2, '1woc', 'Retire verification', '', '', '', '', 'open')"#,
+        )
+        .bind(&epic_id)
+        .bind(&project_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        insert_task(&db, &project_id, &epic_id, "planning", "closed").await;
+        insert_task(&db, &project_id, &epic_id, "planning", "closed").await;
+        let exhausted = insert_task(&db, &project_id, &epic_id, "task", "pr_review").await;
+        sqlx::query("UPDATE tasks SET pr_url = $2 WHERE id = $1")
+            .bind(&exhausted)
+            .bind("https://github.com/djinnos/djinn/pull/2655")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        let dependent = insert_task(&db, &project_id, &epic_id, "task", "open").await;
+        sqlx::query("INSERT INTO blockers (task_id, blocking_task_id) VALUES ($1, $2)")
+            .bind(&dependent)
+            .bind(&exhausted)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let section = stalled_epics_section(db.pool()).await;
+        assert_eq!(section["total"], 1);
+        assert_eq!(section["findings"][0]["id"], epic_id);
+
+        // Neutralization: closing the blocker makes the dependent dispatchable.
+        sqlx::query("UPDATE tasks SET status = 'closed' WHERE id = $1")
+            .bind(&exhausted)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(stalled_epics_section(db.pool()).await["total"], 0);
+    }
+}

--- a/server/crates/djinn-db/src/repositories/task/mod.rs
+++ b/server/crates/djinn-db/src/repositories/task/mod.rs
@@ -13,6 +13,7 @@ mod activity;
 mod blockers;
 mod board_health;
 mod board_health_dispatch_gate;
+mod board_health_stalled_epics;
 mod ci;
 mod parent_disposition;
 mod queries;

--- a/server/crates/djinn-db/src/repositories/task/queries.rs
+++ b/server/crates/djinn-db/src/repositories/task/queries.rs
@@ -655,6 +655,8 @@ impl TaskRepository {
         let stranded_ready = super::board_health::stranded_ready_section(self.db.pool()).await;
         let closed_parent_open_children =
             super::board_health::closed_parent_open_children_section(self.db.pool()).await;
+        let stalled_epics =
+            super::board_health_stalled_epics::stalled_epics_section(self.db.pool()).await;
 
         Ok(serde_json::json!({
             "epic_stats":            epic_stats,
@@ -667,6 +669,7 @@ impl TaskRepository {
             "attribution_findings":  attribution_findings,
             "stranded_ready":        stranded_ready,
             "closed_parent_open_children": closed_parent_open_children,
+            "stalled_epics": stalled_epics,
         }))
     }
 


### PR DESCRIPTION
## Summary

- replace the hold-cycle ceiling PR-poller handoff with one final arbiter whose only terminal exits are supersede-with-replacements or a dossier-backed autonomous Planner replan
- mechanically convert final approve/reopen decisions into the Planner park path, attach that escalation to the source epic, and preserve downstream blocker transfer through the existing supersede transaction
- add a read-only `stalled_epic` doctor check and board-health projection for open epics with no active planning or dispatchable worker work

## Verification

- `RUST_MIN_STACK=33554432 SQLX_OFFLINE=true cargo test -p djinn-coordinator --lib -- --test-threads=1` — 2022 passed; two shared process-wide metrics registry failures passed in isolation
- `SQLX_OFFLINE=true cargo test -p djinn-agent --lib -- --test-threads=1` — 1411 passed, 1 ignored
- focused final-arbiter, supersede/park transaction, stalled-epic, and hold-cycle tests passed after rebase
- neutralization: disabling the final ceiling branch restored the novel-fingerprint redispatch failure; disabling unresolved-blocker recognition made the exact 1woc detector miss the epic
- `cargo fmt --all -- --check`
- `SQLX_OFFLINE=true cargo clippy -p djinn-db -p djinn-coordinator -p djinn-agent --all-targets` — completed with pre-existing warnings outside touched lines; `-D warnings` is blocked by the same existing warnings
- `scripts/check-file-size.sh --files-from-stdin`
- `cargo sqlx prepare --workspace -- --all-targets` was attempted but this environment has no `DATABASE_URL`; the added SQL uses runtime `sqlx::query` and does not create an offline macro cache entry

## Live specimen

Read-only Djinn MCP inspection confirmed the five historical gy53 decisions were all `reopen`. The separately spawned repair agent had already merged gy53 before this change, which released zb05; no production task was mutated during investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)