### PR TITLE
fix(disk): ship Zot tag retention on by default in report-only mode + document kubelet image GC

### DIFF
--- a/deploy/helm/djinn/README.md
+++ b/deploy/helm/djinn/README.md
@@ -54,6 +54,58 @@ each table is bounded to at most N+1 full blobs, while the two compatibility
 tables together are bounded to at most 2(N+1) full blobs. Do not treat the
 combined bound as a per-table allowance.
 
+## Zot catalog retention rollout
+
+`imagePipeline.zot.retention` bounds the in-cluster Zot registry. Without it a
+catalog repo accumulates every manifest ever built — measured on the production
+VPS: **117 manifests in one `djinn-image-*` repo, 83 GB, 41 days deep**. Zot's
+blob GC (`gc: true`) was already working; it reclaimed 0.0 GiB because nothing
+is ever untagged, so *tag* retention is the missing piece. Keeping the newest 5
+tags reclaims ~78.5 GiB.
+
+The chart ships `enabled: true` with `dryRun: true`. That pairing is the point:
+a cluster **reports** the tags it would prune instead of growing silently, and
+still deletes nothing until an operator opts in. `tests/zot-retention-render.sh`
+validates every setting locally; no live cluster is required.
+
+Two independent safety properties hold before anything is deleted:
+
+1. **Scope.** The rendered policy targets `repositories: ["djinn-image-*"]` only.
+   BuildKit cache repos (`djinn-buildkitd-*`) and infra repos are out of scope.
+   Do not widen this glob.
+2. **Digest pins, not tags.** Every task-run and warm Job references its project
+   image *by digest*. The authoritative keep-set is therefore the database
+   (`ImageRepository::list_selected_catalog_images`), not the tag list. The
+   server's startup preflight (`retention_preflight.rs`) independently proves
+   each selected catalog image stays pullable by a retained tag or digest pin,
+   and is fail-closed: an unsafe image blocks the rollout and is reported.
+
+`DJINN_ZOT_RETENTION_ENABLED` is rendered from the *effective* value — the
+`retention.enabled` intent ANDed with `imagePipeline.enabled` and
+`imagePipeline.zot.enabled`. The preflight exits the process on a Zot fetch
+error, so a deployment on an external registry (the chart default
+`zot.enabled: false`) must never be told retention is on; there would be no
+in-cluster Zot to answer and the server would crash-loop on boot.
+
+Rollout order:
+
+1. Deploy the shipped default (`enabled: true`, `dryRun: true`). Zot logs the
+   manifests it would remove; the server logs one
+   `Zot catalog retention preflight report` line per boot.
+2. Read that preflight report and confirm `outcome` is not
+   `destructive_blocked` and that every selected catalog image is retained.
+   This is the gate — do not skip it, because the pinned digest is currently
+   the newest manifest and a tag-only view cannot prove it survives.
+3. Flip destructive with `--set imagePipeline.zot.retention.dryRun=false`.
+   Roll back by setting it to `true` again (or
+   `--set imagePipeline.zot.retention.enabled=false` to remove the policy).
+
+`newestTags` is the number of newest tags kept per catalog repo (default 5), and
+`deleteUntagged` removes manifests left with no tags after pruning. A destructive
+policy cannot render at all unless `imagePipeline.enabled` and
+`imagePipeline.zot.enabled` are both true — `zot-configmap.yaml` fails the
+render otherwise, rather than producing a policy with no matching preflight.
+
 ## Build admission mode
 
 `buildAdmission.mode` selects the literal `DJINN_BUILD_ADMISSION_MODE` emitted

