### PR TITLE
feat(rust): configure Cargo features per workspace

### DIFF
--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -1,22 +1,3 @@
-[build]
-# Feature set djinn's warm-cache pre-build compiles with, so the warm base
-# matches what CI and task-run pods actually build.
-#
-# `djinn-agent-worker::cargo_cache_policy` reads this key to derive the warm
-# job's `--features` args; without it the warm base is built with NO features
-# while CI (`.github/workflows/quality-gate.yml`) and worker commands use
-# `--features qdrant`. Feature resolution differs, so every unit whose
-# resolution depends on it misses the warm base and recompiles.
-#
-# This is djinn's own convention, NOT a cargo key: cargo emits
-# `warning: unused config key build.features` and ignores it. That warning is
-# expected — do not "fix" it by deleting this, and do not move the feature list
-# into the platform, which is deliberately repo-agnostic and reads it from here.
-#
-# Keep in sync with the `--features` used by the Server Clippy / Server Test
-# jobs in `.github/workflows/quality-gate.yml`.
-features = ["qdrant"]
-
 # NOTE: `rustc-wrapper = "sccache"` is intentionally NOT set here. The djinn
 # platform (warm/worker pods) reuses a warm, main-based per-project
 # cargo target base with INCREMENTAL compilation (CI-style, like

--- a/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
@@ -65,7 +65,7 @@ pub struct CargoWarmCommand {
 ///
 /// Reads (but never writes):
 /// * `Cargo.toml` — workspace section detection.
-/// * `.cargo/config.toml` — `build.features`.
+/// * the selected Rust workspace — Cargo feature configuration.
 /// * `env_config` — Rust workspace root for workspace directory resolution.
 ///
 /// Returns `None` when no cargo workspace exists (non-Rust repo).
@@ -93,23 +93,17 @@ pub fn resolve_cargo_cache_policy(
         });
     }
 
-    let workspace_dir = resolve_cargo_workspace_dir(project_root, env_config)?;
+    let (workspace_dir, workspace_config) = resolve_cargo_workspace(project_root, env_config)?;
 
     let is_workspace = detect_workspace_layout(&workspace_dir);
-    let cargo_config = read_cargo_config_toml(&workspace_dir);
-    let config_features = cargo_config
-        .as_ref()
-        .map(|c| c.features.clone())
+    let (features, all_features) = workspace_config
+        .map(|workspace| {
+            (
+                workspace.cargo_features.clone(),
+                workspace.cargo_all_features,
+            )
+        })
         .unwrap_or_default();
-    // Only the explicit `.cargo/config.toml` `build.features = "all-features"`
-    // override can opt into an all-features warm.
-    let all_features = config_features.contains(&"all-features".to_string());
-
-    let features = if all_features {
-        Vec::new()
-    } else {
-        config_features
-    };
 
     let nextest = detect_nextest(&workspace_dir);
 
