### PR TITLE
fix(graph-warm): release the build slot on a terminal warm workload, not on object absence

### DIFF
--- a/server/crates/djinn-coordinator/src/build_lease_integration_tests.rs
+++ b/server/crates/djinn-coordinator/src/build_lease_integration_tests.rs
@@ -878,6 +878,9 @@ async fn production_adapter_cancellation_reconciles_uid_before_capacity_release(
                 ),
                 ("djinn.app/fencing-token".into(), token.0.to_string()),
             ]),
+            // A Pod the cancellation path still has to delete: not finished,
+            // so the terminal-workload release never applies to it.
+            lifecycle: djinn_k8s::WarmObjectLifecycle::Live,
         },
     ]));
     let deleted = Arc::new(std::sync::Mutex::new(Vec::new()));

--- a/server/crates/djinn-k8s/src/graph_warmer.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer.rs
@@ -114,7 +114,7 @@ pub use crate::graph_warmer_candidates::{
     CleanupObservation, GateObservation, KubeWarmCandidateClient, WarmAnnotationValidation,
     WarmCandidate, WarmCandidateClient, WarmCandidateControl, WarmCandidateInventory,
     WarmCandidateKind, WarmCandidateObject, WarmCandidateSet, WarmCandidateSetState,
-    WarmInventoryObservation,
+    WarmInventoryObservation, WarmObjectLifecycle,
 };
 pub use warm_admission::{
     WarmAdmission, WarmAdmissionError, WarmAdmissionPermit, WarmAdmissionRequest,
@@ -1399,6 +1399,37 @@ impl K8sGraphWarmer {
                 }
             }
             if inventory.jobs.candidates.is_empty() && inventory.pods.candidates.is_empty() {
+                let _ = lease
+                    .release(&recovery.identity, recovery.fencing_token.clone())
+                    .await;
+                continue;
+            }
+            // A FINISHED workload releases its slot; a garbage-collected one is
+            // just the special case above.
+            //
+            // Object absence was the only release condition, which made the
+            // build slot's real holder the API server's garbage collector: a
+            // `Complete` warm Job kept one of THREE slots until
+            // `ttlSecondsAfterFinished` fired. Observed in production as
+            // `occupancy=3 cap=3` with only two running task-runs — a third of
+            // the fleet's build capacity held by a Job that had already
+            // finished warming.
+            //
+            // The safety property the absence rule was protecting — never
+            // release a slot whose workload might still be running — is
+            // preserved and stated directly rather than inferred from GC:
+            // `workload_finished` requires BOTH lists observed without error,
+            // every Job carrying Kubernetes' own `Complete`/`Failed` condition
+            // (so no further Pod can be created), and every observed Pod in a
+            // terminal phase (so none is still running). See
+            // [`WarmCandidateInventory::workload_finished`].
+            if inventory.workload_finished() {
+                info!(
+                    request_id = %recovery.identity.warm_request_id,
+                    jobs = inventory.jobs.candidates.len(),
+                    pods = inventory.pods.candidates.len(),
+                    "K8sGraphWarmer: warm workload reached a terminal state; releasing its build slot"
+                );
                 let _ = lease
                     .release(&recovery.identity, recovery.fencing_token.clone())
                     .await;

--- a/server/crates/djinn-k8s/src/graph_warmer_candidates.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_candidates.rs
@@ -720,7 +720,10 @@ mod tests {
             }))
             .expect("pod fixture")
         };
-        assert_eq!(pod_lifecycle(&pod("Succeeded")), WarmObjectLifecycle::Terminal);
+        assert_eq!(
+            pod_lifecycle(&pod("Succeeded")),
+            WarmObjectLifecycle::Terminal
+        );
         assert_eq!(pod_lifecycle(&pod("Failed")), WarmObjectLifecycle::Terminal);
         assert_eq!(pod_lifecycle(&pod("Running")), WarmObjectLifecycle::Live);
         assert_eq!(pod_lifecycle(&pod("Pending")), WarmObjectLifecycle::Live);

