### PR TITLE
ci(cache): warm the check family, give main the pnpm cache, prune dead entries

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -1,0 +1,72 @@
+name: Cache Prune
+# Reclaim GitHub Actions cache budget.
+#
+# The repo cap is 10 GB and eviction is LRU across the whole repo, so dead
+# entries do not merely idle — they evict the live rust families that every CI
+# run reads. Nothing else deletes them: Swatinem/rust-cache never removes the
+# entry it supersedes, and a cache written from a PR or merge-queue ref outlives
+# the ref that alone could read it. Measured 2026-07-27 the repo sat at 10.15 GB
+# against the cap, actively evicting, with ~5 GB of it provably unreadable.
+#
+# Scheduled rather than one-off on purpose: both accumulation mechanisms are
+# continuous, so a manual sweep only resets the clock.
+#
+# `scripts/prune-actions-caches.mjs` holds the rules and the reasoning.
+on:
+  schedule:
+    # 04:20 UTC daily — off the peak of the merge queue, and after the nightly
+    # workflows have written whatever they are going to write.
+    - cron: '20 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List what would be deleted without deleting it
+        type: boolean
+        default: false
+      keep:
+        description: Newest entries to retain per rust cache family
+        type: string
+        default: '2'
+
+# The token needs `actions: write` to delete a cache. Everything else stays
+# read-only: this workflow must never be able to touch repository contents.
+permissions:
+  contents: read
+  actions: write
+
+# A second concurrent prune would race the first on the same entries. Deletes
+# are idempotent (the script tolerates a 404), but serialising keeps the log
+# readable and the reclaimed-bytes figure honest.
+concurrency:
+  group: cache-prune
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune Actions caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Prune
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |-
+          node scripts/prune-actions-caches.mjs \
+            --keep '${{ inputs.keep || '2' }}' \
+            ${{ inputs.dry_run && '--dry-run' || '' }}
+      - name: Report remaining budget
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          total=$(gh api "/repos/${{ github.repository }}/actions/caches?per_page=100" --paginate --slurp \
+            --jq '[.[].actions_caches[].size_in_bytes] | add // 0')
+          count=$(gh api "/repos/${{ github.repository }}/actions/caches?per_page=100" --paginate --slurp \
+            --jq '[.[].actions_caches[]] | length')
+          gb=$(awk "BEGIN { printf \"%.2f\", ${total}/1073741824 }")
+          echo "::notice::cache-budget ${gb} GB across ${count} entries (repo cap 10 GB, LRU eviction)"

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -326,6 +326,47 @@ jobs:
         run: bash -c "$CI_RUNNER_DISK_PREFLIGHT"
       - name: Build test binaries (populate cache)
         run: cargo nextest run --workspace --all-targets --features qdrant --no-run
+      # Deposit the CHECK-mode dependency units. `cargo clippy` is `cargo
+      # check`: workspace crates go through clippy-driver
+      # (RUSTC_WORKSPACE_WRAPPER), but their dependencies compile with ordinary
+      # rustc under `--emit=metadata`, which is CompileMode::Check and is
+      # hashed into every unit's `-C metadata`. Check-mode units are therefore
+      # a DISJOINT set from the codegen units the step above deposits — the
+      # step above cannot serve `Server Clippy` at all. Measured on a local
+      # `server/target/debug/deps`: 2861 unit hashes carry a `.rlib` (codegen)
+      # against 4763 that are `.rmeta`-only (check), with zero overlap.
+      #
+      # The selection here MUST stay byte-identical to the `Clippy` step in
+      # `server-clippy`. `server/Cargo.toml` has a root `[package]`, so
+      # `workspace_default_members` is 1 of 33 and a bare `cargo clippy`
+      # selects `djinn-server` alone. Under resolver 2 feature unification is
+      # computed over the SELECTED package set, so warming with `--workspace`
+      # would resolve a different feature union on shared dependencies, give
+      # them different `-C metadata`, and miss the consumer entirely while
+      # still looking like a populated cache. If the lint lane's selection or
+      # features change, change this line in the same commit.
+      #
+      # `-- -D warnings` is deliberately omitted: it reaches only the selected
+      # workspace units, which rust-cache prunes from the entry anyway. The
+      # workflow-level `RUSTFLAGS: -D warnings` still applies to every unit in
+      # both jobs, so the dependency fingerprints match.
+      #
+      # `--keep-going` because this step exists to DEPOSIT, not to gate. Cargo
+      # aborts the whole run at the first failing unit by default, so one crate
+      # with a lint error would discard the rest of the check family from the
+      # deposit and leave every consumer re-paying for it. Cargo still exits
+      # non-zero when any unit failed, and `cache-on-failure: true` above means
+      # the partial deposit is saved either way.
+      - name: Build check-mode deps (populate cache)
+        run: cargo clippy --all-targets --features qdrant --keep-going
+      # Both artifact sets now coexist in server/target. Recorded so the disk
+      # headroom cost of this job is a measured number rather than an estimate
+      # before anyone adds a third (`--all-features`) warm pass for
+      # server-sqlx-freshness.
+      - name: Report warm footprint
+        if: always()
+        run: |-
+          echo "::notice::warm-footprint target=$(du -sh target 2>/dev/null | cut -f1) free=$(df -h --output=avail . | tail -1 | tr -d ' ')"
       - name: Log cache family and restore status
         run: |-
           echo "cache-family=server-test"