--- a/deploy/helm/djinn/templates/_helpers.tpl
+++ b/deploy/helm/djinn/templates/_helpers.tpl
@@ -194,6 +194,34 @@ directly and the in-cluster Zot Service name is ignored.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Effective Zot retention mode for the server's startup preflight.
+
+`imagePipeline.zot.retention.enabled` is an intent flag; this helper is the
+*effective* value, and it is deliberately ANDed with the two switches that
+decide whether an in-cluster Zot (and therefore a rendered retention policy)
+exists at all. zot-configmap.yaml only renders when
+`imagePipeline.enabled && imagePipeline.zot.enabled`, so without this AND the
+server could be told retention is enabled while no policy — and no reachable
+registry — exists.
+
+That mismatch is not cosmetic. The server's startup preflight is fail-closed:
+on a Zot fetch error it returns Err and the leader calls `std::process::exit(1)`
+("refusing leader startup"). A deployment using an external registry (ECR/GHCR,
+the chart default `zot.enabled: false`) has no in-cluster Zot to answer
+`/v2/_catalog` and no Basic-auth Secret keys rendered, so an unconditional
+`enabled: true` would crash-loop the server on boot. Gating here keeps the
+report-only default safe to ship for every topology: it activates exactly where
+a policy is actually rendered, and stays inert everywhere else.
+*/}}
+{{- define "djinn.imagePipeline.zotRetentionEnabled" -}}
+{{- if and .Values.imagePipeline.enabled .Values.imagePipeline.zot.enabled .Values.imagePipeline.zot.retention.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 {{- define "djinn.imagePipeline.registryAuthSecretName" -}}
 {{- if .Values.imagePipeline.zot.auth.existingSecret -}}
 {{- .Values.imagePipeline.zot.auth.existingSecret -}}

--- a/deploy/helm/djinn/templates/deployment-server.yaml
+++ b/deploy/helm/djinn/templates/deployment-server.yaml
@@ -341,12 +341,20 @@ spec:
               value: {{ include "djinn.serviceAccountName.controller" . | quote }}
             - name: DJINN_IMAGE_REGISTRY_AUTH_SECRET
               value: {{ include "djinn.imagePipeline.registryAuthSecretName" . | quote }}
-            # Retention is disabled and dry-run by default. Keep these runtime
+            # Retention ships enabled but dry-run: a cluster reports the tags it
+            # would prune instead of growing silently, and deletes nothing until
+            # an operator sets `retention.dryRun=false`. Keep these runtime
             # settings adjacent to the Zot registry wiring so a destructive
             # Zot policy cannot be rendered without the server's startup
             # preflight receiving the same mode and newest-tag count.
+            #
+            # The ENABLED value is the *effective* one (see the helper): it is
+            # ANDed with imagePipeline.enabled and zot.enabled so the fail-closed
+            # startup preflight is never pointed at a registry the chart did not
+            # render. Reporting a policy that does not exist would exit(1) the
+            # server on boot.
             - name: DJINN_ZOT_RETENTION_ENABLED
-              value: {{ .Values.imagePipeline.zot.retention.enabled | quote }}
+              value: {{ include "djinn.imagePipeline.zotRetentionEnabled" . | quote }}
             - name: DJINN_ZOT_RETENTION_DRY_RUN
               value: {{ .Values.imagePipeline.zot.retention.dryRun | quote }}
             - name: DJINN_ZOT_RETENTION_NEWEST_TAGS

--- a/deploy/helm/djinn/tests/zot-retention-render.sh
+++ b/deploy/helm/djinn/tests/zot-retention-render.sh
@@ -88,9 +88,19 @@ def assert_value(name, expected):
 assert_value("DJINN_ZOT_RETENTION_ENABLED", retention_enabled)
 assert_value("DJINN_ZOT_RETENTION_DRY_RUN", expected_dry_run)
 assert_value("DJINN_ZOT_RETENTION_NEWEST_TAGS", expected_newest)
+# The preflight endpoint must resolve to the namespace the Zot resources are
+# actually rendered into. Derive that namespace from the render itself rather
+# than hard-coding it, so a change to the chart's namespace default cannot make
+# this assertion stale (it previously hard-coded "default" and silently rotted
+# once values.namespace.name started defaulting to "djinn").
+rendered_ns = next(
+    (m.group(1) for m in (re.match(r"^  namespace: (\S+)$", line) for line in rendered) if m),
+    None,
+)
+assert rendered_ns, "no rendered resource carried a metadata.namespace"
 assert_value(
     "DJINN_ZOT_RETENTION_ENDPOINT",
-    "http://test-release-djinn-zot.default.svc.cluster.local:5000",
+    f"http://test-release-djinn-zot.{rendered_ns}.svc.cluster.local:5000",
 )
 
 for name, key in (("DJINN_ZOT_RETENTION_USERNAME", "username"),
@@ -174,6 +184,99 @@ if helm template test-release "$CHART_DIR" \
     echo "FAIL: destructive retention rendered without an enabled Zot endpoint" >&2
     exit 1
 fi
+
+echo ""
+echo "=== Test 6: shipped chart defaults are report-only, not unbounded growth ==="
+# Every scenario above pins retention with an explicit --set, so none of them
+# can observe what values.yaml actually ships. A cluster installed without any
+# retention override is the common case and is what let one repo accumulate 117
+# manifests / 83 GiB. Render with NO retention.* override at all and assert the
+# shipped default renders a real, non-destructive policy.
+render_manifests "$TMPDIR_RENDER/shipped-defaults.yaml"
+assert_manifests "$TMPDIR_RENDER/shipped-defaults.yaml" true true 5 test-release-djinn-zot-auth
+
+# assert_manifests reads the policy out of the rendered JSON, but the safety
+# glob deserves its own explicit, independent check: widening `repositories`
+# beyond `djinn-image-*` would put the buildkitd cache repos (djinn-buildkitd-*)
+# in scope of tag pruning. Assert the rendered glob is exactly the catalog one.
+python3 - "$TMPDIR_RENDER/shipped-defaults.yaml" <<'PY'
+import json, sys
+
+rendered = open(sys.argv[1], encoding="utf-8").read().splitlines()
+start = rendered.index("  config.json: |") + 1
+lines = []
+for line in rendered[start:]:
+    if line and not line.startswith("    "):
+        break
+    lines.append(line[4:] if line else "")
+config = json.loads("\n".join(lines))
+
+policies = config["storage"]["retention"]["policies"]
+assert len(policies) == 1, f"expected exactly one policy, got {len(policies)}"
+assert policies[0]["repositories"] == ["djinn-image-*"], (
+    "retention repositories glob must stay exactly ['djinn-image-*']; widening it "
+    f"would put buildkitd cache repos in scope, got {policies[0]['repositories']}"
+)
+assert policies[0]["deleteUntagged"] is True, "shipped default must delete untagged manifests"
+assert config["storage"]["retention"]["dryRun"] is True, (
+    "shipped default must be dry-run: destructive deletion is an explicit operator opt-in"
+)
+print("PASS: shipped defaults render a report-only policy scoped to djinn-image-* only")
+PY
+
+echo ""
+echo "=== Test 7: default retention stays inert without an in-cluster Zot ==="
+# The startup preflight is fail-closed: on a Zot fetch error it returns Err and
+# the leader calls std::process::exit(1). External-registry deployments (the
+# chart default imagePipeline.zot.enabled=false) render no Zot ConfigMap and no
+# auth Secret keys, so telling the server retention is enabled would crash-loop
+# it on boot. Assert the shipped `retention.enabled: true` default is ANDed down
+# to an effective "false" whenever no in-cluster Zot is rendered.
+assert_effective_disabled() {
+    local render=$1
+    local label=$2
+    python3 - "$render" "$label" <<'PY'
+import re, sys
+
+render_path, label = sys.argv[1:]
+rendered = open(render_path, encoding="utf-8").read().splitlines()
+
+start = next(i for i, line in enumerate(rendered)
+             if line == "            - name: DJINN_ZOT_RETENTION_ENABLED")
+end = next((i for i in range(start + 1, len(rendered))
+            if rendered[i].startswith("            - name: ")), len(rendered))
+block = "\n".join(rendered[start:end])
+match = re.search(r"^              value: (.+)$", block, re.MULTILINE)
+assert match, "DJINN_ZOT_RETENTION_ENABLED must render a literal value"
+value = match.group(1).strip('"')
+assert value == "false", (
+    f"{label}: effective retention must be false when no in-cluster Zot is "
+    f"rendered, or the fail-closed startup preflight exit(1)s the server; got {value}"
+)
+# A preflight that cannot authenticate is exactly the fetch error that kills
+# boot, so the credential refs must be absent in this topology too.
+assert "DJINN_ZOT_RETENTION_USERNAME" not in "\n".join(rendered), (
+    f"{label}: Zot auth SecretKeyRefs must not render without in-cluster Zot"
+)
+print(f"PASS: {label} renders effective retention=false")
+PY
+}
+
+# 7a: chart defaults (imagePipeline.enabled=true, zot.enabled=false).
+helm template test-release "$CHART_DIR" \
+    --is-upgrade \
+    --show-only templates/deployment-server.yaml \
+    > "$TMPDIR_RENDER/no-zot.yaml"
+assert_effective_disabled "$TMPDIR_RENDER/no-zot.yaml" "external-registry defaults"
+
+# 7b: retention explicitly requested but the whole image pipeline is off.
+helm template test-release "$CHART_DIR" \
+    --is-upgrade \
+    --show-only templates/deployment-server.yaml \
+    --set imagePipeline.enabled=false \
+    --set imagePipeline.zot.retention.enabled=true \
+    > "$TMPDIR_RENDER/no-pipeline.yaml"
+assert_effective_disabled "$TMPDIR_RENDER/no-pipeline.yaml" "image pipeline disabled"
 
 echo ""
 echo "=== All Helm rendering tests passed ==="

--- a/deploy/helm/djinn/values.yaml
+++ b/deploy/helm/djinn/values.yaml
@@ -766,7 +766,13 @@ imagePipeline:
     #
     # Safety model:
     # - `retention.enabled` controls whether the policy is rendered into
-    #   zot-configmap at all. When false, no retention policy exists.
+    #   zot-configmap at all. When false, no retention policy exists and the
+    #   repo grows without bound — a shipped `enabled: false` default meant
+    #   every cluster silently accumulated every catalog manifest ever built.
+    #   The shipped default is therefore `enabled: true` PAIRED WITH
+    #   `dryRun: true`: a cluster REPORTS its retention plan instead of
+    #   growing silently, and still deletes nothing until an operator
+    #   explicitly opts in with `--set imagePipeline.zot.retention.dryRun=false`.
     # - `retention.dryRun` (default true) puts Zot in dry-run mode: it reports
     #   what it WOULD delete but does not actually delete. Safe to enable
     #   alongside monitoring without risk.
@@ -781,7 +787,7 @@ imagePipeline:
     # If the preflight finds an unsafe image, it blocks and reports —
     # destructive retention never silently removes a selected image.
     retention:
-      enabled: false
+      enabled: true
       dryRun: true
       deleteUntagged: true
       newestTags: 5

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -53,6 +53,69 @@ EOF
 sysctl --system
 ```
 
+### Bound the containerd image store (kubelet image GC)
+
+**This repo does not manage kubelet configuration declaratively — there is no
+ansible/terraform tree and nothing writes `/etc/rancher/k3s/config.yaml`. The
+step below is operator-applied, once, per node.**
+
+Every project-image build pushes a new devcontainer image, and the kubelet pulls
+it. Nothing evicts the old ones. On a long-lived node the containerd image store
+becomes the single largest consumer on the root filesystem (measured on the
+production VPS: **129 GB across 433 image refs, of which only 16 were in use**).
+
+kubelet's default image GC is *disk-level* only: it starts evicting when the
+filesystem crosses `imageGCHighThresholdPercent` (default 85%). That threshold
+is the reason the node keeps rediscovering DiskPressure — GC does nothing at
+all until the disk is already nearly full, then evicts under pressure. The
+durable fix is the *age-based* bound `imageMaximumGCAge`, which reclaims unused
+images on a timer regardless of how full the disk is.
+
+`imageMaximumGCAge` has **no kubelet command-line flag** — it exists only in the
+`KubeletConfiguration` file — so it cannot be passed via a bare `kubelet-arg`.
+Point kubelet at a config file instead:
+
+```bash
+cat >/etc/rancher/k3s/kubelet.conf <<'EOF'
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# Reclaim images unused for 7 days, on a timer, independent of disk level.
+# Must be strictly greater than the image GC scan period.
+imageMaximumGCAge: "168h"
+# Disk-level backstop retained at the kubelet defaults.
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
+EOF
+
+cat >/etc/rancher/k3s/config.yaml <<'EOF'
+kubelet-arg:
+  - "config=/etc/rancher/k3s/kubelet.conf"
+EOF
+
+systemctl restart k3s     # running pods are unaffected
+```
+
+Requires Kubernetes ≥ 1.30 (the `ImageMaximumGCAge` feature gate is beta/on by
+default there, GA from 1.32). Check with `k3s --version`.
+
+Safety: kubelet only garbage-collects images **not referenced by any container
+it currently manages**, so images backing Running/Pending pods — including the
+digest-pinned project image every task-run and warm Job references — are never
+candidates. Age is measured from last use, not from pull.
+
+Verify after the restart:
+
+```bash
+# The setting is live if it appears in the kubelet's effective config.
+kubectl get --raw "/api/v1/nodes/$(hostname)/proxy/configz" | grep -o '"imageMaximumGCAge":"[^"]*"'
+
+# Watch the image count fall over the following days.
+k3s crictl images | wc -l
+```
+
+If `/etc/rancher/k3s/config.yaml` already exists, merge the `kubelet-arg` key
+into it rather than overwriting the file.
+
 Install Helm if the box doesn't have it:
 
 ```bash


### PR DESCRIPTION
## The measurement

The production VPS root filesystem is at **317G/484G (66%)** with a recurring DiskPressure incident history. Ranked consumers:

| Consumer | Size | Finding |
|---|---|---|
| containerd image store | **129 GB** | 433 image refs, only **16 in use**. Image GC has never run. |
| zot PVC | **83 GB** | 117 manifests in ONE `djinn-image-*` repo, 41 days deep, ~2.8 builds/day. Keeping newest-5 reclaims **78.5 GiB**. |
| djinn-cache PVC | 83 GB | 36G live warm base + 26G live run dirs + a **27 GB stale `debug/` tree** untouched since 2026-07-17. |

The theme: **nothing here needed to be built.** Two retention mechanisms already existed, fully tested and wired to real call sites, and were simply off.

## 1. Zot tag retention — built, wired, shipped `enabled: false`

Zot's blob GC (`gc: true`) was already working correctly: unreachable garbage measured **0.0 GiB**. Nothing is ever untagged, so blob GC has nothing to collect — **tag** retention is the missing piece.

The newest-N planner (`retention.rs`), its `TagRetained`/`DigestRetained`/`AliasRetained` safety proof, and the fail-closed startup preflight (`retention_preflight.rs`) all exist and are reached from a real production call site. Only the shipped default was `enabled: false`.

Changed to **`enabled: true, dryRun: true`**. A cluster now *reports* the tags it would prune instead of growing silently, and still deletes nothing until an operator explicitly sets `dryRun=false`. `newestTags: 5` and `deleteUntagged: true` are unchanged.

## 2. A hazard the flip exposed, and the fix

Flipping the default alone would have been unsafe.

`AppState::run_zot_retention_preflight` is fail-closed, and its caller does:

```rust
if let Err(error) = self.run_zot_retention_preflight(&retention_config).await {
    tracing::error!(%error, "Zot retention preflight failed; refusing leader startup");
    std::process::exit(1);
}
```

The orchestration returns `Err` for **Zot fetch failures**. The chart default is `imagePipeline.zot.enabled: false` (most cloud deployments use ECR/GCR), which renders **no Zot ConfigMap and no auth Secret keys** — but `DJINN_ZOT_RETENTION_ENABLED` was rendered straight from the intent flag. An unconditional `true` would have pointed the fail-closed preflight at a registry that does not exist and **crash-looped the server on boot** for every external-registry deployment.

`DJINN_ZOT_RETENTION_ENABLED` is now rendered from an *effective* value that ANDs the intent flag with `imagePipeline.enabled` and `imagePipeline.zot.enabled` — the same two switches that already gate whether a retention policy renders at all. This is a coupling fix: the runtime env now agrees with whether a policy actually exists.

Note this was a **pre-existing footgun**, not one introduced here: `retention.enabled=true` + `zot.enabled=false` + `dryRun=true` already slipped past the `{{ fail }}` guard (which only fires on destructive policies) and would exit(1) the server. The default flip would have turned that edge case into the default path.

## Safety properties

1. **Scope.** The rendered policy targets `repositories: ["djinn-image-*"]` only. BuildKit cache repos (`djinn-buildkitd-*`) and infra images are out of scope. Test 6 asserts this glob independently of the policy-shape assertion.
2. **Digest pins, not tags.** Every task-run and warm Job references its project image **by digest**, and the pinned digest is currently the *newest* manifest. The authoritative keep-set is the DB (`ImageRepository::list_selected_catalog_images()`), not the tag list. A tag-only prune is exactly the failure `retention.rs` was written to prevent; the preflight independently proves each selected catalog image stays pullable by retained tag or digest pin before destructive deletion can proceed.
3. **Dry-run by default.** Destructive deletion remains an explicit operator opt-in.
4. **Render-time guard.** A destructive policy still cannot render without an enabled Zot endpoint (`{{ fail }}` in `zot-configmap.yaml`).

## 3. containerd image GC — not repo-managed, documented instead

kubelet has never garbage-collected images here: `imageGCHighThresholdPercent: 85` is never reached at 66% disk, and `imageMaximumGCAge: 0s` disables the age-based path. That is the recurring-incident pattern — disk-level GC only acts once you are already in trouble.

**kubelet configuration is not managed declaratively by this repo.** There is no ansible/terraform tree, and nothing writes `/etc/rancher/k3s/config.yaml` (confirmed absent on the prod node). Rather than invent a mechanism, the exact operator-applied change is documented in `docs/deploy/vps.md` §1.

`imageMaximumGCAge` has **no kubelet command-line flag** — it is `KubeletConfiguration`-only, so it cannot be passed via a bare `kubelet-arg`. The documented step writes `/etc/rancher/k3s/kubelet.conf` with `imageMaximumGCAge: "168h"` (7d) and points kubelet at it via `kubelet-arg: - "config=..."`, plus a `configz` verification command. Prod runs k3s v1.35.5, well past the 1.30 beta gate.

Safety: kubelet only collects images not referenced by any container it manages, so digest-pinned project images backing Running/Pending Jobs are never candidates.

## 4. The 27 GB stale `debug/` tree — a genuine bug, reported not fixed

Investigated as asked. **It is not a config flag that is off.**

- `outcome="safety_disabled_report_only"` is *hardcoded*, not configurable. `CacheCleanupMode` has exactly two variants and `Delete` maps directly to that outcome. It is therefore positive evidence prod is **already running `DJINN_CACHE_CLEANUP_MODE=delete`** (chart default is `delete`; only `values.local.yaml` overrides to `dry_run`). `reclaimed_bytes` is never assigned anywhere in the sweep — it only ever takes its `Default` of 0.
- The real reason the 27 GB survives is **reach, not mode**. `inventory_under` is a strict two-level allowlist walk: level 1 must parse as a UUID, level 2 must satisfy `canonical_mold_jobs_name` (`mold-jobs-N`). The stale tree is from the abandoned pre-`mold-jobs-N` layout — `<uuid>/debug/` — so `canonical_mold_jobs_name("debug")` returns `None` and it lands in an `ignored` counter that is **written 12 times and read zero times**. It never reaches the sweeper, the idle evictor, or the pressure planner. Arming anything would not reclaim it.
- Secondary gap: even for in-scope bases, `inventory_fingerprint_units` measures only `.fingerprint/<unit>` bytes, never `deps`/`build`/`incremental` where the bulk actually lives — so projected sizes are ~3 orders of magnitude low.
- Notable precedent: this exact class of silent-skip bug already bit this code once (the `CARGO_WARM_BASE_ROOT` constant made every pass inventory a nonexistent directory and log `deleted=0 retained=0` — a success line indistinguishable from "nothing to collect"). The root was fixed; the silent-skip semantics that made it undetectable were not.

No fix attempted here, per scope. This needs its own change.

## Testing

`deploy/helm/djinn/tests/zot-retention-render.sh` — 8 assertions, all passing. Two new scenarios, both asserting **rendered YAML**, not constants:

- **Test 6** renders with *no* retention override at all. Every pre-existing scenario pins retention with an explicit `--set`, so none of them could observe what `values.yaml` actually ships — the exact blind spot that let a repo reach 117 manifests. Also asserts the `djinn-image-*` glob and `dryRun: true` independently.
- **Test 7** asserts the effective value stays `false` for external-registry defaults and for a fully disabled pipeline, and that no auth SecretKeyRefs render in those topologies.

Also fixed a stale hard-coded namespace (`default`) in the existing assertions that had silently rotted this whole suite to **red on main** once `values.namespace.name` began defaulting to `djinn`. It now derives the namespace from the render, so a chart default change cannot make it stale again.

**Verified by neutralization** (both new tests):

| Reverted change | Result |
|---|---|
| `retention.enabled` → `false` | Test 6 fails: `DJINN_ZOT_RETENTION_ENABLED should be true, got "false"` |
| effective helper → raw `.Values...enabled` | Test 7 fails: `external-registry defaults: effective retention must be false ... got true` |

Both restored and re-verified green.

Other suites: `djinn-image-controller` **96/96 pass**. `helm lint` clean; chart renders with both default and `values.local.yaml`. `cache-cleanup-render.sh`, `graph-retention-render.sh`, `build-admission-topology.sh`, `volume-ownership-render.sh`, `server-memory-limit-render.sh`, `malloc-conf-render.sh`, `wrapper-manifest-render.sh` all pass. No Rust files changed, so no new clippy surface. (`migration-lifecycle-render.sh` and `projects-pvc-configmap-render.sh` fail identically on a clean checkout of main — pre-existing, untouched here; `incident-observability-contract.sh` needs `vector`, not installed locally.)

## Recommended rollout order

Nothing was deployed and nothing was deleted on prod.

1. **Deploy the chart with the shipped default** (`enabled: true`, `dryRun: true`). Zot logs what it would prune; the server logs one `Zot catalog retention preflight report` per boot.
2. **Verify the preflight.** Confirm `outcome` is not `destructive_blocked` and that every selected catalog image is retained. This is the real gate — the pinned digest is currently the newest manifest, and a tag-only view cannot prove it survives.
3. **Flip destructive**: `--set imagePipeline.zot.retention.dryRun=false`. Expected reclaim ~78.5 GiB. Roll back by setting `dryRun=true` (or `retention.enabled=false` to remove the policy entirely).
4. **Separately**, apply the kubelet `imageMaximumGCAge` step from `docs/deploy/vps.md` §1 on the node. Independent of the chart; expected reclaim is the bulk of the 129 GB image store.
5. The 27 GB stale cache tree needs its own fix — it is out of the current GC's reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