@@ -127,34 +121,6 @@ pub fn resolve_cargo_cache_policy(
 // Internal detection helpers
 // ---------------------------------------------------------------------------
 
-/// Parsed subset of `.cargo/config.toml` relevant to cache policy.
-#[derive(Debug, Default, PartialEq, Eq)]
-struct CargoConfigToml {
-    features: Vec<String>,
-}
-
-fn read_cargo_config_toml(workspace_dir: &Path) -> Option<CargoConfigToml> {
-    let path = workspace_dir.join(".cargo").join("config.toml");
-    let text = std::fs::read_to_string(&path).ok()?;
-    let raw: toml::Table = toml::from_str(&text).ok()?;
-
-    let mut out = CargoConfigToml::default();
-
-    if let Some(build) = raw.get("build").and_then(|v| v.as_table()) {
-        if let Some(features) = build.get("features").and_then(|v| v.as_str()) {
-            out.features = features.split_whitespace().map(|s| s.to_string()).collect();
-        }
-        if let Some(features_arr) = build.get("features").and_then(|v| v.as_array()) {
-            out.features = features_arr
-                .iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect();
-        }
-    }
-
-    Some(out)
-}
-
 fn detect_workspace_layout(workspace_dir: &Path) -> bool {
     let cargo_toml = workspace_dir.join("Cargo.toml");
     let text = match std::fs::read_to_string(&cargo_toml) {
@@ -168,8 +134,6 @@ fn detect_workspace_layout(workspace_dir: &Path) -> bool {
     raw.contains_key("workspace")
 }
 
-// All-features warm is now opt-in only via `.cargo/config.toml`
-// `build.features = "all-features"`.
 /// Detect whether the project uses `cargo-nextest` (a `.config/nextest.toml` or
 /// `nextest.toml` at the cargo workspace root). Drives whether the test-compile
 /// warm step uses `cargo nextest run --no-run` vs `cargo test --no-run`.
@@ -268,33 +232,33 @@ fn build_warm_commands(
 }
 
 // ---------------------------------------------------------------------------
-// resolve_cargo_workspace_dir (mirrors main.rs logic, kept local for purity)
+// Resolve Cargo workspace (mirrors main.rs logic, kept local for purity)
 // ---------------------------------------------------------------------------
 
-fn resolve_cargo_workspace_dir(
+fn resolve_cargo_workspace<'a>(
     project_root: &Path,
-    env_config: Option<&EnvironmentConfig>,
-) -> Option<PathBuf> {
+    env_config: Option<&'a EnvironmentConfig>,
+) -> Option<(PathBuf, Option<&'a djinn_stack::environment::Workspace>)> {
     if let Some(cfg) = env_config {
         for ws in &cfg.workspaces {
             if ws.language.eq_ignore_ascii_case("rust") {
                 let dir = project_root.join(&ws.root);
                 if dir.join("Cargo.toml").is_file() {
-                    return Some(dir);
+                    return Some((dir, Some(ws)));
                 }
             }
         }
     }
 
     if project_root.join("Cargo.toml").is_file() {
-        return Some(project_root.to_path_buf());
+        return Some((project_root.to_path_buf(), None));
     }
 
     if let Ok(entries) = std::fs::read_dir(project_root) {
         for entry in entries.flatten() {
             let dir = entry.path();
             if dir.is_dir() && dir.join("Cargo.toml").is_file() {
-                return Some(dir);
+                return Some((dir, None));
             }
         }
     }
@@ -325,6 +289,8 @@ mod tests {
                 toolchain: None,
                 version: None,
                 package_manager: None,
+                cargo_features: Vec::new(),
+                cargo_all_features: false,
             }],
             system_packages: vec![],
             env: Default::default(),
@@ -501,7 +467,7 @@ version = "0.1.0"
     }
 
     #[test]
-    fn cargo_config_features_array() {
+    fn workspace_config_named_features() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path();
         fs::write(
@@ -512,16 +478,9 @@ version = "0.1.0"
 "#,
         )
         .expect("write Cargo.toml");
-        fs::create_dir_all(root.join(".cargo")).expect("mkdir .cargo");
-        fs::write(
-            root.join(".cargo/config.toml"),
-            r#"[build]
-features = ["foo", "bar"]
-"#,
-        )
-        .expect("write config.toml");
-
-        let policy = resolve_cargo_cache_policy(root, None).expect("policy");
+        let mut cfg = make_env_config_with_rust_workspace(".");
+        cfg.workspaces[0].cargo_features = vec!["foo".into(), "bar".into()];
+        let policy = resolve_cargo_cache_policy(root, Some(&cfg)).expect("policy");
         assert_eq!(policy.features, vec!["foo", "bar"]);
         assert!(!policy.all_features);
 
@@ -558,7 +517,7 @@ features = ["foo", "bar"]
     }
 
     #[test]
-    fn cargo_config_features_string() {
+    fn cargo_config_custom_features_are_ignored() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path();
         fs::write(
@@ -579,34 +538,13 @@ features = "foo bar"
         .expect("write config.toml");
 
         let policy = resolve_cargo_cache_policy(root, None).expect("policy");
-        assert_eq!(policy.features, vec!["foo", "bar"]);
+        assert!(policy.features.is_empty());
         assert!(!policy.all_features);
-
-        // Named features: clippy + build + test, features in feature_args, not in args.
-        assert_eq!(policy.warm_commands.len(), 3);
-        assert_eq!(
-            policy.warm_commands[0].args,
-            vec!["clippy", "--all-targets"]
-        );
-        assert_eq!(
-            policy.warm_commands[0].feature_args,
-            vec!["--features", "foo,bar"]
-        );
-        assert_eq!(policy.warm_commands[1].args, vec!["build", "--all-targets"]);
-        assert_eq!(
-            policy.warm_commands[1].feature_args,
-            vec!["--features", "foo,bar"]
-        );
-        assert_eq!(policy.warm_commands[2].label, "test (--no-run)");
-        assert_eq!(
-            policy.warm_commands[2].feature_args,
-            vec!["--features", "foo,bar"]
-        );
-
-        // Verify features() returns the correct CLI args
-        assert_eq!(
-            policy.features(),
-            vec!["--features".to_string(), "foo,bar".to_string()]
+        assert!(
+            policy
+                .warm_commands
+                .iter()
+                .all(|command| command.feature_args.is_empty())
         );
     }
 
@@ -905,8 +843,8 @@ version = "0.1.0"
         )];
 
         let policy = resolve_cargo_cache_policy(root, Some(&cfg)).expect("policy");
-        // Lifecycle hook scanning removed — all_features only comes from
-        // .cargo/config.toml features override now.
+        // Lifecycle hook scanning was removed; all_features only comes from
+        // the selected workspace configuration now.
         assert!(
             !policy.all_features,
             "lifecycle hook should no longer trigger all-features"

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -4167,6 +4167,8 @@ mod tests {
                 toolchain: None,
                 version: None,
                 package_manager: None,
+                cargo_features: Vec::new(),
+                cargo_all_features: false,
             }],
             ..Default::default()
         };

--- a/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
+++ b/server/crates/djinn-cgroup-launcher/tests/delegated_cpu_lease_lifecycle.rs
@@ -601,16 +601,19 @@ where
     F: djinn_cgroup_launcher::CgroupFs,
     S: djinn_cgroup_launcher::SpawnIntoCgroup,
 {
-    let before: CpuStat = launcher.sample(leaf).expect("sample cpu.stat");
     // Real monotonic time is the point: the whole assertion is CPU consumed per
     // unit of WALL CLOCK. An injected clock would make the measurement describe
     // itself rather than the kernel, which is the failure mode this file exists
-    // to eliminate.
+    // to eliminate. The wall interval deliberately encloses both cpu.stat
+    // samples: the usage delta can include CPU consumed while either sample is
+    // read, so excluding that time creates a tiny, scheduler-dependent false
+    // overrun at the theoretical quota ceiling.
     #[allow(clippy::disallowed_methods)]
     let started = Instant::now();
+    let before: CpuStat = launcher.sample(leaf).expect("sample cpu.stat");
     std::thread::sleep(window);
-    let elapsed = started.elapsed();
     let after: CpuStat = launcher.sample(leaf).expect("sample cpu.stat");
+    let elapsed = started.elapsed();
     Measured {
         usage_usec: after.usage_usec.saturating_sub(before.usage_usec),
         nr_throttled: after.nr_throttled.saturating_sub(before.nr_throttled),

--- a/server/crates/djinn-graph/src/canonical_graph.rs
+++ b/server/crates/djinn-graph/src/canonical_graph.rs
@@ -4180,6 +4180,8 @@ edition = "2024"
                     toolchain: Some("stable".to_string()),
                     version: None,
                     package_manager: None,
+                    cargo_features: Vec::new(),
+                    cargo_all_features: false,
                 },
                 djinn_stack::Workspace {
                     slug: Some("ui".to_string()),
@@ -4190,6 +4192,8 @@ edition = "2024"
                     toolchain: None,
                     version: Some("22".to_string()),
                     package_manager: Some("pnpm".to_string()),
+                    cargo_features: Vec::new(),
+                    cargo_all_features: false,
                 },
             ],
             ..djinn_stack::EnvironmentConfig::empty()
@@ -4333,6 +4337,8 @@ edition = "2024"
                 toolchain: None,
                 version: None,
                 package_manager: None,
+                cargo_features: Vec::new(),
+                cargo_all_features: false,
             }],
             ..djinn_stack::EnvironmentConfig::empty()
         };