@@ -375,6 +416,56 @@ jobs:
           echo "::notice::cache-family=server-aarch64-check shared-key=server-aarch64-check cache-hit=${{ steps.rust-cache.outputs.cache-hit }}"
       - name: cargo check (aarch64)
         run: cargo check -p djinn-sandbox --all-targets --target aarch64-unknown-linux-gnu
+  # Gives `refs/heads/main` ownership of the pnpm store cache. Without a
+  # main-branch entry the `ui-frontend` lane below — which is
+  # `github.event_name != 'push'`, so it NEVER ran on main — made every PR and
+  # every merge-queue ref miss, cold-install, and then write its own 252 MB
+  # copy under its own scope. Measured 2026-07-27: ELEVEN entries carrying the
+  # byte-identical key `node-cache-Linux-x64-pnpm-e23d1dc7…`, on eleven
+  # different `refs/pull/*/merge` and `gh-readonly-queue/*` refs, none on
+  # main — 2.7 GB, 27% of the repo's 10 GB budget, and not one of them able to
+  # serve any other branch, because GitHub scopes a cache to the ref that
+  # wrote it. That duplication is what pushed the repo over quota and started
+  # LRU-evicting the rust families CI actually depends on.
+  #
+  # A branch CAN read caches written by its base branch, so one main-owned
+  # entry serves every PR. `actions/setup-node` skips its save when the
+  # primary key hit exactly, so PRs stop writing entirely; only a PR that
+  # actually changes `ui/pnpm-lock.yaml` misses and writes, which is both rare
+  # and self-limiting.
+  #
+  # This deliberately uses setup-node's built-in cache rather than
+  # `actions/cache/restore`: `scripts/ci-cache-policy.test.mjs` requires every
+  # `actions/cache*` step to name a family declared in its CACHE_OWNERS map,
+  # and that map is about the Rust families whose single-writer discipline it
+  # exists to enforce. Routing pnpm through it would mean encoding a
+  # `hashFiles()` expression as a family name and weakening the check for the
+  # families it was written to protect.
+  cache-warm-ui:
+    name: Cache Warm UI (pnpm)
+    needs:
+      - preflight
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.preflight.outputs.ui == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+      # Install only. This job exists to write the store, not to re-run the
+      # checks in `ui-frontend`; duplicating those would cost a second full
+      # lane on every main push for no added signal.
+      - name: Populate the pnpm store cache
+        run: pnpm install --frozen-lockfile
   # One runner for every cheap guard lane. Each lane was previously its own
   # job doing ~15s of scripting behind ~30s of runner spin-up and a full
   # fetch-depth: 0 clone; merging them frees four to five concurrent job
@@ -498,9 +589,21 @@ jobs:
           # The dedicated `server-quality` family is gone. After #2342 moved
           # server-sqlx-freshness and memory-eval onto server-test, it served
           # exactly one job — this one — while holding ~2.5 GB of a 10 GB