--- a/server/crates/djinn-k8s/src/graph_warmer_candidates.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_candidates.rs
@@ -54,6 +54,27 @@ fn inventory_observation(
     }
 }
 
+/// Whether Kubernetes has declared one observed object finished.
+///
+/// This is deliberately two-valued and fail-safe: everything a probe cannot
+/// positively classify as finished is [`Self::Live`], because the only thing
+/// this answer is used for is releasing a build slot, and releasing a slot
+/// whose workload is still running is the failure mode the object-absence rule
+/// existed to prevent.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WarmObjectLifecycle {
+    /// The object exists and is not provably finished — running, pending,
+    /// unreadable status, or a status shape this code does not understand.
+    #[default]
+    Live,
+    /// A Job carrying a `Complete` or `Failed` condition, or a Pod in the
+    /// `Succeeded` / `Failed` phase. Both are Kubernetes' own terminal
+    /// declarations, not an inference from counters: `status.failed > 0` is NOT
+    /// terminal in general (a Job with retries left keeps running), which is
+    /// why the conditions are read instead.
+    Terminal,
+}
+
 /// Data obtained from Kubernetes before identity validation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WarmCandidateObject {
@@ -61,6 +82,9 @@ pub struct WarmCandidateObject {
     pub name: String,
     pub uid: Option<String>,
     pub annotations: BTreeMap<String, String>,
+    /// Kubernetes' own terminal declaration for this object. Defaults to
+    /// [`WarmObjectLifecycle::Live`] for anything not positively finished.
+    pub lifecycle: WarmObjectLifecycle,
 }
 
 /// Result of checking the three durable annotations against the persisted
@@ -83,6 +107,8 @@ pub struct WarmCandidate {
     pub name: String,
     pub uid: Option<String>,
     pub annotation_validation: WarmAnnotationValidation,
+    /// Carried through from the observation. See [`WarmObjectLifecycle`].
+    pub lifecycle: WarmObjectLifecycle,
 }
 
 /// Classification for candidates of one Kubernetes kind.
@@ -152,6 +178,46 @@ impl WarmCandidateInventory {
             .then(|| self.pods.candidates.first())
             .flatten()
     }
+
+    /// Whether this request's workload has provably finished: Kubernetes has
+    /// declared every observed Job terminal and no observed Pod is still live.
+    ///
+    /// # Why this is safe to release a build slot on
+    ///
+    /// The rule it replaces was "both object lists are empty", which is a proof
+    /// about the API server's garbage collector, not about the workload: a
+    /// `Complete` warm Job holds one of only three slots until
+    /// `ttlSecondsAfterFinished` fires. Observed live as `occupancy=3 cap=3`
+    /// with two running task-runs.
+    ///
+    /// Three conditions, all required, and each one closes a hole the others
+    /// leave open:
+    ///
+    /// * `observation == Observed` — an `ApiError` on EITHER list makes the
+    ///   answer unknown, and unknown is never proof. A degraded API server
+    ///   therefore keeps every slot occupied, exactly like the absence rule.
+    /// * at least one Job candidate, and every Job candidate terminal. A Job's
+    ///   `Complete`/`Failed` condition is the Job controller's own statement
+    ///   that it will create no further Pods, so nothing can start after this
+    ///   observation. (The warm Job is `backoffLimit: 0`, `restartPolicy:
+    ///   Never`, one completion — a single Pod, no retries.)
+    /// * every observed Pod candidate terminal. This is the direct statement of
+    ///   "nothing is still running", and it is what makes the release safe
+    ///   independently of any assumption about the Job controller: a `Running`
+    ///   or `Pending` Pod — including one still terminating — keeps the slot.
+    ///
+    /// A zero-Job inventory deliberately answers `false`: that population is
+    /// the object-absence branch, which releases for its own reason.
+    pub fn workload_finished(&self) -> bool {
+        self.observation == WarmInventoryObservation::Observed
+            && !self.jobs.candidates.is_empty()
+            && self
+                .jobs
+                .candidates
+                .iter()
+                .chain(self.pods.candidates.iter())
+                .all(|candidate| candidate.lifecycle == WarmObjectLifecycle::Terminal)
+    }
 }
 
 /// Outcome of attempting to write a gate authorization.
