### PR TITLE
fix(build-lease): an invocation must outwait the dispatch row blocking it, and every degrade must report

### DIFF
--- a/server/crates/djinn-agent/src/context.rs
+++ b/server/crates/djinn-agent/src/context.rs
@@ -37,7 +37,9 @@ use djinn_orchestration_types::coordinator::BackgroundWorkTracker;
 use djinn_provider::catalog::{CatalogService, HealthTracker};
 use djinn_slot::reply_loop::CompactionCriticalSection;
 use djinn_supervisor::SupervisorServices;
-use djinn_supervisor::services::{DurableInvocationLiftAuthority, WatchdogTerminationRequest};
+use djinn_supervisor::services::{
+    BUILD_LEASE_QUEUE_DEADLINE, DurableInvocationLiftAuthority, WatchdogTerminationRequest,
+};
 
 /// Shared tracker for per-task last-activity timestamps (unix seconds).
 /// Used by stall detection to kill sessions that stop producing tokens.
@@ -198,8 +200,22 @@ impl ShellLaunchContext {
     /// before the coordinator gives up on it. These are RELATIVE timeouts; the
     /// runner converts them to the absolute epoch-millisecond deadlines the
     /// coordinator compares against its wall clock.
-    const QUEUE_TIMEOUT: Duration = Duration::from_secs(30);
+    ///
+    /// The queue deadline is not a number of its own: an invocation must
+    /// outwait the dispatch row blocking it in their shared FIFO, so both
+    /// derive from [`BUILD_LEASE_QUEUE_DEADLINE`]. At 30s against that row's 30
+    /// minutes it always expired first and the compile ran at 250m.
     const LAUNCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// Override in seconds; `0` disables the deadline, unparseable keeps it.
+    pub(crate) const QUEUE_TIMEOUT_ENV: &'static str = "DJINN_INVOCATION_QUEUE_TIMEOUT_SECS";
+
+    pub(crate) fn queue_timeout() -> Duration {
+        std::env::var(Self::QUEUE_TIMEOUT_ENV)
+            .ok()
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .map_or(BUILD_LEASE_QUEUE_DEADLINE, Duration::from_secs)
+    }
 
     pub(crate) fn invocation(&self, timeout: Duration) -> LeaseInvocationConfig {
         LeaseInvocationConfig {
@@ -207,7 +223,7 @@ impl ShellLaunchContext {
             task_run_id: self.task_run_id.clone(),
             pod_uid: self.pod_uid.clone(),
             cpu_usage_threshold_usec: 250_000,
-            queue_timeout: Self::QUEUE_TIMEOUT,
+            queue_timeout: Self::queue_timeout(),
             launch_timeout: Self::LAUNCH_TIMEOUT,
             timeout,
         }

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -656,6 +656,11 @@ impl LeaseInvocationRunner {
                 unavailable_responses += 1;
                 if unavailable_responses >= 3 {
                     lease_failure(
+                        DegradeDiagnostic {
+                            identity: &identity,
+                            observed_usage_usec: cpu.usage_usec,
+                            authority,
+                        },
                         LeaseResult::LeaseUnavailable,
                         &mut deadline,
                         &mut credit_used,
@@ -689,6 +694,11 @@ impl LeaseInvocationRunner {
                     }
                     other => {
                         lease_failure(
+                            DegradeDiagnostic {
+                                identity: &identity,
+                                observed_usage_usec: cpu.usage_usec,
+                                authority,
+                            },
                             other,
                             &mut deadline,
                             &mut credit_used,
@@ -878,6 +888,11 @@ impl LeaseInvocationRunner {
                                 fence = Some(token);
                             }
                             other => lease_failure(
+                                DegradeDiagnostic {
+                                    identity: &identity,
+                                    observed_usage_usec: cpu.usage_usec,
+                                    authority,
+                                },
                                 other,
                                 &mut deadline,
                                 &mut credit_used,
@@ -890,6 +905,11 @@ impl LeaseInvocationRunner {
                         unavailable_responses += 1;
                         if unavailable_responses >= 3 {
                             lease_failure(
+                                DegradeDiagnostic {
+                                    identity: &identity,
+                                    observed_usage_usec: cpu.usage_usec,
+                                    authority,
+                                },
                                 LeaseResult::LeaseUnavailable,
                                 &mut deadline,
                                 &mut credit_used,
@@ -899,6 +919,11 @@ impl LeaseInvocationRunner {
                         }
                     }
                     other => lease_failure(
+                        DegradeDiagnostic {
+                            identity: &identity,
+                            observed_usage_usec: cpu.usage_usec,
+                            authority,
+                        },
                         other,
                         &mut deadline,
                         &mut credit_used,
@@ -1195,8 +1220,103 @@ fn deadline_epoch_ms(now_ms: i64, timeout: Duration) -> i64 {
 ///
 /// Only responses meaning the lease authority cannot be used coherently at all
 /// — an identity conflict, or repeated unavailability — remain hard errors.
+///
+/// # This path REPORTS
+///
+/// The degrade used to be completely silent: no `tracing::` call anywhere on
+/// it, so a command that lost its queue was indistinguishable in the logs from
+/// one that never needed a lease. The only observable was a `lease invocation
+/// launched` line with no matching `cgroup quota lifted`, which is an absence —
+/// nothing greps for it and no alert fires on it. Four armed rollouts were
+/// diagnosed by reading `cpu.max` out of cgroupfs on the node by hand, and the
+/// 16x fleet-wide slowdown this function's caller now names ran for days.
+/// [`degrade_reason`] and the `warn!` below are that missing event.
 #[cfg_attr(not(test), allow(dead_code))] // consumed by the workspace lease wiring task
 fn lease_failure(
+    diagnostic: DegradeDiagnostic<'_>,
+    result: LeaseResult,
+    deadline: &mut std::time::Instant,
+    credit_used: &mut bool,
+    output: &mut Option<LeaseInvocationError>,
+    unleased: &mut bool,
+) {
+    // Read before the match consumes `result`, and compared against the state
+    // BEFORE it so the one-way degrade reports exactly once per invocation
+    // rather than on every subsequent terminal status poll.
+    let reason = degrade_reason(&result);
+    let already_degraded = *unleased;
+    lease_failure_classify(result, deadline, credit_used, output, unleased);
+    if *unleased && !already_degraded {
+        djinn_telemetry::build_admission::record_invocation_degraded(reason);
+        tracing::warn!(
+            invocation_id = %diagnostic.identity.invocation_id,
+            task_run_id = %diagnostic.identity.task_run_id,
+            terminal_reason = reason,
+            observed_usage_usec = diagnostic.observed_usage_usec,
+            authority = ?diagnostic.authority,
+            degraded_quota = degraded_quota(diagnostic.authority),
+            "lease invocation DEGRADED: the build lease will never be granted, so the command \
+             runs the rest of its life at the quota it was born at. Under an Armed authority that \
+             is the launcher's unleased quota (250m by default) — a ~16x slowdown for a compile — \
+             and the degrade is one-way: this invocation will not be escalated again"
+        );
+    }
+}
+
+/// The identity and measurements the degrade diagnostic names.
+///
+/// Carried into [`lease_failure`] rather than logged at its five call sites so
+/// no future arm can be added that degrades without reporting.
+#[cfg_attr(not(test), allow(dead_code))] // consumed by the workspace lease wiring task
+struct DegradeDiagnostic<'a> {
+    identity: &'a TaskInvocationLeaseIdentity,
+    /// `cpu.stat usage_usec` for this leaf at the moment it lost the lease.
+    /// This is the number that makes a degrade actionable: 52.8 CPU-seconds
+    /// against a 0.25 CPU-s escalation threshold says the throttling is being
+    /// applied to real build work, not to a trivial command.
+    observed_usage_usec: u64,
+    /// The authority the leaf was BORN at. `Armed` means it is clamped for the
+    /// rest of its life; `Unarmed` means there was never a quota to lift and
+    /// the degrade costs nothing.
+    authority: djinn_cgroup_launcher::LeaseAuthority,
+}
+
+/// Closed enumeration naming why this invocation can never hold the lease.
+/// Bounded because it is also a metric label.
+#[cfg_attr(not(test), allow(dead_code))] // consumed by the workspace lease wiring task
+fn degrade_reason(result: &LeaseResult) -> &'static str {
+    match result {
+        // The coordinator terminalizes an expired queue row as
+        // `deadline_expired`; a wait that ends without a grant reports it as a
+        // timeout here and as a cancelled terminal state on a later status read.
+        LeaseResult::LeaseWaitTimeout { .. } => "deadline_expired",
+        LeaseResult::Cancelled { .. }
+        | LeaseResult::Status(LeaseStatus {
+            state: LeaseState::Cancelled,
+            ..
+        }) => "cancelled",
+        LeaseResult::Released { .. }
+        | LeaseResult::Status(LeaseStatus {
+            state: LeaseState::Released,
+            ..
+        }) => "released",
+        LeaseResult::Abandoned { .. } => "abandoned",
+        LeaseResult::LeaseUnavailable => "lease_unavailable",
+        _ => "unclassified",
+    }
+}
+
+/// What "degraded" means for a leaf born under `authority`.
+#[cfg_attr(not(test), allow(dead_code))] // consumed by the workspace lease wiring task
+fn degraded_quota(authority: djinn_cgroup_launcher::LeaseAuthority) -> &'static str {
+    match authority {
+        djinn_cgroup_launcher::LeaseAuthority::Armed => "launcher_unleased",
+        djinn_cgroup_launcher::LeaseAuthority::Unarmed => "unrestricted",
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))] // consumed by the workspace lease wiring task
+fn lease_failure_classify(
     result: LeaseResult,
     deadline: &mut std::time::Instant,
     credit_used: &mut bool,
@@ -1606,6 +1726,17 @@ mod tests {
         }
     }
 
+    /// The reporting context every `lease_failure` call carries. These unit
+    /// tests exercise the CLASSIFICATION; the emitted diagnostic itself is
+    /// asserted end-to-end in `process/tests/process_lease_queue_deadline_tests`.
+    fn degrade_diagnostic(identity: &TaskInvocationLeaseIdentity) -> DegradeDiagnostic<'_> {
+        DegradeDiagnostic {
+            identity,
+            observed_usage_usec: 52_800_000,
+            authority: djinn_cgroup_launcher::LeaseAuthority::Armed,
+        }
+    }
+
     /// A long-lived fixture child, contained the way the production handle
     /// contains a leaf: its own process group, torn down as a group. Spawning it
     /// through `sh -c` left the real command as a grandchild on any runner whose
@@ -1670,6 +1801,7 @@ mod tests {
         let mut error = None;
         let mut unleased = false;
         lease_failure(
+            degrade_diagnostic(&test_identity()),
             LeaseResult::LeaseIdentityConflict {
                 identity: LeaseIdentity::TaskInvocation(test_identity()),
             },
@@ -1684,6 +1816,7 @@ mod tests {
         ));
         error = None;
         lease_failure(
+            degrade_diagnostic(&test_identity()),
             LeaseResult::LeaseUnavailable,
             &mut deadline,
             &mut used,
@@ -1736,6 +1869,7 @@ mod tests {
             let mut error = None;
             let mut unleased = false;
             lease_failure(
+                degrade_diagnostic(&test_identity()),
                 result.clone(),
                 &mut deadline,
                 &mut used,
@@ -1758,6 +1892,7 @@ mod tests {
         let mut error = None;
         let mut unleased = false;
         lease_failure(
+            degrade_diagnostic(&test_identity()),
             LeaseResult::Status(LeaseStatus {
                 state: LeaseState::Queued,
                 fencing_token: None,
@@ -1791,6 +1926,7 @@ mod tests {
         };
         let mut unleased = false;
         lease_failure(
+            degrade_diagnostic(&test_identity()),
             credit.clone(),
             &mut deadline,
             &mut used,
@@ -1799,7 +1935,14 @@ mod tests {
         );
         assert_eq!(deadline, original + Duration::from_millis(25));
         assert!(!unleased, "the one credited retry still waits for capacity");
-        lease_failure(credit, &mut deadline, &mut used, &mut error, &mut unleased);
+        lease_failure(
+            degrade_diagnostic(&test_identity()),
+            credit,
+            &mut deadline,
+            &mut used,
+            &mut error,
+            &mut unleased,
+        );
         assert_eq!(deadline, original + Duration::from_millis(25));
         assert!(error.is_none());
         assert!(

--- a/server/crates/djinn-agent/src/process.rs
+++ b/server/crates/djinn-agent/src/process.rs
@@ -591,6 +591,9 @@ impl LeaseInvocationRunner {
         // makes a command SLOW, never dead. Nothing here kills the child, and
         // the durable record is still reconciled to terminal after the loop.
         let mut unleased_degrade = false;
+        // The absolute queue deadline this invocation sent, once it queued.
+        // `0` means it never reached the lease authority.
+        let mut queue_deadline_ms = 0_i64;
         // This variable is assigned only by `terminal_now` or by a service
         // wait that observed terminal intent. Consequently no later response
         // can authorize a cgroup lift.
@@ -613,10 +616,20 @@ impl LeaseInvocationRunner {
                 continue;
             } else if !queued && cpu.usage_usec >= config.cpu_usage_threshold_usec {
                 queued = true;
+                // Captured HERE, not hoisted out of the loop: the deadline is
+                // relative to the moment this invocation actually crossed the
+                // escalation threshold, which for a long command can be minutes
+                // after launch. Retained so the degrade diagnostic can say
+                // whether the queue position had genuinely expired — a status
+                // read reports a terminalized row as `Cancelled` and carries no
+                // terminal reason over the wire, so the deadline and the clock
+                // are the only evidence available in the pod.
+                let queued_deadlines = self.lease_deadlines(&config);
+                queue_deadline_ms = queued_deadlines.queue_deadline_ms;
                 match await_lease_or_terminal(
                     self.services.queue_lease(LeaseQueueRequest {
                         identity: lease.clone(),
-                        deadlines: self.lease_deadlines(&config),
+                        deadlines: queued_deadlines,
                     }),
                     &mut *child,
                     &cancel,
@@ -660,6 +673,8 @@ impl LeaseInvocationRunner {
                             identity: &identity,
                             observed_usage_usec: cpu.usage_usec,
                             authority,
+                            queue_deadline_ms,
+                            now_ms: epoch_ms(self.clock.now()),
                         },
                         LeaseResult::LeaseUnavailable,
                         &mut deadline,
@@ -698,6 +713,8 @@ impl LeaseInvocationRunner {
                                 identity: &identity,
                                 observed_usage_usec: cpu.usage_usec,
                                 authority,
+                                queue_deadline_ms,
+                                now_ms: epoch_ms(self.clock.now()),
                             },
                             other,
                             &mut deadline,
@@ -892,6 +909,8 @@ impl LeaseInvocationRunner {
                                     identity: &identity,
                                     observed_usage_usec: cpu.usage_usec,
                                     authority,
+                                    queue_deadline_ms,
+                                    now_ms: epoch_ms(self.clock.now()),
                                 },
                                 other,
                                 &mut deadline,
@@ -909,6 +928,8 @@ impl LeaseInvocationRunner {
                                     identity: &identity,
                                     observed_usage_usec: cpu.usage_usec,
                                     authority,
+                                    queue_deadline_ms,
+                                    now_ms: epoch_ms(self.clock.now()),
                                 },
                                 LeaseResult::LeaseUnavailable,
                                 &mut deadline,
@@ -923,6 +944,8 @@ impl LeaseInvocationRunner {
                             identity: &identity,
                             observed_usage_usec: cpu.usage_usec,
                             authority,
+                            queue_deadline_ms,
+                            now_ms: epoch_ms(self.clock.now()),
                         },
                         other,
                         &mut deadline,
@@ -1255,6 +1278,10 @@ fn lease_failure(
             observed_usage_usec = diagnostic.observed_usage_usec,
             authority = ?diagnostic.authority,
             degraded_quota = degraded_quota(diagnostic.authority),
+            queue_deadline_ms = diagnostic.queue_deadline_ms,
+            now_ms = diagnostic.now_ms,
+            queue_deadline_passed =
+                diagnostic.queue_deadline_ms > 0 && diagnostic.now_ms >= diagnostic.queue_deadline_ms,
             "lease invocation DEGRADED: the build lease will never be granted, so the command \
              runs the rest of its life at the quota it was born at. Under an Armed authority that \
              is the launcher's unleased quota (250m by default) — a ~16x slowdown for a compile — \
@@ -1279,6 +1306,17 @@ struct DegradeDiagnostic<'a> {
     /// rest of its life; `Unarmed` means there was never a quota to lift and
     /// the degrade costs nothing.
     authority: djinn_cgroup_launcher::LeaseAuthority,
+    /// The absolute queue deadline this invocation sent, and the clock it is
+    /// judged against.
+    ///
+    /// Both are logged because the reason a status read reports is
+    /// structurally lossy: the coordinator terminalizes an expired queue row as
+    /// `deadline_expired`, but `LeaseStatus` carries no terminal reason, so the
+    /// pod sees a bare `Cancelled`. `now_ms >= queue_deadline_ms > 0` is the
+    /// evidence that distinguishes "its queue position expired" from "somebody
+    /// cancelled it".
+    queue_deadline_ms: i64,
+    now_ms: i64,
 }
 
 /// Closed enumeration naming why this invocation can never hold the lease.
@@ -1734,6 +1772,8 @@ mod tests {
             identity,
             observed_usage_usec: 52_800_000,
             authority: djinn_cgroup_launcher::LeaseAuthority::Armed,
+            queue_deadline_ms: 0,
+            now_ms: 0,
         }
     }
 

--- a/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_degrade_tests.rs
@@ -590,16 +590,19 @@ async fn rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift() {
         "the rendered queue deadline must not be in the past"
     );
 
-    // The stored deadlines are absolute instants exactly 30s / 60s past the
-    // runner's `now` — not 1970, and not the raw timeouts.
+    // The stored deadlines are absolute instants exactly one queue deadline /
+    // 60s past the runner's `now` — not 1970, and not the raw timeouts. The
+    // queue value is read from the shared constant rather than restated: it is
+    // deliberately the SAME deadline the coordinator stamps on the dispatch row
+    // that blocks this invocation in the FIFO.
     assert_eq!(
         durable_deadline_ms(
             row.queue_deadline
                 .as_deref()
                 .expect("the queued row retains its deadline"),
         ),
-        now_ms + 30_000,
-        "the durable queue deadline must be now + 30s"
+        now_ms + djinn_supervisor::services::BUILD_LEASE_QUEUE_DEADLINE_MS,
+        "the durable queue deadline must be now + BUILD_LEASE_QUEUE_DEADLINE"
     );
     assert_eq!(
         durable_deadline_ms(

--- a/server/crates/djinn-agent/src/process/tests/process_lease_queue_deadline_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_queue_deadline_tests.rs
@@ -342,7 +342,10 @@ async fn a_degraded_invocation_reports_why_and_at_what_quota() {
         "the line must identify the invocation that is now throttled"
     );
     assert_eq!(
-        degrade.fields.get("observed_usage_usec").map(String::as_str),
+        degrade
+            .fields
+            .get("observed_usage_usec")
+            .map(String::as_str),
         Some("52800000"),
         "the CPU already burned is what makes a degrade actionable"
     );
@@ -350,6 +353,34 @@ async fn a_degraded_invocation_reports_why_and_at_what_quota() {
         degrade.fields.get("degraded_quota").map(String::as_str),
         Some("launcher_unleased"),
         "the line must name the quota the command is stuck at"
+    );
+    // A status read reports a terminalized row as a bare `Cancelled` and
+    // carries no terminal reason over the wire, so the deadline and the clock
+    // are the only evidence in the pod that the queue position expired rather
+    // than somebody cancelling it.
+    assert_eq!(
+        degrade
+            .fields
+            .get("queue_deadline_passed")
+            .map(String::as_str),
+        Some("true")
+    );
+    let deadline: i64 = degrade
+        .fields
+        .get("queue_deadline_ms")
+        .expect("the deadline it sent")
+        .parse()
+        .expect("epoch milliseconds");
+    let now: i64 = degrade
+        .fields
+        .get("now_ms")
+        .expect("the clock it is judged against")
+        .parse()
+        .expect("epoch milliseconds");
+    assert!(
+        deadline > 0 && now >= deadline,
+        "the diagnostic must carry the deadline it actually sent ({deadline}) and the \
+         clock that outlived it ({now})"
     );
 }
 
@@ -370,7 +401,10 @@ fn queue_timeout_defaults_to_the_shared_dispatch_deadline() {
     // thread-per-test runner.
     // SAFETY: single-threaded test body; no other test reads this variable.
     unsafe { std::env::remove_var(ShellLaunchContext::QUEUE_TIMEOUT_ENV) };
-    assert_eq!(ShellLaunchContext::queue_timeout(), BUILD_LEASE_QUEUE_DEADLINE);
+    assert_eq!(
+        ShellLaunchContext::queue_timeout(),
+        BUILD_LEASE_QUEUE_DEADLINE
+    );
     assert_eq!(
         i64::try_from(BUILD_LEASE_QUEUE_DEADLINE.as_millis()).unwrap(),
         BUILD_LEASE_QUEUE_DEADLINE_MS,
@@ -382,5 +416,8 @@ fn queue_timeout_defaults_to_the_shared_dispatch_deadline() {
     assert_eq!(ShellLaunchContext::queue_timeout(), Duration::from_secs(90));
     // SAFETY: as above.
     unsafe { std::env::remove_var(ShellLaunchContext::QUEUE_TIMEOUT_ENV) };
-    assert_eq!(ShellLaunchContext::queue_timeout(), BUILD_LEASE_QUEUE_DEADLINE);
+    assert_eq!(
+        ShellLaunchContext::queue_timeout(),
+        BUILD_LEASE_QUEUE_DEADLINE
+    );
 }

--- a/server/crates/djinn-agent/src/process/tests/process_lease_queue_deadline_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_queue_deadline_tests.rs
@@ -1,0 +1,386 @@
+//! The queue deadline an escalating command actually sends, and what the FIFO
+//! does with it.
+//!
+//! These tests drive the real [`LeaseInvocationRunner`] with the real
+//! [`ShellContext::invocation`] configuration — not a hand-built
+//! `LeaseInvocationConfig` — because the production defect was in the constant,
+//! not in the state machine. Every other test in this suite passes a 100ms
+//! scripted timeout and can never see it.
+//!
+//! # The production failure
+//!
+//! `grant_next` reads only the FIFO head. A denied dispatch attempt leaves a
+//! weight-1 `queued` row carrying a THIRTY MINUTE queue deadline, and denials
+//! fired every ~30s for hours (279 in 3h), so there was almost always such a
+//! row ahead of every zero-weight invocation. The invocation's own deadline was
+//! THIRTY SECONDS, so it always expired first, and because the degrade is
+//! one-way the command then ran its entire life at the launcher's 250m unleased
+//! quota. Measured: two live task-run pods issued 7 and 5 lease invocations and
+//! ZERO escalated, while a sampled leaf still read `cpu.max = 25000 100000`
+//! after burning 52.8 CPU-seconds — 211x the 0.25 CPU-s escalation threshold.
+
+use super::*;
+
+/// Launcher double whose leaf is always past the escalation threshold and whose
+/// child finishes a few polls in. `lifts` is the side effect under test: it is
+/// incremented only by `fenced_lift`, the one call that raises `cpu.max` off
+/// the unleased quota.
+#[derive(Clone)]
+struct QueueLauncher {
+    state: Arc<Mutex<QueueLauncherState>>,
+}
+
+#[derive(Default)]
+struct QueueLauncherState {
+    samples: usize,
+    status: Option<std::process::ExitStatus>,
+    lifts: usize,
+}
+
+impl QueueLauncher {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(QueueLauncherState::default())),
+        }
+    }
+    fn lifts(&self) -> usize {
+        self.state.lock().unwrap().lifts
+    }
+}
+
+impl CgroupLauncherClient for QueueLauncher {
+    fn launch(
+        &self,
+        _: Command,
+        _: &TaskInvocationLeaseIdentity,
+        _: djinn_cgroup_launcher::LeaseAuthority,
+    ) -> io::Result<Box<dyn ProcessHandle>> {
+        Ok(Box::new(QueueHandle {
+            state: self.state.clone(),
+        }))
+    }
+}
+
+struct QueueHandle {
+    state: Arc<Mutex<QueueLauncherState>>,
+}
+
+impl ProcessHandle for QueueHandle {
+    fn drain_stdout(&mut self) -> io::Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+    fn drain_stderr(&mut self) -> io::Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+    fn try_wait(&mut self) -> io::Result<Option<std::process::ExitStatus>> {
+        Ok(self.state.lock().unwrap().status)
+    }
+    fn wait(&mut self) -> io::Result<std::process::ExitStatus> {
+        self.state
+            .lock()
+            .unwrap()
+            .status
+            .ok_or_else(|| io::Error::other("scripted child is still running"))
+    }
+    fn sample_cpu(&mut self) -> io::Result<CpuStat> {
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut state = self.state.lock().unwrap();
+        state.samples += 1;
+        if state.samples >= 4 {
+            state
+                .status
+                .get_or_insert_with(|| std::process::ExitStatus::from_raw(0));
+        }
+        // Build-shaped: always past the 0.25 CPU-s escalation threshold, so the
+        // invocation always reaches the lease authority.
+        Ok(CpuStat {
+            usage_usec: 52_800_000,
+            ..CpuStat::default()
+        })
+    }
+    fn fenced_lift(&mut self) -> io::Result<()> {
+        self.state.lock().unwrap().lifts += 1;
+        Ok(())
+    }
+    fn kill(&mut self) -> io::Result<()> {
+        use std::os::unix::process::ExitStatusExt;
+
+        let mut state = self.state.lock().unwrap();
+        state
+            .status
+            .get_or_insert_with(|| std::process::ExitStatus::from_raw(9));
+        Ok(())
+    }
+    fn wait_empty(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+    fn cleanup(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A `ShellContext` around the runner under test, so the invocation config
+/// comes from PRODUCTION code (`ShellContext::invocation`) rather than from the
+/// suite's 100ms `config()` helper.
+fn shell_context(runner: Arc<LeaseInvocationRunner>) -> crate::context::ShellLaunchContext {
+    crate::context::ShellLaunchContext::for_test(runner, "task".into(), "run".into(), "pod".into())
+}
+
+/// Wait 60 seconds behind the FIFO head — longer than the old 30s queue
+/// timeout, far shorter than the 30-minute dispatch deadline that blocks it —
+/// and the escalation must still land.
+///
+/// The assertion is the SIDE EFFECT: `fenced_lift` was called, i.e. the cgroup
+/// quota was actually raised off the unleased 250m. Reverting the constant to
+/// `Duration::from_secs(30)` makes this fail with `lifts == 0`.
+#[tokio::test]
+async fn invocation_waiting_past_thirty_seconds_still_escalates() {
+    let services = Arc::new(ScriptedServices::new(
+        // Unused: the FIFO answers `queue_lease` from the deadline instead.
+        vec![],
+        // The grant acknowledgement, then the still-live durable state that
+        // authorizes the bind.
+        vec![status(LeaseState::Launching, Some(1))],
+        vec![status(LeaseState::Active, Some(1))],
+    ));
+    let clock = clock();
+    services.honour_queue_deadline(clock.clone(), Duration::from_secs(60));
+    let launcher = Arc::new(QueueLauncher::new());
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        clock.clone(),
+    ));
+    let context = shell_context(runner.clone());
+
+    let output = runner
+        .output(
+            command(),
+            context.invocation(Duration::from_secs(3_600)),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("a queued invocation must not fail the command");
+
+    assert_eq!(
+        launcher.lifts(),
+        1,
+        "an invocation that waited 60s behind the FIFO head must still be \
+         escalated: its queue deadline has to outlast the dispatch row blocking \
+         it, not expire 60x sooner"
+    );
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+}
+
+/// The complement, so the test above is not passing because the deadline is
+/// ignored: a wait past the configured deadline still degrades.
+#[tokio::test]
+async fn invocation_waiting_past_the_queue_deadline_degrades() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![],
+        vec![],
+        vec![status(LeaseState::Cancelled, None); 4],
+    ));
+    let clock = clock();
+    // One second past `BUILD_LEASE_QUEUE_DEADLINE`.
+    services.honour_queue_deadline(
+        clock.clone(),
+        djinn_supervisor::services::BUILD_LEASE_QUEUE_DEADLINE + Duration::from_secs(1),
+    );
+    let launcher = Arc::new(QueueLauncher::new());
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        clock.clone(),
+    ));
+    let context = shell_context(runner.clone());
+
+    let output = runner
+        .output(
+            command(),
+            context.invocation(Duration::from_secs(3_600)),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("a lost queue degrades, it never fails the command");
+
+    assert_eq!(
+        launcher.lifts(),
+        0,
+        "an invocation whose queue deadline genuinely expired must not lift"
+    );
+    assert_eq!(output.process.termination, ProcessTermination::Exited);
+}
+
+// ── Degrade diagnostic ────────────────────────────────────────────────────
+//
+// The degrade path had NO `tracing::` call at all. Its only observable was a
+// `lease invocation launched` line with no matching `cgroup quota lifted` —
+// an absence, which nothing greps for and no alarm fires on. Four armed
+// rollouts were diagnosed by reading `cpu.max` out of cgroupfs by hand.
+
+use std::collections::HashMap;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{Layer, registry::LookupSpan};
+
+#[derive(Clone, Debug)]
+struct CapturedEvent {
+    level: tracing::Level,
+    fields: HashMap<String, String>,
+}
+
+#[derive(Default, Clone)]
+struct EventCaptureLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: HashMap<String, String>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.fields.insert(
+            field.name().to_owned(),
+            format!("{value:?}").trim_matches('"').to_owned(),
+        );
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_owned());
+    }
+}
+
+impl<S> Layer<S> for EventCaptureLayer
+where
+    S: tracing::Subscriber,
+    S: for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        self.events.lock().unwrap().push(CapturedEvent {
+            level: *event.metadata().level(),
+            fields: visitor.fields,
+        });
+    }
+}
+
+/// A silent 16x slowdown must become a greppable event naming what happened,
+/// to whom, how much CPU it had already burned, and what quota it is stuck at.
+#[tokio::test]
+async fn a_degraded_invocation_reports_why_and_at_what_quota() {
+    let services = Arc::new(ScriptedServices::new(
+        vec![],
+        vec![],
+        vec![status(LeaseState::Cancelled, None); 4],
+    ));
+    let clock = clock();
+    services.honour_queue_deadline(
+        clock.clone(),
+        djinn_supervisor::services::BUILD_LEASE_QUEUE_DEADLINE + Duration::from_secs(1),
+    );
+    let launcher = Arc::new(QueueLauncher::new());
+    let runner = Arc::new(LeaseInvocationRunner::new(
+        services.clone(),
+        services.clone(),
+        launcher.clone(),
+        clock.clone(),
+    ));
+    let context = shell_context(runner.clone());
+
+    let capture = EventCaptureLayer::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    let output = runner
+        .output(
+            command(),
+            context.invocation(Duration::from_secs(3_600)),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("a lost queue degrades, it never fails the command");
+    drop(guard);
+
+    assert_eq!(launcher.lifts(), 0, "this invocation must have degraded");
+    let events = capture.events.lock().unwrap().clone();
+    let degrades: Vec<_> = events
+        .iter()
+        .filter(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|message| message.contains("DEGRADED"))
+        })
+        .collect();
+    assert_eq!(
+        degrades.len(),
+        1,
+        "the one-way degrade reports exactly once, and it reports at all \
+         (observed events: {events:?})"
+    );
+    let degrade = degrades[0];
+    assert_eq!(degrade.level, tracing::Level::WARN);
+    assert_eq!(
+        degrade.fields.get("terminal_reason").map(String::as_str),
+        Some("deadline_expired"),
+        "the reason has to name WHY the lease can never be granted"
+    );
+    assert_eq!(
+        degrade.fields.get("invocation_id").map(String::as_str),
+        Some(output.identity.invocation_id.as_str()),
+        "the line must identify the invocation that is now throttled"
+    );
+    assert_eq!(
+        degrade.fields.get("observed_usage_usec").map(String::as_str),
+        Some("52800000"),
+        "the CPU already burned is what makes a degrade actionable"
+    );
+    assert_eq!(
+        degrade.fields.get("degraded_quota").map(String::as_str),
+        Some("launcher_unleased"),
+        "the line must name the quota the command is stuck at"
+    );
+}
+
+/// The invariant the whole defect reduces to: the deadline an invocation sends
+/// and the deadline the coordinator stamps on the dispatch row that can block
+/// it are ONE value. They drifted by a factor of 60 (30s vs 30min) and every
+/// invocation in the fleet expired behind a dispatch row.
+///
+/// Also pins the env override, including that it is what lets an operator make
+/// them differ deliberately.
+#[test]
+fn queue_timeout_defaults_to_the_shared_dispatch_deadline() {
+    use crate::context::ShellLaunchContext;
+    use djinn_supervisor::services::{BUILD_LEASE_QUEUE_DEADLINE, BUILD_LEASE_QUEUE_DEADLINE_MS};
+
+    // Both assertions live in one test on purpose: they read and write the same
+    // process-global environment variable, so splitting them would race under a
+    // thread-per-test runner.
+    // SAFETY: single-threaded test body; no other test reads this variable.
+    unsafe { std::env::remove_var(ShellLaunchContext::QUEUE_TIMEOUT_ENV) };
+    assert_eq!(ShellLaunchContext::queue_timeout(), BUILD_LEASE_QUEUE_DEADLINE);
+    assert_eq!(
+        i64::try_from(BUILD_LEASE_QUEUE_DEADLINE.as_millis()).unwrap(),
+        BUILD_LEASE_QUEUE_DEADLINE_MS,
+        "the dispatch row's deadline and the invocation's are one value"
+    );
+
+    // SAFETY: as above.
+    unsafe { std::env::set_var(ShellLaunchContext::QUEUE_TIMEOUT_ENV, "90") };
+    assert_eq!(ShellLaunchContext::queue_timeout(), Duration::from_secs(90));
+    // SAFETY: as above.
+    unsafe { std::env::remove_var(ShellLaunchContext::QUEUE_TIMEOUT_ENV) };
+    assert_eq!(ShellLaunchContext::queue_timeout(), BUILD_LEASE_QUEUE_DEADLINE);
+}

--- a/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
+++ b/server/crates/djinn-agent/src/process/tests/process_lease_tests.rs
@@ -294,6 +294,12 @@ struct ScriptedServices {
     // `Lift` so the lease-state-machine tests exercise the successful lift path;
     // the epoch-gating tests override it to `Shadow` / `Unleased`.
     lift_decision: Mutex<djinn_supervisor::services::InvocationLiftDecision>,
+    /// When set, `queue_lease` stops replaying a script and behaves like the
+    /// real coordinator FIFO: the invocation waits `.1` behind the row ahead of
+    /// it, and the answer is decided by the deadline the RUNNER sent. That is
+    /// the only way a test can exercise the queue timeout as a decision rather
+    /// than as a scripted constant. See `queue_deadline_tests`.
+    fifo_wait: Mutex<Option<(Arc<TestClock>, Duration)>>,
 }
 
 impl ScriptedServices {
@@ -319,10 +325,18 @@ impl ScriptedServices {
             status_entered: Notify::new(),
             status_resume: Notify::new(),
             lift_decision: Mutex::new(djinn_supervisor::services::InvocationLiftDecision::Lift),
+            fifo_wait: Mutex::new(None),
         }
     }
     fn set_lift_decision(&self, decision: djinn_supervisor::services::InvocationLiftDecision) {
         *self.lift_decision.lock().unwrap() = decision;
+    }
+    /// Answer `queue_lease` the way the coordinator does: advance the shared
+    /// wall clock by `wait` (the time this invocation spent behind the FIFO
+    /// head), then grant it or terminalize it against the queue deadline the
+    /// runner itself computed.
+    fn honour_queue_deadline(&self, clock: Arc<TestClock>, wait: Duration) {
+        *self.fifo_wait.lock().unwrap() = Some((clock, wait));
     }
     fn pop(script: &Mutex<VecDeque<LeaseResult>>) -> LeaseResult {
         script
@@ -338,13 +352,28 @@ impl SupervisorServices for ScriptedServices {
     fn cancel(&self) -> &CancellationToken {
         &self.cancel
     }
-    async fn queue_lease(&self, _: LeaseQueueRequest) -> LeaseResult {
+    async fn queue_lease(&self, request: LeaseQueueRequest) -> LeaseResult {
         self.queue_calls.record();
         self.queue_entered.notify_waiters();
         if self.pause_queue.load(Ordering::SeqCst) {
-            std::future::pending().await
+            return std::future::pending().await;
+        }
+        let fifo = self.fifo_wait.lock().unwrap().clone();
+        let Some((clock, wait)) = fifo else {
+            return Self::pop(&self.queue);
+        };
+        // The wait this position spent behind the head of the shared FIFO.
+        clock.advance_wall(wait);
+        let deadline = request.deadlines.queue_deadline_ms;
+        // Exactly `expire_queued_tx`: a non-positive deadline is NO deadline,
+        // and a position whose deadline has passed is terminalized instead of
+        // granted.
+        if deadline > 0 && epoch_ms(clock.now()) >= deadline {
+            LeaseResult::LeaseWaitTimeout {
+                timeout_credit: None,
+            }
         } else {
-            Self::pop(&self.queue)
+            granted(1)
         }
     }
     async fn grant_lease(&self, _: LeaseGrantRequest) -> LeaseResult {
@@ -1403,5 +1432,7 @@ mod admission_composition_tests;
 mod broker_lift_tests;
 #[path = "process_lease_degrade_tests.rs"]
 mod lease_degrade_tests;
+#[path = "process_lease_queue_deadline_tests.rs"]
+mod queue_deadline_tests;
 #[path = "process_lease_recovery_tests.rs"]
 mod recovery_tests;

--- a/server/crates/djinn-coordinator/src/build_slot_authority.rs
+++ b/server/crates/djinn-coordinator/src/build_slot_authority.rs
@@ -20,8 +20,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use djinn_supervisor::services::{
-    LeaseAbandonRequest, LeaseDeadlines, LeaseGrantRequest, LeaseIdentity, LeaseReleaseRequest,
-    LeaseResult, LeaseState, LeaseStatusRequest, TaskDispatchLeaseIdentity,
+    BUILD_LEASE_QUEUE_DEADLINE_MS, LeaseAbandonRequest, LeaseDeadlines, LeaseGrantRequest,
+    LeaseIdentity, LeaseReleaseRequest, LeaseResult, LeaseState, LeaseStatusRequest,
+    TaskDispatchLeaseIdentity,
 };
 
 use crate::build_admission::{BuildSlotAuthority, DispatchSlotOutcome};
@@ -261,7 +262,14 @@ impl BuildSlotAuthority for BuildLeaseDispatchAuthority {
 /// inside the window keeps its original FIFO position; only a genuinely
 /// abandoned one expires. Too short would silently drop positions under load,
 /// which is the starvation this design exists to avoid.
-const DISPATCH_QUEUE_DEADLINE_MS: i64 = 30 * 60 * 1000;
+///
+/// Derived from the shared [`BUILD_LEASE_QUEUE_DEADLINE_MS`] rather than
+/// restated here: this row sits in the SAME head-of-line-blocking FIFO as the
+/// invocation leases queued behind it, so the two deadlines are one decision.
+/// When they were independent (30 minutes here, 30 seconds in
+/// `djinn-agent`), every invocation expired behind a dispatch row and ran its
+/// whole compile at the 250m unleased quota.
+const DISPATCH_QUEUE_DEADLINE_MS: i64 = BUILD_LEASE_QUEUE_DEADLINE_MS;
 
 struct LeaseQueueRequestShim;
 

--- a/server/crates/djinn-supervisor/src/services/lease.rs
+++ b/server/crates/djinn-supervisor/src/services/lease.rs
@@ -1,5 +1,59 @@
 //! Owned, serde-safe v1 lease protocol contracts.
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// How long anything may hold a position in the ONE build-lease FIFO before the
+/// coordinator terminalizes it as `deadline_expired`.
+///
+/// # Why one constant for two populations
+///
+/// [`grant_next`](../../../../djinn_db/repositories/build_lease) reads only the
+/// queue HEAD and grants nothing when the head does not fit. Head-of-line
+/// blocking is deliberate (it is what keeps a heavy warm Job from starving
+/// behind an unbroken stream of weight-1 dispatches), and its cost is that
+/// every queued row waits for the row in front of it — across consumer kinds.
+///
+/// So the two deadlines are not independent knobs. A dispatch row sits in the
+/// FIFO for up to this long; an invocation queued behind it therefore has to be
+/// willing to wait at least as long, or it expires first, degrades to the
+/// launcher's 250m unleased quota, and — because the degrade is one-way — runs
+/// its whole compile at ~1/16th of the leased quota.
+///
+/// Production ran with 30 MINUTES for dispatch and 30 SECONDS for invocations.
+/// Denied dispatch attempts re-queued every ~30s for hours (279 denials in 3h),
+/// so there was almost always a weight-1 dispatch row ahead of every zero-weight
+/// invocation, and the invocation's own deadline always expired first: two live
+/// task-run pods launched 7 and 5 lease invocations and ZERO escalated, while a
+/// sampled leaf held `cpu.max = 25000 100000` after burning 52.8 CPU-seconds
+/// (211x the 0.25 CPU-s escalation threshold).
+///
+/// Both consumers derive their deadline from this value so the two can no
+/// longer drift apart. Waiting longer is free for the invocation: a queued
+/// invocation's child keeps running (clamped) the whole time, and the command's
+/// own timeout still bounds it — the only thing the queue deadline decides is
+/// whether the escalation is still allowed to land when the FIFO reaches it.
+pub const BUILD_LEASE_QUEUE_DEADLINE: Duration = Duration::from_secs(30 * 60);
+
+/// [`BUILD_LEASE_QUEUE_DEADLINE`] in whole milliseconds, for the coordinator's
+/// epoch-millisecond deadline arithmetic.
+pub const BUILD_LEASE_QUEUE_DEADLINE_MS: i64 = 30 * 60 * 1000;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod queue_deadline_tests {
+    use super::*;
+
+    /// The millisecond projection and the `Duration` are one value expressed
+    /// two ways; a hand-edited drift between them would silently reinstate the
+    /// mismatch this constant exists to remove.
+    #[test]
+    fn millisecond_projection_matches_the_duration() {
+        assert_eq!(
+            BUILD_LEASE_QUEUE_DEADLINE_MS,
+            i64::try_from(BUILD_LEASE_QUEUE_DEADLINE.as_millis()).unwrap()
+        );
+    }
+}
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TaskInvocationLeaseIdentity {
     pub task_id: String,

--- a/server/crates/djinn-telemetry/src/lib.rs
+++ b/server/crates/djinn-telemetry/src/lib.rs
@@ -184,6 +184,19 @@ const BUILD_ADMISSION_CREATE_UNKNOWN_HEALTH: &str = "djinn_build_admission_creat
 const BUILD_ADMISSION_SHADOW_INVOCATION_TOTAL: &str =
     "djinn_build_admission_shadow_invocation_total";
 const BUILD_ADMISSION_LIFT_REJECTED_TOTAL: &str = "djinn_build_admission_lift_rejected_total";
+const BUILD_ADMISSION_INVOCATION_DEGRADED_TOTAL: &str =
+    "djinn_build_admission_invocation_degraded_total";
+/// Closed enumeration of the durable answers that end an invocation's ability
+/// to be escalated. `deadline_expired` is the one that produced the fleet-wide
+/// 16x slowdown: the invocation's queue deadline expired behind a dispatch row.
+const BUILD_ADMISSION_DEGRADE_REASONS: [&str; 6] = [
+    "deadline_expired",
+    "cancelled",
+    "released",
+    "abandoned",
+    "lease_unavailable",
+    "unclassified",
+];
 const BUILD_ADMISSION_TRANSITION_TOTAL: &str = "djinn_build_admission_transition_total";
 // One closed enumeration for every durable journal write attempt: the two
 // lifecycle outcomes plus the two startup-reconciliation outcomes. Extending
@@ -1925,6 +1938,14 @@ fn register_metrics() {
          durable grant was held, and the kernel boundary still refused it."
     );
     metrics::describe_counter!(
+        BUILD_ADMISSION_INVOCATION_DEGRADED_TOTAL,
+        "Lease invocations that lost the build-lease queue and run the rest of \
+         their life at the quota they were born at, by terminal reason. A \
+         non-zero `deadline_expired` share means compiles are being throttled \
+         to the 250m unleased quota because their queue position expired — the \
+         one-way degrade is silent in every other signal."
+    );
+    metrics::describe_counter!(
         BUILD_ADMISSION_TRANSITION_TOTAL,
         "Durable admission-journal lifecycle transitions by outcome. A rejected \
          share near one means the journal is refusing every observation and \
@@ -3311,6 +3332,27 @@ pub mod build_admission {
     /// `/metrics` endpoint, so in a task-run Pod the log line is what escapes.
     pub fn record_lift_rejected() {
         metrics::counter!(super::BUILD_ADMISSION_LIFT_REJECTED_TOTAL).increment(1);
+    }
+
+    /// Record one invocation that lost the build-lease queue and degraded to
+    /// the quota it was born at. `reason` MUST be one of
+    /// [`super::BUILD_ADMISSION_DEGRADE_REASONS`].
+    ///
+    /// Emits a structured `tracing::warn!` at the call site for the same reason
+    /// [`record_shadow_invocation`] logs: every caller lives in the task-run
+    /// Pod and `djinn-agent-worker` exposes no `/metrics` endpoint, so in
+    /// production the log line is what escapes. The counter exists so a server
+    /// -side scrape can still answer "what fraction of invocations degraded"
+    /// wherever the emitter runs with an exporter.
+    ///
+    /// Every series in the family is written on the first degrade, so a
+    /// process that has degraded nothing of a given reason is distinguishable
+    /// from one that never reported at all.
+    pub fn record_invocation_degraded(reason: &'static str) {
+        for candidate in super::BUILD_ADMISSION_DEGRADE_REASONS {
+            metrics::counter!(super::BUILD_ADMISSION_INVOCATION_DEGRADED_TOTAL, "reason" => candidate)
+                .increment(u64::from(candidate == reason));
+        }
     }
 }
 


### PR DESCRIPTION
## The live defect

In production right now, essentially **every compile runs at 250 millicores instead of 4000** — a ~16x slowdown — and it is completely silent.

Measured on the live fleet:

* two task-run pods launched **7 and 5** lease invocations respectively; **zero** escalated;
* a live cgroup leaf sampled over 60s held `cpu.max = 25000 100000` (250m) after burning **52.8 CPU-seconds** — 211x the 0.25 CPU-s escalation threshold;
* a healthy invocation logs `decision=Lift authority=Armed` and then `lease invocation escalated: cgroup quota lifted`. None of these did.

Two causes, both fixed here.

### 1. The two queue deadlines had drifted apart by a factor of 60

`grant_next` reads only the FIFO **head** and returns `Empty` if the head does not fit. That head-of-line blocking is deliberate — it is what stops a heavy warm Job starving behind an unbroken stream of weight-1 dispatches — and its price is that every queued row waits for the row in front of it, **across consumer kinds**.

A denied dispatch attempt leaves a weight-1 `queued` row with `DISPATCH_QUEUE_DEADLINE_MS = 30 * 60 * 1000` — **30 minutes**. Denials fired every ~30s for hours (279 in 3h), so there was almost always such a row ahead of every zero-weight invocation. The invocation's own `QUEUE_TIMEOUT` was **30 seconds**. It always expired first, and the degrade is one-way, so the command then ran its whole life clamped.

**The invariant: an invocation must be able to outwait the dispatch row that can block it.** Any invocation deadline *below* the dispatch deadline reintroduces the bug — the row ahead is allowed to sit in the FIFO for the full dispatch deadline, so a shorter invocation deadline can always be outlasted by it, and the escalation is lost exactly when the queue is busiest (i.e. when it matters).

So the two are no longer independent numbers. Both derive from one constant in a crate both sides already depend on:

```rust
// djinn-supervisor/src/services/lease.rs
pub const BUILD_LEASE_QUEUE_DEADLINE: Duration = Duration::from_secs(30 * 60);
pub const BUILD_LEASE_QUEUE_DEADLINE_MS: i64 = 30 * 60 * 1000;
```

* `build_slot_authority.rs`: `const DISPATCH_QUEUE_DEADLINE_MS: i64 = BUILD_LEASE_QUEUE_DEADLINE_MS;`
* `context.rs`: the invocation queue timeout defaults to `BUILD_LEASE_QUEUE_DEADLINE`, overridable with `DJINN_INVOCATION_QUEUE_TIMEOUT_SECS` (`0` = no deadline) following the crate's existing `from_env` convention.

Waiting longer costs nothing: a queued invocation's child keeps running (clamped) the whole time and the command's own timeout still bounds it. The queue deadline only decides whether the escalation is still allowed to land when the FIFO reaches this row.

### 2. The degrade was entirely silent

There was **no `tracing::` call at all** on the `unleased_degrade` path. The only observable was a `launched` line with no matching `quota lifted` — an absence, which nothing greps for and no alarm fires on. Four armed rollouts were diagnosed by reading `cpu.max` out of cgroupfs on the node by hand.

`lease_failure` now emits, exactly once per invocation (the degrade is one-way), at WARN:

```
lease invocation DEGRADED: ... invocation_id=… task_run_id=… terminal_reason=deadline_expired
observed_usage_usec=52800000 authority=Armed degraded_quota=launcher_unleased
queue_deadline_ms=… now_ms=… queue_deadline_passed=true
```

…plus a bounded counter `djinn_build_admission_invocation_degraded_total{reason=…}`. The reason is carried in a `DegradeDiagnostic` passed into `lease_failure` rather than logged at its five call sites, so a future arm cannot be added that degrades without reporting.

The deadline fields are there because the reason a status read reports is structurally lossy: the coordinator terminalizes an expired queue row as `deadline_expired`, but `LeaseStatus` carries no terminal reason over the wire, so the pod can see a bare `Cancelled`. The deadline this invocation actually sent, and the clock that outlived it, are the only evidence available in the pod that distinguishes "its queue position expired" from "somebody cancelled it".

## Tests, verified by neutralization

Every new test was checked by reverting the production change and confirming it fails.

| Test | Neutralization | Result |
| --- | --- | --- |
| `invocation_waiting_past_thirty_seconds_still_escalates` — waits 60s behind the FIFO head (longer than the old 30s, far shorter than the 30-min row blocking it) and asserts the **side effect**: `fenced_lift` was called, i.e. `cpu.max` actually left the unleased quota | queue timeout back to `Duration::from_secs(30)` | **FAILS** — `lifts: 0, expected 1` |
| `queue_timeout_defaults_to_the_shared_dispatch_deadline` | same | **FAILS** — `left: 30s, right: 1800s` |
| `a_degraded_invocation_reports_why_and_at_what_quota` — asserts the captured WARN event's `terminal_reason`, `invocation_id`, `observed_usage_usec`, `degraded_quota` | `warn!` suppressed | **FAILS** — the only captured event is the `launched` INFO line, which is exactly what production looked like |
| `invocation_waiting_past_the_queue_deadline_degrades` (complement, so the first test cannot pass by the deadline being ignored) | — | stays green under both neutralizations, as it should |

The suite's fake now answers `queue_lease` the way the coordinator does — it advances the shared test clock by the FIFO wait and decides against the deadline the **runner itself computed** — instead of replaying a scripted constant, and the config comes from the production producer (`ShellLaunchContext::invocation`), not a hand-built 100ms `LeaseInvocationConfig`. `rendered_invocation_deadlines_are_granted_and_reach_the_fenced_lift` had a hard-coded `now + 30_000`; it now reads the shared constant.

Full `djinn-agent` process suite: 68 passed (5 consecutive runs, no flakes).

## Deliberately not in this PR

* **Compile-scoped build slots** (removing the dispatch pre-charge) — a separate design decision. `RoleResourceClass::gated_at_dispatch` is untouched.
* **Compile parallelism pinned from the leased quota** (`djinn-cgroup-launcher/src/lib.rs` ~:356) — a degraded leaf still runs `-j4`-class parallelism inside a 250m quota. Aggravating, not causal; deliberately left alone.
* **The queued status-poll loop is unthrottled** (`yield_now` between polls). This is pre-existing and applies to every invocation, not just queued ones — a *degraded* invocation already spins for its entire remaining life today. A longer queue window means proportionally more `lease_status` polls while queued, so a poll interval is worth a follow-up; it is not done here because the interval has to be driven by the injected `Clock` (tokio timers are unusable — tests advance an injected clock while fakes are paused) and the existing suite would hang on any test that does not advance it.
* **The warm build-slot leak** is a separate PR against `djinn-k8s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