-          # repo-wide budget. Clippy only substitutes clippy-driver for
-          # WORKSPACE crates (RUSTC_WORKSPACE_WRAPPER); dependencies build
-          # with ordinary rustc, so a codegen-warm family serves them.
+          # repo-wide budget.
+          #
+          # Clippy only substitutes clippy-driver for WORKSPACE crates
+          # (RUSTC_WORKSPACE_WRAPPER) and their dependencies do build with
+          # ordinary rustc — but NOT into the same artifacts. `cargo clippy` is
+          # `cargo check`, so those dependencies compile under `--emit=metadata`
+          # (CompileMode::Check), which is hashed into `-C metadata`. A
+          # codegen-warm family therefore does NOT serve them: the two unit
+          # sets are disjoint (measured 2861 `.rlib` vs 4763 `.rmeta`-only
+          # hashes, zero overlap). This job is on `server-test` because
+          # `cache-warm-x86_64-test` now deposits BOTH families into that one
+          # entry — see its `Build check-mode deps` step, whose package
+          # selection and features must stay identical to the `Clippy` step
+          # below. The census steps around that step verify the deposit is
+          # actually being restored rather than silently rebuilt.
           shared-key: server-test
           cache-on-failure: true
           cache-all-crates: true
@@ -538,8 +641,26 @@ jobs:
       - name: Runner disk headroom preflight
         # Body/thresholds: CI_RUNNER_DISK_PREFLIGHT at the top of this file.
         run: bash -c "$CI_RUNNER_DISK_PREFLIGHT"
+      # Standing instrumentation, not a one-off probe. A cache family can be
+      # restored, report `cache-hit=true`, and still serve none of what this
+      # lane compiles — that is exactly the state this lane was in until
+      # `cache-warm-x86_64-test` began depositing check-mode units, and nothing
+      # in the log distinguished it from a working cache. The delta below is
+      # the number of compilation units clippy had to build that the restore
+      # did not supply. Near-zero means the warm is serving this lane; several
+      # thousand means the two selections have drifted apart again (see the
+      # resolver-2 note on the warm job) and the lane is silently cold.
+      - name: Fingerprint census (restored)
+        id: fingerprints-restored
+        run: echo "count=$(ls target/debug/.fingerprint 2>/dev/null | wc -l)" >> "$GITHUB_OUTPUT"
       - name: Clippy
         run: cargo clippy --all-targets --features qdrant -- -D warnings
+      - name: Fingerprint census (after clippy)
+        if: always()
+        run: |-
+          before='${{ steps.fingerprints-restored.outputs.count }}'
+          after=$(ls target/debug/.fingerprint 2>/dev/null | wc -l)
+          echo "::notice::clippy-fingerprints restored=${before:-0} after=${after} built=$((after - ${before:-0}))"
   launcher-kernel-boundary:
     name: Launcher Kernel Boundary
     needs: preflight

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,11 @@ name: Release
 #   * workflow_dispatch         — manual rebuild with optional explicit tag.
 #
 # Binaries (djinn-server, djinn-agent-worker, djinn-cgroup-launcher) build in
-# dedicated jobs so they can share Swatinem/rust-cache; the image jobs COPY
-# the pre-built artifacts. runtime FROMs runtime-base at the current commit's
-# sha tag so the two stay coherent.
+# dedicated jobs and the image jobs COPY the pre-built artifacts. Those jobs
+# deliberately carry NO Swatinem/rust-cache: the `release-bins` family was
+# retired for budget (see the `image-builder` job below), so a release
+# cold-compiles. runtime FROMs runtime-base at the current commit's sha tag so
+# the two stay coherent.
 
 on:
   push:
@@ -49,10 +51,14 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   RUSTC_WRAPPER: ""
-  # Explicit cargo default, present so the cargo-relevant env here is
-  # byte-identical to quality-gate.yml's — Swatinem/rust-cache hashes
-  # CARGO_*/RUST* env vars into its key, and the release-bins cache is
-  # warmed by quality-gate's cache-warm-x86_64-release job on main.
+  # Explicit cargo default. This workflow restores NO rust-cache (the
+  # `release-bins` family is retired and there is no `cache-warm-x86_64-release`
+  # job — the only warm owners are `cache-warm-x86_64-test` and
+  # `cache-warm-aarch64`, both in quality-gate.yml), so this var currently
+  # feeds no cache key. It is pinned anyway to keep the cargo-relevant env here
+  # byte-identical to quality-gate.yml's: Swatinem/rust-cache hashes
+  # CARGO_*/RUST* env vars into its key, so if a release cache is ever
+  # reintroduced, a drifted default here would silently key it apart.
   CARGO_BUILD_BUILD_DIR: target
 
 jobs:
@@ -265,9 +271,21 @@ jobs:
       # No Rust cache here on purpose. The release-bins family was retired:
       # it held ~1.53 GB of a 10 GB repo-wide budget to serve ~1.9 releases
       # a day, while CI runs ~298 times a day and its cache was starved by
-      # the same budget. Releases now cold-compile (~22 min); the budget
-      # went to cache-workspace-crates on server-test, which every CI run
-      # reads. Revisit if release cadence rises or the budget grows.
+      # the same budget. Releases now cold-compile (~22 min).
+      #
+      # Where the freed budget went: NOT to `cache-workspace-crates`. That was
+      # the original plan, but the option was measured worthless and removed
+      # (see the long note on `cache-warm-x86_64-test` in quality-gate.yml —
+      # cargo fingerprints workspace crates by mtime and `actions/checkout`
+      # restamps them, so restored workspace artifacts arrive dirty). The
+      # budget now funds the check-mode dependency family on `server-test`,
+      # which `Server Clippy` reads on every PR.
+      #
+      # Note also that a release could not share the CI families even if the
+      # budget were free: this workflow sets RUSTFLAGS to
+      # `-C link-arg=-fuse-ld=mold` against CI's `-D warnings`, and RUSTFLAGS
+      # feeds `-C metadata` on every unit. Revisit only if release cadence
+      # rises enough to justify a family of its own.
       # Worker FIRST so its deps resolve WITHOUT qdrant (default features);
       # the server build then layers only the qdrant-extra deps on top,
       # reusing every shared non-qdrant artifact already on disk.