@@ -219,13 +285,52 @@ fn candidate_object(
     name: Option<String>,
     uid: Option<String>,
     annotations: Option<BTreeMap<String, String>>,
+    lifecycle: WarmObjectLifecycle,
 ) -> Option<WarmCandidateObject> {
     Some(WarmCandidateObject {
         kind,
         name: name?,
         uid,
         annotations: annotations.unwrap_or_default(),
+        lifecycle,
     })
+}
+
+/// Kubernetes' terminal declaration for a Job.
+///
+/// Read from `status.conditions`, never from the `succeeded`/`failed` counters:
+/// a counter says how many Pods have finished, and for a Job with retries left
+/// `failed > 0` is entirely compatible with a Pod that is still running. The
+/// `Complete` / `Failed` conditions are the Job controller's statement that it
+/// is done creating Pods, which is the only thing a slot release may rely on.
+fn job_lifecycle(job: &Job) -> WarmObjectLifecycle {
+    let terminal = job.status.as_ref().is_some_and(|status| {
+        status.conditions.iter().flatten().any(|condition| {
+            matches!(condition.type_.as_str(), "Complete" | "Failed") && condition.status == "True"
+        })
+    });
+    if terminal {
+        WarmObjectLifecycle::Terminal
+    } else {
+        WarmObjectLifecycle::Live
+    }
+}
+
+/// Kubernetes' terminal declaration for a Pod: the two terminal phases. Every
+/// other phase — including an absent or unrecognised one — is [`Live`].
+///
+/// [`Live`]: WarmObjectLifecycle::Live
+fn pod_lifecycle(pod: &Pod) -> WarmObjectLifecycle {
+    let terminal = pod
+        .status
+        .as_ref()
+        .and_then(|status| status.phase.as_deref())
+        .is_some_and(|phase| matches!(phase, "Succeeded" | "Failed"));
+    if terminal {
+        WarmObjectLifecycle::Terminal
+    } else {
+        WarmObjectLifecycle::Live
+    }
 }
 
 fn api_error(error: kube::Error) -> String {
@@ -242,11 +347,13 @@ impl WarmCandidateClient for KubeWarmCandidateClient {
             .items
             .into_iter()
             .filter_map(|job| {
+                let lifecycle = job_lifecycle(&job);
                 candidate_object(
                     WarmCandidateKind::Job,
                     job.metadata.name,
                     job.metadata.uid,
                     job.metadata.annotations,
+                    lifecycle,
                 )
             })
             .collect())
@@ -260,11 +367,13 @@ impl WarmCandidateClient for KubeWarmCandidateClient {
             .items
             .into_iter()
             .filter_map(|pod| {
+                let lifecycle = pod_lifecycle(&pod);
                 candidate_object(
                     WarmCandidateKind::Pod,
                     pod.metadata.name,
                     pod.metadata.uid,
                     pod.metadata.annotations,
+                    lifecycle,
                 )
             })
             .collect())
@@ -377,6 +486,7 @@ impl<C: WarmCandidateClient> WarmCandidateControl<C> {
                 name: object.name,
                 uid: object.uid,
                 annotation_validation: validate_annotations(&object.annotations, identity),
+                lifecycle: object.lifecycle,
             })
             .collect::<Vec<_>>();
         let jobs = candidate_set(
@@ -542,6 +652,159 @@ mod tests {
     fn identity() -> LeasedWarmJobIdentity {
         LeasedWarmJobIdentity::new("project", "request", "revision", 7)
     }
+
+    /// The classification a build-slot release depends on, read off the API
+    /// objects Kubernetes actually returns.
+    ///
+    /// Without this the reconciler's release test could pass forever against a
+    /// mapping that answers `Live` for every real Job — the fix would be inert
+    /// in production and every test would still be green.
+    #[test]
+    fn kubernetes_status_decides_the_lifecycle() {
+        let job = |status: serde_json::Value| -> Job {
+            serde_json::from_value(serde_json::json!({
+                "metadata": {"name": "warm"},
+                "status": status,
+            }))
+            .expect("job fixture")
+        };
+        assert_eq!(
+            job_lifecycle(&job(
+                serde_json::json!({"conditions": [{"type": "Complete", "status": "True"}]})
+            )),
+            WarmObjectLifecycle::Terminal,
+            "a Complete Job is finished and its slot must come back"
+        );
+        assert_eq!(
+            job_lifecycle(&job(
+                serde_json::json!({"conditions": [{"type": "Failed", "status": "True"}]})
+            )),
+            WarmObjectLifecycle::Terminal
+        );
+        assert_eq!(
+            job_lifecycle(&job(serde_json::json!({"active": 1}))),
+            WarmObjectLifecycle::Live
+        );
+        assert_eq!(
+            job_lifecycle(&job(serde_json::json!({}))),
+            WarmObjectLifecycle::Live
+        );
+        // A condition that is present but NOT true says the opposite of what a
+        // type-only match would read.
+        assert_eq!(
+            job_lifecycle(&job(
+                serde_json::json!({"conditions": [{"type": "Complete", "status": "False"}]})
+            )),
+            WarmObjectLifecycle::Live
+        );
+        // The counter trap: `failed > 0` is not terminal on its own, because a
+        // Job with retries left keeps running.
+        assert_eq!(
+            job_lifecycle(&job(serde_json::json!({"failed": 1, "active": 1}))),
+            WarmObjectLifecycle::Live,
+            "a failure counter is not a terminal declaration"
+        );
+        assert_eq!(
+            job_lifecycle(
+                &serde_json::from_value(serde_json::json!({"metadata": {"name": "warm"}}))
+                    .expect("job fixture")
+            ),
+            WarmObjectLifecycle::Live,
+            "an unreported status is unknown, and unknown never releases"
+        );
+
+        let pod = |phase: &str| -> Pod {
+            serde_json::from_value(serde_json::json!({
+                "metadata": {"name": "warm-pod"},
+                "status": {"phase": phase},
+            }))
+            .expect("pod fixture")
+        };
+        assert_eq!(pod_lifecycle(&pod("Succeeded")), WarmObjectLifecycle::Terminal);
+        assert_eq!(pod_lifecycle(&pod("Failed")), WarmObjectLifecycle::Terminal);
+        assert_eq!(pod_lifecycle(&pod("Running")), WarmObjectLifecycle::Live);
+        assert_eq!(pod_lifecycle(&pod("Pending")), WarmObjectLifecycle::Live);
+        assert_eq!(
+            pod_lifecycle(
+                &serde_json::from_value(serde_json::json!({"metadata": {"name": "warm-pod"}}))
+                    .expect("pod fixture")
+            ),
+            WarmObjectLifecycle::Live
+        );
+    }
+
+    /// The slot-release predicate itself: every unknown answers "keep the slot".
+    #[test]
+    fn only_a_finished_and_fully_observed_workload_releases() {
+        let candidate = |kind, lifecycle| WarmCandidate {
+            kind,
+            name: "object".into(),
+            uid: Some("uid".into()),
+            annotation_validation: WarmAnnotationValidation::Matching,
+            lifecycle,
+        };
+        let inventory = |observation: WarmInventoryObservation,
+                         jobs: Vec<WarmCandidate>,
+                         pods: Vec<WarmCandidate>| WarmCandidateInventory {
+            observation,
+            jobs_observation: WarmCandidateListObservation::Observed,
+            jobs: candidate_set(jobs),
+            pods_observation: WarmCandidateListObservation::Observed,
+            pods: candidate_set(pods),
+        };
+        let terminal_job = candidate(WarmCandidateKind::Job, WarmObjectLifecycle::Terminal);
+        let live_job = candidate(WarmCandidateKind::Job, WarmObjectLifecycle::Live);
+        let terminal_pod = candidate(WarmCandidateKind::Pod, WarmObjectLifecycle::Terminal);
+        let live_pod = candidate(WarmCandidateKind::Pod, WarmObjectLifecycle::Live);
+
+        assert!(
+            inventory(
+                WarmInventoryObservation::Observed,
+                vec![terminal_job.clone()],
+                vec![terminal_pod.clone()]
+            )
+            .workload_finished()
+        );
+        assert!(
+            inventory(
+                WarmInventoryObservation::Observed,
+                vec![terminal_job.clone()],
+                vec![]
+            )
+            .workload_finished(),
+            "a finished Job whose Pod is already gone is finished"
+        );
+        assert!(
+            !inventory(
+                WarmInventoryObservation::Observed,
+                vec![terminal_job.clone()],
+                vec![live_pod]
+            )
+            .workload_finished(),
+            "a running Pod keeps the slot however finished its Job claims to be"
+        );
+        assert!(
+            !inventory(
+                WarmInventoryObservation::Observed,
+                vec![live_job],
+                vec![terminal_pod.clone()]
+            )
+            .workload_finished()
+        );
+        assert!(
+            !inventory(
+                WarmInventoryObservation::ApiError("apiserver unavailable".into()),
+                vec![terminal_job],
+                vec![terminal_pod]
+            )
+            .workload_finished(),
+            "an unusable observation is never proof"
+        );
+        assert!(
+            !inventory(WarmInventoryObservation::Observed, vec![], vec![]).workload_finished(),
+            "an empty inventory is the object-absence branch, not this one"
+        );
+    }
     fn object(kind: WarmCandidateKind, name: &str, uid: Option<&str>) -> WarmCandidateObject {
         let id = identity();
         WarmCandidateObject {
@@ -556,6 +819,7 @@ mod tests {
                     id.fencing_token.to_string(),
                 ),
             ]),
+            lifecycle: WarmObjectLifecycle::Live,
         }
     }
     #[tokio::test]
