### PR TITLE
fix(build-admission): read the real v1 authority in the handoff warning

### DIFF
--- a/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_epoch_disruption_tests.rs
@@ -236,7 +236,7 @@ async fn partial_config_updates_fail_closed_onto_the_emergency_authority() {
         BuildAdmissionMode::Enforce,
         true,
         BuildAdmissionReadiness::Healthy,
-        InvocationAuthorityObservation::default(),
+        InvocationAuthorityObservation { enforcing: false },
     );
     assert_eq!(snapshot.state, HandoffState::IllegalModeCombo);
     assert_eq!(

--- a/server/crates/djinn-coordinator/src/build_admission_handoff.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_handoff.rs
@@ -10,7 +10,16 @@ use djinn_db::{AdmissionHandoffPhase, AdmissionHandoffRow};
 use crate::build_admission::{BuildAdmissionMode, BuildAdmissionReadiness};
 
 /// Observation supplied by the invocation authority (or a deterministic fake).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+///
+/// **Deliberately not `Default`.** Every production call site once passed
+/// `::default()` — `enforcing: false` hard-coded — so the server never read the
+/// real v1 authority and emitted a permanent, unclearable `stale_epoch` warning
+/// throughout the forward cutover. Requiring the field to be named forces each
+/// caller to state where its value came from: production derives it from
+/// `evaluate_invocation_lift` over the durable row, and any caller that
+/// genuinely cannot observe v1 must write `enforcing: false` with a comment
+/// saying why.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InvocationAuthorityObservation {
     pub enforcing: bool,
 }
