### PR TITLE
fix(coordinator): dedupe terminal PR handoffs by head

### DIFF
--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
@@ -444,51 +444,39 @@ const HANDOFF_ACTOR_ROLE: &str = "respawn_guard";
 /// other non-closed status (e.g. `open`, `in_progress`, `pr_draft`) is
 /// transitioned to `pr_review`.
 ///
-/// Idempotent for the already-`pr_review` case: the no-op still durably
-/// records the handoff reason via a standalone activity entry so callers
-/// (e.g. the terminal gate) can prove the task was preserved rather than
-/// force-closed. The `TaskRepository::transition` path inserts an activity row
-/// automatically (status.rs:156-172); this no-op path does not, so it records
-/// one itself.
+/// Every successful handoff records a `pr_terminal_handoff` activity keyed by
+/// reason and head SHA. Re-entry for the same head is a durable no-op, while a
+/// new head records a new handoff marker.
 ///
-/// Returns `true` when the task was moved to `pr_review` or was already there,
-/// and an `Err` only when a repository transition/handoff fails (so the
-/// terminal gate can fail safe).
+/// Returns `true` when a new handoff marker was recorded, `false` when that
+/// head was already handed off, and an `Err` when persistence fails.
 pub async fn handoff_pr_to_poller(
     task_repo: &TaskRepository,
     task_id: &str,
     current_status: &str,
     pr_url: &str,
     reason: &str,
+    head_sha: Option<&str>,
 ) -> std::result::Result<bool, String> {
+    let already_handed_off = task_repo
+        .list_activity(task_id)
+        .await
+        .map_err(|e| e.to_string())?
+        .iter()
+        .filter(|entry| entry.event_type == "pr_terminal_handoff")
+        .filter_map(|entry| serde_json::from_str::<serde_json::Value>(&entry.payload).ok())
+        .any(|payload| {
+            payload.get("head_sha").and_then(|value| value.as_str()) == head_sha
+                && payload.get("reason").and_then(|value| value.as_str()) == Some(reason)
+        });
+    if already_handed_off {
+        tracing::debug!(task_id = %task_id, ?head_sha, "respawn_guard: terminal PR handoff already recorded for head");
+        return Ok(false);
+    }
+
     if current_status == TaskStatus::PrReview.as_str() {
         tracing::debug!(task_id = %task_id, current_status = %current_status, "respawn_guard: task already in pr_review — handoff is an idempotent no-op");
-        // No transition runs, so we record a standalone activity entry to make
-        // the handoff reason durable and auditable.
-        let payload = serde_json::json!({
-            "from_status": current_status,
-            "to_status": TaskStatus::PrReview.as_str(),
-            "reason": reason,
-            "pr_url": pr_url,
-            "idempotent": true,
-        })
-        .to_string();
-        task_repo
-            .log_activity(
-                Some(task_id),
-                HANDOFF_ACTOR_ID,
-                HANDOFF_ACTOR_ROLE,
-                "adoption_handoff",
-                &payload,
-            )
-            .await
-            .map_err(|e| {
-                tracing::warn!(task_id = %task_id, pr_url = %pr_url, error = %e, "respawn_guard: failed to record idempotent handoff activity");
-                e.to_string()
-            })?;
-        return Ok(true);
-    }
-    match task_repo
+    } else if let Err(e) = task_repo
         .transition(
             task_id,
             TransitionAction::AdoptionHandoff,
@@ -499,15 +487,30 @@ pub async fn handoff_pr_to_poller(
         )
         .await
     {
-        Ok(task) => {
-            tracing::info!(task_id = %task_id, pr_url = %pr_url, to_status = %task.status, "respawn_guard: PR handed off to poller (pr_review)");
-            Ok(true)
-        }
-        Err(e) => {
-            tracing::warn!(task_id = %task_id, pr_url = %pr_url, error = %e, "respawn_guard: failed to hand PR off to poller");
-            Err(e.to_string())
-        }
+        tracing::warn!(task_id = %task_id, pr_url = %pr_url, error = %e, "respawn_guard: failed to hand PR off to poller");
+        return Err(e.to_string());
     }
+
+    let payload = serde_json::json!({
+        "from_status": current_status,
+        "to_status": TaskStatus::PrReview.as_str(),
+        "reason": reason,
+        "pr_url": pr_url,
+        "head_sha": head_sha,
+    })
+    .to_string();
+    task_repo
+        .log_activity(
+            Some(task_id),
+            HANDOFF_ACTOR_ID,
+            HANDOFF_ACTOR_ROLE,
+            "pr_terminal_handoff",
+            &payload,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    tracing::info!(task_id = %task_id, pr_url = %pr_url, ?head_sha, "respawn_guard: PR handed off to poller (pr_review)");
+    Ok(true)
 }
 
 /// Compatibility wrapper for the respawn-guard adoption path. The terminal
@@ -520,7 +523,7 @@ pub async fn handoff_adopted_pr_to_poller(
 ) -> bool {
     let reason =
         format!("respawn_guard: adopted open PR {pr_url} — handing off to PR poller (pr_review)");
-    handoff_pr_to_poller(task_repo, task_id, current_status, pr_url, &reason)
+    handoff_pr_to_poller(task_repo, task_id, current_status, pr_url, &reason, None)
         .await
         .unwrap_or(false)
 }

--- a/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/respawn_guard.rs
@@ -448,8 +448,9 @@ const HANDOFF_ACTOR_ROLE: &str = "respawn_guard";
 /// reason and head SHA. Re-entry for the same head is a durable no-op, while a
 /// new head records a new handoff marker.
 ///
-/// Returns `true` when a new handoff marker was recorded, `false` when that
-/// head was already handed off, and an `Err` when persistence fails.
+/// Returns `true` when the handoff is established, including when the durable
+/// marker proves it was already established for this head, and an `Err` when
+/// persistence fails.
 pub async fn handoff_pr_to_poller(
     task_repo: &TaskRepository,
     task_id: &str,
@@ -471,7 +472,7 @@ pub async fn handoff_pr_to_poller(
         });
     if already_handed_off {
         tracing::debug!(task_id = %task_id, ?head_sha, "respawn_guard: terminal PR handoff already recorded for head");
-        return Ok(false);
+        return Ok(true);
     }
 
     if current_status == TaskStatus::PrReview.as_str() {
@@ -523,6 +524,26 @@ pub async fn handoff_adopted_pr_to_poller(
 ) -> bool {
     let reason =
         format!("respawn_guard: adopted open PR {pr_url} — handing off to PR poller (pr_review)");
+    if current_status == TaskStatus::PrReview.as_str() {
+        let payload = serde_json::json!({
+            "from_status": current_status,
+            "to_status": TaskStatus::PrReview.as_str(),
+            "reason": reason,
+            "pr_url": pr_url,
+            "idempotent": true,
+        })
+        .to_string();
+        return task_repo
+            .log_activity(
+                Some(task_id),
+                HANDOFF_ACTOR_ID,
+                HANDOFF_ACTOR_ROLE,
+                "adoption_handoff",
+                &payload,
+            )
+            .await
+            .is_ok();
+    }
     handoff_pr_to_poller(task_repo, task_id, current_status, pr_url, &reason, None)
         .await
         .unwrap_or(false)

--- a/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
+++ b/server/crates/djinn-coordinator/src/dispatch/session_recovery.rs
@@ -2074,12 +2074,17 @@ impl CoordinatorActor {
             .filter(|url| !url.is_empty())
         {
             const HANDOFF_REASON: &str = "terminal_close_deferred_pr_handoff";
+            let handoff_head_sha = latest
+                .ci_github_head_sha
+                .as_deref()
+                .or(latest.ci_head_sha.as_deref());
             match super::respawn_guard::handoff_pr_to_poller(
                 &repo,
                 &latest.id,
                 &latest.status,
                 pr_url,
                 HANDOFF_REASON,
+                handoff_head_sha,
             )
             .await
             {

--- a/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
+++ b/server/crates/djinn-coordinator/src/pr_poller/ci_helpers.rs
@@ -708,23 +708,53 @@ impl CoordinatorActor {
                 ci_failure_sections.join("\n")
             )
         };
-        let comment_body = format!("**PR CI Escalation**: {reason}{sections_text}\n\nPR: {pr_url}");
-        let comment_payload = serde_json::json!({ "body": comment_body }).to_string();
-        if let Err(e) = task_repo
-            .log_activity(
-                Some(&task.id),
-                "coordinator",
-                "system",
-                "comment",
-                &comment_payload,
-            )
+        let escalation_head_sha = task
+            .ci_github_head_sha
+            .as_deref()
+            .or(task.ci_head_sha.as_deref())
+            .unwrap_or("unknown");
+        let comment_already_logged = task_repo
+            .list_activity(&task.id)
             .await
-        {
-            tracing::warn!(
-                task_id = %task.short_id,
-                error = %e,
-                "PR poller: failed to log CI escalation comment"
-            );
+            .map(|entries| {
+                entries.iter().any(|entry| {
+                    entry.event_type == "comment"
+                        && serde_json::from_str::<serde_json::Value>(&entry.payload)
+                            .ok()
+                            .and_then(|payload| {
+                                payload
+                                    .get("escalation_head_sha")
+                                    .and_then(|value| value.as_str())
+                                    .map(|sha| sha == escalation_head_sha)
+                            })
+                            .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if !comment_already_logged {
+            let comment_body =
+                format!("**PR CI Escalation**: {reason}{sections_text}\n\nPR: {pr_url}");
+            let comment_payload = serde_json::json!({
+                "body": comment_body,
+                "escalation_head_sha": escalation_head_sha,
+            })
+            .to_string();
+            if let Err(e) = task_repo
+                .log_activity(
+                    Some(&task.id),
+                    "coordinator",
+                    "system",
+                    "comment",
+                    &comment_payload,
+                )
+                .await
+            {
+                tracing::warn!(
+                    task_id = %task.short_id,
+                    error = %e,
+                    "PR poller: failed to log CI escalation comment"
+                );
+            }
         }
 
         // Route the CI-loop park through the autonomous escalation ladder: a

--- a/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
+++ b/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
@@ -357,6 +357,20 @@ async fn hold_cycle_ceiling_hands_a_pr_bearing_task_to_the_poller_idempotently()
         1,
         "the ceiling audit entry is written once per task, not once per tick: {ceiling_markers:?}"
     );
+    let handoff_markers = repo
+        .query_activity(ActivityQuery {
+            task_id: Some(base.id.clone()),
+            event_type: Some("pr_terminal_handoff".to_string()),
+            limit: 100,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        handoff_markers.len(),
+        1,
+        "terminal PR handoff must be durable and idempotent for one head"
+    );
     assert!(
         park_redispatch_markers(&repo, &base.id).await.is_empty(),
         "no sub-guard may run after the ceiling trips"

--- a/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
+++ b/server/crates/djinn-coordinator/src/tests/hold_cycle_ceiling.rs
@@ -354,20 +354,6 @@ async fn hold_cycle_ceiling_dispatches_one_final_arbiter_for_pr_task() {
         1,
         "the ceiling audit entry is written once per task, not once per tick: {ceiling_markers:?}"
     );
-    let handoff_markers = repo
-        .query_activity(ActivityQuery {
-            task_id: Some(base.id.clone()),
-            event_type: Some("pr_terminal_handoff".to_string()),
-            limit: 100,
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    assert_eq!(
-        handoff_markers.len(),
-        1,
-        "terminal PR handoff must be durable and idempotent for one head"
-    );
     assert!(
         park_redispatch_markers(&repo, &base.id).await.is_empty(),
         "no sub-guard may run after the ceiling trips"

--- a/server/crates/djinn-coordinator/src/tests/intervention.rs
+++ b/server/crates/djinn-coordinator/src/tests/intervention.rs
@@ -1991,7 +1991,9 @@ async fn escalate_ci_failure_includes_sections_in_comment_and_reason() {
     let db = test_helpers::create_test_db();
     let (tx, _rx) = broadcast::channel(256);
     let mut actor = coordinator_actor_for_tests(&db, &tx);
-    let task = make_task_with_reopen_count(&db, &tx, 0).await;
+    let mut task = make_task_with_reopen_count(&db, &tx, 0).await;
+    task.ci_head_sha = Some("head-for-escalation".to_string());
+    task.ci_github_head_sha = Some("head-for-escalation".to_string());
     let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
 
     let reason = "PR #42 stuck: required checks (build) failed across 5 rounds.";
@@ -2003,6 +2005,9 @@ async fn escalate_ci_failure_includes_sections_in_comment_and_reason() {
     ];
     let pr_url = "https://github.com/owner/repo/pull/42";
 
+    actor
+        .escalate_ci_failure_and_park(&task, pr_url, reason, &sections)
+        .await;
     actor
         .escalate_ci_failure_and_park(&task, pr_url, reason, &sections)
         .await;
@@ -2023,10 +2028,22 @@ async fn escalate_ci_failure_includes_sections_in_comment_and_reason() {
         .await
         .unwrap();
 
-    let escalation_comment = comments
+    let escalation_comments: Vec<_> = comments
         .iter()
-        .find(|c| c.payload.contains("**PR CI Escalation**"))
-        .expect("escalate_ci_failure_and_park must log a PR CI Escalation comment");
+        .filter(|c| c.payload.contains("**PR CI Escalation**"))
+        .collect();
+    assert_eq!(
+        escalation_comments.len(),
+        1,
+        "CI escalation comments must be deduplicated per head SHA"
+    );
+    let escalation_comment = escalation_comments[0];
+    let escalation_payload: serde_json::Value =
+        serde_json::from_str(&escalation_comment.payload).unwrap();
+    assert_eq!(
+        escalation_payload["escalation_head_sha"], "head-for-escalation",
+        "dedupe marker must carry the current head SHA",
+    );
     assert!(
         escalation_comment
             .payload

--- a/server/crates/djinn-coordinator/src/tests/terminal_gate_latest_row.rs
+++ b/server/crates/djinn-coordinator/src/tests/terminal_gate_latest_row.rs
@@ -157,6 +157,9 @@ async fn terminal_gate_pr_review_handoff_is_idempotent() {
     let repo = TaskRepository::new(db.clone(), crate::events::event_bus_for(&tx));
     let (task, _) = create_task_with_note(&db, &tx, "terminal-pr-review-idempotent").await;
     repo.set_pr_url(&task.id, PR_URL).await.unwrap();
+    repo.reset_ci_snapshot_for_head(&task.id, 9003, "head-9003")
+        .await
+        .unwrap();
     let poller_owned = repo.set_status(&task.id, "pr_review").await.unwrap();
     let task_count = repo.list_by_project(&task.project_id).await.unwrap().len();
 
@@ -191,13 +194,24 @@ async fn terminal_gate_pr_review_handoff_is_idempotent() {
     assert!(dispatch_state.inflight_creator_user_id.is_none());
 
     let activity = repo.list_activity(&task.id).await.unwrap();
+    let handoff_markers: Vec<_> = activity
+        .iter()
+        .filter(|entry| entry.event_type == "pr_terminal_handoff")
+        .collect();
     assert_eq!(
-        activity
-            .iter()
-            .filter(|entry| entry.payload.contains(HANDOFF_REASON))
-            .count(),
-        2,
-        "each idempotent terminal handoff must be durably auditable"
+        handoff_markers.len(),
+        1,
+        "terminal handoff is recorded once for repeated entry at the same head"
+    );
+    let handoff_payload: serde_json::Value =
+        serde_json::from_str(&handoff_markers[0].payload).unwrap();
+    assert_eq!(
+        handoff_payload["reason"], HANDOFF_REASON,
+        "the durable marker identifies the terminal gate"
+    );
+    assert_eq!(
+        handoff_payload["head_sha"], "head-9003",
+        "the durable marker keys idempotence to the observed PR head"
     );
     assert_no_destructive_activity(&activity);
 }


### PR DESCRIPTION
## Summary

- record a durable terminal PR-handoff marker keyed by reason and head SHA
- make repeated terminal-gate entry on the same PR head an idempotent no-op
- deduplicate `PR CI Escalation` comments by head SHA

## Verification

- `RUST_MIN_STACK=33554432 SQLX_OFFLINE=true cargo test -p djinn-coordinator tests::intervention -- --test-threads=1` (71 passed)
- `RUST_MIN_STACK=33554432 SQLX_OFFLINE=true cargo test -p djinn-coordinator tests::hold_cycle_ceiling -- --test-threads=1` (5 passed)
- `SQLX_OFFLINE=true cargo clippy -p djinn-coordinator --all-targets`
- `cargo fmt --all -- --check`
- `scripts/check-file-size.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)