@@ -713,6 +977,7 @@ mod tests {
             name: "pod".into(),
             uid: Some("uid".into()),
             annotation_validation: WarmAnnotationValidation::Matching,
+            lifecycle: WarmObjectLifecycle::Live,
         };
         let control = WarmCandidateControl::new(Fake {
             delete_result: CleanupObservation::Unresolved("timeout".into()),

--- a/server/crates/djinn-k8s/src/graph_warmer_recovery_tests.rs
+++ b/server/crates/djinn-k8s/src/graph_warmer_recovery_tests.rs
@@ -138,6 +138,7 @@ fn pod_inventory(uid: &str) -> WarmCandidateInventory {
         name: "pod".into(),
         uid: Some(uid.into()),
         annotation_validation: WarmAnnotationValidation::Matching,
+        lifecycle: WarmObjectLifecycle::Live,
     };
     WarmCandidateInventory {
         observation: WarmInventoryObservation::Observed,
@@ -149,6 +150,136 @@ fn pod_inventory(uid: &str) -> WarmCandidateInventory {
             candidates: vec![candidate],
         },
     }
+}
+
+/// An inventory carrying one Job and one Pod for this request, each with an
+/// explicit Kubernetes lifecycle.
+fn job_and_pod_inventory(
+    job: WarmObjectLifecycle,
+    pod: WarmObjectLifecycle,
+) -> WarmCandidateInventory {
+    WarmCandidateInventory {
+        observation: WarmInventoryObservation::Observed,
+        jobs_observation: crate::graph_warmer_candidates::WarmCandidateListObservation::Observed,
+        jobs: WarmCandidateSet {
+            state: WarmCandidateSetState::One,
+            candidates: vec![WarmCandidate {
+                kind: WarmCandidateKind::Job,
+                name: "job".into(),
+                uid: Some("job-uid".into()),
+                annotation_validation: WarmAnnotationValidation::Matching,
+                lifecycle: job,
+            }],
+        },
+        pods_observation: crate::graph_warmer_candidates::WarmCandidateListObservation::Observed,
+        pods: WarmCandidateSet {
+            state: WarmCandidateSetState::One,
+            candidates: vec![WarmCandidate {
+                kind: WarmCandidateKind::Pod,
+                name: "pod".into(),
+                uid: Some("uid-a".into()),
+                annotation_validation: WarmAnnotationValidation::Matching,
+                lifecycle: pod,
+            }],
+        },
+    }
+}
+
+/// A `Complete` warm Job used to hold its build slot until Kubernetes garbage
+/// collected the object — one of THREE slots, observed in production as
+/// `occupancy=3 cap=3` with only two running task-runs. The workload is over;
+/// the capacity must come back.
+#[tokio::test]
+async fn a_terminal_warm_job_releases_its_build_slot() {
+    let lease = Arc::new(LeaseFake {
+        rows: StdMutex::new(vec![recovery(LeaseState::Active, Some("uid-a"), false)]),
+        binds: StdMutex::new(Vec::new()),
+        reports: StdMutex::new(Vec::new()),
+        releases: StdMutex::new(0),
+    });
+    let candidates = Arc::new(CandidatesFake {
+        inventories: StdMutex::new(VecDeque::from([job_and_pod_inventory(
+            WarmObjectLifecycle::Terminal,
+            WarmObjectLifecycle::Terminal,
+        )])),
+        deletes: StdMutex::new(Vec::new()),
+        gates: StdMutex::new(Vec::new()),
+        delete_outcome: CleanupObservation::ConfirmedDelete,
+    });
+    let warmer = warmer(lease.clone(), candidates.clone());
+    warmer.reconcile_durable_warm_leases().await;
+
+    assert_eq!(
+        *lease.releases.lock().unwrap(),
+        1,
+        "a finished warm workload must hand its build slot back, not wait for \
+         the API server's garbage collector"
+    );
+    // Replaying the pass must not return the same capacity twice: the release
+    // retires the row, so the second pass has nothing to reconcile.
+    warmer.reconcile_durable_warm_leases().await;
+    assert_eq!(*lease.releases.lock().unwrap(), 1);
+    assert!(candidates.deletes.lock().unwrap().is_empty());
+}
+
+/// The safety property the object-absence rule was protecting, stated
+/// directly: a Job Kubernetes has already declared finished whose Pod is STILL
+/// RUNNING keeps its slot. Releasing here would let a second build start
+/// against capacity the first one is still using.
+#[tokio::test]
+async fn a_terminal_job_with_a_live_pod_keeps_its_build_slot() {
+    let lease = Arc::new(LeaseFake {
+        rows: StdMutex::new(vec![recovery(LeaseState::Active, Some("uid-a"), false)]),
+        binds: StdMutex::new(Vec::new()),
+        reports: StdMutex::new(Vec::new()),
+        releases: StdMutex::new(0),
+    });
+    let candidates = Arc::new(CandidatesFake {
+        inventories: StdMutex::new(VecDeque::from([job_and_pod_inventory(
+            WarmObjectLifecycle::Terminal,
+            WarmObjectLifecycle::Live,
+        )])),
+        deletes: StdMutex::new(Vec::new()),
+        gates: StdMutex::new(Vec::new()),
+        delete_outcome: CleanupObservation::ConfirmedDelete,
+    });
+    warmer(lease.clone(), candidates.clone())
+        .reconcile_durable_warm_leases()
+        .await;
+
+    assert_eq!(
+        *lease.releases.lock().unwrap(),
+        0,
+        "a still-running Pod holds the slot however finished its Job claims to be"
+    );
+}
+
+/// A warm that is simply running keeps its slot and stays on the ordinary
+/// bind/gate path.
+#[tokio::test]
+async fn a_running_warm_keeps_its_build_slot() {
+    let lease = Arc::new(LeaseFake {
+        rows: StdMutex::new(vec![recovery(LeaseState::Bound, Some("uid-a"), false)]),
+        binds: StdMutex::new(Vec::new()),
+        reports: StdMutex::new(Vec::new()),
+        releases: StdMutex::new(0),
+    });
+    let candidates = Arc::new(CandidatesFake {
+        inventories: StdMutex::new(VecDeque::from([job_and_pod_inventory(
+            WarmObjectLifecycle::Live,
+            WarmObjectLifecycle::Live,
+        )])),
+        deletes: StdMutex::new(Vec::new()),
+        gates: StdMutex::new(Vec::new()),
+        delete_outcome: CleanupObservation::ConfirmedDelete,
+    });
+    warmer(lease.clone(), candidates.clone())
+        .reconcile_durable_warm_leases()
+        .await;
+
+    assert_eq!(*lease.releases.lock().unwrap(), 0);
+    assert_eq!(lease.binds.lock().unwrap().as_slice(), ["uid-a"]);
+    assert_eq!(candidates.gates.lock().unwrap().as_slice(), ["uid-a"]);
 }
 
 fn warmer(lease: Arc<LeaseFake>, candidates: Arc<CandidatesFake>) -> K8sGraphWarmer {
@@ -303,6 +434,7 @@ async fn unsafe_recovery_inventory_never_binds_or_opens_graph_work_gate() {
                     expected: "revision".into(),
                     found: Some("other".into()),
                 },
+                lifecycle: WarmObjectLifecycle::Live,
             }],
         },
     };