@@ -336,7 +345,7 @@ mod tests {
             BuildAdmissionMode::Enforce,
             true,
             BuildAdmissionReadiness::Healthy,
-            InvocationAuthorityObservation::default(),
+            InvocationAuthorityObservation { enforcing: false },
         );
         assert_eq!(baseline.state, HandoffState::EmergencyPrimary);
         assert_eq!(
@@ -356,7 +365,7 @@ mod tests {
             BuildAdmissionMode::Enforce,
             true,
             BuildAdmissionReadiness::Healthy,
-            InvocationAuthorityObservation::default(),
+            InvocationAuthorityObservation { enforcing: false },
         );
         assert_eq!(shadow.state, HandoffState::Shadow);
         assert_eq!(
@@ -398,7 +407,7 @@ mod tests {
                 BuildAdmissionMode::Enforce,
                 true,
                 BuildAdmissionReadiness::Healthy,
-                InvocationAuthorityObservation::default(),
+                InvocationAuthorityObservation { enforcing: false },
             );
             assert_eq!(
                 illegal.state,
@@ -411,7 +420,7 @@ mod tests {
                 "illegal combo must fail closed for {v0:?}/{v1:?}"
             );
             assert_eq!(
-                illegal.warning_reason(true, InvocationAuthorityObservation::default()),
+                illegal.warning_reason(true, InvocationAuthorityObservation { enforcing: false }),
                 Some(HandoffWarningReason::StaleEpoch)
             );
         }
@@ -423,7 +432,7 @@ mod tests {
                 BuildAdmissionMode::Enforce,
                 true,
                 BuildAdmissionReadiness::Healthy,
-                InvocationAuthorityObservation::default(),
+                InvocationAuthorityObservation { enforcing: false },
             )
             .emergency,
             EmergencyAuthorityDecision::RequiredFailClosed
@@ -499,7 +508,7 @@ mod tests {
                 BuildAdmissionMode::Enforce,
                 true,
                 BuildAdmissionReadiness::Healthy,
-                InvocationAuthorityObservation::default(),
+                InvocationAuthorityObservation { enforcing: false },
             );
             assert_eq!(snapshot.state, state);
             assert_eq!(snapshot.emergency, decision);
@@ -536,7 +545,7 @@ mod tests {
                 BuildAdmissionReadiness::Healthy,
                 // The invocation authority is not lifting, exactly as
                 // `evaluate_invocation_lift` projects a non-enforcing v1.
-                InvocationAuthorityObservation::default(),
+                InvocationAuthorityObservation { enforcing: false },
             );
             assert_eq!(snapshot.state, HandoffState::InvocationPrimary);
             assert_ne!(
@@ -617,7 +626,7 @@ mod tests {
                     BuildAdmissionMode::Enforce,
                     true,
                     BuildAdmissionReadiness::Healthy,
-                    InvocationAuthorityObservation::default()
+                    InvocationAuthorityObservation { enforcing: false }
                 )
                 .emergency,
                 EmergencyAuthorityDecision::RequiredFailClosed
@@ -632,7 +641,7 @@ mod tests {
             BuildAdmissionMode::Observe,
             false,
             BuildAdmissionReadiness::Healthy,
-            InvocationAuthorityObservation::default(),
+            InvocationAuthorityObservation { enforcing: false },
         );
         assert_eq!(standalone.state, HandoffState::MissingRow);
         assert_eq!(
@@ -664,7 +673,7 @@ mod tests {
                 BuildAdmissionMode::Enforce,
                 readiness.is_healthy(),
                 readiness,
-                InvocationAuthorityObservation::default(),
+                InvocationAuthorityObservation { enforcing: false },
             );
             assert_eq!(
                 snapshot.emergency_acknowledgement_allowed,
@@ -688,7 +697,7 @@ mod tests {
             );
             assert_eq!(snapshot.warning_reason(true, invocation), None, "{phase:?}");
             assert_eq!(
-                snapshot.warning_reason(true, InvocationAuthorityObservation::default()),
+                snapshot.warning_reason(true, InvocationAuthorityObservation { enforcing: false }),
                 Some(HandoffWarningReason::StaleEpoch)
             );
         }
@@ -697,10 +706,10 @@ mod tests {
             BuildAdmissionMode::Enforce,
             true,
             BuildAdmissionReadiness::Healthy,
-            InvocationAuthorityObservation::default(),
+            InvocationAuthorityObservation { enforcing: false },
         );
         assert_eq!(
-            unreadable.warning_reason(true, InvocationAuthorityObservation::default()),
+            unreadable.warning_reason(true, InvocationAuthorityObservation { enforcing: false }),
             Some(HandoffWarningReason::EpochUnreadable)
         );
         let overlap = evaluate_handoff(

--- a/server/crates/djinn-coordinator/src/build_admission_handoff_matrix_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_admission_handoff_matrix_tests.rs
@@ -489,7 +489,7 @@ async fn handoff_crash_matrix_preserves_authority_and_epoch_guards() {
             BuildAdmissionMode::Enforce,
             true,
             BuildAdmissionReadiness::Healthy,
-            InvocationAuthorityObservation::default(),
+            InvocationAuthorityObservation { enforcing: false },
         )
         .state,
         HandoffState::IncompleteEpoch,

--- a/server/src/server/state/handoff_warning_observation_tests.rs
+++ b/server/src/server/state/handoff_warning_observation_tests.rs
@@ -1,0 +1,321 @@
+//! The handoff warning must read the REAL invocation (v1) authority.
+//!
+//! `publish_handoff_warning` is the only producer of the
+//! `build admission handoff warning active` log line and of the
+//! `djinn_build_admission_handoff_warning{reason}` gauge family. It used to build
+//! its invocation-side input as `InvocationAuthorityObservation::default()` —
+//! `enforcing: false`, hard-coded — as did every other production
+//! `evaluate_handoff` call site. The only caller that supplied the real
+//! projection was a `#[cfg(test)]` harness in `djinn-coordinator`.
+//!
+//! Because `warning_reason` classifies `ForwardOverlap`, `RollbackOverlap` and
+//! `InvocationPrimary` as `stale_epoch` whenever the invocation authority is not
+//! enforcing, a genuinely healthy cutover emitted a permanent, unclearable
+//! `stale_epoch` — byte-identical, in both the log and the gauge, to a genuine
+//! incomplete epoch or illegal mode combination. The runbook's stale-epoch
+//! detector was pinned at 1 and could never read 0.
+//!
+//! # The trap these tests are shaped to avoid
+//!
+//! Every pre-existing test around this code stayed green under the defect: the
+//! unit tests pass the observation in by hand (so they never exercise the
+//! production wiring), and no test asserted the *absence* of a warning for a
+//! healthy row driven through the production seam. Asserting "a warning fires in
+//! ForwardOverlap" is exactly the assertion that let this ship. So the anchor
+//! test here asserts `None` for a healthy row, and the stale case asserts that
+//! the genuine signal is still distinguishable from it.
+
+use super::build_admission_config_tests::{
+    BUILD_ADMISSION_TELEMETRY_LOCK, admission, handoff_repository,
+    state_for_admission_config_with_db,
+};
+use super::*;
+use djinn_db::{
+    AdmissionHandoffPhase, AdmissionHandoffRepository, AdmissionHandoffRow, V0Mode, V1Mode,
+};
+use djinn_supervisor::services::{InvocationLiftDecision, evaluate_invocation_lift};
+
+/// The acknowledgements a phase requires to be *complete* at its epoch.
+fn required_authorities(phase: AdmissionHandoffPhase) -> Vec<AdmissionHandoffAuthority> {
+    match phase {
+        AdmissionHandoffPhase::EmergencyPrimary => vec![AdmissionHandoffAuthority::Emergency],
+        AdmissionHandoffPhase::ForwardOverlap | AdmissionHandoffPhase::RollbackOverlap => vec![
+            AdmissionHandoffAuthority::Emergency,
+            AdmissionHandoffAuthority::Invocation,
+        ],
+        AdmissionHandoffPhase::InvocationPrimary => vec![AdmissionHandoffAuthority::Invocation],
+    }
+}
+
+async fn acknowledge_current_phase(repository: &AdmissionHandoffRepository) -> AdmissionHandoffRow {
+    let row = repository.read().await.expect("read").expect("seeded row");
+    for authority in required_authorities(row.phase) {
+        repository
+            .acknowledge(authority, row.epoch)
+            .await
+            .expect("acknowledge");
+    }
+    repository.read().await.expect("read").expect("row")
+}
+
+/// Drive the durable row to `phase` with exactly `v0`/`v1` recorded and every
+/// acknowledgement that phase requires taken at the resulting epoch — i.e. a
+/// *complete* row, through the real repository transitions only.
+async fn arm(
+    repository: &AdmissionHandoffRepository,
+    phase: AdmissionHandoffPhase,
+    v0: V0Mode,
+    v1: V1Mode,
+) -> AdmissionHandoffRow {
+    loop {
+        let row = acknowledge_current_phase(repository).await;
+        if row.phase == phase {
+            break;
+        }
+        let next = match row.phase {
+            AdmissionHandoffPhase::EmergencyPrimary => AdmissionHandoffPhase::ForwardOverlap,
+            AdmissionHandoffPhase::ForwardOverlap => AdmissionHandoffPhase::InvocationPrimary,
+            AdmissionHandoffPhase::InvocationPrimary => AdmissionHandoffPhase::RollbackOverlap,
+            AdmissionHandoffPhase::RollbackOverlap => AdmissionHandoffPhase::EmergencyPrimary,
+        };
+        repository
+            .advance(row.epoch, next, &[])
+            .await
+            .expect("advance");
+    }
+    // Record the modes last: `set_modes_and_cap` bumps the epoch and clears both
+    // acknowledgements, so they must be re-taken afterwards.
+    let epoch = repository.read().await.expect("read").expect("row").epoch;
+    repository
+        .set_modes_and_cap(epoch, v0, v1, Some(3))
+        .await
+        .expect("set modes");
+    acknowledge_current_phase(repository).await
+}
+
+/// The value of one `djinn_build_admission_handoff_warning{reason=...}` series
+/// in the process-global registry `publish_handoff_warning` writes to.
+fn warning_gauge(reason: &str) -> f64 {
+    let rendered = djinn_telemetry::render().expect("render telemetry");
+    let needle = format!("djinn_build_admission_handoff_warning{{reason=\"{reason}\"}}");
+    rendered
+        .lines()
+        .find(|line| line.starts_with(&needle))
+        .unwrap_or_else(|| panic!("missing sample {needle} in:\n{rendered}"))
+        .rsplit_once(' ')
+        .and_then(|(_, value)| value.parse::<f64>().ok())
+        .unwrap_or_else(|| panic!("sample should end with a number for {needle}"))
+}
+
+fn enforce_config() -> BuildAdmissionConfig {
+    BuildAdmissionConfig {
+        mode: BuildAdmissionMode::Enforce,
+        cap: 3,
+    }
+}
+
+/// The regression that was missing: a *healthy* forward overlap warns about
+/// nothing.
+///
+/// Production ran exactly this row — `forward_overlap`, v0 `Enforce`, v1
+/// `Enforce`, both acknowledgements at the current epoch, task-run pods logging
+/// `decision=Lift authority=Armed` — and the server warned `stale_epoch` every
+/// five minutes for as long as the cutover lasted.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn healthy_forward_overlap_publishes_no_warning() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // The recorder must be installed BEFORE the gauge is written: without it,
+    // `set_handoff_warning` writes into no recorder at all and every later read
+    // returns the pre-registered zero, which would make the assertions below
+    // pass for the wrong reason.
+    djinn_telemetry::init().expect("telemetry initializes");
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, enforce_config());
+    let repository = handoff_repository(&state);
+    let row = arm(
+        &repository,
+        AdmissionHandoffPhase::ForwardOverlap,
+        V0Mode::Enforce,
+        V1Mode::Enforce,
+    )
+    .await;
+
+    // Ground truth, from the launcher's own projection: this row DOES lift the
+    // cgroup quota, so the invocation authority is genuinely enforcing.
+    assert_eq!(
+        evaluate_invocation_lift(Ok(Some(row.clone()))),
+        InvocationLiftDecision::Lift,
+        "the armed forward overlap must lift: {row:?}"
+    );
+    assert_eq!(
+        admission(&state).mode(),
+        BuildAdmissionMode::Enforce,
+        "the emergency authority is enforcing too"
+    );
+
+    // Pin the detector at 1 first, so the assertions below prove the publish
+    // actually CLEARED it rather than merely never having set it.
+    djinn_telemetry::build_admission::set_handoff_warning(Some("stale_epoch"));
+    assert_eq!(warning_gauge("stale_epoch"), 1.0);
+
+    assert_eq!(
+        state.publish_handoff_warning().await,
+        None,
+        "both authorities enforce a complete forward overlap: nothing is wrong"
+    );
+    // The runbook's detector must be able to read zero.
+    assert_eq!(warning_gauge("stale_epoch"), 0.0);
+    assert_eq!(warning_gauge("unexpected_overlap"), 0.0);
+    assert_eq!(warning_gauge("epoch_unreadable"), 0.0);
+}
+
+/// A healthy rollback overlap is the same both-enforcing shape and likewise
+/// warns about nothing.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn healthy_rollback_overlap_publishes_no_warning() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // The recorder must be installed BEFORE the gauge is written: without it,
+    // `set_handoff_warning` writes into no recorder at all and every later read
+    // returns the pre-registered zero, which would make the assertions below
+    // pass for the wrong reason.
+    djinn_telemetry::init().expect("telemetry initializes");
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, enforce_config());
+    let repository = handoff_repository(&state);
+    let row = arm(
+        &repository,
+        AdmissionHandoffPhase::RollbackOverlap,
+        V0Mode::Enforce,
+        V1Mode::Enforce,
+    )
+    .await;
+    assert_eq!(
+        evaluate_invocation_lift(Ok(Some(row))),
+        InvocationLiftDecision::Lift
+    );
+    // Pin the detector at 1 first, so the assertions below prove the publish
+    // actually CLEARED it rather than merely never having set it.
+    djinn_telemetry::build_admission::set_handoff_warning(Some("stale_epoch"));
+    assert_eq!(warning_gauge("stale_epoch"), 1.0);
+
+    assert_eq!(state.publish_handoff_warning().await, None);
+    assert_eq!(warning_gauge("stale_epoch"), 0.0);
+}
+
+/// The committed cutover: v1 alone enforces and the emergency authority has
+/// been released by the production seam that observes it.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn committed_invocation_primary_publishes_no_warning() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // The recorder must be installed BEFORE the gauge is written: without it,
+    // `set_handoff_warning` writes into no recorder at all and every later read
+    // returns the pre-registered zero, which would make the assertions below
+    // pass for the wrong reason.
+    djinn_telemetry::init().expect("telemetry initializes");
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, enforce_config());
+    let repository = handoff_repository(&state);
+    let row = arm(
+        &repository,
+        AdmissionHandoffPhase::InvocationPrimary,
+        V0Mode::Observe,
+        V1Mode::Enforce,
+    )
+    .await;
+    assert_eq!(
+        evaluate_invocation_lift(Ok(Some(row))),
+        InvocationLiftDecision::Lift
+    );
+
+    // The real seam the periodic leader loop ticks releases the emergency
+    // authority on a committed invocation-primary row.
+    let controller = admission(&state).clone();
+    state.finalize_build_admission_handoff(&controller).await;
+    assert_eq!(
+        controller.mode(),
+        BuildAdmissionMode::Off,
+        "a committed invocation-primary row releases the emergency authority"
+    );
+
+    // Pin the detector at 1 first, so the assertions below prove the publish
+    // actually CLEARED it rather than merely never having set it.
+    djinn_telemetry::build_admission::set_handoff_warning(Some("stale_epoch"));
+    assert_eq!(warning_gauge("stale_epoch"), 1.0);
+
+    assert_eq!(
+        state.publish_handoff_warning().await,
+        None,
+        "exactly one authority enforces the committed cutover: nothing is wrong"
+    );
+    assert_eq!(warning_gauge("stale_epoch"), 0.0);
+    assert_eq!(warning_gauge("unexpected_overlap"), 0.0);
+}
+
+/// The genuine signal must survive: a forward overlap the invocation authority
+/// has not acknowledged at the current epoch is still `stale_epoch`.
+///
+/// Without this, "no warning ever fires" would satisfy the tests above.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn unacknowledged_invocation_epoch_still_publishes_stale_epoch() {
+    let _telemetry_guard = BUILD_ADMISSION_TELEMETRY_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // The recorder must be installed BEFORE the gauge is written: without it,
+    // `set_handoff_warning` writes into no recorder at all and every later read
+    // returns the pre-registered zero, which would make the assertions below
+    // pass for the wrong reason.
+    djinn_telemetry::init().expect("telemetry initializes");
+    let db = Database::open_in_memory().expect("test database");
+    let state = state_for_admission_config_with_db(db, enforce_config());
+    let repository = handoff_repository(&state);
+    arm(
+        &repository,
+        AdmissionHandoffPhase::ForwardOverlap,
+        V0Mode::Enforce,
+        V1Mode::Enforce,
+    )
+    .await;
+
+    // Re-record the same modes: the epoch advances and BOTH acknowledgements are
+    // cleared. Take only the emergency one, leaving the invocation authority
+    // behind the current epoch — the operator-visible shape of a v1 that has not
+    // come back after an `epoch advance`.
+    let epoch = repository.read().await.expect("read").expect("row").epoch;
+    repository
+        .set_modes_and_cap(epoch, V0Mode::Enforce, V1Mode::Enforce, Some(3))
+        .await
+        .expect("set modes");
+    let row = repository.read().await.expect("read").expect("row");
+    repository
+        .acknowledge(AdmissionHandoffAuthority::Emergency, row.epoch)
+        .await
+        .expect("emergency ack");
+    let row = repository.read().await.expect("read").expect("row");
+    assert_eq!(row.phase, AdmissionHandoffPhase::ForwardOverlap);
+    assert_eq!(
+        row.invocation_ack_epoch, None,
+        "the invocation authority is genuinely behind"
+    );
+    assert_eq!(
+        evaluate_invocation_lift(Ok(Some(row))),
+        InvocationLiftDecision::Unleased,
+        "an incomplete epoch does not lift, so v1 is genuinely not enforcing"
+    );
+
+    assert_eq!(
+        state.publish_handoff_warning().await,
+        Some(HandoffWarningReason::StaleEpoch),
+        "a genuinely incomplete epoch must still raise the stale-epoch alarm"
+    );
+    assert_eq!(warning_gauge("stale_epoch"), 1.0);
+}

