### PR TITLE
fix(warm): repair the clippy denial that fails every graph-warm cycle

### DIFF
--- a/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
+++ b/server/crates/djinn-agent-worker/src/cargo_cache_policy.rs
@@ -203,6 +203,22 @@ fn build_warm_commands(
 
     let mut clippy_args = vec!["clippy".to_string()];
     clippy_args.extend(base_args.clone());
+    // `--keep-going` because the warm exists to DEPOSIT artifacts, not to gate.
+    // Cargo's default is to abort the whole run at the first failing unit, so a
+    // single crate with a lint error wipes the entire remaining check family
+    // from the deposit — which is how the base ended up with 292 `.rmeta`
+    // against 228 `.rlib`. Every downstream consumer then re-pays for the
+    // missing half: rust-analyzer's SCIP cargo prelude (measured at 706s) and
+    // every task-run `cargo clippy -p X`. With `--keep-going` a lint error
+    // costs only that crate's units.
+    //
+    // This does NOT soften the outcome: cargo still exits non-zero when any
+    // unit failed, so the step is still classified `seed_outcome=failed`. It
+    // just compiles more before giving up. Deliberately NOT `--cap-lints warn`
+    // or an `-A` via RUSTFLAGS: RUSTFLAGS feeds `-C metadata`, so touching it
+    // would invalidate all ~2800 units of the warm base on the next cycle.
+    // `--keep-going` is a cargo CLI flag and does not enter any fingerprint.
+    clippy_args.push("--keep-going".to_string());
     commands.push(CargoWarmCommand {
         label: "clippy",
         args: clippy_args,
@@ -329,7 +345,7 @@ version = "0.1.0"
         assert_eq!(policy.warm_commands[0].label, "clippy");
         assert_eq!(
             policy.warm_commands[0].args,
-            vec!["clippy", "--all-targets"]
+            vec!["clippy", "--all-targets", "--keep-going"]
         );
         assert!(policy.warm_commands[0].feature_args.is_empty());
         assert_eq!(policy.warm_commands[1].label, "build (clippy fallback)");
@@ -385,7 +401,7 @@ version = "0.1.0"
         assert_eq!(policy.warm_commands[0].label, "clippy");
         assert_eq!(
             policy.warm_commands[0].args,
-            vec!["clippy", "--workspace", "--all-targets"]
+            vec!["clippy", "--workspace", "--all-targets", "--keep-going"]
         );
         assert!(policy.warm_commands[0].feature_args.is_empty());
 
@@ -448,7 +464,7 @@ version = "0.1.0"
         assert_eq!(policy.warm_commands[0].label, "clippy");
         assert_eq!(
             policy.warm_commands[0].args,
-            vec!["clippy", "--workspace", "--all-targets"]
+            vec!["clippy", "--workspace", "--all-targets", "--keep-going"]
         );
         assert!(policy.warm_commands[0].feature_args.is_empty());
         assert_eq!(policy.warm_commands[2].label, "test (--no-run)");
@@ -488,7 +504,7 @@ version = "0.1.0"
         assert_eq!(policy.warm_commands.len(), 3);
         assert_eq!(
             policy.warm_commands[0].args,
-            vec!["clippy", "--all-targets"]
+            vec!["clippy", "--all-targets", "--keep-going"]
         );
         assert_eq!(
             policy.warm_commands[0].feature_args,
@@ -639,7 +655,10 @@ version = "0.1.0"
         assert_eq!(cmds.len(), 3);
 
         assert_eq!(cmds[0].label, "clippy");
-        assert_eq!(cmds[0].args, vec!["clippy", "--workspace", "--all-targets"]);
+        assert_eq!(
+            cmds[0].args,
+            vec!["clippy", "--workspace", "--all-targets", "--keep-going"]
+        );
         assert_eq!(cmds[0].feature_args, vec!["--all-features"]);
 
         assert_eq!(cmds[1].label, "build (clippy fallback)");
@@ -652,6 +671,47 @@ version = "0.1.0"
             vec!["test", "--workspace", "--all-targets", "--no-run"]
         );
         assert_eq!(cmds[2].feature_args, vec!["--all-features"]);
+    }
+
+    /// The warm's clippy step must carry `--keep-going`, in every shape.
+    ///
+    /// Not cosmetic. Cargo's default aborts the whole run at the first failing
+    /// unit, so one crate with a lint error discards the entire remaining check
+    /// family from the deposit -- which is how the base ended up with 292
+    /// `.rmeta` against 228 `.rlib`, making every downstream consumer re-pay for
+    /// the missing half (rust-analyzer's SCIP cargo prelude, every task-run
+    /// `cargo clippy -p X`). The per-shape assertions above pin the exact argv;
+    /// this one states the invariant so a future shape cannot silently omit it.
+    ///
+    /// It must stay on `clippy` only: `cargo nextest run` does not accept it,
+    /// so pushing it into the shared `base_args` would break the test-compile
+    /// step on every nextest project.
+    #[test]
+    fn every_warm_clippy_shape_keeps_going_past_the_first_failing_crate() {
+        for (workspace, all_features, features, nextest) in [
+            (true, false, vec![], true),
+            (true, true, vec![], false),
+            (false, false, vec![], false),
+            (false, false, vec!["qdrant".to_string()], true),
+        ] {
+            let cmds = build_warm_commands(workspace, all_features, &features, nextest);
+            let clippy = &cmds[0];
+            assert_eq!(clippy.label, "clippy");
+            assert!(
+                clippy.args.iter().any(|arg| arg == "--keep-going"),
+                "warm clippy lost --keep-going: {:?} -- one bad crate would \
+                 again wipe the rest of the deposit",
+                clippy.args
+            );
+            for other in &cmds[1..] {
+                assert!(
+                    !other.args.iter().any(|arg| arg == "--keep-going"),
+                    "{} must not carry --keep-going (cargo nextest rejects it): {:?}",
+                    other.label,
+                    other.args
+                );
+            }
+        }
     }
 
     // (d1b) build_warm_commands: nextest detected → nextest --no-run test step
@@ -675,7 +735,10 @@ version = "0.1.0"
         assert_eq!(cmds.len(), 3);
 
         assert_eq!(cmds[0].label, "clippy");
-        assert_eq!(cmds[0].args, vec!["clippy", "--workspace", "--all-targets"]);
+        assert_eq!(
+            cmds[0].args,
+            vec!["clippy", "--workspace", "--all-targets", "--keep-going"]
+        );
         assert!(
             cmds[0].feature_args.is_empty(),
             "default-features clippy must have empty feature_args"
@@ -705,7 +768,10 @@ version = "0.1.0"
         assert_eq!(cmds.len(), 3);
 
         assert_eq!(cmds[0].label, "clippy");
-        assert_eq!(cmds[0].args, vec!["clippy", "--all-targets"]);
+        assert_eq!(
+            cmds[0].args,
+            vec!["clippy", "--all-targets", "--keep-going"]
+        );
         assert!(
             cmds[0].feature_args.is_empty(),
             "single-crate default clippy must have empty feature_args"
@@ -731,7 +797,10 @@ version = "0.1.0"
         // clippy, build, test — all with --all-features in feature_args
         assert_eq!(cmds.len(), 3);
         assert_eq!(cmds[0].label, "clippy");
-        assert_eq!(cmds[0].args, vec!["clippy", "--all-targets"]);
+        assert_eq!(
+            cmds[0].args,
+            vec!["clippy", "--all-targets", "--keep-going"]
+        );
         assert_eq!(cmds[0].feature_args, vec!["--all-features"]);
 
         assert_eq!(cmds[1].label, "build (clippy fallback)");

--- a/server/crates/djinn-agent-worker/src/main.rs
+++ b/server/crates/djinn-agent-worker/src/main.rs
@@ -1918,14 +1918,28 @@ async fn run_cargo_warm_step_with_cargo(
     let resolved = budgets.resolve(kind);
     let started = djinn_core::clock::Clock::now_instant(&djinn_core::clock::SystemClock::new());
 
+    // Diagnostic tail of the child's stderr, populated only when the step
+    // actually failed. `output_with_timeout` has always piped and captured the
+    // child's output; both branches below used to drop it, so a failing warm
+    // step reported `seed_outcome=failed` and nothing else. That is how a
+    // clippy denial made every production warm cycle burn ~4m26s on a
+    // guaranteed failure for a day without a single log line naming the cause.
+    let mut failure_tail = String::new();
+
     let outcome = if let Some(forced) = forced_warm_step_outcome(project_id) {
         forced
     } else if !cargo_instrumented {
         let mut command = std::process::Command::new(cargo_bin.as_ref());
         command.args(&plan.args).current_dir(workspace_dir);
-        match warm_command_status(command, resolved.budget).await {
-            Ok(status) if status.success() => djinn_telemetry::cargo_warm_step::OUTCOME_OK,
-            Ok(_) => djinn_telemetry::cargo_warm_step::OUTCOME_FAILED,
+        // `warm_command_output`, not `warm_command_status`: on Linux (the only
+        // platform the warm Job runs on) these are the same call, but this one
+        // hands back the captured `Output` the failure branch needs.
+        match warm_command_output(command, resolved.budget).await {
+            Ok(output) if output.status.success() => djinn_telemetry::cargo_warm_step::OUTCOME_OK,
+            Ok(output) => {
+                failure_tail = warm_step_failure_tail(&output.stderr);
+                djinn_telemetry::cargo_warm_step::OUTCOME_FAILED
+            }
             Err(err) => {
                 warn!(
                     project_id,
@@ -1971,6 +1985,7 @@ async fn run_cargo_warm_step_with_cargo(
                 if output.status.success() {
                     djinn_telemetry::cargo_warm_step::OUTCOME_OK
                 } else {
+                    failure_tail = warm_step_failure_tail(&output.stderr);
                     djinn_telemetry::cargo_warm_step::OUTCOME_FAILED
                 }
             }
@@ -2019,6 +2034,10 @@ async fn run_cargo_warm_step_with_cargo(
             budget_clamped_by_job_deadline = resolved.clamped_by_deadline,
             job_deadline_secs = budgets.job_deadline().as_secs(),
             elapsed_ms = elapsed.as_millis() as u64,
+            // Bounded by `warm_step_failure_tail`; empty when the step never
+            // produced a captured `Output` (spawn error, timeout, forced
+            // outcome) or when it wrote nothing to stderr.
+            failure_tail = %failure_tail,
             "cargo warm: step did not succeed (non-fatal; continuing warm)"
         );
     }
@@ -2069,6 +2088,57 @@ async fn warm_command_output(
             .await
             .map_err(std::io::Error::other)?
     }
+}
+
+/// Hard ceiling on the diagnostic tail attached to a failed warm step.
+///
+/// A single `cargo clippy --workspace --all-targets` failure can emit megabytes
+/// of stderr. The tail exists to name the cause, not to mirror the build log.
+const WARM_STEP_FAILURE_TAIL_BYTES: usize = 8 * 1024;
+
+/// Bounded, diagnosis-oriented tail of a failed warm step's stderr.
+///
+/// Prefers rustc/cargo diagnostic blocks: a column-0 `error...` line plus the
+/// indented continuation that carries the `--> file:line:col` location. That is
+/// the whole diagnosis in the common case and drops the thousands of
+/// `Compiling`/`Fresh` progress lines around it. Falls back to the raw tail
+/// when no block matches, because a failure with no `error` line still needs
+/// *something* to look at.
+///
+/// Always truncated to [`WARM_STEP_FAILURE_TAIL_BYTES`] from the END: the last
+/// diagnostics are the ones naming the crate that failed to compile.
+fn warm_step_failure_tail(stderr: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stderr);
+    let mut kept: Vec<&str> = Vec::new();
+    let mut in_diagnostic = false;
+    for line in text.lines() {
+        if line.starts_with("error") {
+            in_diagnostic = true;
+            kept.push(line);
+        } else if in_diagnostic && (line.is_empty() || line.starts_with(char::is_whitespace)) {
+            kept.push(line);
+        } else {
+            in_diagnostic = false;
+        }
+    }
+    let selected = if kept.is_empty() {
+        text.into_owned()
+    } else {
+        kept.join("\n")
+    };
+    bounded_tail(&selected, WARM_STEP_FAILURE_TAIL_BYTES)
+}
+
+/// Last `max_bytes` of `text`, snapped forward to a char boundary.
+fn bounded_tail(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let mut start = text.len() - max_bytes;
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("[truncated to last {max_bytes} bytes] {}", &text[start..])
 }
 
 /// Classify a warm-step process error into its bounded outcome label.
@@ -4856,6 +4926,113 @@ warning: something
         assert!(
             logs.contains("step=\"check\""),
             "missing step label: {logs}"
+        );
+    }
+
+    /// A failing warm step must NAME its cause in its terminal event.
+    ///
+    /// Regression for the 2026-07-26 outage: `graph_warmer_ledger_tests.rs`
+    /// tripped the workspace's `disallowed_methods` denial, so every production
+    /// warm cycle's first command -- `cargo clippy --workspace --all-targets
+    /// --features qdrant` -- exited 101 after ~4m26s and fell through to a
+    /// ~25m `cargo build`. The child's stderr WAS captured by
+    /// `output_with_timeout` and then thrown away, so the only trace of a
+    /// day-long failure was `seed_outcome=failed`. Nothing in the log said
+    /// which file, which lint, or even which crate.
+    ///
+    /// This asserts the side effect, not the label: the WARN event must carry
+    /// the rustc diagnostic block (message AND `-->` location), and must NOT
+    /// carry the `Compiling` progress noise around it, which is what makes the
+    /// tail bounded enough to log at all.
+    #[cfg(unix)]
+    #[test]
+    fn a_failing_warm_step_logs_a_bounded_stderr_tail_naming_the_cause() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // The non-instrumented branch is the one that used to discard the
+        // Output entirely, so pin the env off for this test.
+        let _guard = CARGO_INSTRUMENT_ENV_LOCK.lock().expect("env lock poisoned");
+        // SAFETY: guarded test-only env mutation.
+        unsafe { std::env::remove_var("DJINN_CARGO_INSTRUMENT") };
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cargo_bin = tmp.path().join("cargo-clippy-fail.sh");
+        // Verbatim shape of the production failure, progress noise included.
+        std::fs::write(
+            &cargo_bin,
+            "#!/bin/sh\ncat >&2 <<'MOCKEOF'\n   Compiling djinn-k8s v0.1.0 (/w/server/crates/djinn-k8s)\nerror: use of a disallowed method `std::time::Instant::now`\n  --> crates/djinn-k8s/src/graph_warmer_ledger_tests.rs:97:20\n   |\n   = note: `-D clippy::disallowed-methods` implied by the workspace lint table\n\nerror: could not compile `djinn-k8s` (lib test) due to 2 previous errors\nMOCKEOF\nexit 101\n",
+        )
+        .expect("write mock cargo");
+        let mut perms = std::fs::metadata(&cargo_bin)
+            .expect("metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&cargo_bin, perms).expect("chmod mock cargo");
+
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(logs.clone())
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::NONE)
+            .with_target(false)
+            .with_ansi(false)
+            .finish();
+        let dispatch = Dispatch::new(subscriber);
+
+        let result = tracing::dispatcher::with_default(&dispatch, || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .expect("runtime")
+                .block_on(run_cargo_warm_step_with_cargo(
+                    &cargo_bin,
+                    "project-warm-tail",
+                    tmp.path(),
+                    &["clippy", "--workspace", "--all-targets"],
+                    "clippy",
+                    &warm_step_budget::WarmStepBudgets::now_from_env(),
+                ))
+        });
+
+        assert!(!result.succeeded(), "a 101-exit clippy step is a failure");
+        let logs = logs.take();
+        assert!(
+            logs.contains("cargo warm: step did not succeed"),
+            "missing the terminal failure event: {logs}"
+        );
+        assert!(
+            logs.contains("use of a disallowed method"),
+            "the failure event did not name the cause -- this is the exact \
+             blindness that hid a day of failed warm cycles: {logs}"
+        );
+        assert!(
+            logs.contains("graph_warmer_ledger_tests.rs:97:20"),
+            "the failure event must carry the diagnostic's file:line: {logs}"
+        );
+        assert!(
+            logs.contains("could not compile `djinn-k8s`"),
+            "the failure event must carry the crate that failed: {logs}"
+        );
+        assert!(
+            !logs.contains("Compiling djinn-k8s"),
+            "progress noise must be filtered out so the tail stays bounded: {logs}"
+        );
+    }
+
+    /// The tail is hard-bounded even when a step emits nothing filterable.
+    #[test]
+    fn warm_step_failure_tail_is_bounded_when_no_diagnostic_block_matches() {
+        let noise = "x".repeat(WARM_STEP_FAILURE_TAIL_BYTES * 4);
+        let tail = warm_step_failure_tail(noise.as_bytes());
+        assert!(
+            tail.len() < WARM_STEP_FAILURE_TAIL_BYTES + 128,
+            "unfiltered stderr must still be truncated, got {} bytes",
+            tail.len()
+        );
+        assert!(
+            tail.contains("truncated to last"),
+            "a truncated tail must say so: {tail}"
         );
     }
 

--- a/server/crates/djinn-k8s/src/graph_warmer_ledger_tests.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_ledger_tests.rs
@@ -3,6 +3,13 @@
 //! Split out of `graph_warmer_tests.rs`, which sits close to the 51200-byte
 //! `Server Guards` ceiling. Shares that module's warmer harness rather than
 //! duplicating it.
+//!
+//! Test-only: `Instant::now` bounds the deadlined ledger-poll loop below,
+//! exactly as in the module this was split out of. The workspace denies
+//! `clippy::disallowed_methods`, and that module's allowance did not come
+//! across with the split -- so `cargo clippy --workspace --all-targets`, which
+//! is the first command every production graph-warm cycle runs, failed here.
+#![allow(clippy::disallowed_methods)]
 
 use super::tests::{
     AdmissionRecording, LifecycleRecordingDispatcher, UidWatcher, seed_project_with_ready_image,


### PR DESCRIPTION
**Urgent: every production graph-warm cycle is currently failing its first command.** This is PR A of two — the production repair. The CI blind spot that let it land is #2685.

## The defect

`server/crates/djinn-k8s/src/graph_warmer_ledger_tests.rs` was split out of `graph_warmer_tests.rs` in #2608 (2026-07-26) but did not carry that module's `#![allow(clippy::disallowed_methods)]`. `server/Cargo.toml` denies `disallowed_methods` at workspace level and `server/clippy.toml` bans `std::time::Instant::now`, so the file's two deadline reads are hard errors:

```
graph_warmer_ledger_tests.rs:97:20: error: use of a disallowed method `std::time::Instant::now`
graph_warmer_ledger_tests.rs:107:12: error: use of a disallowed method `std::time::Instant::now`
error: could not compile `djinn-k8s` (lib test) due to 2 previous errors
```

These are **deny**-level, so they fail clippy on their own — no `-D warnings` required. The first command of every graph-warm cycle is `cargo clippy --workspace --all-targets --features qdrant`; since 2026-07-26 it has exited 101 after ~4m26s on every cycle and fallen through to the ~24m40s `cargo build` fallback, which populates a different fingerprint family.

The fix restores the missing allowance, matching the convention of both sibling graph-warmer test modules (`graph_warmer_tests.rs` and `graph_warmer_overlap_tests.rs` each carry the same module-level allow with a justification comment).

## Also here

**`--keep-going` on the warm's clippy command.** The warm exists to **deposit** artifacts, not to gate. Cargo's default aborts the whole run at the first failing unit, so one crate with a lint error discards the entire remaining check family — which is how the base ended up with 292 `.rmeta` against 228 `.rlib`, making every downstream consumer re-pay for the missing half (rust-analyzer's SCIP cargo prelude, measured at 706s; every task-run `cargo clippy -p X`).

Scoped to `clippy` only, **not** the shared `base_args`: `cargo nextest run` does not accept the flag, so pushing it into `base_args` would break the test-compile step on every nextest project. A test pins that boundary in both directions.

Deliberately **not** `--cap-lints warn` and **not** a lint level via `RUSTFLAGS`/`CARGO_BUILD_RUSTFLAGS`: RUSTFLAGS feeds `-C metadata`, so touching it invalidates all ~2800 units of the warm base on the next cycle. `--keep-going` is a cargo CLI flag and never enters a fingerprint.

**It does not mask failure.** Cargo still exits non-zero when any unit failed, so the step is still classified `seed_outcome=failed` — it just compiles more before giving up. Verified directly: `cargo clippy --workspace --all-targets --features qdrant --keep-going -- -D warnings` exited **101** while continuing past the first failing crate to report djinn-db's units too.

**Warm-step diagnostics.** `djinn-graph/src/process.rs` already piped and captured the child's stdout+stderr; both failure branches in `run_cargo_warm_step_with_cargo` dropped it, so a failing step logged `seed_outcome=failed` and nothing else. That is why a month of failed cycles was invisible. The non-instrumented branch now takes `warm_command_output` (on Linux — the only platform the warm Job runs on — this is literally the same call as `warm_command_status`), and the terminal `warn!` carries a bounded `failure_tail`: rustc diagnostic blocks, meaning a column-0 `error...` line plus the indented continuation carrying `--> file:line:col`, with `Compiling`/`Fresh` progress noise filtered out and a hard 8 KiB cap. Falls back to the raw bounded tail when nothing matches.

## Verification

`cargo clippy --workspace --all-targets --features qdrant` from `server/` — **exit 0, no errors**. This is the exact command the warm runs. (Pre-existing *warnings* remain across member crates; they do not fail this command, and clearing them is #2685's business, not this PR's.)

`cargo nextest run -p djinn-agent-worker -p djinn-k8s` — **681 passed**, including `graph_warmer::ledger_tests::a_lease_granted_warm_job_is_still_recorded_in_the_lifecycle_ledger`. `cargo fmt --check` clean. `scripts/check-file-size.sh` clean on all changed files.

## Neutralization evidence

Each production change was reverted independently and the corresponding test confirmed red.

**N1 — remove `failure_tail` from the terminal `warn!`.** `a_failing_warm_step_logs_a_bounded_stderr_tail_naming_the_cause` FAILED, and its output is verbatim the pre-fix production log:

```
the failure event did not name the cause -- this is the exact blindness that hid
a day of failed warm cycles: WARN cargo warm: step did not succeed (non-fatal;
continuing warm) project_id="project-warm-tail" ... step_label="clippy"
seed_outcome="failed" ran_to_completion=false truncated=false ...
```

**N2 — remove `clippy_args.push("--keep-going")`.** `every_warm_clippy_shape_keeps_going_past_the_first_failing_crate` FAILED:

```
warm clippy lost --keep-going: ["clippy", "--workspace", "--all-targets"]
 -- one bad crate would again wipe the rest of the deposit
```

**N3 — remove the `#![allow]`.** `cargo clippy -p djinn-k8s --all-targets` reproduced the exact production failure: two `error: use of a disallowed method` plus `could not compile djinn-k8s (lib test) due to 2 previous errors`.

All three restored; the pushed tree is the fixed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