--- a/server/crates/djinn-graph/src/scip_indexer/indexing.rs
+++ b/server/crates/djinn-graph/src/scip_indexer/indexing.rs
@@ -2787,6 +2787,8 @@ mod tests {
             toolchain: None,
             version: None,
             package_manager: None,
+            cargo_features: Vec::new(),
+            cargo_all_features: false,
         }
     }
 

--- a/server/crates/djinn-image-builder/src/dockerfile.rs
+++ b/server/crates/djinn-image-builder/src/dockerfile.rs
@@ -728,6 +728,8 @@ mod tests {
                 toolchain: Some("stable".into()),
                 version: None,
                 package_manager: None,
+                cargo_features: Vec::new(),
+                cargo_all_features: false,
             },
             djinn_stack::environment::Workspace {
                 slug: None,
@@ -738,6 +740,8 @@ mod tests {
                 toolchain: Some("1.85.0".into()),
                 version: None,
                 package_manager: None,
+                cargo_features: Vec::new(),
+                cargo_all_features: false,
             },
         ];
         let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
@@ -771,6 +775,8 @@ mod tests {
             toolchain: None,
             version: Some("20".into()),
             package_manager: Some("yarn".into()),
+            cargo_features: Vec::new(),
+            cargo_all_features: false,
         }];
         let df = generate_dockerfile(&cfg, &agent_worker()).unwrap();
         assert!(df.dockerfile.contains("NODE_VERSIONS=\"22 20\""));