--- a/server/crates/djinn-k8s/src/lib.rs
+++ b/server/crates/djinn-k8s/src/lib.rs
@@ -47,7 +47,7 @@ pub use graph_warmer_candidates::{
     CleanupObservation, GateObservation, KubeWarmCandidateClient, WarmAnnotationValidation,
     WarmCandidate, WarmCandidateClient, WarmCandidateControl, WarmCandidateInventory,
     WarmCandidateKind, WarmCandidateObject, WarmCandidateSet, WarmCandidateSetState,
-    WarmInventoryObservation,
+    WarmInventoryObservation, WarmObjectLifecycle,
 };
 pub use graph_warmer_identity::{LeasedWarmJobIdentity, deterministic_warm_job_name, warm_work_id};
 pub use runtime::{KubernetesRuntime, taskrun_job_name};


### PR DESCRIPTION
## The leak

There is exactly **one** place a GraphWarm build lease is ever released — `reconcile_durable_warm_leases`, on the 30s server loop — and it released only when **both** the Job and the Pod objects were ABSENT:

```rust
if inventory.jobs.candidates.is_empty() && inventory.pods.candidates.is_empty() { release }
```

That is a proof about the API server's garbage collector, not about the workload. A `Complete` warm Job therefore keeps holding one of only **3** build slots until `ttlSecondsAfterFinished` fires. Observed live: `occupancy=3 cap=3` with only **two** running task-runs — a third of the fleet's build capacity held by a Job that had already finished warming, while every task-run and every later warm queued behind it.