--- a/server/src/server/state/mod.rs
+++ b/server/src/server/state/mod.rs
@@ -49,12 +49,15 @@ use djinn_provider::github_app::AppConfig as GitHubAppConfig;
 use djinn_provider::github_app::CredentialSourceState;
 use djinn_provider::repos::CredentialRepository;
 use djinn_runtime::GraphWarmerService;
+use djinn_supervisor::services::{InvocationLiftDecision, evaluate_invocation_lift};
 use djinn_supervisor::{AllowAllValidator, ConnectionRegistry, ServeHandle, serve_on_tcp};
 use djinn_workspace::{MirrorManager, WorkspaceStore, mirrors_root, workspaces_root};
 
 #[cfg(test)]
 mod admission_epoch_arming_tests;
 mod canonical_graph_refresh_planner;
+#[cfg(test)]
+mod handoff_warning_observation_tests;
 mod provider_catalog_refresh;
 mod settings;
 
@@ -900,21 +903,53 @@ impl AppState {
         Arc::new(build_in_process_graph_warmer(self.clone())) as Arc<dyn GraphWarmerService>
     }
 
+    /// Read the durable handoff row once and project the invocation (v1)
+    /// authority from that exact same read.
+    ///
+    /// Every production `evaluate_handoff` call site used to pass
+    /// `InvocationAuthorityObservation::default()`, i.e. `enforcing: false`
+    /// hard-coded, so the server always believed v1 was not enforcing. The
+    /// consequence was a permanent, unclearable `stale_epoch` warning for every
+    /// phase of the forward cutover — byte-identical to a genuine incomplete
+    /// epoch, which made the runbook's stale-epoch detector unreadable.
+    ///
+    /// The observation is the launcher's own projection,
+    /// [`evaluate_invocation_lift`], applied to the row: v1 is enforcing exactly
+    /// when it lifts the cgroup quota. `Shadow` observes without enforcing and
+    /// `Unleased` is no authority at all, so neither counts.
+    ///
+    /// Reading once and handing the *same* row to both halves also closes a
+    /// torn-read window in which the projection and the warning would disagree
+    /// about which epoch they described.
+    async fn read_handoff_with_invocation_observation(
+        &self,
+    ) -> (
+        Result<Option<djinn_db::AdmissionHandoffRow>, ()>,
+        InvocationAuthorityObservation,
+    ) {
+        let row = AdmissionHandoffRepository::new(self.db().clone())
+            .read()
+            .await
+            .map_err(|_| ());
+        let invocation = InvocationAuthorityObservation {
+            enforcing: evaluate_invocation_lift(row.clone()) == InvocationLiftDecision::Lift,
+        };
+        (row, invocation)
+    }
+
     /// Read the durable handoff row before journal recovery can weaken any emergency gate.
     /// A storage failure remains fail-closed through the existing readiness gates.
     async fn initialize_build_admission_handoff(&self) {
         let Some(admission) = self.inner.build_admission.clone() else {
             return;
         };
+        let (row, invocation) = self.read_handoff_with_invocation_observation().await;
         let snapshot = evaluate_handoff(
-            AdmissionHandoffRepository::new(self.db().clone())
-                .read()
-                .await
-                .map_err(|_| ()),
+            row,
             admission.mode(),
             admission.mode() == BuildAdmissionMode::Enforce,
             admission.readiness(),
-            InvocationAuthorityObservation::default(),
+            invocation,
         );
         match snapshot.emergency {
             EmergencyAuthorityDecision::RequiredFailClosed => admission.require_enforcement(),
@@ -939,12 +974,9 @@ impl AppState {
     async fn publish_handoff_warning(&self) -> Option<HandoffWarningReason> {
         let admission = self.inner.build_admission.clone()?;
         let emergency_enforcing = admission.mode() == BuildAdmissionMode::Enforce;
-        let invocation = InvocationAuthorityObservation::default();
+        let (row, invocation) = self.read_handoff_with_invocation_observation().await;
         let snapshot = evaluate_handoff(
-            AdmissionHandoffRepository::new(self.db().clone())
-                .read()
-                .await
-                .map_err(|_| ()),
+            row,
             admission.mode(),
             emergency_enforcing,
             admission.readiness(),
@@ -1292,15 +1324,13 @@ impl AppState {
     /// Re-read the durable row after topology has made the emergency controller
     /// healthy Enforce, then acknowledge its exact emergency epoch.
     async fn finalize_build_admission_handoff(&self, admission: &BuildAdmissionController) {
+        let (row, invocation) = self.read_handoff_with_invocation_observation().await;
         let mut snapshot = evaluate_handoff(
-            AdmissionHandoffRepository::new(self.db().clone())
-                .read()
-                .await
-                .map_err(|_| ()),
+            row,
             admission.mode(),
             admission.mode() == BuildAdmissionMode::Enforce,
             admission.readiness(),
-            InvocationAuthorityObservation::default(),
+            invocation,
         );
         match snapshot.emergency {
             EmergencyAuthorityDecision::MayDisable => {
@@ -1329,15 +1359,13 @@ impl AppState {
                 // The gates moved, so the earlier projection is stale: re-read so
                 // a now-healthy controller can acknowledge in this same pass
                 // instead of waiting for the next tick.
+                let (row, invocation) = self.read_handoff_with_invocation_observation().await;
                 snapshot = evaluate_handoff(
-                    AdmissionHandoffRepository::new(self.db().clone())
-                        .read()
-                        .await
-                        .map_err(|_| ()),
+                    row,
                     admission.mode(),
                     admission.mode() == BuildAdmissionMode::Enforce,
                     admission.readiness(),
-                    InvocationAuthorityObservation::default(),
+                    invocation,
                 );
                 if snapshot.emergency != EmergencyAuthorityDecision::RequiredFailClosed {
                     return;


### PR DESCRIPTION
## Defect

`djinn-server` emitted `build admission handoff warning active` / `reason=stale_epoch` every 5 minutes, permanently and unclearably, in production — against a **genuinely healthy** rollout (v0 `Enforce` acked at epoch 14, v1 genuinely lifting quota; task-run pods log `decision=Lift authority=Armed` then `lease invocation escalated: cgroup quota lifted`).

All four production `evaluate_handoff` / `warning_reason` call sites in `server/src/server/state/mod.rs` built their invocation-side input as:

```rust
let invocation = InvocationAuthorityObservation::default();   // enforcing: false, hard-coded
```

The real projection — `evaluate_invocation_lift` in `djinn-supervisor` — was wired **only** into the `#[cfg(test)]` harness in `djinn-coordinator/src/build_admission_epoch_support.rs`. Production therefore always read the v1 authority as not-enforcing.

Because `warning_reason` (`build_admission_handoff.rs`) returns `Some(StaleEpoch)` for `ForwardOverlap`, `RollbackOverlap` **and** `InvocationPrimary` whenever `invocation.enforcing` is false, the warning was false **by construction** for every phase of the forward cutover.

### Why it mattered

The defect is functionally inert: the observation only affects an admission outcome on `evaluate_handoff`'s row-ABSENT arm, and with a row present it changes neither the cap, the acks, nor any decision. The real harm is **alarm blindness** — a genuine `IncompleteEpoch`, a genuine `IllegalModeCombo`, and this permanent false positive were byte-identical in both the log line and the `djinn_build_admission_handoff_warning{reason}` gauge. The runbook's designated stale-epoch detector was pinned at `1` and could never read `0`.

## Fix

1. **Supply the real observation at all four production call sites.** A new `AppState::read_handoff_with_invocation_observation` reads the durable row **once** and derives the observation from that same read via the launcher's own projection:

   ```rust
   let invocation = InvocationAuthorityObservation {
       enforcing: evaluate_invocation_lift(row.clone()) == InvocationLiftDecision::Lift,
   };
   ```

   The same `row` is then handed to `evaluate_handoff`. `Shadow` observes without enforcing and `Unleased` is no authority at all, so neither counts as enforcing. Reading once also closes a torn-read window in which the projection and the warning could describe different epochs. No new dependency: `djinn-supervisor` was already a path dependency of `server`.

2. **Made the bug unrepeatable.** `InvocationAuthorityObservation` no longer derives `Default`, so no future call site can silently opt out of supplying a real observation. Callers must name the field; the doc comment records why. The only fallout was three `djinn-coordinator` test files, updated to explicit `{ enforcing: false }`.

3. The optional `HANDOFF_WARNING_INTERVAL` re-log-throttle tweak was **skipped** — see "Deliberately left out" below.

## Testing — neutralization evidence

New file: `server/src/server/state/handoff_warning_observation_tests.rs`. It drives the **real production seam** (`AppState::publish_handoff_warning`, and `finalize_build_admission_handoff` for the committed cutover) against a real Postgres row armed only through real `AdmissionHandoffRepository` transitions.

Coverage:
- `healthy_forward_overlap_publishes_no_warning` — the regression that was missing.
- `healthy_rollback_overlap_publishes_no_warning`
- `committed_invocation_primary_publishes_no_warning`
- `unacknowledged_invocation_epoch_still_publishes_stale_epoch` — the control: the genuine signal must survive, otherwise "never warn" would satisfy the three above.

Each healthy test also **pins the gauge at 1 before publishing** and asserts it reads 0 afterwards, so the assertion proves the publish actually *cleared* the detector rather than merely never having set it. (A first draft did not do this and its gauge assertions were vacuous — the recorder was not installed before the write, so every read returned the pre-registered zero. Caught and fixed; `djinn_telemetry::init()` is now called first.)

**Verified by neutralization.** With the fix reverted to `enforcing: false` and nothing else changed:

```
FAIL healthy_forward_overlap_publishes_no_warning
       left: Some(StaleEpoch)  right: None
FAIL healthy_rollback_overlap_publishes_no_warning
       left: Some(StaleEpoch)  right: None
FAIL committed_invocation_primary_publishes_no_warning
       left: Some(StaleEpoch)  right: None
PASS unacknowledged_invocation_epoch_still_publishes_stale_epoch   (control, correctly unaffected)
Summary: 4 tests run: 1 passed, 3 failed
```

With the fix restored: 4/4 pass.

## Verification

- `cargo clippy --workspace --all-targets` — **zero** warnings attributable to any touched file (`state/mod.rs`, `handoff_warning_observation_tests.rs`, `build_admission_handoff*.rs`). The workspace does emit pre-existing warnings from untouched files (e.g. `djinn-db/src/repositories/readiness/mod.rs`) under the local clippy 0.1.96.
- `cargo fmt --check` clean.
- `cargo nextest run -p djinn-coordinator -E 'test(/handoff|admission/)'` — 148/148 pass.
- `cargo nextest run -p djinn-server --lib -E 'test(/handoff|admission|epoch/)'` — 30/30 pass.
- No generated goldens or schemas are touched: `InvocationAuthorityObservation` is not serialized and no tool/config schema changed.

## Deliberately left out

The optional `HANDOFF_WARNING_INTERVAL` change. The re-log throttle uses `>= HANDOFF_WARNING_INTERVAL` against a ticker of exactly that period; the suggested strictly-less-than comparison would make the drift worse, and shortening the throttle would change the semantics asserted by the existing `handoff_warning_logging_carries_startup_state_into_the_persistent_loop` test (which pins `+299s` → no re-log, `+300s` → re-log). That is more than the "trivial and low-risk" bar this was gated on, so it is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)