--- a/scripts/ci-cache-policy.test.mjs
+++ b/scripts/ci-cache-policy.test.mjs
@@ -27,8 +27,14 @@ function cacheWorkflows() {
 // 10 GB and evicts LRU, and four families sat at ~8.94 GB — so every family
 // was competing with the one CI actually reads on every run. server-quality
 // served a single job after #2342; release-bins served ~1.9 releases a day
-// against ~298 CI runs. Their ~4 GB funds cache-workspace-crates on
-// server-test. Adding a family back means finding budget for it first.
+// against ~298 CI runs. Adding a family back means finding budget for it first.
+//
+// Their ~4 GB did NOT go to `cache-workspace-crates` as originally planned:
+// that option was measured worthless and removed (quality-gate.yml documents
+// why — cargo fingerprints workspace crates by mtime, `actions/checkout`
+// restamps them). It funds the check-mode dependency units now deposited by
+// `cache-warm-x86_64-test`'s clippy step into the same `server-test` entry,
+// which `Server Clippy` reads on every PR.
 const CACHE_OWNERS = new Map([
   ['server-test', 'cache-warm-x86_64-test'],
   ['server-aarch64-check', 'cache-warm-aarch64'],

--- a/scripts/prune-actions-caches.mjs
+++ b/scripts/prune-actions-caches.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Reclaim GitHub Actions cache budget.
+ *
+ * GitHub caps a repository at 10 GB and evicts LRU across the WHOLE repo, so
+ * dead entries do not merely sit there — they push out the live ones. Two
+ * mechanisms accumulate dead entries here, and neither self-corrects:
+ *
+ *  1. Swatinem/rust-cache never deletes the entry it supersedes. Its key ends
+ *     in a hash of Cargo.lock + every workspace Cargo.toml, so every dependency
+ *     bump or manifest edit mints a NEW key and strands the old one forever.
+ *     Restores go through a prefix match, so only the newest entry per family
+ *     is ever read; the rest are pure ballast at ~1.6 GB (server-test) and
+ *     ~0.8 GB (server-aarch64-check) apiece.
+ *
+ *  2. Caches written from an ephemeral ref outlive the ref. A cache is scoped
+ *     to the ref that wrote it, so once a PR merges or a merge-queue branch is
+ *     deleted, its entries can never be read by anything again.
+ *
+ * Measured 2026-07-27 before this script existed: 26 entries, 10.15 GB against
+ * a 10 GB cap — actively evicting — of which 2.7 GB was eleven byte-identical
+ * pnpm entries on eleven dead refs and 2.4 GB was superseded rust entries.
+ *
+ * Usage:
+ *   node scripts/prune-actions-caches.mjs [--dry-run] [--keep N] [--repo O/R]
+ *
+ * Requires the `gh` CLI authenticated with `actions: write` on the repo.
+ */
+import { execFileSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const KEEP = Number(valueOf('--keep') ?? 2);
+const REPO = valueOf('--repo') ?? process.env.GITHUB_REPOSITORY;
+
+function valueOf(flag) {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+if (!REPO) {
+  console.error('prune-actions-caches: pass --repo OWNER/NAME or set GITHUB_REPOSITORY');
+  process.exit(2);
+}
+if (!Number.isInteger(KEEP) || KEEP < 1) {
+  console.error(`prune-actions-caches: --keep must be a positive integer, got ${KEEP}`);
+  process.exit(2);
+}
+
+function gh(endpoint, extra = []) {
+  return execFileSync('gh', ['api', endpoint, ...extra], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/**
+ * All cache entries, following pagination. `--paginate` on a JSON object
+ * endpoint emits one JSON document per page rather than a merged array, so
+ * concatenate the per-page `actions_caches` arrays.
+ */
+function listCaches() {
+  const raw = gh(`/repos/${REPO}/actions/caches?per_page=100`, ['--paginate', '--slurp']);
+  return JSON.parse(raw).flatMap((page) => page.actions_caches ?? []);
+}
+
+/**
+ * Group key for a rust-cache entry: the key with its trailing
+ * `-<env-hash>-<lock-hash>` removed, so `v0-rust-server-test-Linux-x64-6e4c1e9c-fcf0d190`
+ * and `…-6e4c1e9c-d7b4ddff` land in one family.
+ *
+ * Both hashes are stripped, not just the lock hash. The env hash changes when
+ * rustc or any cargo- or rust-prefixed env var changes, and rust-cache's
+ * restore prefix includes it — so entries under a retired env hash are as
+ * unreadable
+ * as entries under a retired lock hash, and must age out the same way. Keying
+ * the family on the env hash would pin two stale entries per retired hash
+ * forever.
+ */
+function rustFamily(key) {
+  const match = /^(v\d+-rust-.+?)-[0-9a-f]{6,}-[0-9a-f]{6,}$/.exec(key);
+  return match ? match[1] : null;
+}
+
+const PR_REF = /^refs\/pull\/(\d+)\/merge$/;
+const QUEUE_REF = /^refs\/heads\/gh-readonly-queue\//;
+
+const prStateCache = new Map();
+function pullRequestIsOpen(number) {
+  if (!prStateCache.has(number)) {
+    let open = true; // fail safe: never delete on an unreadable state
+    try {
+      open = JSON.parse(gh(`/repos/${REPO}/pulls/${number}`)).state === 'open';
+    } catch (error) {
+      console.warn(`  ! could not read PR #${number} state, keeping its caches: ${error.message}`);
+    }
+    prStateCache.set(number, open);
+  }
+  return prStateCache.get(number);
+}
+
+const caches = listCaches();
+const mb = (bytes) => Math.round(bytes / 1048576);
+const totalBefore = caches.reduce((sum, entry) => sum + entry.size_in_bytes, 0);
+console.log(`${caches.length} entries, ${(totalBefore / 1073741824).toFixed(2)} GB\n`);
+
+/** @type {{entry: object, reason: string}[]} */
+const doomed = [];
+
+// ── Dead refs ───────────────────────────────────────────────────────────────
+// A merge-queue branch is deleted the moment the queue concludes, and a merged
+// or closed PR's merge ref stops being checked out. Neither can ever serve a
+// restore again, whatever family it belongs to.
+for (const entry of caches) {
+  if (QUEUE_REF.test(entry.ref)) {
+    doomed.push({ entry, reason: 'merge-queue ref no longer exists' });
+    continue;
+  }
+  const pr = PR_REF.exec(entry.ref);
+  if (pr && !pullRequestIsOpen(Number(pr[1]))) {
+    doomed.push({ entry, reason: `PR #${pr[1]} is closed` });
+  }
+}
+
+// ── Superseded rust entries ─────────────────────────────────────────────────
+const alreadyDoomed = new Set(doomed.map(({ entry }) => entry.id));
+const families = new Map();
+for (const entry of caches) {
+  if (alreadyDoomed.has(entry.id)) continue;
+  const family = rustFamily(entry.key);
+  if (!family) continue;
+  if (!families.has(family)) families.set(family, []);
+  families.get(family).push(entry);
+}
+for (const [family, entries] of families) {
+  entries.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+  for (const entry of entries.slice(KEEP)) {
+    doomed.push({ entry, reason: `superseded in ${family} (keeping newest ${KEEP})` });
+  }
+}
+
+if (doomed.length === 0) {
+  console.log('nothing to prune');
+  process.exit(0);
+}
+
+const reclaimed = doomed.reduce((sum, { entry }) => sum + entry.size_in_bytes, 0);
+for (const { entry, reason } of doomed) {
+  console.log(`${DRY_RUN ? 'would delete' : 'deleting'} ${mb(entry.size_in_bytes)} MB  ${entry.key}`);
+  console.log(`    ref=${entry.ref}  ${reason}`);
+  if (DRY_RUN) continue;
+  try {
+    gh(`/repos/${REPO}/actions/caches/${entry.id}`, ['-X', 'DELETE']);
+  } catch (error) {
+    // A concurrent run, or GitHub's own LRU, may have removed it already.
+    console.warn(`    ! delete failed: ${error.message}`);
+  }
+}
+
+const verb = DRY_RUN ? 'would reclaim' : 'reclaimed';
+console.log(`\n${verb} ${(reclaimed / 1073741824).toFixed(2)} GB across ${doomed.length} entries`);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  console.log(`::notice::cache-prune ${verb} ${(reclaimed / 1073741824).toFixed(2)} GB across ${doomed.length} entries`);
+}

--- a/server/.cargo/config.toml
+++ b/server/.cargo/config.toml
@@ -2,11 +2,15 @@
 # platform (warm/worker pods) reuses a warm, main-based per-project
 # cargo target base with INCREMENTAL compilation (CI-style, like
 # Swatinem/rust-cache); sccache forbids incremental, so forcing it here would
-# disable the whole warm-cache fast path. CI keeps sccache by setting
-# `RUSTC_WRAPPER: sccache` + `CARGO_INCREMENTAL: 0` explicitly in
-# `.github/workflows/quality-gate.yml` (so the GitHub Actions cache stays
-# small and incremental). Local dev + djinn pods therefore default to cargo's
-# normal incremental dev/test profiles.
+# disable the whole warm-cache fast path.
+#
+# sccache is not used in CI either. `.github/workflows/quality-gate.yml` and
+# `release.yml` both set `RUSTC_WRAPPER: ""` — an explicit empty wrapper, so
+# that a wrapper leaking in from a runner image or a caller's environment
+# cannot change `-C metadata` and invalidate the restored rust-cache. CI does
+# pin `CARGO_INCREMENTAL: 0`, which is what keeps the GitHub Actions cache
+# small; that clamp is independent of any wrapper. Local dev + djinn pods
+# default to cargo's normal incremental dev/test profiles.
 #
 # NOTE: do NOT hardcode `target-dir` here, and do NOT add a setup script
 # that mutates this file at runtime.  Each git worktree gets its own
@@ -20,7 +24,7 @@
 # of GB onto tmpfs, (b) hard-coded a Rust assumption into the otherwise
 # language-agnostic command runner, and (c) didn't achieve dep sharing
 # anyway since each worktree got its own dir.  Both the in-file mutation
-# AND the env injection are gone now; cargo's default + sccache is the
+# AND the env injection are gone now; cargo's default target dir is the
 # whole story.
 
 [env]
@@ -50,7 +54,7 @@ DJINN_VAULT_KEY_PATH = "/var/tmp/djinn-test-vault/vault.key"
 # (dev/test = ON). We deliberately do NOT clamp `CARGO_INCREMENTAL` here:
 # the djinn warm/worker pods rely on consistent incremental-on so the
 # warm-base seed is reusable, and a `force = true` clamp would override the
-# env they set. CI still pins `CARGO_INCREMENTAL: 0` + sccache in
+# env they set. CI still pins `CARGO_INCREMENTAL: 0` in
 # `.github/workflows/quality-gate.yml`, so the GitHub Actions cache stays
 # incremental-free.
 


### PR DESCRIPTION
## The main finding

`quality-gate.yml` asserted that a codegen-warm cache family serves the clippy lane:

> Clippy only substitutes clippy-driver for WORKSPACE crates (`RUSTC_WORKSPACE_WRAPPER`); dependencies build with ordinary rustc, so a codegen-warm family serves them.

First clause right, second wrong, and it was load-bearing for the whole lane. `cargo clippy` is `cargo check` — dependencies do build with ordinary rustc, but under `--emit=metadata` (`CompileMode::Check`), which is hashed into each unit's `-C metadata`.

Measured on a local `server/target/debug/deps`:

| unit set | count |
|---|---|
| hashes with a `.rlib` (codegen) | 2861 |
| hashes that are `.rmeta`-only (check) | 4763 |
| **overlap** | **0** |

The warm job ran only `nextest --no-run`, so the entry `Server Clippy` restored held none of what it compiles. It reported `cache-hit=true` and re-checked every dependency cold on every PR.

## What changed

**Warm the check family.** A `cargo clippy --all-targets --features qdrant --keep-going` step in `cache-warm-x86_64-test`, depositing into the *same* `server-test` entry — no new family, no new budget line.

The selection is byte-identical to the lint lane's, deliberately. `server/Cargo.toml` has a root `[package]`, so `workspace_default_members` is **1 of 33** and a bare `cargo clippy` selects `djinn-server` alone (5 targets, not 170). Under resolver 2, feature unification is computed over the selected package set — warming with `--workspace` would resolve a different feature union on shared dependencies, key them apart, and miss the consumer entirely while still looking like a populated cache. **If the lint lane's selection or features change, this line changes in the same commit.**

`--keep-going` for the reason #2684 documents for the pod warm base: a deposit step must not let one lint error discard the rest of the family.

**Instrumentation, kept permanently.** For as long as this was broken, nothing in the log distinguished "restored" from "useful". `Server Clippy` now counts `.fingerprint` entries either side of the lint step and emits `built=N` — near zero means the warm serves it, thousands means the selections drifted apart again.

**Budget, reclaimed first.** The repo sat at **10.15 GB against a 10 GB cap**, actively LRU-evicting the families CI depends on.

- `ui-frontend` is `github.event_name != 'push'`, so main never owned a pnpm entry. Every PR and merge-queue ref missed, cold-installed, and wrote its own 252 MB copy: **11 byte-identical entries on 11 dead refs, 2.7 GB**, not one able to serve another branch. `cache-warm-ui` gives main the entry; `setup-node` skips its save on an exact key hit, so PRs stop writing.
- Nothing ever deleted a superseded rust entry or one stranded on a merged PR / deleted merge-queue ref. `scripts/prune-actions-caches.mjs` does, daily.

Already run against the live repo: **reclaimed 4.83 GB across 12 entries, 10.16 GB → 5.32 GB.**

**Five stale comments** corrected, each of which pushed a reader toward a wrong model: the `cache-warm-x86_64-release` job release.yml credited for warming a cache (it does not exist), the `cache-workspace-crates` budget story in release.yml and `ci-cache-policy.test.mjs` (measured worthless and removed), release.yml's claim its binary jobs share rust-cache (they carry no cache), and `server/.cargo/config.toml`'s claim that CI keeps sccache (CI sets `RUSTC_WRAPPER: ""`).

## Verification

- `node --test scripts/ci-cache-policy.test.mjs` — 3/3 pass; single-writer discipline intact, `cache-warm-ui` uses setup-node's built-in cache rather than `actions/cache*` precisely so it does not need weakening.
- `--keep-going` confirmed accepted by cargo 1.96.0 with clippy.
- Prune script dry-run reviewed before executing: it spared the open PR #2683 entry and the release buildkit blobs.

## What to watch on the first main push

`built=` in the `Server Clippy` annotation should drop from several thousand to near zero, and `Clippy` from ~186s to an estimated 40–70s. The warm job's `warm-footprint` notice reports `target` size and free disk — both artifact sets now coexist there, and that number is the input to deciding whether a third `--all-features` pass for `server-sqlx-freshness` fits the budget.

## Not in this PR

The largest number in CI is not cacheable: `nextest-plan` and each of four `server-test` shards compile the identical unit set, ~24 min of duplicated runner time per run. That needs `cargo nextest archive`, and it is immune to caching for the reason the workspace-crates comment already documents (cargo#11682).