## The fix, and why terminal-Job release is provably safe

Release when the workload has provably **finished**, not when its objects have been collected. The absence case stays exactly as it was; it is now the special case of "finished" rather than the only one.

The safety property the absence rule was protecting — *never release a slot whose workload might still be running* — is preserved, and now stated directly instead of inferred from GC. `WarmCandidateInventory::workload_finished()` requires all three:

1. **`observation == Observed`** — an `ApiError` on either list makes the answer unknown, and unknown is never proof. A degraded API server keeps every slot occupied, exactly like the absence rule.
2. **At least one Job candidate, and every Job candidate terminal.** Terminal means Kubernetes' own `Complete`/`Failed` **condition** — the Job controller's statement that it will create no further Pods — so nothing can start after the observation. Deliberately NOT the `succeeded`/`failed` counters: `failed > 0` is not terminal in general, because a Job with retries left keeps running. (The warm Job is `backoffLimit: 0`, `restartPolicy: Never`, one completion — a single Pod, no retries — but the release does not depend on that.)
3. **Every observed Pod candidate terminal** (`Succeeded`/`Failed` phase). This is the direct statement of "nothing is still running", and it makes the release safe independently of any assumption about the Job controller: a `Running`, `Pending`, or still-terminating Pod keeps the slot.

Conditions 2 and 3 close each other's holes: 3 rules out a live Pod at observation time, 2 rules out a new Pod appearing after it. Everything unclassifiable maps to `WarmObjectLifecycle::Live`, so every unknown keeps the slot.