@@ -833,6 +839,8 @@ mod tests {
             toolchain: None,
             version: None,
             package_manager: None,
+            cargo_features: Vec::new(),
+            cargo_all_features: false,
         }];
         let err = generate_dockerfile(&cfg, &agent_worker()).unwrap_err();
         assert!(matches!(err, DockerfileError::UnknownWorkspaceLanguage(s) if s == "zig"));

--- a/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
+++ b/server/crates/djinn-provider/tests/fixtures/tool_schema_projection/builtin/djinn_mcp_server.json
@@ -4955,7 +4955,7 @@
               }
             },
             "cargo_cache_policy": {
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
               "anyOf": [
                 {
                   "$ref": "#/$defs/CargoCachePolicy"
@@ -5249,6 +5249,19 @@
                 "null"
               ],
               "default": null
+            },
+            "cargo_features": {
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "cargo_all_features": {
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [
@@ -5717,7 +5730,7 @@
               }
             },
             "cargo_cache_policy": {
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
               "anyOf": [
                 {
                   "$ref": "#/$defs/CargoCachePolicy"
@@ -6011,6 +6024,19 @@
                 "null"
               ],
               "default": null
+            },
+            "cargo_features": {
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "cargo_all_features": {
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [
@@ -6421,7 +6447,7 @@
               }
             },
             "cargo_cache_policy": {
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
               "anyOf": [
                 {
                   "$ref": "#/$defs/CargoCachePolicy"
@@ -6715,6 +6741,19 @@
                 "null"
               ],
               "default": null
+            },
+            "cargo_features": {
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "cargo_all_features": {
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [
@@ -12654,7 +12693,7 @@
               }
             },
             "cargo_cache_policy": {
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
               "anyOf": [
                 {
                   "$ref": "#/$defs/CargoCachePolicy"
@@ -12948,6 +12987,19 @@
                 "null"
               ],
               "default": null
+            },
+            "cargo_features": {
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "cargo_all_features": {
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [
@@ -13334,7 +13386,7 @@
               }
             },
             "cargo_cache_policy": {
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
               "anyOf": [
                 {
                   "$ref": "#/$defs/CargoCachePolicy"
@@ -13628,6 +13680,19 @@
                 "null"
               ],
               "default": null
+            },
+            "cargo_features": {
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "cargo_all_features": {
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [
@@ -13988,7 +14053,7 @@
               }
             },
             "cargo_cache_policy": {
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers.",
               "anyOf": [
                 {
                   "$ref": "#/$defs/CargoCachePolicy"
@@ -14282,6 +14347,19 @@
                 "null"
               ],
               "default": null
+            },
+            "cargo_features": {
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
+            "cargo_all_features": {
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean",
+              "default": false
             }
           },
           "required": [

--- a/server/crates/djinn-stack/src/environment.rs
+++ b/server/crates/djinn-stack/src/environment.rs
@@ -140,11 +140,8 @@ pub struct EnvironmentConfig {
     ///
     /// The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
     /// cache strategy from the repository it is about to run, including the
-    /// Cargo workspace layout, `.cargo/config.toml` settings such as
-    /// `rustc-wrapper`, and configured setup command shapes. That
-    /// detection is deliberately read-only. djinn may read `.cargo/config.toml`
-    /// to keep warm-job and worker behavior consistent with the project, but it
-    /// never creates, edits, or rewrites the project's `.cargo/config.toml`.
+    /// Cargo workspace layout and the selected Rust workspace's Cargo feature
+    /// settings.
     ///
     /// Set an explicit policy only when project authors need to override the
     /// detected cargo feature set at the environment-config level. `None` is
@@ -318,6 +315,8 @@ impl EnvironmentConfig {
                     toolchain,
                     version,
                     package_manager: ws.package_manager.clone(),
+                    cargo_features: Vec::new(),
+                    cargo_all_features: false,
                 }
             })
             .collect();
@@ -613,6 +612,14 @@ pub struct Workspace {
     pub version: Option<String>,
     #[serde(default)]
     pub package_manager: Option<String>,
+    /// Cargo features that every platform-generated Cargo command for this
+    /// Rust workspace must enable. Ignored for non-Rust workspaces.
+    #[serde(default)]
+    pub cargo_features: Vec<String>,
+    /// Pass `--all-features` instead of named `cargo_features`. Ignored for
+    /// non-Rust workspaces.
+    #[serde(default)]
+    pub cargo_all_features: bool,
 }
 
 fn validate_workspaces(workspaces: &[Workspace]) -> EnvResult<()> {
@@ -658,6 +665,13 @@ fn validate_workspace_fields(ws: &Workspace) -> EnvResult<()> {
     }
     if let Some(pm) = &ws.package_manager {
         validate_identifier("workspaces[*].package_manager", pm)?;
+    }
+    validate_feature_list("workspaces[*].cargo_features", &ws.cargo_features)?;
+    if ws.cargo_all_features && !ws.cargo_features.is_empty() {
+        return Err(EnvironmentConfigError::UnsafeIdentifier {
+            field: "workspaces[*].cargo_features".into(),
+            value: "cargo_features cannot be combined with cargo_all_features".into(),
+        });
     }
     Ok(())
 }

--- a/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
+++ b/server/src/server/tests/snapshots/djinn_server__server__tests__tool_schemas__mcp_tools_schema.snap
@@ -5079,7 +5079,7 @@ expression: signatures
               "default": {
                 "mode": "auto-detected"
               },
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
             },
             "env": {
               "additionalProperties": {
@@ -5411,6 +5411,19 @@ expression: signatures
         },
         "Workspace": {
           "properties": {
+            "cargo_all_features": {
+              "default": false,
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean"
+            },
+            "cargo_features": {
+              "default": [],
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "language": {
               "type": "string"
             },
@@ -5800,7 +5813,7 @@ expression: signatures
               "default": {
                 "mode": "auto-detected"
               },
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
             },
             "env": {
               "additionalProperties": {
@@ -6171,6 +6184,19 @@ expression: signatures
         },
         "Workspace": {
           "properties": {
+            "cargo_all_features": {
+              "default": false,
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean"
+            },
+            "cargo_features": {
+              "default": [],
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "language": {
               "type": "string"
             },
@@ -6541,7 +6567,7 @@ expression: signatures
               "default": {
                 "mode": "auto-detected"
               },
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
             },
             "env": {
               "additionalProperties": {
@@ -6873,6 +6899,19 @@ expression: signatures
         },
         "Workspace": {
           "properties": {
+            "cargo_all_features": {
+              "default": false,
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean"
+            },
+            "cargo_features": {
+              "default": [],
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "language": {
               "type": "string"
             },
@@ -12734,7 +12773,7 @@ expression: signatures
               "default": {
                 "mode": "auto-detected"
               },
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
             },
             "env": {
               "additionalProperties": {
@@ -13066,6 +13105,19 @@ expression: signatures
         },
         "Workspace": {
           "properties": {
+            "cargo_all_features": {
+              "default": false,
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean"
+            },
+            "cargo_features": {
+              "default": [],
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "language": {
               "type": "string"
             },
@@ -13413,7 +13465,7 @@ expression: signatures
               "default": {
                 "mode": "auto-detected"
               },
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
             },
             "env": {
               "additionalProperties": {
@@ -13745,6 +13797,19 @@ expression: signatures
         },
         "Workspace": {
           "properties": {
+            "cargo_all_features": {
+              "default": false,
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean"
+            },
+            "cargo_features": {
+              "default": [],
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "language": {
               "type": "string"
             },
@@ -14066,7 +14131,7 @@ expression: signatures
               "default": {
                 "mode": "auto-detected"
               },
-              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout, `.cargo/config.toml` settings such as\n`rustc-wrapper`, and configured setup command shapes. That\ndetection is deliberately read-only. djinn may read `.cargo/config.toml`\nto keep warm-job and worker behavior consistent with the project, but it\nnever creates, edits, or rewrites the project's `.cargo/config.toml`.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
+              "description": "Project-level override for Cargo target-cache warming/running policy.\n\nThe default is [`CargoCachePolicy::AutoDetected`]: djinn detects the\ncache strategy from the repository it is about to run, including the\nCargo workspace layout and the selected Rust workspace's Cargo feature\nsettings.\n\nSet an explicit policy only when project authors need to override the\ndetected cargo feature set at the environment-config level. `None` is\naccepted for legacy rows and is treated the same as the\ndefault auto-detected policy by consumers."
             },
             "env": {
               "additionalProperties": {
@@ -14398,6 +14463,19 @@ expression: signatures
         },
         "Workspace": {
           "properties": {
+            "cargo_all_features": {
+              "default": false,
+              "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+              "type": "boolean"
+            },
+            "cargo_features": {
+              "default": [],
+              "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "language": {
               "type": "string"
             },

--- a/server/src/server/tests/tool_schemas.rs
+++ b/server/src/server/tests/tool_schemas.rs
@@ -54,6 +54,16 @@ fn assert_environment_config_workspace_metadata_schema(
         json!({"default": [], "items": {"type": "string"}, "type": "array"}),
         "{context} Workspace.tags schema drifted"
     );
+    assert_eq!(
+        workspace["properties"]["cargo_features"],
+        json!({"default": [], "items": {"type": "string"}, "type": "array"}),
+        "{context} Workspace.cargo_features schema drifted"
+    );
+    assert_eq!(
+        workspace["properties"]["cargo_all_features"],
+        json!({"default": false, "type": "boolean"}),
+        "{context} Workspace.cargo_all_features schema drifted"
+    );
 
     let rendered = serde_json::to_string(schema).expect("schema serializes");
     assert!(
@@ -657,7 +667,13 @@ fn checked_in_mcp_snapshot_exposes_environment_config_workspace_metadata() {
 
             workspace_schema_count += 1;
             let properties = &workspace["properties"];
-            for field in ["slug", "name", "tags"] {
+            for field in [
+                "slug",
+                "name",
+                "tags",
+                "cargo_features",
+                "cargo_all_features",
+            ] {
                 assert!(
                     properties.get(field).is_some(),
                     "checked-in snapshot {tool_name} {schema_key} Workspace missing {field}"

--- a/server/src/server/tests/tool_schemas.rs
+++ b/server/src/server/tests/tool_schemas.rs
@@ -56,12 +56,21 @@ fn assert_environment_config_workspace_metadata_schema(
     );
     assert_eq!(
         workspace["properties"]["cargo_features"],
-        json!({"default": [], "items": {"type": "string"}, "type": "array"}),
+        json!({
+            "default": [],
+            "description": "Cargo features that every platform-generated Cargo command for this\nRust workspace must enable. Ignored for non-Rust workspaces.",
+            "items": {"type": "string"},
+            "type": "array"
+        }),
         "{context} Workspace.cargo_features schema drifted"
     );
     assert_eq!(
         workspace["properties"]["cargo_all_features"],
-        json!({"default": false, "type": "boolean"}),
+        json!({
+            "default": false,
+            "description": "Pass `--all-features` instead of named `cargo_features`. Ignored for\nnon-Rust workspaces.",
+            "type": "boolean"
+        }),
         "{context} Workspace.cargo_all_features schema drifted"
     );
 

--- a/ui/src/api/environmentConfig.ts
+++ b/ui/src/api/environmentConfig.ts
@@ -63,6 +63,8 @@ export interface Workspace {
   toolchain?: string | null;
   version?: string | null;
   package_manager?: string | null;
+  cargo_features?: string[];
+  cargo_all_features?: boolean;
 }
 
 /**

--- a/ui/src/api/generated/mcp-tools.gen.ts
+++ b/ui/src/api/generated/mcp-tools.gen.ts
@@ -2604,11 +2604,8 @@ export namespace ImageCreateInputSchema {
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
    * cache strategy from the repository it is about to run, including the
-   * Cargo workspace layout, `.cargo/config.toml` settings such as
-   * `rustc-wrapper`, and configured setup command shapes. That
-   * detection is deliberately read-only. djinn may read `.cargo/config.toml`
-   * to keep warm-job and worker behavior consistent with the project, but it
-   * never creates, edits, or rewrites the project's `.cargo/config.toml`.
+   * Cargo workspace layout and the selected Rust workspace's Cargo feature
+   * settings.
    * 
    * Set an explicit policy only when project authors need to override the
    * detected cargo feature set at the environment-config level. `None` is
@@ -2827,6 +2824,16 @@ export namespace ImageCreateInputSchema {
   [k: string]: any
   }
   export interface Workspace {
+  /**
+   * Pass `--all-features` instead of named `cargo_features`. Ignored for
+   * non-Rust workspaces.
+   */
+  cargo_all_features?: boolean
+  /**
+   * Cargo features that every platform-generated Cargo command for this
+   * Rust workspace must enable. Ignored for non-Rust workspaces.
+   */
+  cargo_features?: string[]
   language: string
   name?: string
   package_manager?: string
@@ -2960,11 +2967,8 @@ export namespace ImageListOutputSchema {
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
    * cache strategy from the repository it is about to run, including the
-   * Cargo workspace layout, `.cargo/config.toml` settings such as
-   * `rustc-wrapper`, and configured setup command shapes. That
-   * detection is deliberately read-only. djinn may read `.cargo/config.toml`
-   * to keep warm-job and worker behavior consistent with the project, but it
-   * never creates, edits, or rewrites the project's `.cargo/config.toml`.
+   * Cargo workspace layout and the selected Rust workspace's Cargo feature
+   * settings.
    * 
    * Set an explicit policy only when project authors need to override the
    * detected cargo feature set at the environment-config level. `None` is
@@ -3183,6 +3187,16 @@ export namespace ImageListOutputSchema {
   [k: string]: any
   }
   export interface Workspace {
+  /**
+   * Pass `--all-features` instead of named `cargo_features`. Ignored for
+   * non-Rust workspaces.
+   */
+  cargo_all_features?: boolean
+  /**
+   * Cargo features that every platform-generated Cargo command for this
+   * Rust workspace must enable. Ignored for non-Rust workspaces.
+   */
+  cargo_features?: string[]
   language: string
   name?: string
   package_manager?: string
@@ -3292,11 +3306,8 @@ export namespace ImageUpdateInputSchema {
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
    * cache strategy from the repository it is about to run, including the
-   * Cargo workspace layout, `.cargo/config.toml` settings such as
-   * `rustc-wrapper`, and configured setup command shapes. That
-   * detection is deliberately read-only. djinn may read `.cargo/config.toml`
-   * to keep warm-job and worker behavior consistent with the project, but it
-   * never creates, edits, or rewrites the project's `.cargo/config.toml`.
+   * Cargo workspace layout and the selected Rust workspace's Cargo feature
+   * settings.
    * 
    * Set an explicit policy only when project authors need to override the
    * detected cargo feature set at the environment-config level. `None` is
@@ -3515,6 +3526,16 @@ export namespace ImageUpdateInputSchema {
   [k: string]: any
   }
   export interface Workspace {
+  /**
+   * Pass `--all-features` instead of named `cargo_features`. Ignored for
+   * non-Rust workspaces.
+   */
+  cargo_all_features?: boolean
+  /**
+   * Cargo features that every platform-generated Cargo command for this
+   * Rust workspace must enable. Ignored for non-Rust workspaces.
+   */
+  cargo_features?: string[]
   language: string
   name?: string
   package_manager?: string
@@ -5880,11 +5901,8 @@ export namespace ProjectEnvironmentConfigGetOutputSchema {
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
    * cache strategy from the repository it is about to run, including the
-   * Cargo workspace layout, `.cargo/config.toml` settings such as
-   * `rustc-wrapper`, and configured setup command shapes. That
-   * detection is deliberately read-only. djinn may read `.cargo/config.toml`
-   * to keep warm-job and worker behavior consistent with the project, but it
-   * never creates, edits, or rewrites the project's `.cargo/config.toml`.
+   * Cargo workspace layout and the selected Rust workspace's Cargo feature
+   * settings.
    * 
    * Set an explicit policy only when project authors need to override the
    * detected cargo feature set at the environment-config level. `None` is
@@ -6103,6 +6121,16 @@ export namespace ProjectEnvironmentConfigGetOutputSchema {
   [k: string]: any
   }
   export interface Workspace {
+  /**
+   * Pass `--all-features` instead of named `cargo_features`. Ignored for
+   * non-Rust workspaces.
+   */
+  cargo_all_features?: boolean
+  /**
+   * Cargo features that every platform-generated Cargo command for this
+   * Rust workspace must enable. Ignored for non-Rust workspaces.
+   */
+  cargo_features?: string[]
   language: string
   name?: string
   package_manager?: string
@@ -6196,11 +6224,8 @@ export namespace ProjectEnvironmentConfigResetOutputSchema {
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
    * cache strategy from the repository it is about to run, including the
-   * Cargo workspace layout, `.cargo/config.toml` settings such as
-   * `rustc-wrapper`, and configured setup command shapes. That
-   * detection is deliberately read-only. djinn may read `.cargo/config.toml`
-   * to keep warm-job and worker behavior consistent with the project, but it
-   * never creates, edits, or rewrites the project's `.cargo/config.toml`.
+   * Cargo workspace layout and the selected Rust workspace's Cargo feature
+   * settings.
    * 
    * Set an explicit policy only when project authors need to override the
    * detected cargo feature set at the environment-config level. `None` is
@@ -6419,6 +6444,16 @@ export namespace ProjectEnvironmentConfigResetOutputSchema {
   [k: string]: any
   }
   export interface Workspace {
+  /**
+   * Pass `--all-features` instead of named `cargo_features`. Ignored for
+   * non-Rust workspaces.
+   */
+  cargo_all_features?: boolean
+  /**
+   * Cargo features that every platform-generated Cargo command for this
+   * Rust workspace must enable. Ignored for non-Rust workspaces.
+   */
+  cargo_features?: string[]
   language: string
   name?: string
   package_manager?: string
@@ -6505,11 +6540,8 @@ export namespace ProjectEnvironmentConfigSetInputSchema {
    * 
    * The default is [`CargoCachePolicy::AutoDetected`]: djinn detects the
    * cache strategy from the repository it is about to run, including the
-   * Cargo workspace layout, `.cargo/config.toml` settings such as
-   * `rustc-wrapper`, and configured setup command shapes. That
-   * detection is deliberately read-only. djinn may read `.cargo/config.toml`
-   * to keep warm-job and worker behavior consistent with the project, but it
-   * never creates, edits, or rewrites the project's `.cargo/config.toml`.
+   * Cargo workspace layout and the selected Rust workspace's Cargo feature
+   * settings.
    * 
    * Set an explicit policy only when project authors need to override the
    * detected cargo feature set at the environment-config level. `None` is
@@ -6728,6 +6760,16 @@ export namespace ProjectEnvironmentConfigSetInputSchema {
   [k: string]: any
   }
   export interface Workspace {
+  /**
+   * Pass `--all-features` instead of named `cargo_features`. Ignored for
+   * non-Rust workspaces.
+   */
+  cargo_all_features?: boolean
+  /**
+   * Cargo features that every platform-generated Cargo command for this
+   * Rust workspace must enable. Ignored for non-Rust workspaces.
+   */
+  cargo_features?: string[]
   language: string
   name?: string
   package_manager?: string

--- a/ui/src/pages/ProjectEnvironmentPage.tsx
+++ b/ui/src/pages/ProjectEnvironmentPage.tsx
@@ -349,7 +349,7 @@ function WorkspacesEditor({
                       updateAt(idx, {
                         cargo_features: e.target.value
                           .split(",")
-                          .map((feature) => feature.trim())
+                          .map((feature) => feature.trim()),
                         cargo_all_features: false,
                       })
                     }

--- a/ui/src/pages/ProjectEnvironmentPage.tsx
+++ b/ui/src/pages/ProjectEnvironmentPage.tsx
@@ -290,7 +290,7 @@ function WorkspacesEditor({
         {workspaces.map((ws, idx) => (
           <div
             key={idx}
-            className="flex items-end gap-2 rounded-lg border bg-card/50 px-4 py-3 shadow-sm"
+            className="flex flex-wrap items-end gap-2 rounded-lg border bg-card/50 px-4 py-3 shadow-sm"
           >
             <div className="flex flex-1 flex-col gap-1">
               <Label className="text-xs text-muted-foreground">
@@ -334,6 +334,51 @@ function WorkspacesEditor({
             >
               <HugeiconsIcon icon={Delete02Icon} size={14} />
             </Button>
+            {ws.language === "rust" && (
+              <div className="flex w-full items-end gap-3 border-t pt-3">
+                <div className="flex flex-1 flex-col gap-1">
+                  <Label className="text-xs text-muted-foreground">
+                    Cargo features{" "}
+                    <span className="font-normal text-muted-foreground/70">
+                      (comma separated)
+                    </span>
+                  </Label>
+                  <Input
+                    value={(ws.cargo_features ?? []).join(", ")}
+                    onChange={(e) =>
+                      updateAt(idx, {
+                        cargo_features: e.target.value
+                          .split(",")
+                          .map((feature) => feature.trim())
+                        cargo_all_features: false,
+                      })
+                    }
+                    onBlur={() =>
+                      updateAt(idx, {
+                        cargo_features: (ws.cargo_features ?? []).filter(Boolean),
+                      })
+                    }
+                    placeholder="e.g. qdrant"
+                    disabled={ws.cargo_all_features}
+                    className="font-mono text-xs"
+                  />
+                </div>
+                <Label className="flex h-9 cursor-pointer items-center gap-2 whitespace-nowrap text-xs text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={ws.cargo_all_features ?? false}
+                    onChange={(e) =>
+                      updateAt(idx, {
+                        cargo_all_features: e.target.checked,
+                        cargo_features: e.target.checked ? [] : ws.cargo_features,
+                      })
+                    }
+                    className="h-4 w-4 accent-primary"
+                  />
+                  All features
+                </Label>
+              </div>
+            )}
           </div>
         ))}
         <Button


### PR DESCRIPTION
## Summary

- add `cargo_features` and `cargo_all_features` to Rust workspace configuration and expose them in the environment UI
- drive warm Cargo commands from the selected Rust workspace instead of the nonstandard `.cargo/config.toml` `build.features` key
- remove the invalid Cargo key and update schema coverage/snapshots

## Why

Cargo ignores `build.features` and emits an unused-config warning. Keeping the feature set in Djinn-owned workspace configuration makes the warm feature graph explicit and gives future typed Cargo tooling the same source of truth.

## Validation

- `cargo check -p djinn-agent-worker -p djinn-stack`
- `cargo test -p djinn-stack`
- `cargo test -p djinn-agent-worker cargo_cache_policy -- --nocapture`
- `cargo test -p djinn-stack -p djinn-agent-worker --no-run`
- `cargo test -p djinn-server mcp_tools_schema_snapshot -- --nocapture`
- `cargo fmt --all -- --check`
- `pnpm build`

The broader UI test typecheck currently has unrelated pre-existing fixture/type errors; the production TypeScript/Vite build passes.