The lifecycle is read once, at list time, in `KubeWarmCandidateClient` and carried on the candidate; nothing else in the warmer changes.

## Interaction with the in-pod phase-boundary release

A separate change releases the warm build lease from inside the pod at the cargo→graph phase boundary (before `run_warm_graph_command`), because the SCIP phase holds a slot for ~60 minutes while using one core. **The two compose and cannot double-release:**

* this pass only ever sees rows returned by `BuildLeaseGraphWarmAdapter::recoverable`, which filters `state != Terminal` and maps only `Launching`/`Bound`/`Active`/`Suspect`. Once the in-pod release lands, the row is terminal and this pass never looks at it again;
* `release` is fenced by the fencing token and idempotent at the service level. `production_adapter_cancellation_reconciles_uid_before_capacity_release` already pins this against the real repository: three consecutive reconcile passes leave `occupied == 0`, not negative;
* one releases *earlier within* the Job's life, the other stops the slot lingering *past* Job completion. Neither subsumes the other.

## Tests, verified by neutralization

| Test | Neutralization | Result |
| --- | --- | --- |
| `a_terminal_warm_job_releases_its_build_slot` — Complete Job + Succeeded Pod; asserts the **side effect** (`releases == 1`), and that replaying the pass does not return capacity twice | terminal-release branch disabled | **FAILS** — `releases: 0, expected 1` |
| `a_terminal_job_with_a_live_pod_keeps_its_build_slot` — the safety property, stated as a test: a finished Job whose Pod is still Running keeps the slot | — | green under the neutralization too, as it must be |
| `a_running_warm_keeps_its_build_slot` — live Job + live Pod: no release, and the ordinary bind/gate path still runs | — | green |
| `kubernetes_status_decides_the_lifecycle` — the classification read off real API objects: `Complete`/`Failed` conditions, `status: False`, `failed: 1` counters, absent status, Pod phases | `job_lifecycle` forced to `Live` | **FAILS** |
| `only_a_finished_and_fully_observed_workload_releases` — the predicate itself, including `ApiError` and empty-inventory | — | green |

The status-parsing test matters as much as the reconcile test: without it the reconcile test would keep passing against a mapping that answers `Live` for every real Job — the fix would be inert in production with every test green.

`djinn-k8s` lib: 261 passed. `djinn-coordinator` build-lease integration: 16 passed.

Note: `crates/djinn-k8s/src/graph_warmer_ledger_tests.rs:97,107` are red on `main` today (two pre-existing `Instant::now()` `disallowed_methods` errors, being fixed in a separate PR). Nothing in this change adds a clippy diagnostic — the only diagnostics pointing at `djinn-k8s` under `cargo clippy --workspace --all-targets` are those two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
